### PR TITLE
fix(admin): reorder proposal review sidebar in source order

### DIFF
--- a/src/app/(admin)/admin/proposals/[id]/page.tsx
+++ b/src/app/(admin)/admin/proposals/[id]/page.tsx
@@ -86,35 +86,31 @@ export default async function ProposalDetailPage({
         </div>
 
         <div className="w-full lg:w-96 lg:shrink-0">
-          {/* On mobile this column stacks below the proposal content, so the
-              review scoring form is ordered first (post-conference published
-              content and audience feedback follow); desktop keeps source order. */}
-          <div className="flex flex-col gap-4 p-4">
-            <div className="order-2 lg:order-1">
-              <ProposalPublishedContent
-                proposalId={proposal._id}
-                currentVideoUrl={getProposalVideoUrl(proposal)}
-                currentAttachments={proposal.attachments}
-                status={proposal.status}
-                conferenceEndDate={conference.endDate}
-              />
-            </div>
-            <div className="order-3 lg:order-2">
-              <AudienceFeedbackPanel
-                proposalId={proposal._id}
-                currentFeedback={proposal.audienceFeedback}
-                status={proposal.status}
-                conferenceStartDate={conference.startDate}
-              />
-            </div>
-            <div className="order-1 lg:order-3">
-              <ProposalReviewPanel
-                proposalId={proposal._id}
-                initialReviews={proposal.reviews || []}
-                currentUser={session?.speaker}
-                domain={domain}
-              />
-            </div>
+          {/* Review scoring comes first: on mobile this column stacks below
+              the proposal, so a reviewer reaches scoring without scrolling
+              past the post-conference published content and audience feedback.
+              Source order (not CSS order) so keyboard/screen-reader order
+              matches the visual order. */}
+          <div className="space-y-4 p-4">
+            <ProposalReviewPanel
+              proposalId={proposal._id}
+              initialReviews={proposal.reviews || []}
+              currentUser={session?.speaker}
+              domain={domain}
+            />
+            <ProposalPublishedContent
+              proposalId={proposal._id}
+              currentVideoUrl={getProposalVideoUrl(proposal)}
+              currentAttachments={proposal.attachments}
+              status={proposal.status}
+              conferenceEndDate={conference.endDate}
+            />
+            <AudienceFeedbackPanel
+              proposalId={proposal._id}
+              currentFeedback={proposal.audienceFeedback}
+              status={proposal.status}
+              conferenceStartDate={conference.startDate}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Follow-up to the merged #420, addressing its review comments (Copilot + Qodo).

The mobile-first review-panel reorder in #420 used Tailwind `order-*`, which visually moved the review scoring panel to the top on mobile but left the **DOM order** (and thus keyboard/screen-reader reading order) as Published → Audience → Review. It also wrapped each panel in an always-rendered flex child, so the `gap-4` container left an **empty gap** when the post-conference panels (`ProposalPublishedContent`, `AudienceFeedbackPanel`) render null during active review.

Fix: reorder the three panels in **source order** (Review, Published, Audience) inside a plain `space-y-4` container — no CSS `order`, no wrapper divs. Reading order now matches visual order on every viewport, and a null panel leaves no gap (`space-y` only spaces rendered siblings). Desktop shows the review panel first in the sidebar too, which is reasonable — it's the primary action; the published-content/audience-feedback panels are post-conference.

`pnpm typecheck` clean; eslint/prettier clean. Layout-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a follow-up to #420 that fixes two layout bugs in the admin proposal sidebar: a DOM/visual order mismatch introduced by Tailwind `order-*` classes, and spurious empty gaps caused by always-rendered wrapper `div`s surrounding panels that can return `null`.

- Removes the `flex flex-col gap-4` container with its three wrapper `div` children carrying `order-*` classes; replaces it with a plain `space-y-4` container holding the panels directly.
- Reorders panels in source order — `ProposalReviewPanel` first, then `ProposalPublishedContent` and `AudienceFeedbackPanel` — so keyboard/screen-reader traversal matches the visual layout on all viewports without any CSS ordering tricks.
- When post-conference panels render `null`, `space-y-` skips them cleanly with no visible gap, whereas the previous wrapper `div`s would have left phantom `gap-4` spacing in the flex container.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is layout-only and touches a single admin page with no data-fetching or business-logic modifications.

The refactor removes wrapper divs and CSS ordering in favour of straightforward source-order rendering. The new structure is simpler, the gap-on-null bug is genuinely fixed, and the reading-order improvement is correct. No logic, auth, or data paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(admin)/admin/proposals/[id]/page.tsx | Sidebar panel container refactored: wrapper divs and CSS order-* removed, panels reordered in source order (Review → Published → Audience) inside a space-y-4 container to fix DOM reading order and eliminate empty gaps from null-returning panels. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sidebar Column\nspace-y-4 p-4] --> B[ProposalReviewPanel\nalways rendered]
    A --> C{ProposalPublishedContent\nconferenceEndDate check}
    A --> D{AudienceFeedbackPanel\nconferenceStartDate check}
    C -- "post-conference" --> E[Renders panel]
    C -- "pre/during conference" --> F[Returns null - no gap]
    D -- "post-conference" --> G[Renders panel]
    D -- "pre/during conference" --> H[Returns null - no gap]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Sidebar Column\nspace-y-4 p-4] --> B[ProposalReviewPanel\nalways rendered]
    A --> C{ProposalPublishedContent\nconferenceEndDate check}
    A --> D{AudienceFeedbackPanel\nconferenceStartDate check}
    C -- "post-conference" --> E[Renders panel]
    C -- "pre/during conference" --> F[Returns null - no gap]
    D -- "post-conference" --> G[Renders panel]
    D -- "pre/during conference" --> H[Returns null - no gap]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): reorder proposal review side..."](https://github.com/cloudnativebergen/website/commit/a8e68682bcbdfe17b8084eb1c3ddf19c02ee5ee3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44382112)</sub>

<!-- /greptile_comment -->