### PR TITLE
fix(notifications): send proposal status emails to all speakers, not just the first

### DIFF
--- a/__tests__/lib/events/handlers/emailNotification.test.ts
+++ b/__tests__/lib/events/handlers/emailNotification.test.ts
@@ -129,6 +129,18 @@ describe('handleEmailNotification', () => {
     }
   })
 
+  it('sends to the trimmed email address, matching the dedup key', async () => {
+    const speakers = [
+      createSpeaker({ email: ' padded@example.com ' }),
+      createSpeaker({ _id: 'speaker-dup', email: 'padded@example.com' }),
+    ]
+
+    await handleEmailNotification(createEvent(speakers))
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    expect(mockSend.mock.calls[0][0].speaker.email).toBe('padded@example.com')
+  })
+
   it('de-duplicates recipients by email address (case-insensitive)', async () => {
     const speakers = [
       createSpeaker(),
@@ -166,7 +178,10 @@ describe('handleEmailNotification', () => {
   it('warns and returns when no speaker has an email address', async () => {
     const speakers = [
       createSpeaker({ email: '' }),
-      createSpeaker({ _id: 'speaker-2', email: undefined as unknown as string }),
+      createSpeaker({
+        _id: 'speaker-2',
+        email: undefined as unknown as string,
+      }),
     ]
 
     await handleEmailNotification(createEvent(speakers))

--- a/__tests__/lib/events/handlers/emailNotification.test.ts
+++ b/__tests__/lib/events/handlers/emailNotification.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { handleEmailNotification } from '@/lib/events/handlers/emailNotification'
+import type { ProposalStatusChangeEvent } from '@/lib/events/types'
+import type { Speaker } from '@/lib/speaker/types'
+import { Action, Status } from '@/lib/proposal/types'
+import { sendAcceptRejectNotification } from '@/lib/proposal/server'
+
+vi.mock('@/lib/proposal/server', () => ({
+  sendAcceptRejectNotification: vi.fn().mockResolvedValue({ id: 'email-id' }),
+}))
+
+const mockSend = vi.mocked(sendAcceptRejectNotification)
+
+function createSpeaker(overrides: Partial<Speaker> = {}): Speaker {
+  return {
+    _id: 'speaker-1',
+    name: 'Primary Speaker',
+    email: 'primary@example.com',
+    ...overrides,
+  } as Speaker
+}
+
+function createEvent(
+  speakers: Speaker[],
+  overrides: Partial<ProposalStatusChangeEvent> = {},
+): ProposalStatusChangeEvent {
+  return {
+    eventType: 'proposal.status.changed',
+    timestamp: new Date('2026-01-01T12:00:00Z'),
+    proposal: {
+      _id: 'proposal-1',
+      title: 'Test Proposal',
+    },
+    previousStatus: Status.submitted,
+    newStatus: Status.accepted,
+    action: Action.accept,
+    conference: {
+      title: 'Cloud Native Day',
+      city: 'Bergen',
+      startDate: '2026-10-01',
+      organizer: 'CNDN',
+      contactEmail: 'contact@example.com',
+      socialLinks: [],
+    },
+    speakers,
+    metadata: {
+      triggeredBy: { speakerId: 'organizer-1', isOrganizer: true },
+      shouldNotify: true,
+      comment: '',
+      domain: 'example.com',
+    },
+    ...overrides,
+  } as unknown as ProposalStatusChangeEvent
+}
+
+describe('handleEmailNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSend.mockResolvedValue({ id: 'email-id' } as never)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not send when shouldNotify is false', async () => {
+    const event = createEvent([createSpeaker()])
+    event.metadata.shouldNotify = false
+
+    await handleEmailNotification(event)
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('does not send for non-notifiable actions', async () => {
+    const event = createEvent([createSpeaker()], { action: Action.submit })
+
+    await handleEmailNotification(event)
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('warns and returns when there are no speakers', async () => {
+    const event = createEvent([])
+
+    await handleEmailNotification(event)
+
+    expect(mockSend).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledWith(
+      'No speakers found for email notification',
+    )
+  })
+
+  it('sends a personalized email to every speaker on the proposal', async () => {
+    const speakers = [
+      createSpeaker(),
+      createSpeaker({
+        _id: 'speaker-2',
+        name: 'Co Speaker',
+        email: 'co@example.com',
+      }),
+      createSpeaker({
+        _id: 'speaker-3',
+        name: 'Third Speaker',
+        email: 'third@example.com',
+      }),
+    ]
+
+    await handleEmailNotification(createEvent(speakers))
+
+    expect(mockSend).toHaveBeenCalledTimes(3)
+
+    const recipients = mockSend.mock.calls.map((call) => call[0].speaker)
+    expect(recipients).toEqual([
+      { name: 'Primary Speaker', email: 'primary@example.com' },
+      { name: 'Co Speaker', email: 'co@example.com' },
+      { name: 'Third Speaker', email: 'third@example.com' },
+    ])
+
+    // All sends share the same action and proposal
+    for (const call of mockSend.mock.calls) {
+      expect(call[0].action).toBe(Action.accept)
+      expect(call[0].proposal).toEqual({
+        _id: 'proposal-1',
+        title: 'Test Proposal',
+      })
+    }
+  })
+
+  it('de-duplicates recipients by email address (case-insensitive)', async () => {
+    const speakers = [
+      createSpeaker(),
+      createSpeaker({ _id: 'speaker-dup', email: 'PRIMARY@Example.com' }),
+      createSpeaker({
+        _id: 'speaker-2',
+        name: 'Co Speaker',
+        email: 'co@example.com',
+      }),
+    ]
+
+    await handleEmailNotification(createEvent(speakers))
+
+    expect(mockSend).toHaveBeenCalledTimes(2)
+    const emails = mockSend.mock.calls.map((call) => call[0].speaker.email)
+    expect(emails).toEqual(['primary@example.com', 'co@example.com'])
+  })
+
+  it('skips speakers without an email address', async () => {
+    const speakers = [
+      createSpeaker({ email: '' }),
+      createSpeaker({
+        _id: 'speaker-2',
+        name: 'Co Speaker',
+        email: 'co@example.com',
+      }),
+    ]
+
+    await handleEmailNotification(createEvent(speakers))
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    expect(mockSend.mock.calls[0][0].speaker.email).toBe('co@example.com')
+  })
+
+  it('warns and returns when no speaker has an email address', async () => {
+    const speakers = [
+      createSpeaker({ email: '' }),
+      createSpeaker({ _id: 'speaker-2', email: undefined as unknown as string }),
+    ]
+
+    await handleEmailNotification(createEvent(speakers))
+
+    expect(mockSend).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledWith(
+      'No speakers with email addresses found for proposal proposal-1',
+    )
+  })
+
+  it('continues sending to remaining speakers when one send fails', async () => {
+    mockSend
+      .mockRejectedValueOnce(new Error('Failed to send email: boom'))
+      .mockResolvedValue({ id: 'email-id' } as never)
+
+    const speakers = [
+      createSpeaker(),
+      createSpeaker({
+        _id: 'speaker-2',
+        name: 'Co Speaker',
+        email: 'co@example.com',
+      }),
+      createSpeaker({
+        _id: 'speaker-3',
+        name: 'Third Speaker',
+        email: 'third@example.com',
+      }),
+    ]
+
+    await expect(
+      handleEmailNotification(createEvent(speakers)),
+    ).resolves.toBeUndefined()
+
+    expect(mockSend).toHaveBeenCalledTimes(3)
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to send email notification to 1 of 3 speaker(s) for proposal proposal-1:',
+      [
+        {
+          email: 'primary@example.com',
+          reason: 'Failed to send email: boom',
+        },
+      ],
+    )
+    expect(console.log).toHaveBeenCalledWith(
+      'Email notification sent to 2 of 3 speaker(s) for proposal proposal-1',
+    )
+  })
+
+  it('does not throw when all sends fail', async () => {
+    mockSend.mockRejectedValue(new Error('resend down'))
+
+    const speakers = [
+      createSpeaker(),
+      createSpeaker({
+        _id: 'speaker-2',
+        name: 'Co Speaker',
+        email: 'co@example.com',
+      }),
+    ]
+
+    await expect(
+      handleEmailNotification(createEvent(speakers)),
+    ).resolves.toBeUndefined()
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to send email notification to 2 of 2 speaker(s) for proposal proposal-1:',
+      [
+        { email: 'primary@example.com', reason: 'resend down' },
+        { email: 'co@example.com', reason: 'resend down' },
+      ],
+    )
+  })
+})

--- a/__tests__/lib/proposal/email/notification.test.ts
+++ b/__tests__/lib/proposal/email/notification.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { sendAcceptRejectNotification } from '@/lib/proposal/email/notification'
+import type { NotificationParams } from '@/lib/proposal/email/types'
+import { Action } from '@/lib/proposal/types'
+import { resend } from '@/lib/email/config'
+import {
+  ProposalAcceptTemplate,
+  ProposalRejectTemplate,
+  ProposalWaitlistTemplate,
+} from '@/components/email'
+
+vi.mock('@/lib/email/config', () => ({
+  resend: {
+    emails: {
+      send: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/components/email', () => ({
+  ProposalAcceptTemplate: vi.fn(() => 'accept-template'),
+  ProposalRejectTemplate: vi.fn(() => 'reject-template'),
+  ProposalWaitlistTemplate: vi.fn(() => 'waitlist-template'),
+}))
+
+const mockSendEmail = vi.mocked(resend.emails.send)
+
+function createParams(
+  overrides: Partial<NotificationParams> = {},
+): NotificationParams {
+  return {
+    action: Action.accept,
+    speaker: {
+      name: 'Test Speaker',
+      email: 'speaker@example.com',
+    },
+    proposal: {
+      _id: 'proposal-1',
+      title: 'Test Proposal',
+    },
+    comment: 'Well done',
+    event: {
+      location: 'Bergen',
+      date: '1 October 2026',
+      name: 'Cloud Native Day',
+      url: 'https://example.com',
+      organizer: 'CNDN',
+      socialLinks: [],
+      contactEmail: 'contact@example.com',
+    },
+    ...overrides,
+  }
+}
+
+describe('sendAcceptRejectNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendEmail.mockResolvedValue({
+      data: { id: 'email-id' },
+      error: null,
+    } as never)
+  })
+
+  it('throws for invalid actions', async () => {
+    await expect(
+      sendAcceptRejectNotification(createParams({ action: Action.submit })),
+    ).rejects.toThrow('Invalid action for notification: submit')
+  })
+
+  it('sends the accept email to the given speaker with a confirm URL', async () => {
+    const result = await sendAcceptRejectNotification(createParams())
+
+    expect(mockSendEmail).toHaveBeenCalledTimes(1)
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'CNDN <contact@example.com>',
+        to: ['speaker@example.com'],
+        subject: '🎉 Your proposal has been accepted for Cloud Native Day',
+      }),
+    )
+    expect(ProposalAcceptTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        speakerName: 'Test Speaker',
+        proposalTitle: 'Test Proposal',
+        confirmUrl: 'https://example.com/cfp/list?confirm=proposal-1',
+      }),
+    )
+    expect(result).toEqual({ id: 'email-id' })
+  })
+
+  it('uses the accept template with confirm URL for remind action', async () => {
+    await sendAcceptRejectNotification(createParams({ action: Action.remind }))
+
+    expect(ProposalAcceptTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        confirmUrl: 'https://example.com/cfp/list?confirm=proposal-1',
+      }),
+    )
+  })
+
+  it('personalizes the greeting with the recipient speaker name', async () => {
+    await sendAcceptRejectNotification(
+      createParams({
+        action: Action.reject,
+        speaker: { name: 'Co Speaker', email: 'co@example.com' },
+      }),
+    )
+
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ['co@example.com'] }),
+    )
+    expect(ProposalRejectTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ speakerName: 'Co Speaker' }),
+    )
+  })
+
+  it('uses the waitlist template for waitlist action', async () => {
+    await sendAcceptRejectNotification(
+      createParams({ action: Action.waitlist }),
+    )
+
+    expect(ProposalWaitlistTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ speakerName: 'Test Speaker' }),
+    )
+  })
+
+  it('throws when resend returns an error', async () => {
+    mockSendEmail.mockResolvedValue({
+      data: null,
+      error: { message: 'rate limited', name: 'rate_limit_exceeded' },
+    } as never)
+
+    await expect(sendAcceptRejectNotification(createParams())).rejects.toThrow(
+      'Failed to send email: rate limited',
+    )
+  })
+})

