### PR TITLE
feat(sponsor-crm): transition state machine + pipeline tier guard

### DIFF
--- a/__tests__/api/trpc/sponsor-move-stage.test.ts
+++ b/__tests__/api/trpc/sponsor-move-stage.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { appRouter } from '@/server/_app'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { getOrganizersByConference } from '@/lib/speaker/sanity'
+import {
+  getSponsorForConference,
+  updateSponsorForConference,
+} from '@/lib/sponsor-crm/sanity'
+import { logStageChange } from '@/lib/sponsor-crm/activity'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+vi.mock('@/lib/conference/sanity')
+vi.mock('@/lib/speaker/sanity')
+vi.mock('@/lib/sponsor-crm/sanity')
+vi.mock('@/lib/sponsor-crm/activity')
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
+
+const mockOrganizer = {
+  _id: 'org-1',
+  name: 'Org',
+  email: 'org@test.com',
+  isOrganizer: true,
+}
+const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+
+const tier: SponsorForConferenceExpanded['tier'] = {
+  _id: 'tier-gold',
+  title: 'Gold',
+  tagline: '',
+  tierType: 'standard',
+}
+
+function makeSfc(
+  overrides: Partial<SponsorForConferenceExpanded> = {},
+): SponsorForConferenceExpanded {
+  return {
+    _id: 'sfc-1',
+    _createdAt: '',
+    _updatedAt: '',
+    sponsor: { _id: 's1', name: 'Acme', website: 'https://acme.test', logo: '' },
+    conference: { _id: 'conf-1', title: 'Test Conf' },
+    contractStatus: 'none',
+    status: 'negotiating',
+    contractCurrency: 'NOK',
+    invoiceStatus: 'not-sent',
+    ...overrides,
+  }
+}
+
+const createCaller = (speaker: any) =>
+  appRouter.createCaller({
+    session: { user: { email: speaker.email }, speaker },
+    speaker,
+    user: { email: speaker.email },
+  } as any)
+
+describe('sponsor.crm.moveStage — tier guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
+      conference: mockConference as any,
+      domain: 'test.com',
+      error: null,
+    })
+    vi.mocked(getOrganizersByConference).mockResolvedValue({
+      speakers: [mockOrganizer] as any,
+      err: null,
+    })
+    vi.mocked(updateSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc(),
+      error: undefined,
+    })
+    vi.mocked(logStageChange).mockResolvedValue(undefined as any)
+  })
+
+  it('rejects moving to closed-won without a tier', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ tier: undefined, status: 'negotiating' }),
+      error: undefined,
+    })
+
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.moveStage({
+        id: 'sfc-1',
+        newStatus: 'closed-won',
+      }),
+    ).rejects.toThrow(/tier/i)
+
+    expect(updateSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('allows moving to closed-won when a tier is set', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ tier, status: 'negotiating' }),
+      error: undefined,
+    })
+
+    await createCaller(mockOrganizer).sponsor.crm.moveStage({
+      id: 'sfc-1',
+      newStatus: 'closed-won',
+    })
+
+    expect(updateSponsorForConference).toHaveBeenCalledWith('sfc-1', {
+      status: 'closed-won',
+    })
+  })
+
+  it('allows moving to closed-lost without a tier', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ tier: undefined, status: 'negotiating' }),
+      error: undefined,
+    })
+
+    await createCaller(mockOrganizer).sponsor.crm.moveStage({
+      id: 'sfc-1',
+      newStatus: 'closed-lost',
+    })
+
+    expect(updateSponsorForConference).toHaveBeenCalledWith('sfc-1', {
+      status: 'closed-lost',
+    })
+  })
+})

--- a/__tests__/api/trpc/sponsor-move-stage.test.ts
+++ b/__tests__/api/trpc/sponsor-move-stage.test.ts
@@ -7,6 +7,8 @@ import {
   updateSponsorForConference,
 } from '@/lib/sponsor-crm/sanity'
 import { logStageChange } from '@/lib/sponsor-crm/activity'
+import { extractMissingFields } from '@/server/errors'
+import { TRPCError } from '@trpc/server'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 
 vi.mock('@/lib/conference/sanity')
