### PR TITLE
Support multiple users for proposal data structure

### DIFF
--- a/__tests__/testdata/proposals.ts
+++ b/__tests__/testdata/proposals.ts
@@ -23,7 +23,7 @@ const proposals: ProposalExisting[] = [
     status: Status.draft,
     outline: '',
     tos: true,
-    speaker: speakers[0],
+    speakers: [speakers[0]],
   },
   {
     _id: '6e57c550-2c6f-45bc-bf9b-65e8be5f02ee',
@@ -39,7 +39,7 @@ const proposals: ProposalExisting[] = [
     status: Status.submitted,
     outline: '',
     tos: true,
-    speaker: speakers[0],
+    speakers: [speakers[0]],
   },
   {
     _id: '7915e7a0-d312-4225-af28-9a9efb00903f',
@@ -54,7 +54,7 @@ const proposals: ProposalExisting[] = [
     level: Level.beginner,
     outline: '',
     tos: true,
-    speaker: speakers[1],
+    speakers: [speakers[1]],
   },
   {
     _id: '35a99161-1754-474d-840e-3d1c4f5b6c07',
@@ -69,7 +69,7 @@ const proposals: ProposalExisting[] = [
     level: Level.beginner,
     outline: '',
     tos: true,
-    speaker: speakers[1],
+    speakers: [speakers[1]],
   },
   {
     _id: '7e5e24ab-5290-4d38-b10b-ce65482562b2',
@@ -84,7 +84,7 @@ const proposals: ProposalExisting[] = [
     level: Level.beginner,
     outline: '',
     tos: true,
-    speaker: speakers[0],
+    speakers: [speakers[0]],
   },
   {
     _id: '0a5f4493-53e3-4542-a2de-64825cb29c13',
@@ -99,7 +99,7 @@ const proposals: ProposalExisting[] = [
     level: Level.beginner,
     outline: '',
     tos: true,
-    speaker: speakers[0],
+    speakers: [speakers[0]],
   },
   {
     _id: '68da5b0c-ea76-4e3a-afa2-3407007ef022',
@@ -114,7 +114,7 @@ const proposals: ProposalExisting[] = [
     level: Level.beginner,
     outline: '',
     tos: true,
-    speaker: speakers[1],
+    speakers: [speakers[1]],
   },
 ] as ProposalExisting[]
 

--- a/migrations/004-speaker-to-speakers/README.md
+++ b/migrations/004-speaker-to-speakers/README.md
@@ -1,0 +1,38 @@
+# Migration: Speaker to Speakers Array
+
+## Overview
+
+This migration converts the single `speaker` reference field in talk documents to a `speakers` array field to support multiple speakers per proposal.
+
+## What it does
+
+- Converts the existing `speaker` field (single reference) to `speakers` field (array of references)
+- Preserves all existing speaker data by wrapping the single speaker reference in an array
+- Removes the old `speaker` field after migration
+
+## Before running
+
+1. Create a backup of your dataset:
+
+   ```bash
+   npx sanity@latest dataset export production my-backup-filename.tar.gz
+   ```
+
+2. Validate your documents:
+   ```bash
+   npx sanity@latest documents validate -y
+   ```
+
+## Running the migration
+
+```bash
+npx sanity@latest migration run 004-speaker-to-speakers
+```
+
+## Schema changes
+
+After running this migration, you'll need to update your schema to use the new `speakers` field instead of `speaker`.
+
+## Code changes
+
+All code references to `proposal.speaker` need to be updated to handle `proposal.speakers` as an array.

--- a/migrations/004-speaker-to-speakers/index.ts
+++ b/migrations/004-speaker-to-speakers/index.ts
@@ -1,0 +1,82 @@
+import { at, defineMigration, set } from 'sanity/migrate'
+
+/**
+ * IMPORTANT: Before running this migration:
+ * 1. Always create a backup of your dataset:
+ *    npx sanity@latest dataset export production my-backup-filename.tar.gz
+ *
+ * 2. Validate your documents against schema changes:
+ *    npx sanity@latest documents validate -y
+ */
+
+interface TalkDocument {
+  _id: string
+  _type: string
+  title?: string
+  speaker?: {
+    _type: string
+    _ref: string
+  }
+  speakers?: Array<{
+    _type: string
+    _ref: string
+  }>
+}
+
+export default defineMigration({
+  title: 'Migrate speaker to speakers array',
+  description:
+    'Converts the single speaker reference to an array of speakers, preserving existing fields for backward compatibility',
+  documentTypes: ['talk'],
+
+  migrate: {
+    document(doc, context) {
+      const talk = doc as TalkDocument
+
+      // Skip documents that already have speakers array
+      if (talk.speakers && Array.isArray(talk.speakers)) {
+        console.log(
+          `Talk "${talk.title}" (${talk._id}) already has speakers array, skipping`,
+        )
+        return []
+      }
+
+      // Determine which field to migrate from
+      let sourceRef: string | null = null
+      let sourceField: string | null = null
+
+      if (talk.speaker?._ref) {
+        sourceRef = talk.speaker._ref
+        sourceField = 'speaker'
+      }
+
+      // Skip documents that don't have a speaker to migrate
+      if (!sourceRef || !sourceField) {
+        console.log(
+          `Talk "${talk.title}" (${talk._id}) has no speaker to migrate, skipping`,
+        )
+        return []
+      }
+
+      console.log(
+        `Migrating talk "${talk.title}" (${talk._id}) - converting ${sourceField} to speakers array`,
+      )
+
+      // Convert single reference to array
+      const speakersArray = [
+        {
+          _type: 'reference',
+          _ref: sourceRef,
+        },
+      ]
+
+      // Return migration operations
+      return [
+        // Add the new speakers array
+        at('speakers', set(speakersArray)),
+        // Keep the old speaker field for backward compatibility
+        // Do not unset the speaker field
+      ]
+    },
+  },
+})

--- a/sanity/schemaTypes/talk.ts
+++ b/sanity/schemaTypes/talk.ts
@@ -90,9 +90,26 @@ export default defineType({
     }),
     defineField({
       name: 'speaker',
-      title: 'Speaker',
+      title: 'Speaker (Deprecated)',
       type: 'reference',
       to: [{ type: 'speaker' }],
+      deprecated: {
+        reason: 'Use speakers array instead of single speaker reference',
+      },
+      hidden: true,
+    }),
+    defineField({
+      name: 'speakers',
+      title: 'Speakers',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{ type: 'speaker' }],
+        },
+      ],
+      validation: (Rule) =>
+        Rule.min(1).max(3).error('Please select 1-3 speakers'),
     }),
     defineField({
       name: 'conference',
@@ -117,13 +134,16 @@ export default defineType({
   preview: {
     select: {
       title: 'title',
-      speaker: 'speaker.name',
+      speakers: 'speakers',
     },
     prepare(selection) {
-      const { title, speaker } = selection
+      const { title, speakers } = selection
+      const speakerNames =
+        speakers?.map((speaker: any) => speaker.name).join(', ') ||
+        'No speakers'
       return {
         ...selection,
-        title: `${title} (${speaker})`,
+        title: `${title} (${speakerNames})`,
       }
     },
   },

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -51,10 +51,15 @@ export default async function AdminDashboard() {
   // Speaker stats
   const uniqueSpeakers = new Set(
     proposals
-      .map((p) =>
-        typeof p.speaker === 'object' && p.speaker && '_id' in p.speaker
-          ? p.speaker._id
-          : null,
+      .flatMap((p) =>
+        p.speakers && Array.isArray(p.speakers)
+          ? p.speakers
+              .filter(
+                (speaker) =>
+                  typeof speaker === 'object' && speaker && '_id' in speaker,
+              )
+              .map((speaker) => speaker._id)
+          : [],
       )
       .filter(Boolean),
   ).size
@@ -505,12 +510,17 @@ export default async function AdminDashboard() {
               )
               .slice(0, 5)
               .map((proposal, idx) => {
-                const speaker =
-                  typeof proposal.speaker === 'object' &&
-                  proposal.speaker &&
-                  'name' in proposal.speaker
-                    ? (proposal.speaker as Speaker)
-                    : null
+                const speakers =
+                  proposal.speakers && Array.isArray(proposal.speakers)
+                    ? proposal.speakers.filter(
+                        (speaker) =>
+                          typeof speaker === 'object' &&
+                          speaker &&
+                          'name' in speaker,
+                      )
+                    : []
+                const primarySpeaker =
+                  speakers.length > 0 ? (speakers[0] as Speaker) : null
                 const isLast = idx === Math.min(proposals.length - 1, 4)
 
                 return (
@@ -552,7 +562,7 @@ export default async function AdminDashboard() {
                               </Link>{' '}
                               by{' '}
                               <span className="font-medium text-gray-900">
-                                {speaker?.name || 'Unknown Speaker'}
+                                {primarySpeaker?.name || 'Unknown Speaker'}
                               </span>
                             </p>
                             <p className="mt-1 text-xs text-gray-400">

--- a/src/app/(main)/cfp/list/page.tsx
+++ b/src/app/(main)/cfp/list/page.tsx
@@ -103,20 +103,26 @@ export default async function SpeakerDashboard() {
                     <div className="space-y-6">
                       {confirmedProposals.map((proposal) => {
                         // Extract speaker data safely
-                        const speaker =
-                          typeof proposal.speaker === 'object' &&
-                          proposal.speaker
-                            ? (proposal.speaker as Speaker)
-                            : null
+                        const speakers =
+                          proposal.speakers && Array.isArray(proposal.speakers)
+                            ? proposal.speakers.filter(
+                                (speaker) =>
+                                  typeof speaker === 'object' &&
+                                  speaker &&
+                                  'name' in speaker,
+                              )
+                            : []
+                        const primarySpeaker =
+                          speakers.length > 0 ? (speakers[0] as Speaker) : null
 
-                        return speaker ? (
+                        return primarySpeaker ? (
                           <div
                             key={proposal._id}
                             className="flex flex-col items-center"
                           >
                             <SpeakerSharingActions
-                              filename={`${speaker.slug || speaker.name?.replace(/\s+/g, '-').toLowerCase()}-speaker-card`}
-                              speakerUrl={`https://${domain}/speaker/${speaker.slug}`}
+                              filename={`${primarySpeaker.slug || primarySpeaker.name?.replace(/\s+/g, '-').toLowerCase()}-speaker-card`}
+                              speakerUrl={`https://${domain}/speaker/${primarySpeaker.slug}`}
                               talkTitle={proposal.title}
                               eventName={
                                 conference?.title || 'Cloud Native Bergen'
@@ -124,7 +130,7 @@ export default async function SpeakerDashboard() {
                             >
                               <SpeakerPromotion
                                 speaker={{
-                                  ...speaker,
+                                  ...primarySpeaker,
                                   talks: [proposal], // Include the confirmed proposal as a talk
                                 }}
                                 variant="speaker-share"
@@ -132,7 +138,7 @@ export default async function SpeakerDashboard() {
                                   conference?.title || 'Cloud Native Bergen'
                                 }
                                 ctaText="View Profile"
-                                ctaUrl={`https://${domain}/speaker/${speaker.slug}`}
+                                ctaUrl={`https://${domain}/speaker/${primarySpeaker.slug}`}
                                 className="w-full max-w-xs"
                               />
                             </SpeakerSharingActions>

--- a/src/app/(main)/cfp/submit/page.tsx
+++ b/src/app/(main)/cfp/submit/page.tsx
@@ -73,8 +73,19 @@ export default async function Submit({
         loadingError = { type: 'Not Found', message: 'Proposal not found.' }
       } else {
         proposal = fetchedProposal
-        if (fetchedProposal.speaker && 'name' in fetchedProposal.speaker) {
-          speaker = fetchedProposal.speaker as Speaker
+        if (
+          fetchedProposal.speakers &&
+          Array.isArray(fetchedProposal.speakers) &&
+          fetchedProposal.speakers.length > 0
+        ) {
+          const primarySpeaker = fetchedProposal.speakers[0]
+          if (
+            typeof primarySpeaker === 'object' &&
+            primarySpeaker &&
+            'name' in primarySpeaker
+          ) {
+            speaker = primarySpeaker as Speaker
+          }
         }
       }
     } else {

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -15,7 +15,10 @@ export const revalidate = 300 // 5 minutes
 function schedulesHasSpeakers(schedules: ConferenceSchedule[]) {
   return schedules.some((schedule) =>
     schedule.tracks.some((track: ScheduleTrack) =>
-      track.talks.some((talk: TrackTalk) => !!talk.talk?.speaker),
+      track.talks.some(
+        (talk: TrackTalk) =>
+          !!talk.talk?.speakers && talk.talk.speakers.length > 0,
+      ),
     ),
   )
 }

--- a/src/app/(main)/program/page.tsx
+++ b/src/app/(main)/program/page.tsx
@@ -54,7 +54,12 @@ function scheduleToSlots(schedule: ConferenceSchedule) {
       if (previousItem) {
         if (itemIndex === 0) {
           currentSlotIndex = 0
-        } else if (!item.talk?.speaker || !previousItem.talk?.speaker) {
+        } else if (
+          !item.talk?.speakers ||
+          item.talk.speakers.length === 0 ||
+          !previousItem.talk?.speakers ||
+          previousItem.talk.speakers.length === 0
+        ) {
           currentSlotIndex++
         } else if (item.startTime !== previousItem.endTime) {
           const timeDifference = timeDiff(previousItem.endTime, item.startTime)
@@ -76,7 +81,7 @@ function scheduleToSlots(schedule: ConferenceSchedule) {
           tracks: [],
         }
 
-        if (!item.talk?.speaker) {
+        if (!item.talk?.speakers || item.talk.speakers.length === 0) {
           slots[currentSlotIndex].title = item.talk?.title
           slots[currentSlotIndex].start_time = item.startTime
           slots[currentSlotIndex].end_time = item.endTime
@@ -186,7 +191,7 @@ export default async function Info() {
                           <p>{talk.startTime}</p>
                           <p>
                             <Link
-                              href={`/speaker/${talk.talk!.speaker && 'slug' in talk.talk!.speaker ? talk.talk!.speaker.slug : ''}`}
+                              href={`/speaker/${talk.talk!.speakers && talk.talk!.speakers.length > 0 && 'slug' in talk.talk!.speakers[0] ? talk.talk!.speakers[0].slug : ''}`}
                               className="hover:underline"
                             >
                               <span className="font-semibold">
@@ -202,8 +207,10 @@ export default async function Info() {
                           </p>
                           <p className="text-gray-500">
                             by{' '}
-                            {talk.talk!.speaker && 'name' in talk.talk!.speaker
-                              ? talk.talk!.speaker.name
+                            {talk.talk!.speakers &&
+                            talk.talk!.speakers.length > 0 &&
+                            'name' in talk.talk!.speakers[0]
+                              ? talk.talk!.speakers[0].name
                               : ''}
                           </p>
                         </div>

--- a/src/app/api/proposal/[id]/action/route.ts
+++ b/src/app/api/proposal/[id]/action/route.ts
@@ -121,11 +121,12 @@ export const POST = auth(
         action === Action.reject ||
         action === Action.remind)
     ) {
+      const primarySpeaker = proposal.speakers?.[0] as Speaker
       await sendAcceptRejectNotification({
         action,
         speaker: {
-          name: (proposal.speaker as Speaker).name,
-          email: (proposal.speaker as Speaker).email,
+          name: primarySpeaker.name,
+          email: primarySpeaker.email,
         },
         proposal: {
           _id: proposal._id,

--- a/src/app/api/proposal/[id]/action/route.ts
+++ b/src/app/api/proposal/[id]/action/route.ts
@@ -121,7 +121,15 @@ export const POST = auth(
         action === Action.reject ||
         action === Action.remind)
     ) {
-      const primarySpeaker = proposal.speakers?.[0] as Speaker
+      if (!proposal.speakers || proposal.speakers.length === 0) {
+        console.error('No speakers found for the proposal.')
+        return proposalResponseError({
+          message: 'No speakers found for the proposal.',
+          type: 'validation_error',
+          status: 400,
+        })
+      }
+      const primarySpeaker = proposal.speakers[0] as Speaker
       await sendAcceptRejectNotification({
         action,
         speaker: {

--- a/src/app/api/proposal/route.test.ts
+++ b/src/app/api/proposal/route.test.ts
@@ -10,14 +10,18 @@ import { describe } from 'node:test'
 import { testApiHandler } from 'next-test-api-route-handler'
 import { Speaker } from '@/lib/speaker/types'
 
-const speaker = proposals[0].speaker! as Speaker
+const speaker = proposals[0].speakers![0] as Speaker
 
 beforeEach(() => {
   clientReadUncached.fetch = jest
     .fn<() => Promise<any>>()
     .mockResolvedValue(
       proposals.filter(
-        (p) => p.speaker && '_id' in p.speaker && p.speaker._id === speaker._id,
+        (p) =>
+          p.speakers &&
+          p.speakers.length > 0 &&
+          '_id' in p.speakers[0] &&
+          p.speakers[0]._id === speaker._id,
       ),
     )
 })

--- a/src/components/ProposalActionModal.tsx
+++ b/src/components/ProposalActionModal.tsx
@@ -204,8 +204,17 @@ export function ProposalActionModal({
                           </span>{' '}
                           by{' '}
                           <span className="font-semibold">
-                            {proposal.speaker && 'name' in proposal.speaker
-                              ? (proposal.speaker as Speaker).name
+                            {proposal.speakers &&
+                            Array.isArray(proposal.speakers) &&
+                            proposal.speakers.length > 0
+                              ? proposal.speakers
+                                  .map((speaker) =>
+                                    typeof speaker === 'object' &&
+                                    'name' in speaker
+                                      ? (speaker as Speaker).name
+                                      : 'Unknown',
+                                  )
+                                  .join(', ')
                               : 'Unknown author'}
                           </span>
                           ?

--- a/src/components/ProposalCard.tsx
+++ b/src/components/ProposalCard.tsx
@@ -173,12 +173,16 @@ export function ProposalCard({
             )}
           </p>
         </div>
-        {proposal.speaker && 'image' in proposal.speaker ? (
+        {proposal.speakers &&
+        Array.isArray(proposal.speakers) &&
+        proposal.speakers.length > 0 &&
+        proposal.speakers[0] &&
+        'image' in proposal.speakers[0] ? (
           <img
             className="h-10 w-10 flex-shrink-0 rounded-full bg-gray-300"
             src={
-              proposal.speaker.image
-                ? sanityImage(proposal.speaker.image)
+              proposal.speakers[0].image
+                ? sanityImage(proposal.speakers[0].image)
                     .width(80)
                     .height(80)
                     .fit('crop')

--- a/src/components/ProposalCard.tsx
+++ b/src/components/ProposalCard.tsx
@@ -12,7 +12,7 @@ import {
 import { SpinnerIcon } from './SocialIcons'
 import { PortableTextBlock } from '@portabletext/editor'
 import { PortableTextTextBlock, PortableTextObject } from 'sanity'
-import { sanityImage } from '@/lib/sanity/client'
+import { SpeakerAvatars } from './SpeakerAvatars'
 
 interface ProposalButtonAction {
   label: Action
@@ -175,24 +175,11 @@ export function ProposalCard({
         </div>
         {proposal.speakers &&
         Array.isArray(proposal.speakers) &&
-        proposal.speakers.length > 0 &&
-        proposal.speakers[0] &&
-        'image' in proposal.speakers[0] ? (
-          <img
-            className="h-10 w-10 flex-shrink-0 rounded-full bg-gray-300"
-            src={
-              proposal.speakers[0].image
-                ? sanityImage(proposal.speakers[0].image)
-                    .width(80)
-                    .height(80)
-                    .fit('crop')
-                    .url()
-                : 'https://placehold.co/80x80/e5e7eb/6b7280?text=Speaker'
-            }
-            alt="Speaker Image"
-            width={40}
-            height={40}
-            loading="lazy"
+        proposal.speakers.length > 0 ? (
+          <SpeakerAvatars
+            speakers={proposal.speakers}
+            size="md"
+            maxVisible={3}
           />
         ) : (
           <UserCircleIcon

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -149,18 +149,19 @@ function YouTubeEmbed({ url }: { url: string }) {
 }
 
 function TalkTimeSlot({ date, talk }: { date: string; talk: TrackTalk }) {
+  const primarySpeaker = talk.talk?.speakers?.[0]
   return (
     <div className="relative block">
       {!talk.talk ||
-      !talk.talk.speaker ||
-      !(talk.talk.speaker && 'slug' in talk.talk.speaker) ? (
+      !primarySpeaker ||
+      !(primarySpeaker && 'slug' in primarySpeaker) ? (
         <h4 className="text-lg font-semibold tracking-tight text-blue-900">
           {talk.talk?.title || talk.placeholder || 'TBD'}
         </h4>
       ) : (
-        <Link href={`/speaker/${talk.talk.speaker.slug}`} className="block">
+        <Link href={`/speaker/${primarySpeaker.slug}`} className="block">
           <h4 className="text-lg font-semibold tracking-tight text-blue-900">
-            {talk.talk.speaker.name}
+            {primarySpeaker.name}
           </h4>
           <p className="mt-1 tracking-tight text-blue-900">{talk.talk.title}</p>
         </Link>

--- a/src/components/SpeakerAvatars.tsx
+++ b/src/components/SpeakerAvatars.tsx
@@ -1,0 +1,148 @@
+import { UserIcon } from '@heroicons/react/24/outline'
+import { sanityImage } from '@/lib/sanity/client'
+import { Speaker } from '@/lib/speaker/types'
+import { Reference } from 'sanity'
+
+interface SpeakerAvatarsProps {
+  speakers: Speaker[] | Reference[]
+  size?: 'sm' | 'md' | 'lg'
+  maxVisible?: number
+  showTooltip?: boolean
+}
+
+const sizeClasses = {
+  sm: {
+    container: 'h-8 w-8',
+    image: 'h-8 w-8',
+    icon: 'h-4 w-4',
+    spacing: '-ml-2',
+    text: 'text-xs',
+  },
+  md: {
+    container: 'h-12 w-12',
+    image: 'h-12 w-12',
+    icon: 'h-6 w-6',
+    spacing: '-ml-3',
+    text: 'text-sm',
+  },
+  lg: {
+    container: 'h-16 w-16',
+    image: 'h-16 w-16',
+    icon: 'h-8 w-8',
+    spacing: '-ml-4',
+    text: 'text-base',
+  },
+}
+
+/**
+ * Component to display multiple speakers with overlapping circular profile images
+ */
+export function SpeakerAvatars({
+  speakers,
+  size = 'md',
+  maxVisible = 3,
+  showTooltip = true,
+}: SpeakerAvatarsProps) {
+  if (!speakers || speakers.length === 0) {
+    return null
+  }
+
+  const classes = sizeClasses[size]
+  const populatedSpeakers = speakers.filter(
+    (speaker): speaker is Speaker =>
+      speaker && typeof speaker === 'object' && '_id' in speaker,
+  )
+
+  if (populatedSpeakers.length === 0) {
+    return null
+  }
+
+  const visibleSpeakers = populatedSpeakers.slice(0, maxVisible)
+  const remainingCount = populatedSpeakers.length - maxVisible
+
+  return (
+    <div className="flex items-center">
+      {visibleSpeakers.map((speaker, index) => (
+        <div
+          key={speaker._id || index}
+          className={`${classes.container} ${
+            index > 0 ? classes.spacing : ''
+          } relative rounded-full border-2 border-white bg-gray-100 shadow-sm`}
+          title={showTooltip ? speaker.name : undefined}
+        >
+          {speaker.image ? (
+            <img
+              src={sanityImage(speaker.image)
+                .width(size === 'sm' ? 64 : size === 'md' ? 96 : 128)
+                .height(size === 'sm' ? 64 : size === 'md' ? 96 : 128)
+                .fit('crop')
+                .url()}
+              alt={speaker.name}
+              className={`${classes.image} rounded-full object-cover`}
+            />
+          ) : (
+            <div
+              className={`${classes.image} flex items-center justify-center rounded-full bg-gray-200`}
+            >
+              <UserIcon className={`${classes.icon} text-gray-400`} />
+            </div>
+          )}
+        </div>
+      ))}
+
+      {remainingCount > 0 && (
+        <div
+          className={`${classes.container} ${classes.spacing} relative flex items-center justify-center rounded-full border-2 border-white bg-gray-300 shadow-sm`}
+          title={showTooltip ? `+${remainingCount} more speakers` : undefined}
+        >
+          <span className={`${classes.text} font-medium text-gray-600`}>
+            +{remainingCount}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Component to display speaker names alongside avatars
+ */
+export function SpeakerAvatarsWithNames({
+  speakers,
+  size = 'md',
+  maxVisible = 3,
+  showTooltip = true,
+}: SpeakerAvatarsProps) {
+  if (!speakers || speakers.length === 0) {
+    return null
+  }
+
+  const populatedSpeakers = speakers.filter(
+    (speaker): speaker is Speaker =>
+      speaker && typeof speaker === 'object' && '_id' in speaker,
+  )
+
+  if (populatedSpeakers.length === 0) {
+    return null
+  }
+
+  const visibleSpeakers = populatedSpeakers.slice(0, maxVisible)
+  const remainingCount = populatedSpeakers.length - maxVisible
+
+  return (
+    <div className="flex items-center space-x-3">
+      <SpeakerAvatars
+        speakers={speakers}
+        size={size}
+        maxVisible={maxVisible}
+        showTooltip={showTooltip}
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-gray-900">
+          {visibleSpeakers.map((speaker) => speaker.name).join(', ')}
+          {remainingCount > 0 && ` +${remainingCount} more`}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SpeakerAvatars.tsx
+++ b/src/components/SpeakerAvatars.tsx
@@ -34,6 +34,13 @@ const sizeClasses = {
   },
 }
 
+// Image dimensions for retina/high DPI screens (2x the display size)
+const imageDimensions = {
+  sm: { width: 64, height: 64 },
+  md: { width: 96, height: 96 },
+  lg: { width: 128, height: 128 },
+}
+
 /**
  * Component to display multiple speakers with overlapping circular profile images
  */
@@ -73,8 +80,8 @@ export function SpeakerAvatars({
           {speaker.image ? (
             <img
               src={sanityImage(speaker.image)
-                .width(size === 'sm' ? 64 : size === 'md' ? 96 : 128)
-                .height(size === 'sm' ? 64 : size === 'md' ? 96 : 128)
+                .width(imageDimensions[size].width)
+                .height(imageDimensions[size].height)
                 .fit('crop')
                 .url()}
               alt={speaker.name}

--- a/src/components/Speakers.tsx
+++ b/src/components/Speakers.tsx
@@ -188,10 +188,11 @@ export function Speakers({ tracks }: { tracks: ScheduleTrack[] }) {
                     .reduce((acc, talk) => {
                       if (
                         talk.talk &&
-                        talk.talk.speaker &&
-                        'slug' in talk.talk.speaker
+                        talk.talk.speakers &&
+                        talk.talk.speakers.length > 0 &&
+                        'slug' in talk.talk.speakers[0]
                       ) {
-                        const speaker = talk.talk.speaker
+                        const speaker = talk.talk.speakers[0]
                         // Convert speaker to SpeakerWithTalks format
                         const speakerWithTalks: SpeakerWithTalks = {
                           ...speaker,

--- a/src/components/admin/AdminActionBar.tsx
+++ b/src/components/admin/AdminActionBar.tsx
@@ -31,18 +31,35 @@ export function AdminActionBar({ proposal }: AdminActionBarProps) {
     proposal.status === 'submitted' || proposal.status === 'accepted'
 
   // Get speaker information for indicators
-  const speaker = proposal.speaker as SpeakerWithReviewInfo
-  const isSeasonedSpeaker =
-    speaker?.previousAcceptedTalks && speaker.previousAcceptedTalks.length > 0
-  const isNewSpeaker =
-    !speaker?.previousAcceptedTalks ||
-    speaker.previousAcceptedTalks.length === 0
-  const isLocalSpeaker = speaker?.flags?.includes(Flags.localSpeaker)
-  const isUnderrepresentedSpeaker = speaker?.flags?.includes(
-    Flags.diverseSpeaker,
+  const speakers =
+    proposal.speakers && Array.isArray(proposal.speakers)
+      ? proposal.speakers
+          .filter(
+            (speaker) =>
+              typeof speaker === 'object' && speaker && 'name' in speaker,
+          )
+          .map((speaker) => speaker as SpeakerWithReviewInfo)
+      : []
+  const isSeasonedSpeaker = speakers.some(
+    (speaker) =>
+      speaker?.previousAcceptedTalks &&
+      speaker.previousAcceptedTalks.length > 0,
   )
-  const requiresTravelSupport = speaker?.flags?.includes(
-    Flags.requiresTravelFunding,
+  const isNewSpeaker =
+    speakers.length === 0 ||
+    speakers.every(
+      (speaker) =>
+        !speaker?.previousAcceptedTalks ||
+        speaker.previousAcceptedTalks.length === 0,
+    )
+  const isLocalSpeaker = speakers.some((speaker) =>
+    speaker?.flags?.includes(Flags.localSpeaker),
+  )
+  const isUnderrepresentedSpeaker = speakers.some((speaker) =>
+    speaker?.flags?.includes(Flags.diverseSpeaker),
+  )
+  const requiresTravelSupport = speakers.some((speaker) =>
+    speaker?.flags?.includes(Flags.requiresTravelFunding),
   )
 
   return (
@@ -95,7 +112,7 @@ export function AdminActionBar({ proposal }: AdminActionBarProps) {
           )}
 
           {/* Speaker Indicators */}
-          {speaker && (
+          {speakers.length > 0 && (
             <div className="flex flex-shrink-0 items-center gap-2">
               <span className="text-sm font-medium text-gray-600">
                 Speaker:

--- a/src/components/admin/ProposalActionModal.tsx
+++ b/src/components/admin/ProposalActionModal.tsx
@@ -214,8 +214,17 @@ export function ProposalActionModal({
                           </span>{' '}
                           by{' '}
                           <span className="font-semibold">
-                            {proposal.speaker && 'name' in proposal.speaker
-                              ? (proposal.speaker as Speaker).name
+                            {proposal.speakers &&
+                            Array.isArray(proposal.speakers) &&
+                            proposal.speakers.length > 0
+                              ? proposal.speakers
+                                  .map((speaker) =>
+                                    typeof speaker === 'object' &&
+                                    'name' in speaker
+                                      ? (speaker as Speaker).name
+                                      : 'Unknown',
+                                  )
+                                  .join(', ')
                               : 'Unknown author'}
                           </span>
                           ?

--- a/src/components/admin/ProposalCard.tsx
+++ b/src/components/admin/ProposalCard.tsx
@@ -53,7 +53,6 @@ export function ProposalCard({
           .map((speaker) => speaker as SpeakerWithReviewInfo)
       : []
 
-  const primarySpeaker = speakers.length > 0 ? speakers[0] : null
   const averageRating = calculateAverageRating(proposal)
   const reviewCount = proposal.reviews?.length || 0
   const requiresTravelFunding =

--- a/src/components/admin/ProposalCard.tsx
+++ b/src/components/admin/ProposalCard.tsx
@@ -43,40 +43,55 @@ export function ProposalCard({
   onSelect,
   isSelected = false,
 }: ProposalCardProps) {
-  const speaker =
-    typeof proposal.speaker === 'object' &&
-    proposal.speaker &&
-    'name' in proposal.speaker
-      ? (proposal.speaker as SpeakerWithReviewInfo)
-      : null
+  const speakers =
+    proposal.speakers && Array.isArray(proposal.speakers)
+      ? proposal.speakers
+          .filter(
+            (speaker) =>
+              typeof speaker === 'object' && speaker && 'name' in speaker,
+          )
+          .map((speaker) => speaker as SpeakerWithReviewInfo)
+      : []
 
+  const primarySpeaker = speakers.length > 0 ? speakers[0] : null
   const averageRating = calculateAverageRating(proposal)
   const reviewCount = proposal.reviews?.length || 0
   const requiresTravelFunding =
-    speaker?.flags?.includes(Flags.requiresTravelFunding) || false
+    speakers.some((speaker) =>
+      speaker?.flags?.includes(Flags.requiresTravelFunding),
+    ) || false
 
   // Speaker indicators
-  const isSeasonedSpeaker =
-    speaker?.previousAcceptedTalks && speaker.previousAcceptedTalks.length > 0
+  const isSeasonedSpeaker = speakers.some(
+    (speaker) =>
+      speaker?.previousAcceptedTalks &&
+      speaker.previousAcceptedTalks.length > 0,
+  )
   const isNewSpeaker =
-    !speaker?.previousAcceptedTalks ||
-    speaker.previousAcceptedTalks.length === 0
-  const isLocalSpeaker = speaker?.flags?.includes(Flags.localSpeaker)
-  const isUnderrepresentedSpeaker = speaker?.flags?.includes(
-    Flags.diverseSpeaker,
+    speakers.length === 0 ||
+    speakers.every(
+      (speaker) =>
+        !speaker?.previousAcceptedTalks ||
+        speaker.previousAcceptedTalks.length === 0,
+    )
+  const isLocalSpeaker = speakers.some((speaker) =>
+    speaker?.flags?.includes(Flags.localSpeaker),
+  )
+  const isUnderrepresentedSpeaker = speakers.some((speaker) =>
+    speaker?.flags?.includes(Flags.diverseSpeaker),
   )
 
   const CardContent = () => (
     <div className="flex items-start space-x-4">
       <div className="flex-shrink-0">
-        {speaker?.image ? (
+        {primarySpeaker?.image ? (
           <img
-            src={sanityImage(speaker.image)
+            src={sanityImage(primarySpeaker.image)
               .width(96)
               .height(96)
               .fit('crop')
               .url()}
-            alt={speaker.name || 'Speaker'}
+            alt={primarySpeaker.name || 'Speaker'}
             width={48}
             height={48}
             className="h-12 w-12 rounded-full object-cover"
@@ -106,12 +121,14 @@ export function ProposalCard({
           <div className="mb-2 flex items-center justify-between text-sm text-gray-600">
             <div className="flex min-w-0 flex-1 items-center">
               <span className="truncate font-medium">
-                {speaker?.name || 'Unknown Speaker'}
+                {speakers.length > 0
+                  ? speakers.map((s) => s.name).join(', ')
+                  : 'Unknown Speaker'}
               </span>
             </div>
 
             {/* Speaker Indicators */}
-            {speaker && (
+            {speakers.length > 0 && (
               <div className="ml-2 flex items-center gap-1">
                 {isSeasonedSpeaker && (
                   <div

--- a/src/components/admin/ProposalCard.tsx
+++ b/src/components/admin/ProposalCard.tsx
@@ -22,9 +22,9 @@ import {
   audiences,
 } from '@/lib/proposal/types'
 import { SpeakerWithReviewInfo, Flags } from '@/lib/speaker/types'
+import { SpeakerAvatars } from '../SpeakerAvatars'
 import { getStatusBadgeStyle } from './utils'
 import { calculateAverageRating } from './hooks'
-import { sanityImage } from '@/lib/sanity/client'
 
 interface ProposalCardProps {
   proposal: ProposalExisting
@@ -84,18 +84,13 @@ export function ProposalCard({
   const CardContent = () => (
     <div className="flex items-start space-x-4">
       <div className="flex-shrink-0">
-        {primarySpeaker?.image ? (
-          <img
-            src={sanityImage(primarySpeaker.image)
-              .width(96)
-              .height(96)
-              .fit('crop')
-              .url()}
-            alt={primarySpeaker.name || 'Speaker'}
-            width={48}
-            height={48}
-            className="h-12 w-12 rounded-full object-cover"
-            loading="lazy"
+        {proposal.speakers &&
+        Array.isArray(proposal.speakers) &&
+        proposal.speakers.length > 0 ? (
+          <SpeakerAvatars
+            speakers={proposal.speakers}
+            size="md"
+            maxVisible={3}
           />
         ) : (
           <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">

--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -20,6 +20,7 @@ import { SpeakerWithReviewInfo, Flags } from '@/lib/speaker/types'
 import { Topic } from '@/lib/topic/types'
 import { formatDateSafe, formatDateTimeSafe } from '@/lib/time'
 import { sanityImage } from '@/lib/sanity/client'
+import { SpeakerAvatarsWithNames } from '../SpeakerAvatars'
 import { getStatusBadgeStyle } from './utils'
 
 interface ProposalDetailProps {
@@ -278,6 +279,16 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
               </h2>
               {speakers.length > 0 ? (
                 <div className="space-y-6">
+                  {/* Speaker avatars overview */}
+                  <div className="mb-4">
+                    <SpeakerAvatarsWithNames
+                      speakers={proposal.speakers || []}
+                      size="lg"
+                      maxVisible={5}
+                    />
+                  </div>
+
+                  {/* Individual speaker details */}
                   {speakers.map((speaker, index) => (
                     <div
                       key={speaker._id || index}

--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -28,6 +28,18 @@ interface ProposalDetailProps {
 }
 
 /**
+ * Type guard to check if a topic is a Topic object (not a Reference)
+ */
+function isTopicObject(topic: unknown): topic is Topic {
+  return (
+    topic !== null &&
+    typeof topic === 'object' &&
+    '_id' in topic &&
+    'title' in topic
+  )
+}
+
+/**
  * Detailed view component for individual proposals
  * Used in admin proposal detail pages
  */
@@ -156,15 +168,6 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
                             {talk.topics && talk.topics.length > 0 && (
                               <div className="mt-2 flex flex-wrap gap-1">
                                 {talk.topics.map((topic) => {
-                                  // Type guard to check if topic is a Topic object (not a Reference)
-                                  const isTopicObject = (
-                                    t: unknown,
-                                  ): t is Topic =>
-                                    t !== null &&
-                                    typeof t === 'object' &&
-                                    '_id' in t &&
-                                    'title' in t
-
                                   if (!isTopicObject(topic)) return null
 
                                   return (
@@ -240,15 +243,6 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
                             {talk.topics && talk.topics.length > 0 && (
                               <div className="mt-2 flex flex-wrap gap-1">
                                 {talk.topics.map((topic) => {
-                                  // Type guard to check if topic is a Topic object (not a Reference)
-                                  const isTopicObject = (
-                                    t: unknown,
-                                  ): t is Topic =>
-                                    t !== null &&
-                                    typeof t === 'object' &&
-                                    '_id' in t &&
-                                    'title' in t
-
                                   if (!isTopicObject(topic)) return null
 
                                   return (

--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -31,10 +31,20 @@ interface ProposalDetailProps {
  * Used in admin proposal detail pages
  */
 export function ProposalDetail({ proposal }: ProposalDetailProps) {
-  const speaker = proposal.speaker as SpeakerWithReviewInfo
+  const speakers =
+    proposal.speakers && Array.isArray(proposal.speakers)
+      ? proposal.speakers
+          .filter(
+            (speaker) =>
+              typeof speaker === 'object' && speaker && 'name' in speaker,
+          )
+          .map((speaker) => speaker as SpeakerWithReviewInfo)
+      : []
   const topics = proposal.topics as Topic[]
   const requiresTravelFunding =
-    speaker?.flags?.includes(Flags.requiresTravelFunding) || false
+    speakers.some((speaker) =>
+      speaker?.flags?.includes(Flags.requiresTravelFunding),
+    ) || false
 
   return (
     <div className="bg-white">
@@ -111,135 +121,149 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
             )}
 
             {/* Other Submissions */}
-            {speaker?.submittedTalks && speaker.submittedTalks.length > 0 && (
-              <div>
-                <h2 className="mb-4 text-lg font-medium text-gray-900">
-                  Other Submissions
-                </h2>
-                <div className="space-y-3">
-                  {speaker.submittedTalks.map((talk) => (
-                    <div
-                      key={talk._id}
-                      className="flex items-start justify-between rounded-lg bg-gray-50 p-4"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium text-gray-900">
-                          {talk.title}
-                        </p>
-                        <div className="mt-1 flex items-center space-x-2">
-                          <span
-                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(talk.status)}`}
-                          >
-                            {statuses.get(talk.status) || talk.status}
-                          </span>
-                          <span className="text-xs text-gray-500">
-                            {formatDateSafe(talk._createdAt)}
-                          </span>
-                        </div>
-                        {talk.topics && talk.topics.length > 0 && (
-                          <div className="mt-2 flex flex-wrap gap-1">
-                            {talk.topics.map((topic) => {
-                              // Type guard to check if topic is a Topic object (not a Reference)
-                              const isTopicObject = (t: unknown): t is Topic =>
-                                t !== null &&
-                                typeof t === 'object' &&
-                                '_id' in t &&
-                                'title' in t
+            {speakers.length > 0 &&
+              speakers.some(
+                (speaker) =>
+                  speaker?.submittedTalks && speaker.submittedTalks.length > 0,
+              ) && (
+                <div>
+                  <h2 className="mb-4 text-lg font-medium text-gray-900">
+                    Other Submissions
+                  </h2>
+                  <div className="space-y-3">
+                    {speakers
+                      .flatMap((speaker) => speaker.submittedTalks || [])
+                      .map((talk) => (
+                        <div
+                          key={talk._id}
+                          className="flex items-start justify-between rounded-lg bg-gray-50 p-4"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium text-gray-900">
+                              {talk.title}
+                            </p>
+                            <div className="mt-1 flex items-center space-x-2">
+                              <span
+                                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(talk.status)}`}
+                              >
+                                {statuses.get(talk.status) || talk.status}
+                              </span>
+                              <span className="text-xs text-gray-500">
+                                {formatDateSafe(talk._createdAt)}
+                              </span>
+                            </div>
+                            {talk.topics && talk.topics.length > 0 && (
+                              <div className="mt-2 flex flex-wrap gap-1">
+                                {talk.topics.map((topic) => {
+                                  // Type guard to check if topic is a Topic object (not a Reference)
+                                  const isTopicObject = (
+                                    t: unknown,
+                                  ): t is Topic =>
+                                    t !== null &&
+                                    typeof t === 'object' &&
+                                    '_id' in t &&
+                                    'title' in t
 
-                              if (!isTopicObject(topic)) return null
+                                  if (!isTopicObject(topic)) return null
 
-                              return (
-                                <span
-                                  key={topic._id}
-                                  className="inline-flex items-center rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700 ring-1 ring-blue-600/20"
-                                >
-                                  {topic.title}
-                                </span>
-                              )
-                            })}
+                                  return (
+                                    <span
+                                      key={topic._id}
+                                      className="inline-flex items-center rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700 ring-1 ring-blue-600/20"
+                                    >
+                                      {topic.title}
+                                    </span>
+                                  )
+                                })}
+                              </div>
+                            )}
                           </div>
-                        )}
-                      </div>
-                    </div>
-                  ))}
+                        </div>
+                      ))}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
 
             {/* Previous Accepted Talks */}
-            {speaker?.previousAcceptedTalks &&
-              speaker.previousAcceptedTalks.length > 0 && (
+            {speakers.length > 0 &&
+              speakers.some(
+                (speaker) =>
+                  speaker?.previousAcceptedTalks &&
+                  speaker.previousAcceptedTalks.length > 0,
+              ) && (
                 <div>
                   <h2 className="mb-4 text-lg font-medium text-gray-900">
                     Previous Accepted Talks
                   </h2>
                   <div className="space-y-3">
-                    {speaker.previousAcceptedTalks.map((talk) => (
-                      <div
-                        key={talk._id}
-                        className="flex items-start justify-between rounded-lg bg-gray-50 p-4"
-                      >
-                        <div className="min-w-0 flex-1">
-                          <p className="truncate text-sm font-medium text-gray-900">
-                            {talk.title}
-                          </p>
-                          <div className="mt-1 flex items-center space-x-2">
-                            <span
-                              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(talk.status)}`}
-                            >
-                              {statuses.get(talk.status) || talk.status}
-                            </span>
-                            {talk.conference && (
-                              <span className="text-xs text-gray-500">
-                                {(() => {
-                                  // Type guard to check if conference is a Conference object (not a Reference)
-                                  const isConferenceObject = (
-                                    c: unknown,
-                                  ): c is {
-                                    title: string
-                                    start_date: string
-                                  } =>
-                                    c !== null &&
-                                    typeof c === 'object' &&
-                                    'title' in c &&
-                                    'start_date' in c
-
-                                  if (isConferenceObject(talk.conference)) {
-                                    return `${talk.conference.title} (${formatDateSafe(talk.conference.start_date)})`
-                                  }
-                                  return 'Conference'
-                                })()}
+                    {speakers
+                      .flatMap((speaker) => speaker.previousAcceptedTalks || [])
+                      .map((talk) => (
+                        <div
+                          key={talk._id}
+                          className="flex items-start justify-between rounded-lg bg-gray-50 p-4"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium text-gray-900">
+                              {talk.title}
+                            </p>
+                            <div className="mt-1 flex items-center space-x-2">
+                              <span
+                                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(talk.status)}`}
+                              >
+                                {statuses.get(talk.status) || talk.status}
                               </span>
+                              {talk.conference && (
+                                <span className="text-xs text-gray-500">
+                                  {(() => {
+                                    // Type guard to check if conference is a Conference object (not a Reference)
+                                    const isConferenceObject = (
+                                      c: unknown,
+                                    ): c is {
+                                      title: string
+                                      start_date: string
+                                    } =>
+                                      c !== null &&
+                                      typeof c === 'object' &&
+                                      'title' in c &&
+                                      'start_date' in c
+
+                                    if (isConferenceObject(talk.conference)) {
+                                      return `${talk.conference.title} (${formatDateSafe(talk.conference.start_date)})`
+                                    }
+                                    return 'Conference'
+                                  })()}
+                                </span>
+                              )}
+                            </div>
+                            {talk.topics && talk.topics.length > 0 && (
+                              <div className="mt-2 flex flex-wrap gap-1">
+                                {talk.topics.map((topic) => {
+                                  // Type guard to check if topic is a Topic object (not a Reference)
+                                  const isTopicObject = (
+                                    t: unknown,
+                                  ): t is Topic =>
+                                    t !== null &&
+                                    typeof t === 'object' &&
+                                    '_id' in t &&
+                                    'title' in t
+
+                                  if (!isTopicObject(topic)) return null
+
+                                  return (
+                                    <span
+                                      key={topic._id}
+                                      className="inline-flex items-center rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700 ring-1 ring-blue-600/20"
+                                    >
+                                      {topic.title}
+                                    </span>
+                                  )
+                                })}
+                              </div>
                             )}
                           </div>
-                          {talk.topics && talk.topics.length > 0 && (
-                            <div className="mt-2 flex flex-wrap gap-1">
-                              {talk.topics.map((topic) => {
-                                // Type guard to check if topic is a Topic object (not a Reference)
-                                const isTopicObject = (
-                                  t: unknown,
-                                ): t is Topic =>
-                                  t !== null &&
-                                  typeof t === 'object' &&
-                                  '_id' in t &&
-                                  'title' in t
-
-                                if (!isTopicObject(topic)) return null
-
-                                return (
-                                  <span
-                                    key={topic._id}
-                                    className="inline-flex items-center rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700 ring-1 ring-blue-600/20"
-                                  >
-                                    {topic.title}
-                                  </span>
-                                )
-                              })}
-                            </div>
-                          )}
                         </div>
-                      </div>
-                    ))}
+                      ))}
                   </div>
                 </div>
               )}
@@ -250,76 +274,83 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
             {/* Speaker Information */}
             <div className="rounded-lg bg-gray-50 p-6">
               <h2 className="mb-4 text-lg font-medium text-gray-900">
-                Speaker
+                {speakers.length > 1 ? 'Speakers' : 'Speaker'}
               </h2>
-              {speaker ? (
-                <div className="flex items-start space-x-4">
-                  <div className="flex-shrink-0">
-                    {speaker.image ? (
-                      <img
-                        src={sanityImage(speaker.image)
-                          .width(128)
-                          .height(128)
-                          .fit('crop')
-                          .url()}
-                        alt={speaker.name}
-                        width={64}
-                        height={64}
-                        className="h-16 w-16 rounded-full object-cover"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-200">
-                        <UserIcon className="h-8 w-8 text-gray-400" />
+              {speakers.length > 0 ? (
+                <div className="space-y-6">
+                  {speakers.map((speaker, index) => (
+                    <div
+                      key={speaker._id || index}
+                      className="flex items-start space-x-4"
+                    >
+                      <div className="flex-shrink-0">
+                        {speaker.image ? (
+                          <img
+                            src={sanityImage(speaker.image)
+                              .width(128)
+                              .height(128)
+                              .fit('crop')
+                              .url()}
+                            alt={speaker.name}
+                            width={64}
+                            height={64}
+                            className="h-16 w-16 rounded-full object-cover"
+                            loading="lazy"
+                          />
+                        ) : (
+                          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-200">
+                            <UserIcon className="h-8 w-8 text-gray-400" />
+                          </div>
+                        )}
                       </div>
-                    )}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center space-x-2">
-                      <p className="text-sm font-medium text-gray-900">
-                        {speaker.name}
-                      </p>
-                      {requiresTravelFunding && (
-                        <div
-                          className="flex items-center"
-                          title="Requires travel funding"
-                        >
-                          <ExclamationTriangleIcon className="h-4 w-4 text-red-500" />
-                        </div>
-                      )}
-                    </div>
-                    {speaker.bio && (
-                      <p className="mt-1 line-clamp-3 text-sm text-gray-500">
-                        {speaker.bio}
-                      </p>
-                    )}
-                    {speaker.title && (
-                      <p className="mt-1 text-sm text-gray-500">
-                        {speaker.title}
-                      </p>
-                    )}
-                    {speaker.links && speaker.links.length > 0 && (
-                      <div className="mt-3">
-                        <p className="mb-1 text-xs font-medium text-gray-500">
-                          Social Links
-                        </p>
-                        <div className="flex flex-wrap gap-2">
-                          {speaker.links.map((link, index) => (
-                            <a
-                              key={index}
-                              href={link}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-xs break-all text-blue-600 hover:text-blue-800 hover:underline"
-                              title={link}
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center space-x-2">
+                          <p className="text-sm font-medium text-gray-900">
+                            {speaker.name}
+                          </p>
+                          {requiresTravelFunding && (
+                            <div
+                              className="flex items-center"
+                              title="Requires travel funding"
                             >
-                              {new URL(link).hostname}
-                            </a>
-                          ))}
+                              <ExclamationTriangleIcon className="h-4 w-4 text-red-500" />
+                            </div>
+                          )}
                         </div>
+                        {speaker.bio && (
+                          <p className="mt-1 line-clamp-3 text-sm text-gray-500">
+                            {speaker.bio}
+                          </p>
+                        )}
+                        {speaker.title && (
+                          <p className="mt-1 text-sm text-gray-500">
+                            {speaker.title}
+                          </p>
+                        )}
+                        {speaker.links && speaker.links.length > 0 && (
+                          <div className="mt-3">
+                            <p className="mb-1 text-xs font-medium text-gray-500">
+                              Social Links
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                              {speaker.links.map((link, index) => (
+                                <a
+                                  key={index}
+                                  href={link}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-xs break-all text-blue-600 hover:text-blue-800 hover:underline"
+                                  title={link}
+                                >
+                                  {new URL(link).hostname}
+                                </a>
+                              ))}
+                            </div>
+                          </div>
+                        )}
                       </div>
-                    )}
-                  </div>
+                    </div>
+                  ))}
                 </div>
               ) : (
                 <p className="text-sm text-gray-500 italic">

--- a/src/components/admin/ProposalPreview.tsx
+++ b/src/components/admin/ProposalPreview.tsx
@@ -26,7 +26,6 @@ import {
   Language,
   Audience,
 } from '@/lib/proposal/types'
-import type { Speaker } from '@/lib/speaker/types'
 import { Flags } from '@/lib/speaker/types'
 import type { Review } from '@/lib/review/types'
 import { PortableText } from '@portabletext/react'
@@ -60,22 +59,22 @@ function formatAudience(audience: Audience[]): string {
   return audience.map((a) => audiences.get(a) || a).join(', ')
 }
 
-function isSpeaker(speaker: Speaker | unknown): speaker is Speaker {
-  return (
-    speaker !== null &&
-    typeof speaker === 'object' &&
-    speaker !== undefined &&
-    'name' in speaker
-  )
-}
-
 export function ProposalPreview({ proposal, onClose }: ProposalPreviewProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const speaker = isSpeaker(proposal.speaker) ? proposal.speaker : null
+  const speakers =
+    proposal.speakers && Array.isArray(proposal.speakers)
+      ? proposal.speakers.filter(
+          (speaker) =>
+            typeof speaker === 'object' && speaker && 'name' in speaker,
+        )
+      : []
+  const primarySpeaker = speakers.length > 0 ? speakers[0] : null
   const averageRating = calculateAverageRating(proposal)
   const reviewCount = proposal.reviews?.length || 0
   const requiresTravelFunding =
-    speaker?.flags?.includes(Flags.requiresTravelFunding) || false
+    speakers.some((speaker) =>
+      speaker?.flags?.includes(Flags.requiresTravelFunding),
+    ) || false
 
   // Scroll to top when proposal changes
   useEffect(() => {
@@ -106,27 +105,27 @@ export function ProposalPreview({ proposal, onClose }: ProposalPreviewProps) {
       >
         <div className="space-y-6">
           {/* Speaker Info */}
-          {speaker && (
-            <div className="flex items-center space-x-4">
-              {speaker.image && (
+          {primarySpeaker && (
+            <div className="flex items-center space-x-3">
+              {primarySpeaker.image && (
                 <img
-                  src={sanityImage(speaker.image)
+                  src={sanityImage(primarySpeaker.image)
                     .width(96)
                     .height(96)
                     .fit('crop')
                     .url()}
-                  alt={speaker.name}
+                  alt={primarySpeaker.name}
                   width={48}
                   height={48}
                   className="h-12 w-12 rounded-full object-cover"
                   loading="lazy"
                 />
               )}
-              <div>
+              <div className="min-w-0 flex-1">
                 <div className="flex items-center space-x-2">
-                  <h3 className="text-sm font-medium text-gray-900">
-                    {speaker.name}
-                  </h3>
+                  <p className="text-sm font-medium text-gray-900">
+                    {primarySpeaker.name}
+                  </p>
                   {requiresTravelFunding && (
                     <div
                       className="flex items-center"
@@ -136,9 +135,9 @@ export function ProposalPreview({ proposal, onClose }: ProposalPreviewProps) {
                     </div>
                   )}
                 </div>
-                {speaker.bio && (
-                  <p className="line-clamp-2 text-sm text-gray-500">
-                    {speaker.bio}
+                {primarySpeaker.bio && (
+                  <p className="mt-1 line-clamp-2 text-sm text-gray-500">
+                    {primarySpeaker.bio}
                   </p>
                 )}
               </div>

--- a/src/components/admin/ProposalPreview.tsx
+++ b/src/components/admin/ProposalPreview.tsx
@@ -29,9 +29,9 @@ import {
 import { Flags } from '@/lib/speaker/types'
 import type { Review } from '@/lib/review/types'
 import { PortableText } from '@portabletext/react'
+import { SpeakerAvatarsWithNames } from '../SpeakerAvatars'
 import { calculateAverageRating } from './hooks'
 import { formatDateSafe } from '@/lib/time'
-import { sanityImage } from '@/lib/sanity/client'
 
 interface ProposalPreviewProps {
   proposal: ProposalExisting
@@ -105,41 +105,33 @@ export function ProposalPreview({ proposal, onClose }: ProposalPreviewProps) {
       >
         <div className="space-y-6">
           {/* Speaker Info */}
-          {primarySpeaker && (
-            <div className="flex items-center space-x-3">
-              {primarySpeaker.image && (
-                <img
-                  src={sanityImage(primarySpeaker.image)
-                    .width(96)
-                    .height(96)
-                    .fit('crop')
-                    .url()}
-                  alt={primarySpeaker.name}
-                  width={48}
-                  height={48}
-                  className="h-12 w-12 rounded-full object-cover"
-                  loading="lazy"
-                />
-              )}
-              <div className="min-w-0 flex-1">
+          {proposal.speakers &&
+          Array.isArray(proposal.speakers) &&
+          proposal.speakers.length > 0 ? (
+            <div className="space-y-3">
+              <SpeakerAvatarsWithNames
+                speakers={proposal.speakers}
+                size="md"
+                maxVisible={3}
+              />
+              {requiresTravelFunding && (
                 <div className="flex items-center space-x-2">
-                  <p className="text-sm font-medium text-gray-900">
-                    {primarySpeaker.name}
+                  <ExclamationTriangleIcon className="h-4 w-4 text-red-500" />
+                  <p className="text-sm text-gray-500">
+                    Requires travel funding
                   </p>
-                  {requiresTravelFunding && (
-                    <div
-                      className="flex items-center"
-                      title="Requires travel funding"
-                    >
-                      <ExclamationTriangleIcon className="h-4 w-4 text-red-500" />
-                    </div>
-                  )}
                 </div>
-                {primarySpeaker.bio && (
-                  <p className="mt-1 line-clamp-2 text-sm text-gray-500">
-                    {primarySpeaker.bio}
-                  </p>
-                )}
+              )}
+            </div>
+          ) : (
+            <div className="flex items-center space-x-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+                <UserIcon className="h-6 w-6 text-gray-400" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-gray-900">
+                  Unknown Speaker
+                </p>
               </div>
             </div>
           )}

--- a/src/components/admin/ProposalPreview.tsx
+++ b/src/components/admin/ProposalPreview.tsx
@@ -68,7 +68,6 @@ export function ProposalPreview({ proposal, onClose }: ProposalPreviewProps) {
             typeof speaker === 'object' && speaker && 'name' in speaker,
         )
       : []
-  const primarySpeaker = speakers.length > 0 ? speakers[0] : null
   const averageRating = calculateAverageRating(proposal)
   const reviewCount = proposal.reviews?.length || 0
   const requiresTravelFunding =

--- a/src/components/admin/SearchModal.tsx
+++ b/src/components/admin/SearchModal.tsx
@@ -19,7 +19,7 @@ import { useState, useEffect } from 'react'
 import { useProposalSearch } from './hooks/useProposalSearch'
 import { ProposalExisting, statuses, Format } from '@/lib/proposal/types'
 import { Speaker } from '@/lib/speaker/types'
-import { sanityImage } from '@/lib/sanity/client'
+import { SpeakerAvatars } from '../SpeakerAvatars'
 import { getStatusBadgeStyle } from './utils'
 
 interface SearchModalProps {
@@ -135,15 +135,13 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
                       className="group flex cursor-default items-center px-4 py-2 select-none data-focus:bg-indigo-600 data-focus:text-white data-focus:outline-hidden"
                     >
                       <div className="flex-shrink-0">
-                        {primarySpeaker?.image ? (
-                          <img
-                            src={sanityImage(primarySpeaker.image)
-                              .width(64)
-                              .height(64)
-                              .fit('crop')
-                              .url()}
-                            alt={primarySpeaker.name || 'Speaker'}
-                            className="size-6 flex-none rounded-full object-cover"
+                        {proposal.speakers &&
+                        Array.isArray(proposal.speakers) &&
+                        proposal.speakers.length > 0 ? (
+                          <SpeakerAvatars
+                            speakers={proposal.speakers}
+                            size="sm"
+                            maxVisible={1}
                           />
                         ) : (
                           <div className="flex size-6 flex-none items-center justify-center rounded-full bg-gray-200 group-data-focus:bg-white/20">
@@ -155,7 +153,9 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
                         <div className="font-medium">{proposal.title}</div>
                         <div className="flex items-center justify-between">
                           <div className="text-xs text-gray-500 group-data-focus:text-white/70">
-                            by {primarySpeaker?.name || 'Unknown Speaker'}
+                            by{' '}
+                            {speakers.map((s) => s.name).join(', ') ||
+                              'Unknown Speaker'}
                           </div>
                           <span
                             className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(proposal.status)}`}

--- a/src/components/admin/SearchModal.tsx
+++ b/src/components/admin/SearchModal.tsx
@@ -116,7 +116,17 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
                 )
 
                 const renderProposalOption = (proposal: ProposalExisting) => {
-                  const speaker = proposal.speaker as Speaker
+                  const speakers =
+                    proposal.speakers && Array.isArray(proposal.speakers)
+                      ? proposal.speakers.filter(
+                          (speaker) =>
+                            typeof speaker === 'object' &&
+                            speaker &&
+                            'name' in speaker,
+                        )
+                      : []
+                  const primarySpeaker =
+                    speakers.length > 0 ? (speakers[0] as Speaker) : null
                   return (
                     <ComboboxOption
                       as="li"
@@ -125,14 +135,14 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
                       className="group flex cursor-default items-center px-4 py-2 select-none data-focus:bg-indigo-600 data-focus:text-white data-focus:outline-hidden"
                     >
                       <div className="flex-shrink-0">
-                        {speaker?.image ? (
+                        {primarySpeaker?.image ? (
                           <img
-                            src={sanityImage(speaker.image)
+                            src={sanityImage(primarySpeaker.image)
                               .width(64)
                               .height(64)
                               .fit('crop')
                               .url()}
-                            alt={speaker.name || 'Speaker'}
+                            alt={primarySpeaker.name || 'Speaker'}
                             className="size-6 flex-none rounded-full object-cover"
                           />
                         ) : (
@@ -145,7 +155,7 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
                         <div className="font-medium">{proposal.title}</div>
                         <div className="flex items-center justify-between">
                           <div className="text-xs text-gray-500 group-data-focus:text-white/70">
-                            by {speaker?.name || 'Unknown Speaker'}
+                            by {primarySpeaker?.name || 'Unknown Speaker'}
                           </div>
                           <span
                             className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(proposal.status)}`}

--- a/src/components/admin/SearchModal.tsx
+++ b/src/components/admin/SearchModal.tsx
@@ -18,7 +18,6 @@ import {
 import { useState, useEffect } from 'react'
 import { useProposalSearch } from './hooks/useProposalSearch'
 import { ProposalExisting, statuses, Format } from '@/lib/proposal/types'
-import { Speaker } from '@/lib/speaker/types'
 import { SpeakerAvatars } from '../SpeakerAvatars'
 import { getStatusBadgeStyle } from './utils'
 
@@ -125,8 +124,6 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
                             'name' in speaker,
                         )
                       : []
-                  const primarySpeaker =
-                    speakers.length > 0 ? (speakers[0] as Speaker) : null
                   return (
                     <ComboboxOption
                       as="li"

--- a/src/components/admin/SearchResults.tsx
+++ b/src/components/admin/SearchResults.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react'
 import { ProposalExisting, statuses, Format } from '@/lib/proposal/types'
 import { Speaker } from '@/lib/speaker/types'
-import { sanityImage } from '@/lib/sanity/client'
+import { SpeakerAvatars } from '../SpeakerAvatars'
 import { UserIcon } from '@heroicons/react/24/outline'
 import { getStatusBadgeStyle } from './utils'
 
@@ -102,15 +102,13 @@ export function SearchResults({
                     }`}
                   >
                     <div className="flex items-center">
-                      {primarySpeaker?.image ? (
-                        <img
-                          src={sanityImage(primarySpeaker.image)
-                            .width(64)
-                            .height(64)
-                            .fit('crop')
-                            .url()}
-                          alt={primarySpeaker.name || 'Speaker'}
-                          className="size-6 flex-none rounded-full object-cover"
+                      {proposal.speakers &&
+                      Array.isArray(proposal.speakers) &&
+                      proposal.speakers.length > 0 ? (
+                        <SpeakerAvatars
+                          speakers={proposal.speakers}
+                          size="sm"
+                          maxVisible={1}
                         />
                       ) : (
                         <div className="flex size-6 flex-none items-center justify-center rounded-full bg-gray-200">
@@ -121,7 +119,9 @@ export function SearchResults({
                         <div className="font-medium">{proposal.title}</div>
                         <div className="flex items-center justify-between">
                           <div className="text-xs text-gray-500">
-                            by {primarySpeaker?.name || 'Unknown Speaker'}
+                            by{' '}
+                            {speakers.map((s) => s.name).join(', ') ||
+                              'Unknown Speaker'}
                           </div>
                           <span
                             className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(proposal.status)}`}

--- a/src/components/admin/SearchResults.tsx
+++ b/src/components/admin/SearchResults.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef } from 'react'
 import { ProposalExisting, statuses, Format } from '@/lib/proposal/types'
-import { Speaker } from '@/lib/speaker/types'
 import { SpeakerAvatars } from '../SpeakerAvatars'
 import { UserIcon } from '@heroicons/react/24/outline'
 import { getStatusBadgeStyle } from './utils'
@@ -85,8 +84,6 @@ export function SearchResults({
                           'name' in speaker,
                       )
                     : []
-                const primarySpeaker =
-                  speakers.length > 0 ? (speakers[0] as Speaker) : null
                 const isSelected = globalIndex === selectedIndex
 
                 return (

--- a/src/components/admin/SearchResults.tsx
+++ b/src/components/admin/SearchResults.tsx
@@ -76,7 +76,17 @@ export function SearchResults({
             ) => {
               return proposals.map((proposal, index) => {
                 const globalIndex = startIndex + index
-                const speaker = proposal.speaker as Speaker
+                const speakers =
+                  proposal.speakers && Array.isArray(proposal.speakers)
+                    ? proposal.speakers.filter(
+                        (speaker) =>
+                          typeof speaker === 'object' &&
+                          speaker &&
+                          'name' in speaker,
+                      )
+                    : []
+                const primarySpeaker =
+                  speakers.length > 0 ? (speakers[0] as Speaker) : null
                 const isSelected = globalIndex === selectedIndex
 
                 return (
@@ -91,39 +101,30 @@ export function SearchResults({
                       isSelected ? 'bg-blue-50 ring-1 ring-blue-500' : ''
                     }`}
                   >
-                    <div className="flex items-start space-x-3">
-                      <div className="flex-shrink-0">
-                        {speaker?.image ? (
-                          <img
-                            src={sanityImage(speaker.image)
-                              .width(64)
-                              .height(64)
-                              .fit('crop')
-                              .url()}
-                            alt={speaker.name || 'Speaker'}
-                            width={32}
-                            height={32}
-                            className="h-8 w-8 rounded-full object-cover"
-                            loading="lazy"
-                          />
-                        ) : (
-                          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100">
-                            <UserIcon className="h-4 w-4 text-gray-400" />
-                          </div>
-                        )}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-start justify-between">
-                          <div className="min-w-0 flex-1">
-                            <p className="truncate text-sm font-medium text-gray-900">
-                              {proposal.title}
-                            </p>
-                            <p className="text-xs text-gray-500">
-                              by {speaker?.name || 'Unknown Speaker'}
-                            </p>
+                    <div className="flex items-center">
+                      {primarySpeaker?.image ? (
+                        <img
+                          src={sanityImage(primarySpeaker.image)
+                            .width(64)
+                            .height(64)
+                            .fit('crop')
+                            .url()}
+                          alt={primarySpeaker.name || 'Speaker'}
+                          className="size-6 flex-none rounded-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex size-6 flex-none items-center justify-center rounded-full bg-gray-200">
+                          <UserIcon className="size-4 text-gray-400" />
+                        </div>
+                      )}
+                      <div className="ml-3 flex-auto truncate">
+                        <div className="font-medium">{proposal.title}</div>
+                        <div className="flex items-center justify-between">
+                          <div className="text-xs text-gray-500">
+                            by {primarySpeaker?.name || 'Unknown Speaker'}
                           </div>
                           <span
-                            className={`ml-2 inline-flex flex-shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(proposal.status)}`}
+                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${getStatusBadgeStyle(proposal.status)}`}
                           >
                             {statuses.get(proposal.status) || proposal.status}
                           </span>

--- a/src/components/admin/hooks.ts
+++ b/src/components/admin/hooks.ts
@@ -139,13 +139,21 @@ export function useProposalFiltering(
           break
         case 'speaker':
           aValue = (
-            typeof a.speaker === 'object' && a.speaker && 'name' in a.speaker
-              ? (a.speaker as Speaker).name
+            a.speakers &&
+            a.speakers.length > 0 &&
+            typeof a.speakers[0] === 'object' &&
+            a.speakers[0] &&
+            'name' in a.speakers[0]
+              ? (a.speakers[0] as Speaker).name
               : 'Unknown'
           ).toLowerCase()
           bValue = (
-            typeof b.speaker === 'object' && b.speaker && 'name' in b.speaker
-              ? (b.speaker as Speaker).name
+            b.speakers &&
+            b.speakers.length > 0 &&
+            typeof b.speakers[0] === 'object' &&
+            b.speakers[0] &&
+            'name' in b.speakers[0]
+              ? (b.speakers[0] as Speaker).name
               : 'Unknown'
           ).toLowerCase()
           break

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -48,10 +48,13 @@ export function DraggableProposal({
 
       // Extract speaker info if available
       const speaker =
-        proposal.speaker &&
-        typeof proposal.speaker === 'object' &&
-        'name' in proposal.speaker
-          ? proposal.speaker.name
+        proposal.speakers &&
+        Array.isArray(proposal.speakers) &&
+        proposal.speakers.length > 0 &&
+        proposal.speakers[0] &&
+        typeof proposal.speakers[0] === 'object' &&
+        'name' in proposal.speakers[0]
+          ? proposal.speakers[0].name
           : null
 
       return {

--- a/src/components/admin/schedule/UnassignedProposals.tsx
+++ b/src/components/admin/schedule/UnassignedProposals.tsx
@@ -187,9 +187,14 @@ export function UnassignedProposals({ proposals }: UnassignedProposalsProps) {
         const titleMatch = proposal.title.toLowerCase().includes(query)
 
         const speakerMatch =
-          typeof proposal.speaker === 'object' &&
-          'name' in proposal.speaker &&
-          proposal.speaker.name.toLowerCase().includes(query)
+          proposal.speakers &&
+          Array.isArray(proposal.speakers) &&
+          proposal.speakers.some(
+            (speaker) =>
+              typeof speaker === 'object' &&
+              'name' in speaker &&
+              speaker.name.toLowerCase().includes(query),
+          )
 
         const formatMatch = proposal.format.toLowerCase().includes(query)
 

--- a/src/hooks/useProposalFilter.ts
+++ b/src/hooks/useProposalFilter.ts
@@ -31,9 +31,15 @@ export function useProposalFilter(proposals: ProposalExisting[]) {
     const speakerSet = new Set<string>()
     const stats = proposals.reduce(
       (acc, proposal) => {
-        // Add speaker to the set
-        if (proposal.speaker && 'name' in proposal.speaker) {
-          speakerSet.add(proposal.speaker.name)
+        // Add speakers to the set
+        if (proposal.speakers && Array.isArray(proposal.speakers)) {
+          proposal.speakers.forEach((speaker) => {
+            if (typeof speaker === 'object' && 'name' in speaker) {
+              speakerSet.add(speaker.name)
+            } else {
+              speakerSet.add('Unknown author')
+            }
+          })
         } else {
           speakerSet.add('Unknown author')
         }

--- a/src/hooks/useProposalSearch.ts
+++ b/src/hooks/useProposalSearch.ts
@@ -13,12 +13,14 @@ export function useProposalSearch(proposals: ProposalExisting[]) {
       filtered = filtered.filter(
         (proposal) =>
           proposal.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          (proposal.speaker &&
-            typeof proposal.speaker === 'object' &&
-            'name' in proposal.speaker &&
-            proposal.speaker.name
-              .toLowerCase()
-              .includes(searchQuery.toLowerCase())),
+          (proposal.speakers &&
+            Array.isArray(proposal.speakers) &&
+            proposal.speakers.some(
+              (speaker) =>
+                typeof speaker === 'object' &&
+                'name' in speaker &&
+                speaker.name.toLowerCase().includes(searchQuery.toLowerCase()),
+            )),
       )
     }
 

--- a/src/hooks/useProposalSort.ts
+++ b/src/hooks/useProposalSort.ts
@@ -7,7 +7,7 @@ import { getAverageScore } from '@/utils/reviewUtils'
 // Define the sort fields and their types
 export type SortField =
   | 'title'
-  | 'speaker'
+  | 'speakers'
   | 'format'
   | 'language'
   | 'level'
@@ -36,15 +36,31 @@ export function useProposalSort(initialProposals: ProposalExisting[]) {
     if (!sortConfig) return initialProposals
 
     return [...initialProposals].sort((a, b) => {
-      // Special case for speaker field which needs to extract the name
-      if (sortConfig.field === 'speaker') {
-        const speakerA =
-          a.speaker && 'name' in a.speaker ? a.speaker.name : 'Unknown'
-        const speakerB =
-          b.speaker && 'name' in b.speaker ? b.speaker.name : 'Unknown'
+      // Special case for speakers field which needs to extract the names
+      if (sortConfig.field === 'speakers') {
+        const speakersA =
+          a.speakers && Array.isArray(a.speakers)
+            ? a.speakers
+                .map((speaker) =>
+                  typeof speaker === 'object' && 'name' in speaker
+                    ? speaker.name
+                    : 'Unknown',
+                )
+                .join(', ')
+            : 'Unknown'
+        const speakersB =
+          b.speakers && Array.isArray(b.speakers)
+            ? b.speakers
+                .map((speaker) =>
+                  typeof speaker === 'object' && 'name' in speaker
+                    ? speaker.name
+                    : 'Unknown',
+                )
+                .join(', ')
+            : 'Unknown'
         return sortConfig.direction === 'asc'
-          ? speakerA.localeCompare(speakerB)
-          : speakerB.localeCompare(speakerA)
+          ? speakersA.localeCompare(speakersB)
+          : speakersB.localeCompare(speakersA)
       }
 
       // Special case for score field which needs numerical comparison

--- a/src/lib/proposal/client.ts
+++ b/src/lib/proposal/client.ts
@@ -85,10 +85,10 @@ export interface NextUnreviewedProposalResponse {
     _id: string
     title: string
     status: string
-    speaker?: {
+    speakers?: {
       _id: string
       name: string
-    }
+    }[]
   } | null
   error?: string
 }

--- a/src/lib/proposal/types.ts
+++ b/src/lib/proposal/types.ts
@@ -89,7 +89,7 @@ export interface ProposalExisting extends Proposal {
   _createdAt: string
   _updatedAt: string
   status: Status
-  speaker?: Speaker | Reference
+  speakers?: Speaker[] | Reference[]
   schedule?: ConferenceSchedule[]
   conference: Conference | Reference
   reviews?: Review[]


### PR DESCRIPTION
This pull request introduces a migration to support multiple speakers per proposal by replacing the `speaker` field with a `speakers` array. The changes span schema updates, migration scripts, test data adjustments, and updates across the application codebase to handle the new `speakers` array. Below are the most significant changes grouped by theme:

### Migration and Schema Updates:
* Added a migration script (`migrations/004-speaker-to-speakers/index.ts`) to convert the `speaker` field to a `speakers` array while preserving backward compatibility.
* Updated the schema in `sanity/schemaTypes/talk.ts` to deprecate the `speaker` field, introduce the `speakers` array, and enforce validation for selecting 1-3 speakers. [[1]](diffhunk://#diff-68200c16c727c01ff99259f23308239b53e8fea121690a5b4b3c4f13c774645dL93-R112) [[2]](diffhunk://#diff-68200c16c727c01ff99259f23308239b53e8fea121690a5b4b3c4f13c774645dL120-R146)

### Test Data Adjustments:
* Modified test data in `__tests__/testdata/proposals.ts` to replace `speaker` with `speakers` array for all proposals. [[1]](diffhunk://#diff-082af35fe93c65b8343f5f14f4e8474e5927cee1f436614e36e91a289057b77dL26-R26) [[2]](diffhunk://#diff-082af35fe93c65b8343f5f14f4e8474e5927cee1f436614e36e91a289057b77dL42-R42) [[3]](diffhunk://#diff-082af35fe93c65b8343f5f14f4e8474e5927cee1f436614e36e91a289057b77dL57-R57) [[4]](diffhunk://#diff-082af35fe93c65b8343f5f14f4e8474e5927cee1f436614e36e91a289057b77dL72-R72) [[5]](diffhunk://#diff-082af35fe93c65b8343f5f14f4e8474e5927cee1f436614e36e91a289057b77dL87-R87) [[6]](diffhunk://#diff-082af35fe93c65b8343f5f14f4e8474e5927cee1f436614e36e91a289057b77dL102-R102) [[7]](diffhunk://#diff-082af35fe93c65b8343f5f14f4e8474e5927cee1f436614e36e91a289057b77dL117-R117)

### Application Code Updates:
* Refactored the `AdminDashboard` and `SpeakerDashboard` components to handle the `speakers` array, including extracting and displaying the primary speaker. [[1]](diffhunk://#diff-923ed30216cc0a8aa278d00dbcbc8ff3ffab7ee533619fa5fe010e09ff120f43L54-R62) [[2]](diffhunk://#diff-923ed30216cc0a8aa278d00dbcbc8ff3ffab7ee533619fa5fe010e09ff120f43L508-R523) [[3]](diffhunk://#diff-923ed30216cc0a8aa278d00dbcbc8ff3ffab7ee533619fa5fe010e09ff120f43L555-R565) [[4]](diffhunk://#diff-cdf0df42a57c833ba34981186d199243fc62ec070796b39fd8986d7543606e8aL106-R141)
* Updated the program schedule logic in `src/app/(main)/program/page.tsx` to work with the `speakers` array instead of the single `speaker` field. [[1]](diffhunk://#diff-32b25b6ebf07f5719736486153493605f293ce2aec8a53ef820bdf7180c7aa7fL57-R62) [[2]](diffhunk://#diff-32b25b6ebf07f5719736486153493605f293ce2aec8a53ef820bdf7180c7aa7fL79-R84) [[3]](diffhunk://#diff-32b25b6ebf07f5719736486153493605f293ce2aec8a53ef820bdf7180c7aa7fL189-R194) [[4]](diffhunk://#diff-32b25b6ebf07f5719736486153493605f293ce2aec8a53ef820bdf7180c7aa7fL205-R213)

### Notification and API Updates:
* Adjusted the `ProposalActionModal` component and API routes to reference the `speakers` array and use the primary speaker for notifications. ([src/app/api/proposal/[id]/action/route.tsR124-R129](diffhunk://#diff-85ccb8ae133b9d9507eaeb730f665649b01409210294cc036f3312947c918616R124-R129), [src/components/ProposalActionModal.tsxL207-R217](diffhunk://#diff-7be09573c74acaa1ea4492be8f08f3f7374e0e269ee56e78c2cf1fae1cd20351L207-R217))

### Documentation:
* Added a `README.md` file for the migration (`migrations/004-speaker-to-speakers/README.md`) with an overview, instructions, and schema update details.