### PR TITLE
feat(seo): self-canonical tags + Person/Breadcrumb JSON-LD (#396, #398)

### DIFF
--- a/src/app/(main)/cfp/page.tsx
+++ b/src/app/(main)/cfp/page.tsx
@@ -13,14 +13,19 @@ import clsx from 'clsx'
 import Link from 'next/link'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import type { Metadata } from 'next'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
-export const metadata = {
-  title: 'Call for Presentations - Cloud Native Days Norway',
-  description:
-    'Submit your talk proposal for Cloud Native Days Norway conference',
-  twitter: {
-    card: 'summary_large_image',
-  },
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Call for Presentations - Cloud Native Days Norway',
+    description:
+      'Submit your talk proposal for Cloud Native Days Norway conference',
+    alternates: await canonicalAlternates('/cfp'),
+    twitter: {
+      card: 'summary_large_image',
+    },
+  }
 }
 
 async function CachedCFPContent({ domain }: { domain: string }) {

--- a/src/app/(main)/conduct/page.tsx
+++ b/src/app/(main)/conduct/page.tsx
@@ -4,11 +4,16 @@ import { ContentCard } from '@/components/ContentCard'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import type { Metadata } from 'next'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
-export const metadata = {
-  title: 'Code of Conduct - Cloud Native Days Norway',
-  description:
-    'Community Code of Conduct for Cloud Native Days Norway events and activities.',
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Code of Conduct - Cloud Native Days Norway',
+    description:
+      'Community Code of Conduct for Cloud Native Days Norway events and activities.',
+    alternates: await canonicalAlternates('/conduct'),
+  }
 }
 
 async function CachedConductContent({ domain }: { domain: string }) {

--- a/src/app/(main)/info/page.tsx
+++ b/src/app/(main)/info/page.tsx
@@ -6,11 +6,16 @@ import { InfoContent } from '@/components/info/InfoContent'
 import type { ConferenceSchedule } from '@/lib/conference/types'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import type { Metadata } from 'next'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
-export const metadata = {
-  title: 'Practical Information - Cloud Native Days Norway',
-  description:
-    'Essential details for attending Cloud Native Days Norway conference',
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Practical Information - Cloud Native Days Norway',
+    description:
+      'Essential details for attending Cloud Native Days Norway conference',
+    alternates: await canonicalAlternates('/info'),
+  }
 }
 
 function getScheduleDayInfo(schedules: ConferenceSchedule[] | undefined) {

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -29,6 +29,7 @@ import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
 import { EventJsonLd } from '@/components/seo/EventJsonLd'
+import { canonicalUrl } from '@/lib/seo/canonical'
 
 function truncateDescription(text: string, maxLength = 160): string {
   const trimmed = text.trim()
@@ -44,8 +45,13 @@ export async function generateMetadata(): Promise<Metadata> {
 
   const { conference, error } = await getConferenceForDomain(domain)
 
+  const canonical = canonicalUrl(conference, domain, '/')
+
   if (error || !conference?.title) {
-    return { twitter: { card: 'summary_large_image' } }
+    return {
+      alternates: { canonical },
+      twitter: { card: 'summary_large_image' },
+    }
   }
 
   const dates = formatDatesSafe(conference.startDate, conference.endDate)
@@ -65,6 +71,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: { absolute: title },
     ...(description && { description }),
+    alternates: { canonical },
     openGraph: {
       title,
       ...(description && { description }),

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -38,11 +38,16 @@ import {
 } from '@heroicons/react/24/outline'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import type { Metadata } from 'next'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
-export const metadata = {
-  title: 'Privacy Policy - Cloud Native Days Norway',
-  description:
-    'Privacy policy and data protection information for Cloud Native Days Norway conference',
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Privacy Policy - Cloud Native Days Norway',
+    description:
+      'Privacy policy and data protection information for Cloud Native Days Norway conference',
+    alternates: await canonicalAlternates('/privacy'),
+  }
 }
 
 async function CachedPrivacyContent({ domain }: { domain: string }) {

--- a/src/app/(main)/program/page.tsx
+++ b/src/app/(main)/program/page.tsx
@@ -9,14 +9,20 @@ import { DevTimeControl } from '@/components/program/DevTimeControl'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
 import { EventJsonLd } from '@/components/seo/EventJsonLd'
+import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd'
 import { performersFromSchedules } from '@/lib/seo/eventJsonLd'
+import { canonicalAlternates, canonicalUrl } from '@/lib/seo/canonical'
+import type { Metadata } from 'next'
 
-export const metadata = {
-  title: 'Program',
-  description: 'Conference program and schedule',
-  twitter: {
-    card: 'summary_large_image',
-  },
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Program',
+    description: 'Conference program and schedule',
+    alternates: await canonicalAlternates('/program'),
+    twitter: {
+      card: 'summary_large_image',
+    },
+  }
 }
 
 async function CachedProgramContent({ domain }: { domain: string }) {
@@ -80,6 +86,15 @@ async function CachedProgramContent({ domain }: { domain: string }) {
         conference={conference}
         domain={domain}
         performers={performers}
+      />
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', url: canonicalUrl(conference, domain, '/') },
+          {
+            name: 'Program',
+            url: canonicalUrl(conference, domain, '/program'),
+          },
+        ]}
       />
       <DevTimeProvider />
       <DevTimeControl schedules={conference.schedules} />

--- a/src/app/(main)/speaker/[slug]/page.tsx
+++ b/src/app/(main)/speaker/[slug]/page.tsx
@@ -30,6 +30,9 @@ import { PhotoGallerySection } from '@/components/PhotoGallerySection'
 import { AttachmentDisplay } from '@/components/proposal/AttachmentDisplay'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
+import { PersonJsonLd } from '@/components/seo/PersonJsonLd'
+import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd'
+import { canonicalUrl } from '@/lib/seo/canonical'
 
 type Props = {
   params: Promise<{ slug: string }>
@@ -83,6 +86,13 @@ export async function generateMetadata({ params }: Props) {
   return {
     title,
     description,
+    alternates: {
+      canonical: canonicalUrl(
+        conference,
+        domain,
+        `/speaker/${resolvedParams.slug}`,
+      ),
+    },
     openGraph: {
       title,
       description,
@@ -134,8 +144,25 @@ async function CachedSpeakerContent({
     )
   }
 
+  const speakerUrl = canonicalUrl(conference, domain, `/speaker/${slug}`)
+  const speakerImage =
+    speaker.image && typeof speaker.image === 'string'
+      ? speakerImageUrl(speaker.image)
+      : undefined
+
   return (
     <div className="relative py-20 sm:pt-36 sm:pb-24">
+      <PersonJsonLd speaker={speaker} url={speakerUrl} image={speakerImage} />
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', url: canonicalUrl(conference, domain, '/') },
+          {
+            name: 'Speakers',
+            url: canonicalUrl(conference, domain, '/speaker'),
+          },
+          { name: speaker.name, url: speakerUrl },
+        ]}
+      />
       <BackgroundImage className="-top-36 -bottom-14" />
       <Container className="relative">
         <div className="mx-auto max-w-7xl">

--- a/src/app/(main)/speaker/[slug]/page.tsx
+++ b/src/app/(main)/speaker/[slug]/page.tsx
@@ -90,7 +90,9 @@ export async function generateMetadata({ params }: Props) {
       canonical: canonicalUrl(
         conference,
         domain,
-        `/speaker/${resolvedParams.slug}`,
+        // Use the speaker's own slug (not the raw request param) so slug
+        // variants all canonicalize to one URL.
+        `/speaker/${speaker.slug ?? decodedSlug}`,
       ),
     },
     openGraph: {
@@ -144,7 +146,12 @@ async function CachedSpeakerContent({
     )
   }
 
-  const speakerUrl = canonicalUrl(conference, domain, `/speaker/${slug}`)
+  const speakerUrl = canonicalUrl(
+    conference,
+    domain,
+    // Canonicalize on the speaker's own slug, not the request param.
+    `/speaker/${speaker.slug ?? slug}`,
+  )
   const speakerImage =
     speaker.image && typeof speaker.image === 'string'
       ? speakerImageUrl(speaker.image)

--- a/src/app/(main)/speaker/page.tsx
+++ b/src/app/(main)/speaker/page.tsx
@@ -6,6 +6,20 @@ import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { SpeakerWithTalks } from '@/lib/speaker/types'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import type { Metadata } from 'next'
+import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd'
+import { canonicalAlternates, canonicalUrl } from '@/lib/seo/canonical'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Speakers',
+    description: 'Meet the speakers sharing their cloud native expertise.',
+    alternates: await canonicalAlternates('/speaker'),
+    twitter: {
+      card: 'summary_large_image',
+    },
+  }
+}
 
 async function CachedSpeakersContent({ domain }: { domain: string }) {
   'use cache'
@@ -26,6 +40,15 @@ async function CachedSpeakersContent({ domain }: { domain: string }) {
 
   return (
     <>
+      <BreadcrumbJsonLd
+        items={[
+          { name: 'Home', url: canonicalUrl(conference, domain, '/') },
+          {
+            name: 'Speakers',
+            url: canonicalUrl(conference, domain, '/speaker'),
+          },
+        ]}
+      />
       <div className="relative py-20 sm:pt-36 sm:pb-24">
         <BackgroundImage className="-top-36 -bottom-14" />
         <Container className="relative">

--- a/src/app/(main)/sponsor/page.tsx
+++ b/src/app/(main)/sponsor/page.tsx
@@ -6,14 +6,19 @@ import { SponsorTier, ConferenceSponsor } from '@/lib/sponsor/types'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
 import { SponsorProspectus } from '@/components/sponsor/SponsorProspectus'
+import type { Metadata } from 'next'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
-export const metadata = {
-  title: 'Become a Sponsor - Cloud Native Days Norway',
-  description:
-    'Sponsorship opportunities for Cloud Native Days Norway conference',
-  twitter: {
-    card: 'summary_large_image',
-  },
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Become a Sponsor - Cloud Native Days Norway',
+    description:
+      'Sponsorship opportunities for Cloud Native Days Norway conference',
+    alternates: await canonicalAlternates('/sponsor'),
+    twitter: {
+      card: 'summary_large_image',
+    },
+  }
 }
 
 async function CachedSponsorContent({ domain }: { domain: string }) {

--- a/src/app/(main)/sponsor/terms/page.tsx
+++ b/src/app/(main)/sponsor/terms/page.tsx
@@ -6,11 +6,16 @@ import { PortableText } from '@portabletext/react'
 import { portableTextComponents } from '@/lib/portabletext/components'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import type { Metadata } from 'next'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
-export const metadata = {
-  title: 'Sponsorship Terms & Conditions - Cloud Native Days Norway',
-  description:
-    'General terms and conditions for sponsorship of Cloud Native Days Norway',
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Sponsorship Terms & Conditions - Cloud Native Days Norway',
+    description:
+      'General terms and conditions for sponsorship of Cloud Native Days Norway',
+    alternates: await canonicalAlternates('/sponsor/terms'),
+  }
 }
 
 async function CachedTermsContent({ domain }: { domain: string }) {

--- a/src/app/(main)/staff/[role]/page.tsx
+++ b/src/app/(main)/staff/[role]/page.tsx
@@ -1,7 +1,20 @@
 import Image from 'next/image'
 import { cacheLife, cacheTag } from 'next/cache'
+import type { Metadata } from 'next'
 import { getStaffMembers } from '@/lib/staff/sanity'
 import { Container } from '@/components/Container'
+import { canonicalAlternates } from '@/lib/seo/canonical'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ role: string }>
+}): Promise<Metadata> {
+  const { role } = await params
+  return {
+    alternates: await canonicalAlternates(`/staff/${role}`),
+  }
+}
 
 async function CachedStaffContent({ role }: { role: string }) {
   'use cache'

--- a/src/app/(main)/terms/page.tsx
+++ b/src/app/(main)/terms/page.tsx
@@ -18,11 +18,16 @@ import Link from 'next/link'
 import { ContentCard } from '@/components/ContentCard'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import type { Metadata } from 'next'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
-export const metadata = {
-  title: 'Terms of Service - Cloud Native Days',
-  description:
-    'Terms of Service for Cloud Native Days conference and workshop services',
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Terms of Service - Cloud Native Days',
+    description:
+      'Terms of Service for Cloud Native Days conference and workshop services',
+    alternates: await canonicalAlternates('/terms'),
+  }
 }
 
 async function CachedTermsContent({ domain }: { domain: string }) {

--- a/src/app/(main)/tickets/page.tsx
+++ b/src/app/(main)/tickets/page.tsx
@@ -37,6 +37,8 @@ import { headers } from 'next/headers'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { cacheLife, cacheTag } from 'next/cache'
 import type { ElementType } from 'react'
+import type { Metadata } from 'next'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
 const INCLUSION_ICONS: Record<string, ElementType> = {
   MicrophoneIcon,
@@ -61,12 +63,15 @@ const INCLUSION_ICONS: Record<string, ElementType> = {
   CheckBadgeIcon,
 }
 
-export const metadata = {
-  title: 'Tickets - Cloud Native Days Norway',
-  description: 'Get your tickets for Cloud Native Days Norway conference',
-  twitter: {
-    card: 'summary_large_image',
-  },
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Tickets - Cloud Native Days Norway',
+    description: 'Get your tickets for Cloud Native Days Norway conference',
+    alternates: await canonicalAlternates('/tickets'),
+    twitter: {
+      card: 'summary_large_image',
+    },
+  }
 }
 
 function DynamicIcon({

--- a/src/app/(main)/volunteer/page.tsx
+++ b/src/app/(main)/volunteer/page.tsx
@@ -7,10 +7,15 @@ import { Container } from '@/components/Container'
 import { BackgroundImage } from '@/components/BackgroundImage'
 import { cacheLife, cacheTag } from 'next/cache'
 import { headers } from 'next/headers'
+import { canonicalAlternates } from '@/lib/seo/canonical'
 
-export const metadata: Metadata = {
-  title: 'Volunteer | Cloud Native Days Norway',
-  description: 'Join our volunteer team and help make the conference a success',
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Volunteer | Cloud Native Days Norway',
+    description:
+      'Join our volunteer team and help make the conference a success',
+    alternates: await canonicalAlternates('/volunteer'),
+  }
 }
 
 async function CachedVolunteerContent({ domain }: { domain: string }) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,8 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 
 import '@/styles/tailwind.css'
+import { getConferenceForDomain } from '@/lib/conference/sanity'
+import { canonicalOrigin } from '@/lib/seo/canonical'
 import { DevBanner } from '@/components/DevBanner'
 import { ThemeProvider } from '@/components/providers/ThemeProvider'
 import { TRPCProvider } from '@/components/providers/TRPCProvider'
@@ -62,8 +64,13 @@ export async function generateMetadata(): Promise<Metadata> {
   const headersList = await headers()
   const host = headersList.get('host') || 'localhost:3000'
 
-  const protocol = host.includes('localhost') ? 'http' : 'https'
-  const metadataBase = new URL(`${protocol}://${host}`)
+  // Normalize the metadata origin to the resolved edition's canonical
+  // production host (its primary `domains` entry) so OpenGraph and canonical
+  // URLs point at the real domain even when served from a preview or apex
+  // host. When no conference resolves (e.g. localhost), this falls back to the
+  // request host, keeping local development correct.
+  const { conference } = await getConferenceForDomain(host)
+  const metadataBase = new URL(canonicalOrigin(conference, host))
 
   return {
     metadataBase,

--- a/src/components/seo/BreadcrumbJsonLd.tsx
+++ b/src/components/seo/BreadcrumbJsonLd.tsx
@@ -1,0 +1,24 @@
+import { serializeJsonLd } from '@/lib/seo/eventJsonLd'
+import {
+  buildBreadcrumbJsonLd,
+  type BreadcrumbItem,
+} from '@/lib/seo/breadcrumbJsonLd'
+
+/**
+ * Renders a schema.org `BreadcrumbList` JSON-LD `<script>` from an ordered
+ * list of crumbs.
+ *
+ * The object is built by {@link buildBreadcrumbJsonLd} and serialized with
+ * {@link serializeJsonLd} so a value containing `<` cannot break out of the
+ * script element.
+ */
+export function BreadcrumbJsonLd({ items }: { items: BreadcrumbItem[] }) {
+  const data = buildBreadcrumbJsonLd(items)
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
+    />
+  )
+}

--- a/src/components/seo/PersonJsonLd.tsx
+++ b/src/components/seo/PersonJsonLd.tsx
@@ -1,0 +1,23 @@
+import { serializeJsonLd } from '@/lib/seo/eventJsonLd'
+import {
+  buildPersonJsonLd,
+  type BuildPersonJsonLdOptions,
+} from '@/lib/seo/personJsonLd'
+
+/**
+ * Renders a schema.org `Person` JSON-LD `<script>` for a speaker.
+ *
+ * The object is built by {@link buildPersonJsonLd} (which omits every unknown
+ * field) and serialized with {@link serializeJsonLd} so a value containing `<`
+ * cannot break out of the script element.
+ */
+export function PersonJsonLd(props: BuildPersonJsonLdOptions) {
+  const data = buildPersonJsonLd(props)
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
+    />
+  )
+}

--- a/src/lib/seo/__tests__/breadcrumbJsonLd.test.ts
+++ b/src/lib/seo/__tests__/breadcrumbJsonLd.test.ts
@@ -1,0 +1,53 @@
+import { buildBreadcrumbJsonLd } from '../breadcrumbJsonLd'
+
+describe('buildBreadcrumbJsonLd', () => {
+  it('builds a BreadcrumbList with 1-based positions and absolute URLs', () => {
+    const jsonLd = buildBreadcrumbJsonLd([
+      { name: 'Home', url: 'https://cloudnativebergen.dev' },
+      { name: 'Speakers', url: 'https://cloudnativebergen.dev/speaker' },
+      {
+        name: 'Jane Doe',
+        url: 'https://cloudnativebergen.dev/speaker/jane-doe',
+      },
+    ])
+
+    expect(jsonLd).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Home',
+          item: 'https://cloudnativebergen.dev',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Speakers',
+          item: 'https://cloudnativebergen.dev/speaker',
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: 'Jane Doe',
+          item: 'https://cloudnativebergen.dev/speaker/jane-doe',
+        },
+      ],
+    })
+  })
+
+  it('assigns sequential positions in input order', () => {
+    const jsonLd = buildBreadcrumbJsonLd([
+      { name: 'Home', url: 'https://example.com' },
+      { name: 'Program', url: 'https://example.com/program' },
+    ])
+    const items = jsonLd.itemListElement as Array<{ position: number }>
+    expect(items.map((i) => i.position)).toEqual([1, 2])
+  })
+
+  it('returns an empty itemListElement for no crumbs', () => {
+    const jsonLd = buildBreadcrumbJsonLd([])
+    expect(jsonLd.itemListElement).toEqual([])
+  })
+})

--- a/src/lib/seo/__tests__/canonical.test.ts
+++ b/src/lib/seo/__tests__/canonical.test.ts
@@ -1,0 +1,88 @@
+import { canonicalHost, canonicalOrigin, canonicalUrl } from '../canonical'
+import type { Conference } from '@/lib/conference/types'
+
+function makeConference(domains: string[]): Conference {
+  return { domains } as Conference
+}
+
+describe('canonicalHost', () => {
+  it('uses the conference primary domain over the request host', () => {
+    const conference = makeConference([
+      '2099.cloudnativedays.no',
+      'cloudnativedays.no',
+    ])
+    expect(canonicalHost(conference, 'preview.vercel.app')).toBe(
+      '2099.cloudnativedays.no',
+    )
+  })
+
+  it('skips wildcard domain patterns when picking the primary domain', () => {
+    const conference = makeConference([
+      '*.cloudnativedays.no',
+      '2099.cloudnativedays.no',
+    ])
+    expect(canonicalHost(conference, 'preview.vercel.app')).toBe(
+      '2099.cloudnativedays.no',
+    )
+  })
+
+  it('falls back to the request host when no conference resolved', () => {
+    expect(canonicalHost(null, 'localhost:3000')).toBe('localhost:3000')
+    expect(canonicalHost(undefined, 'preview.vercel.app')).toBe(
+      'preview.vercel.app',
+    )
+  })
+
+  it('falls back to the request host when domains is empty', () => {
+    expect(canonicalHost(makeConference([]), 'localhost:3000')).toBe(
+      'localhost:3000',
+    )
+  })
+})
+
+describe('canonicalOrigin', () => {
+  it('uses https for production conference domains', () => {
+    const conference = makeConference(['cloudnativebergen.dev'])
+    expect(canonicalOrigin(conference, 'localhost:3000')).toBe(
+      'https://cloudnativebergen.dev',
+    )
+  })
+
+  it('uses http for localhost when no conference resolved', () => {
+    expect(canonicalOrigin(null, 'localhost:3000')).toBe(
+      'http://localhost:3000',
+    )
+  })
+})
+
+describe('canonicalUrl', () => {
+  const conference = makeConference(['cloudnativebergen.dev'])
+
+  it('builds an absolute URL on the canonical host regardless of request host', () => {
+    // Served from a preview host, but the canonical still points at production.
+    expect(canonicalUrl(conference, 'preview.vercel.app', '/program')).toBe(
+      'https://cloudnativebergen.dev/program',
+    )
+  })
+
+  it('returns the bare origin for the site root', () => {
+    expect(canonicalUrl(conference, 'preview.vercel.app', '/')).toBe(
+      'https://cloudnativebergen.dev',
+    )
+    expect(canonicalUrl(conference, 'preview.vercel.app', '')).toBe(
+      'https://cloudnativebergen.dev',
+    )
+  })
+
+  it('normalizes a path without a leading slash', () => {
+    expect(canonicalUrl(conference, 'preview.vercel.app', 'speaker/jane')).toBe(
+      'https://cloudnativebergen.dev/speaker/jane',
+    )
+  })
+
+  it('keeps localhost self-referential when no conference resolved', () => {
+    expect(canonicalUrl(null, 'localhost:3000', '/tickets')).toBe(
+      'http://localhost:3000/tickets',
+    )
+  })
+})

--- a/src/lib/seo/__tests__/personJsonLd.test.ts
+++ b/src/lib/seo/__tests__/personJsonLd.test.ts
@@ -1,0 +1,84 @@
+import { buildPersonJsonLd, type PersonSpeaker } from '../personJsonLd'
+
+function makeSpeaker(overrides: Partial<PersonSpeaker> = {}): PersonSpeaker {
+  return {
+    name: 'Jane Doe',
+    title: 'Principal Engineer',
+    image: 'https://cdn.sanity.io/images/jane.jpg',
+    links: [
+      'https://twitter.com/janedoe',
+      'https://www.linkedin.com/in/janedoe',
+    ],
+    ...overrides,
+  }
+}
+
+describe('buildPersonJsonLd', () => {
+  it('builds a full Person node with every known field', () => {
+    const jsonLd = buildPersonJsonLd({
+      speaker: makeSpeaker(),
+      url: 'https://cloudnativebergen.dev/speaker/jane-doe',
+    })
+
+    expect(jsonLd).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'Person',
+      name: 'Jane Doe',
+      jobTitle: 'Principal Engineer',
+      image: 'https://cdn.sanity.io/images/jane.jpg',
+      url: 'https://cloudnativebergen.dev/speaker/jane-doe',
+      sameAs: [
+        'https://twitter.com/janedoe',
+        'https://www.linkedin.com/in/janedoe',
+      ],
+    })
+  })
+
+  it('prefers a pre-resolved image URL over the raw speaker image', () => {
+    const jsonLd = buildPersonJsonLd({
+      speaker: makeSpeaker({ image: 'image-abc123-500x500-png' }),
+      image: 'https://cdn.sanity.io/images/resolved.jpg',
+    })
+    expect(jsonLd.image).toBe('https://cdn.sanity.io/images/resolved.jpg')
+  })
+
+  it('omits sameAs when the speaker has no social links', () => {
+    const jsonLd = buildPersonJsonLd({
+      speaker: makeSpeaker({ links: [] }),
+    })
+    expect(jsonLd).not.toHaveProperty('sameAs')
+  })
+
+  it('omits sameAs when links is undefined', () => {
+    const jsonLd = buildPersonJsonLd({
+      speaker: makeSpeaker({ links: undefined }),
+    })
+    expect(jsonLd).not.toHaveProperty('sameAs')
+  })
+
+  it('omits optional fields entirely rather than emitting undefined', () => {
+    const jsonLd = buildPersonJsonLd({
+      speaker: { name: 'No Frills' },
+    })
+
+    expect(jsonLd).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'Person',
+      name: 'No Frills',
+    })
+    // No undefined values leak into the emitted object.
+    expect(Object.values(jsonLd)).not.toContain(undefined)
+  })
+
+  it('omits jobTitle when title is missing', () => {
+    const jsonLd = buildPersonJsonLd({
+      speaker: makeSpeaker({ title: undefined }),
+    })
+    expect(jsonLd).not.toHaveProperty('jobTitle')
+  })
+
+  it('omits url when not provided', () => {
+    const jsonLd = buildPersonJsonLd({ speaker: makeSpeaker() })
+    expect(jsonLd).not.toHaveProperty('url')
+  })
+})

