### PR TITLE
fix(cospeaker): review follow-ups — token exposure, real email abstracts, multi-speaker surfaces

### DIFF
--- a/__tests__/api/trpc/proposal-invitation.test.ts
+++ b/__tests__/api/trpc/proposal-invitation.test.ts
@@ -138,6 +138,35 @@ describe('proposal.invitation router', () => {
       expect(sendInvitationEmail).toHaveBeenCalled()
     })
 
+    it('should not leak the invitation bearer token to the inviter (regression)', async () => {
+      vi.mocked(getProposal).mockResolvedValue({
+        proposal: mockProposal as any,
+        proposalError: null,
+      })
+      vi.mocked(createCoSpeakerInvitation).mockResolvedValue({
+        ...mockInvitation,
+        token: 'super-secret-token',
+      } as any)
+      vi.mocked(sendInvitationEmail).mockResolvedValue(true)
+
+      const caller = createCaller(regularSpeaker)
+      const result = await caller.proposal.invitation.send({
+        proposalId: 'proposal-1',
+        invitedEmail: 'invited@test.com',
+        invitedName: 'Invited Co-Speaker',
+      })
+
+      // The mutation response must never contain the bearer token; only
+      // the invitee receives it, via the emailed invitation link
+      expect(result).not.toHaveProperty('token')
+      expect(JSON.stringify(result)).not.toContain('super-secret-token')
+
+      // The email flow still receives the full invitation with the token
+      expect(sendInvitationEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ token: 'super-secret-token' }),
+      )
+    })
+
     it('should reject if user does not own the proposal', async () => {
       vi.mocked(getProposal).mockResolvedValue({
         proposal: null as any,

--- a/__tests__/lib/cospeaker/sanity.test.ts
+++ b/__tests__/lib/cospeaker/sanity.test.ts
@@ -1,0 +1,67 @@
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: mockFetch,
+  },
+  clientWrite: {},
+}))
+
+import { getProposalAbstract } from '@/lib/cospeaker/sanity'
+
+describe('getProposalAbstract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the plain-text abstract for a proposal', async () => {
+    mockFetch.mockResolvedValue({ abstract: 'A talk about GitOps.' })
+
+    const abstract = await getProposalAbstract('proposal-1')
+
+    expect(abstract).toBe('A talk about GitOps.')
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('pt::text(description)'),
+      { proposalId: 'proposal-1' },
+      { cache: 'no-store' },
+    )
+  })
+
+  it('trims surrounding whitespace from the abstract', async () => {
+    mockFetch.mockResolvedValue({ abstract: '  Spaced out.  ' })
+
+    await expect(getProposalAbstract('proposal-1')).resolves.toBe('Spaced out.')
+  })
+
+  it('returns null when the abstract is empty', async () => {
+    mockFetch.mockResolvedValue({ abstract: '' })
+
+    await expect(getProposalAbstract('proposal-1')).resolves.toBeNull()
+  })
+
+  it('returns null when the abstract is only whitespace', async () => {
+    mockFetch.mockResolvedValue({ abstract: '   ' })
+
+    await expect(getProposalAbstract('proposal-1')).resolves.toBeNull()
+  })
+
+  it('returns null when the proposal does not exist', async () => {
+    mockFetch.mockResolvedValue(null)
+
+    await expect(getProposalAbstract('missing')).resolves.toBeNull()
+  })
+
+  it('returns null when the fetch fails', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mockFetch.mockRejectedValue(new Error('network down'))
+
+    await expect(getProposalAbstract('proposal-1')).resolves.toBeNull()
+
+    expect(consoleSpy).toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+})

