### PR TITLE
ci: run quality checks on merge_group events

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,9 @@ name: PR Checks
 on:
   pull_request:
     branches: ['**']
+  # Required for the merge queue: queued PRs are validated via merge_group
+  # events, and the required "Quality Checks" status must report on them
+  merge_group:
   push:
     branches: ['main']
 


### PR DESCRIPTION
Prerequisite for enabling the merge queue on `main`: queued PRs are validated via `merge_group` events, and the required **Quality Checks** status must report on them — without this trigger every queued PR stalls until the queue times out.

Part of setting up branch protection + merge queue for this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds merge queue support to the existing checks workflow. The main changes are:

- Adds the `merge_group` event trigger to `.github/workflows/pr-checks.yml`.
- Keeps the existing pull request and main-branch push triggers unchanged.
- Runs the existing workflow jobs for queued merge validation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-checks.yml | Adds a valid merge queue trigger while leaving the existing job behavior unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: run quality checks on merge\_group ev..."](https://github.com/cloudnativebergen/website/commit/f1bfc0e7060d6ab5f543387682dae53a0b269f4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44078611)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->