### PR TITLE
feat(seo): per-host robots.txt (#393)

### DIFF
--- a/__tests__/lib/seo/robots.test.ts
+++ b/__tests__/lib/seo/robots.test.ts
@@ -1,0 +1,65 @@
+import { DISALLOWED_PATHS, getBaseUrl, buildRobots } from '@/lib/seo/robots'
+
+describe('getBaseUrl', () => {
+  it('uses http for localhost hosts', () => {
+    expect(getBaseUrl('localhost:3000')).toBe('http://localhost:3000')
+  })
+
+  it('uses https for public tenant domains', () => {
+    expect(getBaseUrl('cloudnativebergen.dev')).toBe(
+      'https://cloudnativebergen.dev',
+    )
+  })
+})
+
+describe('buildRobots', () => {
+  const robots = buildRobots('cloudnativebergen.dev')
+  const rule = Array.isArray(robots.rules) ? robots.rules[0] : robots.rules
+
+  it('allows general crawling', () => {
+    expect(rule?.allow).toBe('/')
+    expect(rule?.userAgent).toBe('*')
+  })
+
+  it('points the sitemap at the current host', () => {
+    expect(robots.sitemap).toBe('https://cloudnativebergen.dev/sitemap.xml')
+  })
+
+  it('derives the sitemap host per-request', () => {
+    const local = buildRobots('localhost:3000')
+    expect(local.sitemap).toBe('http://localhost:3000/sitemap.xml')
+  })
+
+  it('disallows private, portal, token and api prefixes', () => {
+    const disallow = rule?.disallow ?? []
+    for (const path of [
+      '/admin',
+      '/api',
+      '/stream',
+      '/workshop',
+      '/signin',
+      '/cli',
+      '/invitation',
+      '/sponsor/contract/sign/',
+      '/sponsor/onboarding/',
+      '/sponsor/portal/',
+      '/cfp/submit',
+      '/cfp/list',
+    ]) {
+      expect(disallow).toContain(path)
+    }
+  })
+
+  it('does NOT disallow public marketing or public cfp/sponsor pages', () => {
+    const disallow = [...DISALLOWED_PATHS]
+    // Public marketing pages must remain crawlable.
+    expect(disallow).not.toContain('/')
+    expect(disallow).not.toContain('/program')
+    expect(disallow).not.toContain('/speaker')
+    // The bare /cfp landing and public sponsor pages stay allowed; only their
+    // private sub-paths are listed.
+    expect(disallow).not.toContain('/cfp')
+    expect(disallow).not.toContain('/sponsor')
+    expect(disallow).not.toContain('/sponsor/terms')
+  })
+})

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from 'next'
+import { headers } from 'next/headers'
+
+import { buildRobots } from '@/lib/seo/robots'
+
+/**
+ * Per-host `robots.txt` (Next.js file convention).
+ *
+ * The host is derived from the incoming request `Host` header — the same
+ * approach `src/app/layout.tsx` uses to derive `metadataBase` — so the
+ * emitted `Sitemap:` line is correct for whichever tenant domain is served.
+ */
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  const headersList = await headers()
+  const host = headersList.get('host') || 'localhost:3000'
+
+  return buildRobots(host)
+}

