### PR TITLE
feat(cfp): "not seeing your talks?" identity guidance on the speaker dashboard

### DIFF
--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -16,6 +16,9 @@ import { SpeakerShare } from '@/components/SpeakerShare'
 import { BadgeShare } from '@/components/cfp/BadgeShare'
 import { DashboardSidebar } from '@/components/cfp/DashboardSidebar'
 import { ProposalConfirmationHandler } from '@/components/cfp/ProposalConfirmationHandler'
+import { NotSeeingTalksPrompt } from '@/components/cfp/NotSeeingTalksPrompt'
+import { startProviderLink } from '@/app/(cfp)/cfp/profile/link-actions'
+import { getSpeaker } from '@/lib/speaker/sanity'
 import type { Conference } from '@/lib/conference/types'
 import type { ConferenceWithSpeakerData } from '@/lib/dashboard/types'
 import type { BadgeRecord } from '@/lib/badge/types'
@@ -36,6 +39,15 @@ export default async function SpeakerDashboard() {
 
   const speaker = session.speaker
   const speakerId = speaker._id
+
+  // Identity guidance ("not seeing your talks?"): the session speaker doesn't
+  // carry `providers[]`, so fetch it to know which OAuth account is still
+  // unlinked. Non-fatal — the prompt degrades to offering both providers.
+  const { speaker: fullSpeaker } = await getSpeaker(speakerId)
+  const speakerProviders = fullSpeaker?.providers ?? speaker.providers
+  const currentProvider = session.account?.provider
+  const organizerContactEmail =
+    currentConference?.cfpEmail || currentConference?.contactEmail
 
   // Fetch all conferences where speaker has activity (server-side)
   const conferencesQuery = groq`
@@ -212,6 +224,10 @@ export default async function SpeakerDashboard() {
     talks: confirmedTalks,
   }
 
+  // Whether the speaker has any proposals at all. Drives the prominent vs.
+  // subtle "not seeing your talks?" identity guidance below.
+  const hasAnyProposals = activeConferences.some((c) => c.proposals.length > 0)
+
   // Prepare data for speaker share wrapper
   const primaryTalk = confirmedTalks[0]
   const talkTitle = primaryTalk?.title || 'Cloud Native Days Norway'
@@ -257,6 +273,16 @@ export default async function SpeakerDashboard() {
           </p>
         </div>
 
+        <div className="mt-6">
+          <NotSeeingTalksPrompt
+            hasProposals={false}
+            providers={speakerProviders}
+            currentProvider={currentProvider}
+            contactEmail={organizerContactEmail}
+            onLinkAction={startProviderLink}
+          />
+        </div>
+
         <div className="mt-6 max-w-md">
           <SpeakerShare speaker={speakerWithTalks} />
         </div>
@@ -289,6 +315,14 @@ export default async function SpeakerDashboard() {
               defaultExpanded={true}
             />
           ))}
+
+          <NotSeeingTalksPrompt
+            hasProposals={hasAnyProposals}
+            providers={speakerProviders}
+            currentProvider={currentProvider}
+            contactEmail={organizerContactEmail}
+            onLinkAction={startProviderLink}
+          />
         </div>
 
         {/* Sidebar */}

--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -18,7 +18,6 @@ import { DashboardSidebar } from '@/components/cfp/DashboardSidebar'
 import { ProposalConfirmationHandler } from '@/components/cfp/ProposalConfirmationHandler'
 import { NotSeeingTalksPrompt } from '@/components/cfp/NotSeeingTalksPrompt'
 import { startProviderLink } from '@/app/(cfp)/cfp/profile/link-actions'
-import { getSpeaker } from '@/lib/speaker/sanity'
 import type { Conference } from '@/lib/conference/types'
 import type { ConferenceWithSpeakerData } from '@/lib/dashboard/types'
 import type { BadgeRecord } from '@/lib/badge/types'
@@ -41,10 +40,16 @@ export default async function SpeakerDashboard() {
   const speakerId = speaker._id
 
   // Identity guidance ("not seeing your talks?"): the session speaker doesn't
-  // carry `providers[]`, so fetch it to know which OAuth account is still
-  // unlinked. Non-fatal — the prompt degrades to offering both providers.
-  const { speaker: fullSpeaker } = await getSpeaker(speakerId)
-  const speakerProviders = fullSpeaker?.providers ?? speaker.providers
+  // carry `providers[]`, so read just that field (cached, not the whole doc) to
+  // know which OAuth account is still unlinked. Non-fatal — the prompt degrades
+  // to offering both providers.
+  const speakerProviders =
+    (await clientReadCached.fetch<string[] | null>(
+      `*[_type == "speaker" && _id == $id][0].providers`,
+      { id: speakerId },
+    )) ??
+    speaker.providers ??
+    []
   const currentProvider = session.account?.provider
   const organizerContactEmail =
     currentConference?.cfpEmail || currentConference?.contactEmail

--- a/src/components/cfp/NotSeeingTalksPrompt.stories.tsx
+++ b/src/components/cfp/NotSeeingTalksPrompt.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { NotSeeingTalksPrompt } from './NotSeeingTalksPrompt'
+
+const meta = {
+  title: 'Systems/CFP/NotSeeingTalksPrompt',
+  component: NotSeeingTalksPrompt,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'In-product guidance on the speaker dashboard for the most common duplicate-account symptom: signing in with one provider (e.g. LinkedIn) and seeing an empty/incomplete proposal list because the talks live on another provider\'s speaker document. When the speaker has no proposals it shows a prominent card (Step 1: link the other provider via `LinkedProviders`; Step 2: contact the organizers). When they already have proposals it collapses into a subtle "Missing a talk?" affordance.',
+      },
+    },
+  },
+  args: {
+    contactEmail: 'organizers@cloudnativedays.no',
+    onLinkAction: fn(),
+  },
+  argTypes: {
+    hasProposals: {
+      control: 'boolean',
+      description: 'Prominent card when false; subtle affordance when true.',
+    },
+    providers: {
+      control: 'object',
+      description: 'Raw `speaker.providers[]` entries, e.g. "linkedin:456".',
+    },
+    currentProvider: {
+      control: 'select',
+      options: [undefined, 'github', 'linkedin'],
+      description: 'Provider the speaker is currently signed in with.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof NotSeeingTalksPrompt>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Zero-proposals case: the prominent card. Speaker is signed in with LinkedIn,
+ * so GitHub is offered as the account to link (Step 1), with "contact the
+ * organizers" as the Step 2 fallback.
+ */
+export const NoProposals: Story = {
+  args: {
+    hasProposals: false,
+    providers: ['linkedin:abcdef'],
+    currentProvider: 'linkedin',
+  },
+}
+
+/**
+ * Zero proposals but no organizer contact email configured — Step 2 falls back
+ * to a link into the profile page's sign-in methods section.
+ */
+export const NoProposalsWithoutContactEmail: Story = {
+  args: {
+    hasProposals: false,
+    providers: ['linkedin:abcdef'],
+    currentProvider: 'linkedin',
+    contactEmail: undefined,
+  },
+}
+
+/**
+ * Has-proposals case: only the subtle, collapsible "Missing a talk?" link. Open
+ * it (in the canvas) to reveal the same guidance without cluttering the normal
+ * dashboard.
+ */
+export const HasProposals: Story = {
+  args: {
+    hasProposals: true,
+    providers: ['github:1234567'],
+    currentProvider: 'github',
+  },
+}

--- a/src/components/cfp/NotSeeingTalksPrompt.tsx
+++ b/src/components/cfp/NotSeeingTalksPrompt.tsx
@@ -1,0 +1,165 @@
+import Link from 'next/link'
+import {
+  EnvelopeIcon,
+  LifebuoyIcon,
+  QuestionMarkCircleIcon,
+} from '@heroicons/react/24/outline'
+import { LinkedProviders } from './LinkedProviders'
+
+export interface NotSeeingTalksPromptProps {
+  /**
+   * Whether the speaker currently has any proposals. Drives the two-step
+   * progressive disclosure: `false` renders a prominent guidance card, `true`
+   * renders only a subtle, collapsible "Missing a talk?" affordance so the
+   * normal case stays uncluttered.
+   */
+  hasProposals: boolean
+  /** Raw `speaker.providers[]` entries, e.g. `["github:123"]`. */
+  providers?: string[]
+  /** Provider the speaker is currently signed in with (`session.account.provider`). */
+  currentProvider?: string
+  /**
+   * Organizer/CFP contact email for the "contact the organizers" fallback. When
+   * omitted, the fallback points at the profile page's sign-in methods instead.
+   */
+  contactEmail?: string
+  /**
+   * Server Action that starts the "link another provider" flow (typically
+   * `startProviderLink`). Passed straight through to {@link LinkedProviders};
+   * when omitted the link buttons render disabled (e.g. in Storybook).
+   */
+  onLinkAction?: (formData: FormData) => void | Promise<void>
+}
+
+const CONTACT_SUBJECT = 'Not seeing my talks — please merge my speaker accounts'
+
+/**
+ * The shared two-step guidance body reused by both the prominent card and the
+ * subtle affordance.
+ *
+ * - Step 1: link the speaker's other OAuth provider (reusing
+ *   {@link LinkedProviders}) so a duplicate account's talks come together.
+ * - Step 2: contact the organizers to merge accounts as the fallback.
+ */
+function Guidance({
+  providers,
+  currentProvider,
+  contactEmail,
+  onLinkAction,
+}: Omit<NotSeeingTalksPromptProps, 'hasProposals'>) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          You may have submitted them while signed in with a different account.
+          If you used <strong>GitHub</strong> one time and{' '}
+          <strong>LinkedIn</strong> another, link your other account below to
+          bring your talks together.
+        </p>
+        <div className="mt-4">
+          <LinkedProviders
+            providers={providers}
+            currentProvider={currentProvider}
+            onLinkAction={onLinkAction}
+          />
+        </div>
+      </div>
+
+      <div className="border-t border-gray-200 pt-4 dark:border-gray-700">
+        <h4 className="text-sm/6 font-medium text-gray-900 dark:text-white">
+          Still not seeing your talks?
+        </h4>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Contact the organizers and we&apos;ll merge your accounts for you.
+        </p>
+        {contactEmail ? (
+          <a
+            href={`mailto:${contactEmail}?subject=${encodeURIComponent(
+              CONTACT_SUBJECT,
+            )}`}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700/50"
+          >
+            <EnvelopeIcon className="h-4 w-4" aria-hidden="true" />
+            Contact the organizers
+          </a>
+        ) : (
+          <Link
+            href="/cfp/profile#linked-providers-heading"
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700/50"
+          >
+            <EnvelopeIcon className="h-4 w-4" aria-hidden="true" />
+            Manage sign-in methods
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * In-product guidance for the most common duplicate-account symptom: a speaker
+ * signs in (e.g. with LinkedIn) and sees an empty or incomplete proposal list
+ * because their talks live on a different speaker document from another
+ * provider/email.
+ *
+ * Rendered on the authenticated speaker dashboard only. When the speaker has no
+ * proposals it shows a prominent, friendly card; when they already have
+ * proposals it shows an unobtrusive, collapsible "Missing a talk?" link so the
+ * normal case is not cluttered. Both surfaces share the same {@link Guidance}.
+ */
+export function NotSeeingTalksPrompt({
+  hasProposals,
+  providers,
+  currentProvider,
+  contactEmail,
+  onLinkAction,
+}: NotSeeingTalksPromptProps) {
+  if (hasProposals) {
+    return (
+      <details className="group mt-3">
+        <summary className="inline-flex cursor-pointer list-none items-center gap-1.5 rounded-md text-sm text-gray-500 transition-colors hover:text-brand-cloud-blue focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-cloud-blue dark:text-gray-400 dark:hover:text-blue-400 [&::-webkit-details-marker]:hidden">
+          <QuestionMarkCircleIcon className="h-4 w-4" aria-hidden="true" />
+          Missing a talk?
+        </summary>
+        <div className="mt-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <Guidance
+            providers={providers}
+            currentProvider={currentProvider}
+            contactEmail={contactEmail}
+            onLinkAction={onLinkAction}
+          />
+        </div>
+      </details>
+    )
+  }
+
+  return (
+    <section
+      aria-labelledby="not-seeing-talks-heading"
+      className="rounded-lg border border-brand-cloud-blue/30 bg-brand-cloud-blue/5 p-6 dark:border-blue-400/30 dark:bg-blue-400/10"
+    >
+      <div className="flex items-start gap-3">
+        <LifebuoyIcon
+          className="h-6 w-6 shrink-0 text-brand-cloud-blue dark:text-blue-400"
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1">
+          <h3
+            id="not-seeing-talks-heading"
+            className="font-space-grotesk text-lg font-semibold text-gray-900 dark:text-white"
+          >
+            Not seeing your talks?
+          </h3>
+          <div className="mt-3">
+            <Guidance
+              providers={providers}
+              currentProvider={currentProvider}
+              contactEmail={contactEmail}
+              onLinkAction={onLinkAction}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/cfp/NotSeeingTalksPrompt.tsx
+++ b/src/components/cfp/NotSeeingTalksPrompt.tsx
@@ -1,10 +1,21 @@
 import Link from 'next/link'
 import {
   EnvelopeIcon,
+  KeyIcon,
   LifebuoyIcon,
   QuestionMarkCircleIcon,
 } from '@heroicons/react/24/outline'
 import { LinkedProviders } from './LinkedProviders'
+
+/** Provider keys we offer to link (must match `LinkedProviders`). */
+const SUPPORTED_PROVIDER_KEYS = ['github', 'linkedin'] as const
+
+/** True when at least one supported provider is NOT yet linked (so the
+ * "link your other account" step is actually actionable). */
+function hasUnlinkedProvider(providers?: string[]): boolean {
+  const linked = new Set((providers ?? []).map((entry) => entry.split(':')[0]))
+  return SUPPORTED_PROVIDER_KEYS.some((key) => !linked.has(key))
+}
 
 export interface NotSeeingTalksPromptProps {
   /**
@@ -47,25 +58,36 @@ function Guidance({
   contactEmail,
   onLinkAction,
 }: Omit<NotSeeingTalksPromptProps, 'hasProposals'>) {
+  // Only offer the "link your other account" step when a supported provider is
+  // still unlinked — otherwise the copy ("link your other account below") is
+  // non-actionable and every row already reads "Linked".
+  const canLink = hasUnlinkedProvider(providers)
+
   return (
     <div className="space-y-6">
-      <div>
-        <p className="text-sm text-gray-600 dark:text-gray-300">
-          You may have submitted them while signed in with a different account.
-          If you used <strong>GitHub</strong> one time and{' '}
-          <strong>LinkedIn</strong> another, link your other account below to
-          bring your talks together.
-        </p>
-        <div className="mt-4">
-          <LinkedProviders
-            providers={providers}
-            currentProvider={currentProvider}
-            onLinkAction={onLinkAction}
-          />
+      {canLink && (
+        <div>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            You may have submitted them while signed in with a different
+            account. If you used <strong>GitHub</strong> one time and{' '}
+            <strong>LinkedIn</strong> another, link your other account below to
+            bring your talks together.
+          </p>
+          <div className="mt-4">
+            <LinkedProviders
+              providers={providers}
+              currentProvider={currentProvider}
+              onLinkAction={onLinkAction}
+            />
+          </div>
         </div>
-      </div>
+      )}
 
-      <div className="border-t border-gray-200 pt-4 dark:border-gray-700">
+      <div
+        className={
+          canLink ? 'border-t border-gray-200 pt-4 dark:border-gray-700' : ''
+        }
+      >
         <h4 className="text-sm/6 font-medium text-gray-900 dark:text-white">
           Still not seeing your talks?
         </h4>
@@ -87,7 +109,7 @@ function Guidance({
             href="/cfp/profile#linked-providers-heading"
             className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700/50"
           >
-            <EnvelopeIcon className="h-4 w-4" aria-hidden="true" />
+            <KeyIcon className="h-4 w-4" aria-hidden="true" />
             Manage sign-in methods
           </Link>
         )}


### PR DESCRIPTION
## Summary

Implements #448. Gives speakers in-product guidance for the most common consequence of the duplicate-account bug: signing in with one provider (e.g. LinkedIn) and seeing an **empty or incomplete proposal list** because their talks live on a different speaker document from another provider/email.

A new `NotSeeingTalksPrompt` component renders progressive, two-step guidance on the authenticated speaker dashboard (`/cfp/list`), driven by whether the speaker has any proposals.

### Zero proposals — prominent card
- **Step 1 — link your other account.** Friendly copy naming both providers ("If you used **GitHub** one time and **LinkedIn** another…"), then reuses the Phase 2 `LinkedProviders` component wired to the `startProviderLink` server action. The card offers a working "Link GitHub/LinkedIn" CTA for the not-yet-linked provider, marking the current sign-in as already linked.
- **Step 2 — contact the organizers.** Fallback `mailto:` to the conference's `cfpEmail`/`contactEmail` (the existing organizer contact surface) with a prefilled subject, so speakers whose accounts can't be self-linked can ask for an admin merge (Phase 3). If no contact email is configured it degrades to a link into the profile page's sign-in methods section.

### Has proposals — subtle affordance
- A small, collapsible **"Missing a talk?"** `<details>` link under the proposal list that expands to the exact same guidance. Keeps the normal case uncluttered.

### How Step 1 wires into the linking flow
`page.tsx` (server component) fetches the full speaker to get `providers[]` (the session speaker doesn't carry it), reads `currentProvider` from `session.account`, and passes the `startProviderLink` server action straight through `NotSeeingTalksPrompt` → `LinkedProviders`, exactly as the profile page does. Submitting a provider's link button starts the same self-service OAuth link round-trip.

## Acceptance criteria
- [x] Speaker with no proposals sees the Step-1 link-account prompt with a working CTA into the linking flow.
- [x] A "contact the organizers" option (Step 2) with a working contact link.
- [x] Speaker with proposals sees only the subtle "Missing a talk?" affordance, not the big card.
- [x] Accessible (labelled section/heading, `<details>`/`<summary>`, `aria-hidden` icons) + dark-mode consistent with existing CFP UI; no signed-out prompt (authed dashboard only).

## Notes
- No auth logic changed; reuses `LinkedProviders` and `startProviderLink`.
- Signed-out visitors are already redirected to sign-in by the dashboard, so no prompt is shown to them.

## Verification
- `pnpm typecheck` — clean
- `pnpm vitest run` — 2256 passed, 5 skipped (135 files)
- `pnpm lint` — no new issues (one pre-existing unrelated warning)
- `pnpm prettier --check` — clean on changed files
- `pnpm knip` — clean
- Storybook story added covering **zero-proposals**, **zero-proposals without contact email**, and **has-proposals** states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `NotSeeingTalksPrompt` component to the authenticated speaker dashboard to help users who signed in with a different OAuth provider than the one their proposals were submitted under. Two modes are implemented: a prominent guidance card (with OAuth linking and organizer contact options) for speakers with no proposals, and a collapsible "Missing a talk?" affordance for speakers who already have proposals.

- The new component correctly reuses `LinkedProviders` and `startProviderLink` to wire into the existing Phase 2 account-linking flow without touching auth logic.
- The `hasAnyProposals` flag drives the mode selection, but it only checks proposals while `activeConferences` filters on any activity (gallery, badges, travel support, workshops) — a speaker with non-proposal activity lands in the full-dashboard path but still sees the prominent card.
- The "Manage sign-in methods" fallback link uses `EnvelopeIcon` (mail icon) even though the link navigates to a profile settings page, not an email client.

<h3>Confidence Score: 4/5</h3>

Safe to merge with two minor UX issues worth addressing.

The feature is well-structured and reuses existing auth plumbing without touching security logic. Two UX issues exist: a wrong icon on the profile-page fallback link, and an edge case where a speaker with non-proposal activity sees the prominent help card inside a populated dashboard instead of the subtle affordance.

NotSeeingTalksPrompt.tsx (icon mismatch on fallback link) and page.tsx (hasAnyProposals flag in the active-conferences path).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(cfp)/cfp/list/page.tsx | Adds a getSpeaker call to fetch provider data, computes hasAnyProposals, and renders NotSeeingTalksPrompt in both the empty-state and active-state branches. The active-state renders hasProposals={false} when the speaker has non-proposal activity (gallery/badges), triggering the prominent card inside a non-empty dashboard. |
| src/components/cfp/NotSeeingTalksPrompt.tsx | New component correctly implements two-mode guidance (prominent card vs. collapsible details). The EnvelopeIcon on the fallback 'Manage sign-in methods' link is semantically wrong — that link goes to a profile settings page, not an email client. |
| src/components/cfp/NotSeeingTalksPrompt.stories.tsx | Storybook stories cover all three key states (no proposals, no proposals without contact email, has proposals). Well-structured with appropriate args and argTypes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SpeakerDashboard loads] --> B[Fetch session + speaker + fullSpeaker]
    B --> C{activeConferences.length === 0?}

    C -- Yes --> D[Empty state UI]
    D --> E[NotSeeingTalksPrompt\nhasProposals=false\nProminent card]

    C -- No --> F[Active dashboard UI\nConference cards]
    F --> G{hasAnyProposals?}
    G -- true --> H[NotSeeingTalksPrompt\nhasProposals=true\nSubtle details link]
    G -- false --> I[NotSeeingTalksPrompt\nhasProposals=false\nProminent card]

    E --> J{contactEmail?}
    H --> J
    I --> J

    J -- Yes --> K[Step 2: mailto link - Contact organizers]
    J -- No --> L[Step 2: Link to /cfp/profile#linked-providers-heading]

    subgraph Guidance Component
        M[Step 1: LinkedProviders - offer unlinked provider OAuth]
        N[Step 2 Fallback]
    end

    E & H & I --> M
    K & L --> N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SpeakerDashboard loads] --> B[Fetch session + speaker + fullSpeaker]
    B --> C{activeConferences.length === 0?}

    C -- Yes --> D[Empty state UI]
    D --> E[NotSeeingTalksPrompt\nhasProposals=false\nProminent card]

    C -- No --> F[Active dashboard UI\nConference cards]
    F --> G{hasAnyProposals?}
    G -- true --> H[NotSeeingTalksPrompt\nhasProposals=true\nSubtle details link]
    G -- false --> I[NotSeeingTalksPrompt\nhasProposals=false\nProminent card]

    E --> J{contactEmail?}
    H --> J
    I --> J

    J -- Yes --> K[Step 2: mailto link - Contact organizers]
    J -- No --> L[Step 2: Link to /cfp/profile#linked-providers-heading]

    subgraph Guidance Component
        M[Step 1: LinkedProviders - offer unlinked provider OAuth]
        N[Step 2 Fallback]
    end

    E & H & I --> M
    K & L --> N
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(cfp): add &#39;not seeing your talks?&#39; ..."](https://github.com/cloudnativebergen/website/commit/b14681415534cef65477bc9d75806c54db31cdb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44517182)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->