### PR TITLE
feat(terms): add Terms of Service page; document WorkOS in Privacy and link from Workshop

### DIFF
--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -48,7 +48,7 @@ export default async function PrivacyPolicyPage() {
     )
   }
 
-  const lastUpdated = 'October 12, 2025'
+  const lastUpdated = 'October 31, 2025'
   const contactEmail = conference.contact_email || 'hello@cloudnativebergen.no'
   const organizationName = 'Cloud Native Bergen'
 
@@ -243,6 +243,9 @@ export default async function PrivacyPolicyPage() {
                               • Operating system preference (Windows, macOS,
                               Linux)
                             </li>
+                            <li>
+                              • WorkOS User ID (unique authentication identifier)
+                            </li>
                           </ul>
                         </div>
                         <div>
@@ -256,6 +259,7 @@ export default async function PrivacyPolicyPage() {
                             <li>• Signup date and confirmation details</li>
                             <li>• Workshop attendance tracking</li>
                             <li>• Capacity and waitlist management</li>
+                            <li>• Authentication session data for workshop access</li>
                           </ul>
                         </div>
                       </div>
@@ -703,17 +707,34 @@ export default async function PrivacyPolicyPage() {
                       <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
                         Authentication Services
                       </h3>
-                      <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
-                        <div className="flex items-start space-x-3">
-                          <LockClosedIcon className="mt-1 h-4 w-4 flex-shrink-0 text-gray-500 dark:text-gray-400" />
-                          <div>
-                            <p className="font-medium text-gray-900 dark:text-white">
-                              GitHub/LinkedIn
-                            </p>
-                            <p className="text-sm text-gray-600 dark:text-gray-400">
-                              Authentication services (when you choose to sign
-                              in)
-                            </p>
+                      <div className="space-y-3">
+                        <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
+                          <div className="flex items-start space-x-3">
+                            <LockClosedIcon className="mt-1 h-4 w-4 flex-shrink-0 text-gray-500 dark:text-gray-400" />
+                            <div>
+                              <p className="font-medium text-gray-900 dark:text-white">
+                                GitHub/LinkedIn
+                              </p>
+                              <p className="text-sm text-gray-600 dark:text-gray-400">
+                                Authentication services for Call for Papers (when you choose to sign in)
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800/50">
+                          <div className="flex items-start space-x-3">
+                            <LockClosedIcon className="mt-1 h-4 w-4 flex-shrink-0 text-gray-500 dark:text-gray-400" />
+                            <div>
+                              <p className="font-medium text-gray-900 dark:text-white">
+                                WorkOS (AuthKit)
+                              </p>
+                              <p className="text-sm text-gray-600 dark:text-gray-400">
+                                User authentication and identity management for workshop signups (email, name, user ID, authentication sessions)
+                              </p>
+                              <p className="mt-1 text-xs text-gray-500 dark:text-gray-500">
+                                Location: United States • Protected by Standard Contractual Clauses
+                              </p>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -835,11 +856,26 @@ export default async function PrivacyPolicyPage() {
                     </div>
 
                     <p className="text-sm text-gray-700 dark:text-gray-300">
-                      Some providers (e.g., Vercel, Slack, Resend) may process
+                      Some providers (e.g., Vercel, Slack, Resend, WorkOS) may process
                       data in the United States. We rely on Standard Contractual
                       Clauses and other safeguards required by GDPR for such
                       transfers.
                     </p>
+                    
+                    <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
+                      <h4 className="mb-2 font-semibold text-amber-800 dark:text-amber-200">
+                        WorkOS Authentication
+                      </h4>
+                      <p className="text-sm text-amber-700 dark:text-amber-300">
+                        WorkOS processes workshop authentication data in the United States. We rely on:
+                      </p>
+                      <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-amber-700 dark:text-amber-300">
+                        <li>Standard Contractual Clauses (SCCs) approved by the European Commission</li>
+                        <li>WorkOS&apos;s compliance with applicable data protection frameworks</li>
+                        <li>Additional safeguards including encryption at rest and in transit</li>
+                        <li>Transfer Impact Assessment documenting residual risks and mitigations</li>
+                      </ul>
+                    </div>
                   </div>
                 </section>
 
@@ -1028,6 +1064,27 @@ export default async function PrivacyPolicyPage() {
                               Volunteer coordination, event operations, and
                               safety management. Consent for special category
                               data (dietary restrictions)
+                            </td>
+                          </tr>
+                          <tr className="bg-purple-50 dark:bg-purple-900/20">
+                            <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
+                              WorkOS Authentication Data
+                              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                (User ID, email, name, authentication sessions)
+                              </div>
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+                              Duration of active workshop registration + 2 years
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+                              <span className="font-medium text-blue-600 dark:text-blue-400">
+                                Legitimate Interest:
+                              </span>{' '}
+                              User account management, audit trail for capacity management, and preventing duplicate registrations.
+                              <span className="font-medium text-orange-600 dark:text-orange-400">
+                                {' '}Contract Performance:
+                              </span>{' '}
+                              Authentication required to access registered workshops
                             </td>
                           </tr>
                         </tbody>

--- a/src/app/(main)/terms/page.tsx
+++ b/src/app/(main)/terms/page.tsx
@@ -1,0 +1,489 @@
+import { BackgroundImage } from '@/components/BackgroundImage'
+import { Container } from '@/components/Container'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { ErrorDisplay } from '@/components/admin'
+import {
+  DocumentTextIcon,
+  UserGroupIcon,
+  ShieldCheckIcon,
+  ExclamationTriangleIcon,
+  BanknotesIcon,
+  BookOpenIcon,
+  CalendarIcon,
+  XCircleIcon,
+  ScaleIcon,
+  GlobeAltIcon,
+} from '@heroicons/react/24/outline'
+import Link from 'next/link'
+
+export default async function TermsOfServicePage() {
+  const { conference, error: conferenceError } =
+    await getConferenceForCurrentDomain()
+
+  if (conferenceError) {
+    return (
+      <ErrorDisplay
+        title="Error Loading Conference"
+        message={conferenceError.message}
+      />
+    )
+  }
+
+  const lastUpdated = 'October 31, 2025'
+  const contactEmail = conference.contact_email || 'hello@cloudnativebergen.no'
+  const organizationName = 'Cloud Native Bergen'
+
+  return (
+    <>
+      <div className="relative py-20 sm:pt-36 sm:pb-24 print:py-8">
+        <BackgroundImage className="-top-36 -bottom-14 print:hidden" />
+        <Container className="relative print:max-w-none print:px-0">
+          <div className="mx-auto max-w-4xl print:max-w-none">
+            <h1 className="font-jetbrains text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:text-6xl dark:text-blue-400 print:mb-4 print:text-3xl print:font-bold print:text-black">
+              Terms of Service
+            </h1>
+            <div className="font-inter mt-6 space-y-6 text-xl tracking-tight text-brand-slate-gray dark:text-gray-300 print:mt-4 print:space-y-4 print:text-base print:text-black">
+              <p className="print:leading-relaxed">
+                Welcome to {organizationName}. These Terms of Service govern your use of
+                our website, workshop registration system, speaker submission platform,
+                and related services.
+              </p>
+              <p className="print:leading-relaxed">
+                By accessing or using our services, you agree to be bound by these terms.
+                Please read them carefully.
+              </p>
+              <p className="text-xl tracking-tight print:text-base print:font-semibold">
+                <strong>Last updated:</strong> {lastUpdated}
+              </p>
+            </div>
+          </div>
+
+          <div className="mx-auto mt-16 max-w-4xl rounded-xl border border-brand-frosted-steel bg-white p-8 shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:shadow-gray-900/20 print:mt-8 print:max-w-none print:rounded-none print:border-0 print:bg-white print:p-0 print:shadow-none">
+            <div className="prose prose-lg dark:prose-invert print:prose-base max-w-none print:max-w-none">
+              <div className="space-y-8 print:space-y-6">
+                {/* Section 1: Acceptance of Terms */}
+                <section id="acceptance" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <DocumentTextIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      1. Acceptance of Terms
+                    </h2>
+                  </div>
+                  <div className="space-y-4 print:space-y-3">
+                    <p className="text-base leading-7 text-gray-700 dark:text-gray-300 print:leading-relaxed print:text-black">
+                      By creating an account, registering for workshops, submitting a talk
+                      proposal, or otherwise using our services, you acknowledge that you
+                      have read, understood, and agree to be bound by these Terms of Service
+                      and our{' '}
+                      <Link
+                        href="/privacy"
+                        className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                      >
+                        Privacy Policy
+                      </Link>
+                      .
+                    </p>
+                    <p className="text-base leading-7 text-gray-700 dark:text-gray-300">
+                      If you do not agree with any part of these terms, you may not use our
+                      services.
+                    </p>
+                  </div>
+                </section>
+
+                {/* Section 2: User Accounts and Authentication */}
+                <section id="accounts" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <UserGroupIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      2. User Accounts and Authentication
+                    </h2>
+                  </div>
+                  <div className="space-y-4">
+                    <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+                      <h3 className="mb-3 font-semibold text-blue-800 dark:text-blue-200">
+                        Account Creation
+                      </h3>
+                      <ul className="space-y-2 text-sm text-blue-700 dark:text-blue-300">
+                        <li>
+                          • You may create an account using GitHub or LinkedIn (for Call for
+                          Papers) or WorkOS AuthKit (for workshop registration)
+                        </li>
+                        <li>
+                          • You must provide accurate and complete information when creating
+                          an account
+                        </li>
+                        <li>• You are responsible for maintaining the security of your account</li>
+                        <li>
+                          • You must be at least 13 years old to create an account and use
+                          our services
+                        </li>
+                        <li>
+                          • One person may not maintain multiple accounts for the same
+                          purpose
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 dark:border-orange-800 dark:bg-orange-900/20">
+                      <h3 className="mb-3 font-semibold text-orange-800 dark:text-orange-200">
+                        Account Responsibilities
+                      </h3>
+                      <ul className="space-y-2 text-sm text-orange-700 dark:text-orange-300">
+                        <li>
+                          • You are responsible for all activities that occur under your
+                          account
+                        </li>
+                        <li>
+                          • You must notify us immediately of any unauthorized use of your
+                          account
+                        </li>
+                        <li>
+                          • We reserve the right to suspend or terminate accounts that
+                          violate these terms
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </section>
+
+                {/* Section 3: Workshop Registration */}
+                <section id="workshops" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <BookOpenIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      3. Workshop Registration
+                    </h2>
+                  </div>
+                  <div className="space-y-4">
+                    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
+                      <h3 className="mb-3 font-semibold text-amber-800 dark:text-amber-200">
+                        Registration Process
+                      </h3>
+                      <ul className="space-y-2 text-sm text-amber-700 dark:text-amber-300">
+                        <li>
+                          • Workshop registration requires authentication through WorkOS
+                          AuthKit
+                        </li>
+                        <li>
+                          • Workshops have limited capacity and are assigned on a
+                          first-come, first-served basis
+                        </li>
+                        <li>
+                          • Confirmed registrations may be subject to waitlist if capacity
+                          is reached
+                        </li>
+                        <li>
+                          • You will receive a confirmation email upon successful
+                          registration
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
+                      <h3 className="mb-3 flex items-center font-semibold text-red-800 dark:text-red-200">
+                        <XCircleIcon className="mr-2 h-5 w-5" />
+                        Cancellation Policy
+                      </h3>
+                      <ul className="space-y-2 text-sm text-red-700 dark:text-red-300">
+                        <li>
+                          • You may cancel your workshop registration at any time through
+                          the workshop page
+                        </li>
+                        <li>
+                          • Cancellations will open spots for waitlisted participants
+                        </li>
+                        <li>
+                          • We reserve the right to cancel workshops due to low enrollment
+                          or unforeseen circumstances
+                        </li>
+                        <li>
+                          • No-shows may be restricted from future workshop registrations
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div className="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+                      <h3 className="mb-3 font-semibold text-green-800 dark:text-green-200">
+                        Participant Conduct
+                      </h3>
+                      <p className="text-sm text-green-700 dark:text-green-300">
+                        All workshop participants must adhere to our Code of Conduct.
+                        Disruptive or inappropriate behavior may result in removal from the
+                        workshop and conference without refund.
+                      </p>
+                    </div>
+                  </div>
+                </section>
+
+                {/* Section 4: Speaker Submissions (Call for Papers) */}
+                <section id="cfp" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <CalendarIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      4. Speaker Submissions (Call for Papers)
+                    </h2>
+                  </div>
+                  <div className="space-y-4">
+                    <div className="rounded-lg border border-purple-200 bg-purple-50 p-4 dark:border-purple-800 dark:bg-purple-900/20">
+                      <h3 className="mb-3 font-semibold text-purple-800 dark:text-purple-200">
+                        Submission Requirements
+                      </h3>
+                      <ul className="space-y-2 text-sm text-purple-700 dark:text-purple-300">
+                        <li>• All submissions must be original work</li>
+                        <li>
+                          • You warrant that you have the right to present the submitted
+                          content
+                        </li>
+                        <li>
+                          • Submissions are subject to review and acceptance by the program
+                          committee
+                        </li>
+                        <li>
+                          • Accepted speakers agree to have their talks recorded and
+                          published
+                        </li>
+                      </ul>
+                    </div>
+
+                    <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+                      <h3 className="mb-3 font-semibold text-blue-800 dark:text-blue-200">
+                        Content Rights and Licensing
+                      </h3>
+                      <p className="mb-2 text-sm text-blue-700 dark:text-blue-300">
+                        By submitting a talk proposal and speaking at our conference, you
+                        grant {organizationName}:
+                      </p>
+                      <ul className="space-y-2 text-sm text-blue-700 dark:text-blue-300">
+                        <li>
+                          • A non-exclusive, worldwide, perpetual license to record,
+                          reproduce, and distribute your presentation
+                        </li>
+                        <li>
+                          • The right to publish your talk on our website and official video
+                          platforms
+                        </li>
+                        <li>
+                          • The right to use your name, biography, and photograph in
+                          promotional materials
+                        </li>
+                      </ul>
+                      <p className="mt-2 text-sm text-blue-700 dark:text-blue-300">
+                        You retain all other rights to your content and may use it elsewhere
+                        as you wish.
+                      </p>
+                    </div>
+                  </div>
+                </section>
+
+                {/* Section 5: Acceptable Use */}
+                <section id="acceptable-use" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <ShieldCheckIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      5. Acceptable Use
+                    </h2>
+                  </div>
+                  <div className="space-y-4">
+                    <p className="text-base leading-7 text-gray-700 dark:text-gray-300">
+                      You agree not to:
+                    </p>
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                        <p className="text-sm font-semibold text-red-800 dark:text-red-200">
+                          • Violate any applicable laws or regulations
+                        </p>
+                      </div>
+                      <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                        <p className="text-sm font-semibold text-red-800 dark:text-red-200">
+                          • Infringe on intellectual property rights
+                        </p>
+                      </div>
+                      <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                        <p className="text-sm font-semibold text-red-800 dark:text-red-200">
+                          • Transmit malicious code or viruses
+                        </p>
+                      </div>
+                      <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                        <p className="text-sm font-semibold text-red-800 dark:text-red-200">
+                          • Harass, abuse, or harm other users
+                        </p>
+                      </div>
+                      <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                        <p className="text-sm font-semibold text-red-800 dark:text-red-200">
+                          • Attempt unauthorized access to systems
+                        </p>
+                      </div>
+                      <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                        <p className="text-sm font-semibold text-red-800 dark:text-red-200">
+                          • Use automated tools to scrape content
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+
+                {/* Section 6: Intellectual Property */}
+                <section id="ip" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <ScaleIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      6. Intellectual Property
+                    </h2>
+                  </div>
+                  <div className="space-y-4">
+                    <p className="text-base leading-7 text-gray-700 dark:text-gray-300">
+                      All content on our website, including but not limited to text,
+                      graphics, logos, images, and software, is the property of{' '}
+                      {organizationName} or its content suppliers and is protected by
+                      international copyright laws.
+                    </p>
+                    <p className="text-base leading-7 text-gray-700 dark:text-gray-300">
+                      You may not reproduce, distribute, modify, or create derivative works
+                      without our express written permission.
+                    </p>
+                  </div>
+                </section>
+
+                {/* Section 7: Disclaimers and Limitations of Liability */}
+                <section id="disclaimers" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <ExclamationTriangleIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      7. Disclaimers and Limitations of Liability
+                    </h2>
+                  </div>
+                  <div className="space-y-4">
+                    <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-900/20">
+                      <h3 className="mb-3 font-semibold text-yellow-800 dark:text-yellow-200">
+                        Service &quot;As Is&quot;
+                      </h3>
+                      <p className="text-sm text-yellow-700 dark:text-yellow-300">
+                        Our services are provided &quot;as is&quot; and &quot;as
+                        available&quot; without any warranties of any kind, either express or
+                        implied. We do not warrant that the service will be uninterrupted,
+                        timely, secure, or error-free.
+                      </p>
+                    </div>
+
+                    <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 dark:border-orange-800 dark:bg-orange-900/20">
+                      <h3 className="mb-3 font-semibold text-orange-800 dark:text-orange-200">
+                        Limitation of Liability
+                      </h3>
+                      <p className="text-sm text-orange-700 dark:text-orange-300">
+                        To the maximum extent permitted by law, {organizationName} shall not
+                        be liable for any indirect, incidental, special, consequential, or
+                        punitive damages, including but not limited to loss of profits, data,
+                        or other intangible losses resulting from your use of our services.
+                      </p>
+                    </div>
+                  </div>
+                </section>
+
+                {/* Section 8: Indemnification */}
+                <section id="indemnification" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <ScaleIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      8. Indemnification
+                    </h2>
+                  </div>
+                  <p className="text-base leading-7 text-gray-700 dark:text-gray-300">
+                    You agree to indemnify, defend, and hold harmless {organizationName},
+                    its officers, directors, employees, and agents from any claims,
+                    liabilities, damages, losses, and expenses arising from your violation
+                    of these Terms of Service or your use of our services.
+                  </p>
+                </section>
+
+                {/* Section 9: Changes to Terms */}
+                <section id="changes" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <DocumentTextIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      9. Changes to Terms
+                    </h2>
+                  </div>
+                  <p className="text-base leading-7 text-gray-700 dark:text-gray-300">
+                    We reserve the right to modify these Terms of Service at any time. We
+                    will notify users of significant changes via email or through a notice
+                    on our website. Your continued use of our services after such
+                    modifications constitutes acceptance of the updated terms.
+                  </p>
+                </section>
+
+                {/* Section 10: Governing Law */}
+                <section id="governing-law" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <GlobeAltIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      10. Governing Law and Dispute Resolution
+                    </h2>
+                  </div>
+                  <div className="space-y-4">
+                    <p className="text-base leading-7 text-gray-700 dark:text-gray-300">
+                      These Terms of Service are governed by and construed in accordance
+                      with the laws of Norway. Any disputes arising from these terms or your
+                      use of our services shall be subject to the exclusive jurisdiction of
+                      the courts of Norway.
+                    </p>
+                    <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+                      <p className="text-sm text-blue-700 dark:text-blue-300">
+                        Before pursuing formal legal action, we encourage users to contact us
+                        to resolve disputes amicably.
+                      </p>
+                    </div>
+                  </div>
+                </section>
+
+                {/* Section 11: Contact Information */}
+                <section id="contact" className="space-y-6 print:space-y-4">
+                  <div className="flex items-center space-x-3 print:space-x-0">
+                    <BanknotesIcon className="h-6 w-6 text-gray-600 dark:text-gray-400 print:hidden" />
+                    <h2 className="font-space-grotesk text-2xl font-semibold text-brand-cloud-blue dark:text-blue-400 print:mt-6 print:mb-3 print:text-xl print:font-bold print:text-black">
+                      11. Contact Information
+                    </h2>
+                  </div>
+                  <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+                    <p className="text-sm text-blue-700 dark:text-blue-300">
+                      If you have any questions about these Terms of Service, please contact
+                      us at:{' '}
+                      <a
+                        href={`mailto:${contactEmail}`}
+                        className="font-semibold underline hover:text-blue-900 dark:hover:text-blue-200"
+                      >
+                        {contactEmail}
+                      </a>
+                    </p>
+                  </div>
+                </section>
+
+                <hr className="my-8 print:my-4 print:border-black" />
+
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
+                  <p className="text-sm text-gray-700 dark:text-gray-300">
+                    By using {organizationName}&apos;s services, you acknowledge that you
+                    have read and understood these Terms of Service and agree to be bound by
+                    them. These terms work in conjunction with our{' '}
+                    <Link
+                      href="/privacy"
+                      className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                    >
+                      Privacy Policy
+                    </Link>{' '}
+                    to govern your use of our platform.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </Container>
+      </div>
+    </>
+  )
+}
+
+export const metadata = {
+  title: 'Terms of Service - Cloud Native Bergen',
+  description:
+    'Terms of Service for Cloud Native Bergen conference and workshop services',
+}

--- a/src/app/(workshop)/workshop/page.tsx
+++ b/src/app/(workshop)/workshop/page.tsx
@@ -71,6 +71,13 @@ export default async function WorkshopPage() {
             <p className="mt-8 text-sm text-gray-600 dark:text-gray-400">
               By signing in, you agree to our{' '}
               <Link
+                href="/terms"
+                className="underline hover:text-blue-600 dark:hover:text-blue-400"
+              >
+                Terms of Service
+              </Link>{' '}
+              and{' '}
+              <Link
                 href="/privacy"
                 className="underline hover:text-blue-600 dark:hover:text-blue-400"
               >


### PR DESCRIPTION
- Add full Terms of Service page (multiple sections, metadata, contact info)
- Update privacy page: bump "Last updated" date and add WorkOS (AuthKit) details
  - Include WorkOS in personal data list, authentication services entries, US transfer note
  - Add WorkOS Authentication info card (SCCs, safeguards) and retention/processing table row
- Add explicit link to Terms on the workshop signup prompt