### PR TITLE
fix(sponsor-crm): wrap tier/add-on chips and info row to stop overflow

### DIFF
--- a/src/components/admin/sponsor-crm/form/AddonsCheckboxGroup.stories.tsx
+++ b/src/components/admin/sponsor-crm/form/AddonsCheckboxGroup.stories.tsx
@@ -105,6 +105,55 @@ export const AllSelected: Story = {
   },
 }
 
+/**
+ * Regression guard: long add-on titles inside a modal-width column must wrap to
+ * new rows without overflowing the container or overlapping neighbours. Before
+ * the wrapping-chip redesign these labels were `whitespace-nowrap` inside a
+ * fixed 3-column grid, so they bled outside the column and collided.
+ */
+export const LongLabels: Story = {
+  name: 'Long labels (narrow column)',
+  render: () => {
+    const [value, setValue] = useState<string[]>(['addon-barista'])
+    const longAddons = [
+      mockSponsorTier({
+        _id: 'addon-barista',
+        title: 'Barista Bar Sponsorship',
+        tierType: 'addon',
+      }),
+      mockSponsorTier({
+        _id: 'addon-lanyard',
+        title: 'Lanyard Sponsorship',
+        tierType: 'addon',
+      }),
+      mockSponsorTier({
+        _id: 'addon-afterparty',
+        title: 'Afterparty Sponsorship',
+        tierType: 'addon',
+      }),
+      mockSponsorTier({
+        _id: 'addon-streaming',
+        title: 'Streaming & Video Sponsorship',
+        tierType: 'addon',
+      }),
+      mockSponsorTier({
+        _id: 'addon-track',
+        title: 'Track Sponsorship',
+        tierType: 'addon',
+      }),
+    ]
+    return (
+      <div className="max-w-[430px] rounded-lg border border-dashed border-gray-300 p-3 dark:border-gray-600">
+        <AddonsCheckboxGroup
+          addons={longAddons}
+          value={value}
+          onChange={setValue}
+        />
+      </div>
+    )
+  },
+}
+
 export const ManyAddons: Story = {
   render: () => {
     const [value, setValue] = useState<string[]>(['addon-booth'])

--- a/src/components/admin/sponsor-crm/form/AddonsCheckboxGroup.tsx
+++ b/src/components/admin/sponsor-crm/form/AddonsCheckboxGroup.tsx
@@ -33,12 +33,12 @@ export function AddonsCheckboxGroup({
           (optional, multiple allowed)
         </span>
       </legend>
-      <div className="mt-1.5 grid grid-cols-2 gap-1.5 sm:grid-cols-3">
+      <div className="mt-1.5 flex flex-wrap gap-1.5">
         {addons.map((addon) => (
           <label
             key={addon._id}
             aria-label={addon.title}
-            className="group relative flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium hover:bg-gray-50 has-checked:border-emerald-600 has-checked:bg-emerald-50 has-checked:text-emerald-600 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-emerald-600 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:has-checked:border-emerald-500 dark:has-checked:bg-emerald-500/10 dark:has-checked:text-emerald-400"
+            className="group relative flex max-w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium hover:bg-gray-50 has-checked:border-emerald-600 has-checked:bg-emerald-50 has-checked:text-emerald-600 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-emerald-600 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:has-checked:border-emerald-500 dark:has-checked:bg-emerald-500/10 dark:has-checked:text-emerald-400"
           >
             <input
               type="checkbox"
@@ -48,7 +48,7 @@ export function AddonsCheckboxGroup({
               onChange={() => handleToggle(addon._id)}
               className="absolute inset-0 appearance-none focus:outline-none"
             />
-            <span className="whitespace-nowrap text-gray-900 group-has-checked:text-emerald-600 dark:text-white dark:group-has-checked:text-emerald-400">
+            <span className="text-gray-900 group-has-checked:text-emerald-600 dark:text-white dark:group-has-checked:text-emerald-400">
               {addon.title}
             </span>
           </label>

--- a/src/components/admin/sponsor-crm/form/SponsorGlobalInfoFields.tsx
+++ b/src/components/admin/sponsor-crm/form/SponsorGlobalInfoFields.tsx
@@ -37,9 +37,9 @@ export function SponsorGlobalInfoFields({
 
   if (!editing) {
     return (
-      <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
-        <div className="flex min-w-0 flex-1 items-center gap-4">
-          <div className="flex items-center gap-1.5 text-sm font-medium text-gray-900 dark:text-white">
+      <div className="flex items-start justify-between rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-4 gap-y-1">
+          <div className="flex max-w-full min-w-0 items-center gap-1.5 text-sm font-medium text-gray-900 dark:text-white">
             <BuildingOffice2Icon className="h-3.5 w-3.5 shrink-0 text-gray-400" />
             <span className="truncate">{name}</span>
           </div>
@@ -48,7 +48,7 @@ export function SponsorGlobalInfoFields({
               href={website}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1 text-xs text-gray-500 hover:text-indigo-600 dark:text-gray-400 dark:hover:text-indigo-400"
+              className="flex max-w-full min-w-0 items-center gap-1 text-xs text-gray-500 hover:text-indigo-600 dark:text-gray-400 dark:hover:text-indigo-400"
             >
               <GlobeAltIcon className="h-3 w-3 shrink-0" />
               <span className="truncate">
@@ -63,7 +63,7 @@ export function SponsorGlobalInfoFields({
             </span>
           )}
           {address && (
-            <span className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+            <span className="flex max-w-full min-w-0 items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
               <MapPinIcon className="h-3 w-3 shrink-0" />
               <span className="truncate">{address}</span>
             </span>

--- a/src/components/admin/sponsor-crm/form/TierRadioGroup.stories.tsx
+++ b/src/components/admin/sponsor-crm/form/TierRadioGroup.stories.tsx
@@ -86,6 +86,36 @@ export const SingleTier: Story = {
   },
 }
 
+/**
+ * Regression guard: a long tier name inside a modal-width column must wrap
+ * gracefully instead of overflowing outside the container. Before the
+ * wrapping-chip redesign, "Community Partner Package" was `whitespace-nowrap`
+ * inside a fixed 3-column grid and bled outside the modal's left edge.
+ */
+export const LongLabels: Story = {
+  name: 'Long labels (narrow column)',
+  render: () => {
+    const [value, setValue] = useState<string>('tier-community')
+    const longTiers = [
+      mockSponsorTier({
+        _id: 'tier-community',
+        title: 'Community Partner Package',
+      }),
+      mockSponsorTier({ _id: 'tier-gold', title: 'Gold Sponsorship Tier' }),
+      mockSponsorTier({ _id: 'tier-silver', title: 'Silver' }),
+      mockSponsorTier({
+        _id: 'tier-diversity',
+        title: 'Diversity & Inclusion Partner',
+      }),
+    ]
+    return (
+      <div className="max-w-[430px] rounded-lg border border-dashed border-gray-300 p-3 dark:border-gray-600">
+        <TierRadioGroup tiers={longTiers} value={value} onChange={setValue} />
+      </div>
+    )
+  },
+}
+
 export const ManyTiers: Story = {
   render: () => {
     const [value, setValue] = useState<string>('tier-service')

--- a/src/components/admin/sponsor-crm/form/TierRadioGroup.tsx
+++ b/src/components/admin/sponsor-crm/form/TierRadioGroup.tsx
@@ -18,12 +18,12 @@ export function TierRadioGroup({
       <legend className="block text-left text-sm/6 font-medium text-gray-900 dark:text-white">
         Sponsor Tier
       </legend>
-      <div className="mt-1.5 grid grid-cols-2 gap-1.5 sm:grid-cols-3">
+      <div className="mt-1.5 flex flex-wrap gap-1.5">
         {tiers.map((tier) => (
           <label
             key={tier._id}
             aria-label={tier.title}
-            className="group relative flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium hover:bg-gray-50 has-checked:border-indigo-600 has-checked:bg-indigo-50 has-checked:text-indigo-600 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-indigo-600 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:has-checked:border-indigo-500 dark:has-checked:bg-indigo-500/10 dark:has-checked:text-indigo-400"
+            className="group relative flex max-w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium hover:bg-gray-50 has-checked:border-indigo-600 has-checked:bg-indigo-50 has-checked:text-indigo-600 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-indigo-600 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:has-checked:border-indigo-500 dark:has-checked:bg-indigo-500/10 dark:has-checked:text-indigo-400"
           >
             <input
               type="radio"
@@ -33,14 +33,14 @@ export function TierRadioGroup({
               onChange={(e) => onChange(e.target.value)}
               className="absolute inset-0 appearance-none focus:outline-none"
             />
-            <span className="whitespace-nowrap text-gray-900 group-has-checked:text-indigo-600 dark:text-white dark:group-has-checked:text-indigo-400">
+            <span className="text-gray-900 group-has-checked:text-indigo-600 dark:text-white dark:group-has-checked:text-indigo-400">
               {tier.title}
             </span>
           </label>
         ))}
         <label
           aria-label="No tier"
-          className="group relative flex cursor-pointer items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium hover:bg-gray-50 has-checked:border-indigo-600 has-checked:bg-indigo-50 has-checked:text-indigo-600 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-indigo-600 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:has-checked:border-indigo-500 dark:has-checked:bg-indigo-500/10 dark:has-checked:text-indigo-400"
+          className="group relative flex max-w-full cursor-pointer items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium hover:bg-gray-50 has-checked:border-indigo-600 has-checked:bg-indigo-50 has-checked:text-indigo-600 has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-indigo-600 dark:border-gray-600 dark:bg-gray-800 dark:hover:bg-gray-700 dark:has-checked:border-indigo-500 dark:has-checked:bg-indigo-500/10 dark:has-checked:text-indigo-400"
         >
           <input
             type="radio"
@@ -50,7 +50,7 @@ export function TierRadioGroup({
             onChange={() => onChange('')}
             className="absolute inset-0 appearance-none focus:outline-none"
           />
-          <span className="whitespace-nowrap text-gray-900 group-has-checked:text-indigo-600 dark:text-white dark:group-has-checked:text-indigo-400">
+          <span className="text-gray-900 group-has-checked:text-indigo-600 dark:text-white dark:group-has-checked:text-indigo-400">
             No tier
           </span>
         </label>


### PR DESCRIPTION
## Problem

The Sponsor Details form (screenshot below is the reported state) cram­med too many controls into the modal's ~430px left column, so real content overflowed and overlapped:

- **Sponsor Tier & Add-ons** used a fixed `grid-cols-2 sm:grid-cols-3` with **`whitespace-nowrap`** labels. Any option whose name was wider than its ~1/3 cell — "Community Partner Package", "Barista Bar Sponsorship", "Streaming & Video Sponsorship" — overflowed its cell, **bled outside the modal's left edge**, and **overlapped neighbouring options**.
- The read-only **company info row** (name · website · org# · address) packed everything onto one line with no per-item `min-width`, so a long address **overflowed into the Edit button**.

## Fix — wrapping, content-width controls

Same principle everywhere: *let content determine control width and wrap to new rows instead of forcing single-line content into fixed cells.*

- `TierRadioGroup` / `AddonsCheckboxGroup`: `grid → flex flex-wrap`, drop `whitespace-nowrap`, add `max-w-full` so each chip sizes to its label, wraps to the next row when it doesn't fit, and (pathological single label) wraps its own text rather than overflowing. Radio/checkbox semantics and selected styling unchanged.
- `SponsorGlobalInfoFields` (read-only row): `flex-wrap` + top-aligned Edit so items flow to a second line instead of colliding; each item gets `min-w-0 max-w-full` so long values truncate within their own line.

Overflow-proof at any label length or column width.

## Regression coverage

Added a **"Long labels (narrow column)"** Storybook story to both groups that reproduces the overflowing names inside a modal-width (430px) column — Chromatic will catch any regression.

## Verification

`pnpm typecheck` ✅ · eslint ✅ · prettier ✅

## Scope note

This closes the concrete overflow/overlap defects. The broader "design thinking" redesign of the sponsor card/modal information architecture is tracked separately in #459.

Closes #459 partially.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes overflow/collision bugs in the sponsor CRM modal by switching `TierRadioGroup` and `AddonsCheckboxGroup` from a fixed `grid-cols-2/3` + `whitespace-nowrap` layout to `flex flex-wrap` with `max-w-full` chips, and by adding `flex-wrap` + `items-start` to the `SponsorGlobalInfoFields` read-only row so long content wraps instead of colliding with the Edit button.

- **Chip groups** (`TierRadioGroup`, `AddonsCheckboxGroup`): grid replaced with `flex flex-wrap`, `whitespace-nowrap` removed, `max-w-full` added to each chip — semantics and checked styling unchanged.
- **Info row** (`SponsorGlobalInfoFields`): outer container switches to `items-start`, inner div gains `flex-wrap` and split `gap-x-4 gap-y-1`; name, website, and address elements get `min-w-0 max-w-full` so long values truncate within their own flex line.
- **Regression coverage**: a `LongLabels` Storybook story constrained to 430 px is added for both chip-group components so Chromatic will catch any future regressions.

<h3>Confidence Score: 5/5</h3>

Purely additive CSS layout changes with no logic or data-flow modifications — safe to merge.

All five changed files are UI-only: three production components receive targeted Tailwind class swaps (grid→flex-wrap, whitespace-nowrap removal, min-w-0/max-w-full additions), and two Storybook files add regression stories at the reported modal width. No business logic, state management, or API interactions are touched.

No files require special attention. The orgNumber element in SponsorGlobalInfoFields is the only item that did not receive the min-w-0/max-w-full treatment, but formatted org numbers are short fixed-length strings so overflow is not a practical concern.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/sponsor-crm/form/TierRadioGroup.tsx | Grid replaced with flex-wrap, whitespace-nowrap removed, max-w-full added — clean overflow fix with no logic changes. |
| src/components/admin/sponsor-crm/form/AddonsCheckboxGroup.tsx | Same grid→flex-wrap treatment as TierRadioGroup; whitespace-nowrap dropped and max-w-full added — straightforward fix. |
| src/components/admin/sponsor-crm/form/SponsorGlobalInfoFields.tsx | Outer div switches to items-start, inner div gains flex-wrap + gap-x/gap-y split; name, website, and address get min-w-0/max-w-full — orgNumber span is left without these but is a short fixed-format string so overflow is not a practical concern. |
| src/components/admin/sponsor-crm/form/TierRadioGroup.stories.tsx | Adds LongLabels story constrained to 430px to act as a Chromatic regression guard for the overflow fix. |
| src/components/admin/sponsor-crm/form/AddonsCheckboxGroup.stories.tsx | Adds matching LongLabels story at 430px for AddonsCheckboxGroup, mirroring the TierRadioGroup regression guard. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SponsorCRM Modal ~430px column] --> B[TierRadioGroup]
    A --> C[AddonsCheckboxGroup]
    A --> D[SponsorGlobalInfoFields]

    B --> B1["Before: grid grid-cols-2 sm:grid-cols-3\n+ whitespace-nowrap\n→ chips overflow / bleed"]
    B --> B2["After: flex flex-wrap + max-w-full\n→ chips size to label, wrap to next row"]

    C --> C1["Before: grid grid-cols-2 sm:grid-cols-3\n+ whitespace-nowrap\n→ long add-on names overflow"]
    C --> C2["After: flex flex-wrap + max-w-full\n→ wraps cleanly at any label length"]

    D --> D1["Before: flex items-center + gap-4\n→ long address overflows into Edit button"]
    D --> D2["After: flex items-start + flex-wrap\n+ gap-x-4 gap-y-1 + min-w-0/max-w-full\n→ items flow to next line, Edit stays top-aligned"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SponsorCRM Modal ~430px column] --> B[TierRadioGroup]
    A --> C[AddonsCheckboxGroup]
    A --> D[SponsorGlobalInfoFields]

    B --> B1["Before: grid grid-cols-2 sm:grid-cols-3\n+ whitespace-nowrap\n→ chips overflow / bleed"]
    B --> B2["After: flex flex-wrap + max-w-full\n→ chips size to label, wrap to next row"]

    C --> C1["Before: grid grid-cols-2 sm:grid-cols-3\n+ whitespace-nowrap\n→ long add-on names overflow"]
    C --> C2["After: flex flex-wrap + max-w-full\n→ wraps cleanly at any label length"]

    D --> D1["Before: flex items-center + gap-4\n→ long address overflows into Edit button"]
    D --> D2["After: flex items-start + flex-wrap\n+ gap-x-4 gap-y-1 + min-w-0/max-w-full\n→ items flow to next line, Edit stays top-aligned"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(sponsor-crm): wrap tier/add-on chips..."](https://github.com/cloudnativebergen/website/commit/4d312881fce33fff454d68abf5045256667b8f18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44555445)</sub>

<!-- /greptile_comment -->