--- a/__tests__/lib/cospeaker/server.test.ts
+++ b/__tests__/lib/cospeaker/server.test.ts
@@ -1,0 +1,194 @@
+const { mockSend, mockGetConference, mockGetProposalAbstract } = vi.hoisted(
+  () => ({
+    mockSend: vi.fn(),
+    mockGetConference: vi.fn(),
+    mockGetProposalAbstract: vi.fn(),
+  }),
+)
+
+vi.mock('@/lib/email/config', () => ({
+  resend: { emails: { send: mockSend } },
+  retryWithBackoff: (fn: () => unknown) => fn(),
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: mockGetConference,
+}))
+
+vi.mock('@/lib/cospeaker/sanity', () => ({
+  getProposalAbstract: mockGetProposalAbstract,
+}))
+
+import React from 'react'
+import {
+  sendInvitationEmail,
+  truncateAbstract,
+  ABSTRACT_MAX_LENGTH,
+} from '@/lib/cospeaker/server'
+import type { CoSpeakerInvitationFull } from '@/lib/cospeaker/types'
+
+const FALLBACK_ABSTRACT =
+  'Please view the full proposal details for more information.'
+
+const invitation: CoSpeakerInvitationFull = {
+  _id: 'invitation-1',
+  invitedEmail: 'invitee@example.com',
+  invitedName: 'Ida Invitee',
+  status: 'pending',
+  token: 'token-abc',
+  expiresAt: '2026-08-01T00:00:00Z',
+  createdAt: '2026-07-01T00:00:00Z',
+  proposal: {
+    _id: 'proposal-1',
+    title: 'GitOps for Everyone',
+  },
+  invitedBy: {
+    _id: 'speaker-1',
+    name: 'Sam Speaker',
+    email: 'sam@example.com',
+  },
+}
+
+function sentEmailProps(): Record<string, unknown> {
+  expect(mockSend).toHaveBeenCalledTimes(1)
+  const { react } = mockSend.mock.calls[0][0] as {
+    react: React.ReactElement<Record<string, unknown>>
+  }
+  return react.props
+}
+
+describe('truncateAbstract', () => {
+  it('returns short abstracts unchanged', () => {
+    expect(truncateAbstract('A short abstract.')).toBe('A short abstract.')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(truncateAbstract('  padded  ')).toBe('padded')
+  })
+
+  it('returns abstracts exactly at the limit unchanged', () => {
+    const abstract = 'a'.repeat(ABSTRACT_MAX_LENGTH)
+    expect(truncateAbstract(abstract)).toBe(abstract)
+  })
+
+  it('truncates long abstracts at a word boundary with an ellipsis', () => {
+    const word = 'kubernetes '
+    const abstract = word.repeat(100).trim()
+
+    const result = truncateAbstract(abstract)
+
+    expect(result.length).toBeLessThanOrEqual(ABSTRACT_MAX_LENGTH + 1)
+    expect(result.endsWith('…')).toBe(true)
+    // No mid-word cut: everything before the ellipsis is whole words.
+    expect(result.slice(0, -1)).toBe(word.repeat(45).trim())
+  })
+
+  it('strips trailing punctuation before appending the ellipsis', () => {
+    const abstract = `${'word '.repeat(99)}and, ${'x'.repeat(500)}`
+
+    const result = truncateAbstract(abstract)
+
+    expect(result.endsWith('and…')).toBe(true)
+  })
+
+  it('hard-cuts a single unbroken word longer than the limit', () => {
+    const abstract = 'x'.repeat(600)
+
+    const result = truncateAbstract(abstract)
+
+    expect(result).toBe(`${'x'.repeat(ABSTRACT_MAX_LENGTH)}…`)
+  })
+
+  it('respects a custom max length', () => {
+    expect(truncateAbstract('one two three four', 10)).toBe('one two…')
+  })
+})
+
+describe('sendInvitationEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetConference.mockResolvedValue({
+      conference: {
+        title: 'Cloud Native Day Bergen',
+        organizer: 'CNDN',
+        cfpEmail: 'cfp@example.com',
+        city: 'Bergen',
+        country: 'Norway',
+        startDate: '2026-10-01',
+        domains: ['example.com'],
+        socialLinks: [],
+      },
+      domain: 'example.com',
+      error: null,
+    })
+    mockSend.mockResolvedValue({ data: { id: 'email-1' }, error: null })
+  })
+
+  it('includes the fetched proposal abstract in the email', async () => {
+    mockGetProposalAbstract.mockResolvedValue('A deep dive into GitOps.')
+
+    const result = await sendInvitationEmail(invitation)
+
+    expect(result).toBe(true)
+    expect(mockGetProposalAbstract).toHaveBeenCalledWith('proposal-1')
+    expect(sentEmailProps().proposalAbstract).toBe('A deep dive into GitOps.')
+  })
+
+  it('truncates long abstracts before sending', async () => {
+    const longAbstract = 'word '.repeat(200).trim()
+    mockGetProposalAbstract.mockResolvedValue(longAbstract)
+
+    const result = await sendInvitationEmail(invitation)
+
+    expect(result).toBe(true)
+    const abstract = sentEmailProps().proposalAbstract as string
+    expect(abstract.length).toBeLessThanOrEqual(ABSTRACT_MAX_LENGTH + 1)
+    expect(abstract.endsWith('…')).toBe(true)
+  })
+
+  it('falls back to the placeholder when the abstract is empty', async () => {
+    mockGetProposalAbstract.mockResolvedValue(null)
+
+    const result = await sendInvitationEmail(invitation)
+
+    expect(result).toBe(true)
+    expect(sentEmailProps().proposalAbstract).toBe(FALLBACK_ABSTRACT)
+  })
+
+  it('still sends with the placeholder when the abstract fetch throws', async () => {
+    const consoleSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mockGetProposalAbstract.mockRejectedValue(new Error('sanity down'))
+
+    const result = await sendInvitationEmail(invitation)
+
+    expect(result).toBe(true)
+    expect(sentEmailProps().proposalAbstract).toBe(FALLBACK_ABSTRACT)
+    consoleSpy.mockRestore()
+  })
+
+  it('resolves the proposal id from a reference and fetches the abstract', async () => {
+    mockGetProposalAbstract.mockResolvedValue('Referenced abstract.')
+
+    const result = await sendInvitationEmail({
+      ...invitation,
+      proposal: { _ref: 'proposal-ref-1', _type: 'reference' },
+    })
+
+    expect(result).toBe(true)
+    expect(mockGetProposalAbstract).toHaveBeenCalledWith('proposal-ref-1')
+    expect(sentEmailProps().proposalAbstract).toBe('Referenced abstract.')
+  })
+
+  it('skips the abstract fetch when the invitation has no proposal', async () => {
+    const result = await sendInvitationEmail({
+      ...invitation,
+      proposal: undefined,
+    })
+
+    expect(result).toBe(true)
+    expect(mockGetProposalAbstract).not.toHaveBeenCalled()
+    expect(sentEmailProps().proposalAbstract).toBe(FALLBACK_ABSTRACT)
+  })
+})

