### PR TITLE
feat(home): featured speakers peek-and-snap shelf

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -5,6 +5,7 @@ import { Sponsors } from '@/components/Sponsors'
 import { ImageGallery } from '@/components/ImageGallery'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { SpeakerPromotionCard } from '@/components/SpeakerPromotionCard'
+import { FeaturedSpeakersShelf } from '@/components/FeaturedSpeakersShelf'
 import {
   isCfpOpen,
   isProgramPublished,
@@ -249,15 +250,7 @@ async function CachedHomeContent({ domain }: { domain: string }) {
               </p>
             </div>
 
-            <div className="mt-12 grid auto-rows-fr grid-cols-2 gap-4 sm:gap-6 lg:grid-cols-3">
-              {conference.featuredSpeakers!.map((speaker) => (
-                <SpeakerPromotionCard
-                  key={speaker._id}
-                  speaker={speaker}
-                  variant="featured"
-                />
-              ))}
-            </div>
+            <FeaturedSpeakersShelf speakers={conference.featuredSpeakers!} />
 
             <PhaseCtaRow
               conference={conference}

--- a/src/components/FeaturedSpeakerTile.stories.tsx
+++ b/src/components/FeaturedSpeakerTile.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { FeaturedSpeakerTile } from './FeaturedSpeakerTile'
+import {
+  longTitleSpeaker,
+  noImageSpeaker,
+  workshopSpeaker,
+} from './featuredSpeakers.mocks'
+
+const meta = {
+  title: 'Systems/Speakers/FeaturedSpeakersShelf/Tile',
+  component: FeaturedSpeakerTile,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A single photo-forward overlay tile used by the Featured Speakers shelf. The whole tile links to the speaker profile (via a stretched pseudo-element on the name link) while the accessible link text stays the speaker name. A bottom scrim keeps the caption legible over the portrait.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof FeaturedSpeakerTile>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Workshop: Story = {
+  args: { speaker: workshopSpeaker },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A speaker running a workshop shows the sunbeam-yellow "Workshop" badge in the top-left corner.',
+      },
+    },
+  },
+}
+
+export const LongTitle: Story = {
+  args: { speaker: longTitleSpeaker },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A very long title is clamped to a single line so the overlay caption stays legible.',
+      },
+    },
+  },
+}
+
+export const NoImage: Story = {
+  args: { speaker: noImageSpeaker },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without a photo the tile falls back to initials on a brand-tinted gradient instead of a broken frame.',
+      },
+    },
+  },
+}

--- a/src/components/FeaturedSpeakerTile.tsx
+++ b/src/components/FeaturedSpeakerTile.tsx
@@ -41,6 +41,8 @@ export function FeaturedSpeakerTile({ speaker }: FeaturedSpeakerTileProps) {
           })}
           alt=""
           aria-hidden="true"
+          loading="lazy"
+          decoding="async"
           className="absolute inset-0 h-full w-full object-cover object-center transition-transform duration-500 motion-safe:group-hover:scale-105"
         />
       ) : (
@@ -67,8 +69,13 @@ export function FeaturedSpeakerTile({ speaker }: FeaturedSpeakerTileProps) {
         </span>
       )}
 
-      {/* Caption (bottom-left) */}
-      <div className="relative z-10 p-4 sm:p-5">
+      {/* Caption (bottom-left).
+          NOTE: intentionally NOT `position: relative`. As a flex item it still
+          honors `z-10` (stacking above the scrim), while staying out of the
+          containing-block chain so the name link's stretched `after:inset-0`
+          resolves to the whole tile — making the entire portrait clickable,
+          not just this caption strip. */}
+      <div className="z-10 p-4 sm:p-5">
         <h3 className="font-space-grotesk text-lg font-bold text-white sm:text-xl">
           <Link
             href={`/speaker/${slug}`}

