### PR TITLE
feat(admin): fullscreen speaker photo in talk review (#326)

### DIFF
--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -31,7 +31,7 @@ import { RatingDisplay } from '@/lib/proposal/ui'
 import { portableTextComponents } from '@/lib/portabletext/components'
 import { iconForLink } from '@/components/SocialIcons'
 import { ProposalAttachmentsPanel } from '@/components/proposal/ProposalAttachmentsPanel'
-import { SpeakerImageModal } from '@/components/admin/SpeakerImageModal'
+import { SpeakerImageModal } from '@/components/admin'
 
 interface ProposalDetailProps {
   proposal: ProposalExisting

--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -31,6 +31,7 @@ import { RatingDisplay } from '@/lib/proposal/ui'
 import { portableTextComponents } from '@/lib/portabletext/components'
 import { iconForLink } from '@/components/SocialIcons'
 import { ProposalAttachmentsPanel } from '@/components/proposal/ProposalAttachmentsPanel'
+import { SpeakerImageModal } from '@/components/admin/SpeakerImageModal'
 
 interface ProposalDetailProps {
   proposal: ProposalExisting
@@ -71,8 +72,10 @@ interface SpeakerCardProps {
 
 function SpeakerCard({ speaker, requiresTravelFunding }: SpeakerCardProps) {
   const [isBioExpanded, setIsBioExpanded] = useState(false)
+  const [isImageModalOpen, setIsImageModalOpen] = useState(false)
   const bioText = speaker.bio || ''
   const shouldShowExpand = bioText.length > 150
+  const hasImage = typeof speaker.image === 'string' && speaker.image.length > 0
 
   return (
     <div className="rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
@@ -88,10 +91,15 @@ function SpeakerCard({ speaker, requiresTravelFunding }: SpeakerCardProps) {
       </div>
       <div>
         <div className="float-left mr-4 mb-2">
-          {speaker.image && typeof speaker.image === 'string' ? (
-            <div className="h-16 w-16 overflow-hidden rounded-full">
+          {hasImage ? (
+            <button
+              type="button"
+              onClick={() => setIsImageModalOpen(true)}
+              aria-label={`View ${speaker.name}'s photo`}
+              className="block h-16 w-16 overflow-hidden rounded-full transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800"
+            >
               <SpeakerAvatarImage
-                src={speakerImageUrl(speaker.image, {
+                src={speakerImageUrl(speaker.image as string, {
                   width: 128,
                   height: 128,
                   fit: 'crop',
@@ -99,7 +107,7 @@ function SpeakerCard({ speaker, requiresTravelFunding }: SpeakerCardProps) {
                 name={speaker.name}
                 size={64}
               />
-            </div>
+            </button>
           ) : (
             <MissingAvatar
               name={speaker.name}
@@ -161,6 +169,17 @@ function SpeakerCard({ speaker, requiresTravelFunding }: SpeakerCardProps) {
         </div>
         <div className="clear-both" />
       </div>
+      {hasImage && (
+        <SpeakerImageModal
+          isOpen={isImageModalOpen}
+          onClose={() => setIsImageModalOpen(false)}
+          speaker={{
+            name: speaker.name,
+            title: speaker.title,
+            image: speaker.image as string,
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/admin/SpeakerImageModal.stories.tsx
+++ b/src/components/admin/SpeakerImageModal.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test'
+import { SpeakerImageModal } from './SpeakerImageModal'
+
+// Inline SVG portrait so the story renders deterministically without any
+// network request (speakerImageUrl returns non-Sanity URLs untouched).
+const PORTRAIT =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400">
+      <rect width="400" height="400" fill="#1d4ed8"/>
+      <circle cx="200" cy="150" r="80" fill="#93c5fd"/>
+      <rect x="90" y="240" width="220" height="160" rx="110" fill="#93c5fd"/>
+      <text x="200" y="380" font-family="sans-serif" font-size="24" fill="#fff" text-anchor="middle">Speaker photo</text>
+    </svg>`,
+  )
+
+const meta = {
+  title: 'Systems/Speakers/Admin/SpeakerImageModal',
+  component: SpeakerImageModal,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A lightweight modal (built on ModalShell) that shows a speaker photo at a large size during talk review. Opened by clicking a speaker avatar in ProposalDetail. Closes on ESC, backdrop click, or the close button.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    onClose: fn(),
+  },
+} satisfies Meta<typeof SpeakerImageModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    speaker: {
+      name: 'Jane Doe',
+      title: 'Senior Engineer at CloudCorp',
+      image: PORTRAIT,
+    },
+  },
+}
+
+export const NameOnly: Story = {
+  args: {
+    isOpen: true,
+    speaker: {
+      name: 'Alex Rivera',
+      image: PORTRAIT,
+    },
+  },
+}
+
+/**
+ * Interactive example mirroring the ProposalDetail flow: a focusable avatar
+ * button opens the modal, and ESC / the close button dismiss it.
+ */
+export const Interactive: Story = {
+  args: {
+    isOpen: false,
+    speaker: {
+      name: 'Jane Doe',
+      title: 'Senior Engineer at CloudCorp',
+      image: PORTRAIT,
+    },
+  },
+  render: (args) => {
+    function Demo() {
+      const [isOpen, setIsOpen] = useState(false)
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => setIsOpen(true)}
+            aria-label={`View ${args.speaker.name}'s photo`}
+            className="block h-16 w-16 overflow-hidden rounded-full transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            <img
+              src={args.speaker.image}
+              alt={args.speaker.name}
+              className="h-full w-full object-cover"
+            />
+          </button>
+          <SpeakerImageModal
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            speaker={args.speaker}
+          />
+        </>
+      )
+    }
+    return <Demo />
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByRole('button', {
+      name: "View Jane Doe's photo",
+    })
+
+    // Avatar is keyboard-focusable and opens the modal on activation.
+    trigger.focus()
+    await expect(trigger).toHaveFocus()
+    await userEvent.keyboard('{Enter}')
+
+    const dialog = within(document.body)
+    await waitFor(() => expect(dialog.getByRole('dialog')).toBeInTheDocument())
+    await expect(dialog.getByText('Jane Doe')).toBeInTheDocument()
+
+    // ESC closes it.
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() =>
+      expect(dialog.queryByRole('dialog')).not.toBeInTheDocument(),
+    )
+  },
+}

--- a/src/components/admin/SpeakerImageModal.tsx
+++ b/src/components/admin/SpeakerImageModal.tsx
@@ -41,7 +41,7 @@ export function SpeakerImageModal({
         </div>
         <button
           type="button"
-          className="shrink-0 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+          className="shrink-0 rounded text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:text-gray-300"
           onClick={onClose}
           aria-label="Close"
         >

--- a/src/components/admin/SpeakerImageModal.tsx
+++ b/src/components/admin/SpeakerImageModal.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { DialogTitle } from '@headlessui/react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { speakerImageUrl } from '@/lib/sanity/client'
+import { ModalShell } from '@/components/ModalShell'
+import { SpeakerAvatarImage } from '@/components/common/SpeakerAvatarImage'
+
+interface SpeakerImageModalProps {
+  isOpen: boolean
+  onClose: () => void
+  speaker: {
+    name: string
+    title?: string
+    image: string
+  }
+}
+
+export function SpeakerImageModal({
+  isOpen,
+  onClose,
+  speaker,
+}: SpeakerImageModalProps) {
+  return (
+    <ModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      size="2xl"
+      className="overflow-hidden border border-brand-frosted-steel bg-brand-glacier-white dark:border-gray-700"
+    >
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <DialogTitle className="font-space-grotesk truncate text-xl font-semibold text-brand-slate-gray dark:text-white">
+            {speaker.name}
+          </DialogTitle>
+          {speaker.title && (
+            <p className="mt-1 truncate text-sm text-brand-slate-gray/70 dark:text-gray-400">
+              {speaker.title}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          className="shrink-0 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <XMarkIcon className="h-6 w-6" />
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-brand-frosted-steel bg-white dark:border-gray-700 dark:bg-gray-800">
+        <SpeakerAvatarImage
+          src={speakerImageUrl(speaker.image, {
+            width: 800,
+            height: 800,
+            fit: 'max',
+          })}
+          name={speaker.name}
+          size={800}
+        />
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -29,6 +29,7 @@ export { ProposalActionModal } from './ProposalActionModal'
 export { SpeakerTable } from './SpeakerTable'
 export { GeneralBroadcastModal } from './GeneralBroadcastModal'
 export { SpeakerEmailModal } from './SpeakerEmailModal'
+export { SpeakerImageModal } from './SpeakerImageModal'
 export { EmailModal } from './EmailModal'
 export { SpeakerActions } from './SpeakerActions'
 


### PR DESCRIPTION
## Summary

Implements #326: while reviewing talks, organizers can now click a speaker's avatar to see the photo at a large size.

- New `SpeakerImageModal` (`src/components/admin/SpeakerImageModal.tsx`) built on the lightweight `ModalShell` (not the heavy `GalleryModal`). Renders the image via `speakerImageUrl(image, { width: 800, height: 800, fit: 'max' })` with a header showing the speaker name and title, and a close button.
- In `ProposalDetail`'s `SpeakerCard`, the 64px avatar is now a focusable `<button>` (`aria-label="View <name>'s photo"`, hover opacity) that opens the modal. Rendered only when the speaker has a non-empty image string.
- Speakers without a photo keep the existing `MissingAvatar` placeholder, which is **not** clickable.
- Reuses existing `SpeakerAvatarImage` / `MissingAvatar` fallbacks (broken image URLs degrade to initials).
- Storybook story added under `Systems/Speakers/Admin/SpeakerImageModal`, including an interactive `play` function that opens via Enter and closes via ESC.

## Acceptance criteria

- [x] Clicking a speaker avatar with a photo opens a modal showing the image large with the speaker's name.
- [x] ESC / close button / backdrop closes it (handled by `ModalShell` + Headless UI `Dialog`).
- [x] A speaker with no image has a non-clickable placeholder (no modal rendered).
- [x] The avatar button is keyboard-focusable and activates on Enter/Space (native `<button>`; verified in the story `play` function).

## Verification

- `pnpm typecheck` clean
- `pnpm vitest run` green (117 files, 2058 passed / 5 skipped)
- eslint + prettier clean on touched files
- `pnpm build-storybook` completes successfully (story loads)

No migration needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `SpeakerImageModal` component that lets organizers click a speaker avatar in the talk review view to see the photo at full size (800 × 800). The feature is neatly scoped behind a `hasImage` guard, reuses `ModalShell` / `SpeakerAvatarImage`, and is covered by a Storybook play-function story.

- `SpeakerImageModal.tsx` — lightweight modal built on `ModalShell` (size `2xl`); renders `speakerImageUrl(..., { fit: 'max' })` so tall or wide photos are letterboxed rather than cropped.
- `ProposalDetail.tsx` — the 64 px avatar `div` is replaced by a focusable `<button>` with `aria-label`; speakers without an image keep the non-clickable `MissingAvatar` placeholder unchanged.
- `SpeakerImageModal.stories.tsx` — three stories including an `Interactive` play function that verifies keyboard open (Enter) and close (ESC) behaviour deterministically with an inline SVG portrait.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is additive and well-scoped with no impact on existing data flow or access control.

The core feature is correctly implemented and all acceptance criteria are met. Two minor style findings remain: the close button is missing a focus-visible ring (inconsistent with the avatar button in the same PR), and the new component is not re-exported through the established barrel file. Neither affects runtime behaviour.

No files require special attention; both findings are in SpeakerImageModal.tsx.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/SpeakerImageModal.tsx | New modal component for displaying a speaker photo at 800x800px, built on ModalShell. Logic is correct; close button lacks focus-visible ring styles. |
| src/components/admin/ProposalDetail.tsx | Replaces the static div avatar wrapper with a focusable button that opens SpeakerImageModal; hasImage guard and type cast are correct. |
| src/components/admin/SpeakerImageModal.stories.tsx | Adds three Storybook stories including an interactive play function that verifies keyboard open/ESC-close flow; deterministic inline SVG avoids network requests. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant O as Organizer
    participant SC as SpeakerCard
    participant SIM as SpeakerImageModal
    participant MS as ModalShell (Headless UI Dialog)

    O->>SC: Click / Enter on avatar button
    SC->>SC: setIsImageModalOpen(true)
    SC->>SIM: "isOpen=true, speaker={name, title, image}"
    SIM->>MS: "isOpen=true"
    MS-->>O: Backdrop + dialog rendered (portal at body)
    Note over SIM: speakerImageUrl(image, {width:800, height:800, fit:'max'})
    SIM-->>O: Speaker name, title, 800px photo shown

    alt ESC key
        O->>MS: keydown Escape
        MS->>SIM: onClose()
    else Close button click
        O->>SIM: Click XMarkIcon button
        SIM->>SIM: onClick → onClose()
    else Backdrop click
        O->>MS: Click outside DialogPanel
        MS->>SIM: onClose()
    end

    SIM->>SC: onClose() → setIsImageModalOpen(false)
    SC->>SIM: "isOpen=false"
    MS-->>O: Dialog unmounts
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant O as Organizer
    participant SC as SpeakerCard
    participant SIM as SpeakerImageModal
    participant MS as ModalShell (Headless UI Dialog)

    O->>SC: Click / Enter on avatar button
    SC->>SC: setIsImageModalOpen(true)
    SC->>SIM: "isOpen=true, speaker={name, title, image}"
    SIM->>MS: "isOpen=true"
    MS-->>O: Backdrop + dialog rendered (portal at body)
    Note over SIM: speakerImageUrl(image, {width:800, height:800, fit:'max'})
    SIM-->>O: Speaker name, title, 800px photo shown

    alt ESC key
        O->>MS: keydown Escape
        MS->>SIM: onClose()
    else Close button click
        O->>SIM: Click XMarkIcon button
        SIM->>SIM: onClick → onClose()
    else Backdrop click
        O->>MS: Click outside DialogPanel
        MS->>SIM: onClose()
    end

    SIM->>SC: onClose() → setIsImageModalOpen(false)
    SC->>SIM: "isOpen=false"
    MS-->>O: Dialog unmounts
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(admin): fullscreen speaker photo in..."](https://github.com/cloudnativebergen/website/commit/1bc8bf4dbf450f038cd8e3bf7c392f81207c5aaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44427464)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->