### PR TITLE
feat(cfp): show confirmed talk schedule on speaker dashboard

### DIFF
--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -87,6 +87,7 @@ export default async function SpeakerDashboard() {
           speakerId,
           conferenceId: conference._id,
           returnAll: false,
+          includeSchedule: true,
         }),
         getGalleryImages(
           {

--- a/src/components/cfp/CompactProposalList.stories.tsx
+++ b/src/components/cfp/CompactProposalList.stories.tsx
@@ -448,6 +448,102 @@ export const MultiSpeaker: Story = {
   },
 }
 
+export const ScheduledConfirmedTalk: Story = {
+  args: {
+    proposals: [
+      createMockProposal(
+        'talk-1',
+        'Building Scalable Microservices with Kubernetes',
+        Status.confirmed,
+        Format.presentation_45,
+        {
+          scheduleInfo: {
+            date: '2025-10-30',
+            trackTitle: 'Track 1 - Main Stage',
+            timeSlot: { startTime: '10:00', endTime: '10:45' },
+          },
+        },
+      ),
+    ],
+    canEdit: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A confirmed talk with schedule information shows the date, time slot, and track/room.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    expect(canvas.getByText('10:00 - 10:45')).toBeInTheDocument()
+    expect(canvas.getByText('Track 1 - Main Stage')).toBeInTheDocument()
+  },
+}
+
+export const AcceptedNotYetScheduled: Story = {
+  args: {
+    proposals: [
+      createMockProposal(
+        'talk-1',
+        'Accepted But Not Scheduled',
+        Status.accepted,
+        Format.presentation_45,
+      ),
+    ],
+    canEdit: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An accepted talk with no schedule information shows no schedule row and does not crash.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    expect(
+      canvas.queryByText(/\d{2}:\d{2} - \d{2}:\d{2}/),
+    ).not.toBeInTheDocument()
+  },
+}
+
+export const NonApprovedHidesSchedule: Story = {
+  args: {
+    proposals: [
+      createMockProposal(
+        'talk-1',
+        'Submitted With Stray Schedule',
+        Status.submitted,
+        Format.presentation_45,
+        {
+          scheduleInfo: {
+            date: '2025-10-30',
+            trackTitle: 'Track 2',
+            timeSlot: { startTime: '13:00', endTime: '13:45' },
+          },
+        },
+      ),
+    ],
+    canEdit: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Non-approved proposals never show schedule info, even if the field is populated.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    expect(canvas.queryByText('13:00 - 13:45')).not.toBeInTheDocument()
+    expect(canvas.queryByText('Track 2')).not.toBeInTheDocument()
+  },
+}
+
 export const Empty: Story = {
   args: {
     proposals: [],

--- a/src/components/cfp/CompactProposalList.stories.tsx
+++ b/src/components/cfp/CompactProposalList.stories.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/proposal/types'
 import { Flags, Speaker } from '@/lib/speaker/types'
 import { convertStringToPortableTextBlocks } from '@/lib/proposal'
+import { formatConferenceDateLong } from '@/lib/time'
 import { expect, within } from 'storybook/test'
 
 const mockSpeakers: Speaker[] = [
@@ -477,6 +478,9 @@ export const ScheduledConfirmedTalk: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
+    expect(
+      canvas.getByText(formatConferenceDateLong('2025-10-30')),
+    ).toBeInTheDocument()
     expect(canvas.getByText('10:00 - 10:45')).toBeInTheDocument()
     expect(canvas.getByText('Track 1 - Main Stage')).toBeInTheDocument()
   },

--- a/src/components/cfp/CompactProposalList.tsx
+++ b/src/components/cfp/CompactProposalList.tsx
@@ -7,6 +7,9 @@ import {
   VideoCameraIcon,
   ExclamationTriangleIcon,
   MinusCircleIcon,
+  CalendarIcon,
+  ClockIcon as ClockOutlineIcon,
+  MapPinIcon,
 } from '@heroicons/react/24/outline'
 import {
   CheckBadgeIcon,
@@ -18,6 +21,7 @@ import {
 import type { ProposalExisting, Status } from '@/lib/proposal/types'
 import { statuses } from '@/lib/proposal/types'
 import { formatConfig } from '@/lib/proposal'
+import { formatConferenceDateLong } from '@/lib/time'
 import { hasProposalVideo } from '@/lib/proposal/video'
 import { SpeakerAvatars } from '@/components/SpeakerAvatars'
 import { useImpersonateQueryString } from '@/lib/impersonation'
@@ -157,16 +161,39 @@ export function CompactProposalList({
                     className={`h-4 w-4 shrink-0 ${formatInfo.color || 'text-gray-500'}`}
                   />
                 )}
-                <Link
-                  href={`/cfp/proposal/${proposal._id}${queryString}`}
-                  className={`flex-1 truncate font-medium hover:text-brand-cloud-blue dark:hover:text-blue-400 ${
-                    isMuted
-                      ? 'text-gray-600 dark:text-gray-400'
-                      : 'text-gray-900 dark:text-white'
-                  }`}
-                >
-                  {proposal.title}
-                </Link>
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <Link
+                    href={`/cfp/proposal/${proposal._id}${queryString}`}
+                    className={`truncate font-medium hover:text-brand-cloud-blue dark:hover:text-blue-400 ${
+                      isMuted
+                        ? 'text-gray-600 dark:text-gray-400'
+                        : 'text-gray-900 dark:text-white'
+                    }`}
+                  >
+                    {proposal.title}
+                  </Link>
+                  {isApproved &&
+                    proposal.scheduleInfo?.date &&
+                    proposal.scheduleInfo?.timeSlot && (
+                      <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-xs text-gray-500 dark:text-gray-400">
+                        <span className="flex items-center">
+                          <CalendarIcon className="mr-1 h-3.5 w-3.5" />
+                          {formatConferenceDateLong(proposal.scheduleInfo.date)}
+                        </span>
+                        <span className="flex items-center">
+                          <ClockOutlineIcon className="mr-1 h-3.5 w-3.5" />
+                          {proposal.scheduleInfo.timeSlot.startTime} -{' '}
+                          {proposal.scheduleInfo.timeSlot.endTime}
+                        </span>
+                        {proposal.scheduleInfo.trackTitle && (
+                          <span className="flex items-center">
+                            <MapPinIcon className="mr-1 h-3.5 w-3.5" />
+                            {proposal.scheduleInfo.trackTitle}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                </div>
               </div>
               <div className="flex shrink-0 flex-wrap items-center gap-2">
                 {showFeedback && (

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -136,6 +136,7 @@ export async function getProposals({
   formats,
   statuses,
   includeCapacity = false,
+  includeSchedule = false,
 }: {
   speakerId?: string
   conferenceId?: string
@@ -145,6 +146,7 @@ export async function getProposals({
   formats?: string[]
   statuses?: Status[]
   includeCapacity?: boolean
+  includeSchedule?: boolean
 }): Promise<{ proposals: ProposalExisting[]; proposalsError: Error | null }> {
   let proposalsError = null
   let proposals: ProposalExisting[] = []
@@ -215,6 +217,22 @@ export async function getProposals({
         ? `,"signups": count(*[_type == "workshopSignup" && workshop._ref == ^._id && status == "confirmed"]),
     "waitlistCount": count(*[_type == "workshopSignup" && workshop._ref == ^._id && status == "waitlist"]),
     "available": coalesce(capacity, 30) - count(*[_type == "workshopSignup" && workshop._ref == ^._id && status == "confirmed"])`
+        : ''
+    }${
+      includeSchedule
+        ? `,"scheduleInfo": select(
+      (status == "accepted" || status == "confirmed") => {
+        "talkId": _id,
+        "schedule": *[_type == "schedule" && conference._ref == ^.conference._ref && ^._id in tracks[].talks[].talk._ref][0]
+      } {
+        "date": schedule.date,
+        "trackTitle": schedule.tracks[count(talks[talk._ref == ^.talkId]) > 0][0].trackTitle,
+        "timeSlot": schedule.tracks[count(talks[talk._ref == ^.talkId]) > 0][0].talks[talk._ref == ^.talkId][0]{
+          startTime,
+          endTime
+        }
+      }
+    )`
         : ''
     }
   } | order(conference->startDate desc, _updatedAt desc)`


### PR DESCRIPTION
## Summary

Surfaces the schedule for a speaker's confirmed/accepted talks directly on their own dashboard (`/cfp/list`), so speakers can see when and where they are scheduled without visiting the public speaker page.

Closes #197.

## Changes

- **`getProposals` (`src/lib/proposal/data/sanity.ts`)**: added an opt-in `includeSchedule` param. When set, the query populates `scheduleInfo` (date, track title, time slot) for accepted/confirmed proposals only. The subquery mirrors the public speaker page but is scoped per proposal's own conference via `^.conference._ref` (critical: the dashboard loops multiple conferences, so a shared `$conferenceId` would cross-match). Wrapped in `select(...)` so the cost is bounded to approved talks; other callers are unchanged.
- **Dashboard (`src/app/(cfp)/cfp/list/page.tsx`)**: passes `includeSchedule: true` — the only caller that requests schedule data.
- **`CompactProposalList.tsx`**: renders a date / time slot / track row under approved talks that have `scheduleInfo`, reusing `CalendarIcon` / `ClockIcon` / `MapPinIcon` and `formatConferenceDateLong`, matching the public speaker page markup.
- **Stories**: added `ScheduledConfirmedTalk`, `AcceptedNotYetScheduled`, and `NonApprovedHidesSchedule` with play-function assertions covering the acceptance criteria.

## Acceptance criteria

- [x] A confirmed, scheduled talk shows date + time slot + track/room on `/cfp/list`.
- [x] An accepted-but-not-scheduled talk shows no schedule row (graceful, no crash).
- [x] Non-approved proposals (draft/submitted/rejected) show no schedule info.
- [x] Formatting matches the public speaker page.
- [x] Multi-track / multi-conference: the correct track/time is scoped per proposal's conference.

## Verification

- `pnpm typecheck` clean
- `pnpm vitest run` green (2058 passed, 5 skipped)
- `pnpm lint` (only a pre-existing unrelated warning) and `pnpm prettier --write` clean
- No migration required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces confirmed/accepted talk schedule details (date, time slot, track) directly on the speaker dashboard (`/cfp/list`), allowing speakers to see their schedule without visiting the public speaker page. It introduces an `includeSchedule` opt-in to `getProposals`, adds a schedule row to `CompactProposalList`, and covers the new behaviour with three Storybook stories.

- **`getProposals` in `sanity.ts`**: Adds an `includeSchedule` flag that injects a `scheduleInfo` projection via `select(...)`, scoped per-proposal with `^.conference._ref` to avoid cross-conference contamination across multi-conference dashboards. The GROQ pattern is a direct lift from `getPublicSpeaker` in `src/lib/speaker/sanity.ts`, which is already production-proven.
- **`CompactProposalList.tsx`**: Wraps the proposal title in a flex column and renders a date / time-slot / track row beneath approved talks that carry `scheduleInfo`, reusing `CalendarIcon`, `ClockIcon`, `MapPinIcon`, and `formatConferenceDateLong` to match the public speaker page styling.
- **Stories**: Three new stories (`ScheduledConfirmedTalk`, `AcceptedNotYetScheduled`, `NonApprovedHidesSchedule`) with `play` function assertions exercising the acceptance criteria.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are well-contained and the GROQ pattern is a direct copy of the proven getPublicSpeaker query.

The implementation is clean, the multi-conference scoping via ^.conference._ref is correctly handled, and the component rendering is properly guarded. The only gap is that the ScheduledConfirmedTalk story play function does not assert the date element is visible, even though showing the date is one of the explicitly stated acceptance criteria.

src/components/cfp/CompactProposalList.stories.tsx — the ScheduledConfirmedTalk play function is missing a date-display assertion.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/proposal/data/sanity.ts | Adds includeSchedule flag with a select()-guarded GROQ projection that fetches schedule date, track, and time slot per-proposal, correctly scoped to ^.conference._ref for multi-conference safety; mirrors the existing proven pattern in getPublicSpeaker. |
| src/components/cfp/CompactProposalList.tsx | Renders a schedule row (date, time slot, track) beneath approved talks that carry scheduleInfo; guarded by isApproved && scheduleInfo?.date && scheduleInfo?.timeSlot so unscheduled and non-approved proposals see no change. |
| src/components/cfp/CompactProposalList.stories.tsx | Adds three new stories covering scheduled confirmed, accepted-not-yet-scheduled, and non-approved proposals; play functions assert time slot and track but omit the date display assertion despite it being part of the stated acceptance criteria. |
| src/app/(cfp)/cfp/list/page.tsx | One-line change: passes includeSchedule: true to getProposals for the speaker dashboard; minimal blast radius. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Dashboard as /cfp/list page
    participant getProposals
    participant Sanity

    Browser->>Dashboard: GET /cfp/list
    Dashboard->>getProposals: "{ speakerId, conferenceId, includeSchedule: true }"
    getProposals->>Sanity: "GROQ select(accepted|confirmed => scheduleInfo { date, trackTitle, timeSlot })"
    Sanity-->>getProposals: ProposalExisting[] with scheduleInfo for approved talks
    getProposals-->>Dashboard: "{ proposals, proposalsError }"
    Dashboard->>Browser: HTML with CompactProposalList
    Note over Browser: Approved talks with scheduleInfo.date+timeSlot show CalendarIcon+date, ClockIcon+range, MapPinIcon+track
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Dashboard as /cfp/list page
    participant getProposals
    participant Sanity

    Browser->>Dashboard: GET /cfp/list
    Dashboard->>getProposals: "{ speakerId, conferenceId, includeSchedule: true }"
    getProposals->>Sanity: "GROQ select(accepted|confirmed => scheduleInfo { date, trackTitle, timeSlot })"
    Sanity-->>getProposals: ProposalExisting[] with scheduleInfo for approved talks
    getProposals-->>Dashboard: "{ proposals, proposalsError }"
    Dashboard->>Browser: HTML with CompactProposalList
    Note over Browser: Approved talks with scheduleInfo.date+timeSlot show CalendarIcon+date, ClockIcon+range, MapPinIcon+track
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(cfp): assert rendered schedule date..."](https://github.com/cloudnativebergen/website/commit/e937a9b5fa30b2b63af82db66d36e30055b1f13a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44427550)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->