### PR TITLE
feat(pwa): service worker with reliable update flow and offline fallback (#442)

### DIFF
--- a/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
+++ b/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
@@ -132,14 +132,34 @@ describe('ServiceWorkerRegistrar', () => {
     expect(reloadMock).not.toHaveBeenCalled()
   })
 
-  it('reloads the page exactly once on controllerchange (guard prevents a second)', async () => {
-    await renderAndRegister()
+  it('reloads exactly once on controllerchange AFTER the user accepts (guard prevents a second)', async () => {
+    const registration = await renderAndRegister()
+
+    // User accepts the update.
+    container.controller = {}
+    const worker = new FakeWorker()
+    registration.installing = worker
+    registration.dispatch('updatefound')
+    worker.setState('installed')
+    await screen.findByRole('dialog', { name: 'Update available' })
+    fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
 
     container.dispatch('controllerchange')
     container.dispatch('controllerchange')
     container.dispatch('controllerchange')
 
     expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT reload on a first-install controllerchange (no user action)', async () => {
+    // On first install the new worker's clients.claim() fires controllerchange
+    // with no prior Reload click — this must NOT reload the page.
+    await renderAndRegister()
+
+    container.dispatch('controllerchange')
+    container.dispatch('controllerchange')
+
+    expect(reloadMock).not.toHaveBeenCalled()
   })
 
   it('dismissing the banner hides it without reloading', async () => {

--- a/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
+++ b/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ServiceWorkerRegistrar } from '@/components/pwa/ServiceWorkerRegistrar'
+
+/** Minimal event-emitter shared by the service-worker mocks. */
+class Emitter {
+  private listeners: Record<string, Array<(e: unknown) => void>> = {}
+  addEventListener(type: string, cb: (e: unknown) => void) {
+    ;(this.listeners[type] ??= []).push(cb)
+  }
+  removeEventListener(type: string, cb: (e: unknown) => void) {
+    this.listeners[type] = (this.listeners[type] ?? []).filter((l) => l !== cb)
+  }
+  dispatch(type: string, event: unknown = {}) {
+    for (const cb of this.listeners[type] ?? []) cb(event)
+  }
+}
+
+class FakeWorker extends Emitter {
+  state: 'installing' | 'installed' | 'activated' = 'installing'
+  postMessage = vi.fn()
+  setState(state: FakeWorker['state']) {
+    this.state = state
+    this.dispatch('statechange')
+  }
+}
+
+class FakeRegistration extends Emitter {
+  installing: FakeWorker | null = null
+  update = vi.fn().mockResolvedValue(undefined)
+}
+
+class FakeSWContainer extends Emitter {
+  controller: object | null = null
+  registration = new FakeRegistration()
+  register = vi.fn().mockImplementation(async () => this.registration)
+}
+
+let container: FakeSWContainer
+let reloadMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.stubEnv('NODE_ENV', 'production')
+
+  container = new FakeSWContainer()
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: container,
+  })
+
+  reloadMock = vi.fn()
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, reload: reloadMock },
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+/** Render, then wait for the async `register()` call to settle. */
+async function renderAndRegister() {
+  render(<ServiceWorkerRegistrar />)
+  await waitFor(() => expect(container.register).toHaveBeenCalledTimes(1))
+  return container.registration
+}
+
+describe('ServiceWorkerRegistrar', () => {
+  it('registers /sw.js with updateViaCache: none', async () => {
+    await renderAndRegister()
+    expect(container.register).toHaveBeenCalledWith('/sw.js', {
+      updateViaCache: 'none',
+    })
+  })
+
+  it('shows the update banner on updatefound → installed WITH an existing controller', async () => {
+    const registration = await renderAndRegister()
+
+    // An existing controller means the page is already controlled ⇒ UPDATE.
+    container.controller = {}
+    const worker = new FakeWorker()
+    registration.installing = worker
+    registration.dispatch('updatefound')
+    worker.setState('installed')
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Update available' }),
+    ).toBeInTheDocument()
+  })
+
+  it('does NOT show the banner on the first install (no controller yet)', async () => {
+    const registration = await renderAndRegister()
+
+    // No controller ⇒ this is the first install, not an update.
+    container.controller = null
+    const worker = new FakeWorker()
+    registration.installing = worker
+    registration.dispatch('updatefound')
+    worker.setState('installed')
+
+    expect(
+      screen.queryByRole('dialog', { name: 'Update available' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('posts SKIP_WAITING to the waiting worker when Reload is clicked', async () => {
+    const registration = await renderAndRegister()
+
+    container.controller = {}
+    const worker = new FakeWorker()
+    registration.installing = worker
+    registration.dispatch('updatefound')
+    worker.setState('installed')
+
+    await screen.findByRole('dialog', { name: 'Update available' })
+    fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
+
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
+    // Clicking Reload must NOT itself reload — the controllerchange does.
+    expect(reloadMock).not.toHaveBeenCalled()
+  })
+
+  it('reloads the page exactly once on controllerchange (guard prevents a second)', async () => {
+    await renderAndRegister()
+
+    container.dispatch('controllerchange')
+    container.dispatch('controllerchange')
+    container.dispatch('controllerchange')
+
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismissing the banner hides it without reloading', async () => {
+    const registration = await renderAndRegister()
+
+    container.controller = {}
+    const worker = new FakeWorker()
+    registration.installing = worker
+    registration.dispatch('updatefound')
+    worker.setState('installed')
+
+    await screen.findByRole('dialog', { name: 'Update available' })
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss update prompt' }),
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: 'Update available' }),
+      ).not.toBeInTheDocument(),
+    )
+    expect(reloadMock).not.toHaveBeenCalled()
+  })
+
+  it('calls registration.update() on visibilitychange when visible', async () => {
+    const registration = await renderAndRegister()
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    fireEvent(document, new Event('visibilitychange'))
+
+    await waitFor(() => expect(registration.update).toHaveBeenCalled())
+  })
+})

--- a/__tests__/lib/pwa/request-classification.test.ts
+++ b/__tests__/lib/pwa/request-classification.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyRequest,
+  isNeverCachePath,
+  isStaticAssetPath,
+  NEVER_CACHE_PREFIXES,
+} from '@/lib/pwa/request-classification'
+
+const ORIGIN = 'https://cloudnativebergen.dev'
+
+function classify(
+  partial: Partial<Parameters<typeof classifyRequest>[0]> & { url: string },
+) {
+  return classifyRequest({
+    method: 'GET',
+    origin: ORIGIN,
+    ...partial,
+  })
+}
+
+describe('request classification', () => {
+  describe('SECURITY: authenticated paths are NEVER cached', () => {
+    // A non-navigation GET (e.g. an RSC/data fetch) to an authed path must be
+    // passthrough — caching it could leak one user's content to another.
+    const authedPaths = [
+      '/cfp/x',
+      '/cfp/proposal/123',
+      '/admin/x',
+      '/admin/sponsors',
+      '/stream/x',
+      '/api/x',
+      '/api/trpc/foo',
+    ]
+
+    it.each(authedPaths)('never caches non-navigation GET %s', (path) => {
+      expect(classify({ url: `${ORIGIN}${path}`, mode: 'cors' })).toBe(
+        'passthrough',
+      )
+    })
+
+    it.each(authedPaths)('isNeverCachePath is true for %s', (path) => {
+      expect(isNeverCachePath(path)).toBe(true)
+    })
+
+    it('never treats an authed path as a static asset even with a static-looking suffix', () => {
+      // A `.js` under an authed prefix must still be passthrough.
+      expect(classify({ url: `${ORIGIN}/api/export/report.js` })).toBe(
+        'passthrough',
+      )
+      expect(classify({ url: `${ORIGIN}/admin/thing.png` })).toBe('passthrough')
+    })
+
+    it('exports the exact auth prefixes the SW must exclude', () => {
+      expect(NEVER_CACHE_PREFIXES).toEqual([
+        '/api/',
+        '/cfp/',
+        '/admin/',
+        '/stream/',
+      ])
+    })
+  })
+
+  describe('navigations', () => {
+    it('classifies a document navigation as navigate', () => {
+      expect(classify({ url: `${ORIGIN}/program`, mode: 'navigate' })).toBe(
+        'navigate',
+      )
+    })
+
+    it('classifies an authed navigation as navigate (safe: response is never cached)', () => {
+      expect(classify({ url: `${ORIGIN}/cfp/list`, mode: 'navigate' })).toBe(
+        'navigate',
+      )
+    })
+  })
+
+  describe('static assets → stale-while-revalidate', () => {
+    const staticPaths = [
+      '/_next/static/chunks/main-abc123.js',
+      '/_next/static/css/app.css',
+      '/fonts/Inter-SemiBold.ttf',
+      '/pwa/icon/192',
+      '/icon-512.png',
+      '/apple-touch-icon.png',
+      '/favicon-32.png',
+      '/og/cover.webp',
+    ]
+
+    it.each(staticPaths)('classifies %s as static', (path) => {
+      expect(classify({ url: `${ORIGIN}${path}` })).toBe('static')
+    })
+
+    it.each(staticPaths)('isStaticAssetPath is true for %s', (path) => {
+      expect(isStaticAssetPath(path)).toBe(true)
+    })
+  })
+
+  describe('passthrough cases', () => {
+    it('passes through non-GET methods', () => {
+      expect(
+        classify({
+          url: `${ORIGIN}/program`,
+          mode: 'navigate',
+          method: 'POST',
+        }),
+      ).toBe('passthrough')
+    })
+
+    it('passes through cross-origin requests', () => {
+      expect(
+        classify({ url: 'https://cdn.sanity.io/images/x.png', mode: 'cors' }),
+      ).toBe('passthrough')
+    })
+
+    it('passes through cross-origin navigations', () => {
+      expect(
+        classify({ url: 'https://example.com/page', mode: 'navigate' }),
+      ).toBe('passthrough')
+    })
+
+    it('passes through a same-origin non-navigation dynamic request', () => {
+      // A public HTML/RSC route fetched as data (not a navigation) is not a
+      // static asset → passthrough, never cached.
+      expect(
+        classify({ url: `${ORIGIN}/program?_rsc=abc`, mode: 'cors' }),
+      ).toBe('passthrough')
+    })
+
+    it('passes through malformed URLs', () => {
+      expect(classify({ url: 'not a url' })).toBe('passthrough')
+    })
+  })
+})

