### PR TITLE
refactor(speaker): document the read/write image type split

### DIFF
--- a/src/lib/speaker/types.ts
+++ b/src/lib/speaker/types.ts
@@ -68,18 +68,20 @@ export interface Speaker extends SpeakerBase {
   email: string
   providers?: string[]
   /**
-   * Read-side image value: a fully-resolved display URL projected by GROQ as
-   * `coalesce(image.asset->url, imageURL)`. It is either a Sanity CDN URL (from
-   * an uploaded image) or an external OAuth avatar URL (the {@link imageURL}
-   * fallback) — never a raw Sanity image object or a bare asset ID. Pass it
-   * through `speakerImageUrl()` for display transforms.
+   * Read-side image value: a display URL, projected by the speaker GROQ
+   * queries as `coalesce(image.asset->url, imageURL)` — either a Sanity CDN URL
+   * (from an uploaded image) or an external OAuth avatar URL (the
+   * {@link imageURL} fallback). Pass it through `speakerImageUrl()` for display
+   * transforms. Note: a few nested/gallery sub-queries return the raw Sanity
+   * image object instead, but those are modelled by their own types, not this
+   * one.
    */
   image?: string
   /**
    * Legacy OAuth provider avatar URL (GitHub / LinkedIn), stored on first
-   * sign-in by `getOrCreateSpeaker()`. Read queries do not project this field
-   * directly; it is the fallback source for the resolved {@link image} URL
-   * above.
+   * sign-in by `getOrCreateSpeaker()`. It isn't projected as a distinct field
+   * by most queries (full-document `...` spreads do include it) and is the
+   * fallback source for the resolved {@link image} URL above.
    */
   imageURL?: string
   isOrganizer?: boolean

--- a/src/lib/speaker/types.ts
+++ b/src/lib/speaker/types.ts
@@ -35,14 +35,30 @@ interface SpeakerBase {
   slug?: string
   title?: string
   bio?: string
-  image?: string
   links?: string[]
   flags?: Flags[]
   consent?: SpeakerConsent
   galleryImages?: GalleryImageWithSpeakers[]
 }
 
-export type SpeakerInput = SpeakerBase
+/**
+ * Speaker data accepted by write paths (create / update).
+ *
+ * The `image` field is deliberately kept separate from the read-model
+ * {@link Speaker.image} because the two carry different values despite sharing
+ * the `string` type — this is the type ambiguity tracked in issue #353.
+ */
+export interface SpeakerInput extends SpeakerBase {
+  /**
+   * Write-side image value: a Sanity asset ID (e.g.
+   * `image-abc123-500x500-png`) produced by the image upload API when a new
+   * file is uploaded. `updateSpeaker()` only persists it when it matches the
+   * `image-` asset-ID shape; any other value (such as a resolved CDN URL
+   * round-tripped from a read model) is ignored. Forms should only include
+   * this field when a new image was actually uploaded.
+   */
+  image?: string
+}
 
 export interface Speaker extends SpeakerBase {
   _id: string
@@ -51,6 +67,20 @@ export interface Speaker extends SpeakerBase {
   _updatedAt: string
   email: string
   providers?: string[]
+  /**
+   * Read-side image value: a fully-resolved display URL projected by GROQ as
+   * `coalesce(image.asset->url, imageURL)`. It is either a Sanity CDN URL (from
+   * an uploaded image) or an external OAuth avatar URL (the {@link imageURL}
+   * fallback) — never a raw Sanity image object or a bare asset ID. Pass it
+   * through `speakerImageUrl()` for display transforms.
+   */
+  image?: string
+  /**
+   * Legacy OAuth provider avatar URL (GitHub / LinkedIn), stored on first
+   * sign-in by `getOrCreateSpeaker()`. Read queries do not project this field
+   * directly; it is the fallback source for the resolved {@link image} URL
+   * above.
+   */
   imageURL?: string
   isOrganizer?: boolean
 }


### PR DESCRIPTION
Fixes #353 (the Phase-3 type ambiguity; the data-corruption core it originally reported is already fixed on main).

`Speaker.image` and `SpeakerInput.image` share the `string` type but carry different values:
- **Read model** (`Speaker.image`): a fully-resolved display URL, projected by GROQ as `coalesce(image.asset->url, imageURL)` — a Sanity CDN URL or the OAuth-avatar fallback. Passed through `speakerImageUrl()` for display.
- **Write model** (`SpeakerInput.image`): a Sanity **asset ID** (`image-abc…`), persisted by `updateSpeaker()` only when it matches the `image-` shape.

This splits the single ambiguous field on `SpeakerBase` into the two typed fields with JSDoc (and makes `SpeakerInput` an `interface extends SpeakerBase`). **Documentation/structure only** — no runtime, query, or save-flow change; all ~30 consumers compile unchanged, no new casts. A branded/discriminated type was deliberately avoided (it would force casts at all 27 query boundaries for little gain).

`pnpm typecheck` clean; `pnpm vitest run`: 2054 passed / 5 skipped; eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves the type ambiguity in issue #353 by splitting the shared `image?: string` field (which previously sat on `SpeakerBase`) into two explicitly-documented fields: a write-side Sanity asset ID on `SpeakerInput` and a read-side resolved CDN/OAuth URL on `Speaker`. It also promotes `SpeakerInput` from a bare type alias to a proper `interface extends SpeakerBase`, and adds JSDoc to the pre-existing `imageURL` field.

- **No runtime change** — all GROQ queries, save flows, and display helpers are untouched; the PR author confirms `pnpm typecheck` and 2054 tests pass clean.
- **`SpeakerInput` becomes an interface** — changing from `type SpeakerInput = SpeakerBase` to `interface SpeakerInput extends SpeakerBase` is structurally equivalent but allows future interface augmentation if needed.
- **JSDoc cross-references** — `{@link Speaker.image}` and `{@link imageURL}` provide navigable links between the two semantic models directly in the type definitions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation and interface structure only, no runtime behaviour changed.

The change is purely additive JSDoc and a structural split of a single ambiguous field into two explicitly-typed declarations. No query, save, or display logic is touched. The type alias → interface conversion is structurally equivalent in TypeScript and all downstream consumers compile unchanged. The author's typecheck and full test run confirm no regressions.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/speaker/types.ts | Splits the ambiguous `image` field from `SpeakerBase` into separate `SpeakerInput.image` (write-side asset ID) and `Speaker.image` (read-side CDN URL), with JSDoc; changes `SpeakerInput` from a type alias to a proper interface extension. Documentation-only, no runtime impact. |

</details>

<h3>Class Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class SpeakerBase {
        <<interface, unexported>>
        +name: string
        +slug?: string
        +title?: string
        +bio?: string
        +links?: string[]
        +flags?: Flags[]
        +consent?: SpeakerConsent
        +galleryImages?: GalleryImageWithSpeakers[]
    }

    class SpeakerInput {
        <<interface, write model>>
        +image?: string
    }

    class Speaker {
        <<interface, read model>>
        +_id: string
        +email: string
        +image?: string
        +imageURL?: string
        +isOrganizer?: boolean
    }

    class SpeakerWithTalks {
        <<interface>>
        +talks?: ProposalExisting[]
    }

    class SpeakerWithReviewInfo {
        <<interface>>
        +submittedTalks?: ProposalExisting[]
        +previousAcceptedTalks?: ProposalExisting[]
    }

    SpeakerBase <|-- SpeakerInput : extends
    SpeakerBase <|-- Speaker : extends
    Speaker <|-- SpeakerWithTalks : extends
    Speaker <|-- SpeakerWithReviewInfo : extends
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    class SpeakerBase {
        <<interface, unexported>>
        +name: string
        +slug?: string
        +title?: string
        +bio?: string
        +links?: string[]
        +flags?: Flags[]
        +consent?: SpeakerConsent
        +galleryImages?: GalleryImageWithSpeakers[]
    }

    class SpeakerInput {
        <<interface, write model>>
        +image?: string
    }

    class Speaker {
        <<interface, read model>>
        +_id: string
        +email: string
        +image?: string
        +imageURL?: string
        +isOrganizer?: boolean
    }

    class SpeakerWithTalks {
        <<interface>>
        +talks?: ProposalExisting[]
    }

    class SpeakerWithReviewInfo {
        <<interface>>
        +submittedTalks?: ProposalExisting[]
        +previousAcceptedTalks?: ProposalExisting[]
    }

    SpeakerBase <|-- SpeakerInput : extends
    SpeakerBase <|-- Speaker : extends
    Speaker <|-- SpeakerWithTalks : extends
    Speaker <|-- SpeakerWithReviewInfo : extends
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(speaker): document the read/wri..."](https://github.com/cloudnativebergen/website/commit/0aa210d5892546b371929f1e99e4c9cd1a07614e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44420924)</sub>

<!-- /greptile_comment -->