### PR TITLE
ci: skip interactive confirm in the migration apply step

### DIFF
--- a/.github/workflows/run-migration.yml
+++ b/.github/workflows/run-migration.yml
@@ -85,4 +85,7 @@ jobs:
         run: pnpm sanity migration run "${{ inputs.migration }}" --project "$SANITY_STUDIO_PROJECT_ID" --dataset "${{ inputs.dataset }}"
 
       - name: Run migration
-        run: pnpm sanity migration run "${{ inputs.migration }}" --project "$SANITY_STUDIO_PROJECT_ID" --dataset "${{ inputs.dataset }}" --no-dry-run
+        # --no-confirm: the apply step otherwise prompts for confirmation,
+        # which fails in CI (non-interactive). The dry-run step above plus the
+        # dataset backup artifact are the safety gates.
+        run: pnpm sanity migration run "${{ inputs.migration }}" --project "$SANITY_STUDIO_PROJECT_ID" --dataset "${{ inputs.dataset }}" --no-dry-run --no-confirm


### PR DESCRIPTION
The `run-migration` workflow's apply step failed with `NonInteractiveError: Cannot run "confirm" prompt in a non-interactive environment` — `sanity migration run --no-dry-run` prompts for confirmation, which the Actions runner can't answer. (The backup export and dry-run steps succeeded; only the apply prompt failed.)

Adds `--no-confirm` to the apply command. The dry-run step and the 30-day dataset backup artifact remain the safety gates. This unblocks running migration 038 (backfill accepted co-speakers, issue #409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `--no-confirm` to the `sanity migration run` apply step so the CI runner can bypass the interactive confirmation prompt that previously caused a `NonInteractiveError`. The dry-run step immediately before and the 30-day backup artifact provide the same safety gates that the interactive prompt was intended to enforce.

- Adds a single `--no-confirm` flag to the apply command on line 91 of `.github/workflows/run-migration.yml`.
- A well-placed inline comment explains the rationale directly in the workflow file, making the bypass self-documenting.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the single-line change fixes a well-understood CI failure without removing any meaningful safety gate.

The workflow is manually triggered, requires a dataset backup to succeed before the apply step can run, and performs a dry-run immediately beforehand. Skipping the interactive confirmation prompt in a non-interactive environment is the correct fix, and the inline comment documents why the bypass is acceptable.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/run-migration.yml | One-line fix adding --no-confirm to the apply step; dry-run, manual trigger, and backup artifact remain as safety gates. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor Engineer
    participant GHA as GitHub Actions
    participant Sanity as Sanity CLI
    participant Dataset as Sanity Dataset

    Engineer->>GHA: workflow_dispatch (migration id, dataset)
    GHA->>Sanity: dataset export → backup artifact (30-day retention)
    GHA->>Sanity: migration run --dry-run (verify plan)
    Sanity-->>GHA: dry-run output (no writes)
    GHA->>Sanity: migration run --no-dry-run --no-confirm
    Sanity->>Dataset: apply migration writes
    Dataset-->>GHA: success / error
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor Engineer
    participant GHA as GitHub Actions
    participant Sanity as Sanity CLI
    participant Dataset as Sanity Dataset

    Engineer->>GHA: workflow_dispatch (migration id, dataset)
    GHA->>Sanity: dataset export → backup artifact (30-day retention)
    GHA->>Sanity: migration run --dry-run (verify plan)
    Sanity-->>GHA: dry-run output (no writes)
    GHA->>Sanity: migration run --no-dry-run --no-confirm
    Sanity->>Dataset: apply migration writes
    Dataset-->>GHA: success / error
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: skip interactive confirm in the migr..."](https://github.com/cloudnativebergen/website/commit/0e5b7016874697a3f46bf5a5515778f0129c7147) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44393737)</sub>

<!-- /greptile_comment -->