### PR TITLE
fix(admin): wrap long words and links in the reviewer talk view

### DIFF
--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -192,7 +192,7 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
               <h2 className="mb-3 text-lg font-medium text-gray-900 dark:text-white">
                 Description
               </h2>
-              <div className="text-gray-600 dark:text-gray-300">
+              <div className="break-words text-gray-600 dark:text-gray-300">
                 {proposal.description && proposal.description.length > 0 ? (
                   <PortableText
                     value={proposal.description}
@@ -210,7 +210,9 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
                   Outline
                 </h2>
                 <div className="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300">
-                  <p className="whitespace-pre-wrap">{proposal.outline}</p>
+                  <p className="break-words whitespace-pre-wrap">
+                    {proposal.outline}
+                  </p>
                 </div>
               </div>
             )}

--- a/src/lib/portabletext/components.tsx
+++ b/src/lib/portabletext/components.tsx
@@ -43,7 +43,7 @@ export const portableTextComponents: PortableTextComponents = {
       return (
         <a
           href={href}
-          className="font-medium text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+          className="font-medium break-words text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Fixes #371.

The proposal review view (`ProposalDetail`) rendered the **Description**, **Outline**, and portable-text **links** with no `overflow-wrap`, so a long URL or an unbroken string in a submitted abstract/outline overflowed the container horizontally (pushing the layout wide / clipping on mobile). Added `break-words` to both text containers and the link mark so long tokens wrap.

Layout-only, no logic change. `pnpm typecheck` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes horizontal overflow in the admin proposal reviewer view (`ProposalDetail`) by adding Tailwind's `break-words` utility wherever long, unbreakable strings (URLs, raw text) could push the layout past its container boundary. The fix also propagates through the shared `portableTextComponents` link mark, so all eight call sites that render portable text benefit from the same overflow protection.

- `ProposalDetail.tsx`: adds `break-words` to the Description container `div` and the Outline `<p>` element, covering both rich-text and pre-wrapped plain text paths.
- `src/lib/portabletext/components.tsx`: adds `break-words` to the `<a>` link mark, which applies site-wide to every `PortableText` renderer (admin views, workshop cards, speaker pages, sponsor terms, and the CFP read-only view).

<h3>Confidence Score: 5/5</h3>

Safe to merge — three additive CSS class changes with no logic impact.

All three changes add a single Tailwind utility class to existing elements. The shared portableTextComponents link mark change applies globally to 8 call sites, but overflow-wrap: break-word is universally desirable behaviour for link text and carries no risk of visual regression beyond the intended wrapping fix.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/ProposalDetail.tsx | Adds `break-words` to the Description container and Outline paragraph; layout-only, no logic change. |
| src/lib/portabletext/components.tsx | Adds `break-words` to the shared link mark component; change is global across all 8 call sites and is intentionally beneficial. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PD[ProposalDetail]

    PD -->|description| DescDiv["div.break-words ← added"]
    DescDiv --> PT["PortableText\n(portableTextComponents)"]
    PT --> Link["marks.link → a.break-words ← added"]

    PD -->|outline| OutlineP["p.break-words.whitespace-pre-wrap ← added"]

    PT --> Headings["h1 / h2 / h3 / p\n(block renderers)"]
    PT --> Lists["ul / ol / li\n(list renderers)"]
    PT --> InlineMarks["strong / em / u\n(inline marks)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    PD[ProposalDetail]

    PD -->|description| DescDiv["div.break-words ← added"]
    DescDiv --> PT["PortableText\n(portableTextComponents)"]
    PT --> Link["marks.link → a.break-words ← added"]

    PD -->|outline| OutlineP["p.break-words.whitespace-pre-wrap ← added"]

    PT --> Headings["h1 / h2 / h3 / p\n(block renderers)"]
    PT --> Lists["ul / ol / li\n(list renderers)"]
    PT --> InlineMarks["strong / em / u\n(inline marks)"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): wrap long words and links in..."](https://github.com/cloudnativebergen/website/commit/66dab23ae77dd8c693ef8df3e90058ef53e37250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44418887)</sub>

<!-- /greptile_comment -->