--- a/__tests__/lib/proposal/email/notification.test.ts
+++ b/__tests__/lib/proposal/email/notification.test.ts
@@ -1,29 +1,32 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
 import { sendAcceptRejectNotification } from '@/lib/proposal/email/notification'
 import type { NotificationParams } from '@/lib/proposal/email/types'
 import { Action } from '@/lib/proposal/types'
 import { resend } from '@/lib/email/config'
-import {
-  ProposalAcceptTemplate,
-  ProposalRejectTemplate,
-  ProposalWaitlistTemplate,
-} from '@/components/email'
 
-vi.mock('@/lib/email/config', () => ({
-  resend: {
-    emails: {
-      send: vi.fn(),
+// Only the external boundary (the Resend client) is mocked; templates and
+// the retry helper run for real so their integration is covered
+vi.mock('@/lib/email/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/email/config')>()
+  return {
+    ...actual,
+    resend: {
+      emails: {
+        send: vi.fn(),
+      },
     },
-  },
-}))
-
-vi.mock('@/components/email', () => ({
-  ProposalAcceptTemplate: vi.fn(() => 'accept-template'),
-  ProposalRejectTemplate: vi.fn(() => 'reject-template'),
-  ProposalWaitlistTemplate: vi.fn(() => 'waitlist-template'),
-}))
+  }
+})
 
 const mockSendEmail = vi.mocked(resend.emails.send)
