### PR TITLE
chore(auth): test hardening — impersonation/checkin/updateEmail coverage + infra fixes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -95,6 +95,12 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
+      - name: Run scoped auth coverage gate
+        # Enforces the per-file coverage ratchets in vitest.config.ts, scoped
+        # ONLY to the security-critical auth modules. Unrelated files are not
+        # instrumented, so they can never fail this gate.
+        run: pnpm run test:coverage
+
   storybook:
     name: Storybook Tests
     runs-on: ubuntu-latest
@@ -177,9 +183,17 @@ jobs:
       - name: Build application
         run: pnpm run build
         env:
-          # CI environment variables (dummy values for build verification)
+          # CI environment variables (dummy values for build verification).
+          # These MUST match the Auth.js v5 names the code actually reads
+          # (see src/lib/auth.ts): AUTH_SECRET + AUTH_<PROVIDER>_ID/SECRET.
+          # The legacy v4 name (NEXTAUTH_SECRET) is not read by the app.
           NODE_ENV: production
-          NEXTAUTH_SECRET: ci-build-secret-not-for-production
+          AUTH_SECRET: ci-build-secret-not-for-production
+          AUTH_GITHUB_ID: ci-build-github-id-not-for-production
+          AUTH_GITHUB_SECRET: ci-build-github-secret-not-for-production
+          AUTH_LINKEDIN_ID: ci-build-linkedin-id-not-for-production
+          AUTH_LINKEDIN_SECRET: ci-build-linkedin-secret-not-for-production
+          # Still read at runtime by src/lib/contract-signing/self-hosted.ts.
           NEXTAUTH_URL: http://localhost:3000
           RESEND_API_KEY: re_ci_build_key_not_for_production
           INVITATION_TOKEN_SECRET: ci_invitation_token_secret_not_for_production

