### PR TITLE
feat(sponsor-crm): contract & signature axis guards (#375) + #381 review fixes

### DIFF
--- a/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
@@ -278,6 +278,26 @@ describe('updateSignatureStatus — signature axis guards', () => {
     expect(commit).not.toHaveBeenCalled()
   })
 
+  it('allows re-confirming an already-signed record even if contract data has since drifted (idempotent no-op)', async () => {
+    const { commit } = mockPatch()
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      // Already signed; contact later removed. Re-marking signed is a no-op and
+      // must not be rejected (matches updateContractStatus's same-state behavior).
+      sponsorForConference: makeSfc({
+        contractStatus: 'contract-signed',
+        signatureStatus: 'signed',
+        tier: undefined,
+        contractValue: 0,
+      }),
+      error: undefined,
+    })
+    await createCaller(mockOrganizer).sponsor.crm.updateSignatureStatus({
+      id: 'sfc-1',
+      newStatus: 'signed',
+    })
+    expect(commit).toHaveBeenCalled()
+  })
+
   it('rejects marking the signature signed on a closed-lost deal', async () => {
     const { commit } = mockPatch()
     vi.mocked(getSponsorForConference).mockResolvedValue({

--- a/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
@@ -129,6 +129,26 @@ describe('updateContractStatus — contract axis guards', () => {
     expect(updateSponsorForConference).not.toHaveBeenCalled()
   })
 
+  it('rejects marking contract-signed on a closed-lost deal', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        tier,
+        contractValue: 50000,
+        contactPersons: primaryContact,
+        contractStatus: 'contract-sent',
+        status: 'closed-lost',
+      }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.updateContractStatus({
+        id: 'sfc-1',
+        newStatus: 'contract-signed',
+      }),
+    ).rejects.toThrow(/closed-lost|lost/i)
+    expect(updateSponsorForConference).not.toHaveBeenCalled()
+  })
+
   it('rejects marking contract-signed without a primary contact', async () => {
     vi.mocked(getSponsorForConference).mockResolvedValue({
       sponsorForConference: makeSfc({

--- a/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { appRouter } from '@/server/_app'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { getOrganizersByConference } from '@/lib/speaker/sanity'
+import {
+  getSponsorForConference,
+  updateSponsorForConference,
+} from '@/lib/sponsor-crm/sanity'
+import { getContractTemplate } from '@/lib/sponsor-crm/contract-templates'
+import { clientWrite } from '@/lib/sanity/client'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+vi.mock('@/lib/conference/sanity')
+vi.mock('@/lib/speaker/sanity')
+vi.mock('@/lib/sponsor-crm/sanity')
+vi.mock('@/lib/sponsor-crm/activity')
+vi.mock('@/lib/sponsor-crm/contract-templates')
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    fetch: vi.fn(),
+    patch: vi.fn(),
+    transaction: vi.fn(),
+    assets: { upload: vi.fn() },
+  },
+  clientReadUncached: { fetch: vi.fn() },
+  clientRead: { fetch: vi.fn() },
+}))
+
+const mockOrganizer = {
+  _id: 'org-1',
+  name: 'Org',
+  email: 'org@test.com',
+  isOrganizer: true,
+}
+const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+
+const tier: SponsorForConferenceExpanded['tier'] = {
+  _id: 'tier-gold',
+  title: 'Gold',
+  tagline: '',
+  tierType: 'standard',
+}
+
+const primaryContact = [
+  { _key: 'c1', name: 'Jane Doe', email: 'jane@acme.test', isPrimary: true },
+]
+
+function makeSfc(
+  overrides: Partial<SponsorForConferenceExpanded> = {},
+): SponsorForConferenceExpanded {
+  return {
+    _id: 'sfc-1',
+    _createdAt: '',
+    _updatedAt: '',
+    sponsor: {
+      _id: 's1',
+      name: 'Acme',
+      website: 'https://acme.test',
+      logo: '',
+    },
+    conference: { _id: 'conf-1', title: 'Test Conf' },
+    contractStatus: 'none',
+    status: 'negotiating',
+    contractCurrency: 'NOK',
+    invoiceStatus: 'not-sent',
+    ...overrides,
+  }
+}
+
+const createCaller = (speaker: typeof mockOrganizer) =>
+  appRouter.createCaller({
+    session: { user: { email: speaker.email }, speaker },
+    speaker,
+    user: { email: speaker.email },
+  } as never)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
+    conference: mockConference as never,
+    domain: 'test.com',
+    error: null,
+  })
+  vi.mocked(getOrganizersByConference).mockResolvedValue({
+    speakers: [mockOrganizer] as never,
+    err: null,
+  })
+  vi.mocked(updateSponsorForConference).mockResolvedValue({
+    sponsorForConference: makeSfc(),
+    error: undefined,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('updateContractStatus — contract axis guards', () => {
+  it('rejects marking contract-sent when the sponsor has no tier', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ tier: undefined, contractValue: 50000 }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.updateContractStatus({
+        id: 'sfc-1',
+        newStatus: 'contract-sent',
+      }),
+    ).rejects.toThrow(/tier/i)
+    expect(updateSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('rejects marking contract-sent on a closed-lost deal', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        tier,
+        contractValue: 50000,
+        status: 'closed-lost',
+      }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.updateContractStatus({
+        id: 'sfc-1',
+        newStatus: 'contract-sent',
+      }),
+    ).rejects.toThrow(/closed-lost|lost/i)
+    expect(updateSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('rejects marking contract-signed without a primary contact', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        tier,
+        contractValue: 50000,
+        contractStatus: 'contract-sent',
+      }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.updateContractStatus({
+        id: 'sfc-1',
+        newStatus: 'contract-signed',
+      }),
+    ).rejects.toThrow(/contact/i)
+    expect(updateSponsorForConference).not.toHaveBeenCalled()
+  })
+
+  it('allows marking contract-signed with tier, value and a primary contact (offline path)', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        tier,
+        contractValue: 50000,
+        contractStatus: 'contract-sent',
+        contactPersons: primaryContact,
+      }),
+      error: undefined,
+    })
+    await createCaller(mockOrganizer).sponsor.crm.updateContractStatus({
+      id: 'sfc-1',
+      newStatus: 'contract-signed',
+    })
+    expect(updateSponsorForConference).toHaveBeenCalled()
+  })
+
+  it('allows a backward move out of contract-sent without any field guard', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        tier: undefined,
+        contractValue: 0,
+        contractStatus: 'contract-sent',
+      }),
+      error: undefined,
+    })
+    await createCaller(mockOrganizer).sponsor.crm.updateContractStatus({
+      id: 'sfc-1',
+      newStatus: 'verbal-agreement',
+    })
+    expect(updateSponsorForConference).toHaveBeenCalled()
+  })
+})
+
+describe('updateSignatureStatus — signature axis guards', () => {
+  function mockPatch() {
+    const commit = vi.fn().mockResolvedValue({})
+    const set = vi.fn().mockReturnValue({ commit })
+    vi.mocked(clientWrite.patch).mockReturnValue({ set } as never)
+    return { set, commit }
+  }
+
+  it('rejects marking the signature pending before the contract was sent', async () => {
+    const { commit } = mockPatch()
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ contractStatus: 'none' }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.updateSignatureStatus({
+        id: 'sfc-1',
+        newStatus: 'pending',
+      }),
+    ).rejects.toThrow(/sent|contract/i)
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('rejects a manual signature signed before the contract was sent', async () => {
+    const { commit } = mockPatch()
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ contractStatus: 'none' }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.updateSignatureStatus({
+        id: 'sfc-1',
+        newStatus: 'signed',
+      }),
+    ).rejects.toThrow(/sent|contract/i)
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('allows a manual signature signed once the contract was sent', async () => {
+    const { commit } = mockPatch()
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({ contractStatus: 'contract-sent' }),
+      error: undefined,
+    })
+    await createCaller(mockOrganizer).sponsor.crm.updateSignatureStatus({
+      id: 'sfc-1',
+      newStatus: 'signed',
+    })
+    expect(commit).toHaveBeenCalled()
+  })
+})
+
+describe('sendContract — contract-sent readiness guard', () => {
+  it('rejects sending a contract when the sponsor has no tier', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        tier: undefined,
+        contractValue: 50000,
+        contactPersons: primaryContact,
+      }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.sendContract({
+        sponsorForConferenceId: 'sfc-1',
+        templateId: 'tmpl-1',
+      }),
+    ).rejects.toThrow(/tier/i)
+    expect(getContractTemplate).not.toHaveBeenCalled()
+  })
+
+  it('rejects sending a contract when the contract value is not set', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        tier,
+        contractValue: 0,
+        contactPersons: primaryContact,
+      }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.sendContract({
+        sponsorForConferenceId: 'sfc-1',
+        templateId: 'tmpl-1',
+      }),
+    ).rejects.toThrow(/value/i)
+    expect(getContractTemplate).not.toHaveBeenCalled()
+  })
+
+  it('rejects sending a contract on a closed-lost deal', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        tier,
+        contractValue: 50000,
+        status: 'closed-lost',
+        contactPersons: primaryContact,
+      }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.sendContract({
+        sponsorForConferenceId: 'sfc-1',
+        templateId: 'tmpl-1',
+      }),
+    ).rejects.toThrow(/closed-lost|lost/i)
+    expect(getContractTemplate).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
@@ -239,10 +239,15 @@ describe('updateSignatureStatus — signature axis guards', () => {
     expect(commit).not.toHaveBeenCalled()
   })
 