--- a/__tests__/lib/pwa/sw-source.test.ts
+++ b/__tests__/lib/pwa/sw-source.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { NEVER_CACHE_PREFIXES } from '@/lib/pwa/request-classification'
+
+/**
+ * `public/sw.js` is hand-written plain JS and cannot import the TypeScript
+ * classifier, so it MIRRORS the rules inline. These tests are a drift guard:
+ * they fail if the security-critical auth-path exclusions or the "no
+ * unconditional skipWaiting on install" invariant are ever removed from the
+ * worker source.
+ */
+describe('public/sw.js source invariants', () => {
+  const source = readFileSync(
+    resolve(__dirname, '../../../public/sw.js'),
+    'utf8',
+  )
+
+  it('references every auth prefix that must never be cached', () => {
+    for (const prefix of NEVER_CACHE_PREFIXES) {
+      expect(source).toContain(`'${prefix}'`)
+    }
+  })
+
+  it('does not call skipWaiting() inside the install handler', () => {
+    const installBlock = source.slice(
+      source.indexOf("addEventListener('install'"),
+      source.indexOf("addEventListener('activate'"),
+    )
+    expect(installBlock.length).toBeGreaterThan(0)
+    // The literal call `self.skipWaiting()` must not appear in install (a
+    // reference in a comment like "NO skipWaiting() here" is fine).
+    expect(installBlock).not.toContain('self.skipWaiting')
+  })
+
+  it('only calls skipWaiting() in response to a SKIP_WAITING message', () => {
+    expect(source).toContain('SKIP_WAITING')
+    expect(source).toContain('self.skipWaiting()')
+  })
+
+  it('claims clients and cleans up non-allowlisted caches on activate', () => {
+    expect(source).toContain('clients.claim()')
+    expect(source).toContain('caches.delete')
+  })
+
+  it('serves the precached offline page as the navigation fallback', () => {
+    expect(source).toContain('/offline')
+  })
+})

