### PR TITLE
Speaker identity (Phase 2): provider visibility + self-service linking

### DIFF
--- a/src/app/(cfp)/cfp/profile/link-actions.test.ts
+++ b/src/app/(cfp)/cfp/profile/link-actions.test.ts
@@ -44,8 +44,11 @@ describe('startProviderLink — self-service link (security gate)', () => {
     })
   })
 
-  it('mints an httpOnly link cookie bound to the signed-in speaker', async () => {
-    authMock.mockResolvedValue({ speaker: { _id: 'spk-x' } })
+  it('mints an httpOnly link cookie bound to the signed-in speaker + session', async () => {
+    authMock.mockResolvedValue({
+      speaker: { _id: 'spk-x' },
+      user: { sub: 'sess-x' },
+    })
 
     await startProviderLink(form('linkedin'))
 
@@ -54,15 +57,30 @@ describe('startProviderLink — self-service link (security gate)', () => {
     expect(name).toBe(LINK_INTENT_COOKIE)
     expect(options).toMatchObject({ httpOnly: true, sameSite: 'lax' })
 
-    // The token binds THIS speaker + provider and verifies authentically.
+    // The token binds THIS speaker + provider + initiating session and verifies
+    // authentically.
     expect(verifyLinkIntent(token as string, 'linkedin')).toEqual({
       speakerId: 'spk-x',
       provider: 'linkedin',
+      initiatorSub: 'sess-x',
     })
     // A different provider must not accept the same cookie.
     expect(verifyLinkIntent(token as string, 'github')).toBeNull()
 
     expect(signInMock).toHaveBeenCalledWith('linkedin', {
+      redirectTo: '/cfp/profile',
+    })
+  })
+
+  it('does not mint a link cookie when the session lacks a stable id', async () => {
+    // Without an initiating session `sub` we cannot bind the intent, so we must
+    // NOT mint one; fall back to a normal sign-in instead.
+    authMock.mockResolvedValue({ speaker: { _id: 'spk-x' } })
+
+    await startProviderLink(form('github'))
+
+    expect(cookieSetMock).not.toHaveBeenCalled()
+    expect(signInMock).toHaveBeenCalledWith('github', {
       redirectTo: '/cfp/profile',
     })
   })

--- a/src/app/(cfp)/cfp/profile/link-actions.test.ts
+++ b/src/app/(cfp)/cfp/profile/link-actions.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const authMock = vi.fn()
+const signInMock = vi.fn().mockResolvedValue(undefined)
+const cookieSetMock = vi.fn()
+
+vi.mock('@/lib/auth', () => ({
+  auth: (...args: unknown[]) => authMock(...args),
+  signIn: (...args: unknown[]) => signInMock(...args),
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: () => Promise.resolve({ set: cookieSetMock }),
+}))
+
+// Real crypto-backed helpers; AUTH_SECRET must be present for minting.
+process.env.AUTH_SECRET = 'link-actions-test-secret'
+
+import { startProviderLink } from './link-actions'
+import { LINK_INTENT_COOKIE, verifyLinkIntent } from '@/lib/auth-link'
+
+function form(provider: string): FormData {
+  const fd = new FormData()
+  fd.set('provider', provider)
+  return fd
+}
+
+describe('startProviderLink — self-service link (security gate)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    signInMock.mockResolvedValue(undefined)
+  })
+
+  it('requires an authenticated session: no link cookie is minted when signed out', async () => {
+    authMock.mockResolvedValue(null)
+
+    await startProviderLink(form('github'))
+
+    // No link-intent token may be issued for an unauthenticated caller.
+    expect(cookieSetMock).not.toHaveBeenCalled()
+    // They are still sent through a normal (non-link) sign-in.
+    expect(signInMock).toHaveBeenCalledWith('github', {
+      redirectTo: '/cfp/profile',
+    })
+  })
+
+  it('mints an httpOnly link cookie bound to the signed-in speaker', async () => {
+    authMock.mockResolvedValue({ speaker: { _id: 'spk-x' } })
+
+    await startProviderLink(form('linkedin'))
+
+    expect(cookieSetMock).toHaveBeenCalledTimes(1)
+    const [name, token, options] = cookieSetMock.mock.calls[0]
+    expect(name).toBe(LINK_INTENT_COOKIE)
+    expect(options).toMatchObject({ httpOnly: true, sameSite: 'lax' })
+
+    // The token binds THIS speaker + provider and verifies authentically.
+    expect(verifyLinkIntent(token as string, 'linkedin')).toEqual({
+      speakerId: 'spk-x',
+      provider: 'linkedin',
+    })
+    // A different provider must not accept the same cookie.
+    expect(verifyLinkIntent(token as string, 'github')).toBeNull()
+
+    expect(signInMock).toHaveBeenCalledWith('linkedin', {
+      redirectTo: '/cfp/profile',
+    })
+  })
+
+  it('rejects an unsupported provider', async () => {
+    authMock.mockResolvedValue({ speaker: { _id: 'spk-x' } })
+
+    await expect(startProviderLink(form('google'))).rejects.toThrow(
+      /Unsupported provider/,
+    )
+    expect(cookieSetMock).not.toHaveBeenCalled()
+    expect(signInMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(cfp)/cfp/profile/link-actions.ts
+++ b/src/app/(cfp)/cfp/profile/link-actions.ts
@@ -30,15 +30,20 @@ export async function startProviderLink(formData: FormData): Promise<void> {
   }
 
   const session = await auth()
-  if (!session?.speaker?._id) {
+  if (!session?.speaker?._id || !session.user?.sub) {
     // Not signed in — cannot link. Send them through the normal sign-in flow.
     await signIn(provider, { redirectTo: '/cfp/profile' })
     return
   }
 
+  // Bind the intent to THIS session: `speakerId` is the target document and
+  // `initiatorSub` is the initiating session's stable id. Consumption requires
+  // the browser's pre-existing session to still match both, so a lingering
+  // intent cannot be consumed by a different person's sign-in.
   const token = signLinkIntent({
     speakerId: session.speaker._id,
     provider,
+    initiatorSub: session.user.sub,
   })
 
   const jar = await cookies()

--- a/src/app/(cfp)/cfp/profile/link-actions.ts
+++ b/src/app/(cfp)/cfp/profile/link-actions.ts
@@ -1,0 +1,56 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { auth, signIn } from '@/lib/auth'
+import {
+  LINK_INTENT_COOKIE,
+  LINK_INTENT_TTL_SECONDS,
+  isLinkableProvider,
+  signLinkIntent,
+} from '@/lib/auth-link'
+
+/**
+ * Server Action that begins the self-service "link another provider" flow.
+ *
+ * SECURITY: this is the only place a link-intent token is minted, and it does so
+ * ONLY after resolving the caller's active session — the token is bound to the
+ * signed-in speaker's `_id`. A visitor who is not authenticated cannot obtain a
+ * token (they are bounced to sign-in). Because the resulting cookie is httpOnly,
+ * HMAC-signed and short-lived, it cannot be forged or replayed to attach a
+ * provider to a different account (see `@/lib/auth-link`).
+ *
+ * After the cookie is set we hand off to NextAuth `signIn` for the second
+ * provider; proving control of that provider account is the link's ownership
+ * proof, verified on the callback by the `jwt` callback in `@/lib/auth`.
+ */
+export async function startProviderLink(formData: FormData): Promise<void> {
+  const provider = String(formData.get('provider') ?? '')
+  if (!isLinkableProvider(provider)) {
+    throw new Error('Unsupported provider for linking')
+  }
+
+  const session = await auth()
+  if (!session?.speaker?._id) {
+    // Not signed in — cannot link. Send them through the normal sign-in flow.
+    await signIn(provider, { redirectTo: '/cfp/profile' })
+    return
+  }
+
+  const token = signLinkIntent({
+    speakerId: session.speaker._id,
+    provider,
+  })
+
+  const jar = await cookies()
+  jar.set(LINK_INTENT_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: LINK_INTENT_TTL_SECONDS,
+  })
+
+  // Kick off the second-provider OAuth round-trip. On return, the `jwt` callback
+  // detects the link-intent cookie and attaches the provider to this speaker.
+  await signIn(provider, { redirectTo: '/cfp/profile' })
+}

--- a/src/app/(cfp)/cfp/profile/page.tsx
+++ b/src/app/(cfp)/cfp/profile/page.tsx
@@ -5,9 +5,18 @@ import { redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { CFPProfilePage } from '@/components/cfp/CFPProfilePage'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { isLinkResult } from '@/lib/auth-link'
 
-export default async function ProfilePage() {
+export default async function ProfilePage(props: {
+  searchParams: Promise<{ linkResult?: string }>
+}) {
   await connection()
+
+  const { linkResult: linkResultParam } = await props.searchParams
+  const linkResult =
+    linkResultParam && isLinkResult(linkResultParam)
+      ? linkResultParam
+      : undefined
 
   const headersList = await headers()
   const fullUrl = headersList.get('x-url') || ''
@@ -35,6 +44,11 @@ export default async function ProfilePage() {
   const { conference } = await getConferenceForCurrentDomain()
 
   return (
-    <CFPProfilePage initialSpeaker={speaker} conferenceId={conference?._id} />
+    <CFPProfilePage
+      initialSpeaker={speaker}
+      conferenceId={conference?._id}
+      currentProvider={session.account?.provider}
+      linkResult={linkResult}
+    />
   )
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,2 +1,17 @@
+import type { NextRequest } from 'next/server'
 import { handlers } from '@/lib/auth'
-export const { GET, POST } = handlers
+import { linkResultStore } from '@/lib/auth-link'
+
+const { GET: rawGET, POST: rawPOST } = handlers
+
+// Run every auth request inside a fresh link-result store. During the Phase-2
+// "link another provider" callback, the `jwt` callback writes the outcome into
+// this store and the `redirect` callback reads it to append `?linkResult=...`
+// to the post-login URL. Isolating it per request keeps it concurrency-safe.
+export function GET(req: NextRequest): Promise<Response> {
+  return linkResultStore.run({}, () => rawGET(req))
+}
+
+export function POST(req: NextRequest): Promise<Response> {
+  return linkResultStore.run({}, () => rawPOST(req))
+}

--- a/src/components/cfp/CFPProfilePage.tsx
+++ b/src/components/cfp/CFPProfilePage.tsx
@@ -99,8 +99,8 @@ export function CFPProfilePage({
     [],
   )
 
-  const handleProfileSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleProfileSubmit = async (e?: React.SyntheticEvent) => {
+    e?.preventDefault()
     setSubmitError([])
     setSuccessMessage('')
 
@@ -161,7 +161,10 @@ export function CFPProfilePage({
       </div>
 
       <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-        <form onSubmit={handleProfileSubmit} className="space-y-8">
+        {/* Not a <form>: LinkedProviders renders its own <form action> per
+            provider, and nesting forms is invalid HTML that breaks both the
+            profile save and the link buttons. Submit via the button below. */}
+        <div className="space-y-8">
           {linkResult === 'linked' && (
             <div
               role="status"
@@ -287,7 +290,8 @@ export function CFPProfilePage({
 
           <div className="flex justify-end border-t border-gray-200 pt-6 dark:border-gray-600">
             <button
-              type="submit"
+              type="button"
+              onClick={handleProfileSubmit}
               disabled={updateProfileMutation.isPending}
               className="font-space-grotesk inline-flex items-center rounded-lg bg-brand-cloud-blue px-6 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-cloud-blue/90 focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-500 dark:focus:outline-blue-500"
             >
@@ -301,7 +305,7 @@ export function CFPProfilePage({
               )}
             </button>
           </div>
-        </form>
+        </div>
       </div>
     </div>
   )

--- a/src/components/cfp/CFPProfilePage.tsx
+++ b/src/components/cfp/CFPProfilePage.tsx
@@ -5,15 +5,47 @@ import { Speaker, SpeakerInput } from '@/lib/speaker/types'
 import { api } from '@/lib/trpc/client'
 import { SpeakerDetailsForm } from './SpeakerDetailsForm'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
-import { ExclamationCircleIcon } from '@heroicons/react/24/outline'
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline'
 import { useSpeakerImageUpload } from '@/hooks/useSpeakerImageUpload'
+import { LinkedProviders } from './LinkedProviders'
+import { startProviderLink } from '@/app/(cfp)/cfp/profile/link-actions'
+
+const PROVIDER_LABELS: Record<string, string> = {
+  github: 'GitHub',
+  linkedin: 'LinkedIn',
+}
+
+/** Human-readable list of the providers currently managing this profile. */
+function describeProviders(providers?: string[]): string {
+  const names = Array.from(
+    new Set(
+      (providers ?? [])
+        .map((entry) => PROVIDER_LABELS[entry.split(':')[0]])
+        .filter((name): name is string => Boolean(name)),
+    ),
+  )
+  if (names.length === 0) return 'Managed by your sign-in provider'
+  if (names.length === 1) return `Managed by ${names[0]}`
+  return `Managed by ${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
+}
 
 interface CFPProfilePageProps {
   initialSpeaker: Speaker
   conferenceId?: string
+  /** Provider the user is currently signed in with (`session.account.provider`). */
+  currentProvider?: string
+  /** Outcome of a just-completed provider link, from `?linkResult=`. */
+  linkResult?: string
 }
 
-export function CFPProfilePage({ initialSpeaker }: CFPProfilePageProps) {
+export function CFPProfilePage({
+  initialSpeaker,
+  currentProvider,
+  linkResult,
+}: CFPProfilePageProps) {
   const {
     data: profile,
     error: profileError,
@@ -130,6 +162,58 @@ export function CFPProfilePage({ initialSpeaker }: CFPProfilePageProps) {
 
       <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
         <form onSubmit={handleProfileSubmit} className="space-y-8">
+          {linkResult === 'linked' && (
+            <div
+              role="status"
+              className="rounded-lg bg-brand-fresh-green/10 p-4 ring-1 ring-brand-fresh-green/20 dark:bg-green-900/20 dark:ring-green-500/30"
+            >
+              <div className="flex items-center gap-2">
+                <CheckCircleIcon
+                  className="h-5 w-5 text-brand-fresh-green dark:text-green-400"
+                  aria-hidden="true"
+                />
+                <p className="font-inter text-sm font-medium text-brand-fresh-green dark:text-green-400">
+                  Sign-in method linked. You can now use it to reach this
+                  profile.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {linkResult === 'already-linked' && (
+            <div
+              role="alert"
+              className="rounded-lg bg-amber-50 p-4 ring-1 ring-amber-200 dark:bg-amber-900/20 dark:ring-amber-500/30"
+            >
+              <div className="flex">
+                <div className="shrink-0">
+                  <ExclamationCircleIcon
+                    className="h-5 w-5 text-amber-500 dark:text-amber-400"
+                    aria-hidden="true"
+                  />
+                </div>
+                <div className="ml-3">
+                  <p className="font-inter text-sm text-amber-800 dark:text-amber-200">
+                    That account is already linked to a different speaker
+                    profile. To combine the two profiles, please contact the
+                    organizers &mdash; we did not change either profile.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {linkResult === 'error' && (
+            <div
+              role="alert"
+              className="rounded-lg bg-red-50 p-4 ring-1 ring-red-200 dark:bg-red-900/20 dark:ring-red-500/30"
+            >
+              <p className="font-inter text-sm text-red-800 dark:text-red-200">
+                We couldn&apos;t link that sign-in method. Please try again.
+              </p>
+            </div>
+          )}
+
           {successMessage && (
             <div className="rounded-lg bg-brand-fresh-green/10 p-4 ring-1 ring-brand-fresh-green/20 dark:bg-green-900/20 dark:ring-green-500/30">
               <p className="font-inter text-sm font-medium text-brand-fresh-green dark:text-green-400">
@@ -176,9 +260,17 @@ export function CFPProfilePage({ initialSpeaker }: CFPProfilePageProps) {
                 readOnly
               />
               <span className="text-sm text-gray-500 dark:text-gray-400">
-                Managed by your OAuth provider
+                {describeProviders(speaker.providers)}
               </span>
             </div>
+          </div>
+
+          <div className="border-t border-gray-200 pt-6 dark:border-gray-600">
+            <LinkedProviders
+              providers={speaker.providers}
+              currentProvider={currentProvider}
+              onLinkAction={startProviderLink}
+            />
           </div>
 
           <SpeakerDetailsForm

--- a/src/components/cfp/LinkedProviders.stories.tsx
+++ b/src/components/cfp/LinkedProviders.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { LinkedProviders } from './LinkedProviders'
+
+const meta = {
+  title: 'Systems/CFP/LinkedProviders',
+  component: LinkedProviders,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Shows which OAuth providers are linked to a speaker profile (parsed from `speaker.providers[]`), highlights the provider the user is currently signed in with, and offers a "Link" action for providers that are not yet connected (identity Phase 2 self-service linking).',
+      },
+    },
+  },
+  args: {
+    onLinkAction: fn(),
+  },
+  argTypes: {
+    providers: {
+      control: 'object',
+      description: 'Raw `speaker.providers[]` entries, e.g. "github:123".',
+    },
+    currentProvider: {
+      control: 'select',
+      options: [undefined, 'github', 'linkedin'],
+      description: 'Provider the user is currently signed in with.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-md p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof LinkedProviders>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const OnlyGitHubLinked: Story = {
+  args: {
+    providers: ['github:1234567'],
+    currentProvider: 'github',
+  },
+}
+
+export const OnlyLinkedInLinked: Story = {
+  args: {
+    providers: ['linkedin:abcdef'],
+    currentProvider: 'linkedin',
+  },
+}
+
+export const BothProvidersLinked: Story = {
+  args: {
+    providers: ['github:1234567', 'linkedin:abcdef'],
+    currentProvider: 'github',
+  },
+}
+
+export const NoLinkHandler: Story = {
+  args: {
+    providers: ['github:1234567'],
+    currentProvider: 'github',
+    onLinkAction: undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Without an `onLinkAction` (e.g. rendered outside the profile page) the Link buttons render disabled.',
+      },
+    },
+  },
+}

--- a/src/components/cfp/LinkedProviders.tsx
+++ b/src/components/cfp/LinkedProviders.tsx
@@ -1,0 +1,111 @@
+import { CheckBadgeIcon, LinkIcon } from '@heroicons/react/24/outline'
+import { GitHubIcon, LinkedInIcon } from '@/components/SocialIcons'
+
+/**
+ * Providers we support linking. `key` matches the prefix stored in
+ * `speaker.providers[]` (e.g. `"github:<id>"`) and the NextAuth provider id.
+ */
+const SUPPORTED_PROVIDERS = [
+  { key: 'github', name: 'GitHub', Icon: GitHubIcon },
+  { key: 'linkedin', name: 'LinkedIn', Icon: LinkedInIcon },
+] as const
+
+export interface LinkedProvidersProps {
+  /** Raw `speaker.providers[]` entries, e.g. `["github:123", "linkedin:456"]`. */
+  providers?: string[]
+  /** The provider the user is CURRENTLY signed in with (`session.account.provider`). */
+  currentProvider?: string
+  /**
+   * Server Action that starts the "link another provider" OAuth round-trip. The
+   * form submits a hidden `provider` field. When omitted (e.g. in Storybook) the
+   * link buttons render disabled.
+   */
+  onLinkAction?: (formData: FormData) => void | Promise<void>
+}
+
+/**
+ * Shows which OAuth providers are linked to the speaker, highlights the one the
+ * user is currently signed in with, and offers a "Link" action for providers
+ * that are not yet connected (identity Phase 2).
+ */
+export function LinkedProviders({
+  providers,
+  currentProvider,
+  onLinkAction,
+}: LinkedProvidersProps) {
+  const linkedKeys = new Set(
+    (providers ?? [])
+      .map((entry) => entry.split(':')[0])
+      .filter((key): key is string => Boolean(key)),
+  )
+
+  return (
+    <section aria-labelledby="linked-providers-heading">
+      <h3
+        id="linked-providers-heading"
+        className="text-sm/6 font-medium text-gray-900 dark:text-white"
+      >
+        Sign-in methods
+      </h3>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        These accounts can sign in to your speaker profile. Linking another
+        provider lets you use it to reach the same profile.
+      </p>
+
+      <ul role="list" className="mt-3 space-y-3">
+        {SUPPORTED_PROVIDERS.map(({ key, name, Icon }) => {
+          const isLinked = linkedKeys.has(key)
+          const isCurrent = currentProvider === key
+
+          return (
+            <li
+              key={key}
+              className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800/60"
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <Icon
+                  className="h-6 w-6 shrink-0 text-gray-700 dark:text-gray-200"
+                  aria-hidden="true"
+                />
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                    {name}
+                  </p>
+                  {isLinked ? (
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {isCurrent ? 'Linked · current sign-in' : 'Linked'}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      Not linked
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {isLinked ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-brand-fresh-green/10 px-2.5 py-1 text-xs font-medium text-brand-fresh-green dark:bg-green-900/30 dark:text-green-400">
+                  <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
+                  Linked
+                </span>
+              ) : (
+                <form action={onLinkAction}>
+                  <input type="hidden" name="provider" value={key} />
+                  <button
+                    type="submit"
+                    disabled={!onLinkAction}
+                    aria-label={`Link your ${name} account`}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-brand-cloud-blue px-3 py-1.5 text-sm font-medium text-brand-cloud-blue transition-colors hover:bg-brand-cloud-blue/10 focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-400 dark:text-blue-400 dark:hover:bg-blue-400/10"
+                  >
+                    <LinkIcon className="h-4 w-4" aria-hidden="true" />
+                    Link {name}
+                  </button>
+                </form>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/providers/SessionProviderWrapper.tsx
+++ b/src/components/providers/SessionProviderWrapper.tsx
@@ -1,11 +1,18 @@
 import { SessionProvider } from 'next-auth/react'
+import type { Session } from 'next-auth'
 import { auth } from '@/lib/auth'
 
 async function SessionLoader({ children }: { children: React.ReactNode }) {
   const session = await auth()
 
-  // Sanitize session to only expose safe user data
-  // If session exists but has no user, treat it as no session
+  // Sanitize session to only expose safe data to the client.
+  // If session exists but has no user, treat it as no session.
+  //
+  // SECURITY: narrow `account` to just `{ provider }`. The full account carries
+  // the OAuth `access_token`/`refresh_token`; only the provider name is needed
+  // client-side (e.g. to highlight the current provider on the profile page).
+  // Server-side consumers that need the tokens read them via `auth()`, which is
+  // unaffected — this narrowing applies only to the client-serialized session.
   const sanitizedSession =
     session && session.user
       ? {
@@ -15,6 +22,14 @@ async function SessionLoader({ children }: { children: React.ReactNode }) {
             email: session.user.email,
             picture: session.user.picture,
           },
+          // Only the provider name is safe/needed client-side; drop the OAuth
+          // tokens. Cast is required because the client `Session` type still
+          // declares the full `Account` shape.
+          account: session.account
+            ? ({
+                provider: session.account.provider,
+              } as unknown as Session['account'])
+            : undefined,
         }
       : null
 

--- a/src/lib/auth-link.test.ts
+++ b/src/lib/auth-link.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  LINK_INTENT_TTL_SECONDS,
+  signLinkIntent,
+  verifyLinkIntent,
+} from './auth-link'
+
+const SECRET = 'test-secret-value'
+const OTHER_SECRET = 'a-different-secret'
+
+describe('link-intent token', () => {
+  it('round-trips a valid token bound to the speaker + provider', () => {
+    const token = signLinkIntent(
+      { speakerId: 'spk-1', provider: 'github' },
+      SECRET,
+    )
+    expect(verifyLinkIntent(token, 'github', SECRET)).toEqual({
+      speakerId: 'spk-1',
+      provider: 'github',
+    })
+  })
+
+  it('rejects a token verified against a different provider', () => {
+    // The cookie is bound to github; a linkedin callback must not honour it.
+    const token = signLinkIntent(
+      { speakerId: 'spk-1', provider: 'github' },
+      SECRET,
+    )
+    expect(verifyLinkIntent(token, 'linkedin', SECRET)).toBeNull()
+  })
+
+  it('rejects a forged token signed with the wrong secret', () => {
+    const forged = signLinkIntent(
+      { speakerId: 'attacker', provider: 'github' },
+      OTHER_SECRET,
+    )
+    expect(verifyLinkIntent(forged, 'github', SECRET)).toBeNull()
+  })
+
+  it('rejects a token whose payload was tampered with', () => {
+    const token = signLinkIntent(
+      { speakerId: 'spk-1', provider: 'github' },
+      SECRET,
+    )
+    const [, sig] = token.split('.')
+    // Swap the payload for one that claims a different speaker, keep the MAC.
+    const tamperedPayload = Buffer.from(
+      JSON.stringify({
+        speakerId: 'victim',
+        provider: 'github',
+        exp: Math.floor(Date.now() / 1000) + 300,
+        nonce: 'x',
+      }),
+    ).toString('base64url')
+    expect(
+      verifyLinkIntent(`${tamperedPayload}.${sig}`, 'github', SECRET),
+    ).toBeNull()
+  })
+
+  it('rejects a token whose signature was tampered with', () => {
+    const token = signLinkIntent(
+      { speakerId: 'spk-1', provider: 'github' },
+      SECRET,
+    )
+    const [payload] = token.split('.')
+    expect(verifyLinkIntent(`${payload}.deadbeef`, 'github', SECRET)).toBeNull()
+  })
+
+  it('rejects an expired token (no replay after the TTL window)', () => {
+    const mintedAt = 1_000_000_000_000 // fixed epoch ms
+    const token = signLinkIntent(
+      { speakerId: 'spk-1', provider: 'github' },
+      SECRET,
+      mintedAt,
+    )
+    const afterExpiry = mintedAt + (LINK_INTENT_TTL_SECONDS + 1) * 1000
+    expect(verifyLinkIntent(token, 'github', SECRET, afterExpiry)).toBeNull()
+    // still valid just inside the window
+    expect(
+      verifyLinkIntent(token, 'github', SECRET, mintedAt + 1000),
+    ).not.toBeNull()
+  })
+
+  it('rejects empty / malformed tokens and a missing secret', () => {
+    expect(verifyLinkIntent(undefined, 'github', SECRET)).toBeNull()
+    expect(verifyLinkIntent('', 'github', SECRET)).toBeNull()
+    expect(verifyLinkIntent('no-dot-here', 'github', SECRET)).toBeNull()
+    expect(verifyLinkIntent('.', 'github', SECRET)).toBeNull()
+    const token = signLinkIntent(
+      { speakerId: 'spk-1', provider: 'github' },
+      SECRET,
+    )
+    expect(verifyLinkIntent(token, 'github', undefined)).toBeNull()
+  })
+
+  it('throws when minting without a configured secret (fail closed)', () => {
+    expect(() =>
+      signLinkIntent({ speakerId: 'spk-1', provider: 'github' }, undefined),
+    ).toThrow(/AUTH_SECRET/)
+  })
+})

--- a/src/lib/auth-link.test.ts
+++ b/src/lib/auth-link.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { createHmac } from 'node:crypto'
 import {
   LINK_INTENT_TTL_SECONDS,
   signLinkIntent,
@@ -9,21 +10,22 @@ const SECRET = 'test-secret-value'
 const OTHER_SECRET = 'a-different-secret'
 
 describe('link-intent token', () => {
-  it('round-trips a valid token bound to the speaker + provider', () => {
+  it('round-trips a valid token bound to the speaker + provider + session', () => {
     const token = signLinkIntent(
-      { speakerId: 'spk-1', provider: 'github' },
+      { speakerId: 'spk-1', provider: 'github', initiatorSub: 'sess-1' },
       SECRET,
     )
     expect(verifyLinkIntent(token, 'github', SECRET)).toEqual({
       speakerId: 'spk-1',
       provider: 'github',
+      initiatorSub: 'sess-1',
     })
   })
 
   it('rejects a token verified against a different provider', () => {
     // The cookie is bound to github; a linkedin callback must not honour it.
     const token = signLinkIntent(
-      { speakerId: 'spk-1', provider: 'github' },
+      { speakerId: 'spk-1', provider: 'github', initiatorSub: 'sess-1' },
       SECRET,
     )
     expect(verifyLinkIntent(token, 'linkedin', SECRET)).toBeNull()
@@ -31,7 +33,7 @@ describe('link-intent token', () => {
 
   it('rejects a forged token signed with the wrong secret', () => {
     const forged = signLinkIntent(
-      { speakerId: 'attacker', provider: 'github' },
+      { speakerId: 'attacker', provider: 'github', initiatorSub: 'sess-1' },
       OTHER_SECRET,
     )
     expect(verifyLinkIntent(forged, 'github', SECRET)).toBeNull()
@@ -39,7 +41,7 @@ describe('link-intent token', () => {
 
   it('rejects a token whose payload was tampered with', () => {
     const token = signLinkIntent(
-      { speakerId: 'spk-1', provider: 'github' },
+      { speakerId: 'spk-1', provider: 'github', initiatorSub: 'sess-1' },
       SECRET,
     )
     const [, sig] = token.split('.')
@@ -48,6 +50,7 @@ describe('link-intent token', () => {
       JSON.stringify({
         speakerId: 'victim',
         provider: 'github',
+        initiatorSub: 'sess-1',
         exp: Math.floor(Date.now() / 1000) + 300,
         nonce: 'x',
       }),
@@ -59,17 +62,36 @@ describe('link-intent token', () => {
 
   it('rejects a token whose signature was tampered with', () => {
     const token = signLinkIntent(
-      { speakerId: 'spk-1', provider: 'github' },
+      { speakerId: 'spk-1', provider: 'github', initiatorSub: 'sess-1' },
       SECRET,
     )
     const [payload] = token.split('.')
     expect(verifyLinkIntent(`${payload}.deadbeef`, 'github', SECRET)).toBeNull()
   })
 
+  it('rejects an authentic token that is missing the initiator binding', () => {
+    // A well-signed token without `initiatorSub` (e.g. a pre-fix token) must be
+    // rejected so the session binding cannot be bypassed by omission.
+    const payloadB64 = Buffer.from(
+      JSON.stringify({
+        speakerId: 'spk-1',
+        provider: 'github',
+        exp: Math.floor(Date.now() / 1000) + 300,
+        nonce: 'x',
+      }),
+    ).toString('base64url')
+    const sig = createHmac('sha256', SECRET)
+      .update(payloadB64)
+      .digest('base64url')
+    expect(
+      verifyLinkIntent(`${payloadB64}.${sig}`, 'github', SECRET),
+    ).toBeNull()
+  })
+
   it('rejects an expired token (no replay after the TTL window)', () => {
     const mintedAt = 1_000_000_000_000 // fixed epoch ms
     const token = signLinkIntent(
-      { speakerId: 'spk-1', provider: 'github' },
+      { speakerId: 'spk-1', provider: 'github', initiatorSub: 'sess-1' },
       SECRET,
       mintedAt,
     )
@@ -81,13 +103,17 @@ describe('link-intent token', () => {
     ).not.toBeNull()
   })
 
+  it('uses a short TTL (<= 2 minutes) to shrink the shared-browser race', () => {
+    expect(LINK_INTENT_TTL_SECONDS).toBeLessThanOrEqual(120)
+  })
+
   it('rejects empty / malformed tokens and a missing secret', () => {
     expect(verifyLinkIntent(undefined, 'github', SECRET)).toBeNull()
     expect(verifyLinkIntent('', 'github', SECRET)).toBeNull()
     expect(verifyLinkIntent('no-dot-here', 'github', SECRET)).toBeNull()
     expect(verifyLinkIntent('.', 'github', SECRET)).toBeNull()
     const token = signLinkIntent(
-      { speakerId: 'spk-1', provider: 'github' },
+      { speakerId: 'spk-1', provider: 'github', initiatorSub: 'sess-1' },
       SECRET,
     )
     expect(verifyLinkIntent(token, 'github', undefined)).toBeNull()
@@ -95,7 +121,19 @@ describe('link-intent token', () => {
 
   it('throws when minting without a configured secret (fail closed)', () => {
     expect(() =>
-      signLinkIntent({ speakerId: 'spk-1', provider: 'github' }, undefined),
+      signLinkIntent(
+        { speakerId: 'spk-1', provider: 'github', initiatorSub: 'sess-1' },
+        undefined,
+      ),
     ).toThrow(/AUTH_SECRET/)
+  })
+
+  it('throws when minting without an initiating session (fail closed)', () => {
+    expect(() =>
+      signLinkIntent(
+        { speakerId: 'spk-1', provider: 'github', initiatorSub: '' },
+        SECRET,
+      ),
+    ).toThrow(/initiating session/)
   })
 })

--- a/src/lib/auth-link.ts
+++ b/src/lib/auth-link.ts
@@ -1,0 +1,154 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+
+/**
+ * Self-service "link another provider" support (identity Phase 2).
+ *
+ * The problem this solves: a speaker who first signed in with GitHub and then
+ * authenticates with LinkedIn (whose verified email does not match) would, on
+ * the normal login path, get a brand-new duplicate speaker. Link mode lets an
+ * already-signed-in speaker X deliberately attach a second provider to their
+ * EXISTING document.
+ *
+ * SECURITY MODEL — the link-intent token:
+ *  - It is minted only by an authenticated server entry point that has already
+ *    resolved the caller's session (see `/api/auth/link`). At mint time we know
+ *    the caller is speaker X, so the token binds `speakerId = X`.
+ *  - It is integrity-protected with an HMAC over the payload keyed by
+ *    `AUTH_SECRET`. A client cannot forge or tamper with it (no valid MAC).
+ *  - It is delivered as an httpOnly, Secure, SameSite=Lax cookie, so hostile
+ *    JavaScript cannot read it and it is not attachable cross-site.
+ *  - It carries a short expiry (5 min) and a random nonce. Because it is bound
+ *    to X and only ever present in X's own httpOnly cookie, it cannot be
+ *    replayed to attach a provider to a *different* speaker: an attacker can
+ *    neither forge it (no key) nor exfiltrate X's cookie (httpOnly). Replay in
+ *    X's own browser only re-links the same provider to X, which is idempotent.
+ *  - The token is bound to a specific target provider; the OAuth callback only
+ *    honours it when the provider just authenticated matches the bound one.
+ *
+ * The ownership proof for the link itself is the second OAuth round-trip: to
+ * attach `linkedin:<id>` to X you must actually authenticate with that LinkedIn
+ * account, which proves you control it.
+ */
+
+export const LINK_INTENT_COOKIE = 'cndn.link-intent'
+export const LINK_RESULT_PARAM = 'linkResult'
+export const LINK_INTENT_TTL_SECONDS = 5 * 60 // 5 minutes
+
+export const LINKABLE_PROVIDERS = ['github', 'linkedin'] as const
+export type LinkableProvider = (typeof LINKABLE_PROVIDERS)[number]
+
+export function isLinkableProvider(value: string): value is LinkableProvider {
+  return (LINKABLE_PROVIDERS as readonly string[]).includes(value)
+}
+
+/**
+ * Outcome surfaced back to the profile UI after a link round-trip.
+ * - `linked`: the second provider was attached to the existing speaker.
+ * - `already-linked`: the provider account already belongs to a DIFFERENT
+ *   speaker; we did not merge — the user must contact the organizers.
+ * - `error`: an unexpected failure while linking.
+ */
+export type LinkResult = 'linked' | 'already-linked' | 'error'
+
+export function isLinkResult(value: string): value is LinkResult {
+  return value === 'linked' || value === 'already-linked' || value === 'error'
+}
+
+/**
+ * Request-scoped carrier for the link outcome. The NextAuth route handler runs
+ * the whole OAuth callback inside `linkResultStore.run({}, ...)`; the `jwt`
+ * callback writes the outcome into the store and the `redirect` callback reads
+ * it to append `?linkResult=...` to the post-login URL. Using AsyncLocalStorage
+ * (rather than a module global) keeps this safe under concurrent requests.
+ */
+export const linkResultStore = new AsyncLocalStorage<{ result?: LinkResult }>()
+
+interface LinkIntentPayload {
+  speakerId: string
+  provider: LinkableProvider
+  exp: number // epoch seconds
+  nonce: string
+}
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url')
+}
+
+function hmac(payloadB64: string, secret: string): string {
+  return createHmac('sha256', secret).update(payloadB64).digest('base64url')
+}
+
+/**
+ * Mint a signed, short-lived link-intent token binding the initiating speaker to
+ * a target provider. Throws if `AUTH_SECRET` is not configured (fail closed).
+ */
+export function signLinkIntent(
+  input: { speakerId: string; provider: LinkableProvider },
+  secret: string | undefined = process.env.AUTH_SECRET,
+  now: number = Date.now(),
+): string {
+  if (!secret) {
+    throw new Error('AUTH_SECRET is not configured; cannot mint link intent')
+  }
+  if (!input.speakerId) {
+    throw new Error('Cannot mint link intent without a speaker id')
+  }
+  const payload: LinkIntentPayload = {
+    speakerId: input.speakerId,
+    provider: input.provider,
+    exp: Math.floor(now / 1000) + LINK_INTENT_TTL_SECONDS,
+    nonce: base64url(randomBytes(12)),
+  }
+  const payloadB64 = base64url(JSON.stringify(payload))
+  return `${payloadB64}.${hmac(payloadB64, secret)}`
+}
+
+/**
+ * Verify a link-intent token for a given just-authenticated provider. Returns
+ * the bound `{ speakerId, provider }` when the token is authentic, unexpired and
+ * bound to `expectedProvider`; otherwise `null` (forged, tampered, expired,
+ * wrong provider, or malformed — all rejected the same way).
+ */
+export function verifyLinkIntent(
+  token: string | undefined | null,
+  expectedProvider: string,
+  secret: string | undefined = process.env.AUTH_SECRET,
+  now: number = Date.now(),
+): { speakerId: string; provider: LinkableProvider } | null {
+  if (!token || !secret) return null
+
+  const dot = token.indexOf('.')
+  if (dot <= 0 || dot === token.length - 1) return null
+  const payloadB64 = token.slice(0, dot)
+  const providedSig = token.slice(dot + 1)
+
+  const expectedSig = hmac(payloadB64, secret)
+  const a = Buffer.from(providedSig)
+  const b = Buffer.from(expectedSig)
+  // Constant-time comparison; length mismatch is an immediate reject.
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null
+
+  let payload: LinkIntentPayload
+  try {
+    payload = JSON.parse(
+      Buffer.from(payloadB64, 'base64url').toString('utf8'),
+    ) as LinkIntentPayload
+  } catch {
+    return null
+  }
+
+  if (!payload || typeof payload.speakerId !== 'string' || !payload.speakerId) {
+    return null
+  }
+  if (
+    typeof payload.provider !== 'string' ||
+    !isLinkableProvider(payload.provider)
+  ) {
+    return null
+  }
+  if (payload.provider !== expectedProvider) return null
+  if (typeof payload.exp !== 'number' || payload.exp * 1000 < now) return null
+
+  return { speakerId: payload.speakerId, provider: payload.provider }
+}

--- a/src/lib/auth-link.ts
+++ b/src/lib/auth-link.ts
@@ -18,13 +18,18 @@ import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
  *    `AUTH_SECRET`. A client cannot forge or tamper with it (no valid MAC).
  *  - It is delivered as an httpOnly, Secure, SameSite=Lax cookie, so hostile
  *    JavaScript cannot read it and it is not attachable cross-site.
- *  - It carries a short expiry (5 min) and a random nonce. Because it is bound
+ *  - It carries a short expiry (120s) and a random nonce. Because it is bound
  *    to X and only ever present in X's own httpOnly cookie, it cannot be
  *    replayed to attach a provider to a *different* speaker: an attacker can
  *    neither forge it (no key) nor exfiltrate X's cookie (httpOnly). Replay in
  *    X's own browser only re-links the same provider to X, which is idempotent.
  *  - The token is bound to a specific target provider; the OAuth callback only
  *    honours it when the provider just authenticated matches the bound one.
+ *  - It is bound to the INITIATING session: the payload carries the initiating
+ *    session's stable `sub`. At consumption the callback requires the browser's
+ *    pre-existing session to still be speaker X (see `@/lib/auth.ts`). Combined
+ *    with single-use deletion and the short TTL this closes the account-takeover
+ *    where a lingering intent is consumed by a *different* person's sign-in.
  *
  * The ownership proof for the link itself is the second OAuth round-trip: to
  * attach `linkedin:<id>` to X you must actually authenticate with that LinkedIn
@@ -33,7 +38,9 @@ import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
 
 export const LINK_INTENT_COOKIE = 'cndn.link-intent'
 export const LINK_RESULT_PARAM = 'linkResult'
-export const LINK_INTENT_TTL_SECONDS = 5 * 60 // 5 minutes
+// Deliberately short: the intent only needs to survive one OAuth round-trip.
+// A tighter window shrinks the residual shared-browser race (see auth.ts).
+export const LINK_INTENT_TTL_SECONDS = 120 // 2 minutes
 
 export const LINKABLE_PROVIDERS = ['github', 'linkedin'] as const
 export type LinkableProvider = (typeof LINKABLE_PROVIDERS)[number]
@@ -67,6 +74,10 @@ export const linkResultStore = new AsyncLocalStorage<{ result?: LinkResult }>()
 interface LinkIntentPayload {
   speakerId: string
   provider: LinkableProvider
+  // Stable identifier of the session that initiated the link (its JWT `sub`).
+  // Consumption requires the browser's pre-existing session to still match this
+  // AND `speakerId`, binding the intent to the initiating session.
+  initiatorSub: string
   exp: number // epoch seconds
   nonce: string
 }
@@ -84,7 +95,11 @@ function hmac(payloadB64: string, secret: string): string {
  * a target provider. Throws if `AUTH_SECRET` is not configured (fail closed).
  */
 export function signLinkIntent(
-  input: { speakerId: string; provider: LinkableProvider },
+  input: {
+    speakerId: string
+    provider: LinkableProvider
+    initiatorSub: string
+  },
   secret: string | undefined = process.env.AUTH_SECRET,
   now: number = Date.now(),
 ): string {
@@ -94,9 +109,13 @@ export function signLinkIntent(
   if (!input.speakerId) {
     throw new Error('Cannot mint link intent without a speaker id')
   }
+  if (!input.initiatorSub) {
+    throw new Error('Cannot mint link intent without an initiating session')
+  }
   const payload: LinkIntentPayload = {
     speakerId: input.speakerId,
     provider: input.provider,
+    initiatorSub: input.initiatorSub,
     exp: Math.floor(now / 1000) + LINK_INTENT_TTL_SECONDS,
     nonce: base64url(randomBytes(12)),
   }
@@ -115,7 +134,11 @@ export function verifyLinkIntent(
   expectedProvider: string,
   secret: string | undefined = process.env.AUTH_SECRET,
   now: number = Date.now(),
-): { speakerId: string; provider: LinkableProvider } | null {
+): {
+  speakerId: string
+  provider: LinkableProvider
+  initiatorSub: string
+} | null {
   if (!token || !secret) return null
 
   const dot = token.indexOf('.')
@@ -147,8 +170,15 @@ export function verifyLinkIntent(
   ) {
     return null
   }
+  if (typeof payload.initiatorSub !== 'string' || !payload.initiatorSub) {
+    return null
+  }
   if (payload.provider !== expectedProvider) return null
   if (typeof payload.exp !== 'number' || payload.exp * 1000 < now) return null
 
-  return { speakerId: payload.speakerId, provider: payload.provider }
+  return {
+    speakerId: payload.speakerId,
+    provider: payload.provider,
+    initiatorSub: payload.initiatorSub,
+  }
 }

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { JWT } from 'next-auth/jwt'
+import type { Account } from 'next-auth'
+
+// AUTH_SECRET must be present: the real auth-link crypto and the prior-session
+// decode both require it.
+process.env.AUTH_SECRET = 'auth-callback-test-secret'
+
+// --- Mocks -----------------------------------------------------------------
+
+// In-memory cookie jar shared with the module under test via next/headers.
+type Jar = {
+  store: Map<string, string>
+  get: (name: string) => { value: string } | undefined
+  set: (name: string, value: string) => void
+  delete: ReturnType<typeof vi.fn>
+}
+
+function createJar(initial: Record<string, string> = {}): Jar {
+  const store = new Map(Object.entries(initial))
+  const del = vi.fn((name: string) => {
+    store.delete(name)
+  })
+  return {
+    store,
+    get: (name: string) => {
+      const value = store.get(name)
+      return value === undefined ? undefined : { value }
+    },
+    set: (name: string, value: string) => {
+      store.set(name, value)
+    },
+    delete: del,
+  }
+}
+
+let currentJar: Jar = createJar()
+
+vi.mock('next/headers', () => ({
+  cookies: () => Promise.resolve(currentJar),
+}))
+
+// Control the pre-existing session decode.
+const decodeMap = new Map<string, unknown>()
+vi.mock('next-auth/jwt', () => ({
+  decode: vi.fn(async ({ token }: { token: string }) =>
+    decodeMap.has(token) ? decodeMap.get(token) : null,
+  ),
+}))
+
+// Speaker resolution boundary.
+const attachProviderToSpeaker = vi.fn()
+const getOrCreateSpeaker = vi.fn()
+const getSpeaker = vi.fn()
+vi.mock('@/lib/speaker/sanity', () => ({
+  attachProviderToSpeaker: (...args: unknown[]) =>
+    attachProviderToSpeaker(...args),
+  getOrCreateSpeaker: (...args: unknown[]) => getOrCreateSpeaker(...args),
+  getSpeaker: (...args: unknown[]) => getSpeaker(...args),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  speakerImageUrl: (src: string) => `img:${src}`,
+}))
+
+import { jwtSignInCallback, signOutHandler } from './auth'
+import { signLinkIntent, LINK_INTENT_COOKIE } from './auth-link'
+
+const SESSION_COOKIE = 'authjs.session-token'
+const GITHUB: Account = {
+  provider: 'github',
+  providerAccountId: 'gh-999',
+  type: 'oidc',
+  access_token: 'tok',
+}
+
+function freshSignInToken(over: Partial<JWT> = {}): JWT {
+  return {
+    sub: 'new-random-sub',
+    email: 'y@example.com',
+    name: 'Y User',
+    picture: undefined,
+    ...over,
+  } as JWT
+}
+
+/** A pre-existing session token for the given speaker + session id. */
+function priorSession(speakerId: string, sub: string) {
+  return {
+    sub,
+    speaker: { _id: speakerId, name: 'X', email: 'x@example.com' },
+    account: { provider: 'github', providerAccountId: 'x-gh', type: 'oidc' },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  decodeMap.clear()
+  currentJar = createJar()
+})
+
+describe('jwtSignInCallback — Phase 2 link consumption security', () => {
+  it('links to the initiating speaker when the browser is still that speaker', async () => {
+    // X is signed in (prior session = X) and started a github link.
+    const intent = signLinkIntent({
+      speakerId: 'spk-X',
+      provider: 'github',
+      initiatorSub: 'sess-X',
+    })
+    currentJar = createJar({
+      [LINK_INTENT_COOKIE]: intent,
+      [SESSION_COOKIE]: 'PRIOR_X',
+    })
+    decodeMap.set('PRIOR_X', priorSession('spk-X', 'sess-X'))
+    attachProviderToSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-X', name: 'X', email: 'x@example.com' },
+      status: 'linked',
+      err: null,
+    })
+
+    const token = await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+
+    expect(attachProviderToSpeaker).toHaveBeenCalledTimes(1)
+    expect(attachProviderToSpeaker.mock.calls[0][0]).toBe('spk-X')
+    expect(getOrCreateSpeaker).not.toHaveBeenCalled()
+    expect((token as JWT & { speaker?: { _id: string } }).speaker?._id).toBe(
+      'spk-X',
+    )
+    // Single-use: the intent cookie is deleted on consumption.
+    expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
+  })
+
+  it('is single-use: a second sign-in with the same jar does NOT attach again', async () => {
+    const intent = signLinkIntent({
+      speakerId: 'spk-X',
+      provider: 'github',
+      initiatorSub: 'sess-X',
+    })
+    currentJar = createJar({
+      [LINK_INTENT_COOKIE]: intent,
+      [SESSION_COOKIE]: 'PRIOR_X',
+    })
+    decodeMap.set('PRIOR_X', priorSession('spk-X', 'sess-X'))
+    attachProviderToSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-X', name: 'X', email: 'x@example.com' },
+      status: 'linked',
+      err: null,
+    })
+    getOrCreateSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-Y', name: 'Y', email: 'y@example.com' },
+      err: null,
+    })
+
+    // First sign-in consumes and deletes the intent.
+    await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+    expect(attachProviderToSpeaker).toHaveBeenCalledTimes(1)
+
+    // Second sign-in on the SAME browser: cookie is gone → normal sign-in.
+    const token2 = await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+    expect(attachProviderToSpeaker).toHaveBeenCalledTimes(1) // not called again
+    expect(getOrCreateSpeaker).toHaveBeenCalledTimes(1)
+    expect((token2 as JWT & { speaker?: { _id: string } }).speaker?._id).toBe(
+      'spk-Y',
+    )
+  })
+
+  it('does NOT honour the intent when a DIFFERENT user completes the sign-in (the takeover)', async () => {
+    // X abandoned a github link (intent lingers). Y signs in with github on the
+    // same browser while the session still belongs to Y (different speaker).
+    const intent = signLinkIntent({
+      speakerId: 'spk-X',
+      provider: 'github',
+      initiatorSub: 'sess-X',
+    })
+    currentJar = createJar({
+      [LINK_INTENT_COOKIE]: intent,
+      [SESSION_COOKIE]: 'PRIOR_Y',
+    })
+    decodeMap.set('PRIOR_Y', priorSession('spk-Y', 'sess-Y'))
+    getOrCreateSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-Y', name: 'Y', email: 'y@example.com' },
+      err: null,
+    })
+
+    const token = await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+
+    // The lingering intent is NOT consumed onto X.
+    expect(attachProviderToSpeaker).not.toHaveBeenCalled()
+    // Y gets their own normal session.
+    expect(getOrCreateSpeaker).toHaveBeenCalledTimes(1)
+    expect((token as JWT & { speaker?: { _id: string } }).speaker?._id).toBe(
+      'spk-Y',
+    )
+    // The lingering intent is still cleared (single-use), so it cannot linger.
+    expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
+  })
+
+  it('does NOT honour the intent when there is NO active session', async () => {
+    const intent = signLinkIntent({
+      speakerId: 'spk-X',
+      provider: 'github',
+      initiatorSub: 'sess-X',
+    })
+    currentJar = createJar({ [LINK_INTENT_COOKIE]: intent }) // no session cookie
+    getOrCreateSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-Z', name: 'Z', email: 'z@example.com' },
+      err: null,
+    })
+
+    await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+
+    expect(attachProviderToSpeaker).not.toHaveBeenCalled()
+    expect(getOrCreateSpeaker).toHaveBeenCalledTimes(1)
+    expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
+  })
+
+  it('binds to the SPECIFIC initiating session: same speaker, different session sub is rejected', async () => {
+    // Same speaker X but the browser session's `sub` no longer matches the one
+    // captured at mint time — fail closed to a normal sign-in.
+    const intent = signLinkIntent({
+      speakerId: 'spk-X',
+      provider: 'github',
+      initiatorSub: 'sess-X',
+    })
+    currentJar = createJar({
+      [LINK_INTENT_COOKIE]: intent,
+      [SESSION_COOKIE]: 'PRIOR_X2',
+    })
+    decodeMap.set('PRIOR_X2', priorSession('spk-X', 'sess-OTHER'))
+    getOrCreateSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-X', name: 'X', email: 'x@example.com' },
+      err: null,
+    })
+
+    await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+
+    expect(attachProviderToSpeaker).not.toHaveBeenCalled()
+    expect(getOrCreateSpeaker).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not attempt a link when there is no intent cookie at all', async () => {
+    currentJar = createJar({ [SESSION_COOKIE]: 'PRIOR_X' })
+    decodeMap.set('PRIOR_X', priorSession('spk-X', 'sess-X'))
+    getOrCreateSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-X', name: 'X', email: 'x@example.com' },
+      err: null,
+    })
+
+    await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+
+    expect(attachProviderToSpeaker).not.toHaveBeenCalled()
+    expect(getOrCreateSpeaker).toHaveBeenCalledTimes(1)
+    expect(currentJar.delete).not.toHaveBeenCalled()
+  })
+
+  it('clears the intent even when the provider account is already linked elsewhere', async () => {
+    const intent = signLinkIntent({
+      speakerId: 'spk-X',
+      provider: 'github',
+      initiatorSub: 'sess-X',
+    })
+    currentJar = createJar({
+      [LINK_INTENT_COOKIE]: intent,
+      [SESSION_COOKIE]: 'PRIOR_X',
+    })
+    decodeMap.set('PRIOR_X', priorSession('spk-X', 'sess-X'))
+    attachProviderToSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-Z' },
+      status: 'already-linked-elsewhere',
+      err: null,
+    })
+    getSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-X', name: 'X', email: 'x@example.com' },
+      err: null,
+    })
+
+    const token = await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+
+    // Not merged: the session stays X, and the intent is single-use deleted.
+    expect((token as JWT & { speaker?: { _id: string } }).speaker?._id).toBe(
+      'spk-X',
+    )
+    expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
+  })
+})
+
+describe('signOutHandler — clears link-flow state', () => {
+  it('deletes the link-intent cookie on sign-out', async () => {
+    currentJar = createJar({ [LINK_INTENT_COOKIE]: 'anything' })
+
+    await signOutHandler()
+
+    expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
+  })
+})

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -314,6 +314,42 @@ describe('jwtSignInCallback — Phase 2 link consumption security', () => {
     )
     expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
   })
+
+  it('fails closed to the prior session when the initiating speaker cannot be loaded (never adopts the conflicting speaker)', async () => {
+    const intent = signLinkIntent({
+      speakerId: 'spk-X',
+      provider: 'github',
+      initiatorSub: 'sess-X',
+    })
+    currentJar = createJar({
+      [LINK_INTENT_COOKIE]: intent,
+      [SESSION_COOKIE]: 'PRIOR_X',
+    })
+    decodeMap.set('PRIOR_X', priorSession('spk-X', 'sess-X'))
+    attachProviderToSpeaker.mockResolvedValue({
+      speaker: { _id: 'spk-Z' },
+      status: 'already-linked-elsewhere',
+      err: null,
+    })
+    // X's document can no longer be loaded (deleted between mint and consume).
+    getSpeaker.mockResolvedValue({ speaker: {}, err: null })
+
+    const token = await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })
+
+    // Session is restored to X (the prior session) — NEVER switched to spk-Z —
+    // and the intent cookie is single-use deleted.
+    expect((token as JWT & { speaker?: { _id: string } }).speaker?._id).toBe(
+      'spk-X',
+    )
+    expect(
+      (token as JWT & { speaker?: { _id: string } }).speaker?._id,
+    ).not.toBe('spk-Z')
+    expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
+  })
 })
 
 describe('signOutHandler — clears link-flow state', () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -239,6 +239,20 @@ export async function jwtSignInCallback({
           applySpeakerToToken(token, originX, priorAccount)
           return token
         }
+        // X's document could not be loaded (deleted/not found between mint and
+        // consumption). FAIL CLOSED: never fall through to the normal login path,
+        // which would adopt the conflicting speaker Z's identity. Restore the
+        // validated prior session (X); if there is none, keep the fresh token but
+        // do not run getOrCreateSpeaker.
+        if (prior) {
+          return prior
+        }
+        if (resultStore) resultStore.result = 'error'
+        console.error(
+          'Provider link already-linked-elsewhere but initiating speaker not found; keeping current session',
+          { speakerId: intent.speakerId },
+        )
+        return token
       }
 
       // Unexpected link failure — surface it and fall through to the normal

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,15 +1,46 @@
 import NextAuth from 'next-auth'
 import GitHub from 'next-auth/providers/github'
 import LinkedIn from 'next-auth/providers/linkedin'
-import type { NextAuthConfig, Session, User } from 'next-auth'
+import type { Account, NextAuthConfig, Session, User } from 'next-auth'
 import { decode } from 'next-auth/jwt'
 import { NextRequest } from 'next/server'
 import { getOrCreateSpeaker } from '@/lib/speaker/sanity'
 import { speakerImageUrl } from '@/lib/sanity/client'
 import { AppEnvironment } from '@/lib/environment/config'
+import type { Speaker } from '@/lib/speaker/types'
+import type { JWT } from 'next-auth/jwt'
 
 export interface NextAuthRequest extends NextRequest {
   auth: Session | null
+}
+
+/**
+ * Write a resolved speaker (and the account just authenticated with) onto the
+ * JWT. Shared by the normal login path and the Phase-2 link path so both mint an
+ * identical token shape.
+ */
+function applySpeakerToToken(
+  token: JWT,
+  speaker: Speaker,
+  account: Account,
+): void {
+  if (speaker.image && typeof speaker.image === 'string') {
+    token.picture = speakerImageUrl(speaker.image, {
+      width: 192,
+      height: 192,
+      fit: 'crop',
+    })
+  }
+
+  token.account = account
+  token.speaker = {
+    _id: speaker._id,
+    name: speaker.name,
+    email: speaker.email,
+    image: speaker.image,
+    isOrganizer: speaker.isOrganizer,
+    flags: speaker.flags,
+  }
 }
 
 const config = {
@@ -74,6 +105,71 @@ const config = {
           name: token.name,
           image: token.picture,
         }
+
+        // --- Phase 2: self-service "link another provider" -----------------
+        // If this sign-in carries a valid, integrity-protected link-intent
+        // cookie (minted only for an already-authenticated speaker X, bound to
+        // this provider), attach the just-authenticated account to the EXISTING
+        // speaker X instead of creating/switching to another document.
+        //
+        // `@/lib/auth-link` is imported dynamically so its Node-only crypto does
+        // not enter the edge middleware bundle that statically imports this file.
+        const { LINK_INTENT_COOKIE, verifyLinkIntent, linkResultStore } =
+          await import('@/lib/auth-link')
+        const { cookies } = await import('next/headers')
+        const linkToken = (await cookies()).get(LINK_INTENT_COOKIE)?.value
+        const intent = verifyLinkIntent(linkToken, account.provider)
+
+        if (intent) {
+          const { attachProviderToSpeaker, getSpeaker } =
+            await import('@/lib/speaker/sanity')
+          const resultStore = linkResultStore.getStore()
+
+          const {
+            speaker: linked,
+            status,
+            err: linkErr,
+          } = await attachProviderToSpeaker(
+            intent.speakerId,
+            user,
+            account,
+            profile,
+          )
+
+          if (!linkErr && status === 'linked') {
+            if (resultStore) resultStore.result = 'linked'
+            applySpeakerToToken(token, linked, account)
+            return token
+          }
+
+          if (status === 'already-linked-elsewhere') {
+            // Pre-existing duplicate. Do NOT merge and do NOT switch the session
+            // to the other speaker: keep the user signed in as X (their
+            // pre-link identity) and surface a clear "already linked" message.
+            if (resultStore) resultStore.result = 'already-linked'
+            const { speaker: originX } = await getSpeaker(intent.speakerId)
+            if (originX?._id) {
+              // Preserve X's original account (do not adopt the account that
+              // belongs to the other speaker).
+              const priorAccount = (token.account as Account) ?? account
+              applySpeakerToToken(token, originX, priorAccount)
+              return token
+            }
+          }
+
+          // Unexpected link failure — surface it and fall through to the normal
+          // login path so the user still ends up with a working session.
+          if (resultStore) resultStore.result = 'error'
+          console.error(
+            'Provider link failed; falling back to normal sign-in',
+            {
+              status,
+              linkErr,
+            },
+          )
+        }
+        // --- end Phase 2 link handling -------------------------------------
+
         const { speaker, err } = await getOrCreateSpeaker(
           user,
           account,
@@ -84,29 +180,32 @@ const config = {
           return {}
         }
 
-        if (speaker.image && typeof speaker.image === 'string') {
-          token.picture = speakerImageUrl(speaker.image, {
-            width: 192,
-            height: 192,
-            fit: 'crop',
-          })
-        }
-
-        token.account = account
-        token.speaker = {
-          _id: speaker._id,
-          name: speaker.name,
-          email: speaker.email,
-          image: speaker.image,
-          isOrganizer: speaker.isOrganizer,
-          flags: speaker.flags,
-        }
+        applySpeakerToToken(token, speaker, account)
       }
 
       return token
     },
-    redirect({ url, baseUrl }) {
-      return url.startsWith(baseUrl) ? url : baseUrl
+    async redirect({ url, baseUrl }) {
+      let target = url.startsWith(baseUrl) ? url : baseUrl
+
+      // Phase 2: append the link outcome (set by the jwt callback in the same
+      // request) so the profile page can show a success / already-linked banner.
+      const { linkResultStore, LINK_RESULT_PARAM } =
+        await import('@/lib/auth-link')
+      const result = linkResultStore.getStore()?.result
+      if (result) {
+        try {
+          const resolved = new URL(target, baseUrl)
+          if (resolved.origin === new URL(baseUrl).origin) {
+            resolved.searchParams.set(LINK_RESULT_PARAM, result)
+            target = resolved.toString()
+          }
+        } catch {
+          // Leave target unchanged on any URL parsing issue.
+        }
+      }
+
+      return target
     },
   },
 } satisfies NextAuthConfig

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,7 @@
 import NextAuth from 'next-auth'
 import GitHub from 'next-auth/providers/github'
 import LinkedIn from 'next-auth/providers/linkedin'
-import type { Account, NextAuthConfig, Session, User } from 'next-auth'
+import type { Account, NextAuthConfig, Profile, Session, User } from 'next-auth'
 import { decode } from 'next-auth/jwt'
 import { NextRequest } from 'next/server'
 import { getOrCreateSpeaker } from '@/lib/speaker/sanity'
@@ -43,6 +43,226 @@ function applySpeakerToToken(
   }
 }
 
+/**
+ * Decode the browser's PRE-EXISTING NextAuth session token from the request
+ * cookies.
+ *
+ * Why this is needed: on an OAuth sign-in, `@auth/core` builds a FRESH default
+ * token from the just-authenticated provider and passes THAT to the `jwt`
+ * callback — it does NOT hand us the session that was active before the flow
+ * started. To bind a link-intent to its initiating session we therefore decode
+ * the still-present session cookie ourselves (same secret/salt as `@auth/core`).
+ * Handles the chunked cookie form (`<name>.0`, `.1`, …) that `@auth/core` uses
+ * for large tokens. Returns `null` when there is no valid prior session.
+ */
+async function readPriorSessionToken(jar: {
+  get(name: string): { value: string } | undefined
+}): Promise<
+  (JWT & { speaker?: Session['speaker']; account?: Session['account'] }) | null
+> {
+  const secret = process.env.AUTH_SECRET
+  if (!secret) return null
+
+  // Prod uses the __Secure- prefix; dev uses the bare name. Salt === cookie name.
+  const baseNames = ['__Secure-authjs.session-token', 'authjs.session-token']
+  for (const base of baseNames) {
+    let value = jar.get(base)?.value
+    if (!value) {
+      const chunks: string[] = []
+      for (let i = 0; ; i++) {
+        const chunk = jar.get(`${base}.${i}`)?.value
+        if (!chunk) break
+        chunks.push(chunk)
+      }
+      if (chunks.length) value = chunks.join('')
+    }
+    if (!value) continue
+
+    try {
+      const decoded = await decode({ token: value, secret, salt: base })
+      if (decoded) {
+        return decoded as JWT & {
+          speaker?: Session['speaker']
+          account?: Session['account']
+        }
+      }
+    } catch {
+      // Try the next candidate cookie name.
+    }
+  }
+  return null
+}
+
+/**
+ * NextAuth `events.signOut` handler. Clears any residual link-flow state on
+ * sign-out so a pending link-intent cannot outlive the session that created it
+ * (defence-in-depth alongside the single-use deletion in the jwt callback). The
+ * signout route handler makes `cookies()` writable.
+ *
+ * Exported so it can be unit-tested; it is referenced from `config.events`
+ * (used-in-file), so it is not an unused export.
+ */
+export async function signOutHandler(): Promise<void> {
+  try {
+    const { LINK_INTENT_COOKIE } = await import('@/lib/auth-link')
+    const { cookies } = await import('next/headers')
+    ;(await cookies()).delete(LINK_INTENT_COOKIE)
+  } catch (err) {
+    console.error('Failed to clear link-intent cookie on sign-out', err)
+  }
+}
+
+type JwtCallbackParams = {
+  token: JWT
+  account?: Account | null
+  profile?: Profile
+  trigger?: 'signIn' | 'signUp' | 'update'
+}
+
+/**
+ * The `jwt` callback body. Extracted (and exported) so the Phase-2 link
+ * consumption — single-use deletion, initiating-session binding, and the
+ * fall-through to a normal sign-in — is directly unit-testable. Referenced from
+ * `config.callbacks.jwt` (used-in-file), so it is not an unused export.
+ */
+export async function jwtSignInCallback({
+  token,
+  account,
+  profile,
+  trigger,
+}: JwtCallbackParams): Promise<JWT> {
+  if (!trigger && !(token.account && token.speaker)) {
+    console.error('Invalid auth token', token)
+    return {}
+  }
+
+  if (trigger === 'signIn') {
+    if (!token || !token.email || !token.name) {
+      console.error('Invalid auth token', token)
+      return {}
+    }
+
+    if (!account || !account.provider || !account.providerAccountId) {
+      console.error('Invalid auth account', account)
+      return {}
+    }
+
+    const user: User = {
+      email: token.email,
+      name: token.name,
+      image: token.picture,
+    }
+
+    // --- Phase 2: self-service "link another provider" -------------------
+    // If this sign-in carries a valid, integrity-protected link-intent cookie
+    // (minted only for an already-authenticated speaker X, bound to this
+    // provider AND to X's session), attach the just-authenticated account to
+    // the EXISTING speaker X instead of creating/switching to another document.
+    //
+    // `@/lib/auth-link` is imported dynamically so its Node-only crypto does not
+    // enter the edge middleware bundle that statically imports this file.
+    const { LINK_INTENT_COOKIE, verifyLinkIntent, linkResultStore } =
+      await import('@/lib/auth-link')
+    const { cookies } = await import('next/headers')
+    const jar = await cookies()
+    const linkToken = jar.get(LINK_INTENT_COOKIE)?.value
+
+    // SINGLE-USE: delete the cookie the moment it is observed — BEFORE any use —
+    // so a lingering intent can never be consumed twice regardless of outcome
+    // (success, already-linked-elsewhere, or a thrown error). The route-handler
+    // context that wraps this callback makes `cookies()` writable. This is the
+    // primary defence against replay of an abandoned intent by a later sign-in.
+    if (linkToken) {
+      jar.delete(LINK_INTENT_COOKIE)
+    }
+
+    const rawIntent = linkToken
+      ? verifyLinkIntent(linkToken, account.provider)
+      : null
+
+    // BIND TO THE INITIATING SESSION: honour the intent only if the browser is
+    // STILL authenticated as the speaker that started the link. `@auth/core`
+    // gives us a fresh token here (not the prior session), so decode the
+    // pre-existing session cookie ourselves and require it to match both the
+    // target speaker and the initiating session's `sub`. If there is no active
+    // session, or it belongs to a different user, we ignore the intent and fall
+    // through to a normal sign-in.
+    let intent: typeof rawIntent = null
+    // The pre-existing session decoded once and reused below.
+    const prior = rawIntent ? await readPriorSessionToken(jar) : null
+    if (rawIntent) {
+      if (
+        prior?.speaker?._id === rawIntent.speakerId &&
+        prior?.sub === rawIntent.initiatorSub
+      ) {
+        intent = rawIntent
+      } else {
+        console.warn(
+          'Link intent ignored: initiating session mismatch (treating as normal sign-in)',
+        )
+      }
+    }
+
+    if (intent) {
+      const { attachProviderToSpeaker, getSpeaker } =
+        await import('@/lib/speaker/sanity')
+      const resultStore = linkResultStore.getStore()
+
+      const {
+        speaker: linked,
+        status,
+        err: linkErr,
+      } = await attachProviderToSpeaker(
+        intent.speakerId,
+        user,
+        account,
+        profile,
+      )
+
+      if (!linkErr && status === 'linked') {
+        if (resultStore) resultStore.result = 'linked'
+        applySpeakerToToken(token, linked, account)
+        return token
+      }
+
+      if (status === 'already-linked-elsewhere') {
+        // Pre-existing duplicate. Do NOT merge and do NOT switch the session to
+        // the other speaker: keep the user signed in as X (their pre-link
+        // identity) and surface a clear "already linked" message.
+        if (resultStore) resultStore.result = 'already-linked'
+        const { speaker: originX } = await getSpeaker(intent.speakerId)
+        if (originX?._id) {
+          // Preserve X's original account (do not adopt the account that belongs
+          // to the other speaker). We validated the prior session is X above, so
+          // its account is X's own.
+          const priorAccount = (prior?.account as Account) ?? account
+          applySpeakerToToken(token, originX, priorAccount)
+          return token
+        }
+      }
+
+      // Unexpected link failure — surface it and fall through to the normal
+      // login path so the user still ends up with a working session.
+      if (resultStore) resultStore.result = 'error'
+      console.error('Provider link failed; falling back to normal sign-in', {
+        status,
+        linkErr,
+      })
+    }
+    // --- end Phase 2 link handling ---------------------------------------
+
+    const { speaker, err } = await getOrCreateSpeaker(user, account, profile)
+    if (err) {
+      console.error('Error fetching or creating speaker profile', err)
+      return {}
+    }
+
+    applySpeakerToToken(token, speaker, account)
+  }
+
+  return token
+}
+
 const config = {
   providers: [
     GitHub({
@@ -65,6 +285,10 @@ const config = {
     signIn: '/signin',
   },
 
+  events: {
+    signOut: signOutHandler,
+  },
+
   callbacks: {
     async session({ session, token }) {
       const speaker = token.speaker
@@ -83,107 +307,8 @@ const config = {
       } as Session
     },
 
-    async jwt({ token, account, profile, trigger }) {
-      if (!trigger && !(token.account && token.speaker)) {
-        console.error('Invalid auth token', token)
-        return {}
-      }
-
-      if (trigger === 'signIn') {
-        if (!token || !token.email || !token.name) {
-          console.error('Invalid auth token', token)
-          return {}
-        }
-
-        if (!account || !account.provider || !account.providerAccountId) {
-          console.error('Invalid auth account', account)
-          return {}
-        }
-
-        const user: User = {
-          email: token.email,
-          name: token.name,
-          image: token.picture,
-        }
-
-        // --- Phase 2: self-service "link another provider" -----------------
-        // If this sign-in carries a valid, integrity-protected link-intent
-        // cookie (minted only for an already-authenticated speaker X, bound to
-        // this provider), attach the just-authenticated account to the EXISTING
-        // speaker X instead of creating/switching to another document.
-        //
-        // `@/lib/auth-link` is imported dynamically so its Node-only crypto does
-        // not enter the edge middleware bundle that statically imports this file.
-        const { LINK_INTENT_COOKIE, verifyLinkIntent, linkResultStore } =
-          await import('@/lib/auth-link')
-        const { cookies } = await import('next/headers')
-        const linkToken = (await cookies()).get(LINK_INTENT_COOKIE)?.value
-        const intent = verifyLinkIntent(linkToken, account.provider)
-
-        if (intent) {
-          const { attachProviderToSpeaker, getSpeaker } =
-            await import('@/lib/speaker/sanity')
-          const resultStore = linkResultStore.getStore()
-
-          const {
-            speaker: linked,
-            status,
-            err: linkErr,
-          } = await attachProviderToSpeaker(
-            intent.speakerId,
-            user,
-            account,
-            profile,
-          )
-
-          if (!linkErr && status === 'linked') {
-            if (resultStore) resultStore.result = 'linked'
-            applySpeakerToToken(token, linked, account)
-            return token
-          }
-
-          if (status === 'already-linked-elsewhere') {
-            // Pre-existing duplicate. Do NOT merge and do NOT switch the session
-            // to the other speaker: keep the user signed in as X (their
-            // pre-link identity) and surface a clear "already linked" message.
-            if (resultStore) resultStore.result = 'already-linked'
-            const { speaker: originX } = await getSpeaker(intent.speakerId)
-            if (originX?._id) {
-              // Preserve X's original account (do not adopt the account that
-              // belongs to the other speaker).
-              const priorAccount = (token.account as Account) ?? account
-              applySpeakerToToken(token, originX, priorAccount)
-              return token
-            }
-          }
-
-          // Unexpected link failure — surface it and fall through to the normal
-          // login path so the user still ends up with a working session.
-          if (resultStore) resultStore.result = 'error'
-          console.error(
-            'Provider link failed; falling back to normal sign-in',
-            {
-              status,
-              linkErr,
-            },
-          )
-        }
-        // --- end Phase 2 link handling -------------------------------------
-
-        const { speaker, err } = await getOrCreateSpeaker(
-          user,
-          account,
-          profile,
-        )
-        if (err) {
-          console.error('Error fetching or creating speaker profile', err)
-          return {}
-        }
-
-        applySpeakerToToken(token, speaker, account)
-      }
-
-      return token
+    async jwt(params) {
+      return jwtSignInCallback(params)
     },
     async redirect({ url, baseUrl }) {
       let target = url.startsWith(baseUrl) ? url : baseUrl

--- a/src/lib/speaker/sanity.test.ts
+++ b/src/lib/speaker/sanity.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/lib/profile/github', () => ({
   verifiedEmails: (...args: unknown[]) => verifiedEmailsMock(...args),
 }))
 
-import { getOrCreateSpeaker } from './sanity'
+import { attachProviderToSpeaker, getOrCreateSpeaker } from './sanity'
 
 // --- Fetch routing helpers -------------------------------------------------
 
@@ -371,5 +371,135 @@ describe('getOrCreateSpeaker — new speaker creation', () => {
     )
 
     expect(speaker.slug).toBe('speaker')
+  })
+})
+
+// --- Phase 2: attachProviderToSpeaker (self-service linking) ----------------
+
+interface AttachRoutes {
+  providerOwner?: Speaker | Record<string, never> | null
+  target?: Speaker | null
+  takenSlugs?: Set<string>
+}
+
+function attachRouteFetch(routes: AttachRoutes) {
+  const taken = routes.takenSlugs ?? new Set<string>()
+  return (query: string, params: Record<string, unknown> = {}) => {
+    if (query.includes('$id in providers')) {
+      return Promise.resolve(routes.providerOwner ?? {})
+    }
+    if (query.includes('_id == $speakerId')) {
+      return Promise.resolve(routes.target ?? null)
+    }
+    if (query.includes('slug.current == $slug')) {
+      return Promise.resolve(
+        taken.has(params.slug as string) ? 'taken-id' : null,
+      )
+    }
+    return Promise.resolve(null)
+  }
+}
+
+describe('attachProviderToSpeaker — explicit self-service link', () => {
+  it('attaches a new provider to the EXISTING speaker without creating a doc', async () => {
+    // Speaker X currently only has LinkedIn; we link a GitHub account to X.
+    verifiedEmailsMock.mockResolvedValue({
+      error: null,
+      emails: [{ email: 'jane.work@corp.com', verified: true }],
+    })
+    const target = existingSpeaker({
+      _id: 'spk-x',
+      providers: ['linkedin:li-456'],
+      knownEmails: ['jane@example.com'],
+    })
+    fetchMock.mockImplementation(
+      attachRouteFetch({ providerOwner: {}, target }),
+    )
+
+    const { speaker, status, err } = await attachProviderToSpeaker(
+      'spk-x',
+      user({ email: 'jane@example.com' }),
+      githubAccount(),
+    )
+
+    expect(err).toBeNull()
+    expect(status).toBe('linked')
+    expect(createMock).not.toHaveBeenCalled()
+    expect(patchMock).toHaveBeenCalledWith('spk-x')
+    expect(speaker._id).toBe('spk-x')
+    // Gains the second provider (deduped) ...
+    expect(speaker.providers).toEqual(
+      expect.arrayContaining(['linkedin:li-456', 'github:gh-123']),
+    )
+    // ... and this login's VERIFIED email is unioned into knownEmails.
+    expect(speaker.knownEmails).toEqual(
+      expect.arrayContaining(['jane@example.com', 'jane.work@corp.com']),
+    )
+  })
+
+  it('does NOT merge when the provider is already linked to another speaker', async () => {
+    // The GitHub account already belongs to a DIFFERENT speaker Z.
+    const otherSpeaker = existingSpeaker({ _id: 'spk-z' })
+    fetchMock.mockImplementation(
+      attachRouteFetch({
+        providerOwner: otherSpeaker,
+        target: existingSpeaker({ _id: 'spk-x' }),
+      }),
+    )
+
+    const { speaker, status, err } = await attachProviderToSpeaker(
+      'spk-x',
+      user({ email: 'jane@example.com' }),
+      githubAccount(),
+    )
+
+    expect(err).toBeNull()
+    expect(status).toBe('already-linked-elsewhere')
+    // Neither document is mutated — merging is the Phase-3 admin tool.
+    expect(patchMock).not.toHaveBeenCalled()
+    expect(createMock).not.toHaveBeenCalled()
+    // Surfaces the conflicting speaker so the UI can advise contacting organizers.
+    expect(speaker._id).toBe('spk-z')
+  })
+
+  it('is idempotent when the provider is already linked to the same speaker', async () => {
+    verifiedEmailsMock.mockResolvedValue({ error: null, emails: [] })
+    const target = existingSpeaker({
+      _id: 'spk-x',
+      providers: ['github:gh-123'],
+    })
+    fetchMock.mockImplementation(
+      attachRouteFetch({ providerOwner: target, target }),
+    )
+
+    const { speaker, status, err } = await attachProviderToSpeaker(
+      'spk-x',
+      user({ email: 'jane@example.com' }),
+      githubAccount(),
+    )
+
+    expect(err).toBeNull()
+    expect(status).toBe('linked')
+    expect(createMock).not.toHaveBeenCalled()
+    expect(speaker.providers).toEqual(['github:gh-123'])
+  })
+
+  it('fails closed when the user has no email (cannot compute verified set)', async () => {
+    fetchMock.mockImplementation(
+      attachRouteFetch({
+        providerOwner: {},
+        target: existingSpeaker({ _id: 'spk-x' }),
+      }),
+    )
+
+    const { status, err } = await attachProviderToSpeaker(
+      'spk-x',
+      { name: 'Jane Doe' } as User,
+      githubAccount(),
+    )
+
+    expect(err).toBeInstanceOf(Error)
+    expect(status).toBe('linked')
+    expect(patchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -388,6 +388,97 @@ export async function getOrCreateSpeaker(
   }
 }
 
+/** Outcome of an explicit self-service provider link. */
+export type ProviderLinkStatus = 'linked' | 'already-linked-elsewhere'
+
+/**
+ * Explicitly attach a just-authenticated provider account to an EXISTING speaker
+ * (identity Phase 2 "link another provider"). Unlike {@link getOrCreateSpeaker},
+ * this never creates or switches to a different document: the target speaker is
+ * fixed by `speakerId` (resolved from a verified, integrity-protected link-intent
+ * token — see `@/lib/auth-link`).
+ *
+ * SECURITY:
+ *  - The ownership proof is the OAuth round-trip the caller just completed with
+ *    `account`; only that provider id is attached.
+ *  - `knownEmails` is only ever unioned with this login's VERIFIED emails
+ *    (`computeVerifiedEmails`), preserving the Phase-1 verified-only invariant.
+ *  - If the provider account is ALREADY linked to a DIFFERENT speaker Z we do
+ *    NOT merge (that is the Phase-3 admin tool). We return
+ *    `already-linked-elsewhere` and leave BOTH documents untouched so the UI can
+ *    tell the user to contact the organizers.
+ *  - Re-linking a provider already on the target speaker is idempotent.
+ */
+export async function attachProviderToSpeaker(
+  speakerId: string,
+  user: User,
+  account: Account,
+  profile?: Profile,
+): Promise<{
+  speaker: Speaker
+  status: ProviderLinkStatus
+  err: Error | null
+}> {
+  if (!speakerId) {
+    return {
+      speaker: {} as Speaker,
+      status: 'linked',
+      err: new Error('Missing target speaker id'),
+    }
+  }
+  if (!user.email) {
+    return {
+      speaker: {} as Speaker,
+      status: 'linked',
+      err: new Error('Missing user email for provider link'),
+    }
+  }
+
+  const providerAccountId = providerAccount(
+    account.provider,
+    account.providerAccountId,
+  )
+
+  // Guard: is this provider account already claimed by some speaker?
+  const existing = await findSpeakerByProvider(providerAccountId)
+  if (existing.err) {
+    return { speaker: {} as Speaker, status: 'linked', err: existing.err }
+  }
+  if (existing.speaker?._id && existing.speaker._id !== speakerId) {
+    // Pre-existing duplicate: belongs to a DIFFERENT speaker. Do not merge.
+    return {
+      speaker: existing.speaker,
+      status: 'already-linked-elsewhere',
+      err: null,
+    }
+  }
+
+  // Load the fixed link target.
+  const { speaker: target, err: targetErr } = await getSpeaker(speakerId)
+  if (targetErr) {
+    return { speaker: {} as Speaker, status: 'linked', err: targetErr }
+  }
+  if (!target?._id) {
+    return {
+      speaker: {} as Speaker,
+      status: 'linked',
+      err: new Error('Link target speaker not found'),
+    }
+  }
+
+  // Attach the provider + this login's verified emails to the existing speaker.
+  const primaryEmail = normalizeEmail(user.email)
+  const verifiedIncoming = await computeVerifiedEmails(user, account, profile)
+  const { speaker, err } = await linkProviderToSpeaker(
+    target,
+    providerAccountId,
+    verifiedIncoming,
+    primaryEmail,
+  )
+
+  return { speaker, status: 'linked', err }
+}
+
 export async function getSpeaker(
   speakerId: string,
 ): Promise<{ speaker: Speaker; err: Error | null }> {


### PR DESCRIPTION
## Summary

Identity **Phase 2** — makes a speaker's linked sign-in providers visible and adds a secure **self-service "link another provider"** flow. A user who first signed in with GitHub can now also link LinkedIn (or vice-versa) to the **same** speaker document instead of creating a duplicate.

> **Stacked on #440** (`feat/speaker-identity-hardening`, Phase 1). This branch is cut from that PR's head and depends on its `getOrCreateSpeaker` / `linkProviderToSpeaker` / `computeVerifiedEmails` / `knownEmails` work. **Rebase onto `main` after #440 merges.**

> ⚠️ **HELD for maintainer review + preview login test.** This is an auth-flow change; please do not merge/enqueue until the linking round-trip has been exercised on a login preview.

## Part A — provider visibility (lower risk)

- The CFP profile page (`CFPProfilePage`) now renders a **Sign-in methods** section (`LinkedProviders`) that parses `speaker.providers[]` (`"github:<id>"` / `"linkedin:<id>"`), maps each prefix to a provider name + icon (reusing `GitHubIcon` / `LinkedInIcon`), and marks which provider the user is **currently** signed in with (`session.account.provider`, passed from the server page — the client `SessionProvider` is sanitized and does not expose `account`).
- The vague *"Managed by your OAuth provider"* label is replaced with the concrete provider name(s) (e.g. *"Managed by GitHub and LinkedIn"*).
- Storybook story added: `Systems/CFP/LinkedProviders` (only-GitHub, only-LinkedIn, both, and no-handler states; light + dark).

## Part B — self-service linking + security model

**The problem:** today, if signed-in speaker X authenticates with a second provider whose verified email doesn't match X, `getOrCreateSpeaker` creates a **new** speaker Y. Link mode deliberately attaches the second provider to X instead.

**Chosen approach — in-callback attach (not a post-hoc mutation).** The attach must happen *inside* the OAuth callback, because that is the only point that intercepts the second sign-in **before** `getOrCreateSpeaker` would create a duplicate. Flow:

1. **Start (server action `startProviderLink`)** — runs only for an authenticated caller (`auth()`), mints a **link-intent token** bound to `speaker._id` + target provider, stores it in an httpOnly cookie, then calls `signIn(provider)`.
2. **Callback (`jwt` callback in `@/lib/auth`)** — reads + verifies the cookie; if valid and the just-authenticated provider matches, calls `attachProviderToSpeaker(speakerId, …)` and keeps the session as **X** (with both providers). `@/lib/auth-link` is imported **dynamically** here so its Node-only crypto never enters the edge middleware bundle.
3. **Result surfacing** — the `[...nextauth]` route wraps each request in an `AsyncLocalStorage` store; the `jwt` callback writes the outcome and the `redirect` callback appends `?linkResult=…`, which the profile page renders as a success / already-linked / error banner. (Concurrency-safe; no sticky JWT flags.)

### Security-relevant decisions (please scrutinize)

- **Link-intent token is integrity-protected + bound to X.** HMAC-SHA256 over the payload keyed by `AUTH_SECRET`; payload carries `speakerId`, target `provider`, a 5-min `exp`, and a random nonce. Verification is constant-time. A client cannot **forge** or **tamper** with it (no key).
- **Requires an active authenticated session for X.** The token is minted **only** by the server action after `auth()` resolves the caller to X — an unauthenticated caller cannot obtain one.
- **Not replayable to attack another account.** The token lives solely in X's **httpOnly, Secure, SameSite=Lax** cookie, so it cannot be exfiltrated by hostile JS or attached cross-site; replay in X's own browser only re-links the same provider to X (idempotent). Short TTL bounds the window.
- **Ownership proof for the link** = the second OAuth round-trip itself (you must actually authenticate with the provider account being linked).
- **Already-linked-to-another guard.** If `provider:id` already belongs to a **different** speaker Z, `attachProviderToSpeaker` returns `already-linked-elsewhere` and mutates **nothing** — no silent merge. The user sees *"already linked to another profile — contact the organizers"*. The session stays X (we do **not** switch to Z). Actual merging is the Phase-3 admin tool.
- **Phase-1 invariant preserved.** `knownEmails` is only ever unioned with this login's **verified** emails (`computeVerifiedEmails`) via the existing `linkProviderToSpeaker`; the raw/unverified primary is never folded into the match-set.
- **Fail-closed.** Missing `AUTH_SECRET` throws at mint; malformed/expired/wrong-provider tokens all verify to `null` and fall back to a normal sign-in.

## Files

- `src/lib/auth-link.ts` — link-intent sign/verify (HMAC), constants, `AsyncLocalStorage` result store, provider/result guards.
- `src/lib/speaker/sanity.ts` — `attachProviderToSpeaker()` (fixed-target attach + already-linked-elsewhere guard, reusing `computeVerifiedEmails` / `linkProviderToSpeaker`).
- `src/lib/auth.ts` — `jwt` link handling + `redirect` result-param; shared `applySpeakerToToken` helper.
- `src/app/api/auth/[...nextauth]/route.ts` — wraps handlers in the result store.
- `src/app/(cfp)/cfp/profile/link-actions.ts` — authenticated `startProviderLink` server action.
- `src/app/(cfp)/cfp/profile/page.tsx`, `src/components/cfp/CFPProfilePage.tsx`, `src/components/cfp/LinkedProviders.tsx` (+ story) — UI.

## Verification

- `pnpm typecheck` ✅ clean
- `pnpm vitest run` ✅ **2199 passed, 5 skipped** (130 files) — new tests cover: link-mode attach (existing speaker gains provider + verified emails, **no new doc**), the already-linked-to-another-speaker guard (no merge, clear status, both docs intact), idempotent re-link, fail-closed on missing email, and the link-intent token (forge / tamper / expiry / wrong-provider / missing-secret rejection), and that starting a link **requires an authenticated session** (no cookie minted when signed out).
- `eslint` ✅ / `prettier` ✅

## Assumptions for the maintainer to confirm

1. **Runtime/bundling:** `@/lib/auth-link` (uses `node:crypto` + `node:async_hooks`) is only ever imported dynamically from `auth.ts` and statically from Node route handlers / server actions / the server page — never from the edge middleware graph. Please confirm `next build` succeeds (middleware is edge; a full build wasn't run in this environment).
2. **AsyncLocalStorage propagation** through NextAuth's `jwt` → `redirect` callbacks holds in the deployed Node runtime (verified by design/tests; confirm on preview).
3. Setting `session.account` to the newly-linked provider after a successful link is the desired "current sign-in" semantics.
4. Exposing `session.account` server-side to the profile page is acceptable (pre-existing session shape from Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Phase-2 speaker identity features: a **Sign-in methods** panel on the CFP profile page showing linked OAuth providers, and a secure self-service flow that lets an authenticated speaker link a second provider to their existing document instead of creating a duplicate.

- **Part A** (`LinkedProviders`, `CFPProfilePage` updates): reads `speaker.providers[]`, maps each `\"provider:id\"` entry to a name/icon, highlights the currently active sign-in, and surfaces a link button backed by the new server action.
- **Part B** (`auth-link.ts`, `link-actions.ts`, `auth.ts` callback, `[...nextauth]/route.ts`): mints an HMAC-signed, httpOnly-cookie-bound link-intent token; the JWT callback verifies and consumes it during the second OAuth round-trip, calling the new `attachProviderToSpeaker` helper; the link outcome is threaded back to the profile page via an `AsyncLocalStorage` store and a `?linkResult=` query param.
- **`attachProviderToSpeaker`** correctly guards against already-linked-elsewhere conflicts, is idempotent on re-link, and preserves the verified-email-only invariant for `knownEmails`.

<h3>Confidence Score: 3/5</h3>

The linking crypto and data-layer guards are solid, but the JWT callback has a code path that can sign the user in as a completely different speaker in an edge case — this should be fixed before the flow goes live on a preview.

The token design, already-linked guard, and idempotency properties are well-thought-out. The weak spot is in auth.ts: when the already-linked-elsewhere branch can't re-fetch speaker X, the callback falls through to getOrCreateSpeaker with the new provider's credentials, which resolves to speaker Z and overwrites the session with Z's identity. Additionally, the link-intent cookie is never cleared after being consumed, causing the link flow to re-fire on the next same-provider sign-in within the 5-minute TTL.

src/lib/auth.ts — the already-linked-elsewhere branch (lines ~145–170) needs an explicit early return to prevent fallthrough to getOrCreateSpeaker when speaker X cannot be retrieved, and the link-intent cookie should be deleted immediately after it is read.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/auth-link.ts | New file: HMAC-based link-intent token mint/verify, AsyncLocalStorage result carrier, provider/result type guards. Crypto is well-implemented (timing-safe compare, nonce, short TTL, fail-closed on missing secret). |
| src/lib/auth.ts | JWT callback extended with Phase-2 link flow. Contains a fallthrough bug: when already-linked-elsewhere is detected but speaker X can't be re-fetched, the code falls through to getOrCreateSpeaker with the new provider's credentials, potentially signing the user in as a different speaker (Z). |
| src/lib/speaker/sanity.ts | Adds attachProviderToSpeaker with correct already-linked-elsewhere guard, idempotent re-link, and verified-email-only knownEmails update. Error return statuses default to 'linked' on failure, which is intentional (caller checks linkErr independently). |
| src/app/(cfp)/cfp/profile/link-actions.ts | startProviderLink server action correctly gates token minting behind auth() session check. Cookie attributes (httpOnly, secure, sameSite=lax) are properly set. |
| src/app/api/auth/[...nextauth]/route.ts | Wraps both GET and POST auth handlers in a fresh AsyncLocalStorage context for per-request link result isolation. Clean and correct. |
| src/components/cfp/LinkedProviders.tsx | New component: displays linked OAuth providers with correct linked/current-sign-in status badges and link forms. Gracefully disables link buttons when no server action is provided. |
| src/components/cfp/CFPProfilePage.tsx | Integrates LinkedProviders and linkResult banners. linkResult values are validated server-side before being passed as props. describeProviders helper cleanly maps provider entries to human-readable names. |
| src/app/(cfp)/cfp/profile/page.tsx | Reads linkResult from search params, validates it with isLinkResult(), and passes currentProvider from the server-side session to the client component. Correct pattern for passing server-only session data. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(speaker): provider visibility + sel..."](https://github.com/cloudnativebergen/website/commit/0380b9ce1040483d478756964ea1ad925e50dadc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44483419)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->