--- a/src/lib/seo/breadcrumbJsonLd.ts
+++ b/src/lib/seo/breadcrumbJsonLd.ts
@@ -1,0 +1,28 @@
+/** A single breadcrumb entry: a human label and its absolute URL. */
+export interface BreadcrumbItem {
+  name: string
+  /** Absolute URL for this crumb. */
+  url: string
+}
+
+/**
+ * Builds a schema.org `BreadcrumbList` JSON-LD object from an ordered list of
+ * crumbs. Positions are 1-based and follow the input order; each crumb becomes
+ * a `ListItem` with an absolute `item` URL.
+ *
+ * @see https://schema.org/BreadcrumbList
+ */
+export function buildBreadcrumbJsonLd(
+  items: BreadcrumbItem[],
+): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  }
+}

--- a/src/lib/seo/canonical.ts
+++ b/src/lib/seo/canonical.ts
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+
+import type { Conference } from '@/lib/conference/types'
+import { getConferenceForDomain } from '@/lib/conference/sanity'
+
+/** The conference shape the canonical helpers actually depend on. */
+type ConferenceLike = Pick<Conference, 'domains'> | null | undefined
+
+/**
+ * `http` for localhost hosts, `https` everywhere else — mirrors the protocol
+ * logic used for `metadataBase` in `src/app/layout.tsx` and `getBaseUrl` in
+ * `src/lib/seo/robots.ts`.
+ */
+function protocolFor(host: string): string {
+  return host.includes('localhost') ? 'http' : 'https'
+}
+
+/**
+ * Resolve the canonical host for a conference edition.
+ *
+ * Prefers the edition's primary production domain (`domains[0]`, skipping any
+ * wildcard patterns such as `*.example.com`) so that preview and apex deploys
+ * still emit the production canonical host. Falls back to the request host when
+ * no conference resolved — this keeps localhost and unknown preview hosts
+ * working rather than pointing them at a domain we cannot know.
+ */
+export function canonicalHost(
+  conference: ConferenceLike,
+  requestHost: string,
+): string {
+  const primary = conference?.domains?.find(
+    (domain) => domain && !domain.includes('*'),
+  )
+  return primary || requestHost || 'localhost:3000'
+}
+
+/**
+ * Absolute origin (`https://host`) for the conference's canonical host.
+ */
+export function canonicalOrigin(
+  conference: ConferenceLike,
+  requestHost: string,
+): string {
+  const host = canonicalHost(conference, requestHost)
+  return `${protocolFor(host)}://${host}`
+}
+
+/**
+ * Build an absolute canonical URL for `path` on the conference's canonical
+ * host. The path is normalized to a single leading slash; the site root (`/`)
+ * yields the bare origin with no trailing slash.
+ */
+export function canonicalUrl(
+  conference: ConferenceLike,
+  requestHost: string,
+  path: string,
+): string {
+  const origin = canonicalOrigin(conference, requestHost)
+  if (!path || path === '/') {
+    return origin
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${origin}${normalizedPath}`
+}
+
+/**
+ * Server helper that resolves the current request host and conference edition,
+ * returning the `alternates` object (self-referential canonical) to merge into
+ * a route's `metadata` / `generateMetadata`. Use this from pages that do not
+ * already have the conference in hand; pages that already fetched it should
+ * call {@link canonicalUrl} directly to avoid a redundant lookup.
+ */
+export async function canonicalAlternates(
+  path: string,
+): Promise<NonNullable<Metadata['alternates']>> {
+  const headersList = await headers()
+  const host = headersList.get('host') || 'localhost:3000'
+  const { conference } = await getConferenceForDomain(host)
+  return { canonical: canonicalUrl(conference, host, path) }
+}

--- a/src/lib/seo/personJsonLd.ts
+++ b/src/lib/seo/personJsonLd.ts
@@ -1,0 +1,57 @@
+import type { Speaker } from '@/lib/speaker/types'
+
+/** The speaker fields the Person builder actually depends on. */
+export type PersonSpeaker = Pick<Speaker, 'name' | 'title' | 'image' | 'links'>
+
+export interface BuildPersonJsonLdOptions {
+  speaker: PersonSpeaker
+  /** Absolute canonical URL of the speaker's profile page. */
+  url?: string
+  /**
+   * Pre-resolved absolute image URL, when known. Preferred over the raw
+   * `speaker.image` (which may be a Sanity asset reference) so the emitted
+   * `image` is always a usable absolute URL.
+   */
+  image?: string
+}
+
+/**
+ * Builds a schema.org `Person` JSON-LD object from a speaker.
+ *
+ * Every optional field is guarded: unknown fields are omitted rather than
+ * emitted as `undefined` or empty, so the result always validates (passes
+ * Google's Rich Results Test).
+ *
+ * @see https://schema.org/Person
+ */
+export function buildPersonJsonLd({
+  speaker,
+  url,
+  image,
+}: BuildPersonJsonLdOptions): Record<string, unknown> {
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: speaker.name,
+  }
+
+  if (speaker.title) {
+    jsonLd.jobTitle = speaker.title
+  }
+
+  const resolvedImage = image ?? speaker.image
+  if (resolvedImage && typeof resolvedImage === 'string') {
+    jsonLd.image = resolvedImage
+  }
+
+  if (url) {
+    jsonLd.url = url
+  }
+
+  // `sameAs` links the person to their authoritative social/web profiles.
+  if (speaker.links && speaker.links.length > 0) {
+    jsonLd.sameAs = speaker.links
+  }
+
+  return jsonLd
+}


### PR DESCRIPTION
Implements **#396** (self-canonical tags + `metadataBase` audit) and the **non-hub parts of #398** (Person + BreadcrumbList JSON-LD). The Organization JSON-LD node is **deferred** — it depends on the not-yet-built hub (#392).

Builds on the SEO infra merged in #435 (noindex) and #436 (`serializeJsonLd` / `EventJsonLd`), reusing `serializeJsonLd` for injection safety and mirroring the `EventJsonLd` component pattern.

## Part A — #396 self-canonical + metadataBase

New helper `src/lib/seo/canonical.ts`:
- `canonicalHost` / `canonicalOrigin` / `canonicalUrl` build an absolute self URL on the edition's **primary production domain** (`conference.domains[0]`, skipping wildcard `*` patterns), so preview/apex deploys still emit the production canonical.
- Falls back to the request host for localhost and for preview hosts that resolve no conference (self-referential, never broken).
- `canonicalAlternates(path)` — server convenience that resolves host + conference and returns the `alternates` object.

`layout.tsx`: `metadataBase` now resolves to the canonical production origin per edition instead of the raw `Host` header (falls back to the request host on localhost / unresolved hosts).

Pages that received a self-referential canonical (the full indexable set NOT noindexed by #435):

| Page | Path |
|------|------|
| Home | `/` |
| Program | `/program` |
| Speakers | `/speaker` |
| Speaker detail | `/speaker/[slug]` |
| Tickets | `/tickets` |
| Sponsor | `/sponsor` |
| Sponsor terms | `/sponsor/terms` |
| Code of Conduct | `/conduct` |
| Practical info | `/info` |
| Privacy | `/privacy` |
| Terms | `/terms` |
| Volunteer | `/volunteer` |
| CFP landing | `/cfp` |
| Staff | `/staff/[role]` |

Static `export const metadata` blocks were converted to async `generateMetadata` where the host had to be resolved. The noindexed routes from #435 (`/signin`, sponsor token flows) intentionally get **no** canonical.

### metadataBase / preview-host decision
The canonical host is the edition's primary `domains[0]` entry. For production and any host that resolves a conference (including configured wildcard subdomains), canonicals point at the real production domain. For **unknown preview hosts** (e.g. a `*.vercel.app` deploy not present in any `domains` array) no conference resolves, so we fall back to the **request host** — a self-referential canonical rather than a guessed/broken production URL. Localhost keeps `http://` + the request host.

## Part B — #398 (non-hub) Person + BreadcrumbList

- `src/lib/seo/personJsonLd.ts` + `PersonJsonLd` component: `Person` node on `/speaker/[slug]` (`name`, `jobTitle` from title, `image` via `speakerImageUrl`, `url` = canonical speaker URL, `sameAs` = social `links`). Every optional field guarded — no `undefined`/empty nodes.
- `src/lib/seo/breadcrumbJsonLd.ts` + `BreadcrumbJsonLd` component: `BreadcrumbList` with 1-based `ListItem` positions and absolute `item` URLs. Emitted on `/program` (Home ▸ Program), `/speaker` (Home ▸ Speakers) and `/speaker/[slug]` (Home ▸ Speakers ▸ Name).
- All JSON-LD serialized via `serializeJsonLd` (escapes `<`).

## Deferred
**No Organization JSON-LD** is emitted — deferred with hub #392.

## Verification
- `pnpm typecheck` — clean
- `pnpm vitest run` — 2149 passed / 5 skipped (124 files), incl. 20 new tests for the canonical helper (production vs preview/localhost), the Person builder (full + missing-social guards) and the Breadcrumb builder
- `pnpm eslint` + `pnpm prettier` — clean
- `pnpm knip` — clean

Closes #396

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds self-referential canonical tags across all indexable routes, upgrades `metadataBase` in `layout.tsx` to resolve to each edition's primary production domain, and introduces `Person` + `BreadcrumbList` JSON-LD on the speaker and program pages. The new `canonical.ts` helper correctly skips wildcard domain entries and falls back to the request host for unresolved (preview/localhost) environments.

- `src/lib/seo/canonical.ts` centralises canonical URL building; `canonicalAlternates` is a server convenience used by the many static-metadata pages that don't already hold a conference object, while pages that do (home, speaker detail) call `canonicalUrl` directly.
- `PersonJsonLd` and `BreadcrumbJsonLd` mirror the `EventJsonLd` component pattern and both go through `serializeJsonLd` for `<`-escaping before `dangerouslySetInnerHTML`.
- 2 149 tests pass (20 new ones) and the Organization JSON-LD node is intentionally deferred pending the hub feature.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the SEO changes are additive and the canonical/fallback logic is thoroughly tested.

The implementation is clean and well-tested. The one notable design issue is that serializeJsonLd is exported from eventJsonLd.ts — a domain-specific file — yet is now imported by two additional unrelated components. This doesn't affect correctness today but makes the module's responsibilities harder to understand over time. Everything else — canonical resolution, wildcard skipping, preview-host fallback, JSON-LD guards — looks correct and is backed by targeted unit tests.

No files require special attention. The BreadcrumbJsonLd.tsx and PersonJsonLd.tsx components share the minor coupling noted above.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/seo/canonical.ts | New helper module with canonicalHost/canonicalOrigin/canonicalUrl/canonicalAlternates. Logic is sound: picks first non-wildcard domain, falls back to request host, uses http for localhost. Well-tested (20 cases). |
| src/lib/seo/breadcrumbJsonLd.ts | New BreadcrumbList builder. Clean, minimal, 1-based positions. Tests cover empty list, 2-item and 3-item lists. |
| src/lib/seo/personJsonLd.ts | New Person JSON-LD builder. Every optional field is guarded to avoid emitting undefined values. Prefers pre-resolved image URL over raw Sanity reference. Tests cover all guard paths. |
| src/components/seo/BreadcrumbJsonLd.tsx | React component wrapping buildBreadcrumbJsonLd. Uses serializeJsonLd for XSS-safe injection, but imports it from the domain-specific eventJsonLd module rather than a shared utility. |
| src/components/seo/PersonJsonLd.tsx | React component wrapping buildPersonJsonLd. Same serializeJsonLd import coupling as BreadcrumbJsonLd. |
| src/app/layout.tsx | metadataBase now resolves to the canonical production origin via getConferenceForDomain + canonicalOrigin. Falls back to request host when no conference resolves. Correct handling for preview/apex deploys. |
| src/app/(main)/speaker/[slug]/page.tsx | Adds self-canonical to generateMetadata (uses already-fetched conference), PersonJsonLd and BreadcrumbJsonLd inside the 'use cache' boundary. Early-return path for missing speakers correctly skips both JSON-LD blocks. |
| src/app/(main)/program/page.tsx | Converts static metadata to generateMetadata with canonicalAlternates. Adds BreadcrumbJsonLd (Home > Program) inside the cached content component — URLs always resolve to production canonical. |
| src/app/(main)/speaker/page.tsx | Adds generateMetadata with canonical and BreadcrumbJsonLd (Home > Speakers) inside cached component. Clean. |
| src/lib/seo/__tests__/canonical.test.ts | 20 test cases covering production vs preview/localhost for canonicalHost, canonicalOrigin, and canonicalUrl — including wildcard skipping and path normalization. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js (generateMetadata)
    participant PageComp as Page Component
    participant canonical as canonical.ts
    participant conf as getConferenceForDomain
    participant sanity as Sanity ('use cache')

    Browser->>NextJS: GET /speaker/jane-doe
    NextJS->>conf: getConferenceForDomain(host)
    conf->>sanity: fetchConferenceData (cache hit/miss)
    sanity-->>conf: "Conference { domains: ['prod.com', ...] }"
    conf-->>NextJS: "{ conference }"
    NextJS->>canonical: canonicalUrl(conference, host, '/speaker/jane-doe')
    canonical-->>NextJS: 'https://prod.com/speaker/jane-doe'
    NextJS-->>Browser: alternates.canonical + og/twitter meta

    Browser->>PageComp: render CachedSpeakerContent(domain, slug)
    PageComp->>conf: getConferenceForDomain(domain) [cache hit]
    conf-->>PageComp: Conference
    PageComp->>canonical: canonicalUrl(conference, domain, '/speaker/jane-doe')
    canonical-->>PageComp: 'https://prod.com/speaker/jane-doe'
    PageComp-->>Browser: PersonJsonLd + BreadcrumbJsonLd scripts in HTML
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js (generateMetadata)
    participant PageComp as Page Component
    participant canonical as canonical.ts
    participant conf as getConferenceForDomain
    participant sanity as Sanity ('use cache')

    Browser->>NextJS: GET /speaker/jane-doe
    NextJS->>conf: getConferenceForDomain(host)
    conf->>sanity: fetchConferenceData (cache hit/miss)
    sanity-->>conf: "Conference { domains: ['prod.com', ...] }"
    conf-->>NextJS: "{ conference }"
    NextJS->>canonical: canonicalUrl(conference, host, '/speaker/jane-doe')
    canonical-->>NextJS: 'https://prod.com/speaker/jane-doe'
    NextJS-->>Browser: alternates.canonical + og/twitter meta

    Browser->>PageComp: render CachedSpeakerContent(domain, slug)
    PageComp->>conf: getConferenceForDomain(domain) [cache hit]
    conf-->>PageComp: Conference
    PageComp->>canonical: canonicalUrl(conference, domain, '/speaker/jane-doe')
    canonical-->>PageComp: 'https://prod.com/speaker/jane-doe'
    PageComp-->>Browser: PersonJsonLd + BreadcrumbJsonLd scripts in HTML
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(seo): self-canonical tags + Person/..."](https://github.com/cloudnativebergen/website/commit/6130cdd1bdb6327a39d39a07cf83b12a7f00e96e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44452488)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->