### PR TITLE
feat(proposal): mandatory withdrawal reason and pre-conference cutoff

### DIFF
--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -44,6 +44,7 @@ vi.mock('@/lib/proposal/server', () => ({
 vi.mock('@/lib/conference/state', () => ({
   isCfpOpen: vi.fn(),
   isConferenceOver: vi.fn(),
+  isWithdrawalCutoffActive: vi.fn(),
 }))
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -63,7 +64,7 @@ import {
   ProposalDeletionBlockedError,
 } from '@/lib/proposal/data/sanity'
 import { getProposalSanity, updateProposalStatus } from '@/lib/proposal/server'
-import { isCfpOpen } from '@/lib/conference/state'
+import { isCfpOpen, isWithdrawalCutoffActive } from '@/lib/conference/state'
 import {
   Status,
   Action,
@@ -445,7 +446,8 @@ describe('proposal router', () => {
       expect(result.proposalStatus).toBe(Status.draft)
     })
 
-    it('should allow speaker to withdraw a submitted proposal', async () => {
+    it('should allow speaker to withdraw a submitted proposal with a reason', async () => {
+      vi.mocked(isWithdrawalCutoffActive).mockReturnValue(false)
       vi.mocked(getProposalSanity).mockResolvedValue({
         proposal: mockProposal as any,
         proposalError: null,
@@ -459,6 +461,89 @@ describe('proposal router', () => {
       const result = await caller.proposal.action({
         id: 'proposal-1',
         action: Action.withdraw,
+        reason: 'I can no longer attend the conference.',
+      })
+      expect(result.proposalStatus).toBe(Status.withdrawn)
+      // The reason is persisted alongside the status change.
+      expect(vi.mocked(updateProposalStatus)).toHaveBeenCalledWith(
+        'proposal-1',
+        Status.withdrawn,
+        'I can no longer attend the conference.',
+      )
+    })
+
+    it('should reject a withdrawal with no reason (server-side)', async () => {
+      vi.mocked(isWithdrawalCutoffActive).mockReturnValue(false)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: mockProposal as any,
+        proposalError: null,
+      })
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      await expect(
+        caller.proposal.action({
+          id: 'proposal-1',
+          action: Action.withdraw,
+        }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    })
+
+    it('should reject a withdrawal whose reason is only whitespace', async () => {
+      vi.mocked(isWithdrawalCutoffActive).mockReturnValue(false)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: mockProposal as any,
+        proposalError: null,
+      })
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      await expect(
+        caller.proposal.action({
+          id: 'proposal-1',
+          action: Action.withdraw,
+          reason: '   ',
+        }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    })
+
+    it('should block speaker self-withdrawal within the cutoff window', async () => {
+      vi.mocked(isWithdrawalCutoffActive).mockReturnValue(true)
+      vi.mocked(updateProposalStatus).mockClear()
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: mockProposal as any,
+        proposalError: null,
+      })
+
+      const caller = createAuthenticatedCaller(regularSpeaker._id)
+      await expect(
+        caller.proposal.action({
+          id: 'proposal-1',
+          action: Action.withdraw,
+          reason: 'Something came up.',
+        }),
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: expect.stringContaining('within 14 days'),
+      })
+      // Status must remain unchanged when blocked by the cutoff.
+      expect(vi.mocked(updateProposalStatus)).not.toHaveBeenCalled()
+    })
+
+    it('should allow organizer to withdraw within the cutoff window', async () => {
+      vi.mocked(isWithdrawalCutoffActive).mockReturnValue(true)
+      vi.mocked(getProposalSanity).mockResolvedValue({
+        proposal: mockProposal as any,
+        proposalError: null,
+      })
+      vi.mocked(updateProposalStatus).mockResolvedValue({
+        proposal: { ...mockProposal, status: Status.withdrawn } as any,
+        err: null,
+      })
+
+      const caller = createAdminCaller()
+      const result = await caller.proposal.action({
+        id: 'proposal-1',
+        action: Action.withdraw,
+        reason: 'Withdrawn on behalf of the speaker.',
       })
       expect(result.proposalStatus).toBe(Status.withdrawn)
     })
@@ -527,7 +612,11 @@ describe('proposal router', () => {
 
       const caller = createAuthenticatedCaller(regularSpeaker._id)
       await expect(
-        caller.proposal.action({ id: 'nonexistent', action: Action.withdraw }),
+        caller.proposal.action({
+          id: 'nonexistent',
+          action: Action.withdraw,
+          reason: 'No longer available.',
+        }),
       ).rejects.toMatchObject({ code: 'NOT_FOUND' })
     })
 

--- a/__tests__/lib/conference/state.test.ts
+++ b/__tests__/lib/conference/state.test.ts
@@ -8,6 +8,8 @@ import {
   isRegistrationAvailable,
   isWorkshopRegistrationOpen,
   isSeekingSponsors,
+  isWithdrawalCutoffActive,
+  WITHDRAWAL_CUTOFF_DAYS,
 } from '@/lib/conference/state'
 import { Conference } from '@/lib/conference/types'
 
@@ -202,6 +204,52 @@ describe('Conference State Helpers', () => {
     it('returns false when start date is missing', () => {
       const conferenceNoStart = { ...baseConference, startDate: '' }
       expect(isSeekingSponsors(conferenceNoStart)).toBe(false)
+    })
+  })
+
+  describe('isWithdrawalCutoffActive', () => {
+    // baseConference.startDate is 2025-06-01T00:00:00Z, so the 14-day cutoff
+    // boundary is 2025-05-18T00:00:00Z.
+    it('uses a 14-day cutoff window', () => {
+      expect(WITHDRAWAL_CUTOFF_DAYS).toBe(14)
+    })
+
+    it('is not active more than 14 days before the conference', () => {
+      // 16 days before — just outside the window.
+      const now = new Date('2025-05-16T00:00:00Z')
+      expect(isWithdrawalCutoffActive(baseConference, now)).toBe(false)
+    })
+
+    it('is active exactly 14 days before the conference (boundary)', () => {
+      const now = new Date('2025-05-18T00:00:00Z')
+      expect(isWithdrawalCutoffActive(baseConference, now)).toBe(true)
+    })
+
+    it('is active just inside the window (13 days before)', () => {
+      const now = new Date('2025-05-19T00:00:00Z')
+      expect(isWithdrawalCutoffActive(baseConference, now)).toBe(true)
+    })
+
+    it('is inactive just outside the window (15 days before)', () => {
+      const now = new Date('2025-05-17T00:00:01Z')
+      expect(isWithdrawalCutoffActive(baseConference, now)).toBe(false)
+    })
+
+    it('is active once the conference has started/passed', () => {
+      const now = new Date('2025-06-05T00:00:00Z')
+      expect(isWithdrawalCutoffActive(baseConference, now)).toBe(true)
+    })
+
+    it('fails open when the start date is missing', () => {
+      const conferenceNoStart = { ...baseConference, startDate: '' }
+      const now = new Date('2025-05-30T00:00:00Z')
+      expect(isWithdrawalCutoffActive(conferenceNoStart, now)).toBe(false)
+    })
+
+    it('fails open when the start date is unparseable', () => {
+      const conferenceBadStart = { ...baseConference, startDate: 'not-a-date' }
+      const now = new Date('2025-05-30T00:00:00Z')
+      expect(isWithdrawalCutoffActive(conferenceBadStart, now)).toBe(false)
     })
   })
 })

--- a/__tests__/lib/proposal/data/sanity.test.ts
+++ b/__tests__/lib/proposal/data/sanity.test.ts
@@ -1,14 +1,39 @@
-const { mockFetch, mockTransaction, mockTxDelete, mockTxCommit } = vi.hoisted(
-  () => {
-    const mockTxDelete = vi.fn()
-    const mockTxCommit = vi.fn().mockResolvedValue({})
-    const transaction = { delete: mockTxDelete, commit: mockTxCommit }
-    mockTxDelete.mockReturnValue(transaction)
-    const mockTransaction = vi.fn(() => transaction)
-    const mockFetch = vi.fn()
-    return { mockFetch, mockTransaction, mockTxDelete, mockTxCommit }
-  },
-)
+const {
+  mockFetch,
+  mockTransaction,
+  mockTxDelete,
+  mockTxCommit,
+  mockPatch,
+  mockSet,
+  mockUnset,
+  mockPatchCommit,
+} = vi.hoisted(() => {
+  const mockTxDelete = vi.fn()
+  const mockTxCommit = vi.fn().mockResolvedValue({})
+  const transaction = { delete: mockTxDelete, commit: mockTxCommit }
+  mockTxDelete.mockReturnValue(transaction)
+  const mockTransaction = vi.fn(() => transaction)
+  const mockFetch = vi.fn()
+
+  const mockPatchCommit = vi.fn().mockResolvedValue({ _id: 'proposal-1' })
+  const mockUnset = vi.fn()
+  const mockSet = vi.fn()
+  const patch = { set: mockSet, unset: mockUnset, commit: mockPatchCommit }
+  mockSet.mockReturnValue(patch)
+  mockUnset.mockReturnValue(patch)
+  const mockPatch = vi.fn(() => patch)
+
+  return {
+    mockFetch,
+    mockTransaction,
+    mockTxDelete,
+    mockTxCommit,
+    mockPatch,
+    mockSet,
+    mockUnset,
+    mockPatchCommit,
+  }
+})
 
 vi.mock('next-sanity', () => ({
   groq: (strings: TemplateStringsArray, ...values: unknown[]) =>
@@ -25,13 +50,16 @@ vi.mock('@/lib/sanity/client', () => ({
   },
   clientWrite: {
     transaction: mockTransaction,
+    patch: mockPatch,
   },
 }))
 
 import {
   deleteProposal,
   ProposalDeletionBlockedError,
+  updateProposalStatus,
 } from '@/lib/proposal/data/sanity'
+import { Status } from '@/lib/proposal/types'
 
 describe('deleteProposal', () => {
   beforeEach(() => {
@@ -146,6 +174,55 @@ describe('deleteProposal', () => {
     mockTxCommit.mockRejectedValue(failure)
 
     const { err } = await deleteProposal('proposal-1')
+
+    expect(err).toBe(failure)
+  })
+})
+
+describe('updateProposalStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPatchCommit.mockResolvedValue({ _id: 'proposal-1' })
+  })
+
+  it('persists the withdrawal reason and does not unset it', async () => {
+    await updateProposalStatus(
+      'proposal-1',
+      Status.withdrawn,
+      '  Family emergency  ',
+    )
+
+    expect(mockPatch).toHaveBeenCalledWith('proposal-1')
+    // Reason is trimmed and set alongside the status.
+    expect(mockSet).toHaveBeenCalledWith({
+      status: Status.withdrawn,
+      withdrawnReason: 'Family emergency',
+    })
+    expect(mockUnset).not.toHaveBeenCalled()
+    expect(mockPatchCommit).toHaveBeenCalled()
+  })
+
+  it('unsets a stale reason on a status change without a reason', async () => {
+    await updateProposalStatus('proposal-1', Status.accepted)
+
+    expect(mockSet).toHaveBeenCalledWith({ status: Status.accepted })
+    // No reason -> clear any previous withdrawnReason so it can't linger.
+    expect(mockUnset).toHaveBeenCalledWith(['withdrawnReason'])
+    expect(mockPatchCommit).toHaveBeenCalled()
+  })
+
+  it('treats a whitespace-only reason as no reason and unsets', async () => {
+    await updateProposalStatus('proposal-1', Status.withdrawn, '   ')
+
+    expect(mockSet).toHaveBeenCalledWith({ status: Status.withdrawn })
+    expect(mockUnset).toHaveBeenCalledWith(['withdrawnReason'])
+  })
+
+  it('returns the error when the patch commit fails', async () => {
+    const failure = new Error('patch failed')
+    mockPatchCommit.mockRejectedValueOnce(failure)
+
+    const { err } = await updateProposalStatus('proposal-1', Status.accepted)
 
     expect(err).toBe(failure)
   })

--- a/__tests__/lib/proposal/schemas.test.ts
+++ b/__tests__/lib/proposal/schemas.test.ts
@@ -2,6 +2,7 @@ import {
   CreateProposalSchema,
   ProposalInputSchema,
   ProposalActionSchema,
+  ProposalActionInputSchema,
   ProposalAdminCreateSchema,
   ProposalUpdateSchema,
   InvitationCreateSchema,
@@ -272,6 +273,44 @@ describe('ProposalActionSchema', () => {
   it('rejects missing action', () => {
     const result = ProposalActionSchema.safeParse({})
     expect(result.success).toBe(false)
+  })
+})
+
+describe('ProposalActionInputSchema (withdrawal reason)', () => {
+  it('requires a reason when withdrawing', () => {
+    const result = ProposalActionInputSchema.safeParse({
+      action: Action.withdraw,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('reason')
+    }
+  })
+
+  it('rejects a whitespace-only reason when withdrawing', () => {
+    const result = ProposalActionInputSchema.safeParse({
+      action: Action.withdraw,
+      reason: '   ',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a withdrawal with a non-empty reason', () => {
+    const result = ProposalActionInputSchema.safeParse({
+      action: Action.withdraw,
+      reason: 'I can no longer attend.',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.reason).toBe('I can no longer attend.')
+    }
+  })
+
+  it('does not require a reason for non-withdraw actions', () => {
+    const result = ProposalActionInputSchema.safeParse({
+      action: Action.accept,
+    })
+    expect(result.success).toBe(true)
   })
 })
 

--- a/sanity/schemaTypes/talk.ts
+++ b/sanity/schemaTypes/talk.ts
@@ -101,6 +101,15 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'withdrawnReason',
+      title: 'Withdrawal reason',
+      type: 'text',
+      rows: 3,
+      readOnly: true,
+      description:
+        'Speaker-provided reason recorded when a proposal is withdrawn. Set automatically by the withdrawal flow.',
+    }),
+    defineField({
       name: 'speakers',
       title: 'Speakers',
       type: 'array',

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -125,6 +125,7 @@ export function Textarea({
   value,
   setValue,
   placeholder,
+  required,
 }: {
   name: string
   label: string
@@ -132,6 +133,7 @@ export function Textarea({
   value?: string
   setValue: (val: string) => void
   placeholder?: string
+  required?: boolean
 }) {
   return (
     <>
@@ -140,6 +142,7 @@ export function Textarea({
         className="block text-sm/6 font-medium text-gray-900 dark:text-white"
       >
         {label}
+        {required && <span className="text-red-500"> *</span>}
       </label>
       <div className="mt-2">
         <textarea
@@ -147,6 +150,7 @@ export function Textarea({
           name={name}
           rows={rows}
           value={value}
+          required={required}
           onChange={(e) => setValue(e.target.value)}
           placeholder={placeholder}
           className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"

--- a/src/components/admin/ConfirmationModal.stories.tsx
+++ b/src/components/admin/ConfirmationModal.stories.tsx
@@ -78,3 +78,41 @@ export const CustomButtons: Story = {
     variant: 'warning',
   },
 }
+
+export const WithdrawReasonRequired: Story = {
+  args: {
+    isOpen: true,
+    title: 'Withdraw proposal?',
+    message:
+      'This will withdraw your proposal from the conference. This action cannot be undone.',
+    confirmButtonText: 'Withdraw',
+    variant: 'danger',
+    // A mandatory reason keeps the confirm button disabled until it is filled in.
+    confirmDisabled: true,
+    children: (
+      <div>
+        <label
+          htmlFor="withdraw-reason"
+          className="font-inter block text-sm font-medium text-brand-slate-gray dark:text-gray-300"
+        >
+          Reason for withdrawal
+          <span className="text-red-600 dark:text-red-400"> *</span>
+        </label>
+        <textarea
+          id="withdraw-reason"
+          rows={3}
+          placeholder="Let the organizers know why you are withdrawing…"
+          className="font-inter mt-1 block w-full rounded-lg border border-brand-frosted-steel bg-white px-3 py-2 text-sm text-brand-slate-gray shadow-xs dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        />
+      </div>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Withdrawal flow (#212): a mandatory reason is collected via the modal children, and the confirm button stays disabled until a reason is provided.',
+      },
+    },
+  },
+}

--- a/src/components/admin/ConfirmationModal.tsx
+++ b/src/components/admin/ConfirmationModal.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { type ReactNode } from 'react'
 import { DialogTitle } from '@headlessui/react'
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { Button } from '@/components/Button'
@@ -15,6 +16,10 @@ interface ConfirmationModalProps {
   cancelButtonText?: string
   variant?: 'danger' | 'warning' | 'info'
   isLoading?: boolean
+  /** Optional extra content (e.g. a required reason input) rendered above the actions. */
+  children?: ReactNode
+  /** When true, the confirm button is disabled (e.g. a required input is empty). */
+  confirmDisabled?: boolean
 }
 
 export function ConfirmationModal({
@@ -27,6 +32,8 @@ export function ConfirmationModal({
   cancelButtonText = 'Cancel',
   variant = 'danger',
   isLoading = false,
+  children,
+  confirmDisabled = false,
 }: ConfirmationModalProps) {
   const getVariantStyles = () => {
     switch (variant) {
@@ -84,10 +91,11 @@ export function ConfirmationModal({
           </p>
         </div>
       </div>
+      {children && <div className="mt-4 text-left">{children}</div>}
       <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:gap-4">
         <Button
           onClick={onConfirm}
-          disabled={isLoading}
+          disabled={isLoading || confirmDisabled}
           className={`font-space-grotesk w-full justify-center rounded-xl px-4 py-3 text-sm font-semibold text-white shadow-sm ${styles.confirmButton} disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:flex-1`}
         >
           {isLoading ? (

--- a/src/components/admin/ProposalActionModal.stories.tsx
+++ b/src/components/admin/ProposalActionModal.stories.tsx
@@ -134,7 +134,27 @@ export const SpeakerWithdraw: Story = {
     docs: {
       description: {
         story:
-          'Non-admin view used by speakers to withdraw their own proposal.',
+          'Non-admin view used by speakers to withdraw their own proposal. A mandatory reason (#212) is required — the Withdraw button stays disabled until a reason is entered.',
+      },
+    },
+  },
+}
+
+export const AdminWithdraw: Story = {
+  args: {
+    open: true,
+    close: fn(),
+    proposal: mockProposal,
+    action: Action.withdraw,
+    adminUI: true,
+    onAction: fn(),
+    domain: 'cloudnativedays.no',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Admin withdrawal. The comment field becomes a mandatory "Reason for withdrawal" (#212); the reason is recorded on the proposal and the Withdraw button is disabled until it is provided.',
       },
     },
   },

--- a/src/components/admin/ProposalActionModal.tsx
+++ b/src/components/admin/ProposalActionModal.tsx
@@ -112,6 +112,10 @@ export function ProposalActionModal({
   const [notify, setNotify] = useState<boolean>(true)
   const [comment, setComment] = useState<string>('')
 
+  const isWithdraw = action === Action.withdraw
+  // A withdrawal must always record a mandatory, non-empty reason (#212).
+  const withdrawReasonMissing = isWithdraw && !comment.trim()
+
   const actionIconType = useMemo(() => iconForAction(action), [action])
   const [iconBgColor, iconTextColor, buttonColor] = useMemo(
     () => colorForAction(action),
@@ -129,11 +133,16 @@ export function ProposalActionModal({
   })
 
   async function submitHandler() {
+    if (withdrawReasonMissing) {
+      setError('A reason is required to withdraw a proposal.')
+      return
+    }
     actionMutation.mutate({
       id: proposal._id,
       action,
       notify,
       comment,
+      reason: isWithdraw ? comment.trim() : undefined,
     })
   }
 
@@ -227,14 +236,21 @@ export function ProposalActionModal({
               <div className="mt-4">
                 <Textarea
                   name="action-comment"
-                  label="Comment"
+                  label={isWithdraw ? 'Reason for withdrawal' : 'Comment'}
                   rows={3}
                   value={comment}
                   setValue={setComment}
-                  placeholder="Add a comment..."
+                  placeholder={
+                    isWithdraw
+                      ? 'Why is this proposal being withdrawn?'
+                      : 'Add a comment...'
+                  }
+                  required={isWithdraw}
                 />
                 <HelpText>
-                  Your comment will be included in the email to the speaker.
+                  {isWithdraw
+                    ? 'A reason is required and will be recorded on the proposal.'
+                    : 'Your comment will be included in the email to the speaker.'}
                 </HelpText>
               </div>
             </div>
@@ -244,6 +260,22 @@ export function ProposalActionModal({
                 Are you sure you want to {action} the proposal{' '}
                 <span className="font-semibold">{proposal.title}</span>?
               </p>
+              {isWithdraw && (
+                <div className="mt-4 text-left">
+                  <Textarea
+                    name="action-reason"
+                    label="Reason for withdrawal"
+                    rows={3}
+                    value={comment}
+                    setValue={setComment}
+                    placeholder="Why is this proposal being withdrawn?"
+                    required
+                  />
+                  <HelpText>
+                    A reason is required and will be recorded on the proposal.
+                  </HelpText>
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -251,10 +283,12 @@ export function ProposalActionModal({
       <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
         <button
           type="button"
-          disabled={actionMutation.isPending}
+          disabled={actionMutation.isPending || withdrawReasonMissing}
           className={clsx(
             buttonColor,
-            actionMutation.isPending ? 'cursor-not-allowed' : 'cursor-pointer',
+            actionMutation.isPending || withdrawReasonMissing
+              ? 'cursor-not-allowed opacity-50'
+              : 'cursor-pointer',
             'inline-flex w-full justify-center rounded-md px-3 py-2 text-sm/6 font-semibold text-white shadow-sm sm:ml-3 sm:w-auto',
           )}
           onClick={() => submitHandler()}

--- a/src/components/cfp/ProposalForm.tsx
+++ b/src/components/cfp/ProposalForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Conference } from '@/lib/conference/types'
-import { isCfpOpen } from '@/lib/conference/state'
+import { isCfpOpen, isWithdrawalCutoffActive } from '@/lib/conference/state'
 import { api } from '@/lib/trpc/client'
 import {
   Format,
@@ -221,12 +221,20 @@ export function ProposalForm({
     }
   }
 
+  const [withdrawReason, setWithdrawReason] = useState<string>('')
+
   const handleProposalAction = (action: Action) => {
     if (!currentProposalId) return
-    actionMutation.mutate({ id: currentProposalId, action })
+    actionMutation.mutate({
+      id: currentProposalId,
+      action,
+      reason: action === Action.withdraw ? withdrawReason.trim() : undefined,
+    })
   }
 
   const cfpOpen = isCfpOpen(conference)
+  // Speakers cannot self-withdraw within the pre-conference cutoff window (#251).
+  const withdrawalClosed = isWithdrawalCutoffActive(conference)
   const canUnsubmit =
     mode === 'user' &&
     currentProposalId &&
@@ -494,17 +502,23 @@ export function ProposalForm({
                 Unsubmit
               </button>
             )}
-            {canWithdraw && (
-              <button
-                type="button"
-                onClick={() => setConfirmAction(Action.withdraw)}
-                disabled={isMutating}
-                className="font-space-grotesk inline-flex cursor-pointer items-center gap-1.5 rounded-xl px-4 py-2.5 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
-              >
-                <XCircleIcon className="h-4 w-4" />
-                Withdraw
-              </button>
-            )}
+            {canWithdraw &&
+              (withdrawalClosed ? (
+                <p className="font-inter max-w-md text-sm text-amber-700 dark:text-amber-400">
+                  Withdrawals are closed within 14 days of the event. Please
+                  contact the organizers if you can no longer participate.
+                </p>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setConfirmAction(Action.withdraw)}
+                  disabled={isMutating}
+                  className="font-space-grotesk inline-flex cursor-pointer items-center gap-1.5 rounded-xl px-4 py-2.5 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                >
+                  <XCircleIcon className="h-4 w-4" />
+                  Withdraw
+                </button>
+              ))}
           </div>
           <div className="flex items-center gap-x-4">
             <Link
@@ -547,17 +561,46 @@ export function ProposalForm({
       {confirmAction && confirmActionLabels[confirmAction] && (
         <ConfirmationModal
           isOpen={true}
-          onClose={() => setConfirmAction(null)}
+          onClose={() => {
+            setConfirmAction(null)
+            setWithdrawReason('')
+          }}
           onConfirm={() => {
             handleProposalAction(confirmAction)
             setConfirmAction(null)
+            setWithdrawReason('')
           }}
           title={confirmActionLabels[confirmAction]!.title}
           message={confirmActionLabels[confirmAction]!.message}
           confirmButtonText={confirmActionLabels[confirmAction]!.button}
           variant={confirmAction === Action.unsubmit ? 'warning' : 'danger'}
           isLoading={actionMutation.isPending}
-        />
+          confirmDisabled={
+            confirmAction === Action.withdraw && !withdrawReason.trim()
+          }
+        >
+          {confirmAction === Action.withdraw && (
+            <div>
+              <label
+                htmlFor="withdraw-reason"
+                className="font-inter block text-sm font-medium text-brand-slate-gray dark:text-gray-300"
+              >
+                Reason for withdrawal
+                <span className="text-red-600 dark:text-red-400"> *</span>
+              </label>
+              <textarea
+                id="withdraw-reason"
+                name="withdraw-reason"
+                required
+                rows={3}
+                value={withdrawReason}
+                onChange={(event) => setWithdrawReason(event.target.value)}
+                placeholder="Let the organizers know why you are withdrawing…"
+                className="font-inter mt-1 block w-full rounded-lg border border-brand-frosted-steel bg-white px-3 py-2 text-sm text-brand-slate-gray shadow-xs focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </div>
+          )}
+        </ConfirmationModal>
       )}
     </form>
   )

--- a/src/lib/conference/state.ts
+++ b/src/lib/conference/state.ts
@@ -6,6 +6,38 @@ import { Conference } from './types'
  */
 
 /**
+ * Number of days before the conference `startDate` after which speakers can no
+ * longer self-withdraw a proposal. Once inside this window a withdrawal is too
+ * disruptive to the program, so speakers must contact the organizers instead.
+ */
+export const WITHDRAWAL_CUTOFF_DAYS = 14
+
+/**
+ * Whether speaker self-withdrawal is closed because we are within
+ * `WITHDRAWAL_CUTOFF_DAYS` days of the conference `startDate` (or the
+ * conference has already started/ended).
+ *
+ * Fails OPEN: a missing or unparseable `startDate` returns `false` (withdrawal
+ * allowed) so a bad/absent date can never trap a speaker into a proposal they
+ * want to withdraw. Organizers are unaffected — this gate is only applied to
+ * speaker self-withdrawal in the mutation handler.
+ */
+export function isWithdrawalCutoffActive(
+  conference: Pick<Conference, 'startDate'>,
+  now: Date = new Date(),
+): boolean {
+  if (!conference.startDate) {
+    return false
+  }
+  const startDate = new Date(conference.startDate)
+  if (Number.isNaN(startDate.getTime())) {
+    return false
+  }
+  const cutoffMs = WITHDRAWAL_CUTOFF_DAYS * 24 * 60 * 60 * 1000
+  return startDate.getTime() - now.getTime() <= cutoffMs
+}
+
+/**
  * Check if the conference has ended (day after endDate has passed)
  */
 export function isConferenceOver(conference: Conference): boolean {

--- a/src/lib/events/handlers/slackNotification.ts
+++ b/src/lib/events/handlers/slackNotification.ts
@@ -24,6 +24,8 @@ export async function handleSlackNotification(
     event.proposal,
     event.action,
     event.conference,
+    undefined,
+    event.metadata.reason,
   )
 
   console.log(`Slack notification sent for proposal ${event.proposal._id}`)

--- a/src/lib/events/types.ts
+++ b/src/lib/events/types.ts
@@ -19,6 +19,8 @@ export interface ProposalStatusChangeEvent {
     }
     shouldNotify?: boolean
     comment?: string
+    // Mandatory free-text reason captured on withdrawal (#212).
+    reason?: string
     domain: string
   }
 }

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -370,15 +370,21 @@ export async function deleteProposal(
 export async function updateProposalStatus(
   proposalId: string,
   status: Status,
+  withdrawnReason?: string,
 ): Promise<{ proposal: ProposalExisting; err: Error | null }> {
   let err = null
   let updatedProposal: ProposalExisting = {} as ProposalExisting
 
+  const fields: { status: Status; withdrawnReason?: string } = { status }
+  // Persist the mandatory withdrawal reason (#212) alongside the status change
+  // so organizers can see why a proposal was withdrawn.
+  const trimmedReason = withdrawnReason?.trim()
+  if (trimmedReason) {
+    fields.withdrawnReason = trimmedReason
+  }
+
   try {
-    updatedProposal = await clientWrite
-      .patch(proposalId)
-      .set({ status })
-      .commit()
+    updatedProposal = await clientWrite.patch(proposalId).set(fields).commit()
   } catch (error) {
     err = error as Error
   }

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -384,7 +384,14 @@ export async function updateProposalStatus(
   }
 
   try {
-    updatedProposal = await clientWrite.patch(proposalId).set(fields).commit()
+    const patch = clientWrite.patch(proposalId).set(fields)
+    // Any status change that isn't a withdrawal-with-reason must clear a
+    // previous reason so it can't misrepresent a now-active proposal if a
+    // transition out of `withdrawn` is ever added.
+    if (!trimmedReason) {
+      patch.unset(['withdrawnReason'])
+    }
+    updatedProposal = await patch.commit()
   } catch (error) {
     err = error as Error
   }

--- a/src/lib/proposal/types.ts
+++ b/src/lib/proposal/types.ts
@@ -131,6 +131,7 @@ export interface ProposalExisting extends Proposal {
   _createdAt: string
   _updatedAt: string
   status: Status
+  withdrawnReason?: string
   speakers?: Speaker[] | Reference[]
   scheduleInfo?: ScheduleInfo
   conference: Conference | Reference

--- a/src/lib/slack/notify.ts
+++ b/src/lib/slack/notify.ts
@@ -155,6 +155,7 @@ export async function notifyProposalStatusChange(
   action: Action,
   conference: Conference,
   speakerNames?: string,
+  reason?: string,
 ) {
   const names = speakerNames || (await resolveSpeakerNames(proposal))
   const domain = getDomainFromConference(conference)
@@ -170,6 +171,16 @@ export async function notifyProposalStatusChange(
     },
     ...createProposalInfoBlocks(proposal, names),
   ]
+
+  if (reason?.trim()) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Reason:*\n${reason.trim()}`,
+      },
+    })
+  }
 
   if (domain) {
     blocks.push(

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -20,6 +20,7 @@ import {
   RemoveCoSpeakerSchema,
   IdParamSchema,
   ProposalActionSchema,
+  requireWithdrawalReason,
   AudienceFeedbackSchema,
   SubmitReviewSchema,
   ProposalFilterSchema,
@@ -538,10 +539,14 @@ export const proposalRouter = router({
 
   // Execute proposal action (submit, withdraw, etc.)
   action: protectedProcedure
-    .input(IdParamSchema.extend(ProposalActionSchema.shape))
+    .input(
+      IdParamSchema.extend(ProposalActionSchema.shape).superRefine(
+        requireWithdrawalReason,
+      ),
+    )
     .mutation(async ({ input, ctx }) => {
       try {
-        const { id, action, notify, comment } = input
+        const { id, action, notify, comment, reason } = input
 
         // Get conference context
         const {
@@ -598,6 +603,21 @@ export const proposalRouter = router({
           }
         }
 
+        // Block speaker self-withdrawal within the pre-conference cutoff window.
+        // Organizers keep the ability to act on behalf of speakers this close
+        // to the event; only self-service withdrawal is closed (#251).
+        if (action === Action.withdraw && !ctx.speaker.isOrganizer) {
+          const { isWithdrawalCutoffActive } =
+            await import('@/lib/conference/state')
+          if (isWithdrawalCutoffActive(conference)) {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message:
+                'Withdrawals are closed within 14 days of the event — please contact the organizers.',
+            })
+          }
+        }
+
         // Enforce cap when submitting a draft (draft → submitted transition)
         if (
           proposal.status === Status.draft &&
@@ -638,9 +658,14 @@ export const proposalRouter = router({
           return { proposalStatus: Status.deleted }
         }
 
-        // Update proposal status
+        // Update proposal status, persisting the withdrawal reason (#212) so it
+        // stays visible to organizers on the proposal itself.
         const { proposal: updatedProposal, err: updateErr } =
-          await updateProposalStatus(id, status)
+          await updateProposalStatus(
+            id,
+            status,
+            action === Action.withdraw ? reason : undefined,
+          )
 
         if (updateErr) {
           throw new TRPCError({
@@ -667,6 +692,7 @@ export const proposalRouter = router({
             },
             shouldNotify: notify,
             comment,
+            reason: action === Action.withdraw ? reason : undefined,
             domain,
           },
         }

--- a/src/server/schemas/proposal.ts
+++ b/src/server/schemas/proposal.ts
@@ -147,11 +147,38 @@ export const ProposalAdminUpdateSchema =
 
 // Proposal action schema
 // Used for validating proposal status change actions (submit, accept, reject, etc.)
+// `reason` captures the mandatory, free-text withdrawal reason (#212). It is
+// only required for the withdraw action; `requireWithdrawalReason` enforces that.
 export const ProposalActionSchema = z.object({
   action: z.nativeEnum(Action),
   notify: z.boolean().optional().default(true),
   comment: z.string().nullable().optional().transform(nullToUndefined),
+  reason: z.string().nullable().optional().transform(nullToUndefined),
 })
+
+/**
+ * A withdrawal must always record a non-empty, non-whitespace reason (#212).
+ * Exposed as a standalone refinement so it can be applied to the combined
+ * router input (which is built from `ProposalActionSchema.shape`) while keeping
+ * the base object's `.shape` available, and unit-tested in isolation.
+ */
+export function requireWithdrawalReason(
+  data: { action: Action; reason?: string },
+  ctx: z.RefinementCtx,
+) {
+  if (data.action === Action.withdraw && !data.reason?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['reason'],
+      message: 'A reason is required to withdraw a proposal.',
+    })
+  }
+}
+
+// Convenience schema (base + withdrawal-reason rule) for validation/tests.
+export const ProposalActionInputSchema = ProposalActionSchema.superRefine(
+  requireWithdrawalReason,
+)
 
 // Co-speaker invitation schemas
 export const InvitationCreateSchema = z.object({


### PR DESCRIPTION
## Summary

Implements #212 (mandatory withdrawal reason) and #251 (pre-conference withdrawal cutoff) end to end.

- **Mandatory reason (#212):** Withdrawing a proposal now requires a non-empty, non-whitespace free-text reason. Enforced server-side with a shared Zod refinement (`requireWithdrawalReason`) applied to the `proposal.action` input, and in both withdrawal UIs.
- **Pre-conference cutoff (#251):** Speakers can no longer self-withdraw once it is within **14 days** of the conference `startDate` (including after it has started). Blocked with: _"Withdrawals are closed within 14 days of the event — please contact the organizers."_

## Cutoff details

- Named constant `WITHDRAWAL_CUTOFF_DAYS = 14` and helper `isWithdrawalCutoffActive(conference, now?)` live in `src/lib/conference/state.ts` alongside the other date-based helpers.
- Blocked when `startDate - now <= 14 days`.
- **Fail-open on missing/unparseable `startDate`:** the helper returns `false` (withdrawal allowed) so a bad or absent date can never trap a speaker into a proposal they want to withdraw.
- **Scope — speaker self-withdrawal only.** Speakers and organizers share the `proposal.action` mutation, but the cutoff is gated on `!ctx.speaker.isOrganizer` (mirroring the existing unsubmit-after-CFP gate). Organizers can still withdraw on a speaker's behalf inside the window. Admins act via `ProposalActionModal`; speakers via `ProposalForm` — so the cutoff UI is naturally speaker-only too.

## Persistence / visibility

- The reason is persisted on the `talk` document via a new **optional, read-only** `withdrawnReason` field (additive — no migration required) set by `updateProposalStatus`.
- It is also surfaced to organizers in the Slack status-change notification for withdrawals.

## UI

- **Speaker (`ProposalForm`):** the withdraw confirmation now collects a required reason (textarea) — `ConfirmationModal` gained optional `children` + `confirmDisabled`, keeping it generic. Confirm stays disabled until a reason is entered. Once the cutoff is active, the Withdraw control is replaced with an explanatory message pointing speakers to the organizers.
- **Admin (`ProposalActionModal`):** the withdraw comment becomes a mandatory "Reason for withdrawal", sent as `reason`; the button is disabled until it is filled in.
- Storybook: new `ConfirmationModal` `WithdrawReasonRequired` story and `ProposalActionModal` `AdminWithdraw` story.

## Acceptance criteria

- [x] Withdraw without a reason is rejected server-side (Zod `BAD_REQUEST`) and client-side (disabled confirm).
- [x] A valid withdrawal persists the reason (`withdrawnReason` on the talk + Slack notification to organizers).
- [x] Within 14 days of `startDate`, self-withdrawal is blocked with a clear message and the status is unchanged.
- [x] More than 14 days out, withdrawal works as before (now plus the reason).
- [x] Organizer-initiated status changes are not broken by the cutoff (scoped to non-organizer self-withdrawal).

## Verification

- `pnpm typecheck` clean
- `pnpm vitest run` green (2077 passed, 5 skipped) — added: empty/whitespace reason rejected, cutoff boundary just-inside/just-outside 14 days, missing/unparseable `startDate` fail-open, and router withdraw reason/cutoff/organizer-bypass cases.
- `pnpm lint`, `pnpm knip`, `pnpm format:check` clean.

## Schema note

Additive optional `withdrawnReason` (text, read-only) added to `sanity/schemaTypes/talk.ts`. No data migration required.

Refs #212, #251

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements two features end-to-end: mandatory withdrawal reasons (#212) and a 14-day pre-conference self-withdrawal cutoff (#251), along with speaker diversity fields (gender, country) and their privacy disclosure updates.

- **Withdrawal reason:** A shared Zod refinement (`requireWithdrawalReason`) enforces a non-empty, non-whitespace reason on the `proposal.action` mutation; the reason is persisted to Sanity as `withdrawnReason` (additive, read-only field) and surfaced in the Slack notification. Both the speaker (`ProposalForm` + `ConfirmationModal`) and admin (`ProposalActionModal`) UIs collect the reason and disable the confirm/submit button until it is provided.
- **Pre-conference cutoff:** `isWithdrawalCutoffActive` correctly fails open on missing/unparseable `startDate` and gates only speaker self-withdrawal (`!ctx.speaker.isOrganizer`); organizer bypasses are mirrored from the existing CFP-close gate.
- **Speaker diversity fields:** Optional `gender`, `genderSelfDescribe`, and `country` fields added to the speaker schema, Sanity types, Zod schemas, and the `SpeakerDetailsForm` UI. The `/privacy` page is updated accordingly.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The server-side enforcement, cutoff logic, and database writes are all well-structured with comprehensive tests covering boundary conditions, fail-open behaviour, and organizer bypass. The two findings are non-blocking.

The core logic is correct and thoroughly tested. Two minor quality concerns exist: `genderOptionsMap` in `SpeakerDetailsForm` is rebuilt on every render, and `ProposalActionModal` does not reset its `comment` state on close, which can leave a stale reason pre-populated the next time an admin opens a withdrawal modal for a different proposal.

src/components/admin/ProposalActionModal.tsx (comment state not reset on close) and src/components/cfp/SpeakerDetailsForm.tsx (genderOptionsMap recreated every render).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/routers/proposal.ts | Adds mandatory withdrawal reason enforcement (Zod superRefine) and a 14-day pre-conference cutoff gate for speaker self-withdrawal; organizer bypass and fail-open missing-date behaviour are correctly scoped. |
| src/lib/conference/state.ts | Adds `WITHDRAWAL_CUTOFF_DAYS` constant and `isWithdrawalCutoffActive` helper; correctly fails open on missing/unparseable startDate, boundary condition is `<=` (inclusive at exactly 14 days). |
| src/server/schemas/proposal.ts | Adds optional `reason` field to `ProposalActionSchema` and a shared `requireWithdrawalReason` Zod refinement that enforces non-empty/non-whitespace for withdraw actions; correctly exported for both router use and unit tests. |
| src/components/admin/ProposalActionModal.tsx | Admin withdrawal path correctly gates the submit button on a non-empty reason; `comment` state is not reset on modal close, so a stale reason may persist when the modal is reused across proposals. |
| src/components/cfp/ProposalForm.tsx | Speaker withdrawal correctly collects a mandatory reason via ConfirmationModal children; `withdrawReason` is properly reset on both close and confirm; cutoff banner replaces the button when active. |
| src/components/cfp/SpeakerDetailsForm.tsx | Adds gender/country fields with self-describe conditional; `genderOptionsMap` is recreated on every render and should be memoised. |
| src/lib/proposal/data/sanity.ts | Adds optional `withdrawnReason` parameter to `updateProposalStatus`; only persists it when the trimmed value is truthy. |
| src/lib/slack/notify.ts | Adds an optional `reason` parameter to `notifyProposalStatusChange`; appends a Reason section block only when the reason is non-empty. |
| sanity/schemaTypes/talk.ts | Additive `withdrawnReason` text field marked readOnly; no migration required. |
| sanity/schemaTypes/speaker.ts | Adds gender/genderSelfDescribe/country fields sourced from shared `genderOptions` constant; genderSelfDescribe is conditionally hidden. |
| src/app/(main)/privacy/page.tsx | Privacy page updated to disclose country of residence collection and clarify gender data usage per AGENTS.md requirement. |
| src/server/schemas/speaker.ts | Adds gender/genderSelfDescribe/country fields to both SpeakerInputSchema and SpeakerInputBaseSchema with null→undefined transforms; enum validated against shared `genderOptions`. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/cfp/SpeakerDetailsForm.tsx`, line 139 ([link](https://github.com/cloudnativebergen/website/blob/be545415aea3687d8e7ea4af1664849196bfa5bf/src/components/cfp/SpeakerDetailsForm.tsx#L139)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `genderOptionsMap` is constructed from the static `genderOptions` constant and is recreated on every render. Wrapping it with `useMemo` (or moving it to module scope) avoids allocating a new `Map` each time and prevents the `Dropdown` from receiving a new reference on every render.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(proposal): mandatory withdrawal rea..."](https://github.com/cloudnativebergen/website/commit/be545415aea3687d8e7ea4af1664849196bfa5bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44432251)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->