### PR TITLE
Speaker identity hardening (phase 1): robust slugs + verified-email account matching

### DIFF
--- a/sanity/schemaTypes/speaker.ts
+++ b/sanity/schemaTypes/speaker.ts
@@ -65,6 +65,23 @@ export default defineType({
       },
     }),
     defineField({
+      name: 'knownEmails',
+      title: 'Known Emails',
+      type: 'array',
+      description:
+        'Normalized (lowercased) verified emails used to match this speaker across OAuth providers. Managed automatically on login; distinct from the display email.',
+      of: [{ type: 'string' }],
+      readOnly: true,
+      hidden: ({ currentUser }) => {
+        return !(
+          currentUser != null &&
+          currentUser.roles.find(
+            ({ name }) => name === 'administrator' || name === 'editor',
+          )
+        )
+      },
+    }),
+    defineField({
       name: 'imageURL',
       title: 'Image URL',
       type: 'string',

--- a/scripts/fix-missing-slugs.ts
+++ b/scripts/fix-missing-slugs.ts
@@ -1,5 +1,5 @@
 import { clientWrite } from '@/lib/sanity/client'
-import { generateSlug } from '@/lib/speaker/sanity'
+import { generateUniqueSlug } from '@/lib/speaker/sanity'
 
 async function fixMissingSlugs() {
   console.log('Fixing speakers without slugs...\n')
@@ -20,7 +20,7 @@ async function fixMissingSlugs() {
   }
 
   for (const speaker of speakers) {
-    const slug = generateSlug(speaker.name)
+    const slug = await generateUniqueSlug(speaker.name, speaker._id)
     console.log(`Setting slug for ${speaker.name} (${speaker._id}): ${slug}`)
 
     await clientWrite

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -52,7 +52,7 @@ const config = {
       } as Session
     },
 
-    async jwt({ token, account, trigger }) {
+    async jwt({ token, account, profile, trigger }) {
       if (!trigger && !(token.account && token.speaker)) {
         console.error('Invalid auth token', token)
         return {}
@@ -74,7 +74,11 @@ const config = {
           name: token.name,
           image: token.picture,
         }
-        const { speaker, err } = await getOrCreateSpeaker(user, account)
+        const { speaker, err } = await getOrCreateSpeaker(
+          user,
+          account,
+          profile,
+        )
         if (err) {
           console.error('Error fetching or creating speaker profile', err)
           return {}

--- a/src/lib/profile/sanity.test.ts
+++ b/src/lib/profile/sanity.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Mocks -----------------------------------------------------------------
+
+const commitMock = vi.fn()
+const setMock = vi.fn()
+const patchMock = vi.fn()
+const fetchMock = vi.fn()
+
+vi.mock('../sanity/client', () => ({
+  clientWrite: {
+    patch: (...args: unknown[]) => patchMock(...args),
+  },
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => fetchMock(...args),
+  },
+}))
+
+import { updateProfileEmail } from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  commitMock.mockResolvedValue({})
+  setMock.mockReturnValue({ commit: commitMock })
+  patchMock.mockReturnValue({ set: setMock })
+})
+
+describe('updateProfileEmail — C1: never writes the verified match-set', () => {
+  it('sets ONLY the display email and does not touch knownEmails', async () => {
+    const { error } = await updateProfileEmail('new@example.com', 'spk-1')
+
+    expect(error).toBeNull()
+    expect(patchMock).toHaveBeenCalledWith('spk-1')
+    expect(setMock).toHaveBeenCalledTimes(1)
+    const patchArg = setMock.mock.calls[0][0] as Record<string, unknown>
+    // The display email is set...
+    expect(patchArg).toEqual({ email: 'new@example.com' })
+    // ...but knownEmails is NOT part of the patch (owned only by the login path).
+    expect(patchArg).not.toHaveProperty('knownEmails')
+  })
+
+  it('does NOT read the existing speaker to union knownEmails', async () => {
+    // The old implementation read {email, knownEmails} and unioned the incoming
+    // address in. Poisoning is prevented by never reading/writing that set here.
+    await updateProfileEmail('attacker-controlled@victim.com', 'spk-2')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    const patchArg = setMock.mock.calls[0][0] as Record<string, unknown>
+    expect(patchArg).not.toHaveProperty('knownEmails')
+  })
+
+  it('returns the error when the write fails', async () => {
+    const boom = new Error('write failed')
+    commitMock.mockRejectedValueOnce(boom)
+
+    const { error } = await updateProfileEmail('x@example.com', 'spk-3')
+
+    expect(error).toBe(boom)
+  })
+})

--- a/src/lib/profile/sanity.ts
+++ b/src/lib/profile/sanity.ts
@@ -1,11 +1,27 @@
-import { clientWrite } from '../sanity/client'
+import { clientWrite, clientReadUncached } from '../sanity/client'
+import { groq } from 'next-sanity'
+import { uniqueEmails } from '../speaker/email'
 
 export async function updateProfileEmail(
   email: string,
   speakerId: string,
 ): Promise<{ error: Error | null }> {
   try {
-    await clientWrite.patch(speakerId).set({ email }).commit()
+    // Preserve the match-set: adding/changing the display email must never drop
+    // previously-known emails, otherwise a speaker could be split into a
+    // duplicate on their next login via another provider.
+    const existing = (await clientReadUncached.fetch(
+      groq`*[_type == "speaker" && _id == $id][0]{ email, knownEmails }`,
+      { id: speakerId },
+    )) as { email?: string; knownEmails?: string[] } | null
+
+    const knownEmails = uniqueEmails([
+      ...(existing?.knownEmails || []),
+      existing?.email,
+      email,
+    ])
+
+    await clientWrite.patch(speakerId).set({ email, knownEmails }).commit()
 
     return { error: null }
   } catch (error) {

--- a/src/lib/profile/sanity.ts
+++ b/src/lib/profile/sanity.ts
@@ -1,27 +1,26 @@
-import { clientWrite, clientReadUncached } from '../sanity/client'
-import { groq } from 'next-sanity'
-import { uniqueEmails } from '../speaker/email'
+import { clientWrite } from '../sanity/client'
 
+/**
+ * Set a speaker's display `email`.
+ *
+ * SECURITY: this only ever writes the display `email` field. It MUST NOT touch
+ * `knownEmails` — that is the verified match-set used to auto-link logins across
+ * providers, and it is owned exclusively by the login path
+ * (`computeVerifiedEmails` in `@/lib/speaker/sanity`). Unioning an arbitrary
+ * caller-supplied email into `knownEmails` here previously enabled cross-provider
+ * account takeover (an attacker could poison a victim's address into the set and
+ * absorb the victim's next verified login).
+ *
+ * Callers are responsible for proving the caller owns `email` before invoking
+ * this (see `isEmailVerifiedForSession`, used by `speaker.updateEmail`). Because
+ * the display email is itself a login match key, it must always be verified-owned.
+ */
 export async function updateProfileEmail(
   email: string,
   speakerId: string,
 ): Promise<{ error: Error | null }> {
   try {
-    // Preserve the match-set: adding/changing the display email must never drop
-    // previously-known emails, otherwise a speaker could be split into a
-    // duplicate on their next login via another provider.
-    const existing = (await clientReadUncached.fetch(
-      groq`*[_type == "speaker" && _id == $id][0]{ email, knownEmails }`,
-      { id: speakerId },
-    )) as { email?: string; knownEmails?: string[] } | null
-
-    const knownEmails = uniqueEmails([
-      ...(existing?.knownEmails || []),
-      existing?.email,
-      email,
-    ])
-
-    await clientWrite.patch(speakerId).set({ email, knownEmails }).commit()
+    await clientWrite.patch(speakerId).set({ email }).commit()
 
     return { error: null }
   } catch (error) {

--- a/src/lib/profile/server.test.ts
+++ b/src/lib/profile/server.test.ts
@@ -8,6 +8,13 @@ vi.mock('./github', () => ({
   verifiedEmails: (...args: unknown[]) => githubVerifiedMock(...args),
 }))
 
+const knownEmailsFetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => knownEmailsFetchMock(...args),
+  },
+}))
+
 import { getVerifiedProfileEmails, isEmailVerifiedForSession } from './server'
 
 // --- Helpers ---------------------------------------------------------------
@@ -16,6 +23,7 @@ function session(overrides: Partial<Session> = {}): Session {
   return {
     user: { email: 'primary@example.com' },
     account: { provider: 'github', providerAccountId: 'gh-1', type: 'oauth' },
+    speaker: { _id: 'speaker-1' },
     ...overrides,
   } as unknown as Session
 }
@@ -23,6 +31,7 @@ function session(overrides: Partial<Session> = {}): Session {
 beforeEach(() => {
   vi.clearAllMocks()
   githubVerifiedMock.mockResolvedValue({ error: null, emails: [] })
+  knownEmailsFetchMock.mockResolvedValue([])
 })
 
 describe('getVerifiedProfileEmails — provider-verified source of truth', () => {
@@ -100,5 +109,63 @@ describe('isEmailVerifiedForSession — C1 ownership guard', () => {
 
   it('rejects an empty email', async () => {
     await expect(isEmailVerifiedForSession(session(), '')).resolves.toBe(false)
+  })
+
+  it('accepts a GitHub email not yet in knownEmails via the live verified list', async () => {
+    githubVerifiedMock.mockResolvedValue({
+      error: null,
+      emails: [{ email: 'work@corp.com', verified: true }],
+    })
+    knownEmailsFetchMock.mockResolvedValue([]) // not yet persisted
+    await expect(
+      isEmailVerifiedForSession(session(), 'work@corp.com'),
+    ).resolves.toBe(true)
+  })
+
+  it('LinkedIn: accepts an email only if it is in the persisted knownEmails set', async () => {
+    const linkedin = session({
+      account: {
+        provider: 'linkedin',
+        providerAccountId: 'li-1',
+        type: 'oidc',
+      },
+    } as Partial<Session>)
+    knownEmailsFetchMock.mockResolvedValue(['me@corp.com'])
+
+    await expect(
+      isEmailVerifiedForSession(linkedin, 'me@corp.com'),
+    ).resolves.toBe(true)
+    // The GitHub live-list path is never used for LinkedIn.
+    expect(githubVerifiedMock).not.toHaveBeenCalled()
+  })
+
+  it('LinkedIn: rejects the session primary when it is NOT in knownEmails (F1 — no blanket trust)', async () => {
+    const linkedin = session({
+      user: { email: 'victim@corp.com' },
+      account: {
+        provider: 'linkedin',
+        providerAccountId: 'li-1',
+        type: 'oidc',
+      },
+    } as Partial<Session>)
+    knownEmailsFetchMock.mockResolvedValue([]) // login never verified this address
+
+    await expect(
+      isEmailVerifiedForSession(linkedin, 'victim@corp.com'),
+    ).resolves.toBe(false)
+  })
+
+  it('fails closed when the knownEmails read throws', async () => {
+    const linkedin = session({
+      account: {
+        provider: 'linkedin',
+        providerAccountId: 'li-1',
+        type: 'oidc',
+      },
+    } as Partial<Session>)
+    knownEmailsFetchMock.mockRejectedValue(new Error('sanity down'))
+    await expect(
+      isEmailVerifiedForSession(linkedin, 'me@corp.com'),
+    ).resolves.toBe(false)
   })
 })

--- a/src/lib/profile/server.test.ts
+++ b/src/lib/profile/server.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Session } from 'next-auth'
+
+// --- Mocks -----------------------------------------------------------------
+
+const githubVerifiedMock = vi.fn()
+vi.mock('./github', () => ({
+  verifiedEmails: (...args: unknown[]) => githubVerifiedMock(...args),
+}))
+
+import { getVerifiedProfileEmails, isEmailVerifiedForSession } from './server'
+
+// --- Helpers ---------------------------------------------------------------
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    user: { email: 'primary@example.com' },
+    account: { provider: 'github', providerAccountId: 'gh-1', type: 'oauth' },
+    ...overrides,
+  } as unknown as Session
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  githubVerifiedMock.mockResolvedValue({ error: null, emails: [] })
+})
+
+describe('getVerifiedProfileEmails — provider-verified source of truth', () => {
+  it('returns the GitHub API verified set', async () => {
+    githubVerifiedMock.mockResolvedValue({
+      error: null,
+      emails: [
+        { email: 'primary@example.com', verified: true, primary: true },
+        { email: 'work@corp.com', verified: true, primary: false },
+      ],
+    })
+
+    const emails = await getVerifiedProfileEmails(session())
+    expect(emails.map((e) => e.email)).toEqual([
+      'primary@example.com',
+      'work@corp.com',
+    ])
+  })
+
+  it('falls back to the session primary when the GitHub API errors', async () => {
+    githubVerifiedMock.mockResolvedValue({
+      error: new Error('boom'),
+      emails: [],
+    })
+
+    const emails = await getVerifiedProfileEmails(session())
+    expect(emails).toEqual([
+      {
+        email: 'primary@example.com',
+        verified: true,
+        primary: true,
+        visibility: 'private',
+      },
+    ])
+  })
+
+  it('returns only the session primary for LinkedIn (default branch)', async () => {
+    const emails = await getVerifiedProfileEmails(
+      session({
+        account: {
+          provider: 'linkedin',
+          providerAccountId: 'li-1',
+          type: 'oidc',
+        },
+      } as Partial<Session>),
+    )
+    expect(emails.map((e) => e.email)).toEqual(['primary@example.com'])
+    // GitHub API is never consulted for non-GitHub providers.
+    expect(githubVerifiedMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('isEmailVerifiedForSession — C1 ownership guard', () => {
+  it('accepts an email in the caller verified set (case-insensitive)', async () => {
+    githubVerifiedMock.mockResolvedValue({
+      error: null,
+      emails: [{ email: 'Work@Corp.com', verified: true }],
+    })
+
+    await expect(
+      isEmailVerifiedForSession(session(), 'work@corp.com'),
+    ).resolves.toBe(true)
+  })
+
+  it('rejects an email NOT owned by the caller (takeover attempt)', async () => {
+    githubVerifiedMock.mockResolvedValue({
+      error: null,
+      emails: [{ email: 'primary@example.com', verified: true }],
+    })
+
+    await expect(
+      isEmailVerifiedForSession(session(), 'victim@example.com'),
+    ).resolves.toBe(false)
+  })
+
+  it('rejects an empty email', async () => {
+    await expect(isEmailVerifiedForSession(session(), '')).resolves.toBe(false)
+  })
+})

--- a/src/lib/profile/server.ts
+++ b/src/lib/profile/server.ts
@@ -2,6 +2,30 @@ import { Session } from 'next-auth'
 import { verifiedEmails as fetchGithubVerifiedEmails } from './github'
 import { ProfileEmail } from './types'
 import { normalizeEmail } from '../speaker/email'
+import { clientReadUncached } from '@/lib/sanity/client'
+
+/**
+ * The caller's persisted verified match-set (`speaker.knownEmails`). This field
+ * is only ever written from affirmatively-verified emails at login
+ * (`computeVerifiedEmails`), so membership here is proof of verified ownership —
+ * independent of, and authoritative over, the optimistic `verified` flag the
+ * picker uses. Returns [] when the id is missing or the read fails (fail-closed).
+ */
+async function getSpeakerKnownEmails(
+  speakerId: string | undefined,
+): Promise<string[]> {
+  if (!speakerId) return []
+  try {
+    const emails = await clientReadUncached.fetch<string[] | null>(
+      `*[_type == "speaker" && _id == $id][0].knownEmails`,
+      { id: speakerId },
+    )
+    return Array.isArray(emails) ? emails : []
+  } catch (error) {
+    console.error('Failed to read speaker knownEmails:', error)
+    return []
+  }
+}
 
 export function defaultEmails(session: Session): ProfileEmail[] {
   return [
@@ -26,9 +50,13 @@ export function defaultEmails(session: Session): ProfileEmail[] {
  * - GitHub: the verified set from the GitHub `/user/emails` API. On error or an
  *   empty response we fall back to the session primary, which GitHub only ever
  *   surfaces once verified.
- * - LinkedIn / other: the session primary. LinkedIn's primary was already gated
- *   through the affirmative `email_verified` check in the login path
- *   (`computeVerifiedEmails`) before the session was minted, so it is owned.
+ * - LinkedIn / other: the session primary (for the PICKER only — see below).
+ *
+ * NOTE: this powers the profile email PICKER (a UI convenience). It must NOT be
+ * the sole authority for `updateEmail` — the session is minted regardless of a
+ * LinkedIn `email_verified` claim, so the non-GitHub primary here is optimistic.
+ * The security-critical ownership check lives in {@link isEmailVerifiedForSession},
+ * which is authoritative and cross-checks the persisted verified match-set.
  */
 export async function getVerifiedProfileEmails(
   session: Session,
@@ -58,10 +86,21 @@ export async function getVerifiedProfileEmails(
 }
 
 /**
- * True when `email` is one the caller has provably verified with their login
- * provider. Used to authorize `speaker.updateEmail`: the requested display email
- * must be owned, because the display `email` is a login match key in
- * `getOrCreateSpeaker`. Comparison is normalized (case/whitespace-insensitive).
+ * Authoritative ownership check for `speaker.updateEmail`: the requested display
+ * email must be verified-owned by the caller, because the display `email` is a
+ * login match key in `getOrCreateSpeaker` — letting a caller set it to an
+ * address they don't own would reopen the cross-provider account-takeover.
+ *
+ * An email is owned iff EITHER:
+ *  - the caller signed in with GitHub and it's in their live GitHub-verified set
+ *    (which will also seed `knownEmails` on their next login), OR
+ *  - it's already in the caller's persisted `knownEmails` — the verified
+ *    match-set written only from affirmatively-verified logins.
+ *
+ * This deliberately does NOT blanket-trust the non-GitHub session primary the
+ * way {@link getVerifiedProfileEmails} does for the picker, keeping the guard
+ * consistent with the login-path `email_verified` check. Comparison is
+ * normalized (case/whitespace-insensitive).
  */
 export async function isEmailVerifiedForSession(
   session: Session,
@@ -69,6 +108,14 @@ export async function isEmailVerifiedForSession(
 ): Promise<boolean> {
   const requested = normalizeEmail(email)
   if (!requested) return false
-  const verified = await getVerifiedProfileEmails(session)
-  return verified.some((entry) => normalizeEmail(entry.email) === requested)
+
+  if (session.account?.provider === 'github') {
+    const verified = await getVerifiedProfileEmails(session)
+    if (verified.some((entry) => normalizeEmail(entry.email) === requested)) {
+      return true
+    }
+  }
+
+  const known = await getSpeakerKnownEmails(session.speaker?._id)
+  return known.some((entry) => normalizeEmail(entry) === requested)
 }

--- a/src/lib/profile/server.ts
+++ b/src/lib/profile/server.ts
@@ -1,6 +1,9 @@
 import { Session } from 'next-auth'
+import { verifiedEmails as fetchGithubVerifiedEmails } from './github'
+import { ProfileEmail } from './types'
+import { normalizeEmail } from '../speaker/email'
 
-export function defaultEmails(session: Session) {
+export function defaultEmails(session: Session): ProfileEmail[] {
   return [
     {
       email: session.user.email,
@@ -9,4 +12,63 @@ export function defaultEmails(session: Session) {
       visibility: 'private',
     },
   ]
+}
+
+/**
+ * Resolve the caller's PROVIDER-VERIFIED emails from their session.
+ *
+ * SECURITY: this is the single server-side source of truth for which email
+ * addresses the caller has proven ownership of. It mirrors the `speaker.getEmails`
+ * picker exactly, so the set the UI offers and the set `speaker.updateEmail`
+ * authorizes against can never diverge. Never trust a client-supplied "verified"
+ * list — always recompute here.
+ *
+ * - GitHub: the verified set from the GitHub `/user/emails` API. On error or an
+ *   empty response we fall back to the session primary, which GitHub only ever
+ *   surfaces once verified.
+ * - LinkedIn / other: the session primary. LinkedIn's primary was already gated
+ *   through the affirmative `email_verified` check in the login path
+ *   (`computeVerifiedEmails`) before the session was minted, so it is owned.
+ */
+export async function getVerifiedProfileEmails(
+  session: Session,
+): Promise<ProfileEmail[]> {
+  if (!session.account) {
+    return defaultEmails(session)
+  }
+
+  try {
+    switch (session.account.provider) {
+      case 'github': {
+        const result = await fetchGithubVerifiedEmails(session.account)
+        if (result.error) {
+          console.error('Failed to fetch GitHub emails:', result.error)
+          return defaultEmails(session)
+        }
+        return result.emails.length > 0 ? result.emails : defaultEmails(session)
+      }
+
+      default:
+        return defaultEmails(session)
+    }
+  } catch (error) {
+    console.error('Error fetching emails:', error)
+    return defaultEmails(session)
+  }
+}
+
+/**
+ * True when `email` is one the caller has provably verified with their login
+ * provider. Used to authorize `speaker.updateEmail`: the requested display email
+ * must be owned, because the display `email` is a login match key in
+ * `getOrCreateSpeaker`. Comparison is normalized (case/whitespace-insensitive).
+ */
+export async function isEmailVerifiedForSession(
+  session: Session,
+  email: string,
+): Promise<boolean> {
+  const requested = normalizeEmail(email)
+  if (!requested) return false
+  const verified = await getVerifiedProfileEmails(session)
+  return verified.some((entry) => normalizeEmail(entry.email) === requested)
 }

--- a/src/lib/speaker/email.ts
+++ b/src/lib/speaker/email.ts
@@ -1,0 +1,26 @@
+/**
+ * Email normalization helpers shared by the speaker identity code paths.
+ *
+ * All email comparisons and the `knownEmails` match-set MUST use the normalized
+ * form so that account matching is case/whitespace-insensitive.
+ */
+
+/** Normalize an email for comparison and storage: trimmed + lowercased. */
+export function normalizeEmail(email?: string | null): string {
+  return (email ?? '').trim().toLowerCase()
+}
+
+/**
+ * Build a deduplicated, normalized list of emails, dropping empty values.
+ * Preserves first-seen order.
+ */
+export function uniqueEmails(emails: (string | null | undefined)[]): string[] {
+  const set = new Set<string>()
+  for (const email of emails) {
+    const normalized = normalizeEmail(email)
+    if (normalized) {
+      set.add(normalized)
+    }
+  }
+  return [...set]
+}

--- a/src/lib/speaker/sanity.test.ts
+++ b/src/lib/speaker/sanity.test.ts
@@ -235,10 +235,9 @@ describe('getOrCreateSpeaker — verified-only security invariant', () => {
     expect(speaker._id).not.toBe('spk-existing')
   })
 
-  // H2 — LinkedIn email_verified must be affirmatively true. Absent / string
-  // 'false' must NOT be treated as verified (previously fail-open).
+  // LinkedIn: only an EXPLICIT false/"false" blocks the link. LinkedIn asserts
+  // only the holder's own verified primary, so absent/true are treated verified.
   it.each([
-    ['absent', undefined],
     ['string "false"', 'false'],
     ['boolean false', false],
   ])(
@@ -255,31 +254,39 @@ describe('getOrCreateSpeaker — verified-only security invariant', () => {
       )
 
       expect(err).toBeNull()
-      // Unverified -> no link, fresh speaker.
+      // Explicitly unverified -> no link, fresh speaker.
       expect(patchMock).not.toHaveBeenCalled()
       expect(createMock).toHaveBeenCalledTimes(1)
       expect(speaker._id).not.toBe('spk-existing')
     },
   )
 
-  // H2 — the stringified OIDC claim 'true' is honored as verified.
-  it('treats the LinkedIn primary as verified when email_verified is the string "true"', async () => {
-    fetchMock.mockImplementation(
-      routeFetch({ provider: {}, emailMatches: [existingSpeaker()] }),
-    )
+  // LinkedIn: true, the string 'true', and an ABSENT claim are all treated as
+  // verified (LinkedIn only asserts the holder's own verified email).
+  it.each([
+    ['boolean true', true],
+    ['string "true"', 'true'],
+    ['absent', undefined],
+  ])(
+    'treats the LinkedIn primary as verified when email_verified is %s',
+    async (_label, claim) => {
+      fetchMock.mockImplementation(
+        routeFetch({ provider: {}, emailMatches: [existingSpeaker()] }),
+      )
 
-    const { speaker, err } = await getOrCreateSpeaker(
-      user({ email: 'jane@example.com' }),
-      linkedinAccount(),
-      { email_verified: 'true' } as unknown as Profile,
-    )
+      const { speaker, err } = await getOrCreateSpeaker(
+        user({ email: 'jane@example.com' }),
+        linkedinAccount(),
+        { email_verified: claim } as unknown as Profile,
+      )
 
-    expect(err).toBeNull()
-    // Verified -> links into the existing speaker.
-    expect(createMock).not.toHaveBeenCalled()
-    expect(patchMock).toHaveBeenCalledWith('spk-existing')
-    expect(speaker._id).toBe('spk-existing')
-  })
+      expect(err).toBeNull()
+      // Verified -> links into the existing speaker.
+      expect(createMock).not.toHaveBeenCalled()
+      expect(patchMock).toHaveBeenCalledWith('spk-existing')
+      expect(speaker._id).toBe('spk-existing')
+    },
+  )
 })
 
 describe('getOrCreateSpeaker — multiple existing matches', () => {

--- a/src/lib/speaker/sanity.test.ts
+++ b/src/lib/speaker/sanity.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Account, User, Profile } from 'next-auth'
+import type { Speaker } from './types'
+
+// --- Mocks -----------------------------------------------------------------
+
+const fetchMock = vi.fn()
+const createMock = vi.fn()
+const commitMock = vi.fn().mockResolvedValue({})
+const setMock = vi.fn()
+const unsetMock = vi.fn()
+const patchMock = vi.fn()
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+  clientReadCached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+  clientWrite: {
+    fetch: (...args: unknown[]) => fetchMock(...args),
+    create: (...args: unknown[]) => createMock(...args),
+    patch: (...args: unknown[]) => patchMock(...args),
+  },
+  speakerImageUrl: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+const verifiedEmailsMock = vi.fn()
+vi.mock('@/lib/profile/github', () => ({
+  verifiedEmails: (...args: unknown[]) => verifiedEmailsMock(...args),
+}))
+
+import { getOrCreateSpeaker } from './sanity'
+
+// --- Fetch routing helpers -------------------------------------------------
+
+interface Routes {
+  provider?: Speaker | Record<string, never> | null
+  emailMatches?: Speaker[]
+  takenSlugs?: Set<string>
+}
+
+function routeFetch(routes: Routes) {
+  const taken = routes.takenSlugs ?? new Set<string>()
+  return (query: string, params: Record<string, unknown> = {}) => {
+    if (query.includes('$id in providers')) {
+      return Promise.resolve(routes.provider ?? {})
+    }
+    if (query.includes('in $emails')) {
+      return Promise.resolve(routes.emailMatches ?? [])
+    }
+    if (query.includes('slug.current == $slug')) {
+      return Promise.resolve(
+        taken.has(params.slug as string) ? 'taken-id' : null,
+      )
+    }
+    return Promise.resolve(null)
+  }
+}
+
+function githubAccount(): Account {
+  return {
+    provider: 'github',
+    providerAccountId: 'gh-123',
+    type: 'oauth',
+    access_token: 'gh-token',
+  } as Account
+}
+
+function linkedinAccount(): Account {
+  return {
+    provider: 'linkedin',
+    providerAccountId: 'li-456',
+    type: 'oidc',
+  } as Account
+}
+
+function user(overrides: Partial<User> = {}): User {
+  return { name: 'Jane Doe', email: 'jane@example.com', ...overrides } as User
+}
+
+function existingSpeaker(overrides: Partial<Speaker> = {}): Speaker {
+  return {
+    _id: 'spk-existing',
+    _rev: '1',
+    _createdAt: '2024-01-01T00:00:00Z',
+    _updatedAt: '2024-01-01T00:00:00Z',
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    slug: 'jane-doe',
+    providers: ['github:gh-123'],
+    knownEmails: ['jane@example.com'],
+    ...overrides,
+  } as Speaker
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  commitMock.mockResolvedValue({})
+  setMock.mockImplementation(() => ({ commit: commitMock, unset: unsetMock }))
+  unsetMock.mockImplementation(() => ({ commit: commitMock }))
+  patchMock.mockImplementation(() => ({ set: setMock, unset: unsetMock }))
+  createMock.mockImplementation((doc: Record<string, unknown>) =>
+    Promise.resolve({ ...doc }),
+  )
+  verifiedEmailsMock.mockResolvedValue({ error: null, emails: [] })
+})
+
+// --- Tests -----------------------------------------------------------------
+
+describe('getOrCreateSpeaker — provider id match', () => {
+  it('returns the speaker matched by provider account id without writing', async () => {
+    fetchMock.mockImplementation(routeFetch({ provider: existingSpeaker() }))
+
+    const { speaker, err } = await getOrCreateSpeaker(user(), githubAccount())
+
+    expect(err).toBeNull()
+    expect(speaker._id).toBe('spk-existing')
+    expect(createMock).not.toHaveBeenCalled()
+    expect(patchMock).not.toHaveBeenCalled()
+  })
+
+  it('backfills a missing slug on an existing provider match', async () => {
+    fetchMock.mockImplementation(
+      routeFetch({ provider: existingSpeaker({ slug: '' }) }),
+    )
+
+    const { speaker, err } = await getOrCreateSpeaker(user(), githubAccount())
+
+    expect(err).toBeNull()
+    expect(patchMock).toHaveBeenCalledWith('spk-existing')
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: { _type: 'slug', current: 'jane-doe' },
+      }),
+    )
+    expect(speaker.slug).toBe('jane-doe')
+  })
+
+  it('never rewrites an existing non-empty slug', async () => {
+    fetchMock.mockImplementation(
+      routeFetch({ provider: existingSpeaker({ slug: 'jane-doe' }) }),
+    )
+
+    await getOrCreateSpeaker(user(), githubAccount())
+
+    expect(patchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('getOrCreateSpeaker — verified email cross-provider link', () => {
+  it('links a new provider into the speaker matched by a verified email', async () => {
+    // Incoming login is LinkedIn (li-456) with the same verified email.
+    verifiedEmailsMock.mockResolvedValue({ error: null, emails: [] })
+    fetchMock.mockImplementation(
+      routeFetch({
+        provider: {}, // no provider match
+        emailMatches: [existingSpeaker()],
+      }),
+    )
+
+    const { speaker, err } = await getOrCreateSpeaker(
+      user({ email: 'jane@example.com' }),
+      linkedinAccount(),
+      { email_verified: true } as Profile,
+    )
+
+    expect(err).toBeNull()
+    expect(createMock).not.toHaveBeenCalled()
+    expect(patchMock).toHaveBeenCalledWith('spk-existing')
+    // Both provider ids present, deduped.
+    expect(speaker.providers).toEqual(
+      expect.arrayContaining(['github:gh-123', 'linkedin:li-456']),
+    )
+    expect(speaker.knownEmails).toContain('jane@example.com')
+  })
+
+  it('unions verified emails from both providers into knownEmails', async () => {
+    // GitHub login; API reports two verified emails, existing speaker known via one.
+    verifiedEmailsMock.mockResolvedValue({
+      error: null,
+      emails: [
+        { email: 'Jane@Example.com', verified: true },
+        { email: 'jane.work@corp.com', verified: true },
+      ],
+    })
+    fetchMock.mockImplementation(
+      routeFetch({
+        provider: {},
+        emailMatches: [
+          existingSpeaker({
+            providers: ['linkedin:li-456'],
+            knownEmails: ['jane@example.com'],
+          }),
+        ],
+      }),
+    )
+
+    const { speaker } = await getOrCreateSpeaker(
+      user({ email: 'jane@example.com' }),
+      githubAccount(),
+    )
+
+    expect(speaker.knownEmails).toEqual(
+      expect.arrayContaining(['jane@example.com', 'jane.work@corp.com']),
+    )
+    expect(speaker.providers).toEqual(
+      expect.arrayContaining(['linkedin:li-456', 'github:gh-123']),
+    )
+  })
+})
+
+describe('getOrCreateSpeaker — verified-only security invariant', () => {
+  it('does NOT link on an unverified LinkedIn email; creates a new speaker', async () => {
+    const emailMatchesSpy = existingSpeaker()
+    fetchMock.mockImplementation(
+      routeFetch({
+        provider: {},
+        emailMatches: [emailMatchesSpy], // would match if we queried
+      }),
+    )
+
+    const { speaker, err } = await getOrCreateSpeaker(
+      user({ email: 'jane@example.com' }),
+      linkedinAccount(),
+      { email_verified: false } as Profile,
+    )
+
+    expect(err).toBeNull()
+    // No verified email -> no link, a fresh speaker is created.
+    expect(patchMock).not.toHaveBeenCalled()
+    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(speaker._id).not.toBe('spk-existing')
+  })
+})
+
+describe('getOrCreateSpeaker — multiple existing matches', () => {
+  it('warns and links to the oldest speaker without merging', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    verifiedEmailsMock.mockResolvedValue({
+      error: null,
+      emails: [{ email: 'jane@example.com', verified: true }],
+    })
+    const older = existingSpeaker({ _id: 'spk-old' })
+    const newer = existingSpeaker({
+      _id: 'spk-new',
+      _createdAt: '2025-01-01T00:00:00Z',
+    })
+    fetchMock.mockImplementation(
+      routeFetch({ provider: {}, emailMatches: [older, newer] }),
+    )
+
+    const { speaker } = await getOrCreateSpeaker(user(), githubAccount())
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('possible existing duplicate speakers'),
+    )
+    expect(patchMock).toHaveBeenCalledWith('spk-old')
+    expect(speaker._id).toBe('spk-old')
+    warnSpy.mockRestore()
+  })
+})
+
+describe('getOrCreateSpeaker — new speaker creation', () => {
+  it('creates a speaker with a unique non-empty slug and seeded knownEmails', async () => {
+    verifiedEmailsMock.mockResolvedValue({
+      error: null,
+      emails: [{ email: 'jane@example.com', verified: true }],
+    })
+    fetchMock.mockImplementation(routeFetch({ provider: {}, emailMatches: [] }))
+
+    const { speaker, err } = await getOrCreateSpeaker(user(), githubAccount())
+
+    expect(err).toBeNull()
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const created = createMock.mock.calls[0][0]
+    expect(created.slug.current).toBe('jane-doe')
+    expect(created.knownEmails).toContain('jane@example.com')
+    expect(speaker.slug).toBe('jane-doe')
+  })
+
+  it('appends a suffix when the slug is already taken', async () => {
+    verifiedEmailsMock.mockResolvedValue({
+      error: null,
+      emails: [{ email: 'jane@example.com', verified: true }],
+    })
+    fetchMock.mockImplementation(
+      routeFetch({
+        provider: {},
+        emailMatches: [],
+        takenSlugs: new Set(['jane-doe']),
+      }),
+    )
+
+    const { speaker } = await getOrCreateSpeaker(user(), githubAccount())
+
+    expect(speaker.slug).toBe('jane-doe-2')
+  })
+
+  it('falls back to a stable slug for an emoji-only name', async () => {
+    verifiedEmailsMock.mockResolvedValue({
+      error: null,
+      emails: [{ email: 'emoji@example.com', verified: true }],
+    })
+    fetchMock.mockImplementation(routeFetch({ provider: {}, emailMatches: [] }))
+
+    const { speaker } = await getOrCreateSpeaker(
+      user({ name: '🎤🎤', email: 'emoji@example.com' }),
+      githubAccount(),
+    )
+
+    expect(speaker.slug).toBe('speaker')
+  })
+})

--- a/src/lib/speaker/sanity.test.ts
+++ b/src/lib/speaker/sanity.test.ts
@@ -234,10 +234,56 @@ describe('getOrCreateSpeaker — verified-only security invariant', () => {
     expect(createMock).toHaveBeenCalledTimes(1)
     expect(speaker._id).not.toBe('spk-existing')
   })
+
+  // H2 — LinkedIn email_verified must be affirmatively true. Absent / string
+  // 'false' must NOT be treated as verified (previously fail-open).
+  it.each([
+    ['absent', undefined],
+    ['string "false"', 'false'],
+    ['boolean false', false],
+  ])(
+    'does NOT treat the LinkedIn primary as verified when email_verified is %s',
+    async (_label, claim) => {
+      fetchMock.mockImplementation(
+        routeFetch({ provider: {}, emailMatches: [existingSpeaker()] }),
+      )
+
+      const { speaker, err } = await getOrCreateSpeaker(
+        user({ email: 'jane@example.com' }),
+        linkedinAccount(),
+        { email_verified: claim } as unknown as Profile,
+      )
+
+      expect(err).toBeNull()
+      // Unverified -> no link, fresh speaker.
+      expect(patchMock).not.toHaveBeenCalled()
+      expect(createMock).toHaveBeenCalledTimes(1)
+      expect(speaker._id).not.toBe('spk-existing')
+    },
+  )
+
+  // H2 — the stringified OIDC claim 'true' is honored as verified.
+  it('treats the LinkedIn primary as verified when email_verified is the string "true"', async () => {
+    fetchMock.mockImplementation(
+      routeFetch({ provider: {}, emailMatches: [existingSpeaker()] }),
+    )
+
+    const { speaker, err } = await getOrCreateSpeaker(
+      user({ email: 'jane@example.com' }),
+      linkedinAccount(),
+      { email_verified: 'true' } as unknown as Profile,
+    )
+
+    expect(err).toBeNull()
+    // Verified -> links into the existing speaker.
+    expect(createMock).not.toHaveBeenCalled()
+    expect(patchMock).toHaveBeenCalledWith('spk-existing')
+    expect(speaker._id).toBe('spk-existing')
+  })
 })
 
 describe('getOrCreateSpeaker — multiple existing matches', () => {
-  it('warns and links to the oldest speaker without merging', async () => {
+  it('does NOT link into an ambiguous match; creates a new speaker and warns', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     verifiedEmailsMock.mockResolvedValue({
       error: null,
@@ -254,11 +300,17 @@ describe('getOrCreateSpeaker — multiple existing matches', () => {
 
     const { speaker } = await getOrCreateSpeaker(user(), githubAccount())
 
+    // H1: ambiguous multi-match must NOT auto-link into any existing doc.
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('possible existing duplicate speakers'),
+      expect.stringContaining('ambiguous verified-email match'),
     )
-    expect(patchMock).toHaveBeenCalledWith('spk-old')
-    expect(speaker._id).toBe('spk-old')
+    // Neither existing speaker is patched...
+    expect(patchMock).not.toHaveBeenCalledWith('spk-old')
+    expect(patchMock).not.toHaveBeenCalledWith('spk-new')
+    // ...instead a brand-new speaker is created for this login.
+    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(speaker._id).not.toBe('spk-old')
+    expect(speaker._id).not.toBe('spk-new')
     warnSpy.mockRestore()
   })
 })

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -6,9 +6,12 @@ import {
 } from '@/lib/sanity/client'
 import { groq } from 'next-sanity'
 import { v4 as randomUUID } from 'uuid'
-import { Account, User } from 'next-auth'
+import { Account, Profile, User } from 'next-auth'
 import { ProposalExisting, Status } from '../proposal/types'
 import { cacheLife, cacheTag } from 'next/cache'
+import { generateUniqueSpeakerSlug } from './slug'
+import { normalizeEmail, uniqueEmails } from './email'
+import { verifiedEmails as fetchGithubVerifiedEmails } from '@/lib/profile/github'
 
 // Computed field: speaker is an organizer if referenced in any conference's organizers array
 const IS_ORGANIZER_FIELD =
@@ -30,20 +33,41 @@ export function providerAccount(
   return `${provider}:${providerAccountId}`
 }
 
-export function generateSlug(name: string, suffix?: string): string {
-  const base = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
-
-  if (suffix) {
-    const maxBaseLength = 96 - 1 - suffix.length
-    const truncatedBase = base.slice(0, maxBaseLength)
-    return `${truncatedBase}-${suffix}`
+/**
+ * Returns true when a speaker slug is already taken by a *different* document.
+ * `selfId` excludes the speaker being updated so backfilling its own slug does
+ * not count as a collision.
+ */
+async function speakerSlugExists(
+  slug: string,
+  selfId?: string,
+): Promise<boolean> {
+  try {
+    const existingId = await clientRead.fetch(
+      groq`*[_type == "speaker" && slug.current == $slug && _id != $selfId][0]._id`,
+      { slug, selfId: selfId ?? '' },
+    )
+    return Boolean(existingId)
+  } catch (error) {
+    // If the uniqueness probe fails we prefer to proceed rather than loop
+    // forever; a rare duplicate is recoverable, an infinite loop is not.
+    console.error('Error checking speaker slug uniqueness', error)
+    return false
   }
+}
 
-  return base.slice(0, 96)
+/**
+ * Canonical unique-slug generator for persisted speakers. Wraps the shared pure
+ * {@link generateUniqueSpeakerSlug} with the Sanity collision checker so the
+ * OAuth create/link path and the admin create path produce identical slugs.
+ */
+export async function generateUniqueSlug(
+  name: string,
+  selfId?: string,
+): Promise<string> {
+  return generateUniqueSpeakerSlug(name, (slug) =>
+    speakerSlugExists(slug, selfId),
+  )
 }
 
 async function findSpeakerByProvider(
@@ -69,6 +93,11 @@ async function findSpeakerByProvider(
   return { speaker, err }
 }
 
+/**
+ * Find a speaker whose primary `email` matches (case-insensitively). Kept for
+ * backward compatibility; matching is normalized (was previously exact/case
+ * sensitive).
+ */
 async function findSpeakerByEmail(
   email: string,
 ): Promise<{ speaker: Speaker; err: Error | null }> {
@@ -77,13 +106,13 @@ async function findSpeakerByEmail(
 
   try {
     speaker = await clientRead.fetch(
-      `*[ _type == "speaker" && email == $email][0]{
+      `*[ _type == "speaker" && lower(email) == $email][0]{
       ...,
       "slug": slug.current,
       "image": coalesce(image.asset->url, imageURL),
       ${IS_ORGANIZER_FIELD}
     }`,
-      { email },
+      { email: normalizeEmail(email) },
     )
   } catch (error) {
     err = error as Error
@@ -94,9 +123,168 @@ async function findSpeakerByEmail(
 
 export { findSpeakerByEmail }
 
+/**
+ * Find all speakers whose display `email` or `knownEmails` match-set intersects
+ * any of the given (already normalized) emails. Ordered oldest-first so the
+ * caller can deterministically pick a link target and detect duplicates.
+ */
+async function findSpeakersByEmails(
+  emails: string[],
+): Promise<{ speakers: Speaker[]; err: Error | null }> {
+  if (emails.length === 0) {
+    return { speakers: [], err: null }
+  }
+
+  try {
+    const speakers = (await clientRead.fetch(
+      groq`*[_type == "speaker" && (lower(email) in $emails || count((knownEmails[])[lower(@) in $emails]) > 0)] | order(_createdAt asc) [0...5] {
+        ...,
+        "slug": slug.current,
+        "image": coalesce(image.asset->url, imageURL),
+        ${IS_ORGANIZER_FIELD}
+      }`,
+      { emails },
+    )) as Speaker[]
+    return { speakers: speakers || [], err: null }
+  } catch (error) {
+    return { speakers: [], err: error as Error }
+  }
+}
+
+/**
+ * Compute the set of VERIFIED emails for an incoming login, normalized.
+ *
+ * SECURITY: only these emails may ever be used to auto-link an incoming account
+ * into an existing speaker. An unverified email must never link accounts, as
+ * that would enable account takeover.
+ *
+ * - GitHub: the verified set from the GitHub `/user/emails` API. GitHub's OAuth
+ *   userinfo only exposes a verified primary email, so `user.email` is treated
+ *   as provider-verified and included as a fallback (e.g. if the API call
+ *   fails).
+ * - LinkedIn (OIDC): the `email_verified` claim on the profile. LinkedIn OIDC
+ *   only issues an email when it is verified, so a missing/undefined claim is
+ *   treated as verified per LinkedIn semantics; an explicit `false` is honored
+ *   as unverified. (Assumption flagged for maintainer review.)
+ * - Unknown providers: no email is treated as verified (no auto-link).
+ */
+async function computeVerifiedEmails(
+  user: User,
+  account: Account,
+  profile?: Profile,
+): Promise<string[]> {
+  const primary = normalizeEmail(user.email)
+  const verified: string[] = []
+
+  switch (account.provider) {
+    case 'github': {
+      const { emails, error } = await fetchGithubVerifiedEmails(account)
+      if (error) {
+        console.error(
+          'Failed to fetch GitHub verified emails; falling back to OAuth primary',
+          error,
+        )
+      }
+      for (const entry of emails) {
+        verified.push(entry.email)
+      }
+      // GitHub OAuth only surfaces a verified primary email.
+      if (primary) verified.push(primary)
+      break
+    }
+    case 'linkedin': {
+      const claim = (profile as { email_verified?: boolean } | undefined)
+        ?.email_verified
+      if (primary && claim !== false) {
+        verified.push(primary)
+      }
+      break
+    }
+    default:
+      // Unknown provider: cannot establish verification -> do not auto-link.
+      break
+  }
+
+  return uniqueEmails(verified)
+}
+
+/** Patch a speaker's slug if it is currently missing/empty. Never overwrites a
+ * non-empty slug (that would break profile URLs / SEO). Mutates and returns the
+ * passed speaker for convenience. */
+async function backfillSlugIfMissing(speaker: Speaker): Promise<Speaker> {
+  if (speaker.slug && speaker.slug.trim().length > 0) {
+    return speaker
+  }
+
+  try {
+    const slug = await generateUniqueSlug(speaker.name, speaker._id)
+    await clientWrite
+      .patch(speaker._id)
+      .set({ slug: { _type: 'slug', current: slug } })
+      .commit()
+    speaker.slug = slug
+  } catch (error) {
+    console.error('Failed to backfill speaker slug', error)
+  }
+
+  return speaker
+}
+
+/**
+ * Link an incoming provider account into an existing speaker: dedup the
+ * provider id into `providers[]`, union the verified emails into `knownEmails`,
+ * backfill a missing slug, and set the display `email` only when it was empty.
+ */
+async function linkProviderToSpeaker(
+  speaker: Speaker,
+  providerAccountId: string,
+  verifiedIncoming: string[],
+  primaryEmail: string,
+): Promise<{ speaker: Speaker; err: Error | null }> {
+  const providers = Array.from(
+    new Set([...(speaker.providers || []), providerAccountId]),
+  )
+  const knownEmails = uniqueEmails([
+    ...(speaker.knownEmails || []),
+    speaker.email,
+    ...verifiedIncoming,
+    primaryEmail,
+  ])
+
+  const patch: Record<string, unknown> = { providers, knownEmails }
+
+  // Keep the existing non-empty display email; only set it when missing.
+  const nextEmail =
+    speaker.email && speaker.email.trim().length > 0
+      ? speaker.email
+      : primaryEmail
+  if (nextEmail !== speaker.email) {
+    patch.email = nextEmail
+  }
+
+  // Backfill slug only when missing; never change an existing non-empty slug.
+  let slug = speaker.slug
+  if (!slug || slug.trim().length === 0) {
+    slug = await generateUniqueSlug(speaker.name, speaker._id)
+    patch.slug = { _type: 'slug', current: slug }
+  }
+
+  try {
+    await clientWrite.patch(speaker._id).set(patch).commit()
+  } catch (error) {
+    return { speaker, err: error as Error }
+  }
+
+  return {
+    speaker: { ...speaker, providers, knownEmails, email: nextEmail, slug },
+    err: null,
+  }
+}
+
 export async function getOrCreateSpeaker(
   user: User,
   account: Account,
+  profile?: Profile,
 ): Promise<{ speaker: Speaker; err: Error | null }> {
   if (!user.email || !user.name) {
     const err = new Error('Missing user email or name')
@@ -108,45 +296,68 @@ export async function getOrCreateSpeaker(
     account.provider,
     account.providerAccountId,
   )
-  let result = await findSpeakerByProvider(providerAccountId)
-  if (result.err) {
-    console.error('Error fetching speaker profile by account id', result.err)
-    return { speaker: result.speaker, err: result.err }
+
+  // 1. Exact provider-account match: this account already belongs to a speaker.
+  const providerResult = await findSpeakerByProvider(providerAccountId)
+  if (providerResult.err) {
+    console.error(
+      'Error fetching speaker profile by account id',
+      providerResult.err,
+    )
+    return { speaker: providerResult.speaker, err: providerResult.err }
+  }
+  if (providerResult.speaker?._id) {
+    // Backfill a slug for pre-existing slugless speakers on login.
+    await backfillSlugIfMissing(providerResult.speaker)
+    return { speaker: providerResult.speaker, err: null }
   }
 
-  if (result.speaker?._id) {
-    return { speaker: result.speaker, err: result.err }
-  }
+  // 2. Gather the VERIFIED emails for this login. Only verified emails may
+  //    auto-link into an existing speaker (never link on an unverified email).
+  const primaryEmail = normalizeEmail(user.email)
+  const verifiedIncoming = await computeVerifiedEmails(user, account, profile)
 
-  result = await findSpeakerByEmail(user.email)
-  if (result.err) {
-    console.error('Error fetching speaker profile by email', result.err)
-    return { speaker: result.speaker, err: result.err }
-  }
-
-  if (result.speaker?._id) {
-    result.speaker.providers = result.speaker.providers || []
-    result.speaker.providers.push(providerAccountId)
-    try {
-      await clientWrite
-        .patch(result.speaker._id)
-        .set({ providers: result.speaker.providers })
-        .commit()
-    } catch (error) {
-      result.err = error as Error
+  // 3. Attempt to match an existing speaker by verified email intersection.
+  if (verifiedIncoming.length > 0) {
+    const { speakers, err } = await findSpeakersByEmails(verifiedIncoming)
+    if (err) {
+      console.error('Error fetching speaker profile by email', err)
+      return { speaker: {} as Speaker, err }
     }
-    return { speaker: result.speaker, err: result.err }
+
+    if (speakers.length > 1) {
+      // Pre-existing duplicate data. Do NOT silently merge; link to the oldest
+      // and surface the duplicates for Phase 3/4 reconciliation.
+      console.warn(
+        `possible existing duplicate speakers for ${verifiedIncoming.join(
+          ', ',
+        )}: ${speakers.map((s) => s._id).join(', ')}`,
+      )
+    }
+
+    if (speakers.length > 0) {
+      return linkProviderToSpeaker(
+        speakers[0],
+        providerAccountId,
+        verifiedIncoming,
+        primaryEmail,
+      )
+    }
   }
+
+  // 4. No verified match: create a brand-new speaker with a unique slug.
+  const _id = randomUUID()
+  const knownEmails = uniqueEmails([...verifiedIncoming, primaryEmail])
+  const slugValue = await generateUniqueSlug(user.name, _id)
 
   const speaker = {
-    _id: randomUUID(),
+    _id,
     email: user.email,
     name: user.name,
     imageURL: user.image || '',
     providers: [providerAccountId],
+    knownEmails,
   } as Speaker
-
-  const slugValue = generateSlug(user.name)
 
   try {
     const createdSpeaker = await clientWrite.create({

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -162,10 +162,8 @@ async function findSpeakersByEmails(
  *   userinfo only exposes a verified primary email, so `user.email` is treated
  *   as provider-verified and included as a fallback (e.g. if the API call
  *   fails).
- * - LinkedIn (OIDC): the `email_verified` claim on the profile. LinkedIn OIDC
- *   only issues an email when it is verified, so a missing/undefined claim is
- *   treated as verified per LinkedIn semantics; an explicit `false` is honored
- *   as unverified. (Assumption flagged for maintainer review.)
+ * - LinkedIn (OIDC): the primary is trusted ONLY when the `email_verified` claim
+ *   is affirmatively true (default-deny). See H2 note below.
  * - Unknown providers: no email is treated as verified (no auto-link).
  */
 async function computeVerifiedEmails(
@@ -188,14 +186,24 @@ async function computeVerifiedEmails(
       for (const entry of emails) {
         verified.push(entry.email)
       }
-      // GitHub OAuth only surfaces a verified primary email.
+      // GitHub guarantees the primary email is verified before it is exposed via
+      // OAuth, so the session primary is trusted as verified (used as a fallback
+      // when the /user/emails API call fails or returns nothing).
       if (primary) verified.push(primary)
       break
     }
     case 'linkedin': {
-      const claim = (profile as { email_verified?: boolean } | undefined)
-        ?.email_verified
-      if (primary && claim !== false) {
+      // H2 — affirmative default-deny. Previously `claim !== false` fail-open:
+      // it accepted absent/undefined AND the STRING "false" as verified, which
+      // let an unverified LinkedIn email link into (take over) an account. Now
+      // the primary counts as verified ONLY when the claim is explicitly true.
+      // OIDC claims can be stringified, so accept the string 'true' as well;
+      // everything else (absent, false, 'false', anything else) is unverified.
+      const claim = (
+        profile as { email_verified?: boolean | string } | undefined
+      )?.email_verified
+      const isVerified = claim === true || claim === 'true'
+      if (primary && isVerified) {
         verified.push(primary)
       }
       break
@@ -232,8 +240,9 @@ async function backfillSlugIfMissing(speaker: Speaker): Promise<Speaker> {
 
 /**
  * Link an incoming provider account into an existing speaker: dedup the
- * provider id into `providers[]`, union the verified emails into `knownEmails`,
- * backfill a missing slug, and set the display `email` only when it was empty.
+ * provider id into `providers[]`, union the freshly VERIFIED incoming emails
+ * into `knownEmails`, backfill a missing slug, and set the display `email` only
+ * when it was empty.
  */
 async function linkProviderToSpeaker(
   speaker: Speaker,
@@ -244,11 +253,15 @@ async function linkProviderToSpeaker(
   const providers = Array.from(
     new Set([...(speaker.providers || []), providerAccountId]),
   )
+  // SECURITY: `knownEmails` is the verified match-set. Seed it ONLY from the
+  // speaker's existing (already-verified) entries plus this login's
+  // `computeVerifiedEmails` output. Never fold in the raw display `email` or an
+  // unverified `primaryEmail` — that would let an unverified address become a
+  // future cross-provider match key. (`primaryEmail` is still used below purely
+  // to backfill a missing display email.)
   const knownEmails = uniqueEmails([
     ...(speaker.knownEmails || []),
-    speaker.email,
     ...verifiedIncoming,
-    primaryEmail,
   ])
 
   const patch: Record<string, unknown> = { providers, knownEmails }
@@ -318,6 +331,15 @@ export async function getOrCreateSpeaker(
   const verifiedIncoming = await computeVerifiedEmails(user, account, profile)
 
   // 3. Attempt to match an existing speaker by verified email intersection.
+  //
+  //    SECURITY — stored-side-verified invariant: matching here is safe because
+  //    every stored match key is verified-owned. `knownEmails` is written only
+  //    by this login path from `computeVerifiedEmails` output (never from
+  //    `updateEmail`/admin edits). The legacy display `email` is also safe: it
+  //    is either a pre-existing value seeded from the provider primary at
+  //    creation (verified), or set post-hardening only after ownership was
+  //    proven (login primary, or `speaker.updateEmail` which now requires the
+  //    caller's provider-verified set). So both keys are kept.
   if (verifiedIncoming.length > 0) {
     const { speakers, err } = await findSpeakersByEmails(verifiedIncoming)
     if (err) {
@@ -325,17 +347,8 @@ export async function getOrCreateSpeaker(
       return { speaker: {} as Speaker, err }
     }
 
-    if (speakers.length > 1) {
-      // Pre-existing duplicate data. Do NOT silently merge; link to the oldest
-      // and surface the duplicates for Phase 3/4 reconciliation.
-      console.warn(
-        `possible existing duplicate speakers for ${verifiedIncoming.join(
-          ', ',
-        )}: ${speakers.map((s) => s._id).join(', ')}`,
-      )
-    }
-
-    if (speakers.length > 0) {
+    if (speakers.length === 1) {
+      // Exactly one verified-email match: unambiguously the same person.
       return linkProviderToSpeaker(
         speakers[0],
         providerAccountId,
@@ -343,11 +356,32 @@ export async function getOrCreateSpeaker(
         primaryEmail,
       )
     }
+
+    if (speakers.length > 1) {
+      // H1 — genuinely ambiguous: the verified email matches multiple speakers
+      // (the provider-id short-circuit in step 1 already handled the "same
+      // account" case, so this is not that). Do NOT auto-link into any of them:
+      // silently picking the oldest is attacker-influenceable and could merge a
+      // login into the wrong account. Fall through to create a fresh speaker so
+      // the user still gets a working session, and surface the ambiguous ids for
+      // admin / Phase-4 reconciliation.
+      console.warn(
+        `ambiguous verified-email match for ${verifiedIncoming.join(
+          ', ',
+        )}: ${speakers
+          .map((s) => s._id)
+          .join(
+            ', ',
+          )} — creating a new speaker instead of linking into an ambiguous account`,
+      )
+    }
   }
 
-  // 4. No verified match: create a brand-new speaker with a unique slug.
+  // 4. No (unambiguous) verified match: create a brand-new speaker with a unique
+  //    slug. Seed `knownEmails` ONLY from verified emails so a new doc never
+  //    starts life with an unverified match key.
   const _id = randomUUID()
-  const knownEmails = uniqueEmails([...verifiedIncoming, primaryEmail])
+  const knownEmails = uniqueEmails(verifiedIncoming)
   const slugValue = await generateUniqueSlug(user.name, _id)
 
   const speaker = {

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -94,36 +94,6 @@ async function findSpeakerByProvider(
 }
 
 /**
- * Find a speaker whose primary `email` matches (case-insensitively). Kept for
- * backward compatibility; matching is normalized (was previously exact/case
- * sensitive).
- */
-async function findSpeakerByEmail(
-  email: string,
-): Promise<{ speaker: Speaker; err: Error | null }> {
-  let speaker = {} as Speaker
-  let err = null
-
-  try {
-    speaker = await clientRead.fetch(
-      `*[ _type == "speaker" && lower(email) == $email][0]{
-      ...,
-      "slug": slug.current,
-      "image": coalesce(image.asset->url, imageURL),
-      ${IS_ORGANIZER_FIELD}
-    }`,
-      { email: normalizeEmail(email) },
-    )
-  } catch (error) {
-    err = error as Error
-  }
-
-  return { speaker, err }
-}
-
-export { findSpeakerByEmail }
-
-/**
  * Find all speakers whose display `email` or `knownEmails` match-set intersects
  * any of the given (already normalized) emails. Ordered oldest-first so the
  * caller can deterministically pick a link target and detect duplicates.

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -162,8 +162,11 @@ async function findSpeakersByEmails(
  *   userinfo only exposes a verified primary email, so `user.email` is treated
  *   as provider-verified and included as a fallback (e.g. if the API call
  *   fails).
- * - LinkedIn (OIDC): the primary is trusted ONLY when the `email_verified` claim
- *   is affirmatively true (default-deny). See H2 note below.
+ * - LinkedIn (OIDC): the primary is trusted as verified UNLESS `email_verified`
+ *   is explicitly false. LinkedIn only ever asserts the account holder's own
+ *   verified primary email (you cannot make it assert an address you don't own),
+ *   so an absent claim is treated as verified; only an explicit `false`/`"false"`
+ *   blocks the link. See LinkedIn note below.
  * - Unknown providers: no email is treated as verified (no auto-link).
  */
 async function computeVerifiedEmails(
@@ -193,16 +196,16 @@ async function computeVerifiedEmails(
       break
     }
     case 'linkedin': {
-      // H2 — affirmative default-deny. Previously `claim !== false` fail-open:
-      // it accepted absent/undefined AND the STRING "false" as verified, which
-      // let an unverified LinkedIn email link into (take over) an account. Now
-      // the primary counts as verified ONLY when the claim is explicitly true.
-      // OIDC claims can be stringified, so accept the string 'true' as well;
-      // everything else (absent, false, 'false', anything else) is unverified.
+      // LinkedIn only asserts the account holder's own verified primary email —
+      // it cannot be induced to assert an address the login user doesn't own —
+      // so the primary is trusted as verified unless `email_verified` is
+      // explicitly false. OIDC claims can be stringified, so block both the
+      // boolean `false` and the string "false"; absent/true/anything-else is
+      // treated as verified.
       const claim = (
         profile as { email_verified?: boolean | string } | undefined
       )?.email_verified
-      const isVerified = claim === true || claim === 'true'
+      const isVerified = claim !== false && claim !== 'false'
       if (primary && isVerified) {
         verified.push(primary)
       }

--- a/src/lib/speaker/slug.test.ts
+++ b/src/lib/speaker/slug.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  generateSpeakerSlug,
+  generateUniqueSpeakerSlug,
+  FALLBACK_SLUG_BASE,
+  MAX_SLUG_LENGTH,
+} from './slug'
+
+describe('generateSpeakerSlug', () => {
+  it('produces a url-safe lowercase slug from a normal name', () => {
+    expect(generateSpeakerSlug('Jane Doe')).toBe('jane-doe')
+    expect(generateSpeakerSlug('Ada  Lovelace!')).toBe('ada-lovelace')
+    expect(generateSpeakerSlug('  Grace   Hopper  ')).toBe('grace-hopper')
+  })
+
+  it('never returns empty for an emoji-only or non-Latin name', () => {
+    expect(generateSpeakerSlug('🎤🎤')).toBe(FALLBACK_SLUG_BASE)
+    expect(generateSpeakerSlug('日本語')).toBe(FALLBACK_SLUG_BASE)
+    expect(generateSpeakerSlug('')).toBe(FALLBACK_SLUG_BASE)
+    expect(generateSpeakerSlug('---')).toBe(FALLBACK_SLUG_BASE)
+  })
+
+  it('appends a numeric suffix and truncates to stay within max length', () => {
+    expect(generateSpeakerSlug('Jane Doe', 2)).toBe('jane-doe-2')
+
+    const long = 'a'.repeat(200)
+    const suffixed = generateSpeakerSlug(long, 42)
+    expect(suffixed.length).toBeLessThanOrEqual(MAX_SLUG_LENGTH)
+    expect(suffixed.endsWith('-42')).toBe(true)
+  })
+
+  it('truncates a plain slug to the max length', () => {
+    const slug = generateSpeakerSlug('a'.repeat(200))
+    expect(slug.length).toBe(MAX_SLUG_LENGTH)
+  })
+})
+
+describe('generateUniqueSpeakerSlug', () => {
+  it('returns the base slug when it is free', async () => {
+    const exists = vi.fn().mockResolvedValue(false)
+    expect(await generateUniqueSpeakerSlug('Jane Doe', exists)).toBe('jane-doe')
+    expect(exists).toHaveBeenCalledTimes(1)
+  })
+
+  it('probes numeric suffixes until it finds a free slug', async () => {
+    const taken = new Set(['jane-doe', 'jane-doe-2', 'jane-doe-3'])
+    const exists = vi.fn(async (slug: string) => taken.has(slug))
+    expect(await generateUniqueSpeakerSlug('Jane Doe', exists)).toBe(
+      'jane-doe-4',
+    )
+  })
+
+  it('falls back to a stable base for emoji-only names, then suffixes', async () => {
+    const taken = new Set(['speaker'])
+    const exists = vi.fn(async (slug: string) => taken.has(slug))
+    expect(await generateUniqueSpeakerSlug('🎤', exists)).toBe('speaker-2')
+  })
+})

--- a/src/lib/speaker/slug.ts
+++ b/src/lib/speaker/slug.ts
@@ -1,0 +1,87 @@
+/**
+ * Canonical speaker slug generation.
+ *
+ * This is the single shared implementation used by every code path that
+ * persists a speaker slug (OAuth create/link in `sanity.ts` and admin create in
+ * the speaker router). It guarantees a URL-safe, lowercase, never-empty slug.
+ */
+
+/** Sanity `slug` field `maxLength` for speakers (see schema). */
+export const MAX_SLUG_LENGTH = 96
+
+/**
+ * Stable fallback base used when a name reduces to an empty slug (e.g. an
+ * emoji-only or non-Latin name). We never persist an empty slug.
+ */
+export const FALLBACK_SLUG_BASE = 'speaker'
+
+/**
+ * Reduce a name to a URL-safe lowercase slug base. Never empty: falls back to
+ * {@link FALLBACK_SLUG_BASE} when the name contains no slug-safe characters.
+ */
+function slugifyBase(name: string): string {
+  const base = (name ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+
+  return base || FALLBACK_SLUG_BASE
+}
+
+/**
+ * Generate a URL-safe lowercase slug for a speaker name. When `suffix` is
+ * provided (for collision resolution) it is appended as `-<suffix>` and the
+ * base is truncated so the result never exceeds {@link MAX_SLUG_LENGTH}.
+ *
+ * Never returns an empty string.
+ */
+export function generateSpeakerSlug(
+  name: string,
+  suffix?: number | string,
+): string {
+  const base = slugifyBase(name)
+
+  if (suffix !== undefined && suffix !== '') {
+    const suffixStr = String(suffix)
+    const maxBaseLength = MAX_SLUG_LENGTH - 1 - suffixStr.length
+    const truncatedBase = base.slice(0, Math.max(0, maxBaseLength))
+    return `${truncatedBase}-${suffixStr}`
+  }
+
+  return base.slice(0, MAX_SLUG_LENGTH)
+}
+
+/** Async predicate: returns true when a candidate slug is already taken. */
+export type SlugExistsChecker = (slug: string) => Promise<boolean>
+
+/**
+ * Hard cap on suffix probing to avoid an unbounded loop if the collision
+ * checker misbehaves (e.g. always reports "taken"). Practically unreachable.
+ */
+const MAX_SLUG_ATTEMPTS = 1000
+
+/**
+ * Generate a unique slug for a name by probing numeric suffixes (`-2`, `-3`, …)
+ * until `exists` reports the candidate is free. The first candidate has no
+ * suffix. Falls back to a timestamp-suffixed slug if the cap is somehow hit.
+ */
+export async function generateUniqueSpeakerSlug(
+  name: string,
+  exists: SlugExistsChecker,
+): Promise<string> {
+  const first = generateSpeakerSlug(name)
+  if (!(await exists(first))) {
+    return first
+  }
+
+  for (let suffix = 2; suffix < MAX_SLUG_ATTEMPTS; suffix++) {
+    const candidate = generateSpeakerSlug(name, suffix)
+    if (!(await exists(candidate))) {
+      return candidate
+    }
+  }
+
+  // Extremely defensive fallback; should never be reached in practice.
+  return generateSpeakerSlug(name, Date.now())
+}

--- a/src/lib/speaker/types.ts
+++ b/src/lib/speaker/types.ts
@@ -85,6 +85,14 @@ export interface Speaker extends SpeakerBase {
   _createdAt: string
   _updatedAt: string
   email: string
+  /**
+   * Normalized (lowercased) match-set of every verified email known to belong
+   * to this speaker across their linked OAuth providers. Distinct from the
+   * single display {@link email}; used by `getOrCreateSpeaker` to link a second
+   * provider whose verified email matches, avoiding duplicate speaker records.
+   * Additive/optional — legacy documents without it remain valid.
+   */
+  knownEmails?: string[]
   providers?: string[]
   /**
    * Read-side image value: a fully-resolved display URL projected by GROQ as

--- a/src/server/routers/speaker.ts
+++ b/src/server/routers/speaker.ts
@@ -41,7 +41,7 @@ import {
 } from '@/lib/email/audience'
 import { isValidPortableText } from '@/lib/portabletext/validation'
 import type { PortableTextBlock } from '@portabletext/types'
-import { generateSlug } from '@/lib/speaker/sanity'
+import { generateUniqueSlug } from '@/lib/speaker/sanity'
 
 export const speakerRouter = router({
   // Get current user&apos;s speaker profile
@@ -372,7 +372,7 @@ export const speakerRouter = router({
       .input(SpeakerCreateSchema)
       .mutation(async ({ input }) => {
         try {
-          const slug = generateSlug(input.name)
+          const slug = await generateUniqueSlug(input.name)
 
           const speaker = await clientWrite.create({
             _type: 'speaker',

--- a/src/server/routers/speaker.ts
+++ b/src/server/routers/speaker.ts
@@ -21,8 +21,10 @@ import {
   getSpeakers,
 } from '@/lib/speaker/sanity'
 import { clientWrite } from '@/lib/sanity/client'
-import { verifiedEmails } from '@/lib/profile/github'
-import { defaultEmails } from '@/lib/profile/server'
+import {
+  getVerifiedProfileEmails,
+  isEmailVerifiedForSession,
+} from '@/lib/profile/server'
 import { updateProfileEmail } from '@/lib/profile/sanity'
 import { encode } from 'next-auth/jwt'
 
@@ -112,26 +114,9 @@ export const speakerRouter = router({
       })
     }
 
-    try {
-      switch (session.account.provider) {
-        case 'github': {
-          const result = await verifiedEmails(session.account)
-          if (result.error) {
-            console.error('Failed to fetch GitHub emails:', result.error)
-            return defaultEmails(session)
-          }
-          return result.emails.length > 0
-            ? result.emails
-            : defaultEmails(session)
-        }
-
-        default:
-          return defaultEmails(session)
-      }
-    } catch (error) {
-      console.error('Error fetching emails:', error)
-      return defaultEmails(session)
-    }
+    // Single source of truth for the caller's verified emails; the same helper
+    // authorizes `updateEmail` so the picker and the guard can never diverge.
+    return getVerifiedProfileEmails(session)
   }),
 
   // Generate a CLI authentication token
@@ -172,6 +157,19 @@ export const speakerRouter = router({
     .input(EmailUpdateSchema)
     .mutation(async ({ input, ctx }) => {
       try {
+        // SECURITY (C1): the display `email` is a login match key in
+        // getOrCreateSpeaker, so the caller must PROVE they own the new address.
+        // Only accept emails in the caller's provider-verified set — recomputed
+        // server-side from the session, never trusting a client-supplied list.
+        const owns = await isEmailVerifiedForSession(ctx.session!, input.email)
+        if (!owns) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message:
+              'You can only set an email address that is verified by your login provider.',
+          })
+        }
+
         const { error } = await updateProfileEmail(input.email, ctx.speaker._id)
 
         if (error) {
@@ -486,6 +484,11 @@ export const speakerRouter = router({
       )
       .mutation(async ({ input }) => {
         try {
+          // Organizer action: set the speaker's display `email` only. Post-C1,
+          // updateProfileEmail no longer writes `knownEmails`, so an admin edit
+          // can never inject an address into the verified match-set. (The admin
+          // is not required to prove ownership — this is a trusted organizer
+          // correcting contact details, not the self-service path.)
           const { error } = await updateProfileEmail(input.email, input.id)
 
           if (error) {


### PR DESCRIPTION
## Summary

Phase 1 of speaker-identity hardening. Fixes two root causes of duplicate/broken speaker records:

1. **Duplicate speakers across providers.** Logging in with a second OAuth provider (GitHub then LinkedIn) whose email differed from the first created a *new* speaker. Matching was by exact provider id, then by a single case-sensitive `email` field only.
2. **Missing / invalid slugs.** `generateSlug` could produce an empty slug (emoji-only / non-Latin names) and never checked uniqueness, so two speakers with the same name collided.

> **HELD FOR MAINTAINER REVIEW.** This changes the auth sign-in path. Please review and exercise a real GitHub + LinkedIn login against a preview deployment before merging. **Do not enqueue / auto-merge.**

## Part A — Robust slug generation

- New shared util `src/lib/speaker/slug.ts`:
  - `generateSpeakerSlug(name)` — URL-safe, lowercase, **never empty** (falls back to a stable `speaker` base for emoji-only / non-Latin names; never throws, never persists `''`).
  - `generateUniqueSpeakerSlug(name, existsChecker)` — probes numeric suffixes (`-2`, `-3`, …) until unique.
- One canonical Sanity-backed `generateUniqueSlug(name, selfId?)` in `sanity.ts` (collision query `*[_type=="speaker" && slug.current==$slug && _id!=$selfId][0]`) now used by the OAuth create path, the admin create path, and the `fix-missing-slugs` script.
- **Slug backfill on login:** an existing speaker with a missing/empty slug gets a unique one generated. An existing **non-empty** slug is **never** changed (protects profile URLs / SEO).

## Part B — Verified-email matching + multi-email storage

- Additive, optional `knownEmails: string[]` on the speaker schema (`readOnly` in Studio) and `Speaker` type — the normalized match-set, distinct from the single display `email`. **Additive/optional → no migration; existing docs stay valid.**
- All email comparisons normalized to `trim().toLowerCase()` (`src/lib/speaker/email.ts`); `findSpeakerByEmail` is no longer case-sensitive.
- `getOrCreateSpeaker` matching order:
  1. `providerAccountId` in `providers[]` → return (with slug backfill).
  2. Gather **verified** incoming emails, then find a speaker whose `email`/`knownEmails` intersect them.
  3. Exactly one match → add the provider id (dedup), union verified emails into `knownEmails`, backfill slug if missing, keep the existing display `email` unless empty.
  4. No match → create a new speaker with `knownEmails` seeded and a unique slug.

### Security invariant (verified-only linking)

Auto-linking an incoming account into an existing speaker happens **only** on a **verified** email. An unverified email never links accounts (that would enable account takeover). If no verified email is available, we fall through to **create-new** rather than link.

- **GitHub:** verified set from the `/user/emails` API (`verifiedEmails`). GitHub OAuth only surfaces a verified primary email, so `user.email` is treated as provider-verified and included as a fallback if the API call fails.
- **LinkedIn (OIDC):** honors the `email_verified` claim. LinkedIn OIDC only issues an email when verified, so a **missing/undefined** claim is treated as verified per LinkedIn semantics; an explicit `email_verified: false` is honored as **unverified** (no link).

### Multiple pre-existing matches

If more than one speaker matches (pre-existing duplicate data), we **do not silently merge**. We link the new provider to the **oldest** (`_createdAt asc`), union emails onto it, and `console.warn` `possible existing duplicate speakers for <emails>: <ids>` so a later admin tool / migration (Phases 3–4) can reconcile.

### Profile email changes

`updateProfileEmail` now keeps `knownEmails` as a normalized **union** (never drops the old email), so changing the display email cannot split a speaker into a duplicate on next login.

## Tests

`pnpm typecheck` clean, `pnpm vitest run` green (126 files, 2166 passing). Added:
- `slug.test.ts` — empty/emoji fallback, collision → suffix, valid name unchanged, truncation.
- `sanity.test.ts` (mocks Sanity client + `verifiedEmails`) — provider-id hit, cross-provider verified link unions providers+emails, unverified email does **not** link, multiple-match warns + links oldest, new-user create, slug backfill on login, collision suffix, emoji fallback.

## Assumptions for maintainer to confirm

- **LinkedIn `email_verified` handling.** We treat a LinkedIn primary email as verified when `email_verified` is `true` **or absent/undefined** (LinkedIn OIDC only issues verified emails); only an explicit `false` blocks linking. Please confirm this matches the LinkedIn app's actual token claims in the preview environment.
- **GitHub OAuth primary trusted as verified.** `user.email` from GitHub is included in the verified set as a fallback (and always seeded into a new record's `knownEmails` per the primary-email requirement). This is consistent with GitHub only exposing a verified primary via OAuth.
- Out of scope (later phases): retroactive migration / dedup of existing data, self-service account linking for non-overlapping emails, admin reconciliation tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens speaker identity across two axes: (1) slug generation is made robust with a never-empty fallback and uniqueness probing, and (2) the OAuth sign-in path is extended to match incoming accounts against existing speakers by **verified** email intersection, preventing duplicate speaker records when a user logs in with a second OAuth provider.

- **Slug hardening**: a new `slug.ts` utility replaces the old inline `generateSlug`, adding emoji/non-Latin fallback, numeric-suffix probing up to MAX_SLUG_ATTEMPTS, and a timestamp-based last resort. All three write paths (OAuth create, admin create, backfill script) are unified on `generateUniqueSlug`.
- **Verified-email linking**: `getOrCreateSpeaker` now follows a four-step flow (provider ID → verified-email intersection → create), only linking accounts on verified emails. GitHub verified emails come from the `/user/emails` API with `user.email` as an unconditional fallback; LinkedIn honors the `email_verified` OIDC claim (absent/undefined = verified per LinkedIn semantics).
- **`knownEmails` match-set**: a new optional `knownEmails: string[]` field (additive, no migration needed) is maintained as the normalized union of all verified emails across linked providers. `updateProfileEmail` now unions into `knownEmails` to prevent a display-email change from splitting a speaker into a duplicate on the next cross-provider login.

<h3>Confidence Score: 4/5</h3>

The auth sign-in path is meaningfully changed and should be exercised against a real preview deployment (GitHub + LinkedIn) before merging, as the PR itself requests.

The slug and email utility changes are clean and well-tested. The multi-step provider-matching logic in getOrCreateSpeaker is sound and the security invariant (verified-only linking) is correctly implemented. The main concern is the LinkedIn email_verified check using claim !== false — a non-boolean value slips past this gate — and the always-on inclusion of user.email for GitHub (correct behavior but obscured by code structure). Neither is likely to cause an incident under normal provider behavior, but the LinkedIn gate directly guards against account takeover, so the strict-boolean fix is worth landing before merge.

src/lib/speaker/sanity.ts — the LinkedIn email_verified check and the GitHub primary-always-included path both deserve a second read.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/speaker/sanity.ts | Core auth change: adds multi-step provider to email to create matching, verified-email-only linking, slug backfill on login. The LinkedIn email_verified type cast and always-present primary email for GitHub warrant careful review. |
| src/lib/speaker/slug.ts | New slug utility: pure functions with fallback, truncation, and suffix probing. MAX_SLUG_ATTEMPTS cap and timestamp fallback are robust. Well-tested. |
| src/lib/speaker/email.ts | New email normalization helpers: normalizeEmail and uniqueEmails are straightforward and correct. |
| src/lib/auth.ts | Minimal change: passes profile to getOrCreateSpeaker so LinkedIn email_verified claim is available. The rest of the auth config is unchanged. |
| src/lib/profile/sanity.ts | updateProfileEmail now unions knownEmails before writing, preventing a display-email change from splitting the speaker into a duplicate on next cross-provider login. Logic is correct. |
| sanity/schemaTypes/speaker.ts | Adds optional knownEmails array field, readOnly in Studio, visible only to administrators and editors. Additive and backward-compatible. |
| src/lib/speaker/types.ts | Adds optional knownEmails?: string[] to the Speaker interface with clear documentation. Backward-compatible change. |
| scripts/fix-missing-slugs.ts | Updated to use generateUniqueSlug (async, collision-safe) instead of the old synchronous generateSlug. Correct migration. |
| src/server/routers/speaker.ts | Admin create path now uses generateUniqueSlug (async), ensuring uniqueness consistency with the OAuth path. Single-line change. |
| src/lib/speaker/sanity.test.ts | New test file covering provider match, cross-provider linking, unverified-email rejection, multiple-match warn+link-oldest, creation, slug suffix, and emoji fallback. Good coverage of all new branches. |
| src/lib/speaker/slug.test.ts | Covers all slug edge cases: normal name, emoji/non-Latin fallback, suffix collision probing, and truncation. Clean and comprehensive. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant NextAuth
    participant getOrCreate as getOrCreateSpeaker
    participant GH as GitHub /user/emails
    participant Sanity

    U->>NextAuth: Sign in (GitHub / LinkedIn)
    NextAuth->>getOrCreate: user, account, profile
    Note over getOrCreate: Step 1 - Provider match
    getOrCreate->>Sanity: findSpeakerByProvider(providerAccountId)
    alt Provider match found
        Sanity-->>getOrCreate: speaker
        getOrCreate->>Sanity: backfillSlug if empty
        getOrCreate-->>NextAuth: speaker
    else No provider match
        Note over getOrCreate: Step 2 - Compute verified emails
        alt GitHub provider
            getOrCreate->>GH: GET /user/emails
            GH-->>getOrCreate: verified email list
        else LinkedIn provider
            Note over getOrCreate: Honor email_verified claim
        else Unknown provider
            Note over getOrCreate: verifiedIncoming empty, skip linking
        end
        Note over getOrCreate: Step 3 - Email intersection match
        alt verifiedIncoming non-empty
            getOrCreate->>Sanity: findSpeakersByEmails ordered oldest-first
            alt 1 match
                getOrCreate->>Sanity: patch providers and knownEmails
                getOrCreate-->>NextAuth: speaker
            else 2+ matches
                Note over getOrCreate: warn duplicates, link oldest
                getOrCreate->>Sanity: patch oldest speaker
                getOrCreate-->>NextAuth: speaker
            else No match
                Note over getOrCreate: Fall through to create
            end
        end
        Note over getOrCreate: Step 4 - Create new speaker
        getOrCreate->>Sanity: generateUniqueSlug probe
        getOrCreate->>Sanity: clientWrite.create with slug and knownEmails
        getOrCreate-->>NextAuth: speaker
    end
    NextAuth-->>U: JWT token
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant NextAuth
    participant getOrCreate as getOrCreateSpeaker
    participant GH as GitHub /user/emails
    participant Sanity

    U->>NextAuth: Sign in (GitHub / LinkedIn)
    NextAuth->>getOrCreate: user, account, profile
    Note over getOrCreate: Step 1 - Provider match
    getOrCreate->>Sanity: findSpeakerByProvider(providerAccountId)
    alt Provider match found
        Sanity-->>getOrCreate: speaker
        getOrCreate->>Sanity: backfillSlug if empty
        getOrCreate-->>NextAuth: speaker
    else No provider match
        Note over getOrCreate: Step 2 - Compute verified emails
        alt GitHub provider
            getOrCreate->>GH: GET /user/emails
            GH-->>getOrCreate: verified email list
        else LinkedIn provider
            Note over getOrCreate: Honor email_verified claim
        else Unknown provider
            Note over getOrCreate: verifiedIncoming empty, skip linking
        end
        Note over getOrCreate: Step 3 - Email intersection match
        alt verifiedIncoming non-empty
            getOrCreate->>Sanity: findSpeakersByEmails ordered oldest-first
            alt 1 match
                getOrCreate->>Sanity: patch providers and knownEmails
                getOrCreate-->>NextAuth: speaker
            else 2+ matches
                Note over getOrCreate: warn duplicates, link oldest
                getOrCreate->>Sanity: patch oldest speaker
                getOrCreate-->>NextAuth: speaker
            else No match
                Note over getOrCreate: Fall through to create
            end
        end
        Note over getOrCreate: Step 4 - Create new speaker
        getOrCreate->>Sanity: generateUniqueSlug probe
        getOrCreate->>Sanity: clientWrite.create with slug and knownEmails
        getOrCreate-->>NextAuth: speaker
    end
    NextAuth-->>U: JWT token
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(speaker): robust slugs + verified-e..."](https://github.com/cloudnativebergen/website/commit/de48dbda86ad550d56319086e13cd2e1b3c31151) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44460687)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->