--- a/src/components/FeaturedSpeakerTile.tsx
+++ b/src/components/FeaturedSpeakerTile.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link'
+import { MissingAvatar } from '@/components/common/MissingAvatar'
+import { speakerImageUrl } from '@/lib/sanity/client'
+import { SpeakerWithTalks } from '@/lib/speaker/types'
+import {
+  computeSpeakerData,
+  stripCompanyFromTitle,
+} from '@/lib/speaker/promotion'
+
+interface FeaturedSpeakerTileProps {
+  speaker: SpeakerWithTalks
+}
+
+/**
+ * A single photo-forward overlay tile for the Featured Speakers shelf.
+ *
+ * The whole tile is clickable (a stretched pseudo-element on the name link),
+ * while the accessible link text remains the speaker's name. A bottom scrim
+ * keeps the caption legible over the portrait photo; speakers without an image
+ * fall back to initials on a brand-tinted gradient so the frame never looks
+ * broken.
+ */
+export function FeaturedSpeakerTile({ speaker }: FeaturedSpeakerTileProps) {
+  const { name, slug, title, image } = speaker
+  const { company, hasWorkshop } = computeSpeakerData(speaker)
+
+  // Prefer the (short) company as the sub-line for overlay legibility, falling
+  // back to the role with any trailing "at Company" fragment removed.
+  const role = stripCompanyFromTitle(title, company)
+  const subline = company || role
+
+  return (
+    <div className="group relative flex aspect-[4/5] flex-col justify-end overflow-hidden rounded-2xl bg-brand-slate-gray focus-within:ring-2 focus-within:ring-brand-cloud-blue focus-within:ring-offset-2 focus-within:ring-offset-brand-slate-gray">
+      {/* Portrait photo (or initials fallback) filling the tile */}
+      {image ? (
+        <img
+          src={speakerImageUrl(image, {
+            width: 640,
+            height: 800,
+            fit: 'crop',
+          })}
+          alt=""
+          aria-hidden="true"
+          className="absolute inset-0 h-full w-full object-cover object-center transition-transform duration-500 motion-safe:group-hover:scale-105"
+        />
+      ) : (
+        <div className="absolute inset-0 bg-linear-to-br from-brand-cloud-blue/40 via-brand-nordic-purple/30 to-brand-slate-gray">
+          <MissingAvatar
+            name={name}
+            size={640}
+            className="absolute inset-0 !bg-transparent"
+            textSizeClass="text-6xl"
+          />
+        </div>
+      )}
+
+      {/* Bottom scrim for caption legibility */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/45 to-transparent"
+      />
+
+      {/* Workshop badge (top-left) — the only signal we can derive reliably */}
+      {hasWorkshop && (
+        <span className="font-inter absolute top-3 left-3 z-10 rounded-full bg-accent-yellow px-2.5 py-1 text-xs font-bold text-black shadow-md">
+          Workshop
+        </span>
+      )}
+
+      {/* Caption (bottom-left) */}
+      <div className="relative z-10 p-4 sm:p-5">
+        <h3 className="font-space-grotesk text-lg font-bold text-white sm:text-xl">
+          <Link
+            href={`/speaker/${slug}`}
+            className="after:absolute after:inset-0 after:content-[''] focus:outline-none"
+          >
+            {name}
+          </Link>
+        </h3>
+        {subline && (
+          <p className="font-inter mt-1 line-clamp-1 text-sm text-slate-200">
+            {subline}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/FeaturedSpeakersShelf.stories.tsx
+++ b/src/components/FeaturedSpeakersShelf.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { FeaturedSpeakersShelf } from './FeaturedSpeakersShelf'
+import { mockFeaturedSpeakers } from './featuredSpeakers.mocks'
+
+const meta = {
+  title: 'Systems/Speakers/FeaturedSpeakersShelf',
+  component: FeaturedSpeakersShelf,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A horizontal peek-and-snap shelf of photo-forward speaker overlay tiles for the conference front page. Manual only (no auto-advance): tiles snap into place, the next tile peeks at the right edge, desktop shows prev/next arrows, and the row is a focusable region that keyboard users can arrow-scroll. Ends with a dashed "View all speakers" endcap linking to /speaker. Respects prefers-reduced-motion.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-white px-6 py-12 dark:bg-gray-950">
+        <div className="mx-auto max-w-7xl">
+          <h2 className="font-space-grotesk mb-2 text-4xl font-medium tracking-tighter text-brand-cloud-blue dark:text-blue-400">
+            Featured Speakers
+          </h2>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof FeaturedSpeakersShelf>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Desktop: Story = {
+  args: { speakers: mockFeaturedSpeakers },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Desktop layout: roughly three tiles plus a peek of the next, with working prev/next arrows in the top-right.',
+      },
+    },
+  },
+}
+
+export const Mobile: Story = {
+  args: { speakers: mockFeaturedSpeakers },
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+    docs: {
+      description: {
+        story:
+          'Mobile layout: one and a half tiles visible (a clear peek of the next), navigated by touch swipe — arrows are hidden.',
+      },
+    },
+  },
+}
+
+export const FewSpeakers: Story = {
+  args: { speakers: mockFeaturedSpeakers.slice(0, 2) },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With only a couple of speakers the shelf still renders cleanly, ending with the "View all speakers" endcap.',
+      },
+    },
+  },
+}