-  it('allows a manual signature signed once the contract was sent', async () => {
+  it('allows a manual signature signed once the contract was sent and contract invariants are met', async () => {
     const { commit } = mockPatch()
     vi.mocked(getSponsorForConference).mockResolvedValue({
-      sponsorForConference: makeSfc({ contractStatus: 'contract-sent' }),
+      sponsorForConference: makeSfc({
+        contractStatus: 'contract-sent',
+        tier,
+        contractValue: 50000,
+        contactPersons: primaryContact,
+      }),
       error: undefined,
     })
     await createCaller(mockOrganizer).sponsor.crm.updateSignatureStatus({
@@ -250,6 +255,48 @@ describe('updateSignatureStatus — signature axis guards', () => {
       newStatus: 'signed',
     })
     expect(commit).toHaveBeenCalled()
+  })
+
+  it('rejects a manual signature signed when contract-signed invariants are unmet (it would write contract-signed)', async () => {
+    const { commit } = mockPatch()
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      // Contract was sent (passes the signature guard) but tier/value/contact
+      // are missing — marking signed here would write an invalid contract-signed.
+      sponsorForConference: makeSfc({
+        contractStatus: 'contract-sent',
+        tier: undefined,
+        contractValue: 0,
+      }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.updateSignatureStatus({
+        id: 'sfc-1',
+        newStatus: 'signed',
+      }),
+    ).rejects.toThrow(/tier|value|contact/i)
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('rejects marking the signature signed on a closed-lost deal', async () => {
+    const { commit } = mockPatch()
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        contractStatus: 'contract-sent',
+        tier,
+        contractValue: 50000,
+        contactPersons: primaryContact,
+        status: 'closed-lost',
+      }),
+      error: undefined,
+    })
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.updateSignatureStatus({
+        id: 'sfc-1',
+        newStatus: 'signed',
+      }),
+    ).rejects.toThrow(/closed-lost|lost/i)
+    expect(commit).not.toHaveBeenCalled()
   })
 })
 

--- a/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
@@ -6,6 +6,7 @@ import {
   getSponsorForConference,
   createSponsorForConference,
   updateSponsorForConference,
+  tierExists,
 } from '@/lib/sponsor-crm/sanity'
 import { bulkUpdateSponsors } from '@/lib/sponsor-crm/bulk'
 import { clientReadUncached } from '@/lib/sanity/client'
@@ -92,6 +93,8 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
       updatedCount: 2,
       totalCount: 2,
     })
+    // Tiers resolve by default; reject-path tests override to false.
+    vi.mocked(tierExists).mockResolvedValue(true)
   })
 
   afterEach(() => {
@@ -121,7 +124,24 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
         contractStatus: 'none',
         invoiceStatus: 'not-sent',
       } as any)
-      expect(createSponsorForConference).toHaveBeenCalled()
+      expect(createSponsorForConference).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'closed-won', tier: 'tier-gold' }),
+      )
+    })
+
+    it('rejects creating a closed-won sponsor whose tier reference does not resolve', async () => {
+      vi.mocked(tierExists).mockResolvedValue(false)
+      await expect(
+        createCaller(mockOrganizer).sponsor.crm.create({
+          sponsor: 's1',
+          conference: 'conf-1',
+          tier: 'deleted-tier',
+          status: 'closed-won',
+          contractStatus: 'none',
+          invoiceStatus: 'not-sent',
+        } as any),
+      ).rejects.toThrow(/tier/i)
+      expect(createSponsorForConference).not.toHaveBeenCalled()
     })
   })
 
@@ -170,6 +190,25 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
         notes: 'just a note',
       } as any)
       expect(updateSponsorForConference).toHaveBeenCalled()
+    })
+
+    it('rejects moving to closed-won with a tier reference that does not resolve', async () => {
+      vi.mocked(tierExists).mockResolvedValue(false)
+      vi.mocked(getSponsorForConference).mockResolvedValue({
+        sponsorForConference: makeSfc({
+          tier: undefined,
+          status: 'negotiating',
+        }),
+        error: undefined,
+      })
+      await expect(
+        createCaller(mockOrganizer).sponsor.crm.update({
+          id: 'sfc-1',
+          status: 'closed-won',
+          tier: 'deleted-tier',
+        } as any),
+      ).rejects.toThrow(/tier/i)
+      expect(updateSponsorForConference).not.toHaveBeenCalled()
     })
 
     it('allows moving to closed-won when a tier is provided in the same update', async () => {
@@ -222,7 +261,10 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
         ids: ['a', 'b'],
         status: 'closed-won',
       } as any)
-      expect(bulkUpdateSponsors).toHaveBeenCalled()
+      expect(bulkUpdateSponsors).toHaveBeenCalledWith(
+        expect.objectContaining({ ids: ['a', 'b'], status: 'closed-won' }),
+        mockOrganizer._id,
+      )
     })
   })
 })

--- a/__tests__/lib/sponsor-crm/contract-readiness.test.ts
+++ b/__tests__/lib/sponsor-crm/contract-readiness.test.ts
@@ -199,7 +199,7 @@ describe('contract-readiness', () => {
       )
     })
 
