### PR TITLE
fix(admin): optimise proposal review for mobile

### DIFF
--- a/src/app/(admin)/admin/proposals/[id]/page.tsx
+++ b/src/app/(admin)/admin/proposals/[id]/page.tsx
@@ -86,26 +86,35 @@ export default async function ProposalDetailPage({
         </div>
 
         <div className="w-full lg:w-96 lg:shrink-0">
-          <div className="space-y-4 p-4">
-            <ProposalPublishedContent
-              proposalId={proposal._id}
-              currentVideoUrl={getProposalVideoUrl(proposal)}
-              currentAttachments={proposal.attachments}
-              status={proposal.status}
-              conferenceEndDate={conference.endDate}
-            />
-            <AudienceFeedbackPanel
-              proposalId={proposal._id}
-              currentFeedback={proposal.audienceFeedback}
-              status={proposal.status}
-              conferenceStartDate={conference.startDate}
-            />
-            <ProposalReviewPanel
-              proposalId={proposal._id}
-              initialReviews={proposal.reviews || []}
-              currentUser={session?.speaker}
-              domain={domain}
-            />
+          {/* On mobile this column stacks below the proposal content, so the
+              review scoring form is ordered first (post-conference published
+              content and audience feedback follow); desktop keeps source order. */}
+          <div className="flex flex-col gap-4 p-4">
+            <div className="order-2 lg:order-1">
+              <ProposalPublishedContent
+                proposalId={proposal._id}
+                currentVideoUrl={getProposalVideoUrl(proposal)}
+                currentAttachments={proposal.attachments}
+                status={proposal.status}
+                conferenceEndDate={conference.endDate}
+              />
+            </div>
+            <div className="order-3 lg:order-2">
+              <AudienceFeedbackPanel
+                proposalId={proposal._id}
+                currentFeedback={proposal.audienceFeedback}
+                status={proposal.status}
+                conferenceStartDate={conference.startDate}
+              />
+            </div>
+            <div className="order-1 lg:order-3">
+              <ProposalReviewPanel
+                proposalId={proposal._id}
+                initialReviews={proposal.reviews || []}
+                currentUser={session?.speaker}
+                domain={domain}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/admin/AdminActionBar.tsx
+++ b/src/components/admin/AdminActionBar.tsx
@@ -158,7 +158,7 @@ export function AdminActionBar({
 
   return (
     <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
         <div className="flex min-w-0 flex-wrap items-center gap-4">
           <div className="flex shrink-0 items-center gap-2">
             <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
@@ -248,7 +248,7 @@ export function AdminActionBar({
           )}
         </div>
 
-        <div className="flex shrink-0 items-center gap-1.5">
+        <div className="flex flex-wrap items-center gap-1.5 sm:shrink-0">
           <AdminButton
             size="xs"
             onClick={handleEditProposal}

--- a/src/components/admin/ProposalStatistics.tsx
+++ b/src/components/admin/ProposalStatistics.tsx
@@ -238,18 +238,22 @@ export const ProposalStatistics = memo(function ProposalStatistics({
         aria-expanded={isExpanded}
         aria-controls="proposal-statistics-content"
       >
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 items-center gap-3">
           <ChartBarIcon
-            className="h-5 w-5 text-indigo-600 dark:text-indigo-400"
+            className="h-5 w-5 shrink-0 text-indigo-600 dark:text-indigo-400"
             aria-hidden="true"
           />
-          <span className="text-sm font-medium text-gray-900 dark:text-white">
-            Proposal Statistics
-          </span>
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            ({proposals.length} proposal{proposals.length !== 1 ? 's' : ''} •{' '}
-            {totalMinutes} total minutes)
-          </span>
+          {/* Stack title and count on mobile so the count doesn't force the
+              collapsed header to wrap into a tall block; inline from sm up. */}
+          <div className="flex min-w-0 flex-col items-start text-left sm:flex-row sm:items-center sm:gap-2">
+            <span className="text-sm font-medium text-gray-900 dark:text-white">
+              Proposal Statistics
+            </span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              ({proposals.length} proposal{proposals.length !== 1 ? 's' : ''} •{' '}
+              {totalMinutes} total minutes)
+            </span>
+          </div>
         </div>
         {isExpanded ? (
           <ChevronDownIcon

--- a/src/components/admin/ProposalsList.tsx
+++ b/src/components/admin/ProposalsList.tsx
@@ -89,7 +89,7 @@ export function ProposalsList({
   const displayProposals = filteredProposals || initialProposals
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4 sm:space-y-6">
       <AdminPageHeader
         icon={<DocumentTextIcon />}
         title="Proposal Management"
@@ -131,7 +131,7 @@ export function ProposalsList({
         ) : (
           <>
             <ProposalStatistics proposals={displayProposals} />
-            <div className="mt-8">
+            <div className="mt-4 sm:mt-8">
               {displayProposals.length === 0 ? (
                 <EmptyState
                   hasProposals={initialProposals.length > 0}


### PR DESCRIPTION
Follow-up to the merged #419 (filter collapse). Targets the two proposal admin pages on mobile, from real-device feedback.

## Detail page (`/admin/proposals/[id]`)
- **AdminActionBar no longer overflows off-screen.** The action row (Edit/Preview/Email/Approve/Waitlist…) was a non-wrapping `shrink-0` row that ran off the right edge on a phone. It now stacks (info above actions) and the buttons **wrap** below `sm`, so every action stays visible and tappable. Kept wrapping rather than a `⋯` overflow menu deliberately — for a review flow, Approve/Reject should stay visible, not hidden behind a tap. Desktop unchanged.
- **Review scoring panel is no longer buried last.** On mobile the `lg:w-96` sidebar stacks below the proposal, and the review panel sat dead last — below the full proposal *plus* the post-conference published-content and audience-feedback panels. It's now ordered first in the mobile stack so a reviewer reaches scoring without scrolling past everything; desktop keeps source order.

## List page (`/admin/proposals`)
- **Collapsed Statistics header** packed its title + "(N proposals · M minutes)" into one flex row that wrapped into a ~150px block on narrow screens; stacked so it stays a compact bar.
- Tightened the mobile vertical rhythm so content sits higher. (The filter row itself is already handled by #419's AdminFilterBar collapse.)

## Verification
`pnpm typecheck` clean; `pnpm vitest run`: 116 files, 2054 passed / 5 skipped; eslint/prettier clean. Responsive-layout-only (no logic/data changes) — best verified on the Vercel preview on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the mobile layout of the proposal admin review pages. The main changes are:

- Moves the review panel ahead of post-conference panels on mobile.
- Lets the admin action bar stack and wrap below the small-screen breakpoint.
- Stacks the statistics title and count on mobile.
- Tightens vertical spacing on the proposals list page.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(admin)/admin/proposals/[id]/page.tsx | Reorders the proposal detail sidebar visually on mobile while keeping desktop order. |
| src/components/admin/AdminActionBar.tsx | Changes the action bar to stack info above actions and wrap buttons on narrow screens. |
| src/components/admin/ProposalStatistics.tsx | Stacks the collapsed statistics title and count on mobile and preserves the toggle structure. |
| src/components/admin/ProposalsList.tsx | Reduces mobile spacing around the statistics section and proposal list. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): optimise proposal review for..."](https://github.com/cloudnativebergen/website/commit/7be0c8e6e06def5e4c974d8c9209c73d573a1ba4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44283195)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->