### PR TITLE
fix: Display SpeakerShareSidebar alongside BadgeShare for accepted proposals

### DIFF
--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -265,22 +265,27 @@ export default async function SpeakerDashboard() {
 
         {/* Sidebar */}
         <div className="w-full shrink-0 space-y-4 lg:w-80">
-          {showBadgeInSidebar && latestBadge ? (
-            <BadgeShare
-              badge={latestBadge}
-              eventName={badgeEventName || 'Cloud Native Days Norway'}
-              domain={domain}
-              className="w-full"
-            />
-          ) : (
-            <SpeakerShareSidebar
-              speaker={speakerWithTalks}
-              talkTitle={talkTitle}
-              eventName={eventName}
-              baseDomain={domain}
-            />
-          )}
-          <DashboardSidebar />
+          <div className="space-y-4 lg:sticky lg:top-4">
+            {latestBadge && (
+              <BadgeShare
+                badge={latestBadge}
+                eventName={badgeEventName || 'Cloud Native Days Norway'}
+                domain={domain}
+                className="w-full"
+              />
+            )}
+
+            {(confirmedTalks.length > 0 || !latestBadge) && (
+              <SpeakerShareSidebar
+                speaker={speakerWithTalks}
+                talkTitle={talkTitle}
+                eventName={eventName}
+                baseDomain={domain}
+              />
+            )}
+
+            <DashboardSidebar />
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -25,7 +25,8 @@ export default async function SpeakerDashboard() {
 
   const headersList = await headers()
   const fullUrl = headersList.get('x-url') || ''
-  const { domain } = await getConferenceForCurrentDomain({})
+  const { conference: currentConference, domain } =
+    await getConferenceForCurrentDomain({})
   const session = await getAuthSession({ url: fullUrl })
 
   if (!session?.speaker) {
@@ -152,7 +153,7 @@ export default async function SpeakerDashboard() {
   const conferencesWithData = await Promise.all(conferenceDataPromises)
 
   // Filter out conferences with no activity
-  const activeConferences = conferencesWithData.filter(
+  const activeConferencesRaw = conferencesWithData.filter(
     (c) =>
       c.proposals.length > 0 ||
       c.galleryImages.length > 0 ||
@@ -160,6 +161,18 @@ export default async function SpeakerDashboard() {
       c.travelSupport !== null ||
       c.badges.length > 0,
   )
+
+  // Prioritize the current conference by moving it to the top of the list
+  const activeConferences = currentConference?._id
+    ? [
+        ...activeConferencesRaw.filter(
+          (c) => c.conference._id === currentConference._id,
+        ),
+        ...activeConferencesRaw.filter(
+          (c) => c.conference._id !== currentConference._id,
+        ),
+      ]
+    : activeConferencesRaw
 
   // Get confirmed talks for speaker share
   const confirmedTalks = activeConferences
@@ -170,12 +183,26 @@ export default async function SpeakerDashboard() {
     )
     .slice(0, 1) // Show only the first confirmed talk
 
-  // Get all badges sorted by issue date (newest first)
+  // Get all badges sorted by issue date (newest first), prioritizing the current conference
   const allBadges = activeConferences
-    .flatMap((c) => c.badges)
-    .sort(
-      (a, b) => new Date(b.issuedAt).getTime() - new Date(a.issuedAt).getTime(),
+    .flatMap((c) =>
+      c.badges.map((b) => ({ ...b, conferenceId: c.conference._id })),
     )
+    .sort((a, b) => {
+      if (currentConference?._id) {
+        if (
+          a.conferenceId === currentConference._id &&
+          b.conferenceId !== currentConference._id
+        )
+          return -1
+        if (
+          b.conferenceId === currentConference._id &&
+          a.conferenceId !== currentConference._id
+        )
+          return 1
+      }
+      return new Date(b.issuedAt).getTime() - new Date(a.issuedAt).getTime()
+    })
 
   const latestBadge = allBadges[0]
 

--- a/src/components/cfp/SpeakerShareSidebar.tsx
+++ b/src/components/cfp/SpeakerShareSidebar.tsx
@@ -1,4 +1,3 @@
-import { DashboardSidebar } from '@/components/cfp/DashboardSidebar'
 import { SpeakerShareWrapper } from '@/components/cfp/SpeakerShareWrapper'
 import { generateQRCode } from '@/components/SpeakerShare'
 import type { SpeakerWithTalks } from '@/lib/speaker/types'
@@ -23,18 +22,14 @@ export async function SpeakerShareSidebar({
   const qrCodeUrl = await generateQRCode(speakerUrl, 512, baseDomain)
 
   return (
-    <div className="space-y-4 lg:sticky lg:top-4">
-      <SpeakerShareWrapper
-        speakerUrl={fullSpeakerUrl}
-        talkTitle={talkTitle}
-        eventName={eventName}
-        speakerName={speaker.name}
-        qrCodeUrl={qrCodeUrl}
-        speaker={speaker}
-        className="w-full"
-      />
-
-      <DashboardSidebar />
-    </div>
+    <SpeakerShareWrapper
+      speakerUrl={fullSpeakerUrl}
+      talkTitle={talkTitle}
+      eventName={eventName}
+      speakerName={speaker.name}
+      qrCodeUrl={qrCodeUrl}
+      speaker={speaker}
+      className="w-full"
+    />
   )
 }


### PR DESCRIPTION
## Description

Fixes an issue where speakers could not see the social share card for their accepted/confirmed proposals on the `/cfp/list` page if they had also earned a speaker badge.

## Changes
- Extracted `DashboardSidebar` out of `SpeakerShareSidebar` to prevent duplication.
- Modified the render logic in `cfp/list/page.tsx` so both the `BadgeShare` and the `SpeakerShareSidebar` can be rendered at the same time.
- Wrapped the sidebar elements in a sticky container in `page.tsx`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where speakers with an earned badge could not see the speaker social share card for their accepted/confirmed proposals on the `/cfp/list` dashboard — previously the badge took exclusive priority over the speaker share sidebar.

- `SpeakerShareSidebar` is simplified to return only `SpeakerShareWrapper`; the sticky positioning and `DashboardSidebar` are lifted into `page.tsx`, preventing a pre-existing double-`DashboardSidebar` render in the no-badge path.
- The render condition `(confirmedTalks.length > 0 || !latestBadge)` correctly gates the `SpeakerShareSidebar`: shown when confirmed talks exist (regardless of badge) or when there is no badge at all, and hidden when only a badge is present with no confirmed talks.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change correctly renders both sidebar widgets together and removes a pre-existing duplicate DashboardSidebar.

The logic change is small and well-scoped. A redundant showBadgeInSidebar variable with a now-inaccurate comment remains, but it does not affect runtime behaviour. No functional regressions identified.

Minor cleanup opportunity in src/app/(cfp)/cfp/list/page.tsx around the showBadgeInSidebar variable.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/(cfp)/cfp/list/page.tsx | Render logic updated to show BadgeShare and SpeakerShareSidebar together in a sticky container; sidebar condition is correct but retains a now-redundant showBadgeInSidebar variable with a stale comment. |
| src/components/cfp/SpeakerShareSidebar.tsx | Correctly stripped the DashboardSidebar and sticky wrapper from the component so those concerns now live in the parent page; the component now returns a plain SpeakerShareWrapper. |

</details>


</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Speaker visits /cfp/list] --> B{latestBadge exists?}
    B -- Yes --> C[Render BadgeShare]
    B -- No --> D{confirmedTalks > 0?}
    C --> E{confirmedTalks.length > 0?}
    E -- Yes --> F[Render SpeakerShareSidebar]
    E -- No --> G[Skip SpeakerShareSidebar]
    D -- Yes --> F
    D -- No --> F
    F --> H[Render DashboardSidebar]
    G --> H
    C --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Speaker visits /cfp/list] --> B{latestBadge exists?}
    B -- Yes --> C[Render BadgeShare]
    B -- No --> D{confirmedTalks > 0?}
    C --> E{confirmedTalks.length > 0?}
    E -- Yes --> F[Render SpeakerShareSidebar]
    E -- No --> G[Skip SpeakerShareSidebar]
    D -- Yes --> F
    D -- No --> F
    F --> H[Render DashboardSidebar]
    G --> H
    C --> H
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/(cfp)/cfp/list/page.tsx`, line 196-208 ([link](https://github.com/cloudnativebergen/website/blob/c67f75ccee8bc798d20d2a7f4c941f3ce2fdb8c4/src/app/(cfp)/cfp/list/page.tsx#L196-L208)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale variable and outdated comment**

   `showBadgeInSidebar` is only used on line 201 as `if (showBadgeInSidebar && latestBadge)`, which is equivalent to `if (latestBadge && latestBadge)` — it adds no logic over `latestBadge` itself. The variable is also no longer referenced in the JSX. The accompanying comment ("latest badge takes priority over confirmed talk") describes the old exclusive-or render logic that this PR intentionally removes. Both the variable and the comment are now misleading.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: display SpeakerShareSidebar alongsi..."](https://github.com/cloudnativebergen/website/commit/c67f75ccee8bc798d20d2a7f4c941f3ce2fdb8c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39024091)</sub>

<!-- /greptile_comment -->