### PR TITLE
feat(sponsor-crm): guided tier picker on drag-to-won (#377)

### DIFF
--- a/__tests__/components/admin/sponsor-crm/TierPickerPrompt.test.tsx
+++ b/__tests__/components/admin/sponsor-crm/TierPickerPrompt.test.tsx
@@ -6,21 +6,12 @@ import { TierPickerPrompt } from '@/components/admin/sponsor-crm/TierPickerPromp
 import type { SponsorTier } from '@/lib/sponsor/types'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 
-// The modal chrome (animation, focus trap, theming) is a boundary; render its
-// children directly so the test can exercise the picker's own behaviour.
-vi.mock('@/components/ModalShell', () => ({
-  ModalShell: ({
-    isOpen,
-    children,
-  }: {
-    isOpen: boolean
-    children: React.ReactNode
-  }) => (isOpen ? <div>{children}</div> : null),
-}))
+// Render through the REAL ModalShell (headlessui Dialog) so the dialog's
+// accessible name and Escape/backdrop dismissal are exercised, not mocked away.
 
 const tiers = [
-  { _id: 'tier-bronze', title: 'Bronze' },
-  { _id: 'tier-gold', title: 'Gold' },
+  { _id: 'tier-bronze', title: 'Bronze', tierType: 'standard' },
+  { _id: 'tier-gold', title: 'Gold', tierType: 'standard' },
 ] as unknown as SponsorTier[]
 
 const sponsor = {
@@ -41,6 +32,21 @@ describe('TierPickerPrompt', () => {
 
     expect(screen.getByRole('button', { name: 'Bronze' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Gold' })).toBeInTheDocument()
+  })
+
+  it('exposes an accessible dialog name', () => {
+    render(
+      <TierPickerPrompt
+        sponsor={sponsor}
+        tiers={tiers}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('dialog')).toHaveAccessibleName(
+      'Set a tier to mark as Won',
+    )
   })
 
   it('completes the move with the chosen tier in one click', () => {
@@ -75,8 +81,63 @@ describe('TierPickerPrompt', () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
+  it('cancels on Escape (backdrop/Escape dismissal leaves the sponsor put)', () => {
+    const onCancel = vi.fn()
+    render(
+      <TierPickerPrompt
+        sponsor={sponsor}
+        tiers={tiers}
+        onSelect={vi.fn()}
+        onCancel={onCancel}
+      />,
+    )
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not offer addon tiers as a primary tier', () => {
+    const withAddon = [
+      ...tiers,
+      { _id: 'tier-booth', title: 'Booth upgrade', tierType: 'addon' },
+    ] as unknown as SponsorTier[]
+    render(
+      <TierPickerPrompt
+        sponsor={sponsor}
+        tiers={withAddon}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Bronze' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Booth upgrade' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('guides the user to Studio when no selectable tiers exist', () => {
+    const onlyAddons = [
+      { _id: 'tier-booth', title: 'Booth upgrade', tierType: 'addon' },
+    ] as unknown as SponsorTier[]
+    render(
+      <TierPickerPrompt
+        sponsor={sponsor}
+        tiers={onlyAddons}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Booth upgrade' })).toBeNull()
+    expect(screen.getByText(/no tiers are configured/i)).toBeInTheDocument()
+  })
+
   it('renders nothing when there is no pending sponsor', () => {
-    const { container } = render(
+    // ModalShell portals to document.body when open, so a body-scoped query —
+    // not the render container — is the meaningful "closed" assertion.
+    render(
       <TierPickerPrompt
         sponsor={null}
         tiers={tiers}
@@ -85,6 +146,6 @@ describe('TierPickerPrompt', () => {
       />,
     )
 
-    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/__tests__/components/admin/sponsor-crm/TierPickerPrompt.test.tsx
+++ b/__tests__/components/admin/sponsor-crm/TierPickerPrompt.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TierPickerPrompt } from '@/components/admin/sponsor-crm/TierPickerPrompt'
+import type { SponsorTier } from '@/lib/sponsor/types'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+// The modal chrome (animation, focus trap, theming) is a boundary; render its
+// children directly so the test can exercise the picker's own behaviour.
+vi.mock('@/components/ModalShell', () => ({
+  ModalShell: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean
+    children: React.ReactNode
+  }) => (isOpen ? <div>{children}</div> : null),
+}))
+
+const tiers = [
+  { _id: 'tier-bronze', title: 'Bronze' },
+  { _id: 'tier-gold', title: 'Gold' },
+] as unknown as SponsorTier[]
+
+const sponsor = {
+  _id: 'spc-1',
+  sponsor: { name: 'Acme' },
+} as unknown as SponsorForConferenceExpanded
+
+describe('TierPickerPrompt', () => {
+  it('offers a button for each tier', () => {
+    render(
+      <TierPickerPrompt
+        sponsor={sponsor}
+        tiers={tiers}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Bronze' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Gold' })).toBeInTheDocument()
+  })
+
+  it('completes the move with the chosen tier in one click', () => {
+    const onSelect = vi.fn()
+    render(
+      <TierPickerPrompt
+        sponsor={sponsor}
+        tiers={tiers}
+        onSelect={onSelect}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Gold' }))
+
+    expect(onSelect).toHaveBeenCalledWith('tier-gold')
+  })
+
+  it('cancels without selecting a tier', () => {
+    const onCancel = vi.fn()
+    render(
+      <TierPickerPrompt
+        sponsor={sponsor}
+        tiers={tiers}
+        onSelect={vi.fn()}
+        onCancel={onCancel}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders nothing when there is no pending sponsor', () => {
+    const { container } = render(
+      <TierPickerPrompt
+        sponsor={null}
+        tiers={tiers}
+        onSelect={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/__tests__/hooks/useSponsorDragDrop.test.tsx
+++ b/__tests__/hooks/useSponsorDragDrop.test.tsx
@@ -98,6 +98,10 @@ describe('dropNeedsTier', () => {
     expect(
       dropNeedsTier('pipeline', 'closed-won', { tier: { _id: 'tier-1' } }),
     ).toBe(false)
+    // a tier supplied as a bare id string also counts as set
+    expect(dropNeedsTier('pipeline', 'closed-won', { tier: 'tier-1' })).toBe(
+      false,
+    )
   })
 
   it('does not prompt for other pipeline columns', () => {
@@ -129,6 +133,10 @@ describe('useSponsorDragDrop — guided completion', () => {
 
     expect(mockMoveStage).not.toHaveBeenCalled()
     expect(mockShowNotification).not.toHaveBeenCalled()
+    // The move is held: nothing is optimistically applied, so the card stays in
+    // its source column until a tier is chosen.
+    expect(mockListCancel).not.toHaveBeenCalled()
+    expect(mockSetQueriesData).not.toHaveBeenCalled()
     expect(result.current.pendingTierMove).toEqual({
       sponsor,
       targetColumnKey: 'closed-won',
@@ -157,6 +165,11 @@ describe('useSponsorDragDrop — guided completion', () => {
     })
     expect(mockMoveStage).not.toHaveBeenCalled()
     expect(mockShowNotification).not.toHaveBeenCalled()
+    // The guided path runs through the shared optimistic machinery: cancel
+    // in-flight refetches, apply the optimistic move, then reconcile.
+    expect(mockListCancel).toHaveBeenCalled()
+    expect(mockSetQueriesData).toHaveBeenCalledTimes(1)
+    expect(mockListInvalidate).toHaveBeenCalledTimes(1)
     expect(result.current.pendingTierMove).toBeNull()
   })
 
@@ -180,6 +193,8 @@ describe('useSponsorDragDrop — guided completion', () => {
       await result.current.confirmTierMove('tier-gold')
     })
 
+    // Optimistic move applied, then rolled back to the snapshot on failure.
+    expect(mockSetQueriesData).toHaveBeenCalledTimes(1)
     expect(mockSetQueryData).toHaveBeenCalledWith(['k1'], [sponsor])
     expect(mockShowNotification).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -187,6 +202,8 @@ describe('useSponsorDragDrop — guided completion', () => {
         message: 'Set a sponsor tier before marking as Won.',
       }),
     )
+    // Still reconciles with the server even after a failed move.
+    expect(mockListInvalidate).toHaveBeenCalledTimes(1)
     expect(result.current.pendingTierMove).toBeNull()
   })
 
@@ -229,6 +246,89 @@ describe('useSponsorDragDrop — guided completion', () => {
       newStatus: 'closed-won',
     })
     expect(mockUpdate).not.toHaveBeenCalled()
+    expect(result.current.pendingTierMove).toBeNull()
+
+    // The optimistic updater flips status (and only status) for the pipeline
+    // board — guards applyOptimisticMove's pipeline arm against a field misroute.
+    const updater = mockSetQueriesData.mock.calls[0][1] as (
+      old: SponsorForConferenceExpanded[],
+    ) => SponsorForConferenceExpanded[]
+    const next = updater([sponsor])
+    expect(next[0].status).toBe('closed-won')
+    expect(next[0].invoiceStatus).toBe(sponsor.invoiceStatus)
+  })
+
+  it('confirmTierMove is a no-op when nothing is pending', async () => {
+    const { result } = renderHook(() => useSponsorDragDrop('pipeline'))
+
+    await act(async () => {
+      await result.current.confirmTierMove('tier-gold')
+    })
+
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockSetQueriesData).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSponsorDragDrop — direct moves (non-guided)', () => {
+  it('routes an invoice-board drag through the invoice mutation', async () => {
+    const sponsor = makeSponsor({ invoiceStatus: 'not-sent' })
+    const { result } = renderHook(() => useSponsorDragDrop('invoice'))
+
+    await act(async () => {
+      await result.current.handleDragEnd(dragEvent(sponsor, 'not-sent', 'sent'))
+    })
+
+    expect(mockUpdateInvoice).toHaveBeenCalledWith({
+      id: 'spc-1',
+      newStatus: 'sent',
+    })
+    expect(mockMoveStage).not.toHaveBeenCalled()
+    expect(mockUpdateContract).not.toHaveBeenCalled()
+    expect(mockListInvalidate).toHaveBeenCalledTimes(1)
+
+    // The optimistic updater flips invoiceStatus and only that — proving the
+    // refactored switch routes the invoice board to the invoice field.
+    const updater = mockSetQueriesData.mock.calls[0][1] as (
+      old: SponsorForConferenceExpanded[],
+    ) => SponsorForConferenceExpanded[]
+    const next = updater([sponsor])
+    expect(next[0].invoiceStatus).toBe('sent')
+    expect(next[0].status).toBe(sponsor.status)
+  })
+
+  it('routes a contract-board drag through the contract mutation', async () => {
+    const sponsor = makeSponsor({ contractStatus: 'none' })
+    const { result } = renderHook(() => useSponsorDragDrop('contract'))
+
+    await act(async () => {
+      await result.current.handleDragEnd(
+        dragEvent(sponsor, 'none', 'contract-sent'),
+      )
+    })
+
+    expect(mockUpdateContract).toHaveBeenCalledWith({
+      id: 'spc-1',
+      newStatus: 'contract-sent',
+    })
+    expect(mockMoveStage).not.toHaveBeenCalled()
+    expect(mockUpdateInvoice).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when a card is dropped back on its own column', async () => {
+    const sponsor = makeSponsor({ status: 'negotiating' })
+    const { result } = renderHook(() => useSponsorDragDrop('pipeline'))
+
+    await act(async () => {
+      await result.current.handleDragEnd(
+        dragEvent(sponsor, 'negotiating', 'negotiating'),
+      )
+    })
+
+    // No wasted mutation or optimistic write for an in-place drop.
+    expect(mockMoveStage).not.toHaveBeenCalled()
+    expect(mockSetQueriesData).not.toHaveBeenCalled()
+    expect(mockListCancel).not.toHaveBeenCalled()
     expect(result.current.pendingTierMove).toBeNull()
   })
 })

--- a/__tests__/hooks/useSponsorDragDrop.test.tsx
+++ b/__tests__/hooks/useSponsorDragDrop.test.tsx
@@ -89,34 +89,49 @@ beforeEach(() => {
 
 describe('dropNeedsTier', () => {
   it('flags a tierless pipeline drop onto closed-won', () => {
-    expect(dropNeedsTier('pipeline', 'closed-won', { tier: undefined })).toBe(
-      true,
-    )
+    expect(
+      dropNeedsTier('pipeline', 'negotiating', 'closed-won', {
+        tier: undefined,
+      }),
+    ).toBe(true)
   })
 
   it('does not prompt when a tier is already set', () => {
     expect(
-      dropNeedsTier('pipeline', 'closed-won', { tier: { _id: 'tier-1' } }),
+      dropNeedsTier('pipeline', 'negotiating', 'closed-won', {
+        tier: { _id: 'tier-1' },
+      }),
     ).toBe(false)
     // a tier supplied as a bare id string also counts as set
-    expect(dropNeedsTier('pipeline', 'closed-won', { tier: 'tier-1' })).toBe(
-      false,
-    )
+    expect(
+      dropNeedsTier('pipeline', 'negotiating', 'closed-won', {
+        tier: 'tier-1',
+      }),
+    ).toBe(false)
   })
 
-  it('does not prompt for other pipeline columns', () => {
-    expect(dropNeedsTier('pipeline', 'negotiating', { tier: undefined })).toBe(
-      false,
-    )
+  it('does not prompt for transitions the shared guard allows', () => {
+    // moving to an unguarded column never needs a tier
+    expect(
+      dropNeedsTier('pipeline', 'contacted', 'negotiating', {
+        tier: undefined,
+      }),
+    ).toBe(false)
+    // a same-state move is a no-op the guard permits
+    expect(
+      dropNeedsTier('pipeline', 'closed-won', 'closed-won', { tier: undefined }),
+    ).toBe(false)
   })
 
   it('does not prompt on the contract or invoice boards', () => {
-    expect(dropNeedsTier('contract', 'closed-won', { tier: undefined })).toBe(
-      false,
-    )
-    expect(dropNeedsTier('invoice', 'closed-won', { tier: undefined })).toBe(
-      false,
-    )
+    expect(
+      dropNeedsTier('contract', 'verbal-agreement', 'contract-sent', {
+        tier: undefined,
+      }),
+    ).toBe(false)
+    expect(
+      dropNeedsTier('invoice', 'not-sent', 'sent', { tier: undefined }),
+    ).toBe(false)
   })
 })
 

--- a/__tests__/hooks/useSponsorDragDrop.test.tsx
+++ b/__tests__/hooks/useSponsorDragDrop.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react'
+import type { DragEndEvent } from '@dnd-kit/core'
+import { dropNeedsTier, useSponsorDragDrop } from '@/hooks/useSponsorDragDrop'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+const mockMoveStage = vi.fn(() => Promise.resolve())
+const mockUpdate = vi.fn(() => Promise.resolve())
+const mockUpdateInvoice = vi.fn(() => Promise.resolve())
+const mockUpdateContract = vi.fn(() => Promise.resolve())
+const mockShowNotification = vi.fn()
+const mockListCancel = vi.fn(() => Promise.resolve())
+const mockListInvalidate = vi.fn()
+const mockGetQueriesData = vi.fn(() => [] as unknown[])
+const mockSetQueriesData = vi.fn()
+const mockSetQueryData = vi.fn()
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    useUtils: () => ({
+      sponsor: {
+        crm: {
+          list: { cancel: mockListCancel, invalidate: mockListInvalidate },
+        },
+      },
+    }),
+    sponsor: {
+      crm: {
+        moveStage: { useMutation: () => ({ mutateAsync: mockMoveStage }) },
+        update: { useMutation: () => ({ mutateAsync: mockUpdate }) },
+        updateInvoiceStatus: {
+          useMutation: () => ({ mutateAsync: mockUpdateInvoice }),
+        },
+        updateContractStatus: {
+          useMutation: () => ({ mutateAsync: mockUpdateContract }),
+        },
+      },
+    },
+  },
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    getQueriesData: mockGetQueriesData,
+    setQueriesData: mockSetQueriesData,
+    setQueryData: mockSetQueryData,
+  }),
+}))
+
+vi.mock('@/components/admin/NotificationProvider', () => ({
+  useNotification: () => ({ showNotification: mockShowNotification }),
+}))
+
+function makeSponsor(
+  overrides: Partial<SponsorForConferenceExpanded> = {},
+): SponsorForConferenceExpanded {
+  return {
+    _id: 'spc-1',
+    status: 'negotiating',
+    contractStatus: 'none',
+    invoiceStatus: 'not-sent',
+    tier: undefined,
+    ...overrides,
+  } as unknown as SponsorForConferenceExpanded
+}
+
+function dragEvent(
+  sponsor: SponsorForConferenceExpanded,
+  sourceColumnKey: string,
+  targetColumnKey: string,
+): DragEndEvent {
+  return {
+    active: {
+      id: sponsor._id,
+      data: { current: { type: 'sponsor', sponsor, sourceColumnKey } },
+    },
+    over: {
+      id: targetColumnKey,
+      data: { current: { type: 'column', columnKey: targetColumnKey } },
+    },
+  } as unknown as DragEndEvent
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('dropNeedsTier', () => {
+  it('flags a tierless pipeline drop onto closed-won', () => {
+    expect(dropNeedsTier('pipeline', 'closed-won', { tier: undefined })).toBe(
+      true,
+    )
+  })
+
+  it('does not prompt when a tier is already set', () => {
+    expect(
+      dropNeedsTier('pipeline', 'closed-won', { tier: { _id: 'tier-1' } }),
+    ).toBe(false)
+  })
+
+  it('does not prompt for other pipeline columns', () => {
+    expect(dropNeedsTier('pipeline', 'negotiating', { tier: undefined })).toBe(
+      false,
+    )
+  })
+
+  it('does not prompt on the contract or invoice boards', () => {
+    expect(dropNeedsTier('contract', 'closed-won', { tier: undefined })).toBe(
+      false,
+    )
+    expect(dropNeedsTier('invoice', 'closed-won', { tier: undefined })).toBe(
+      false,
+    )
+  })
+})
+
+describe('useSponsorDragDrop — guided completion', () => {
+  it('opens a tier prompt instead of moving a tierless sponsor to closed-won', async () => {
+    const sponsor = makeSponsor({ tier: undefined, status: 'negotiating' })
+    const { result } = renderHook(() => useSponsorDragDrop('pipeline'))
+
+    await act(async () => {
+      await result.current.handleDragEnd(
+        dragEvent(sponsor, 'negotiating', 'closed-won'),
+      )
+    })
+
+    expect(mockMoveStage).not.toHaveBeenCalled()
+    expect(mockShowNotification).not.toHaveBeenCalled()
+    expect(result.current.pendingTierMove).toEqual({
+      sponsor,
+      targetColumnKey: 'closed-won',
+    })
+  })
+
+  it('completes the move in one atomic update when a tier is chosen', async () => {
+    const sponsor = makeSponsor({ tier: undefined, status: 'negotiating' })
+    const { result } = renderHook(() => useSponsorDragDrop('pipeline'))
+
+    await act(async () => {
+      await result.current.handleDragEnd(
+        dragEvent(sponsor, 'negotiating', 'closed-won'),
+      )
+    })
+
+    await act(async () => {
+      await result.current.confirmTierMove('tier-gold')
+    })
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith({
+      id: 'spc-1',
+      tier: 'tier-gold',
+      status: 'closed-won',
+    })
+    expect(mockMoveStage).not.toHaveBeenCalled()
+    expect(mockShowNotification).not.toHaveBeenCalled()
+    expect(result.current.pendingTierMove).toBeNull()
+  })
+
+  it('rolls back and surfaces the guard message when the completion fails', async () => {
+    const sponsor = makeSponsor({ tier: undefined, status: 'negotiating' })
+    const snapshot = [['k1'], [sponsor]]
+    mockGetQueriesData.mockReturnValueOnce([snapshot])
+    mockUpdate.mockRejectedValueOnce(
+      Object.assign(new Error('Set a sponsor tier before marking as Won.'), {
+        data: { code: 'PRECONDITION_FAILED' },
+      }),
+    )
+    const { result } = renderHook(() => useSponsorDragDrop('pipeline'))
+
+    await act(async () => {
+      await result.current.handleDragEnd(
+        dragEvent(sponsor, 'negotiating', 'closed-won'),
+      )
+    })
+    await act(async () => {
+      await result.current.confirmTierMove('tier-gold')
+    })
+
+    expect(mockSetQueryData).toHaveBeenCalledWith(['k1'], [sponsor])
+    expect(mockShowNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        message: 'Set a sponsor tier before marking as Won.',
+      }),
+    )
+    expect(result.current.pendingTierMove).toBeNull()
+  })
+
+  it('leaves the sponsor put when the tier prompt is cancelled', async () => {
+    const sponsor = makeSponsor({ tier: undefined, status: 'negotiating' })
+    const { result } = renderHook(() => useSponsorDragDrop('pipeline'))
+
+    await act(async () => {
+      await result.current.handleDragEnd(
+        dragEvent(sponsor, 'negotiating', 'closed-won'),
+      )
+    })
+
+    act(() => {
+      result.current.cancelTierMove()
+    })
+
+    expect(result.current.pendingTierMove).toBeNull()
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockMoveStage).not.toHaveBeenCalled()
+    expect(mockSetQueriesData).not.toHaveBeenCalled()
+  })
+
+  it('moves a sponsor that already has a tier straight to closed-won', async () => {
+    const sponsor = makeSponsor({
+      tier: { _id: 'tier-1' } as SponsorForConferenceExpanded['tier'],
+      status: 'negotiating',
+    })
+    const { result } = renderHook(() => useSponsorDragDrop('pipeline'))
+
+    await act(async () => {
+      await result.current.handleDragEnd(
+        dragEvent(sponsor, 'negotiating', 'closed-won'),
+      )
+    })
+
+    expect(mockMoveStage).toHaveBeenCalledTimes(1)
+    expect(mockMoveStage).toHaveBeenCalledWith({
+      id: 'spc-1',
+      newStatus: 'closed-won',
+    })
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(result.current.pendingTierMove).toBeNull()
+  })
+})

--- a/__tests__/hooks/useSponsorDragDrop.test.tsx
+++ b/__tests__/hooks/useSponsorDragDrop.test.tsx
@@ -188,6 +188,15 @@ describe('useSponsorDragDrop — guided completion', () => {
     expect(mockSetQueriesData).toHaveBeenCalledTimes(1)
     expect(mockListInvalidate).toHaveBeenCalledTimes(1)
     expect(result.current.pendingTierMove).toBeNull()
+
+    // The optimistic updater sets BOTH status and the chosen tier, so the card
+    // never shows as tierless in closed-won before the refetch lands.
+    const updater = mockSetQueriesData.mock.calls[0][1] as (
+      old: SponsorForConferenceExpanded[],
+    ) => SponsorForConferenceExpanded[]
+    const next = updater([sponsor])
+    expect(next[0].status).toBe('closed-won')
+    expect(next[0].tier).toEqual({ _id: 'tier-gold' })
   })
 
   it('rolls back and surfaces the guard message when the completion fails', async () => {

--- a/__tests__/hooks/useSponsorDragDrop.test.tsx
+++ b/__tests__/hooks/useSponsorDragDrop.test.tsx
@@ -119,7 +119,9 @@ describe('dropNeedsTier', () => {
     ).toBe(false)
     // a same-state move is a no-op the guard permits
     expect(
-      dropNeedsTier('pipeline', 'closed-won', 'closed-won', { tier: undefined }),
+      dropNeedsTier('pipeline', 'closed-won', 'closed-won', {
+        tier: undefined,
+      }),
     ).toBe(false)
   })
 

--- a/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
@@ -39,6 +39,7 @@ import { SponsorTier } from '@/lib/sponsor/types'
 import { useSponsorDragDrop } from '@/hooks/useSponsorDragDrop'
 import { SponsorDeleteModal } from '@/components/admin/sponsor-crm/SponsorDeleteModal'
 import type { DeleteCleanupOptions } from '@/components/admin/sponsor-crm/SponsorDeleteModal'
+import { TierPickerPrompt } from '@/components/admin/sponsor-crm/TierPickerPrompt'
 import { DndContext, DragOverlay, pointerWithin } from '@dnd-kit/core'
 import clsx from 'clsx'
 
@@ -89,8 +90,15 @@ export function SponsorCRMPipeline({
 
   const utils = api.useUtils()
 
-  const { activeItem, isDragging, handleDragStart, handleDragEnd } =
-    useSponsorDragDrop(currentView)
+  const {
+    activeItem,
+    isDragging,
+    handleDragStart,
+    handleDragEnd,
+    pendingTierMove,
+    confirmTierMove,
+    cancelTierMove,
+  } = useSponsorDragDrop(currentView)
 
   const deleteMutation = api.sponsor.crm.delete.useMutation({
     onSuccess: () => {
@@ -116,7 +124,11 @@ export function SponsorCRMPipeline({
 
   // Pause background refresh when user is actively interacting
   const isUserBusy =
-    isFormOpen || isEmailModalOpen || isDragging || selectedIds.length > 0
+    isFormOpen ||
+    isEmailModalOpen ||
+    isDragging ||
+    pendingTierMove !== null ||
+    selectedIds.length > 0
 
   // Fetch with filters
   const { data: sponsors = [], isLoading } = api.sponsor.crm.list.useQuery(
@@ -447,6 +459,12 @@ export function SponsorCRMPipeline({
   return (
     <div className="flex h-full flex-col gap-2 lg:gap-4">
       {/* Modals */}
+      <TierPickerPrompt
+        sponsor={pendingTierMove?.sponsor ?? null}
+        tiers={tiers}
+        onSelect={confirmTierMove}
+        onCancel={cancelTierMove}
+      />
       <SponsorDeleteModal
         isOpen={deleteConfirmSponsor !== null}
         onClose={() => setDeleteConfirmSponsor(null)}

--- a/src/components/admin/sponsor-crm/TierPickerPrompt.stories.tsx
+++ b/src/components/admin/sponsor-crm/TierPickerPrompt.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, fn, screen, userEvent } from 'storybook/test'
+import { TierPickerPrompt } from './TierPickerPrompt'
+import { mockSponsor, mockSponsorTier } from '@/__mocks__/sponsor-data'
+
+const regularTiers = [
+  mockSponsorTier({
+    _id: 'tier-ingress',
+    title: 'Ingress',
+    price: [{ _key: 'p1', amount: 100000, currency: 'NOK' }],
+  }),
+  mockSponsorTier({
+    _id: 'tier-service',
+    title: 'Service',
+    price: [{ _key: 'p2', amount: 50000, currency: 'NOK' }],
+  }),
+  mockSponsorTier({
+    _id: 'tier-pod',
+    title: 'Pod',
+    price: [{ _key: 'p3', amount: 25000, currency: 'NOK' }],
+  }),
+]
+
+const addonTier = mockSponsorTier({
+  _id: 'tier-booth',
+  title: 'Booth upgrade',
+  tierType: 'addon',
+})
+
+const meta = {
+  title: 'Systems/Sponsors/Admin/Pipeline/TierPickerPrompt',
+  component: TierPickerPrompt,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Guided completion shown when a tierless sponsor is dragged to `closed-won`. Untiered sponsors are hidden from the public site, so the move is held until a tier is picked — clicking a tier completes the move in one step; Cancel (or Escape/backdrop) leaves the sponsor in its original stage. Addon tiers are excluded since they cannot be a sponsor’s primary tier.',
+      },
+    },
+  },
+  args: {
+    sponsor: mockSponsor({}),
+    tiers: regularTiers,
+    onSelect: fn(),
+    onCancel: fn(),
+  },
+} satisfies Meta<typeof TierPickerPrompt>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const ManyTiers: Story = {
+  args: {
+    tiers: [
+      ...regularTiers,
+      mockSponsorTier({ _id: 'tier-deployment', title: 'Deployment' }),
+      mockSponsorTier({ _id: 'tier-namespace', title: 'Namespace' }),
+      mockSponsorTier({
+        _id: 'tier-community',
+        title: 'Community Supporter (in-kind)',
+      }),
+    ],
+  },
+}
+
+export const ExcludesAddonTiers: Story = {
+  args: {
+    tiers: [...regularTiers, addonTier],
+  },
+  play: async () => {
+    // Standard tiers are offered, addon tiers are not — an addon must never
+    // become a sponsor's primary tier.
+    await expect(
+      screen.getByRole('button', { name: 'Ingress' }),
+    ).toBeInTheDocument()
+    await expect(
+      screen.queryByRole('button', { name: 'Booth upgrade' }),
+    ).not.toBeInTheDocument()
+  },
+}
+
+export const NoSelectableTiers: Story = {
+  args: {
+    // Only addon tiers configured: nothing selectable, so the guidance shows.
+    tiers: [addonTier],
+  },
+  play: async () => {
+    await expect(screen.getByText(/no tiers are configured/i)).toBeVisible()
+    await expect(
+      screen.queryByRole('button', { name: 'Booth upgrade' }),
+    ).not.toBeInTheDocument()
+  },
+}
+
+export const SelectingTierCompletesMove: Story = {
+  play: async ({ args }) => {
+    await userEvent.click(screen.getByRole('button', { name: 'Service' }))
+    await expect(args.onSelect).toHaveBeenCalledWith('tier-service')
+  },
+}
+
+export const CancelLeavesSponsorPut: Story = {
+  play: async ({ args }) => {
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await expect(args.onCancel).toHaveBeenCalledTimes(1)
+  },
+}
+
+export const Closed: Story = {
+  args: {
+    sponsor: null,
+  },
+  play: async () => {
+    await expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  },
+}

--- a/src/components/admin/sponsor-crm/TierPickerPrompt.stories.tsx
+++ b/src/components/admin/sponsor-crm/TierPickerPrompt.stories.tsx
@@ -89,7 +89,11 @@ export const NoSelectableTiers: Story = {
     tiers: [addonTier],
   },
   play: async () => {
-    await expect(screen.getByText(/no tiers are configured/i)).toBeVisible()
+    // Assert presence rather than visibility: headlessui's enter transition
+    // starts the panel at opacity-0, which `toBeVisible()` would reject mid-anim.
+    await expect(
+      screen.getByText(/no tiers are configured/i),
+    ).toBeInTheDocument()
     await expect(
       screen.queryByRole('button', { name: 'Booth upgrade' }),
     ).not.toBeInTheDocument()

--- a/src/components/admin/sponsor-crm/TierPickerPrompt.tsx
+++ b/src/components/admin/sponsor-crm/TierPickerPrompt.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { DialogTitle } from '@headlessui/react'
 import { Button } from '@/components/Button'
 import { ModalShell } from '@/components/ModalShell'
 import { sortSponsorTiers } from '@/components/admin/sponsor-crm/utils'
@@ -27,12 +28,22 @@ export function TierPickerPrompt({
   onSelect,
   onCancel,
 }: TierPickerPromptProps) {
+  // Only standard/special tiers can be a sponsor's primary tier — addons are a
+  // separate concern (the form keeps them out of its tier picker too), and the
+  // closed-won guard checks the primary tier, so an addon must not be offered.
+  const selectableTiers = sortSponsorTiers(tiers).filter(
+    (tier) => tier.tierType !== 'addon',
+  )
+
   return (
     <ModalShell isOpen={sponsor !== null} onClose={onCancel} size="md">
       <div className="text-center">
-        <h2 className="font-space-grotesk text-lg font-semibold text-brand-slate-gray dark:text-white">
+        <DialogTitle
+          as="h2"
+          className="font-space-grotesk text-lg font-semibold text-brand-slate-gray dark:text-white"
+        >
           Set a tier to mark as Won
-        </h2>
+        </DialogTitle>
         <p className="mt-2 text-sm text-brand-slate-gray/80 dark:text-gray-400">
           {sponsor?.sponsor?.name
             ? `${sponsor.sponsor.name} needs a tier before it can be Won — `
@@ -42,21 +53,23 @@ export function TierPickerPrompt({
       </div>
 
       <div className="mt-5 grid grid-cols-2 gap-2 sm:grid-cols-3">
-        {sortSponsorTiers(tiers).map((tier) => (
+        {selectableTiers.map((tier) => (
           <button
             key={tier._id}
             type="button"
+            title={tier.title}
             onClick={() => onSelect(tier._id)}
-            className="rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm font-medium text-gray-900 transition-colors hover:border-indigo-500 hover:bg-indigo-50 hover:text-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-indigo-500 dark:hover:bg-indigo-500/10 dark:hover:text-indigo-400"
+            className="min-w-0 truncate rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm font-medium text-gray-900 transition-colors hover:border-indigo-500 hover:bg-indigo-50 hover:text-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-indigo-500 dark:hover:bg-indigo-500/10 dark:hover:text-indigo-400"
           >
             {tier.title}
           </button>
         ))}
       </div>
 
-      {tiers.length === 0 && (
+      {selectableTiers.length === 0 && (
         <p className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
-          No tiers are configured for this conference yet.
+          No tiers are configured for this conference yet. Add one in Sanity
+          Studio before marking sponsors as Won.
         </p>
       )}
 

--- a/src/components/admin/sponsor-crm/TierPickerPrompt.tsx
+++ b/src/components/admin/sponsor-crm/TierPickerPrompt.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { Button } from '@/components/Button'
+import { ModalShell } from '@/components/ModalShell'
+import { sortSponsorTiers } from '@/components/admin/sponsor-crm/utils'
+import type { SponsorTier } from '@/lib/sponsor/types'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+interface TierPickerPromptProps {
+  /** The sponsor held mid-move; `null` keeps the prompt closed. */
+  sponsor: SponsorForConferenceExpanded | null
+  tiers: SponsorTier[]
+  /** Sets the tier and completes the move to closed-won in one step. */
+  onSelect: (tierId: string) => void
+  onCancel: () => void
+}
+
+/**
+ * Guided completion for a tierless drag onto `closed-won`: an untiered sponsor
+ * is hidden from the public site, so the move is held until a tier is picked.
+ * Clicking a tier completes the move in a single interaction; Cancel leaves the
+ * sponsor in its original stage.
+ */
+export function TierPickerPrompt({
+  sponsor,
+  tiers,
+  onSelect,
+  onCancel,
+}: TierPickerPromptProps) {
+  return (
+    <ModalShell isOpen={sponsor !== null} onClose={onCancel} size="md">
+      <div className="text-center">
+        <h2 className="font-space-grotesk text-lg font-semibold text-brand-slate-gray dark:text-white">
+          Set a tier to mark as Won
+        </h2>
+        <p className="mt-2 text-sm text-brand-slate-gray/80 dark:text-gray-400">
+          {sponsor?.sponsor?.name
+            ? `${sponsor.sponsor.name} needs a tier before it can be Won — `
+            : 'A tier is required before marking as Won — '}
+          untiered sponsors are hidden from the public site.
+        </p>
+      </div>
+
+      <div className="mt-5 grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {sortSponsorTiers(tiers).map((tier) => (
+          <button
+            key={tier._id}
+            type="button"
+            onClick={() => onSelect(tier._id)}
+            className="rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-sm font-medium text-gray-900 transition-colors hover:border-indigo-500 hover:bg-indigo-50 hover:text-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-indigo-500 dark:hover:bg-indigo-500/10 dark:hover:text-indigo-400"
+          >
+            {tier.title}
+          </button>
+        ))}
+      </div>
+
+      {tiers.length === 0 && (
+        <p className="mt-4 text-center text-sm text-gray-500 dark:text-gray-400">
+          No tiers are configured for this conference yet.
+        </p>
+      )}
+
+      <div className="mt-6 flex justify-end">
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          className="font-space-grotesk rounded-xl border-brand-frosted-steel px-4 py-2.5 text-sm font-semibold text-brand-slate-gray transition-all duration-200 hover:bg-brand-sky-mist dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          Cancel
+        </Button>
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -1,6 +1,6 @@
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback } from 'react'
 import { DragStartEvent, DragEndEvent } from '@dnd-kit/core'
-import { useQueryClient, type QueryKey } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 import { BoardView } from '@/components/admin/sponsor-crm/BoardViewSwitcher'
 import { useNotification } from '@/components/admin/NotificationProvider'
@@ -12,8 +12,6 @@ interface DragItem {
   sponsor: SponsorForConferenceExpanded
   sourceColumnKey: string
 }
-
-type CachedQueryEntry = [QueryKey, SponsorForConferenceExpanded[] | undefined]
 
 /**
  * A drop needs a guided tier prompt when it would move a sponsor to the
@@ -73,7 +71,6 @@ export function useSponsorDragDrop(currentView: BoardView) {
   const utils = api.useUtils()
   const queryClient = useQueryClient()
   const { showNotification } = useNotification()
-  const previousDataRef = useRef<CachedQueryEntry[]>([])
 
   const moveStage = api.sponsor.crm.moveStage.useMutation()
   const update = api.sponsor.crm.update.useMutation()
@@ -96,22 +93,29 @@ export function useSponsorDragDrop(currentView: BoardView) {
       targetColumnKey: string,
       mutate: () => Promise<unknown>,
     ) => {
+      // Cancel in-flight refetches so they can't clobber the optimistic write,
+      // then snapshot the cache for rollback before applying the move.
       await utils.sponsor.crm.list.cancel()
-      previousDataRef.current = queryClient.getQueriesData<
-        SponsorForConferenceExpanded[]
-      >(LIST_QUERY_KEY_FILTER)
+      const previous = queryClient.getQueriesData<SponsorForConferenceExpanded[]>(
+        LIST_QUERY_KEY_FILTER,
+      )
       queryClient.setQueriesData<SponsorForConferenceExpanded[]>(
         LIST_QUERY_KEY_FILTER,
         (old) =>
           applyOptimisticMove(old, sponsorId, currentView, targetColumnKey),
       )
+      // Tear down the drag overlay only once the optimistic move is in the cache,
+      // so the card never flashes back in its source column.
+      setActiveItem(null)
 
       try {
         await mutate()
       } catch (error) {
         console.error('Failed to update sponsor status:', error)
-        // Rollback to previous data on failure
-        for (const [key, data] of previousDataRef.current) {
+        // Roll back to the snapshot captured for THIS move. Keeping it local (not
+        // a shared ref) means overlapping moves can't clobber each other's
+        // rollback — a fast second drag while this mutation is still in flight.
+        for (const [key, data] of previous) {
           queryClient.setQueryData(key, data)
         }
         // Surface why the move was rejected: the server's actionable message for
@@ -124,8 +128,6 @@ export function useSponsorDragDrop(currentView: BoardView) {
             'Failed to update sponsor status. Please try again.',
           ),
         })
-      } finally {
-        previousDataRef.current = []
       }
 
       // Always refetch from server to ensure consistency
@@ -171,8 +173,7 @@ export function useSponsorDragDrop(currentView: BoardView) {
         return
       }
 
-      setActiveItem(null)
-
+      // runOptimisticMove clears the drag overlay once the optimistic move lands.
       await runOptimisticMove(sponsor._id, targetColumnKey, () => {
         switch (currentView) {
           case 'pipeline':

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -15,6 +15,19 @@ interface DragItem {
 
 type CachedQueryEntry = [QueryKey, SponsorForConferenceExpanded[] | undefined]
 
+/**
+ * A drop needs a guided tier prompt when it would move a sponsor to the
+ * pipeline's `closed-won` column without a tier set — the one transition the
+ * server guard blocks for lack of a tier. Every other drop proceeds directly.
+ */
+export function dropNeedsTier(
+  view: BoardView,
+  targetColumnKey: string,
+  sponsor: { tier?: unknown },
+): boolean {
+  return view === 'pipeline' && targetColumnKey === 'closed-won' && !sponsor.tier
+}
+
 function applyOptimisticMove(
   sponsors: SponsorForConferenceExpanded[] | undefined,
   sponsorId: string,
@@ -48,14 +61,22 @@ function applyOptimisticMove(
 
 const LIST_QUERY_KEY_FILTER = { queryKey: [['sponsor', 'crm', 'list']] }
 
+interface PendingTierMove {
+  sponsor: SponsorForConferenceExpanded
+  targetColumnKey: string
+}
+
 export function useSponsorDragDrop(currentView: BoardView) {
   const [activeItem, setActiveItem] = useState<DragItem | null>(null)
+  const [pendingTierMove, setPendingTierMove] =
+    useState<PendingTierMove | null>(null)
   const utils = api.useUtils()
   const queryClient = useQueryClient()
   const { showNotification } = useNotification()
   const previousDataRef = useRef<CachedQueryEntry[]>([])
 
   const moveStage = api.sponsor.crm.moveStage.useMutation()
+  const update = api.sponsor.crm.update.useMutation()
   const updateInvoiceStatus = api.sponsor.crm.updateInvoiceStatus.useMutation()
   const updateContractStatus =
     api.sponsor.crm.updateContractStatus.useMutation()
@@ -65,6 +86,53 @@ export function useSponsorDragDrop(currentView: BoardView) {
     const dragData = active.data.current as DragItem
     setActiveItem(dragData)
   }, [])
+
+  // Optimistically move a card, run the backing mutation, and on failure roll
+  // the cache back and surface why. Shared by direct drags and the guided
+  // tier-completion so both stay consistent.
+  const runOptimisticMove = useCallback(
+    async (
+      sponsorId: string,
+      targetColumnKey: string,
+      mutate: () => Promise<unknown>,
+    ) => {
+      await utils.sponsor.crm.list.cancel()
+      previousDataRef.current = queryClient.getQueriesData<
+        SponsorForConferenceExpanded[]
+      >(LIST_QUERY_KEY_FILTER)
+      queryClient.setQueriesData<SponsorForConferenceExpanded[]>(
+        LIST_QUERY_KEY_FILTER,
+        (old) =>
+          applyOptimisticMove(old, sponsorId, currentView, targetColumnKey),
+      )
+
+      try {
+        await mutate()
+      } catch (error) {
+        console.error('Failed to update sponsor status:', error)
+        // Rollback to previous data on failure
+        for (const [key, data] of previousDataRef.current) {
+          queryClient.setQueryData(key, data)
+        }
+        // Surface why the move was rejected: the server's actionable message for
+        // a guard rejection, a generic fallback for transient/internal errors.
+        showNotification({
+          type: 'error',
+          title: 'Could not move sponsor',
+          message: mutationRejectionMessage(
+            error,
+            'Failed to update sponsor status. Please try again.',
+          ),
+        })
+      } finally {
+        previousDataRef.current = []
+      }
+
+      // Always refetch from server to ensure consistency
+      utils.sponsor.crm.list.invalidate()
+    },
+    [currentView, utils, queryClient, showNotification],
+  )
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
@@ -94,23 +162,21 @@ export function useSponsorDragDrop(currentView: BoardView) {
         return
       }
 
-      // Capture previous data for rollback, then optimistically update
-      await utils.sponsor.crm.list.cancel()
-      previousDataRef.current = queryClient.getQueriesData<
-        SponsorForConferenceExpanded[]
-      >(LIST_QUERY_KEY_FILTER)
-      queryClient.setQueriesData<SponsorForConferenceExpanded[]>(
-        LIST_QUERY_KEY_FILTER,
-        (old) =>
-          applyOptimisticMove(old, sponsor._id, currentView, targetColumnKey),
-      )
+      // Guided completion: a tierless move to closed-won would be rejected by
+      // the server guard. Instead of letting it fail and bounce back, hold the
+      // move and ask for a tier — confirmTierMove finishes it in one step.
+      if (dropNeedsTier(currentView, targetColumnKey, sponsor)) {
+        setPendingTierMove({ sponsor, targetColumnKey })
+        setActiveItem(null)
+        return
+      }
 
       setActiveItem(null)
 
-      try {
+      await runOptimisticMove(sponsor._id, targetColumnKey, () => {
         switch (currentView) {
           case 'pipeline':
-            await moveStage.mutateAsync({
+            return moveStage.mutateAsync({
               id: sponsor._id,
               newStatus: targetColumnKey as
                 | 'prospect'
@@ -119,9 +185,8 @@ export function useSponsorDragDrop(currentView: BoardView) {
                 | 'closed-won'
                 | 'closed-lost',
             })
-            break
           case 'invoice':
-            await updateInvoiceStatus.mutateAsync({
+            return updateInvoiceStatus.mutateAsync({
               id: sponsor._id,
               newStatus: targetColumnKey as
                 | 'not-sent'
@@ -130,9 +195,8 @@ export function useSponsorDragDrop(currentView: BoardView) {
                 | 'overdue'
                 | 'cancelled',
             })
-            break
           case 'contract':
-            await updateContractStatus.mutateAsync({
+            return updateContractStatus.mutateAsync({
               id: sponsor._id,
               newStatus: targetColumnKey as
                 | 'none'
@@ -140,46 +204,53 @@ export function useSponsorDragDrop(currentView: BoardView) {
                 | 'contract-sent'
                 | 'contract-signed',
             })
-            break
+          default:
+            return Promise.resolve()
         }
-      } catch (error) {
-        console.error('Failed to update sponsor status:', error)
-        // Rollback to previous data on failure
-        for (const [key, data] of previousDataRef.current) {
-          queryClient.setQueryData(key, data)
-        }
-        // Surface why the move was rejected: the server's actionable message for
-        // a guard rejection, a generic fallback for transient/internal errors.
-        showNotification({
-          type: 'error',
-          title: 'Could not move sponsor',
-          message: mutationRejectionMessage(
-            error,
-            'Failed to update sponsor status. Please try again.',
-          ),
-        })
-      } finally {
-        previousDataRef.current = []
-      }
-
-      // Always refetch from server to ensure consistency
-      utils.sponsor.crm.list.invalidate()
+      })
     },
     [
       currentView,
+      runOptimisticMove,
       moveStage,
       updateInvoiceStatus,
       updateContractStatus,
-      utils,
-      queryClient,
-      showNotification,
     ],
   )
+
+  // Finish a held closed-won move with the chosen tier. Sets tier + status in a
+  // single atomic update so the server guard is satisfied and there is no
+  // half-done state (tier set but still not won).
+  const confirmTierMove = useCallback(
+    async (tierId: string) => {
+      if (!pendingTierMove) return
+      const { sponsor, targetColumnKey } = pendingTierMove
+      setPendingTierMove(null)
+
+      await runOptimisticMove(sponsor._id, targetColumnKey, () =>
+        update.mutateAsync({
+          id: sponsor._id,
+          tier: tierId,
+          status: targetColumnKey as SponsorForConferenceExpanded['status'],
+        }),
+      )
+    },
+    [pendingTierMove, update, runOptimisticMove],
+  )
+
+  // Abort a held move: nothing was optimistically applied, so the sponsor stays
+  // exactly where it started.
+  const cancelTierMove = useCallback(() => {
+    setPendingTierMove(null)
+  }, [])
 
   return {
     activeItem,
     isDragging: activeItem !== null,
     handleDragStart,
     handleDragEnd,
+    pendingTierMove,
+    confirmTierMove,
+    cancelTierMove,
   }
 }

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -6,6 +6,10 @@ import { BoardView } from '@/components/admin/sponsor-crm/BoardViewSwitcher'
 import { useNotification } from '@/components/admin/NotificationProvider'
 import { api } from '@/lib/trpc/client'
 import { mutationRejectionMessage } from '@/lib/trpc/errors'
+import {
+  canTransition,
+  type SponsorState,
+} from '@/lib/sponsor-crm/state-machine'
 
 interface DragItem {
   type: 'sponsor'
@@ -14,16 +18,22 @@ interface DragItem {
 }
 
 /**
- * A drop needs a guided tier prompt when it would move a sponsor to the
- * pipeline's `closed-won` column without a tier set — the one transition the
- * server guard blocks for lack of a tier. Every other drop proceeds directly.
+ * A drop needs a guided tier prompt when the pipeline transition the user is
+ * attempting is blocked specifically by a missing tier. The decision is
+ * delegated to the shared {@link canTransition} guard — the same source of truth
+ * the server enforces in `moveStage` — so the UX layer can never drift from the
+ * rule. The picker only resolves a tier, so it appears only when tier is the
+ * blocking field; every other drop (and every other axis) proceeds directly.
  */
 export function dropNeedsTier(
   view: BoardView,
-  targetColumnKey: string,
-  sponsor: { tier?: unknown },
+  from: string,
+  to: string,
+  sponsor: SponsorState,
 ): boolean {
-  return view === 'pipeline' && targetColumnKey === 'closed-won' && !sponsor.tier
+  if (view !== 'pipeline') return false
+  const result = canTransition('pipeline', from, to, sponsor)
+  return !result.ok && result.missing.some((field) => field.field === 'tier')
 }
 
 function applyOptimisticMove(
@@ -167,7 +177,7 @@ export function useSponsorDragDrop(currentView: BoardView) {
       // Guided completion: a tierless move to closed-won would be rejected by
       // the server guard. Instead of letting it fail and bounce back, hold the
       // move and ask for a tier — confirmTierMove finishes it in one step.
-      if (dropNeedsTier(currentView, targetColumnKey, sponsor)) {
+      if (dropNeedsTier(currentView, sourceColumnKey, targetColumnKey, sponsor)) {
         setPendingTierMove({ sponsor, targetColumnKey })
         setActiveItem(null)
         return

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -106,9 +106,9 @@ export function useSponsorDragDrop(currentView: BoardView) {
       // Cancel in-flight refetches so they can't clobber the optimistic write,
       // then snapshot the cache for rollback before applying the move.
       await utils.sponsor.crm.list.cancel()
-      const previous = queryClient.getQueriesData<SponsorForConferenceExpanded[]>(
-        LIST_QUERY_KEY_FILTER,
-      )
+      const previous = queryClient.getQueriesData<
+        SponsorForConferenceExpanded[]
+      >(LIST_QUERY_KEY_FILTER)
       queryClient.setQueriesData<SponsorForConferenceExpanded[]>(
         LIST_QUERY_KEY_FILTER,
         (old) =>
@@ -177,7 +177,9 @@ export function useSponsorDragDrop(currentView: BoardView) {
       // Guided completion: a tierless move to closed-won would be rejected by
       // the server guard. Instead of letting it fail and bounce back, hold the
       // move and ask for a tier — confirmTierMove finishes it in one step.
-      if (dropNeedsTier(currentView, sourceColumnKey, targetColumnKey, sponsor)) {
+      if (
+        dropNeedsTier(currentView, sourceColumnKey, targetColumnKey, sponsor)
+      ) {
         setPendingTierMove({ sponsor, targetColumnKey })
         setActiveItem(null)
         return

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -41,25 +41,30 @@ function applyOptimisticMove(
   sponsorId: string,
   currentView: BoardView,
   targetColumnKey: string,
+  patch?: Partial<SponsorForConferenceExpanded>,
 ): SponsorForConferenceExpanded[] | undefined {
   if (!sponsors) return sponsors
   return sponsors.map((s) => {
     if (s._id !== sponsorId) return s
+    // `patch` carries fields the move also sets (e.g. the tier chosen in the
+    // guided closed-won completion) so the optimistic cache matches what the
+    // mutation persists, not just the column change.
+    const base = { ...s, ...patch }
     switch (currentView) {
       case 'pipeline':
         return {
-          ...s,
+          ...base,
           status: targetColumnKey as SponsorForConferenceExpanded['status'],
         }
       case 'contract':
         return {
-          ...s,
+          ...base,
           contractStatus:
             targetColumnKey as SponsorForConferenceExpanded['contractStatus'],
         }
       case 'invoice':
         return {
-          ...s,
+          ...base,
           invoiceStatus:
             targetColumnKey as SponsorForConferenceExpanded['invoiceStatus'],
         }
@@ -102,6 +107,7 @@ export function useSponsorDragDrop(currentView: BoardView) {
       sponsorId: string,
       targetColumnKey: string,
       mutate: () => Promise<unknown>,
+      patch?: Partial<SponsorForConferenceExpanded>,
     ) => {
       // Cancel in-flight refetches so they can't clobber the optimistic write,
       // then snapshot the cache for rollback before applying the move.
@@ -112,7 +118,13 @@ export function useSponsorDragDrop(currentView: BoardView) {
       queryClient.setQueriesData<SponsorForConferenceExpanded[]>(
         LIST_QUERY_KEY_FILTER,
         (old) =>
-          applyOptimisticMove(old, sponsorId, currentView, targetColumnKey),
+          applyOptimisticMove(
+            old,
+            sponsorId,
+            currentView,
+            targetColumnKey,
+            patch,
+          ),
       )
       // Tear down the drag overlay only once the optimistic move is in the cache,
       // so the card never flashes back in its source column.
@@ -240,12 +252,18 @@ export function useSponsorDragDrop(currentView: BoardView) {
       const { sponsor, targetColumnKey } = pendingTierMove
       setPendingTierMove(null)
 
-      await runOptimisticMove(sponsor._id, targetColumnKey, () =>
-        update.mutateAsync({
-          id: sponsor._id,
-          tier: tierId,
-          status: targetColumnKey as SponsorForConferenceExpanded['status'],
-        }),
+      await runOptimisticMove(
+        sponsor._id,
+        targetColumnKey,
+        () =>
+          update.mutateAsync({
+            id: sponsor._id,
+            tier: tierId,
+            status: targetColumnKey as SponsorForConferenceExpanded['status'],
+          }),
+        // Reflect the chosen tier optimistically so the card isn't briefly shown
+        // as tierless in closed-won; the refetch fills in the full tier object.
+        { tier: { _id: tierId } as SponsorForConferenceExpanded['tier'] },
       )
     },
     [pendingTierMove, update, runOptimisticMove],


### PR DESCRIPTION
## Summary

Turns the blocked "move to won without a tier" interaction into a **guided completion** (#377). When an organizer drags a tierless sponsor to `closed-won`, an inline tier picker now appears instead of the card bouncing back with an error. The server guard from the #374 foundation stays the source of truth — this is purely the UX layer over it.

## Changes
- **`useSponsorDragDrop`** — `dropNeedsTier()` classifier; `pendingTierMove` state with `confirmTierMove`/`cancelTierMove`. A tierless drag to `closed-won` is held (no doomed mutation, no error toast) until a tier is chosen, then completed with a single atomic `update({ id, tier, status: 'closed-won' })`. Extracted a shared `runOptimisticMove` helper that de-dupes the optimistic-move → mutate → rollback/notify → invalidate flow used by both direct drags and the guided path.
- **`TierPickerPrompt`** — new click-a-tier-to-move modal, fed by the conference's tiers.
- **`SponsorCRMPipeline`** — renders the prompt from `pendingTierMove`; pauses background refetch while it's open.

## Acceptance criteria
- [x] Dragging a tierless sponsor to `closed-won` opens the inline tier picker rather than failing.
- [x] Selecting a tier sets it and completes the move in one interaction.
- [x] Cancelling leaves the sponsor in its original stage with no change.
- [x] If a tier is already set, the move completes with no extra prompt.
- [x] The server-side guard still enforces the rule independently of the UI.

## Testing (TDD)
- 9 hook tests: `dropNeedsTier` truth table, prompt-on-tierless (no mutation), atomic confirm, rollback + guard message on failure, cancel, direct move regression.
- 4 picker component tests: renders tiers, click → select, cancel, closed when no pending sponsor.
- Full suite: **1913 passed, 5 skipped** · `tsc --noEmit` clean · lint clean.

## Notes
- Server enforcement (`moveStage` / `update` guards) is unchanged; the guided path goes through the existing `update` mutation, so the dangling-tier check (`assertTierResolvable`) and stage-change activity logging still apply.
- The headlessui modal rendering over the board is worth a quick manual smoke-test (component tests mock the modal chrome).

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the previous \"bounce-back\" error when a tierless sponsor is dragged to `closed-won` with a guided tier-picker modal. When the drop is intercepted, a `pendingTierMove` state holds the move, a modal collects the tier, and `confirmTierMove` completes both the tier assignment and stage transition in a single atomic server call.

- **`useSponsorDragDrop`** gains `dropNeedsTier`, `pendingTierMove`, `confirmTierMove`, and `cancelTierMove`; a shared `runOptimisticMove` helper deduplicates the optimistic-update/rollback flow used by both direct drags and the guided path.
- **`TierPickerPrompt`** is a new modal component fed by the conference's tier list; `SponsorCRMPipeline` mounts it and correctly extends `isUserBusy` to pause background polling while the prompt is open.

<h3>Confidence Score: 4/5</h3>

The guided tier-picker path is safe to merge: the server guard remains the authoritative enforcer, the cancel path makes no mutations, and tests cover the key scenarios including rollback.

The refactored hook and new modal work correctly end-to-end. The missing tier in the optimistic cache patch (`applyOptimisticMove` spreads `status` but not the selected `tier`) leaves a transient inconsistency between the optimistic state and the final server-synced state. It self-corrects on invalidate but could be jarring if the sponsor detail panel is open at the same time. No Storybook story was added for `TierPickerPrompt` despite AGENTS.md requiring it as the source of truth for UI components.

`src/hooks/useSponsorDragDrop.ts` — the `runOptimisticMove` / `applyOptimisticMove` combination for the `confirmTierMove` path; `src/components/admin/sponsor-crm/TierPickerPrompt.tsx` — missing Storybook story and no-tiers empty state UX.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/hooks/useSponsorDragDrop.ts | Core hook refactor: adds `pendingTierMove` state, exported `dropNeedsTier` classifier, and shared `runOptimisticMove` helper; the optimistic update for the guided tier path does not include the chosen tier in the cache, leaving a brief gap before the invalidate refetch corrects it |
| src/components/admin/sponsor-crm/TierPickerPrompt.tsx | New modal component for picking a tier mid-drag; well-structured with accessible buttons and dark-mode classes, but lacks a Storybook story (required by AGENTS.md) and provides no CTA when no tiers are configured |
| src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx | Minimal integration: destructures new hook returns, mounts `TierPickerPrompt`, and correctly adds `pendingTierMove !== null` to `isUserBusy` to pause background polling while the prompt is open |
| __tests__/hooks/useSponsorDragDrop.test.tsx | Comprehensive hook tests: covers `dropNeedsTier` truth table, tierless intercept (no mutation), atomic confirm, rollback + guard-message surfacing, cancel, and direct-move regression |
| __tests__/components/admin/sponsor-crm/TierPickerPrompt.test.tsx | Four focused component tests covering tier rendering, click-to-select, cancel, and the null-sponsor closed state; correctly mocks ModalShell at the boundary |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Board as SponsorCRMPipeline
    participant Hook as useSponsorDragDrop
    participant Modal as TierPickerPrompt
    participant Cache as React Query Cache
    participant Server as tRPC Server

    User->>Board: Drag tierless sponsor → closed-won
    Board->>Hook: handleDragEnd()
    Hook->>Hook: dropNeedsTier() → true
    Hook->>Hook: "setPendingTierMove({ sponsor, targetColumnKey })"
    Hook-->>Board: pendingTierMove (non-null)
    Board->>Modal: "Render (isOpen=true)"

    alt User selects a tier
        User->>Modal: Click tier button
        Modal->>Hook: confirmTierMove(tierId)
        Hook->>Hook: setPendingTierMove(null)
        Hook->>Cache: cancel() + optimistic update (status only)
        Hook->>Server: "update({ id, tier, status: 'closed-won' })"
        Server-->>Hook: success
        Hook->>Cache: invalidate() → refetch (tier + status)
    else User cancels
        User->>Modal: Click Cancel
        Modal->>Hook: cancelTierMove()
        Hook->>Hook: setPendingTierMove(null)
        Note over Hook,Cache: No mutation, no cache change
    end
```

<sub>Reviews (1): Last reviewed commit: ["feat(sponsor-crm): guided tier picker on..."](https://github.com/cloudnativebergen/website/commit/394e4cf4a8df6fb7e781261c43dc6b7f41dcd905) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36035794)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->