@@ -87,6 +89,28 @@ describe('sponsor.crm.moveStage — tier guard', () => {
     ).rejects.toThrow(/tier/i)
 
     expect(updateSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('rejects with a structured missingFields payload (not just a string message)', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ tier: undefined, status: 'negotiating' }),
+      error: undefined,
+    })
+
+    try {
+      await createCaller(mockOrganizer).sponsor.crm.moveStage({
+        id: 'sfc-1',
+        newStatus: 'closed-won',
+      })
+      expect.unreachable('moveStage should have rejected')
+    } catch (error) {
+      expect(error).toBeInstanceOf(TRPCError)
+      expect((error as TRPCError).code).toBe('PRECONDITION_FAILED')
+      const missing = extractMissingFields(error as TRPCError)
+      expect(missing).toBeDefined()
+      expect(missing?.[0]?.field).toBe('tier')
+      expect(missing?.[0]?.message).toMatch(/tier/i)
+    }
   })
 
   it('allows moving to closed-won when a tier is set', async () => {

--- a/__tests__/api/trpc/sponsor-move-stage.test.ts
+++ b/__tests__/api/trpc/sponsor-move-stage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { appRouter } from '@/server/_app'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { getOrganizersByConference } from '@/lib/speaker/sanity'
@@ -73,6 +73,10 @@ describe('sponsor.crm.moveStage — tier guard', () => {
       error: undefined,
     })
     vi.mocked(logStageChange).mockResolvedValue(undefined as any)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('rejects moving to closed-won without a tier', async () => {

--- a/__tests__/api/trpc/sponsor-move-stage.test.ts
+++ b/__tests__/api/trpc/sponsor-move-stage.test.ts
@@ -39,7 +39,12 @@ function makeSfc(
     _id: 'sfc-1',
     _createdAt: '',
     _updatedAt: '',
-    sponsor: { _id: 's1', name: 'Acme', website: 'https://acme.test', logo: '' },
+    sponsor: {
+      _id: 's1',
+      name: 'Acme',
+      website: 'https://acme.test',
+      logo: '',
+    },
     conference: { _id: 'conf-1', title: 'Test Conf' },
     contractStatus: 'none',
     status: 'negotiating',

--- a/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
@@ -45,7 +45,12 @@ function makeSfc(
     _id: 'sfc-1',
     _createdAt: '',
     _updatedAt: '',
-    sponsor: { _id: 's1', name: 'Acme', website: 'https://acme.test', logo: '' },
+    sponsor: {
+      _id: 's1',
+      name: 'Acme',
+      website: 'https://acme.test',
+      logo: '',
+    },
     conference: { _id: 'conf-1', title: 'Test Conf' },
     contractStatus: 'none',
     status: 'negotiating',
@@ -123,7 +128,10 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
   describe('update', () => {
     it('rejects moving an untiered sponsor to closed-won', async () => {
       vi.mocked(getSponsorForConference).mockResolvedValue({
-        sponsorForConference: makeSfc({ tier: undefined, status: 'negotiating' }),
+        sponsorForConference: makeSfc({
+          tier: undefined,
+          status: 'negotiating',
+        }),
         error: undefined,
       })
       await expect(
@@ -151,7 +159,10 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
 
     it('allows unrelated edits to a legacy tierless closed-won record (does not trap existing data)', async () => {
       vi.mocked(getSponsorForConference).mockResolvedValue({
-        sponsorForConference: makeSfc({ tier: undefined, status: 'closed-won' }),
+        sponsorForConference: makeSfc({
+          tier: undefined,
+          status: 'closed-won',
+        }),
         error: undefined,
       })
       await createCaller(mockOrganizer).sponsor.crm.update({
@@ -163,7 +174,10 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
 
     it('allows moving to closed-won when a tier is provided in the same update', async () => {
       vi.mocked(getSponsorForConference).mockResolvedValue({
-        sponsorForConference: makeSfc({ tier: undefined, status: 'negotiating' }),
+        sponsorForConference: makeSfc({
+          tier: undefined,
+          status: 'negotiating',
+        }),
         error: undefined,
       })
       await createCaller(mockOrganizer).sponsor.crm.update({
@@ -176,7 +190,10 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
 
     it('allows repairing a legacy tierless closed-won record by setting a tier', async () => {
       vi.mocked(getSponsorForConference).mockResolvedValue({
-        sponsorForConference: makeSfc({ tier: undefined, status: 'closed-won' }),
+        sponsorForConference: makeSfc({
+          tier: undefined,
+          status: 'closed-won',
+        }),
         error: undefined,
       })
       await createCaller(mockOrganizer).sponsor.crm.update({

--- a/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { appRouter } from '@/server/_app'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { getOrganizersByConference } from '@/lib/speaker/sanity'
@@ -87,6 +87,10 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
       updatedCount: 2,
       totalCount: 2,
     })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   describe('create', () => {

--- a/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { appRouter } from '@/server/_app'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { getOrganizersByConference } from '@/lib/speaker/sanity'
+import {
+  getSponsorForConference,
+  createSponsorForConference,
+  updateSponsorForConference,
+} from '@/lib/sponsor-crm/sanity'
+import { bulkUpdateSponsors } from '@/lib/sponsor-crm/bulk'
+import { clientReadUncached } from '@/lib/sanity/client'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+vi.mock('@/lib/conference/sanity')
+vi.mock('@/lib/speaker/sanity')
+vi.mock('@/lib/sponsor-crm/sanity')
+vi.mock('@/lib/sponsor-crm/activity')
+vi.mock('@/lib/sponsor-crm/bulk')
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: vi.fn(), patch: vi.fn(), transaction: vi.fn() },
+  clientReadUncached: { fetch: vi.fn() },
+  clientRead: { fetch: vi.fn() },
+}))
+
+const mockOrganizer = {
+  _id: 'org-1',
+  name: 'Org',
+  email: 'org@test.com',
+  isOrganizer: true,
+}
+const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+
+const tier: SponsorForConferenceExpanded['tier'] = {
+  _id: 'tier-gold',
+  title: 'Gold',
+  tagline: '',
+  tierType: 'standard',
+}
+
+function makeSfc(
+  overrides: Partial<SponsorForConferenceExpanded> = {},
+): SponsorForConferenceExpanded {
+  return {
+    _id: 'sfc-1',
+    _createdAt: '',
+    _updatedAt: '',
+    sponsor: { _id: 's1', name: 'Acme', website: 'https://acme.test', logo: '' },
+    conference: { _id: 'conf-1', title: 'Test Conf' },
+    contractStatus: 'none',
+    status: 'negotiating',
+    contractCurrency: 'NOK',
+    invoiceStatus: 'not-sent',
+    ...overrides,
+  }
+}
+
+const createCaller = (speaker: any) =>
+  appRouter.createCaller({
+    session: { user: { email: speaker.email }, speaker },
+    speaker,
+    user: { email: speaker.email },
+  } as any)
+
+describe('sponsor CRM pipeline tier invariant — all write paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
+      conference: mockConference as any,
+      domain: 'test.com',
+      error: null,
+    })
+    vi.mocked(getOrganizersByConference).mockResolvedValue({
+      speakers: [mockOrganizer] as any,
+      err: null,
+    })
+    vi.mocked(createSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ status: 'closed-won', tier }),
+      error: undefined,
+    })
+    vi.mocked(updateSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc(),
+      error: undefined,
+    })
+    vi.mocked(bulkUpdateSponsors).mockResolvedValue({
+      success: true,
+      updatedCount: 2,
+      totalCount: 2,
+    })
+  })
+
+  describe('create', () => {
+    it('rejects creating a closed-won sponsor without a tier', async () => {
+      await expect(
+        createCaller(mockOrganizer).sponsor.crm.create({
+          sponsor: 's1',
+          conference: 'conf-1',
+          status: 'closed-won',
+          contractStatus: 'none',
+          invoiceStatus: 'not-sent',
+        } as any),
+      ).rejects.toThrow(/tier/i)
+      expect(createSponsorForConference).not.toHaveBeenCalled()
+    })
+
+    it('allows creating a closed-won sponsor with a tier', async () => {
+      await createCaller(mockOrganizer).sponsor.crm.create({
+        sponsor: 's1',
+        conference: 'conf-1',
+        tier: 'tier-gold',
+        status: 'closed-won',
+        contractStatus: 'none',
+        invoiceStatus: 'not-sent',
+      } as any)
+      expect(createSponsorForConference).toHaveBeenCalled()
+    })
+  })
+
+  describe('update', () => {
+    it('rejects moving an untiered sponsor to closed-won', async () => {
+      vi.mocked(getSponsorForConference).mockResolvedValue({
+        sponsorForConference: makeSfc({ tier: undefined, status: 'negotiating' }),
+        error: undefined,
+      })
+      await expect(
+        createCaller(mockOrganizer).sponsor.crm.update({
+          id: 'sfc-1',
+          status: 'closed-won',
+        } as any),
+      ).rejects.toThrow(/tier/i)
+      expect(updateSponsorForConference).not.toHaveBeenCalled()
+    })
+
+    it('rejects clearing the tier of a closed-won sponsor', async () => {
+      vi.mocked(getSponsorForConference).mockResolvedValue({
+        sponsorForConference: makeSfc({ tier, status: 'closed-won' }),
+        error: undefined,
+      })
+      await expect(
+        createCaller(mockOrganizer).sponsor.crm.update({
+          id: 'sfc-1',
+          tier: '',
+        } as any),
+      ).rejects.toThrow(/tier/i)
+      expect(updateSponsorForConference).not.toHaveBeenCalled()
+    })
+
+    it('allows unrelated edits to a legacy tierless closed-won record (does not trap existing data)', async () => {
+      vi.mocked(getSponsorForConference).mockResolvedValue({
+        sponsorForConference: makeSfc({ tier: undefined, status: 'closed-won' }),
+        error: undefined,
+      })
+      await createCaller(mockOrganizer).sponsor.crm.update({
+        id: 'sfc-1',
+        notes: 'just a note',
+      } as any)
+      expect(updateSponsorForConference).toHaveBeenCalled()
+    })
+
+    it('allows moving to closed-won when a tier is provided in the same update', async () => {
+      vi.mocked(getSponsorForConference).mockResolvedValue({
+        sponsorForConference: makeSfc({ tier: undefined, status: 'negotiating' }),
+        error: undefined,
+      })
+      await createCaller(mockOrganizer).sponsor.crm.update({
+        id: 'sfc-1',
+        status: 'closed-won',
+        tier: 'tier-gold',
+      } as any)
+      expect(updateSponsorForConference).toHaveBeenCalled()
+    })
+
+    it('allows repairing a legacy tierless closed-won record by setting a tier', async () => {
+      vi.mocked(getSponsorForConference).mockResolvedValue({
+        sponsorForConference: makeSfc({ tier: undefined, status: 'closed-won' }),
+        error: undefined,
+      })
+      await createCaller(mockOrganizer).sponsor.crm.update({
+        id: 'sfc-1',
+        tier: 'tier-gold',
+      } as any)
+      expect(updateSponsorForConference).toHaveBeenCalled()
+    })
+  })
+
+  describe('bulkUpdate', () => {
+    it('rejects bulk-marking Won when a selected sponsor has no tier', async () => {
+      vi.mocked(clientReadUncached.fetch as any).mockResolvedValue(['b']) // 'b' is tierless
+      await expect(
+        createCaller(mockOrganizer).sponsor.crm.bulkUpdate({
+          ids: ['a', 'b'],
+          status: 'closed-won',
+        } as any),
+      ).rejects.toThrow(/tier/i)
+      expect(bulkUpdateSponsors).not.toHaveBeenCalled()
+    })
+
+    it('allows bulk-marking Won when every selected sponsor has a tier', async () => {
+      vi.mocked(clientReadUncached.fetch as any).mockResolvedValue([])
+      await createCaller(mockOrganizer).sponsor.crm.bulkUpdate({
+        ids: ['a', 'b'],
+        status: 'closed-won',
+      } as any)
+      expect(bulkUpdateSponsors).toHaveBeenCalled()
+    })
+  })
+})

--- a/__tests__/lib/sponsor-crm/state-machine.test.ts
+++ b/__tests__/lib/sponsor-crm/state-machine.test.ts
@@ -1,4 +1,7 @@
-import { canTransition } from '@/lib/sponsor-crm/state-machine'
+import {
+  canTransition,
+  checkPipelineState,
+} from '@/lib/sponsor-crm/state-machine'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 
 function makeSfc(
@@ -78,5 +81,37 @@ describe('canTransition — pipeline axis', () => {
     expect(
       canTransition('pipeline', 'contacted', 'negotiating', makeSfc()).ok,
     ).toBe(true)
+  })
+
+  it('treats a same-status move as an allowed no-op even when guards are unmet', () => {
+    const result = canTransition(
+      'pipeline',
+      'closed-won',
+      'closed-won',
+      makeSfc({ tier: undefined, status: 'closed-won' }),
+    )
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('checkPipelineState — direct state invariant', () => {
+  it('blocks a closed-won record without a tier', () => {
+    const result = checkPipelineState('closed-won', { tier: undefined })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing[0].field).toBe('tier')
+    }
+  })
+
+  it('allows a closed-won record with a tier reference id', () => {
+    expect(checkPipelineState('closed-won', { tier: 'tier-gold' }).ok).toBe(true)
+  })
+
+  it('allows non-won states without a tier', () => {
+    expect(checkPipelineState('negotiating', { tier: undefined }).ok).toBe(true)
+  })
+
+  it('treats an empty-string tier as no tier', () => {
+    expect(checkPipelineState('closed-won', { tier: '' }).ok).toBe(false)
   })
 })

--- a/__tests__/lib/sponsor-crm/state-machine.test.ts
+++ b/__tests__/lib/sponsor-crm/state-machine.test.ts
@@ -103,6 +103,19 @@ describe('checkPipelineState — direct state invariant', () => {
     }
   })
 
+  it('emits the shared MissingField shape (reuses the readiness pattern)', () => {
+    const result = checkPipelineState('closed-won', { tier: undefined })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing[0]).toMatchObject({
+        field: 'tier',
+        source: 'pipeline',
+        severity: 'required',
+      })
+      expect(result.missing[0].message).toMatch(/tier/i)
+    }
+  })
+
   it('allows a closed-won record with a tier reference id', () => {
     expect(checkPipelineState('closed-won', { tier: 'tier-gold' }).ok).toBe(true)
   })

--- a/__tests__/lib/sponsor-crm/state-machine.test.ts
+++ b/__tests__/lib/sponsor-crm/state-machine.test.ts
@@ -1,0 +1,82 @@
+import { canTransition } from '@/lib/sponsor-crm/state-machine'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+function makeSfc(
+  overrides: Partial<SponsorForConferenceExpanded> = {},
+): SponsorForConferenceExpanded {
+  return {
+    _id: 'sfc-1',
+    _createdAt: '',
+    _updatedAt: '',
+    sponsor: { _id: 's1', name: 'Acme', website: 'https://acme.test', logo: '' },
+    conference: { _id: 'c1', title: 'Test Conf' },
+    contractStatus: 'none',
+    status: 'negotiating',
+    contractCurrency: 'NOK',
+    invoiceStatus: 'not-sent',
+    ...overrides,
+  }
+}
+
+const tier: SponsorForConferenceExpanded['tier'] = {
+  _id: 'tier-gold',
+  title: 'Gold',
+  tagline: '',
+  tierType: 'standard',
+}
+
+describe('canTransition — pipeline axis', () => {
+  it('blocks moving to closed-won without a tier and reports the missing field', () => {
+    const result = canTransition(
+      'pipeline',
+      'negotiating',
+      'closed-won',
+      makeSfc({ tier: undefined }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing).toHaveLength(1)
+      expect(result.missing[0].field).toBe('tier')
+      expect(result.missing[0].message).toMatch(/tier/i)
+    }
+  })
+
+  it('allows moving to closed-won when a tier is set', () => {
+    const result = canTransition(
+      'pipeline',
+      'negotiating',
+      'closed-won',
+      makeSfc({ tier }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('never blocks moving to closed-lost, even without a tier', () => {
+    const result = canTransition(
+      'pipeline',
+      'negotiating',
+      'closed-lost',
+      makeSfc({ tier: undefined }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('allows backward moves out of closed-won without any field guard', () => {
+    const result = canTransition(
+      'pipeline',
+      'closed-won',
+      'negotiating',
+      makeSfc({ tier: undefined, status: 'closed-won' }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('allows ordinary forward moves between early stages', () => {
+    expect(
+      canTransition('pipeline', 'prospect', 'contacted', makeSfc()).ok,
+    ).toBe(true)
+    expect(
+      canTransition('pipeline', 'contacted', 'negotiating', makeSfc()).ok,
+    ).toBe(true)
+  })
+})

--- a/__tests__/lib/sponsor-crm/state-machine.test.ts
+++ b/__tests__/lib/sponsor-crm/state-machine.test.ts
@@ -11,7 +11,12 @@ function makeSfc(
     _id: 'sfc-1',
     _createdAt: '',
     _updatedAt: '',
-    sponsor: { _id: 's1', name: 'Acme', website: 'https://acme.test', logo: '' },
+    sponsor: {
+      _id: 's1',
+      name: 'Acme',
+      website: 'https://acme.test',
+      logo: '',
+    },
     conference: { _id: 'c1', title: 'Test Conf' },
     contractStatus: 'none',
     status: 'negotiating',
@@ -117,7 +122,9 @@ describe('checkPipelineState — direct state invariant', () => {
   })
 
   it('allows a closed-won record with a tier reference id', () => {
-    expect(checkPipelineState('closed-won', { tier: 'tier-gold' }).ok).toBe(true)
+    expect(checkPipelineState('closed-won', { tier: 'tier-gold' }).ok).toBe(
+      true,
+    )
   })
 
   it('allows non-won states without a tier', () => {

--- a/__tests__/lib/sponsor-crm/tier-validation.test.ts
+++ b/__tests__/lib/sponsor-crm/tier-validation.test.ts
@@ -22,7 +22,9 @@ describe('closedWonTierWarning', () => {
   })
 
   it('passes when the closed-won tier reference resolves to an existing doc', async () => {
-    expect(await closedWonTierWarning('closed-won', 'tier-x', exists)).toBe(true)
+    expect(await closedWonTierWarning('closed-won', 'tier-x', exists)).toBe(
+      true,
+    )
   })
 
   it('skips the existence check when there is no tier reference', async () => {

--- a/__tests__/lib/sponsor-crm/tier-validation.test.ts
+++ b/__tests__/lib/sponsor-crm/tier-validation.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { closedWonTierWarning } from '@/lib/sponsor-crm/tier-validation'
+
+const exists = () => Promise.resolve(true)
+const absent = () => Promise.resolve(false)
+
+describe('closedWonTierWarning', () => {
+  it('passes for non-closed-won statuses regardless of tier', async () => {
+    expect(await closedWonTierWarning('negotiating', undefined, absent)).toBe(
+      true,
+    )
+  })
+
+  it('warns when a closed-won sponsor has no tier reference', async () => {
+    const result = await closedWonTierWarning('closed-won', undefined, exists)
+    expect(result).toMatch(/tier/i)
+  })
+
+  it('warns when the closed-won tier reference is dangling (doc deleted)', async () => {
+    const result = await closedWonTierWarning('closed-won', 'tier-x', absent)
+    expect(result).toMatch(/no longer exists/i)
+  })
+
+  it('passes when the closed-won tier reference resolves to an existing doc', async () => {
+    expect(await closedWonTierWarning('closed-won', 'tier-x', exists)).toBe(true)
+  })
+
+  it('skips the existence check when there is no tier reference', async () => {
+    const check = vi.fn().mockResolvedValue(true)
+    await closedWonTierWarning('closed-won', undefined, check)
+    expect(check).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/server/errors.test.ts
+++ b/__tests__/server/errors.test.ts
@@ -37,7 +37,10 @@ describe('extractMissingFields', () => {
 describe('structuredErrorData', () => {
   it('exposes code and missingFields when the cause carries them', () => {
     const data = structuredErrorData(preconditionFailed(missing))
-    expect(data).toEqual({ code: 'PRECONDITION_FAILED', missingFields: missing })
+    expect(data).toEqual({
+      code: 'PRECONDITION_FAILED',
+      missingFields: missing,
+    })
   })
 
   it('exposes only the code for ordinary errors', () => {

--- a/__tests__/server/errors.test.ts
+++ b/__tests__/server/errors.test.ts
@@ -5,8 +5,17 @@ import {
   extractMissingFields,
   structuredErrorData,
 } from '@/server/errors'
+import type { MissingField } from '@/lib/sponsor-crm/contract-readiness'
 
-const missing = [{ field: 'tier', message: 'Set a sponsor tier first.' }]
+const missing: MissingField[] = [
+  {
+    field: 'tier',
+    label: 'Sponsor tier',
+    source: 'pipeline',
+    severity: 'required',
+    message: 'Set a sponsor tier first.',
+  },
+]
 
 describe('preconditionFailed', () => {
   it('builds a PRECONDITION_FAILED TRPCError carrying structured missing fields', () => {

--- a/__tests__/server/errors.test.ts
+++ b/__tests__/server/errors.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { TRPCError } from '@trpc/server'
+import {
+  preconditionFailed,
+  extractMissingFields,
+  structuredErrorData,
+} from '@/server/errors'
+
+const missing = [{ field: 'tier', message: 'Set a sponsor tier first.' }]
+
+describe('preconditionFailed', () => {
+  it('builds a PRECONDITION_FAILED TRPCError carrying structured missing fields', () => {
+    const err = preconditionFailed(missing)
+    expect(err).toBeInstanceOf(TRPCError)
+    expect(err.code).toBe('PRECONDITION_FAILED')
+    expect(err.message).toMatch(/tier/i)
+    expect(extractMissingFields(err)).toEqual(missing)
+  })
+})
+
+describe('extractMissingFields', () => {
+  it('returns undefined for an error without a structured cause', () => {
+    const err = new TRPCError({ code: 'NOT_FOUND', message: 'nope' })
+    expect(extractMissingFields(err)).toBeUndefined()
+  })
+})
+
+describe('structuredErrorData', () => {
+  it('exposes code and missingFields when the cause carries them', () => {
+    const data = structuredErrorData(preconditionFailed(missing))
+    expect(data).toEqual({ code: 'PRECONDITION_FAILED', missingFields: missing })
+  })
+
+  it('exposes only the code for ordinary errors', () => {
+    const data = structuredErrorData(
+      new TRPCError({ code: 'BAD_REQUEST', message: 'bad' }),
+    )
+    expect(data).toEqual({ code: 'BAD_REQUEST' })
+  })
+})

--- a/sanity/schemaTypes/sponsorForConference.ts
+++ b/sanity/schemaTypes/sponsorForConference.ts
@@ -1,6 +1,8 @@
 import { defineField, defineType } from 'sanity'
 import { CONTACT_ROLE_OPTIONS } from '../../src/lib/sponsor/types'
+import { closedWonTierWarning } from '../../src/lib/sponsor-crm/tier-validation'
 import { CURRENCY_OPTIONS } from './constants'
+import { apiVersion } from '../env'
 
 const SPONSOR_TAGS = [
   'warm-lead',
@@ -47,17 +49,24 @@ export default defineType({
           }
         },
       },
-      // Non-blocking warning: a closed-won sponsor without a tier is hidden from
-      // the public site until one is set. Mirrors the tRPC moveStage guard for
-      // edits made directly in the Studio (which bypass the API).
+      // Non-blocking warning: a closed-won sponsor that is effectively untiered
+      // is hidden from the public site. "Effectively untiered" covers a missing
+      // tier reference AND a dangling one (the tier doc was deleted) — a dangling
+      // ref is still a truthy { _ref }, so existence must be checked. Mirrors the
+      // tRPC guards for edits made directly in the Studio (which bypass the API).
       validation: (Rule) =>
         Rule.custom((tier, context) => {
           const status = (context.document as { status?: string } | undefined)
             ?.status
-          if (status === 'closed-won' && !tier) {
-            return 'Closed-won sponsors should have a tier — they stay hidden from the public site until one is set.'
-          }
-          return true
+          const tierRef = (tier as { _ref?: string } | undefined)?._ref
+          const client = context.getClient({ apiVersion })
+          return closedWonTierWarning(status, tierRef, async (ref) => {
+            const baseId = ref.replace(/^drafts\./, '')
+            return client.fetch<boolean>(
+              'count(*[_id == $id || _id == $draftId]) > 0',
+              { id: baseId, draftId: `drafts.${baseId}` },
+            )
+          })
         }).warning(),
     }),
     defineField({

--- a/sanity/schemaTypes/sponsorForConference.ts
+++ b/sanity/schemaTypes/sponsorForConference.ts
@@ -47,6 +47,18 @@ export default defineType({
           }
         },
       },
+      // Non-blocking warning: a closed-won sponsor without a tier is hidden from
+      // the public site until one is set. Mirrors the tRPC moveStage guard for
+      // edits made directly in the Studio (which bypass the API).
+      validation: (Rule) =>
+        Rule.custom((tier, context) => {
+          const status = (context.document as { status?: string } | undefined)
+            ?.status
+          if (status === 'closed-won' && !tier) {
+            return 'Closed-won sponsors should have a tier — they stay hidden from the public site until one is set.'
+          }
+          return true
+        }).warning(),
     }),
     defineField({
       name: 'addons',

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -147,15 +147,18 @@ export function useSponsorDragDrop(currentView: BoardView) {
         for (const [key, data] of previousDataRef.current) {
           queryClient.setQueryData(key, data)
         }
-        // Surface why the move was rejected (e.g. a required field is missing)
-        // instead of silently snapping the card back.
+        // Surface why the move was rejected. For a guard rejection
+        // (PRECONDITION_FAILED) the server message is user-facing and actionable;
+        // for transient/internal errors show a generic message instead of
+        // leaking a raw client error string.
+        const code = (error as { data?: { code?: string } } | null)?.data?.code
         showNotification({
           type: 'error',
           title: 'Could not move sponsor',
           message:
-            error instanceof Error
+            code === 'PRECONDITION_FAILED' && error instanceof Error
               ? error.message
-              : 'Failed to update sponsor status.',
+              : 'Failed to update sponsor status. Please try again.',
         })
       } finally {
         previousDataRef.current = []

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -3,6 +3,7 @@ import { DragStartEvent, DragEndEvent } from '@dnd-kit/core'
 import { useQueryClient, type QueryKey } from '@tanstack/react-query'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 import { BoardView } from '@/components/admin/sponsor-crm/BoardViewSwitcher'
+import { useNotification } from '@/components/admin/NotificationProvider'
 import { api } from '@/lib/trpc/client'
 
 interface DragItem {
@@ -50,6 +51,7 @@ export function useSponsorDragDrop(currentView: BoardView) {
   const [activeItem, setActiveItem] = useState<DragItem | null>(null)
   const utils = api.useUtils()
   const queryClient = useQueryClient()
+  const { showNotification } = useNotification()
   const previousDataRef = useRef<CachedQueryEntry[]>([])
 
   const moveStage = api.sponsor.crm.moveStage.useMutation()
@@ -145,6 +147,16 @@ export function useSponsorDragDrop(currentView: BoardView) {
         for (const [key, data] of previousDataRef.current) {
           queryClient.setQueryData(key, data)
         }
+        // Surface why the move was rejected (e.g. a required field is missing)
+        // instead of silently snapping the card back.
+        showNotification({
+          type: 'error',
+          title: 'Could not move sponsor',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Failed to update sponsor status.',
+        })
       } finally {
         previousDataRef.current = []
       }
@@ -159,6 +171,7 @@ export function useSponsorDragDrop(currentView: BoardView) {
       updateContractStatus,
       utils,
       queryClient,
+      showNotification,
     ],
   )
 

--- a/src/lib/sponsor-crm/contract-readiness.ts
+++ b/src/lib/sponsor-crm/contract-readiness.ts
@@ -8,6 +8,8 @@ export interface MissingField {
   label: string
   source: ReadinessSource
   severity: ReadinessSeverity
+  /** Actionable, user-facing sentence. Falls back to `label` where absent. */
+  message?: string
 }
 
 export interface ContractReadiness {
@@ -16,12 +18,38 @@ export interface ContractReadiness {
   missing: MissingField[]
 }
 
-interface FieldDef {
+/**
+ * A required/recommended field and how to check it. Generic over the subject so
+ * the same model serves both contract readiness (the expanded record) and the
+ * transition state machine (a narrower state view).
+ */
+export interface FieldDef<T = SponsorForConferenceExpanded> {
   field: string
   label: string
   source: ReadinessSource
   severity: ReadinessSeverity
-  check: (sfc: SponsorForConferenceExpanded) => boolean
+  message?: string
+  check: (subject: T) => boolean
+}
+
+/**
+ * Evaluates field definitions against a subject and returns the structured
+ * MissingField records for those whose check fails. Shared by the contract
+ * readiness check and the transition state machine so both speak one model.
+ */
+export function collectMissing<T>(
+  defs: FieldDef<T>[],
+  subject: T,
+): MissingField[] {
+  return defs
+    .filter((def) => !def.check(subject))
+    .map(({ field, label, source, severity, message }) => ({
+      field,
+      label,
+      source,
+      severity,
+      ...(message ? { message } : {}),
+    }))
 }
 
 const ORGANIZER_FIELDS: FieldDef[] = [
@@ -119,19 +147,10 @@ const PIPELINE_FIELDS: FieldDef[] = [
 export function checkContractReadiness(
   sfc: SponsorForConferenceExpanded,
 ): ContractReadiness {
-  const missing: MissingField[] = []
-
-  const ALL_FIELDS = [
-    ...ORGANIZER_FIELDS,
-    ...SPONSOR_FIELDS,
-    ...PIPELINE_FIELDS,
-  ]
-
-  for (const { field, label, source, severity, check } of ALL_FIELDS) {
-    if (!check(sfc)) {
-      missing.push({ field, label, source, severity })
-    }
-  }
+  const missing = collectMissing(
+    [...ORGANIZER_FIELDS, ...SPONSOR_FIELDS, ...PIPELINE_FIELDS],
+    sfc,
+  )
 
   const allRequiredPresent = !missing.some((m) => m.severity === 'required')
 

--- a/src/lib/sponsor-crm/state-machine.ts
+++ b/src/lib/sponsor-crm/state-machine.ts
@@ -1,0 +1,64 @@
+import type { SponsorForConferenceExpanded } from './types'
+
+/**
+ * The sponsor record moves along several independent axes (pipeline status,
+ * contract status, etc.). Each axis is its own coordinated state machine.
+ * Only the pipeline axis is implemented today; contract/signature/invoice
+ * axes are added in later slices.
+ */
+export type TransitionAxis = 'pipeline'
+
+/** A required field that is missing for a guarded transition. */
+export interface MissingRequirement {
+  field: string
+  message: string
+}
+
+export type TransitionResult =
+  | { ok: true }
+  | { ok: false; missing: MissingRequirement[] }
+
+interface FieldGuard {
+  field: string
+  message: string
+  satisfied: (sponsor: SponsorForConferenceExpanded) => boolean
+}
+
+/**
+ * Permissive-with-guards: every transition is allowed unless the target state
+ * carries required-field guards. Backward moves and unguarded targets always
+ * pass. Keyed by target state.
+ */
+const PIPELINE_GUARDS: Record<string, FieldGuard[]> = {
+  'closed-won': [
+    {
+      field: 'tier',
+      message:
+        'Set a sponsor tier before marking as Won — untiered sponsors are hidden from the public site.',
+      satisfied: (sponsor) => sponsor.tier != null,
+    },
+  ],
+}
+
+const GUARDS: Record<TransitionAxis, Record<string, FieldGuard[]>> = {
+  pipeline: PIPELINE_GUARDS,
+}
+
+/**
+ * Decides whether `sponsor` may move along `axis` from `from` to `to`.
+ * Returns `{ ok: true }` when allowed, or `{ ok: false, missing }` listing the
+ * required fields (with user-facing messages) that block the transition.
+ */
+export function canTransition(
+  axis: TransitionAxis,
+  from: string,
+  to: string,
+  sponsor: SponsorForConferenceExpanded,
+): TransitionResult {
+  const guards = GUARDS[axis][to] ?? []
+  const missing = guards
+    .filter((guard) => !guard.satisfied(sponsor))
+    .map(({ field, message }) => ({ field, message }))
+
+  return missing.length === 0 ? { ok: true } : { ok: false, missing }
+}

--- a/src/lib/sponsor-crm/state-machine.ts
+++ b/src/lib/sponsor-crm/state-machine.ts
@@ -45,10 +45,12 @@ const PIPELINE_GUARDS: Record<string, FieldDef<SponsorState>[]> = {
   ],
 }
 
-const GUARDS: Record<TransitionAxis, Record<string, FieldDef<SponsorState>[]>> =
-  {
-    pipeline: PIPELINE_GUARDS,
-  }
+const GUARDS: Record<
+  TransitionAxis,
+  Record<string, FieldDef<SponsorState>[]>
+> = {
+  pipeline: PIPELINE_GUARDS,
+}
 
 function evaluate(
   axis: TransitionAxis,

--- a/src/lib/sponsor-crm/state-machine.ts
+++ b/src/lib/sponsor-crm/state-machine.ts
@@ -1,3 +1,9 @@
+import {
+  collectMissing,
+  type FieldDef,
+  type MissingField,
+} from './contract-readiness'
+
 /**
  * The sponsor record moves along several independent axes (pipeline status,
  * contract status, etc.). Each axis is its own coordinated state machine.
@@ -5,16 +11,6 @@
  * axes are added in later slices.
  */
 export type TransitionAxis = 'pipeline'
-
-/** A required field that is missing for a guarded transition. */
-export interface MissingRequirement {
-  field: string
-  message: string
-}
-
-export type TransitionResult =
-  | { ok: true }
-  | { ok: false; missing: MissingRequirement[] }
 
 /**
  * The slice of a sponsor record the guards read. A tier may arrive as the
@@ -25,41 +21,41 @@ export interface SponsorState {
   tier?: { _id?: string } | string | null
 }
 
-interface FieldGuard {
-  field: string
-  message: string
-  satisfied: (sponsor: SponsorState) => boolean
-}
+export type TransitionResult =
+  | { ok: true }
+  | { ok: false; missing: MissingField[] }
 
 /**
  * Permissive-with-guards: every state is allowed unless it carries required
  * fields. Keyed by the state being entered. Unguarded states always pass.
+ * Guards reuse the shared readiness FieldDef model so UI and server agree on
+ * one definition of "required fields".
  */
-const PIPELINE_GUARDS: Record<string, FieldGuard[]> = {
+const PIPELINE_GUARDS: Record<string, FieldDef<SponsorState>[]> = {
   'closed-won': [
     {
       field: 'tier',
+      label: 'Sponsor tier',
+      source: 'pipeline',
+      severity: 'required',
       message:
         'Set a sponsor tier before marking as Won — untiered sponsors are hidden from the public site.',
-      satisfied: (sponsor) => Boolean(sponsor.tier),
+      check: (sponsor) => Boolean(sponsor.tier),
     },
   ],
 }
 
-const GUARDS: Record<TransitionAxis, Record<string, FieldGuard[]>> = {
-  pipeline: PIPELINE_GUARDS,
-}
+const GUARDS: Record<TransitionAxis, Record<string, FieldDef<SponsorState>[]>> =
+  {
+    pipeline: PIPELINE_GUARDS,
+  }
 
 function evaluate(
   axis: TransitionAxis,
   state: string,
   sponsor: SponsorState,
 ): TransitionResult {
-  const guards = (GUARDS[axis] ?? {})[state] ?? []
-  const missing = guards
-    .filter((guard) => !guard.satisfied(sponsor))
-    .map(({ field, message }) => ({ field, message }))
-
+  const missing = collectMissing((GUARDS[axis] ?? {})[state] ?? [], sponsor)
   return missing.length === 0 ? { ok: true } : { ok: false, missing }
 }
 

--- a/src/lib/sponsor-crm/state-machine.ts
+++ b/src/lib/sponsor-crm/state-machine.ts
@@ -1,5 +1,3 @@
-import type { SponsorForConferenceExpanded } from './types'
-
 /**
  * The sponsor record moves along several independent axes (pipeline status,
  * contract status, etc.). Each axis is its own coordinated state machine.
@@ -18,16 +16,24 @@ export type TransitionResult =
   | { ok: true }
   | { ok: false; missing: MissingRequirement[] }
 
+/**
+ * The slice of a sponsor record the guards read. A tier may arrive as the
+ * dereferenced object (read paths), a reference id string (create/update
+ * input), or be absent/cleared — all are normalised by truthiness.
+ */
+export interface SponsorState {
+  tier?: { _id?: string } | string | null
+}
+
 interface FieldGuard {
   field: string
   message: string
-  satisfied: (sponsor: SponsorForConferenceExpanded) => boolean
+  satisfied: (sponsor: SponsorState) => boolean
 }
 
 /**
- * Permissive-with-guards: every transition is allowed unless the target state
- * carries required-field guards. Backward moves and unguarded targets always
- * pass. Keyed by target state.
+ * Permissive-with-guards: every state is allowed unless it carries required
+ * fields. Keyed by the state being entered. Unguarded states always pass.
  */
 const PIPELINE_GUARDS: Record<string, FieldGuard[]> = {
   'closed-won': [
@@ -35,7 +41,7 @@ const PIPELINE_GUARDS: Record<string, FieldGuard[]> = {
       field: 'tier',
       message:
         'Set a sponsor tier before marking as Won — untiered sponsors are hidden from the public site.',
-      satisfied: (sponsor) => sponsor.tier != null,
+      satisfied: (sponsor) => Boolean(sponsor.tier),
     },
   ],
 }
@@ -44,21 +50,45 @@ const GUARDS: Record<TransitionAxis, Record<string, FieldGuard[]>> = {
   pipeline: PIPELINE_GUARDS,
 }
 
-/**
- * Decides whether `sponsor` may move along `axis` from `from` to `to`.
- * Returns `{ ok: true }` when allowed, or `{ ok: false, missing }` listing the
- * required fields (with user-facing messages) that block the transition.
- */
-export function canTransition(
+function evaluate(
   axis: TransitionAxis,
-  from: string,
-  to: string,
-  sponsor: SponsorForConferenceExpanded,
+  state: string,
+  sponsor: SponsorState,
 ): TransitionResult {
-  const guards = GUARDS[axis][to] ?? []
+  const guards = (GUARDS[axis] ?? {})[state] ?? []
   const missing = guards
     .filter((guard) => !guard.satisfied(sponsor))
     .map(({ field, message }) => ({ field, message }))
 
   return missing.length === 0 ? { ok: true } : { ok: false, missing }
+}
+
+/**
+ * Decides whether `sponsor` may move along `axis` from `from` to `to`.
+ * A same-state move is a no-op and always allowed (nothing changes, so there
+ * is nothing to guard). Otherwise the target state's required-field guards
+ * must be satisfied. Returns `{ ok: false, missing }` listing the blocking
+ * fields with user-facing messages.
+ */
+export function canTransition(
+  axis: TransitionAxis,
+  from: string,
+  to: string,
+  sponsor: SponsorState,
+): TransitionResult {
+  if (from === to) return { ok: true }
+  return evaluate(axis, to, sponsor)
+}
+
+/**
+ * Validates that a record resting in pipeline `status` satisfies that state's
+ * required-field invariants, independent of any transition. Use at direct
+ * write paths (create / update / bulk) that set status without going through
+ * a transition, so the same rule is enforced however the state is reached.
+ */
+export function checkPipelineState(
+  status: string,
+  sponsor: SponsorState,
+): TransitionResult {
+  return evaluate('pipeline', status, sponsor)
 }

--- a/src/lib/sponsor-crm/tier-validation.ts
+++ b/src/lib/sponsor-crm/tier-validation.ts
@@ -1,0 +1,24 @@
+export const MISSING_TIER_WARNING =
+  'Closed-won sponsors should have a tier — they stay hidden from the public site until one is set.'
+
+export const DANGLING_TIER_WARNING =
+  'Selected tier no longer exists — choose a valid tier, or the sponsor stays hidden from the public site.'
+
+/**
+ * Decides the non-blocking Studio warning for a closed-won sponsor's tier.
+ *
+ * A closed-won sponsor is hidden from the public site unless it has a tier that
+ * actually resolves. That means both a *missing* reference and a *dangling* one
+ * (the tier document was deleted) must warn — a dangling ref is still a truthy
+ * `{ _ref }` object, so a plain falsiness check would miss it. Existence is
+ * injected so this stays pure and testable without the Studio client.
+ */
+export async function closedWonTierWarning(
+  status: string | undefined,
+  tierRef: string | undefined,
+  tierExists: (ref: string) => Promise<boolean>,
+): Promise<true | string> {
+  if (status !== 'closed-won') return true
+  if (!tierRef) return MISSING_TIER_WARNING
+  return (await tierExists(tierRef)) ? true : DANGLING_TIER_WARNING
+}

--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -1,5 +1,7 @@
 import { TRPCError } from '@trpc/server'
-import type { MissingRequirement } from '@/lib/sponsor-crm/state-machine'
+import type { MissingField } from '@/lib/sponsor-crm/contract-readiness'
+
+const describe = (field: MissingField) => field.message ?? field.label
 
 /**
  * Error carrying structured missing-field requirements. Attached as the `cause`
@@ -7,21 +9,21 @@ import type { MissingRequirement } from '@/lib/sponsor-crm/state-machine'
  * client via the tRPC error formatter, rather than being flattened to a string.
  */
 export class MissingFieldsError extends Error {
-  constructor(public readonly missingFields: MissingRequirement[]) {
-    super(missingFields.map((field) => field.message).join(' '))
+  constructor(public readonly missingFields: MissingField[]) {
+    super(missingFields.map(describe).join(' '))
     this.name = 'MissingFieldsError'
   }
 }
 
 /**
- * Builds a PRECONDITION_FAILED error from a list of missing requirements. The
+ * Builds a PRECONDITION_FAILED error from a list of missing fields. The
  * human-readable `message` is preserved for callers that only read it, while
  * the structured `missingFields` ride along on the cause.
  */
-export function preconditionFailed(missing: MissingRequirement[]): TRPCError {
+export function preconditionFailed(missing: MissingField[]): TRPCError {
   return new TRPCError({
     code: 'PRECONDITION_FAILED',
-    message: missing.map((field) => field.message).join(' '),
+    message: missing.map(describe).join(' '),
     cause: new MissingFieldsError(missing),
   })
 }
@@ -29,7 +31,7 @@ export function preconditionFailed(missing: MissingRequirement[]): TRPCError {
 /** Returns the structured missing fields carried by an error, if any. */
 export function extractMissingFields(error: {
   cause?: unknown
-}): MissingRequirement[] | undefined {
+}): MissingField[] | undefined {
   return error.cause instanceof MissingFieldsError
     ? error.cause.missingFields
     : undefined

--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -1,0 +1,52 @@
+import { TRPCError } from '@trpc/server'
+import type { MissingRequirement } from '@/lib/sponsor-crm/state-machine'
+
+/**
+ * Error carrying structured missing-field requirements. Attached as the `cause`
+ * of a PRECONDITION_FAILED TRPCError so the structured payload survives to the
+ * client via the tRPC error formatter, rather than being flattened to a string.
+ */
+export class MissingFieldsError extends Error {
+  constructor(public readonly missingFields: MissingRequirement[]) {
+    super(missingFields.map((field) => field.message).join(' '))
+    this.name = 'MissingFieldsError'
+  }
+}
+
+/**
+ * Builds a PRECONDITION_FAILED error from a list of missing requirements. The
+ * human-readable `message` is preserved for callers that only read it, while
+ * the structured `missingFields` ride along on the cause.
+ */
+export function preconditionFailed(missing: MissingRequirement[]): TRPCError {
+  return new TRPCError({
+    code: 'PRECONDITION_FAILED',
+    message: missing.map((field) => field.message).join(' '),
+    cause: new MissingFieldsError(missing),
+  })
+}
+
+/** Returns the structured missing fields carried by an error, if any. */
+export function extractMissingFields(error: {
+  cause?: unknown
+}): MissingRequirement[] | undefined {
+  return error.cause instanceof MissingFieldsError
+    ? error.cause.missingFields
+    : undefined
+}
+
+/**
+ * The fields the tRPC error formatter merges into `shape.data`: always the
+ * error `code`, plus the structured `missingFields` payload when the error
+ * carries them. Kept separate from the formatter so it is trivially testable.
+ */
+export function structuredErrorData(error: {
+  code: string
+  cause?: unknown
+}): Record<string, unknown> {
+  const missingFields = extractMissingFields(error)
+  return {
+    code: error.code,
+    ...(missingFields ? { missingFields } : {}),
+  }
+}

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -117,6 +117,7 @@ import {
   canTransition,
   checkPipelineState,
 } from '@/lib/sponsor-crm/state-machine'
+import { preconditionFailed } from '@/server/errors'
 import { UpdateSignatureStatusSchema } from '@/server/schemas/sponsorForConference'
 import {
   getSigningProvider,
@@ -743,10 +744,7 @@ export const sponsorRouter = router({
         // just on drag-drop moves (closed-won requires a tier).
         const createCheck = checkPipelineState(data.status, { tier: data.tier })
         if (!createCheck.ok) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: createCheck.missing.map((m) => m.message).join(' '),
-          })
+          throw preconditionFailed(createCheck.missing)
         }
 
         // Auto-assign to current user if not provided (undefined)
@@ -825,10 +823,7 @@ export const sponsorRouter = router({
             tier: resultingTier,
           })
           if (!updateCheck.ok) {
-            throw new TRPCError({
-              code: 'PRECONDITION_FAILED',
-              message: updateCheck.missing.map((m) => m.message).join(' '),
-            })
+            throw preconditionFailed(updateCheck.missing)
           }
         }
 
@@ -946,10 +941,7 @@ export const sponsorRouter = router({
           existing,
         )
         if (!transition.ok) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: transition.missing.map((m) => m.message).join(' '),
-          })
+          throw preconditionFailed(transition.missing)
         }
 
         const { sponsorForConference, error } =
@@ -1140,10 +1132,12 @@ export const sponsorRouter = router({
               { ids: input.ids },
             )
             if (tierlessIds.length > 0) {
-              throw new TRPCError({
-                code: 'PRECONDITION_FAILED',
-                message: `${tierlessIds.length} selected sponsor(s) have no tier and can't be marked Won. Set a tier first.`,
-              })
+              throw preconditionFailed([
+                {
+                  field: 'tier',
+                  message: `${tierlessIds.length} selected sponsor(s) have no tier and can't be marked Won. Set a tier first.`,
+                },
+              ])
             }
           }
 

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -113,7 +113,10 @@ import {
   ORGANIZER_DATE_MARKER,
 } from '@/lib/pdf/constants'
 import { checkContractReadiness } from '@/lib/sponsor-crm/contract-readiness'
-import { canTransition } from '@/lib/sponsor-crm/state-machine'
+import {
+  canTransition,
+  checkPipelineState,
+} from '@/lib/sponsor-crm/state-machine'
 import { UpdateSignatureStatusSchema } from '@/server/schemas/sponsorForConference'
 import {
   getSigningProvider,
@@ -736,6 +739,16 @@ export const sponsorRouter = router({
           tags: input.tags as SponsorTag[] | undefined,
         }
 
+        // Enforce the pipeline invariant however the record is created, not
+        // just on drag-drop moves (closed-won requires a tier).
+        const createCheck = checkPipelineState(data.status, { tier: data.tier })
+        if (!createCheck.ok) {
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: createCheck.missing.map((m) => m.message).join(' '),
+          })
+        }
+
         // Auto-assign to current user if not provided (undefined)
         if (data.assignedTo === undefined && userId) {
           data.assignedTo = userId
@@ -793,6 +806,30 @@ export const sponsorRouter = router({
             code: 'NOT_FOUND',
             message: 'Sponsor relationship not found',
           })
+        }
+
+        // Enforce the pipeline invariant when an edit changes status or tier (a
+        // field edit can reach closed-won, or clear the tier of a closed-won
+        // sponsor, without going through moveStage). Only guard when one of
+        // those actually changes, so unrelated edits to a pre-existing invalid
+        // record aren't trapped — that back-catalog is cleaned in #379.
+        const statusChanging =
+          updateData.status !== undefined &&
+          updateData.status !== existing.status
+        const tierChanging = updateData.tier !== undefined
+        if (statusChanging || tierChanging) {
+          const resultingStatus = updateData.status ?? existing.status
+          const resultingTier =
+            updateData.tier !== undefined ? updateData.tier : existing.tier
+          const updateCheck = checkPipelineState(resultingStatus, {
+            tier: resultingTier,
+          })
+          if (!updateCheck.ok) {
+            throw new TRPCError({
+              code: 'PRECONDITION_FAILED',
+              message: updateCheck.missing.map((m) => m.message).join(' '),
+            })
+          }
         }
 
         // Ensure assigned person is an organizer of this conference
@@ -1090,6 +1127,22 @@ export const sponsorRouter = router({
                 code: 'BAD_REQUEST',
                 message:
                   'Assigned person must be an organizer of this conference',
+              })
+            }
+          }
+
+          // Enforce the pipeline invariant: a record can only be bulk-marked
+          // Won if it has a resolvable tier. Reject the whole batch (rather
+          // than silently skipping) so the organizer knows which ones to fix.
+          if (input.status === 'closed-won') {
+            const tierlessIds = await clientReadUncached.fetch<string[]>(
+              `*[_type == "sponsorForConference" && _id in $ids && !defined(tier->_id)]._id`,
+              { ids: input.ids },
+            )
+            if (tierlessIds.length > 0) {
+              throw new TRPCError({
+                code: 'PRECONDITION_FAILED',
+                message: `${tierlessIds.length} selected sponsor(s) have no tier and can't be marked Won. Set a tier first.`,
               })
             }
           }

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -113,6 +113,7 @@ import {
   ORGANIZER_DATE_MARKER,
 } from '@/lib/pdf/constants'
 import { checkContractReadiness } from '@/lib/sponsor-crm/contract-readiness'
+import { canTransition } from '@/lib/sponsor-crm/state-machine'
 import { UpdateSignatureStatusSchema } from '@/server/schemas/sponsorForConference'
 import {
   getSigningProvider,
@@ -900,6 +901,19 @@ export const sponsorRouter = router({
         }
 
         const oldStatus = existing.status
+
+        const transition = canTransition(
+          'pipeline',
+          existing.status,
+          input.newStatus,
+          existing,
+        )
+        if (!transition.ok) {
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: transition.missing.map((m) => m.message).join(' '),
+          })
+        }
 
         const { sponsorForConference, error } =
           await updateSponsorForConference(input.id, {

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -1135,6 +1135,9 @@ export const sponsorRouter = router({
               throw preconditionFailed([
                 {
                   field: 'tier',
+                  label: 'Sponsor tier',
+                  source: 'pipeline',
+                  severity: 'required',
                   message: `${tierlessIds.length} selected sponsor(s) have no tier and can't be marked Won. Set a tier first.`,
                 },
               ])

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -2,6 +2,7 @@ import { initTRPC, TRPCError } from '@trpc/server'
 import { NextRequest } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { structuredErrorData } from './errors'
 
 export async function createTRPCContext(opts: { req: NextRequest }) {
   const session = await getAuthSession({
@@ -37,7 +38,7 @@ const t = initTRPC.context<Context>().create({
       ...shape,
       data: {
         ...shape.data,
-        code: error.code,
+        ...structuredErrorData(error),
       },
     }
   },


### PR DESCRIPTION
## Summary

Foundation slice for the sponsor CRM state machine (#374). Establishes the machine as the single source of truth for valid transitions and required fields, and enforces the first rule end-to-end: **a sponsor cannot reach `closed-won` without a tier** (the condition that crashed the front page in #373).

## Changes
- **New `src/lib/sponsor-crm/state-machine.ts`** — `canTransition(axis, from, to, sponsor)` returns `{ ok: true }` or `{ ok: false, missing: [{ field, message }] }`. Permissive-with-guards: only guarded target states block; backward moves and unguarded targets always pass. Structured so the contract/signature/invoice axes slot in (#375/#376).
- **tRPC `moveStage`** — calls `canTransition` and hard-throws `PRECONDITION_FAILED` with the missing-field message before writing.
- **Sanity Studio** (`sponsorForConference` tier field) — non-blocking `.warning()` when `status == closed-won` and no tier, catching direct Studio edits that bypass the API. (Promoted to a blocking error later, in #379, after the back-catalog audit.)
- **CRM drag-drop** (`useSponsorDragDrop`) — surfaces the rejection via a notification instead of silently snapping the card back.

## Testing (TDD)
- 5 unit tests for the pipeline transition table + tier guard (block without tier; allow with tier; closed-lost never blocked; backward unguarded; permissive forward moves).
- 3 integration tests for `moveStage` (reject closed-won without tier; allow with tier; allow closed-lost without tier).
- `tsc --noEmit`: 0 errors · full suite: 1824 passed, 5 skipped · lint clean.

## Notes
- Folding the existing `contract-readiness.ts` into this module is deferred to #375 (the contract-axis slice) to avoid a big-bang refactor in the foundation.
- Respects the constraint that `getPublicSponsorsForConference` is shared with admin — no query-layer changes here.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes the sponsor CRM state machine as the single source of truth for pipeline transition rules, enforcing the first invariant end-to-end: a sponsor cannot reach `closed-won` without a tier. Guards are wired into all four write paths (create, update, moveStage, bulkUpdate), the tRPC error formatter is extended to carry structured `missingFields` payloads, and the drag-drop hook surfaces rejection messages via a notification.

- **`state-machine.ts`** — new `canTransition` / `checkPipelineState` pair backed by a `PIPELINE_GUARDS` table; reuses `collectMissing` / `FieldDef` from `contract-readiness.ts` so UI and server share one definition of "required fields".
- **`sponsor.ts` (tRPC router)** — all four write paths now call the appropriate guard before writing; `bulkUpdate` additionally queries Sanity to verify tier existence via `!defined(tier->_id)`.
- **`errors.ts` + `trpc.ts`** — new `MissingFieldsError` / `preconditionFailed` utilities attach structured missing-field payloads to `PRECONDITION_FAILED` errors, surfaced to clients through the updated error formatter.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one gap to track: the create/update paths protect against a missing tier but not a dangling one.

The core logic is well-tested and the structural additions (state machine, error helpers, drag-drop notifications) are clean. One gap: the `create` and `update` guards check only that a tier value is truthy — a client-supplied ID string passes even if the referenced tier document does not exist. The `moveStage` path avoids this because it reads the expanded record (dangling ref → null), and `bulkUpdate` explicitly verifies existence via GROQ. This inconsistency means a crafted API call with a fake tier ID on the create/update paths can still produce a broken record. The Studio warning is currently non-blocking and the blocking follow-up (#379) covers Studio edits, not direct API writes, so the gap persists past this PR.

The `create` and `update` mutations in `src/server/routers/sponsor.ts` — specifically the tier guard logic at lines 745–748 and the corresponding `update` block.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/sponsor-crm/state-machine.ts | New state-machine module with `canTransition` and `checkPipelineState`; well-structured permissive-with-guards design. The `from` parameter in `canTransition` is unused beyond the same-state early-return (noted in a prior thread). |
| src/server/routers/sponsor.ts | Guards added to create, update, moveStage, and bulkUpdate paths. The create/update paths check tier presence only (truthy string ID), while bulkUpdate verifies actual existence via GROQ — a dangling ref ID in create/update bypasses the guard. |
| src/server/errors.ts | New structured-error module. `preconditionFailed`, `extractMissingFields`, and `structuredErrorData` are clean and well-tested. |
| src/lib/sponsor-crm/tier-validation.ts | Pure, dependency-injected validation function for the Studio warning. Correctly handles both missing and dangling tier references. |
| src/hooks/useSponsorDragDrop.ts | Surfaces PRECONDITION_FAILED rejections via `showNotification` with a user-facing message; generic fallback for transient errors. Clean addition to the drag-drop error path. |
| sanity/schemaTypes/sponsorForConference.ts | Adds a non-blocking `.warning()` for closed-won sponsors without a resolvable tier. Existence check correctly handles both missing and dangling references via draft/published ID pair. |
| src/server/trpc.ts | Error formatter updated to spread `structuredErrorData`, adding `missingFields` to the client-visible `shape.data`. Non-breaking: `code` is still always present. |
| src/lib/sponsor-crm/contract-readiness.ts | Refactored to extract `collectMissing` helper and make `FieldDef` generic; existing `checkContractReadiness` simplified to use the shared utility with no behavioral change. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant tRPC Router
    participant StateMachine
    participant Sanity

    Note over Client,Sanity: moveStage path
    Client->>tRPC Router: moveStage(id, newStatus)
    tRPC Router->>Sanity: getSponsorForConference(id)
    Sanity-->>tRPC Router: existing (expanded, tier resolved)
    tRPC Router->>StateMachine: canTransition('pipeline', from, to, existing)
    alt guard fails (e.g. closed-won, no tier)
        StateMachine-->>tRPC Router: {ok:false, missing:[{field:'tier'}]}
        tRPC Router-->>Client: PRECONDITION_FAILED + missingFields
    else guard passes
        StateMachine-->>tRPC Router: {ok:true}
        tRPC Router->>Sanity: updateSponsorForConference(id, {status})
        Sanity-->>tRPC Router: updated record
        tRPC Router-->>Client: success
    end

    Note over Client,Sanity: create / update path
    Client->>tRPC Router: create/update(data)
    tRPC Router->>StateMachine: checkPipelineState(status, {tier: id_string})
    alt closed-won + no tier string
        StateMachine-->>tRPC Router: {ok:false, missing}
        tRPC Router-->>Client: PRECONDITION_FAILED
    else passes (truthy string, not existence-verified)
        tRPC Router->>Sanity: write record
        Sanity-->>tRPC Router: saved
        tRPC Router-->>Client: success
    end

    Note over Client,Sanity: bulkUpdate path (closed-won)
    Client->>tRPC Router: bulkUpdate(ids, 'closed-won')
    tRPC Router->>Sanity: GROQ !defined(tier->_id) for ids
    Sanity-->>tRPC Router: tierlessIds[]
    alt any tierless
        tRPC Router-->>Client: PRECONDITION_FAILED (count + field)
    else all have resolvable tiers
        tRPC Router->>Sanity: bulkUpdateSponsors(ids, status)
        tRPC Router-->>Client: success
    end
```

<sub>Reviews (2): Last reviewed commit: ["style(sponsor-crm): apply Prettier forma..."](https://github.com/cloudnativebergen/website/commit/ddc4d5fed16682e62362294fce2616787eff6ed2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35958408)</sub>

<!-- /greptile_comment -->