### PR TITLE
feat(admin): sort proposals by review count (#389)

### DIFF
--- a/__tests__/lib/proposal/utils/filtering.test.ts
+++ b/__tests__/lib/proposal/utils/filtering.test.ts
@@ -95,6 +95,28 @@ describe('filterProposals', () => {
     expect(result[2].title).toBe('Alpha')
   })
 
+  it('should sort by reviews asc', () => {
+    const proposalsWithReviews = [
+      mockProposal({ _id: 'two', reviews: [{} as any, {} as any] }),
+      mockProposal({ _id: 'zero', reviews: [] }),
+      mockProposal({ _id: 'one', reviews: [{} as any] }),
+    ]
+    const filters: ProposalFilters = { sortBy: 'reviews', sortOrder: 'asc' }
+    const result = filterProposals(proposalsWithReviews, filters)
+    expect(result.map((p) => p._id)).toEqual(['zero', 'one', 'two'])
+  })
+
+  it('should sort by reviews desc', () => {
+    const proposalsWithReviews = [
+      mockProposal({ _id: 'one', reviews: [{} as any] }),
+      mockProposal({ _id: 'zero', reviews: [] }),
+      mockProposal({ _id: 'two', reviews: [{} as any, {} as any] }),
+    ]
+    const filters: ProposalFilters = { sortBy: 'reviews', sortOrder: 'desc' }
+    const result = filterProposals(proposalsWithReviews, filters)
+    expect(result.map((p) => p._id)).toEqual(['two', 'one', 'zero'])
+  })
+
   it('should filter by review status (reviewed)', () => {
     const proposalsWithReviews = [
       mockProposal({ _id: '1', reviews: [{ reviewer: { _id: 'u1' } } as any] }),

--- a/__tests__/lib/proposal/utils/filtering.test.ts
+++ b/__tests__/lib/proposal/utils/filtering.test.ts
@@ -96,6 +96,8 @@ describe('filterProposals', () => {
   })
 
   it('should sort by reviews asc', () => {
+    // Input order is intentionally NOT the expected order, so a broken
+    // comparator that falls through to the stable default sort is caught.
     const proposalsWithReviews = [
       mockProposal({ _id: 'two', reviews: [{} as any, {} as any] }),
       mockProposal({ _id: 'zero', reviews: [] }),
@@ -115,6 +117,27 @@ describe('filterProposals', () => {
     const filters: ProposalFilters = { sortBy: 'reviews', sortOrder: 'desc' }
     const result = filterProposals(proposalsWithReviews, filters)
     expect(result.map((p) => p._id)).toEqual(['two', 'one', 'zero'])
+  })
+
+  it('should retain prior order for equal review counts (stable)', () => {
+    const proposalsWithReviews = [
+      mockProposal({ _id: 'b', reviews: [{} as any] }),
+      mockProposal({ _id: 'a', reviews: [{} as any] }),
+      mockProposal({ _id: 'c', reviews: [{} as any] }),
+    ]
+    const filters: ProposalFilters = { sortBy: 'reviews', sortOrder: 'asc' }
+    const result = filterProposals(proposalsWithReviews, filters)
+    expect(result.map((p) => p._id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('should treat missing reviews as zero when sorting', () => {
+    const proposalsWithReviews = [
+      mockProposal({ _id: 'has', reviews: [{} as any] }),
+      mockProposal({ _id: 'none' }),
+    ]
+    const filters: ProposalFilters = { sortBy: 'reviews', sortOrder: 'asc' }
+    const result = filterProposals(proposalsWithReviews, filters)
+    expect(result.map((p) => p._id)).toEqual(['none', 'has'])
   })
 
   it('should filter by review status (reviewed)', () => {

--- a/src/components/admin/ProposalsFilter.tsx
+++ b/src/components/admin/ProposalsFilter.tsx
@@ -31,7 +31,7 @@ export interface FilterState {
   reviewStatus: ReviewStatus
   hideMultipleTalks: boolean
   searchQuery: string
-  sortBy: 'title' | 'status' | 'created' | 'speaker' | 'rating'
+  sortBy: 'title' | 'status' | 'created' | 'speaker' | 'rating' | 'reviews'
   sortOrder: 'asc' | 'desc'
 }
 
@@ -258,7 +258,7 @@ export function ProposalsFilter({
           )}
 
           <FilterDropdown
-            label={`Sort: ${filters.sortBy === 'created' ? 'Date' : filters.sortBy === 'speaker' ? 'Speaker' : filters.sortBy === 'rating' ? 'Rating' : filters.sortBy === 'title' ? 'Title' : 'Status'}`}
+            label={`Sort: ${filters.sortBy === 'created' ? 'Date' : filters.sortBy === 'speaker' ? 'Speaker' : filters.sortBy === 'rating' ? 'Rating' : filters.sortBy === 'reviews' ? 'Reviews' : filters.sortBy === 'title' ? 'Title' : 'Status'}`}
             activeCount={0}
             position="right"
           >
@@ -268,6 +268,7 @@ export function ProposalsFilter({
               { key: 'speaker', label: 'Speaker' },
               { key: 'status', label: 'Status' },
               { key: 'rating', label: 'Rating' },
+              { key: 'reviews', label: 'Review Count' },
             ].map((option) => (
               <FilterOption
                 key={option.key}

--- a/src/components/admin/ProposalsFilter.tsx
+++ b/src/components/admin/ProposalsFilter.tsx
@@ -258,7 +258,7 @@ export function ProposalsFilter({
           )}
 
           <FilterDropdown
-            label={`Sort: ${filters.sortBy === 'created' ? 'Date' : filters.sortBy === 'speaker' ? 'Speaker' : filters.sortBy === 'rating' ? 'Rating' : filters.sortBy === 'reviews' ? 'Reviews' : filters.sortBy === 'title' ? 'Title' : 'Status'}`}
+            label={`Sort: ${filters.sortBy === 'created' ? 'Date' : filters.sortBy === 'speaker' ? 'Speaker' : filters.sortBy === 'rating' ? 'Rating' : filters.sortBy === 'reviews' ? 'Review Count' : filters.sortBy === 'title' ? 'Title' : 'Status'}`}
             activeCount={0}
             position="right"
           >

--- a/src/components/admin/hooks.ts
+++ b/src/components/admin/hooks.ts
@@ -241,7 +241,9 @@ function parseFiltersFromURL(
   const sortByParam = searchParams.get('sortBy')
   if (
     sortByParam &&
-    ['title', 'status', 'created', 'speaker', 'rating'].includes(sortByParam)
+    ['title', 'status', 'created', 'speaker', 'rating', 'reviews'].includes(
+      sortByParam,
+    )
   ) {
     filters.sortBy = sortByParam as FilterState['sortBy']
   }

--- a/src/lib/proposal/utils/filtering.ts
+++ b/src/lib/proposal/utils/filtering.ts
@@ -21,7 +21,7 @@ export interface ProposalFilters {
   reviewStatus?: ReviewStatus
   hideMultipleTalks?: boolean
   searchQuery?: string
-  sortBy?: 'title' | 'status' | 'created' | 'speaker' | 'rating'
+  sortBy?: 'title' | 'status' | 'created' | 'speaker' | 'rating' | 'reviews'
   sortOrder?: 'asc' | 'desc'
 }
 
@@ -207,6 +207,10 @@ export function filterProposals(
       case 'rating':
         aValue = calculateAverageRating(a)
         bValue = calculateAverageRating(b)
+        break
+      case 'reviews':
+        aValue = a.reviews?.length ?? 0
+        bValue = b.reviews?.length ?? 0
         break
       case 'created':
       default:

--- a/src/server/schemas/proposal.ts
+++ b/src/server/schemas/proposal.ts
@@ -194,7 +194,7 @@ export const ProposalFilterSchema = z.object({
   hideMultipleTalks: z.boolean().optional().default(false),
   searchQuery: z.string().optional(),
   sortBy: z
-    .enum(['title', 'status', 'created', 'speaker', 'rating'])
+    .enum(['title', 'status', 'created', 'speaker', 'rating', 'reviews'])
     .optional()
     .default('created'),
   sortOrder: z.enum(['asc', 'desc']).optional().default('desc'),


### PR DESCRIPTION
## Summary

Adds a **"Review Count"** option to the admin proposals sort dropdown, letting organizers order proposals by how many reviews each has received. Toggling to ascending surfaces under-reviewed proposals — the primary "what still needs review?" workflow.

The new `'reviews'` sort is a faithful twin of the existing `rating` sort: the value flows through the same path (filter schema → URL-param allowlist → comparator → dropdown). It sorts by `reviews.length`, reuses the shared direction toggle (URL-persisted), and ties fall back to the existing stable order with **no special tiebreaker**. Admin-only; no public-facing list is affected.

Closes #389.

## Changes

- **`src/lib/proposal/utils/filtering.ts`** — `case 'reviews'` in the comparator (`reviews?.length ?? 0`) + type
- **`src/server/schemas/proposal.ts`** — `'reviews'` added to the zod `sortBy` enum
- **`src/components/admin/hooks.ts`** — `'reviews'` added to the URL-param allowlist
- **`src/components/admin/ProposalsFilter.tsx`** — `FilterState` type, "Review Count" option (after Rating), "Sort: Reviews" button label
- **`__tests__/lib/proposal/utils/filtering.test.ts`** — asc + desc sort tests (mirroring the title-sort tests)

## Testing

- `vitest run` — 1957 passed, 5 skipped, 0 failed (110 files)
- `tsc --noEmit` — 0 errors
- `eslint` on changed files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Review Count" sort option to the admin proposals page, letting organizers surface under-reviewed proposals by sorting ascending on `reviews.length`. The change is consistently threaded through the filter schema, URL-param allowlist, sort comparator, and dropdown UI.

- **`filtering.ts` / `proposal.ts` / `hooks.ts`**: `'reviews'` added to the `sortBy` type union, Zod enum, and URL allowlist — all three stay in sync.
- **`ProposalsFilter.tsx`**: New dropdown option (\"Review Count\") and button label (\"Reviews\") wired up; the label differs slightly between the two surfaces (minor cosmetic inconsistency).
- **`filtering.test.ts`**: Asc and desc sort tests added, mirroring the existing title-sort pattern.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the sort logic is correct, all four layers (schema, allowlist, comparator, UI) are updated consistently, and the new tests pass.

The implementation is a minimal, well-scoped addition that mirrors the existing rating sort path exactly. The only notable rough edge is the label discrepancy between the dropdown option ("Review Count") and the active button label ("Reviews"), which is a cosmetic issue and does not affect correctness.

src/components/admin/ProposalsFilter.tsx — the dropdown label vs. button label inconsistency is worth a quick look before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/proposal/utils/filtering.ts | Adds `case 'reviews'` to the sort comparator using `reviews?.length ?? 0`; clean and consistent with the existing pattern. |
| src/server/schemas/proposal.ts | Extends the Zod `sortBy` enum to include `'reviews'`; minimal, correct change. |
| src/components/admin/hooks.ts | Adds `'reviews'` to the URL-param allowlist; consistent with how existing sort keys are handled. |
| src/components/admin/ProposalsFilter.tsx | Adds `'reviews'` to `FilterState`, dropdown option ("Review Count"), and button label ("Reviews"); minor label inconsistency between the dropdown item and the button header. |
| __tests__/lib/proposal/utils/filtering.test.ts | Adds asc and desc sort tests for `'reviews'`, mirroring the existing title-sort test structure; good coverage. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[URL param: ?sortBy=reviews] --> B{hooks.ts allowlist check}
    B -->|'reviews' allowed| C[FilterState.sortBy = 'reviews']
    B -->|not in list| D[ignored / default used]
    C --> E[ProposalsFilter.tsx dropdown\nshows 'Review Count' option]
    C --> F[filterProposals called\nwith sortBy = 'reviews']
    F --> G{switch sortBy}
    G -->|'reviews'| H[aValue = a.reviews?.length ?? 0\nbValue = b.reviews?.length ?? 0]
    H --> I{sortOrder}
    I -->|'asc'| J[fewest reviews first\nsurfaces under-reviewed]
    I -->|'desc'| K[most reviews first]
    E --> L[Button label: 'Sort: Reviews']
```

<sub>Reviews (1): Last reviewed commit: ["feat(admin): sort proposals by review co..."](https://github.com/cloudnativebergen/website/commit/2d5b2fb19ab7e7b88bab3c989358a57c39d0b0da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36084952)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->