### PR TITLE
Speaker identity (Phase 3): admin merge tool for duplicate speakers

### DIFF
--- a/src/components/admin/SpeakerMergeModal.tsx
+++ b/src/components/admin/SpeakerMergeModal.tsx
@@ -1,0 +1,293 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { DialogTitle } from '@headlessui/react'
+import { ArrowRightIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { Button } from '@/components/Button'
+import { ModalShell } from '@/components/ModalShell'
+import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
+import { useNotification } from '@/components/admin/NotificationProvider'
+import { api } from '@/lib/trpc/client'
+import { useQueryClient } from '@tanstack/react-query'
+
+/** Minimal speaker shape needed to pick merge candidates. */
+export interface MergeCandidate {
+  _id: string
+  name: string
+  email?: string | null
+}
+
+interface SpeakerMergeModalProps {
+  isOpen: boolean
+  onClose: () => void
+  speakers: MergeCandidate[]
+  onMerged?: () => void
+}
+
+function optionLabel(speaker: MergeCandidate): string {
+  return speaker.email ? `${speaker.name} — ${speaker.email}` : speaker.name
+}
+
+function EmailList({ emails }: { emails: string[] }) {
+  if (emails.length === 0) {
+    return <span className="text-brand-slate-gray/50 italic">none</span>
+  }
+  return <span>{emails.join(', ')}</span>
+}
+
+export function SpeakerMergeModal({
+  isOpen,
+  onClose,
+  speakers,
+  onMerged,
+}: SpeakerMergeModalProps) {
+  const queryClient = useQueryClient()
+  const { showNotification } = useNotification()
+
+  const [survivorId, setSurvivorId] = useState('')
+  const [loserId, setLoserId] = useState('')
+  const [previewRequested, setPreviewRequested] = useState(false)
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+
+  const bothSelected = Boolean(survivorId && loserId)
+  const sameSelected = bothSelected && survivorId === loserId
+
+  const sortedSpeakers = useMemo(
+    () => [...speakers].sort((a, b) => a.name.localeCompare(b.name)),
+    [speakers],
+  )
+
+  const previewEnabled = previewRequested && bothSelected && !sameSelected
+
+  const previewQuery = api.speaker.admin.mergePreview.useQuery(
+    { survivorId, loserId },
+    { enabled: previewEnabled, retry: false },
+  )
+
+  const mergeMutation = api.speaker.admin.merge.useMutation({
+    onSuccess: (data) => {
+      showNotification({
+        type: 'success',
+        title: 'Speakers merged',
+        message: `Repointed references in ${data.preview.referencingDocCount} document(s) and deleted the duplicate.`,
+      })
+      queryClient.invalidateQueries({ queryKey: [['speaker']] })
+      resetAndClose()
+      onMerged?.()
+    },
+    onError: (error) => {
+      showNotification({
+        type: 'error',
+        title: 'Merge failed',
+        message: error.message,
+      })
+    },
+  })
+
+  function resetState() {
+    setSurvivorId('')
+    setLoserId('')
+    setPreviewRequested(false)
+    setIsConfirmOpen(false)
+  }
+
+  function resetAndClose() {
+    resetState()
+    onClose()
+  }
+
+  const preview = previewQuery.data
+  const survivor = sortedSpeakers.find((s) => s._id === survivorId)
+  const loser = sortedSpeakers.find((s) => s._id === loserId)
+
+  return (
+    <>
+      <ModalShell isOpen={isOpen} onClose={resetAndClose} size="2xl">
+        <div className="flex items-start justify-between">
+          <div>
+            <DialogTitle className="font-space-grotesk text-lg font-semibold text-brand-slate-gray dark:text-white">
+              Merge duplicate speakers
+            </DialogTitle>
+            <p className="font-inter mt-1 text-sm text-brand-slate-gray/70 dark:text-gray-400">
+              Fold a duplicate speaker into a canonical one. All references are
+              repointed to the survivor and the duplicate is deleted. This
+              cannot be undone.
+            </p>
+          </div>
+          <button
+            onClick={resetAndClose}
+            className="ml-4 rounded-lg p-1 text-brand-slate-gray/60 hover:bg-brand-sky-mist dark:hover:bg-gray-800"
+            aria-label="Close"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 items-end gap-4 sm:grid-cols-[1fr_auto_1fr]">
+          <label className="block">
+            <span className="font-inter text-sm font-medium text-brand-slate-gray dark:text-gray-200">
+              Survivor (kept, keeps its URL)
+            </span>
+            <select
+              value={survivorId}
+              onChange={(e) => {
+                setSurvivorId(e.target.value)
+                setPreviewRequested(false)
+              }}
+              className="mt-1 w-full rounded-lg border border-brand-frosted-steel bg-white px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+              <option value="">Select survivor…</option>
+              {sortedSpeakers.map((s) => (
+                <option key={s._id} value={s._id} disabled={s._id === loserId}>
+                  {optionLabel(s)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="hidden justify-center pb-2 sm:flex">
+            <ArrowRightIcon className="h-5 w-5 text-brand-slate-gray/40" />
+          </div>
+
+          <label className="block">
+            <span className="font-inter text-sm font-medium text-brand-slate-gray dark:text-gray-200">
+              Duplicate (folded in, then deleted)
+            </span>
+            <select
+              value={loserId}
+              onChange={(e) => {
+                setLoserId(e.target.value)
+                setPreviewRequested(false)
+              }}
+              className="mt-1 w-full rounded-lg border border-brand-frosted-steel bg-white px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+              <option value="">Select duplicate…</option>
+              {sortedSpeakers.map((s) => (
+                <option
+                  key={s._id}
+                  value={s._id}
+                  disabled={s._id === survivorId}
+                >
+                  {optionLabel(s)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {sameSelected && (
+          <p className="mt-3 text-sm text-red-600 dark:text-red-400">
+            Survivor and duplicate must be different speakers.
+          </p>
+        )}
+
+        <div className="mt-4">
+          <Button
+            variant="secondary"
+            onClick={() => setPreviewRequested(true)}
+            disabled={!bothSelected || sameSelected}
+          >
+            Preview changes
+          </Button>
+        </div>
+
+        {previewEnabled && (
+          <div className="mt-5 rounded-xl border border-brand-frosted-steel bg-brand-sky-mist/40 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+            {previewQuery.isLoading && (
+              <p className="font-inter text-sm text-brand-slate-gray/70 dark:text-gray-400">
+                Computing preview…
+              </p>
+            )}
+            {previewQuery.isError && (
+              <p className="font-inter text-sm text-red-600 dark:text-red-400">
+                {previewQuery.error.message}
+              </p>
+            )}
+            {preview && (
+              <div className="space-y-4 text-sm">
+                <div>
+                  <h4 className="font-space-grotesk font-semibold text-brand-slate-gray dark:text-white">
+                    References to repoint
+                  </h4>
+                  {preview.referencingDocCount === 0 ? (
+                    <p className="text-brand-slate-gray/70 dark:text-gray-400">
+                      No documents reference the duplicate.
+                    </p>
+                  ) : (
+                    <ul className="mt-1 list-inside list-disc text-brand-slate-gray/80 dark:text-gray-300">
+                      {Object.entries(preview.referenceRepointsByType).map(
+                        ([type, count]) => (
+                          <li key={type}>
+                            <span className="font-medium">{type}</span>: {count}{' '}
+                            reference{count === 1 ? '' : 's'}
+                          </li>
+                        ),
+                      )}
+                    </ul>
+                  )}
+                </div>
+
+                <div>
+                  <h4 className="font-space-grotesk font-semibold text-brand-slate-gray dark:text-white">
+                    Identity union on survivor
+                  </h4>
+                  <dl className="mt-1 space-y-1 text-brand-slate-gray/80 dark:text-gray-300">
+                    <div>
+                      <dt className="inline font-medium">Providers: </dt>
+                      <dd className="inline">
+                        {preview.fieldChanges.providers.after.join(', ') ||
+                          'none'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="inline font-medium">Known emails: </dt>
+                      <dd className="inline">
+                        <EmailList
+                          emails={preview.fieldChanges.knownEmails.after}
+                        />
+                      </dd>
+                    </div>
+                    {preview.fieldChanges.filledFromLoser.length > 0 && (
+                      <div>
+                        <dt className="inline font-medium">
+                          Filled from duplicate:{' '}
+                        </dt>
+                        <dd className="inline">
+                          {preview.fieldChanges.filledFromLoser.join(', ')}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
+                </div>
+
+                <div className="pt-1">
+                  <Button
+                    variant="primary"
+                    onClick={() => setIsConfirmOpen(true)}
+                    className="bg-red-600 hover:bg-red-500 dark:bg-red-700 dark:hover:bg-red-600"
+                  >
+                    Merge and delete duplicate
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </ModalShell>
+
+      <ConfirmationModal
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={() => {
+          setIsConfirmOpen(false)
+          mergeMutation.mutate({ survivorId, loserId })
+        }}
+        title="Merge speakers?"
+        message={`This permanently deletes "${loser?.name ?? 'the duplicate'}" and repoints its references to "${survivor?.name ?? 'the survivor'}". This cannot be undone.`}
+        confirmButtonText="Merge and delete"
+        variant="danger"
+        isLoading={mergeMutation.isPending}
+      />
+    </>
+  )
+}

--- a/src/components/admin/SpeakersPageClient.tsx
+++ b/src/components/admin/SpeakersPageClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { SpeakerTable } from '@/components/admin/SpeakerTable'
 import { SpeakerManagementModal } from '@/components/admin/SpeakerManagementModal'
 import { SpeakerActions } from '@/components/admin/SpeakerActions'
+import { SpeakerMergeModal } from '@/components/admin/SpeakerMergeModal'
 import SpeakerProfilePreview from '@/components/SpeakerProfilePreview'
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
 import {
@@ -13,6 +14,7 @@ import {
   EnvelopeIcon,
   AcademicCapIcon,
   CreditCardIcon,
+  ArrowsPointingInIcon,
 } from '@heroicons/react/24/outline'
 import { Speaker } from '@/lib/speaker/types'
 import { ProposalExisting, Status } from '@/lib/proposal/types'
@@ -47,6 +49,7 @@ export default function SpeakersPageClient({
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false)
   const [isEmailModalOpen, setIsEmailModalOpen] = useState(false)
+  const [isMergeModalOpen, setIsMergeModalOpen] = useState(false)
   const [selectedSpeaker, setSelectedSpeaker] = useState<
     (Speaker & { proposals: ProposalExisting[] }) | null
   >(null)
@@ -191,6 +194,12 @@ export default function SpeakersPageClient({
               variant: 'secondary',
             },
             {
+              label: 'Merge Duplicates',
+              onClick: () => setIsMergeModalOpen(true),
+              icon: <ArrowsPointingInIcon className="h-4 w-4" />,
+              variant: 'secondary',
+            },
+            {
               label: 'Email Speakers',
               onClick: () => setIsEmailModalOpen(true),
               icon: <EnvelopeIcon className="h-4 w-4" />,
@@ -235,6 +244,17 @@ export default function SpeakersPageClient({
             talks={previewTalks}
           />
         )}
+
+        <SpeakerMergeModal
+          isOpen={isMergeModalOpen}
+          onClose={() => setIsMergeModalOpen(false)}
+          speakers={speakers.map((s) => ({
+            _id: s._id,
+            name: s.name,
+            email: s.email,
+          }))}
+          onMerged={() => router.refresh()}
+        />
       </div>
 
       <SpeakerActions

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -27,6 +27,7 @@ export { ProposalReviewList } from './ProposalReviewList'
 export { ProposalActionModal } from './ProposalActionModal'
 
 export { SpeakerTable } from './SpeakerTable'
+export { SpeakerMergeModal } from './SpeakerMergeModal'
 export { GeneralBroadcastModal } from './GeneralBroadcastModal'
 export { SpeakerEmailModal } from './SpeakerEmailModal'
 export { SpeakerImageModal } from './SpeakerImageModal'

--- a/src/lib/speaker/merge.sanity.test.ts
+++ b/src/lib/speaker/merge.sanity.test.ts
@@ -7,22 +7,41 @@ const fetchMock = vi.fn()
 const commitMock = vi.fn().mockResolvedValue({ transactionId: 'tx-1' })
 const deleteMock = vi.fn()
 
-// Each `.patch(id, fn)` invokes `fn` with a fake patch builder whose `.set()`
-// records the argument, so tests can assert the exact ops in the transaction.
-const patchOps: Array<{ id: string; set: Record<string, unknown> }> = []
+// Ordered record of every op staged on the transaction, so tests can assert
+// not just WHAT was staged but the ORDER (delete must come last).
+const txOrder: Array<'patch' | 'delete'> = []
+
+// Each `.patch(id, fn)` invokes `fn` with a fake, chainable patch builder whose
+// `.set()`/`.ifRevisionId()` record their arguments, so tests can assert the
+// exact ops AND that each referencing-doc patch is revision-guarded.
+const patchOps: Array<{
+  id: string
+  set: Record<string, unknown>
+  rev?: string
+}> = []
 const patchMock = vi.fn(
   (
     id: string,
     fn: (p: { set: (o: Record<string, unknown>) => unknown }) => unknown,
   ) => {
-    const op = { id, set: {} as Record<string, unknown> }
-    fn({
+    const op = { id, set: {} as Record<string, unknown>, rev: undefined } as {
+      id: string
+      set: Record<string, unknown>
+      rev?: string
+    }
+    const builder = {
       set: (o: Record<string, unknown>) => {
         op.set = o
-        return {}
+        return builder
       },
-    })
+      ifRevisionId: (rev: string) => {
+        op.rev = rev
+        return builder
+      },
+    }
+    fn(builder)
     patchOps.push(op)
+    txOrder.push('patch')
     return transactionApi
   },
 )
@@ -33,6 +52,7 @@ const transactionApi = {
   delete: (id: string) => {
     deletedIds.push(id)
     deleteMock(id)
+    txOrder.push('delete')
     return transactionApi
   },
   commit: commitMock,
@@ -78,9 +98,23 @@ const referencingDocs = [
   {
     _id: 'talk-1',
     _type: 'talk',
+    _rev: 'rev-talk-1',
     speakers: [ref('other', 'k0'), ref(LOSER, 'k1')],
   },
-  { _id: 'conf-1', _type: 'conference', organizers: [ref(LOSER, 'k2')] },
+  {
+    _id: 'conf-1',
+    _type: 'conference',
+    _rev: 'rev-conf-1',
+    organizers: [ref(LOSER, 'k2')],
+  },
+  // A reference nested inside an object inside an array — the deep walk must
+  // still repoint it.
+  {
+    _id: 'review-1',
+    _type: 'review',
+    _rev: 'rev-review-1',
+    entries: [{ note: 'x', by: ref(LOSER) }],
+  },
 ]
 
 function routeFetch(query: string, params: Record<string, unknown> = {}) {
@@ -99,6 +133,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   patchOps.length = 0
   deletedIds.length = 0
+  txOrder.length = 0
   fetchMock.mockImplementation(routeFetch)
 })
 
@@ -116,7 +151,11 @@ describe('mergeSpeakers (transaction wrapper)', () => {
     expect(patchMock).not.toHaveBeenCalled()
     expect(commitMock).not.toHaveBeenCalled()
     expect(deletedIds).toEqual([])
-    expect(preview?.referenceRepointsByType).toEqual({ talk: 1, conference: 1 })
+    expect(preview?.referenceRepointsByType).toEqual({
+      talk: 1,
+      conference: 1,
+      review: 1,
+    })
   })
 
   it('commits repoint patches, the survivor patch, and deletes the loser LAST', async () => {
@@ -142,6 +181,12 @@ describe('mergeSpeakers (transaction wrapper)', () => {
       { _type: 'reference', _ref: SURVIVOR, _key: 'k2' },
     ])
 
+    // Reference nested in an object inside an array is repointed too.
+    const reviewPatch = patchOps.find((p) => p.id === 'review-1')!
+    expect(reviewPatch.set.entries).toEqual([
+      { note: 'x', by: { _type: 'reference', _ref: SURVIVOR } },
+    ])
+
     // Survivor identity union patch.
     const survivorPatch = patchOps.find((p) => p.id === SURVIVOR)!
     expect(survivorPatch.set.providers).toEqual(['github:1', 'linkedin:2'])
@@ -150,9 +195,16 @@ describe('mergeSpeakers (transaction wrapper)', () => {
       'ada.l@work.io',
     ])
 
-    // Loser deleted, and deletion happens after all patches were staged.
+    // Referencing-doc repoints are revision-guarded so a concurrent edit aborts
+    // the whole transaction instead of being clobbered.
+    expect(talkPatch.rev).toBeTruthy()
+    expect(confPatch.rev).toBeTruthy()
+
+    // Loser deleted, and deletion is the LAST op — after every patch was staged.
     expect(deletedIds).toEqual([LOSER])
     expect(deleteMock).toHaveBeenCalledWith(LOSER)
+    expect(txOrder[txOrder.length - 1]).toBe('delete')
+    expect(txOrder.slice(0, -1).every((op) => op === 'patch')).toBe(true)
   })
 
   it('rejects a self-merge without any read/write', async () => {

--- a/src/lib/speaker/merge.sanity.test.ts
+++ b/src/lib/speaker/merge.sanity.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { MergeSpeakerDoc } from './merge'
+
+// --- Sanity client mock (transaction boundary) -----------------------------
+
+const fetchMock = vi.fn()
+const commitMock = vi.fn().mockResolvedValue({ transactionId: 'tx-1' })
+const deleteMock = vi.fn()
+
+// Each `.patch(id, fn)` invokes `fn` with a fake patch builder whose `.set()`
+// records the argument, so tests can assert the exact ops in the transaction.
+const patchOps: Array<{ id: string; set: Record<string, unknown> }> = []
+const patchMock = vi.fn(
+  (
+    id: string,
+    fn: (p: { set: (o: Record<string, unknown>) => unknown }) => unknown,
+  ) => {
+    const op = { id, set: {} as Record<string, unknown> }
+    fn({
+      set: (o: Record<string, unknown>) => {
+        op.set = o
+        return {}
+      },
+    })
+    patchOps.push(op)
+    return transactionApi
+  },
+)
+
+const deletedIds: string[] = []
+const transactionApi = {
+  patch: patchMock,
+  delete: (id: string) => {
+    deletedIds.push(id)
+    deleteMock(id)
+    return transactionApi
+  },
+  commit: commitMock,
+}
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+  clientWrite: {
+    transaction: () => transactionApi,
+  },
+}))
+
+import { mergeSpeakers } from './merge'
+
+const SURVIVOR = 'speaker-survivor'
+const LOSER = 'speaker-loser'
+
+function ref(id: string, key?: string) {
+  return key
+    ? { _type: 'reference', _ref: id, _key: key }
+    : { _type: 'reference', _ref: id }
+}
+
+const survivorDoc: MergeSpeakerDoc = {
+  _id: SURVIVOR,
+  _type: 'speaker',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  providers: ['github:1'],
+  knownEmails: ['ada@example.com'],
+}
+
+const loserDoc: MergeSpeakerDoc = {
+  _id: LOSER,
+  _type: 'speaker',
+  name: 'Ada L',
+  email: 'ada.l@work.io',
+  providers: ['linkedin:2'],
+  knownEmails: ['ada.l@work.io'],
+}
+
+const referencingDocs = [
+  {
+    _id: 'talk-1',
+    _type: 'talk',
+    speakers: [ref('other', 'k0'), ref(LOSER, 'k1')],
+  },
+  { _id: 'conf-1', _type: 'conference', organizers: [ref(LOSER, 'k2')] },
+]
+
+function routeFetch(query: string, params: Record<string, unknown> = {}) {
+  if (query.includes('_id == $id')) {
+    if (params.id === SURVIVOR) return Promise.resolve(survivorDoc)
+    if (params.id === LOSER) return Promise.resolve(loserDoc)
+    return Promise.resolve(null)
+  }
+  if (query.includes('references($loserId)')) {
+    return Promise.resolve(referencingDocs)
+  }
+  return Promise.resolve(null)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  patchOps.length = 0
+  deletedIds.length = 0
+  fetchMock.mockImplementation(routeFetch)
+})
+
+describe('mergeSpeakers (transaction wrapper)', () => {
+  it('dry-run writes nothing and returns a preview', async () => {
+    const { preview, committed, err } = await mergeSpeakers({
+      survivorId: SURVIVOR,
+      loserId: LOSER,
+      actor: { _id: 'admin-1' },
+      dryRun: true,
+    })
+
+    expect(err).toBeNull()
+    expect(committed).toBe(false)
+    expect(patchMock).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+    expect(deletedIds).toEqual([])
+    expect(preview?.referenceRepointsByType).toEqual({ talk: 1, conference: 1 })
+  })
+
+  it('commits repoint patches, the survivor patch, and deletes the loser LAST', async () => {
+    const { committed, err } = await mergeSpeakers({
+      survivorId: SURVIVOR,
+      loserId: LOSER,
+      actor: { _id: 'admin-1', name: 'Admin' },
+      dryRun: false,
+    })
+
+    expect(err).toBeNull()
+    expect(committed).toBe(true)
+    expect(commitMock).toHaveBeenCalledTimes(1)
+
+    // Referencing docs repointed to the survivor.
+    const talkPatch = patchOps.find((p) => p.id === 'talk-1')!
+    expect(talkPatch.set.speakers).toEqual([
+      ref('other', 'k0'),
+      { _type: 'reference', _ref: SURVIVOR, _key: 'k1' },
+    ])
+    const confPatch = patchOps.find((p) => p.id === 'conf-1')!
+    expect(confPatch.set.organizers).toEqual([
+      { _type: 'reference', _ref: SURVIVOR, _key: 'k2' },
+    ])
+
+    // Survivor identity union patch.
+    const survivorPatch = patchOps.find((p) => p.id === SURVIVOR)!
+    expect(survivorPatch.set.providers).toEqual(['github:1', 'linkedin:2'])
+    expect(survivorPatch.set.knownEmails).toEqual([
+      'ada@example.com',
+      'ada.l@work.io',
+    ])
+
+    // Loser deleted, and deletion happens after all patches were staged.
+    expect(deletedIds).toEqual([LOSER])
+    expect(deleteMock).toHaveBeenCalledWith(LOSER)
+  })
+
+  it('rejects a self-merge without any read/write', async () => {
+    const { err, committed } = await mergeSpeakers({
+      survivorId: SURVIVOR,
+      loserId: SURVIVOR,
+      actor: { _id: 'admin-1' },
+    })
+    expect(committed).toBe(false)
+    expect(err?.message).toMatch(/into itself/)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a validation error when the loser is missing', async () => {
+    fetchMock.mockImplementation(
+      (query: string, params: Record<string, unknown>) => {
+        if (query.includes('_id == $id')) {
+          return params.id === SURVIVOR
+            ? Promise.resolve(survivorDoc)
+            : Promise.resolve(null)
+        }
+        if (query.includes('references($loserId)')) return Promise.resolve([])
+        return Promise.resolve(null)
+      },
+    )
+
+    const { err, committed } = await mergeSpeakers({
+      survivorId: SURVIVOR,
+      loserId: 'missing',
+      actor: { _id: 'admin-1' },
+    })
+    expect(committed).toBe(false)
+    expect(err?.message).toMatch(/Loser speaker not found/)
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/speaker/merge.test.ts
+++ b/src/lib/speaker/merge.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest'
+import {
+  repointReferencesInDocument,
+  computeSurvivorFieldMerge,
+  assertMergeable,
+  buildMergePlan,
+  MergeValidationError,
+  type MergeSpeakerDoc,
+} from './merge'
+
+const SURVIVOR = 'speaker-survivor'
+const LOSER = 'speaker-loser'
+
+function ref(id: string, key?: string) {
+  return key
+    ? { _type: 'reference', _ref: id, _key: key }
+    : { _type: 'reference', _ref: id }
+}
+
+function speaker(overrides: Partial<MergeSpeakerDoc> = {}): MergeSpeakerDoc {
+  return {
+    _id: SURVIVOR,
+    _type: 'speaker',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    ...overrides,
+  }
+}
+
+// --- repointReferencesInDocument -------------------------------------------
+
+describe('repointReferencesInDocument', () => {
+  it('replaces a single top-level reference (review.reviewer)', () => {
+    const doc = { _id: 'review-1', _type: 'review', reviewer: ref(LOSER) }
+    const {
+      doc: out,
+      changedKeys,
+      repointed,
+    } = repointReferencesInDocument(doc, LOSER, SURVIVOR)
+    expect(repointed).toBe(1)
+    expect(changedKeys).toEqual(['reviewer'])
+    expect(out.reviewer).toEqual({ _type: 'reference', _ref: SURVIVOR })
+  })
+
+  it('replaces a reference inside an array (talk.speakers[])', () => {
+    const doc = {
+      _id: 'talk-1',
+      _type: 'talk',
+      speakers: [ref('speaker-other', 'k1'), ref(LOSER, 'k2')],
+    }
+    const {
+      doc: out,
+      changedKeys,
+      repointed,
+    } = repointReferencesInDocument(doc, LOSER, SURVIVOR)
+    expect(repointed).toBe(1)
+    expect(changedKeys).toEqual(['speakers'])
+    expect(out.speakers).toEqual([
+      ref('speaker-other', 'k1'),
+      { _type: 'reference', _ref: SURVIVOR, _key: 'k2' },
+    ])
+  })
+
+  it('deduplicates when the survivor is already present in the array', () => {
+    const doc = {
+      _id: 'talk-1',
+      _type: 'talk',
+      speakers: [ref(SURVIVOR, 'k1'), ref(LOSER, 'k2')],
+    }
+    const { doc: out, repointed } = repointReferencesInDocument(
+      doc,
+      LOSER,
+      SURVIVOR,
+    )
+    expect(repointed).toBe(1)
+    // Loser entry collapses into the existing survivor entry — no duplicate.
+    expect(out.speakers).toEqual([ref(SURVIVOR, 'k1')])
+  })
+
+  it('keeps the loser entry (repointed) when survivor comes after it', () => {
+    const doc = {
+      _id: 'gallery-1',
+      _type: 'imageGallery',
+      speakers: [ref(LOSER, 'k1'), ref(SURVIVOR, 'k2')],
+    }
+    const { doc: out } = repointReferencesInDocument(doc, LOSER, SURVIVOR)
+    // First survivor-pointing entry kept (the repointed loser, key k1).
+    expect(out.speakers).toEqual([
+      { _type: 'reference', _ref: SURVIVOR, _key: 'k1' },
+    ])
+  })
+
+  it('reports no change when the document does not reference the loser', () => {
+    const doc = { _id: 'review-2', _type: 'review', reviewer: ref('someone') }
+    const {
+      doc: out,
+      changedKeys,
+      repointed,
+    } = repointReferencesInDocument(doc, LOSER, SURVIVOR)
+    expect(repointed).toBe(0)
+    expect(changedKeys).toEqual([])
+    // Structural sharing: unchanged doc is returned by identity.
+    expect(out).toBe(doc)
+  })
+
+  it('repoints multiple single refs in one document (travelSupport)', () => {
+    const doc = {
+      _id: 'ts-1',
+      _type: 'travelSupport',
+      speaker: ref(LOSER),
+      reviewedBy: ref(LOSER),
+    }
+    const {
+      changedKeys,
+      repointed,
+      doc: out,
+    } = repointReferencesInDocument(doc, LOSER, SURVIVOR)
+    expect(repointed).toBe(2)
+    expect(new Set(changedKeys)).toEqual(new Set(['speaker', 'reviewedBy']))
+    expect(out.speaker).toEqual({ _type: 'reference', _ref: SURVIVOR })
+    expect(out.reviewedBy).toEqual({ _type: 'reference', _ref: SURVIVOR })
+  })
+
+  it('preserves the survivor in conference.organizers[] (isOrganizer guarantee)', () => {
+    const doc = {
+      _id: 'conf-1',
+      _type: 'conference',
+      organizers: [ref('org-a', 'k1'), ref(LOSER, 'k2')],
+      featuredSpeakers: [ref(LOSER, 'f1')],
+    }
+    const { doc: out, repointed } = repointReferencesInDocument(
+      doc,
+      LOSER,
+      SURVIVOR,
+    )
+    expect(repointed).toBe(2)
+    expect(out.organizers).toContainEqual({
+      _type: 'reference',
+      _ref: SURVIVOR,
+      _key: 'k2',
+    })
+    expect(out.featuredSpeakers).toEqual([
+      { _type: 'reference', _ref: SURVIVOR, _key: 'f1' },
+    ])
+  })
+})
+
+// --- computeSurvivorFieldMerge ---------------------------------------------
+
+describe('computeSurvivorFieldMerge', () => {
+  it('unions providers (deduplicated)', () => {
+    const survivor = speaker({ providers: ['github:1'] })
+    const loser = speaker({ _id: LOSER, providers: ['github:1', 'linkedin:2'] })
+    const { set, identity } = computeSurvivorFieldMerge(survivor, loser)
+    expect(set.providers).toEqual(['github:1', 'linkedin:2'])
+    expect(identity.providers.after).toEqual(['github:1', 'linkedin:2'])
+  })
+
+  it('does not set providers when the union adds nothing', () => {
+    const survivor = speaker({ providers: ['github:1', 'linkedin:2'] })
+    const loser = speaker({ _id: LOSER, providers: ['github:1'] })
+    const { set } = computeSurvivorFieldMerge(survivor, loser)
+    expect(set.providers).toBeUndefined()
+  })
+
+  it('unions and normalizes knownEmails, folding both display emails', () => {
+    const survivor = speaker({
+      email: 'Ada@Example.com',
+      knownEmails: ['ada@example.com'],
+    })
+    const loser = speaker({
+      _id: LOSER,
+      email: 'ADA.L@Work.io',
+      knownEmails: ['ada.l@work.io'],
+    })
+    const { set } = computeSurvivorFieldMerge(survivor, loser)
+    expect(set.knownEmails).toEqual(['ada@example.com', 'ada.l@work.io'])
+  })
+
+  it('preserves the survivor display email when non-empty', () => {
+    const survivor = speaker({ email: 'keep@me.com' })
+    const loser = speaker({ _id: LOSER, email: 'other@me.com' })
+    const { set } = computeSurvivorFieldMerge(survivor, loser)
+    expect(set.email).toBeUndefined()
+  })
+
+  it('fills the display email from the loser when the survivor has none', () => {
+    const survivor = speaker({ email: '' })
+    const loser = speaker({ _id: LOSER, email: 'fallback@me.com' })
+    const { set } = computeSurvivorFieldMerge(survivor, loser)
+    expect(set.email).toBe('fallback@me.com')
+  })
+
+  it('keeps survivor scalars and fills only the gaps from the loser', () => {
+    const survivor = speaker({
+      bio: 'Survivor bio',
+      title: '',
+      links: [],
+      flags: ['local'],
+    })
+    const loser = speaker({
+      _id: LOSER,
+      bio: 'Loser bio',
+      title: 'Loser title',
+      links: ['https://loser.dev'],
+      flags: ['diverse'],
+      imageURL: 'https://img/loser.png',
+    })
+    const { set, filledFromLoser } = computeSurvivorFieldMerge(survivor, loser)
+    expect(set.bio).toBeUndefined() // survivor kept
+    expect(set.flags).toBeUndefined() // survivor kept (non-empty)
+    expect(set.title).toBe('Loser title') // gap filled
+    expect(set.links).toEqual(['https://loser.dev']) // gap filled
+    expect(set.imageURL).toBe('https://img/loser.png') // gap filled
+    expect(new Set(filledFromLoser)).toEqual(
+      new Set(['title', 'links', 'imageURL']),
+    )
+  })
+
+  it('never emits slug in the survivor patch', () => {
+    const survivor = speaker({ slug: { current: 'ada' } })
+    const loser = speaker({ _id: LOSER, slug: { current: 'ada-2' } })
+    const { set } = computeSurvivorFieldMerge(survivor, loser)
+    expect('slug' in set).toBe(false)
+  })
+})
+
+// --- assertMergeable / buildMergePlan --------------------------------------
+
+describe('assertMergeable', () => {
+  it('rejects a self-merge', () => {
+    const s = speaker()
+    expect(() => assertMergeable(s, { ...s })).toThrow(MergeValidationError)
+  })
+
+  it('rejects when a document is missing', () => {
+    expect(() => assertMergeable(speaker(), null)).toThrow(
+      /Loser speaker not found/,
+    )
+    expect(() => assertMergeable(null, speaker())).toThrow(
+      /Survivor speaker not found/,
+    )
+  })
+
+  it('rejects non-speaker documents', () => {
+    const survivor = speaker()
+    const loser = speaker({ _id: LOSER, _type: 'talk' })
+    expect(() => assertMergeable(survivor, loser)).toThrow(/must be speakers/)
+  })
+
+  it('rejects draft documents', () => {
+    const survivor = speaker({ _id: 'drafts.speaker-survivor' })
+    const loser = speaker({ _id: LOSER })
+    expect(() => assertMergeable(survivor, loser)).toThrow(/draft/)
+  })
+})
+
+describe('buildMergePlan', () => {
+  const survivor = speaker({ providers: ['github:1'] })
+  const loser = speaker({
+    _id: LOSER,
+    providers: ['linkedin:2'],
+    email: 'loser@example.com',
+  })
+  const referencingDocs = [
+    { _id: 'talk-1', _type: 'talk', speakers: [ref(LOSER, 'k1')] },
+    {
+      _id: 'conf-1',
+      _type: 'conference',
+      organizers: [ref(LOSER, 'k2')],
+    },
+    { _id: 'review-1', _type: 'review', reviewer: ref(LOSER) },
+    // A doc that does NOT reference the loser must produce no patch.
+    { _id: 'talk-2', _type: 'talk', speakers: [ref('other', 'k3')] },
+  ]
+
+  it('produces per-type repoint counts and a survivor patch', () => {
+    const plan = buildMergePlan(survivor, loser, referencingDocs)
+    expect(plan.summary.referenceRepointsByType).toEqual({
+      talk: 1,
+      conference: 1,
+      review: 1,
+    })
+    expect(plan.summary.referencingDocCount).toBe(3)
+    expect(plan.documentPatches.map((p) => p.id).sort()).toEqual([
+      'conf-1',
+      'review-1',
+      'talk-1',
+    ])
+    expect(plan.survivorSet.providers).toEqual(['github:1', 'linkedin:2'])
+  })
+
+  it('preserves isOrganizer by repointing conference.organizers to the survivor', () => {
+    const plan = buildMergePlan(survivor, loser, referencingDocs)
+    const confPatch = plan.documentPatches.find((p) => p.id === 'conf-1')!
+    expect(confPatch.set.organizers).toContainEqual({
+      _type: 'reference',
+      _ref: SURVIVOR,
+      _key: 'k2',
+    })
+  })
+
+  it('dry-run summary matches the committed plan (same pure function)', () => {
+    const plan = buildMergePlan(survivor, loser, referencingDocs)
+    // The summary is derived from exactly the patches/field-merge that would be
+    // written, so counts in the preview equal the actual patch set.
+    const actualByType = plan.documentPatches.reduce<Record<string, number>>(
+      (acc, p) => {
+        acc[p.type] = (acc[p.type] ?? 0) + p.repointed
+        return acc
+      },
+      {},
+    )
+    expect(plan.summary.referenceRepointsByType).toEqual(actualByType)
+    expect(plan.summary.willDeleteLoserId).toBe(LOSER)
+  })
+})

--- a/src/lib/speaker/merge.ts
+++ b/src/lib/speaker/merge.ts
@@ -1,0 +1,505 @@
+/**
+ * Speaker merge (identity Phase 3).
+ *
+ * An ADMIN-only, destructive operation that folds a duplicate ("loser") speaker
+ * document into a canonical ("survivor") one:
+ *  1. Every inbound reference to the loser is repointed to the survivor.
+ *  2. Identity fields (`providers`, `knownEmails`) are unioned onto the survivor
+ *     and the loser's display email is folded into the survivor's match-set.
+ *  3. Scalar fields fill ONLY the survivor's gaps (survivor wins deterministically).
+ *  4. The loser document is deleted — all in one atomic Sanity transaction so
+ *     nothing dangles.
+ *
+ * This module is split into a PURE core (fully unit-testable, no I/O) plus a
+ * thin {@link mergeSpeakers} wrapper that performs the Sanity reads and the
+ * single write transaction. The pure core is what the tests exercise.
+ *
+ * SECURITY / CORRECTNESS notes:
+ *  - `conference.organizers[]` is one of the repointed reference sites, so the
+ *    computed `isOrganizer` flag is preserved when the loser was an organizer.
+ *  - `slug` is NEVER changed — the survivor keeps its live public URL.
+ *  - Draft documents are rejected; only published `speaker` docs may be merged.
+ */
+
+import {
+  clientReadUncached as clientRead,
+  clientWrite,
+} from '@/lib/sanity/client'
+import { groq } from 'next-sanity'
+import { normalizeEmail, uniqueEmails } from './email'
+
+/** Minimal shape of a raw (unprojected) speaker document used by the merge. */
+export interface MergeSpeakerDoc {
+  _id: string
+  _type: string
+  name?: string
+  email?: string
+  slug?: { _type?: string; current?: string } | string
+  providers?: (string | null | undefined)[]
+  knownEmails?: (string | null | undefined)[]
+  bio?: string
+  title?: string
+  links?: unknown[]
+  flags?: unknown[]
+  consent?: unknown
+  image?: unknown
+  imageURL?: string
+  [key: string]: unknown
+}
+
+/** A raw Sanity reference object: `{ _ref, _key?, _type? }`. */
+interface SanityReference {
+  _ref: string
+  _key?: string
+  _type?: string
+}
+
+/** Thrown for precondition failures (self-merge, missing / non-speaker docs). */
+export class MergeValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'MergeValidationError'
+  }
+}
+
+function isReference(value: unknown): value is SanityReference {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { _ref?: unknown })._ref === 'string'
+  )
+}
+
+/**
+ * Deep-transform a JSON value, repointing every reference to `loserId` so it
+ * points at `survivorId` instead. Within arrays, references to the survivor are
+ * deduplicated (survivor already present, or a repointed loser entry now
+ * duplicates it) — the first occurrence is kept so its `_key` survives.
+ *
+ * Returns the SAME reference when nothing below it changed, which lets callers
+ * detect changed top-level fields by identity comparison.
+ */
+function transformValue(
+  value: unknown,
+  loserId: string,
+  survivorId: string,
+  counter: { count: number },
+): unknown {
+  if (Array.isArray(value)) {
+    let changed = false
+    const mapped = value.map((item) => {
+      const next = transformValue(item, loserId, survivorId, counter)
+      if (next !== item) changed = true
+      return next
+    })
+
+    // Collapse duplicate references to the survivor into a single entry.
+    let seenSurvivor = false
+    const deduped: unknown[] = []
+    for (const item of mapped) {
+      if (isReference(item) && item._ref === survivorId) {
+        if (seenSurvivor) {
+          changed = true
+          continue
+        }
+        seenSurvivor = true
+      }
+      deduped.push(item)
+    }
+
+    return changed ? deduped : value
+  }
+
+  if (isReference(value)) {
+    if (value._ref === loserId) {
+      counter.count += 1
+      return { ...value, _ref: survivorId }
+    }
+    return value
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    let changed = false
+    const out: Record<string, unknown> = {}
+    for (const [key, child] of Object.entries(value)) {
+      const next = transformValue(child, loserId, survivorId, counter)
+      if (next !== child) changed = true
+      out[key] = next
+    }
+    return changed ? out : value
+  }
+
+  return value
+}
+
+/** Result of repointing a single referencing document. */
+export interface RepointedDocument {
+  /** The transformed document (same reference if unchanged). */
+  doc: Record<string, unknown>
+  /** Top-level keys whose value changed and must be `.set()` on the patch. */
+  changedKeys: string[]
+  /** Number of individual loser references that were repointed. */
+  repointed: number
+}
+
+/**
+ * Repoint every reference to `loserId` inside `doc` to `survivorId`, generically
+ * (works for array refs, single refs, and refs nested in objects). Returns the
+ * changed top-level keys so a minimal `.set()` patch can be built.
+ */
+export function repointReferencesInDocument(
+  doc: Record<string, unknown>,
+  loserId: string,
+  survivorId: string,
+): RepointedDocument {
+  const counter = { count: 0 }
+  const transformed = transformValue(
+    doc,
+    loserId,
+    survivorId,
+    counter,
+  ) as Record<string, unknown>
+
+  const changedKeys: string[] = []
+  if (transformed !== doc) {
+    for (const key of Object.keys(transformed)) {
+      if (transformed[key] !== doc[key]) changedKeys.push(key)
+    }
+  }
+
+  return { doc: transformed, changedKeys, repointed: counter.count }
+}
+
+/** A `before`/`after` view of a normalized string-list identity field. */
+export interface IdentityFieldChange {
+  before: string[]
+  after: string[]
+}
+
+/** The computed patch to apply to the survivor, plus a preview-friendly view. */
+export interface SurvivorFieldMerge {
+  /** Only the fields that actually change (used to build the survivor patch). */
+  set: Record<string, unknown>
+  identity: {
+    providers: IdentityFieldChange
+    knownEmails: IdentityFieldChange
+    email: { before: string; after: string }
+  }
+  /** Scalar fields that were empty on the survivor and filled from the loser. */
+  filledFromLoser: string[]
+}
+
+/** Scalar/opaque fields the survivor keeps; the loser only fills gaps. */
+const SCALAR_FILL_FIELDS = [
+  'bio',
+  'title',
+  'links',
+  'flags',
+  'consent',
+  'image',
+  'imageURL',
+] as const
+
+function isEmptyValue(value: unknown): boolean {
+  if (value === undefined || value === null) return true
+  if (typeof value === 'string') return value.trim().length === 0
+  if (Array.isArray(value)) return value.length === 0
+  if (typeof value === 'object') return Object.keys(value).length === 0
+  return false
+}
+
+function stringList(
+  values: (string | null | undefined)[] | undefined,
+): string[] {
+  return (values ?? []).filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  )
+}
+
+/**
+ * Compute the identity union + scalar reconciliation to apply to the survivor.
+ *
+ * - `providers`: deduplicated union.
+ * - `knownEmails`: normalized, deduplicated union of both match-sets PLUS both
+ *   display emails (so the loser's address becomes a future match key).
+ * - `email` (display): keep the survivor's unless empty, then fall back to the
+ *   loser's. The survivor's `slug` is intentionally never touched.
+ * - Scalars: keep the survivor's; fill from the loser only where the survivor's
+ *   value is empty. Deterministic — the admin picked the survivor deliberately.
+ */
+export function computeSurvivorFieldMerge(
+  survivor: MergeSpeakerDoc,
+  loser: MergeSpeakerDoc,
+): SurvivorFieldMerge {
+  const set: Record<string, unknown> = {}
+  const filledFromLoser: string[] = []
+
+  // providers — deduplicated union, survivor order first.
+  const providersBefore = stringList(survivor.providers)
+  const providersAfter = Array.from(
+    new Set([...providersBefore, ...stringList(loser.providers)]),
+  )
+  if (providersAfter.length !== providersBefore.length) {
+    set.providers = providersAfter
+  }
+
+  // knownEmails — normalized union incl. both display emails.
+  const knownBefore = uniqueEmails(survivor.knownEmails ?? [])
+  const knownAfter = uniqueEmails([
+    ...(survivor.knownEmails ?? []),
+    ...(loser.knownEmails ?? []),
+    survivor.email,
+    loser.email,
+  ])
+  if (knownAfter.length !== knownBefore.length) {
+    set.knownEmails = knownAfter
+  }
+
+  // display email — preserve survivor's; only fall back to loser's when empty.
+  const emailBefore = survivor.email ?? ''
+  const emailAfter = isEmptyValue(survivor.email)
+    ? (loser.email ?? '')
+    : survivor.email!
+  if (emailAfter !== emailBefore && !isEmptyValue(emailAfter)) {
+    set.email = emailAfter
+  }
+
+  // scalar fields — survivor kept, loser fills gaps only.
+  for (const field of SCALAR_FILL_FIELDS) {
+    if (isEmptyValue(survivor[field]) && !isEmptyValue(loser[field])) {
+      set[field] = loser[field]
+      filledFromLoser.push(field)
+    }
+  }
+
+  return {
+    set,
+    identity: {
+      providers: { before: providersBefore, after: providersAfter },
+      knownEmails: { before: knownBefore, after: knownAfter },
+      email: {
+        before: normalizeEmail(emailBefore),
+        after: normalizeEmail(emailAfter),
+      },
+    },
+    filledFromLoser,
+  }
+}
+
+/**
+ * Reject merges that must never proceed: self-merge, missing documents, draft
+ * documents, or non-speaker documents.
+ */
+export function assertMergeable(
+  survivor: MergeSpeakerDoc | null | undefined,
+  loser: MergeSpeakerDoc | null | undefined,
+): asserts survivor is MergeSpeakerDoc {
+  if (!survivor?._id) {
+    throw new MergeValidationError('Survivor speaker not found')
+  }
+  if (!loser?._id) {
+    throw new MergeValidationError('Loser speaker not found')
+  }
+  if (survivor._id === loser._id) {
+    throw new MergeValidationError('Cannot merge a speaker into itself')
+  }
+  if (survivor._id.startsWith('drafts.') || loser._id.startsWith('drafts.')) {
+    throw new MergeValidationError('Cannot merge draft speaker documents')
+  }
+  if (survivor._type !== 'speaker' || loser._type !== 'speaker') {
+    throw new MergeValidationError('Both documents must be speakers')
+  }
+}
+
+/** Per-referencing-document patch produced by the plan. */
+export interface MergeDocumentPatch {
+  id: string
+  type: string
+  set: Record<string, unknown>
+  repointed: number
+}
+
+/**
+ * Human-readable summary of a merge — returned by the dry-run preview and, after
+ * a successful merge, describing exactly what was written.
+ */
+export interface MergePreview {
+  survivorId: string
+  loserId: string
+  /** Number of documents that will have (or had) a reference repointed. */
+  referencingDocCount: number
+  /** Per document `_type`, how many individual references were repointed. */
+  referenceRepointsByType: Record<string, number>
+  fieldChanges: {
+    providers: IdentityFieldChange
+    knownEmails: IdentityFieldChange
+    email: { before: string; after: string }
+    filledFromLoser: string[]
+  }
+  willDeleteLoserId: string
+}
+
+/** The full, precomputed plan for a merge (pure — no I/O performed). */
+export interface MergePlan {
+  survivorId: string
+  loserId: string
+  survivorSet: Record<string, unknown>
+  documentPatches: MergeDocumentPatch[]
+  summary: MergePreview
+}
+
+/**
+ * Build the complete merge plan from already-fetched documents. Pure and
+ * deterministic: the dry-run preview and the committed write are produced from
+ * exactly this function, so they can never diverge.
+ */
+export function buildMergePlan(
+  survivor: MergeSpeakerDoc,
+  loser: MergeSpeakerDoc,
+  referencingDocs: Array<Record<string, unknown>>,
+): MergePlan {
+  assertMergeable(survivor, loser)
+
+  const fieldMerge = computeSurvivorFieldMerge(survivor, loser)
+
+  const documentPatches: MergeDocumentPatch[] = []
+  const referenceRepointsByType: Record<string, number> = {}
+
+  for (const doc of referencingDocs) {
+    // The loser is deleted, and the survivor's own fields are handled separately.
+    if (doc._id === loser._id || doc._id === survivor._id) continue
+
+    const {
+      changedKeys,
+      doc: transformed,
+      repointed,
+    } = repointReferencesInDocument(doc, loser._id, survivor._id)
+    if (repointed === 0 || changedKeys.length === 0) continue
+
+    const set: Record<string, unknown> = {}
+    for (const key of changedKeys) set[key] = transformed[key]
+
+    const type = String(doc._type ?? 'unknown')
+    documentPatches.push({ id: String(doc._id), type, set, repointed })
+    referenceRepointsByType[type] =
+      (referenceRepointsByType[type] ?? 0) + repointed
+  }
+
+  const summary: MergePreview = {
+    survivorId: survivor._id,
+    loserId: loser._id,
+    referencingDocCount: documentPatches.length,
+    referenceRepointsByType,
+    fieldChanges: {
+      providers: fieldMerge.identity.providers,
+      knownEmails: fieldMerge.identity.knownEmails,
+      email: fieldMerge.identity.email,
+      filledFromLoser: fieldMerge.filledFromLoser,
+    },
+    willDeleteLoserId: loser._id,
+  }
+
+  return {
+    survivorId: survivor._id,
+    loserId: loser._id,
+    survivorSet: fieldMerge.set,
+    documentPatches,
+    summary,
+  }
+}
+
+/** Options for {@link mergeSpeakers}. */
+export interface MergeSpeakersOptions {
+  survivorId: string
+  loserId: string
+  /** The organizer performing the merge (for the audit log). */
+  actor: { _id: string; name?: string }
+  /** When true, compute and return the preview WITHOUT writing anything. */
+  dryRun?: boolean
+}
+
+/** Result of {@link mergeSpeakers}. */
+export interface MergeSpeakersResult {
+  preview: MergePreview | null
+  committed: boolean
+  err: Error | null
+}
+
+async function fetchRawSpeaker(id: string): Promise<MergeSpeakerDoc | null> {
+  return clientRead.fetch<MergeSpeakerDoc | null>(
+    groq`*[_id == $id][0]`,
+    { id },
+    { cache: 'no-store' },
+  )
+}
+
+/**
+ * Merge the `loser` speaker into the `survivor` speaker (or, with `dryRun`,
+ * preview the operation). Reference repointing, the survivor field patch and the
+ * loser deletion all happen in ONE atomic Sanity transaction, with the delete
+ * ordered last so no inbound reference dangles.
+ */
+export async function mergeSpeakers(
+  opts: MergeSpeakersOptions,
+): Promise<MergeSpeakersResult> {
+  const { survivorId, loserId, actor, dryRun = false } = opts
+
+  try {
+    if (survivorId === loserId) {
+      throw new MergeValidationError('Cannot merge a speaker into itself')
+    }
+
+    const [survivor, loser] = await Promise.all([
+      fetchRawSpeaker(survivorId),
+      fetchRawSpeaker(loserId),
+    ])
+
+    // Enumerate every inbound reference to the loser generically (mirrors
+    // deleteProposal), then repoint each one to the survivor.
+    const referencingDocs =
+      (await clientRead.fetch<Array<Record<string, unknown>>>(
+        groq`*[references($loserId) && _id != $loserId]`,
+        { loserId },
+        { cache: 'no-store' },
+      )) ?? []
+
+    const plan = buildMergePlan(
+      survivor as MergeSpeakerDoc,
+      loser as MergeSpeakerDoc,
+      referencingDocs,
+    )
+
+    if (dryRun) {
+      return { preview: plan.summary, committed: false, err: null }
+    }
+
+    const transaction = clientWrite.transaction()
+    for (const patch of plan.documentPatches) {
+      transaction.patch(patch.id, (p) => p.set(patch.set))
+    }
+    if (Object.keys(plan.survivorSet).length > 0) {
+      transaction.patch(survivorId, (p) => p.set(plan.survivorSet))
+    }
+    // Delete the loser LAST so all inbound references are already repointed.
+    transaction.delete(loserId)
+    await transaction.commit()
+
+    // Audit log: who merged what, and the shape of the change.
+    console.info('[speaker-merge] merged duplicate speaker', {
+      actor: actor._id,
+      actorName: actor.name,
+      survivorId,
+      loserId,
+      referencingDocCount: plan.summary.referencingDocCount,
+      referenceRepointsByType: plan.summary.referenceRepointsByType,
+      filledFromLoser: plan.summary.fieldChanges.filledFromLoser,
+    })
+
+    return { preview: plan.summary, committed: true, err: null }
+  } catch (error) {
+    if (!(error instanceof MergeValidationError)) {
+      console.error('Error merging speakers:', error)
+    }
+    return { preview: null, committed: false, err: error as Error }
+  }
+}

--- a/src/lib/speaker/merge.ts
+++ b/src/lib/speaker/merge.ts
@@ -190,12 +190,15 @@ export interface SurvivorFieldMerge {
 }
 
 /** Scalar/opaque fields the survivor keeps; the loser only fills gaps. */
+// NOTE: `consent` is deliberately NOT gap-filled. A GDPR consent record belongs
+// to the specific person/session that granted it; copying the loser's consent
+// onto the survivor would mis-attribute a consent artifact. Leave the survivor's
+// consent as-is (empty if they never granted one).
 const SCALAR_FILL_FIELDS = [
   'bio',
   'title',
   'links',
   'flags',
-  'consent',
   'image',
   'imageURL',
 ] as const
@@ -473,9 +476,21 @@ export async function mergeSpeakers(
       return { preview: plan.summary, committed: false, err: null }
     }
 
+    // Guard each referencing-doc repoint with the revision we read, so a
+    // concurrent edit to that doc's arrays (e.g. someone adds a co-speaker
+    // between our read and commit) makes the WHOLE transaction fail with a 409
+    // rather than silently clobbering their change with our stale full-array
+    // `.set()`. The admin simply retries the merge. Atomic + now isolated.
+    const revById = new Map(
+      referencingDocs.map((d) => [d._id as string, d._rev as string]),
+    )
     const transaction = clientWrite.transaction()
     for (const patch of plan.documentPatches) {
-      transaction.patch(patch.id, (p) => p.set(patch.set))
+      const rev = revById.get(patch.id)
+      transaction.patch(patch.id, (p) => {
+        const applied = p.set(patch.set)
+        return rev ? applied.ifRevisionId(rev) : applied
+      })
     }
     if (Object.keys(plan.survivorSet).length > 0) {
       transaction.patch(survivorId, (p) => p.set(plan.survivorSet))

--- a/src/server/routers/speaker.merge.test.ts
+++ b/src/server/routers/speaker.merge.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { TRPCError } from '@trpc/server'
+import type { Context } from '@/server/trpc'
+
+// Mock the merge library so the router test exercises ONLY the tRPC wiring and
+// the adminProcedure auth gate — not the Sanity transaction (covered elsewhere).
+const mergeSpeakersMock = vi.fn()
+vi.mock('@/lib/speaker/merge', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/speaker/merge')>(
+    '@/lib/speaker/merge',
+  )
+  return {
+    ...actual,
+    mergeSpeakers: (...args: unknown[]) => mergeSpeakersMock(...args),
+  }
+})
+
+import { speakerRouter } from './speaker'
+import { MergeValidationError } from '@/lib/speaker/merge'
+
+const PREVIEW = {
+  survivorId: 'survivor',
+  loserId: 'loser',
+  referencingDocCount: 2,
+  referenceRepointsByType: { talk: 1, conference: 1 },
+  fieldChanges: {
+    providers: { before: [], after: ['github:1'] },
+    knownEmails: { before: [], after: ['a@b.com'] },
+    email: { before: 'a@b.com', after: 'a@b.com' },
+    filledFromLoser: [],
+  },
+  willDeleteLoserId: 'loser',
+}
+
+function makeCaller(opts: { isOrganizer: boolean }) {
+  const ctx = {
+    session: {
+      speaker: {
+        _id: 'admin-1',
+        name: 'Admin',
+        isOrganizer: opts.isOrganizer,
+      },
+      user: { name: 'Admin' },
+    },
+    speaker: { _id: 'admin-1', name: 'Admin', isOrganizer: opts.isOrganizer },
+  } as unknown as Context
+  return speakerRouter.createCaller(ctx)
+}
+
+const input = { survivorId: 'survivor', loserId: 'loser' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('speaker.admin.merge auth gate', () => {
+  it('rejects a non-organizer for the preview query', async () => {
+    const caller = makeCaller({ isOrganizer: false })
+    await expect(caller.admin.mergePreview(input)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+    expect(mergeSpeakersMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-organizer for the merge mutation', async () => {
+    const caller = makeCaller({ isOrganizer: false })
+    await expect(caller.admin.merge(input)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+    expect(mergeSpeakersMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('speaker.admin.mergePreview', () => {
+  it('calls mergeSpeakers with dryRun=true and writes nothing', async () => {
+    mergeSpeakersMock.mockResolvedValue({
+      preview: PREVIEW,
+      committed: false,
+      err: null,
+    })
+    const caller = makeCaller({ isOrganizer: true })
+    const result = await caller.admin.mergePreview(input)
+
+    expect(result).toEqual(PREVIEW)
+    expect(mergeSpeakersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        survivorId: 'survivor',
+        loserId: 'loser',
+        dryRun: true,
+        actor: expect.objectContaining({ _id: 'admin-1' }),
+      }),
+    )
+  })
+
+  it('maps a validation error to BAD_REQUEST', async () => {
+    mergeSpeakersMock.mockResolvedValue({
+      preview: null,
+      committed: false,
+      err: new MergeValidationError('Cannot merge a speaker into itself'),
+    })
+    const caller = makeCaller({ isOrganizer: true })
+    await expect(caller.admin.mergePreview(input)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    })
+  })
+})
+
+describe('speaker.admin.merge', () => {
+  it('calls mergeSpeakers with dryRun=false and returns success', async () => {
+    mergeSpeakersMock.mockResolvedValue({
+      preview: PREVIEW,
+      committed: true,
+      err: null,
+    })
+    const caller = makeCaller({ isOrganizer: true })
+    const result = await caller.admin.merge(input)
+
+    expect(result).toEqual({ success: true, preview: PREVIEW })
+    expect(mergeSpeakersMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: false }),
+    )
+  })
+
+  it('maps an unexpected error to INTERNAL_SERVER_ERROR', async () => {
+    mergeSpeakersMock.mockResolvedValue({
+      preview: null,
+      committed: false,
+      err: new Error('sanity exploded'),
+    })
+    const caller = makeCaller({ isOrganizer: true })
+    await expect(caller.admin.merge(input)).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    })
+  })
+
+  it('rejects a self-merge at the input-schema layer', async () => {
+    const caller = makeCaller({ isOrganizer: true })
+    await expect(
+      caller.admin.merge({ survivorId: 'x', loserId: 'x' }),
+    ).rejects.toBeInstanceOf(TRPCError)
+    expect(mergeSpeakersMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/routers/speaker.ts
+++ b/src/server/routers/speaker.ts
@@ -11,9 +11,11 @@ import {
   SpeakerCreateSchema,
   SpeakerUpdateSchema,
   SpeakerSearchSchema,
+  SpeakerMergeSchema,
   EmailUpdateSchema,
   IdParamSchema,
 } from '@/server/schemas/speaker'
+import { mergeSpeakers, MergeValidationError } from '@/lib/speaker/merge'
 import {
   getSpeaker,
   updateSpeaker,
@@ -474,6 +476,60 @@ export const speakerRouter = router({
         })
       }
     }),
+
+    // Preview a duplicate-speaker merge (identity Phase 3). Read-only: computes
+    // exactly what the mutation would repoint/change WITHOUT writing anything so
+    // the organizer can review before confirming this destructive operation.
+    mergePreview: adminProcedure
+      .input(SpeakerMergeSchema)
+      .query(async ({ input, ctx }) => {
+        const { preview, err } = await mergeSpeakers({
+          survivorId: input.survivorId,
+          loserId: input.loserId,
+          actor: { _id: ctx.speaker._id, name: ctx.speaker.name },
+          dryRun: true,
+        })
+
+        if (err) {
+          throw new TRPCError({
+            code:
+              err instanceof MergeValidationError
+                ? 'BAD_REQUEST'
+                : 'INTERNAL_SERVER_ERROR',
+            message: err.message || 'Failed to preview speaker merge',
+            cause: err,
+          })
+        }
+
+        return preview!
+      }),
+
+    // Merge a duplicate ("loser") speaker into the canonical ("survivor") one.
+    // Repoints every inbound reference, unions identity fields, then deletes the
+    // loser — all in one atomic Sanity transaction.
+    merge: adminProcedure
+      .input(SpeakerMergeSchema)
+      .mutation(async ({ input, ctx }) => {
+        const { preview, committed, err } = await mergeSpeakers({
+          survivorId: input.survivorId,
+          loserId: input.loserId,
+          actor: { _id: ctx.speaker._id, name: ctx.speaker.name },
+          dryRun: false,
+        })
+
+        if (err) {
+          throw new TRPCError({
+            code:
+              err instanceof MergeValidationError
+                ? 'BAD_REQUEST'
+                : 'INTERNAL_SERVER_ERROR',
+            message: err.message || 'Failed to merge speakers',
+            cause: err,
+          })
+        }
+
+        return { success: committed, preview: preview! }
+      }),
 
     // Update speaker email
     updateEmail: adminProcedure

--- a/src/server/schemas/speaker.ts
+++ b/src/server/schemas/speaker.ts
@@ -140,3 +140,19 @@ export const SpeakerSearchSchema = z.object({
   query: z.string().min(1, 'Search query is required'),
   includeFeatured: z.boolean().optional().default(false),
 })
+
+/**
+ * Merge two duplicate speaker documents (identity Phase 3). `survivorId` is the
+ * canonical record kept (its slug/URL is preserved); `loserId` is folded in and
+ * deleted. A server-side guard rejects a self-merge, but we also block it here
+ * so the client can't even request it.
+ */
+export const SpeakerMergeSchema = z
+  .object({
+    survivorId: z.string().min(1, 'Survivor speaker id is required'),
+    loserId: z.string().min(1, 'Loser speaker id is required'),
+  })
+  .refine((data) => data.survivorId !== data.loserId, {
+    message: 'Cannot merge a speaker into itself',
+    path: ['loserId'],
+  })


### PR DESCRIPTION
## Summary

Identity Phase 3. Adds a privileged, **destructive** ADMIN operation that merges a duplicate speaker document into a canonical one, plus a minimal admin UI to invoke it safely. Pairs with the CFP "contact organizers" prompt (#448) as the resolution path when a self-service provider link hits an `already-linked-elsewhere` duplicate.

**Held for maintainer review — not enqueued/merged** (privileged + data-destructive).

## Reference-repointing approach

Inbound references to the loser are enumerated **generically** with `*[references($loserId) && _id != $loserId]` (mirrors `deleteProposal`). Each referencing document is deep-walked and every `{ _ref: loserId }` is repointed to the survivor — this is field-agnostic, so it handles array refs, single refs, and refs nested in objects, including any site not in the list below. Array references to the survivor are de-duplicated (survivor already present, or a repointed loser entry that now duplicates it), keeping one entry so `_key` uniqueness is preserved. Everything — reference repoints, the survivor field patch, and the loser deletion — runs in **one atomic Sanity transaction**, with the delete ordered **last** so no inbound reference ever dangles.

### Reference sites found in the schema (verified vs. the task's list)

| Document.field | Shape | In task list? |
|---|---|---|
| `talk.speakers[]` | array | yes |
| `conference.organizers[]` | array | yes (drives `isOrganizer`) |
| `conference.featuredSpeakers[]` | array | yes (task called it featured `speakers[]`) |
| `coSpeakerInvitation.invitedBy` | single | yes |
| `coSpeakerInvitation.acceptedSpeaker` | single | yes (task: accepted-by) |
| `review.reviewer` | single | yes |
| `speakerBadge.speaker` | single | yes |
| `travelSupport.speaker` | single | yes (2 refs) |
| `travelSupport.reviewedBy` | single | yes (2nd ref) |
| `imageGallery.speakers[]` | array | yes |
| `imageGallery.untaggedSpeakers[]` | array | **not in task list** — found in schema, handled generically |
| `volunteer.reviewedBy` | single | task said `volunteer.speaker`; actual field is `reviewedBy` |
| `sponsorActivity.createdBy` | single | task said `sponsorActivity.speaker`; actual field is `createdBy` |
| `sponsorForConference.assignedTo` | single | task said `sponsorForConference.speaker`; actual field is `assignedTo` |

Because the repointer is generic, the exact field names don't need to be enumerated in code — but they were verified against `sanity/schemaTypes/*` to confirm coverage and to write faithful tests.

## `isOrganizer` preservation guarantee

`isOrganizer` is a **computed** field (`_id in *[_type == "conference"].organizers[]._ref`). Since `conference.organizers[]` is one of the repointed reference sites, when the loser was an organizer the survivor inherits the organizer reference, so `isOrganizer` remains true after the merge. Covered by a dedicated unit test.

## Identity union / scalar reconciliation

- `providers[]`: deduplicated union.
- `knownEmails[]`: normalized (`normalizeEmail`) deduplicated union of both match-sets **plus both display emails**, so the loser's address becomes a future login match key.
- display `email`: survivor's is preserved unless empty, then falls back to the loser's.
- `slug`: **never changed** — the survivor keeps its live public URL.
- Scalars (`bio`, `title`, `links`, `flags`, `consent`, `image`, `imageURL`): survivor wins deterministically; the loser only fills gaps where the survivor's value is empty.

## Dry-run / preview

An `adminProcedure` **query** (`speaker.admin.mergePreview`) returns exactly what *would* be repointed (per-type counts) and the field-union result **without writing**. The preview and the committed write are produced by the same pure `buildMergePlan`, so they can never diverge. The admin UI shows this preview before an explicit destructive confirmation; the `speaker.admin.merge` mutation performs the transaction.

## Guards

Self-merge rejected (Zod schema + server guard), missing documents rejected, draft documents rejected (`drafts.*`), and both documents must be `_type === "speaker"`. Validation failures map to `BAD_REQUEST`; the operation is audit-logged (actor, survivor, loser, repointed types/counts).

## Tests

- **Pure core** (`merge.test.ts`): reference repointing for each shape (array/single/nested), array dedup (survivor already present, both orders), provider/email union + normalization, scalar reconciliation, slug never emitted, `isOrganizer` preserved, guards, and dry-run summary == committed plan.
- **Sanity boundary** (`merge.sanity.test.ts`): mocks the transaction and asserts the exact patch/delete ops (repoints, survivor union patch, delete-loser-last), and that dry-run writes nothing.
- **Router** (`speaker.merge.test.ts`): `adminProcedure` rejects a non-organizer (FORBIDDEN), preview passes `dryRun: true`, mutation passes `dryRun: false`, error mapping, self-merge rejected at the schema layer.

## Verification

`pnpm typecheck`, `pnpm vitest run` (135 files / 2266 tests), `pnpm knip`, `pnpm lint`, `pnpm format:check` — all clean. No Sanity migration (runtime admin op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the admin-only speaker merge tool (Identity Phase 3): a pure-core `buildMergePlan` function handles generic reference repointing, identity-field union, and scalar reconciliation; a thin `mergeSpeakers` wrapper executes everything in a single atomic Sanity transaction with the delete ordered last; two `adminProcedure` tRPC endpoints expose a dry-run preview and the destructive commit; and a modal UI shows the preview before requiring an explicit confirmation.

- **Core logic** (`merge.ts`): well-decomposed into pure functions with comprehensive unit and transaction-boundary tests; one gap — the survivor document is excluded from the generic repoint loop (its identity fields are patched separately), so any future schema field on a speaker that holds a `_ref` to another speaker would be left dangling after a merge.
- **Type safety**: `fetchRawSpeaker` returns `MergeSpeakerDoc | null`, but both values are cast with `as MergeSpeakerDoc` before being passed to `buildMergePlan`; runtime safety is preserved by `assertMergeable` inside `buildMergePlan`, but TypeScript's null check is bypassed.
- **Admin UI** (`SpeakerMergeModal`): the confirmation modal closes the moment the admin clicks \"Confirm\", before the mutation completes, leaving the main modal fully interactive with no pending indicator while the Sanity transaction runs.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness: the destructive transaction is atomic and well-guarded, but the UI provides no feedback during the in-flight write and a theoretical schema evolution could silently leave dangling refs inside the survivor document.

The atomic transaction design (delete ordered last, all repoints in one commit) and the layered guards (Zod schema, assertMergeable, adminProcedure) make the data-destructive operation solid. The test suite is thorough. The findings are bounded to a UX gap during the mutation and a TypeScript cast that bypasses null checking — neither causes incorrect data today.

src/lib/speaker/merge.ts around the survivor-skip guard and the null casts; src/components/admin/SpeakerMergeModal.tsx around the post-confirm pending state.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/speaker/merge.ts | Core merge logic: well-designed pure/effectful split; one gap where the survivor document's own loser references are skipped in the repoint loop; unsafe null-as-MergeSpeakerDoc casts before assertMergeable |
| src/server/routers/speaker.ts | Adds adminProcedure-guarded mergePreview (query) and merge (mutation) endpoints; error mapping to BAD_REQUEST / INTERNAL_SERVER_ERROR is clean and correct |
| src/server/schemas/speaker.ts | Adds SpeakerMergeSchema with self-merge guard at the Zod layer; straightforward and correct |
| src/components/admin/SpeakerMergeModal.tsx | Admin UI for the merge flow; confirmation modal closes immediately on click while mutation runs in background, leaving no in-progress feedback on the main modal |
| src/lib/speaker/merge.test.ts | Comprehensive pure-core unit tests covering all reference shapes, dedup, identity union, scalar fill, slug invariant, and guards |
| src/lib/speaker/merge.sanity.test.ts | Transaction-boundary tests mock the Sanity client to assert exact patch/delete op ordering and dry-run write-nothing guarantee |
| src/server/routers/speaker.merge.test.ts | Router-level tests verify adminProcedure auth gate, dryRun flag routing, and error-code mapping for all cases |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor Admin
    participant UI as SpeakerMergeModal
    participant tRPC as speaker.admin.*
    participant Core as merge.ts (pure)
    participant Sanity as Sanity Client

    Admin->>UI: Select survivor + loser, click "Preview changes"
    UI->>tRPC: "mergePreview({ survivorId, loserId })"
    Note over tRPC: adminProcedure: isOrganizer check
    tRPC->>Sanity: fetch survivor doc
    tRPC->>Sanity: fetch loser doc
    tRPC->>Sanity: "*[references($loserId) && _id != $loserId]"
    Sanity-->>tRPC: survivor, loser, referencingDocs
    tRPC->>Core: buildMergePlan(survivor, loser, refs)
    Core->>Core: assertMergeable() - self/draft/type checks
    Core->>Core: repointReferencesInDocument() per ref doc
    Core->>Core: computeSurvivorFieldMerge()
    Core-->>tRPC: "MergePlan (dryRun=true, no write)"
    tRPC-->>UI: MergePreview (counts + field changes)
    UI-->>Admin: Show preview panel

    Admin->>UI: Click Merge and delete duplicate
    UI->>UI: Open ConfirmationModal
    Admin->>UI: Confirm
    UI->>tRPC: "merge({ survivorId, loserId })"
    Note over tRPC: adminProcedure: isOrganizer check
    tRPC->>Sanity: "fetch + buildMergePlan (dryRun=false)"
    tRPC->>Sanity: transaction.patch(refDoc) x N
    tRPC->>Sanity: transaction.patch(survivor identity fields)
    tRPC->>Sanity: transaction.delete(loser) last
    Sanity-->>tRPC: commit()
    tRPC-->>UI: "{ success: true, preview }"
    UI->>UI: invalidateQueries + router.refresh()
    UI-->>Admin: Success notification
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor Admin
    participant UI as SpeakerMergeModal
    participant tRPC as speaker.admin.*
    participant Core as merge.ts (pure)
    participant Sanity as Sanity Client

    Admin->>UI: Select survivor + loser, click "Preview changes"
    UI->>tRPC: "mergePreview({ survivorId, loserId })"
    Note over tRPC: adminProcedure: isOrganizer check
    tRPC->>Sanity: fetch survivor doc
    tRPC->>Sanity: fetch loser doc
    tRPC->>Sanity: "*[references($loserId) && _id != $loserId]"
    Sanity-->>tRPC: survivor, loser, referencingDocs
    tRPC->>Core: buildMergePlan(survivor, loser, refs)
    Core->>Core: assertMergeable() - self/draft/type checks
    Core->>Core: repointReferencesInDocument() per ref doc
    Core->>Core: computeSurvivorFieldMerge()
    Core-->>tRPC: "MergePlan (dryRun=true, no write)"
    tRPC-->>UI: MergePreview (counts + field changes)
    UI-->>Admin: Show preview panel

    Admin->>UI: Click Merge and delete duplicate
    UI->>UI: Open ConfirmationModal
    Admin->>UI: Confirm
    UI->>tRPC: "merge({ survivorId, loserId })"
    Note over tRPC: adminProcedure: isOrganizer check
    tRPC->>Sanity: "fetch + buildMergePlan (dryRun=false)"
    tRPC->>Sanity: transaction.patch(refDoc) x N
    tRPC->>Sanity: transaction.patch(survivor identity fields)
    tRPC->>Sanity: transaction.delete(loser) last
    Sanity-->>tRPC: commit()
    tRPC-->>UI: "{ success: true, preview }"
    UI->>UI: invalidateQueries + router.refresh()
    UI-->>Admin: Success notification
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/lib/speaker/merge.ts`, line 1265-1267 ([link](https://github.com/cloudnativebergen/website/blob/185715647b9c206dafe07ecaba21835f6391142b/src/lib/speaker/merge.ts#L1265-L1267)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Survivor's own loser references are silently skipped**

   The guard skips the survivor document in the repoint loop, deferring its field updates to `computeSurvivorFieldMerge`. That function only patches identity fields (`providers`, `knownEmails`, `email`, scalar fills) — it does **not** generically repoint arbitrary reference fields within the survivor document. If the survivor's Sanity document ever contains a non-identity field that holds a `_ref: loserId` (e.g., after a schema addition that adds a speaker→speaker relation), the GROQ query `*[references($loserId) …]` would include the survivor, this guard would skip it, the loser would be deleted, and the reference inside the survivor would dangle. The PR's "field-agnostic" claim holds for *other* documents but not for the survivor itself. Currently safe given the schema has no speaker→speaker relations outside identity fields, but worth making explicit in the comment.


2. `src/lib/speaker/merge.ts`, line 1363-1367 ([link](https://github.com/cloudnativebergen/website/blob/185715647b9c206dafe07ecaba21835f6391142b/src/lib/speaker/merge.ts#L1363-L1367)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unsafe `as MergeSpeakerDoc` cast on potentially-null fetch results**

   `fetchRawSpeaker` returns `MergeSpeakerDoc | null`, so `survivor` and `loser` here are nullable. The `as MergeSpeakerDoc` casts lie to TypeScript — passing `null` is valid at compile time. At runtime `assertMergeable` inside `buildMergePlan` correctly catches the null case via `!survivor?._id`, so there is no crash, but TypeScript's type guard is bypassed. A simple null check before the call (or updating `assertMergeable`'s return to also assert `loser is MergeSpeakerDoc`) would restore static safety.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


3. `src/components/admin/SpeakerMergeModal.tsx`, line 284-296 ([link](https://github.com/cloudnativebergen/website/blob/185715647b9c206dafe07ecaba21835f6391142b/src/components/admin/SpeakerMergeModal.tsx#L284-L296)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No in-flight feedback on the main modal after confirmation**

   The `onConfirm` handler closes the confirmation modal (`setIsConfirmOpen(false)`) and immediately fires `mergeMutation.mutate(…)`. The confirmation modal is gone before the mutation starts, so `isLoading={mergeMutation.isPending}` never shows. The main merge modal remains fully interactive — selectors and the "Preview changes" button are all enabled — while the transaction is in flight. A user who doesn't see the success notification could click "Preview" (triggering a new query) or try to confirm a second merge. Disabling the main modal's interactive elements while `mergeMutation.isPending` or keeping the confirmation modal open until the mutation settles would close this gap.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(speaker): admin tool to merge dupli..."](https://github.com/cloudnativebergen/website/commit/185715647b9c206dafe07ecaba21835f6391142b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44508028)</sub>

<!-- /greptile_comment -->