### PR TITLE
Load optimized Sanity images

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,7 @@ const config: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'via.placeholder.com',
+        hostname: 'placehold.co',
       },
       {
         protocol: 'https',

--- a/src/app/(main)/speaker/[slug]/opengraph-image.tsx
+++ b/src/app/(main)/speaker/[slug]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ImageResponse } from '@vercel/og'
 import { getPublicSpeaker } from '@/lib/speaker/sanity'
+import { sanityImage } from '@/lib/sanity/client'
 
 export const runtime = 'edge'
 
@@ -53,7 +54,7 @@ export default async function Image({ params }: { params: Promise<{ slug: string
         </div>
         <div style={{ display: 'flex' }}>
           <img
-            src={speaker.image}
+            src={speaker.image ? sanityImage(speaker.image).width(800).height(800).fit('crop').url() : 'https://placehold.co/800x800/e5e7eb/6b7280?text=Speaker'}
             alt={alt}
             height={400}
             style={{ marginRight: 40, marginBottom: 50, borderRadius: '50%' }}

--- a/src/app/(main)/speaker/[slug]/page.tsx
+++ b/src/app/(main)/speaker/[slug]/page.tsx
@@ -7,12 +7,12 @@ import {
   ProposalExisting,
 } from '@/lib/proposal/types'
 import { flags, Flags } from '@/lib/speaker/types'
-import Image from 'next/image'
 import * as social from '@/components/SocialIcons'
 import { getPublicSpeaker } from '@/lib/speaker/sanity'
 import { Button } from '@/components/Button'
 import { CalendarIcon } from '@heroicons/react/24/solid'
 import { TrackTalk } from '@/lib/conference/types'
+import { sanityImage } from '@/lib/sanity/client'
 import { PortableText } from '@portabletext/react'
 
 type Props = {
@@ -27,14 +27,14 @@ export async function generateMetadata({ params }: Props) {
     return {
       title: 'Speaker not found',
       description: 'Sorry, we could not find the speaker you are looking for.',
-      image: 'https://via.placeholder.com/1200',
+      image: 'https://placehold.co/1200x630/e5e7eb/6b7280?text=Speaker',
     }
   }
 
   return {
     title: `${speaker.name} - ${talks[0].title}`,
     description: talks[0].description.slice(0, 200),
-    image: speaker.image || 'https://via.placeholder.com/1200',
+    image: speaker.image ? sanityImage(speaker.image).width(2400).height(1200).fit('crop').url() : 'https://placehold.co/1200x630/e5e7eb/6b7280?text=Speaker',
   }
 }
 
@@ -176,8 +176,8 @@ export default async function Profile({ params }: Props) {
               {/* speaker details */}
               <div className="flex flex-col items-center text-center">
                 <div className="relative h-40 w-40 overflow-hidden rounded-full">
-                  <Image
-                    src={speaker.image || 'https://via.placeholder.com/150'}
+                  <img
+                    src={speaker.image ? sanityImage(speaker.image).width(300).height(300).fit('crop').url() : 'https://placehold.co/300x300/e5e7eb/6b7280?text=Speaker'}
                     alt={speaker.name}
                     width={150}
                     height={150}

--- a/src/app/(main)/speaker/page.tsx
+++ b/src/app/(main)/speaker/page.tsx
@@ -1,7 +1,7 @@
 import { BackgroundImage } from '@/components/BackgroundImage'
 import { Container } from '@/components/Container'
-import Image from 'next/image'
 import { getPublicSpeakers } from '@/lib/speaker/sanity'
+import { sanityImage } from '@/lib/sanity/client'
 
 export const revalidate = 3600
 
@@ -34,9 +34,9 @@ export default async function Speakers() {
               {speakers.map((speaker) => (
                 <li key={speaker._id}>
                   <a href={`/speaker/${speaker.slug}`} className="block">
-                    <Image
+                    <img
                       alt=""
-                      src={`${speaker.image || 'https://via.placeholder.com/300'}?h=300&w=300&auto=format&fit=crop`}
+                      src={speaker.image ? sanityImage(speaker.image).width(600).height(600).fit('crop').url() : 'https://placehold.co/600x600/e5e7eb/6b7280?text=Speaker'}
                       width={300}
                       height={300}
                       className="mx-auto h-30 w-30 rounded-full"

--- a/src/components/FeaturedSpeakers.tsx
+++ b/src/components/FeaturedSpeakers.tsx
@@ -1,6 +1,6 @@
-import Image from 'next/image'
 import { Container } from '@/components/Container'
 import { iconForLink } from '@/components/SocialIcons'
+import { sanityImage } from '@/lib/sanity/client'
 
 import { Speaker } from '@/lib/speaker/types'
 
@@ -43,9 +43,9 @@ export function FeaturedSpeakers({
                 <li key={person.name}>
                   {isOrganizers ? (
                     <>
-                      <Image
+                      <img
                         className="mx-auto h-56 w-56 rounded-full object-contain"
-                        src={person.image || '/images/default-avatar.png'}
+                        src={person.image ? sanityImage(person.image).width(448).height(448).fit('crop').url() : 'https://placehold.co/448x448/e5e7eb/6b7280?text=Speaker'}
                         alt={person.name}
                         width={224}
                         height={224}
@@ -56,9 +56,9 @@ export function FeaturedSpeakers({
                     </>
                   ) : (
                     <a href={`/speaker/${person.slug}`}>
-                      <Image
+                      <img
                         className="mx-auto h-56 w-56 rounded-full object-contain"
-                        src={person.image || '/images/default-avatar.png'}
+                        src={person.image ? sanityImage(person.image).width(448).height(448).fit('crop').url() : 'https://placehold.co/448x448/e5e7eb/6b7280?text=Speaker'}
                         alt={person.name}
                         width={224}
                         height={224}

--- a/src/components/FeaturedSpeakers.tsx
+++ b/src/components/FeaturedSpeakers.tsx
@@ -49,6 +49,7 @@ export function FeaturedSpeakers({
                         alt={person.name}
                         width={224}
                         height={224}
+                        loading="lazy"
                       />
                       <h3 className="mt-6 text-2xl leading-7 font-semibold tracking-tight text-gray-900">
                         {person.name}
@@ -62,6 +63,7 @@ export function FeaturedSpeakers({
                         alt={person.name}
                         width={224}
                         height={224}
+                        loading="lazy"
                       />
                       <h3 className="mt-6 text-2xl leading-7 font-semibold tracking-tight text-gray-900">
                         {person.name}

--- a/src/components/ProposalCard.tsx
+++ b/src/components/ProposalCard.tsx
@@ -9,10 +9,10 @@ import {
   UserCircleIcon,
   XMarkIcon,
 } from '@heroicons/react/24/solid'
-import Image from 'next/image'
 import { SpinnerIcon } from './SocialIcons'
 import { PortableTextBlock } from '@portabletext/editor'
 import { PortableTextTextBlock, PortableTextObject } from 'sanity'
+import { sanityImage } from '@/lib/sanity/client'
 
 interface ProposalButtonAction {
   label: Action
@@ -169,9 +169,9 @@ export function ProposalCard({
           </p>
         </div>
         {proposal.speaker && 'image' in proposal.speaker ? (
-          <Image
+          <img
             className="h-10 w-10 flex-shrink-0 rounded-full bg-gray-300"
-            src={proposal.speaker.image || '/images/default-avatar.png'}
+            src={proposal.speaker.image ? sanityImage(proposal.speaker.image).width(80).height(80).fit('crop').url() : 'https://placehold.co/80x80/e5e7eb/6b7280?text=Speaker'}
             alt="Speaker Image"
             width={40}
             height={40}

--- a/src/components/ProposalCard.tsx
+++ b/src/components/ProposalCard.tsx
@@ -175,6 +175,7 @@ export function ProposalCard({
             alt="Speaker Image"
             width={40}
             height={40}
+            loading="lazy"
           />
         ) : (
           <UserCircleIcon

--- a/src/components/Speakers.tsx
+++ b/src/components/Speakers.tsx
@@ -225,6 +225,7 @@ export function Speakers({ tracks }: { tracks: ScheduleTrack[] }) {
                             >
                               <img
                                 className="absolute inset-0 h-full w-full object-cover transition duration-300 group-hover:scale-110"
+                                loading="lazy"
                                 src={
                                   speaker.image
                                     ? sanityImage(speaker.image).width(600).height(600).fit('crop').url()

--- a/src/components/Speakers.tsx
+++ b/src/components/Speakers.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useEffect, useId, useState } from 'react'
-import Image from 'next/image'
 import { Tab } from '@headlessui/react'
 import clsx from 'clsx'
 import { ScheduleTrack } from '@/lib/conference/types'
+import { sanityImage } from '@/lib/sanity/client'
 
 import { Container } from '@/components/Container'
 import { DiamondIcon } from '@/components/DiamondIcon'
@@ -223,18 +223,16 @@ export function Speakers({ tracks }: { tracks: ScheduleTrack[] }) {
                               href={`/speaker/${speaker.slug}`}
                               className="absolute inset-0"
                             >
-                              <Image
+                              <img
                                 className="absolute inset-0 h-full w-full object-cover transition duration-300 group-hover:scale-110"
                                 src={
                                   speaker.image
-                                    ? `${speaker.image}?h=300`
-                                    : 'https://via.placeholder.com/300'
+                                    ? sanityImage(speaker.image).width(600).height(600).fit('crop').url()
+                                    : 'https://placehold.co/600x600/e5e7eb/6b7280?text=Speaker'
                                 }
                                 width={300}
                                 height={300}
                                 alt=""
-                                priority
-                                sizes="(min-width: 1280px) 17.5rem, (min-width: 1024px) 25vw, (min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw"
                               />
                             </a>
                           </div>

--- a/src/components/admin/ProposalCard.tsx
+++ b/src/components/admin/ProposalCard.tsx
@@ -38,7 +38,7 @@ export function ProposalCard({
       <div className="flex-shrink-0">
         {speaker?.image ? (
           <img
-            src={sanityImage(speaker.image).width(96).height(96).url()}
+            src={sanityImage(speaker.image).width(96).height(96).fit('crop').url()}
             alt={speaker.name || 'Speaker'}
             width={48}
             height={48}

--- a/src/components/admin/ProposalCard.tsx
+++ b/src/components/admin/ProposalCard.tsx
@@ -43,6 +43,7 @@ export function ProposalCard({
             width={48}
             height={48}
             className="h-12 w-12 rounded-full object-cover"
+            loading="lazy"
           />
         ) : (
           <div className="h-12 w-12 rounded-full bg-gray-100 flex items-center justify-center">

--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -123,6 +123,7 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
                         width={64}
                         height={64}
                         className="h-16 w-16 rounded-full object-cover"
+                        loading="lazy"
                       />
                     ) : (
                       <div className="h-16 w-16 rounded-full bg-gray-200 flex items-center justify-center">

--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -118,7 +118,7 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
                   <div className="flex-shrink-0">
                     {speaker.image ? (
                       <img
-                        src={sanityImage(speaker.image).width(128).height(128).url()}
+                        src={sanityImage(speaker.image).width(128).height(128).fit('crop').url()}
                         alt={speaker.name}
                         width={64}
                         height={64}

--- a/src/components/admin/ProposalPreview.tsx
+++ b/src/components/admin/ProposalPreview.tsx
@@ -93,6 +93,7 @@ export function ProposalPreview({ proposal, onClose }: ProposalPreviewProps) {
                   width={48}
                   height={48}
                   className="h-12 w-12 rounded-full object-cover"
+                  loading="lazy"
                 />
               )}
               <div>

--- a/src/components/admin/ProposalPreview.tsx
+++ b/src/components/admin/ProposalPreview.tsx
@@ -88,7 +88,7 @@ export function ProposalPreview({ proposal, onClose }: ProposalPreviewProps) {
             <div className="flex items-center space-x-4">
               {speaker.image && (
                 <img
-                  src={sanityImage(speaker.image).width(96).height(96).url()}
+                  src={sanityImage(speaker.image).width(96).height(96).fit('crop').url()}
                   alt={speaker.name}
                   width={48}
                   height={48}

--- a/src/components/admin/ProposalReviewList.tsx
+++ b/src/components/admin/ProposalReviewList.tsx
@@ -71,6 +71,7 @@ export function ProposalReviewList({ reviews, currentUserId }: ProposalReviewLis
                       width={32}
                       height={32}
                       className="h-8 w-8 rounded-full object-cover"
+                      loading="lazy"
                     />
                   ) : (
                     <div className="h-8 w-8 rounded-full bg-gray-100 flex items-center justify-center">

--- a/src/components/admin/ProposalReviewList.tsx
+++ b/src/components/admin/ProposalReviewList.tsx
@@ -66,7 +66,7 @@ export function ProposalReviewList({ reviews, currentUserId }: ProposalReviewLis
                 <div className="flex-shrink-0">
                   {reviewer?.image ? (
                     <img
-                      src={sanityImage(reviewer.image).width(64).height(64).url()}
+                      src={sanityImage(reviewer.image).width(64).height(64).fit('crop').url()}
                       alt={reviewer.name || 'Reviewer'}
                       width={32}
                       height={32}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -87,8 +87,12 @@ const config = {
           return {}
         }
 
-        if (speaker.image && typeof speaker.image === 'object') {
-          token.picture = sanityImage(speaker.image).width(192).height(192).fit('crop').url()
+        if (speaker.image) {
+          if (typeof speaker.image === 'object') {
+            token.picture = sanityImage(speaker.image).width(192).height(192).fit('crop').url()
+          } else if (typeof speaker.image === 'string') {
+            token.picture = speaker.image
+          }
         }
 
         token.account = account

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import LinkedIn from 'next-auth/providers/linkedin'
 import type { NextAuthConfig, Session, User } from 'next-auth'
 import { NextRequest } from 'next/server'
 import { getOrCreateSpeaker } from '@/lib/speaker/sanity'
+import { sanityImage } from '@/lib/sanity/client'
 
 export interface NextAuthRequest extends NextRequest {
   auth: Session | null
@@ -86,8 +87,8 @@ const config = {
           return {}
         }
 
-        if (speaker.image && typeof speaker.image === 'string') {
-          token.picture = `${speaker.image}?w=96&h=96&fit=crop`
+        if (speaker.image && typeof speaker.image === 'object') {
+          token.picture = sanityImage(speaker.image).width(192).height(192).fit('crop').url()
         }
 
         token.account = account


### PR DESCRIPTION
This pull request introduces several changes to enhance image handling across the codebase by replacing `next/image` with standard `img` tags and integrating the `sanityImage` utility for more consistent image processing. Additionally, it updates placeholder URLs to use `placehold.co` instead of `via.placeholder.com`.

### Image Handling Updates:

* Replaced `next/image` with standard `img` tags in multiple components, ensuring compatibility with the `sanityImage` utility for dynamic image transformations. (`[src/app/(main)/speaker/[slug]/opengraph-image.tsxL56-R57](diffhunk://#diff-9e5afc0e9043054f6cff493481edb475eb14474b989cf001fde2ce90b998d561L56-R57)`, `[src/app/(main)/speaker/[slug]/page.tsxL179-R180](diffhunk://#diff-6dee58e84fc928a71296dae734431781af8dfe304ed5161545e9fe4c73d72c07L179-R180)`, `[[1]](diffhunk://#diff-72459d318d3d3967afbeb850d7ffb2f190c493fba3c6a24aa4135dbfe6866b52L37-R39)`, `[[2]](diffhunk://#diff-61e8d32e6a42f3a68213974e23c5e7e468aafdae0469f333e0b3c67f6fef87f8L46-R48)`, `[[3]](diffhunk://#diff-a2348f6ee3407e5d9c98ab86dd2bdac36b740e1bf789fda3f26574194074666fL172-R174)`, `[[4]](diffhunk://#diff-6c0ede111445e5e263438ace1053416f61334cc128ba156732bd5fe18296330eL226-L237)`, `[[5]](diffhunk://#diff-0ac868ce312b1a60e4a56ae584e7731c7cbcbb309e5b3db8cbaa046e81d50503L41-R41)`, `[[6]](diffhunk://#diff-343ad45195f583a77bebf8d8af1b0df1694fe432669b8f240cf2b8c2b3c6e1e2L121-R121)`, `[[7]](diffhunk://#diff-50d097e71694d7b4a82b77dcd474fce6dbd35d164b2ce016def7e628c6ce6fb6L91-R91)`, `[[8]](diffhunk://#diff-91d09670cfe7435d79d79bfc0adf14489dce01dac67e264396b81c0b6d394934L69-R69)`)

* Integrated the `sanityImage` utility for dynamic image transformations, including cropping, resizing, and fitting, across components and pages. (`[src/app/(main)/speaker/[slug]/opengraph-image.tsxR4](diffhunk://#diff-9e5afc0e9043054f6cff493481edb475eb14474b989cf001fde2ce90b998d561R4)`, `[src/app/(main)/speaker/[slug]/page.tsxL10-R15](diffhunk://#diff-6dee58e84fc928a71296dae734431781af8dfe304ed5161545e9fe4c73d72c07L10-R15)`, `[[1]](diffhunk://#diff-72459d318d3d3967afbeb850d7ffb2f190c493fba3c6a24aa4135dbfe6866b52L3-R4)`, `[[2]](diffhunk://#diff-61e8d32e6a42f3a68213974e23c5e7e468aafdae0469f333e0b3c67f6fef87f8L1-R3)`, `[[3]](diffhunk://#diff-a2348f6ee3407e5d9c98ab86dd2bdac36b740e1bf789fda3f26574194074666fL12-R15)`, `F0ad47e4L1`, `[[4]](diffhunk://#diff-486994d46df34c53636a706a1ca6a05bd8261ccde47463ea2c739af56f090b78R7)`)

### Placeholder URL Updates:

* Updated placeholder image URLs to use `placehold.co` for improved aesthetics and consistency. (`[[1]](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL15-R15)`, `[src/app/(main)/speaker/[slug]/page.tsxL30-R37](diffhunk://#diff-6dee58e84fc928a71296dae734431781af8dfe304ed5161545e9fe4c73d72c07L30-R37)`, `[src/app/(main)/speaker/[slug]/page.tsxL179-R180](diffhunk://#diff-6dee58e84fc928a71296dae734431781af8dfe304ed5161545e9fe4c73d72c07L179-R180)`, `[[2]](diffhunk://#diff-72459d318d3d3967afbeb850d7ffb2f190c493fba3c6a24aa4135dbfe6866b52L37-R39)`, `[[3]](diffhunk://#diff-6c0ede111445e5e263438ace1053416f61334cc128ba156732bd5fe18296330eL226-L237)`)