### PR TITLE
feat(seo): Event JSON-LD on edition home + /program (#397)

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -27,6 +27,7 @@ import { formatDatesSafe } from '@/lib/time'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import { EventJsonLd } from '@/components/seo/EventJsonLd'
 
 function truncateDescription(text: string, maxLength = 160): string {
   const trimmed = text.trim()
@@ -71,78 +72,6 @@ export async function generateMetadata(): Promise<Metadata> {
       card: 'summary_large_image',
     },
   }
-}
-
-/**
- * Builds a schema.org Event JSON-LD object for the homepage.
- * https://nextjs.org/docs/app/guides/json-ld
- */
-function buildEventJsonLd(
-  conference: Conference,
-  domain: string,
-  lowestTicketPrice: LowestTicketPrice | null,
-): Record<string, unknown> {
-  const protocol = domain.includes('localhost') ? 'http' : 'https'
-  const siteUrl = `${protocol}://${domain}`
-
-  const jsonLd: Record<string, unknown> = {
-    '@context': 'https://schema.org',
-    '@type': 'Event',
-    name: conference.title,
-    startDate: conference.startDate,
-    endDate: conference.endDate,
-    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
-    eventStatus: 'https://schema.org/EventScheduled',
-    image: [`${siteUrl}/opengraph-image`],
-    organizer: {
-      '@type': 'Organization',
-      name: conference.organizer,
-      url: siteUrl,
-    },
-  }
-
-  if (conference.description && typeof conference.description === 'string') {
-    jsonLd.description = conference.description
-  }
-
-  if (conference.venueName || conference.city) {
-    const address: Record<string, unknown> = { '@type': 'PostalAddress' }
-    if (conference.venueAddress) {
-      address.streetAddress = conference.venueAddress
-    }
-    if (conference.city) {
-      address.addressLocality = conference.city
-    }
-    if (conference.country) {
-      address.addressCountry = conference.country
-    }
-
-    jsonLd.location = {
-      '@type': 'Place',
-      name: conference.venueName || conference.city,
-      address,
-    }
-  }
-
-  // Offers only while registration is genuinely available (registrationEnabled
-  // + link + conference not over) — structured data must never claim tickets
-  // are purchasable while the site itself hides every ticket CTA
-  if (isRegistrationAvailable(conference) && conference.registrationLink) {
-    const offers: Record<string, unknown> = {
-      '@type': 'Offer',
-      url: conference.registrationLink,
-      priceCurrency: 'NOK',
-      availability: 'https://schema.org/InStock',
-    }
-    if (lowestTicketPrice) {
-      // Google's Event spec wants the lowest price including all mandatory
-      // charges, so the structured-data price is incl. VAT
-      offers.price = lowestTicketPrice.amountInclVat
-    }
-    jsonLd.offers = offers
-  }
-
-  return jsonLd
 }
 
 /**
@@ -273,8 +202,6 @@ async function CachedHomeContent({ domain }: { domain: string }) {
     }
   }
 
-  const jsonLd = buildEventJsonLd(conference, domain, lowestTicketPrice)
-
   const hasSchedule =
     isProgramPublished(conference) &&
     conference.schedules &&
@@ -290,11 +217,10 @@ async function CachedHomeContent({ domain }: { domain: string }) {
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c'),
-        }}
+      <EventJsonLd
+        conference={conference}
+        domain={domain}
+        lowestTicketPrice={lowestTicketPrice}
       />
       <Hero
         conference={conference}

--- a/src/app/(main)/program/page.tsx
+++ b/src/app/(main)/program/page.tsx
@@ -8,6 +8,8 @@ import { DevTimeProvider } from '@/components/program/DevTimeProvider'
 import { DevTimeControl } from '@/components/program/DevTimeControl'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import { EventJsonLd } from '@/components/seo/EventJsonLd'
+import { performersFromSchedules } from '@/lib/seo/eventJsonLd'
 
 export const metadata = {
   title: 'Program',
@@ -70,8 +72,15 @@ async function CachedProgramContent({ domain }: { domain: string }) {
     )
   }
 
+  const performers = performersFromSchedules(conference.schedules)
+
   return (
     <div className="relative py-20 sm:pt-36 sm:pb-24 print:py-0">
+      <EventJsonLd
+        conference={conference}
+        domain={domain}
+        performers={performers}
+      />
       <DevTimeProvider />
       <DevTimeControl schedules={conference.schedules} />
       <BackgroundImage className="-top-40 -bottom-32 print:hidden" />

--- a/src/components/seo/EventJsonLd.stories.tsx
+++ b/src/components/seo/EventJsonLd.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { EventJsonLd } from './EventJsonLd'
+import {
+  buildEventJsonLd,
+  type BuildEventJsonLdOptions,
+} from '@/lib/seo/eventJsonLd'
+import type { Conference } from '@/lib/conference/types'
+
+const baseConference = {
+  title: 'Cloud Native Bergen 2099',
+  organizer: 'Cloud Native Bergen',
+  city: 'Bergen',
+  country: 'NO',
+  venueName: 'Grieghallen',
+  venueAddress: 'Edvard Griegs plass 1',
+  description: 'A community conference for cloud native practitioners.',
+  startDate: '2099-10-27T09:00:00Z',
+  endDate: '2099-10-27T17:00:00Z',
+  socialLinks: [
+    'https://twitter.com/cloudnativeberg',
+    'https://www.linkedin.com/company/cloud-native-bergen',
+  ],
+  registrationEnabled: true,
+  registrationLink: 'https://checkin.no/event/12345',
+} as unknown as Conference
+
+/**
+ * `<EventJsonLd>` emits an invisible `<script type="application/ld+json">`.
+ * These stories render that script and, for review, pretty-print the exact
+ * object it serializes so the mapping is visible in Storybook.
+ */
+function JsonLdPreview(props: BuildEventJsonLdOptions) {
+  const data = buildEventJsonLd(props)
+  return (
+    <div className="max-w-3xl font-mono text-sm">
+      <EventJsonLd {...props} />
+      <p className="mb-3 font-sans text-gray-600 dark:text-gray-300">
+        Rendered schema.org <code>Event</code> JSON-LD (paste into Google&apos;s
+        Rich Results Test to validate):
+      </p>
+      <pre className="overflow-x-auto rounded-lg bg-gray-900 p-4 text-gray-100">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  )
+}
+
+const meta = {
+  title: 'Systems/SEO/EventJsonLd',
+  component: JsonLdPreview,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta<typeof JsonLdPreview>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Home page: full data, no performers (kept simple). */
+export const HomePage: Story = {
+  args: {
+    conference: baseConference,
+    domain: 'cloudnativebergen.dev',
+    lowestTicketPrice: { amountInclVat: 1500, formatted: '1 500' } as never,
+  },
+}
+
+/** Program page: adds `performer` entries for confirmed speakers. */
+export const ProgramPage: Story = {
+  args: {
+    conference: baseConference,
+    domain: 'cloudnativebergen.dev',
+    performers: [
+      { name: 'Ada Lovelace', image: 'https://cdn.example/ada.jpg' },
+      { name: 'Alan Turing' },
+    ],
+  },
+}
+
+/** Venue unknown: the whole `location` block is gracefully omitted. */
+export const MissingVenue: Story = {
+  args: {
+    conference: {
+      ...baseConference,
+      venueName: undefined,
+      venueAddress: undefined,
+      city: undefined,
+      country: undefined,
+    } as unknown as Conference,
+    domain: 'cloudnativebergen.dev',
+  },
+}

--- a/src/components/seo/EventJsonLd.tsx
+++ b/src/components/seo/EventJsonLd.tsx
@@ -1,0 +1,23 @@
+import {
+  buildEventJsonLd,
+  serializeJsonLd,
+  type BuildEventJsonLdOptions,
+} from '@/lib/seo/eventJsonLd'
+
+/**
+ * Renders a schema.org `Event` JSON-LD `<script>` for the given conference.
+ *
+ * The object is built by {@link buildEventJsonLd} (which omits every unknown
+ * field) and serialized with {@link serializeJsonLd} so a value containing
+ * `<` cannot break out of the script element.
+ */
+export function EventJsonLd(props: BuildEventJsonLdOptions) {
+  const data = buildEventJsonLd(props)
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
+    />
+  )
+}

