### PR TITLE
feat(admin): responsive card layouts for the wide admin tables

### DIFF
--- a/src/app/(admin)/admin/tickets/TicketBreakdownTables.tsx
+++ b/src/app/(admin)/admin/tickets/TicketBreakdownTables.tsx
@@ -1,0 +1,285 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { DataTable, type Column } from '@/components/DataTable'
+import { formatCurrency } from '@/lib/format'
+import { SPONSOR_TIER_TICKET_ALLOCATION } from '@/lib/tickets/config'
+import {
+  calculateFreeTicketClaimRate,
+  type CategoryStat,
+  type FreeTicketAllocation,
+  type SponsorTicketData,
+} from '@/lib/tickets/utils'
+
+type PillColor = 'purple' | 'blue' | 'green' | 'indigo'
+
+const pillColorClasses: Record<PillColor, string> = {
+  purple:
+    'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300',
+  blue: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
+  green: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+  indigo:
+    'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-300',
+}
+
+function Pill({ color, children }: { color: PillColor; children: ReactNode }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${pillColorClasses[color]}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+function ProgressBar({
+  percentage,
+  color,
+}: {
+  percentage: number
+  color: 'blue' | 'purple'
+}) {
+  const barColor = color === 'blue' ? 'bg-blue-600' : 'bg-purple-600'
+  return (
+    <div className="flex items-center justify-end md:justify-start">
+      <div className="mr-2 text-xs">{percentage.toFixed(1)}%</div>
+      <div className="h-2 w-16 rounded-full bg-gray-200">
+        <div
+          className={`h-2 rounded-full ${barColor}`}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Free Ticket Allocation & Usage                                             */
+/* -------------------------------------------------------------------------- */
+
+interface FreeAllocationRow {
+  key: string
+  category: string
+  allocated: number
+  pill: PillColor
+  status: string
+}
+
+export function FreeTicketAllocationTable({
+  allocation,
+}: {
+  allocation: FreeTicketAllocation
+}) {
+  const rows: FreeAllocationRow[] = [
+    {
+      key: 'sponsors',
+      category: 'Sponsors',
+      allocated: allocation.sponsorTickets,
+      pill: 'purple',
+      status: 'Based on sponsor tier agreements',
+    },
+    {
+      key: 'speakers',
+      category: 'Confirmed Speakers',
+      allocated: allocation.speakerTickets,
+      pill: 'blue',
+      status: 'One ticket per confirmed speaker',
+    },
+    {
+      key: 'organizers',
+      category: 'Organizers',
+      allocated: allocation.organizerTickets,
+      pill: 'green',
+      status: 'Conference organizers',
+    },
+  ]
+
+  const columns: Column<FreeAllocationRow>[] = [
+    {
+      key: 'category',
+      header: 'Category',
+      primary: true,
+      render: (row) => (
+        <span className="font-medium text-gray-900 dark:text-white">
+          {row.category}
+        </span>
+      ),
+    },
+    {
+      key: 'allocated',
+      header: 'Allocated',
+      render: (row) => <Pill color={row.pill}>{row.allocated}</Pill>,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (row) => (
+        <span className="text-gray-500 dark:text-gray-400">{row.status}</span>
+      ),
+    },
+  ]
+
+  const claimRate = calculateFreeTicketClaimRate(
+    allocation.totalClaimed,
+    allocation.totalAllocated,
+  )
+
+  return (
+    <>
+      <DataTable<FreeAllocationRow>
+        data={rows}
+        columns={columns}
+        keyExtractor={(row) => row.key}
+      />
+      {/* Totals row (DataTable has no footer slot, rendered separately). */}
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-900 md:rounded-lg dark:border-gray-700 dark:bg-gray-800 dark:text-white">
+        <span>Total</span>
+        <div className="flex items-center gap-3">
+          <Pill color="indigo">{allocation.totalAllocated}</Pill>
+          <span className="font-normal text-gray-900 dark:text-white">
+            {allocation.totalClaimed} claimed ({claimRate.toFixed(1)}%)
+          </span>
+        </div>
+      </div>
+    </>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Breakdown by Ticket Type                                                   */
+/* -------------------------------------------------------------------------- */
+
+export function CategoryBreakdownTable({ stats }: { stats: CategoryStat[] }) {
+  const columns: Column<CategoryStat>[] = [
+    {
+      key: 'category',
+      header: 'Ticket Type',
+      primary: true,
+      render: (stat) => (
+        <span className="font-medium text-gray-900 dark:text-white">
+          {stat.category}
+        </span>
+      ),
+    },
+    {
+      key: 'count',
+      header: 'Tickets Sold',
+      render: (stat) => <Pill color="blue">{stat.count}</Pill>,
+    },
+    {
+      key: 'orders',
+      header: 'Orders',
+      render: (stat) => (
+        <span className="text-gray-900 dark:text-white">{stat.orders}</span>
+      ),
+    },
+    {
+      key: 'revenue',
+      header: 'Revenue',
+      render: (stat) => (
+        <span className="font-medium text-green-600 dark:text-green-400">
+          {formatCurrency(stat.revenue)}
+        </span>
+      ),
+    },
+    {
+      key: 'percentage',
+      header: 'Percentage',
+      render: (stat) => (
+        <ProgressBar percentage={stat.percentage} color="blue" />
+      ),
+    },
+  ]
+
+  return (
+    <DataTable<CategoryStat>
+      data={stats}
+      columns={columns}
+      keyExtractor={(stat) => stat.category}
+    />
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Sponsor Ticket Allocations                                                 */
+/* -------------------------------------------------------------------------- */
+
+interface SponsorAllocationRow {
+  tierName: string
+  sponsors: number
+  ticketsPerSponsor: number
+  tickets: number
+  percentage: number
+}
+
+export function SponsorAllocationTable({
+  tierData,
+  totalSponsorTickets,
+}: {
+  tierData: Record<string, SponsorTicketData>
+  totalSponsorTickets: number
+}) {
+  const rows: SponsorAllocationRow[] = Object.entries(tierData)
+    .sort(([, a], [, b]) => b.tickets - a.tickets)
+    .map(([tierName, data]) => ({
+      tierName,
+      sponsors: data.sponsors,
+      ticketsPerSponsor: SPONSOR_TIER_TICKET_ALLOCATION[tierName] || 0,
+      tickets: data.tickets,
+      percentage:
+        totalSponsorTickets > 0
+          ? (data.tickets / totalSponsorTickets) * 100
+          : 0,
+    }))
+
+  const columns: Column<SponsorAllocationRow>[] = [
+    {
+      key: 'tierName',
+      header: 'Sponsor Tier',
+      primary: true,
+      render: (row) => (
+        <span className="font-medium text-gray-900 dark:text-white">
+          {row.tierName}
+        </span>
+      ),
+    },
+    {
+      key: 'sponsors',
+      header: 'Sponsors',
+      render: (row) => <Pill color="purple">{row.sponsors}</Pill>,
+    },
+    {
+      key: 'ticketsPerSponsor',
+      header: 'Tickets per Sponsor',
+      render: (row) => (
+        <span className="text-gray-900 dark:text-white">
+          {row.ticketsPerSponsor}
+        </span>
+      ),
+    },
+    {
+      key: 'tickets',
+      header: 'Total Tickets',
+      render: (row) => (
+        <span className="font-medium text-purple-600 dark:text-purple-400">
+          {row.tickets}
+        </span>
+      ),
+    },
+    {
+      key: 'percentage',
+      header: 'Percentage',
+      render: (row) => (
+        <ProgressBar percentage={row.percentage} color="purple" />
+      ),
+    },
+  ]
+
+  return (
+    <DataTable<SponsorAllocationRow>
+      data={rows}
+      columns={columns}
+      keyExtractor={(row) => row.tierName}
+    />
+  )
+}

--- a/src/app/(admin)/admin/tickets/companies/CompanyBreakdownTable.tsx
+++ b/src/app/(admin)/admin/tickets/companies/CompanyBreakdownTable.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { DataTable, type Column } from '@/components/DataTable'
+
+export interface CompanyBreakdownRow {
+  originalName: string
+  normalizedName: string
+  attendeeCount: number
+  orderCount: number
+}
+
+export function CompanyBreakdownTable({
+  companies,
+  totalAttendees,
+}: {
+  companies: CompanyBreakdownRow[]
+  totalAttendees: number
+}) {
+  const columns: Column<CompanyBreakdownRow>[] = [
+    {
+      key: 'rank',
+      header: 'Rank',
+      width: '80px',
+      render: (_company, index) => (
+        <span className="text-gray-500 dark:text-gray-400">#{index + 1}</span>
+      ),
+    },
+    {
+      key: 'company',
+      header: 'Company',
+      primary: true,
+      render: (company) => (
+        <div>
+          <div className="text-sm font-medium text-gray-900 dark:text-white">
+            {company.originalName}
+          </div>
+          {company.normalizedName !== company.originalName.toLowerCase() && (
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              Normalized: {company.normalizedName}
+            </div>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'attendees',
+      header: 'Attendees',
+      render: (company) => (
+        <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-300">
+          {company.attendeeCount}{' '}
+          {company.attendeeCount === 1 ? 'ticket' : 'tickets'}
+        </span>
+      ),
+    },
+    {
+      key: 'orders',
+      header: 'Orders',
+      render: (company) => (
+        <span className="text-gray-900 dark:text-white">
+          {company.orderCount}
+        </span>
+      ),
+    },
+  ]
+
+  return (
+    <>
+      <DataTable<CompanyBreakdownRow>
+        data={companies}
+        columns={columns}
+        keyExtractor={(company) => company.normalizedName}
+      />
+      {/* Summary footer (DataTable has no footer slot, rendered separately). */}
+      <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 px-6 py-4 text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
+        Showing {companies.length} companies with {totalAttendees} total
+        attendees (excluding speaker tickets)
+      </div>
+    </>
+  )
+}

--- a/src/app/(admin)/admin/tickets/companies/page.tsx
+++ b/src/app/(admin)/admin/tickets/companies/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { EmptyState } from '@/components/EmptyState'
+import { CompanyBreakdownTable } from './CompanyBreakdownTable'
 
 async function getTicketData(
   customerId: number,
@@ -310,69 +311,10 @@ export default async function CompaniesAdminPage() {
             className="rounded-lg bg-white p-12 shadow dark:bg-gray-900"
           />
         ) : (
-          <div className="overflow-hidden rounded-lg bg-white shadow dark:bg-gray-900">
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-800">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                      Rank
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                      Company
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                      Attendees
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                      Orders
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-                  {companyBreakdown.map((company, index) => (
-                    <tr
-                      key={company.normalizedName}
-                      className="hover:bg-gray-50 dark:hover:bg-gray-800"
-                    >
-                      <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                        #{index + 1}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm font-medium text-gray-900 dark:text-white">
-                          {company.originalName}
-                        </div>
-                        {company.normalizedName !==
-                          company.originalName.toLowerCase() && (
-                          <div className="text-xs text-gray-500 dark:text-gray-400">
-                            Normalized: {company.normalizedName}
-                          </div>
-                        )}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="flex items-center">
-                          <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-                            {company.attendeeCount}{' '}
-                            {company.attendeeCount === 1 ? 'ticket' : 'tickets'}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                        {company.orderCount}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            <div className="border-t border-gray-200 bg-gray-50 px-6 py-4 dark:border-gray-700 dark:bg-gray-800">
-              <div className="text-sm text-gray-500 dark:text-gray-400">
-                Showing {companyBreakdown.length} companies with{' '}
-                {totalAttendees} total attendees (excluding speaker tickets)
-              </div>
-            </div>
-          </div>
+          <CompanyBreakdownTable
+            companies={companyBreakdown}
+            totalAttendees={totalAttendees}
+          />
         )}
       </div>
 

--- a/src/app/(admin)/admin/tickets/page.tsx
+++ b/src/app/(admin)/admin/tickets/page.tsx
@@ -10,6 +10,11 @@ import {
 } from '@/components/admin'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
 import {
+  FreeTicketAllocationTable,
+  CategoryBreakdownTable,
+  SponsorAllocationTable,
+} from './TicketBreakdownTables'
+import {
   TicketIcon,
   ShoppingBagIcon,
   HomeIcon,
@@ -18,7 +23,6 @@ import {
   QueueListIcon,
 } from '@heroicons/react/24/outline'
 
-import { formatCurrency } from '@/lib/format'
 import {
   SPONSOR_TIER_TICKET_ALLOCATION,
   DEFAULT_TARGET_CONFIG,
@@ -29,7 +33,6 @@ import {
   calculateSponsorTickets,
   calculateFreeTicketAllocation,
   calculateTicketStatistics,
-  calculateFreeTicketClaimRate,
   deduplicateTicketsByEmail,
 } from '@/lib/tickets/utils'
 import { getSpeakers, getOrganizerCount } from '@/lib/speaker/sanity'
@@ -246,93 +249,7 @@ export default async function AdminTickets() {
           title="Free Ticket Allocation & Usage"
           defaultOpen={true}
         >
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-              <thead className="bg-gray-50 dark:bg-gray-800">
-                <tr>
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                  >
-                    Category
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                  >
-                    Allocated
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                  >
-                    Status
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-                <tr className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                  <td className="px-6 py-4 text-sm font-medium whitespace-nowrap text-gray-900 dark:text-white">
-                    Sponsors
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                    <span className="inline-flex items-center rounded-full bg-purple-100 px-2.5 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-300">
-                      {freeTicketAllocation.sponsorTickets}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                    Based on sponsor tier agreements
-                  </td>
-                </tr>
-                <tr className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                  <td className="px-6 py-4 text-sm font-medium whitespace-nowrap text-gray-900 dark:text-white">
-                    Confirmed Speakers
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                    <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-                      {freeTicketAllocation.speakerTickets}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                    One ticket per confirmed speaker
-                  </td>
-                </tr>
-                <tr className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                  <td className="px-6 py-4 text-sm font-medium whitespace-nowrap text-gray-900 dark:text-white">
-                    Organizers
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                    <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-300">
-                      {freeTicketAllocation.organizerTickets}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                    Conference organizers
-                  </td>
-                </tr>
-                <tr className="bg-gray-50 font-semibold dark:bg-gray-800">
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                    Total
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                    <span className="inline-flex items-center rounded-full bg-indigo-100 px-2.5 py-0.5 text-xs font-medium text-indigo-800 dark:bg-indigo-900 dark:text-indigo-300">
-                      {freeTicketAllocation.totalAllocated}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap">
-                    <span className="text-gray-900 dark:text-white">
-                      {freeTicketAllocation.totalClaimed} claimed (
-                      {calculateFreeTicketClaimRate(
-                        freeTicketAllocation.totalClaimed,
-                        freeTicketAllocation.totalAllocated,
-                      ).toFixed(1)}
-                      %)
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          <FreeTicketAllocationTable allocation={freeTicketAllocation} />
           <div className="mt-4 text-sm text-gray-600 dark:text-gray-400">
             <p>
               <strong>Note:</strong> Free tickets are allocated to sponsors
@@ -351,88 +268,7 @@ export default async function AdminTickets() {
             title="Breakdown by Ticket Type"
             defaultOpen={false}
           >
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-800">
-                  <tr>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Ticket Type
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Tickets Sold
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Orders
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Revenue
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Percentage
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-                  {categoryStats.map((stat) => (
-                    <tr
-                      key={stat.category}
-                      className="hover:bg-gray-50 dark:hover:bg-gray-800"
-                    >
-                      <td className="px-6 py-4 text-sm font-medium whitespace-nowrap text-gray-900 dark:text-white">
-                        {stat.category}
-                      </td>
-                      <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                        <span className="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-                          {stat.count}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                        {stat.orders}
-                      </td>
-                      <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                        <span className="font-medium text-green-600 dark:text-green-400">
-                          {formatCurrency(stat.revenue)}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                        <div className="flex items-center">
-                          <div className="flex-1">
-                            <div className="flex items-center">
-                              <div className="mr-2 text-xs">
-                                {stat.percentage.toFixed(1)}%
-                              </div>
-                              <div className="h-2 w-16 rounded-full bg-gray-200">
-                                <div
-                                  className="h-2 rounded-full bg-blue-600"
-                                  style={{
-                                    width: `${stat.percentage}%`,
-                                  }}
-                                ></div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <CategoryBreakdownTable stats={categoryStats} />
           </CollapsibleSection>
         </div>
       )}
@@ -444,100 +280,10 @@ export default async function AdminTickets() {
             title="Sponsor Ticket Allocations"
             defaultOpen={false}
           >
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-800">
-                  <tr>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Sponsor Tier
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Sponsors
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Tickets per Sponsor
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Total Tickets
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Percentage
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-                  {Object.entries(sponsorTicketsByTier)
-                    .sort(([, a], [, b]) => b.tickets - a.tickets)
-                    .map(([tierName, tierData]) => {
-                      const ticketsPerSponsor =
-                        SPONSOR_TIER_TICKET_ALLOCATION[tierName] || 0
-
-                      return (
-                        <tr
-                          key={tierName}
-                          className="hover:bg-gray-50 dark:hover:bg-gray-800"
-                        >
-                          <td className="px-6 py-4 text-sm font-medium whitespace-nowrap text-gray-900 dark:text-white">
-                            {tierName}
-                          </td>
-                          <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                            <span className="inline-flex items-center rounded-full bg-purple-100 px-2.5 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-300">
-                              {tierData.sponsors}
-                            </span>
-                          </td>
-                          <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                            {ticketsPerSponsor}
-                          </td>
-                          <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                            <span className="font-medium text-purple-600 dark:text-purple-400">
-                              {tierData.tickets}
-                            </span>
-                          </td>
-                          <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                            <div className="flex items-center">
-                              <div className="flex-1">
-                                <div className="flex items-center">
-                                  <div className="mr-2 text-xs">
-                                    {(
-                                      (tierData.tickets /
-                                        statistics.sponsorTickets) *
-                                      100
-                                    ).toFixed(1)}
-                                    %
-                                  </div>
-                                  <div className="h-2 w-16 rounded-full bg-gray-200">
-                                    <div
-                                      className="h-2 rounded-full bg-purple-600"
-                                      style={{
-                                        width: `${(tierData.tickets / statistics.sponsorTickets) * 100}%`,
-                                      }}
-                                    ></div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </td>
-                        </tr>
-                      )
-                    })}
-                </tbody>
-              </table>
-            </div>
+            <SponsorAllocationTable
+              tierData={sponsorTicketsByTier}
+              totalSponsorTickets={statistics.sponsorTickets}
+            />
             <div className="mt-4 text-sm text-gray-600 dark:text-gray-400">
               <p>
                 <strong>Note:</strong> Sponsor tickets are allocated through

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -485,8 +485,11 @@ export const InteractionTest: StoryObj = {
     )
   },
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
-    const firstRow = canvas.getByText('Alice Johnson').closest('tr')
+    // Card mode also renders each value in a mobile card (CSS-hidden at desktop
+    // width), so scope the query to the table subtree to avoid duplicate matches.
+    const table = canvasElement.querySelector('table')
+    if (!table) throw new Error('table not rendered')
+    const firstRow = within(table).getByText('Alice Johnson').closest('tr')
     if (firstRow) {
       firstRow.click()
       // Note: fn() in render doesn't persist for testing, so we just verify the row is clickable

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -129,6 +129,39 @@ export const Default: StoryObj = {
   ),
 }
 
+export const MobileCards: StoryObj = {
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+    docs: {
+      description: {
+        story:
+          'Below `md`, rows collapse into stacked label/value cards (the default `mobileVariant="cards"`). The `primary` column becomes the card title; `cardHidden` columns are omitted. View at a phone width to see the cards; at `md+` the same data renders as the table.',
+      },
+    },
+  },
+  render: () => (
+    <DataTable<SampleItem>
+      data={sampleData}
+      columns={[
+        { key: 'name', header: 'Name', primary: true },
+        { key: 'email', header: 'Email' },
+        { key: 'role', header: 'Role' },
+        {
+          key: 'status',
+          header: 'Status',
+          render: (item: SampleItem) => (
+            <StatusBadge
+              label={item.status.charAt(0).toUpperCase() + item.status.slice(1)}
+              color={getStatusColor(item.status)}
+            />
+          ),
+        },
+      ]}
+      keyExtractor={(item: SampleItem) => item.id}
+    />
+  ),
+}
+
 export const WithEmptyState: StoryObj = {
   render: () => (
     <DataTable<SampleItem>

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -82,7 +82,7 @@ export function DataTable<T>({
   )
 
   const cards =
-    mobileVariant === 'cards' ? (
+    mobileVariant === 'cards' && primaryColumn ? (
       <div className="space-y-3 md:hidden">
         {data.map((item, index) => {
           const selected = isRowSelected?.(item, index) ?? false
@@ -124,7 +124,12 @@ export function DataTable<T>({
                     {detailColumns.map((column) => (
                       <div
                         key={column.key}
-                        className="flex justify-between gap-3"
+                        className={clsx(
+                          'flex justify-between gap-3',
+                          // Honour hiddenBelow in cards too, matching the table
+                          column.hiddenBelow &&
+                            CARD_HIDDEN_BELOW[column.hiddenBelow],
+                        )}
                       >
                         <dt className="shrink-0 text-gray-500 dark:text-gray-400">
                           {column.header}
@@ -217,6 +222,18 @@ export function DataTable<T>({
       </TableContainer>
     </>
   )
+}
+
+// A card detail row is a flex element, so map hiddenBelow to flex utilities
+// (the table cells use table-cell equivalents in Th/Td).
+const CARD_HIDDEN_BELOW: Record<
+  NonNullable<Column<unknown>['hiddenBelow']>,
+  string
+> = {
+  sm: 'hidden sm:flex',
+  md: 'hidden md:flex',
+  lg: 'hidden lg:flex',
+  xl: 'hidden xl:flex',
 }
 
 function getCellValue<T>(item: T, key: string): string {

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -15,6 +15,13 @@ export interface Column<T> {
   hiddenBelow?: 'sm' | 'md' | 'lg' | 'xl'
   render?: (item: T, index: number) => ReactNode
   className?: string
+  /**
+   * Marks the column shown as the card title in the mobile card layout.
+   * If no column is marked primary, the first column is used.
+   */
+  primary?: boolean
+  /** Omit this column from the mobile card layout (e.g. redundant/duplicated). */
+  cardHidden?: boolean
 }
 
 export interface DataTableProps<T> {
@@ -31,6 +38,14 @@ export interface DataTableProps<T> {
   isRowSelected?: (item: T, index: number) => boolean
   tableClassName?: string
   className?: string
+  /**
+   * How the table renders below `md`. `cards` (default) stacks each row into a
+   * label/value card — the mobile-friendly default. `scroll` keeps the table
+   * and lets it scroll horizontally (use for tables that read poorly as cards).
+   */
+  mobileVariant?: 'cards' | 'scroll'
+  /** Full override for a mobile card's body; receives the item and its index. */
+  renderCard?: (item: T, index: number) => ReactNode
 }
 
 export function DataTable<T>({
@@ -42,6 +57,8 @@ export function DataTable<T>({
   isRowSelected,
   tableClassName,
   className,
+  mobileVariant = 'cards',
+  renderCard,
 }: DataTableProps<T>) {
   if (data.length === 0) {
     if (emptyState) {
@@ -59,77 +76,155 @@ export function DataTable<T>({
     return null
   }
 
+  const primaryColumn = columns.find((column) => column.primary) ?? columns[0]
+  const detailColumns = columns.filter(
+    (column) => column !== primaryColumn && !column.cardHidden,
+  )
+
+  const cards =
+    mobileVariant === 'cards' ? (
+      <div className="space-y-3 md:hidden">
+        {data.map((item, index) => {
+          const selected = isRowSelected?.(item, index) ?? false
+          const clickable = Boolean(onRowClick)
+          return (
+            <div
+              key={keyExtractor(item, index)}
+              role={clickable ? 'button' : undefined}
+              tabIndex={clickable ? 0 : undefined}
+              onClick={clickable ? () => onRowClick!(item, index) : undefined}
+              onKeyDown={
+                clickable
+                  ? (event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        onRowClick!(item, index)
+                      }
+                    }
+                  : undefined
+              }
+              className={clsx(
+                'rounded-lg border p-4 text-sm shadow-sm',
+                'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900',
+                clickable &&
+                  'cursor-pointer hover:border-gray-300 dark:hover:border-gray-600',
+                selected && 'ring-2 ring-brand-cloud-blue dark:ring-blue-500',
+              )}
+            >
+              {renderCard ? (
+                renderCard(item, index)
+              ) : (
+                <div className="min-h-[44px] space-y-2">
+                  <div className="font-medium text-gray-900 dark:text-white">
+                    {primaryColumn.render
+                      ? primaryColumn.render(item, index)
+                      : getCellValue(item, primaryColumn.key)}
+                  </div>
+                  <dl className="space-y-1">
+                    {detailColumns.map((column) => (
+                      <div
+                        key={column.key}
+                        className="flex justify-between gap-3"
+                      >
+                        <dt className="shrink-0 text-gray-500 dark:text-gray-400">
+                          {column.header}
+                        </dt>
+                        <dd className="text-right text-gray-900 dark:text-gray-200">
+                          {column.render
+                            ? column.render(item, index)
+                            : getCellValue(item, column.key)}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    ) : null
+
+  const tableWrapperClass =
+    mobileVariant === 'cards' ? 'hidden md:block' : undefined
+
   return (
-    <TableContainer className={className}>
-      <table
-        className={clsx(
-          'min-w-full divide-y divide-gray-300 dark:divide-gray-700',
-          tableClassName,
-        )}
-      >
-        <TableHeader>
-          <tr>
-            {columns.map((column) => (
-              <Th
-                key={column.key}
-                width={column.width}
-                align={column.align}
-                hiddenBelow={column.hiddenBelow}
-                className={column.className}
-              >
-                {column.header}
-              </Th>
-            ))}
-          </tr>
-        </TableHeader>
-        <TableBody>
-          {data.map((item, index) => {
-            const handleRowClick = onRowClick
-              ? () => onRowClick(item, index)
-              : undefined
+    <>
+      {cards}
+      <TableContainer className={clsx(tableWrapperClass, className)}>
+        <table
+          className={clsx(
+            'min-w-full divide-y divide-gray-300 dark:divide-gray-700',
+            tableClassName,
+          )}
+        >
+          <TableHeader>
+            <tr>
+              {columns.map((column) => (
+                <Th
+                  key={column.key}
+                  width={column.width}
+                  align={column.align}
+                  hiddenBelow={column.hiddenBelow}
+                  className={column.className}
+                >
+                  {column.header}
+                </Th>
+              ))}
+            </tr>
+          </TableHeader>
+          <TableBody>
+            {data.map((item, index) => {
+              const handleRowClick = onRowClick
+                ? () => onRowClick(item, index)
+                : undefined
 
-            const handleRowKeyDown = onRowClick
-              ? (event: KeyboardEvent<HTMLTableRowElement>) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault()
-                    onRowClick(item, index)
+              const handleRowKeyDown = onRowClick
+                ? (event: KeyboardEvent<HTMLTableRowElement>) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      onRowClick(item, index)
+                    }
                   }
-                }
-              : undefined
+                : undefined
 
-            return (
-              <Tr
-                key={keyExtractor(item, index)}
-                role={onRowClick ? 'button' : undefined}
-                tabIndex={onRowClick ? 0 : undefined}
-                onClick={handleRowClick}
-                onKeyDown={handleRowKeyDown}
-                selected={isRowSelected ? isRowSelected(item, index) : false}
-              >
-                {columns.map((column) => (
-                  <Td
-                    key={column.key}
-                    align={column.align}
-                    hiddenBelow={column.hiddenBelow}
-                    className={column.className}
-                  >
-                    {column.render
-                      ? column.render(item, index)
-                      : String(
-                          typeof item === 'object' &&
-                            item !== null &&
-                            (item as Record<string, unknown>)[column.key] !==
-                              undefined
-                            ? (item as Record<string, unknown>)[column.key]
-                            : '',
-                        )}
-                  </Td>
-                ))}
-              </Tr>
-            )
-          })}
-        </TableBody>
-      </table>
-    </TableContainer>
+              return (
+                <Tr
+                  key={keyExtractor(item, index)}
+                  role={onRowClick ? 'button' : undefined}
+                  tabIndex={onRowClick ? 0 : undefined}
+                  onClick={handleRowClick}
+                  onKeyDown={handleRowKeyDown}
+                  selected={isRowSelected ? isRowSelected(item, index) : false}
+                >
+                  {columns.map((column) => (
+                    <Td
+                      key={column.key}
+                      align={column.align}
+                      hiddenBelow={column.hiddenBelow}
+                      className={column.className}
+                    >
+                      {column.render
+                        ? column.render(item, index)
+                        : getCellValue(item, column.key)}
+                    </Td>
+                  ))}
+                </Tr>
+              )
+            })}
+          </TableBody>
+        </table>
+      </TableContainer>
+    </>
+  )
+}
+
+function getCellValue<T>(item: T, key: string): string {
+  return String(
+    typeof item === 'object' &&
+      item !== null &&
+      (item as Record<string, unknown>)[key] !== undefined
+      ? (item as Record<string, unknown>)[key]
+      : '',
   )
 }

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -38,6 +38,7 @@ import {
   ActionMenuItem,
   ActionMenuDivider,
 } from '@/components/ActionMenu'
+import { DataTable, type Column } from '@/components/DataTable'
 import type { Speaker } from '@/lib/speaker/types'
 import type { ProposalExisting } from '@/lib/proposal/types'
 
@@ -351,6 +352,139 @@ export function BadgeManagementClient({
 
   const isDevelopment = isLocalhostClient()
 
+  const columns: Column<SpeakerWithProposals>[] = [
+    {
+      key: 'speaker',
+      header: 'Speaker',
+      primary: true,
+      render: (speaker) => {
+        const isSelected = selectedSpeakers.has(speaker._id)
+        const hasBadge = hasExistingBadge(speaker._id)
+        return (
+          <div className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={isSelected}
+              onChange={() => handleSelectSpeaker(speaker._id)}
+              disabled={hasBadge}
+              className="text-brand-aqua focus:ring-brand-aqua rounded border-gray-300 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-brand-cloud-blue dark:focus:ring-brand-cloud-blue"
+            />
+            {speaker.image && (
+              <img
+                src={`${speaker.image}?w=80&h=80&q=85&auto=format&fit=crop`}
+                alt={speaker.name}
+                className="h-10 w-10 rounded-full object-cover"
+              />
+            )}
+            <div>
+              <div className="font-medium text-gray-900 dark:text-white">
+                {speaker.name}
+              </div>
+              {speaker.title && (
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {speaker.title}
+                </div>
+              )}
+            </div>
+          </div>
+        )
+      },
+    },
+    {
+      key: 'email',
+      header: 'Email',
+      render: (speaker) => (
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {speaker.email}
+        </span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Badge Status',
+      width: '13rem',
+      render: (speaker) => {
+        const hasBadge = hasExistingBadge(speaker._id)
+        const badge = getBadgeForSpeaker(speaker._id)
+        const hasEmailError = badge && !badge.emailSent && badge.emailError
+        return hasBadge && badge ? (
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              {hasEmailError ? (
+                <StatusBadge
+                  label="Email Failed"
+                  color="red"
+                  icon={ExclamationTriangleIcon}
+                />
+              ) : (
+                <StatusBadge label="Issued" color="green" icon={CheckIcon} />
+              )}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              {new Date(badge.issuedAt).toLocaleDateString()}
+            </div>
+            {hasEmailError && badge.emailError && (
+              <div className="text-xs text-red-600 dark:text-red-400">
+                {badge.emailError}
+              </div>
+            )}
+          </div>
+        ) : (
+          <StatusBadge label="Not Issued" color="gray" />
+        )
+      },
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      align: 'right',
+      width: '11rem',
+      render: (speaker) => {
+        const hasBadge = hasExistingBadge(speaker._id)
+        const badge = getBadgeForSpeaker(speaker._id)
+        return hasBadge && badge ? (
+          <ActionMenu ariaLabel="Badge actions">
+            <ActionMenuItem
+              onClick={() => handleViewBadge(badge)}
+              icon={EyeIcon}
+            >
+              View Badge
+            </ActionMenuItem>
+            <ActionMenuItem
+              onClick={() => handleCopyBadgeUrl(badge.badgeId, speaker.name)}
+              icon={ClipboardDocumentIcon}
+            >
+              Copy URL
+            </ActionMenuItem>
+            <ActionMenuItem
+              onClick={() => {}}
+              icon={ArrowDownTrayIcon}
+              href={`/api/badge/${badge.badgeId}/download`}
+              download
+            >
+              Download
+            </ActionMenuItem>
+            {isDevelopment && (
+              <>
+                <ActionMenuDivider />
+                <ActionMenuItem
+                  onClick={() => handleDeleteBadge(badge.badgeId, speaker.name)}
+                  icon={TrashIcon}
+                  variant="danger"
+                  disabled={deleteMutation.isPending}
+                >
+                  Delete
+                </ActionMenuItem>
+              </>
+            )}
+          </ActionMenu>
+        ) : (
+          <span className="text-xs text-gray-400 dark:text-gray-500">—</span>
+        )
+      },
+    },
+  ]
+
   return (
     <div className="space-y-6">
       {/* Tab Navigation */}
@@ -530,216 +664,44 @@ export function BadgeManagementClient({
             </div>
           </div>
 
-          <div className="text-sm text-gray-500 dark:text-gray-400">
-            Showing {eligibleSpeakers.length} of {eligibleSpeakers.length}{' '}
-            speakers
+          <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+            {eligibleSpeakers.length > 0 && (
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={
+                    eligibleSpeakers.length > 0 &&
+                    selectedSpeakers.size === eligibleSpeakers.length
+                  }
+                  onChange={handleSelectAll}
+                  className="text-brand-aqua focus:ring-brand-aqua rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-brand-cloud-blue dark:focus:ring-brand-cloud-blue"
+                />
+                Select all
+              </label>
+            )}
+            <span>
+              Showing {eligibleSpeakers.length} of {eligibleSpeakers.length}{' '}
+              speakers
+            </span>
           </div>
 
           {/* Speakers Table */}
-          <div className="overflow-x-auto">
-            <div className="overflow-hidden shadow-sm ring-1 ring-gray-200 md:rounded-lg dark:ring-gray-700">
-              <table className="w-full table-fixed divide-y divide-gray-300 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-800">
-                  <tr>
-                    <th scope="col" className="w-12 px-4 py-3">
-                      <input
-                        type="checkbox"
-                        checked={
-                          eligibleSpeakers.length > 0 &&
-                          selectedSpeakers.size === eligibleSpeakers.length
-                        }
-                        onChange={handleSelectAll}
-                        className="text-brand-aqua focus:ring-brand-aqua rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-brand-cloud-blue dark:focus:ring-brand-cloud-blue"
-                      />
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-4 py-3 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Speaker
-                    </th>
-                    <th
-                      scope="col"
-                      className="px-4 py-3 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Email
-                    </th>
-                    <th
-                      scope="col"
-                      className="w-52 px-4 py-3 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Badge Status
-                    </th>
-                    <th
-                      scope="col"
-                      className="w-44 px-4 py-3 text-right text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-                  {eligibleSpeakers.length === 0 ? (
-                    <tr>
-                      <td colSpan={5} className="px-4 py-12 text-center">
-                        <div className="text-gray-500 dark:text-gray-400">
-                          {badgeType === 'speaker' ? (
-                            <p>
-                              No eligible speakers found. Speakers must have
-                              accepted or confirmed talks.
-                            </p>
-                          ) : (
-                            <p>No organizers found.</p>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  ) : (
-                    eligibleSpeakers.map((speaker: SpeakerWithProposals) => {
-                      const isSelected = selectedSpeakers.has(speaker._id)
-                      const hasBadge = hasExistingBadge(speaker._id)
-                      const badge = getBadgeForSpeaker(speaker._id)
-                      const hasEmailError =
-                        badge && !badge.emailSent && badge.emailError
-
-                      return (
-                        <tr
-                          key={speaker._id}
-                          className={`${
-                            isSelected
-                              ? 'bg-brand-sky-mist dark:bg-brand-cloud-blue/10'
-                              : hasBadge
-                                ? 'bg-gray-50 dark:bg-gray-900/50'
-                                : 'hover:bg-gray-50 dark:hover:bg-gray-900/50'
-                          } transition-colors`}
-                        >
-                          <td className="px-4 py-4">
-                            <input
-                              type="checkbox"
-                              checked={isSelected}
-                              onChange={() => handleSelectSpeaker(speaker._id)}
-                              disabled={hasBadge}
-                              className="text-brand-aqua focus:ring-brand-aqua rounded border-gray-300 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-brand-cloud-blue dark:focus:ring-brand-cloud-blue"
-                            />
-                          </td>
-                          <td className="px-4 py-4">
-                            <div className="flex items-center gap-3">
-                              {speaker.image && (
-                                <img
-                                  src={`${speaker.image}?w=80&h=80&q=85&auto=format&fit=crop`}
-                                  alt={speaker.name}
-                                  className="h-10 w-10 rounded-full object-cover"
-                                />
-                              )}
-                              <div>
-                                <div className="font-medium text-gray-900 dark:text-white">
-                                  {speaker.name}
-                                </div>
-                                {speaker.title && (
-                                  <div className="text-sm text-gray-500 dark:text-gray-400">
-                                    {speaker.title}
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                          </td>
-                          <td className="px-4 py-4 text-sm text-gray-500 dark:text-gray-400">
-                            {speaker.email}
-                          </td>
-                          <td className="px-4 py-4">
-                            {hasBadge && badge ? (
-                              <div className="space-y-1">
-                                <div className="flex items-center gap-2">
-                                  {hasEmailError ? (
-                                    <StatusBadge
-                                      label="Email Failed"
-                                      color="red"
-                                      icon={ExclamationTriangleIcon}
-                                    />
-                                  ) : (
-                                    <StatusBadge
-                                      label="Issued"
-                                      color="green"
-                                      icon={CheckIcon}
-                                    />
-                                  )}
-                                </div>
-                                <div className="text-xs text-gray-500 dark:text-gray-400">
-                                  {new Date(
-                                    badge.issuedAt,
-                                  ).toLocaleDateString()}
-                                </div>
-                                {hasEmailError && badge.emailError && (
-                                  <div className="text-xs text-red-600 dark:text-red-400">
-                                    {badge.emailError}
-                                  </div>
-                                )}
-                              </div>
-                            ) : (
-                              <StatusBadge label="Not Issued" color="gray" />
-                            )}
-                          </td>
-                          <td className="px-4 py-4 text-right">
-                            {hasBadge && badge ? (
-                              <ActionMenu ariaLabel="Badge actions">
-                                <ActionMenuItem
-                                  onClick={() => handleViewBadge(badge)}
-                                  icon={EyeIcon}
-                                >
-                                  View Badge
-                                </ActionMenuItem>
-                                <ActionMenuItem
-                                  onClick={() =>
-                                    handleCopyBadgeUrl(
-                                      badge.badgeId,
-                                      speaker.name,
-                                    )
-                                  }
-                                  icon={ClipboardDocumentIcon}
-                                >
-                                  Copy URL
-                                </ActionMenuItem>
-                                <ActionMenuItem
-                                  onClick={() => {}}
-                                  icon={ArrowDownTrayIcon}
-                                  href={`/api/badge/${badge.badgeId}/download`}
-                                  download
-                                >
-                                  Download
-                                </ActionMenuItem>
-                                {isDevelopment && (
-                                  <>
-                                    <ActionMenuDivider />
-                                    <ActionMenuItem
-                                      onClick={() =>
-                                        handleDeleteBadge(
-                                          badge.badgeId,
-                                          speaker.name,
-                                        )
-                                      }
-                                      icon={TrashIcon}
-                                      variant="danger"
-                                      disabled={deleteMutation.isPending}
-                                    >
-                                      Delete
-                                    </ActionMenuItem>
-                                  </>
-                                )}
-                              </ActionMenu>
-                            ) : (
-                              <span className="text-xs text-gray-400 dark:text-gray-500">
-                                —
-                              </span>
-                            )}
-                          </td>
-                        </tr>
-                      )
-                    })
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </div>
+          <DataTable<SpeakerWithProposals>
+            data={eligibleSpeakers}
+            columns={columns}
+            keyExtractor={(speaker) => speaker._id}
+            isRowSelected={(speaker) => selectedSpeakers.has(speaker._id)}
+            emptyState={{
+              title:
+                badgeType === 'speaker'
+                  ? 'No eligible speakers found'
+                  : 'No organizers found',
+              description:
+                badgeType === 'speaker'
+                  ? 'Speakers must have accepted or confirmed talks.'
+                  : undefined,
+            }}
+          />
 
           {/* Badge Preview Modal */}
           <Transition appear show={showPreview}>

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { formatDateSafe } from '@/lib/time'
+
 import { useState, useEffect } from 'react'
 import {
   Dialog,
@@ -421,7 +423,7 @@ export function BadgeManagementClient({
               )}
             </div>
             <div className="text-xs text-gray-500 dark:text-gray-400">
-              {new Date(badge.issuedAt).toLocaleDateString()}
+              {formatDateSafe(badge.issuedAt)}
             </div>
             {hasEmailError && badge.emailError && (
               <div className="text-xs text-red-600 dark:text-red-400">

--- a/src/components/admin/DiscountCodeManager.tsx
+++ b/src/components/admin/DiscountCodeManager.tsx
@@ -21,6 +21,7 @@ import {
   ActionMenuItem,
   ActionMenuDivider,
 } from '@/components/ActionMenu'
+import { DataTable, type Column } from '@/components/DataTable'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import type { EventDiscountWithUsage } from '@/lib/discounts/types'
 
@@ -402,6 +403,306 @@ export function DiscountCodeManager({
     })
   }
 
+  const statusColorClasses = {
+    scheduled: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    active: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    expired: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+    permanent: 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200',
+  }
+
+  const customDiscountColumns: Column<EventDiscountWithUsage>[] = [
+    {
+      key: 'code',
+      header: 'Discount Code',
+      primary: true,
+      render: (discount) => (
+        <div className="flex items-center space-x-2">
+          <span className="font-mono text-sm font-medium text-gray-900 dark:text-white">
+            {discount.triggerValue || 'N/A'}
+          </span>
+          {discount.triggerValue && (
+            <button
+              onClick={() => copyToClipboard(discount.triggerValue || '')}
+              className="inline-flex items-center rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              title="Copy discount code"
+            >
+              <ClipboardIcon className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'type',
+      header: 'Type',
+      render: (discount) => (
+        <span className="inline-flex rounded-full bg-blue-100 px-2 text-xs leading-5 font-semibold text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+          {discount.type} {discount.value}%
+        </span>
+      ),
+    },
+    {
+      key: 'value',
+      header: 'Value',
+      render: (discount) => (
+        <span className="text-sm text-gray-900 dark:text-white">
+          {discount.affects === 'total' ? 'Total Order' : discount.affects}
+          {discount.affectsValue && ` (${discount.affectsValue})`}
+        </span>
+      ),
+    },
+    {
+      key: 'usage',
+      header: 'Usage',
+      render: (discount) => (
+        <div>
+          <div className="text-sm text-gray-900 dark:text-white">
+            {discountData?.hasUsageData
+              ? `${discount.actualUsage?.usageCount || 0} / ${discount.timesTotal || '∞'}`
+              : `${discount.times || 0} / ${discount.timesTotal || '∞'}`}
+          </div>
+          <div className="text-xs text-gray-500">
+            {discount.timesTotal
+              ? discountData?.hasUsageData
+                ? `${Math.round(((discount.actualUsage?.usageCount || 0) / discount.timesTotal) * 100)}% used`
+                : `${Math.round(((discount.times || 0) / discount.timesTotal) * 100)}% used (estimated)`
+              : 'No limit'}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (discount) => {
+        const statusInfo = getDiscountStatus(discount)
+        return (
+          <span
+            className={`inline-flex rounded-full px-2 text-xs leading-5 font-semibold ${statusColorClasses[statusInfo.status as keyof typeof statusColorClasses]}`}
+          >
+            {statusInfo.label}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'affects',
+      header: 'Affects',
+      cardHidden: true,
+      render: (discount) => (
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {discount.ticketsOnly ? 'Tickets Only' : 'All Items'}
+        </span>
+      ),
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (discount) => (
+        <button
+          onClick={() => deleteDiscountCode(discount.triggerValue)}
+          disabled={loading === discount.triggerValue}
+          className="inline-flex items-center rounded-md border border-rose-300 bg-rose-50 p-2 text-rose-700 shadow-xs hover:border-rose-400 hover:bg-rose-100 hover:text-rose-800 disabled:opacity-50 dark:border-rose-500 dark:bg-rose-900/50 dark:text-rose-300 dark:hover:border-rose-400 dark:hover:bg-rose-800/60 dark:hover:text-rose-200"
+          title="Delete Code"
+        >
+          {loading === discount.triggerValue ? (
+            <ArrowPathIcon className="h-4 w-4 animate-spin" />
+          ) : (
+            <TrashIcon className="h-4 w-4" />
+          )}
+        </button>
+      ),
+    },
+  ]
+
+  const sponsorColumns: Column<SponsorWithTierInfo>[] = [
+    {
+      key: 'sponsor',
+      header: 'Sponsor',
+      primary: true,
+      render: (sponsor) => (
+        <div>
+          <div className="text-sm font-medium text-gray-900 dark:text-white">
+            {sponsor.name}
+          </div>
+          <div className="text-sm text-gray-500 dark:text-gray-400">
+            {sponsor.website}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'tierUsage',
+      header: 'Tier & Usage',
+      render: (sponsor) => {
+        const { used, total } = getSponsorUsageStats(sponsor)
+        const pillClass =
+          used === 0
+            ? 'bg-orange-100 text-orange-800 dark:bg-gray-700 dark:text-gray-300'
+            : used > total
+              ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300'
+              : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300'
+        return (
+          <div className="space-y-1">
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${pillClass}`}
+            >
+              {sponsor.tier.title}
+            </span>
+            <div className="text-sm text-gray-900 dark:text-white">
+              <span>
+                <span className="font-medium">{used}</span>
+                <span className="text-gray-500 dark:text-gray-400">
+                  {' '}
+                  / {total}
+                </span>
+                <span className="text-gray-500 dark:text-gray-400">
+                  {' '}
+                  tickets
+                </span>
+              </span>
+            </div>
+          </div>
+        )
+      },
+    },
+    {
+      key: 'eligible',
+      header: 'Eligible Ticket Types',
+      render: (sponsor) =>
+        sponsor.ticketEntitlement > 0 &&
+        getSponsorDiscounts(sponsor).length === 0 ? (
+          <FilterDropdown
+            label={
+              discountsLoading
+                ? 'Loading...'
+                : getSelectedTicketTypesDisplay(sponsor.id)
+            }
+            activeCount={selectedTicketTypes[sponsor.id]?.length || 0}
+            width="wider"
+            position="left"
+            fixedWidth={true}
+          >
+            {availableTicketTypes.map((ticketType) => (
+              <FilterOption
+                key={ticketType.id}
+                onClick={() =>
+                  toggleTicketType(sponsor.id, String(ticketType.id))
+                }
+                checked={
+                  selectedTicketTypes[sponsor.id]?.includes(
+                    String(ticketType.id),
+                  ) || false
+                }
+                type="checkbox"
+                keepOpen={true}
+              >
+                {ticketType.name}
+              </FilterOption>
+            ))}
+          </FilterDropdown>
+        ) : getSponsorDiscounts(sponsor).length > 0 ? (
+          <div className="text-sm text-gray-900 dark:text-white">
+            <div className="font-medium">
+              {getExistingDiscountTicketTypes(sponsor)}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              Discount code created
+            </div>
+          </div>
+        ) : (
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            No ticket entitlement
+          </span>
+        ),
+    },
+    {
+      key: 'codes',
+      header: 'Discount Codes',
+      render: (sponsor) =>
+        getSponsorDiscounts(sponsor).length > 0 ? (
+          <div className="space-y-1">
+            {getSponsorDiscounts(sponsor).map((discount, index) => (
+              <div key={index} className="flex items-center space-x-2">
+                <span className="font-mono text-sm font-medium text-gray-900 dark:text-white">
+                  {discount.triggerValue || 'N/A'}
+                </span>
+                <button
+                  onClick={() => copyToClipboard(discount.triggerValue || '')}
+                  className="inline-flex items-center rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+                  title="Copy discount code"
+                >
+                  <ClipboardIcon className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            No codes created
+          </span>
+        ),
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      align: 'right',
+      render: (sponsor) =>
+        getSponsorDiscounts(sponsor).length > 0 ? (
+          <ActionMenu ariaLabel={`Actions for ${sponsor.name}`}>
+            <ActionMenuItem
+              onClick={() => {
+                const sponsorDiscounts = getSponsorDiscounts(sponsor)
+                if (sponsorDiscounts.length > 0) {
+                  openEmailModal(
+                    sponsor,
+                    sponsorDiscounts[0].triggerValue || '',
+                  )
+                }
+              }}
+              icon={EnvelopeIcon}
+              disabled={loading !== null}
+            >
+              Send Email
+            </ActionMenuItem>
+            <ActionMenuDivider />
+            <ActionMenuItem
+              onClick={() => {
+                const sponsorDiscounts = getSponsorDiscounts(sponsor)
+                if (sponsorDiscounts.length > 0) {
+                  deleteDiscountCode(sponsorDiscounts[0].triggerValue)
+                }
+              }}
+              icon={TrashIcon}
+              variant="danger"
+              disabled={
+                getSponsorDiscounts(sponsor).length > 0 &&
+                loading === getSponsorDiscounts(sponsor)[0]?.triggerValue
+              }
+            >
+              {getSponsorDiscounts(sponsor).length > 0 &&
+              loading === getSponsorDiscounts(sponsor)[0]?.triggerValue
+                ? 'Deleting...'
+                : 'Delete Code'}
+            </ActionMenuItem>
+          </ActionMenu>
+        ) : (
+          <button
+            onClick={() => createDiscountCode(sponsor)}
+            disabled={loading === sponsor.id || sponsor.ticketEntitlement === 0}
+            className="inline-flex items-center rounded-md border border-gray-300 p-2 text-gray-700 shadow-xs hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800 dark:focus-visible:outline-gray-400"
+            title="Create Code"
+          >
+            {loading === sponsor.id ? (
+              <ArrowPathIcon className="h-4 w-4 animate-spin" />
+            ) : (
+              <PlusIcon className="h-4 w-4" />
+            )}
+          </button>
+        ),
+    },
+  ]
+
   return (
     <div className="space-y-6">
       {discountsLoading && (
@@ -430,134 +731,16 @@ export function DiscountCodeManager({
           </p>
         </div>
 
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Discount Code
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Type
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Value
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Usage
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Status
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Affects
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-              {customDiscounts.map((discount, index) => (
-                <tr
-                  key={index}
-                  className="hover:bg-gray-50 dark:hover:bg-gray-800"
-                >
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center space-x-2">
-                      <span className="font-mono text-sm font-medium text-gray-900 dark:text-white">
-                        {discount.triggerValue || 'N/A'}
-                      </span>
-                      {discount.triggerValue && (
-                        <button
-                          onClick={() =>
-                            copyToClipboard(discount.triggerValue || '')
-                          }
-                          className="inline-flex items-center rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-                          title="Copy discount code"
-                        >
-                          <ClipboardIcon className="h-4 w-4" />
-                        </button>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span className="inline-flex rounded-full bg-blue-100 px-2 text-xs leading-5 font-semibold text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                      {discount.type} {discount.value}%
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900 dark:text-white">
-                    {discount.affects === 'total'
-                      ? 'Total Order'
-                      : discount.affects}
-                    {discount.affectsValue && ` (${discount.affectsValue})`}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-900 dark:text-white">
-                      {discountData?.hasUsageData
-                        ? `${discount.actualUsage?.usageCount || 0} / ${discount.timesTotal || '∞'}`
-                        : `${discount.times || 0} / ${discount.timesTotal || '∞'}`}
-                    </div>
-                    <div className="text-xs text-gray-500">
-                      {discount.timesTotal
-                        ? discountData?.hasUsageData
-                          ? `${Math.round(((discount.actualUsage?.usageCount || 0) / discount.timesTotal) * 100)}% used`
-                          : `${Math.round(((discount.times || 0) / discount.timesTotal) * 100)}% used (estimated)`
-                        : 'No limit'}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    {(() => {
-                      const statusInfo = getDiscountStatus(discount)
-                      const colorClasses = {
-                        scheduled:
-                          'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-                        active:
-                          'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-                        expired:
-                          'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-                        permanent:
-                          'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200',
-                      }
-                      return (
-                        <span
-                          className={`inline-flex rounded-full px-2 text-xs leading-5 font-semibold ${colorClasses[statusInfo.status as keyof typeof colorClasses]}`}
-                        >
-                          {statusInfo.label}
-                        </span>
-                      )
-                    })()}
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                    {discount.ticketsOnly ? 'Tickets Only' : 'All Items'}
-                  </td>
-                  <td className="px-6 py-4 text-sm font-medium whitespace-nowrap">
-                    <button
-                      onClick={() => deleteDiscountCode(discount.triggerValue)}
-                      disabled={loading === discount.triggerValue}
-                      className="inline-flex items-center rounded-md border border-rose-300 bg-rose-50 p-2 text-rose-700 shadow-xs hover:border-rose-400 hover:bg-rose-100 hover:text-rose-800 disabled:opacity-50 dark:border-rose-500 dark:bg-rose-900/50 dark:text-rose-300 dark:hover:border-rose-400 dark:hover:bg-rose-800/60 dark:hover:text-rose-200"
-                      title="Delete Code"
-                    >
-                      {loading === discount.triggerValue ? (
-                        <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <TrashIcon className="h-4 w-4" />
-                      )}
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="p-4">
+          <DataTable<EventDiscountWithUsage>
+            data={customDiscounts}
+            columns={customDiscountColumns}
+            keyExtractor={(discount, index) =>
+              discount.triggerValue || String(index)
+            }
+            emptyState={{ title: 'No custom discount codes found' }}
+          />
         </div>
-
-        {customDiscounts.length === 0 && (
-          <div className="py-12 text-center">
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              No custom discount codes found
-            </p>
-          </div>
-        )}
       </div>
 
       <div className="overflow-hidden rounded-lg bg-white shadow dark:bg-gray-900">
@@ -570,254 +753,19 @@ export function DiscountCodeManager({
           </p>
         </div>
 
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Sponsor
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Tier & Usage
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Eligible Ticket Types
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Discount Codes
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-              {sponsors.map((sponsor) => {
-                const { used, total } = getSponsorUsageStats(sponsor)
-                const isOverLimit = used > total
-                return (
-                  <tr
-                    key={sponsor.id}
-                    className={
-                      isOverLimit
-                        ? 'bg-red-50 hover:bg-red-100 dark:bg-red-950/30 dark:hover:bg-red-950/40'
-                        : 'hover:bg-gray-50 dark:hover:bg-gray-800'
-                    }
-                  >
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="flex items-center">
-                        <div className="ml-4">
-                          <div className="text-sm font-medium text-gray-900 dark:text-white">
-                            {sponsor.name}
-                          </div>
-                          <div className="text-sm text-gray-500 dark:text-gray-400">
-                            {sponsor.website}
-                          </div>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="space-y-1">
-                        <span
-                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${(() => {
-                            const { used, total } =
-                              getSponsorUsageStats(sponsor)
-                            if (used === 0) {
-                              return 'bg-orange-100 text-orange-800 dark:bg-gray-700 dark:text-gray-300'
-                            } else if (used > total) {
-                              return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300'
-                            } else {
-                              return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300'
-                            }
-                          })()}`}
-                        >
-                          {sponsor.tier.title}
-                        </span>
-                        <div className="text-sm text-gray-900 dark:text-white">
-                          {(() => {
-                            const { used, total } =
-                              getSponsorUsageStats(sponsor)
-                            return (
-                              <span>
-                                <span className="font-medium">{used}</span>
-                                <span className="text-gray-500 dark:text-gray-400">
-                                  {' '}
-                                  / {total}
-                                </span>
-                                <span className="text-gray-500 dark:text-gray-400">
-                                  {' '}
-                                  tickets
-                                </span>
-                              </span>
-                            )
-                          })()}
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-6 py-4">
-                      {sponsor.ticketEntitlement > 0 &&
-                      getSponsorDiscounts(sponsor).length === 0 ? (
-                        <FilterDropdown
-                          label={
-                            discountsLoading
-                              ? 'Loading...'
-                              : getSelectedTicketTypesDisplay(sponsor.id)
-                          }
-                          activeCount={
-                            selectedTicketTypes[sponsor.id]?.length || 0
-                          }
-                          width="wider"
-                          position="left"
-                          fixedWidth={true}
-                        >
-                          {availableTicketTypes.map((ticketType) => (
-                            <FilterOption
-                              key={ticketType.id}
-                              onClick={() =>
-                                toggleTicketType(
-                                  sponsor.id,
-                                  String(ticketType.id),
-                                )
-                              }
-                              checked={
-                                selectedTicketTypes[sponsor.id]?.includes(
-                                  String(ticketType.id),
-                                ) || false
-                              }
-                              type="checkbox"
-                              keepOpen={true}
-                            >
-                              {ticketType.name}
-                            </FilterOption>
-                          ))}
-                        </FilterDropdown>
-                      ) : getSponsorDiscounts(sponsor).length > 0 ? (
-                        <div className="text-sm text-gray-900 dark:text-white">
-                          <div className="font-medium">
-                            {getExistingDiscountTicketTypes(sponsor)}
-                          </div>
-                          <div className="text-xs text-gray-500 dark:text-gray-400">
-                            Discount code created
-                          </div>
-                        </div>
-                      ) : (
-                        <span className="text-sm text-gray-500 dark:text-gray-400">
-                          No ticket entitlement
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-6 py-4">
-                      {getSponsorDiscounts(sponsor).length > 0 ? (
-                        <div className="space-y-1">
-                          {getSponsorDiscounts(sponsor).map(
-                            (discount, index) => (
-                              <div
-                                key={index}
-                                className="flex items-center space-x-2"
-                              >
-                                <span className="font-mono text-sm font-medium text-gray-900 dark:text-white">
-                                  {discount.triggerValue || 'N/A'}
-                                </span>
-                                <button
-                                  onClick={() =>
-                                    copyToClipboard(discount.triggerValue || '')
-                                  }
-                                  className="inline-flex items-center rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-                                  title="Copy discount code"
-                                >
-                                  <ClipboardIcon className="h-4 w-4" />
-                                </button>
-                              </div>
-                            ),
-                          )}
-                        </div>
-                      ) : (
-                        <span className="text-sm text-gray-500 dark:text-gray-400">
-                          No codes created
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-6 py-4 text-right text-sm whitespace-nowrap">
-                      {getSponsorDiscounts(sponsor).length > 0 ? (
-                        <ActionMenu ariaLabel={`Actions for ${sponsor.name}`}>
-                          <ActionMenuItem
-                            onClick={() => {
-                              const sponsorDiscounts =
-                                getSponsorDiscounts(sponsor)
-                              if (sponsorDiscounts.length > 0) {
-                                openEmailModal(
-                                  sponsor,
-                                  sponsorDiscounts[0].triggerValue || '',
-                                )
-                              }
-                            }}
-                            icon={EnvelopeIcon}
-                            disabled={loading !== null}
-                          >
-                            Send Email
-                          </ActionMenuItem>
-                          <ActionMenuDivider />
-                          <ActionMenuItem
-                            onClick={() => {
-                              const sponsorDiscounts =
-                                getSponsorDiscounts(sponsor)
-                              if (sponsorDiscounts.length > 0) {
-                                deleteDiscountCode(
-                                  sponsorDiscounts[0].triggerValue,
-                                )
-                              }
-                            }}
-                            icon={TrashIcon}
-                            variant="danger"
-                            disabled={
-                              getSponsorDiscounts(sponsor).length > 0 &&
-                              loading ===
-                                getSponsorDiscounts(sponsor)[0]?.triggerValue
-                            }
-                          >
-                            {getSponsorDiscounts(sponsor).length > 0 &&
-                            loading ===
-                              getSponsorDiscounts(sponsor)[0]?.triggerValue
-                              ? 'Deleting...'
-                              : 'Delete Code'}
-                          </ActionMenuItem>
-                        </ActionMenu>
-                      ) : (
-                        <button
-                          onClick={() => createDiscountCode(sponsor)}
-                          disabled={
-                            loading === sponsor.id ||
-                            sponsor.ticketEntitlement === 0
-                          }
-                          className="inline-flex items-center rounded-md border border-gray-300 p-2 text-gray-700 shadow-xs hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800 dark:focus-visible:outline-gray-400"
-                          title="Create Code"
-                        >
-                          {loading === sponsor.id ? (
-                            <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <PlusIcon className="h-4 w-4" />
-                          )}
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+        <div className="p-4">
+          <DataTable<SponsorWithTierInfo>
+            data={sponsors}
+            columns={sponsorColumns}
+            keyExtractor={(sponsor) => sponsor.id}
+            emptyState={{
+              icon: ExclamationTriangleIcon,
+              title: 'No sponsors found',
+              description:
+                'Add sponsors to the conference to manage their discount codes.',
+            }}
+          />
         </div>
-
-        {sponsors.length === 0 && (
-          <div className="py-12 text-center">
-            <ExclamationTriangleIcon className="mx-auto h-12 w-12 text-gray-400" />
-            <h3 className="mt-2 text-sm font-semibold text-gray-900 dark:text-white">
-              No sponsors found
-            </h3>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              Add sponsors to the conference to manage their discount codes.
-            </p>
-          </div>
-        )}
       </div>
 
       {emailModal.sponsor && (

--- a/src/components/admin/DiscountCodeManager.tsx
+++ b/src/components/admin/DiscountCodeManager.tsx
@@ -488,7 +488,6 @@ export function DiscountCodeManager({
     {
       key: 'affects',
       header: 'Affects',
-      cardHidden: true,
       render: (discount) => (
         <span className="text-sm text-gray-500 dark:text-gray-400">
           {discount.ticketsOnly ? 'Tickets Only' : 'All Items'}

--- a/src/components/admin/SpeakerTable.stories.tsx
+++ b/src/components/admin/SpeakerTable.stories.tsx
@@ -236,6 +236,32 @@ export const ManySpeakers: Story = {
   },
 }
 
+export const Mobile: Story = {
+  args: {
+    speakers: mockSpeakers,
+    currentConferenceId: 'conf-2025',
+    onEditSpeaker: fn(),
+    onPreviewSpeaker: fn(),
+  },
+  parameters: {
+    viewport: {
+      viewports: {
+        mobile360: {
+          name: 'Mobile 360px',
+          styles: { width: '360px', height: '740px' },
+        },
+      },
+      defaultViewport: 'mobile360',
+    },
+    docs: {
+      description: {
+        story:
+          'Below `md`, the wide speaker table collapses into a stacked card layout — no horizontal scroll on a phone. Each card shows the speaker name, title, indicators, email, and talks with status badges, plus the action menu.',
+      },
+    },
+  },
+}
+
 export const WithoutConferenceFilter: Story = {
   args: {
     speakers: mockSpeakers,

--- a/src/components/admin/SpeakerTable.tsx
+++ b/src/components/admin/SpeakerTable.tsx
@@ -302,6 +302,97 @@ export function SpeakerTable({
     typeof value === 'boolean' ? value : value !== 'all',
   ).length
 
+  const renderSpeakerTalks = (speaker: SpeakerWithProposals) => (
+    <div className="space-y-1">
+      {speaker.proposals
+        .filter((proposal) => {
+          if (!currentConferenceId) return true
+          return getProposalConferenceId(proposal) === currentConferenceId
+        })
+        .map((proposal) => (
+          <div
+            key={`${speaker._id}-${proposal._id}`}
+            className="flex items-center gap-2 text-xs"
+          >
+            <StatusBadge
+              label={
+                proposal.status.charAt(0).toUpperCase() +
+                proposal.status.slice(1)
+              }
+              color={getProposalBadgeColor(proposal.status)}
+              icon={
+                proposal.status === Status.confirmed
+                  ? CheckBadgeIcon
+                  : ClockIcon
+              }
+            />
+            <span
+              className="min-w-0 flex-1 truncate text-gray-900 dark:text-white"
+              title={proposal.title}
+            >
+              {proposal.title}
+            </span>
+            <span
+              className="shrink-0 text-gray-500 dark:text-gray-400"
+              title={`${formats.get(proposal.format)} in ${languages.get(proposal.language)}`}
+            >
+              {getCompactFormat(proposal.format)} •{' '}
+              {languages.get(proposal.language)}
+            </span>
+          </div>
+        ))}
+    </div>
+  )
+
+  const renderSpeakerActions = (speaker: SpeakerWithProposals) => (
+    <ActionMenu ariaLabel={`Actions for ${speaker.name}`}>
+      <ActionMenuItem
+        onClick={() =>
+          toggleFeatured(speaker._id, featuredSpeakerIds.includes(speaker._id))
+        }
+        icon={StarIcon}
+      >
+        {featuredSpeakerIds.includes(speaker._id)
+          ? 'Remove from Featured'
+          : 'Feature Speaker'}
+      </ActionMenuItem>
+      <ActionMenuDivider />
+      <ActionMenuItem onClick={() => onEditSpeaker(speaker)} icon={PencilIcon}>
+        Edit Speaker
+      </ActionMenuItem>
+      <ActionMenuItem onClick={() => onPreviewSpeaker(speaker)} icon={EyeIcon}>
+        Preview Profile
+      </ActionMenuItem>
+      {AppEnvironment.isDevelopment && (
+        <>
+          <ActionMenuDivider />
+          <ActionMenuItem
+            onClick={async () => {
+              const { addImpersonateParam } =
+                await import('@/lib/impersonation')
+              window.open(
+                addImpersonateParam('/cfp/list', speaker._id),
+                '_blank',
+              )
+            }}
+            icon={ArrowRightCircleIcon}
+          >
+            View as Speaker (dev)
+          </ActionMenuItem>
+        </>
+      )}
+    </ActionMenu>
+  )
+
+  const renderSpeakerAvatar = (speaker: SpeakerWithProposals) =>
+    speaker.image ? (
+      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+        <SpeakerAvatarImage src={speaker.image} name={speaker.name} size={32} />
+      </div>
+    ) : (
+      <MissingAvatar name={speaker.name} size={32} />
+    )
+
   if (speakers.length === 0) {
     return (
       <TableEmptyState
@@ -448,7 +539,110 @@ export function SpeakerTable({
         </FilterDropdown>
       </TableToolbar>
 
-      <TableContainer>
+      <div className="space-y-3 md:hidden">
+        {filteredSpeakers.map((speaker) => {
+          const linkedinLink = extractLinkedInLink(speaker.links)
+          const blueskyLink = hasBlueskySocial(speaker.links)
+
+          return (
+            <div
+              key={speaker._id}
+              className="rounded-lg border border-gray-200 bg-white p-4 text-sm shadow-sm dark:border-gray-700 dark:bg-gray-900"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex min-w-0 items-center">
+                  <div className="h-8 w-8 shrink-0">
+                    {renderSpeakerAvatar(speaker)}
+                  </div>
+                  <div className="ml-3 min-w-0">
+                    <div className="truncate font-medium text-gray-900 dark:text-white">
+                      {speaker.name}
+                    </div>
+                    {speaker.title && (
+                      <div className="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {speaker.title}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="shrink-0">{renderSpeakerActions(speaker)}</div>
+              </div>
+
+              {columnVisibility.indicators && (
+                <div className="mt-3">
+                  <SpeakerIndicators
+                    speakers={[speaker]}
+                    size="md"
+                    maxVisible={5}
+                    className="justify-start"
+                    currentConferenceId={currentConferenceId}
+                    featuredSpeakerIds={featuredSpeakerIds}
+                  />
+                </div>
+              )}
+
+              {columnVisibility.email && speaker.email && (
+                <div className="mt-3 flex min-w-0 items-center text-sm text-gray-900 dark:text-white">
+                  <EnvelopeIcon className="mr-2 h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                  <a
+                    href={`mailto:${speaker.email}`}
+                    className="truncate hover:text-blue-600 dark:hover:text-blue-400"
+                    title={speaker.email}
+                  >
+                    {speaker.email}
+                  </a>
+                  <CopyEmailButton email={speaker.email} />
+                </div>
+              )}
+
+              {columnVisibility.linkedin && linkedinLink && (
+                <div className="mt-3 flex min-w-0 items-center text-sm text-gray-900 dark:text-white">
+                  <div className="mr-2 h-4 w-4 shrink-0">
+                    {iconForLink(
+                      linkedinLink,
+                      'h-4 w-4 text-gray-400 dark:text-gray-500',
+                    )}
+                  </div>
+                  <a
+                    href={linkedinLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="truncate hover:text-blue-600 dark:hover:text-blue-400"
+                    title={titleForLink(linkedinLink)}
+                  >
+                    View Profile
+                  </a>
+                </div>
+              )}
+
+              {columnVisibility.bluesky && blueskyLink && (
+                <div className="mt-3 flex min-w-0 items-center text-sm text-gray-900 dark:text-white">
+                  <div className="mr-2 h-4 w-4 shrink-0">
+                    {iconForLink(
+                      blueskyLink,
+                      'h-4 w-4 text-gray-400 dark:text-gray-500',
+                    )}
+                  </div>
+                  <a
+                    href={blueskyLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="truncate hover:text-blue-600 dark:hover:text-blue-400"
+                    title={titleForLink(blueskyLink)}
+                  >
+                    View Profile
+                  </a>
+                  <CopyBlueskyUsernameButton blueskyLink={blueskyLink} />
+                </div>
+              )}
+
+              <div className="mt-3">{renderSpeakerTalks(speaker)}</div>
+            </div>
+          )
+        })}
+      </div>
+
+      <TableContainer className="hidden md:block">
         <table className="w-full table-fixed divide-y divide-gray-300 dark:divide-gray-700">
           <TableHeader>
             <tr>
@@ -477,17 +671,7 @@ export function SpeakerTable({
                   <Td>
                     <div className="flex min-w-0 items-center">
                       <div className="h-8 w-8 shrink-0">
-                        {speaker.image ? (
-                          <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
-                            <SpeakerAvatarImage
-                              src={speaker.image}
-                              name={speaker.name}
-                              size={32}
-                            />
-                          </div>
-                        ) : (
-                          <MissingAvatar name={speaker.name} size={32} />
-                        )}
+                        {renderSpeakerAvatar(speaker)}
                       </div>
                       <div className="ml-3 min-w-0 flex-1">
                         <div className="truncate text-sm font-medium text-gray-900 dark:text-white">
@@ -585,98 +769,10 @@ export function SpeakerTable({
                       )}
                     </Td>
                   )}
-                  <Td>
-                    <div className="space-y-1">
-                      {speaker.proposals
-                        .filter((proposal) => {
-                          if (!currentConferenceId) return true
-                          return (
-                            getProposalConferenceId(proposal) ===
-                            currentConferenceId
-                          )
-                        })
-                        .map((proposal) => (
-                          <div
-                            key={`${speaker._id}-${proposal._id}`}
-                            className="flex items-center gap-2 text-xs"
-                          >
-                            <StatusBadge
-                              label={
-                                proposal.status.charAt(0).toUpperCase() +
-                                proposal.status.slice(1)
-                              }
-                              color={getProposalBadgeColor(proposal.status)}
-                              icon={
-                                proposal.status === Status.confirmed
-                                  ? CheckBadgeIcon
-                                  : ClockIcon
-                              }
-                            />
-                            <span
-                              className="min-w-0 flex-1 truncate text-gray-900 dark:text-white"
-                              title={proposal.title}
-                            >
-                              {proposal.title}
-                            </span>
-                            <span
-                              className="shrink-0 text-gray-500 dark:text-gray-400"
-                              title={`${formats.get(proposal.format)} in ${languages.get(proposal.language)}`}
-                            >
-                              {getCompactFormat(proposal.format)} •{' '}
-                              {languages.get(proposal.language)}
-                            </span>
-                          </div>
-                        ))}
-                    </div>
-                  </Td>
+                  <Td>{renderSpeakerTalks(speaker)}</Td>
                   <Td align="right" className="whitespace-nowrap">
                     <div className="flex items-center justify-end">
-                      <ActionMenu ariaLabel={`Actions for ${speaker.name}`}>
-                        <ActionMenuItem
-                          onClick={() =>
-                            toggleFeatured(
-                              speaker._id,
-                              featuredSpeakerIds.includes(speaker._id),
-                            )
-                          }
-                          icon={StarIcon}
-                        >
-                          {featuredSpeakerIds.includes(speaker._id)
-                            ? 'Remove from Featured'
-                            : 'Feature Speaker'}
-                        </ActionMenuItem>
-                        <ActionMenuDivider />
-                        <ActionMenuItem
-                          onClick={() => onEditSpeaker(speaker)}
-                          icon={PencilIcon}
-                        >
-                          Edit Speaker
-                        </ActionMenuItem>
-                        <ActionMenuItem
-                          onClick={() => onPreviewSpeaker(speaker)}
-                          icon={EyeIcon}
-                        >
-                          Preview Profile
-                        </ActionMenuItem>
-                        {AppEnvironment.isDevelopment && (
-                          <>
-                            <ActionMenuDivider />
-                            <ActionMenuItem
-                              onClick={async () => {
-                                const { addImpersonateParam } =
-                                  await import('@/lib/impersonation')
-                                window.open(
-                                  addImpersonateParam('/cfp/list', speaker._id),
-                                  '_blank',
-                                )
-                              }}
-                              icon={ArrowRightCircleIcon}
-                            >
-                              View as Speaker (dev)
-                            </ActionMenuItem>
-                          </>
-                        )}
-                      </ActionMenu>
+                      {renderSpeakerActions(speaker)}
                     </div>
                   </Td>
                 </Tr>

--- a/src/components/admin/sponsor/ContractTemplateListPage.tsx
+++ b/src/components/admin/sponsor/ContractTemplateListPage.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/trpc/client'
 import { AdminPageHeader } from '@/components/admin'
 import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import { useNotification } from '@/components/admin'
+import { DataTable, type Column } from '@/components/DataTable'
 import { AdobeSignConfigPanel } from './AdobeSignConfigPanel'
 import { ConferenceOrgInfoPanel } from './ConferenceOrgInfoPanel'
 import { SigningProviderPanel } from './SigningProviderPanel'
@@ -37,6 +38,83 @@ export function ContractTemplateListPage({
     isLoading,
     refetch,
   } = api.sponsor.contractTemplates.list.useQuery({})
+
+  type ContractTemplate = NonNullable<typeof templates>[number]
+
+  const columns: Column<ContractTemplate>[] = [
+    {
+      key: 'title',
+      header: 'Template',
+      primary: true,
+      render: (template) => (
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-900 dark:text-white">
+            {template.title}
+          </span>
+          {template.isDefault && (
+            <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+              Default
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'language',
+      header: 'Language',
+      render: (template) =>
+        template.language === 'nb' ? '🇳🇴 Norwegian' : '🇬🇧 English',
+    },
+    {
+      key: 'tier',
+      header: 'Tier',
+      render: (template) => template.tier?.title || '—',
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (template) =>
+        template.isActive ? (
+          <span className="inline-flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
+            <CheckCircleIcon className="h-4 w-4" />
+            Active
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-sm text-gray-400 dark:text-gray-500">
+            <XCircleIcon className="h-4 w-4" />
+            Inactive
+          </span>
+        ),
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      align: 'right',
+      render: (template) => (
+        <div className="flex items-center justify-end gap-2">
+          <Link
+            href={`/admin/sponsors/contracts/${template._id}`}
+            className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+            title="Edit"
+          >
+            <PencilSquareIcon className="h-4 w-4" />
+          </Link>
+          <button
+            onClick={() =>
+              setDeleteTarget({
+                _id: template._id,
+                title: template.title,
+              })
+            }
+            className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            title="Delete"
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      ),
+    },
+  ]
 
   const deleteMutation = api.sponsor.contractTemplates.delete.useMutation({
     onSuccess: () => {
@@ -85,113 +163,27 @@ export function ContractTemplateListPage({
         <div className="py-12 text-center text-gray-500 dark:text-gray-400">
           Loading templates...
         </div>
-      ) : !templates || templates.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-gray-300 py-12 text-center dark:border-gray-700">
-          <DocumentTextIcon className="mx-auto h-12 w-12 text-gray-400" />
-          <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
-            No contract templates
-          </h3>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Create your first contract template to start generating sponsor
-            agreements.
-          </p>
-          <div className="mt-6">
-            <Link
-              href="/admin/sponsors/contracts/new"
-              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-            >
-              <PlusIcon className="h-4 w-4" />
-              New Template
-            </Link>
-          </div>
-        </div>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-            <thead className="bg-gray-50 dark:bg-gray-800">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Template
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Language
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Tier
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Status
-                </th>
-                <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
-              {templates.map((template) => (
-                <tr
-                  key={template._id}
-                  className="hover:bg-gray-50 dark:hover:bg-gray-800"
-                >
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-gray-900 dark:text-white">
-                        {template.title}
-                      </span>
-                      {template.isDefault && (
-                        <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
-                          Default
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                    {template.language === 'nb' ? '🇳🇴 Norwegian' : '🇬🇧 English'}
-                  </td>
-                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                    {template.tier?.title || '—'}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    {template.isActive ? (
-                      <span className="inline-flex items-center gap-1 text-sm text-green-600 dark:text-green-400">
-                        <CheckCircleIcon className="h-4 w-4" />
-                        Active
-                      </span>
-                    ) : (
-                      <span className="inline-flex items-center gap-1 text-sm text-gray-400 dark:text-gray-500">
-                        <XCircleIcon className="h-4 w-4" />
-                        Inactive
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-6 py-4 text-right text-sm whitespace-nowrap">
-                    <div className="flex items-center justify-end gap-2">
-                      <Link
-                        href={`/admin/sponsors/contracts/${template._id}`}
-                        className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-                        title="Edit"
-                      >
-                        <PencilSquareIcon className="h-4 w-4" />
-                      </Link>
-                      <button
-                        onClick={() =>
-                          setDeleteTarget({
-                            _id: template._id,
-                            title: template.title,
-                          })
-                        }
-                        className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-                        title="Delete"
-                      >
-                        <TrashIcon className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <DataTable<ContractTemplate>
+          data={templates ?? []}
+          columns={columns}
+          keyExtractor={(template) => template._id}
+          emptyState={{
+            icon: DocumentTextIcon,
+            title: 'No contract templates',
+            description:
+              'Create your first contract template to start generating sponsor agreements.',
+            action: (
+              <Link
+                href="/admin/sponsors/contracts/new"
+                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                <PlusIcon className="h-4 w-4" />
+                New Template
+              </Link>
+            ),
+          }}
+        />
       )}
 
       <ConfirmationModal

--- a/src/components/admin/sponsor/SponsorContactTable.tsx
+++ b/src/components/admin/sponsor/SponsorContactTable.tsx
@@ -141,7 +141,7 @@ export function SponsorContactTable({
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div>
       {/* Editor Modal */}
       <Transition appear show={!!editingSponsor} as={Fragment}>
         <Dialog as="div" className="relative z-50" onClose={handleCloseEdit}>
@@ -200,7 +200,136 @@ export function SponsorContactTable({
         </Dialog>
       </Transition>
 
-      <TableContainer>
+      <div className="space-y-3 md:hidden">
+        {contactRows.map((row, index) => (
+          <div
+            key={`${row.sfc._id}-${row.contact._key}-${index}`}
+            className="rounded-lg border border-gray-200 bg-white p-4 text-sm shadow-sm dark:border-gray-700 dark:bg-gray-900"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 font-medium text-gray-900 dark:text-white">
+                  <BuildingOffice2Icon className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                  <span className="truncate">{row.sfc.sponsor.name}</span>
+                </div>
+                {row.sfc.sponsor.orgNumber && (
+                  <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    Org: {row.sfc.sponsor.orgNumber}
+                  </div>
+                )}
+              </div>
+              <button
+                onClick={() => handleStartEdit(row.sfc)}
+                className="inline-flex shrink-0 cursor-pointer items-center rounded p-1 text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                title="Manage contacts"
+              >
+                <PencilIcon className="h-4 w-4" />
+              </button>
+            </div>
+
+            <dl className="mt-3 space-y-2">
+              <div className="flex justify-between gap-3">
+                <dt className="shrink-0 text-gray-500 dark:text-gray-400">
+                  Contact
+                </dt>
+                <dd className="text-right text-gray-900 dark:text-gray-200">
+                  {row.contact.name || (
+                    <span className="text-gray-500 italic dark:text-gray-400">
+                      No contact person
+                    </span>
+                  )}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="shrink-0 text-gray-500 dark:text-gray-400">
+                  Email
+                </dt>
+                <dd className="flex min-w-0 items-center justify-end text-right text-gray-900 dark:text-gray-200">
+                  {row.contact.email ? (
+                    <>
+                      <a
+                        href={`mailto:${row.contact.email}`}
+                        className="truncate hover:text-blue-600 dark:hover:text-blue-400"
+                        title={row.contact.email}
+                      >
+                        {row.contact.email}
+                      </a>
+                      <CopyEmailButton email={row.contact.email} />
+                    </>
+                  ) : (
+                    <span className="text-gray-500 italic dark:text-gray-400">
+                      No email
+                    </span>
+                  )}
+                </dd>
+              </div>
+              {row.contact.phone && (
+                <div className="flex justify-between gap-3">
+                  <dt className="shrink-0 text-gray-500 dark:text-gray-400">
+                    Phone
+                  </dt>
+                  <dd className="text-right text-gray-900 dark:text-gray-200">
+                    <a
+                      href={`tel:${row.contact.phone}`}
+                      className="hover:text-blue-600 dark:hover:text-blue-400"
+                    >
+                      {row.contact.phone}
+                    </a>
+                  </dd>
+                </div>
+              )}
+              {row.contact.role && (
+                <div className="flex justify-between gap-3">
+                  <dt className="shrink-0 text-gray-500 dark:text-gray-400">
+                    Role
+                  </dt>
+                  <dd className="text-right text-gray-900 dark:text-gray-200">
+                    {row.contact.role}
+                  </dd>
+                </div>
+              )}
+            </dl>
+
+            {row.isFirstContactForSponsor &&
+              row.sfc.billing &&
+              row.sfc.billing.email && (
+                <div className="mt-3 border-t border-gray-200 pt-3 dark:border-gray-700">
+                  <div className="mb-1 text-xs font-medium text-gray-500 dark:text-gray-400">
+                    Billing
+                  </div>
+                  <div className="flex min-w-0 items-center text-sm text-gray-900 dark:text-white">
+                    <EnvelopeIcon className="mr-2 h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                    <a
+                      href={`mailto:${row.sfc.billing.email}`}
+                      className="truncate hover:text-blue-600 dark:hover:text-blue-400"
+                      title={row.sfc.billing.email}
+                    >
+                      {row.sfc.billing.email}
+                    </a>
+                    <CopyEmailButton email={row.sfc.billing.email} />
+                  </div>
+                  <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {row.sfc.billing.invoiceFormat === 'ehf'
+                      ? 'EHF (Digital)'
+                      : 'PDF via Email'}
+                  </div>
+                  {row.sfc.billing.reference && (
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      Ref: {row.sfc.billing.reference}
+                    </div>
+                  )}
+                  {row.sfc.billing.comments && (
+                    <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      {row.sfc.billing.comments}
+                    </div>
+                  )}
+                </div>
+              )}
+          </div>
+        ))}
+      </div>
+
+      <TableContainer className="hidden md:block">
         <table className="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
           <TableHeader>
             <tr>

--- a/src/components/admin/workshop/SignupDetailsModal.tsx
+++ b/src/components/admin/workshop/SignupDetailsModal.tsx
@@ -3,6 +3,7 @@
 import { DialogTitle } from '@headlessui/react'
 import { XMarkIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
+import { DataTable, type Column } from '@/components/DataTable'
 import type {
   WorkshopSignupExisting,
   WorkshopSignupStatus,
@@ -35,6 +36,62 @@ export function SignupDetailsModal({
     ? status.charAt(0).toUpperCase() + status.slice(1)
     : ''
 
+  const columns: Column<WorkshopSignupExisting>[] = [
+    {
+      key: 'userName',
+      header: 'Name',
+      primary: true,
+      render: (signup) => (
+        <div className="text-sm font-medium text-gray-900 dark:text-white">
+          {signup.userName}
+        </div>
+      ),
+    },
+    {
+      key: 'userEmail',
+      header: 'Email',
+      render: (signup) => (
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          {signup.userEmail}
+        </div>
+      ),
+    },
+    {
+      key: 'signedUpAt',
+      header: 'Signup Date',
+      render: (signup) => {
+        const dateStr = signup.signedUpAt || signup._createdAt
+        if (!dateStr || typeof dateStr !== 'string') return 'N/A'
+        return new Date(dateStr).toLocaleDateString()
+      },
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (signup) => (
+        <div className="flex items-center gap-2">
+          {signup.status === 'waitlist' && (
+            <button
+              onClick={() => onConfirmSignup(signup._id, signup.userName)}
+              disabled={isConfirming || isDeleting}
+              className="text-green-600 hover:text-green-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-green-400 dark:hover:text-green-300"
+            >
+              Move to Confirmed
+            </button>
+          )}
+          <button
+            onClick={() => onDeleteSignup(signup._id, signup.userName)}
+            disabled={isConfirming || isDeleting}
+            className="text-gray-600 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-red-400"
+            title="Delete participant"
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        </div>
+      ),
+    },
+  ]
+
   return (
     <ModalShell
       isOpen={isOpen}
@@ -63,87 +120,14 @@ export function SignupDetailsModal({
           </DialogTitle>
 
           <div className="mt-4">
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                <thead className="bg-gray-50 dark:bg-gray-700">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                      Name
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                      Email
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                      Signup Date
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
-                  {signups.length === 0 ? (
-                    <tr>
-                      <td
-                        colSpan={4}
-                        className="py-8 text-center text-gray-500 dark:text-gray-400"
-                      >
-                        No {status} signups for this workshop
-                      </td>
-                    </tr>
-                  ) : (
-                    signups.map((signup) => (
-                      <tr key={signup._id}>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="text-sm font-medium text-gray-900 dark:text-white">
-                            {signup.userName}
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <div className="text-sm text-gray-500 dark:text-gray-400">
-                            {signup.userEmail}
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500 dark:text-gray-400">
-                          {(() => {
-                            const dateStr =
-                              signup.signedUpAt || signup._createdAt
-                            if (!dateStr || typeof dateStr !== 'string')
-                              return 'N/A'
-                            return new Date(dateStr).toLocaleDateString()
-                          })()}
-                        </td>
-                        <td className="px-6 py-4 text-sm whitespace-nowrap">
-                          <div className="flex items-center gap-2">
-                            {signup.status === 'waitlist' && (
-                              <button
-                                onClick={() =>
-                                  onConfirmSignup(signup._id, signup.userName)
-                                }
-                                disabled={isConfirming || isDeleting}
-                                className="text-green-600 hover:text-green-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-green-400 dark:hover:text-green-300"
-                              >
-                                Move to Confirmed
-                              </button>
-                            )}
-                            <button
-                              onClick={() =>
-                                onDeleteSignup(signup._id, signup.userName)
-                              }
-                              disabled={isConfirming || isDeleting}
-                              className="text-gray-600 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-red-400"
-                              title="Delete participant"
-                            >
-                              <TrashIcon className="h-4 w-4" />
-                            </button>
-                          </div>
-                        </td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </div>
+            <DataTable<WorkshopSignupExisting>
+              data={signups}
+              columns={columns}
+              keyExtractor={(signup) => signup._id}
+              emptyState={{
+                title: `No ${status ?? ''} signups for this workshop`,
+              }}
+            />
           </div>
         </div>
       </div>

--- a/src/components/admin/workshop/SignupDetailsModal.tsx
+++ b/src/components/admin/workshop/SignupDetailsModal.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { formatDateSafe } from '@/lib/time'
+
 import { DialogTitle } from '@headlessui/react'
 import { XMarkIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
@@ -62,7 +64,7 @@ export function SignupDetailsModal({
       render: (signup) => {
         const dateStr = signup.signedUpAt || signup._createdAt
         if (!dateStr || typeof dateStr !== 'string') return 'N/A'
-        return new Date(dateStr).toLocaleDateString()
+        return formatDateSafe(dateStr)
       },
     },
     {


### PR DESCRIPTION
Turns the wide, horizontally-scrolling admin tables into a consistent mobile card layout — the "degraded tables" tier from the admin mobile audit. Two commits: the reusable primitive, then the migrations.

## 1. `DataTable` card-stack mode (primitive)
`DataTable` now collapses to stacked label/value **cards below `md`** by default (`mobileVariant='cards'`) instead of only horizontal-scrolling: the `primary` column becomes the card title, `cardHidden` columns are omitted, the whole card is the tap target, and `renderCard` allows a custom body. At `md+` the existing table is unchanged. Verified in Storybook (cards at 360px, table at desktop).

## 2. Migrations (9 tables)
- **Speakers, Sponsor Contacts** — kept their desktop tables (column-visibility toggles / billing-grouping the `DataTable` component can't express) and added `md:hidden` card stacks in the primitive's visual language. SpeakerTable was the worst offender (~730px forced scroll); now a clean card stack (screenshot below).
- **Ticket breakdowns** (allocation, by-type, sponsor allocations), **Companies**, **Discount codes** (custom + sponsor), **Badge management**, **Contract templates**, **Workshop signup modal** — converted to the `DataTable` component with column configs. The tickets/companies pages are server components, so their tables moved to small `'use client'` wrappers.
- **Orders** was already card-based below `lg` — left unchanged.

Row actions, status badges (the shared `StatusBadge`), sorting, empty states, and footer/total rows (rendered separately — `DataTable` has no footer slot) are all preserved.

### Known minor changes (documented, not regressions)
- Badge-management **select-all** moved from a header checkbox into the count bar (`Column.header` is text-only).
- The sponsor discount **over-limit** full-row red tint is now conveyed by its red usage badge (the primitive has no per-row style hook). The state stays clearly visible.

A follow-up could add `rowClassName`, a footer slot, and `ReactNode` headers to the primitive to recover these exactly — worth it only if we hit them again.

## Verification
`pnpm typecheck` clean; `pnpm vitest run`: 116 files, 2054 passed / 5 skipped; eslint/prettier clean. Net −175 lines (config replacing hand-rolled markup). Best verified on the Vercel preview on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds responsive card layouts for wide admin tables. The main changes are:

- New `DataTable` mobile card mode below `md`.
- Client table wrappers for ticket and company breakdowns.
- Admin table migrations for discounts, badges, contracts, workshops, speakers, and sponsor contacts.

<h3>Confidence Score: 4/5</h3>

The discount-code mobile card path needs a small fix before merging.

- Custom discount cards hide the ticket-only versus all-items scope.
- Other migrated admin actions and table data look preserved in the changed code.

src/components/admin/DiscountCodeManager.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/DataTable/DataTable.tsx | Adds the reusable mobile card rendering mode, primary/card-hidden column metadata, and a scroll opt-out. |
| src/components/admin/DiscountCodeManager.tsx | Migrates custom and sponsor discount tables to DataTable; custom discount scope is now hidden from mobile cards. |
| src/components/admin/BadgeManagementClient.tsx | Migrates badge management to DataTable while preserving selection, badge status, and row actions. |
| src/components/admin/SpeakerTable.tsx | Adds a custom mobile card stack while keeping the desktop speaker table. |
| src/components/admin/sponsor/SponsorContactTable.tsx | Adds mobile sponsor contact cards while preserving contact and billing details. |
| src/app/(admin)/admin/tickets/TicketBreakdownTables.tsx | Introduces client DataTable wrappers for ticket allocation, category, and sponsor allocation displays. |
| src/app/(admin)/admin/tickets/companies/CompanyBreakdownTable.tsx | Introduces a client DataTable wrapper for company breakdown rows and the summary footer. |
| src/components/admin/sponsor/ContractTemplateListPage.tsx | Migrates contract template listing to DataTable with edit/delete actions and empty-state CTA. |
| src/components/admin/workshop/SignupDetailsModal.tsx | Migrates workshop signup details to DataTable while preserving signup date and row actions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(admin): mobile card layouts for the..."](https://github.com/cloudnativebergen/website/commit/9f72275519dacd20bfa8b1b66ca2e70ec8e43da8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44288795)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->