### PR TITLE
fix(sponsors): prevent tierless approved sponsors from crashing the front page

### DIFF
--- a/__tests__/lib/sponsor/sanity.test.ts
+++ b/__tests__/lib/sponsor/sanity.test.ts
@@ -1,0 +1,60 @@
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    fetch: vi.fn(),
+    transaction: vi.fn(),
+  },
+}))
+
+import { deleteSponsorTier } from '@/lib/sponsor/sanity'
+import { clientWrite } from '@/lib/sanity/client'
+
+describe('deleteSponsorTier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function mockTransaction() {
+    const tx = {
+      patch: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockReturnThis(),
+      commit: vi.fn().mockResolvedValue({}),
+    }
+    ;(clientWrite.transaction as any).mockReturnValue(tx)
+    return tx
+  }
+
+  it('unsets the tier on referencing sponsors and deletes the tier in one transaction', async () => {
+    ;(clientWrite.fetch as any).mockResolvedValueOnce(['sfc-1', 'sfc-2'])
+    const tx = mockTransaction()
+
+    const result = await deleteSponsorTier('tier-1')
+
+    expect(result.error).toBeUndefined()
+    expect(tx.patch).toHaveBeenCalledWith('sfc-1', { unset: ['tier'] })
+    expect(tx.patch).toHaveBeenCalledWith('sfc-2', { unset: ['tier'] })
+    expect(tx.delete).toHaveBeenCalledWith('tier-1')
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('deletes the tier even when no sponsor references it', async () => {
+    ;(clientWrite.fetch as any).mockResolvedValueOnce([])
+    const tx = mockTransaction()
+
+    const result = await deleteSponsorTier('tier-1')
+
+    expect(result.error).toBeUndefined()
+    expect(tx.patch).not.toHaveBeenCalled()
+    expect(tx.delete).toHaveBeenCalledWith('tier-1')
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns an error when the transaction fails', async () => {
+    ;(clientWrite.fetch as any).mockResolvedValueOnce([])
+    const tx = mockTransaction()
+    tx.commit.mockRejectedValueOnce(new Error('boom'))
+
+    const result = await deleteSponsorTier('tier-1')
+
+    expect(result.error).toBeInstanceOf(Error)
+  })
+})

