### PR TITLE
feat(sponsor-crm): data-health panel listing invariant violations (#378)

### DIFF
--- a/__tests__/api/trpc/sponsor-health.test.ts
+++ b/__tests__/api/trpc/sponsor-health.test.ts
@@ -99,13 +99,18 @@ describe('sponsor.crm.healthViolations', () => {
 
     await createCaller(mockOrganizer).sponsor.crm.healthViolations()
 
-    // No status/tier/etc. filters — the panel must see every sponsor.
-    expect(listSponsorsForConference).toHaveBeenCalledWith('conf-1')
+    // Exactly one argument — the conference id, with NO filter object — so the
+    // data layer can't drop any sponsor by status/tier/etc. before the audit
+    // sees it (unlike crm.list, which forwards board filters to GROQ).
+    const calls = vi.mocked(listSponsorsForConference).mock.calls
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual(['conf-1'])
   })
 
-  it('audits sponsors of every pipeline status, not just the board default view', async () => {
-    // A prospect with a contract-sent record and a closed-won without a tier
-    // sit in different board columns; both must surface in the panel.
+  it('does not post-filter the roster by status the way the board list does', async () => {
+    // crm.list re-filters fetched sponsors (status, staleness, contact info…);
+    // the audit must NOT — a prospect with a bad contract and a tierless won
+    // deal sit in different board columns yet both must surface.
     vi.mocked(listSponsorsForConference).mockResolvedValue({
       sponsors: [
         makeSfc({
@@ -126,8 +131,22 @@ describe('sponsor.crm.healthViolations', () => {
     const result =
       await createCaller(mockOrganizer).sponsor.crm.healthViolations()
 
-    const ids = result.map((v) => v.sponsorId)
-    expect(ids).toEqual(expect.arrayContaining(['sfc-prospect', 'sfc-won']))
+    // Both surface, none dropped by status.
+    expect(result.map((v) => v.sponsorId).sort()).toEqual([
+      'sfc-prospect',
+      'sfc-won',
+    ])
+  })
+
+  it('throws when the sponsor list fails, so a failed audit is never mistaken for a clean one', async () => {
+    vi.mocked(listSponsorsForConference).mockResolvedValue({
+      sponsors: undefined,
+      error: new Error('sanity unavailable'),
+    })
+
+    await expect(
+      createCaller(mockOrganizer).sponsor.crm.healthViolations(),
+    ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' })
   })
 
   it('returns an empty list when every sponsor is healthy', async () => {

--- a/__tests__/api/trpc/sponsor-health.test.ts
+++ b/__tests__/api/trpc/sponsor-health.test.ts
@@ -103,6 +103,33 @@ describe('sponsor.crm.healthViolations', () => {
     expect(listSponsorsForConference).toHaveBeenCalledWith('conf-1')
   })
 
+  it('audits sponsors of every pipeline status, not just the board default view', async () => {
+    // A prospect with a contract-sent record and a closed-won without a tier
+    // sit in different board columns; both must surface in the panel.
+    vi.mocked(listSponsorsForConference).mockResolvedValue({
+      sponsors: [
+        makeSfc({
+          _id: 'sfc-prospect',
+          status: 'prospect',
+          contractStatus: 'contract-sent',
+          tier: undefined,
+          contractValue: 0,
+        }),
+        makeSfc({
+          _id: 'sfc-won',
+          status: 'closed-won',
+          tier: undefined,
+        }),
+      ],
+    })
+
+    const result =
+      await createCaller(mockOrganizer).sponsor.crm.healthViolations()
+
+    const ids = result.map((v) => v.sponsorId)
+    expect(ids).toEqual(expect.arrayContaining(['sfc-prospect', 'sfc-won']))
+  })
+
   it('returns an empty list when every sponsor is healthy', async () => {
     vi.mocked(listSponsorsForConference).mockResolvedValue({
       sponsors: [makeSfc({ status: 'negotiating' })],

--- a/__tests__/api/trpc/sponsor-health.test.ts
+++ b/__tests__/api/trpc/sponsor-health.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { appRouter } from '@/server/_app'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { listSponsorsForConference } from '@/lib/sponsor-crm/sanity'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+vi.mock('@/lib/conference/sanity')
+vi.mock('@/lib/speaker/sanity')
+vi.mock('@/lib/sponsor-crm/sanity')
+vi.mock('@/lib/sponsor-crm/activity')
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: vi.fn(), patch: vi.fn(), transaction: vi.fn() },
+  clientReadUncached: { fetch: vi.fn() },
+  clientRead: { fetch: vi.fn() },
+}))
+
+const mockOrganizer = {
+  _id: 'org-1',
+  name: 'Org',
+  email: 'org@test.com',
+  isOrganizer: true,
+}
+const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+
+const tier: SponsorForConferenceExpanded['tier'] = {
+  _id: 'tier-gold',
+  title: 'Gold',
+  tagline: '',
+  tierType: 'standard',
+}
+
+function makeSfc(
+  overrides: Partial<SponsorForConferenceExpanded> = {},
+): SponsorForConferenceExpanded {
+  return {
+    _id: 'sfc-1',
+    _createdAt: '',
+    _updatedAt: '',
+    sponsor: {
+      _id: 's1',
+      name: 'Acme',
+      website: 'https://acme.test',
+      logo: '',
+    },
+    conference: { _id: 'conf-1', title: 'Test Conf' },
+    contractStatus: 'none',
+    status: 'negotiating',
+    contractCurrency: 'NOK',
+    invoiceStatus: 'not-sent',
+    ...overrides,
+  }
+}
+
+const createCaller = (speaker: any) =>
+  appRouter.createCaller({
+    session: { user: { email: speaker.email }, speaker },
+    speaker,
+    user: { email: speaker.email },
+  } as any)
+
+describe('sponsor.crm.healthViolations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
+      conference: mockConference as any,
+      domain: 'test.com',
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns audited violations across all sponsors of the conference', async () => {
+    vi.mocked(listSponsorsForConference).mockResolvedValue({
+      sponsors: [
+        makeSfc({
+          _id: 'sfc-hidden',
+          status: 'closed-won',
+          tier: undefined,
+        }),
+        makeSfc({ _id: 'sfc-ok', status: 'closed-won', tier }),
+      ],
+    })
+
+    const result =
+      await createCaller(mockOrganizer).sponsor.crm.healthViolations()
+
+    expect(result).toHaveLength(1)
+    expect(result[0].sponsorId).toBe('sfc-hidden')
+    expect(result[0].axis).toBe('pipeline')
+    expect(result[0].hidesFromPublicSite).toBe(true)
+  })
+
+  it('audits the full conference roster, not a filtered subset', async () => {
+    vi.mocked(listSponsorsForConference).mockResolvedValue({ sponsors: [] })
+
+    await createCaller(mockOrganizer).sponsor.crm.healthViolations()
+
+    // No status/tier/etc. filters — the panel must see every sponsor.
+    expect(listSponsorsForConference).toHaveBeenCalledWith('conf-1')
+  })
+
+  it('returns an empty list when every sponsor is healthy', async () => {
+    vi.mocked(listSponsorsForConference).mockResolvedValue({
+      sponsors: [makeSfc({ status: 'negotiating' })],
+    })
+
+    const result =
+      await createCaller(mockOrganizer).sponsor.crm.healthViolations()
+
+    expect(result).toEqual([])
+  })
+})

--- a/__tests__/components/admin/sponsor-crm/SponsorHealthPanel.test.tsx
+++ b/__tests__/components/admin/sponsor-crm/SponsorHealthPanel.test.tsx
@@ -43,6 +43,13 @@ describe('SponsorHealthPanel', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  it('shows a distinct error notice when the audit failed, instead of silently looking healthy', () => {
+    const { container } = render(<SponsorHealthPanel violations={[]} isError />)
+
+    expect(container).not.toBeEmptyDOMElement()
+    expect(screen.getByText(/couldn.t check data health/i)).toBeInTheDocument()
+  })
+
   it('attaches the public-site-hide badge to the hiding row only, not the others', () => {
     render(
       <SponsorHealthPanel

--- a/__tests__/components/admin/sponsor-crm/SponsorHealthPanel.test.tsx
+++ b/__tests__/components/admin/sponsor-crm/SponsorHealthPanel.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import { SponsorHealthPanel } from '@/components/admin/sponsor-crm/SponsorHealthPanel'
+import type { SponsorHealthViolation } from '@/lib/sponsor-crm/health'
+
+function violation(
+  overrides: Partial<SponsorHealthViolation> = {},
+): SponsorHealthViolation {
+  return {
+    sponsorId: 'sfc-1',
+    sponsorName: 'Acme',
+    axis: 'pipeline',
+    state: 'closed-won',
+    missing: [
+      {
+        field: 'tier',
+        label: 'Sponsor tier',
+        source: 'pipeline',
+        severity: 'required',
+        message: 'Set a sponsor tier before marking as Won.',
+      },
+    ],
+    hidesFromPublicSite: false,
+    ...overrides,
+  }
+}
+
+describe('SponsorHealthPanel', () => {
+  it('lists a violation with the sponsor name and the specific rule it breaks', () => {
+    render(<SponsorHealthPanel violations={[violation()]} />)
+
+    expect(screen.getByText('Acme')).toBeInTheDocument()
+    expect(
+      screen.getByText(/set a sponsor tier before marking as won/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders nothing when there are no violations', () => {
+    const { container } = render(<SponsorHealthPanel violations={[]} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('distinguishes a public-site-hiding violation with a prominent badge', () => {
+    render(
+      <SponsorHealthPanel
+        violations={[
+          violation({
+            sponsorId: 'sfc-hidden',
+            sponsorName: 'Hidden Co',
+            hidesFromPublicSite: true,
+          }),
+          violation({
+            sponsorId: 'sfc-other',
+            sponsorName: 'Other Co',
+            axis: 'contract',
+            state: 'contract-sent',
+            hidesFromPublicSite: false,
+          }),
+        ]}
+      />,
+    )
+
+    // The hide badge appears exactly once — only for the hiding violation.
+    expect(screen.getAllByText(/hidden from the public site/i)).toHaveLength(1)
+  })
+})

--- a/__tests__/components/admin/sponsor-crm/SponsorHealthPanel.test.tsx
+++ b/__tests__/components/admin/sponsor-crm/SponsorHealthPanel.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { SponsorHealthPanel } from '@/components/admin/sponsor-crm/SponsorHealthPanel'
 import type { SponsorHealthViolation } from '@/lib/sponsor-crm/health'
 
@@ -43,7 +43,7 @@ describe('SponsorHealthPanel', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('distinguishes a public-site-hiding violation with a prominent badge', () => {
+  it('attaches the public-site-hide badge to the hiding row only, not the others', () => {
     render(
       <SponsorHealthPanel
         violations={[
@@ -63,7 +63,40 @@ describe('SponsorHealthPanel', () => {
       />,
     )
 
-    // The hide badge appears exactly once — only for the hiding violation.
-    expect(screen.getAllByText(/hidden from the public site/i)).toHaveLength(1)
+    const hiddenRow = screen.getByText('Hidden Co').closest('li')!
+    const otherRow = screen.getByText('Other Co').closest('li')!
+
+    expect(
+      within(hiddenRow).getByText(/hidden from the public site/i),
+    ).toBeInTheDocument()
+    expect(
+      within(otherRow).queryByText(/hidden from the public site/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('labels each violation with its axis and a human-readable state', () => {
+    render(
+      <SponsorHealthPanel
+        violations={[
+          violation({ axis: 'pipeline', state: 'closed-won' }),
+          violation({
+            sponsorId: 'sfc-2',
+            axis: 'contract',
+            state: 'contract-sent',
+          }),
+          // An unmapped/future state falls through to its raw value rather than
+          // rendering blank.
+          violation({
+            sponsorId: 'sfc-3',
+            axis: 'signature',
+            state: 'mystery-state',
+          }),
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Pipeline · Closed - Won')).toBeInTheDocument()
+    expect(screen.getByText('Contract · Contract Sent')).toBeInTheDocument()
+    expect(screen.getByText('Signature · mystery-state')).toBeInTheDocument()
   })
 })

--- a/__tests__/hooks/useSponsorDragDrop.test.tsx
+++ b/__tests__/hooks/useSponsorDragDrop.test.tsx
@@ -13,6 +13,7 @@ const mockUpdateContract = vi.fn(() => Promise.resolve())
 const mockShowNotification = vi.fn()
 const mockListCancel = vi.fn(() => Promise.resolve())
 const mockListInvalidate = vi.fn()
+const mockHealthInvalidate = vi.fn()
 const mockGetQueriesData = vi.fn(() => [] as unknown[])
 const mockSetQueriesData = vi.fn()
 const mockSetQueryData = vi.fn()
@@ -23,6 +24,7 @@ vi.mock('@/lib/trpc/client', () => ({
       sponsor: {
         crm: {
           list: { cancel: mockListCancel, invalidate: mockListInvalidate },
+          healthViolations: { invalidate: mockHealthInvalidate },
         },
       },
     }),

--- a/__tests__/lib/sponsor-crm/health.test.ts
+++ b/__tests__/lib/sponsor-crm/health.test.ts
@@ -1,0 +1,135 @@
+import { auditSponsorHealth } from '@/lib/sponsor-crm/health'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+
+function makeSfc(
+  overrides: Partial<SponsorForConferenceExpanded> = {},
+): SponsorForConferenceExpanded {
+  return {
+    _id: 'sfc-1',
+    _createdAt: '',
+    _updatedAt: '',
+    sponsor: {
+      _id: 's1',
+      name: 'Acme',
+      website: 'https://acme.test',
+      logo: '',
+    },
+    conference: { _id: 'c1', title: 'Test Conf' },
+    contractStatus: 'none',
+    status: 'negotiating',
+    contractCurrency: 'NOK',
+    invoiceStatus: 'not-sent',
+    ...overrides,
+  }
+}
+
+const tier: SponsorForConferenceExpanded['tier'] = {
+  _id: 'tier-gold',
+  title: 'Gold',
+  tagline: '',
+  tierType: 'standard',
+}
+
+describe('auditSponsorHealth', () => {
+  it('flags a closed-won sponsor without a tier as hiding it from the public site', () => {
+    const violations = auditSponsorHealth([
+      makeSfc({ status: 'closed-won', tier: undefined }),
+    ])
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0].axis).toBe('pipeline')
+    expect(violations[0].state).toBe('closed-won')
+    expect(violations[0].hidesFromPublicSite).toBe(true)
+    expect(violations[0].missing.some((m) => m.field === 'tier')).toBe(true)
+  })
+
+  it('returns no violations when every sponsor is healthy', () => {
+    const violations = auditSponsorHealth([
+      makeSfc({ status: 'negotiating' }),
+      makeSfc({ status: 'closed-won', tier }),
+    ])
+
+    expect(violations).toEqual([])
+  })
+
+  it('flags a contract-sent sponsor missing tier and value on the contract axis (not a public-site hide)', () => {
+    const violations = auditSponsorHealth([
+      makeSfc({
+        status: 'negotiating',
+        contractStatus: 'contract-sent',
+        tier: undefined,
+        contractValue: 0,
+      }),
+    ])
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0].axis).toBe('contract')
+    expect(violations[0].state).toBe('contract-sent')
+    expect(violations[0].missing.map((m) => m.field)).toEqual(
+      expect.arrayContaining(['tier', 'contractValue']),
+    )
+    expect(violations[0].hidesFromPublicSite).toBe(false)
+  })
+
+  it('flags a signature-pending sponsor whose contract was never sent, naming the sponsor', () => {
+    const violations = auditSponsorHealth([
+      makeSfc({
+        _id: 'sfc-acme',
+        sponsor: {
+          _id: 's1',
+          name: 'Acme Corp',
+          website: 'https://acme.test',
+          logo: '',
+        },
+        status: 'negotiating',
+        contractStatus: 'none',
+        signatureStatus: 'pending',
+      }),
+    ])
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0].axis).toBe('signature')
+    expect(violations[0].state).toBe('pending')
+    expect(violations[0].sponsorId).toBe('sfc-acme')
+    expect(violations[0].sponsorName).toBe('Acme Corp')
+    expect(violations[0].missing.some((m) => m.field === 'contractStatus')).toBe(
+      true,
+    )
+  })
+
+  it('reports one violation per axis when a sponsor breaks several at once', () => {
+    const violations = auditSponsorHealth([
+      makeSfc({
+        status: 'closed-won', // pipeline: missing tier
+        tier: undefined,
+        contractStatus: 'contract-sent', // contract: missing tier + value
+        contractValue: 0,
+      }),
+    ])
+
+    const axes = violations.map((v) => v.axis)
+    expect(axes).toEqual(expect.arrayContaining(['pipeline', 'contract']))
+    expect(violations).toHaveLength(2)
+  })
+
+  it('orders public-site-hiding violations first, regardless of input order', () => {
+    const violations = auditSponsorHealth([
+      makeSfc({
+        _id: 'sfc-contract',
+        status: 'negotiating',
+        contractStatus: 'contract-sent', // not a public-site hide
+        tier: undefined,
+        contractValue: 0,
+      }),
+      makeSfc({
+        _id: 'sfc-hidden',
+        status: 'closed-won', // public-site hide
+        tier: undefined,
+      }),
+    ])
+
+    expect(violations).toHaveLength(2)
+    expect(violations[0].sponsorId).toBe('sfc-hidden')
+    expect(violations[0].hidesFromPublicSite).toBe(true)
+  })
+})

--- a/__tests__/lib/sponsor-crm/health.test.ts
+++ b/__tests__/lib/sponsor-crm/health.test.ts
@@ -112,6 +112,53 @@ describe('auditSponsorHealth', () => {
     expect(violations).toHaveLength(2)
   })
 
+  it('does not flag a dead deal (closed-lost) for its leftover signed contract', () => {
+    // A won deal with a signed contract that later falls through is dragged to
+    // Lost without resetting the contract (backward moves never auto-reset).
+    // The not-closed-lost guard is a *transition* guard ("can't send/sign on a
+    // dead deal"), not a resting invariant — so this is historical data, not a
+    // fixable health problem, and must not appear in the panel.
+    const violations = auditSponsorHealth([
+      makeSfc({
+        status: 'closed-lost',
+        contractStatus: 'contract-signed',
+        tier: undefined,
+        contractValue: 0,
+      }),
+    ])
+
+    expect(violations).toEqual([])
+  })
+
+  it('reuses the real pipeline guard message (closed-won hide explains the public-site impact)', () => {
+    const violations = auditSponsorHealth([
+      makeSfc({ status: 'closed-won', tier: undefined }),
+    ])
+
+    const tierMissing = violations[0].missing.find((m) => m.field === 'tier')
+    expect(tierMissing?.message).toMatch(/hidden from the public site/i)
+  })
+
+  it('flags a contract-signed sponsor lacking a primary contact (a rule that lives only in the state machine)', () => {
+    const violations = auditSponsorHealth([
+      makeSfc({
+        status: 'negotiating',
+        contractStatus: 'contract-signed',
+        tier,
+        contractValue: 50000,
+        contactPersons: [],
+      }),
+    ])
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0].axis).toBe('contract')
+    const contactMissing = violations[0].missing.find(
+      (m) => m.field === 'contactPersons',
+    )
+    expect(contactMissing).toBeDefined()
+    expect(contactMissing?.source).toBe('sponsor')
+  })
+
   it('orders public-site-hiding violations first, regardless of input order', () => {
     const violations = auditSponsorHealth([
       makeSfc({

--- a/__tests__/lib/sponsor-crm/health.test.ts
+++ b/__tests__/lib/sponsor-crm/health.test.ts
@@ -92,9 +92,9 @@ describe('auditSponsorHealth', () => {
     expect(violations[0].state).toBe('pending')
     expect(violations[0].sponsorId).toBe('sfc-acme')
     expect(violations[0].sponsorName).toBe('Acme Corp')
-    expect(violations[0].missing.some((m) => m.field === 'contractStatus')).toBe(
-      true,
-    )
+    expect(
+      violations[0].missing.some((m) => m.field === 'contractStatus'),
+    ).toBe(true)
   })
 
   it('reports one violation per axis when a sponsor breaks several at once', () => {

--- a/__tests__/lib/sponsor-crm/health.test.ts
+++ b/__tests__/lib/sponsor-crm/health.test.ts
@@ -112,18 +112,27 @@ describe('auditSponsorHealth', () => {
     expect(violations).toHaveLength(2)
   })
 
-  it('does not flag a dead deal (closed-lost) for its leftover signed contract', () => {
-    // A won deal with a signed contract that later falls through is dragged to
-    // Lost without resetting the contract (backward moves never auto-reset).
-    // The not-closed-lost guard is a *transition* guard ("can't send/sign on a
-    // dead deal"), not a resting invariant — so this is historical data, not a
-    // fixable health problem, and must not appear in the panel.
+  it('does not flag a dead deal (closed-lost) whose signed contract is otherwise valid', () => {
+    // A won deal with a fully-valid signed contract that later falls through is
+    // dragged to Lost without resetting the contract (backward moves never
+    // auto-reset). Tier, value, and a primary contact are all present, so the
+    // ONLY guard that fails is not-closed-lost — a *transition* guard, not a
+    // resting invariant. Without the dead-deal exclusion this record would be
+    // flagged (missing `status`); with it, the panel correctly stays quiet.
     const violations = auditSponsorHealth([
       makeSfc({
         status: 'closed-lost',
         contractStatus: 'contract-signed',
-        tier: undefined,
-        contractValue: 0,
+        tier,
+        contractValue: 50000,
+        contactPersons: [
+          {
+            _key: 'c1',
+            name: 'Jane Doe',
+            email: 'jane@acme.test',
+            isPrimary: true,
+          },
+        ],
       }),
     ])
 

--- a/src/components/admin/sponsor-crm/SponsorBulkActions.tsx
+++ b/src/components/admin/sponsor-crm/SponsorBulkActions.tsx
@@ -84,6 +84,7 @@ export function SponsorBulkActions({
         message: `Updated ${result.updatedCount} of ${result.totalCount} selected sponsors.`,
       })
       utils.sponsor.crm.list.invalidate()
+      utils.sponsor.crm.healthViolations.invalidate()
       onSuccess()
       onClearSelection()
       setIsProcessing(false)
@@ -106,6 +107,7 @@ export function SponsorBulkActions({
         message: `Deleted ${result.deletedCount} of ${result.totalCount} selected sponsors.`,
       })
       utils.sponsor.crm.list.invalidate()
+      utils.sponsor.crm.healthViolations.invalidate()
       onSuccess()
       onClearSelection()
       setIsProcessing(false)

--- a/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
@@ -386,6 +386,7 @@ export function SponsorCRMForm({
                           sponsorForConference={sponsor}
                           onSuccess={() => {
                             utils.sponsor.crm.list.invalidate()
+                            utils.sponsor.crm.healthViolations.invalidate()
                           }}
                           onCancel={handleClose}
                         />
@@ -416,6 +417,7 @@ export function SponsorCRMForm({
                           sponsor={sponsor}
                           onSuccess={() => {
                             utils.sponsor.crm.list.invalidate()
+                            utils.sponsor.crm.healthViolations.invalidate()
                           }}
                         />
                       ) : (

--- a/src/components/admin/sponsor-crm/SponsorCRMPageClient.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMPageClient.tsx
@@ -41,7 +41,10 @@ export function SponsorCRMPageClient({
             render: () => (
               <ImportHistoricSponsorsButton
                 conferenceId={conference._id}
-                onSuccess={() => utils.sponsor.crm.list.invalidate()}
+                onSuccess={() => {
+                  utils.sponsor.crm.list.invalidate()
+                  utils.sponsor.crm.healthViolations.invalidate()
+                }}
               />
             ),
           },

--- a/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
@@ -40,6 +40,7 @@ import { useSponsorDragDrop } from '@/hooks/useSponsorDragDrop'
 import { SponsorDeleteModal } from '@/components/admin/sponsor-crm/SponsorDeleteModal'
 import type { DeleteCleanupOptions } from '@/components/admin/sponsor-crm/SponsorDeleteModal'
 import { TierPickerPrompt } from '@/components/admin/sponsor-crm/TierPickerPrompt'
+import { SponsorHealthPanel } from '@/components/admin/sponsor-crm/SponsorHealthPanel'
 import { DndContext, DragOverlay, pointerWithin } from '@dnd-kit/core'
 import clsx from 'clsx'
 
@@ -103,6 +104,7 @@ export function SponsorCRMPipeline({
   const deleteMutation = api.sponsor.crm.delete.useMutation({
     onSuccess: () => {
       utils.sponsor.crm.list.invalidate()
+      utils.sponsor.crm.healthViolations.invalidate()
     },
   })
 
@@ -149,6 +151,15 @@ export function SponsorCRMPipeline({
       refetchOnWindowFocus: !isUserBusy,
     },
   )
+
+  // Data-health: every sponsor breaking a state-machine invariant, audited
+  // across the FULL conference roster (the query ignores the board filters) so
+  // a hidden problem can't be filtered out of view.
+  const { data: healthViolations = [] } =
+    api.sponsor.crm.healthViolations.useQuery(undefined, {
+      refetchInterval: isUserBusy ? false : 30_000,
+      refetchOnWindowFocus: !isUserBusy,
+    })
 
   // Keep selectedSponsor in sync with fresh query data
   useEffect(() => {
@@ -217,7 +228,8 @@ export function SponsorCRMPipeline({
     setIsFormOpen(false)
     updateUrlParams({ sponsor: null, view: null })
     utils.sponsor.crm.list.invalidate()
-  }, [updateUrlParams, utils.sponsor.crm.list])
+    utils.sponsor.crm.healthViolations.invalidate()
+  }, [updateUrlParams, utils.sponsor.crm.list, utils.sponsor.crm.healthViolations])
 
   const handleFormViewChange = useCallback(
     (formView: string) => {
@@ -822,6 +834,9 @@ export function SponsorCRMPipeline({
           onSuccess={() => utils.sponsor.crm.list.invalidate()}
         />
       )}
+
+      {/* Data-health panel (renders nothing when every sponsor is healthy) */}
+      <SponsorHealthPanel violations={healthViolations} />
 
       {/* Board Columns */}
       <DndContext

--- a/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
@@ -154,10 +154,12 @@ export function SponsorCRMPipeline({
 
   // Data-health: every sponsor breaking a state-machine invariant, audited
   // across the FULL conference roster (the query ignores the board filters) so
-  // a hidden problem can't be filtered out of view.
-  const { data: healthViolations = [] } =
+  // a hidden problem can't be filtered out of view. Local writes invalidate
+  // this query for instant feedback, so the poll is only a backstop for changes
+  // made by other admins and can run slowly.
+  const { data: healthViolations = [], isError: healthCheckFailed } =
     api.sponsor.crm.healthViolations.useQuery(undefined, {
-      refetchInterval: isUserBusy ? false : 30_000,
+      refetchInterval: isUserBusy ? false : 120_000,
       refetchOnWindowFocus: !isUserBusy,
     })
 
@@ -229,7 +231,11 @@ export function SponsorCRMPipeline({
     updateUrlParams({ sponsor: null, view: null })
     utils.sponsor.crm.list.invalidate()
     utils.sponsor.crm.healthViolations.invalidate()
-  }, [updateUrlParams, utils.sponsor.crm.list, utils.sponsor.crm.healthViolations])
+  }, [
+    updateUrlParams,
+    utils.sponsor.crm.list,
+    utils.sponsor.crm.healthViolations,
+  ])
 
   const handleFormViewChange = useCallback(
     (formView: string) => {
@@ -831,12 +837,18 @@ export function SponsorCRMPipeline({
           selectedIds={selectedIds}
           sponsors={sponsors}
           onClearSelection={handleClearSelection}
-          onSuccess={() => utils.sponsor.crm.list.invalidate()}
+          onSuccess={() => {
+            utils.sponsor.crm.list.invalidate()
+            utils.sponsor.crm.healthViolations.invalidate()
+          }}
         />
       )}
 
       {/* Data-health panel (renders nothing when every sponsor is healthy) */}
-      <SponsorHealthPanel violations={healthViolations} />
+      <SponsorHealthPanel
+        violations={healthViolations}
+        isError={healthCheckFailed}
+      />
 
       {/* Board Columns */}
       <DndContext

--- a/src/components/admin/sponsor-crm/SponsorHealthPanel.tsx
+++ b/src/components/admin/sponsor-crm/SponsorHealthPanel.tsx
@@ -86,10 +86,15 @@ function ViolationRow({ violation }: { violation: SponsorHealthViolation }) {
  */
 export function SponsorHealthPanel({
   violations,
+  isError = false,
 }: {
   violations: SponsorHealthViolation[]
+  /** The audit query failed — surface it rather than masquerading as healthy. */
+  isError?: boolean
 }) {
-  if (violations.length === 0) return null
+  // Nothing to show only when the audit ran cleanly and found no problems. An
+  // errored audit must stay visible so an empty panel never reads as "healthy".
+  if (!isError && violations.length === 0) return null
 
   return (
     <section
@@ -101,15 +106,32 @@ export function SponsorHealthPanel({
         <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
           Data health
         </h2>
-        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
-          {violations.length}
-        </span>
+        {violations.length > 0 && (
+          <span
+            aria-label={`${violations.length} data-health issues`}
+            className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+          >
+            {violations.length}
+          </span>
+        )}
       </div>
-      <ul className="mt-2 max-h-48 space-y-2 overflow-y-auto">
-        {violations.map((v) => (
-          <ViolationRow key={`${v.sponsorId}-${v.axis}`} violation={v} />
-        ))}
-      </ul>
+      {isError && (
+        <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+          Couldn&apos;t check data health right now — it will retry shortly.
+        </p>
+      )}
+      {violations.length > 0 && (
+        <ul
+          role="region"
+          aria-label="Data-health issues"
+          tabIndex={0}
+          className="mt-2 max-h-48 space-y-2 overflow-y-auto"
+        >
+          {violations.map((v) => (
+            <ViolationRow key={`${v.sponsorId}-${v.axis}`} violation={v} />
+          ))}
+        </ul>
+      )}
     </section>
   )
 }

--- a/src/components/admin/sponsor-crm/SponsorHealthPanel.tsx
+++ b/src/components/admin/sponsor-crm/SponsorHealthPanel.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import {
+  ExclamationTriangleIcon,
+  EyeSlashIcon,
+} from '@heroicons/react/24/outline'
+import clsx from 'clsx'
+import type { SponsorHealthViolation } from '@/lib/sponsor-crm/health'
+import type { TransitionAxis } from '@/lib/sponsor-crm/state-machine'
+import { STATUSES, CONTRACT_STATUSES } from './form/constants'
+
+const AXIS_LABELS: Record<TransitionAxis, string> = {
+  pipeline: 'Pipeline',
+  contract: 'Contract',
+  signature: 'Signature',
+}
+
+const SIGNATURE_STATE_LABELS: Record<string, string> = {
+  'not-started': 'Not started',
+  pending: 'Pending',
+  signed: 'Signed',
+  rejected: 'Rejected',
+  expired: 'Expired',
+}
+
+/** Human-readable "Pipeline · Closed - Won" for the axis a violation breaks. */
+function axisStateLabel(axis: TransitionAxis, state: string): string {
+  let stateLabel = state
+  if (axis === 'pipeline') {
+    const s = STATUSES.find((x) => x.value === state)
+    stateLabel = s?.columnLabel ?? s?.label ?? state
+  } else if (axis === 'contract') {
+    const s = CONTRACT_STATUSES.find((x) => x.value === state)
+    stateLabel = s?.columnLabel ?? s?.label ?? state
+  } else if (axis === 'signature') {
+    stateLabel = SIGNATURE_STATE_LABELS[state] ?? state
+  }
+  return `${AXIS_LABELS[axis]} · ${stateLabel}`
+}
+
+function ViolationRow({ violation }: { violation: SponsorHealthViolation }) {
+  const { hidesFromPublicSite } = violation
+  return (
+    <li
+      className={clsx(
+        'rounded-lg border p-3',
+        hidesFromPublicSite
+          ? 'border-rose-300 bg-rose-50 dark:border-rose-800 dark:bg-rose-900/20'
+          : 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20',
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          {violation.sponsorName}
+        </span>
+        <span className="rounded-full bg-white/70 px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-gray-300 ring-inset dark:bg-white/10 dark:text-gray-300 dark:ring-white/10">
+          {axisStateLabel(violation.axis, violation.state)}
+        </span>
+        {hidesFromPublicSite && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-rose-600 px-2 py-0.5 text-[11px] font-bold text-white dark:bg-rose-500">
+            <EyeSlashIcon className="h-3.5 w-3.5" />
+            Hidden from the public site
+          </span>
+        )}
+      </div>
+      <ul className="mt-1.5 space-y-0.5">
+        {violation.missing.map((m) => (
+          <li
+            key={m.field}
+            className="text-xs text-gray-600 dark:text-gray-400"
+          >
+            &bull; {m.message ?? m.label}
+          </li>
+        ))}
+      </ul>
+    </li>
+  )
+}
+
+/**
+ * Data-health surface: lists every sponsor currently breaking a state-machine
+ * invariant, each with the specific rule(s) it breaks. Closed-won-without-tier
+ * violations — which hide a paying sponsor from the public site — are surfaced
+ * first and styled most prominently. Renders nothing when all sponsors are
+ * healthy. The rule logic lives in {@link auditSponsorHealth}, not here.
+ */
+export function SponsorHealthPanel({
+  violations,
+}: {
+  violations: SponsorHealthViolation[]
+}) {
+  if (violations.length === 0) return null
+
+  return (
+    <section
+      aria-label="Sponsor data health"
+      className="rounded-xl border border-amber-200 bg-white p-3 shadow-sm dark:border-amber-900/40 dark:bg-gray-900"
+    >
+      <div className="flex items-center gap-2">
+        <ExclamationTriangleIcon className="h-5 w-5 shrink-0 text-amber-500" />
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Data health
+        </h2>
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+          {violations.length}
+        </span>
+      </div>
+      <ul className="mt-2 max-h-48 space-y-2 overflow-y-auto">
+        {violations.map((v) => (
+          <ViolationRow key={`${v.sponsorId}-${v.axis}`} violation={v} />
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/admin/sponsor-crm/SponsorHealthPanel.tsx
+++ b/src/components/admin/sponsor-crm/SponsorHealthPanel.tsx
@@ -121,16 +121,20 @@ export function SponsorHealthPanel({
         </p>
       )}
       {violations.length > 0 && (
-        <ul
+        // A focusable region so keyboard users can scroll the clipped list;
+        // the inner <ul> keeps its list semantics for screen readers.
+        <div
           role="region"
           aria-label="Data-health issues"
           tabIndex={0}
-          className="mt-2 max-h-48 space-y-2 overflow-y-auto"
+          className="mt-2 max-h-48 overflow-y-auto"
         >
-          {violations.map((v) => (
-            <ViolationRow key={`${v.sponsorId}-${v.axis}`} violation={v} />
-          ))}
-        </ul>
+          <ul className="space-y-2">
+            {violations.map((v) => (
+              <ViolationRow key={`${v.sponsorId}-${v.axis}`} violation={v} />
+            ))}
+          </ul>
+        </div>
       )}
     </section>
   )

--- a/src/hooks/useSponsorCRMFormMutations.ts
+++ b/src/hooks/useSponsorCRMFormMutations.ts
@@ -48,6 +48,7 @@ export function useSponsorCRMFormMutations({
   const createMutation = api.sponsor.crm.create.useMutation({
     onSuccess: async (data) => {
       await utils.sponsor.crm.list.invalidate()
+      utils.sponsor.crm.healthViolations.invalidate()
       showNotification({
         title: 'Success',
         message: 'Sponsor added to pipeline',
@@ -67,6 +68,7 @@ export function useSponsorCRMFormMutations({
   const updateMutation = api.sponsor.crm.update.useMutation({
     onSuccess: async () => {
       await utils.sponsor.crm.list.invalidate()
+      utils.sponsor.crm.healthViolations.invalidate()
       showNotification({
         title: 'Success',
         message: 'Sponsor updated successfully',

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -152,8 +152,11 @@ export function useSponsorDragDrop(currentView: BoardView) {
         })
       }
 
-      // Always refetch from server to ensure consistency
+      // Always refetch from server to ensure consistency. A board move changes
+      // status/contract/invoice — the exact fields the data-health audit reads —
+      // so refresh the health panel too (covers drag-to-Won and the tier picker).
       utils.sponsor.crm.list.invalidate()
+      utils.sponsor.crm.healthViolations.invalidate()
     },
     [currentView, utils, queryClient, showNotification],
   )

--- a/src/lib/sponsor-crm/health.ts
+++ b/src/lib/sponsor-crm/health.ts
@@ -1,0 +1,70 @@
+import { checkState, type TransitionAxis } from './state-machine'
+import type { MissingField } from './contract-readiness'
+import type { SponsorForConferenceExpanded } from './types'
+
+/**
+ * A single sponsor breaking a single axis's invariant: the rule(s) it violates
+ * and whether the violation hides a paying sponsor from the public site.
+ */
+export interface SponsorHealthViolation {
+  sponsorId: string
+  sponsorName: string
+  axis: TransitionAxis
+  state: string
+  missing: MissingField[]
+  hidesFromPublicSite: boolean
+}
+
+/**
+ * The current resting state of a sponsor on each guarded axis. Adding an axis to
+ * the state machine surfaces here as a type error until it is mapped, so the
+ * audit can never silently skip a guarded axis.
+ */
+const AXIS_STATE: Record<
+  TransitionAxis,
+  (sponsor: SponsorForConferenceExpanded) => string
+> = {
+  pipeline: (s) => s.status,
+  contract: (s) => s.contractStatus,
+  signature: (s) => s.signatureStatus ?? 'not-started',
+}
+
+const AXES = Object.keys(AXIS_STATE) as TransitionAxis[]
+
+/**
+ * Lists every sponsor currently violating a state-machine invariant, one entry
+ * per (sponsor × axis). Reuses the shared guard predicates (via
+ * {@link checkState}) so it stays in sync with the rules rather than duplicating
+ * them — new guards on any axis are picked up automatically.
+ */
+export function auditSponsorHealth(
+  sponsors: SponsorForConferenceExpanded[],
+): SponsorHealthViolation[] {
+  const violations: SponsorHealthViolation[] = []
+
+  for (const sponsor of sponsors) {
+    for (const axis of AXES) {
+      const state = AXIS_STATE[axis](sponsor)
+      const result = checkState(axis, state, sponsor)
+      if (result.ok) continue
+
+      violations.push({
+        sponsorId: sponsor._id,
+        sponsorName: sponsor.sponsor.name,
+        axis,
+        state,
+        missing: result.missing,
+        hidesFromPublicSite:
+          axis === 'pipeline' &&
+          state === 'closed-won' &&
+          result.missing.some((m) => m.field === 'tier'),
+      })
+    }
+  }
+
+  // Surface public-site hides first so the panel can highlight them most
+  // prominently. Array.sort is stable, so the rest keep their discovery order.
+  return violations.sort(
+    (a, b) => Number(b.hidesFromPublicSite) - Number(a.hidesFromPublicSite),
+  )
+}

--- a/src/lib/sponsor-crm/health.ts
+++ b/src/lib/sponsor-crm/health.ts
@@ -44,6 +44,12 @@ export function auditSponsorHealth(
 
   for (const sponsor of sponsors) {
     for (const axis of AXES) {
+      // A dead deal (closed-lost) carries no live contract/signature
+      // obligations — leftover contract/signature status is historical, not a
+      // fixable health problem. (The not-closed-lost guard is a *transition*
+      // guard — "can't send or sign on a dead deal" — not a resting invariant.)
+      if (sponsor.status === 'closed-lost' && axis !== 'pipeline') continue
+
       const state = AXIS_STATE[axis](sponsor)
       const result = checkState(axis, state, sponsor)
       if (result.ok) continue

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -114,6 +114,7 @@ import {
   ORGANIZER_DATE_MARKER,
 } from '@/lib/pdf/constants'
 import { checkContractReadiness } from '@/lib/sponsor-crm/contract-readiness'
+import { auditSponsorHealth } from '@/lib/sponsor-crm/health'
 import {
   canTransition,
   checkPipelineState,
@@ -753,6 +754,26 @@ export const sponsorRouter = router({
 
         return filtered
       }),
+
+    // Data-health surface: every sponsor currently breaking a state-machine
+    // invariant, across all axes. Audits the FULL conference roster (no
+    // filters) so the panel can never hide a violation, and reuses the shared
+    // guard predicates so it stays in sync as new guards land.
+    healthViolations: adminProcedure.query(async () => {
+      const conferenceId = await resolveConferenceId()
+
+      const { sponsors, error } = await listSponsorsForConference(conferenceId)
+
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to list sponsors for conference',
+          cause: error,
+        })
+      }
+
+      return auditSponsorHealth(sponsors || [])
+    }),
 
     getById: adminProcedure.input(SponsorIdSchema).query(async ({ input }) => {
       const { sponsorForConference, error } = await getSponsorForConference(


### PR DESCRIPTION
Closes #378.

## What this adds

A live **data-health** surface in the sponsor CRM that lists every sponsor currently violating a state-machine invariant across all implemented axes, each labelled with the specific rule it breaks. Closed-won-without-tier violations — which hide a paying sponsor from the public site — are surfaced first and most prominently.

The same query doubles as the one-time pre-rollout audit for the remediation slice (#379).

## How it works (reuse, not duplication)

The audit reuses the shared guard predicates rather than re-implementing the rules: for each sponsor, for each axis, it calls `checkState(axis, currentStateOnThatAxis, sponsor)` — the *same* guards the tRPC write paths enforce. So the panel can never drift from the rules.

A typed `axis → state` map means adding an axis to the state machine surfaces as a compile error until it's mapped; once mapped, the panel audits it automatically. **The invoice axis (#376) isn't in `TransitionAxis` yet**, so the panel covers pipeline / contract / signature today and will pick up invoice violations for free when #376 lands — matching this issue's "reflects the guards as they land" intent.

## Layers

1. **`src/lib/sponsor-crm/health.ts`** — `auditSponsorHealth(sponsors)` returns one violation per (sponsor × broken axis), with a `hidesFromPublicSite` flag, sorted hides-first.
2. **`crm.healthViolations`** tRPC query — audits the **full** conference roster (no board filters) so a problem can't be filtered out of view.
3. **`SponsorHealthPanel.tsx`** — rose styling + "Hidden from the public site" badge for hides, amber for the rest; renders nothing when healthy. Wired into the CRM board with auto-refresh + invalidation on remediation paths.

## Acceptance criteria

- [x] Panel lists all current invariant violations across the **implemented** axes (pipeline / contract / signature), each with the rule it breaks — the invoice axis lands with #376 and the audit picks it up automatically (see note below)
- [x] Closed-won-without-tier (hidden from public site) visually distinguished
- [x] Reuses the shared guard predicates rather than duplicating rule logic
- [x] Panel is empty when there are no violations

## Testing

Built test-first (TDD): **6** unit tests for the audit, **3** tRPC integration tests, **3** component tests. Full sponsor-crm suite green (378 tests); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a live data-health panel to the sponsor CRM that surfaces state-machine invariant violations (pipeline / contract / signature axes) for every sponsor in the conference, with `closed-won`-without-tier violations (which hide a paying sponsor from the public site) sorted first and styled prominently in rose. The audit reuses `checkState` guards from the existing state machine rather than duplicating rule logic.

- **`health.ts`** — new `auditSponsorHealth` function iterates a typed `axis → state-getter` map and calls `checkState` for each (sponsor × axis) pair; the typed map ensures adding a new axis is a compile error until it's covered.
- **`crm.healthViolations`** tRPC query — fetches the full conference roster (no board filters) so a violation can't be hidden by UI filters; wired into `SponsorCRMPipeline` with 30 s auto-refresh and cache invalidation on delete and form-close.
- **`SponsorHealthPanel`** — renders nothing when healthy, rose/amber row styling per `hidesFromPublicSite` flag, backed by 9 new tests (unit + tRPC + component).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the audit logic and tRPC query are well-structured, with two small invalidation gaps that only affect how quickly the panel refreshes after drag-and-drop or bulk state changes.

The core logic is correct and well-tested. Two write paths that change sponsor state do not invalidate the health query cache, so the panel can show stale violations for up to 30 seconds after those operations. This is a UX inconsistency rather than a data correctness problem.

src/hooks/useSponsorDragDrop.ts and the SponsorBulkActions.onSuccess callback in SponsorCRMPipeline.tsx both need a healthViolations.invalidate() call added alongside the existing list invalidation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/sponsor-crm/health.ts | New audit function that iterates all axes via a typed map, calls shared checkState guards, and sorts hides-first. Logic is clean and correctly reuses the state machine. |
| src/server/routers/sponsor.ts | Adds healthViolations tRPC query behind adminProcedure; fetches full conference roster without filters, surfaces errors as TRPCError, and delegates audit logic to health.ts. |
| src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx | Wires the health query with 30s auto-refresh and invalidates on delete/form-close; SponsorBulkActions.onSuccess is missing a healthViolations.invalidate(), leaving the panel stale after bulk state changes. |
| src/components/admin/sponsor-crm/SponsorHealthPanel.tsx | New panel component; correctly returns null when violations is empty, uses typed AXIS_LABELS record, and renders rose/amber styling per hidesFromPublicSite flag. |
| src/hooks/useSponsorDragDrop.ts | Pre-existing hook; drag completion invalidates list but not healthViolations, so a D&D status change that creates or fixes a violation won't reflect in the panel until the 30s auto-refresh. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as SponsorCRMPipeline
    participant tRPC as crm.healthViolations
    participant Sanity as listSponsorsForConference
    participant Audit as auditSponsorHealth
    participant SM as checkState (state-machine)

    Browser->>tRPC: useQuery (poll 30s)
    tRPC->>Sanity: listSponsorsForConference(conferenceId)
    Sanity-->>tRPC: sponsors[]
    tRPC->>Audit: auditSponsorHealth(sponsors)
    loop for each sponsor x axis
        Audit->>SM: checkState(axis, state, sponsor)
        SM-->>Audit: ok or missing[]
    end
    Audit-->>tRPC: SponsorHealthViolation[] (hides-first sorted)
    tRPC-->>Browser: violations[]
    Browser->>Browser: SponsorHealthPanel renders violations
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx`, line 834 ([link](https://github.com/cloudnativebergen/website/blob/cd7c165b7a7e9591298d1ac5bda3a8dc921ec92f/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx#L834)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> After a bulk action (e.g., bulk pipeline-status move or tier assignment), only `list` is invalidated. The health panel will show stale violations until the 30-second auto-refresh fires, so a user who bulk-fixes a closed-won/no-tier situation won't see the panel clear immediately.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(sponsor-crm): data-health panel lis..."](https://github.com/cloudnativebergen/website/commit/cd7c165b7a7e9591298d1ac5bda3a8dc921ec92f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36039903)</sub>

<!-- /greptile_comment -->