--- a/src/components/FeaturedSpeakersShelf.tsx
+++ b/src/components/FeaturedSpeakersShelf.tsx
@@ -68,7 +68,11 @@ export function FeaturedSpeakersShelf({
   }, [])
 
   return (
-    <div className="relative mt-12">
+    <div
+      className="relative mt-12"
+      role="region"
+      aria-label="Featured speakers"
+    >
       {/* Desktop prev/next controls (hidden on mobile — touch swipe there). */}
       <div className="pointer-events-none absolute -top-16 right-0 hidden gap-2 lg:flex">
         <button
@@ -91,11 +95,13 @@ export function FeaturedSpeakersShelf({
         </button>
       </div>
 
+      {/* Keep the <ul> a real list (no role override) so AT announces
+          "list, N items". The region role/label lives on the wrapper above;
+          tabIndex keeps the row keyboard-scrollable. */}
       <ul
         ref={scrollerRef}
-        role="region"
-        aria-label="Featured speakers"
         tabIndex={0}
+        aria-label="Featured speakers"
         className="no-scrollbar flex snap-x snap-mandatory gap-4 overflow-x-auto pb-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-offset-2 motion-safe:scroll-smooth"
       >
         {speakers.map((speaker) => (

--- a/src/components/FeaturedSpeakersShelf.tsx
+++ b/src/components/FeaturedSpeakersShelf.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  ArrowRightIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from '@heroicons/react/24/outline'
+import { FeaturedSpeakerTile } from '@/components/FeaturedSpeakerTile'
+import { SpeakerWithTalks } from '@/lib/speaker/types'
+
+interface FeaturedSpeakersShelfProps {
+  speakers: SpeakerWithTalks[]
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/**
+ * Horizontal peek-and-snap shelf of photo-forward speaker overlay tiles.
+ *
+ * Manual only — no auto-advance or timers. On desktop, prev/next buttons scroll
+ * by roughly one tile; on touch/mobile the row is swiped. The row itself is a
+ * focusable region so keyboard users can arrow-scroll it, and the whole thing
+ * respects `prefers-reduced-motion`.
+ */
+export function FeaturedSpeakersShelf({
+  speakers,
+}: FeaturedSpeakersShelfProps) {
+  const scrollerRef = useRef<HTMLUListElement>(null)
+  const [canScrollPrev, setCanScrollPrev] = useState(false)
+  const [canScrollNext, setCanScrollNext] = useState(false)
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollerRef.current
+    if (!el) return
+    const { scrollLeft, scrollWidth, clientWidth } = el
+    // Small epsilon to absorb sub-pixel rounding at the extremes.
+    setCanScrollPrev(scrollLeft > 4)
+    setCanScrollNext(scrollLeft + clientWidth < scrollWidth - 4)
+  }, [])
+
+  useEffect(() => {
+    const el = scrollerRef.current
+    if (!el) return
+    updateScrollState()
+    el.addEventListener('scroll', updateScrollState, { passive: true })
+    window.addEventListener('resize', updateScrollState)
+    return () => {
+      el.removeEventListener('scroll', updateScrollState)
+      window.removeEventListener('resize', updateScrollState)
+    }
+  }, [updateScrollState])
+
+  const scrollByTile = useCallback((direction: 1 | -1) => {
+    const el = scrollerRef.current
+    if (!el) return
+    // Advance by the width of the first tile (plus gap) so we move ~one card.
+    const firstTile = el.querySelector<HTMLElement>('[data-shelf-item]')
+    const step = firstTile ? firstTile.offsetWidth + 16 : el.clientWidth * 0.8
+    el.scrollBy({
+      left: direction * step,
+      behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+    })
+  }, [])
+
+  return (
+    <div className="relative mt-12">
+      {/* Desktop prev/next controls (hidden on mobile — touch swipe there). */}
+      <div className="pointer-events-none absolute -top-16 right-0 hidden gap-2 lg:flex">
+        <button
+          type="button"
+          aria-label="Previous speakers"
+          onClick={() => scrollByTile(-1)}
+          disabled={!canScrollPrev}
+          className="pointer-events-auto flex size-11 items-center justify-center rounded-full border border-brand-frosted-steel bg-white text-brand-slate-gray shadow-xs transition hover:border-brand-cloud-blue hover:text-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-brand-frosted-steel disabled:hover:text-brand-slate-gray dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+        >
+          <ChevronLeftIcon className="size-5" />
+        </button>
+        <button
+          type="button"
+          aria-label="Next speakers"
+          onClick={() => scrollByTile(1)}
+          disabled={!canScrollNext}
+          className="pointer-events-auto flex size-11 items-center justify-center rounded-full border border-brand-frosted-steel bg-white text-brand-slate-gray shadow-xs transition hover:border-brand-cloud-blue hover:text-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-brand-frosted-steel disabled:hover:text-brand-slate-gray dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+        >
+          <ChevronRightIcon className="size-5" />
+        </button>
+      </div>
+
+      <ul
+        ref={scrollerRef}
+        role="region"
+        aria-label="Featured speakers"
+        tabIndex={0}
+        className="no-scrollbar flex snap-x snap-mandatory gap-4 overflow-x-auto pb-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-offset-2 motion-safe:scroll-smooth"
+      >
+        {speakers.map((speaker) => (
+          <li
+            key={speaker._id}
+            data-shelf-item
+            className="shrink-0 basis-[62%] snap-start sm:basis-[42%] lg:basis-[30%]"
+          >
+            <FeaturedSpeakerTile speaker={speaker} />
+          </li>
+        ))}
+
+        {/* Endcap: link to the full speaker listing. */}
+        <li
+          data-shelf-item
+          className="shrink-0 basis-[62%] snap-start sm:basis-[42%] lg:basis-[30%]"
+        >
+          <Link
+            href="/speaker"
+            className="group flex aspect-[4/5] flex-col items-center justify-center rounded-2xl border-2 border-dashed border-brand-frosted-steel text-brand-slate-gray transition hover:border-brand-cloud-blue hover:text-brand-cloud-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:border-gray-700 dark:text-gray-300"
+          >
+            <span className="font-space-grotesk text-lg font-bold">
+              View all speakers
+            </span>
+            <ArrowRightIcon className="mt-2 size-6 transition-transform group-hover:translate-x-1" />
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/src/components/SpeakerPromotionCard.tsx
+++ b/src/components/SpeakerPromotionCard.tsx
@@ -10,10 +10,12 @@ import {
 } from '@heroicons/react/24/outline'
 import { UserIcon, MicrophoneIcon, StarIcon } from '@heroicons/react/24/solid'
 import { speakerImageUrl } from '@/lib/sanity/client'
-import { Format } from '@/lib/proposal/types'
-import { formatConfig } from '@/lib/proposal'
 import { SpeakerWithTalks } from '@/lib/speaker/types'
 import { Flags } from '@/lib/speaker/types'
+import {
+  computeSpeakerData,
+  stripCompanyFromTitle,
+} from '@/lib/speaker/promotion'
 import Link from 'next/link'
 import { memo, useMemo } from 'react'
 import { SpeakerAvatarImage } from '@/components/common/SpeakerAvatarImage'
@@ -30,14 +32,6 @@ interface SpeakerPromotionCardProps {
   ctaText?: string
 
   ctaUrl?: string
-}
-
-interface ComputedSpeakerData {
-  talks: SpeakerWithTalks['talks']
-  expertise: string[]
-  company: string | undefined
-  talkCount: number
-  hasWorkshop: boolean
 }
 
 const variantConfig = {
@@ -74,80 +68,6 @@ const variantConfig = {
     showCloudNativePattern: false,
   },
 } as const
-
-const deriveExpertise = (talks: SpeakerWithTalks['talks']): string[] => {
-  if (!talks?.length) return []
-
-  const expertise = new Set<string>()
-  talks.forEach((talk) => {
-    if (talk.format) {
-      const formatLabel = formatConfig[talk.format as Format]?.label
-      if (formatLabel) {
-        expertise.add(formatLabel)
-      }
-    }
-  })
-  return Array.from(expertise)
-}
-
-const deriveCompany = (title: string | undefined): string | undefined => {
-  if (!title) return undefined
-
-  let company: string | undefined
-
-  if (title.includes(' at ')) {
-    company = title.split(' at ')[1].trim()
-  } else if (title.includes('@')) {
-    company = title.split('@')[1].trim()
-  }
-
-  if (!company) return undefined
-
-  const separators = ['|', ',', '•', '·', '-', '–', '—', '/', '\\']
-  for (const separator of separators) {
-    if (company.includes(separator)) {
-      company = company.split(separator)[0].trim()
-      break
-    }
-  }
-
-  return company
-}
-
-const escapeRegex = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
-const stripCompanyFromTitle = (
-  title: string | undefined,
-  company: string | undefined,
-): string | undefined => {
-  if (!title || !company) return title
-
-  const pattern = new RegExp(`\\s+(at|@)\\s+${escapeRegex(company)}\\s*$`, 'i')
-  if (!pattern.test(title)) return title
-
-  return title.replace(pattern, '').trim()
-}
-
-function computeSpeakerData(speaker: SpeakerWithTalks): ComputedSpeakerData {
-  const talks = speaker.talks || []
-  const expertise = deriveExpertise(talks)
-  const company = deriveCompany(speaker.title)
-  const talkCount = talks.length
-  const hasWorkshop = talks.some(
-    (talk) =>
-      talk.format === Format.workshop_120 ||
-      talk.format === Format.workshop_240,
-  )
-
-  return {
-    talks,
-    expertise,
-    company,
-    talkCount,
-    hasWorkshop,
-  }
-}
 
 interface SpeakerImageProps {
   image?: SpeakerWithTalks['image']

--- a/src/components/featuredSpeakers.mocks.ts
+++ b/src/components/featuredSpeakers.mocks.ts
@@ -1,0 +1,78 @@
+import { Format, type ProposalExisting } from '@/lib/proposal/types'
+import { Flags, type SpeakerWithTalks } from '@/lib/speaker/types'
+
+/**
+ * Realistic mock speakers for the Featured Speakers shelf and tile stories.
+ * Covers the tricky cases the design must handle gracefully: a long title, a
+ * speaker with no image, and a workshop presenter (badge).
+ */
+
+const talk = (format: Format): ProposalExisting =>
+  ({ format }) as unknown as ProposalExisting
+
+const base = (
+  id: string,
+  overrides: Partial<SpeakerWithTalks>,
+): SpeakerWithTalks =>
+  ({
+    _id: id,
+    _rev: '1',
+    _createdAt: '2024-01-01T00:00:00Z',
+    _updatedAt: '2024-01-01T00:00:00Z',
+    email: `${id}@example.com`,
+    ...overrides,
+  }) as SpeakerWithTalks
+
+// Portrait (4:5) placeholder images so the crop matches the tile aspect ratio.
+const portrait = (bg: string, label: string) =>
+  `https://placehold.co/640x800/${bg}/ffffff?text=${encodeURIComponent(label)}`
+
+export const workshopSpeaker = base('speaker-workshop', {
+  name: 'Alice Johnson',
+  slug: 'alice-johnson',
+  title: 'Principal Platform Engineer at Google Cloud',
+  image: portrait('1d4ed8', 'Alice'),
+  flags: [Flags.localSpeaker],
+  talks: [talk(Format.workshop_120)],
+})
+
+export const longTitleSpeaker = base('speaker-long-title', {
+  name: 'Bjørn-Kristian Aleksandersen',
+  slug: 'bjorn-kristian',
+  title:
+    'Senior Staff Site Reliability Engineer and Observability Lead at MegaCorp International Systems',
+  image: portrait('10b981', 'Bjorn'),
+  talks: [talk(Format.presentation_45)],
+})
+
+export const noImageSpeaker = base('speaker-no-image', {
+  name: 'Chen Wei',
+  slug: 'chen-wei',
+  title: 'Developer Advocate at Fastly',
+  talks: [talk(Format.presentation_25)],
+})
+
+export const plainSpeaker = base('speaker-plain', {
+  name: 'Dana Okoro',
+  slug: 'dana-okoro',
+  title: 'Independent Kubernetes Consultant',
+  image: portrait('6366f1', 'Dana'),
+  talks: [talk(Format.presentation_45)],
+})
+
+export const shortRoleSpeaker = base('speaker-short-role', {
+  name: 'Erik Sørensen',
+  slug: 'erik-sorensen',
+  title: 'CTO @ Nordcloud',
+  image: portrait('facc15', 'Erik'),
+  flags: [Flags.firstTimeSpeaker],
+  talks: [talk(Format.lightning_10)],
+})
+
+export const mockFeaturedSpeakers: SpeakerWithTalks[] = [
+  workshopSpeaker,
+  longTitleSpeaker,
+  noImageSpeaker,
+  plainSpeaker,
+  shortRoleSpeaker,
+]

--- a/src/lib/speaker/promotion.test.ts
+++ b/src/lib/speaker/promotion.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deriveCompany,
+  stripCompanyFromTitle,
+  deriveExpertise,
+  computeSpeakerData,
+} from './promotion'
+import { Format } from '@/lib/proposal/types'
+import type { SpeakerWithTalks } from '@/lib/speaker/types'
+import type { ProposalExisting } from '@/lib/proposal/types'
+
+const talk = (format: Format): ProposalExisting =>
+  ({ format }) as unknown as ProposalExisting
+
+const speaker = (overrides: Partial<SpeakerWithTalks>): SpeakerWithTalks =>
+  ({
+    _id: 'id',
+    _rev: '1',
+    _createdAt: '',
+    _updatedAt: '',
+    name: 'Test Speaker',
+    email: 'test@example.com',
+    ...overrides,
+  }) as SpeakerWithTalks
+
+describe('deriveCompany', () => {
+  it('returns undefined when no title', () => {
+    expect(deriveCompany(undefined)).toBeUndefined()
+    expect(deriveCompany('')).toBeUndefined()
+  })
+
+  it('extracts company after " at "', () => {
+    expect(deriveCompany('Senior Engineer at Acme')).toBe('Acme')
+  })
+
+  it('extracts company after "@"', () => {
+    expect(deriveCompany('Developer @ Acme')).toBe('Acme')
+  })
+
+  it('trims trailing detail after a separator', () => {
+    expect(deriveCompany('Engineer at Acme | DevRel')).toBe('Acme')
+    expect(deriveCompany('Engineer at Acme, Norway')).toBe('Acme')
+  })
+
+  it('returns undefined when the title has no affiliation marker', () => {
+    expect(deriveCompany('Independent Consultant')).toBeUndefined()
+  })
+})
+
+describe('stripCompanyFromTitle', () => {
+  it('removes a trailing "at Company" fragment', () => {
+    expect(stripCompanyFromTitle('Senior Engineer at Acme', 'Acme')).toBe(
+      'Senior Engineer',
+    )
+  })
+
+  it('removes a trailing "@ Company" fragment case-insensitively', () => {
+    expect(stripCompanyFromTitle('Developer @ ACME', 'acme')).toBe('Developer')
+  })
+
+  it('leaves the title untouched when company is absent', () => {
+    expect(stripCompanyFromTitle('Independent Consultant', undefined)).toBe(
+      'Independent Consultant',
+    )
+  })
+})
+
+describe('deriveExpertise', () => {
+  it('returns [] for empty talks', () => {
+    expect(deriveExpertise([])).toEqual([])
+    expect(deriveExpertise(undefined)).toEqual([])
+  })
+
+  it('collects distinct format labels', () => {
+    const result = deriveExpertise([
+      talk(Format.presentation_45),
+      talk(Format.presentation_45),
+      talk(Format.workshop_120),
+    ])
+    // Two distinct formats -> two distinct labels (duplicates collapsed).
+    expect(result).toHaveLength(2)
+    expect(new Set(result).size).toBe(2)
+    result.forEach((label) => expect(typeof label).toBe('string'))
+  })
+})
+
+describe('computeSpeakerData', () => {
+  it('flags workshops from talk formats', () => {
+    const data = computeSpeakerData(
+      speaker({ talks: [talk(Format.workshop_240)] }),
+    )
+    expect(data.hasWorkshop).toBe(true)
+    expect(data.talkCount).toBe(1)
+  })
+
+  it('does not flag a workshop for non-workshop talks', () => {
+    const data = computeSpeakerData(
+      speaker({ talks: [talk(Format.presentation_25)] }),
+    )
+    expect(data.hasWorkshop).toBe(false)
+  })
+
+  it('derives the company from the speaker title', () => {
+    const data = computeSpeakerData(
+      speaker({ title: 'Principal Engineer at Acme' }),
+    )
+    expect(data.company).toBe('Acme')
+  })
+
+  it('handles a speaker with no talks and no title', () => {
+    const data = computeSpeakerData(speaker({}))
+    expect(data.talkCount).toBe(0)
+    expect(data.hasWorkshop).toBe(false)
+    expect(data.company).toBeUndefined()
+    expect(data.expertise).toEqual([])
+  })
+})

--- a/src/lib/speaker/promotion.ts
+++ b/src/lib/speaker/promotion.ts
@@ -1,0 +1,111 @@
+import { Format } from '@/lib/proposal/types'
+import { formatConfig } from '@/lib/proposal'
+import { SpeakerWithTalks } from '@/lib/speaker/types'
+
+/**
+ * Pure, framework-agnostic helpers for deriving promotional display data from a
+ * speaker. Shared by {@link SpeakerPromotionCard} and the front-page
+ * FeaturedSpeakers shelf so the company/role parsing lives in a single place.
+ */
+
+export interface ComputedSpeakerData {
+  talks: SpeakerWithTalks['talks']
+  expertise: string[]
+  company: string | undefined
+  talkCount: number
+  hasWorkshop: boolean
+}
+
+/**
+ * Collects the distinct human-readable format labels across a speaker's talks
+ * (e.g. "Presentation (45 min)", "Workshop (2 hours)").
+ */
+export const deriveExpertise = (talks: SpeakerWithTalks['talks']): string[] => {
+  if (!talks?.length) return []
+
+  const expertise = new Set<string>()
+  talks.forEach((talk) => {
+    if (talk.format) {
+      const formatLabel = formatConfig[talk.format as Format]?.label
+      if (formatLabel) {
+        expertise.add(formatLabel)
+      }
+    }
+  })
+  return Array.from(expertise)
+}
+
+/**
+ * Extracts a company name from a free-form speaker title such as
+ * "Senior Engineer at Acme" or "Developer @ Acme | DevRel".
+ */
+export const deriveCompany = (
+  title: string | undefined,
+): string | undefined => {
+  if (!title) return undefined
+
+  let company: string | undefined
+
+  if (title.includes(' at ')) {
+    company = title.split(' at ')[1].trim()
+  } else if (title.includes('@')) {
+    company = title.split('@')[1].trim()
+  }
+
+  if (!company) return undefined
+
+  const separators = ['|', ',', '•', '·', '-', '–', '—', '/', '\\']
+  for (const separator of separators) {
+    if (company.includes(separator)) {
+      company = company.split(separator)[0].trim()
+      break
+    }
+  }
+
+  return company
+}
+
+const escapeRegex = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/**
+ * Removes the trailing "at Company" / "@ Company" fragment from a title so the
+ * role can be shown without duplicating the company shown elsewhere.
+ */
+export const stripCompanyFromTitle = (
+  title: string | undefined,
+  company: string | undefined,
+): string | undefined => {
+  if (!title || !company) return title
+
+  const pattern = new RegExp(`\\s+(at|@)\\s+${escapeRegex(company)}\\s*$`, 'i')
+  if (!pattern.test(title)) return title
+
+  return title.replace(pattern, '').trim()
+}
+
+/**
+ * Computes the derived promotional data (talks, expertise, company, workshop
+ * signal) for a speaker in a single pass.
+ */
+export function computeSpeakerData(
+  speaker: SpeakerWithTalks,
+): ComputedSpeakerData {
+  const talks = speaker.talks || []
+  const expertise = deriveExpertise(talks)
+  const company = deriveCompany(speaker.title)
+  const talkCount = talks.length
+  const hasWorkshop = talks.some(
+    (talk) =>
+      talk.format === Format.workshop_120 ||
+      talk.format === Format.workshop_240,
+  )
+
+  return {
+    talks,
+    expertise,
+    company,
+    talkCount,
+    hasWorkshop,
+  }
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -28,6 +28,17 @@
 
 /* Critical utilities for production builds - Force arbitrary values to be included */
 /* Using explicit class names instead of @layer utilities for better compatibility */
+
+/* Hide the scrollbar while keeping the element keyboard/touch scrollable.
+   Used by the Featured Speakers shelf. */
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 .chart-height-300 {
   height: 300px !important;
 }


### PR DESCRIPTION
## Featured Speakers — peek-and-snap shelf

Redesigns the front-page **Featured Speakers** section (the `hasFeaturedSpeakers` branch of `src/app/(main)/page.tsx`) from a static grid of `SpeakerPromotionCard variant="featured"` into a horizontal, photo-forward **overlay shelf**. The section heading and the `PhaseCtaRow` below it are unchanged.

> [!IMPORTANT]
> Held for visual review — please do **not** enqueue/merge until the design has been eyeballed against a real conference with featured speakers. Check the Vercel preview.

### Design rationale
Photo-forward tiles put the speakers' faces first, which reads as a modern conference "line-up". The interaction pattern is deliberately conservative and research-backed to avoid the usual carousel pitfalls:

- **Manual only, no auto-advance / no timers** — rotating carousels are widely shown to hurt engagement and accessibility.
- **Peek + snap** — the next tile visibly peeks at the right edge (mobile `62%`, `sm 42%`, `lg 30%` basis) so it's obvious the row scrolls; `snap-x snap-mandatory` snaps tiles into place.
- **Desktop prev/next arrows** (`hidden lg:flex`, real `<button>`s with aria-labels) scroll by ~one tile and disable at the start/end; mobile relies on native touch swipe.
- **Block-link a11y done right** — each tile's accessible link is the speaker **name** (`<h3><Link>`), stretched over the whole tile via an `after:absolute after:inset-0` pseudo-element, rather than a card-wide anchor that screen readers announce as one giant link.
- **Reduced-motion** — smooth scroll is gated behind `motion-safe:` and the arrow `scrollBy` uses `behavior: 'auto'` when the user prefers reduced motion.
- **Legibility** — a bottom `from-black/90 via-black/45` scrim keeps white name + light-slate sub-line above 4.5:1 contrast; the sub-line is `line-clamp-1`.
- **Never broken** — a speaker with no image falls back to initials on a brand-tinted gradient.
- **Semantics** — the row is a `<ul>`/`<li>` list, `role="region"` + `aria-label` + `tabIndex={0}` so keyboard users can arrow-scroll it; visible focus rings throughout.
- A dashed **"View all speakers"** endcap tile links to `/speaker`.

### What changed
- **New** `src/components/FeaturedSpeakerTile.tsx` — a single 4:5 overlay tile.
- **New** `src/components/FeaturedSpeakersShelf.tsx` (`'use client'`) — the scroller, arrows, endcap.
- **New** `src/lib/speaker/promotion.ts` — extracted the pure helpers (`deriveCompany`, `stripCompanyFromTitle`, `deriveExpertise`, `computeSpeakerData`) previously private to `SpeakerPromotionCard`, now shared by both. `SpeakerPromotionCard` imports them and is otherwise unchanged (all variants intact).
- **New** `src/lib/speaker/promotion.test.ts` — unit tests for the extracted helpers (14 cases).
- **New** stories + mocks: `FeaturedSpeakersShelf.stories.tsx`, `FeaturedSpeakerTile.stories.tsx`, `featuredSpeakers.mocks.ts` (long title, no image, workshop badge; desktop + mobile viewports).
- **New** `.no-scrollbar` utility in `src/styles/tailwind.css` (hides scrollbar, stays touch/keyboard scrollable).
- **Wired** `page.tsx`: grid → `<FeaturedSpeakersShelf speakers={conference.featuredSpeakers!} />`. Heading + `PhaseCtaRow` kept.

### Note on ProgramHighlights
`src/components/ProgramHighlights.tsx` (the `hasSchedule` branch, which pre-empts the featured-speakers branch once a schedule is published) also renders featured speakers via `SpeakerPromotionCard variant="featured"`. That is a separate surface and is **left untouched** per scope — flagging it in case a follow-up wants the same treatment there.

### Acceptance criteria
- [x] Single horizontal, swipeable/scrollable row; next tile peeks on mobile and desktop
- [x] Tiles snap into place
- [x] Desktop prev/next arrows scroll ~one tile; hidden on mobile (touch swipe)
- [x] No auto-advance / rotation anywhere
- [x] Each tile: 4:5 portrait, name + one short sub-line over a scrim, whole tile → `/speaker/[slug]`
- [x] Keyboard: row focusable + arrow-scrollable; name link reachable/activatable; visible focus ring
- [x] Screen-reader: `<ul>`/`<li>`; the link is the name, not a card-wide anchor
- [x] No image → initials on a gradient
- [x] `prefers-reduced-motion` disables smooth scroll
- [x] "View all speakers" affordance → `/speaker`
- [x] Old grid + `variant="featured"` no longer on the home page; component + other variants intact

### Verification
- `pnpm typecheck` — clean
- `pnpm vitest run` — 121 files, 2129 passed / 5 skipped
- eslint + prettier on all touched files — clean
- `pnpm build-storybook` — succeeds; `FeaturedSpeakersShelf` + `FeaturedSpeakerTile` present in the index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the static featured-speakers grid on the home page with a horizontal peek-and-snap shelf (`FeaturedSpeakersShelf` + `FeaturedSpeakerTile`). Speaker helpers previously private to `SpeakerPromotionCard` are extracted into a new shared module (`src/lib/speaker/promotion.ts`) with 14 unit tests; the existing card component is unchanged.

- **New shelf** (`FeaturedSpeakersShelf.tsx`): client component managing scroll-state, desktop prev/next arrows, snap scrolling, and a \"View all speakers\" endcap; reduced-motion respected on arrow clicks.
- **New tile** (`FeaturedSpeakerTile.tsx`): 4:5 portrait tile with scrim, workshop badge, initials fallback, and a stretched pseudo-element link — correct a11y pattern for block-link cards.
- **Helper extraction** (`promotion.ts` / `promotion.test.ts`): `deriveCompany`, `stripCompanyFromTitle`, `deriveExpertise`, `computeSpeakerData` now shared between the card and the shelf.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the role="region" on the ul is resolved — the rest of the shelf is well-structured and the helper extraction is clean.

The `role="region"` attribute on the `<ul>` in `FeaturedSpeakersShelf` overrides the element's native list role. Screen readers will announce the shelf as a landmark region rather than a list with item count, directly contradicting the PR's stated screen-reader goal. The two P2 findings (hardcoded gap value and plain `<img>`) are non-blocking. The helper extraction, unit tests, and overall component structure are solid.

src/components/FeaturedSpeakersShelf.tsx — the `role="region"` placement needs correction before the a11y claims in the PR description hold up.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/FeaturedSpeakersShelf.tsx | New 'use client' shelf component with scroll-state management and prev/next arrows; `role="region"` on the `<ul>` overrides list semantics (screen readers won't report item count), and the hardcoded gap of 16 px in the scroll-step calculation is brittle |
| src/components/FeaturedSpeakerTile.tsx | New overlay tile component; a11y approach (empty alt, aria-hidden portrait, stretched pseudo-element link) is correct; uses a plain `<img>` instead of Next.js `<Image>`, missing format negotiation and responsive srcset |
| src/lib/speaker/promotion.ts | Clean extraction of previously private helpers into a shared module; logic is unchanged from the original SpeakerPromotionCard |
| src/lib/speaker/promotion.test.ts | 14 well-targeted unit tests covering the four extracted helpers; edge cases are represented |
| src/components/SpeakerPromotionCard.tsx | Refactored to import shared helpers from promotion.ts; no functional changes to the component itself |
| src/app/(main)/page.tsx | Minimal change: replaces the static featured-speakers grid with FeaturedSpeakersShelf; heading and PhaseCtaRow are untouched |
| src/styles/tailwind.css | Adds .no-scrollbar utility with vendor-prefixed scrollbar-hiding rules; correctly placed outside @layer |
| src/components/featuredSpeakers.mocks.ts | Realistic mock dataset covering workshop badge, long title clamp, and no-image fallback scenarios for Storybook stories |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[page.tsx: hasFeaturedSpeakers] -->|renders| B[FeaturedSpeakersShelf]
    B --> C[useEffect: attach scroll + resize listeners]
    C --> D[updateScrollState]
    D --> E{scrollLeft > 4?}
    E -->|yes| F[canScrollPrev = true]
    E -->|no| G[canScrollPrev = false]
    D --> H{scrollLeft + clientWidth < scrollWidth - 4?}
    H -->|yes| I[canScrollNext = true]
    H -->|no| J[canScrollNext = false]
    B --> K[Desktop: Prev/Next buttons]
    K -->|onClick| L[scrollByTile ±1]
    L --> M{firstTile offsetWidth?}
    M -->|found| N[step = offsetWidth + gap]
    M -->|not found| O[step = clientWidth × 0.8]
    N --> P{prefersReducedMotion?}
    O --> P
    P -->|yes| Q[scrollBy behavior: auto]
    P -->|no| R[scrollBy behavior: smooth]
    B --> S[ul: speakers.map → FeaturedSpeakerTile]
    B --> T[ul: endcap → /speaker link]
    S --> U{image exists?}
    U -->|yes| V[img src=speakerImageUrl]
    U -->|no| W[MissingAvatar initials fallback]
    S --> X{hasWorkshop?}
    X -->|yes| Y[Workshop badge]
    S --> Z[Name Link with after:inset-0 stretched hit target]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[page.tsx: hasFeaturedSpeakers] -->|renders| B[FeaturedSpeakersShelf]
    B --> C[useEffect: attach scroll + resize listeners]
    C --> D[updateScrollState]
    D --> E{scrollLeft > 4?}
    E -->|yes| F[canScrollPrev = true]
    E -->|no| G[canScrollPrev = false]
    D --> H{scrollLeft + clientWidth < scrollWidth - 4?}
    H -->|yes| I[canScrollNext = true]
    H -->|no| J[canScrollNext = false]
    B --> K[Desktop: Prev/Next buttons]
    K -->|onClick| L[scrollByTile ±1]
    L --> M{firstTile offsetWidth?}
    M -->|found| N[step = offsetWidth + gap]
    M -->|not found| O[step = clientWidth × 0.8]
    N --> P{prefersReducedMotion?}
    O --> P
    P -->|yes| Q[scrollBy behavior: auto]
    P -->|no| R[scrollBy behavior: smooth]
    B --> S[ul: speakers.map → FeaturedSpeakerTile]
    B --> T[ul: endcap → /speaker link]
    S --> U{image exists?}
    U -->|yes| V[img src=speakerImageUrl]
    U -->|no| W[MissingAvatar initials fallback]
    S --> X{hasWorkshop?}
    X -->|yes| Y[Workshop badge]
    S --> Z[Name Link with after:inset-0 stretched hit target]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(home): featured speakers peek-and-s..."](https://github.com/cloudnativebergen/website/commit/cc46f28df809f6e3ed8d6e60413dbef9606bc936) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44444681)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->