--- a/__tests__/mocks/sanity-client.ts
+++ b/__tests__/mocks/sanity-client.ts
@@ -1,5 +1,15 @@
 import { vi } from 'vitest'
 
+export const groq = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): string =>
+  strings.reduce(
+    (query, str, i) =>
+      query + str + (i < values.length ? String(values[i]) : ''),
+    '',
+  )
+
 export const createClient = vi.fn(() => ({
   fetch: vi.fn(),
   create: vi.fn(),

--- a/src/components/admin/AdminActionBar.tsx
+++ b/src/components/admin/AdminActionBar.tsx
@@ -208,8 +208,14 @@ export function AdminActionBar({
           {speakers.length > 0 && (
             <div className="flex shrink-0 items-center gap-2">
               <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                Speaker:
+                {speakers.length > 1 ? 'Speakers:' : 'Speaker:'}
               </span>
+              {speakers.length > 1 && (
+                <span className="text-xs whitespace-nowrap text-gray-500 dark:text-gray-400">
+                  +{speakers.length - 1} co-speaker
+                  {speakers.length > 2 ? 's' : ''}
+                </span>
+              )}
               <div className="flex items-center gap-1">
                 {isSeasonedSpeaker && (
                   <div
@@ -271,7 +277,11 @@ export function AdminActionBar({
               color="purple"
               size="xs"
               onClick={handlePreviewSpeaker}
-              title="Preview speaker profile (⌘P)"
+              title={
+                speakers.length > 1
+                  ? `Preview first speaker profile of ${speakers.length} speakers (⌘P)`
+                  : 'Preview speaker profile (⌘P)'
+              }
             >
               <EyeIcon className="h-3 w-3" />
               Preview

--- a/src/components/admin/schedule/DraggableProposal.stories.tsx
+++ b/src/components/admin/schedule/DraggableProposal.stories.tsx
@@ -143,6 +143,43 @@ export const Workshop: Story = {
   },
 }
 
+export const MultipleSpeakers: Story = {
+  args: {
+    proposal: createMockProposal({
+      _id: 'proposal-multi-speaker',
+      title: 'Panel: Platform Engineering in Practice',
+      speakers: [
+        {
+          _id: 'speaker-1',
+          _rev: '1',
+          _createdAt: '2024-01-01T00:00:00Z',
+          _updatedAt: '2024-01-01T00:00:00Z',
+          name: 'Alice Johnson',
+          email: 'alice@example.com',
+          slug: 'alice-johnson',
+        },
+        {
+          _id: 'speaker-2',
+          _rev: '1',
+          _createdAt: '2024-01-01T00:00:00Z',
+          _updatedAt: '2024-01-01T00:00:00Z',
+          name: 'Bob Hansen',
+          email: 'bob@example.com',
+          slug: 'bob-hansen',
+        },
+      ],
+    }),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows all speaker names for talks with multiple speakers, formatted with formatSpeakerNames.',
+      },
+    },
+  },
+}
+
 export const AcceptedNotConfirmed: Story = {
   args: {
     proposal: createMockProposal({

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -7,6 +7,8 @@ import { formats, audiences } from '@/lib/proposal/types'
 import { getProposalDurationMinutes } from '@/lib/schedule/types'
 import { Topic } from '@/lib/topic/types'
 import { LevelIndicator, getLevelConfig } from '@/lib/proposal'
+import { formatSpeakerNames } from '@/lib/speaker/formatSpeakerNames'
+import type { Speaker } from '@/lib/speaker/types'
 import {
   ClockIcon,
   UserIcon,
@@ -71,14 +73,14 @@ export function DraggableProposal({
       else if (duration <= TALK_THRESHOLDS.MEDIUM) size = 'medium'
       else size = 'long'
 
+      const populatedSpeakers = Array.isArray(proposal.speakers)
+        ? (proposal.speakers.filter(
+            (s) => s && typeof s === 'object' && 'name' in s,
+          ) as Speaker[])
+        : []
       const speaker =
-        proposal.speakers &&
-        Array.isArray(proposal.speakers) &&
-        proposal.speakers.length > 0 &&
-        proposal.speakers[0] &&
-        typeof proposal.speakers[0] === 'object' &&
-        'name' in proposal.speakers[0]
-          ? proposal.speakers[0].name
+        populatedSpeakers.length > 0
+          ? formatSpeakerNames(populatedSpeakers)
           : null
 
       return {

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -75,7 +75,11 @@ export function DraggableProposal({
 
       const populatedSpeakers = Array.isArray(proposal.speakers)
         ? (proposal.speakers.filter(
-            (s) => s && typeof s === 'object' && 'name' in s,
+            (s) =>
+              s &&
+              typeof s === 'object' &&
+              'name' in s &&
+              typeof s.name === 'string',
           ) as Speaker[])
         : []
       const speaker =

--- a/src/components/cfp/ProposalCoSpeaker.stories.tsx
+++ b/src/components/cfp/ProposalCoSpeaker.stories.tsx
@@ -28,7 +28,6 @@ const mockPendingInvitations: CoSpeakerInvitationMinimal[] = [
     invitedEmail: 'sofia@example.com',
     invitedName: 'Sofia Berg',
     status: 'pending',
-    token: 'token123',
     expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
   },
 ]
@@ -39,7 +38,6 @@ const mixedInvitations: CoSpeakerInvitationMinimal[] = [
     invitedEmail: 'sofia@example.com',
     invitedName: 'Sofia Berg',
     status: 'pending',
-    token: 'token123',
     expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
   },
   {
@@ -47,7 +45,6 @@ const mixedInvitations: CoSpeakerInvitationMinimal[] = [
     invitedEmail: 'magnus@example.com',
     invitedName: 'Magnus Olsen',
     status: 'declined',
-    token: 'token456',
     expiresAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
     declineReason: 'Schedule conflict',
   },
@@ -56,7 +53,6 @@ const mixedInvitations: CoSpeakerInvitationMinimal[] = [
     invitedEmail: 'ingrid@example.com',
     invitedName: 'Ingrid Nilsen',
     status: 'expired',
-    token: 'token789',
     expiresAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(),
   },
 ]
@@ -70,7 +66,6 @@ const handlers = [
           invitedEmail: 'newco@example.com',
           invitedName: 'New Co-Speaker',
           status: 'pending',
-          token: 'newtoken',
           expiresAt: new Date(
             Date.now() + 7 * 24 * 60 * 60 * 1000,
           ).toISOString(),

--- a/src/lib/cospeaker/sanity.ts
+++ b/src/lib/cospeaker/sanity.ts
@@ -2,6 +2,37 @@ import { groq } from 'next-sanity'
 import { clientReadUncached as clientRead } from '@/lib/sanity/client'
 import { CoSpeakerInvitationFull } from './types'
 
+/**
+ * Fetches the plain-text abstract for a proposal by id. The Portable Text
+ * `description` field is flattened server-side via `pt::text()`.
+ *
+ * Returns null if the proposal is missing, the abstract is empty, or the
+ * fetch fails — callers are expected to fall back to a placeholder.
+ */
+export async function getProposalAbstract(
+  proposalId: string,
+): Promise<string | null> {
+  const query = groq`*[
+    _type == "talk" &&
+    _id == $proposalId
+  ][0] {
+    "abstract": pt::text(description)
+  }`
+
+  try {
+    const result = await clientRead.fetch<{ abstract?: string | null } | null>(
+      query,
+      { proposalId },
+      { cache: 'no-store' },
+    )
+    const abstract = result?.abstract?.trim()
+    return abstract || null
+  } catch (error) {
+    console.error('Error fetching proposal abstract:', error)
+    return null
+  }
+}
+
 export async function getInvitationByToken(
   token: string,
 ): Promise<CoSpeakerInvitationFull | null> {

--- a/src/lib/cospeaker/server.ts
+++ b/src/lib/cospeaker/server.ts
@@ -9,6 +9,7 @@ import {
   InvitationStatus,
 } from './types'
 import { INVITATION_VALID_DAYS } from './constants'
+import { getProposalAbstract } from './sanity'
 import { CoSpeakerInvitationTemplate } from '@/components/email/CoSpeakerInvitationTemplate'
 import { CoSpeakerResponseTemplate } from '@/components/email/CoSpeakerResponseTemplate'
 import { AppEnvironment } from '@/lib/environment'
@@ -195,6 +196,34 @@ export async function createCoSpeakerInvitation(params: {
   }
 }
 
+const FALLBACK_PROPOSAL_ABSTRACT =
+  'Please view the full proposal details for more information.'
+
+export const ABSTRACT_MAX_LENGTH = 500
+
+/**
+ * Truncates a plain-text abstract for inclusion in an email. Abstracts
+ * longer than maxLength are cut at the last word boundary before the
+ * limit, trailing punctuation is stripped, and an ellipsis is appended.
+ *
+ * Exported for testing.
+ */
+export function truncateAbstract(
+  abstract: string,
+  maxLength: number = ABSTRACT_MAX_LENGTH,
+): string {
+  const normalized = abstract.trim()
+  if (normalized.length <= maxLength) {
+    return normalized
+  }
+
+  const slice = normalized.slice(0, maxLength)
+  const lastSpace = slice.lastIndexOf(' ')
+  const truncated = lastSpace > 0 ? slice.slice(0, lastSpace) : slice
+
+  return `${truncated.replace(/[\s.,;:!?-]+$/, '')}…`
+}
+
 export async function sendInvitationEmail(
   invitation: CoSpeakerInvitationFull,
 ): Promise<boolean> {
@@ -222,10 +251,29 @@ export async function sendInvitationEmail(
       buildEmailEventContext(conference, domain)
     const invitationUrl = `${protocol}${domain}/invitation/respond?token=${token}${AppEnvironment.isTestMode ? '&test=true' : ''}`
 
-    // TODO: Fetch proposal details when we can do so without speakerId
+    const proposalId =
+      typeof invitation.proposal === 'object' && invitation.proposal !== null
+        ? '_id' in invitation.proposal
+          ? invitation.proposal._id
+          : invitation.proposal._ref
+        : undefined
 
-    const proposalAbstract =
-      'Please view the full proposal details for more information.'
+    let abstract: string | null = null
+    if (proposalId) {
+      try {
+        abstract = await getProposalAbstract(proposalId)
+      } catch (error) {
+        // The email must never fail to send because of the abstract fetch.
+        console.error(
+          'Failed to fetch proposal abstract for invitation email:',
+          error,
+        )
+      }
+    }
+
+    const proposalAbstract = abstract
+      ? truncateAbstract(abstract)
+      : FALLBACK_PROPOSAL_ABSTRACT
 
     const proposalTitle =
       typeof invitation.proposal === 'object' && 'title' in invitation.proposal

--- a/src/lib/cospeaker/types.ts
+++ b/src/lib/cospeaker/types.ts
@@ -10,19 +10,26 @@ export const INVITATION_STATUSES = [
 
 export type InvitationStatus = (typeof INVITATION_STATUSES)[number]
 
+/**
+ * Client-safe invitation shape. Deliberately excludes the bearer `token`:
+ * queries and mutations that reach the browser must never include it. The
+ * invitee receives the token exclusively via the emailed invitation link.
+ */
 export interface CoSpeakerInvitationMinimal {
   _id: string
   invitedEmail: string
   invitedName?: string
   status: InvitationStatus
-  token: string
   expiresAt: string
   createdAt?: string
   respondedAt?: string
   declineReason?: string
 }
 
+/** Server-side invitation shape; includes the bearer token. Never send to clients. */
 export interface CoSpeakerInvitationFull extends CoSpeakerInvitationMinimal {
+  token: string
+
   _createdAt?: string
   _updatedAt?: string
 
@@ -92,14 +99,13 @@ export function formatProposalFormat(format: string): string {
 }
 
 export function toMinimalInvitation(
-  invitation: CoSpeakerInvitationFull,
+  invitation: Omit<CoSpeakerInvitationFull, 'token'>,
 ): CoSpeakerInvitationMinimal {
   return {
     _id: invitation._id,
     invitedEmail: invitation.invitedEmail,
     invitedName: invitation.invitedName,
     status: invitation.status,
-    token: invitation.token,
     expiresAt: invitation.expiresAt,
     createdAt: invitation.createdAt,
     respondedAt: invitation.respondedAt,

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -90,7 +90,6 @@ export async function getProposal({
         invitedEmail,
         invitedName,
         status,
-        token,
         expiresAt,
         createdAt,
         respondedAt,
@@ -198,7 +197,6 @@ export async function getProposals({
       invitedEmail,
       invitedName,
       status,
-      token,
       expiresAt,
       createdAt,
       respondedAt,
@@ -422,7 +420,7 @@ export async function fetchNextUnreviewedProposal({
     _id: string
     title: string
     status: string
-    speaker?: { _id: string; name: string }
+    speakers?: Array<{ _id: string; name: string }>
   } | null
   error: Error | null
 }> {
@@ -552,7 +550,6 @@ export async function searchProposals({
         invitedEmail,
         invitedName,
         status,
-        token,
         expiresAt,
         createdAt,
         respondedAt,

--- a/src/lib/workshop/sanity.ts
+++ b/src/lib/workshop/sanity.ts
@@ -34,10 +34,10 @@ export async function getWorkshopSignups(
         title,
         format,
         description,
-        "speaker": speaker->{
+        "speakers": speakers[]->{
           name,
           "slug": slug.current,
-          organization
+          title
         }
       }
     }
@@ -213,13 +213,13 @@ export async function getWorkshopById(
         120
       ),
       "capacity": coalesce(capacity, 30),
-      "speaker": speakers[0]->{
+      "speakers": speakers[]->{
         _id,
         name,
         "slug": slug.current,
+        title,
         bio,
-        "avatar": coalesce(image.asset->url, imageURL),
-        company
+        "image": coalesce(image.asset->url, imageURL)
       },
       "signupCount": count(*[_type == "workshopSignup" && workshop._ref == ^._id && status == "confirmed"])
     }

--- a/src/lib/workshop/sanity.ts
+++ b/src/lib/workshop/sanity.ts
@@ -35,6 +35,7 @@ export async function getWorkshopSignups(
         format,
         description,
         "speakers": speakers[]->{
+          _id,
           name,
           "slug": slug.current,
           title

--- a/src/lib/workshop/types.ts
+++ b/src/lib/workshop/types.ts
@@ -57,6 +57,11 @@ export interface WorkshopSignup {
     date?: string
     startTime?: string
     endTime?: string
+    speakers?: {
+      name: string
+      slug?: string
+      title?: string
+    }[]
   }
   conference: {
     _type: 'reference'

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -1555,7 +1555,11 @@ export const proposalRouter = router({
             })
           }
 
-          return invitation
+          // Never expose the invitation bearer token to the inviter's
+          // browser; the invitee receives it via the emailed link.
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { token: _token, ...safeInvitation } = invitation
+          return safeInvitation
         } catch (error) {
           if (error instanceof TRPCError) throw error
 


### PR DESCRIPTION
Follow-ups from the adversarial review behind #406, in three independent commits:

## 1. Stop exposing invitation bearer tokens to clients
The `coSpeakerInvitations` subqueries in `getProposal` / `getProposals` / `searchProposals` projected `token`, shipping live bearer tokens for other people's invitations to every co-listed speaker's browser — and `invitation.send` returned the token to the inviter. The respond flow reads the token exclusively from the emailed link, so no client ever needed it.

- `token` removed from all three projections and from the `send` mutation response (type-level too — the inferred tRPC client type no longer includes it)
- `CoSpeakerInvitationMinimal` is now the documented client-safe shape without `token`; `CoSpeakerInvitationFull` (server-only) keeps it
- Regression test: send response carries no token while `sendInvitationEmail` still receives it
- Bonus: `fetchNextUnreviewedProposal`'s declared return type corrected to `speakers[]` (the singular `speaker` field never existed at runtime; no consumers read it)

## 2. Real proposal abstract in co-speaker invitation emails
Closes the standing TODO — invitees were deciding whether to co-present from an email with a hardcoded placeholder abstract. The abstract is now fetched via `pt::text(description)` by proposal id, truncated at 500 chars on a word boundary with an ellipsis, and the placeholder remains strictly as a fallback so the email can never fail on the fetch. 19 new tests; the shared `next-sanity` test mock gains its missing `groq` export.

## 3. Multi-speaker representation on workshop and admin surfaces
With #406 merged, co-speakers actually land in `talk.speakers[]`; these surfaces rendered only `speakers[0]`:

- `getWorkshopById` now projects all speakers (previous projection also used fields that don't exist on `Speaker`); `getWorkshopSignups` dereferenced a **nonexistent singular `speaker` field that always resolved null** — latent bug fixed
- Admin schedule drag cards show all speaker names via `formatSpeakerNames`
- `AdminActionBar` pluralizes its label with a "+N co-speakers" badge; the profile-preview modal stays single-speaker by design, with a clarified tooltip
- Verified-and-skipped: `WorkshopCard` already renders multiple speakers correctly; admin sort-by-first-speaker-name left as-is deliberately

## Testing
`pnpm typecheck` clean; `pnpm vitest run`: 114 files, 2031 passed / 5 skipped. Each commit is independently revertable.

Still open from the review (deliberately not in this PR): the `getCoSpeakerLimit` unknown-format fallback (product decision: fail open at 1 vs closed at 0), proactive invitation expiry/cleanup, fabricated invitee names from email local parts, story date mocks, legacy format-map keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens co-speaker invitations and expands multi-speaker workshop/admin data. The main changes are:

- Removes invitation bearer tokens from client-facing responses and proposal projections.
- Fetches real proposal abstracts for co-speaker invitation emails with a fallback.
- Updates workshop and admin surfaces to use speaker arrays.
- Adds tests and story coverage for the new invitation and multi-speaker behavior.

<h3>Confidence Score: 4/5</h3>

The changed workshop signup projection needs a small data-shape fix before merging.

- Token removal and email fallback paths look consistent in the changed code.
- `getWorkshopSignups` now returns speaker objects without `_id`, which can make resolved speakers disappear in shared speaker-rendering paths.

src/lib/workshop/sanity.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/proposal.ts | Strips the invitation token before returning the send mutation result. |
| src/lib/cospeaker/types.ts | Splits client-safe minimal invitations from server-only full invitations with tokens. |
| src/lib/proposal/data/sanity.ts | Removes tokens from proposal invitation projections and corrects an unreviewed-proposal type. |
| src/lib/cospeaker/sanity.ts | Adds a server-side abstract fetch that returns null on missing or failed reads. |
| src/lib/cospeaker/server.ts | Adds abstract truncation and fallback handling to invitation email sending. |
| src/lib/workshop/sanity.ts | Changes workshop projections to speaker arrays; the signup projection omits `_id` from speaker entries. |
| src/components/admin/schedule/DraggableProposal.tsx | Formats all populated proposal speakers on schedule drag cards. |
| src/components/admin/AdminActionBar.tsx | Pluralizes the speaker label and clarifies first-speaker profile preview behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(speakers): represent all speakers on..."](https://github.com/cloudnativebergen/website/commit/1d7326b02ed9bd80648775f8f321823e9de7500c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44077896)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->