--- a/src/lib/seo/robots.ts
+++ b/src/lib/seo/robots.ts
@@ -1,0 +1,64 @@
+import type { MetadataRoute } from 'next'
+
+/**
+ * Path prefixes that should be hidden from search-engine crawlers.
+ *
+ * These map to private organizer portals, token-gated flows, auth/CLI
+ * handshakes, API endpoints and thin/utility pages that provide no public
+ * SEO value. Every entry has been verified against the App Router tree in
+ * `src/app`.
+ *
+ * IMPORTANT: The bare `/cfp` landing page (`src/app/(main)/cfp`) and the
+ * public sponsor pages (`/sponsor`, `/sponsor/terms`) are intentionally
+ * left crawlable — only their private sub-paths are disallowed.
+ */
+export const DISALLOWED_PATHS = [
+  '/admin', // (admin) organizer dashboard
+  '/api', // route handlers / server endpoints
+  '/stream', // (stream) live stream portal
+  '/workshop', // (workshop) attendee portal
+  '/signin', // auth entry page
+  '/cli', // CLI login handshake
+  '/invitation', // token-gated invitation responses
+  '/error', // thin error page
+  '/css-test', // internal style test page
+  // Token-gated sponsor flows (public /sponsor and /sponsor/terms stay allowed)
+  '/sponsor/contract/sign/',
+  '/sponsor/onboarding/',
+  '/sponsor/portal/',
+  // Private CFP portal sub-paths. The bare /cfp landing page is public, so we
+  // only disallow the authenticated portal routes that live under (cfp)/cfp.
+  '/cfp/admin',
+  '/cfp/expense',
+  '/cfp/list',
+  '/cfp/profile',
+  '/cfp/proposal',
+  '/cfp/submit',
+  '/cfp/workshop',
+] as const
+
+/**
+ * Build the absolute origin for a given `host` header value, mirroring the
+ * protocol logic used for `metadataBase` in `src/app/layout.tsx`.
+ */
+export function getBaseUrl(host: string): string {
+  const protocol = host.includes('localhost') ? 'http' : 'https'
+  return `${protocol}://${host}`
+}
+
+/**
+ * Produce the per-host robots policy: allow general crawling, disallow the
+ * private/portal/token/api prefixes, and point at the host's sitemap.
+ */
+export function buildRobots(host: string): MetadataRoute.Robots {
+  const baseUrl = getBaseUrl(host)
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: [...DISALLOWED_PATHS],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}


### PR DESCRIPTION
## Summary

Implements #393: a per-host `robots.txt` via Next.js's `robots.ts` file convention (`MetadataRoute.Robots`). Public marketing pages stay crawlable; private/portal/token/api/thin routes are disallowed.

