### PR TITLE
feat(crm): Kanban Board UX Improvements

### DIFF
--- a/src/components/admin/sponsor-crm/SponsorBoardColumn.tsx
+++ b/src/components/admin/sponsor-crm/SponsorBoardColumn.tsx
@@ -4,11 +4,12 @@ import { useMemo } from 'react'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 import type { CrmActivityThreshold } from '@/lib/conference/types'
 import { SponsorCard } from './SponsorCard'
-import { PlusIcon } from '@heroicons/react/24/outline'
+import { PlusIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { useExchangeRates } from '@/hooks/useExchangeRates'
-import { calculateSponsorValue } from './utils'
+import { calculateSponsorValue, checkSponsorNeedsFollowUp } from './utils'
 import { BoardView } from './BoardViewSwitcher'
 import { useDroppable } from '@dnd-kit/core'
+import { formatNumber } from '@/lib/format'
 import clsx from 'clsx'
 
 interface SponsorBoardColumnProps {
@@ -54,8 +55,11 @@ export function SponsorBoardColumn({
     },
   })
 
-  const sortedSponsors = useMemo(() => {
-    return [...sponsors].sort((a, b) => {
+  const { sortedSponsors, totalValueNOK, inactiveCount } = useMemo(() => {
+    let totalNOK = 0
+    let inactive = 0
+
+    const sorted = [...sponsors].sort((a, b) => {
       const aVal = calculateSponsorValue(a)
       const bVal = calculateSponsorValue(b)
       const aNOK = convertCurrency(
@@ -70,7 +74,27 @@ export function SponsorBoardColumn({
       )
       return bNOK - aNOK
     })
-  }, [sponsors, convertCurrency])
+
+    for (const sponsor of sponsors) {
+      const val = calculateSponsorValue(sponsor)
+      const nok = convertCurrency(
+        val.value,
+        val.currency as 'NOK' | 'USD' | 'EUR' | 'GBP',
+        'NOK',
+      )
+      totalNOK += nok
+
+      if (checkSponsorNeedsFollowUp(sponsor, thresholds)) {
+        inactive++
+      }
+    }
+
+    return {
+      sortedSponsors: sorted,
+      totalValueNOK: totalNOK,
+      inactiveCount: inactive,
+    }
+  }, [sponsors, convertCurrency, thresholds])
 
   return (
     <div
@@ -83,16 +107,29 @@ export function SponsorBoardColumn({
       )}
     >
       <div className="mb-3 flex shrink-0 items-center justify-between px-2">
-        <h3 className="font-semibold text-brand-cloud-blue dark:text-blue-400">
-          {title}
-        </h3>
-        <span className="min-w-6 rounded-full bg-brand-cloud-blue px-2 py-1 text-center text-xs text-white dark:bg-blue-600">
-          {isLoading ? (
-            <span className="inline-block h-4 w-4 animate-pulse rounded-full bg-white/30" />
-          ) : (
-            sponsors.length
+        <div className="flex flex-col">
+          <h3 className="font-semibold text-brand-cloud-blue dark:text-blue-400">
+            {title}
+          </h3>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {formatNumber(totalValueNOK)} NOK
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {inactiveCount > 0 && (
+            <span className="flex items-center gap-1 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+              <ExclamationTriangleIcon className="h-3 w-3" />
+              {inactiveCount}
+            </span>
           )}
-        </span>
+          <span className="min-w-6 rounded-full bg-brand-cloud-blue px-2 py-1 text-center text-xs text-white dark:bg-blue-600">
+            {isLoading ? (
+              <span className="inline-block h-4 w-4 animate-pulse rounded-full bg-white/30" />
+            ) : (
+              sponsors.length
+            )}
+          </span>
+        </div>
       </div>
 
       {isLoading ? (

--- a/src/components/admin/sponsor-crm/SponsorBoardColumn.tsx
+++ b/src/components/admin/sponsor-crm/SponsorBoardColumn.tsx
@@ -25,6 +25,11 @@ interface SponsorBoardColumnProps {
   onSponsorDelete: (sponsorId: string) => void
   onSponsorEmail?: (sponsor: SponsorForConferenceExpanded) => void
   onSponsorContract?: (sponsor: SponsorForConferenceExpanded) => void
+  onSponsorOpenHistory?: (sponsor: SponsorForConferenceExpanded) => void
+  onSponsorAdvanceStage?: (
+    sponsor: SponsorForConferenceExpanded,
+    targetStage: string,
+  ) => void
   onSponsorToggleSelect?: (id: string) => void
   onAddClick: () => void
 }
@@ -42,6 +47,8 @@ export function SponsorBoardColumn({
   onSponsorDelete,
   onSponsorEmail,
   onSponsorContract,
+  onSponsorOpenHistory,
+  onSponsorAdvanceStage,
   onSponsorToggleSelect,
   onAddClick,
 }: SponsorBoardColumnProps) {
@@ -169,6 +176,16 @@ export function SponsorBoardColumn({
               }
               onContract={
                 onSponsorContract ? () => onSponsorContract(sponsor) : undefined
+              }
+              onOpenHistory={
+                onSponsorOpenHistory
+                  ? () => onSponsorOpenHistory(sponsor)
+                  : undefined
+              }
+              onAdvanceStage={
+                onSponsorAdvanceStage
+                  ? (targetStage) => onSponsorAdvanceStage(sponsor, targetStage)
+                  : undefined
               }
             />
           ))}

--- a/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
@@ -17,6 +17,9 @@ import type {
   SponsorTag,
 } from '@/lib/sponsor-crm/types'
 import { sortSponsorTiers } from '@/components/admin/sponsor-crm/utils'
+import { canTransition } from '@/lib/sponsor-crm/state-machine'
+import { StatusListbox } from './form'
+import { STATUSES, INVOICE_STATUSES, CONTRACT_STATUSES } from './form/constants'
 import {
   XMarkIcon,
   PencilSquareIcon,
@@ -221,6 +224,35 @@ export function SponsorCRMForm({
     }
   }, [sponsor, formData.logo])
 
+  const invoiceOptions = useMemo(() => {
+    return INVOICE_STATUSES.map((opt) => {
+      const fromStatus = sponsor?.invoiceStatus || 'not-sent'
+      const transition = canTransition('invoice', fromStatus, opt.value, {
+        tier: formData.tierId,
+        contractValue: formData.contractValue
+          ? parseFloat(formData.contractValue)
+          : undefined,
+        contractCurrency: formData.contractCurrency,
+        billing: sponsor?.billing,
+        contractStatus: formData.contractStatus,
+        invoiceStatus: fromStatus,
+      })
+      return {
+        ...opt,
+        disabled: !transition.ok,
+        disabledReason: !transition.ok
+          ? transition.missing.map((m) => m.message).join('\n')
+          : undefined,
+      }
+    })
+  }, [
+    sponsor,
+    formData.tierId,
+    formData.contractValue,
+    formData.contractCurrency,
+    formData.contractStatus,
+  ])
+
   return (
     <>
       <Transition show={isOpen} as={Fragment}>
@@ -262,6 +294,41 @@ export function SponsorCRMForm({
                             {sponsor.sponsor.name}
                           </p>
                         )}
+                        <div className="mt-3 flex flex-wrap items-center gap-3">
+                          <StatusListbox
+                            label=""
+                            value={formData.status}
+                            onChange={(value) =>
+                              setFormData((prev) => ({
+                                ...prev,
+                                status: value,
+                              }))
+                            }
+                            options={STATUSES}
+                          />
+                          <StatusListbox
+                            label=""
+                            value={formData.contractStatus}
+                            onChange={(value) =>
+                              setFormData((prev) => ({
+                                ...prev,
+                                contractStatus: value,
+                              }))
+                            }
+                            options={CONTRACT_STATUSES}
+                          />
+                          <StatusListbox
+                            label=""
+                            value={formData.invoiceStatus}
+                            onChange={(value) =>
+                              setFormData((prev) => ({
+                                ...prev,
+                                invoiceStatus: value,
+                              }))
+                            }
+                            options={invoiceOptions}
+                          />
+                        </div>
                       </div>
 
                       <div className="flex items-center gap-2">

--- a/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
@@ -97,6 +97,7 @@ export function SponsorCRMPipeline({
     isDragging,
     handleDragStart,
     handleDragEnd,
+    handleAdvanceStage,
     pendingTierMove,
     confirmTierMove,
     cancelTierMove,
@@ -954,6 +955,10 @@ export function SponsorCRMPipeline({
                 }
                 onSponsorToggleSelect={handleToggleSelect}
                 onAddClick={() => handleOpenForm()}
+                onSponsorOpenHistory={(sponsor) =>
+                  handleOpenForm(sponsor, 'history')
+                }
+                onSponsorAdvanceStage={handleAdvanceStage}
               />
             )
           })}

--- a/src/components/admin/sponsor-crm/SponsorCard.stories.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCard.stories.tsx
@@ -74,6 +74,8 @@ export const Interactive: Story = {
     onEdit: () => console.log('Edit clicked'),
     onDelete: () => console.log('Delete clicked'),
     onEmail: () => console.log('Email clicked'),
+    onOpenHistory: () => console.log('Open history clicked'),
+    onAdvanceStage: (stage) => console.log(`Advance stage clicked: ${stage}`),
   },
   parameters: {
     docs: {

--- a/src/components/admin/sponsor-crm/SponsorCard.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCard.tsx
@@ -16,7 +16,9 @@ import {
   DocumentTextIcon,
   ExclamationTriangleIcon,
   Bars2Icon,
+  EllipsisHorizontalIcon,
 } from '@heroicons/react/24/outline'
+import { Menu, MenuButton, MenuItems, MenuItem } from '@headlessui/react'
 import {
   getInvoiceStatusColor,
   formatInvoiceStatusLabel,
@@ -43,6 +45,8 @@ interface SponsorCardProps {
   onDelete: () => void
   onEmail?: () => void
   onContract?: () => void
+  onOpenHistory?: () => void
+  onAdvanceStage?: (targetStage: string) => void
 }
 
 const TAG_BADGES: {
@@ -88,6 +92,8 @@ export function SponsorCard({
   onDelete,
   onEmail,
   onContract,
+  onOpenHistory,
+  onAdvanceStage,
 }: SponsorCardProps) {
   const { value, currency } = calculateSponsorValue(sponsor)
   const needsFollowUp = checkSponsorNeedsFollowUp(sponsor, thresholds)
@@ -145,11 +151,40 @@ export function SponsorCard({
         ? `${(v / 1000).toFixed(0)}K`
         : formatNumber(v)
 
+  let nextStage: { key: string; label: string } | null = null
+  if (currentView === 'pipeline') {
+    if (sponsor.status === 'prospect')
+      nextStage = { key: 'contacted', label: 'Contacted' }
+    else if (sponsor.status === 'contacted')
+      nextStage = { key: 'negotiating', label: 'Negotiating' }
+    else if (sponsor.status === 'negotiating')
+      nextStage = { key: 'closed-won', label: 'Closed Won' }
+  } else if (currentView === 'contract') {
+    if (!sponsor.contractStatus || sponsor.contractStatus === 'none')
+      nextStage = { key: 'verbal-agreement', label: 'Verbal Agreement' }
+    else if (sponsor.contractStatus === 'verbal-agreement')
+      nextStage = { key: 'contract-sent', label: 'Contract Sent' }
+    else if (sponsor.contractStatus === 'contract-sent')
+      nextStage = { key: 'contract-signed', label: 'Contract Signed' }
+  } else if (currentView === 'invoice') {
+    if (!sponsor.invoiceStatus || sponsor.invoiceStatus === 'not-sent')
+      nextStage = { key: 'sent', label: 'Sent' }
+    else if (sponsor.invoiceStatus === 'sent')
+      nextStage = { key: 'paid', label: 'Paid' }
+  }
+
+  const handleAdvanceStage = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (nextStage) {
+      onAdvanceStage?.(nextStage.key)
+    }
+  }
+
   return (
     <div
       ref={setNodeRef}
       className={clsx(
-        'group relative flex gap-2 overflow-hidden rounded-lg border py-3 pr-3 pl-2 transition-all hover:border-brand-cloud-blue hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-blue-500',
+        'group relative flex flex-col gap-2 overflow-hidden rounded-lg border py-3 pr-3 pl-2 transition-all hover:border-brand-cloud-blue hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-blue-500',
         isSelected
           ? 'border-indigo-500 bg-indigo-50/30 shadow-sm ring-1 ring-indigo-500 dark:border-indigo-400 dark:bg-indigo-900/20'
           : 'border-gray-200 bg-white',
@@ -160,176 +195,217 @@ export function SponsorCard({
       )}
       onClick={handleCardClick}
     >
-      {/* Drag Handle */}
-      <div
-        className={clsx(
-          'flex shrink-0 cursor-grab items-center justify-center text-gray-400 hover:text-gray-600 active:cursor-grabbing dark:text-gray-500 dark:hover:text-gray-300',
-          (isSelectionMode || !columnKey) && 'invisible pointer-events-none'
-        )}
-        {...attributes}
-        {...listeners}
-      >
-        <Bars2Icon className="h-5 w-5" />
-      </div>
-
-      {/* Selection Checkbox */}
-      <div
-        className={clsx(
-          'absolute top-1 left-1 z-10 transition-opacity',
-          isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
-        )}
-        onClick={handleSelectClick}
-        onPointerDown={(e) => e.stopPropagation()}
-      >
-        <input
-          type="checkbox"
-          checked={isSelected}
-          onChange={() => {}}
-          className="h-3.5 w-3.5 cursor-pointer rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 dark:border-gray-600 dark:bg-gray-700"
-        />
-      </div>
-
-      {/* Left: Logo + Assignee */}
-      <div className="flex w-14 shrink-0 flex-col items-center justify-center gap-1.5">
-        {/* Logo */}
-        <div className="flex h-9 w-14 items-center justify-center overflow-hidden">
-          {sponsor.sponsor.logo ? (
-            <SponsorLogo
-              logo={sponsor.sponsor.logo}
-              logoBright={sponsor.sponsor.logoBright}
-              name={sponsor.sponsor.name}
-              className="max-h-full w-auto max-w-14 object-contain"
-            />
-          ) : (
-            <span className="truncate text-center text-[10px] leading-tight font-bold text-gray-500 uppercase dark:text-gray-400">
-              {sponsor.sponsor.name}
-            </span>
-          )}
-        </div>
-        {/* Assignee */}
-        {sponsor.assignedTo && (
-          <div className="scale-[0.8] transform">
-            <SpeakerAvatars
-              speakers={[
-                {
-                  _id: sponsor.assignedTo._id,
-                  name: sponsor.assignedTo.name,
-                  image: sponsor.assignedTo.image,
-                } as Speaker,
-              ]}
-              size="sm"
-              maxVisible={1}
-              showTooltip={true}
-            />
-          </div>
-        )}
-      </div>
-
-      {/* Right: Name + Value + Tags */}
-      <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
-        {/* Name */}
-        <p className="truncate text-base leading-snug font-semibold text-gray-900 dark:text-white">
-          {sponsor.sponsor.name}
-        </p>
-
-        {/* Value */}
-        {value > 0 && (
-          <div className="flex items-center text-base leading-snug">
-            <span className="shrink-0 font-bold text-brand-cloud-blue dark:text-blue-400">
-              {formatValue(value)} {currency}
-            </span>
-          </div>
-        )}
-
-        {/* Tags + Invoice status */}
-        <div className="flex items-center gap-1">
-          {activeTags.map((t) => (
-            <span
-              key={t.tag}
-              title={TAG_TOOLTIPS[t.label]}
-              className={clsx(
-                'inline-flex items-center rounded px-1.5 py-0.5 text-[10px] leading-none font-bold uppercase ring-1 ring-inset',
-                t.classes,
-              )}
-            >
-              {t.label}
-            </span>
-          ))}
-          {value > 0 && currentView !== 'pipeline' && (
-            <span
-              className={clsx(
-                'inline-flex items-center rounded px-1.5 py-0.5 text-[10px] leading-none font-medium whitespace-nowrap',
-                getInvoiceStatusColor(sponsor.invoiceStatus),
-              )}
-            >
-              {formatInvoiceStatusLabel(sponsor.invoiceStatus)}
-            </span>
-          )}
-          {currentView === 'contract' &&
-            sponsor.signatureStatus &&
-            sponsor.signatureStatus !== 'not-started' && (
-              <SignatureBadge
-                status={sponsor.signatureStatus}
-                contractSentAt={sponsor.contractSentAt}
-              />
-            )}
-          {currentView === 'contract' &&
-            sponsor.registrationComplete &&
-            sponsor.contractStatus !== 'contract-sent' &&
-            sponsor.contractStatus !== 'contract-signed' && (
-              <span className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-[10px] leading-none font-bold whitespace-nowrap text-amber-700 ring-1 ring-amber-700/20 ring-inset dark:bg-amber-900/30 dark:text-amber-400 dark:ring-amber-400/20">
-                READY
-              </span>
-            )}
-        </div>
-      </div>
-
-      {/* Action Buttons - Top Right */}
-      <div className="absolute top-1.5 right-1.5 flex items-center gap-1">
-        {needsFollowUp && inactiveDays !== null && (
-          <span className="mr-2 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-amber-600/20 dark:bg-amber-900/30 dark:text-amber-400">
-            <ExclamationTriangleIcon className="mr-1 h-3.5 w-3.5" />
-            ⚠ {inactiveDays}d inactive
-          </span>
-        )}
+      <div className="flex w-full gap-2">
+        {/* Drag Handle */}
         <div
-          className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100"
+          className={clsx(
+            'flex shrink-0 cursor-grab items-center justify-center text-gray-400 hover:text-gray-600 active:cursor-grabbing dark:text-gray-500 dark:hover:text-gray-300',
+            (isSelectionMode || !columnKey) && 'pointer-events-none invisible',
+          )}
+          {...attributes}
+          {...listeners}
+        >
+          <Bars2Icon className="h-5 w-5" />
+        </div>
+
+        {/* Selection Checkbox */}
+        <div
+          className={clsx(
+            'absolute top-1 left-1 z-10 transition-opacity',
+            isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+          )}
+          onClick={handleSelectClick}
           onPointerDown={(e) => e.stopPropagation()}
         >
-        {onContract && (
-          <button
-            onClick={handleContractClick}
-            className="cursor-pointer rounded bg-white/90 p-1 shadow-sm hover:bg-blue-50 dark:bg-gray-700/90 dark:hover:bg-gray-600"
-            title="Contract"
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={() => {}}
+            className="h-3.5 w-3.5 cursor-pointer rounded border-gray-300 text-indigo-600 focus:ring-indigo-600 dark:border-gray-600 dark:bg-gray-700"
+          />
+        </div>
+
+        {/* Left: Logo + Assignee */}
+        <div className="flex w-14 shrink-0 flex-col items-center justify-center gap-1.5">
+          {/* Logo */}
+          <div className="flex h-9 w-14 items-center justify-center overflow-hidden">
+            {sponsor.sponsor.logo ? (
+              <SponsorLogo
+                logo={sponsor.sponsor.logo}
+                logoBright={sponsor.sponsor.logoBright}
+                name={sponsor.sponsor.name}
+                className="max-h-full w-auto max-w-14 object-contain"
+              />
+            ) : (
+              <span className="truncate text-center text-[10px] leading-tight font-bold text-gray-500 uppercase dark:text-gray-400">
+                {sponsor.sponsor.name}
+              </span>
+            )}
+          </div>
+          {/* Assignee */}
+          {sponsor.assignedTo && (
+            <div className="scale-[0.8] transform">
+              <SpeakerAvatars
+                speakers={[
+                  {
+                    _id: sponsor.assignedTo._id,
+                    name: sponsor.assignedTo.name,
+                    image: sponsor.assignedTo.image,
+                  } as Speaker,
+                ]}
+                size="sm"
+                maxVisible={1}
+                showTooltip={true}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Right: Name + Value + Tags */}
+        <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
+          {/* Name */}
+          <p className="truncate text-base leading-snug font-semibold text-gray-900 dark:text-white">
+            {sponsor.sponsor.name}
+          </p>
+
+          {/* Value */}
+          {value > 0 && (
+            <div className="flex items-center text-base leading-snug">
+              <span className="shrink-0 font-bold text-brand-cloud-blue dark:text-blue-400">
+                {formatValue(value)} {currency}
+              </span>
+            </div>
+          )}
+
+          {/* Tags + Invoice status */}
+          <div className="flex items-center gap-1">
+            {activeTags.map((t) => (
+              <span
+                key={t.tag}
+                title={TAG_TOOLTIPS[t.label]}
+                className={clsx(
+                  'inline-flex items-center rounded px-1.5 py-0.5 text-[10px] leading-none font-bold uppercase ring-1 ring-inset',
+                  t.classes,
+                )}
+              >
+                {t.label}
+              </span>
+            ))}
+            {value > 0 && currentView !== 'pipeline' && (
+              <span
+                className={clsx(
+                  'inline-flex items-center rounded px-1.5 py-0.5 text-[10px] leading-none font-medium whitespace-nowrap',
+                  getInvoiceStatusColor(sponsor.invoiceStatus),
+                )}
+              >
+                {formatInvoiceStatusLabel(sponsor.invoiceStatus)}
+              </span>
+            )}
+            {currentView === 'contract' &&
+              sponsor.signatureStatus &&
+              sponsor.signatureStatus !== 'not-started' && (
+                <SignatureBadge
+                  status={sponsor.signatureStatus}
+                  contractSentAt={sponsor.contractSentAt}
+                />
+              )}
+            {currentView === 'contract' &&
+              sponsor.registrationComplete &&
+              sponsor.contractStatus !== 'contract-sent' &&
+              sponsor.contractStatus !== 'contract-signed' && (
+                <span className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-[10px] leading-none font-bold whitespace-nowrap text-amber-700 ring-1 ring-amber-700/20 ring-inset dark:bg-amber-900/30 dark:text-amber-400 dark:ring-amber-400/20">
+                  READY
+                </span>
+              )}
+          </div>
+        </div>
+
+        {/* Action Buttons - Top Right */}
+        <div className="absolute top-1.5 right-1.5 flex items-center gap-1">
+          {needsFollowUp && inactiveDays !== null && (
+            <span className="mr-2 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-amber-600/20 dark:bg-amber-900/30 dark:text-amber-400">
+              <ExclamationTriangleIcon className="mr-1 h-3.5 w-3.5" />⚠{' '}
+              {inactiveDays}d inactive
+            </span>
+          )}
+          <div
+            className="flex opacity-40 transition-opacity group-hover:opacity-100 hover:opacity-100"
+            onPointerDown={(e) => e.stopPropagation()}
           >
-            <DocumentTextIcon className="h-3.5 w-3.5 text-brand-cloud-blue dark:text-blue-400" />
-          </button>
-        )}
-        {onEmail && (
-          <button
-            onClick={handleEmailClick}
-            className="cursor-pointer rounded bg-white/90 p-1 shadow-sm hover:bg-blue-50 dark:bg-gray-700/90 dark:hover:bg-gray-600"
-            title="Email Sponsor"
-          >
-            <EnvelopeIcon className="h-3.5 w-3.5 text-brand-cloud-blue dark:text-blue-400" />
-          </button>
-        )}
-        <button
-          onClick={handleEditClick}
-          className="cursor-pointer rounded bg-white/90 p-1 shadow-sm hover:bg-gray-50 dark:bg-gray-700/90 dark:hover:bg-gray-600"
-          title="Edit"
-        >
-          <PencilIcon className="h-3.5 w-3.5 text-brand-cloud-blue dark:text-blue-400" />
-        </button>
-        <button
-          onClick={handleDeleteClick}
-          className="cursor-pointer rounded bg-white/90 p-1 shadow-sm hover:bg-red-50 dark:bg-gray-700/90 dark:hover:bg-red-900"
-          title="Delete"
-        >
-          <TrashIcon className="h-3.5 w-3.5 text-red-600 dark:text-red-400" />
-        </button>
+            <Menu as="div" className="relative inline-block text-left">
+              <MenuButton className="flex items-center rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-700">
+                <span className="sr-only">Open options</span>
+                <EllipsisHorizontalIcon className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+              </MenuButton>
+              <MenuItems className="absolute right-0 z-10 mt-2 w-40 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-gray-800 dark:ring-white/10">
+                <div className="py-1">
+                  {onEmail && (
+                    <MenuItem>
+                      <button
+                        onClick={handleEmailClick}
+                        className="block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 data-[focus]:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 dark:data-[focus]:bg-gray-700"
+                      >
+                        Send Email
+                      </button>
+                    </MenuItem>
+                  )}
+                  {onOpenHistory && (
+                    <MenuItem>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onOpenHistory()
+                        }}
+                        className="block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 data-[focus]:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 dark:data-[focus]:bg-gray-700"
+                      >
+                        Log Note
+                      </button>
+                    </MenuItem>
+                  )}
+                  {onContract && (
+                    <MenuItem>
+                      <button
+                        onClick={handleContractClick}
+                        className="block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 data-[focus]:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 dark:data-[focus]:bg-gray-700"
+                      >
+                        Send Contract
+                      </button>
+                    </MenuItem>
+                  )}
+                  <MenuItem>
+                    <button
+                      onClick={handleEditClick}
+                      className="block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 data-[focus]:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 dark:data-[focus]:bg-gray-700"
+                    >
+                      Edit Details
+                    </button>
+                  </MenuItem>
+                  <MenuItem>
+                    <button
+                      onClick={handleDeleteClick}
+                      className="block w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 data-[focus]:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/50 dark:data-[focus]:bg-red-900/50"
+                    >
+                      Delete
+                    </button>
+                  </MenuItem>
+                </div>
+              </MenuItems>
+            </Menu>
+          </div>
         </div>
       </div>
+
+      {/* Bottom Row - CTA */}
+      {nextStage && (
+        <div className="mt-2 flex w-full border-t border-gray-100 pt-2 dark:border-gray-700">
+          <button
+            onClick={handleAdvanceStage}
+            className="flex w-full cursor-pointer items-center justify-center rounded bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 transition-colors hover:bg-indigo-100 dark:bg-indigo-900/30 dark:text-indigo-400 dark:hover:bg-indigo-900/50"
+          >
+            &rarr; {nextStage.label}
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/admin/sponsor-crm/SponsorCard.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCard.tsx
@@ -15,6 +15,7 @@ import {
   EnvelopeIcon,
   DocumentTextIcon,
   ExclamationTriangleIcon,
+  Bars2Icon,
 } from '@heroicons/react/24/outline'
 import {
   getInvoiceStatusColor,
@@ -23,6 +24,7 @@ import {
   getSignatureStatusBadgeProps,
   getDaysPending,
   checkSponsorNeedsFollowUp,
+  getDaysInactive,
 } from './utils'
 import type { CrmActivityThreshold } from '@/lib/conference/types'
 import clsx from 'clsx'
@@ -89,6 +91,7 @@ export function SponsorCard({
 }: SponsorCardProps) {
   const { value, currency } = calculateSponsorValue(sponsor)
   const needsFollowUp = checkSponsorNeedsFollowUp(sponsor, thresholds)
+  const inactiveDays = getDaysInactive(sponsor)
 
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: sponsor._id,
@@ -146,16 +149,29 @@ export function SponsorCard({
     <div
       ref={setNodeRef}
       className={clsx(
-        'group relative flex cursor-grab gap-3 overflow-hidden rounded-lg border p-3 transition-all hover:border-brand-cloud-blue hover:shadow-md active:cursor-grabbing dark:border-gray-700 dark:bg-gray-800 dark:hover:border-blue-500',
+        'group relative flex gap-2 overflow-hidden rounded-lg border py-3 pr-3 pl-2 transition-all hover:border-brand-cloud-blue hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-blue-500',
         isSelected
           ? 'border-indigo-500 bg-indigo-50/30 shadow-sm ring-1 ring-indigo-500 dark:border-indigo-400 dark:bg-indigo-900/20'
           : 'border-gray-200 bg-white',
+        needsFollowUp
+          ? 'border-l-4 border-l-amber-500'
+          : 'border-l-[3px] border-l-gray-400',
         isDragging && 'opacity-30',
       )}
       onClick={handleCardClick}
-      {...attributes}
-      {...listeners}
     >
+      {/* Drag Handle */}
+      <div
+        className={clsx(
+          'flex shrink-0 cursor-grab items-center justify-center text-gray-400 hover:text-gray-600 active:cursor-grabbing dark:text-gray-500 dark:hover:text-gray-300',
+          (isSelectionMode || !columnKey) && 'invisible pointer-events-none'
+        )}
+        {...attributes}
+        {...listeners}
+      >
+        <Bars2Icon className="h-5 w-5" />
+      </div>
+
       {/* Selection Checkbox */}
       <div
         className={clsx(
@@ -227,15 +243,6 @@ export function SponsorCard({
 
         {/* Tags + Invoice status */}
         <div className="flex items-center gap-1">
-          {needsFollowUp && (
-            <span
-              title="Needs Follow-up (Inactive)"
-              className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-[10px] leading-none font-bold whitespace-nowrap text-amber-700 ring-1 ring-amber-700/20 ring-inset dark:bg-amber-900/30 dark:text-amber-400 dark:ring-amber-400/20"
-            >
-              <ExclamationTriangleIcon className="mr-0.5 h-3 w-3" />
-              INACTIVE
-            </span>
-          )}
           {activeTags.map((t) => (
             <span
               key={t.tag}
@@ -278,10 +285,17 @@ export function SponsorCard({
       </div>
 
       {/* Action Buttons - Top Right */}
-      <div
-        className="absolute top-1.5 right-1.5 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100"
-        onPointerDown={(e) => e.stopPropagation()}
-      >
+      <div className="absolute top-1.5 right-1.5 flex items-center gap-1">
+        {needsFollowUp && inactiveDays !== null && (
+          <span className="mr-2 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-amber-600/20 dark:bg-amber-900/30 dark:text-amber-400">
+            <ExclamationTriangleIcon className="mr-1 h-3.5 w-3.5" />
+            ⚠ {inactiveDays}d inactive
+          </span>
+        )}
+        <div
+          className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
         {onContract && (
           <button
             onClick={handleContractClick}
@@ -314,6 +328,7 @@ export function SponsorCard({
         >
           <TrashIcon className="h-3.5 w-3.5 text-red-600 dark:text-red-400" />
         </button>
+        </div>
       </div>
     </div>
   )

--- a/src/components/admin/sponsor-crm/SponsorCard.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCard.tsx
@@ -10,10 +10,6 @@ import { SponsorLogo } from '@/components/SponsorLogo'
 import { SpeakerAvatars } from '@/components/SpeakerAvatars'
 import { formatNumber } from '@/lib/format'
 import {
-  PencilIcon,
-  TrashIcon,
-  EnvelopeIcon,
-  DocumentTextIcon,
   ExclamationTriangleIcon,
   Bars2Icon,
   EllipsisHorizontalIcon,

--- a/src/components/admin/sponsor-crm/SponsorPipelineView.tsx
+++ b/src/components/admin/sponsor-crm/SponsorPipelineView.tsx
@@ -7,10 +7,9 @@ import type {
   ContractStatus,
   SponsorTag,
 } from '@/lib/sponsor-crm/types'
-import { canTransition } from '@/lib/sponsor-crm/state-machine'
+import { SponsorActivityTimeline } from '../sponsor/SponsorActivityTimeline'
 import type { SponsorTier } from '@/lib/sponsor/types'
 import {
-  StatusListbox,
   SponsorCombobox,
   TierRadioGroup,
   AddonsCheckboxGroup,
@@ -19,7 +18,6 @@ import {
   TagCombobox,
   SponsorGlobalInfoFields,
 } from './form'
-import { STATUSES, INVOICE_STATUSES, CONTRACT_STATUSES } from './form/constants'
 import clsx from 'clsx'
 
 export interface SponsorPipelineFormData {
@@ -89,143 +87,76 @@ export function SponsorPipelineView({
     sponsor?.contractStatus === 'contract-sent' ||
     sponsor?.contractStatus === 'contract-signed'
 
-  const invoiceOptions = INVOICE_STATUSES.map((opt) => {
-    const fromStatus = sponsor?.invoiceStatus || 'not-sent'
-    const transition = canTransition('invoice', fromStatus, opt.value, {
-      tier: formData.tierId,
-      contractValue: formData.contractValue
-        ? parseFloat(formData.contractValue)
-        : undefined,
-      contractCurrency: formData.contractCurrency,
-      billing: sponsor?.billing,
-      contractStatus: formData.contractStatus,
-      invoiceStatus: fromStatus,
-    })
-    return {
-      ...opt,
-      disabled: !transition.ok,
-      disabledReason: !transition.ok
-        ? transition.missing.map((m) => m.message).join('\n')
-        : undefined,
-    }
-  })
-
   return (
     <form onSubmit={onSubmit}>
-      <div className="space-y-3">
-        {/* Sponsor Selection - Only show when adding new */}
-        {!sponsor && (
-          <SponsorCombobox
-            value={formData.sponsorId}
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-5">
+        <div className="col-span-1 space-y-4 md:col-span-3">
+          {/* Sponsor Selection - Only show when adding new */}
+          {!sponsor && (
+            <SponsorCombobox
+              value={formData.sponsorId}
+              onChange={(value) =>
+                onFormDataChange((prev) => ({
+                  ...prev,
+                  sponsorId: value,
+                }))
+              }
+              availableSponsors={availableSponsors}
+              disabled={!!sponsor}
+            />
+          )}
+
+          {sponsor && (
+            <SponsorGlobalInfoFields
+              name={formData.name}
+              website={formData.website}
+              orgNumber={formData.orgNumber}
+              address={formData.address}
+              onNameChange={(name) =>
+                onFormDataChange((prev) => ({ ...prev, name }))
+              }
+              onWebsiteChange={(website) =>
+                onFormDataChange((prev) => ({ ...prev, website }))
+              }
+              onOrgNumberChange={(orgNumber) =>
+                onFormDataChange((prev) => ({
+                  ...prev,
+                  orgNumber,
+                }))
+              }
+              onAddressChange={(address) =>
+                onFormDataChange((prev) => ({
+                  ...prev,
+                  address,
+                }))
+              }
+            />
+          )}
+
+          {/* Tier Selection */}
+          <TierRadioGroup
+            tiers={regularTiers}
+            value={formData.tierId}
             onChange={(value) =>
               onFormDataChange((prev) => ({
                 ...prev,
-                sponsorId: value,
-              }))
-            }
-            availableSponsors={availableSponsors}
-            disabled={!!sponsor}
-          />
-        )}
-
-        {sponsor && (
-          <SponsorGlobalInfoFields
-            name={formData.name}
-            website={formData.website}
-            orgNumber={formData.orgNumber}
-            address={formData.address}
-            onNameChange={(name) =>
-              onFormDataChange((prev) => ({ ...prev, name }))
-            }
-            onWebsiteChange={(website) =>
-              onFormDataChange((prev) => ({ ...prev, website }))
-            }
-            onOrgNumberChange={(orgNumber) =>
-              onFormDataChange((prev) => ({
-                ...prev,
-                orgNumber,
-              }))
-            }
-            onAddressChange={(address) =>
-              onFormDataChange((prev) => ({
-                ...prev,
-                address,
+                tierId: value,
               }))
             }
           />
-        )}
 
-        {/* Tier Selection */}
-        <TierRadioGroup
-          tiers={regularTiers}
-          value={formData.tierId}
-          onChange={(value) =>
-            onFormDataChange((prev) => ({
-              ...prev,
-              tierId: value,
-            }))
-          }
-        />
+          {/* Addons Selection */}
+          <AddonsCheckboxGroup
+            addons={addonTiers}
+            value={formData.addonIds}
+            onChange={(value) =>
+              onFormDataChange((prev) => ({
+                ...prev,
+                addonIds: value,
+              }))
+            }
+          />
 
-        {/* Addons Selection */}
-        <AddonsCheckboxGroup
-          addons={addonTiers}
-          value={formData.addonIds}
-          onChange={(value) =>
-            onFormDataChange((prev) => ({
-              ...prev,
-              addonIds: value,
-            }))
-          }
-        />
-
-        {/* Status, Contract Status, and Invoice Status */}
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-          <div>
-            <StatusListbox
-              label="Status *"
-              value={formData.status}
-              onChange={(value) =>
-                onFormDataChange((prev) => ({
-                  ...prev,
-                  status: value,
-                }))
-              }
-              options={STATUSES}
-            />
-          </div>
-
-          <div>
-            <StatusListbox
-              label="Contract Status *"
-              value={formData.contractStatus}
-              onChange={(value) =>
-                onFormDataChange((prev) => ({
-                  ...prev,
-                  contractStatus: value,
-                }))
-              }
-              options={CONTRACT_STATUSES}
-            />
-          </div>
-
-          <div>
-            <StatusListbox
-              label="Invoice Status *"
-              value={formData.invoiceStatus}
-              onChange={(value) =>
-                onFormDataChange((prev) => ({
-                  ...prev,
-                  invoiceStatus: value,
-                }))
-              }
-              options={invoiceOptions}
-            />
-          </div>
-        </div>
-
-        {/* Assigned To and Contract Value */}
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <OrganizerCombobox
             value={formData.assignedTo}
             onChange={(value) =>
@@ -236,7 +167,9 @@ export function SponsorPipelineView({
             }
             organizers={organizers}
           />
+        </div>
 
+        <div className="col-span-1 space-y-4 border-l border-gray-200 pl-6 md:col-span-2 dark:border-gray-700">
           <ContractValueInput
             value={formData.contractValue}
             currency={formData.contractCurrency}
@@ -260,18 +193,25 @@ export function SponsorPipelineView({
                 : undefined
             }
           />
-        </div>
 
-        {/* Tags */}
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <div className="col-span-full">
-            <TagCombobox
-              value={formData.tags}
-              onChange={(tags) =>
-                onFormDataChange((prev) => ({ ...prev, tags }))
-              }
-            />
-          </div>
+          <TagCombobox
+            value={formData.tags}
+            onChange={(tags) => onFormDataChange((prev) => ({ ...prev, tags }))}
+          />
+
+          {sponsor && (
+            <div className="border-t border-gray-200 pt-4 dark:border-gray-700">
+              <h4 className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                Recent Activity
+              </h4>
+              <SponsorActivityTimeline
+                sponsorForConferenceId={sponsor._id}
+                limit={2}
+                compact={true}
+                showHeaderFooter={false}
+              />
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/admin/sponsor-crm/utils.ts
+++ b/src/components/admin/sponsor-crm/utils.ts
@@ -238,6 +238,18 @@ export function getDaysPending(contractSentAt?: string): number | null {
   return Math.max(0, days)
 }
 
+export function getDaysInactive(
+  sponsor: SponsorForConferenceExpanded,
+): number | null {
+  const lastActivityDate = sponsor.lastActivity?.createdAt ?? sponsor._updatedAt
+  if (!lastActivityDate) return null
+
+  const activityTime = new Date(lastActivityDate).getTime()
+  const now = Date.now()
+  const days = Math.floor((now - activityTime) / (1000 * 60 * 60 * 24))
+  return Math.max(0, days)
+}
+
 export function checkSponsorNeedsFollowUp(
   sponsor: SponsorForConferenceExpanded,
   thresholds?: CrmActivityThreshold[],

--- a/src/components/admin/sponsor/SponsorActivityTimeline.tsx
+++ b/src/components/admin/sponsor/SponsorActivityTimeline.tsx
@@ -19,6 +19,7 @@ interface SponsorActivityTimelineProps {
   sponsorForConferenceId?: string
   limit?: number
   showHeaderFooter?: boolean
+  compact?: boolean
 }
 
 interface SponsorDayGroup {
@@ -152,7 +153,13 @@ function UserAvatar({
   )
 }
 
-function ActivityLine({ activity }: { activity: SponsorActivityExpanded }) {
+function ActivityLine({
+  activity,
+  compact,
+}: {
+  activity: SponsorActivityExpanded
+  compact?: boolean
+}) {
   const iconType = useMemo(
     () => getActivityIcon(activity.activityType),
     [activity.activityType],
@@ -162,26 +169,48 @@ function ActivityLine({ activity }: { activity: SponsorActivityExpanded }) {
   })
 
   return (
-    <div className="group flex items-start gap-2.5 py-1.5">
+    <div
+      className={clsx(
+        'group flex items-start py-1.5',
+        compact ? 'gap-2' : 'gap-2.5',
+      )}
+    >
       <div
         className={clsx(
-          'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full',
+          compact ? 'mt-0 flex h-4 w-4' : 'mt-0.5 flex h-5 w-5',
+          'shrink-0 items-center justify-center rounded-full',
           getActivityColor(activity.activityType),
         )}
       >
-        {React.createElement(iconType, { className: 'h-3 w-3' })}
+        {React.createElement(iconType, {
+          className: compact ? 'h-2.5 w-2.5' : 'h-3 w-3',
+        })}
       </div>
-      <p className="min-w-0 flex-1 text-sm text-gray-600 dark:text-gray-300">
-        {activity.description}
+      <p
+        className={clsx(
+          'min-w-0 flex-1 text-gray-600 dark:text-gray-300',
+          compact ? 'text-xs' : 'text-sm',
+        )}
+      >
+        {compact && activity.description.length > 50
+          ? activity.description.substring(0, 50) + '...'
+          : activity.description}
       </p>
       <div className="flex shrink-0 items-center gap-1.5">
-        <UserAvatar
-          name={activity.createdBy?.name ?? 'Automatic'}
-          image={activity.createdBy?.image}
-          isSystem={!activity.createdBy}
-          size="sm"
-        />
-        <time className="text-xs text-gray-400 dark:text-gray-500">
+        {!compact && (
+          <UserAvatar
+            name={activity.createdBy?.name ?? 'Automatic'}
+            image={activity.createdBy?.image}
+            isSystem={!activity.createdBy}
+            size="sm"
+          />
+        )}
+        <time
+          className={clsx(
+            'text-gray-400 dark:text-gray-500',
+            compact ? 'text-[10px]' : 'text-xs',
+          )}
+        >
           {timeAgo}
         </time>
       </div>
@@ -194,11 +223,13 @@ function SponsorCard({
   sponsorForConferenceId,
   activities,
   hideSponsorName,
+  compact,
 }: {
   sponsorName: string
   sponsorForConferenceId: string
   activities: SponsorActivityExpanded[]
   hideSponsorName: boolean
+  compact?: boolean
 }) {
   return (
     <div>
@@ -224,7 +255,11 @@ function SponsorCard({
         )}
       >
         {activities.map((activity) => (
-          <ActivityLine key={activity._id} activity={activity} />
+          <ActivityLine
+            key={activity._id}
+            activity={activity}
+            compact={compact}
+          />
         ))}
       </div>
     </div>
@@ -235,6 +270,7 @@ export function SponsorActivityTimeline({
   sponsorForConferenceId,
   limit = 10,
   showHeaderFooter = true,
+  compact = false,
 }: SponsorActivityTimelineProps) {
   const { data: activities = [], isLoading } =
     api.sponsor.crm.activities.list.useQuery({
@@ -309,7 +345,13 @@ export function SponsorActivityTimeline({
           </p>
         </div>
       ) : (
-        <div className={clsx('space-y-5', showHeaderFooter && 'mt-4')}>
+        <div
+          className={clsx(
+            'space-y-5',
+            showHeaderFooter && 'mt-4',
+            compact && '!space-y-2',
+          )}
+        >
           {grouped.map((dayGroup) => (
             <div key={dayGroup.dateKey}>
               <div className="mb-2 flex items-center gap-2">
@@ -326,6 +368,7 @@ export function SponsorActivityTimeline({
                     sponsorForConferenceId={group.sponsorForConferenceId}
                     activities={group.activities}
                     hideSponsorName={!!sponsorForConferenceId}
+                    compact={compact}
                   />
                 ))}
               </div>

--- a/src/hooks/useSponsorDragDrop.ts
+++ b/src/hooks/useSponsorDragDrop.ts
@@ -246,6 +246,60 @@ export function useSponsorDragDrop(currentView: BoardView) {
     ],
   )
 
+  const handleAdvanceStage = useCallback(
+    async (sponsor: SponsorForConferenceExpanded, targetColumnKey: string) => {
+      if (
+        dropNeedsTier(currentView, sponsor.status, targetColumnKey, sponsor)
+      ) {
+        setPendingTierMove({ sponsor, targetColumnKey })
+        return
+      }
+
+      await runOptimisticMove(sponsor._id, targetColumnKey, () => {
+        switch (currentView) {
+          case 'pipeline':
+            return moveStage.mutateAsync({
+              id: sponsor._id,
+              newStatus: targetColumnKey as
+                | 'prospect'
+                | 'contacted'
+                | 'negotiating'
+                | 'closed-won'
+                | 'closed-lost',
+            })
+          case 'invoice':
+            return updateInvoiceStatus.mutateAsync({
+              id: sponsor._id,
+              newStatus: targetColumnKey as
+                | 'not-sent'
+                | 'sent'
+                | 'paid'
+                | 'overdue'
+                | 'cancelled',
+            })
+          case 'contract':
+            return updateContractStatus.mutateAsync({
+              id: sponsor._id,
+              newStatus: targetColumnKey as
+                | 'none'
+                | 'verbal-agreement'
+                | 'contract-sent'
+                | 'contract-signed',
+            })
+          default:
+            return Promise.resolve()
+        }
+      })
+    },
+    [
+      currentView,
+      runOptimisticMove,
+      moveStage,
+      updateInvoiceStatus,
+      updateContractStatus,
+    ],
+  )
+
   // Finish a held closed-won move with the chosen tier. Sets tier + status in a
   // single atomic update so the server guard is satisfied and there is no
   // half-done state (tier set but still not won).
@@ -283,6 +337,7 @@ export function useSponsorDragDrop(currentView: BoardView) {
     isDragging: activeItem !== null,
     handleDragStart,
     handleDragEnd,
+    handleAdvanceStage,
     pendingTierMove,
     confirmTierMove,
     cancelTierMove,


### PR DESCRIPTION
## Overview
This PR implements comprehensive UX improvements for the Sponsor CRM Kanban Board, focusing on making the interface more scannable, actionable, and space-efficient.

**Note: All GUI components introduced or modified in this PR need to be reviewed.**

## Phase 1: Visuals & Board Details
- **Column Totals**: The Kanban board now calculates and displays the total NOK pipeline value beneath each column header.
- **Inactivity Warnings**: Added inactivity warning counts to the column headers (e.g. `⚠ 3`).
- **Stale Cards**: Added an amber left border and a `⚠ Xd inactive` pill for inactive sponsors.
- **Drag Handles**: Separated card dragging from card clicking by introducing a discrete `Bars2Icon` drag handle.

## Phase 2: Card Actions & Safety Guards
- **Context Menu**: Swapped the absolute positioned hover buttons for a clean, accessible `@headlessui/react` `Menu` (ellipsis `···`).
- **Stage-Aware CTA**: Added a stage-aware CTA button (e.g., `→ Contacted`, `Verbal Agreement`) at the bottom of the card for 1-click stage advancement.
- **Guard Safety**: Hooked the new CTA into the existing `useSponsorDragDrop` state machine. If a sponsor is missing a tier, clicking `→ Closed Won` gracefully launches the `TierPickerPrompt` rather than throwing a backend error.

## Phase 3: Modal Redesign
- **2-Column Layout**: Split the monolithic `SponsorPipelineView` into a dense, two-column grid (`md:grid-cols-5`).
- **Header Status Pills**: Moved Pipeline Status, Contract Status, and Invoice Status out of the form body and up into the modal header as interactive, compact pills bound safely to local `formData`.
- **Compact Activity**: Created a `compact` mode for `SponsorActivityTimeline` and embedded the 2 most recent activities into the right column.

---

<details>
<summary><h2>GUI QA Checklist (Click to expand)</h2></summary>

This checklist maps out all React components modified in PR #402 and enumerates every visual state and variation that requires GUI review.

### 1. `SponsorBoardColumn` (Column Headers)
**Location:** Kanban Board View

- [ ] **Standard State:** Displays column title and the total number of sponsors in the blue count badge.
- [ ] **Value Calculation:** Displays the accurate `totalValueNOK` beneath the column title in muted gray text (e.g., "150,000 NOK").
- [ ] **Healthy State:** If no sponsors are inactive, the amber warning badge should **not** render.
- [ ] **Warning State:** If 1 or more sponsors exceed the inactivity threshold, the amber warning pill (e.g., `⚠ 3`) should render immediately to the left of the blue count badge.

### 2. `SponsorCard` (The Kanban Card)
**Location:** Kanban Board View

#### Inactivity Visuals
- [ ] **Active/Healthy:** Renders a standard subtle gray left border (`border-l-[3px] border-l-gray-400`).
- [ ] **Stale/Inactive:** Renders a thick amber left border (`border-l-4 border-l-amber-500`).
- [ ] **Inactivity Pill:** An absolute-positioned pill at the top-right reads `⚠ Xd inactive` (dynamically displaying the exact days). Ensure it doesn't overlap the context menu.

#### HeadlessUI Context Menu (`···`)
- [ ] **Idle State:** The ellipsis icon sits at the top right, always visible but subdued (40% opacity).
- [ ] **Hover State:** Reaches 100% opacity on hover.
- [ ] **Open State:** The dropdown menu opens cleanly without being clipped by the card's `overflow-hidden` properties.
- [ ] **Conditional Items:** 
  - "Send Email" renders only if the sponsor has an email contact.
  - "Send Contract" renders only if applicable.
  - "Delete" is rendered at the bottom in red.

#### Stage-Aware CTA (Bottom Button Row)
- [ ] **Pipeline View:** Renders relevant pipeline transitions (e.g., `→ Contacted`, `→ Negotiating`).
- [ ] **Contract View:** Renders relevant contract transitions (e.g., `Verbal Agreement`, `Contract Sent`).
- [ ] **Invoice View:** Renders relevant invoice transitions (e.g., `Sent`, `Paid`).
- [ ] **Terminal State:** Ensure no CTA renders if a sponsor is at the end of a terminal pipeline (e.g., already `Paid` on the invoice board).

#### Drag Handle
- [ ] **Placement:** Sits on the far left edge of the card.
- [ ] **Interactions:** Changes to `cursor-grab` on hover and `cursor-grabbing` on drag. 

### 3. `SponsorCRMForm` (The Modal Header)
**Location:** Sponsor Detail Modal (Top)

- [ ] **Pill Layout:** The 3 status fields (Pipeline, Contract, Invoice) render horizontally as compact pills beneath the Sponsor name and website.
- [ ] **Responsiveness:** If the screen is narrow, the pills should wrap cleanly to a second row using `flex-wrap`.
- [ ] **Local State Binding:** Changing a pill updates the visual state immediately but should **not** fire a toast notification or backend save until the main "Save ⌘S" button is clicked.

### 4. `SponsorPipelineView` (The Modal Body)
**Location:** Sponsor Detail Modal (Pipeline Tab)

- [ ] **Desktop Layout:** Renders as a 2-column layout (60% Left / 40% Right) separated by a subtle vertical border.
- [ ] **Mobile Layout:** Collapses cleanly into a single vertical column on smaller screens (`md:` breakpoint).
- [ ] **Creation Mode vs Edit Mode:** If clicking "Add Sponsor" (creation mode), the right column should look balanced despite the lack of a Recent Activity section.

### 5. `SponsorActivityTimeline`
**Location:** Sponsor Detail Modal (History Tab vs Pipeline Tab)

- [ ] **Standard Mode (History Tab):** Renders the full timeline with user avatars, large icons, generous spacing, and full un-truncated text.
- [ ] **Compact Mode (Pipeline Tab Right-Column):**
  - Only renders the 2 most recent activities.
  - Avatars are hidden to save horizontal space.
  - Padding and gaps are tightly reduced (`text-xs`, `!space-y-2`).
  - Extremely long notes are truncated to 50 characters with `...` appended.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a comprehensive UX overhaul of the Sponsor CRM Kanban board across three phases: column-level value totals and inactivity warnings, a HeadlessUI context menu and stage-aware CTA button on each card, and a two-column modal layout with status pills promoted to the header.

- **SponsorCard** replaces flat hover buttons with a `@headlessui/react` `Menu` and adds a `Bars2Icon` drag handle, an amber inactivity pill, and a CTA row that integrates with the existing `useSponsorDragDrop` tier-guard.
- **SponsorBoardColumn** accumulates `totalValueNOK` and `inactiveCount` inside the existing sort `useMemo` and surfaces them in a redesigned column header.
- **SponsorCRMForm / SponsorPipelineView** moves the three status dropdowns into the modal header as compact pills and splits the form body into a 3/2 grid with a compact `SponsorActivityTimeline` in the right column.

<h3>Confidence Score: 3/5</h3>

The new HeadlessUI context menu is the centrepiece of Phase 2 but will be visually clipped by the card's `overflow-hidden` on every sponsor row across all three board views, requiring a fix before the feature is usable.

The dropdown panel is rendered inline inside a card wrapper that carries `overflow-hidden`. CSS clipping is not overridden by `z-index`, so the menu will be cut off on every card on the board. The PR's own QA checklist explicitly flags this concern and no fix was applied.

src/components/admin/sponsor-crm/SponsorCard.tsx for the `overflow-hidden` / `MenuItems` clipping issue; src/components/admin/sponsor-crm/utils.ts for the `Date.now()` vs `getCurrentDateTime()` inconsistency.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/sponsor-crm/SponsorCard.tsx | Major redesign replacing hover buttons with HeadlessUI Menu, adding drag handle, inactivity pill, and stage CTA — but the Menu dropdown will be clipped by the card's `overflow-hidden` wrapper. |
| src/hooks/useSponsorDragDrop.ts | Adds `handleAdvanceStage` correctly reusing `runOptimisticMove` and `dropNeedsTier` for consistent tier-guard behavior with CTA-initiated moves. |
| src/components/admin/sponsor-crm/SponsorBoardColumn.tsx | Adds column value totals and inactive-sponsor count badge; `calculateSponsorValue` and `convertCurrency` are called twice per sponsor inside the same `useMemo`. |
| src/components/admin/sponsor-crm/SponsorCRMForm.tsx | Adds three compact status pill dropdowns to the modal header with correctly guarded `invoiceOptions` memo. |
| src/components/admin/sponsor-crm/SponsorPipelineView.tsx | Refactored to a 5-column grid layout with status fields moved to the modal header and compact `SponsorActivityTimeline` in the right column. |
| src/components/admin/sponsor/SponsorActivityTimeline.tsx | Adds `compact` prop hiding avatars, reducing text sizes, and truncating descriptions to 50 chars for inline modal use. |
| src/components/admin/sponsor-crm/utils.ts | Adds `getDaysInactive` helper using `Date.now()` directly, inconsistent with `getDaysPending` which uses `getCurrentDateTime()`. |
| src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx | Wires `onSponsorOpenHistory` and `onSponsorAdvanceStage` callbacks down to `SponsorBoardColumn`. |
| src/components/admin/sponsor-crm/SponsorCard.stories.tsx | Adds `onOpenHistory` and `onAdvanceStage` handlers to the Interactive story. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Card as SponsorCard (CTA)
    participant Col as SponsorBoardColumn
    participant Hook as useSponsorDragDrop
    participant Guard as dropNeedsTier
    participant SM as state-machine (canTransition)
    participant API as tRPC mutation
    participant Cache as React Query Cache

    Card->>Col: onAdvanceStage(targetStage)
    Col->>Hook: handleAdvanceStage(sponsor, targetStage)
    Hook->>Guard: dropNeedsTier(view, sponsor.status, targetStage, sponsor)
    Guard->>SM: canTransition('pipeline', from, to, sponsor)
    SM-->>Guard: ok false, missing tier
    Guard-->>Hook: true
    Hook-->>Col: setPendingTierMove, TierPickerPrompt shown

    Note over Card,Cache: When tier present or non-pipeline view

    Hook->>Cache: cancel in-flight refetches + snapshot
    Hook->>Cache: applyOptimisticMove
    Hook->>API: moveStage / updateContractStatus / updateInvoiceStatus
    API-->>Hook: success
    Hook->>Cache: invalidate list + healthViolations
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Card as SponsorCard (CTA)
    participant Col as SponsorBoardColumn
    participant Hook as useSponsorDragDrop
    participant Guard as dropNeedsTier
    participant SM as state-machine (canTransition)
    participant API as tRPC mutation
    participant Cache as React Query Cache

    Card->>Col: onAdvanceStage(targetStage)
    Col->>Hook: handleAdvanceStage(sponsor, targetStage)
    Hook->>Guard: dropNeedsTier(view, sponsor.status, targetStage, sponsor)
    Guard->>SM: canTransition('pipeline', from, to, sponsor)
    SM-->>Guard: ok false, missing tier
    Guard-->>Hook: true
    Hook-->>Col: setPendingTierMove, TierPickerPrompt shown

    Note over Card,Cache: When tier present or non-pipeline view

    Hook->>Cache: cancel in-flight refetches + snapshot
    Hook->>Cache: applyOptimisticMove
    Hook->>API: moveStage / updateContractStatus / updateInvoiceStatus
    API-->>Hook: success
    Hook->>Cache: invalidate list + healthViolations
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(crm): remove unused icon imports aft..."](https://github.com/cloudnativebergen/website/commit/70472644b506d712c867ff8fca4e3c5fc38240e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44414283)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->