### PR TITLE
fix(auth): signed-out header on Back button (bfcache session restore)

### DIFF
--- a/__tests__/components/providers/SessionRefreshOnRestore.test.tsx
+++ b/__tests__/components/providers/SessionRefreshOnRestore.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock next-auth/react so `useSession()` returns a spy `update` we can assert on.
+const update = vi.fn()
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ update }),
+}))
+
+import { SessionRefreshOnRestore } from '@/components/providers/SessionRefreshOnRestore'
+
+/** Dispatch a `pageshow` event carrying a `persisted` flag (as bfcache does). */
+function firePageShow(persisted: boolean) {
+  const event = new Event('pageshow')
+  Object.defineProperty(event, 'persisted', { value: persisted })
+  window.dispatchEvent(event)
+}
+
+beforeEach(() => {
+  update.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('SessionRefreshOnRestore', () => {
+  it('renders nothing', () => {
+    const { container } = render(<SessionRefreshOnRestore />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('calls update() on a bfcache restore (pageshow with persisted === true)', () => {
+    render(<SessionRefreshOnRestore />)
+
+    firePageShow(true)
+
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call update() on a normal load (pageshow with persisted === false)', () => {
+    render(<SessionRefreshOnRestore />)
+
+    firePageShow(false)
+
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('removes the pageshow listener on unmount', () => {
+    const { unmount } = render(<SessionRefreshOnRestore />)
+
+    unmount()
+    firePageShow(true)
+
+    expect(update).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/providers/SessionProviderWrapper.tsx
+++ b/src/components/providers/SessionProviderWrapper.tsx
@@ -1,6 +1,7 @@
 import { SessionProvider } from 'next-auth/react'
 import type { Session } from 'next-auth'
 import { auth } from '@/lib/auth'
+import { SessionRefreshOnRestore } from './SessionRefreshOnRestore'
 
 async function SessionLoader({ children }: { children: React.ReactNode }) {
   const session = await auth()
@@ -34,7 +35,10 @@ async function SessionLoader({ children }: { children: React.ReactNode }) {
       : null
 
   return (
-    <SessionProvider session={sanitizedSession}>{children}</SessionProvider>
+    <SessionProvider session={sanitizedSession}>
+      <SessionRefreshOnRestore />
+      {children}
+    </SessionProvider>
   )
 }
 

--- a/src/components/providers/SessionRefreshOnRestore.tsx
+++ b/src/components/providers/SessionRefreshOnRestore.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+
+/**
+ * Refreshes the client session when the page is restored from the browser's
+ * back/forward cache (bfcache).
+ *
+ * On sign-in the browser performs a cross-document OAuth navigation and may
+ * store the previous (signed-out) page in bfcache as a frozen snapshot where
+ * `useSession()` is still `null`. Pressing Back restores that frozen tree
+ * without re-rendering, so a session-derived header shows as signed-out until
+ * a manual reload.
+ *
+ * NextAuth's default `refetchOnWindowFocus` listens on `visibilitychange`,
+ * which a same-tab bfcache restore does NOT fire. A bfcache restore instead
+ * fires `pageshow` with `event.persisted === true`. Handling that event and
+ * calling `update()` re-fetches `/api/auth/session` and updates the client
+ * session context, correcting the UI while preserving bfcache (we do not
+ * disable it).
+ *
+ * Renders nothing; must be mounted inside a `SessionProvider`.
+ */
+export function SessionRefreshOnRestore() {
+  const { update } = useSession()
+
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        void update()
+      }
+    }
+
+    window.addEventListener('pageshow', handlePageShow)
+    return () => window.removeEventListener('pageshow', handlePageShow)
+  }, [update])
+
+  return null
+}


### PR DESCRIPTION
## Problem

After signing in and navigating to the CFP dashboard, pressing the browser **Back** button to the landing page showed the header as **signed-out** (avatar replaced by the generic user icon) until a manual reload.

## Root cause

The header (`src/components/Header.tsx`) derives auth purely from the client `useSession()`. On sign-in the browser performs a cross-document OAuth navigation and stores the landing page in the **back/forward cache (bfcache)** as a frozen snapshot where `useSession()` is still `null`. Pressing Back restores that frozen React tree with **no re-render**, so the header shows signed-out. A reload fixes it only because it forces a fresh render.

NextAuth's default `refetchOnWindowFocus` listens on `visibilitychange`, which a **same-tab bfcache restore does NOT fire**. A bfcache restore instead fires a `pageshow` event with `event.persisted === true` — which nothing currently handled.

## The fix (minimal, preserves bfcache)

- New client component `src/components/providers/SessionRefreshOnRestore.tsx`: on a `pageshow` with `event.persisted === true`, it calls `update()` from `useSession()`, which re-fetches `/api/auth/session` and updates the client session context. It renders `null` and cleans up its listener on unmount.
- Mounted **inside** `<SessionProvider>` in `src/components/providers/SessionProviderWrapper.tsx` so it can consume the session context.

Why this is correct and minimal:
- `pageshow` + `persisted` is the standardized signal for a bfcache restore — the exact event NextAuth's focus refetch misses.
- It **preserves bfcache** — no `Cache-Control: no-store`, bfcache is not disabled, so instant Back/Forward navigation is retained.
- The `SessionProvider` lives once in the root layout, so this single change fixes the signed-out-header-on-Back **across all public pages**. The header, caching, and `auth()` are untouched — this is the only behavioral change.

## Tests

`__tests__/components/providers/SessionRefreshOnRestore.test.tsx` (mocks `next-auth/react`'s `useSession` to return a spy `update`):
- `pageshow` with `persisted: true` calls `update()` once
- `pageshow` with `persisted: false` does NOT call `update()`
- the listener is removed on unmount
- the component renders nothing

## Verification

- `pnpm typecheck` clean
- `pnpm vitest run` green (143 files, 2356 passed / 5 skipped)
- eslint + prettier clean on changed files
- `pnpm knip` clean (new component is used by `SessionProviderWrapper`)

**Manual:** Chrome DevTools → Application → Back/forward cache; sign in; press Back → the header shows the avatar with a single `/api/auth/session` request and **no reload**.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX regression where pressing the browser Back button after signing in showed a signed-out header until a manual reload. The root cause is that NextAuth's `refetchOnWindowFocus` hooks onto `visibilitychange`, which bfcache restores do not fire — bfcache instead fires `pageshow` with `event.persisted === true`.

- Adds `SessionRefreshOnRestore`, a null-rendering client component that attaches a `pageshow` listener and calls `useSession().update()` on bfcache restores, triggering a fresh `/api/auth/session` fetch without disabling bfcache.
- Mounts the new component inside `<SessionProvider>` in `SessionProviderWrapper.tsx` so it can consume the session context.
- Covers the new behavior with a Vitest test suite verifying all four observable behaviors (fires on `persisted: true`, skips on `persisted: false`, cleans up on unmount, renders `null`).

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is small and self-contained, adds a listener that fires only on bfcache restore, and does not touch auth logic, the sanitization layer, or any existing component.

The fix correctly targets the exact platform event that NextAuth focus-refetch misses, the integration point inside SessionProvider is correct, and the test suite covers all observable behaviors. The only note is that including update in the useEffect dependency array causes listener re-registration on every session change; using a ref would be cleaner, but it is not a functional bug.

No files require special attention. The suggestion in SessionRefreshOnRestore.tsx is a minor style improvement.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/providers/SessionRefreshOnRestore.tsx | New null-rendering client component; correctly attaches a pageshow listener and calls update() on bfcache restore. Minor concern: listing update in the useEffect dependency array means the listener is re-registered whenever the session changes, but this is harmless in practice. |
| src/components/providers/SessionProviderWrapper.tsx | Minimal change: mounts SessionRefreshOnRestore inside SessionProvider so it can access the session context. No logic changes to sanitization or the provider itself. |
| __tests__/components/providers/SessionRefreshOnRestore.test.tsx | Comprehensive Vitest suite covering all four behavioral cases. Helper correctly uses Object.defineProperty to simulate the read-only persisted flag. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant bfcache as bfcache (frozen page)
    participant Component as SessionRefreshOnRestore
    participant NextAuth as useSession / SessionProvider
    participant Server as /api/auth/session

    Browser->>bfcache: Store landing page snapshot (signed-out useSession)
    Note over Browser: User signs in via OAuth
    Browser->>Component: Mount: addEventListener("pageshow", handler)
    Browser-->>bfcache: (landing page frozen)

    Note over Browser: User presses Back button
    Browser->>bfcache: Restore frozen page
    Browser->>Component: "pageshow { persisted: true }"
    Component->>NextAuth: update()
    NextAuth->>Server: GET /api/auth/session
    Server-->>NextAuth: "{ user: { name, email, picture } }"
    NextAuth-->>Browser: Re-render header with signed-in avatar
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant bfcache as bfcache (frozen page)
    participant Component as SessionRefreshOnRestore
    participant NextAuth as useSession / SessionProvider
    participant Server as /api/auth/session

    Browser->>bfcache: Store landing page snapshot (signed-out useSession)
    Note over Browser: User signs in via OAuth
    Browser->>Component: Mount: addEventListener("pageshow", handler)
    Browser-->>bfcache: (landing page frozen)

    Note over Browser: User presses Back button
    Browser->>bfcache: Restore frozen page
    Browser->>Component: "pageshow { persisted: true }"
    Component->>NextAuth: update()
    NextAuth->>Server: GET /api/auth/session
    Server-->>NextAuth: "{ user: { name, email, picture } }"
    NextAuth-->>Browser: Re-render header with signed-in avatar
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): refresh session on bfcache re..."](https://github.com/cloudnativebergen/website/commit/97bede5172849bafccde4ba0e4dc9fa6817b8b2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44551234)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->