--- a/src/lib/seo/__tests__/eventJsonLd.test.ts
+++ b/src/lib/seo/__tests__/eventJsonLd.test.ts
@@ -71,7 +71,6 @@ describe('buildEventJsonLd', () => {
       offers: {
         '@type': 'Offer',
         url: 'https://checkin.no/event/12345',
-        priceCurrency: 'NOK',
         availability: 'https://schema.org/InStock',
       },
     })
@@ -97,6 +96,20 @@ describe('buildEventJsonLd', () => {
       lowestTicketPrice: { amountInclVat: 1500, formatted: '1 500' } as never,
     })
     expect(jsonLd.offers).toMatchObject({ price: 1500, priceCurrency: 'NOK' })
+  })
+
+  it('omits priceCurrency when no price is provided (avoids incomplete Offer)', () => {
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference(),
+      domain: 'cloudnativebergen.dev',
+    })
+    expect(jsonLd.offers).not.toHaveProperty('price')
+    expect(jsonLd.offers).not.toHaveProperty('priceCurrency')
+    // A bare Offer (url + availability) is still valid structured data.
+    expect(jsonLd.offers).toMatchObject({
+      '@type': 'Offer',
+      availability: 'https://schema.org/InStock',
+    })
   })
 
   it('omits location entirely when venue and city are unknown', () => {

--- a/src/lib/seo/__tests__/eventJsonLd.test.ts
+++ b/src/lib/seo/__tests__/eventJsonLd.test.ts
@@ -1,0 +1,258 @@
+import {
+  buildEventJsonLd,
+  performersFromSchedules,
+  serializeJsonLd,
+  type EventPerformer,
+} from '../eventJsonLd'
+import type { Conference, ConferenceSchedule } from '@/lib/conference/types'
+import { Status } from '@/lib/proposal/types'
+
+/**
+ * Minimal conference factory. Registration defaults to available (enabled +
+ * link + far-future end date) so `offers` is emitted unless a test overrides
+ * these fields.
+ */
+function makeConference(overrides: Partial<Conference> = {}): Conference {
+  return {
+    title: 'Cloud Native Bergen 2099',
+    organizer: 'Cloud Native Bergen',
+    city: 'Bergen',
+    country: 'NO',
+    venueName: 'Grieghallen',
+    venueAddress: 'Edvard Griegs plass 1',
+    description: 'A community conference for cloud native practitioners.',
+    startDate: '2099-10-27T09:00:00Z',
+    endDate: '2099-10-27T17:00:00Z',
+    socialLinks: [
+      'https://twitter.com/cloudnativeberg',
+      'https://www.linkedin.com/company/cloud-native-bergen',
+    ],
+    registrationEnabled: true,
+    registrationLink: 'https://checkin.no/event/12345',
+    ...overrides,
+  } as unknown as Conference
+}
+
+describe('buildEventJsonLd', () => {
+  it('maps full conference data to a complete, valid Event object', () => {
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference(),
+      domain: 'cloudnativebergen.dev',
+    })
+
+    expect(jsonLd).toMatchObject({
+      '@context': 'https://schema.org',
+      '@type': 'Event',
+      name: 'Cloud Native Bergen 2099',
+      startDate: '2099-10-27T09:00:00Z',
+      endDate: '2099-10-27T17:00:00Z',
+      eventStatus: 'https://schema.org/EventScheduled',
+      eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+      url: 'https://cloudnativebergen.dev',
+      organizer: {
+        '@type': 'Organization',
+        name: 'Cloud Native Bergen',
+        url: 'https://cloudnativebergen.dev',
+        sameAs: [
+          'https://twitter.com/cloudnativeberg',
+          'https://www.linkedin.com/company/cloud-native-bergen',
+        ],
+      },
+      location: {
+        '@type': 'Place',
+        name: 'Grieghallen',
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: 'Edvard Griegs plass 1',
+          addressLocality: 'Bergen',
+          addressCountry: 'NO',
+        },
+      },
+      offers: {
+        '@type': 'Offer',
+        url: 'https://checkin.no/event/12345',
+        priceCurrency: 'NOK',
+        availability: 'https://schema.org/InStock',
+      },
+    })
+
+    // Home page keeps it simple: no performer without explicit performers.
+    expect(jsonLd).not.toHaveProperty('performer')
+    // Every value is defined — no `undefined` leaks (invalid JSON-LD).
+    expect(JSON.stringify(jsonLd)).not.toContain('undefined')
+  })
+
+  it('uses http and localhost host for local domains', () => {
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference(),
+      domain: 'localhost:3000',
+    })
+    expect(jsonLd.url).toBe('http://localhost:3000')
+  })
+
+  it('includes the lowest ticket price incl. VAT on the offer when provided', () => {
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference(),
+      domain: 'cloudnativebergen.dev',
+      lowestTicketPrice: { amountInclVat: 1500, formatted: '1 500' } as never,
+    })
+    expect(jsonLd.offers).toMatchObject({ price: 1500, priceCurrency: 'NOK' })
+  })
+
+  it('omits location entirely when venue and city are unknown', () => {
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference({
+        venueName: undefined,
+        venueAddress: undefined,
+        city: undefined as unknown as string,
+        country: undefined as unknown as string,
+      }),
+      domain: 'cloudnativebergen.dev',
+    })
+
+    expect(jsonLd).not.toHaveProperty('location')
+    // Still a valid object with the required Event fields present.
+    expect(jsonLd).toMatchObject({
+      '@type': 'Event',
+      name: 'Cloud Native Bergen 2099',
+      startDate: '2099-10-27T09:00:00Z',
+    })
+    expect(JSON.stringify(jsonLd)).not.toContain('undefined')
+  })
+
+  it('emits location with only the venue name when address fields are missing', () => {
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference({
+        venueAddress: undefined,
+        city: undefined as unknown as string,
+        country: undefined as unknown as string,
+      }),
+      domain: 'cloudnativebergen.dev',
+    })
+
+    expect(jsonLd.location).toEqual({
+      '@type': 'Place',
+      name: 'Grieghallen',
+      address: { '@type': 'PostalAddress' },
+    })
+  })
+
+  it('omits offers when registration is disabled', () => {
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference({ registrationEnabled: false }),
+      domain: 'cloudnativebergen.dev',
+    })
+    expect(jsonLd).not.toHaveProperty('offers')
+  })
+
+  it('omits the organizer sameAs when there are no social links', () => {
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference({ socialLinks: [] }),
+      domain: 'cloudnativebergen.dev',
+    })
+    expect(jsonLd.organizer).not.toHaveProperty('sameAs')
+  })
+
+  it('adds performer Person entries when performers are supplied', () => {
+    const performers: EventPerformer[] = [
+      { name: 'Ada Lovelace', image: 'https://cdn.example/ada.jpg' },
+      { name: 'Alan Turing' },
+    ]
+    const jsonLd = buildEventJsonLd({
+      conference: makeConference(),
+      domain: 'cloudnativebergen.dev',
+      performers,
+    })
+
+    expect(jsonLd.performer).toEqual([
+      {
+        '@type': 'Person',
+        name: 'Ada Lovelace',
+        image: 'https://cdn.example/ada.jpg',
+      },
+      { '@type': 'Person', name: 'Alan Turing' },
+    ])
+  })
+})
+
+describe('performersFromSchedules', () => {
+  function schedule(
+    talks: Array<{
+      status?: Status
+      speakers?: Array<{ _id?: string; name?: string; image?: string }>
+    }>,
+  ): ConferenceSchedule {
+    return {
+      _id: 'sched-1',
+      date: '2099-10-27',
+      tracks: [
+        {
+          trackTitle: 'Track A',
+          trackDescription: '',
+          talks: talks.map((t) => ({
+            startTime: '09:00',
+            endTime: '09:30',
+            talk: {
+              status: t.status ?? Status.confirmed,
+              speakers: t.speakers,
+            },
+          })),
+        },
+      ],
+    } as unknown as ConferenceSchedule
+  }
+
+  it('returns confirmed speakers, de-duplicated by id', () => {
+    const performers = performersFromSchedules([
+      schedule([
+        {
+          speakers: [
+            { _id: 's1', name: 'Ada Lovelace', image: 'https://x/ada.jpg' },
+          ],
+        },
+        { speakers: [{ _id: 's1', name: 'Ada Lovelace' }] },
+        { speakers: [{ _id: 's2', name: 'Alan Turing' }] },
+      ]),
+    ])
+
+    expect(performers).toEqual([
+      { name: 'Ada Lovelace', image: 'https://x/ada.jpg' },
+      { name: 'Alan Turing' },
+    ])
+  })
+
+  it('skips talks that are not confirmed', () => {
+    const performers = performersFromSchedules([
+      schedule([
+        { status: Status.accepted, speakers: [{ _id: 's1', name: 'Ada' }] },
+        { status: Status.confirmed, speakers: [{ _id: 's2', name: 'Alan' }] },
+      ]),
+    ])
+    expect(performers).toEqual([{ name: 'Alan' }])
+  })
+
+  it('skips unresolved speaker references (no name)', () => {
+    const performers = performersFromSchedules([
+      schedule([{ speakers: [{ _id: 's1' }, { _id: 's2', name: 'Grace' }] }]),
+    ])
+    expect(performers).toEqual([{ name: 'Grace' }])
+  })
+
+  it('returns an empty array for undefined schedules', () => {
+    expect(performersFromSchedules(undefined)).toEqual([])
+  })
+})
+
+describe('serializeJsonLd', () => {
+  it('escapes < so a value cannot break out of the script element', () => {
+    const serialized = serializeJsonLd({
+      name: 'Evil </script><script>alert(1)</script>',
+    })
+    expect(serialized).not.toContain('</script>')
+    expect(serialized).toContain('\\u003c/script>')
+    // Round-trips back to the original value once parsed.
+    expect(JSON.parse(serialized).name).toBe(
+      'Evil </script><script>alert(1)</script>',
+    )
+  })
+})