--- a/__tests__/api/trpc/speaker-update-email.test.ts
+++ b/__tests__/api/trpc/speaker-update-email.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment node
+ *
+ * tRPC-level authorization tests for `speaker.updateEmail` (the self-service
+ * mutation). The ownership GUARD (`isEmailVerifiedForSession`) is unit-tested in
+ * src/lib/profile/server.test.ts; this suite covers the MUTATION wiring:
+ *
+ *   - owned email      → the write is performed against the CALLER's own id.
+ *   - non-owned email  → FORBIDDEN, and NO write happens (display `email` /
+ *                        `knownEmails` are left untouched).
+ *   - the self path can only ever target `ctx.speaker._id` — the input schema
+ *     carries no speaker id, so a caller cannot direct the write at another id.
+ *
+ * The guard is genuinely exercised (NOT stubbed): we mock only its data-source
+ * boundary — `clientReadUncached.fetch`, which backs the persisted verified
+ * match-set (`speaker.knownEmails`) — and the `clientWrite` patch chain that the
+ * mutation uses to persist. The session used has no GitHub account, so the guard
+ * resolves ownership purely from the mocked `knownEmails` set.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { TRPCError } from '@trpc/server'
+
+const { mockKnownEmailsFetch, mockPatch, mockSet, mockCommit } = vi.hoisted(
+  () => ({
+    mockKnownEmailsFetch: vi.fn(),
+    mockPatch: vi.fn(),
+    mockSet: vi.fn(),
+    mockCommit: vi.fn(),
+  }),
+)
+
+vi.mock('@/lib/sanity/client', () => ({
+  // Backs getSpeakerKnownEmails() inside the real isEmailVerifiedForSession guard.
+  clientReadUncached: { fetch: mockKnownEmailsFetch },
+  // Backs updateProfileEmail(): clientWrite.patch(id).set({ email }).commit().
+  clientWrite: { patch: mockPatch },
+}))
+
+import { createAuthenticatedCaller, speakers } from '../../helpers/trpc'
+
+const caller = () => createAuthenticatedCaller() // defaults to speakers[0]
+const CALLER = speakers[0]
+const OTHER_SPEAKER = speakers[1]
+
+describe('speaker.updateEmail — authorization (tRPC integration)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Re-establish the patch chain after clearAllMocks reset return values:
+    // clientWrite.patch(id).set({ email }).commit().
+    mockPatch.mockReturnValue({ set: mockSet })
+    mockSet.mockReturnValue({ commit: mockCommit })
+    mockCommit.mockResolvedValue({})
+  })
+
+  it('ALLOWS setting an email the caller owns, writing to the caller own id', async () => {
+    // The caller's persisted verified match-set contains the requested email.
+    mockKnownEmailsFetch.mockResolvedValue(['owned@example.com'])
+
+    const result = await caller().speaker.updateEmail({
+      email: 'owned@example.com',
+    })
+
+    expect(result).toEqual({ success: true, email: 'owned@example.com' })
+    // Write targeted the CALLER's own speaker id — never a client-chosen id.
+    expect(mockPatch).toHaveBeenCalledWith(CALLER._id)
+    expect(mockPatch).not.toHaveBeenCalledWith(OTHER_SPEAKER._id)
+    expect(mockSet).toHaveBeenCalledWith({ email: 'owned@example.com' })
+  })
+
+  it('allows an owned email case-insensitively (guard normalizes)', async () => {
+    mockKnownEmailsFetch.mockResolvedValue(['Owned@Example.com'])
+
+    const result = await caller().speaker.updateEmail({
+      email: 'owned@example.com',
+    })
+
+    expect(result.success).toBe(true)
+    expect(mockPatch).toHaveBeenCalledWith(CALLER._id)
+  })
+
+  it('FORBIDS setting an email the caller does NOT own and performs NO write', async () => {
+    // Caller owns a different address than the one requested.
+    mockKnownEmailsFetch.mockResolvedValue(['owned@example.com'])
+
+    await expect(
+      caller().speaker.updateEmail({ email: 'attacker@evil.com' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+
+    // Nothing was persisted: display `email` / `knownEmails` left unchanged.
+    expect(mockPatch).not.toHaveBeenCalled()
+    expect(mockSet).not.toHaveBeenCalled()
+  })
+
+  it('FORBIDS when the caller has no verified emails at all', async () => {
+    mockKnownEmailsFetch.mockResolvedValue([])
+
+    await expect(
+      caller().speaker.updateEmail({ email: 'anything@example.com' }),
+    ).rejects.toBeInstanceOf(TRPCError)
+    expect(mockPatch).not.toHaveBeenCalled()
+  })
+
+  it('cannot be pointed at another speaker id (schema carries no id; write uses ctx.speaker._id)', async () => {
+    mockKnownEmailsFetch.mockResolvedValue(['owned@example.com'])
+
+    // Even if a caller smuggles an `id` into the payload, the input schema
+    // strips it and the mutation always writes to the session speaker's id.
+    await caller().speaker.updateEmail({
+      email: 'owned@example.com',
+      // @ts-expect-error — EmailUpdateSchema has no `id`; asserting it is ignored.
+      id: OTHER_SPEAKER._id,
+    })
+
+    expect(mockPatch).toHaveBeenCalledWith(CALLER._id)
+    expect(mockPatch).not.toHaveBeenCalledWith(OTHER_SPEAKER._id)
+  })
+})

--- a/__tests__/api/webhooks/checkin-ticket-sold.test.ts
+++ b/__tests__/api/webhooks/checkin-ticket-sold.test.ts
@@ -165,6 +165,19 @@ describe('api/webhooks/checkin/ticket-sold — HMAC signature', () => {
     expect(mockGetConference).not.toHaveBeenCalled()
   })
 
+  it('rejects a signature of the wrong length (timingSafeEqual length-guard) (401)', async () => {
+    const { POST } =
+      await import('@/app/api/webhooks/checkin/ticket-sold/route')
+
+    const payload = makePayload(makeData())
+    // A too-short signature makes crypto.timingSafeEqual throw on the buffer
+    // length mismatch; the verifier must catch it and reject (401), not 500.
+    const response = await POST(postRequest(payload, 'deadbeef'))
+
+    expect(response.status).toBe(401)
+    expect(mockGetConference).not.toHaveBeenCalled()
+  })
+
   it('rejects when the signature is valid for different data (tamper) (401)', async () => {
     const { POST } =
       await import('@/app/api/webhooks/checkin/ticket-sold/route')

--- a/__tests__/api/webhooks/checkin-ticket-sold.test.ts
+++ b/__tests__/api/webhooks/checkin-ticket-sold.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @vitest-environment node
+ *
+ * HMAC signature verification tests for the Checkin ticket-sold webhook
+ * (src/app/api/webhooks/checkin/ticket-sold/route.ts). The route authenticates
+ * inbound webhooks with an HMAC-SHA256 over `JSON.stringify(payload.data)`
+ * compared via `crypto.timingSafeEqual`. These tests use the REAL HMAC to mint a
+ * valid signature and assert the accept/reject behaviour at each boundary.
+ */
+import { NextRequest } from 'next/server'
+import crypto from 'crypto'
+
+const mockSendWorkshop = vi.fn()
+const mockGetConference = vi.fn()
+
+vi.mock('@/lib/email/workshop', () => ({
+  sendWorkshopSignupInstructions: (...args: unknown[]) =>
+    mockSendWorkshop(...args),
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceByCheckinEventId: (...args: unknown[]) =>
+    mockGetConference(...args),
+}))
+
+const SECRET = 'checkin-webhook-test-secret'
+
+function sign(data: unknown, secret: string): string {
+  return crypto
+    .createHmac('sha256', secret)
+    .update(JSON.stringify(data))
+    .digest('hex')
+}
+
+function makeData(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    eventId: 42,
+    users: [],
+    orderContact: {
+      crm: {
+        id: 9,
+        firstName: 'Order',
+        lastName: 'Contact',
+        email: { email: 'order@example.com' },
+      },
+    },
+    ...overrides,
+  }
+}
+
+function makePayload(data: unknown, event = 'event-order-created') {
+  return {
+    payloadId: 'p-1',
+    event,
+    dataType: 'order',
+    data,
+  }
+}
+
+function postRequest(payload: unknown, signature: string | null): NextRequest {
+  return new NextRequest(
+    'http://localhost:3000/api/webhooks/checkin/ticket-sold',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(signature !== null && { 'checkin-signature': signature }),
+      },
+      body: JSON.stringify(payload),
+    },
+  )
+}
+
+describe('api/webhooks/checkin/ticket-sold — HMAC signature', () => {
+  beforeAll(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterAll(() => {
+    vi.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CHECKIN_WEBHOOK_SECRET = SECRET
+  })
+
+  afterEach(() => {
+    delete process.env.CHECKIN_WEBHOOK_SECRET
+  })
+
+  it('accepts a request with a valid signature', async () => {
+    const { POST } =
+      await import('@/app/api/webhooks/checkin/ticket-sold/route')
+
+    // Empty users → the route short-circuits with 200 AFTER passing the
+    // signature gate, so a 200 here proves the signature was accepted.
+    const data = makeData({ users: [] })
+    const payload = makePayload(data)
+    const response = await POST(postRequest(payload, sign(data, SECRET)))
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+  })
+
+  it('processes the order when the signature is valid (full happy path)', async () => {
+    const { POST } =
+      await import('@/app/api/webhooks/checkin/ticket-sold/route')
+
+    mockGetConference.mockResolvedValue({
+      conference: { _id: 'conf-1', title: 'CNDN' },
+      error: null,
+    })
+    mockSendWorkshop.mockResolvedValue({
+      data: { emailId: 'em-1' },
+      error: null,
+    })
+
+    const data = makeData({
+      users: [
+        {
+          id: 1,
+          crm: {
+            id: 2,
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            email: { email: 'ada@example.com' },
+          },
+          ticket: { id: 3, name: 'Speaker ticket', type: 'speaker' },
+          isPaid: true,
+        },
+      ],
+    })
+    const payload = makePayload(data)
+    const response = await POST(postRequest(payload, sign(data, SECRET)))
+
+    expect(response.status).toBe(200)
+    expect(mockGetConference).toHaveBeenCalledWith(42)
+    expect(mockSendWorkshop).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a request with a missing signature header (401)', async () => {
+    const { POST } =
+      await import('@/app/api/webhooks/checkin/ticket-sold/route')
+
+    const payload = makePayload(makeData())
+    const response = await POST(postRequest(payload, null))
+
+    expect(response.status).toBe(401)
+    expect(mockGetConference).not.toHaveBeenCalled()
+  })
+
+  it('rejects a request with a wrong signature (401)', async () => {
+    const { POST } =
+      await import('@/app/api/webhooks/checkin/ticket-sold/route')
+
+    const data = makeData()
+    const payload = makePayload(data)
+    // Correct length, wrong bytes: a HMAC computed with a different secret.
+    const wrong = sign(data, 'a-different-secret')
+    const response = await POST(postRequest(payload, wrong))
+
+    expect(response.status).toBe(401)
+    expect(mockGetConference).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the signature is valid for different data (tamper) (401)', async () => {
+    const { POST } =
+      await import('@/app/api/webhooks/checkin/ticket-sold/route')
+
+    const signedData = makeData({ eventId: 42 })
+    const tamperedData = makeData({ eventId: 999 })
+    // Signature is over the original data, but we send tampered data.
+    const payload = makePayload(tamperedData)
+    const response = await POST(postRequest(payload, sign(signedData, SECRET)))
+
+    expect(response.status).toBe(401)
+  })
+
+  it('returns 500 (not accepted) when the webhook secret is not configured', async () => {
+    delete process.env.CHECKIN_WEBHOOK_SECRET
+    const { POST } =
+      await import('@/app/api/webhooks/checkin/ticket-sold/route')
+
+    const data = makeData()
+    const payload = makePayload(data)
+    const response = await POST(postRequest(payload, sign(data, SECRET)))
+
+    expect(response.status).toBe(500)
+    expect(mockGetConference).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 (not accepted) when the webhook secret is empty', async () => {
+    process.env.CHECKIN_WEBHOOK_SECRET = ''
+    const { POST } =
+      await import('@/app/api/webhooks/checkin/ticket-sold/route')
+
+    const data = makeData()
+    const payload = makePayload(data)
+    // Even a signature computed with the empty secret must not be accepted.
+    const response = await POST(postRequest(payload, sign(data, '')))
+
+    expect(response.status).toBe(500)
+    expect(mockGetConference).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/lib/auth/impersonation.test.ts
+++ b/__tests__/lib/auth/impersonation.test.ts
@@ -1,0 +1,246 @@
+/**
+ * @vitest-environment node
+ *
+ * Security tests for the dev-only impersonation path in `getAuthSession`
+ * (src/lib/auth.ts). Impersonation lets a DEV organizer view the site as another
+ * (non-organizer) speaker via `?impersonate=<speakerId>`. These tests lock down
+ * every guard around that power:
+ *   - HARD-DISABLED in production (NODE_ENV==='production').
+ *   - dev + organizer-only gating.
+ *   - id sanity validation (pattern + length).
+ *   - privilege-escalation block: organizer cannot impersonate ANOTHER organizer.
+ *   - happy path for a dev organizer impersonating a non-organizer speaker.
+ *
+ * The boundaries of `getAuthSession` are mocked: the resolved auth session
+ * (`_auth`), the environment flags (`AppEnvironment`), and the speaker lookup
+ * (`getSpeaker`). NODE_ENV is set per-test where the production bypass matters.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Session } from 'next-auth'
+
+const h = vi.hoisted(() => ({
+  // Mutable environment flags read via getters on the mocked AppEnvironment.
+  env: { isTestMode: false, isDevelopment: true, isProduction: false },
+  mockAuth: vi.fn(),
+  mockGetSpeaker: vi.fn(),
+}))
+
+// Control what `_auth()` resolves to (the browser cookie session).
+vi.mock('next-auth', () => ({
+  default: () => ({
+    auth: h.mockAuth,
+    signIn: vi.fn(),
+    handlers: { GET: vi.fn(), POST: vi.fn() },
+  }),
+  AuthError: class AuthError extends Error {},
+}))
+
+// Control the environment gate. Getters so per-test mutation of `h.env` is live.
+vi.mock('@/lib/environment/config', () => ({
+  AppEnvironment: {
+    get isTestMode() {
+      return h.env.isTestMode
+    },
+    get isDevelopment() {
+      return h.env.isDevelopment
+    },
+    get isProduction() {
+      return h.env.isProduction
+    },
+    createMockAuthContext: () => ({ user: { email: 'mock@test' } }),
+  },
+}))
+
+// `getSpeaker` is dynamically imported inside getAuthSession; mock the module.
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeaker: h.mockGetSpeaker,
+  getOrCreateSpeaker: vi.fn(),
+}))
+
+import { getAuthSession } from '@/lib/auth'
+
+const ADMIN_ID = 'org-admin-1'
+const TARGET_SPEAKER_ID = 'speaker-2'
+const OTHER_ORGANIZER_ID = 'org-admin-2'
+
+function organizerSession(): Session {
+  return {
+    expires: new Date(Date.now() + 3_600_000).toISOString(),
+    user: {
+      sub: 'sub-admin',
+      name: 'Admin',
+      email: 'admin@cloudnativedays.no',
+      picture: '',
+    },
+    speaker: {
+      _id: ADMIN_ID,
+      email: 'admin@cloudnativedays.no',
+      isOrganizer: true,
+    },
+    account: { provider: 'github', providerAccountId: '1', type: 'oauth' },
+  } as unknown as Session
+}
+
+function nonOrganizerSession(): Session {
+  const s = organizerSession()
+  ;(s.speaker as { _id: string; isOrganizer: boolean })._id = TARGET_SPEAKER_ID
+  ;(s.speaker as { isOrganizer: boolean }).isOrganizer = false
+  return s
+}
+
+function reqWithImpersonate(id: string) {
+  return {
+    url: `http://localhost:3000/?impersonate=${id}`,
+    headers: new Headers(),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Default: development, non-test mode. Individual tests override as needed.
+  h.env.isTestMode = false
+  h.env.isDevelopment = true
+  h.env.isProduction = false
+  // Silence audit/security console output the code emits.
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('getAuthSession impersonation — production hard-disable', () => {
+  it('IGNORES impersonation entirely in production, even for a dev organizer', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    // Even if the env flags were somehow both true, the explicit NODE_ENV
+    // check must short-circuit BEFORE any impersonation logic runs.
+    h.env.isDevelopment = true
+    h.mockAuth.mockResolvedValue(organizerSession())
+
+    const result = await getAuthSession(reqWithImpersonate(TARGET_SPEAKER_ID))
+
+    expect(result?.speaker?._id).toBe(ADMIN_ID)
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.realAdmin).toBeUndefined()
+    // The speaker lookup must never even be attempted in production.
+    expect(h.mockGetSpeaker).not.toHaveBeenCalled()
+  })
+})
+
+describe('getAuthSession impersonation — dev/organizer gating', () => {
+  it('does not impersonate when NODE_ENV is not development (double-check gate)', async () => {
+    h.env.isDevelopment = false
+    h.mockAuth.mockResolvedValue(organizerSession())
+
+    const result = await getAuthSession(reqWithImpersonate(TARGET_SPEAKER_ID))
+
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.speaker?._id).toBe(ADMIN_ID)
+    expect(h.mockGetSpeaker).not.toHaveBeenCalled()
+  })
+
+  it('does not allow a NON-organizer session to impersonate', async () => {
+    h.mockAuth.mockResolvedValue(nonOrganizerSession())
+
+    const result = await getAuthSession(
+      reqWithImpersonate('some-other-speaker'),
+    )
+
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.speaker?._id).toBe(TARGET_SPEAKER_ID)
+    expect(h.mockGetSpeaker).not.toHaveBeenCalled()
+  })
+
+  it('returns the session unchanged when no impersonate param is present', async () => {
+    h.mockAuth.mockResolvedValue(organizerSession())
+
+    const result = await getAuthSession({
+      url: 'http://localhost:3000/dashboard',
+      headers: new Headers(),
+    })
+
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.speaker?._id).toBe(ADMIN_ID)
+    expect(h.mockGetSpeaker).not.toHaveBeenCalled()
+  })
+})
+
+describe('getAuthSession impersonation — id validation', () => {
+  it('rejects an impersonation id that fails the SANITY_ID_PATTERN', async () => {
+    h.mockAuth.mockResolvedValue(organizerSession())
+
+    // Space + punctuation are not allowed by /^[a-zA-Z0-9_-]+$/.
+    const result = await getAuthSession(reqWithImpersonate('bad id!'))
+
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.speaker?._id).toBe(ADMIN_ID)
+    expect(h.mockGetSpeaker).not.toHaveBeenCalled()
+  })
+
+  it('rejects an impersonation id that exceeds the max length', async () => {
+    h.mockAuth.mockResolvedValue(organizerSession())
+
+    const longId = 'a'.repeat(101)
+    const result = await getAuthSession(reqWithImpersonate(longId))
+
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.speaker?._id).toBe(ADMIN_ID)
+    expect(h.mockGetSpeaker).not.toHaveBeenCalled()
+  })
+})
+
+describe('getAuthSession impersonation — privilege escalation block', () => {
+  it('BLOCKS an organizer from impersonating ANOTHER organizer', async () => {
+    h.mockAuth.mockResolvedValue(organizerSession())
+    h.mockGetSpeaker.mockResolvedValue({
+      speaker: {
+        _id: OTHER_ORGANIZER_ID,
+        email: 'other-admin@cloudnativedays.no',
+        isOrganizer: true,
+      },
+      err: null,
+    })
+
+    const result = await getAuthSession(reqWithImpersonate(OTHER_ORGANIZER_ID))
+
+    // Must fall through: session stays as the real admin, no impersonation.
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.realAdmin).toBeUndefined()
+    expect(result?.speaker?._id).toBe(ADMIN_ID)
+  })
+
+  it('does not impersonate when the target speaker is not found', async () => {
+    h.mockAuth.mockResolvedValue(organizerSession())
+    h.mockGetSpeaker.mockResolvedValue({ speaker: null, err: null })
+
+    const result = await getAuthSession(reqWithImpersonate('ghost-speaker'))
+
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.speaker?._id).toBe(ADMIN_ID)
+  })
+})
+
+describe('getAuthSession impersonation — happy path', () => {
+  it('lets a dev organizer impersonate a NON-organizer speaker with flags set', async () => {
+    h.mockAuth.mockResolvedValue(organizerSession())
+    const impersonated = {
+      _id: TARGET_SPEAKER_ID,
+      email: 'speaker@example.com',
+      name: 'Regular Speaker',
+      isOrganizer: false,
+    }
+    h.mockGetSpeaker.mockResolvedValue({ speaker: impersonated, err: null })
+
+    const result = await getAuthSession(reqWithImpersonate(TARGET_SPEAKER_ID))
+
+    expect(h.mockGetSpeaker).toHaveBeenCalledWith(TARGET_SPEAKER_ID)
+    expect(result?.isImpersonating).toBe(true)
+    expect(result?.speaker?._id).toBe(TARGET_SPEAKER_ID)
+    expect(result?.speaker?.email).toBe('speaker@example.com')
+    // realAdmin preserves the true organizer identity for audit / un-impersonate.
+    expect(result?.realAdmin?._id).toBe(ADMIN_ID)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint --cache .",
     "lint:fix": "eslint --cache --fix .",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:debug": "vitest run --reporter=verbose",
     "test:watch": "vitest",
     "test:badges": "vitest run __tests__/lib/badge/",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,10 +49,71 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['**/__tests__/**/*.test.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
-    exclude: ['node_modules', '.next', 'storybook-static'],
+    exclude: [
+      'node_modules',
+      '.next',
+      'storybook-static',
+      // Ignore copies of the suite living inside git worktrees (e.g. those
+      // created under .claude/worktrees/*). Without this, the `**/__tests__/**`
+      // include glob picks up stale duplicate suites and reports false failures.
+      '**/worktrees/**',
+      '.claude/worktrees/**',
+    ],
     setupFiles: ['./vitest.setup.ts'],
     coverage: {
       provider: 'v8',
+      // SCOPED coverage gate: only the security-critical auth modules are
+      // instrumented and gated. This deliberately keeps unrelated low-coverage
+      // files OUT of the report so they can never fail the build. In Vitest 4
+      // every file matching `include` is reported even if untested (so an
+      // untested included file such as proxy.ts counts as 0, not dropped).
+      include: [
+        'src/lib/auth.ts',
+        'src/lib/auth-link.ts',
+        'src/lib/speaker/sanity.ts',
+        'src/lib/profile/server.ts',
+        'src/proxy.ts',
+      ],
+      // Per-file RATCHET thresholds, set a few points below the coverage
+      // measured on 2026-07 so they lock in current coverage without being
+      // flaky. Raise these as coverage improves; never lower them. Only these
+      // globbed files are gated — there is no global threshold, so other files
+      // are never checked. Run via `pnpm test:coverage`.
+      thresholds: {
+        'src/lib/auth.ts': {
+          statements: 67,
+          branches: 64,
+          functions: 60,
+          lines: 70,
+        },
+        'src/lib/auth-link.ts': {
+          statements: 85,
+          branches: 83,
+          functions: 80,
+          lines: 85,
+        },
+        'src/lib/speaker/sanity.ts': {
+          statements: 61,
+          branches: 61,
+          functions: 63,
+          lines: 61,
+        },
+        'src/lib/profile/server.ts': {
+          statements: 84,
+          branches: 75,
+          functions: 95,
+          lines: 85,
+        },
+        // proxy.ts currently has no direct tests. Gate at 0 so it stays in the
+        // report (surfacing the gap) without failing the build; raise once
+        // tests are added.
+        'src/proxy.ts': {
+          statements: 0,
+          branches: 0,
+          functions: 0,
+          lines: 0,
+        },
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary

An auth test-hardening batch: two real infra bugs, three untested high-risk auth paths now covered, and a scoped coverage ratchet. No product logic was changed and no security check was weakened.

## A. Stale-worktree test pollution (real bug)
Vitest's `**/__tests__/**` include glob was picking up copies of the suite inside `.claude/worktrees/*`, so a local `pnpm test` ran duplicate stale suites and reported false failures. Added `**/worktrees/**` and `.claude/worktrees/**` to `vitest.config.ts` `exclude`. Verified: a failing test placed under a `worktrees/` path is no longer collected ("No test files found").

## B. CI auth env-var contract mismatch (real bug)
`src/lib/auth.ts` reads Auth.js **v5** names, but the `build` job in `pr-checks.yml` set **v4** names (`NEXTAUTH_SECRET`) that the app never reads — so the `next build` gate wasn't exercising the real auth contract. Updated the build env to the names the code actually reads: `AUTH_SECRET`, `AUTH_GITHUB_ID`/`AUTH_GITHUB_SECRET`, `AUTH_LINKEDIN_ID`/`AUTH_LINKEDIN_SECRET` (dummy values). Kept `NEXTAUTH_URL` — it is still read at runtime by `src/lib/contract-signing/self-hosted.ts`.

## C. Impersonation security tests (was zero coverage) — highest priority
New `__tests__/lib/auth/impersonation.test.ts` for `getAuthSession`'s dev-only impersonation path, mocking its boundaries (`_auth`, `AppEnvironment`, `getSpeaker`):
- **Production hard-disable** — `NODE_ENV==='production'` short-circuits before any impersonation logic; `getSpeaker` is never called.
- **Dev + organizer-only gating** — non-organizer sessions cannot impersonate; the `isDevelopment` double-check is enforced.
- **Id sanity validation** — ids failing `SANITY_ID_PATTERN` or exceeding the length cap are rejected.
- **Privilege-escalation block** (security-critical) — an organizer **cannot** impersonate another organizer; the session falls through unchanged.
- **Happy path** — a dev organizer impersonating a non-organizer returns the impersonated session with `isImpersonating`/`realAdmin` set.

## D. Checkin webhook HMAC test (was zero coverage)
New `__tests__/api/webhooks/checkin-ticket-sold.test.ts` using the **real** HMAC to mint signatures: valid signature accepted (incl. full happy path), missing/wrong/tampered signature → 401, missing/empty secret → 500 (fails safe, never accepted).

## E. updateEmail authorization integration test (guard was unit-tested, mutation was not)
New `__tests__/api/trpc/speaker-update-email.test.ts` at the tRPC caller level. The real `isEmailVerifiedForSession` guard is genuinely exercised by mocking only its data-source boundary (`clientReadUncached.fetch` → `knownEmails`):
- non-owned email → `FORBIDDEN` and **no** write (display `email`/`knownEmails` untouched);
- owned email → allowed, write always targets `ctx.speaker._id`;
- the input schema carries no speaker id, so the self path can never be pointed at another speaker's id.

## F. Scoped coverage gate
Per-file **ratchet** thresholds in `vitest.config.ts`, scoped ONLY to auth modules (`src/lib/auth.ts`, `auth-link.ts`, `speaker/sanity.ts`, `profile/server.ts`, `proxy.ts`), set a few points below measured so they lock current coverage without flaking. Coverage is scoped via `coverage.include` to just these files, so unrelated low-coverage files can never fail the build. Added `test:coverage` script and a CI "Run scoped auth coverage gate" step. The gate passes (exit 0).

### Coverage — before / after (auth.ts, from the full suite)
| Metric | Before (no new tests) | After |
| --- | --- | --- |
| Statements | 53.29% | 70.05% |
| Branches | 50.41% | 67.76% |
| Functions | 54.54% | 63.63% |
| Lines | 54.60% | 73.02% |

The impersonation path (`getAuthSession`, ~L430–507) went from entirely uncovered to covered. Locked-in ratchets: auth.ts 70/67/60/64, auth-link.ts 85/85/80/83, speaker/sanity.ts 61/61/63/61, profile/server.ts 85/84/95/75, proxy.ts 0 (no direct tests yet — gated at 0 to surface the gap without failing the build).

## Real bugs surfaced by new tests
None. All security checks behaved correctly under test; no check was weakened to make a test pass.

## Verification
- `pnpm typecheck` clean
- `pnpm test` green — 135 files, 2255 passed / 5 skipped
- `pnpm test:coverage` scoped gate passes (exit 0)
- `pnpm knip` clean (exit 0)
- eslint: 0 errors (1 pre-existing warning in an untouched file), prettier clean
- worktree-exclude confirmed to drop stale-copy pollution

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the auth test suite across three untested security-critical paths (impersonation, HMAC webhook auth, tRPC email mutation authorization) and fixes two real infrastructure bugs: stale worktree test pollution and Auth.js v4/v5 env-var mismatch in the CI build job.

- **Infra fixes**: worktree exclusion in `vitest.config.ts` prevents stale duplicate suites from causing false failures; `pr-checks.yml` now sets Auth.js v5 env var names (`AUTH_SECRET`, `AUTH_GITHUB_ID/SECRET`, `AUTH_LINKEDIN_ID/SECRET`) that the code actually reads, replacing the v4 `NEXTAUTH_SECRET` that was never consumed.
- **New tests**: three test files cover the impersonation guard (production disable, organizer-only gating, id validation, privilege-escalation block), HMAC signature verification for the Checkin webhook (valid/missing/wrong/tampered signatures, misconfigured secret → 500), and `speaker.updateEmail` authorization at the tRPC caller level.
- **Coverage gate**: per-file ratchet thresholds scoped to 5 auth modules are added to `vitest.config.ts` and enforced in CI via a new `pnpm test:coverage` step; `@vitest/coverage-v8@^4.1.7` is already in devDependencies.

<h3>Confidence Score: 4/5</h3>

Safe to merge — no product logic or security checks were changed, only tests and CI infrastructure were added.

The new tests are well-constructed and correctly exercise the real security guards without stubbing them out. The infra fixes (env-var names, worktree exclusion) are accurate. The one friction point is that the CI test job now runs the full suite twice — once for tests, once for coverage — which is wasteful but not incorrect.

.github/workflows/pr-checks.yml — the sequential pnpm test + pnpm test:coverage steps both execute the full 135-file suite; worth collapsing into a single coverage run.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-checks.yml | Fixes Auth.js v5 env-var names in the build job and adds coverage gate step; the coverage step re-runs the full test suite immediately after the normal test run, doubling execution time. |
| __tests__/api/webhooks/checkin-ticket-sold.test.ts | New HMAC signature tests using the real crypto primitive; env var is read inside the handler (not at module scope), so beforeEach/afterEach env changes work correctly across all test cases. |
| __tests__/lib/auth/impersonation.test.ts | New security tests covering production hard-disable, organizer gating, id sanity validation, privilege-escalation block, and happy path; mocking strategy is sound and aligns with vitest.config.ts aliases. |
| __tests__/api/trpc/speaker-update-email.test.ts | Integration-level tests for updateEmail authorization; the real guard is exercised by mocking only the Sanity fetch boundary, and the schema-level id-stripping test is a useful addition. |
| vitest.config.ts | Adds worktree exclusions and per-file coverage thresholds scoped to 5 auth modules; thresholds are set correctly below measured values with @vitest/coverage-v8@4 already in devDependencies. |
| package.json | Adds test:coverage script; straightforward addition. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI (pr-checks.yml)
    participant Tests as pnpm test
    participant Coverage as pnpm test:coverage
    participant Auth as src/lib/auth.ts
    participant Webhook as checkin/ticket-sold route
    participant tRPC as speaker.updateEmail

    CI->>Tests: Run all 135 test files
    Tests->>Auth: impersonation.test.ts prod disable / org gate / id validation / escalation block
    Tests->>Webhook: checkin-ticket-sold.test.ts valid / missing / wrong / tampered sig / no secret 500
    Tests->>tRPC: speaker-update-email.test.ts owned / non-owned / id stripping

    CI->>Coverage: Run all 135 test files + collect coverage
    Coverage-->>CI: thresholds checked for 5 auth files only
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI (pr-checks.yml)
    participant Tests as pnpm test
    participant Coverage as pnpm test:coverage
    participant Auth as src/lib/auth.ts
    participant Webhook as checkin/ticket-sold route
    participant tRPC as speaker.updateEmail

    CI->>Tests: Run all 135 test files
    Tests->>Auth: impersonation.test.ts prod disable / org gate / id validation / escalation block
    Tests->>Webhook: checkin-ticket-sold.test.ts valid / missing / wrong / tampered sig / no secret 500
    Tests->>tRPC: speaker-update-email.test.ts owned / non-owned / id stripping

    CI->>Coverage: Run all 135 test files + collect coverage
    Coverage-->>CI: thresholds checked for 5 auth files only
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(auth): test hardening — impersonat..."](https://github.com/cloudnativebergen/website/commit/22a32204dd8d9546e9db44bd8d34c8c807f90e40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44509510)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->