### PR TITLE
feat(sponsor-crm): auto-advance pipeline to closed-won on contract sent/signed

### DIFF
--- a/src/lib/signing/sanity.ts
+++ b/src/lib/signing/sanity.ts
@@ -2,6 +2,7 @@ import { clientReadUncached } from '@/lib/sanity/client'
 
 export interface SigningContractData {
   _id: string
+  status?: string
   signatureStatus: string
   signatureId: string
   signerEmail: string
@@ -38,6 +39,7 @@ export interface SigningContractData {
 
 const SIGNING_CONTRACT_QUERY = `*[_type == "sponsorForConference" && signatureId == $signingToken][0]{
   _id,
+  status,
   signatureStatus,
   signatureId,
   signerEmail,

--- a/src/lib/sponsor-crm/__tests__/pipeline-promotion.test.ts
+++ b/src/lib/sponsor-crm/__tests__/pipeline-promotion.test.ts
@@ -2,12 +2,28 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Control the Sanity write client so we can assert on the patch/log calls the
 // promotion helper makes without touching a real dataset.
+type MutationResult = {
+  transactionId: string
+  documentIds: string[]
+  results: { id: string; operation: string }[]
+}
+
 const { patch, set, commit, create } = vi.hoisted(() => {
-  const commit = vi.fn(async () => ({}))
+  // Default: the conditional patch matched the record and applied the update.
+  const commit = vi.fn<() => Promise<MutationResult>>(async () => ({
+    transactionId: 'txn-1',
+    documentIds: ['sfc-123'],
+    results: [{ id: 'sfc-123', operation: 'update' }],
+  }))
   const set = vi.fn<(fields: unknown) => { commit: typeof commit }>(() => ({
     commit,
   }))
-  const patch = vi.fn<(id: string) => { set: typeof set }>(() => ({ set }))
+  // The promotion helper selects the record with a GROQ query selection
+  // (`{ query, params }`), not a bare id, so the write is gated on the *stored*
+  // status.
+  const patch = vi.fn<(selection: unknown) => { set: typeof set }>(() => ({
+    set,
+  }))
   const create = vi.fn<(doc: unknown) => Promise<{ _id: string }>>(
     async () => ({
       _id: 'activity-id',
@@ -41,8 +57,20 @@ describe('promoteToClosedWonOnContract', () => {
 
       expect(result).toEqual({ promoted: true })
 
-      // Pipeline status patched to closed-won on the right record.
-      expect(patch).toHaveBeenCalledWith(SFC_ID)
+      // Pipeline status patched to closed-won on the right record, via a
+      // status-gated GROQ selection (not a bare id) so the write is conditional
+      // on the record still resting in an early stage.
+      const selection = patch.mock.calls[0][0] as {
+        query: string
+        params: { id: string; earlyStages: string[] }
+      }
+      expect(selection.params.id).toBe(SFC_ID)
+      expect(selection.query).toContain('status in $earlyStages')
+      expect(selection.params.earlyStages).toEqual([
+        'prospect',
+        'contacted',
+        'negotiating',
+      ])
       expect(set).toHaveBeenCalledWith({ status: 'closed-won' })
       expect(commit).toHaveBeenCalledTimes(1)
 
@@ -73,15 +101,61 @@ describe('promoteToClosedWonOnContract', () => {
     },
   )
 
-  it('defaults a missing status to an early stage and promotes', async () => {
+  it('fails closed on a missing status — skips without patching', async () => {
     const result = await promoteToClosedWonOnContract(
       SFC_ID,
       { tier: TIER },
       'user-1',
     )
 
-    expect(result).toEqual({ promoted: true })
-    expect(set).toHaveBeenCalledWith({ status: 'closed-won' })
+    // A missing status must never default into a promotable stage.
+    expect(result).toEqual({ promoted: false, reason: 'unknown-status' })
+    expect(patch).not.toHaveBeenCalled()
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it.each([null, 'weird-legacy-value'] as const)(
+    'fails closed on an unrecognised status (%o) — skips without patching',
+    async (status) => {
+      const result = await promoteToClosedWonOnContract(
+        SFC_ID,
+        { status, tier: TIER },
+        'user-1',
+      )
+
+      expect(result).toEqual({ promoted: false, reason: 'unknown-status' })
+      expect(patch).not.toHaveBeenCalled()
+      expect(create).not.toHaveBeenCalled()
+    },
+  )
+
+  it('does not resurrect a closed-lost deal when the stored status changed after a stale read', async () => {
+    // Caller read `negotiating`, but between that read and the write an admin
+    // marked the deal closed-lost. The conditional patch matches nothing.
+    commit.mockResolvedValueOnce({
+      transactionId: 'txn-empty',
+      documentIds: [],
+      results: [],
+    })
+
+    const result = await promoteToClosedWonOnContract(
+      SFC_ID,
+      { status: 'negotiating', tier: TIER },
+      'user-1',
+    )
+
+    expect(result).toEqual({ promoted: false, reason: 'concurrent-transition' })
+
+    // It attempted the status-gated conditional patch...
+    const selection = patch.mock.calls[0][0] as {
+      query: string
+      params: { id: string; earlyStages: string[] }
+    }
+    expect(selection.params.id).toBe(SFC_ID)
+    expect(selection.query).toContain('status in $earlyStages')
+
+    // ...but logged no phantom stage change since nothing was overwritten.
+    expect(create).not.toHaveBeenCalled()
   })
 
   it('skips promotion and logs a note when the tier guard fails', async () => {

--- a/src/lib/sponsor-crm/__tests__/pipeline-promotion.test.ts
+++ b/src/lib/sponsor-crm/__tests__/pipeline-promotion.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Control the Sanity write client so we can assert on the patch/log calls the
+// promotion helper makes without touching a real dataset.
+const { patch, set, commit, create } = vi.hoisted(() => {
+  const commit = vi.fn(async () => ({}))
+  const set = vi.fn<(fields: unknown) => { commit: typeof commit }>(() => ({
+    commit,
+  }))
+  const patch = vi.fn<(id: string) => { set: typeof set }>(() => ({ set }))
+  const create = vi.fn<(doc: unknown) => Promise<{ _id: string }>>(
+    async () => ({
+      _id: 'activity-id',
+    }),
+  )
+  return { patch, set, commit, create }
+})
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { patch, create },
+}))
+
+import { promoteToClosedWonOnContract } from '../activity'
+
+const SFC_ID = 'sfc-123'
+const TIER = { _ref: 'tier-abc' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('promoteToClosedWonOnContract', () => {
+  it.each(['prospect', 'contacted', 'negotiating'] as const)(
+    'promotes a %s deal with a tier to closed-won and logs a stage change',
+    async (status) => {
+      const result = await promoteToClosedWonOnContract(
+        SFC_ID,
+        { status, tier: TIER },
+        'user-1',
+      )
+
+      expect(result).toEqual({ promoted: true })
+
+      // Pipeline status patched to closed-won on the right record.
+      expect(patch).toHaveBeenCalledWith(SFC_ID)
+      expect(set).toHaveBeenCalledWith({ status: 'closed-won' })
+      expect(commit).toHaveBeenCalledTimes(1)
+
+      // A stage_change activity was recorded reflecting the move.
+      expect(create).toHaveBeenCalledTimes(1)
+      const activity = create.mock.calls[0][0] as {
+        activityType: string
+        metadata?: { oldValue?: string; newValue?: string }
+      }
+      expect(activity.activityType).toBe('stage_change')
+      expect(activity.metadata?.oldValue).toBe(status)
+      expect(activity.metadata?.newValue).toBe('closed-won')
+    },
+  )
+
+  it.each(['closed-won', 'closed-lost'] as const)(
+    'no-ops on a terminal %s deal without patching or re-logging',
+    async (status) => {
+      const result = await promoteToClosedWonOnContract(
+        SFC_ID,
+        { status, tier: TIER },
+        'user-1',
+      )
+
+      expect(result).toEqual({ promoted: false, reason: 'not-early-stage' })
+      expect(patch).not.toHaveBeenCalled()
+      expect(create).not.toHaveBeenCalled()
+    },
+  )
+
+  it('defaults a missing status to an early stage and promotes', async () => {
+    const result = await promoteToClosedWonOnContract(
+      SFC_ID,
+      { tier: TIER },
+      'user-1',
+    )
+
+    expect(result).toEqual({ promoted: true })
+    expect(set).toHaveBeenCalledWith({ status: 'closed-won' })
+  })
+
+  it('skips promotion and logs a note when the tier guard fails', async () => {
+    const result = await promoteToClosedWonOnContract(
+      SFC_ID,
+      { status: 'negotiating', tier: null },
+      'user-1',
+    )
+
+    expect(result).toEqual({ promoted: false, reason: 'tier-missing' })
+
+    // Never patches the record to an invalid (tier-less) closed-won.
+    expect(patch).not.toHaveBeenCalled()
+
+    // Logs a skip note (not a stage_change) for the audit trail.
+    expect(create).toHaveBeenCalledTimes(1)
+    const activity = create.mock.calls[0][0] as { activityType: string }
+    expect(activity.activityType).toBe('note')
+  })
+
+  it('reports an error without throwing when the patch fails', async () => {
+    commit.mockRejectedValueOnce(new Error('sanity down'))
+
+    const result = await promoteToClosedWonOnContract(
+      SFC_ID,
+      { status: 'prospect', tier: TIER },
+      'user-1',
+    )
+
+    expect(result.promoted).toBe(false)
+    expect(result.error).toBeInstanceOf(Error)
+    // Failed before it could log a stage change.
+    expect(create).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/sponsor-crm/__tests__/pipeline-promotion.test.ts
+++ b/src/lib/sponsor-crm/__tests__/pipeline-promotion.test.ts
@@ -34,12 +34,17 @@ const { patch, set, commit, create } = vi.hoisted(() => {
 
 vi.mock('@/lib/sanity/client', () => ({
   clientWrite: { patch, create },
+  // Used (indirectly) by createSponsorActivity to denormalize the tenant key;
+  // resolving no org keeps the created activity doc free of an organization.
+  clientReadUncached: { fetch: async () => null },
 }))
 
 import { promoteToClosedWonOnContract } from '../activity'
 
 const SFC_ID = 'sfc-123'
-const TIER = { _ref: 'tier-abc' }
+// Call sites pass a GROQ-dereferenced tier (`tier->{ ... }`), never a raw
+// `{ _ref }` — a dangling reference arrives here as null.
+const TIER = { _id: 'tier-abc', title: 'Gold' }
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -174,6 +179,39 @@ describe('promoteToClosedWonOnContract', () => {
     expect(create).toHaveBeenCalledTimes(1)
     const activity = create.mock.calls[0][0] as { activityType: string }
     expect(activity.activityType).toBe('note')
+  })
+
+  it('surfaces the note-write error when the tier-guard skip note fails', async () => {
+    create.mockRejectedValueOnce(new Error('sanity down'))
+
+    const result = await promoteToClosedWonOnContract(
+      SFC_ID,
+      { status: 'negotiating', tier: null },
+      'user-1',
+    )
+
+    // The skip decision stands, and the failed audit write is surfaced per the
+    // PromotionResult contract instead of being silently dropped.
+    expect(result.promoted).toBe(false)
+    expect(result.reason).toBe('tier-missing')
+    expect(result.error).toBeInstanceOf(Error)
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('reports a successful promotion with the log error when the stage-change log fails', async () => {
+    create.mockRejectedValueOnce(new Error('sanity down'))
+
+    const result = await promoteToClosedWonOnContract(
+      SFC_ID,
+      { status: 'negotiating', tier: TIER },
+      'user-1',
+    )
+
+    // The pipeline WAS advanced — that must not be masked — but the dropped
+    // audit entry is surfaced via PromotionResult.error.
+    expect(result.promoted).toBe(true)
+    expect(result.error).toBeInstanceOf(Error)
+    expect(commit).toHaveBeenCalledTimes(1)
   })
 
   it('reports an error without throwing when the patch fails', async () => {

--- a/src/lib/sponsor-crm/activity.ts
+++ b/src/lib/sponsor-crm/activity.ts
@@ -93,9 +93,25 @@ const EARLY_PIPELINE_STAGES: ReadonlyArray<string> = [
   'negotiating',
 ]
 
+/**
+ * Every pipeline status the CRM recognises. Used only to distinguish a *known*
+ * non-early stage (e.g. a legitimate `closed-lost` no-op) from a missing or
+ * unrecognised status — which signals a data problem, or a call site that
+ * forgot to select `status`, and must fail closed rather than promote.
+ */
+const KNOWN_PIPELINE_STAGES: ReadonlyArray<string> = [
+  ...EARLY_PIPELINE_STAGES,
+  'closed-won',
+  'closed-lost',
+]
+
 export type PromotionResult = {
   promoted: boolean
-  reason?: 'not-early-stage' | 'tier-missing'
+  reason?:
+    | 'not-early-stage'
+    | 'tier-missing'
+    | 'unknown-status'
+    | 'concurrent-transition'
   error?: Error
 }
 
@@ -123,6 +139,17 @@ export interface ContractPromotionSponsor {
  * — which would be silently hidden from the public site. When the tier is
  * missing the promotion is skipped and a note is logged for the audit trail.
  *
+ * Fails **closed**: a missing or unrecognised `status` is never treated as an
+ * early stage, so a legacy record without a status (or a future call site that
+ * forgets to select it) can never be silently auto-advanced.
+ *
+ * Guards against a TOCTOU resurrection: the caller passes a separately-fetched,
+ * potentially stale `status`, so the write is a GROQ-conditional patch that
+ * only sets `closed-won` while the record is *still* stored in an early stage.
+ * If an admin marked the deal `closed-lost` (or it reached any terminal state)
+ * between the read and this write, the patch matches nothing and the deal is
+ * left untouched — no overwrite, no phantom stage-change log.
+ *
  * Best-effort: failures are swallowed and returned in `error`, never thrown,
  * so a promotion problem cannot fail the contract send/sign it rides along on.
  */
@@ -131,10 +158,22 @@ export async function promoteToClosedWonOnContract(
   sponsor: ContractPromotionSponsor,
   createdBy: string,
 ): Promise<PromotionResult> {
-  const currentStatus = sponsor.status ?? 'prospect'
+  const currentStatus = sponsor.status
 
-  if (!EARLY_PIPELINE_STAGES.includes(currentStatus)) {
-    return { promoted: false, reason: 'not-early-stage' }
+  // Fail closed: only an explicit early stage is eligible. A missing or
+  // unrecognised status must never default into a promotable stage.
+  if (!currentStatus || !EARLY_PIPELINE_STAGES.includes(currentStatus)) {
+    if (currentStatus && KNOWN_PIPELINE_STAGES.includes(currentStatus)) {
+      // A recognised non-early stage (e.g. closed-won / closed-lost): a
+      // legitimate forward-only no-op, left silent so re-sends don't spam.
+      return { promoted: false, reason: 'not-early-stage' }
+    }
+    console.warn(
+      '[promoteToClosedWonOnContract] Skipping auto-promotion for %s: status %o is missing or not a recognised early stage',
+      sponsorForConferenceId,
+      currentStatus,
+    )
+    return { promoted: false, reason: 'unknown-status' }
   }
 
   const guard = checkPipelineState('closed-won', {
@@ -151,14 +190,32 @@ export async function promoteToClosedWonOnContract(
     return { promoted: false, reason: 'tier-missing' }
   }
 
+  // Conditional write: only advance while the *stored* status is still early.
+  // This closes the TOCTOU window between the caller's stale read and here, so
+  // a concurrently set terminal state (closed-lost / closed-won) is never
+  // clobbered.
+  let applied = false
   try {
-    await clientWrite
-      .patch(sponsorForConferenceId)
+    const result = await clientWrite
+      .patch({
+        query: '*[_id == $id && status in $earlyStages]',
+        params: {
+          id: sponsorForConferenceId,
+          earlyStages: [...EARLY_PIPELINE_STAGES],
+        },
+      })
       .set({ status: 'closed-won' })
-      .commit()
+      .commit({ returnFirst: false, returnDocuments: false })
+    applied = (result.results?.length ?? 0) > 0
   } catch (error) {
     console.error('Failed to auto-promote sponsor to closed-won:', error)
     return { promoted: false, error: error as Error }
+  }
+
+  if (!applied) {
+    // The stored status left the early stages between the caller's read and
+    // this write. Do not resurrect the deal and do not log a phantom change.
+    return { promoted: false, reason: 'concurrent-transition' }
   }
 
   await logStageChange(

--- a/src/lib/sponsor-crm/activity.ts
+++ b/src/lib/sponsor-crm/activity.ts
@@ -7,7 +7,7 @@ import {
   getOrganizationRefViaParentConference,
   organizationField,
 } from '@/lib/organization/sanity'
-import { checkPipelineState, type SponsorState } from './state-machine'
+import { checkPipelineState } from './state-machine'
 
 export async function createSponsorActivity(
   sponsorForConferenceId: string,
@@ -116,14 +116,15 @@ export type PromotionResult = {
 }
 
 /**
- * The slice of a sponsor record the promotion helper reads. The tier arrives in
- * different shapes at each call site (a dereferenced doc `{ _id, title, ... }`,
- * a raw reference `{ _ref }`, or a partial `{ title }`) and only its presence
- * matters to the tier guard, so it is accepted as `unknown`.
+ * The slice of a sponsor record the promotion helper reads. Callers MUST pass
+ * a GROQ-*dereferenced* tier (`tier->{ ... }`), never a raw `{ _ref }`: a
+ * dangling reference then dereferences to `null` and correctly fails the tier
+ * guard instead of passing a truthiness check. All current call sites (the
+ * signing flow and the contract-send paths) select the tier with `tier->`.
  */
 export interface ContractPromotionSponsor {
   status?: string | null
-  tier?: unknown
+  tier?: { _id?: string; title?: string } | null
 }
 
 /**
@@ -135,9 +136,10 @@ export interface ContractPromotionSponsor {
  * pipeline nor spam the activity feed.
  *
  * The `closed-won` tier guard is enforced *before* promoting, so an automated
- * caller (e.g. the Adobe Sign webhook) can never mint a tier-less `closed-won`
- * — which would be silently hidden from the public site. When the tier is
- * missing the promotion is skipped and a note is logged for the audit trail.
+ * caller (e.g. the public signing flow) can never mint a tier-less
+ * `closed-won` — which would be silently hidden from the public site. When the
+ * tier is missing the promotion is skipped and a note is logged for the audit
+ * trail.
  *
  * Fails **closed**: a missing or unrecognised `status` is never treated as an
  * early stage, so a legacy record without a status (or a future call site that
@@ -176,18 +178,26 @@ export async function promoteToClosedWonOnContract(
     return { promoted: false, reason: 'unknown-status' }
   }
 
-  const guard = checkPipelineState('closed-won', {
-    tier: sponsor.tier as SponsorState['tier'],
-  })
+  const guard = checkPipelineState('closed-won', { tier: sponsor.tier })
   if (!guard.ok) {
-    await createSponsorActivity(
+    const { error: noteError } = await createSponsorActivity(
       sponsorForConferenceId,
       'note',
       'Auto-promotion to Won skipped: set a sponsor tier before this deal can be marked Won.',
       createdBy,
       { timestamp: getCurrentDateTime() },
     )
-    return { promoted: false, reason: 'tier-missing' }
+    if (noteError) {
+      console.error(
+        'Failed to log tier-guard skip note for sponsor promotion:',
+        noteError,
+      )
+    }
+    return {
+      promoted: false,
+      reason: 'tier-missing',
+      ...(noteError && { error: noteError }),
+    }
   }
 
   // Conditional write: only advance while the *stored* status is still early.
@@ -218,12 +228,21 @@ export async function promoteToClosedWonOnContract(
     return { promoted: false, reason: 'concurrent-transition' }
   }
 
-  await logStageChange(
+  // The promotion itself succeeded; a failed audit log must not mask that,
+  // but it is surfaced (never dropped) per the PromotionResult contract.
+  const { error: logError } = await logStageChange(
     sponsorForConferenceId,
     currentStatus,
     'closed-won',
     createdBy,
   )
+  if (logError) {
+    console.error(
+      'Promoted sponsor to closed-won but failed to log the stage change:',
+      logError,
+    )
+    return { promoted: true, error: logError }
+  }
 
   return { promoted: true }
 }

--- a/src/lib/sponsor-crm/activity.ts
+++ b/src/lib/sponsor-crm/activity.ts
@@ -7,6 +7,7 @@ import {
   getOrganizationRefViaParentConference,
   organizationField,
 } from '@/lib/organization/sanity'
+import { checkPipelineState, type SponsorState } from './state-machine'
 
 export async function createSponsorActivity(
   sponsorForConferenceId: string,
@@ -79,6 +80,95 @@ export async function logStageChange(
       timestamp: getCurrentDateTime(),
     },
   )
+}
+
+/**
+ * Pipeline stages a deal can be auto-advanced *from* when a contract is sent
+ * or signed. These are the pre-won, non-terminal stages; `closed-won` and
+ * `closed-lost` are deliberately excluded so promotion is forward-only.
+ */
+const EARLY_PIPELINE_STAGES: ReadonlyArray<string> = [
+  'prospect',
+  'contacted',
+  'negotiating',
+]
+
+export type PromotionResult = {
+  promoted: boolean
+  reason?: 'not-early-stage' | 'tier-missing'
+  error?: Error
+}
+
+/**
+ * The slice of a sponsor record the promotion helper reads. The tier arrives in
+ * different shapes at each call site (a dereferenced doc `{ _id, title, ... }`,
+ * a raw reference `{ _ref }`, or a partial `{ title }`) and only its presence
+ * matters to the tier guard, so it is accepted as `unknown`.
+ */
+export interface ContractPromotionSponsor {
+  status?: string | null
+  tier?: unknown
+}
+
+/**
+ * Forward-only pipeline promotion to `closed-won`, fired when a contract is
+ * sent or signed (issue #348). Monotonic and idempotent: it only advances a
+ * deal still resting in an early stage (prospect / contacted / negotiating).
+ * Records already `closed-won` or `closed-lost` are left untouched and never
+ * re-logged, so a re-send or a duplicate webhook can neither regress the
+ * pipeline nor spam the activity feed.
+ *
+ * The `closed-won` tier guard is enforced *before* promoting, so an automated
+ * caller (e.g. the Adobe Sign webhook) can never mint a tier-less `closed-won`
+ * — which would be silently hidden from the public site. When the tier is
+ * missing the promotion is skipped and a note is logged for the audit trail.
+ *
+ * Best-effort: failures are swallowed and returned in `error`, never thrown,
+ * so a promotion problem cannot fail the contract send/sign it rides along on.
+ */
+export async function promoteToClosedWonOnContract(
+  sponsorForConferenceId: string,
+  sponsor: ContractPromotionSponsor,
+  createdBy: string,
+): Promise<PromotionResult> {
+  const currentStatus = sponsor.status ?? 'prospect'
+
+  if (!EARLY_PIPELINE_STAGES.includes(currentStatus)) {
+    return { promoted: false, reason: 'not-early-stage' }
+  }
+
+  const guard = checkPipelineState('closed-won', {
+    tier: sponsor.tier as SponsorState['tier'],
+  })
+  if (!guard.ok) {
+    await createSponsorActivity(
+      sponsorForConferenceId,
+      'note',
+      'Auto-promotion to Won skipped: set a sponsor tier before this deal can be marked Won.',
+      createdBy,
+      { timestamp: getCurrentDateTime() },
+    )
+    return { promoted: false, reason: 'tier-missing' }
+  }
+
+  try {
+    await clientWrite
+      .patch(sponsorForConferenceId)
+      .set({ status: 'closed-won' })
+      .commit()
+  } catch (error) {
+    console.error('Failed to auto-promote sponsor to closed-won:', error)
+    return { promoted: false, error: error as Error }
+  }
+
+  await logStageChange(
+    sponsorForConferenceId,
+    currentStatus,
+    'closed-won',
+    createdBy,
+  )
+
+  return { promoted: true }
 }
 
 export async function logInvoiceStatusChange(

--- a/src/lib/sponsor-crm/contract-send.ts
+++ b/src/lib/sponsor-crm/contract-send.ts
@@ -12,7 +12,11 @@ import {
 } from './contract-templates'
 import { generateContractPdf } from './contract-pdf'
 import type { ContractSigningProvider } from '@/lib/contract-signing'
-import { logContractStatusChange, logSignatureStatusChange } from './activity'
+import {
+  logContractStatusChange,
+  logSignatureStatusChange,
+  promoteToClosedWonOnContract,
+} from './activity'
 import { sanitizeSponsorName } from './utils'
 
 export interface SendContractResult {
@@ -288,6 +292,20 @@ export async function generateAndSendContract(
         logError,
       )
     }
+  }
+
+  // Sending a contract advances the deal to Won (forward-only, tier-guarded).
+  try {
+    await promoteToClosedWonOnContract(
+      sponsorForConferenceId,
+      { status: sfc.status, tier: sfc.tier },
+      actorId,
+    )
+  } catch (promoteError) {
+    console.error(
+      `${logCtxFull} Failed to auto-promote pipeline to closed-won:`,
+      promoteError,
+    )
   }
 
   return { success: true, agreementId, signingUrl }

--- a/src/server/routers/signing.ts
+++ b/src/server/routers/signing.ts
@@ -9,6 +9,7 @@ import {
 import {
   logContractStatusChange,
   logSignatureStatusChange,
+  promoteToClosedWonOnContract,
 } from '@/lib/sponsor-crm/activity'
 import { sanitizeSponsorName } from '@/lib/sponsor-crm/utils'
 import { getCurrentDateTime } from '@/lib/time'
@@ -183,6 +184,20 @@ export const signingRouter = router({
         )
       } catch (logError) {
         console.error('[signing] Failed to log signing activity:', logError)
+      }
+
+      // A signed contract advances the deal to Won (forward-only, tier-guarded).
+      try {
+        await promoteToClosedWonOnContract(
+          doc._id,
+          { status: doc.status, tier: doc.tier },
+          'signer',
+        )
+      } catch (promoteError) {
+        console.error(
+          '[signing] Failed to auto-promote pipeline to closed-won:',
+          promoteError,
+        )
       }
 
       // Send Slack notification (best-effort, non-critical)

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -71,6 +71,7 @@ import {
   createSponsorActivity,
   updateSponsorActivity,
   deleteSponsorActivity,
+  promoteToClosedWonOnContract,
 } from '@/lib/sponsor-crm/activity'
 import { createNotifications } from '@/lib/notification/sanity'
 import { resolveRoutedOrganizerIds } from '@/lib/teams'
@@ -2160,6 +2161,21 @@ export const sponsorRouter = router({
               )
             }
           }
+        }
+
+        // Sending a contract advances the deal to Won (forward-only,
+        // tier-guarded). Best-effort: never fail the send over this.
+        try {
+          await promoteToClosedWonOnContract(
+            input.sponsorForConferenceId,
+            { status: sfc.status, tier: sfc.tier },
+            ctx.speaker._id,
+          )
+        } catch (promoteError) {
+          console.error(
+            `${logCtxFull} Failed to auto-promote pipeline to closed-won:`,
+            promoteError,
+          )
         }
 
         // Send branded signing email if we have a signing URL (non-critical)


### PR DESCRIPTION
## Summary

Closes #348.

Contract events previously updated only `contractStatus` / `signatureStatus` and never touched the pipeline `status`, so deals that were effectively won stayed stale in early stages. This wires contract send/sign into the pipeline with a single forward-only promotion helper.

## What changed

New helper `promoteToClosedWonOnContract` in `src/lib/sponsor-crm/activity.ts`, called from the four contract-event sites:

- `src/lib/sponsor-crm/contract-send.ts` — automated `generateAndSendContract`
- `src/server/routers/sponsor.ts` — manual `sendContract` mutation
- `src/server/routers/signing.ts` — self-hosted `submitSignature`
- `src/app/api/webhooks/adobe-sign/route.ts` — `AGREEMENT_WORKFLOW_COMPLETED` webhook

## Behaviour

- **Forward-only + idempotent:** only advances deals still in `prospect` / `contacted` / `negotiating`. `closed-won` / `closed-lost` are left untouched and never re-logged, so re-sends and duplicate webhooks can neither regress the pipeline nor spam the activity feed.
- **Tier-guarded:** enforces the existing `closed-won` tier guard before promoting, so an automated path (e.g. the Adobe Sign webhook) can never mint a tier-less `closed-won` that would be hidden from the public site. A missing tier skips promotion and logs a note.
- **Portal invites unaffected:** `registration-sent` does not promote.
- **Best-effort:** promotion failures are swallowed and never fail the contract send/sign they ride along on. A successful promotion logs a single `stage_change` activity.

Promotion ships unconditionally (no per-conference manual-pipeline toggle — deferred).

## Verification

- `pnpm typecheck` clean
- `pnpm vitest run` green — 118 files, 2066 passed / 5 skipped, including 8 new tests for the helper (promotes from each early stage, no-ops on terminal states, skips + logs when tier missing, defaults missing status, surfaces patch errors without throwing)
- eslint (no new errors) / prettier clean
- No migration required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires contract-sent and contract-signed events into pipeline stage promotion, adding a new `promoteToClosedWonOnContract` helper that auto-advances deals from `prospect`/`contacted`/`negotiating` to `closed-won`. The helper is forward-only, idempotent, tier-guarded, and best-effort (swallows failures so they never break the contract send/sign that triggered them).

- New `promoteToClosedWonOnContract` in `activity.ts` called from all four contract event sites: automated send (`contract-send.ts`), manual send tRPC mutation (`sponsor.ts`), self-hosted signing (`signing.ts`), and the Adobe Sign webhook (`route.ts`).
- `signing/sanity.ts` and `route.ts` are updated to fetch `status` (and `tier`) so the helper has the fields it needs at each call site.
- 8 new unit tests cover early-stage promotion, terminal no-ops, missing-tier skipping, missing-status defaulting, and patch failure handling.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the minor tier-dereference fix considered — the only realistic gap is the Adobe Sign webhook path, which could leave a deal with a dangling tier in an unlikely race where a tier is deleted mid-flight.

The core logic is sound, well-tested, and idempotent across all four call sites. The one gap worth addressing is that `findSponsorByAgreementId` in the webhook fetches `tier` as a raw reference rather than dereferencing it, meaning a deleted tier still passes the guard — unlike the `signing.ts` path which dereferences correctly. The `logStageChange` call sitting outside the patch try-catch is a theoretical fragility but not an active defect given `createSponsorActivity`'s own internal error handling.

src/app/api/webhooks/adobe-sign/route.ts — the GROQ query for findSponsorByAgreementId should dereference tier to align with the other call sites.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/sponsor-crm/activity.ts | Adds promoteToClosedWonOnContract helper — forward-only, tier-guarded, best-effort. logStageChange sits outside the catch block but cannot throw in practice; tier guard is truthiness-only (dangling refs pass). |
| src/app/api/webhooks/adobe-sign/route.ts | Adds promotion on AGREEMENT_WORKFLOW_COMPLETED; findSponsorByAgreementId fetches tier as a raw reference (no dereference arrow), which stays truthy even when the referenced tier doc is deleted. |
| src/lib/signing/sanity.ts | Adds status and tier->{ title } fields to SIGNING_CONTRACT_QUERY; tier is correctly dereferenced so a deleted tier returns null rather than a stale raw reference. |
| src/lib/sponsor-crm/__tests__/pipeline-promotion.test.ts | 8 unit tests covering each early stage, terminal no-ops, missing tier guard, missing status default, and patch failure — comprehensive coverage of the new helper. |
| src/lib/sponsor-crm/contract-send.ts | Promotion added after the contract patch and activity logging; sfc is fetched via getSponsorForConference which dereferences tier, so deletion is handled correctly. |
| src/server/routers/signing.ts | Promotion added after signature record is updated; doc.tier is dereferenced (title-only projection), so a missing/deleted tier correctly returns null and fails the guard. |
| src/server/routers/sponsor.ts | Manual sendContract mutation gets one new promotion call after all existing activity logging — placed correctly and uses the expanded sfc.tier from the full record fetch. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CS as contract-send.ts
    participant SR as sponsor.ts (tRPC)
    participant SG as signing.ts (tRPC)
    participant AS as adobe-sign/route.ts
    participant ACT as activity.ts
    participant SM as state-machine.ts
    participant DB as Sanity DB

    CS->>ACT: "promoteToClosedWonOnContract(id, {status, tier}, actorId)"
    SR->>ACT: "promoteToClosedWonOnContract(id, {status, tier}, userId)"
    SG->>ACT: "promoteToClosedWonOnContract(id, {status, tier}, signer)"
    AS->>ACT: "promoteToClosedWonOnContract(id, {status, tier}, system)"

    activate ACT
    ACT->>ACT: status ?? prospect
    ACT->>ACT: EARLY_PIPELINE_STAGES.includes(status)?
    alt not early stage
        ACT-->>AS: promoted:false, reason:not-early-stage
    else tier missing
        ACT->>SM: "checkPipelineState(closed-won, {tier})"
        SM-->>ACT: ok:false
        ACT->>DB: createSponsorActivity(note)
        ACT-->>AS: promoted:false, reason:tier-missing
    else tier present + early stage
        ACT->>SM: "checkPipelineState(closed-won, {tier})"
        SM-->>ACT: ok:true
        ACT->>DB: patch(id).set(status:closed-won).commit()
        ACT->>DB: logStageChange(id, oldStatus, closed-won)
        ACT-->>AS: promoted:true
    end
    deactivate ACT
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CS as contract-send.ts
    participant SR as sponsor.ts (tRPC)
    participant SG as signing.ts (tRPC)
    participant AS as adobe-sign/route.ts
    participant ACT as activity.ts
    participant SM as state-machine.ts
    participant DB as Sanity DB

    CS->>ACT: "promoteToClosedWonOnContract(id, {status, tier}, actorId)"
    SR->>ACT: "promoteToClosedWonOnContract(id, {status, tier}, userId)"
    SG->>ACT: "promoteToClosedWonOnContract(id, {status, tier}, signer)"
    AS->>ACT: "promoteToClosedWonOnContract(id, {status, tier}, system)"

    activate ACT
    ACT->>ACT: status ?? prospect
    ACT->>ACT: EARLY_PIPELINE_STAGES.includes(status)?
    alt not early stage
        ACT-->>AS: promoted:false, reason:not-early-stage
    else tier missing
        ACT->>SM: "checkPipelineState(closed-won, {tier})"
        SM-->>ACT: ok:false
        ACT->>DB: createSponsorActivity(note)
        ACT-->>AS: promoted:false, reason:tier-missing
    else tier present + early stage
        ACT->>SM: "checkPipelineState(closed-won, {tier})"
        SM-->>ACT: ok:true
        ACT->>DB: patch(id).set(status:closed-won).commit()
        ACT->>DB: logStageChange(id, oldStatus, closed-won)
        ACT-->>AS: promoted:true
    end
    deactivate ACT
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(sponsor-crm): auto-advance pipeline..."](https://github.com/cloudnativebergen/website/commit/b83a44199bc6ec55837cb9a899110f42fc9efa23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44428478)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->