--- a/src/lib/seo/eventJsonLd.ts
+++ b/src/lib/seo/eventJsonLd.ts
@@ -1,0 +1,192 @@
+import type { Conference, ConferenceSchedule } from '@/lib/conference/types'
+import { isRegistrationAvailable } from '@/lib/conference/state'
+import type { LowestTicketPrice } from '@/lib/tickets/public'
+import { Status } from '@/lib/proposal/types'
+import type { Speaker } from '@/lib/speaker/types'
+
+/**
+ * A single schema.org `Person` performer entry derived from a confirmed
+ * speaker. Only ever includes fields we actually have — an undefined image is
+ * omitted so the emitted JSON-LD never carries `undefined` values.
+ */
+export interface EventPerformer {
+  name: string
+  image?: string
+}
+
+export interface BuildEventJsonLdOptions {
+  conference: Conference
+  /** Request host (e.g. `cloudnativebergen.dev`) used to derive canonical URLs. */
+  domain: string
+  /**
+   * Lowest ticket price, when known. Included as the `offers.price` only while
+   * registration is genuinely available. Omitted entirely (no price) otherwise
+   * — the offer still carries the ticket URL.
+   */
+  lowestTicketPrice?: LowestTicketPrice | null
+  /**
+   * Confirmed speakers to expose as `performer`. Supplied only on the program
+   * page; the home page keeps the block simple and omits performers.
+   */
+  performers?: EventPerformer[]
+}
+
+/**
+ * Builds a schema.org `Event` JSON-LD object from conference data.
+ *
+ * Every optional field is guarded: sub-fields that are unknown are omitted
+ * rather than emitted as `undefined`, so the result is always valid JSON-LD
+ * (passes Google's Rich Results Test). Dates are passed through untouched —
+ * the conference stores them as ISO 8601 strings.
+ *
+ * @see https://schema.org/Event
+ * @see https://nextjs.org/docs/app/guides/json-ld
+ */
+export function buildEventJsonLd({
+  conference,
+  domain,
+  lowestTicketPrice,
+  performers,
+}: BuildEventJsonLdOptions): Record<string, unknown> {
+  const protocol = domain.includes('localhost') ? 'http' : 'https'
+  const siteUrl = `${protocol}://${domain}`
+
+  const organizer: Record<string, unknown> = {
+    '@type': 'Organization',
+    name: conference.organizer,
+    url: siteUrl,
+  }
+  if (conference.socialLinks && conference.socialLinks.length > 0) {
+    organizer.sameAs = conference.socialLinks
+  }
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: conference.title,
+    startDate: conference.startDate,
+    endDate: conference.endDate,
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    url: siteUrl,
+    image: [`${siteUrl}/opengraph-image`],
+    organizer,
+  }
+
+  if (conference.description && typeof conference.description === 'string') {
+    jsonLd.description = conference.description
+  }
+
+  // Location only when we know at least a venue name or city — otherwise omit
+  // the whole Place rather than emit a partial address with `undefined` fields.
+  if (conference.venueName || conference.city) {
+    const address: Record<string, unknown> = { '@type': 'PostalAddress' }
+    if (conference.venueAddress) {
+      address.streetAddress = conference.venueAddress
+    }
+    if (conference.city) {
+      address.addressLocality = conference.city
+    }
+    if (conference.country) {
+      address.addressCountry = conference.country
+    }
+
+    jsonLd.location = {
+      '@type': 'Place',
+      name: conference.venueName || conference.city,
+      address,
+    }
+  }
+
+  // Offers only while registration is genuinely available (registrationEnabled
+  // + link + conference not over) — structured data must never claim tickets
+  // are purchasable while the site itself hides every ticket CTA.
+  if (isRegistrationAvailable(conference) && conference.registrationLink) {
+    const offers: Record<string, unknown> = {
+      '@type': 'Offer',
+      url: conference.registrationLink,
+      priceCurrency: 'NOK',
+      availability: 'https://schema.org/InStock',
+    }
+    if (lowestTicketPrice) {
+      // Google's Event spec wants the lowest price including all mandatory
+      // charges, so the structured-data price is incl. VAT.
+      offers.price = lowestTicketPrice.amountInclVat
+    }
+    jsonLd.offers = offers
+  }
+
+  if (performers && performers.length > 0) {
+    jsonLd.performer = performers.map((performer) => {
+      const person: Record<string, unknown> = {
+        '@type': 'Person',
+        name: performer.name,
+      }
+      if (performer.image) {
+        person.image = performer.image
+      }
+      return person
+    })
+  }
+
+  return jsonLd
+}
+
+type MaybeSpeaker = Speaker | { _ref: string } | null | undefined
+
+function isResolvedSpeaker(speaker: MaybeSpeaker): speaker is Speaker {
+  return (
+    !!speaker &&
+    typeof (speaker as Speaker).name === 'string' &&
+    (speaker as Speaker).name.length > 0
+  )
+}
+
+/**
+ * Extracts confirmed speakers from a set of schedules as `performer` entries,
+ * de-duplicated by speaker id (falling back to name). Only talks with a
+ * `confirmed` status contribute performers; unresolved speaker references
+ * (GROQ returned only a `_ref`) are skipped.
+ */
+export function performersFromSchedules(
+  schedules: ConferenceSchedule[] | undefined,
+): EventPerformer[] {
+  if (!schedules) return []
+
+  const performers: EventPerformer[] = []
+  const seen = new Set<string>()
+
+  for (const schedule of schedules) {
+    for (const track of schedule.tracks ?? []) {
+      for (const slot of track.talks ?? []) {
+        const talk = slot.talk
+        if (!talk || talk.status !== Status.confirmed) continue
+
+        for (const speaker of (talk.speakers ?? []) as MaybeSpeaker[]) {
+          if (!isResolvedSpeaker(speaker)) continue
+
+          const key = speaker._id || speaker.name
+          if (seen.has(key)) continue
+          seen.add(key)
+
+          const performer: EventPerformer = { name: speaker.name }
+          if (speaker.image) {
+            performer.image = speaker.image
+          }
+          performers.push(performer)
+        }
+      }
+    }
+  }
+
+  return performers
+}
+
+/**
+ * Serializes a JSON-LD object for inline `<script>` injection, escaping `<`
+ * as its unicode escape so a value containing `</script>` (or any `<`) cannot
+ * break out of the script element — the standard Next.js XSS guard.
+ */
+export function serializeJsonLd(data: Record<string, unknown>): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}