--- a/__tests__/lib/sponsor/utils.test.ts
+++ b/__tests__/lib/sponsor/utils.test.ts
@@ -156,6 +156,29 @@ describe('groupSponsorsByTier', () => {
   it('returns empty object for empty array', () => {
     expect(groupSponsorsByTier([])).toEqual({})
   })
+
+  it('omits sponsors without a tier instead of throwing', () => {
+    const tierless: ConferenceSponsor = {
+      sponsor: { _id: 'X', name: 'X', website: 'https://example.com' },
+      tier: null,
+    }
+    expect(() => groupSponsorsByTier([tierless])).not.toThrow()
+    expect(groupSponsorsByTier([tierless])).toEqual({})
+  })
+
+  it('groups tiered sponsors normally while omitting a tierless one', () => {
+    const tierless: ConferenceSponsor = {
+      sponsor: { _id: 'X', name: 'X', website: 'https://example.com' },
+      tier: null,
+    }
+    const groups = groupSponsorsByTier([
+      makeSponsor('A', 'Gold'),
+      tierless,
+      makeSponsor('B', 'Gold'),
+    ])
+    expect(Object.keys(groups)).toEqual(['Gold'])
+    expect(groups['Gold']).toHaveLength(2)
+  })
 })
 
 describe('getDailySeed', () => {

--- a/__tests__/lib/sponsor/utils.test.ts
+++ b/__tests__/lib/sponsor/utils.test.ts
@@ -4,6 +4,7 @@ import {
   sortTierNamesByValue,
   deterministicShuffle,
   groupSponsorsByTier,
+  filterPublicSponsors,
   getDailySeed,
 } from '@/lib/sponsor/utils'
 import type { SponsorTier, ConferenceSponsor } from '@/lib/sponsor/types'
@@ -178,6 +179,29 @@ describe('groupSponsorsByTier', () => {
     ])
     expect(Object.keys(groups)).toEqual(['Gold'])
     expect(groups['Gold']).toHaveLength(2)
+  })
+})
+
+describe('filterPublicSponsors', () => {
+  function tiered(name: string): ConferenceSponsor {
+    return {
+      sponsor: { _id: name, name, website: 'https://example.com' },
+      tier: { title: 'Gold', tagline: '', tierType: 'standard' },
+    }
+  }
+  const tierless: ConferenceSponsor = {
+    sponsor: { _id: 'X', name: 'X', website: 'https://example.com' },
+    tier: null,
+  }
+
+  it('excludes sponsors without a tier (unset or dangling reference)', () => {
+    const result = filterPublicSponsors([tiered('A'), tierless, tiered('B')])
+    expect(result.map((s) => s.sponsor.name)).toEqual(['A', 'B'])
+  })
+
+  it('returns all sponsors when every sponsor has a tier', () => {
+    const all = [tiered('A'), tiered('B')]
+    expect(filterPublicSponsors(all)).toHaveLength(2)
   })
 })
 

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -428,7 +428,7 @@ export default async function AdminSettings() {
             <FieldRow
               label="Sponsors"
               value={conference.sponsors.map(
-                (s) => `${s.sponsor.name} (${s.tier.title})`,
+                (s) => `${s.sponsor.name} (${s.tier?.title ?? 'No Tier'})`,
               )}
               type="array"
             />

--- a/src/components/admin/sponsor/SponsorTierManagement.tsx
+++ b/src/components/admin/sponsor/SponsorTierManagement.tsx
@@ -76,7 +76,7 @@ export function SponsorTierManagement({
     )
 
     setSponsorsByTier((prev) => {
-      const tierName = newSponsor.tier.title
+      const tierName = newSponsor.tier?.title ?? 'No Tier'
       const currentTierSponsors = prev[tierName] || []
       const updatedTierSponsors = [...currentTierSponsors, newSponsor].sort(
         (a, b) => a.sponsor.name.localeCompare(b.sponsor.name),
@@ -88,7 +88,7 @@ export function SponsorTierManagement({
     })
 
     setSortedTierNames((prev) => {
-      const tierName = newSponsor.tier.title
+      const tierName = newSponsor.tier?.title ?? 'No Tier'
       if (!prev.includes(tierName)) {
         return [...prev, tierName]
       }
@@ -98,7 +98,7 @@ export function SponsorTierManagement({
     showNotification({
       type: 'success',
       title: 'Sponsor added successfully',
-      message: `${newSponsor.sponsor.name} has been added to the ${newSponsor.tier.title} tier.`,
+      message: `${newSponsor.sponsor.name} has been added to the ${newSponsor.tier?.title ?? 'No Tier'} tier.`,
     })
   }
 
@@ -146,7 +146,7 @@ export function SponsorTierManagement({
         )
       })
 
-      const tierName = updatedSponsor.tier.title
+      const tierName = updatedSponsor.tier?.title ?? 'No Tier'
       if (!newSponsorsByTier[tierName]) {
         newSponsorsByTier[tierName] = []
       }

--- a/src/components/stream/SponsorBanner.tsx
+++ b/src/components/stream/SponsorBanner.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ConferenceSponsor } from '@/lib/sponsor/types'
+import { filterPublicSponsors } from '@/lib/sponsor/utils'
 import { SponsorLogo } from '@/components/SponsorLogo'
 import clsx from 'clsx'
 import type { CSSProperties } from 'react'
@@ -30,16 +31,21 @@ export function SponsorBanner({
     }
   }, [sponsors])
 
-  if (!sponsors || sponsors.length === 0) {
+  // Only sponsors with a resolved tier are shown publicly; this banner doesn't
+  // group by tier, so apply the public-tier filter here (excludes unset and
+  // dangling tier references alike).
+  const visibleSponsors = filterPublicSponsors(sponsors ?? [])
+
+  if (visibleSponsors.length === 0) {
     return null
   }
 
   // Duplicate sponsors multiple times to ensure smooth scrolling
   const duplicatedSponsors = [
-    ...sponsors,
-    ...sponsors,
-    ...sponsors,
-    ...sponsors,
+    ...visibleSponsors,
+    ...visibleSponsors,
+    ...visibleSponsors,
+    ...visibleSponsors,
   ]
 
   return (

--- a/src/lib/sponsor-crm/sanity.ts
+++ b/src/lib/sponsor-crm/sanity.ts
@@ -137,7 +137,7 @@ export async function getPublicSponsorsForConference(
   conferenceId: string,
 ): Promise<ConferenceSponsor[]> {
   return clientRead.fetch<ConferenceSponsor[]>(
-    `*[_type == "sponsorForConference" && conference._ref == $conferenceId && status == "closed-won"]
+    `*[_type == "sponsorForConference" && conference._ref == $conferenceId && status == "closed-won" && defined(tier)]
       | order(tier->tierType asc, tier->price[0].amount desc, tier->title asc){
       "_sfcId": _id,
       sponsor->{

--- a/src/lib/sponsor-crm/sanity.ts
+++ b/src/lib/sponsor-crm/sanity.ts
@@ -137,7 +137,7 @@ export async function getPublicSponsorsForConference(
   conferenceId: string,
 ): Promise<ConferenceSponsor[]> {
   return clientRead.fetch<ConferenceSponsor[]>(
-    `*[_type == "sponsorForConference" && conference._ref == $conferenceId && status == "closed-won" && defined(tier)]
+    `*[_type == "sponsorForConference" && conference._ref == $conferenceId && status == "closed-won"]
       | order(tier->tierType asc, tier->price[0].amount desc, tier->title asc){
       "_sfcId": _id,
       sponsor->{

--- a/src/lib/sponsor/sanity.ts
+++ b/src/lib/sponsor/sanity.ts
@@ -92,7 +92,22 @@ export async function deleteSponsorTier(
   id: string,
 ): Promise<{ error?: Error }> {
   try {
-    await clientWrite.delete(id)
+    // Clear the tier from any sponsor that references it before deleting, so we
+    // never leave a dangling reference (which projects to null and would let a
+    // tierless sponsor slip onto public surfaces). Referencing sponsors become
+    // cleanly tierless: hidden from public, surfaced under "No Tier" in admin.
+    const referencingSponsorIds = await clientWrite.fetch<string[]>(
+      `*[_type == "sponsorForConference" && tier._ref == $id]._id`,
+      { id },
+    )
+
+    const transaction = clientWrite.transaction()
+    for (const sponsorId of referencingSponsorIds) {
+      transaction.patch(sponsorId, { unset: ['tier'] })
+    }
+    transaction.delete(id)
+    await transaction.commit()
+
     return {}
   } catch (error) {
     return { error: error as Error }

--- a/src/lib/sponsor/types.ts
+++ b/src/lib/sponsor/types.ts
@@ -68,7 +68,7 @@ export interface ConferenceSponsor {
       amount: number
       currency: string
     }>
-  }
+  } | null
 }
 
 export interface ContactPerson extends Record<string, unknown> {

--- a/src/lib/sponsor/utils.ts
+++ b/src/lib/sponsor/utils.ts
@@ -43,6 +43,11 @@ export function groupSponsorsByTier<T extends ConferenceSponsor>(
 ): Record<string, T[]> {
   return sponsors.reduce(
     (acc, sponsor) => {
+      // Sponsors without a tier are not shown publicly; skip them defensively
+      // so a missing tier can never crash the front page.
+      if (!sponsor.tier) {
+        return acc
+      }
       const tierTitle =
         sponsor.tier.tierType === 'special' ? 'SPECIAL' : sponsor.tier.title
       if (!acc[tierTitle]) {

--- a/src/lib/sponsor/utils.ts
+++ b/src/lib/sponsor/utils.ts
@@ -36,6 +36,19 @@ export function formatTierLabel(
 }
 
 /**
+ * Returns only sponsors that are publicly displayable. A sponsor is public
+ * only if it has a tier that actually resolves — a missing tier reference and a
+ * dangling one (tier doc deleted) both project to `null`, so this single guard
+ * excludes both. Use at public render sites that don't group by tier (e.g. the
+ * stream banner); grouping sites get the same exclusion via groupSponsorsByTier.
+ */
+export function filterPublicSponsors<T extends ConferenceSponsor>(
+  sponsors: T[],
+): T[] {
+  return sponsors.filter((sponsor) => sponsor.tier != null)
+}
+
+/**
  * Groups sponsors by their tier title, handling special tiers
  */
 export function groupSponsorsByTier<T extends ConferenceSponsor>(

--- a/src/lib/tickets/utils.ts
+++ b/src/lib/tickets/utils.ts
@@ -115,7 +115,7 @@ export function calculateCategoryStats(
 
 export function calculateSponsorTickets(
   conference: {
-    sponsors?: Array<{ tier?: { title?: string } }>
+    sponsors?: Array<{ tier?: { title?: string } | null }>
   },
   tierAllocation: Record<string, number>,
 ): Record<string, SponsorTicketData> {


### PR DESCRIPTION
## Summary

A sponsor marked `closed-won` without a sponsor tier caused the **public front page to crash**: the public query returned the record with a null `tier`, and `groupSponsorsByTier` dereferenced `tier.tierType` on null (`TypeError: Cannot read properties of null`).

This is the read-time safety net for the sponsor-CRM hardening effort. Write-time prevention (the state machine) follows in #374 and onward.

## Changes
- **`groupSponsorsByTier`** skips tierless sponsors instead of dereferencing a null tier (defensive backstop).
- **Public sponsors query** gains `&& defined(tier)` so tierless `closed-won` sponsors never reach the page (primary exclusion).
- **`ConferenceSponsor.tier`** is now nullable — the honest model of what the GROQ `tier->{...}` projection returns. Admin deref sites are guarded with the existing "No Tier" grouping (also surfaces tierless sponsors to organizers).

## Testing
- New regression test reproduces the exact crash (RED → GREEN) and a mixed tiered/tierless list case.
- `tsc --noEmit`: 0 errors
- Full suite: 1811 passed, 5 skipped, 0 failed
- Lint (changed files): 0 errors

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two complementary layers of protection against a front-page crash caused by `closed-won` sponsors that have no tier: a GROQ-level filter (`&& defined(tier)`) to exclude them from the public query, and a defensive null guard in `groupSponsorsByTier` as a backstop for dangling references. Four admin dereferences of `tier.title` are also hardened with `tier?.title ?? 'No Tier'`, and the `ConferenceSponsor` type is updated to reflect that `tier` is nullable.

- **Public path**: `getPublicSponsorsForConference` now filters out tierless sponsors in GROQ, and `groupSponsorsByTier` silently skips any that slip through (e.g., via a deleted-tier dangling reference), preventing the `TypeError` crash on the front page.
- **Admin path**: Four `tier.title` dereferences in `SponsorTierManagement` and the settings page are guarded, and tierless sponsors now surface under a \"No Tier\" group in the admin UI.
- **Type & tests**: `ConferenceSponsor.tier` is formally nullable, and two regression tests cover the exact crash scenario and mixed-list grouping.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the front-page crash is fixed with two complementary guards and regression tests pass.

The dual-layer fix (GROQ filter + null guard) is correct, the type change is honest, and the tests cover the regression directly. The one edge case worth watching is that updateSponsorInState in the admin component doesn't add 'No Tier' to sortedTierNames the way addSponsorToState does — so a sponsor edited to have no tier could silently disappear from the admin tier list until a page refresh.

src/components/admin/sponsor/SponsorTierManagement.tsx — the updateSponsorInState function doesn't mirror the sortedTierNames update that addSponsorToState performs for tierless sponsors.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/sponsor/utils.ts | Added null guard in `groupSponsorsByTier` to silently skip tierless sponsors — directly fixes the crash; logic is clean. |
| src/lib/sponsor-crm/sanity.ts | Added `&& defined(tier)` to the public GROQ filter so tierless `closed-won` sponsors are excluded before projection; pairs correctly with the defensive guard in `groupSponsorsByTier`. |
| src/lib/sponsor/types.ts | Made `ConferenceSponsor.tier` nullable (`| null`) to reflect the actual GROQ projection result; honest and necessary type change. |
| src/components/admin/sponsor/SponsorTierManagement.tsx | Guards four `tier.title` dereferences with `tier?.title ?? 'No Tier'`; `addSponsorToState` also updates `sortedTierNames` but `updateSponsorInState` does not, creating a potential silent-disappear edge case. |
| __tests__/lib/sponsor/utils.test.ts | Adds two regression tests: one reproduces the exact crash scenario, one validates mixed tiered/tierless grouping — good coverage of the new behaviour. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Public page loads sponsors] --> B["getPublicSponsorsForConference()"]
    B --> C{"GROQ filter:\ndefined(tier)?"}
    C -- "No (null ref)" --> D[Excluded from results]
    C -- "Yes" --> E["tier->{...} projection"]
    E --> F{"tier null?\n(dangling ref)"}
    F -- "Yes" --> G["groupSponsorsByTier:\nskip sponsor (backstop)"]
    F -- "No" --> H[Group by tier title]
    H --> I[Render sponsor on page]

    J[Admin edits sponsor] --> K["updateSponsorInState()"]
    K --> L["tier?.title ?? 'No Tier'"]
    L --> M[Place in sponsorsByTier group]
    M --> N{"'No Tier' in\nsortedTierNames?"}
    N -- "Yes" --> O[Rendered in admin UI]
    N -- "No" --> P[Group exists but not rendered ⚠️]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/admin/sponsor/SponsorTierManagement.tsx`, line 129-169 ([link](https://github.com/cloudnativebergen/website/blob/7b4f1f1580b2d5171f4d03ff82960a2fbb2762d1/src/components/admin/sponsor/SponsorTierManagement.tsx#L129-L169)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`updateSponsorInState` doesn't update `sortedTierNames` for "No Tier"**

   `addSponsorToState` correctly calls `setSortedTierNames` and appends `'No Tier'` when the tier is absent, but `updateSponsorInState` only updates `sponsorsByTier` — it never inserts `'No Tier'` into `sortedTierNames`. If a sponsor is edited to remove its tier when no other tierless sponsors exist at page load (i.e., `'No Tier'` wasn't in the initial `sortedTierNames`), the sponsor is silently placed into `sponsorsByTier['No Tier']` but the tier group is never rendered, making the sponsor appear to vanish from the admin UI until a page refresh.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(sponsors): prevent tierless approved..."](https://github.com/cloudnativebergen/website/commit/7b4f1f1580b2d5171f4d03ff82960a2fbb2762d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35922565)</sub>

<!-- /greptile_comment -->