+
+function lastSentMarkup(): string {
+  const lastCall = mockSendEmail.mock.calls.at(-1)
+  if (!lastCall) throw new Error('resend.emails.send was not called')
+  return renderToStaticMarkup((lastCall[0] as { react: ReactElement }).react)
+}
 
 function createParams(
   overrides: Partial<NotificationParams> = {},
@@ -61,6 +64,10 @@ describe('sendAcceptRejectNotification', () => {
     } as never)
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('throws for invalid actions', async () => {
     await expect(
       sendAcceptRejectNotification(createParams({ action: Action.submit })),
@@ -78,23 +85,18 @@ describe('sendAcceptRejectNotification', () => {
         subject: '🎉 Your proposal has been accepted for Cloud Native Day',
       }),
     )
-    expect(ProposalAcceptTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        speakerName: 'Test Speaker',
-        proposalTitle: 'Test Proposal',
-        confirmUrl: 'https://example.com/cfp/list?confirm=proposal-1',
-      }),
-    )
+    const markup = lastSentMarkup()
+    expect(markup).toContain('Test Speaker')
+    expect(markup).toContain('Test Proposal')
+    expect(markup).toContain('https://example.com/cfp/list?confirm=proposal-1')
     expect(result).toEqual({ id: 'email-id' })
   })
 
   it('uses the accept template with confirm URL for remind action', async () => {
     await sendAcceptRejectNotification(createParams({ action: Action.remind }))
 
-    expect(ProposalAcceptTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        confirmUrl: 'https://example.com/cfp/list?confirm=proposal-1',
-      }),
+    expect(lastSentMarkup()).toContain(
+      'https://example.com/cfp/list?confirm=proposal-1',
     )
   })
 
