### PR TITLE
feat(admin): mobile consistency sweep — shared filter bar, status badges, page header

### DIFF
--- a/src/app/(admin)/admin/tickets/types/page.tsx
+++ b/src/app/(admin)/admin/tickets/types/page.tsx
@@ -9,25 +9,26 @@ import {
 import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
 import { TicketIcon } from '@heroicons/react/24/outline'
 import { EmptyState } from '@/components/EmptyState'
+import {
+  StatusBadge as SharedStatusBadge,
+  type BadgeColor,
+} from '@/components/StatusBadge'
 
 function StatusBadge({
   status,
 }: {
   status: 'expired' | 'active' | 'upcoming'
 }) {
-  const styles = {
-    active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
-    expired: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
-    upcoming:
-      'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
+  const config: Record<
+    'expired' | 'active' | 'upcoming',
+    { label: string; color: BadgeColor }
+  > = {
+    active: { label: 'Active', color: 'green' },
+    expired: { label: 'Expired', color: 'gray' },
+    upcoming: { label: 'Upcoming', color: 'yellow' },
   }
-  return (
-    <span
-      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${styles[status]}`}
-    >
-      {status}
-    </span>
-  )
+  const { label, color } = config[status]
+  return <SharedStatusBadge label={label} color={color} />
 }
 
 function formatDate(dateStr: string | null): string {
@@ -115,9 +116,7 @@ export default async function TicketTypesAdminPage() {
                   </h3>
                   <StatusBadge status={status} />
                   {ticket.requiresInvitation && (
-                    <span className="inline-flex items-center rounded-full bg-purple-100 px-2.5 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-300">
-                      Invite-only
-                    </span>
+                    <SharedStatusBadge label="Invite-only" color="purple" />
                   )}
                 </div>
                 <div className="text-right text-sm text-gray-500 dark:text-gray-400">

--- a/src/components/admin/AdminActionBar.tsx
+++ b/src/components/admin/AdminActionBar.tsx
@@ -17,6 +17,7 @@ import {
   ArrowUturnLeftIcon,
 } from '@heroicons/react/20/solid'
 import { ProposalExisting, Action } from '@/lib/proposal/types'
+import { ProposalStatusBadge } from '@/lib/proposal/ui'
 import { extractSpeakersFromProposal } from '@/lib/proposal/utils'
 import { getSpeakerIndicators } from '@/lib/speaker/utils'
 import { Speaker } from '@/lib/speaker/types'
@@ -163,22 +164,7 @@ export function AdminActionBar({
             <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
               Status:
             </span>
-            <span
-              className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
-                proposal.status === 'accepted'
-                  ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                  : proposal.status === 'waitlisted'
-                    ? 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200'
-                    : proposal.status === 'rejected'
-                      ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
-                      : proposal.status === 'submitted'
-                        ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
-                        : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200'
-              }`}
-            >
-              {proposal.status.charAt(0).toUpperCase() +
-                proposal.status.slice(1)}
-            </span>
+            <ProposalStatusBadge status={proposal.status} />
           </div>
 
           {proposal.reviews && proposal.reviews.length > 0 && (

--- a/src/components/admin/AdminFilterBar.stories.tsx
+++ b/src/components/admin/AdminFilterBar.stories.tsx
@@ -1,0 +1,211 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+import { AdminFilterBar, type FilterGroup } from './AdminFilterBar'
+
+const meta = {
+  title: 'Systems/Admin/AdminFilterBar',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Shared responsive filter bar for the admin area. On desktop it renders an inline row of dropdowns, optional search and a result count. Below `lg` the dropdowns collapse into a single "Filters (n)" button that opens a full-height bottom sheet.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const STATUS_OPTIONS = [
+  { value: 'draft', label: 'Draft' },
+  { value: 'submitted', label: 'Submitted' },
+  { value: 'accepted', label: 'Accepted' },
+  { value: 'rejected', label: 'Rejected' },
+]
+
+const FORMAT_OPTIONS = [
+  { value: 'talk', label: 'Talk (25 min)' },
+  { value: 'workshop', label: 'Workshop (90 min)' },
+  { value: 'lightning', label: 'Lightning talk (10 min)' },
+]
+
+const LEVEL_OPTIONS = [
+  { value: 'beginner', label: 'Beginner' },
+  { value: 'intermediate', label: 'Intermediate' },
+  { value: 'advanced', label: 'Advanced' },
+]
+
+const OWNER_OPTIONS = [
+  { value: '', label: 'All owners' },
+  { value: 'alice', label: 'Alice Johnson' },
+  { value: 'bob', label: 'Bob Smith' },
+  { value: 'carol', label: 'Carol Williams' },
+]
+
+/**
+ * Interactive harness that wires the declarative config to local state so the
+ * dropdowns, chips and search all behave in Storybook.
+ */
+function AdminFilterBarDemo({
+  withSearch = true,
+  withCount = true,
+  many = false,
+}: {
+  withSearch?: boolean
+  withCount?: boolean
+  many?: boolean
+}) {
+  const [status, setStatus] = useState<string[]>(['submitted'])
+  const [format, setFormat] = useState<string[]>([])
+  const [level, setLevel] = useState<string[]>([])
+  const [owner, setOwner] = useState<string>('')
+  const [search, setSearch] = useState('')
+
+  const toggle = (
+    setter: React.Dispatch<React.SetStateAction<string[]>>,
+    value: string,
+  ) =>
+    setter((prev) =>
+      prev.includes(value)
+        ? prev.filter((item) => item !== value)
+        : [...prev, value],
+    )
+
+  const filters: FilterGroup[] = [
+    {
+      key: 'status',
+      label: 'Status',
+      options: STATUS_OPTIONS,
+      selected: status,
+      onChange: (value) => toggle(setStatus, value),
+    },
+    {
+      key: 'format',
+      label: 'Format',
+      options: FORMAT_OPTIONS,
+      selected: format,
+      onChange: (value) => toggle(setFormat, value),
+    },
+    {
+      key: 'level',
+      label: 'Level',
+      options: LEVEL_OPTIONS,
+      selected: level,
+      onChange: (value) => toggle(setLevel, value),
+    },
+  ]
+
+  if (many) {
+    filters.push(
+      {
+        key: 'owner',
+        label: 'Owner',
+        options: OWNER_OPTIONS,
+        selected: [owner],
+        onChange: setOwner,
+        multi: false,
+      },
+      {
+        key: 'tags',
+        label: 'Tags',
+        options: [
+          { value: 'keynote', label: 'Keynote' },
+          { value: 'sponsored', label: 'Sponsored' },
+          { value: 'community', label: 'Community' },
+          { value: 'diversity', label: 'Diversity & inclusion' },
+          { value: 'security', label: 'Security' },
+          { value: 'observability', label: 'Observability' },
+        ],
+        selected: [],
+        onChange: () => {},
+      },
+    )
+  }
+
+  const activeCount =
+    status.filter(Boolean).length +
+    format.length +
+    level.length +
+    (owner ? 1 : 0)
+
+  return (
+    <AdminFilterBar
+      filters={filters}
+      search={
+        withSearch
+          ? {
+              value: search,
+              onChange: setSearch,
+              placeholder: 'Search proposals or speakers...',
+            }
+          : undefined
+      }
+      resultCount={withCount ? 42 : undefined}
+      totalCount={withCount ? 128 : undefined}
+      resultLabel="proposals"
+      activeFilterCount={activeCount}
+      onClearAll={() => {
+        setStatus([])
+        setFormat([])
+        setLevel([])
+        setOwner('')
+        setSearch('')
+      }}
+    />
+  )
+}
+
+export const Desktop: Story = {
+  render: () => <AdminFilterBarDemo />,
+}
+
+export const WithSearchAndCount: Story = {
+  render: () => <AdminFilterBarDemo withSearch withCount />,
+}
+
+export const EmptyState: Story = {
+  render: () => {
+    function EmptyDemo() {
+      const [search, setSearch] = useState('')
+      return (
+        <AdminFilterBar
+          filters={[
+            {
+              key: 'status',
+              label: 'Status',
+              options: [],
+              selected: [],
+              onChange: () => {},
+              emptyText: 'No statuses available',
+            },
+          ]}
+          search={{ value: search, onChange: setSearch }}
+          resultCount={0}
+          resultLabel="proposals"
+        />
+      )
+    }
+    return <EmptyDemo />
+  },
+}
+
+export const ManyFilters: Story = {
+  render: () => <AdminFilterBarDemo many />,
+}
+
+export const MobileViewport: Story = {
+  render: () => <AdminFilterBarDemo many />,
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-[360px]">
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/components/admin/AdminFilterBar.tsx
+++ b/src/components/admin/AdminFilterBar.tsx
@@ -1,0 +1,265 @@
+'use client'
+
+import { Fragment, ReactNode, useState } from 'react'
+import { FunnelIcon } from '@heroicons/react/20/solid'
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import clsx from 'clsx'
+import { FilterDropdown, FilterOption } from '@/components/admin/FilterDropdown'
+import { MobileFilterSheet } from '@/components/admin/sponsor-crm/MobileFilterSheet'
+
+/** A single selectable option within a filter group. */
+export interface AdminFilterOption {
+  /** Stable value used for selection state and callbacks. */
+  value: string
+  /** Rendered label (may be rich content such as a status badge). */
+  label: ReactNode
+  /** Render a divider above this option (desktop dropdown only). */
+  dividerBefore?: boolean
+}
+
+/**
+ * Declarative description of a single filter. Rendered as a `FilterDropdown`
+ * on desktop and as a chip section inside the mobile bottom sheet.
+ */
+export interface FilterGroup {
+  /** Unique key for the group. */
+  key: string
+  /** Human readable label shown on the dropdown button / sheet section. */
+  label: string
+  /** Selectable options. */
+  options: AdminFilterOption[]
+  /** Currently selected option values. */
+  selected: string[]
+  /** Toggle (multi) or set (single) the given option value. */
+  onChange: (value: string) => void
+  /**
+   * When `false` the group behaves as a single-select (radio, closes on
+   * pick). Defaults to `true` (multi-select checkboxes that keep the menu
+   * open).
+   */
+  multi?: boolean
+  /** Message shown when `options` is empty. */
+  emptyText?: string
+  /** Desktop dropdown panel width. */
+  width?: 'default' | 'wide' | 'wider'
+  /** Desktop dropdown panel alignment. */
+  position?: 'left' | 'right'
+}
+
+export interface AdminFilterSearch {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}
+
+export interface AdminFilterBarProps {
+  /** Declarative filter groups. */
+  filters: FilterGroup[]
+  /** Optional free-text search. */
+  search?: AdminFilterSearch
+  /** Number of results currently shown (rendered as a status line). */
+  resultCount?: number
+  /** Total number of results before filtering. */
+  totalCount?: number
+  /** Noun used in the result count line. */
+  resultLabel?: string
+  /** Clears all filters. Shown as a desktop link and sheet footer action. */
+  onClearAll?: () => void
+  /**
+   * Override the active filter count shown on the mobile trigger and used to
+   * decide sheet footer text. Defaults to the number of non-empty selected
+   * values across all groups.
+   */
+  activeFilterCount?: number
+  /**
+   * `card` (default) wraps the bar in a padded container with search and
+   * result count. `bare` renders only the responsive filter controls so it
+   * can be slotted into an existing toolbar.
+   */
+  variant?: 'card' | 'bare'
+  /** Extra controls rendered inline on desktop (e.g. sort, view switcher). */
+  desktopExtra?: ReactNode
+  /** Extra controls rendered inside the mobile sheet body. */
+  sheetExtra?: ReactNode
+  /** Label for the mobile filter trigger. Defaults to "Filters". */
+  mobileFilterLabel?: string
+  className?: string
+}
+
+/** Number of "active" selections in a group (ignores empty-string sentinels). */
+export function groupActiveCount(group: FilterGroup): number {
+  return group.selected.filter((value) => value !== '').length
+}
+
+function DesktopFilterDropdown({ group }: { group: FilterGroup }) {
+  const isMulti = group.multi !== false
+  return (
+    <FilterDropdown
+      label={group.label}
+      activeCount={groupActiveCount(group)}
+      position={group.position ?? 'left'}
+      width={group.width ?? 'default'}
+      size="sm"
+    >
+      {group.options.length === 0 ? (
+        <div className="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">
+          {group.emptyText ?? 'No options available'}
+        </div>
+      ) : (
+        group.options.map((option) => (
+          <Fragment key={option.value}>
+            {option.dividerBefore && (
+              <div className="my-1 border-t border-gray-100 dark:border-gray-700" />
+            )}
+            <FilterOption
+              onClick={() => group.onChange(option.value)}
+              checked={group.selected.includes(option.value)}
+              type={isMulti ? 'checkbox' : 'radio'}
+              keepOpen={isMulti}
+            >
+              {option.label}
+            </FilterOption>
+          </Fragment>
+        ))
+      )}
+    </FilterDropdown>
+  )
+}
+
+/**
+ * Shared, responsive filter bar for the admin area.
+ *
+ * Desktop (`lg+`): an inline row of dropdowns, optional search and a result
+ * count. Below `lg`: the dropdowns collapse into a single "Filters (n)"
+ * button that opens a full-height bottom sheet.
+ */
+export function AdminFilterBar({
+  filters,
+  search,
+  resultCount,
+  totalCount,
+  resultLabel = 'items',
+  onClearAll,
+  activeFilterCount,
+  variant = 'card',
+  desktopExtra,
+  sheetExtra,
+  mobileFilterLabel = 'Filters',
+  className,
+}: AdminFilterBarProps) {
+  const [isSheetOpen, setIsSheetOpen] = useState(false)
+
+  const computedActiveCount =
+    activeFilterCount ??
+    filters.reduce((total, group) => total + groupActiveCount(group), 0)
+
+  const hasResultCount = resultCount !== undefined
+  const hasMobileTrigger = filters.length > 0 || sheetExtra !== undefined
+
+  const filterControls = (
+    <>
+      {/* Desktop: inline dropdown row */}
+      <div className="hidden items-center gap-1.5 lg:flex">
+        {filters.map((group) => (
+          <DesktopFilterDropdown key={group.key} group={group} />
+        ))}
+        {desktopExtra}
+        {variant !== 'bare' && onClearAll && computedActiveCount > 0 && (
+          <button
+            onClick={onClearAll}
+            className="ml-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >
+            Clear all ({computedActiveCount})
+          </button>
+        )}
+      </div>
+
+      {/* Mobile: single trigger opening the bottom sheet */}
+      {hasMobileTrigger && (
+        <button
+          onClick={() => setIsSheetOpen(true)}
+          className={clsx(
+            'relative flex h-9 items-center gap-1.5 rounded-lg px-3 text-sm font-medium transition-colors lg:hidden',
+            computedActiveCount > 0
+              ? 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-300 ring-inset dark:bg-indigo-900/40 dark:text-indigo-300 dark:ring-indigo-700'
+              : 'text-gray-600 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:text-gray-400 dark:ring-white/10 dark:hover:bg-gray-800',
+          )}
+        >
+          <FunnelIcon className="h-4 w-4" />
+          <span>{mobileFilterLabel}</span>
+          {computedActiveCount > 0 && (
+            <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-indigo-600 px-1 text-[10px] font-bold text-white dark:bg-indigo-500">
+              {computedActiveCount}
+            </span>
+          )}
+        </button>
+      )}
+
+      <MobileFilterSheet
+        isOpen={isSheetOpen}
+        onClose={() => setIsSheetOpen(false)}
+        groups={filters}
+        onClearAll={onClearAll ?? (() => {})}
+        activeFilterCount={computedActiveCount}
+        extra={sheetExtra}
+      />
+    </>
+  )
+
+  if (variant === 'bare') {
+    return filterControls
+  }
+
+  return (
+    <div
+      className={clsx(
+        'space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800',
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-2">
+          {search && (
+            <div className="relative w-full lg:w-64">
+              <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                value={search.value}
+                onChange={(event) => search.onChange(event.target.value)}
+                placeholder={search.placeholder ?? 'Search...'}
+                className="block h-9 w-full rounded-md border-gray-300 bg-white py-1.5 pr-8 pl-9 text-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500"
+              />
+              {search.value && (
+                <button
+                  onClick={() => search.onChange('')}
+                  className="absolute top-1/2 right-2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                  aria-label="Clear search"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {filterControls}
+        </div>
+      </div>
+
+      {hasResultCount && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-sm text-gray-500 dark:text-gray-400"
+        >
+          Showing {resultCount}
+          {totalCount !== undefined && totalCount !== resultCount && (
+            <> of {totalCount}</>
+          )}{' '}
+          {resultLabel}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -28,6 +28,7 @@ import { BadgePreviewModal } from '@/components/admin/BadgePreviewModal'
 import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import BadgeValidator from '@/components/admin/BadgeValidator'
 import { SearchInput } from '@/components/SearchInput'
+import { StatusBadge } from '@/components/StatusBadge'
 import type { BadgeRecord } from '@/lib/badge/types'
 import { createLocalhostWarning } from '@/lib/localhost-warning'
 import { useNotification } from './NotificationProvider'
@@ -649,25 +650,19 @@ export function BadgeManagementClient({
                             {hasBadge && badge ? (
                               <div className="space-y-1">
                                 <div className="flex items-center gap-2">
-                                  <span
-                                    className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                                      hasEmailError
-                                        ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
-                                        : 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                                    }`}
-                                  >
-                                    {hasEmailError ? (
-                                      <>
-                                        <ExclamationTriangleIcon className="h-3 w-3" />
-                                        Email Failed
-                                      </>
-                                    ) : (
-                                      <>
-                                        <CheckIcon className="h-3 w-3" />
-                                        Issued
-                                      </>
-                                    )}
-                                  </span>
+                                  {hasEmailError ? (
+                                    <StatusBadge
+                                      label="Email Failed"
+                                      color="red"
+                                      icon={ExclamationTriangleIcon}
+                                    />
+                                  ) : (
+                                    <StatusBadge
+                                      label="Issued"
+                                      color="green"
+                                      icon={CheckIcon}
+                                    />
+                                  )}
                                 </div>
                                 <div className="text-xs text-gray-500 dark:text-gray-400">
                                   {new Date(
@@ -681,9 +676,7 @@ export function BadgeManagementClient({
                                 )}
                               </div>
                             ) : (
-                              <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300">
-                                Not Issued
-                              </span>
+                              <StatusBadge label="Not Issued" color="gray" />
                             )}
                           </td>
                           <td className="px-4 py-4 text-right">

--- a/src/components/admin/OrdersTableWithSearch.tsx
+++ b/src/components/admin/OrdersTableWithSearch.tsx
@@ -20,6 +20,10 @@ import {
   TableBody,
   TableEmptyState,
 } from '@/components/DataTable'
+import {
+  OrderPaymentStatusBadge,
+  type OrderPaymentStatus,
+} from '@/components/admin/badges'
 
 interface OrdersTableWithSearchProps {
   orders: GroupedOrder[]
@@ -30,18 +34,11 @@ interface OrdersTableWithSearchProps {
 type PaymentFilter = 'all' | 'paid' | 'unpaid' | 'overdue'
 
 interface PaymentStatus {
-  status: string
+  status: OrderPaymentStatus
   label: string
-  colorClass: string
 }
 
 const PAYMENT_TERM_DAYS = 30
-
-const STATUS_STYLES = {
-  paid: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-  due: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-  overdue: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-} as const
 
 export function OrdersTableWithSearch({
   orders,
@@ -84,7 +81,6 @@ export function OrdersTableWithSearch({
         return {
           status: 'paid',
           label: 'Paid',
-          colorClass: STATUS_STYLES.paid,
         }
       }
 
@@ -92,14 +88,12 @@ export function OrdersTableWithSearch({
         return {
           status: 'overdue',
           label: 'Overdue',
-          colorClass: STATUS_STYLES.overdue,
         }
       }
 
       return {
         status: 'due',
         label: 'Due',
-        colorClass: STATUS_STYLES.due,
       }
     },
     [isOrderOverdue],
@@ -410,16 +404,9 @@ export function OrdersTableWithSearch({
                         </div>
                       </td>
                       <td className="px-4 py-4 whitespace-nowrap">
-                        {(() => {
-                          const { label, colorClass } = getPaymentStatus(order)
-                          return (
-                            <span
-                              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${colorClass}`}
-                            >
-                              {label}
-                            </span>
-                          )
-                        })()}
+                        <OrderPaymentStatusBadge
+                          status={getPaymentStatus(order).status}
+                        />
                       </td>
                       <td className="px-4 py-4 whitespace-nowrap">
                         <button
@@ -529,16 +516,9 @@ export function OrdersTableWithSearch({
                   )}
                 </div>
                 <div className="flex items-center space-x-2">
-                  {(() => {
-                    const { label, colorClass } = getPaymentStatus(order)
-                    return (
-                      <span
-                        className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${colorClass}`}
-                      >
-                        {label}
-                      </span>
-                    )
-                  })()}
+                  <OrderPaymentStatusBadge
+                    status={getPaymentStatus(order).status}
+                  />
                   <button
                     onClick={() => handleViewPaymentDetails(order.order_id)}
                     className="inline-flex items-center justify-center rounded-md p-1.5 text-gray-400 transition-colors hover:bg-indigo-50 hover:text-indigo-600 dark:text-gray-500 dark:hover:bg-indigo-900/20 dark:hover:text-indigo-400"

--- a/src/components/admin/ProposalsFilter.tsx
+++ b/src/components/admin/ProposalsFilter.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { FunnelIcon } from '@heroicons/react/20/solid'
 import {
   Status,
   Format,
@@ -14,6 +13,12 @@ import {
 import { Flags } from '@/lib/speaker/types'
 import { FilterDropdown, FilterOption } from './FilterDropdown'
 import { getStatusBadgeConfig } from '@/lib/proposal/ui'
+import {
+  AdminFilterBar,
+  type FilterGroup,
+} from '@/components/admin/AdminFilterBar'
+import { FilterSection } from '@/components/admin/sponsor-crm/MobileFilterSheet'
+import clsx from 'clsx'
 
 export enum ReviewStatus {
   unreviewed = 'unreviewed',
@@ -52,7 +57,27 @@ interface ProposalsFilterProps {
   allowedFormats?: Format[]
 }
 
-import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline'
+const SORT_OPTIONS: { key: FilterState['sortBy']; label: string }[] = [
+  { key: 'created', label: 'Date Created' },
+  { key: 'title', label: 'Title' },
+  { key: 'speaker', label: 'Speaker' },
+  { key: 'status', label: 'Status' },
+  { key: 'rating', label: 'Rating' },
+  { key: 'reviews', label: 'Review Count' },
+]
+
+const SORT_LABELS: Record<FilterState['sortBy'], string> = {
+  created: 'Date',
+  title: 'Title',
+  speaker: 'Speaker',
+  status: 'Status',
+  rating: 'Rating',
+  reviews: 'Review Count',
+}
+
+// Sentinel value used to model the "hide speakers with accepted talks" toggle
+// as a regular option inside the declarative Speakers filter group.
+const HIDE_MULTIPLE_TALKS = 'hideMultipleTalks'
 
 export function ProposalsFilter({
   filters,
@@ -67,240 +92,169 @@ export function ProposalsFilter({
   currentUserId,
   allowedFormats,
 }: ProposalsFilterProps) {
-  return (
-    <div className="space-y-4 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="flex items-center space-x-2">
-            <FunnelIcon className="h-5 w-5 text-gray-400 dark:text-gray-500" />
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Filters:
-            </span>
-          </div>
+  const filterGroups: FilterGroup[] = [
+    {
+      key: 'status',
+      label: 'Status',
+      options: Object.values(Status).map((status) => ({
+        value: status,
+        label: (
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${getStatusBadgeConfig(status).bgColor} ${getStatusBadgeConfig(status).textColor}`}
+          >
+            {statuses.get(status)}
+          </span>
+        ),
+      })),
+      selected: filters.status,
+      onChange: (value) => onFilterChange('status', value as Status),
+    },
+    {
+      key: 'format',
+      label: 'Format',
+      options: (allowedFormats || Object.values(Format)).map((format) => ({
+        value: format,
+        label: formats.get(format) ?? format,
+      })),
+      selected: filters.format,
+      onChange: (value) => onFilterChange('format', value as Format),
+    },
+    {
+      key: 'level',
+      label: 'Level',
+      options: Object.values(Level).map((level) => ({
+        value: level,
+        label: levels.get(level) ?? level,
+      })),
+      selected: filters.level,
+      onChange: (value) => onFilterChange('level', value as Level),
+    },
+    {
+      key: 'speakers',
+      label: 'Speakers',
+      width: 'wider',
+      options: [
+        {
+          value: HIDE_MULTIPLE_TALKS,
+          label: (
+            <div className="flex flex-col space-y-1 text-left">
+              <span className="font-medium text-gray-900 dark:text-white">
+                Hide speakers with accepted talks
+              </span>
+              <span className="max-w-xs text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+                Only show submitted proposals from speakers who don&apos;t
+                already have accepted or confirmed talks
+              </span>
+            </div>
+          ),
+        },
+        {
+          value: Flags.diverseSpeaker,
+          label: 'Underrepresented speakers',
+          dividerBefore: true,
+        },
+        { value: Flags.firstTimeSpeaker, label: 'New speakers' },
+        { value: Flags.localSpeaker, label: 'Local speakers' },
+        {
+          value: Flags.requiresTravelFunding,
+          label: 'Requires travel funding',
+        },
+      ],
+      selected: [
+        ...(filters.hideMultipleTalks ? [HIDE_MULTIPLE_TALKS] : []),
+        ...filters.speakerFlags,
+      ],
+      onChange: (value) => {
+        if (value === HIDE_MULTIPLE_TALKS) {
+          onMultipleTalksFilterChange(!filters.hideMultipleTalks)
+        } else {
+          onFilterChange('speakerFlags', value as Flags)
+        }
+      },
+    },
+  ]
 
-          <div className="relative min-w-[240px]">
-            <MagnifyingGlassIcon className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />
-            <input
-              type="text"
-              value={filters.searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="Search proposals or speakers..."
-              className="block w-full rounded-md border-gray-300 bg-white py-1.5 pr-8 pl-9 text-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500"
-            />
-            {filters.searchQuery && (
-              <button
-                onClick={() => onSearchChange('')}
-                className="absolute top-1/2 right-2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-              >
-                <XMarkIcon className="h-4 w-4" />
-              </button>
+  if (currentUserId) {
+    filterGroups.push({
+      key: 'reviews',
+      label: 'Reviews',
+      width: 'wide',
+      position: 'right',
+      multi: false,
+      selected: [filters.reviewStatus],
+      onChange: (value) => onReviewStatusChange(value as ReviewStatus),
+      options: [
+        { value: ReviewStatus.unreviewed, label: 'Todo (not reviewed by me)' },
+        { value: ReviewStatus.reviewed, label: 'Done (reviewed by me)' },
+        { value: ReviewStatus.all, label: 'All proposals' },
+      ],
+    })
+  }
+
+  const sortDropdown = (
+    <FilterDropdown
+      label={`Sort: ${SORT_LABELS[filters.sortBy]}`}
+      activeCount={0}
+      position="right"
+      size="sm"
+    >
+      {SORT_OPTIONS.map((option) => (
+        <FilterOption
+          key={option.key}
+          onClick={() => onSortChange(option.key)}
+          checked={filters.sortBy === option.key}
+          type="radio"
+        >
+          {option.label}
+        </FilterOption>
+      ))}
+      <hr className="my-1" />
+      <FilterOption onClick={onSortOrderToggle} checked={false} type="checkbox">
+        {filters.sortOrder === 'asc' ? '↑ Ascending' : '↓ Descending'}
+      </FilterOption>
+    </FilterDropdown>
+  )
+
+  const sortSheet = (
+    <FilterSection title={`Sort: ${SORT_LABELS[filters.sortBy]}`}>
+      <div className="flex flex-wrap gap-2">
+        {SORT_OPTIONS.map((option) => (
+          <button
+            key={option.key}
+            onClick={() => onSortChange(option.key)}
+            className={clsx(
+              'flex min-h-11 items-center rounded-full px-3.5 text-sm font-medium transition-colors',
+              filters.sortBy === option.key
+                ? 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-300 ring-inset dark:bg-indigo-900/40 dark:text-indigo-300 dark:ring-indigo-700'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
             )}
-          </div>
-
-          <FilterDropdown
-            label="Status"
-            activeCount={filters.status.length}
-            keepOpen
           >
-            {Object.values(Status).map((status) => (
-              <FilterOption
-                key={status}
-                onClick={() => onFilterChange('status', status)}
-                checked={filters.status.includes(status)}
-                type="checkbox"
-                keepOpen
-              >
-                <span
-                  className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${getStatusBadgeConfig(status).bgColor} ${getStatusBadgeConfig(status).textColor}`}
-                >
-                  {statuses.get(status)}
-                </span>
-              </FilterOption>
-            ))}
-          </FilterDropdown>
-
-          <FilterDropdown
-            label="Format"
-            activeCount={filters.format.length}
-            keepOpen
-          >
-            {(allowedFormats || Object.values(Format)).map((format) => (
-              <FilterOption
-                key={format}
-                onClick={() => onFilterChange('format', format)}
-                checked={filters.format.includes(format)}
-                type="checkbox"
-                keepOpen
-              >
-                {formats.get(format)}
-              </FilterOption>
-            ))}
-          </FilterDropdown>
-
-          <FilterDropdown
-            label="Level"
-            activeCount={filters.level.length}
-            keepOpen
-          >
-            {Object.values(Level).map((level) => (
-              <FilterOption
-                key={level}
-                onClick={() => onFilterChange('level', level)}
-                checked={filters.level.includes(level)}
-                type="checkbox"
-                keepOpen
-              >
-                {levels.get(level)}
-              </FilterOption>
-            ))}
-          </FilterDropdown>
-
-          <FilterDropdown
-            label="Speakers"
-            activeCount={
-              (filters.hideMultipleTalks ? 1 : 0) + filters.speakerFlags.length
-            }
-            keepOpen
-            width="wider"
-          >
-            <FilterOption
-              onClick={() =>
-                onMultipleTalksFilterChange(!filters.hideMultipleTalks)
-              }
-              checked={filters.hideMultipleTalks}
-              type="checkbox"
-              keepOpen
-              className="text-left"
-            >
-              <div className="flex flex-col space-y-1 text-left">
-                <span className="font-medium text-gray-900 dark:text-white">
-                  Hide speakers with accepted talks
-                </span>
-                <span className="max-w-xs text-xs leading-relaxed text-gray-500 dark:text-gray-400">
-                  Only show submitted proposals from speakers who don&apos;t
-                  already have accepted or confirmed talks
-                </span>
-              </div>
-            </FilterOption>
-
-            <hr className="my-2" />
-
-            <FilterOption
-              onClick={() =>
-                onFilterChange('speakerFlags', Flags.diverseSpeaker)
-              }
-              checked={filters.speakerFlags.includes(Flags.diverseSpeaker)}
-              type="checkbox"
-              keepOpen
-              className="text-left"
-            >
-              Underrepresented speakers
-            </FilterOption>
-            <FilterOption
-              onClick={() =>
-                onFilterChange('speakerFlags', Flags.firstTimeSpeaker)
-              }
-              checked={filters.speakerFlags.includes(Flags.firstTimeSpeaker)}
-              type="checkbox"
-              keepOpen
-              className="text-left"
-            >
-              New speakers
-            </FilterOption>
-            <FilterOption
-              onClick={() => onFilterChange('speakerFlags', Flags.localSpeaker)}
-              checked={filters.speakerFlags.includes(Flags.localSpeaker)}
-              type="checkbox"
-              keepOpen
-              className="text-left"
-            >
-              Local speakers
-            </FilterOption>
-            <FilterOption
-              onClick={() =>
-                onFilterChange('speakerFlags', Flags.requiresTravelFunding)
-              }
-              checked={filters.speakerFlags.includes(
-                Flags.requiresTravelFunding,
-              )}
-              type="checkbox"
-              keepOpen
-              className="text-left"
-            >
-              Requires travel funding
-            </FilterOption>
-          </FilterDropdown>
-        </div>
-
-        <div className="flex items-center gap-3">
-          {currentUserId && (
-            <FilterDropdown
-              label="Reviews"
-              activeCount={filters.reviewStatus !== ReviewStatus.all ? 1 : 0}
-              position="right"
-              width="wide"
-            >
-              {Object.values(ReviewStatus).map((status) => (
-                <FilterOption
-                  key={status}
-                  onClick={() => onReviewStatusChange(status)}
-                  checked={filters.reviewStatus === status}
-                  type="radio"
-                >
-                  {status === ReviewStatus.unreviewed
-                    ? 'Todo (not reviewed by me)'
-                    : status === ReviewStatus.reviewed
-                      ? 'Done (reviewed by me)'
-                      : 'All proposals'}
-                </FilterOption>
-              ))}
-            </FilterDropdown>
-          )}
-
-          <FilterDropdown
-            label={`Sort: ${filters.sortBy === 'created' ? 'Date' : filters.sortBy === 'speaker' ? 'Speaker' : filters.sortBy === 'rating' ? 'Rating' : filters.sortBy === 'reviews' ? 'Review Count' : filters.sortBy === 'title' ? 'Title' : 'Status'}`}
-            activeCount={0}
-            position="right"
-          >
-            {[
-              { key: 'created', label: 'Date Created' },
-              { key: 'title', label: 'Title' },
-              { key: 'speaker', label: 'Speaker' },
-              { key: 'status', label: 'Status' },
-              { key: 'rating', label: 'Rating' },
-              { key: 'reviews', label: 'Review Count' },
-            ].map((option) => (
-              <FilterOption
-                key={option.key}
-                onClick={() =>
-                  onSortChange(option.key as FilterState['sortBy'])
-                }
-                checked={filters.sortBy === option.key}
-                type="radio"
-              >
-                {option.label}
-              </FilterOption>
-            ))}
-            <hr className="my-1" />
-            <FilterOption
-              onClick={onSortOrderToggle}
-              checked={false}
-              type="checkbox"
-            >
-              {filters.sortOrder === 'asc' ? '↑ Ascending' : '↓ Descending'}
-            </FilterOption>
-          </FilterDropdown>
-
-          {activeFilterCount > 0 && (
-            <button
-              onClick={onClearAll}
-              className="text-sm text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
-            >
-              Clear all ({activeFilterCount})
-            </button>
-          )}
-        </div>
+            {option.label}
+          </button>
+        ))}
+        <button
+          onClick={onSortOrderToggle}
+          className="flex min-h-11 items-center rounded-full bg-gray-100 px-3.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          {filters.sortOrder === 'asc' ? '↑ Ascending' : '↓ Descending'}
+        </button>
       </div>
-    </div>
+    </FilterSection>
+  )
+
+  return (
+    <AdminFilterBar
+      filters={filterGroups}
+      search={{
+        value: filters.searchQuery,
+        onChange: onSearchChange,
+        placeholder: 'Search proposals or speakers...',
+      }}
+      onClearAll={onClearAll}
+      activeFilterCount={activeFilterCount}
+      desktopExtra={sortDropdown}
+      sheetExtra={sortSheet}
+      mobileFilterLabel="Filters"
+    />
   )
 }

--- a/src/components/admin/badges/OrderPaymentStatusBadge.stories.tsx
+++ b/src/components/admin/badges/OrderPaymentStatusBadge.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import {
+  OrderPaymentStatusBadge,
+  type OrderPaymentStatus,
+} from './OrderPaymentStatusBadge'
+
+const meta: Meta<typeof OrderPaymentStatusBadge> = {
+  title: 'Systems/Tickets/OrderPaymentStatusBadge',
+  component: OrderPaymentStatusBadge,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Domain adapter that maps an order/invoice payment state (paid/due/overdue) to the shared `StatusBadge`, keeping the colour ladder in one place.',
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof OrderPaymentStatusBadge>
+
+export const Paid: Story = { args: { status: 'paid' } }
+export const Due: Story = { args: { status: 'due' } }
+export const Overdue: Story = { args: { status: 'overdue' } }
+
+const ALL_STATUSES: OrderPaymentStatus[] = ['paid', 'due', 'overdue']
+
+export const AllStatuses: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      {ALL_STATUSES.map((status) => (
+        <OrderPaymentStatusBadge key={status} status={status} />
+      ))}
+    </div>
+  ),
+}

--- a/src/components/admin/badges/OrderPaymentStatusBadge.tsx
+++ b/src/components/admin/badges/OrderPaymentStatusBadge.tsx
@@ -1,0 +1,40 @@
+import { StatusBadge, type BadgeColor } from '@/components/StatusBadge'
+
+export type OrderPaymentStatus = 'paid' | 'due' | 'overdue'
+
+interface OrderPaymentStatusConfig {
+  label: string
+  color: BadgeColor
+}
+
+const ORDER_PAYMENT_STATUS_CONFIG: Record<
+  OrderPaymentStatus,
+  OrderPaymentStatusConfig
+> = {
+  paid: { label: 'Paid', color: 'green' },
+  due: { label: 'Due', color: 'yellow' },
+  overdue: { label: 'Overdue', color: 'red' },
+}
+
+export function getOrderPaymentStatusConfig(
+  status: OrderPaymentStatus,
+): OrderPaymentStatusConfig {
+  return ORDER_PAYMENT_STATUS_CONFIG[status]
+}
+
+interface OrderPaymentStatusBadgeProps {
+  status: OrderPaymentStatus
+  className?: string
+}
+
+/**
+ * Domain adapter around the shared {@link StatusBadge} for order/invoice payment
+ * state. Keeps the paid/due/overdue colour ladder in one place.
+ */
+export function OrderPaymentStatusBadge({
+  status,
+  className,
+}: OrderPaymentStatusBadgeProps) {
+  const { label, color } = getOrderPaymentStatusConfig(status)
+  return <StatusBadge label={label} color={color} className={className} />
+}

--- a/src/components/admin/badges/index.ts
+++ b/src/components/admin/badges/index.ts
@@ -1,0 +1,5 @@
+export {
+  OrderPaymentStatusBadge,
+  getOrderPaymentStatusConfig,
+  type OrderPaymentStatus,
+} from './OrderPaymentStatusBadge'

--- a/src/components/admin/gallery/GalleryFilters.tsx
+++ b/src/components/admin/gallery/GalleryFilters.tsx
@@ -13,6 +13,8 @@ import {
 import { api } from '@/lib/trpc/client'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { AdminFilterBar } from '@/components/admin/AdminFilterBar'
+import clsx from 'clsx'
 
 interface GalleryFiltersProps {
   filters: {
@@ -202,14 +204,24 @@ export function GalleryFilters({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- filters and callbacks are stable
   }, [debouncedLocation])
 
-  return (
-    <div className="rounded-lg bg-white p-3 shadow dark:bg-gray-900 dark:ring-1 dark:ring-gray-800">
-      <div className="flex flex-wrap items-center gap-2">
+  const activeFilterCount = [
+    filters.featured,
+    filters.speakerId,
+    filters.dateFrom,
+    filters.dateTo,
+    filters.photographerSearch,
+    filters.locationSearch,
+  ].filter((value) => value !== undefined && value !== '').length
+
+  const renderControls = (idPrefix: string, stacked: boolean) => {
+    const fieldWidth = (inline: string) => (stacked ? 'w-full' : inline)
+    return (
+      <>
         {/* Featured Filter */}
-        <div className="relative">
+        <div className={clsx('relative', stacked && 'w-full')}>
           <StarIcon className="pointer-events-none absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-gray-400" />
           <select
-            id="featured-filter"
+            id={`${idPrefix}-featured`}
             value={
               filters.featured === undefined
                 ? 'all'
@@ -218,7 +230,10 @@ export function GalleryFilters({
                   : 'non-featured'
             }
             onChange={(e) => handleFeaturedChange(e.target.value)}
-            className="h-9 w-32 appearance-none rounded-md border-gray-300 py-1.5 pr-8 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            className={clsx(
+              'h-11 appearance-none rounded-md border-gray-300 py-1.5 pr-8 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white',
+              fieldWidth('w-32'),
+            )}
             aria-label="Featured filter"
           >
             <option value="all">All</option>
@@ -230,7 +245,12 @@ export function GalleryFilters({
 
         {/* Speaker Filter */}
         {selectedSpeaker ? (
-          <div className="flex h-9 items-center gap-1 rounded-md border border-gray-300 bg-gray-50 px-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white">
+          <div
+            className={clsx(
+              'flex h-11 items-center gap-1 rounded-md border border-gray-300 bg-gray-50 px-2 text-sm lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white',
+              stacked && 'w-full',
+            )}
+          >
             <UserIcon className="h-4 w-4 text-gray-400" />
             <span className="max-w-32 truncate">{selectedSpeaker.name}</span>
             <button
@@ -243,10 +263,14 @@ export function GalleryFilters({
           </div>
         ) : (
           <Combobox value={selectedSpeaker} onChange={handleSpeakerSelect}>
-            <div className="relative">
+            <div className={clsx('relative', stacked && 'w-full')}>
               <UserIcon className="pointer-events-none absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-gray-400" />
               <Combobox.Input
-                className="h-9 w-40 rounded-md border-gray-300 py-1.5 pr-8 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500"
+                id={`${idPrefix}-speaker`}
+                className={clsx(
+                  'h-11 rounded-md border-gray-300 py-1.5 pr-8 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
+                  fieldWidth('w-40'),
+                )}
                 displayValue={(speaker: { _id: string; name: string } | null) =>
                   speaker?.name || ''
                 }
@@ -281,39 +305,45 @@ export function GalleryFilters({
         )}
 
         {/* Photographer Filter */}
-        <div className="relative">
+        <div className={clsx('relative', stacked && 'w-full')}>
           <CameraIcon className="pointer-events-none absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-gray-400" />
           <input
             type="text"
-            id="photographer"
+            id={`${idPrefix}-photographer`}
             value={localPhotographer}
             onChange={(e) => setLocalPhotographer(e.target.value)}
             placeholder="Photographer"
-            className="h-9 w-36 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500"
+            className={clsx(
+              'h-11 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
+              fieldWidth('w-36'),
+            )}
             aria-label="Filter by photographer"
           />
         </div>
 
         {/* Location Filter */}
-        <div className="relative">
+        <div className={clsx('relative', stacked && 'w-full')}>
           <MapPinIcon className="pointer-events-none absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-gray-400" />
           <input
             type="text"
-            id="location"
+            id={`${idPrefix}-location`}
             value={localLocation}
             onChange={(e) => setLocalLocation(e.target.value)}
             placeholder="Location"
-            className="h-9 w-32 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500"
+            className={clsx(
+              'h-11 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
+              fieldWidth('w-32'),
+            )}
             aria-label="Filter by location"
           />
         </div>
 
         {/* Date From Filter */}
-        <div className="relative">
+        <div className={clsx('relative', stacked && 'w-full')}>
           <CalendarIcon className="pointer-events-none absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-gray-400" />
           <input
             type="date"
-            id="date-from"
+            id={`${idPrefix}-date-from`}
             value={localDateFrom}
             onChange={(e) => {
               setLocalDateFrom(e.target.value)
@@ -324,17 +354,20 @@ export function GalleryFilters({
               onFiltersChange(newFilters)
               updateURL(newFilters)
             }}
-            className="h-9 w-36 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:scheme-dark"
+            className={clsx(
+              'h-11 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:scheme-dark',
+              fieldWidth('w-36'),
+            )}
             aria-label="Filter from date"
           />
         </div>
 
         {/* Date To Filter */}
-        <div className="relative">
+        <div className={clsx('relative', stacked && 'w-full')}>
           <CalendarIcon className="pointer-events-none absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2 text-gray-400" />
           <input
             type="date"
-            id="date-to"
+            id={`${idPrefix}-date-to`}
             value={localDateTo}
             onChange={(e) => {
               setLocalDateTo(e.target.value)
@@ -345,22 +378,46 @@ export function GalleryFilters({
               onFiltersChange(newFilters)
               updateURL(newFilters)
             }}
-            className="h-9 w-36 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:scheme-dark"
+            className={clsx(
+              'h-11 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:scheme-dark',
+              fieldWidth('w-36'),
+            )}
             aria-label="Filter to date"
           />
         </div>
 
-        {/* Clear All Button */}
-        {hasActiveFilters && (
+        {/* Clear All Button (desktop only; the sheet footer provides its own) */}
+        {hasActiveFilters && !stacked && (
           <button
             onClick={clearAllFilters}
-            className="h-9 rounded-md bg-gray-100 px-3 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            className="h-11 rounded-md bg-gray-100 px-3 text-sm font-medium text-gray-700 hover:bg-gray-200 lg:h-9 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
             aria-label="Clear all filters"
           >
             Clear
           </button>
         )}
-      </div>
+      </>
+    )
+  }
+
+  return (
+    <div className="rounded-lg bg-white p-3 shadow dark:bg-gray-900 dark:ring-1 dark:ring-gray-800">
+      <AdminFilterBar
+        variant="bare"
+        filters={[]}
+        activeFilterCount={activeFilterCount}
+        onClearAll={hasActiveFilters ? clearAllFilters : undefined}
+        desktopExtra={
+          <div className="flex flex-wrap items-center gap-2">
+            {renderControls('gallery', false)}
+          </div>
+        }
+        sheetExtra={
+          <div className="flex flex-col gap-3">
+            {renderControls('gallery-sheet', true)}
+          </div>
+        }
+      />
     </div>
   )
 }

--- a/src/components/admin/sponsor-crm/MobileFilterSheet.stories.tsx
+++ b/src/components/admin/sponsor-crm/MobileFilterSheet.stories.tsx
@@ -1,17 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { XMarkIcon, FunnelIcon, CheckIcon } from '@heroicons/react/24/outline'
 import { useState } from 'react'
+import { MobileFilterSheet } from './MobileFilterSheet'
+import type { FilterGroup } from '@/components/admin/AdminFilterBar'
 
 const meta = {
   title: 'Systems/Sponsors/Admin/Pipeline/MobileFilterSheet',
   tags: ['autodocs'],
   parameters: {
-    layout: 'centered',
-    options: { showPanel: false },
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'mobile1' },
     docs: {
       description: {
         component:
-          'Bottom sheet filter panel optimized for mobile devices. Provides status, tier, and organizer filter controls with chip-based active filter display and clear-all action.',
+          'Full-height, slide-up bottom sheet used below `lg` to host filter controls on mobile. Config-driven via `FilterGroup[]`; rendered by `AdminFilterBar` and reused directly by the sponsor CRM pipeline.',
       },
     },
   },
@@ -20,314 +21,87 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const mockStatuses = [
-  { value: 'prospect', label: 'Prospect', count: 12 },
-  { value: 'contacted', label: 'Contacted', count: 8 },
-  { value: 'negotiating', label: 'Negotiating', count: 5 },
-  { value: 'confirmed', label: 'Confirmed', count: 4 },
-  { value: 'declined', label: 'Declined', count: 2 },
-]
-
-const mockTiers = [
-  { value: 'platinum', label: 'Platinum' },
-  { value: 'gold', label: 'Gold' },
-  { value: 'silver', label: 'Silver' },
-  { value: 'bronze', label: 'Bronze' },
-]
-
-const mockTags = [
-  { value: 'returning', label: 'Returning Sponsor' },
-  { value: 'priority', label: 'Priority' },
-  { value: 'follow-up', label: 'Needs Follow-up' },
-  { value: 'local', label: 'Local Company' },
-]
-
 function MobileFilterSheetDemo() {
   const [isOpen, setIsOpen] = useState(true)
-  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([
-    'prospect',
-    'contacted',
-  ])
-  const [selectedTiers, setSelectedTiers] = useState<string[]>(['gold'])
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [tiers, setTiers] = useState<string[]>(['gold'])
+  const [owner, setOwner] = useState<string>('')
+  const [tags, setTags] = useState<string[]>([])
 
-  const toggleStatus = (status: string) => {
-    setSelectedStatuses((prev) =>
-      prev.includes(status)
-        ? prev.filter((s) => s !== status)
-        : [...prev, status],
+  const toggle = (
+    setter: React.Dispatch<React.SetStateAction<string[]>>,
+    value: string,
+  ) =>
+    setter((prev) =>
+      prev.includes(value)
+        ? prev.filter((item) => item !== value)
+        : [...prev, value],
     )
-  }
 
-  const toggleTier = (tier: string) => {
-    setSelectedTiers((prev) =>
-      prev.includes(tier) ? prev.filter((t) => t !== tier) : [...prev, tier],
-    )
-  }
+  const groups: FilterGroup[] = [
+    {
+      key: 'tier',
+      label: 'Tier',
+      options: [
+        { value: 'platinum', label: 'Platinum' },
+        { value: 'gold', label: 'Gold' },
+        { value: 'silver', label: 'Silver' },
+        { value: 'bronze', label: 'Bronze' },
+      ],
+      selected: tiers,
+      onChange: (value) => toggle(setTiers, value),
+    },
+    {
+      key: 'owner',
+      label: 'Owner',
+      multi: false,
+      options: [
+        { value: '', label: 'All' },
+        { value: 'unassigned', label: 'Unassigned' },
+        { value: 'alice', label: 'Alice Johnson' },
+        { value: 'bob', label: 'Bob Smith' },
+      ],
+      selected: [owner],
+      onChange: setOwner,
+    },
+    {
+      key: 'tags',
+      label: 'Tags',
+      options: [
+        { value: 'returning', label: 'Returning Sponsor' },
+        { value: 'priority', label: 'Priority' },
+        { value: 'follow-up', label: 'Needs Follow-up' },
+        { value: 'local', label: 'Local Company' },
+      ],
+      selected: tags,
+      onChange: (value) => toggle(setTags, value),
+    },
+  ]
 
-  const toggleTag = (tag: string) => {
-    setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
-    )
-  }
-
-  const activeFilterCount =
-    selectedStatuses.length + selectedTiers.length + selectedTags.length
+  const activeFilterCount = tiers.length + (owner ? 1 : 0) + tags.length
 
   return (
-    <div className="relative">
-      {/* Trigger button */}
+    <div className="min-h-screen bg-gray-100 p-4 dark:bg-gray-950">
       <button
         onClick={() => setIsOpen(true)}
-        className="relative flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+        className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white"
       >
-        <FunnelIcon className="h-4 w-4" />
-        Filters
-        {activeFilterCount > 0 && (
-          <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-indigo-600 text-xs text-white">
-            {activeFilterCount}
-          </span>
-        )}
+        Open filters
       </button>
-
-      {/* Sheet overlay */}
-      {isOpen && (
-        <div className="fixed inset-0 z-50">
-          <div
-            className="absolute inset-0 bg-black/50"
-            onClick={() => setIsOpen(false)}
-          />
-
-          {/* Sheet panel */}
-          <div className="absolute inset-x-0 bottom-0 max-h-[85vh] overflow-y-auto rounded-t-2xl bg-white shadow-xl dark:bg-gray-800">
-            {/* Handle */}
-            <div className="sticky top-0 bg-white pt-3 dark:bg-gray-800">
-              <div className="mx-auto h-1 w-12 rounded-full bg-gray-300 dark:bg-gray-600" />
-            </div>
-
-            {/* Header */}
-            <div className="sticky top-4 flex items-center justify-between border-b border-gray-200 bg-white px-4 pt-2 pb-4 dark:border-gray-700 dark:bg-gray-800">
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-                Filters
-              </h2>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => {
-                    setSelectedStatuses([])
-                    setSelectedTiers([])
-                    setSelectedTags([])
-                  }}
-                  className="text-sm text-indigo-600 hover:text-indigo-700 dark:text-indigo-400"
-                >
-                  Clear all
-                </button>
-                <button
-                  onClick={() => setIsOpen(false)}
-                  className="rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-700"
-                >
-                  <XMarkIcon className="h-6 w-6 text-gray-500" />
-                </button>
-              </div>
-            </div>
-
-            <div className="space-y-6 p-4 pb-8">
-              {/* Status filter */}
-              <div>
-                <h3 className="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Status
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  {mockStatuses.map((status) => (
-                    <button
-                      key={status.value}
-                      onClick={() => toggleStatus(status.value)}
-                      className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm transition-colors ${
-                        selectedStatuses.includes(status.value)
-                          ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {selectedStatuses.includes(status.value) && (
-                        <CheckIcon className="h-3.5 w-3.5" />
-                      )}
-                      {status.label}
-                      <span className="text-xs opacity-60">
-                        ({status.count})
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Tier filter */}
-              <div>
-                <h3 className="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Tier
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  {mockTiers.map((tier) => (
-                    <button
-                      key={tier.value}
-                      onClick={() => toggleTier(tier.value)}
-                      className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm transition-colors ${
-                        selectedTiers.includes(tier.value)
-                          ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {selectedTiers.includes(tier.value) && (
-                        <CheckIcon className="h-3.5 w-3.5" />
-                      )}
-                      {tier.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Tags filter */}
-              <div>
-                <h3 className="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Tags
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  {mockTags.map((tag) => (
-                    <button
-                      key={tag.value}
-                      onClick={() => toggleTag(tag.value)}
-                      className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm transition-colors ${
-                        selectedTags.includes(tag.value)
-                          ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
-                      }`}
-                    >
-                      {selectedTags.includes(tag.value) && (
-                        <CheckIcon className="h-3.5 w-3.5" />
-                      )}
-                      {tag.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            {/* Apply button */}
-            <div className="sticky bottom-0 border-t border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-              <button
-                onClick={() => setIsOpen(false)}
-                className="w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-medium text-white hover:bg-indigo-700"
-              >
-                Apply Filters
-                {activeFilterCount > 0 && ` (${activeFilterCount})`}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <MobileFilterSheet
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        groups={groups}
+        onClearAll={() => {
+          setTiers([])
+          setOwner('')
+          setTags([])
+        }}
+        activeFilterCount={activeFilterCount}
+      />
     </div>
   )
 }
 
 export const Default: Story = {
-  render: () => (
-    <div className="flex min-h-150 w-93.75 items-start justify-center bg-gray-100 p-4 dark:bg-gray-900">
-      <MobileFilterSheetDemo />
-    </div>
-  ),
-}
-
-export const TriggerOnly: Story = {
-  render: () => (
-    <div className="p-6">
-      <button className="relative flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300">
-        <FunnelIcon className="h-4 w-4" />
-        Filters
-        <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-indigo-600 text-xs text-white">
-          3
-        </span>
-      </button>
-    </div>
-  ),
-}
-
-export const Documentation: Story = {
-  render: () => (
-    <div className="max-w-lg space-y-6 p-6">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-          MobileFilterSheet
-        </h1>
-        <p className="mt-2 text-gray-600 dark:text-gray-400">
-          Bottom sheet filter UI for mobile devices. Provides touch-friendly
-          filter selection for the sponsor CRM pipeline view.
-        </p>
-      </div>
-
-      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
-        <h3 className="font-semibold text-gray-900 dark:text-white">Props</h3>
-        <ul className="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-400">
-          <li>
-            <code className="rounded bg-gray-200 px-1 dark:bg-gray-700">
-              isOpen
-            </code>{' '}
-            - Whether the sheet is visible
-          </li>
-          <li>
-            <code className="rounded bg-gray-200 px-1 dark:bg-gray-700">
-              onClose
-            </code>{' '}
-            - Callback when sheet is closed
-          </li>
-          <li>
-            <code className="rounded bg-gray-200 px-1 dark:bg-gray-700">
-              filters
-            </code>{' '}
-            - Current filter state (status, tier, tags)
-          </li>
-          <li>
-            <code className="rounded bg-gray-200 px-1 dark:bg-gray-700">
-              onFiltersChange
-            </code>{' '}
-            - Callback when filters change
-          </li>
-          <li>
-            <code className="rounded bg-gray-200 px-1 dark:bg-gray-700">
-              availableTiers
-            </code>{' '}
-            - Tier options from conference
-          </li>
-          <li>
-            <code className="rounded bg-gray-200 px-1 dark:bg-gray-700">
-              statusCounts
-            </code>{' '}
-            - Count of sponsors per status
-          </li>
-        </ul>
-      </div>
-
-      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
-        <h3 className="font-semibold text-gray-900 dark:text-white">
-          Features
-        </h3>
-        <ul className="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-400">
-          <li>• Touch-friendly pill-style filter toggles</li>
-          <li>• Swipe-down to close gesture (via drag handle)</li>
-          <li>• Clear all filters option</li>
-          <li>• Sticky apply button at bottom</li>
-          <li>• Status counts shown inline</li>
-          <li>• Badge on trigger shows active filter count</li>
-        </ul>
-      </div>
-
-      <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
-        <h3 className="font-semibold text-blue-800 dark:text-blue-200">
-          Responsive Design
-        </h3>
-        <p className="mt-2 text-sm text-blue-700 dark:text-blue-300">
-          This component is only rendered on mobile viewports. On desktop,
-          filters are displayed in a sidebar or dropdown instead. Use responsive
-          utilities to conditionally render.
-        </p>
-      </div>
-    </div>
-  ),
+  render: () => <MobileFilterSheetDemo />,
 }

--- a/src/components/admin/sponsor-crm/MobileFilterSheet.tsx
+++ b/src/components/admin/sponsor-crm/MobileFilterSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Fragment } from 'react'
+import { Fragment, ReactNode } from 'react'
 import {
   Dialog,
   DialogPanel,
@@ -9,50 +9,37 @@ import {
   TransitionChild,
 } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
-import { SponsorTag } from '@/lib/sponsor-crm/types'
-import { SponsorTier } from '@/lib/sponsor/types'
-import {
-  sortSponsorTiers,
-  formatTierLabel,
-} from '@/components/admin/sponsor-crm/utils'
-import { TAGS } from '@/components/admin/sponsor-crm/form/constants'
 import clsx from 'clsx'
-
-interface Organizer {
-  _id: string
-  name: string
-  email?: string
-  avatar?: string
-}
+import type { FilterGroup } from '@/components/admin/AdminFilterBar'
 
 interface MobileFilterSheetProps {
   isOpen: boolean
   onClose: () => void
-  tiers: SponsorTier[]
-  tiersFilter: string[]
-  onToggleTier: (tierId: string) => void
-  organizers: Organizer[]
-  assignedToFilter: string | undefined
-  onSetOrganizer: (organizerId: string | null) => void
-  tagsFilter: SponsorTag[]
-  onToggleTag: (tag: SponsorTag) => void
+  /** Declarative filter groups rendered as chip sections. */
+  groups: FilterGroup[]
+  /** Clears all active filters. */
   onClearAll: () => void
+  /** Number of active filters (drives footer copy). */
   activeFilterCount: number
+  /** Extra controls rendered below the chip groups (dates, sort, etc.). */
+  extra?: ReactNode
+  /** Sheet heading. */
+  title?: string
 }
 
+/**
+ * Full-height, slide-up bottom sheet used below `lg` to host filter controls
+ * on mobile. Config-driven via {@link FilterGroup}; rendered by
+ * `AdminFilterBar` and reused directly by the sponsor CRM pipeline.
+ */
 export function MobileFilterSheet({
   isOpen,
   onClose,
-  tiers,
-  tiersFilter,
-  onToggleTier,
-  organizers,
-  assignedToFilter,
-  onSetOrganizer,
-  tagsFilter,
-  onToggleTag,
+  groups,
   onClearAll,
   activeFilterCount,
+  extra,
+  title = 'Filters',
 }: MobileFilterSheetProps) {
   return (
     <Transition show={isOpen} as={Fragment}>
@@ -80,98 +67,64 @@ export function MobileFilterSheet({
           leaveFrom="translate-y-0"
           leaveTo="translate-y-full"
         >
-          <DialogPanel className="fixed inset-x-0 bottom-0 max-h-[85vh] overflow-y-auto rounded-t-2xl bg-white shadow-2xl dark:bg-gray-900">
+          <DialogPanel className="fixed inset-x-0 bottom-0 flex max-h-[90vh] flex-col rounded-t-2xl bg-white shadow-2xl dark:bg-gray-900">
             {/* Handle bar */}
-            <div className="sticky top-0 z-10 bg-white pt-3 pb-2 dark:bg-gray-900">
+            <div className="shrink-0 bg-white pt-3 pb-2 dark:bg-gray-900">
               <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-gray-300 dark:bg-gray-600" />
               <div className="flex items-center justify-between px-5">
                 <DialogTitle className="text-base font-semibold text-gray-900 dark:text-white">
-                  Filters
+                  {title}
                 </DialogTitle>
                 <button
                   onClick={onClose}
-                  className="rounded-full p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                  className="flex h-11 w-11 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                  aria-label="Close filters"
                 >
                   <XMarkIcon className="h-5 w-5" />
                 </button>
               </div>
             </div>
 
-            <div className="space-y-6 px-5 pb-6">
-              {/* Tier Section */}
-              <FilterSection title="Tier">
-                {tiers.length === 0 ? (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    No tiers available
-                  </p>
-                ) : (
-                  <div className="flex flex-wrap gap-2">
-                    {sortSponsorTiers(tiers).map((tier: SponsorTier) => (
-                      <FilterChip
-                        key={tier._id}
-                        label={formatTierLabel(tier)}
-                        active={tiersFilter.includes(tier._id)}
-                        onClick={() => onToggleTier(tier._id)}
-                      />
-                    ))}
-                  </div>
-                )}
-              </FilterSection>
+            <div className="flex-1 space-y-6 overflow-y-auto px-5 pb-6">
+              {groups.map((group) => (
+                <FilterSection key={group.key} title={group.label}>
+                  {group.options.length === 0 ? (
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {group.emptyText ?? 'No options available'}
+                    </p>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {group.options.map((option) => (
+                        <FilterChip
+                          key={option.value}
+                          label={option.label}
+                          active={group.selected.includes(option.value)}
+                          onClick={() => group.onChange(option.value)}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </FilterSection>
+              ))}
 
-              {/* Owner Section */}
-              <FilterSection title="Owner">
-                <div className="flex flex-wrap gap-2">
-                  <FilterChip
-                    label="All"
-                    active={!assignedToFilter}
-                    onClick={() => onSetOrganizer(null)}
-                  />
-                  <FilterChip
-                    label="Unassigned"
-                    active={assignedToFilter === 'unassigned'}
-                    onClick={() => onSetOrganizer('unassigned')}
-                  />
-                  {organizers.map((org) => (
-                    <FilterChip
-                      key={org._id}
-                      label={org.name}
-                      active={assignedToFilter === org._id}
-                      onClick={() => onSetOrganizer(org._id)}
-                    />
-                  ))}
-                </div>
-              </FilterSection>
-
-              {/* Tags Section */}
-              <FilterSection title="Tags">
-                <div className="flex flex-wrap gap-2">
-                  {TAGS.map((tag) => (
-                    <FilterChip
-                      key={tag.value}
-                      label={tag.label}
-                      active={tagsFilter.includes(tag.value)}
-                      onClick={() => onToggleTag(tag.value)}
-                    />
-                  ))}
-                </div>
-              </FilterSection>
+              {extra}
             </div>
 
             {/* Sticky footer */}
-            <div className="sticky bottom-0 flex items-center gap-3 border-t border-gray-200 bg-white px-5 py-4 dark:border-gray-700 dark:bg-gray-900">
+            <div className="flex shrink-0 items-center gap-3 border-t border-gray-200 bg-white px-5 py-4 dark:border-gray-700 dark:bg-gray-900">
               {activeFilterCount > 0 && (
                 <button
                   onClick={onClearAll}
-                  className="flex-1 rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                  className="flex min-h-11 flex-1 items-center justify-center rounded-lg border border-gray-300 px-4 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
                 >
                   Clear all
                 </button>
               )}
               <button
                 onClick={onClose}
-                className="flex-1 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+                className="flex min-h-11 flex-1 items-center justify-center rounded-lg bg-indigo-600 px-4 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
               >
-                {activeFilterCount > 0 ? `Show results` : 'Done'}
+                {activeFilterCount > 0 ? 'Show results' : 'Done'}
               </button>
             </div>
           </DialogPanel>
@@ -181,12 +134,12 @@ export function MobileFilterSheet({
   )
 }
 
-function FilterSection({
+export function FilterSection({
   title,
   children,
 }: {
   title: string
-  children: React.ReactNode
+  children: ReactNode
 }) {
   return (
     <div>
@@ -203,7 +156,7 @@ function FilterChip({
   active,
   onClick,
 }: {
-  label: string
+  label: ReactNode
   active: boolean
   onClick: () => void
 }) {
@@ -211,7 +164,7 @@ function FilterChip({
     <button
       onClick={onClick}
       className={clsx(
-        'rounded-full px-3.5 py-2 text-sm font-medium transition-colors',
+        'flex min-h-11 items-center rounded-full px-3.5 text-sm font-medium transition-colors',
         active
           ? 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-300 ring-inset dark:bg-indigo-900/40 dark:text-indigo-300 dark:ring-indigo-700'
           : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',

--- a/src/components/admin/sponsor-crm/SponsorCRMFilterBar.stories.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMFilterBar.stories.tsx
@@ -77,7 +77,6 @@ const meta = {
     onClearSelection: fn(),
     isMobileSearchOpen: false,
     onToggleMobileSearch: fn(),
-    onOpenMobileFilter: fn(),
   },
   decorators: [
     (Story) => (

--- a/src/components/admin/sponsor-crm/SponsorCRMFilterBar.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMFilterBar.tsx
@@ -1,11 +1,7 @@
 'use client'
 
-import {
-  MagnifyingGlassIcon,
-  XMarkIcon,
-  FunnelIcon,
-} from '@heroicons/react/20/solid'
-import { FilterDropdown, FilterOption } from '@/components/admin/FilterDropdown'
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/20/solid'
+import { AdminFilterBar } from '@/components/admin/AdminFilterBar'
 import {
   BoardViewSwitcher,
   type BoardView,
@@ -63,8 +59,6 @@ export interface SponsorCRMFilterBarProps {
   isMobileSearchOpen?: boolean
   /** Callback to toggle mobile search */
   onToggleMobileSearch?: () => void
-  /** Callback to open mobile filter sheet */
-  onOpenMobileFilter?: () => void
 }
 
 export function SponsorCRMFilterBar({
@@ -86,7 +80,6 @@ export function SponsorCRMFilterBar({
   onClearSelection,
   isMobileSearchOpen = false,
   onToggleMobileSearch,
-  onOpenMobileFilter,
 }: SponsorCRMFilterBarProps) {
   const activeFilterCount =
     tiersFilter.length + (assignedToFilter ? 1 : 0) + tagsFilter.length
@@ -143,104 +136,51 @@ export function SponsorCRMFilterBar({
 
         <div className="hidden h-6 w-px bg-gray-200 sm:block dark:bg-gray-700" />
 
-        {/* Filter dropdowns - desktop only */}
-        <div className="hidden items-center gap-1.5 lg:flex">
-          <FilterDropdown
-            label="Tier"
-            activeCount={tiersFilter.length}
-            position="left"
-            size="sm"
-          >
-            {tiers.length === 0 ? (
-              <div className="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">
-                No tiers available
-              </div>
-            ) : (
-              sortSponsorTiers(tiers).map((tier: SponsorTier) => (
-                <FilterOption
-                  key={tier._id}
-                  onClick={() => onToggleTier(tier._id)}
-                  checked={tiersFilter.includes(tier._id)}
-                  keepOpen
-                >
-                  {formatTierLabel(tier)}
-                </FilterOption>
-              ))
-            )}
-          </FilterDropdown>
-
-          <FilterDropdown
-            label="Owner"
-            activeCount={assignedToFilter ? 1 : 0}
-            position="left"
-            size="sm"
-          >
-            <FilterOption
-              onClick={() => onSetOrganizer(null)}
-              checked={!assignedToFilter}
-              type="radio"
-            >
-              All Owners
-            </FilterOption>
-            <FilterOption
-              onClick={() => onSetOrganizer('unassigned')}
-              checked={assignedToFilter === 'unassigned'}
-              type="radio"
-            >
-              Unassigned
-            </FilterOption>
-            <div className="my-1 border-t border-gray-100 dark:border-gray-700" />
-            {organizers.map((organizer) => (
-              <FilterOption
-                key={organizer._id}
-                onClick={() => onSetOrganizer(organizer._id)}
-                checked={assignedToFilter === organizer._id}
-                type="radio"
-              >
-                {organizer.name}
-              </FilterOption>
-            ))}
-          </FilterDropdown>
-
-          <FilterDropdown
-            label="Tags"
-            activeCount={tagsFilter.length}
-            position="left"
-            size="sm"
-          >
-            {TAGS.map((tag) => (
-              <FilterOption
-                key={tag.value}
-                onClick={() => onToggleTag(tag.value)}
-                checked={tagsFilter.includes(tag.value)}
-                keepOpen
-              >
-                {tag.label}
-              </FilterOption>
-            ))}
-          </FilterDropdown>
-        </div>
-
-        {/* Mobile: Filter button with badge */}
-        {onOpenMobileFilter && (
-          <button
-            onClick={onOpenMobileFilter}
-            className={clsx(
-              'relative flex h-9 items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium transition-colors lg:hidden',
-              activeFilterCount > 0
-                ? 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-300 ring-inset dark:bg-indigo-900/40 dark:text-indigo-300 dark:ring-indigo-700'
-                : 'text-gray-600 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:text-gray-400 dark:ring-white/10 dark:hover:bg-gray-800',
-            )}
-          >
-            <FunnelIcon className="h-4 w-4" />
-            <span className="hidden sm:inline">Filter</span>
-            {activeFilterCount > 0 && (
-              <span className="inline-flex h-4.5 min-w-4.5 items-center justify-center rounded-full bg-indigo-600 px-1 text-[10px] font-bold text-white dark:bg-indigo-500">
-                {activeFilterCount}
-              </span>
-            )}
-          </button>
-        )}
+        {/* Filters: desktop dropdowns + mobile bottom sheet */}
+        <AdminFilterBar
+          variant="bare"
+          filters={[
+            {
+              key: 'tier',
+              label: 'Tier',
+              options: sortSponsorTiers(tiers).map((tier: SponsorTier) => ({
+                value: tier._id,
+                label: formatTierLabel(tier),
+              })),
+              selected: tiersFilter,
+              onChange: onToggleTier,
+              emptyText: 'No tiers available',
+            },
+            {
+              key: 'owner',
+              label: 'Owner',
+              options: [
+                { value: '', label: 'All Owners' },
+                { value: 'unassigned', label: 'Unassigned' },
+                ...organizers.map((organizer) => ({
+                  value: organizer._id,
+                  label: organizer.name,
+                })),
+              ],
+              selected: [assignedToFilter ?? ''],
+              onChange: (value) => onSetOrganizer(value === '' ? null : value),
+              multi: false,
+            },
+            {
+              key: 'tags',
+              label: 'Tags',
+              options: TAGS.map((tag) => ({
+                value: tag.value,
+                label: tag.label,
+              })),
+              selected: tagsFilter,
+              onChange: (value) => onToggleTag(value as SponsorTag),
+            },
+          ]}
+          onClearAll={onClearAllFilters}
+          activeFilterCount={activeFilterCount}
+          mobileFilterLabel="Filter"
+        />
 
         <div className="ml-auto hidden h-6 w-px bg-gray-200 sm:block dark:bg-gray-700" />
 

--- a/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
@@ -857,14 +857,42 @@ export function SponsorCRMPipeline({
       <MobileFilterSheet
         isOpen={isMobileFilterOpen}
         onClose={() => setIsMobileFilterOpen(false)}
-        tiers={tiers}
-        tiersFilter={tiersFilter}
-        onToggleTier={toggleTierFilter}
-        organizers={organizers}
-        assignedToFilter={assignedToFilter}
-        onSetOrganizer={setOrganizerFilter}
-        tagsFilter={tagsFilter}
-        onToggleTag={toggleTagFilter}
+        groups={[
+          {
+            key: 'tier',
+            label: 'Tier',
+            options: sortSponsorTiers(tiers).map((tier) => ({
+              value: tier._id,
+              label: formatTierLabel(tier),
+            })),
+            selected: tiersFilter,
+            onChange: toggleTierFilter,
+            emptyText: 'No tiers available',
+          },
+          {
+            key: 'owner',
+            label: 'Owner',
+            options: [
+              { value: '', label: 'All' },
+              { value: 'unassigned', label: 'Unassigned' },
+              ...organizers.map((org) => ({ value: org._id, label: org.name })),
+            ],
+            selected: [assignedToFilter ?? ''],
+            onChange: (value) =>
+              setOrganizerFilter(value === '' ? null : value),
+            multi: false,
+          },
+          {
+            key: 'tags',
+            label: 'Tags',
+            options: TAGS.map((tag) => ({
+              value: tag.value,
+              label: tag.label,
+            })),
+            selected: tagsFilter,
+            onChange: (value) => toggleTagFilter(value as SponsorTag),
+          },
+        ]}
         onClearAll={() => {
           clearAllFilters()
           setSearchQuery('')

--- a/src/components/travel-support/TravelSupportAdminPage.tsx
+++ b/src/components/travel-support/TravelSupportAdminPage.tsx
@@ -14,6 +14,7 @@ import { ExpenseSummary } from './ExpenseSummary'
 import { ErrorBoundary } from './ErrorBoundary'
 import { CurrencyDollarIcon, PaperClipIcon } from '@heroicons/react/24/outline'
 import { SkeletonCard } from '@/components/admin/LoadingSkeleton'
+import { AdminPageHeader } from '@/components/admin'
 import { useExchangeRates } from '@/hooks/useExchangeRates'
 import { ReceiptViewer } from './ReceiptViewer'
 
@@ -127,25 +128,17 @@ export function TravelSupportAdminPage() {
 
   return (
     <div className="space-y-6">
-      <div className="pb-6">
-        <div className="flex items-center gap-3">
-          <CurrencyDollarIcon className="h-8 w-8 text-brand-cloud-blue" />
-          <div>
-            <h1 className="font-space-grotesk text-2xl leading-7 font-bold text-brand-slate-gray sm:truncate sm:text-3xl sm:tracking-tight dark:text-white">
-              Travel Support Administration
-            </h1>
-            <p className="font-inter mt-2 text-sm text-brand-slate-gray/70 dark:text-gray-400">
-              Review and approve travel support requests from speakers
-            </p>
-          </div>
-        </div>
-
+      <AdminPageHeader
+        icon={<CurrencyDollarIcon />}
+        title="Travel Support Administration"
+        description="Review and approve travel support requests from speakers"
+      >
         {requests && (
           <div className="font-inter mt-4">
             <SummaryStats requests={requests} />
           </div>
         )}
-      </div>
+      </AdminPageHeader>
 
       <SpeakersRequiringSupport />
 

--- a/src/lib/proposal/ui/ProposalStatusBadge.stories.tsx
+++ b/src/lib/proposal/ui/ProposalStatusBadge.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ProposalStatusBadge } from './badges'
+import { Status, statuses } from '../types'
+
+const meta: Meta<typeof ProposalStatusBadge> = {
+  title: 'Systems/Proposals/ProposalStatusBadge',
+  component: ProposalStatusBadge,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Domain adapter that maps a proposal `Status` to the shared `StatusBadge`, giving every proposal surface the same label and colour ladder without re-deriving it.',
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ProposalStatusBadge>
+
+export const Draft: Story = { args: { status: Status.draft } }
+export const Submitted: Story = { args: { status: Status.submitted } }
+export const Accepted: Story = { args: { status: Status.accepted } }
+export const Waitlisted: Story = { args: { status: Status.waitlisted } }
+export const Confirmed: Story = { args: { status: Status.confirmed } }
+export const Rejected: Story = { args: { status: Status.rejected } }
+export const Withdrawn: Story = { args: { status: Status.withdrawn } }
+export const Deleted: Story = { args: { status: Status.deleted } }
+
+export const AllStatuses: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      {Array.from(statuses.keys()).map((status) => (
+        <ProposalStatusBadge key={status} status={status} />
+      ))}
+    </div>
+  ),
+}

--- a/src/lib/proposal/ui/badges.tsx
+++ b/src/lib/proposal/ui/badges.tsx
@@ -9,6 +9,56 @@ import {
   audiences,
 } from '../types'
 import { getFormatConfig } from './config'
+import {
+  StatusBadge as SharedStatusBadge,
+  type BadgeColor,
+} from '@/components/StatusBadge'
+
+/**
+ * Canonical proposal-status → shared badge colour mapping. Mirrors the hues in
+ * {@link getStatusBadgeConfig} so the shared {@link SharedStatusBadge} renders the
+ * same colour ladder used across proposal surfaces.
+ */
+const PROPOSAL_STATUS_BADGE_COLOR: Record<Status, BadgeColor> = {
+  [Status.draft]: 'yellow',
+  [Status.submitted]: 'blue',
+  [Status.accepted]: 'purple',
+  [Status.waitlisted]: 'orange',
+  [Status.confirmed]: 'green',
+  [Status.rejected]: 'red',
+  [Status.withdrawn]: 'gray',
+  [Status.deleted]: 'gray',
+}
+
+export function getProposalStatusBadgeColor(status: Status): BadgeColor {
+  return PROPOSAL_STATUS_BADGE_COLOR[status] ?? 'gray'
+}
+
+interface ProposalStatusBadgeProps {
+  status: Status
+  icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>
+  className?: string
+}
+
+/**
+ * Thin domain adapter around the shared {@link SharedStatusBadge}. Callers pass a
+ * proposal {@link Status} and get the canonical label + colour without
+ * re-deriving the ladder.
+ */
+export function ProposalStatusBadge({
+  status,
+  icon,
+  className,
+}: ProposalStatusBadgeProps) {
+  return (
+    <SharedStatusBadge
+      label={statuses.get(status) ?? 'Unknown'}
+      color={getProposalStatusBadgeColor(status)}
+      icon={icon}
+      className={className}
+    />
+  )
+}
 
 export interface BadgeConfig {
   text: string

--- a/src/lib/proposal/ui/index.ts
+++ b/src/lib/proposal/ui/index.ts
@@ -1,5 +1,7 @@
 export {
   StatusBadge,
+  ProposalStatusBadge,
+  getProposalStatusBadgeColor,
   LevelBadge,
   FormatBadge,
   AudienceBadge,


### PR DESCRIPTION
First wave of admin mobile-responsiveness work, scoped to **consistency via shared components** (audit found admin is already mostly responsive — the shell nav, modals, dashboard, and sponsor-CRM already handle mobile well; this sweep makes the rest consistent rather than rewriting anything).

## 1. Shared responsive `AdminFilterBar` (new)
Generalizes the sponsor-CRM's mobile filter pattern — the codebase's best mobile affordance — into a declarative bar: inline `FilterDropdown`s + search + result count on desktop, collapsing below `lg` to a **"Filters (n)"** button opening a full-height bottom sheet (44px tap targets, Clear / Show-results footer). Routes the CRM, **proposals, and gallery** through it, so proposals and gallery gain a mobile filter affordance where their filter rows previously overflowed the viewport. All existing filter options/callbacks/URL-sync preserved; the sheet is additive.

## 2. Status pills → shared `StatusBadge`
Consolidates hand-rolled status pills onto the shared component via thin domain adapters — `ProposalStatusBadge` (wired to the canonical `getStatusBadgeConfig` ladder that `ProposalDetail` already uses) and `OrderPaymentStatusBadge`. Replaces the inline colour ladders in `AdminActionBar`, the orders table, ticket-type status, and badge management. `AdminActionBar`'s proposal-status hues unify onto the canonical ladder (accepted→purple, submitted→blue, confirmed→green, draft→yellow); labels unchanged. Ring-outline detail chips, compact CRM card chips, and non-status count chips are deliberately left as distinct visual families.

## 3. `AdminPageHeader` adoption
The audit over-counted here — verification (`git show main:<file>`) showed the flagged pages already route through `AdminPageHeader`. Only the travel-support admin page was genuinely hand-rolling its header; migrated it for the responsive title scale and consistent styling.

## Verification
`pnpm typecheck` clean; `pnpm vitest run`: 116 files, **2054 passed** / 5 skipped; eslint/prettier clean. New Storybook stories for `AdminFilterBar` (desktop + 360px mobile + overflow), `ProposalStatusBadge`, and `OrderPaymentStatusBadge` — screenshot-verified the mobile collapse (no overflow) and the unified badge ladder render correctly.

## Not in scope (follow-up)
The audit found **one true mobile blocker: the Schedule Editor** — fixed 320px unassigned sidebar + 320px track cards with no stacking and touch-hostile drag-drop. That needs a bespoke mobile mode (drawer + single-column tracks + tap-to-assign) and is a separate wave. Everything else in admin is usable on a phone; the remaining wide data tables horizontal-scroll (degraded, not blocking) — a responsive `AdminTable` card-collapse is the recommended next reusable-component investment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes several admin UI patterns for mobile and status display.

- Adds a shared responsive `AdminFilterBar` and mobile filter sheet.
- Moves proposal, gallery, and sponsor CRM filters onto the shared filter UI.
- Adds shared proposal and order payment status badge adapters.
- Replaces several inline admin status pills with shared badges.
- Migrates the travel-support admin header to `AdminPageHeader`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The changed filter callers provide the expected desktop and mobile controls.
- The new badge adapters cover the statuses used by the updated call sites.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/AdminFilterBar.tsx | Adds the shared responsive admin filter bar with desktop dropdowns and a mobile sheet trigger. |
| src/components/admin/sponsor-crm/MobileFilterSheet.tsx | Generalizes the sponsor CRM mobile sheet to render declarative filter groups and extra controls. |
| src/components/admin/ProposalsFilter.tsx | Moves proposal filtering and mobile sort controls onto the shared filter bar. |
| src/components/admin/gallery/GalleryFilters.tsx | Adds a mobile sheet path for gallery filters while keeping the desktop inline controls. |
| src/components/admin/sponsor-crm/SponsorCRMFilterBar.tsx | Replaces custom sponsor CRM filter dropdowns and mobile trigger with shared filter groups. |
| src/components/admin/OrdersTableWithSearch.tsx | Uses the shared order payment status badge for table and mobile card payment states. |
| src/lib/proposal/ui/badges.tsx | Adds a proposal status badge adapter backed by the existing proposal status config. |
| src/components/admin/badges/OrderPaymentStatusBadge.tsx | Adds an order payment status badge adapter for paid, due, and overdue states. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(admin): migrate travel-support ..."](https://github.com/cloudnativebergen/website/commit/e03e192a9107655b9435c67e12a22df76a322fc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44277677)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->