### PR TITLE
fix(cospeaker): fail closed on unmapped format co-speaker limit

### DIFF
--- a/__tests__/lib/cospeaker/constants.test.ts
+++ b/__tests__/lib/cospeaker/constants.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getCoSpeakerLimit,
+  getTotalSpeakerLimit,
+  allowsCoSpeakers,
+} from '@/lib/cospeaker/constants'
+import { Format } from '@/lib/proposal/types'
+
+describe('getCoSpeakerLimit', () => {
+  it('returns the per-format limit for mapped formats', () => {
+    expect(getCoSpeakerLimit(Format.lightning_10)).toBe(0)
+    expect(getCoSpeakerLimit(Format.presentation_25)).toBe(1)
+    expect(getCoSpeakerLimit(Format.presentation_40)).toBe(2)
+    expect(getCoSpeakerLimit(Format.workshop_240)).toBe(3)
+  })
+
+  it('fails closed (0) for an unmapped/legacy format', () => {
+    expect(getCoSpeakerLimit('some-legacy-format' as Format)).toBe(0)
+    expect(getCoSpeakerLimit(undefined as unknown as Format)).toBe(0)
+  })
+
+  it('allowsCoSpeakers is false for an unmapped format', () => {
+    expect(allowsCoSpeakers('unknown' as Format)).toBe(false)
+    expect(allowsCoSpeakers(Format.lightning_10)).toBe(false)
+    expect(allowsCoSpeakers(Format.presentation_25)).toBe(true)
+  })
+
+  it('getTotalSpeakerLimit is the co-speaker limit plus the primary speaker', () => {
+    expect(getTotalSpeakerLimit(Format.presentation_40)).toBe(3)
+    expect(getTotalSpeakerLimit('unknown' as Format)).toBe(1)
+  })
+})

--- a/src/lib/cospeaker/constants.ts
+++ b/src/lib/cospeaker/constants.ts
@@ -16,7 +16,10 @@ export const CO_SPEAKER_LIMITS = {
 } as const
 
 export function getCoSpeakerLimit(format: Format): number {
-  return CO_SPEAKER_LIMITS[format] ?? 1
+  // Fail closed: an unmapped/legacy format allows no co-speakers rather than
+  // silently bypassing the per-format limit. New formats must be added to
+  // CO_SPEAKER_LIMITS to opt in.
+  return CO_SPEAKER_LIMITS[format] ?? 0
 }
 
 export function getTotalSpeakerLimit(format: Format): number {


### PR DESCRIPTION
`getCoSpeakerLimit` fell back to **1** for any format not in `CO_SPEAKER_LIMITS`, so an unmapped or legacy talk format silently permitted a co-speaker and could bypass the intended per-format cap (a latent issue flagged during the co-speaker review).

Fall back to **0** (fail closed): an unrecognized format allows no co-speakers, and a new format opts in by being added to `CO_SPEAKER_LIMITS`. Adds tests for the mapped limits and the fail-closed fallback.

No migration needed (runtime logic only). `pnpm typecheck` clean; new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the co-speaker enforcement logic by changing `getCoSpeakerLimit`'s fallback return value from `1` to `0`, so any talk format not explicitly listed in `CO_SPEAKER_LIMITS` is treated as "no co-speakers allowed" rather than silently permitting one. A new test file validates the per-format limits, the fail-closed path, and derived helpers.

- **`src/lib/cospeaker/constants.ts`**: Single-line change (`?? 1` → `?? 0`) with an explanatory comment; all downstream helpers (`getTotalSpeakerLimit`, `allowsCoSpeakers`, `getSpeakerLimitDescription`) behave correctly under the new default.
- **`__tests__/lib/cospeaker/constants.test.ts`**: New suite covers the fix directly — mapped limits, undefined/legacy format fallback, and derived helper behaviour. Three of seven mapped formats (`presentation_20`, `presentation_45`, `workshop_120`) are not explicitly asserted but the sampled coverage demonstrates the invariant.

<h3>Confidence Score: 5/5</h3>

Minimal, well-scoped change that makes the fallback behaviour more restrictive — safe to merge.

The fix is a single-character change to a fallback value, the intent is clearly documented in both the comment and the PR description, and the new tests directly exercise the changed code path including the `undefined` edge case. All derived helpers work correctly under the new default without modification. No data migrations, API changes, or cross-cutting concerns are involved.

No files require special attention; the change is self-contained within the cospeaker constants module.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/cospeaker/constants.ts | One-line fix changes the fallback in `getCoSpeakerLimit` from `1` to `0`, accompanied by a clear explanatory comment. No other logic is affected. |
| __tests__/lib/cospeaker/constants.test.ts | New test file covers mapped limits, the fail-closed fallback, `allowsCoSpeakers`, and `getTotalSpeakerLimit`. Three of the seven mapped formats (`presentation_20`, `presentation_45`, `workshop_120`) are not explicitly asserted. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getCoSpeakerLimit(format)"] --> B{"format in CO_SPEAKER_LIMITS?"}
    B -- Yes --> C["Return mapped limit (0, 1, 2, or 3)"]
    B -- "No / undefined" --> D["Return 0 (fail-closed)"]
    C --> E["getTotalSpeakerLimit = limit + 1"]
    D --> E
    C --> F["allowsCoSpeakers = limit > 0"]
    D --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["getCoSpeakerLimit(format)"] --> B{"format in CO_SPEAKER_LIMITS?"}
    B -- Yes --> C["Return mapped limit (0, 1, 2, or 3)"]
    B -- "No / undefined" --> D["Return 0 (fail-closed)"]
    C --> E["getTotalSpeakerLimit = limit + 1"]
    D --> E
    C --> F["allowsCoSpeakers = limit > 0"]
    D --> F
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(cospeaker): fail closed on unmapped ..."](https://github.com/cloudnativebergen/website/commit/e6a07244811983c7b5be573aaf9b38b9835d8cf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44423246)</sub>

<!-- /greptile_comment -->