--- a/next.config.ts
+++ b/next.config.ts
@@ -52,6 +52,23 @@ const config: NextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        // The service worker lives at a stable URL and must never be cached by
+        // the browser HTTP cache — otherwise a deploy's new `/sw.js` bytes are
+        // not seen and the update flow never fires. Registration also uses
+        // `updateViaCache: 'none'` for the same reason.
+        source: '/sw.js',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, must-revalidate',
+          },
+        ],
+      },
+    ]
+  },
   async redirects() {
     return [
       {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,188 @@
+/**
+ * Cloud Native Days service worker — hand-rolled, minimal, and explicit.
+ *
+ * Why hand-rolled (not Serwist / next-pwa): those need a webpack build (this
+ * app builds with Turbopack) and their default runtime caching NetworkFirst-
+ * caches page/RSC HTML — which in a multi-user, JWT-cookie-authenticated app
+ * can serve a stale or WRONG-USER page. We control caching explicitly here.
+ *
+ * Caching contract (mirrors `src/lib/pwa/request-classification.ts`):
+ *   - NEVER cache authenticated HTML/data: `/cfp/*`, `/admin/*`, `/stream/*`,
+ *     `/api/*`. These carry per-user content. A violation is an auth leak.
+ *   - Navigations (document requests): NETWORK-FIRST, falling back to the
+ *     precached `/offline` page only on network failure. The live HTML is never
+ *     cached, so fresh HTML always references current hashed chunks → this
+ *     kills post-deploy ChunkLoadError. We never serve cached HTML for a nav.
+ *   - Static, content-hashed assets (`/_next/static/*`, `/fonts/*`,
+ *     `/pwa/icon/*`, image/font files): stale-while-revalidate.
+ *   - Precache ONLY a tiny shell: the `/offline` page and the PWA icons.
+ *   - Only GET is handled; everything else passes through untouched.
+ *
+ * Update flow: this file lives at the stable URL `/sw.js` and is served with
+ * `Cache-Control: no-cache`. Changing its bytes (e.g. bumping CACHE_VERSION)
+ * is what triggers the browser to install a new worker. We do NOT call
+ * skipWaiting() on install — the new worker waits until the user clicks
+ * "Reload" in the update banner, which posts { type: 'SKIP_WAITING' }.
+ */
+
+// Bump this to invalidate the precache and force an update. The changed bytes
+// are what the browser diffs to detect a new worker.
+const CACHE_VERSION = 'cndn-v1'
+const PRECACHE = `${CACHE_VERSION}-precache`
+const RUNTIME = `${CACHE_VERSION}-runtime`
+
+// The offline shell: the fallback page plus committed static PWA icons. We do
+// NOT precache `/` or any HTML document other than `/offline`.
+const OFFLINE_URL = '/offline'
+const PRECACHE_URLS = [
+  OFFLINE_URL,
+  '/icon-192.png',
+  '/icon-512.png',
+  '/icon-192-maskable.png',
+  '/icon-512-maskable.png',
+  '/apple-touch-icon.png',
+  '/favicon-32.png',
+  '/favicon-16.png',
+]
+
+// The set of cache names this worker version is allowed to keep. Any cache not
+// in this list is deleted on activate (cleans up caches from older versions).
+const EXPECTED_CACHES = [PRECACHE, RUNTIME]
+
+// --- Request classification (mirror of request-classification.ts) ----------
+
+const NEVER_CACHE_PREFIXES = ['/api/', '/cfp/', '/admin/', '/stream/']
+const STATIC_ASSET_PREFIXES = ['/_next/static/', '/fonts/', '/pwa/icon/']
+const STATIC_ASSET_EXTENSIONS = [
+  '.js',
+  '.css',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.webp',
+  '.avif',
+  '.ico',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+]
+
+function isNeverCachePath(pathname) {
+  return NEVER_CACHE_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+}
+
+function isStaticAssetPath(pathname) {
+  if (STATIC_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return true
+  }
+  return STATIC_ASSET_EXTENSIONS.some((ext) => pathname.endsWith(ext))
+}
+
+/** Returns 'passthrough' | 'navigate' | 'static'. */
+function classifyRequest(request) {
+  if (request.method !== 'GET') return 'passthrough'
+
+  let url
+  try {
+    url = new URL(request.url)
+  } catch (e) {
+    return 'passthrough'
+  }
+
+  if (url.origin !== self.location.origin) return 'passthrough'
+  if (request.mode === 'navigate') return 'navigate'
+  if (isNeverCachePath(url.pathname)) return 'passthrough'
+  if (isStaticAssetPath(url.pathname)) return 'static'
+  return 'passthrough'
+}
+
+// --- Lifecycle -------------------------------------------------------------
+
+self.addEventListener('install', (event) => {
+  // Precache the offline shell. Intentionally NO skipWaiting() here — the new
+  // worker stays in "waiting" until the user opts in via the update banner.
+  event.waitUntil(
+    caches.open(PRECACHE).then((cache) => cache.addAll(PRECACHE_URLS)),
+  )
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const names = await caches.keys()
+      await Promise.all(
+        names
+          .filter((name) => !EXPECTED_CACHES.includes(name))
+          .map((name) => caches.delete(name)),
+      )
+      await self.clients.claim()
+    })(),
+  )
+})
+
+self.addEventListener('message', (event) => {
+  // The registration client posts this when the user clicks "Reload" in the
+  // update banner. Only then do we activate the waiting worker.
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})
+
+// --- Fetch strategies ------------------------------------------------------
+
+/**
+ * Network-first for navigations. Never caches the (possibly authed) HTML; on
+ * network failure serves the precached `/offline` page.
+ */
+async function handleNavigate(request) {
+  try {
+    return await fetch(request)
+  } catch (e) {
+    const cache = await caches.open(PRECACHE)
+    const offline = await cache.match(OFFLINE_URL)
+    return (
+      offline ||
+      new Response('You are offline.', {
+        status: 503,
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+      })
+    )
+  }
+}
+
+/**
+ * Stale-while-revalidate for content-hashed static assets: serve from cache
+ * immediately if present, and refresh the cache entry in the background.
+ */
+async function handleStatic(request) {
+  const cache = await caches.open(RUNTIME)
+  const cached = await cache.match(request)
+
+  const network = fetch(request)
+    .then((response) => {
+      if (response && response.ok) {
+        cache.put(request, response.clone())
+      }
+      return response
+    })
+    .catch(() => undefined)
+
+  return cached || (await network) || fetch(request)
+}
+
+self.addEventListener('fetch', (event) => {
+  const strategy = classifyRequest(event.request)
+
+  if (strategy === 'navigate') {
+    event.respondWith(handleNavigate(event.request))
+    return
+  }
+  if (strategy === 'static') {
+    event.respondWith(handleStatic(event.request))
+    return
+  }
+  // 'passthrough' — do not intercept; let the browser handle it normally.
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ import '@/styles/tailwind.css'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { canonicalOrigin } from '@/lib/seo/canonical'
 import { DevBanner } from '@/components/DevBanner'
-import { InstallPrompt } from '@/components/pwa'
+import { InstallPrompt, ServiceWorkerRegistrar } from '@/components/pwa'
 import { ThemeProvider } from '@/components/providers/ThemeProvider'
 import { TRPCProvider } from '@/components/providers/TRPCProvider'
 import { SessionProviderWrapper } from '@/components/providers/SessionProviderWrapper'
@@ -170,6 +170,7 @@ export default function RootLayout({
                 <SessionProviderWrapper>{children}</SessionProviderWrapper>
               </Suspense>
               <InstallPrompt />
+              <ServiceWorkerRegistrar />
             </div>
           </TRPCProvider>
         </ThemeProvider>

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Logo } from '@/components/Logo'
+
+/**
+ * Offline fallback page.
+ *
+ * The service worker precaches this route and serves it for a document
+ * navigation ONLY when the network is unreachable. It is deliberately:
+ *
+ *  - NOT under any authenticated route group (`(cfp)`/`(admin)`/`(stream)`), so
+ *    it carries no per-user content and is safe to cache and serve to anyone.
+ *  - Fully static and self-contained (no `headers()`, no data fetching), so it
+ *    prerenders to cacheable HTML that never goes stale in a harmful way.
+ *
+ * `metadata` is intentionally omitted here so the route inherits the root
+ * layout's title template.
+ */
+export default function OfflinePage() {
+  return (
+    <div className="flex min-h-[70vh] w-full flex-col items-center justify-center px-6 py-20 text-center">
+      <Logo className="h-12 w-auto" aria-hidden="true" />
+
+      <h1 className="font-display mt-10 text-3xl font-medium tracking-tighter text-blue-600 sm:text-4xl dark:text-blue-300">
+        You&apos;re offline
+      </h1>
+
+      <p className="mt-4 max-w-md text-lg tracking-tight text-blue-900 dark:text-blue-100">
+        We couldn&apos;t reach the network. Check your connection and try again
+        — pages you&apos;ve already visited may still work.
+      </p>
+
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="mt-8 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue"
+      >
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/src/components/pwa/ServiceWorkerRegistrar.tsx
+++ b/src/components/pwa/ServiceWorkerRegistrar.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { UpdateBanner } from './UpdateBanner'
+
+/**
+ * Registers the service worker and drives the update lifecycle.
+ *
+ * Mounted once in the root layout. It:
+ *
+ *  1. Registers `/sw.js` (stable URL, `updateViaCache: 'none'` so the browser
+ *     always revalidates the worker script — paired with the `no-cache` header
+ *     set in `next.config.ts`).
+ *  2. Detects a genuine UPDATE (not the first install) by watching a newly
+ *     `installing` worker reach the `installed` state WHILE a controller already
+ *     exists, and surfaces the "new version available" banner.
+ *  3. On the user clicking Reload, posts `SKIP_WAITING` to the waiting worker.
+ *  4. Reloads the page EXACTLY ONCE on `controllerchange`, guarded by a
+ *     `refreshing` flag so the swap can never spiral into a reload loop.
+ *  5. Calls `registration.update()` on focus / visibility change so long-lived
+ *     tabs pick up a deploy without a manual refresh.
+ *
+ * Registration happens only in the browser and only in production builds, so it
+ * never fights Turbopack HMR during `next dev`.
+ */
+export function ServiceWorkerRegistrar() {
+  const [updateAvailable, setUpdateAvailable] = useState(false)
+  // The worker that is installed and waiting to activate.
+  const waitingWorkerRef = useRef<ServiceWorker | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (!('serviceWorker' in navigator)) return
+    // Registering the SW under Turbopack HMR fights dev reloads; prod only.
+    if (process.env.NODE_ENV !== 'production') return
+
+    // Reload exactly once when the active worker changes (i.e. the new worker
+    // took control after SKIP_WAITING). The guard prevents an infinite loop.
+    let refreshing = false
+    const onControllerChange = () => {
+      if (refreshing) return
+      refreshing = true
+      window.location.reload()
+    }
+    navigator.serviceWorker.addEventListener(
+      'controllerchange',
+      onControllerChange,
+    )
+
+    let registration: ServiceWorkerRegistration | undefined
+
+    const trackInstalling = (worker: ServiceWorker) => {
+      worker.addEventListener('statechange', () => {
+        if (
+          worker.state === 'installed' &&
+          // A non-null controller means this page is already controlled by an
+          // older worker ⇒ this is an UPDATE, not the first install.
+          navigator.serviceWorker.controller
+        ) {
+          waitingWorkerRef.current = worker
+          setUpdateAvailable(true)
+        }
+      })
+    }
+
+    const onFocusOrVisible = () => {
+      if (document.visibilityState !== 'visible') return
+      // Ask the browser to re-check `/sw.js` so long-lived tabs notice deploys.
+      registration?.update().catch(() => {})
+    }
+
+    const register = async () => {
+      try {
+        registration = await navigator.serviceWorker.register('/sw.js', {
+          updateViaCache: 'none',
+        })
+
+        // A worker already installing at registration time is an update.
+        if (registration.installing) {
+          trackInstalling(registration.installing)
+        }
+
+        registration.addEventListener('updatefound', () => {
+          const installing = registration?.installing
+          if (installing) trackInstalling(installing)
+        })
+
+        window.addEventListener('focus', onFocusOrVisible)
+        document.addEventListener('visibilitychange', onFocusOrVisible)
+      } catch {
+        // Registration failing (unsupported / blocked) is non-fatal.
+      }
+    }
+
+    // Register after load so it never contends with initial page rendering.
+    if (document.readyState === 'complete') {
+      register()
+    } else {
+      window.addEventListener('load', register, { once: true })
+    }
+
+    return () => {
+      navigator.serviceWorker.removeEventListener(
+        'controllerchange',
+        onControllerChange,
+      )
+      window.removeEventListener('focus', onFocusOrVisible)
+      document.removeEventListener('visibilitychange', onFocusOrVisible)
+      window.removeEventListener('load', register)
+    }
+  }, [])
+
+  const handleReload = () => {
+    const worker = waitingWorkerRef.current
+    if (worker) {
+      // Tell the waiting worker to activate; `controllerchange` then reloads.
+      worker.postMessage({ type: 'SKIP_WAITING' })
+    } else {
+      // No tracked worker (edge case) — a plain reload still recovers.
+      window.location.reload()
+    }
+  }
+
+  const handleDismiss = () => {
+    // Keep the current version for now; the banner reappears on the next
+    // `update()` check (focus / visibility) while a worker is still waiting.
+    setUpdateAvailable(false)
+  }
+
+  if (!updateAvailable) return null
+
+  return <UpdateBanner onReload={handleReload} onDismiss={handleDismiss} />
+}

--- a/src/components/pwa/ServiceWorkerRegistrar.tsx
+++ b/src/components/pwa/ServiceWorkerRegistrar.tsx
@@ -27,6 +27,10 @@ export function ServiceWorkerRegistrar() {
   const [updateAvailable, setUpdateAvailable] = useState(false)
   // The worker that is installed and waiting to activate.
   const waitingWorkerRef = useRef<ServiceWorker | null>(null)
+  // Set only when the USER accepts the update (clicks Reload). Gates the
+  // controllerchange reload so a first-install `clients.claim()` — which also
+  // fires controllerchange — never triggers an unsolicited page reload.
+  const reloadRequestedRef = useRef(false)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -34,10 +38,13 @@ export function ServiceWorkerRegistrar() {
     // Registering the SW under Turbopack HMR fights dev reloads; prod only.
     if (process.env.NODE_ENV !== 'production') return
 
-    // Reload exactly once when the active worker changes (i.e. the new worker
-    // took control after SKIP_WAITING). The guard prevents an infinite loop.
+    // Reload exactly once when the active worker changes AFTER the user accepted
+    // the update. The `refreshing` guard prevents an infinite loop; the
+    // `reloadRequestedRef` guard prevents an unsolicited reload on first install
+    // (where `clients.claim()` also fires controllerchange).
     let refreshing = false
     const onControllerChange = () => {
+      if (!reloadRequestedRef.current) return
       if (refreshing) return
       refreshing = true
       window.location.reload()
@@ -111,6 +118,9 @@ export function ServiceWorkerRegistrar() {
   }, [])
 
   const handleReload = () => {
+    // Mark the reload as user-accepted so the controllerchange handler is
+    // allowed to reload (an unsolicited first-install controllerchange is not).
+    reloadRequestedRef.current = true
     const worker = waitingWorkerRef.current
     if (worker) {
       // Tell the waiting worker to activate; `controllerchange` then reloads.
@@ -122,8 +132,11 @@ export function ServiceWorkerRegistrar() {
   }
 
   const handleDismiss = () => {
-    // Keep the current version for now; the banner reappears on the next
-    // `update()` check (focus / visibility) while a worker is still waiting.
+    // Keep the current (waiting) version for now. The already-installed worker
+    // stays in `waiting`; the user gets it on their next manual reload / tab
+    // close, or when the NEXT deploy installs a newer worker (which re-fires the
+    // banner). `update()` alone will NOT re-surface the banner for this same
+    // waiting version, since an already-`installed` worker doesn't re-emit.
     setUpdateAvailable(false)
   }
 

--- a/src/components/pwa/UpdateBanner.stories.tsx
+++ b/src/components/pwa/UpdateBanner.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { UpdateBanner } from './UpdateBanner'
+
+const meta = {
+  title: 'Components/PWA/UpdateBanner',
+  component: UpdateBanner,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Presentational "new version available" banner shown after the service worker installs an update. Clicking Reload posts `SKIP_WAITING` to the waiting worker (handled by the `ServiceWorkerRegistrar` container), which then reloads the page exactly once. This component is pure — all service-worker logic lives in the container — so it renders standalone. The entrance animation is suppressed under `prefers-reduced-motion`.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    onReload: fn(),
+    onDismiss: fn(),
+  },
+} satisfies Meta<typeof UpdateBanner>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/components/pwa/UpdateBanner.tsx
+++ b/src/components/pwa/UpdateBanner.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ArrowPathIcon, XMarkIcon } from '@heroicons/react/24/outline'
+
+export interface UpdateBannerProps {
+  /** Invoked by the Reload button — triggers activation of the waiting worker. */
+  onReload: () => void
+  /** Invoked by the dismiss control (keeps the current version for now). */
+  onDismiss: () => void
+}
+
+/**
+ * Presentational "new version available" banner. Mirrors {@link InstallBanner}'s
+ * anchored, dismissible pill styling so the two PWA affordances feel identical.
+ * Kept free of any service-worker logic so it renders standalone in Storybook
+ * and unit tests.
+ *
+ * Motion: a subtle slide/fade entrance driven by a mount flag and core
+ * `transition` utilities. The `motion-reduce:` variant disables the transform
+ * and transition entirely for users who prefer reduced motion.
+ */
+export function UpdateBanner({ onReload, onDismiss }: UpdateBannerProps) {
+  const [entered, setEntered] = useState(false)
+
+  useEffect(() => {
+    // Defer to the next frame so the transition animates from the initial state.
+    const id = requestAnimationFrame(() => setEntered(true))
+    return () => cancelAnimationFrame(id)
+  }, [])
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Update available"
+      className="fixed inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-4"
+    >
+      <div
+        className={`flex w-full max-w-md items-center gap-3 rounded-2xl bg-white p-3 shadow-lg ring-1 ring-gray-900/10 transition duration-300 ease-out motion-reduce:transform-none motion-reduce:transition-none dark:bg-gray-800 dark:ring-white/10 ${
+          entered ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'
+        }`}
+      >
+        <div className="flex size-10 flex-none items-center justify-center rounded-xl bg-brand-cloud-blue/10 text-brand-cloud-blue dark:bg-brand-cloud-blue/20">
+          <ArrowPathIcon className="size-5" />
+        </div>
+
+        <div className="flex-1 text-sm text-gray-700 dark:text-gray-200">
+          <span>A new version is available.</span>
+        </div>
+
+        <button
+          type="button"
+          onClick={onReload}
+          className="flex-none rounded-lg bg-brand-cloud-blue px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue"
+        >
+          Reload
+        </button>
+
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss update prompt"
+          className="flex-none rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:hover:bg-gray-700 dark:hover:text-gray-200"
+        >
+          <XMarkIcon className="size-5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -1,3 +1,6 @@
 export { InstallBanner } from './InstallBanner'
 export type { InstallBannerProps } from './InstallBanner'
 export { InstallPrompt } from './InstallPrompt'
+export { UpdateBanner } from './UpdateBanner'
+export type { UpdateBannerProps } from './UpdateBanner'
+export { ServiceWorkerRegistrar } from './ServiceWorkerRegistrar'

--- a/src/lib/pwa/request-classification.ts
+++ b/src/lib/pwa/request-classification.ts
@@ -1,0 +1,125 @@
+/**
+ * Pure request-classification logic shared (in spirit) with `public/sw.js`.
+ *
+ * The service worker itself is hand-written plain JS served as a static file,
+ * so it cannot import this TypeScript module at runtime — it mirrors the exact
+ * same rules inline. This module exists so the SECURITY-CRITICAL decision of
+ * "what may ever be cached" is expressed once, unit-tested exhaustively, and
+ * kept honest by a drift-guard test that asserts `sw.js` still references the
+ * same auth-path prefixes.
+ *
+ * The single non-negotiable invariant: authenticated HTML/data
+ * (`/cfp/*`, `/admin/*`, `/stream/*`, `/api/*`) is NEVER cached. Serving a
+ * cached authed response could leak one user's page to another user.
+ */
+
+/**
+ * URL path prefixes that carry per-user, JWT-cookie-scoped content. A response
+ * for any of these must never be written to a cache, under any strategy.
+ */
+export const NEVER_CACHE_PREFIXES = [
+  '/api/',
+  '/cfp/',
+  '/admin/',
+  '/stream/',
+] as const
+
+/** File extensions that are content-hashed / immutable enough to cache safely. */
+const STATIC_ASSET_EXTENSIONS = [
+  '.js',
+  '.css',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.webp',
+  '.avif',
+  '.ico',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+] as const
+
+/** Path prefixes whose responses are static, public, and safe to cache. */
+const STATIC_ASSET_PREFIXES = [
+  '/_next/static/',
+  '/fonts/',
+  '/pwa/icon/',
+] as const
+
+/**
+ * How the service worker should treat a request.
+ *
+ * - `passthrough`  — do NOT call `respondWith`; let the network handle it with
+ *   no SW caching. Used for non-GET, cross-origin, authed, and API requests.
+ * - `navigate`     — document navigation: network-first, falling back to the
+ *   precached `/offline` page ONLY when the network fails. The network response
+ *   itself is never cached, so fresh HTML always references current hashed
+ *   chunks (this is what prevents post-deploy `ChunkLoadError`).
+ * - `static`       — content-hashed static asset: stale-while-revalidate.
+ */
+export type RequestStrategy = 'passthrough' | 'navigate' | 'static'
+
+export interface ClassifiableRequest {
+  /** HTTP method, e.g. `GET`. */
+  method: string
+  /** The request's `mode`; `navigate` marks a document navigation. */
+  mode?: string
+  /** Absolute request URL. */
+  url: string
+  /** The service worker's own origin (`self.location.origin`). */
+  origin: string
+}
+
+/** True when `pathname` targets authenticated / per-user content. */
+export function isNeverCachePath(pathname: string): boolean {
+  return NEVER_CACHE_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+}
+
+/** True when `pathname` targets a content-hashed / immutable static asset. */
+export function isStaticAssetPath(pathname: string): boolean {
+  if (STATIC_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return true
+  }
+  return STATIC_ASSET_EXTENSIONS.some((ext) => pathname.endsWith(ext))
+}
+
+/**
+ * Decide how the service worker should handle a request. Deliberately
+ * conservative: anything not provably safe to cache falls through to
+ * `passthrough` (plain network, no caching).
+ */
+export function classifyRequest(request: ClassifiableRequest): RequestStrategy {
+  // Only GET is ever eligible for SW handling.
+  if (request.method !== 'GET') return 'passthrough'
+
+  let pathname: string
+  let sameOrigin: boolean
+  try {
+    const parsed = new URL(request.url)
+    pathname = parsed.pathname
+    sameOrigin = parsed.origin === request.origin
+  } catch {
+    return 'passthrough'
+  }
+
+  // Cross-origin (analytics, CDNs, third-party) — never intercept.
+  if (!sameOrigin) return 'passthrough'
+
+  // Document navigations: network-first with an offline fallback. This applies
+  // even to authed navigations (e.g. `/cfp/*`) — safe because the response is
+  // never cached; only the static `/offline` shell is served on failure.
+  if (request.mode === 'navigate') return 'navigate'
+
+  // SECURITY: authed HTML/data must never be cached, regardless of extension.
+  if (isNeverCachePath(pathname)) return 'passthrough'
+
+  // Content-hashed static assets: stale-while-revalidate.
+  if (isStaticAssetPath(pathname)) return 'static'
+
+  // Everything else (RSC data fetches, dynamic public routes, etc.): plain
+  // network, no caching.
+  return 'passthrough'
+}


### PR DESCRIPTION
Closes #442. Adds a hand-rolled service worker with a reliable, opt-in update flow and an offline fallback.

> [!IMPORTANT]
> **Stacked on #453** (`feat/pwa-manifest-icons`) — it builds on that PR's layout/manifest/icons. This PR's base is `main`, so until #453 merges the diff here also shows #453's commits. **Rebase onto `main` after #453 merges.**
>
> **Held for review + a real preview-deploy test.** The SW update lifecycle can only be fully verified on a deployed preview (two successive deploys). Please do not merge before the manual check below is done.

## Why not Serwist / next-pwa
Serwist needs a webpack build, which breaks our Turbopack builds; and its `defaultCache` NetworkFirst-caches page/RSC HTML — in this multi-tenant, per-user JWT-cookie app that can serve a **stale or wrong-user page**. We hand-roll `public/sw.js` and control caching explicitly instead.

## Caching table (what is cached vs never cached)

| Request | Strategy | Cached? |
| --- | --- | --- |
| Authed HTML/data — `/cfp/*`, `/admin/*`, `/stream/*`, `/api/*` | passthrough (plain network) | **Never** — per-user JWT content; caching would be an auth leak |
| Document navigations (any route, incl. authed) | network-first; precached `/offline` only on network failure | **No** — live HTML never cached |
| `/_next/static/*`, `/fonts/*`, `/pwa/icon/*`, image/font files | stale-while-revalidate | Yes — content-hashed, safe |
| Precache shell: `/offline` + PWA icons | precached on install | Yes — static, non-authed |
| Non-GET, cross-origin, other same-origin dynamic (RSC data) | passthrough | No |

## ChunkLoadError avoidance
A navigation is **never** served cached HTML — we always go to the network for documents and only fall back to the static `/offline` page when the network is unreachable. Fresh HTML therefore always references the current deploy's hashed chunk URLs, so a post-deploy navigation can never load an old HTML shell that points at chunks that no longer exist.

## The update flow (implemented precisely)
1. **One SW at a stable URL** `/sw.js`, served `Cache-Control: no-cache, no-store, must-revalidate` (added in `next.config.ts` `headers()`), registered with `{ updateViaCache: 'none' }`. The URL is never versioned; the changed `sw.js` bytes (bump `CACHE_VERSION`, currently `cndn-v1`) are what trigger an update.
2. **No unconditional `skipWaiting()` on install** — the new worker waits.
3. **`ServiceWorkerRegistrar`** (`'use client'`, mounted once in `src/app/layout.tsx`, prod-only so it never fights Turbopack HMR): on `updatefound` → new worker `statechange` to `installed` **and `navigator.serviceWorker.controller` is non-null** (⇒ update, not first install) → shows the "New version available — Reload" banner (mirrors `InstallBanner`, respects `prefers-reduced-motion`). Reload → `worker.postMessage({ type: 'SKIP_WAITING' })`. A single `controllerchange` handler reloads the page **exactly once**, guarded by a `refreshing` flag (no infinite reload loop). `registration.update()` runs on `focus`/`visibilitychange` so long-lived tabs pick up deploys.
4. **In `sw.js`**: `message` handler → `if (data?.type === 'SKIP_WAITING') self.skipWaiting()`; `activate` handler `clients.claim()`s and deletes any cache not in the current version allowlist.

Expected sequence on a deploy: new `/sw.js` detected → installs & waits → banner appears → user clicks Reload → `SKIP_WAITING` → `controllerchange` → exactly one reload onto the new version.

## Offline page
`src/app/offline/page.tsx` — a branded, fully static page (no `headers()`/data), **not** under any authed route group, precached by the SW and served for a failed navigation.

## Tests / verification
- `pnpm typecheck` clean · `pnpm knip` clean · eslint 0 errors · prettier clean · `pnpm vitest run` green (142 files).
- `next build` **compiles** (Turbopack + TypeScript pass); build only fails later at page-data collection on an unrelated cron route due to a missing `RESEND_API_KEY` secret in the sandbox — not related to this change.
- `ServiceWorkerRegistrar` tests (mocked `navigator.serviceWorker`): updatefound→installed-with-controller shows the toast; first install (no controller) does **not**; Reload posts `SKIP_WAITING` and does not itself reload; `controllerchange` reloads exactly once across repeated dispatches; dismiss hides without reloading; `update()` fires on visibilitychange.
- `request-classification` unit tests assert the security-critical exclusions: `/cfp/x`, `/admin/x`, `/stream/x`, `/api/x` are **never** cached (even with static-looking suffixes).
- `sw-source` drift guard: asserts `public/sw.js` still references every auth prefix, never calls `self.skipWaiting()` in `install`, claims clients + cleans caches on `activate`, and serves `/offline`.
- Storybook story for the `UpdateBanner`.

## What the maintainer must test on a preview deploy
1. Load the preview, confirm the SW registers (Application → Service Workers) and `/offline` + icons are precached.
2. Ship a second deploy (bump nothing else needed — new hashed chunks suffice; optionally bump `CACHE_VERSION`), keep the tab open, then focus it: the **"New version available — Reload"** banner should appear.
3. Click **Reload** → page should reload **exactly once** onto the new version (no reload loop, no `ChunkLoadError`).
4. Go offline (DevTools) and navigate to a fresh route → the branded `/offline` page renders; re-enable network and confirm normal navigation returns live HTML.
5. Confirm an authed route (`/cfp`, `/admin`) is never served from cache (network entry every navigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a hand-rolled service worker with a carefully designed opt-in update banner and an offline fallback page. The security-critical decision — never caching authenticated HTML from `/cfp/*`, `/admin/*`, `/stream/*`, or `/api/*` — is well-implemented, unit-tested exhaustively, and protected by a drift-guard test that will fail if the auth exclusions are ever removed from the worker source.

- **`public/sw.js`** implements three strategies: passthrough for authed/non-GET/cross-origin requests, network-first (never cached) for document navigations, and stale-while-revalidate for content-hashed static assets; the `handleStatic` background revalidation promise is not covered by `event.waitUntil()`, so the cache write may be cut short when the SW is evicted after a cached response is returned.
- **`ServiceWorkerRegistrar`** drives the `updatefound → installed → banner → SKIP_WAITING → controllerchange → reload` lifecycle correctly for the happy path, but does not check `registration.waiting` at mount time — meaning a user who dismisses the banner and navigates to a new page will never see the update prompt again for that SW version, and the worker stays in `waiting` indefinitely.
- **`next.config.ts`**, request classification, offline page, icon pipeline, and test coverage are all solid.

<h3>Confidence Score: 3/5</h3>

The auth-leak prevention logic is correct and well-tested, but two functional defects in the SW and registrar should be fixed before the manual preview-deploy verification described in the PR.

The missing `event.waitUntil()` for background SWR revalidation means static-asset cache entries for non-content-hashed URLs (icons, fonts) may never actually refresh after the initial cache miss — the browser can terminate the SW between the cached response being returned and `cache.put()` completing. The missing `registration.waiting` check means a dismissed update banner is permanently gone for that SW version; the user is silently stuck on the old worker until a new deploy arrives. Both defects are in the core paths this PR is shipping.

`public/sw.js` (handleStatic background revalidation) and `src/components/pwa/ServiceWorkerRegistrar.tsx` (registration.waiting check on mount) need the most attention before the manual preview test.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| public/sw.js | New hand-rolled service worker with stale-while-revalidate for static assets, network-first for navigations, and SKIP_WAITING message-based update flow; the SWR fetch handler is missing event.waitUntil() for the background revalidation promise, risking premature SW termination before cache.put() completes. |
| src/components/pwa/ServiceWorkerRegistrar.tsx | Client component that registers the SW and manages the update banner lifecycle; correctly guards first-install vs update with a controller check, but does not inspect registration.waiting on mount — so a dismissed update banner is never re-shown after a subsequent navigation within the same deploy. |
| src/lib/pwa/request-classification.ts | Clean TypeScript implementation of the request classifier with exhaustive unit tests; auth-prefix NEVER_CACHE guard is correctly ordered before the static-asset check, preventing authenticated paths from leaking into cache. |
| next.config.ts | Adds Cache-Control: no-cache, no-store, must-revalidate header for /sw.js; correctly paired with updateViaCache: 'none' in the registrar to ensure browser always re-fetches the worker script. |
| src/app/offline/page.tsx | Branded offline fallback page; correctly placed outside any authenticated route group, no data fetching, safe to precache. |
| __tests__/lib/pwa/sw-source.test.ts | Drift-guard test that reads public/sw.js and asserts auth-prefix presence, no unconditional skipWaiting() in install, and claims/cleans on activate; good invariant coverage but does not assert event.waitUntil() is called for the background SWR revalidation. |
| __tests__/components/pwa/ServiceWorkerRegistrar.test.tsx | Comprehensive mock-based test suite covering updatefound→installed-with-controller, first-install guard, SKIP_WAITING posting, single-reload guard, dismiss, and visibility-triggered update(); does not test the registration.waiting-on-mount case. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Layout as RootLayout (layout.tsx)
    participant Reg as ServiceWorkerRegistrar
    participant SW as /sw.js (Service Worker)
    participant Cache as CacheStorage

    Browser->>Layout: Page load (production)
    Layout->>Reg: mount (after window load)
    Reg->>Browser: "navigator.serviceWorker.register('/sw.js', {updateViaCache:'none'})"
    Browser->>SW: "Download & install (if new bytes)"
    SW->>Cache: install: cache.addAll(PRECACHE_URLS)
    SW-->>Browser: "state = installed (waiting)"
    Browser->>Reg: "updatefound → statechange(installed) + controller != null"
    Reg-->>Browser: Show UpdateBanner

    Browser->>Reg: User clicks Reload
    Reg->>SW: "postMessage({type:'SKIP_WAITING'})"
    SW->>SW: self.skipWaiting()
    SW->>Cache: activate: delete old caches, clients.claim()
    SW-->>Browser: controllerchange event
    Browser->>Reg: onControllerChange (refreshing guard)
    Reg->>Browser: window.location.reload() exactly once

    Note over Browser,Cache: Fetch strategies
    Browser->>SW: navigate request
    SW->>Browser: fetch(request) network only, never cached
    Browser->>SW: "static asset e.g. /_next/static/* /fonts/* etc."
    SW->>Cache: cache.match(request)
    Cache-->>SW: cached response (if any)
    SW->>Browser: return cached immediately
    SW->>Browser: fetch(request) in background cache.put() no waitUntil
    Browser->>SW: "authed path /api/* /cfp/* /admin/* /stream/*"
    SW->>Browser: passthrough (no respondWith)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Layout as RootLayout (layout.tsx)
    participant Reg as ServiceWorkerRegistrar
    participant SW as /sw.js (Service Worker)
    participant Cache as CacheStorage

    Browser->>Layout: Page load (production)
    Layout->>Reg: mount (after window load)
    Reg->>Browser: "navigator.serviceWorker.register('/sw.js', {updateViaCache:'none'})"
    Browser->>SW: "Download & install (if new bytes)"
    SW->>Cache: install: cache.addAll(PRECACHE_URLS)
    SW-->>Browser: "state = installed (waiting)"
    Browser->>Reg: "updatefound → statechange(installed) + controller != null"
    Reg-->>Browser: Show UpdateBanner

    Browser->>Reg: User clicks Reload
    Reg->>SW: "postMessage({type:'SKIP_WAITING'})"
    SW->>SW: self.skipWaiting()
    SW->>Cache: activate: delete old caches, clients.claim()
    SW-->>Browser: controllerchange event
    Browser->>Reg: onControllerChange (refreshing guard)
    Reg->>Browser: window.location.reload() exactly once

    Note over Browser,Cache: Fetch strategies
    Browser->>SW: navigate request
    SW->>Browser: fetch(request) network only, never cached
    Browser->>SW: "static asset e.g. /_next/static/* /fonts/* etc."
    SW->>Cache: cache.match(request)
    Cache-->>SW: cached response (if any)
    SW->>Browser: return cached immediately
    SW->>Browser: fetch(request) in background cache.put() no waitUntil
    Browser->>SW: "authed path /api/* /cfp/* /admin/* /stream/*"
    SW->>Browser: passthrough (no respondWith)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(pwa): service worker with reliable ..."](https://github.com/cloudnativebergen/website/commit/0a466dbf32e10013a1a650b644dead348bfc8722) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44530983)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->