-    it('should detect missing pipeline fields as recommended', () => {
+    it('should detect missing pipeline fields as required and block canSend', () => {
       const sponsor = createMockSponsor({
         tier: undefined,
         contractValue: 0,
@@ -208,26 +208,26 @@ describe('contract-readiness', () => {
       const result = checkContractReadiness(sponsor)
 
       expect(result.ready).toBe(false)
-      expect(result.canSend).toBe(true)
+      expect(result.canSend).toBe(false)
       expect(result.missing).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             field: 'tier',
             label: 'Sponsor tier',
             source: 'pipeline',
-            severity: 'recommended',
+            severity: 'required',
           }),
           expect.objectContaining({
             field: 'contractValue',
             label: 'Contract value',
             source: 'pipeline',
-            severity: 'recommended',
+            severity: 'required',
           }),
         ]),
       )
     })
 
-    it('should allow sending with only contact person and conference title', () => {
+    it('should block sending when tier and contract value are missing, even with a contact person', () => {
       const sponsor = createMockSponsor({
         sponsor: {
           _id: 'sponsor-1',
@@ -254,10 +254,10 @@ describe('contract-readiness', () => {
       const result = checkContractReadiness(sponsor)
 
       expect(result.ready).toBe(false)
-      expect(result.canSend).toBe(true)
-      expect(result.missing.length).toBeGreaterThan(0)
-      expect(result.missing.every((m) => m.severity === 'recommended')).toBe(
-        true,
+      expect(result.canSend).toBe(false)
+      const blocking = result.missing.filter((m) => m.severity === 'required')
+      expect(blocking.map((m) => m.field)).toEqual(
+        expect.arrayContaining(['tier', 'contractValue']),
       )
     })
 

--- a/__tests__/lib/sponsor-crm/contract-validation.test.ts
+++ b/__tests__/lib/sponsor-crm/contract-validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { contractSentWarning } from '@/lib/sponsor-crm/contract-validation'
+
+describe('contractSentWarning', () => {
+  it('passes for statuses before the contract is sent', () => {
+    expect(contractSentWarning('none', undefined, undefined)).toBe(true)
+    expect(contractSentWarning('verbal-agreement', undefined, 0)).toBe(true)
+    expect(contractSentWarning('registration-sent', undefined, undefined)).toBe(
+      true,
+    )
+  })
+
+  it('warns when a sent contract has no tier', () => {
+    const result = contractSentWarning('contract-sent', undefined, 50000)
+    expect(result).toMatch(/tier/i)
+  })
+
+  it('warns when a sent contract has no positive value', () => {
+    expect(contractSentWarning('contract-sent', 'tier-x', 0)).toMatch(/value/i)
+    expect(contractSentWarning('contract-sent', 'tier-x', undefined)).toMatch(
+      /value/i,
+    )
+  })
+
+  it('warns about both a missing tier and value at once', () => {
+    const result = contractSentWarning('contract-sent', undefined, 0)
+    expect(result).toMatch(/tier/i)
+    expect(result).toMatch(/value/i)
+  })
+
+  it('passes when a sent contract has a tier and a positive value', () => {
+    expect(contractSentWarning('contract-sent', 'tier-x', 50000)).toBe(true)
+  })
+
+  it('applies the same invariant to a signed contract', () => {
+    expect(contractSentWarning('contract-signed', undefined, 0)).toMatch(
+      /tier/i,
+    )
+    expect(contractSentWarning('contract-signed', 'tier-x', 50000)).toBe(true)
+  })
+})

--- a/__tests__/lib/sponsor-crm/state-machine.test.ts
+++ b/__tests__/lib/sponsor-crm/state-machine.test.ts
@@ -204,6 +204,27 @@ describe('canTransition — contract axis: contract-signed (path-independent)', 
     )
     expect(result.ok).toBe(true)
   })
+
+  it('blocks marking contract-signed on a closed-lost deal, even with tier, value and contact', () => {
+    const result = canTransition(
+      'contract',
+      'none',
+      'contract-signed',
+      makeSfc({
+        tier,
+        contractValue: 50000,
+        contactPersons: primaryContact,
+        status: 'closed-lost',
+      }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing.some((m) => m.field === 'status')).toBe(true)
+      expect(result.missing.find((m) => m.field === 'status')?.message).toMatch(
+        /closed-lost|lost|dead/i,
+      )
+    }
+  })
 })
 
 describe('canTransition — signature axis', () => {

--- a/__tests__/lib/sponsor-crm/state-machine.test.ts
+++ b/__tests__/lib/sponsor-crm/state-machine.test.ts
@@ -1,6 +1,7 @@
 import {
   canTransition,
   checkPipelineState,
+  checkState,
 } from '@/lib/sponsor-crm/state-machine'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 
@@ -96,6 +97,213 @@ describe('canTransition — pipeline axis', () => {
       makeSfc({ tier: undefined, status: 'closed-won' }),
     )
     expect(result.ok).toBe(true)
+  })
+})
+
+describe('canTransition — contract axis', () => {
+  it('blocks moving to contract-sent without a tier', () => {
+    const result = canTransition(
+      'contract',
+      'none',
+      'contract-sent',
+      makeSfc({ tier: undefined, contractValue: 50000 }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing.some((m) => m.field === 'tier')).toBe(true)
+    }
+  })
+
+  it('blocks moving to contract-sent without a positive contract value', () => {
+    const result = canTransition(
+      'contract',
+      'none',
+      'contract-sent',
+      makeSfc({ tier, contractValue: 0 }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing.some((m) => m.field === 'contractValue')).toBe(true)
+    }
+  })
+
+  it('allows moving to contract-sent with tier and contract value set', () => {
+    const result = canTransition(
+      'contract',
+      'none',
+      'contract-sent',
+      makeSfc({ tier, contractValue: 50000 }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('blocks moving to contract-sent on a closed-lost deal even with tier and value', () => {
+    const result = canTransition(
+      'contract',
+      'none',
+      'contract-sent',
+      makeSfc({ tier, contractValue: 50000, status: 'closed-lost' }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing.some((m) => m.field === 'status')).toBe(true)
+      expect(result.missing.find((m) => m.field === 'status')?.message).toMatch(
+        /closed-lost|lost|dead/i,
+      )
+    }
+  })
+})
+
+const primaryContact = [
+  {
+    _key: 'c1',
+    name: 'Jane Doe',
+    email: 'jane@acme.test',
+    isPrimary: true,
+  },
+]
+
+describe('canTransition — contract axis: contract-signed (path-independent)', () => {
+  it('blocks marking contract-signed without a primary contact', () => {
+    const result = canTransition(
+      'contract',
+      'contract-sent',
+      'contract-signed',
+      makeSfc({ tier, contractValue: 50000 }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing.some((m) => m.field === 'contactPersons')).toBe(
+        true,
+      )
+    }
+  })
+
+  it('blocks marking contract-signed on an empty record (tier, value, contact all missing)', () => {
+    const result = canTransition(
+      'contract',
+      'none',
+      'contract-signed',
+      makeSfc({ tier: undefined, contractValue: undefined }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      const fields = result.missing.map((m) => m.field)
+      expect(fields).toEqual(
+        expect.arrayContaining(['tier', 'contractValue', 'contactPersons']),
+      )
+    }
+  })
+
+  it('allows marking contract-signed with tier, value, and a primary contact (offline/manual path)', () => {
+    const result = canTransition(
+      'contract',
+      'none',
+      'contract-signed',
+      makeSfc({ tier, contractValue: 50000, contactPersons: primaryContact }),
+    )
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('canTransition — signature axis', () => {
+  it('blocks moving signature to pending when the contract has not been sent', () => {
+    const result = canTransition(
+      'signature',
+      'not-started',
+      'pending',
+      makeSfc({ contractStatus: 'none' }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing.some((m) => m.field === 'contractStatus')).toBe(
+        true,
+      )
+    }
+  })
+
+  it('allows signature pending once the contract has been sent', () => {
+    const result = canTransition(
+      'signature',
+      'not-started',
+      'pending',
+      makeSfc({ contractStatus: 'contract-sent' }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('blocks a manual signature signed when the contract has not been sent', () => {
+    const result = canTransition(
+      'signature',
+      'not-started',
+      'signed',
+      makeSfc({ contractStatus: 'none' }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing.some((m) => m.field === 'contractStatus')).toBe(
+        true,
+      )
+    }
+  })
+
+  it('allows a manual signature signed once the contract has been sent', () => {
+    const result = canTransition(
+      'signature',
+      'pending',
+      'signed',
+      makeSfc({ contractStatus: 'contract-sent' }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('never blocks resetting a signature backward (rejected, expired, not-started)', () => {
+    expect(
+      canTransition(
+        'signature',
+        'pending',
+        'rejected',
+        makeSfc({ contractStatus: 'contract-sent' }),
+      ).ok,
+    ).toBe(true)
+    expect(
+      canTransition(
+        'signature',
+        'pending',
+        'not-started',
+        makeSfc({ contractStatus: 'none' }),
+      ).ok,
+    ).toBe(true)
+  })
+})
+
+describe('checkState — direct axis state invariant', () => {
+  it('enforces contract-sent guards regardless of the current state (re-send path)', () => {
+    const result = checkState(
+      'contract',
+      'contract-sent',
+      makeSfc({
+        tier: undefined,
+        contractValue: 0,
+        contractStatus: 'contract-sent',
+      }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.missing.map((m) => m.field)).toEqual(
+        expect.arrayContaining(['tier', 'contractValue']),
+      )
+    }
+  })
+
+  it('passes when the contract-sent invariants are met', () => {
+    expect(
+      checkState(
+        'contract',
+        'contract-sent',
+        makeSfc({ tier, contractValue: 50000 }),
+      ).ok,
+    ).toBe(true)
   })
 })
 

--- a/__tests__/lib/sponsor-crm/tier-validation.test.ts
+++ b/__tests__/lib/sponsor-crm/tier-validation.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
-import { closedWonTierWarning } from '@/lib/sponsor-crm/tier-validation'
+import {
+  closedWonTierWarning,
+  tierExistenceQuery,
+} from '@/lib/sponsor-crm/tier-validation'
 
 const exists = () => Promise.resolve(true)
 const absent = () => Promise.resolve(false)
@@ -31,5 +34,24 @@ describe('closedWonTierWarning', () => {
     const check = vi.fn().mockResolvedValue(true)
     await closedWonTierWarning('closed-won', undefined, check)
     expect(check).not.toHaveBeenCalled()
+  })
+})
+
+describe('tierExistenceQuery', () => {
+  it('checks for a published sponsorTier with the given id', () => {
+    const { query, params } = tierExistenceQuery('tier-x')
+    expect(query).toContain('_type == "sponsorTier"')
+    expect(query).toContain('_id == $id')
+    expect(params).toEqual({ id: 'tier-x' })
+  })
+
+  it('does not count draft-only tiers (no drafts arm — the public site reads published)', () => {
+    const { query } = tierExistenceQuery('tier-x')
+    expect(query).not.toContain('drafts')
+    expect(query).not.toContain('$draftId')
+  })
+
+  it('normalises a drafts-prefixed ref to its published id', () => {
+    expect(tierExistenceQuery('drafts.tier-x').params).toEqual({ id: 'tier-x' })
   })
 })

--- a/__tests__/lib/trpc/errors.test.ts
+++ b/__tests__/lib/trpc/errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clientMissingFields,
+  mutationRejectionMessage,
+} from '@/lib/trpc/errors'
+import type { MissingField } from '@/lib/sponsor-crm/contract-readiness'
+
+const missing: MissingField[] = [
+  {
+    field: 'tier',
+    label: 'Sponsor tier',
+    source: 'pipeline',
+    severity: 'required',
+    message: 'Set a tier.',
+  },
+]
+
+describe('clientMissingFields', () => {
+  it('reads the structured payload from error.data (where it lands on the client)', () => {
+    expect(clientMissingFields({ data: { missingFields: missing } })).toEqual(
+      missing,
+    )
+  })
+
+  it('returns undefined when there is no structured payload', () => {
+    expect(clientMissingFields({ data: { code: 'NOT_FOUND' } })).toBeUndefined()
+    expect(clientMissingFields(null)).toBeUndefined()
+    expect(clientMissingFields(undefined)).toBeUndefined()
+  })
+})
+
+describe('mutationRejectionMessage', () => {
+  const fallback = 'Something went wrong.'
+
+  it('surfaces the server message for a guard rejection (PRECONDITION_FAILED)', () => {
+    const err = Object.assign(new Error('Set a tier before marking as Won.'), {
+      data: { code: 'PRECONDITION_FAILED' },
+    })
+    expect(mutationRejectionMessage(err, fallback)).toBe(
+      'Set a tier before marking as Won.',
+    )
+  })
+
+  it('uses the fallback for transient/internal errors', () => {
+    const err = Object.assign(new Error('connection reset'), {
+      data: { code: 'INTERNAL_SERVER_ERROR' },
+    })
+    expect(mutationRejectionMessage(err, fallback)).toBe(fallback)
+  })
+
+  it('uses the fallback when a PRECONDITION_FAILED carries no message', () => {
+    const err = Object.assign(new Error(''), {
+      data: { code: 'PRECONDITION_FAILED' },
+    })
+    expect(mutationRejectionMessage(err, fallback)).toBe(fallback)
+  })
+
+  it('uses the fallback for a non-Error value', () => {
+    expect(mutationRejectionMessage(null, fallback)).toBe(fallback)
+  })
+})

--- a/__tests__/server/error-formatter.test.ts
+++ b/__tests__/server/error-formatter.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { formatTRPCError } from '@/server/trpc'
+import { preconditionFailed } from '@/server/errors'
+
+/**
+ * Pins the wiring between the structured-error helpers and the tRPC error
+ * formatter, i.e. that `missingFields` actually reaches `shape.data` (and so the
+ * client). The pure helpers are unit-tested separately; this guards the seam.
+ */
+describe('formatTRPCError', () => {
+  it('merges structured missingFields and code into shape.data', () => {
+    const error = preconditionFailed([
+      {
+        field: 'tier',
+        label: 'Sponsor tier',
+        source: 'pipeline',
+        severity: 'required',
+        message: 'Set a tier.',
+      },
+    ])
+    const shape = {
+      message: error.message,
+      code: -32000,
+      data: { code: 'PRECONDITION_FAILED', httpStatus: 412, path: 'x' },
+    }
+
+    const result = formatTRPCError({ shape, error })
+
+    expect(result.data.missingFields?.[0].field).toBe('tier')
+    expect(result.data.code).toBe('PRECONDITION_FAILED')
+    // Pre-existing data fields are preserved, not clobbered.
+    expect(result.data.httpStatus).toBe(412)
+    expect(result.data.path).toBe('x')
+  })
+
+  it('passes ordinary errors through without adding missingFields', () => {
+    const shape = { data: { code: 'NOT_FOUND', httpStatus: 404 } }
+    const result = formatTRPCError({ shape, error: { code: 'NOT_FOUND' } })
+
+    expect(result.data.missingFields).toBeUndefined()
+    expect(result.data.code).toBe('NOT_FOUND')
+  })
+})

--- a/__tests__/server/errors.test.ts
+++ b/__tests__/server/errors.test.ts
@@ -25,6 +25,25 @@ describe('preconditionFailed', () => {
     expect(err.message).toMatch(/tier/i)
     expect(extractMissingFields(err)).toEqual(missing)
   })
+
+  it('never produces an empty message, even for an empty field list', () => {
+    const err = preconditionFailed([])
+    expect(err.message.trim().length).toBeGreaterThan(0)
+  })
+
+  it('falls back to a sentence when a field carries no explicit message', () => {
+    const err = preconditionFailed([
+      {
+        field: 'tier',
+        label: 'Sponsor tier',
+        source: 'pipeline',
+        severity: 'required',
+      },
+    ])
+    // Not just the bare label — a readable sentence.
+    expect(err.message).toMatch(/Sponsor tier/)
+    expect(err.message).toMatch(/required/i)
+  })
 })
 
 describe('extractMissingFields', () => {

--- a/sanity/schemaTypes/sponsorForConference.ts
+++ b/sanity/schemaTypes/sponsorForConference.ts
@@ -1,6 +1,7 @@
 import { defineField, defineType } from 'sanity'
 import { CONTACT_ROLE_OPTIONS } from '../../src/lib/sponsor/types'
 import { closedWonTierWarning } from '../../src/lib/sponsor-crm/tier-validation'
+import { contractSentWarning } from '../../src/lib/sponsor-crm/contract-validation'
 import { CURRENCY_OPTIONS } from './constants'
 import { apiVersion } from '../env'
 
@@ -107,7 +108,23 @@ export default defineType({
         layout: 'dropdown',
       },
       initialValue: 'none',
-      validation: (Rule) => Rule.required(),
+      // Non-blocking warning: a sent/signed contract should carry a tier and a
+      // value (the data a valid contract requires). Mirrors the tRPC contract
+      // axis guards for Studio edits that bypass the API. Promoted to a blocking
+      // error later (#379), after the back-catalog audit.
+      validation: (Rule) => [
+        Rule.required(),
+        Rule.custom((status, context) => {
+          const doc = context.document as
+            | { tier?: { _ref?: string }; contractValue?: number }
+            | undefined
+          return contractSentWarning(
+            status as string | undefined,
+            doc?.tier?._ref,
+            doc?.contractValue,
+          )
+        }).warning(),
+      ],
     }),
     defineField({
       name: 'signatureStatus',

--- a/sanity/schemaTypes/sponsorForConference.ts
+++ b/sanity/schemaTypes/sponsorForConference.ts
@@ -1,6 +1,9 @@
 import { defineField, defineType } from 'sanity'
 import { CONTACT_ROLE_OPTIONS } from '../../src/lib/sponsor/types'
-import { closedWonTierWarning } from '../../src/lib/sponsor-crm/tier-validation'
+import {
+  closedWonTierWarning,
+  tierExistenceQuery,
+} from '../../src/lib/sponsor-crm/tier-validation'
 import { contractSentWarning } from '../../src/lib/sponsor-crm/contract-validation'
 import { CURRENCY_OPTIONS } from './constants'
 import { apiVersion } from '../env'
@@ -62,11 +65,8 @@ export default defineType({
           const tierRef = (tier as { _ref?: string } | undefined)?._ref
           const client = context.getClient({ apiVersion })
           return closedWonTierWarning(status, tierRef, async (ref) => {
-            const baseId = ref.replace(/^drafts\./, '')
-            return client.fetch<boolean>(
-              'count(*[_id == $id || _id == $draftId]) > 0',
-              { id: baseId, draftId: `drafts.${baseId}` },
-            )
+            const { query, params } = tierExistenceQuery(ref)
+            return client.fetch<boolean>(query, params)
           })
         }).warning(),
     }),

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -5,6 +5,7 @@ import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 import { BoardView } from '@/components/admin/sponsor-crm/BoardViewSwitcher'
 import { useNotification } from '@/components/admin/NotificationProvider'
 import { api } from '@/lib/trpc/client'
+import { mutationRejectionMessage } from '@/lib/trpc/errors'
 
 interface DragItem {
   type: 'sponsor'
@@ -147,18 +148,15 @@ export function useSponsorDragDrop(currentView: BoardView) {
         for (const [key, data] of previousDataRef.current) {
           queryClient.setQueryData(key, data)
         }
-        // Surface why the move was rejected. For a guard rejection
-        // (PRECONDITION_FAILED) the server message is user-facing and actionable;
-        // for transient/internal errors show a generic message instead of
-        // leaking a raw client error string.
-        const code = (error as { data?: { code?: string } } | null)?.data?.code
+        // Surface why the move was rejected: the server's actionable message for
+        // a guard rejection, a generic fallback for transient/internal errors.
         showNotification({
           type: 'error',
           title: 'Could not move sponsor',
-          message:
-            code === 'PRECONDITION_FAILED' && error instanceof Error
-              ? error.message
-              : 'Failed to update sponsor status. Please try again.',
+          message: mutationRejectionMessage(
+            error,
+            'Failed to update sponsor status. Please try again.',
+          ),
         })
       } finally {
         previousDataRef.current = []

--- a/src/lib/sponsor-crm/contract-readiness.ts
+++ b/src/lib/sponsor-crm/contract-readiness.ts
@@ -132,14 +132,14 @@ const PIPELINE_FIELDS: FieldDef[] = [
     field: 'tier',
     label: 'Sponsor tier',
     source: 'pipeline',
-    severity: 'recommended',
+    severity: 'required',
     check: (sfc) => !!sfc.tier,
   },
   {
     field: 'contractValue',
     label: 'Contract value',
     source: 'pipeline',
-    severity: 'recommended',
+    severity: 'required',
     check: (sfc) => sfc.contractValue != null && sfc.contractValue > 0,
   },
 ]

--- a/src/lib/sponsor-crm/contract-readiness.ts
+++ b/src/lib/sponsor-crm/contract-readiness.ts
@@ -1,4 +1,27 @@
 import type { SponsorForConferenceExpanded } from './types'
+import type { ContactPerson } from '@/lib/sponsor/types'
+
+/**
+ * Shared field predicates — the single definition of what counts as a valid
+ * primary contact and a valid contract value, reused by both the readiness
+ * check here and the transition state machine so the UI and the guards never
+ * disagree.
+ */
+export function hasPrimaryContact(
+  contactPersons: ContactPerson[] | null | undefined,
+): boolean {
+  if (!contactPersons) return false
+  return contactPersons.some(
+    (c) =>
+      !!c.name && !!c.email && (c.isPrimary || contactPersons.length === 1),
+  )
+}
+
+export function hasPositiveContractValue(
+  value: number | null | undefined,
+): boolean {
+  return value != null && value > 0
+}
 
 export type ReadinessSource = 'organizer' | 'sponsor' | 'pipeline'
 export type ReadinessSeverity = 'required' | 'recommended'
@@ -117,13 +140,7 @@ const SPONSOR_FIELDS: FieldDef[] = [
     label: 'Primary contact person',
     source: 'sponsor',
     severity: 'required',
-    check: (sfc) =>
-      !!sfc.contactPersons?.some(
-        (c) =>
-          c.name &&
-          c.email &&
-          (c.isPrimary || sfc.contactPersons?.length === 1),
-      ),
+    check: (sfc) => hasPrimaryContact(sfc.contactPersons),
   },
 ]
 
@@ -140,7 +157,7 @@ const PIPELINE_FIELDS: FieldDef[] = [
     label: 'Contract value',
     source: 'pipeline',
     severity: 'required',
-    check: (sfc) => sfc.contractValue != null && sfc.contractValue > 0,
+    check: (sfc) => hasPositiveContractValue(sfc.contractValue),
   },
 ]
 

--- a/src/lib/sponsor-crm/contract-validation.ts
+++ b/src/lib/sponsor-crm/contract-validation.ts
@@ -1,0 +1,27 @@
+/**
+ * Non-blocking Studio warning for the contract-sent invariant: a contract that
+ * has been sent (or signed) should carry the data a valid contract requires — a
+ * tier and a positive value. Mirrors the tRPC `contract` axis guards for edits
+ * made directly in the Studio, which bypass the API.
+ *
+ * Shipped as a WARNING first; promoted to a blocking error after the
+ * back-catalog audit (#379). Pure and synchronous — presence is all the
+ * invariant needs, so no client fetch (unlike the dangling-tier check).
+ */
+const CONTRACT_SENT_STATES = new Set(['contract-sent', 'contract-signed'])
+
+export function contractSentWarning(
+  contractStatus: string | undefined,
+  tierRef: string | undefined,
+  contractValue: number | undefined,
+): true | string {
+  if (!contractStatus || !CONTRACT_SENT_STATES.has(contractStatus)) return true
+
+  const missing: string[] = []
+  if (!tierRef) missing.push('a tier')
+  if (contractValue == null || contractValue <= 0) missing.push('a value')
+  if (missing.length === 0) return true
+
+  const noun = contractStatus === 'contract-signed' ? 'signed' : 'sent'
+  return `A ${noun} contract should have ${missing.join(' and ')} set.`
+}

--- a/src/lib/sponsor-crm/sanity.ts
+++ b/src/lib/sponsor-crm/sanity.ts
@@ -3,6 +3,7 @@ import {
   clientReadUncached as clientRead,
 } from '@/lib/sanity/client'
 import { prepareArrayWithKeys } from '@/lib/sanity/helpers'
+import { tierExistenceQuery } from './tier-validation'
 import type { ConferenceSponsor } from '@/lib/sponsor/types'
 import type {
   SponsorForConference,
@@ -383,6 +384,19 @@ export async function getSponsorForConference(id: string): Promise<{
   } catch (error) {
     return { error: error as Error }
   }
+}
+
+/**
+ * Whether a tier reference id resolves to a real (published) sponsor tier.
+ * Used by the create/update guards to reject a dangling tier on a closed-won
+ * record — the truthiness check in the state machine can't see that a non-empty
+ * id points at a deleted tier, which would leave the sponsor silently hidden
+ * from the public site. Matches how moveStage (expanded record) and bulkUpdate
+ * (`!defined(tier->_id)`) already enforce resolvability.
+ */
+export async function tierExists(tierId: string): Promise<boolean> {
+  const { query, params } = tierExistenceQuery(tierId)
+  return clientRead.fetch<boolean>(query, params)
 }
 
 export async function listSponsorsForConference(

--- a/src/lib/sponsor-crm/state-machine.ts
+++ b/src/lib/sponsor-crm/state-machine.ts
@@ -1,5 +1,7 @@
 import {
   collectMissing,
+  hasPrimaryContact,
+  hasPositiveContractValue,
   type FieldDef,
   type MissingField,
 } from './contract-readiness'
@@ -71,8 +73,7 @@ const CONTRACT_VALUE_GUARD: FieldDef<SponsorState> = {
   source: 'pipeline',
   severity: 'required',
   message: 'Set a contract value before sending or signing the contract.',
-  check: (sponsor) =>
-    sponsor.contractValue != null && sponsor.contractValue > 0,
+  check: (sponsor) => hasPositiveContractValue(sponsor.contractValue),
 }
 
 /** No contracts on dead deals — applies to sending and to marking signed. */
@@ -97,13 +98,7 @@ const PRIMARY_CONTACT_GUARD: FieldDef<SponsorState> = {
   severity: 'required',
   message:
     'Add a primary contact (name + email) before marking the contract signed.',
-  check: (sponsor) =>
-    !!sponsor.contactPersons?.some(
-      (c) =>
-        c.name &&
-        c.email &&
-        (c.isPrimary || sponsor.contactPersons?.length === 1),
-    ),
+  check: (sponsor) => hasPrimaryContact(sponsor.contactPersons),
 }
 
 const CONTRACT_GUARDS: Record<string, FieldDef<SponsorState>[]> = {

--- a/src/lib/sponsor-crm/state-machine.ts
+++ b/src/lib/sponsor-crm/state-machine.ts
@@ -3,6 +3,7 @@ import {
   type FieldDef,
   type MissingField,
 } from './contract-readiness'
+import type { ContactPerson } from '@/lib/sponsor/types'
 
 /**
  * The sponsor record moves along several independent axes (pipeline status,
@@ -10,7 +11,7 @@ import {
  * Only the pipeline axis is implemented today; contract/signature/invoice
  * axes are added in later slices.
  */
-export type TransitionAxis = 'pipeline'
+export type TransitionAxis = 'pipeline' | 'contract' | 'signature'
 
 /**
  * The slice of a sponsor record the guards read. A tier may arrive as the
@@ -19,6 +20,10 @@ export type TransitionAxis = 'pipeline'
  */
 export interface SponsorState {
   tier?: { _id?: string } | string | null
+  contractValue?: number | null
+  status?: string
+  contractStatus?: string
+  contactPersons?: ContactPerson[] | null
 }
 
 export type TransitionResult =
@@ -45,11 +50,106 @@ const PIPELINE_GUARDS: Record<string, FieldDef<SponsorState>[]> = {
   ],
 }
 
+/**
+ * A valid contract — whether it is being *sent* or marked *signed* — requires a
+ * tier and a positive value. These two guards are shared by both contract
+ * states so the invariant holds path-independently (an offline mark-signed is
+ * held to the same standard as an in-app send).
+ */
+const CONTRACT_TIER_GUARD: FieldDef<SponsorState> = {
+  field: 'tier',
+  label: 'Sponsor tier',
+  source: 'pipeline',
+  severity: 'required',
+  message: 'Set a sponsor tier before sending or signing the contract.',
+  check: (sponsor) => Boolean(sponsor.tier),
+}
+
+const CONTRACT_VALUE_GUARD: FieldDef<SponsorState> = {
+  field: 'contractValue',
+  label: 'Contract value',
+  source: 'pipeline',
+  severity: 'required',
+  message: 'Set a contract value before sending or signing the contract.',
+  check: (sponsor) =>
+    sponsor.contractValue != null && sponsor.contractValue > 0,
+}
+
+/** No contracts on dead deals. */
+const NOT_CLOSED_LOST_GUARD: FieldDef<SponsorState> = {
+  field: 'status',
+  label: 'Pipeline status',
+  source: 'pipeline',
+  severity: 'required',
+  message: "Can't send a contract on a closed-lost deal.",
+  check: (sponsor) => sponsor.status !== 'closed-lost',
+}
+
+/**
+ * A signed contract names who signed it. Mirrors the readiness primary-contact
+ * rule: a contact with name + email that is either flagged primary or the only
+ * one on record.
+ */
+const PRIMARY_CONTACT_GUARD: FieldDef<SponsorState> = {
+  field: 'contactPersons',
+  label: 'Primary contact person',
+  source: 'sponsor',
+  severity: 'required',
+  message:
+    'Add a primary contact (name + email) before marking the contract signed.',
+  check: (sponsor) =>
+    !!sponsor.contactPersons?.some(
+      (c) =>
+        c.name &&
+        c.email &&
+        (c.isPrimary || sponsor.contactPersons?.length === 1),
+    ),
+}
+
+const CONTRACT_GUARDS: Record<string, FieldDef<SponsorState>[]> = {
+  'contract-sent': [
+    CONTRACT_TIER_GUARD,
+    CONTRACT_VALUE_GUARD,
+    NOT_CLOSED_LOST_GUARD,
+  ],
+  'contract-signed': [
+    CONTRACT_TIER_GUARD,
+    CONTRACT_VALUE_GUARD,
+    PRIMARY_CONTACT_GUARD,
+  ],
+}
+
+/**
+ * A signature can only be tracked once a contract is on the table. Both states
+ * are reachable manually (mark pending / mark signed), so the rule lives in the
+ * machine rather than only in the send flow. "Sent" subsumes "signed": a signed
+ * contract was necessarily sent.
+ */
+const contractWasSent = (sponsor: SponsorState) =>
+  sponsor.contractStatus === 'contract-sent' ||
+  sponsor.contractStatus === 'contract-signed'
+
+const CONTRACT_SENT_GUARD: FieldDef<SponsorState> = {
+  field: 'contractStatus',
+  label: 'Contract sent',
+  source: 'pipeline',
+  severity: 'required',
+  message: 'Send the contract before tracking a signature.',
+  check: contractWasSent,
+}
+
+const SIGNATURE_GUARDS: Record<string, FieldDef<SponsorState>[]> = {
+  pending: [CONTRACT_SENT_GUARD],
+  signed: [CONTRACT_SENT_GUARD],
+}
+
 const GUARDS: Record<
   TransitionAxis,
   Record<string, FieldDef<SponsorState>[]>
 > = {
   pipeline: PIPELINE_GUARDS,
+  contract: CONTRACT_GUARDS,
+  signature: SIGNATURE_GUARDS,
 }
 
 function evaluate(
@@ -79,14 +179,24 @@ export function canTransition(
 }
 
 /**
- * Validates that a record resting in pipeline `status` satisfies that state's
- * required-field invariants, independent of any transition. Use at direct
- * write paths (create / update / bulk) that set status without going through
- * a transition, so the same rule is enforced however the state is reached.
+ * Validates that a record resting in `state` on `axis` satisfies that state's
+ * required-field invariants, independent of any transition. Use at direct write
+ * paths (create / update / bulk / send) that set a state without going through a
+ * transition — including re-entering the same state — so the same rule holds
+ * however the state is reached.
  */
+export function checkState(
+  axis: TransitionAxis,
+  state: string,
+  sponsor: SponsorState,
+): TransitionResult {
+  return evaluate(axis, state, sponsor)
+}
+
+/** Pipeline-axis convenience wrapper around {@link checkState}. */
 export function checkPipelineState(
   status: string,
   sponsor: SponsorState,
 ): TransitionResult {
-  return evaluate('pipeline', status, sponsor)
+  return checkState('pipeline', status, sponsor)
 }

--- a/src/lib/sponsor-crm/state-machine.ts
+++ b/src/lib/sponsor-crm/state-machine.ts
@@ -75,13 +75,13 @@ const CONTRACT_VALUE_GUARD: FieldDef<SponsorState> = {
     sponsor.contractValue != null && sponsor.contractValue > 0,
 }
 
-/** No contracts on dead deals. */
+/** No contracts on dead deals — applies to sending and to marking signed. */
 const NOT_CLOSED_LOST_GUARD: FieldDef<SponsorState> = {
   field: 'status',
   label: 'Pipeline status',
   source: 'pipeline',
   severity: 'required',
-  message: "Can't send a contract on a closed-lost deal.",
+  message: "Can't send or sign a contract on a closed-lost deal.",
   check: (sponsor) => sponsor.status !== 'closed-lost',
 }
 
@@ -116,6 +116,7 @@ const CONTRACT_GUARDS: Record<string, FieldDef<SponsorState>[]> = {
     CONTRACT_TIER_GUARD,
     CONTRACT_VALUE_GUARD,
     PRIMARY_CONTACT_GUARD,
+    NOT_CLOSED_LOST_GUARD,
   ],
 }
 

--- a/src/lib/sponsor-crm/tier-validation.ts
+++ b/src/lib/sponsor-crm/tier-validation.ts
@@ -13,6 +13,25 @@ export const DANGLING_TIER_WARNING =
  * `{ _ref }` object, so a plain falsiness check would miss it. Existence is
  * injected so this stays pure and testable without the Studio client.
  */
+/**
+ * GROQ to test whether a sponsor tier reference resolves to a real tier the
+ * public site can see. Published-only: a draft-only tier is invisible to the
+ * front-end (which reads the published perspective), so it must NOT count as
+ * existing — otherwise a closed-won sponsor pointing at it stays silently
+ * hidden. The drafts prefix on the incoming ref is normalised away. Shared by
+ * the Studio warning and the tRPC create/update guards so all paths agree on
+ * one definition of "resolvable tier".
+ */
+export function tierExistenceQuery(ref: string): {
+  query: string
+  params: { id: string }
+} {
+  return {
+    query: 'count(*[_type == "sponsorTier" && _id == $id]) > 0',
+    params: { id: ref.replace(/^drafts\./, '') },
+  }
+}
+
 export async function closedWonTierWarning(
   status: string | undefined,
   tierRef: string | undefined,

--- a/src/lib/trpc/errors.ts
+++ b/src/lib/trpc/errors.ts
@@ -1,0 +1,41 @@
+import type { MissingField } from '@/lib/sponsor-crm/contract-readiness'
+
+/**
+ * Client-side accessors for the structured error payload the tRPC error
+ * formatter attaches to `shape.data`. On the CLIENT the structured data lives at
+ * `error.data` (a plain object) — the server-side `extractMissingFields` reads
+ * `error.cause` and does NOT work here, because the cause is not serialized as a
+ * live `MissingFieldsError` instance over the wire.
+ */
+interface ClientError {
+  message?: string
+  data?: { code?: string; missingFields?: MissingField[] } | null
+}
+
+/** The structured missing fields a guard rejection carries, as seen on the client. */
+export function clientMissingFields(
+  error: ClientError | null | undefined,
+): MissingField[] | undefined {
+  return error?.data?.missingFields ?? undefined
+}
+
+/**
+ * Picks a user-facing message for a failed mutation. A guard rejection
+ * (PRECONDITION_FAILED) carries an actionable, user-safe message from the
+ * server, so surface it; for transient/internal errors (or an empty message)
+ * use the caller's generic fallback rather than leaking a raw error string.
+ */
+export function mutationRejectionMessage(
+  error: unknown,
+  fallback: string,
+): string {
+  const code = (error as ClientError | null)?.data?.code
+  if (
+    code === 'PRECONDITION_FAILED' &&
+    error instanceof Error &&
+    error.message
+  ) {
+    return error.message
+  }
+  return fallback
+}

--- a/src/server/errors.ts
+++ b/src/server/errors.ts
@@ -1,7 +1,13 @@
 import { TRPCError } from '@trpc/server'
 import type { MissingField } from '@/lib/sponsor-crm/contract-readiness'
 
-const describe = (field: MissingField) => field.message ?? field.label
+const FALLBACK_MESSAGE = 'This action is not allowed in the current state.'
+
+const describe = (field: MissingField) =>
+  field.message ?? `${field.label} is required.`
+
+const summarize = (missing: MissingField[]) =>
+  missing.map(describe).join(' ') || FALLBACK_MESSAGE
 
 /**
  * Error carrying structured missing-field requirements. Attached as the `cause`
@@ -10,7 +16,7 @@ const describe = (field: MissingField) => field.message ?? field.label
  */
 export class MissingFieldsError extends Error {
   constructor(public readonly missingFields: MissingField[]) {
-    super(missingFields.map(describe).join(' '))
+    super(summarize(missingFields))
     this.name = 'MissingFieldsError'
   }
 }
@@ -23,18 +29,28 @@ export class MissingFieldsError extends Error {
 export function preconditionFailed(missing: MissingField[]): TRPCError {
   return new TRPCError({
     code: 'PRECONDITION_FAILED',
-    message: missing.map(describe).join(' '),
+    message: summarize(missing),
     cause: new MissingFieldsError(missing),
   })
 }
 
-/** Returns the structured missing fields carried by an error, if any. */
+/**
+ * Returns the structured missing fields carried by an error, if any.
+ * SERVER-ONLY: reads `error.cause`, which is a live `MissingFieldsError` only
+ * in-process. On the client the payload is serialized to `error.data`; use
+ * `clientMissingFields` from `@/lib/trpc/errors` there.
+ */
 export function extractMissingFields(error: {
   cause?: unknown
 }): MissingField[] | undefined {
   return error.cause instanceof MissingFieldsError
     ? error.cause.missingFields
     : undefined
+}
+
+export interface StructuredErrorData {
+  code: string
+  missingFields?: MissingField[]
 }
 
 /**
@@ -45,7 +61,7 @@ export function extractMissingFields(error: {
 export function structuredErrorData(error: {
   code: string
   cause?: unknown
-}): Record<string, unknown> {
+}): StructuredErrorData {
   const missingFields = extractMissingFields(error)
   return {
     code: error.code,

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -57,6 +57,7 @@ import {
   listSponsorsForConference,
   copySponsorsFromPreviousYear,
   importAllHistoricSponsors,
+  tierExists,
 } from '@/lib/sponsor-crm/sanity'
 import {
   logStageChange,
@@ -219,6 +220,24 @@ async function sendContractSignedSlackNotification(
     )
   }
 }
+
+/**
+ * Reported when a closed-won record carries a tier id that no longer resolves
+ * to a real tier (a dangling reference). The state-machine truthiness check
+ * accepts any non-empty id, so create/update verify existence separately and
+ * raise this so the organizer fixes the ref rather than silently hiding the
+ * sponsor from the public site.
+ */
+const DANGLING_TIER_MISSING = [
+  {
+    field: 'tier',
+    label: 'Sponsor tier',
+    source: 'pipeline' as const,
+    severity: 'required' as const,
+    message:
+      'The selected sponsor tier no longer exists. Choose a valid tier before marking as Won.',
+  },
+]
 
 export const sponsorRouter = router({
   list: adminProcedure
@@ -747,6 +766,16 @@ export const sponsorRouter = router({
         if (!createCheck.ok) {
           throw preconditionFailed(createCheck.missing)
         }
+        // The guard above only checks tier truthiness; a non-empty id can still
+        // point at a deleted tier. Verify it resolves before persisting a Won
+        // record (matches moveStage/bulk, which read the dereferenced tier).
+        if (
+          data.status === 'closed-won' &&
+          data.tier &&
+          !(await tierExists(data.tier))
+        ) {
+          throw preconditionFailed(DANGLING_TIER_MISSING)
+        }
 
         // Auto-assign to current user if not provided (undefined)
         if (data.assignedTo === undefined && userId) {
@@ -825,6 +854,17 @@ export const sponsorRouter = router({
           })
           if (!updateCheck.ok) {
             throw preconditionFailed(updateCheck.missing)
+          }
+          // A freshly-supplied tier id is an unresolved string here (unlike the
+          // dereferenced existing.tier), so verify it points at a real tier when
+          // the result is Won — otherwise a dangling ref slips past the guard.
+          if (
+            resultingStatus === 'closed-won' &&
+            tierChanging &&
+            updateData.tier &&
+            !(await tierExists(updateData.tier))
+          ) {
+            throw preconditionFailed(DANGLING_TIER_MISSING)
           }
         }
 

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -116,6 +116,7 @@ import { checkContractReadiness } from '@/lib/sponsor-crm/contract-readiness'
 import {
   canTransition,
   checkPipelineState,
+  checkState,
 } from '@/lib/sponsor-crm/state-machine'
 import { preconditionFailed } from '@/server/errors'
 import { UpdateSignatureStatusSchema } from '@/server/schemas/sponsorForConference'
@@ -1046,6 +1047,20 @@ export const sponsorRouter = router({
           })
         }
 
+        // Contract-axis guards: contract-sent / contract-signed carry required
+        // field invariants (tier + value, plus a primary contact to sign, and
+        // no contracts on dead deals). Enforced here so a manual/offline status
+        // change is held to the same standard as the in-app send flow.
+        const contractTransition = canTransition(
+          'contract',
+          existing.contractStatus,
+          input.newStatus,
+          existing,
+        )
+        if (!contractTransition.ok) {
+          throw preconditionFailed(contractTransition.missing)
+        }
+
         const oldStatus = existing.contractStatus
         const updateData: Partial<{
           contractStatus: string
@@ -1497,6 +1512,19 @@ export const sponsorRouter = router({
 
         const oldStatus = existing.signatureStatus || 'not-started'
 
+        // Signature-axis guard: a signature can only be tracked once the
+        // contract has been sent. Blocks manually marking pending/signed on a
+        // record whose contract never went out.
+        const signatureTransition = canTransition(
+          'signature',
+          oldStatus,
+          input.newStatus,
+          existing,
+        )
+        if (!signatureTransition.ok) {
+          throw preconditionFailed(signatureTransition.missing)
+        }
+
         try {
           await clientWrite
             .patch(input.id)
@@ -1571,6 +1599,15 @@ export const sponsorRouter = router({
             message:
               'Sponsor information is missing. Please ensure the sponsor is linked before sending a contract.',
           })
+        }
+
+        // Contract-sent invariants: tier + positive value, and not a dead deal.
+        // Checked path-independently (re-sends included) before any costly work
+        // (template fetch, PDF generation, asset upload). The contact / title /
+        // template / signing-provider runtime guards below remain in force.
+        const sendReadiness = checkState('contract', 'contract-sent', sfc)
+        if (!sendReadiness.ok) {
+          throw preconditionFailed(sendReadiness.missing)
         }
 
         const { template, error: templateError } = await getContractTemplate(

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -118,6 +118,7 @@ import {
   canTransition,
   checkPipelineState,
   checkState,
+  type TransitionResult,
 } from '@/lib/sponsor-crm/state-machine'
 import { preconditionFailed } from '@/server/errors'
 import { UpdateSignatureStatusSchema } from '@/server/schemas/sponsorForConference'
@@ -238,6 +239,26 @@ const DANGLING_TIER_MISSING = [
       'The selected sponsor tier no longer exists. Choose a valid tier before marking as Won.',
   },
 ]
+
+/** Throws a PRECONDITION_FAILED with the blocking fields when a guard rejects. */
+function assertGuard(result: TransitionResult): void {
+  if (!result.ok) throw preconditionFailed(result.missing)
+}
+
+/**
+ * Rejects a Won record whose tier reference doesn't resolve. The synchronous
+ * state-machine guard only checks truthiness, so a non-empty id pointing at a
+ * deleted tier needs this existence round-trip. No-op for non-Won states or a
+ * cleared tier (those are handled by the truthiness guard).
+ */
+async function assertTierResolvable(
+  status: string,
+  tierRef: string | undefined,
+): Promise<void> {
+  if (status === 'closed-won' && tierRef && !(await tierExists(tierRef))) {
+    throw preconditionFailed(DANGLING_TIER_MISSING)
+  }
+}
 
 export const sponsorRouter = router({
   list: adminProcedure
@@ -761,21 +782,9 @@ export const sponsorRouter = router({
         }
 
         // Enforce the pipeline invariant however the record is created, not
-        // just on drag-drop moves (closed-won requires a tier).
-        const createCheck = checkPipelineState(data.status, { tier: data.tier })
-        if (!createCheck.ok) {
-          throw preconditionFailed(createCheck.missing)
-        }
-        // The guard above only checks tier truthiness; a non-empty id can still
-        // point at a deleted tier. Verify it resolves before persisting a Won
-        // record (matches moveStage/bulk, which read the dereferenced tier).
-        if (
-          data.status === 'closed-won' &&
-          data.tier &&
-          !(await tierExists(data.tier))
-        ) {
-          throw preconditionFailed(DANGLING_TIER_MISSING)
-        }
+        // just on drag-drop moves (closed-won requires a tier that resolves).
+        assertGuard(checkPipelineState(data.status, { tier: data.tier }))
+        await assertTierResolvable(data.status, data.tier)
 
         // Auto-assign to current user if not provided (undefined)
         if (data.assignedTo === undefined && userId) {
@@ -849,22 +858,13 @@ export const sponsorRouter = router({
           const resultingStatus = updateData.status ?? existing.status
           const resultingTier =
             updateData.tier !== undefined ? updateData.tier : existing.tier
-          const updateCheck = checkPipelineState(resultingStatus, {
-            tier: resultingTier,
-          })
-          if (!updateCheck.ok) {
-            throw preconditionFailed(updateCheck.missing)
-          }
+          assertGuard(
+            checkPipelineState(resultingStatus, { tier: resultingTier }),
+          )
           // A freshly-supplied tier id is an unresolved string here (unlike the
-          // dereferenced existing.tier), so verify it points at a real tier when
-          // the result is Won — otherwise a dangling ref slips past the guard.
-          if (
-            resultingStatus === 'closed-won' &&
-            tierChanging &&
-            updateData.tier &&
-            !(await tierExists(updateData.tier))
-          ) {
-            throw preconditionFailed(DANGLING_TIER_MISSING)
+          // dereferenced existing.tier), so verify it points at a real tier.
+          if (tierChanging) {
+            await assertTierResolvable(resultingStatus, updateData.tier)
           }
         }
 
@@ -975,15 +975,9 @@ export const sponsorRouter = router({
 
         const oldStatus = existing.status
 
-        const transition = canTransition(
-          'pipeline',
-          existing.status,
-          input.newStatus,
-          existing,
+        assertGuard(
+          canTransition('pipeline', existing.status, input.newStatus, existing),
         )
-        if (!transition.ok) {
-          throw preconditionFailed(transition.missing)
-        }
 
         const { sponsorForConference, error } =
           await updateSponsorForConference(input.id, {
@@ -1091,15 +1085,14 @@ export const sponsorRouter = router({
         // field invariants (tier + value, plus a primary contact to sign, and
         // no contracts on dead deals). Enforced here so a manual/offline status
         // change is held to the same standard as the in-app send flow.
-        const contractTransition = canTransition(
-          'contract',
-          existing.contractStatus,
-          input.newStatus,
-          existing,
+        assertGuard(
+          canTransition(
+            'contract',
+            existing.contractStatus,
+            input.newStatus,
+            existing,
+          ),
         )
-        if (!contractTransition.ok) {
-          throw preconditionFailed(contractTransition.missing)
-        }
 
         const oldStatus = existing.contractStatus
         const updateData: Partial<{
@@ -1555,29 +1548,24 @@ export const sponsorRouter = router({
         // Signature-axis guard: a signature can only be tracked once the
         // contract has been sent. Blocks manually marking pending/signed on a
         // record whose contract never went out.
-        const signatureTransition = canTransition(
-          'signature',
-          oldStatus,
-          input.newStatus,
-          existing,
+        assertGuard(
+          canTransition('signature', oldStatus, input.newStatus, existing),
         )
-        if (!signatureTransition.ok) {
-          throw preconditionFailed(signatureTransition.missing)
-        }
 
         // Marking the signature signed also drives the contract to
         // contract-signed (below), so it must satisfy that state's invariants
-        // (tier + value + primary contact, not a dead deal). Enforced
-        // path-independently so this side-door matches updateContractStatus.
+        // (tier + value + primary contact, not a dead deal). Routed through
+        // canTransition (not checkState) so re-confirming an already-signed
+        // record stays a no-op, matching updateContractStatus.
         if (input.newStatus === 'signed') {
-          const contractSigned = checkState(
-            'contract',
-            'contract-signed',
-            existing,
+          assertGuard(
+            canTransition(
+              'contract',
+              existing.contractStatus,
+              'contract-signed',
+              existing,
+            ),
           )
-          if (!contractSigned.ok) {
-            throw preconditionFailed(contractSigned.missing)
-          }
         }
 
         try {
@@ -1660,10 +1648,7 @@ export const sponsorRouter = router({
         // Checked path-independently (re-sends included) before any costly work
         // (template fetch, PDF generation, asset upload). The contact / title /
         // template / signing-provider runtime guards below remain in force.
-        const sendReadiness = checkState('contract', 'contract-sent', sfc)
-        if (!sendReadiness.ok) {
-          throw preconditionFailed(sendReadiness.missing)
-        }
+        assertGuard(checkState('contract', 'contract-sent', sfc))
 
         const { template, error: templateError } = await getContractTemplate(
           input.templateId,

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -1565,6 +1565,21 @@ export const sponsorRouter = router({
           throw preconditionFailed(signatureTransition.missing)
         }
 
+        // Marking the signature signed also drives the contract to
+        // contract-signed (below), so it must satisfy that state's invariants
+        // (tier + value + primary contact, not a dead deal). Enforced
+        // path-independently so this side-door matches updateContractStatus.
+        if (input.newStatus === 'signed') {
+          const contractSigned = checkState(
+            'contract',
+            'contract-signed',
+            existing,
+          )
+          if (!contractSigned.ok) {
+            throw preconditionFailed(contractSigned.missing)
+          }
+        }
+
         try {
           await clientWrite
             .patch(input.id)

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -2,7 +2,7 @@ import { initTRPC, TRPCError } from '@trpc/server'
 import { NextRequest } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
-import { structuredErrorData } from './errors'
+import { structuredErrorData, type StructuredErrorData } from './errors'
 
 export async function createTRPCContext(opts: { req: NextRequest }) {
   const session = await getAuthSession({
@@ -32,16 +32,29 @@ export async function createTRPCContext(opts: { req: NextRequest }) {
 
 export type Context = Awaited<ReturnType<typeof createTRPCContext>>
 
+/**
+ * Merges the structured-error payload (`code` + `missingFields`) into the tRPC
+ * error shape's `data`, so guard rejections survive serialization to the
+ * client. Extracted from the formatter config so the wiring is unit-testable.
+ */
+export function formatTRPCError<
+  S extends { data: Record<string, unknown> },
+>(opts: {
+  shape: S
+  error: { code: string; cause?: unknown }
+}): Omit<S, 'data'> & { data: S['data'] & StructuredErrorData } {
+  const { shape, error } = opts
+  return {
+    ...shape,
+    data: {
+      ...shape.data,
+      ...structuredErrorData(error),
+    },
+  }
+}
+
 const t = initTRPC.context<Context>().create({
-  errorFormatter({ shape, error }) {
-    return {
-      ...shape,
-      data: {
-        ...shape.data,
-        ...structuredErrorData(error),
-      },
-    }
-  },
+  errorFormatter: formatTRPCError,
 })
 
 const requireAuth = t.middleware(({ ctx, next }) => {


### PR DESCRIPTION
## Summary

Extends the sponsor-CRM transition state machine (#374/#381) to the **contract** and **signature** axes, enforcing the data a valid contract requires — path-independently, so an offline/manual mark is held to the same standard as the in-app flow. Also folds in fixes from an adversarial review of the #381 foundation.

Closes #375.

## #375 — Contract & signature axis guards

**State machine (`state-machine.ts`)**
- `TransitionAxis` gains `'contract'` and `'signature'`; `SponsorState` widens to the slice the guards read (`SponsorForConferenceExpanded` satisfies it).
- `contract-sent`: tier + contractValue (>0) required, plus a **dead-deal block** (no contracts when status is `closed-lost`).
- `contract-signed`: tier + contractValue (>0) + a **primary contact** (so offline marks meet the bar, but a misclick on an empty record is rejected).
- signature `pending` / `signed`: the contract must have been sent.
- New generic `checkState(axis, state, sponsor)` for path-independent direct checks (re-sends included); `checkPipelineState` now wraps it.

**Mutations (`sponsor.ts`)** — hard-throw `PRECONDITION_FAILED` with structured missing fields:
- `sendContract` → `checkState('contract','contract-sent')` before any costly work; existing contact/title/template/provider guards remain.
- `updateContractStatus` → `canTransition('contract', …)`.
- `updateSignatureStatus` → `canTransition('signature', …)`.

**Send Contract form** — promoted `tier` + `contractValue` `recommended`→`required` in `contract-readiness.ts`. The form's `canSend` and `ContractReadinessIndicator` already consume the shared check, so Send disables and lists what's missing automatically. *(Deliberate behavior change.)*

**Sanity** — non-blocking `.warning()`: a sent/signed contract should have a tier and a value (`contract-validation.ts`). Promoted to a blocking error later, in #379, after the back-catalog audit.

## #381 review fixes (folded in)

An adversarial review of the merged #374/#381 foundation surfaced one real bug plus some hardening:

- **F1 (bug)** — `create`/`update` accepted a **dangling tier reference** for `closed-won`, silently hiding the sponsor from the public site (the invariant was enforced only on `moveStage`/`bulkUpdate`). Added `sanity.tierExists()` and verify resolvability on create/update when the result is `closed-won`.
- **F2/F8** — extracted a pure, published-only `tierExistenceQuery(ref)` shared by the Studio warning and the server guard (no longer counts draft-only tiers as existing); unit-tested.
- **F7** — extracted `formatTRPCError()` and unit-tested that structured `missingFields` + `code` actually merge into `shape.data` (the server→client seam was previously unexercised).
- **F3/F9** — new client-safe `@/lib/trpc/errors` (`clientMissingFields`, `mutationRejectionMessage`); `useSponsorDragDrop` uses the latter; `extractMissingFields` documented as server-only.
- **F4/F5** — `preconditionFailed([])` never yields an empty message; a field without an explicit message falls back to a sentence.
- **F10** — strengthened weak create/bulkUpdate "allows" assertions to pin the persisted payload.

## Testing (TDD)

- Unit: contract/signature transition tables + guards; `tierExistenceQuery`; `formatTRPCError` wiring; client error helpers; `errors.ts` message hardening; contract-sent Sanity warning.
- Integration: send / contract-status / signature-status reject+allow paths; create/update dangling-tier rejects.
- Readiness tests updated for the deliberate promotion.
- `tsc --noEmit`: 0 errors · full suite **1895 passed, 5 skipped** · lint 0 errors · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the sponsor-CRM state machine with `contract` and `signature` axis guards, enforces data invariants path-independently (offline/manual marks held to the same standard as the in-app flow), and folds in hardening fixes from the #381 review.

- **Contract/signature axis guards** — `canTransition` and `checkState` now cover `contract-sent` (tier + value + dead-deal block), `contract-signed` (tier + value + primary contact), and signature `pending`/`signed` (contract must be sent); all three write paths (`sendContract`, `updateContractStatus`, `updateSignatureStatus`) are gated accordingly.
- **Dangling-tier fix** — `create` and `update` now verify that a `closed-won` tier reference resolves to a published document via the new shared `tierExistenceQuery`, closing the silent-hide gap that `moveStage`/`bulkUpdate` already handled.
- **Error infrastructure hardening** — `formatTRPCError` extracted for testability; `preconditionFailed([])` always produces a non-empty message; `clientMissingFields`/`mutationRejectionMessage` provide safe client-side accessors.

<h3>Confidence Score: 4/5</h3>

Safe to merge; findings are clarifying questions about intentional design asymmetries, not regressions.

The core guard machinery is solid and comprehensively tested (1895 passing, 0 TS errors). Two open questions remain: whether `contract-signed` intentionally omits the dead-deal block that `contract-sent` carries, and whether `updateSignatureStatus → signed` intentionally bypasses the primary-contact guard when auto-promoting `contractStatus`. Both may be by-design, but neither is documented at the callsite and no test would catch a regression if the intent changes.

`src/lib/sponsor-crm/state-machine.ts` (dead-deal block gap in `contract-signed`), `src/server/routers/sponsor.ts` (`updateSignatureStatus` side-effect to `contractStatus`), and `src/lib/sponsor-crm/tier-validation.ts` (orphaned JSDoc).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/sponsor-crm/state-machine.ts | Adds contract and signature axes with well-structured guards; `NOT_CLOSED_LOST_GUARD` is present for `contract-sent` but absent from `contract-signed`, leaving the dead-deal block incomplete for that state. |
| src/server/routers/sponsor.ts | Adds contract, signature, and dangling-tier guards to three mutation paths; `updateSignatureStatus` auto-promotes `contractStatus` to `contract-signed` without running the contract-axis guards for that state. |
| src/lib/sponsor-crm/tier-validation.ts | Extracts `tierExistenceQuery` as a published-only GROQ helper; insertion position leaves an orphaned JSDoc from `closedWonTierWarning` stacked above the new function. |
| src/server/errors.ts | Adds `summarize` helper so `preconditionFailed([])` never yields an empty message; exports `StructuredErrorData` interface. |
| src/server/trpc.ts | Extracts `formatTRPCError` from the inline `errorFormatter` config, making the server→client seam independently unit-testable. |
| src/lib/trpc/errors.ts | New client-safe helpers `clientMissingFields` and `mutationRejectionMessage`; correctly accesses `error.data` instead of server-only `error.cause`. |
| src/lib/sponsor-crm/contract-validation.ts | New pure `contractSentWarning` for Studio non-blocking validation; correctly handles `contract-sent` and `contract-signed` statuses. |
| src/lib/sponsor-crm/sanity.ts | Adds `tierExists` using the shared `tierExistenceQuery` so create/update guard and Studio warning agree on the same published-only definition of resolvable tier. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph ContractAxis [Contract Axis]
        CS[contract-sent] --> CSG{Guards}
        CSG --> TierG[tier present]
        CSG --> ValG[contractValue gt 0]
        CSG --> DeadG[status not closed-lost]
        CSN[contract-signed] --> CSNG{Guards}
        CSNG --> TierG2[tier present]
        CSNG --> ValG2[contractValue gt 0]
        CSNG --> ContactG[primary contact]
    end
    subgraph SigAxis [Signature Axis]
        SP[pending / signed] --> SIG{Guard}
        SIG --> SentG[contractStatus is sent or signed]
    end
    subgraph PipelineAxis [Pipeline Axis]
        CW[closed-won] --> PG{Guard}
        PG --> PTier[tier present]
        PTier --> TierExists{tierExists published?}
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/sponsor-crm/tier-validation.ts`, line 7-16 ([link](https://github.com/cloudnativebergen/website/blob/7337d8045b35fdfab1c289415324bf0ffe2ba377/src/lib/sponsor-crm/tier-validation.ts#L7-L16)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Orphaned JSDoc stacked above `tierExistenceQuery`**

   The `tierExistenceQuery` function was inserted between `closedWonTierWarning`'s original JSDoc (lines 7–15, describing the Studio warning) and the function itself. The existing JSDoc is now detached from `closedWonTierWarning` and sits immediately above `tierExistenceQuery`'s own JSDoc, creating two stacked comments — the first of which describes the wrong function. The original JSDoc should be moved back above `closedWonTierWarning`.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `src/server/routers/sponsor.ts`, line 1568-1578 ([link](https://github.com/cloudnativebergen/website/blob/7337d8045b35fdfab1c289415324bf0ffe2ba377/src/server/routers/sponsor.ts#L1568-L1578)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`updateSignatureStatus → signed` side-effects `contractStatus: contract-signed` without the contract-axis guards**

   When `input.newStatus === 'signed'`, the handler also writes `contractStatus: 'contract-signed'` to Sanity directly (line 1574). Only the signature-axis guard (`CONTRACT_SENT_GUARD`) runs at this point — the contract-axis guards for `contract-signed` (tier + value + primary contact) are not checked. This means the primary-contact requirement documented for the offline path is bypassed whenever a signature is accepted via the in-app signing flow. The asymmetry is not documented here. Is it intentional that the `contract-signed` contract-axis guards (specifically `PRIMARY_CONTACT_GUARD`) are not enforced when `updateSignatureStatus` auto-promotes `contractStatus` to `contract-signed`?

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(sponsor-crm): adversarial-review fol..."](https://github.com/cloudnativebergen/website/commit/7337d8045b35fdfab1c289415324bf0ffe2ba377) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36032019)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->