### PR TITLE
Remind speaker to accept

### DIFF
--- a/src/app/api/proposal/[id]/action/route.test.ts
+++ b/src/app/api/proposal/[id]/action/route.test.ts
@@ -102,6 +102,13 @@ describe('actionStateMachine', () => {
     },
     {
       currentStatus: Status.accepted,
+      action: Action.remind,
+      isOrganizer: true,
+      expectedStatus: Status.accepted,
+      expectedValidAction: true,
+    },
+    {
+      currentStatus: Status.accepted,
       action: Action.withdraw,
       isOrganizer: false,
       expectedStatus: Status.withdrawn,

--- a/src/app/api/proposal/[id]/action/route.ts
+++ b/src/app/api/proposal/[id]/action/route.ts
@@ -110,7 +110,7 @@ export const POST = auth(
       })
     }
 
-    if (notify && (action === Action.accept || action === Action.reject)) {
+    if (notify && (action === Action.accept || action === Action.reject || action === Action.remind)) {
       await sendAcceptRejectNotification({
         action,
         speaker: proposal.speaker as Speaker,

--- a/src/components/admin/ProposalActionModal.tsx
+++ b/src/components/admin/ProposalActionModal.tsx
@@ -14,6 +14,7 @@ import {
   EnvelopeIcon,
   HeartIcon,
   XMarkIcon,
+  BellIcon,
 } from '@heroicons/react/20/solid'
 import { Speaker } from '@/lib/speaker/types'
 import { postProposalAction } from '@/lib/proposal/client'
@@ -35,6 +36,12 @@ function colorForAction(action: Action): [string, string, string] {
         'text-green-600',
         'bg-green-600 hover:bg-green-500',
       ]
+    case Action.remind:
+      return [
+        'bg-yellow-100',
+        'text-yellow-600',
+        'bg-yellow-600 hover:bg-yellow-500',
+      ]
     case Action.reject:
     case Action.withdraw:
     case Action.delete:
@@ -53,6 +60,8 @@ function iconForAction(
     case Action.accept:
     case Action.confirm:
       return HeartIcon
+    case Action.remind:
+      return BellIcon
     case Action.reject:
       return ArchiveBoxXMarkIcon
     case Action.withdraw:

--- a/src/components/admin/ProposalActionPanel.tsx
+++ b/src/components/admin/ProposalActionPanel.tsx
@@ -8,7 +8,7 @@ import { ProposalReviewSummary } from './ProposalReviewSummary'
 import { ProposalReviewForm } from './ProposalReviewForm'
 import { ProposalReviewList } from './ProposalReviewList'
 import { ProposalActionModal } from './ProposalActionModal'
-import { CheckIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { CheckIcon, XMarkIcon, BellIcon } from '@heroicons/react/24/outline'
 
 interface ProposalActionPanelProps {
   proposal: ProposalExisting
@@ -80,6 +80,7 @@ export function ProposalActionPanel({
   }
 
   const canApprove = proposalStatus === Status.submitted
+  const canRemind = proposalStatus === Status.accepted
   const canReject = proposalStatus === Status.submitted || proposalStatus === Status.accepted
 
   return (
@@ -91,18 +92,32 @@ export function ProposalActionPanel({
 
           {/* Button Group */}
           <div className="inline-flex rounded-md shadow-sm w-full" role="group">
-            {/* Approve Button */}
-            <button
-              onClick={() => handleAction(Action.accept)}
-              disabled={!canApprove}
-              className={`relative inline-flex flex-1 items-center justify-center gap-x-2 rounded-l-md px-3 py-2 text-sm font-semibold text-white focus:z-10 focus:ring-2 focus:ring-green-600 focus:ring-offset-2 ${canApprove
-                ? 'bg-green-600 hover:bg-green-700 cursor-pointer'
-                : 'bg-green-600 opacity-50 cursor-not-allowed'
-                }`}
-            >
-              <CheckIcon className="h-4 w-4" />
-              Approve
-            </button>
+            {/* Approve or Remind Button */}
+            {canApprove ? (
+              <button
+                onClick={() => handleAction(Action.accept)}
+                className="relative inline-flex flex-1 items-center justify-center gap-x-2 rounded-l-md px-3 py-2 text-sm font-semibold text-white focus:z-10 focus:ring-2 focus:ring-green-600 focus:ring-offset-2 bg-green-600 hover:bg-green-700 cursor-pointer"
+              >
+                <CheckIcon className="h-4 w-4" />
+                Approve
+              </button>
+            ) : canRemind ? (
+              <button
+                onClick={() => handleAction(Action.remind)}
+                className="relative inline-flex flex-1 items-center justify-center gap-x-2 rounded-l-md px-3 py-2 text-sm font-semibold text-white focus:z-10 focus:ring-2 focus:ring-yellow-600 focus:ring-offset-2 bg-yellow-600 hover:bg-yellow-700 cursor-pointer"
+              >
+                <BellIcon className="h-4 w-4" />
+                Remind
+              </button>
+            ) : (
+              <button
+                disabled
+                className="relative inline-flex flex-1 items-center justify-center gap-x-2 rounded-l-md px-3 py-2 text-sm font-semibold text-white focus:z-10 focus:ring-2 focus:ring-green-600 focus:ring-offset-2 bg-green-600 opacity-50 cursor-not-allowed"
+              >
+                <CheckIcon className="h-4 w-4" />
+                Approve
+              </button>
+            )}
 
             {/* Reject Button */}
             <button

--- a/src/lib/proposal/notification.ts
+++ b/src/lib/proposal/notification.ts
@@ -23,6 +23,7 @@ const templateReject = process.env.SENDGRID_TEMPALTE_ID_CFP_REJECT as string
 function getTemplate(action: Action) {
   switch (action) {
     case Action.accept:
+    case Action.remind:
       return templateAccept
     case Action.reject:
       return templateReject

--- a/src/lib/proposal/states.ts
+++ b/src/lib/proposal/states.ts
@@ -7,56 +7,58 @@ export function actionStateMachine(
   isOrganizer: boolean,
 ): { status: Status; isValidAction: boolean } {
   let status = currentStatus || Status.draft
-  let isValidAction = false
+  let isValidAction = true
 
   switch (status) {
     case Status.draft:
       if (action === Action.submit) {
         status = Status.submitted
-        isValidAction = true
       } else if (action === Action.delete) {
         status = Status.deleted
-        isValidAction = true
+      } else {
+        isValidAction = false
       }
       break
     case Status.submitted:
       if (action === Action.unsubmit) {
         status = Status.draft
-        isValidAction = true
       } else if (isOrganizer && action === Action.accept) {
         status = Status.accepted
-        isValidAction = true
       } else if (isOrganizer && action === Action.reject) {
         status = Status.rejected
-        isValidAction = true
+      } else {
+        isValidAction = false
       }
       break
     case Status.accepted:
       if (isOrganizer && action === Action.remind) {
-        status = Status.accepted
-        isValidAction = true
+        // status remains the same
       } else if (action === Action.confirm) {
         status = Status.confirmed
-        isValidAction = true
       } else if (action === Action.withdraw) {
         status = Status.withdrawn
-        isValidAction = true
       } else if (isOrganizer && action === Action.reject) {
         status = Status.rejected
-        isValidAction = true
+      } else {
+        isValidAction = false
       }
       break
     case Status.rejected:
       if (isOrganizer && action === Action.accept) {
         status = Status.accepted
-        isValidAction = true
+      } else {
+        isValidAction = false
       }
+      break
     case Status.confirmed:
       if (action === Action.withdraw) {
         status = Status.withdrawn
-        isValidAction = true
+      } else {
+        isValidAction = false
       }
       break
+    default:
+      isValidAction = false
   }
 
   return { status, isValidAction }

--- a/src/lib/proposal/states.ts
+++ b/src/lib/proposal/states.ts
@@ -7,43 +7,57 @@ export function actionStateMachine(
   isOrganizer: boolean,
 ): { status: Status; isValidAction: boolean } {
   let status = currentStatus || Status.draft
+  let isValidAction = false
 
   switch (status) {
     case Status.draft:
       if (action === Action.submit) {
         status = Status.submitted
+        isValidAction = true
       } else if (action === Action.delete) {
         status = Status.deleted
+        isValidAction = true
       }
       break
     case Status.submitted:
       if (action === Action.unsubmit) {
         status = Status.draft
+        isValidAction = true
       } else if (isOrganizer && action === Action.accept) {
         status = Status.accepted
+        isValidAction = true
       } else if (isOrganizer && action === Action.reject) {
         status = Status.rejected
+        isValidAction = true
       }
       break
     case Status.accepted:
-      if (action === Action.confirm) {
+      if (isOrganizer && action === Action.remind) {
+        status = Status.accepted
+        isValidAction = true
+      } else if (action === Action.confirm) {
         status = Status.confirmed
+        isValidAction = true
       } else if (action === Action.withdraw) {
         status = Status.withdrawn
+        isValidAction = true
       } else if (isOrganizer && action === Action.reject) {
         status = Status.rejected
+        isValidAction = true
       }
       break
     case Status.rejected:
       if (isOrganizer && action === Action.accept) {
         status = Status.accepted
+        isValidAction = true
       }
     case Status.confirmed:
       if (action === Action.withdraw) {
         status = Status.withdrawn
+        isValidAction = true
       }
       break
   }
 
-  return { status, isValidAction: status !== currentStatus }
+  return { status, isValidAction }
 }

--- a/src/lib/proposal/types.ts
+++ b/src/lib/proposal/types.ts
@@ -53,6 +53,7 @@ export enum Action {
   submit = 'submit',
   unsubmit = 'unsubmit',
   accept = 'accept',
+  remind = 'remind',
   confirm = 'confirm',
   reject = 'reject',
   withdraw = 'withdraw',


### PR DESCRIPTION
This pull request introduces a new "remind" action for proposal management, allowing organizers to send reminders for accepted proposals. The changes span multiple files to integrate this new action into the system, including updates to the state machine, UI components, notification handling, and action definitions.

### Backend Logic Updates:
* [`src/lib/proposal/types.ts`](diffhunk://#diff-d6126e4cb386af9f14641b51b53a506f89781dd9c606381e99cb1c22c37deeecR56): Added a new `Action.remind` enum value to represent the "remind" action.
* [`src/lib/proposal/states.ts`](diffhunk://#diff-c8463224fbd2bafb5e924547430b255052a8943b724a0df2edab51c6f8aa2c0aR10-R62): Updated the `actionStateMachine` function to handle the "remind" action, ensuring it is valid only for organizers and does not change the proposal status.
* [`src/lib/proposal/notification.ts`](diffhunk://#diff-b28ec543659fb675dbe82cc292ffd68928ab6da926bf78342e6e3af8a654d584R26): Modified `getTemplate` to use the "accept" notification template for the "remind" action.
* `src/app/api/proposal/[id]/action/route.ts`: Extended the notification logic to include the "remind" action when sending accept/reject notifications. ([src/app/api/proposal/[id]/action/route.tsL113-R113](diffhunk://#diff-85ccb8ae133b9d9507eaeb730f665649b01409210294cc036f3312947c918616L113-R113))

### Frontend UI Updates:
* `src/components/admin/ProposalActionModal.tsx`: 
  - Added `BellIcon` for the "remind" action.
  - Updated `colorForAction` and `iconForAction` functions to define styles and icons for the "remind" action. [[1]](diffhunk://#diff-6fb821729456416261c7ffbb041b010af5fd8e6945a26457295482d80c80a68eR17) [[2]](diffhunk://#diff-6fb821729456416261c7ffbb041b010af5fd8e6945a26457295482d80c80a68eR39-R44) [[3]](diffhunk://#diff-6fb821729456416261c7ffbb041b010af5fd8e6945a26457295482d80c80a68eR63-R64)
* `src/components/admin/ProposalActionPanel.tsx`: 
  - Introduced logic to display a "Remind" button when the proposal status is "accepted."
  - Updated the button group to conditionally render "Approve," "Remind," or a disabled button based on the proposal status. [[1]](diffhunk://#diff-93293715d67fcfd91d294d74c46bbcd833eab794afdd80806d596682def89672R83) [[2]](diffhunk://#diff-93293715d67fcfd91d294d74c46bbcd833eab794afdd80806d596682def89672L94-R120)

### Testing Updates:
* `src/app/api/proposal/[id]/action/route.test.ts`: Added test cases for the "remind" action to ensure it behaves as expected in various scenarios. ([src/app/api/proposal/[id]/action/route.test.tsR103-R109](diffhunk://#diff-e6b01b03c9dc534e03ee59eaa59f0ff097a8b378ce3878f0e58ddf4afa975c2fR103-R109))