### PR TITLE
feat(admin): surface withdrawal reason in proposal detail

### DIFF
--- a/src/components/admin/ProposalDetail.stories.tsx
+++ b/src/components/admin/ProposalDetail.stories.tsx
@@ -243,3 +243,37 @@ export const WithOtherSubmissions: Story = {
     },
   },
 }
+
+export const WithdrawnWithReason: Story = {
+  args: {
+    proposal: createMockProposal({
+      status: Status.withdrawn,
+      withdrawnReason:
+        'The speaker is no longer able to attend the conference due to a scheduling conflict with another commitment, and has asked us to withdraw the talk so the slot can be offered to someone on the waitlist.',
+    }),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A withdrawn proposal surfaces the persisted withdrawal reason in a labelled callout near the top of the detail view.',
+      },
+    },
+  },
+}
+
+export const WithdrawnWithoutReason: Story = {
+  args: {
+    proposal: createMockProposal({
+      status: Status.withdrawn,
+    }),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A legacy withdrawn proposal with no stored reason renders no callout (and does not crash).',
+      },
+    },
+  },
+}

--- a/src/components/admin/ProposalDetail.tsx
+++ b/src/components/admin/ProposalDetail.tsx
@@ -13,6 +13,7 @@ import { ExclamationTriangleIcon } from '@heroicons/react/24/solid'
 import { PortableText } from '@portabletext/react'
 import {
   ProposalExisting,
+  Status,
   statuses,
   formats,
   levels,
@@ -191,6 +192,9 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
     speakers.some((speaker) =>
       speaker?.flags?.includes(Flags.requiresTravelFunding),
     ) || false
+  const withdrawnReason = proposal.withdrawnReason?.trim()
+  const showWithdrawnReason =
+    proposal.status === Status.withdrawn && !!withdrawnReason
 
   return (
     <div>
@@ -207,6 +211,22 @@ export function ProposalDetail({ proposal }: ProposalDetailProps) {
       <div className="pt-4">
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
           <div className="space-y-6 lg:col-span-2">
+            {showWithdrawnReason && (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/50 dark:bg-amber-950/40">
+                <div className="flex items-start gap-3">
+                  <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-500 dark:text-amber-400" />
+                  <div className="min-w-0">
+                    <h2 className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+                      Withdrawal reason
+                    </h2>
+                    <p className="mt-1 text-sm break-words whitespace-pre-wrap text-amber-700 dark:text-amber-300">
+                      {withdrawnReason}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+
             <div>
               <h2 className="mb-3 text-lg font-medium text-gray-900 dark:text-white">
                 Description


### PR DESCRIPTION
## Summary

Follow-up to #212.

PR #433 (merged) added a read-only `withdrawnReason` field to the `talk` Sanity schema, set by `updateProposalStatus`. However, the reason was never read back into the app, so organizers could only see it via Slack/Studio. This PR surfaces it in the admin proposal detail view.

## Changes

- **Rendering** (`src/components/admin/ProposalDetail.tsx`): when `proposal.status === Status.withdrawn` and a trimmed `withdrawnReason` is present, render a clearly-labelled "Withdrawal reason" callout (amber, dark-mode aware, `break-words whitespace-pre-wrap`) at the top of the detail view.
- **Storybook** (`ProposalDetail.stories.tsx`): added `WithdrawnWithReason` and `WithdrawnWithoutReason` stories.

Note: the admin `getProposal` GROQ query already projects all top-level talk fields via the `...` spread, so `withdrawnReason` was already returned to `ProposalDetail` — no query/projection change was needed. No migration (field already exists).

## Acceptance criteria

- [x] A withdrawn proposal shows its withdrawal reason in the admin proposal detail view, clearly labelled.
- [x] A non-withdrawn proposal shows no reason block.
- [x] A withdrawn proposal with no stored reason (legacy) doesn't render an empty block or crash.
- [x] Long reasons wrap (no overflow).

## Verification

- `pnpm typecheck` clean
- `pnpm vitest run` green (2129 passed, 5 skipped)
- eslint + prettier clean on touched files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces the `withdrawnReason` field (added by #433) in the admin proposal detail view for organizers, eliminating the need to check Slack or Sanity Studio to see why a talk was withdrawn.

- **`ProposalDetail.tsx`**: Adds a guarded amber callout block at the top of the main content column, visible only when `status === Status.withdrawn` and a non-empty (trimmed) reason exists; handles legacy proposals with no stored reason by silently suppressing the block.
- **`ProposalDetail.stories.tsx`**: Adds `WithdrawnWithReason` and `WithdrawnWithoutReason` stories covering both display paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, additive UI block with correct guards and no side effects on existing proposal states.

The withdrawal-reason callout is gated by two independent conditions (status check + trimmed non-empty string), so neither non-withdrawn proposals nor legacy withdrawn ones without a stored reason are affected. The withdrawnReason field was already typed as optional in ProposalExisting, the optional-chain trim handles undefined cleanly, and the content is rendered as plain text so there is no XSS surface. Story coverage matches both branches. No query, schema, or migration changes were needed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/ProposalDetail.tsx | Adds withdrawn-reason callout with correct status guard, optional-chaining + trim for safety, and reuses existing amber design tokens; no logic issues found. |
| src/components/admin/ProposalDetail.stories.tsx | Adds two Storybook stories covering the with-reason and without-reason withdrawal paths; both use createMockProposal correctly and document their intent. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProposalDetail receives proposal] --> B{status equals withdrawn?}
    B -- No --> D[Render normal detail view]
    B -- Yes --> C{withdrawnReason trimmed non-empty?}
    C -- No --> D
    C -- Yes --> E[Render amber callout with reason text]
    E --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ProposalDetail receives proposal] --> B{status equals withdrawn?}
    B -- No --> D[Render normal detail view]
    B -- Yes --> C{withdrawnReason trimmed non-empty?}
    C -- No --> D
    C -- Yes --> E[Render amber callout with reason text]
    E --> D
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(admin): surface withdrawal reason i..."](https://github.com/cloudnativebergen/website/commit/67a628696781916108c4a87aae62273a82707d80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44451001)</sub>

<!-- /greptile_comment -->