- `src/app/robots.ts` — thin handler; reads the request `Host` header (mirroring `layout.tsx`'s `metadataBase` derivation) and delegates to a pure builder.
- `src/lib/seo/robots.ts` — pure, unit-testable helpers: `DISALLOWED_PATHS`, `getBaseUrl(host)`, `buildRobots(host)`.
- `__tests__/lib/seo/robots.test.ts` — unit tests for host derivation, sitemap host, and allow/disallow rules.

## Verified against the real App Router tree

Each disallow prefix maps to a confirmed private/token/thin route. Crucially, the **public** `/cfp` landing (`(main)/cfp`) and public `/sponsor`, `/sponsor/terms` pages are left crawlable — only the **private** `(cfp)/cfp/*` portal sub-paths and token-gated sponsor flows are disallowed.

Disallowed: `/admin`, `/api`, `/stream`, `/workshop`, `/signin`, `/cli`, `/invitation`, `/error`, `/css-test`, `/sponsor/contract/sign/`, `/sponsor/onboarding/`, `/sponsor/portal/`, and `/cfp/{admin,expense,list,profile,proposal,submit,workshop}`.

## Host-derivation decision

Host comes from `headers().get('host')` (falling back to `localhost:3000`), with `http` for localhost and `https` otherwise — identical to `layout.tsx`. This makes the `Sitemap:` line per-tenant correct across multi-tenant domains.

## Sitemap-reference decision

`#394` (sitemap) is not yet implemented. I chose to **still reference** `${host}/sitemap.xml`: it's the standard robots directive, harmless if it 404s temporarily, and will light up the moment #394 lands — no follow-up edit to robots needed. Kept per-host so it stays correct for every domain.

## Acceptance criteria

- [x] `/robots.txt` returns **200** and lists the disallow rules (curl-verified against the dev server).
- [x] Public marketing pages (home, `/program`, `/speaker/*`) are NOT disallowed.
- [x] Admin/portal/token/api routes ARE disallowed.
- [x] The `Sitemap:` line points at the current host (`http://localhost:3000/sitemap.xml` locally; `https://cloudnativebergen.dev/sitemap.xml` when served with that Host header).

## Verification

- `pnpm typecheck` — clean
- `pnpm vitest run __tests__/lib/seo/robots.test.ts` — 7/7 green
- `prettier` — formatted; `eslint` — clean; `knip` — no new findings
- Dev server curl of `/robots.txt` confirmed 200 + correct per-host sitemap (localhost `http`, spoofed `Host: cloudnativebergen.dev` → `https`)

No migration.

Closes #393

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements per-host `robots.txt` via Next.js's `robots.ts` file convention. The Host header drives both the `Sitemap:` line and the protocol selection, mirroring the existing `layout.tsx` `metadataBase` pattern across all tenant domains.

- `src/lib/seo/robots.ts` exposes a pure `buildRobots(host)` helper with a thoroughly annotated `DISALLOWED_PATHS` constant covering admin, API, portal, token-gated, and thin-utility routes — all verified against the current App Router tree.
- `src/app/robots.ts` is a minimal Next.js handler that reads the `Host` header and delegates to `buildRobots`; the 7-test suite covers host derivation, per-tenant sitemap URLs, and the allow/disallow matrix.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the feature is well-scoped and all disallow paths are verified against the live App Router tree.

The implementation is clean and the test coverage is solid. The one thing worth addressing is that getBaseUrl re-implements localhost detection with a substring check (host.includes('localhost')) rather than the existing protocolForDomain utility, which uses a stricter exact-hostname match. In practice this only matters for contrived hostnames containing 'localhost' as a substring, so it won't affect real deployments — but it's worth aligning with the existing utility to avoid divergence.

src/lib/seo/robots.ts — the getBaseUrl protocol check should delegate to protocolForDomain from src/lib/environment/localhost.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/seo/robots.ts | New pure helper exporting DISALLOWED_PATHS, getBaseUrl, and buildRobots; all disallow paths verified against the App Router tree. getBaseUrl re-implements protocol detection with host.includes('localhost') instead of the existing protocolForDomain utility from src/lib/environment/localhost.ts, which uses a stricter exact-hostname match. |
| src/app/robots.ts | Thin Next.js file-convention handler; reads Host header with correct localhost fallback, delegates to buildRobots. Mirrors the same pattern used in layout.tsx generateMetadata. |
| __tests__/lib/seo/robots.test.ts | Seven unit tests covering host derivation, per-request sitemap URL, allow rule, disallow paths, and public-page allowlist. Handles both single-rule and array-rules shapes with the ternary guard. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Crawler as Search Crawler
    participant Next as Next.js App Router
    participant Handler as src/app/robots.ts
    participant Lib as src/lib/seo/robots.ts
    participant Env as src/lib/environment/localhost.ts

    Crawler->>Next: GET /robots.txt
    Next->>Handler: invoke robots()
    Handler->>Handler: await headers().get('host') fallback 'localhost:3000'
    Handler->>Lib: buildRobots(host)
    Lib->>Lib: getBaseUrl(host) host.includes('localhost') → http/https
    Note over Lib,Env: existing protocolForDomain() does exact hostname match
    Lib-->>Handler: "{ rules: { userAgent, allow, disallow[] }, sitemap }"
    Handler-->>Next: MetadataRoute.Robots
    Next-->>Crawler: robots.txt 200
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Crawler as Search Crawler
    participant Next as Next.js App Router
    participant Handler as src/app/robots.ts
    participant Lib as src/lib/seo/robots.ts
    participant Env as src/lib/environment/localhost.ts

    Crawler->>Next: GET /robots.txt
    Next->>Handler: invoke robots()
    Handler->>Handler: await headers().get('host') fallback 'localhost:3000'
    Handler->>Lib: buildRobots(host)
    Lib->>Lib: getBaseUrl(host) host.includes('localhost') → http/https
    Note over Lib,Env: existing protocolForDomain() does exact hostname match
    Lib-->>Handler: "{ rules: { userAgent, allow, disallow[] }, sitemap }"
    Handler-->>Next: MetadataRoute.Robots
    Next-->>Crawler: robots.txt 200
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(seo): add per-host robots.txt (#393..."](https://github.com/cloudnativebergen/website/commit/edb4b8060f3936a03391c5bd908417ad5263860e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44437237)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->