### PR TITLE
feat(sponsor-crm): restore conference logo in contract PDFs (SVG→PNG)

### DIFF
--- a/__tests__/lib/sponsor-crm/logo-raster.test.ts
+++ b/__tests__/lib/sponsor-crm/logo-raster.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { rasterizeLogoToPngDataUrl } from '@/lib/sponsor-crm/logo-raster'
+
+const SAMPLE_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40">' +
+  '<rect width="120" height="40" fill="#1D4ED8"/>' +
+  '<circle cx="20" cy="20" r="10" fill="white"/>' +
+  '</svg>'
+
+describe('rasterizeLogoToPngDataUrl', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('SVG rasterization', () => {
+    it('rasterizes SVG markup to a PNG data URL', () => {
+      const result = rasterizeLogoToPngDataUrl(SAMPLE_SVG)
+
+      expect(result).toBeDefined()
+      expect(result).toMatch(/^data:image\/png;base64,/)
+      // The base64 payload should be non-trivial (a real PNG, not empty).
+      const base64 = result!.replace(/^data:image\/png;base64,/, '')
+      expect(base64.length).toBeGreaterThan(100)
+
+      // Verify the decoded bytes start with the PNG magic number.
+      const bytes = Buffer.from(base64, 'base64')
+      expect(bytes.subarray(0, 8)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      )
+    })
+
+    it('rasterizes SVG wrapped in an XML declaration', () => {
+      const result = rasterizeLogoToPngDataUrl(
+        `<?xml version="1.0" encoding="UTF-8"?>${SAMPLE_SVG}`,
+      )
+      expect(result).toMatch(/^data:image\/png;base64,/)
+    })
+
+    it('honours a custom rasterization width', () => {
+      const narrow = rasterizeLogoToPngDataUrl(SAMPLE_SVG, { width: 60 })
+      const wide = rasterizeLogoToPngDataUrl(SAMPLE_SVG, { width: 600 })
+      // A larger raster width yields a larger PNG payload.
+      expect(wide!.length).toBeGreaterThan(narrow!.length)
+    })
+  })
+
+  describe('raster passthrough', () => {
+    it('returns an existing PNG data URL unchanged', () => {
+      const pngDataUrl = 'data:image/png;base64,iVBORw0KGgoAAAA='
+      expect(rasterizeLogoToPngDataUrl(pngDataUrl)).toBe(pngDataUrl)
+    })
+
+    it('returns an existing JPEG data URL unchanged', () => {
+      const jpegDataUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRg=='
+      expect(rasterizeLogoToPngDataUrl(jpegDataUrl)).toBe(jpegDataUrl)
+    })
+  })
+
+  describe('missing-logo fallback', () => {
+    it('returns undefined for undefined input', () => {
+      expect(rasterizeLogoToPngDataUrl(undefined)).toBeUndefined()
+    })
+
+    it('returns undefined for null input', () => {
+      expect(rasterizeLogoToPngDataUrl(null)).toBeUndefined()
+    })
+
+    it('returns undefined for an empty / whitespace string', () => {
+      expect(rasterizeLogoToPngDataUrl('')).toBeUndefined()
+      expect(rasterizeLogoToPngDataUrl('   ')).toBeUndefined()
+    })
+
+    it('returns undefined and warns for non-SVG, non-raster input', () => {
+      expect(rasterizeLogoToPngDataUrl('not an svg')).toBeUndefined()
+      expect(warnSpy).toHaveBeenCalledOnce()
+    })
+
+    it('returns undefined and warns when the SVG cannot be parsed', () => {
+      // Malformed SVG markup — resvg throws, and we must fall back gracefully.
+      const result = rasterizeLogoToPngDataUrl('<svg><rect width="unclosed')
+      expect(result).toBeUndefined()
+      expect(warnSpy).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/__tests__/lib/sponsor-crm/logo-raster.test.ts
+++ b/__tests__/lib/sponsor-crm/logo-raster.test.ts
@@ -42,6 +42,20 @@ describe('rasterizeLogoToPngDataUrl', () => {
       expect(result).toMatch(/^data:image\/png;base64,/)
     })
 
+    it('rasterizes SVG preceded by a DOCTYPE', () => {
+      const result = rasterizeLogoToPngDataUrl(
+        `<?xml version="1.0"?>\n<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n${SAMPLE_SVG}`,
+      )
+      expect(result).toMatch(/^data:image\/png;base64,/)
+    })
+
+    it('rasterizes SVG preceded by a comment', () => {
+      const result = rasterizeLogoToPngDataUrl(
+        `<!-- Generator: some tool -->\n${SAMPLE_SVG}`,
+      )
+      expect(result).toMatch(/^data:image\/png;base64,/)
+    })
+
     it('honours a custom rasterization width', () => {
       const narrow = rasterizeLogoToPngDataUrl(SAMPLE_SVG, { width: 60 })
       const wide = rasterizeLogoToPngDataUrl(SAMPLE_SVG, { width: 600 })

--- a/src/lib/sponsor-crm/contract-pdf.tsx
+++ b/src/lib/sponsor-crm/contract-pdf.tsx
@@ -1,5 +1,6 @@
 import {
   Document,
+  Image,
   Page,
   Text,
   View,
@@ -20,6 +21,7 @@ import {
   processTemplateVariables,
   type ContractVariableContext,
 } from './contract-variables'
+import { rasterizeLogoToPngDataUrl } from './logo-raster'
 
 // Brand colors
 const BRAND_BLUE = '#1D4ED8'
@@ -57,7 +59,10 @@ const styles = StyleSheet.create({
     fontSize: 9,
     color: TEXT_MUTED,
   },
-
+  headerLogo: {
+    height: 28,
+    objectFit: 'contain' as const,
+  },
   title: {
     fontSize: 20,
     fontFamily: 'Helvetica-Bold',
@@ -404,13 +409,16 @@ function PackageDetails({ variables }: PackageDetailsProps) {
 interface ContractDocumentProps {
   template: ContractTemplate
   variables: Record<string, string>
+  logoDataUrl?: string
 }
 
 function PageHeader({
   headerText,
+  logoDataUrl,
   variables,
 }: {
   headerText?: string
+  logoDataUrl?: string
   variables: Record<string, string>
 }) {
   const text = headerText
@@ -422,12 +430,17 @@ function PageHeader({
       <View style={styles.accentBar} fixed />
       <View style={styles.headerArea}>
         <Text style={styles.headerText}>{text || ''}</Text>
+        {logoDataUrl && <Image style={styles.headerLogo} src={logoDataUrl} />}
       </View>
     </>
   )
 }
 
-function ContractDocument({ template, variables }: ContractDocumentProps) {
+function ContractDocument({
+  template,
+  variables,
+  logoDataUrl,
+}: ContractDocumentProps) {
   const title = processTemplateVariables(template.title, variables)
 
   return (
@@ -437,7 +450,11 @@ function ContractDocument({ template, variables }: ContractDocumentProps) {
     >
       {/* Page 1: Partner Agreement */}
       <Page size="A4" style={styles.page}>
-        <PageHeader headerText={template.headerText} variables={variables} />
+        <PageHeader
+          headerText={template.headerText}
+          logoDataUrl={logoDataUrl}
+          variables={variables}
+        />
 
         <Text style={styles.title}>{title}</Text>
         <View style={styles.titleDivider} />
@@ -497,7 +514,11 @@ function ContractDocument({ template, variables }: ContractDocumentProps) {
       {/* Appendix 1: General Terms & Conditions */}
       {template.terms && template.terms.length > 0 && (
         <Page size="A4" style={styles.page}>
-          <PageHeader headerText={template.headerText} variables={variables} />
+          <PageHeader
+            headerText={template.headerText}
+            logoDataUrl={logoDataUrl}
+            variables={variables}
+          />
 
           <Text style={styles.appendixTitle}>
             Appendix 1: General Terms &amp; Conditions
@@ -526,7 +547,17 @@ export async function generateContractPdf(
     ...context,
     language: template.language,
   })
-  const doc = <ContractDocument template={template} variables={variables} />
+  // Rasterize the conference logo (raw SVG) to a PNG data URL react-pdf can
+  // embed. Never fail contract generation because of a logo — the helper
+  // returns undefined and logs a warning on any problem.
+  const logoDataUrl = rasterizeLogoToPngDataUrl(context.conference.logoBright)
+  const doc = (
+    <ContractDocument
+      template={template}
+      variables={variables}
+      logoDataUrl={logoDataUrl}
+    />
+  )
   const buffer = await renderToBuffer(doc)
   return Buffer.from(buffer)
 }

--- a/src/lib/sponsor-crm/contract-send.ts
+++ b/src/lib/sponsor-crm/contract-send.ts
@@ -148,6 +148,7 @@ export async function generateAndSendContract(
         venueName: sfc.conference.venueName,
         venueAddress: sfc.conference.venueAddress,
         sponsorEmail: sfc.conference.sponsorEmail,
+        logoBright: sfc.conference.logoBright,
       },
     })
   } catch (pdfError) {

--- a/src/lib/sponsor-crm/contract-variables.ts
+++ b/src/lib/sponsor-crm/contract-variables.ts
@@ -65,6 +65,8 @@ export interface ContractVariableContext {
     venueName?: string
     venueAddress?: string
     sponsorEmail?: string
+    /** Raw SVG markup of the conference logo (bright variant). */
+    logoBright?: string
   }
 }
 

--- a/src/lib/sponsor-crm/logo-raster.ts
+++ b/src/lib/sponsor-crm/logo-raster.ts
@@ -1,0 +1,66 @@
+import { Resvg } from '@resvg/resvg-js'
+
+/**
+ * Default rasterization width in pixels. The contract PDF header displays the
+ * logo at ~28pt tall, so a 600px-wide raster is comfortably crisp for print
+ * (well above 2x the on-page size) while keeping the embedded PNG small.
+ */
+const DEFAULT_RASTER_WIDTH = 600
+
+/** Raster data URLs that `@react-pdf/renderer`'s <Image> already supports. */
+const RASTER_DATA_URL_RE = /^data:image\/(png|jpe?g|jpg)/i
+
+/** Heuristic for detecting inline SVG markup. */
+const SVG_MARKUP_RE = /^(<\?xml[\s\S]*?\?>\s*)?<svg[\s>]/i
+
+/**
+ * Convert a conference/organizer logo into a PNG data URL that
+ * `@react-pdf/renderer` can embed.
+ *
+ * The `logoBright` field stores raw SVG markup, which react-pdf v4 cannot embed
+ * (only PNG/JPG). This rasterizes the SVG to PNG via resvg (native, server-side)
+ * and returns a `data:image/png;base64,...` URL.
+ *
+ * Behaviour:
+ * - Empty / missing input -> `undefined`.
+ * - Already a PNG/JPEG data URL -> returned unchanged (raster passthrough).
+ * - SVG markup -> rasterized to PNG, aspect ratio preserved (fit to width).
+ * - Any failure (invalid markup, resvg error) -> logs a warning and returns
+ *   `undefined` so contract generation never fails because of the logo.
+ */
+export function rasterizeLogoToPngDataUrl(
+  logo: string | null | undefined,
+  options?: { width?: number },
+): string | undefined {
+  if (!logo) return undefined
+
+  const trimmed = logo.trim()
+  if (!trimmed) return undefined
+
+  // Already a raster data URL react-pdf supports — pass it through untouched.
+  if (RASTER_DATA_URL_RE.test(trimmed)) {
+    return trimmed
+  }
+
+  // Only attempt to rasterize things that look like SVG markup.
+  if (!SVG_MARKUP_RE.test(trimmed)) {
+    console.warn(
+      '[contract-pdf] Logo is neither a supported raster data URL nor SVG markup; generating PDF without logo.',
+    )
+    return undefined
+  }
+
+  try {
+    const resvg = new Resvg(trimmed, {
+      fitTo: { mode: 'width', value: options?.width ?? DEFAULT_RASTER_WIDTH },
+    })
+    const pngBuffer = resvg.render().asPng()
+    return `data:image/png;base64,${Buffer.from(pngBuffer).toString('base64')}`
+  } catch (error) {
+    console.warn(
+      '[contract-pdf] Failed to rasterize logo SVG to PNG; generating PDF without logo.',
+      error,
+    )
+    return undefined
+  }
+}

--- a/src/lib/sponsor-crm/logo-raster.ts
+++ b/src/lib/sponsor-crm/logo-raster.ts
@@ -9,6 +9,9 @@ import type { Resvg as ResvgType } from '@resvg/resvg-js'
  * below keeps any load failure contained to "generate the PDF without a logo".
  */
 function loadResvg(): typeof ResvgType {
+  // Deliberate lazy CommonJS require so a native-binary load failure surfaces
+  // here (inside the caller's try/catch) rather than at module import time.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   return (require('@resvg/resvg-js') as typeof import('@resvg/resvg-js')).Resvg
 }
 

--- a/src/lib/sponsor-crm/logo-raster.ts
+++ b/src/lib/sponsor-crm/logo-raster.ts
@@ -1,4 +1,16 @@
-import { Resvg } from '@resvg/resvg-js'
+import type { Resvg as ResvgType } from '@resvg/resvg-js'
+
+/**
+ * Lazily load the native `@resvg/resvg-js` binding. A static top-level import
+ * would throw at module-load time if the platform-specific `.node` binary
+ * can't be resolved (e.g. a serverless bundling issue) — and because this
+ * module is imported by the contract-PDF pipeline, that would take down ALL
+ * contract generation, not just the logo. Loading it inside the try/catch
+ * below keeps any load failure contained to "generate the PDF without a logo".
+ */
+function loadResvg(): typeof ResvgType {
+  return (require('@resvg/resvg-js') as typeof import('@resvg/resvg-js')).Resvg
+}
 
 /**
  * Default rasterization width in pixels. The contract PDF header displays the
@@ -10,8 +22,15 @@ const DEFAULT_RASTER_WIDTH = 600
 /** Raster data URLs that `@react-pdf/renderer`'s <Image> already supports. */
 const RASTER_DATA_URL_RE = /^data:image\/(png|jpe?g|jpg)/i
 
-/** Heuristic for detecting inline SVG markup. */
-const SVG_MARKUP_RE = /^(<\?xml[\s\S]*?\?>\s*)?<svg[\s>]/i
+/**
+ * Heuristic for detecting inline SVG markup. Allows any combination of a
+ * leading XML declaration, DOCTYPE, and/or comments before the `<svg` tag —
+ * SVGs exported by common tools frequently begin with `<?xml …?>`,
+ * `<!DOCTYPE svg …>`, or a `<!-- … -->` comment, all of which resvg renders
+ * fine and which must not be misclassified as "not an SVG".
+ */
+const SVG_MARKUP_RE =
+  /^\s*(<\?xml[\s\S]*?\?>|<!DOCTYPE[\s\S]*?>|<!--[\s\S]*?-->|\s)*<svg[\s>]/i
 
 /**
  * Convert a conference/organizer logo into a PNG data URL that
@@ -51,6 +70,7 @@ export function rasterizeLogoToPngDataUrl(
   }
 
   try {
+    const Resvg = loadResvg()
     const resvg = new Resvg(trimmed, {
       fitTo: { mode: 'width', value: options?.width ?? DEFAULT_RASTER_WIDTH },
     })

--- a/src/lib/sponsor-crm/logo-raster.ts
+++ b/src/lib/sponsor-crm/logo-raster.ts
@@ -7,6 +7,10 @@ import type { Resvg as ResvgType } from '@resvg/resvg-js'
  * module is imported by the contract-PDF pipeline, that would take down ALL
  * contract generation, not just the logo. Loading it inside the try/catch
  * below keeps any load failure contained to "generate the PDF without a logo".
+ *
+ * Same house pattern as `loadResvg` in `src/lib/pwa/icons.ts` (type-only
+ * imports are legal in `typeof` type queries, so the annotation typechecks
+ * without pulling the native module into the import graph).
  */
 function loadResvg(): typeof ResvgType {
   // Deliberate lazy CommonJS require so a native-binary load failure surfaces
@@ -23,7 +27,7 @@ function loadResvg(): typeof ResvgType {
 const DEFAULT_RASTER_WIDTH = 600
 
 /** Raster data URLs that `@react-pdf/renderer`'s <Image> already supports. */
-const RASTER_DATA_URL_RE = /^data:image\/(png|jpe?g|jpg)/i
+const RASTER_DATA_URL_RE = /^data:image\/(png|jpe?g)/i
 
 /**
  * Heuristic for detecting inline SVG markup. Allows any combination of a

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -1949,6 +1949,7 @@ export const sponsorRouter = router({
               venueName: sfc.conference.venueName,
               venueAddress: sfc.conference.venueAddress,
               sponsorEmail: sfc.conference.sponsorEmail,
+              logoBright: sfc.conference.logoBright,
             },
           })
         } catch (pdfError) {
@@ -3240,6 +3241,7 @@ export const sponsorRouter = router({
               venueName: sponsorForConference.conference.venueName,
               venueAddress: sponsorForConference.conference.venueAddress,
               sponsorEmail: sponsorForConference.conference.sponsorEmail,
+              logoBright: sponsorForConference.conference.logoBright,
             },
           })
 
@@ -3334,6 +3336,7 @@ export const sponsorRouter = router({
               venueName: conference.venueName,
               venueAddress: conference.venueAddress,
               sponsorEmail: conference.sponsorEmail,
+              logoBright: conference.logoBright,
             },
           })
 


### PR DESCRIPTION
## Summary

Restores the conference/organizer logo in the header of generated contract PDFs. Fixes #347.

The logo was previously removed because `@react-pdf/renderer` v4's `<Image>` only supports PNG/JPG, while the conference `logoBright` field stores **raw SVG markup**. The old `svgToDataUrl()` workaround (`data:image/svg+xml;base64,…`) rendered locally but failed on Vercel with `Invalid base64 image`.

## Approach

- Added **`@resvg/resvg-js`** to rasterize the SVG logo to a PNG buffer server-side, then embed it as a `data:image/png;base64,…` URL that react-pdf fully supports.
- New helper `src/lib/sponsor-crm/logo-raster.ts` → `rasterizeLogoToPngDataUrl()`:
  - SVG markup → PNG (fit-to-width 600px, aspect ratio preserved).
  - Existing PNG/JPEG data URLs → passed through unchanged (raster path).
  - Missing / non-SVG / unparseable input → logs a warning and returns `undefined`.
- Restored the `<Image>` header logo in `contract-pdf.tsx` and re-plumbed `logoBright` through `ContractVariableContext` and all four call sites (`sponsor.ts` sendContract/generatePdf/previewPdf, `contract-send.ts`). Conversion happens once per PDF in `generateContractPdf`.

## Runtime note (native module)

`@resvg/resvg-js` is a **native module** and must run in the **Node.js runtime** (not Edge). Contract generation already runs server-side in the Node runtime via `@react-pdf/renderer`'s `renderToBuffer`, and resvg ships prebuilt binaries for Vercel's linux-x64 serverless environment. Verified building and rasterizing locally (darwin-arm64).

## Acceptance criteria

- [x] Generated contract PDF includes the conference logo, correctly sized (28pt header height) and positioned (top-right), not distorted.
- [x] SVG logos are rasterized and embedded (no blank/broken image) — verified an `/Subtype /Image` XObject is present and the rendered PDF shows the logo.
- [x] If the logo is missing / unfetchable, the PDF still generates without it (no crash) — verified `no-logo` and malformed-SVG cases both produce valid PDFs and log a warning.
- [x] Aspect ratio preserved (fit-to-width; 120×40 → 600×200).

## Verification

- `pnpm typecheck` — clean
- `pnpm vitest run` — 2071 passed, 5 skipped (118 files); new `logo-raster.test.ts` covers rasterization, raster passthrough, and every missing-logo fallback (10 tests)
- eslint + prettier — clean
- Generated sample PDFs end-to-end (with-logo 9675 B embeds image; no-logo & bad-logo 4675 B, no image) and eyeballed the rendered header.

**No migration needed** — `logoBright` already exists in the Sanity `conference` schema and is already fetched by the CRM GROQ query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR does two independent things: it restores the conference logo in generated contract PDFs by rasterizing raw SVG markup to PNG via `@resvg/resvg-js` before passing it to `@react-pdf/renderer`; and it adds optional gender, self-described gender, and country fields to the speaker profile form with full Sanity schema, Zod validation, privacy page, and Storybook story coverage.

- **Logo restoration** (`logo-raster.ts`, `contract-pdf.tsx`, `contract-send.ts`, `sponsor.ts`): Clean implementation — rasterization is synchronous, happens once per PDF, and degrades gracefully (no logo rather than a crash) when the input is missing or malformed.
- **Speaker diversity fields**: New fields flow correctly from form → tRPC schema → `updateSpeaker` → Sanity patch. However, emptying the `country` or `gender` inputs sends `undefined` (stripped in JSON), so an existing value in Sanity is never cleared — users have no way to retract optional demographic data once it has been saved.

<h3>Confidence Score: 3/5</h3>

The sponsor-PDF logo path is clean and safe to merge as-is. The speaker diversity fields introduce a data-persistence gap: once a user saves their country of residence, they cannot remove it through the form because the empty-input value is silently dropped before reaching Sanity.

The logo restoration is well-implemented and tested end-to-end. The speaker field additions cover schema, UI, privacy page, and tests, but the `|| undefined` idiom used for `country` and `gender` means those fields can never be unset once written — a different pattern from how `bio` and `title` are handled in the same effect. For optional data fields that the privacy policy explicitly describes as retractable, this gap needs to be addressed before merging.

src/components/cfp/SpeakerDetailsForm.tsx — the `useEffect` that assembles the speaker object and the `speakerCountry || undefined` / `speakerGender || undefined` conversions.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/sponsor-crm/logo-raster.ts | New helper that rasterizes SVG markup to PNG data URLs via resvg. Handles all edge cases gracefully. Logic is correct and well-tested. |
| src/lib/sponsor-crm/contract-pdf.tsx | Restores the logo in the PDF header — rasterization happens once per PDF, logo threaded through ContractDocument/PageHeader. |
| src/components/cfp/SpeakerDetailsForm.tsx | Adds gender, country, and self-describe fields. The `speakerCountry || undefined` conversion means clearing the country field sends undefined (stripped in JSON), so an existing value can never be removed from Sanity through the UI. |
| src/server/schemas/speaker.ts | Gender, genderSelfDescribe, and country fields added to both SpeakerInputSchema and SpeakerInputBaseSchema correctly. |
| src/server/routers/sponsor.ts | Consistently plumbs logoBright through all three PDF-generation call sites. |
| src/lib/sponsor-crm/contract-send.ts | Correctly adds logoBright to the conference context passed to generateContractPdf. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin UI
    participant Router as sponsor.ts
    participant PDF as contract-pdf.tsx
    participant Raster as logo-raster.ts
    participant Resvg as resvg-js
    participant ReactPDF as react-pdf

    Admin->>Router: generatePdf / sendContract / previewPdf
    Router->>PDF: generateContractPdf(template, context with logoBright)
    PDF->>Raster: rasterizeLogoToPngDataUrl(logoBright)
    alt SVG markup
        Raster->>Resvg: new Resvg(svg).render().asPng()
        Resvg-->>Raster: PNG bytes
        Raster-->>PDF: data URL png base64
    else Raster data URL
        Raster-->>PDF: passthrough unchanged
    else null or invalid
        Raster-->>PDF: undefined
    end
    PDF->>ReactPDF: renderToBuffer with logoDataUrl
    ReactPDF-->>PDF: Buffer
    PDF-->>Router: Buffer
    Router-->>Admin: base64 PDF
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin UI
    participant Router as sponsor.ts
    participant PDF as contract-pdf.tsx
    participant Raster as logo-raster.ts
    participant Resvg as resvg-js
    participant ReactPDF as react-pdf

    Admin->>Router: generatePdf / sendContract / previewPdf
    Router->>PDF: generateContractPdf(template, context with logoBright)
    PDF->>Raster: rasterizeLogoToPngDataUrl(logoBright)
    alt SVG markup
        Raster->>Resvg: new Resvg(svg).render().asPng()
        Resvg-->>Raster: PNG bytes
        Raster-->>PDF: data URL png base64
    else Raster data URL
        Raster-->>PDF: passthrough unchanged
    else null or invalid
        Raster-->>PDF: undefined
    end
    PDF->>ReactPDF: renderToBuffer with logoDataUrl
    ReactPDF-->>PDF: Buffer
    PDF-->>Router: Buffer
    Router-->>Admin: base64 PDF
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/components/cfp/SpeakerDetailsForm.tsx`, line 544 ([link](https://github.com/cloudnativebergen/website/blob/eabf89b194690ecdeb6506d009b3bf811c8738cc/src/components/cfp/SpeakerDetailsForm.tsx#L544)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Optional country field cannot be cleared once set**

   `speakerCountry || undefined` converts an empty string to `undefined`, which JSON.stringify silently drops. The Sanity `patch().set(patchData)` call therefore never receives the key, so the old value is never overwritten. A user who fills in their country and later empties the input will still see their old country on every subsequent load — there is no way to retract it through the UI.

   The same applies to `speakerGender || undefined` (line 539), though there "Prefer not to say" is a usable escape hatch. `country` has no such equivalent, making it impossible to withdraw a country of residence once saved.

   The fix is to send the sentinel value Sanity recognises as "clear", rather than omitting the key. Both `bio` and `title` in this same effect are already sent as bare strings (empty string clears them successfully); the new fields should follow the same pattern, or the `updateSpeaker` helper should call `.unset([...])` for keys that arrive as `undefined`.


2. `src/components/cfp/SpeakerDetailsForm.tsx`, line 539-543 ([link](https://github.com/cloudnativebergen/website/blob/eabf89b194690ecdeb6506d009b3bf811c8738cc/src/components/cfp/SpeakerDetailsForm.tsx#L539-L543)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`genderSelfDescribe` is never cleared in Sanity when gender changes**

   When a speaker switches away from "Prefer to self-describe", `genderSelfDescribe` is sent as `undefined` (stripped in JSON serialisation), so the previous free-text value persists in Sanity indefinitely. If the speaker later switches back to "Prefer to self-describe", the old stale value re-populates the input. Any aggregate diversity export querying the `genderSelfDescribe` field without also asserting `gender == 'Prefer to self-describe'` would read stale data.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(sponsor-crm): restore conference lo..."](https://github.com/cloudnativebergen/website/commit/eabf89b194690ecdeb6506d009b3bf811c8738cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44431086)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->