--- a/src/lib/seo/eventJsonLd.ts
+++ b/src/lib/seo/eventJsonLd.ts
@@ -105,13 +105,15 @@ export function buildEventJsonLd({
     const offers: Record<string, unknown> = {
       '@type': 'Offer',
       url: conference.registrationLink,
-      priceCurrency: 'NOK',
       availability: 'https://schema.org/InStock',
     }
     if (lowestTicketPrice) {
       // Google's Event spec wants the lowest price including all mandatory
-      // charges, so the structured-data price is incl. VAT.
+      // charges, so the structured-data price is incl. VAT. Only emit
+      // `priceCurrency` alongside a real `price` — a currency without a price
+      // is an incomplete Offer that Rich Results flags as a warning.
       offers.price = lowestTicketPrice.amountInclVat
+      offers.priceCurrency = 'NOK'
     }
     jsonLd.offers = offers
   }


### PR DESCRIPTION
Closes #397 (part of #391 SEO P1).

## What

Emit schema.org `Event` JSON-LD on the **edition home page** and **/program** so both pass Google's Rich Results Test for Event.

The homepage already had an inline `buildEventJsonLd` (from #413). This PR extracts it into a reusable helper + server component and reuses it on `/program`, adding `performer` (confirmed speakers) there.

## Changes

- `src/lib/seo/eventJsonLd.ts` — `buildEventJsonLd()` (pure builder), `performersFromSchedules()` (confirmed speakers, de-duplicated), `serializeJsonLd()` (escapes `<`).
- `src/components/seo/EventJsonLd.tsx` — server component rendering `<script type="application/ld+json">`.
- `src/app/(main)/page.tsx` — home now uses the shared component (no performers, kept simple).
- `src/app/(main)/program/page.tsx` — renders the component with `performer` from the schedule.
- Unit tests + Storybook story (`Systems/SEO/EventJsonLd`).

## Field mapping (conference → schema.org Event)

| schema.org | source |
| --- | --- |
| `name` | `conference.title` |
| `startDate` / `endDate` | `conference.startDate` / `endDate` (ISO 8601) |
| `eventStatus` | `https://schema.org/EventScheduled` |
| `eventAttendanceMode` | `https://schema.org/OfflineEventAttendanceMode` |
| `url` / `image` | derived from request host |
| `location` (`Place` + `PostalAddress`) | `venueName`, `venueAddress`, `city`, `country` |
| `organizer` (`Organization`) | `organizer`, site url, `sameAs: socialLinks` |
| `offers` (`Offer`) | `registrationLink`, `NOK`, `InStock` (+ lowest incl-VAT price on home) |
| `performer` (`Person[]`) | confirmed speakers from `schedules` (**/program only**) |

## Guards

Every optional field is guarded — unknown sub-fields are omitted rather than emitted as `undefined`, so the output is always valid JSON-LD (no crash when venue fields are missing). Offers are only emitted while registration is genuinely available. `<` is escaped to `<` to prevent script breakout / XSS.

## Acceptance criteria

- [x] Home and `/program` each emit a valid `Event` block (name, start/end, location when venue known, organizer, ticket offer URL).
- [x] Valid JSON-LD — no `undefined`, ISO 8601 dates.
- [x] `/program` includes `performer` for confirmed speakers; home does not.
- [x] Graceful omission when venue fields are missing.

## Verification

- `pnpm typecheck` — clean
- `pnpm vitest run` — 2107 passed / 5 skipped (13 new tests in `src/lib/seo`)
- eslint + prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracts the inline `buildEventJsonLd` from the homepage into a reusable `src/lib/seo/eventJsonLd.ts` helper and `<EventJsonLd>` server component, then reuses it on `/program` with confirmed-speaker `performer` entries. The refactor also adds two fields the old inline version omitted (`url` at the top level and `sameAs` on the organizer).

- **`eventJsonLd.ts`** — pure builder with full field guards, `<`-escaping in `serializeJsonLd`, and speaker de-duplication by `_id` in `performersFromSchedules`; 13 unit tests cover all branches.
- **`page.tsx` / `program/page.tsx`** — home drops the inline copy and delegates to `<EventJsonLd>`; program page gates the component behind the existing `isProgramPublished` + schedule-existence check so JSON-LD only appears when the schedule is live.
- **`EventJsonLd.stories.tsx`** — three Storybook stories (HomePage, ProgramPage, MissingVenue) using far-future 2099 dates; `globalThis.Date` is not mocked per the project's Storybook convention.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactor is a clean extraction of an already-working inline block, the new builder is pure and well-tested, and the XSS guard is preserved.

The inline JSON-LD code is removed from the homepage, moved to a shared helper, and reused on the program page. All optional fields are guarded, the `<` escape is in place, the 13 unit tests cover every branch, and the program page correctly gates the component behind the existing schedule-published check. The only open item is the missing `globalThis.Date` mock in the Storybook stories, which is a project style convention; the 2099 dates make the stories functionally stable regardless.

No files require special attention. `EventJsonLd.stories.tsx` has the minor date-mock gap noted above.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/seo/eventJsonLd.ts | New pure builder: `buildEventJsonLd`, `performersFromSchedules`, `serializeJsonLd`. Guards on every optional field, correct deduplication by speaker `_id`, and `<` escaped to prevent script breakout. Logic is sound. |
| src/components/seo/EventJsonLd.tsx | Thin server component wrapping `buildEventJsonLd` + `serializeJsonLd` into a `<script type="application/ld+json">`. Straightforward and correct. |
| src/app/(main)/page.tsx | Inline `buildEventJsonLd` removed; replaced by the shared `<EventJsonLd>` component. Net gain: adds `url` and organizer `sameAs` fields that the old inline version omitted. |
| src/app/(main)/program/page.tsx | Correctly gates `performersFromSchedules` and `<EventJsonLd>` behind the existing `isProgramPublished` + schedule-existence guard; JSON-LD only emitted when the program is live. |
| src/lib/seo/__tests__/eventJsonLd.test.ts | 13 tests covering full mapping, localhost protocol, price, missing venue, disabled registration, social links, performers, deduplication, status filtering, and XSS escaping. Coverage is thorough. |
| src/components/seo/EventJsonLd.stories.tsx | Three stories (HomePage, ProgramPage, MissingVenue) with a `JsonLdPreview` wrapper. Uses far-future 2099 dates making registration checks practically deterministic, but `globalThis.Date` is not mocked per the project's Storybook convention. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant HP as Home page.tsx
    participant PP as Program page.tsx
    participant EJL as EventJsonLd.tsx
    participant Builder as eventJsonLd.ts
    participant State as conference/state.ts

    HP->>EJL: EventJsonLd conference domain lowestTicketPrice
    EJL->>Builder: buildEventJsonLd(options)
    Builder->>State: isRegistrationAvailable(conference)
    State-->>Builder: boolean
    Builder-->>EJL: Record string unknown
    EJL->>Builder: serializeJsonLd(data)
    Builder-->>EJL: escaped JSON string
    EJL-->>HP: script type application/ld+json

    PP->>Builder: performersFromSchedules(schedules)
    Builder-->>PP: EventPerformer[]
    PP->>EJL: EventJsonLd conference domain performers
    EJL->>Builder: buildEventJsonLd(options)
    Builder->>State: isRegistrationAvailable(conference)
    State-->>Builder: boolean
    Builder-->>EJL: Record string unknown
    EJL->>Builder: serializeJsonLd(data)
    Builder-->>EJL: escaped JSON string
    EJL-->>PP: script type application/ld+json
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant HP as Home page.tsx
    participant PP as Program page.tsx
    participant EJL as EventJsonLd.tsx
    participant Builder as eventJsonLd.ts
    participant State as conference/state.ts

    HP->>EJL: EventJsonLd conference domain lowestTicketPrice
    EJL->>Builder: buildEventJsonLd(options)
    Builder->>State: isRegistrationAvailable(conference)
    State-->>Builder: boolean
    Builder-->>EJL: Record string unknown
    EJL->>Builder: serializeJsonLd(data)
    Builder-->>EJL: escaped JSON string
    EJL-->>HP: script type application/ld+json

    PP->>Builder: performersFromSchedules(schedules)
    Builder-->>PP: EventPerformer[]
    PP->>EJL: EventJsonLd conference domain performers
    EJL->>Builder: buildEventJsonLd(options)
    Builder->>State: isRegistrationAvailable(conference)
    State-->>Builder: boolean
    Builder-->>EJL: Record string unknown
    EJL->>Builder: serializeJsonLd(data)
    Builder-->>EJL: escaped JSON string
    EJL-->>PP: script type application/ld+json
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(seo): Event schema.org JSON-LD on h..."](https://github.com/cloudnativebergen/website/commit/ec1bc3883934317bd0acac1abafd623b46e85ca8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44438113)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->