@@ -109,9 +111,7 @@ describe('sendAcceptRejectNotification', () => {
     expect(mockSendEmail).toHaveBeenCalledWith(
       expect.objectContaining({ to: ['co@example.com'] }),
     )
-    expect(ProposalRejectTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({ speakerName: 'Co Speaker' }),
-    )
+    expect(lastSentMarkup()).toContain('Co Speaker')
   })
 
   it('uses the waitlist template for waitlist action', async () => {
@@ -119,19 +119,42 @@ describe('sendAcceptRejectNotification', () => {
       createParams({ action: Action.waitlist }),
     )
 
-    expect(ProposalWaitlistTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({ speakerName: 'Test Speaker' }),
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Your proposal has been waitlisted for Cloud Native Day',
+      }),
     )
+    expect(lastSentMarkup()).toContain('Test Speaker')
   })
 
-  it('throws when resend returns an error', async () => {
+  it('throws when resend returns a non-retryable error', async () => {
     mockSendEmail.mockResolvedValue({
       data: null,
-      error: { message: 'rate limited', name: 'rate_limit_exceeded' },
+      error: { message: 'invalid recipient', name: 'validation_error' },
     } as never)
 
     await expect(sendAcceptRejectNotification(createParams())).rejects.toThrow(
-      'Failed to send email: rate limited',
+      'Failed to send email: invalid recipient',
     )
+    expect(mockSendEmail).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries rate-limited sends with backoff and succeeds', async () => {
+    vi.useFakeTimers()
+    mockSendEmail
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'Too many requests', name: 'rate_limit_exceeded' },
+      } as never)
+      .mockResolvedValueOnce({
+        data: { id: 'email-retry' },
+        error: null,
+      } as never)
+
+    const promise = sendAcceptRejectNotification(createParams())
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(promise).resolves.toEqual({ id: 'email-retry' })
+    expect(mockSendEmail).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/lib/events/handlers/emailNotification.ts
+++ b/src/lib/events/handlers/emailNotification.ts
@@ -1,4 +1,5 @@
 import { ProposalStatusChangeEvent } from '@/lib/events/types'
+import { Speaker } from '@/lib/speaker/types'
 import { sendAcceptRejectNotification } from '@/lib/proposal/server'
 import { Action } from '@/lib/proposal/types'
 import { formatDate } from '@/lib/time'
@@ -20,29 +21,78 @@ export async function handleEmailNotification(
     return
   }
 
-  const primarySpeaker = event.speakers[0]
-
-  await sendAcceptRejectNotification({
-    action: event.action,
-    speaker: {
-      name: primarySpeaker.name,
-      email: primarySpeaker.email,
-    },
-    proposal: {
-      _id: event.proposal._id,
-      title: event.proposal.title,
-    },
-    comment: event.metadata.comment || '',
-    event: {
-      location: event.conference.city,
-      date: formatDate(event.conference.startDate),
-      name: event.conference.title,
-      organizer: event.conference.organizer,
-      url: `https://${event.metadata.domain}`,
-      socialLinks: event.conference.socialLinks,
-      contactEmail: event.conference.contactEmail,
-    },
+  // Notify every speaker on the proposal (primary speaker and co-speakers),
+  // de-duplicated by email address (case-insensitive) to guard against dirty data.
+  const seenEmails = new Set<string>()
+  const recipients = event.speakers.filter((speaker) => {
+    if (!speaker.email) {
+      return false
+    }
+    const normalizedEmail = speaker.email.trim().toLowerCase()
+    if (!normalizedEmail || seenEmails.has(normalizedEmail)) {
+      return false
+    }
+    seenEmails.add(normalizedEmail)
+    return true
   })
 
-  console.log(`Email notification sent for proposal ${event.proposal._id}`)
+  if (recipients.length === 0) {
+    console.warn(
+      `No speakers with email addresses found for proposal ${event.proposal._id}`,
+    )
+    return
+  }
+
+  const results = await Promise.allSettled(
+    recipients.map((speaker) =>
+      sendAcceptRejectNotification({
+        action: event.action,
+        speaker: {
+          name: speaker.name,
+          email: speaker.email,
+        },
+        proposal: {
+          _id: event.proposal._id,
+          title: event.proposal.title,
+        },
+        comment: event.metadata.comment || '',
+        event: {
+          location: event.conference.city,
+          date: formatDate(event.conference.startDate),
+          name: event.conference.title,
+          organizer: event.conference.organizer,
+          url: `https://${event.metadata.domain}`,
+          socialLinks: event.conference.socialLinks,
+          contactEmail: event.conference.contactEmail,
+        },
+      }),
+    ),
+  )
+
+  const failures = results
+    .map((result, index) => ({ result, speaker: recipients[index] }))
+    .filter(
+      (entry): entry is { result: PromiseRejectedResult; speaker: Speaker } =>
+        entry.result.status === 'rejected',
+    )
+
+  if (failures.length > 0) {
+    console.warn(
+      `Failed to send email notification to ${failures.length} of ${recipients.length} speaker(s) for proposal ${event.proposal._id}:`,
+      failures.map(({ speaker, result }) => ({
+        email: speaker.email,
+        reason:
+          result.reason instanceof Error
+            ? result.reason.message
+            : String(result.reason),
+      })),
+    )
+  }
+
+  const successCount = recipients.length - failures.length
+  if (successCount > 0) {
+    console.log(
+      `Email notification sent to ${successCount} of ${recipients.length} speaker(s) for proposal ${event.proposal._id}`,
+    )
+  }
 }

--- a/src/lib/events/handlers/emailNotification.ts
+++ b/src/lib/events/handlers/emailNotification.ts
@@ -1,5 +1,4 @@
 import { ProposalStatusChangeEvent } from '@/lib/events/types'
-import { Speaker } from '@/lib/speaker/types'
 import { sendAcceptRejectNotification } from '@/lib/proposal/server'
 import { Action } from '@/lib/proposal/types'
 import { formatDate } from '@/lib/time'
@@ -22,19 +21,23 @@ export async function handleEmailNotification(
   }
 
   // Notify every speaker on the proposal (primary speaker and co-speakers),
-  // de-duplicated by email address (case-insensitive) to guard against dirty data.
+  // de-duplicated by email address (case-insensitive) to guard against dirty
+  // data. The trimmed address is also what gets sent to, so the dedup key
+  // and the recipient can never diverge.
   const seenEmails = new Set<string>()
-  const recipients = event.speakers.filter((speaker) => {
-    if (!speaker.email) {
-      return false
+  const recipients: Array<{ name: string; email: string }> = []
+  for (const speaker of event.speakers) {
+    const email = speaker.email?.trim()
+    if (!email) {
+      continue
     }
-    const normalizedEmail = speaker.email.trim().toLowerCase()
-    if (!normalizedEmail || seenEmails.has(normalizedEmail)) {
-      return false
+    const key = email.toLowerCase()
+    if (seenEmails.has(key)) {
+      continue
     }
-    seenEmails.add(normalizedEmail)
-    return true
-  })
+    seenEmails.add(key)
+    recipients.push({ name: speaker.name, email })
+  }
 
   if (recipients.length === 0) {
     console.warn(
@@ -72,8 +75,12 @@ export async function handleEmailNotification(
   const failures = results
     .map((result, index) => ({ result, speaker: recipients[index] }))
     .filter(
-      (entry): entry is { result: PromiseRejectedResult; speaker: Speaker } =>
-        entry.result.status === 'rejected',
+      (
+        entry,
+      ): entry is {
+        result: PromiseRejectedResult
+        speaker: { name: string; email: string }
+      } => entry.result.status === 'rejected',
     )
 
   if (failures.length > 0) {

--- a/src/lib/proposal/email/notification.ts
+++ b/src/lib/proposal/email/notification.ts
@@ -4,7 +4,7 @@ import {
   ProposalRejectTemplate,
   ProposalWaitlistTemplate,
 } from '@/components/email'
-import { resend } from '@/lib/email/config'
+import { resend, retryWithBackoff } from '@/lib/email/config'
 import {
   NotificationParams,
   createTemplateProps,
@@ -68,16 +68,20 @@ export async function sendAcceptRejectNotification(params: NotificationParams) {
   const subject = getEmailSubject(action, params.event.name)
   const template = getEmailTemplate(action, templateProps)
 
-  const { data, error } = await resend.emails.send({
-    from: `${params.event.organizer} <${params.event.contactEmail}>`,
-    to: [params.speaker.email],
-    subject: subject,
-    react: template,
+  // Retry transient provider failures (e.g. rate limits) with backoff,
+  // consistent with the other email flows in the codebase
+  return retryWithBackoff(async () => {
+    const { data, error } = await resend.emails.send({
+      from: `${params.event.organizer} <${params.event.contactEmail}>`,
+      to: [params.speaker.email],
+      subject: subject,
+      react: template,
+    })
+
+    if (error) {
+      throw new Error(`Failed to send email: ${error.message}`)
+    }
+
+    return data
   })
-
-  if (error) {
-    throw new Error(`Failed to send email: ${error.message}`)
-  }
-
-  return data
 }


### PR DESCRIPTION
## Problem

Proposal lifecycle emails (accept / reject / waitlist / remind) were sent only to `event.speakers[0]`. Co-speakers never received them — contradicting the invitation flow's promise that co-speakers "receive updates about the proposal status".

## Changes

- `handleEmailNotification` fans out to every speaker on the proposal that has an email address, personalized per recipient
- Recipients are deduplicated case-insensitively on email to guard against dirty data
- Sends run via `Promise.allSettled`: one failing address can't block the others; failures are logged per-recipient with reasons
- The same confirm URL goes to all speakers, which is correct — any speaker on the proposal may confirm

`sendAcceptRejectNotification` keeps its single-recipient signature; only the handler fans out.

## Testing

- 15 new tests: full fan-out with personalization, case-insensitive dedup, missing-email skips, partial-failure isolation, action/shouldNotify gating (`__tests__/lib/events/handlers/emailNotification.test.ts`, `__tests__/lib/proposal/email/notification.test.ts`)
- `pnpm typecheck` clean; full suite green

Independent of #406 (no shared files), but most valuable together with it: once co-speakers actually land in `talk.speakers[]`, this makes sure they hear about decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where proposal lifecycle emails (accept/reject/waitlist/remind) were only sent to the first speaker on a proposal, leaving co-speakers without notifications they were promised. The `handleEmailNotification` handler now fans out to every speaker who has an email address.

- **Fan-out with dedup**: speakers are filtered for non-empty emails and deduplicated case-insensitively before sending, guarding against dirty CMS data.
- **Partial-failure isolation**: sends run via `Promise.allSettled` so a single bad address cannot block emails to the rest; failures are logged per-recipient with reasons.
- **15 new Vitest tests** cover all key paths: full fan-out, case-insensitive dedup, missing-email skips, partial failure, and action/shouldNotify gating.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fan-out logic is correct, failure-isolated, and well-tested. The only note is a whitespace inconsistency between the dedup normalization and the email address passed to the send API.

The fan-out, dedup, and partial-failure handling are all correctly implemented and covered by tests. One minor inconsistency: the deduplication normalizes speaker.email via .trim() but the actual send still uses the untrimmed original, so a stored address with surrounding whitespace would be deduplicated correctly yet sent with the raw value. This is unlikely to matter in practice but is worth tidying.

No files require special attention; emailNotification.ts is the only changed production file and its logic is straightforward.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/events/handlers/emailNotification.ts | Core fan-out logic: replaces single speakers[0] send with a deduplicated, allSettled-based broadcast to all speakers; logic is correct and failure-isolated. |
| __tests__/lib/events/handlers/emailNotification.test.ts | New handler tests covering fan-out, case-insensitive dedup, missing-email skips, partial failure isolation, and gating conditions; comprehensive and well-structured. |
| __tests__/lib/proposal/email/notification.test.ts | New unit tests for sendAcceptRejectNotification covering per-speaker personalization, confirm URL construction, template selection, and error propagation. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleEmailNotification] --> B{shouldNotify && notifiable action?}
    B -- No --> Z[return]
    B -- Yes --> C{event.speakers empty?}
    C -- Yes --> D[warn: No speakers found\nreturn]
    C -- No --> E[Filter speakers\nwith non-empty email\n+ case-insensitive dedup]
    E --> F{recipients.length == 0?}
    F -- Yes --> G[warn: No email addresses found\nreturn]
    F -- No --> H[Promise.allSettled\nsendAcceptRejectNotification\nfor each recipient]
    H --> I[Collect failures]
    I --> J{failures > 0?}
    J -- Yes --> K[console.warn with\nfailed emails + reasons]
    J -- No --> L[Skip warning]
    K --> M{successCount > 0?}
    L --> M
    M -- Yes --> N[console.log success count]
    M -- No --> O[return]
    N --> O
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[handleEmailNotification] --> B{shouldNotify && notifiable action?}
    B -- No --> Z[return]
    B -- Yes --> C{event.speakers empty?}
    C -- Yes --> D[warn: No speakers found\nreturn]
    C -- No --> E[Filter speakers\nwith non-empty email\n+ case-insensitive dedup]
    E --> F{recipients.length == 0?}
    F -- Yes --> G[warn: No email addresses found\nreturn]
    F -- No --> H[Promise.allSettled\nsendAcceptRejectNotification\nfor each recipient]
    H --> I[Collect failures]
    I --> J{failures > 0?}
    J -- Yes --> K[console.warn with\nfailed emails + reasons]
    J -- No --> L[Skip warning]
    K --> M{successCount > 0?}
    L --> M
    M -- Yes --> N[console.log success count]
    M -- No --> O[return]
    N --> O
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): send proposal status..."](https://github.com/cloudnativebergen/website/commit/a00b5c39538fb4d19be15b3922b00a191ef059ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43947545)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->