### PR TITLE
fix(auth): heal sticky signed-out header (SessionProvider seeded with null)

### DIFF
--- a/__tests__/components/providers/SessionProviderWrapper.test.tsx
+++ b/__tests__/components/providers/SessionProviderWrapper.test.tsx
@@ -1,62 +1,42 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import type { Session } from 'next-auth'
+import { sanitizeSession } from '@/components/providers/SessionProviderWrapper'
 
-// Mock the auth module so we control what `auth()` resolves to. Mocking the
-// whole module also avoids pulling in the real NextAuth config graph.
-vi.mock('@/lib/auth', () => ({ auth: vi.fn() }))
-
-import { auth } from '@/lib/auth'
-import { SessionProviderWrapper } from '@/components/providers/SessionProviderWrapper'
-
-/**
- * Resolve the async server tree and return the `session` prop actually handed
- * to `<SessionProvider>`. We inspect the React element tree directly (no DOM
- * render) since both server components just return elements.
- */
-async function resolveSessionProp(authReturn: unknown) {
-  vi.mocked(auth).mockResolvedValue(authReturn as never)
-  // SessionProviderWrapper -> <SessionLoader>{children}</SessionLoader>
-  const wrapper = (await SessionProviderWrapper({ children: null })) as {
-    type: (props: { children: React.ReactNode }) => Promise<{
-      props: { session: unknown }
-    }>
-    props: { children: React.ReactNode }
-  }
-  // Resolve SessionLoader -> <SessionProvider session={...}>…</SessionProvider>
-  const loader = await wrapper.type(wrapper.props)
-  return loader.props.session
-}
-
-beforeEach(() => {
-  vi.mocked(auth).mockReset()
-})
-
-describe('SessionProviderWrapper', () => {
-  it('passes `undefined` (not null) when there is no session, so the client refetches on mount', async () => {
-    expect(await resolveSessionProp(null)).toBeUndefined()
+describe('sanitizeSession', () => {
+  it('returns undefined (not null) for a missing session, so SessionProvider refetches on mount', () => {
+    expect(sanitizeSession(null)).toBeUndefined()
   })
 
-  it('passes `undefined` when the session has no user', async () => {
-    expect(await resolveSessionProp({ expires: '2099-01-01' })).toBeUndefined()
+  it('returns undefined when the session has no user', () => {
+    expect(
+      sanitizeSession({ expires: '2099-01-01' } as Session),
+    ).toBeUndefined()
   })
 
-  it('passes the sanitized session (user only, OAuth tokens stripped) when present', async () => {
-    const session = (await resolveSessionProp({
+  it('passes through user (name/email/picture only) and strips OAuth tokens from account', () => {
+    const result = sanitizeSession({
       user: { name: 'Ada', email: 'ada@example.com', picture: 'p.png' },
       account: { provider: 'github', access_token: 'SECRET_TOKEN' },
       expires: '2099-01-01',
-    })) as {
-      user: unknown
-      account: unknown
-    }
+    } as unknown as Session)
 
-    expect(session).toBeTruthy()
-    expect(session.user).toEqual({
+    expect(result).toBeDefined()
+    expect(result?.user).toEqual({
       name: 'Ada',
       email: 'ada@example.com',
       picture: 'p.png',
     })
     // account narrowed to just the provider name; tokens must not survive.
-    expect(session.account).toEqual({ provider: 'github' })
-    expect(JSON.stringify(session)).not.toContain('SECRET_TOKEN')
+    expect(result?.account).toEqual({ provider: 'github' })
+    expect(JSON.stringify(result)).not.toContain('SECRET_TOKEN')
+  })
+
+  it('leaves account undefined when the session has no account', () => {
+    const result = sanitizeSession({
+      user: { name: 'Ada', email: 'ada@example.com', picture: null },
+      expires: '2099-01-01',
+    } as unknown as Session)
+
+    expect(result?.account).toBeUndefined()
   })
 })

--- a/__tests__/components/providers/SessionProviderWrapper.test.tsx
+++ b/__tests__/components/providers/SessionProviderWrapper.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Mock the auth module so we control what `auth()` resolves to. Mocking the
+// whole module also avoids pulling in the real NextAuth config graph.
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }))
+
+import { auth } from '@/lib/auth'
+import { SessionProviderWrapper } from '@/components/providers/SessionProviderWrapper'
+
+/**
+ * Resolve the async server tree and return the `session` prop actually handed
+ * to `<SessionProvider>`. We inspect the React element tree directly (no DOM
+ * render) since both server components just return elements.
+ */
+async function resolveSessionProp(authReturn: unknown) {
+  vi.mocked(auth).mockResolvedValue(authReturn as never)
+  // SessionProviderWrapper -> <SessionLoader>{children}</SessionLoader>
+  const wrapper = (await SessionProviderWrapper({ children: null })) as {
+    type: (props: { children: React.ReactNode }) => Promise<{
+      props: { session: unknown }
+    }>
+    props: { children: React.ReactNode }
+  }
+  // Resolve SessionLoader -> <SessionProvider session={...}>…</SessionProvider>
+  const loader = await wrapper.type(wrapper.props)
+  return loader.props.session
+}
+
+beforeEach(() => {
+  vi.mocked(auth).mockReset()
+})
+
+describe('SessionProviderWrapper', () => {
+  it('passes `undefined` (not null) when there is no session, so the client refetches on mount', async () => {
+    expect(await resolveSessionProp(null)).toBeUndefined()
+  })
+
+  it('passes `undefined` when the session has no user', async () => {
+    expect(await resolveSessionProp({ expires: '2099-01-01' })).toBeUndefined()
+  })
+
+  it('passes the sanitized session (user only, OAuth tokens stripped) when present', async () => {
+    const session = (await resolveSessionProp({
+      user: { name: 'Ada', email: 'ada@example.com', picture: 'p.png' },
+      account: { provider: 'github', access_token: 'SECRET_TOKEN' },
+      expires: '2099-01-01',
+    })) as {
+      user: unknown
+      account: unknown
+    }
+
+    expect(session).toBeTruthy()
+    expect(session.user).toEqual({
+      name: 'Ada',
+      email: 'ada@example.com',
+      picture: 'p.png',
+    })
+    // account narrowed to just the provider name; tokens must not survive.
+    expect(session.account).toEqual({ provider: 'github' })
+    expect(JSON.stringify(session)).not.toContain('SECRET_TOKEN')
+  })
+})

--- a/src/components/providers/SessionProviderWrapper.tsx
+++ b/src/components/providers/SessionProviderWrapper.tsx
@@ -3,56 +3,58 @@ import type { Session } from 'next-auth'
 import { auth } from '@/lib/auth'
 import { SessionRefreshOnRestore } from './SessionRefreshOnRestore'
 
+/**
+ * Narrow the server session into what is safe to serialize to the client, and
+ * return `undefined` (never `null`) when there is no usable session.
+ *
+ * Two things happen here:
+ *
+ * 1. **Security narrowing** — expose only `user.{name,email,picture}` and the
+ *    account *provider name*. The full `account` carries the OAuth
+ *    `access_token`/`refresh_token`; those must never reach the client. Server
+ *    consumers that need the tokens read them via `auth()`, which is unaffected.
+ *
+ * 2. **`undefined`, not `null`, when absent** — NextAuth's `SessionProvider`
+ *    treats an explicit `session` prop (including `null`) as authoritative:
+ *    `hasInitialSession = props.session !== undefined`, and its mount effect
+ *    skips the `/api/auth/session` fetch when the seeded session is `null` (see
+ *    next-auth/react.js). So a `null` handed to the client is *sticky* — the
+ *    header renders signed-out and only self-corrects on a later tab refocus.
+ *    Returning `undefined` leaves `hasInitialSession` false, so the client
+ *    fetches the session on mount and heals the state. This matters under
+ *    `cacheComponents`, where `auth()` can return falsy for a request that
+ *    actually has a session (e.g. a host-only cookie not sent across
+ *    subdomains) — most visibly on the heavily-linked front page.
+ *
+ * Present sessions are still returned for SSR, so authenticated dynamic renders
+ * show the signed-in header with no flash.
+ */
+export function sanitizeSession(session: Session | null): Session | undefined {
+  if (!session || !session.user) return undefined
+
+  return {
+    ...session,
+    user: {
+      name: session.user.name,
+      email: session.user.email,
+      picture: session.user.picture,
+    },
+    // Only the provider name is safe/needed client-side; drop the OAuth tokens.
+    // Cast is required because the client `Session` type still declares the
+    // full `Account` shape.
+    account: session.account
+      ? ({
+          provider: session.account.provider,
+        } as unknown as Session['account'])
+      : undefined,
+  } as Session
+}
+
 async function SessionLoader({ children }: { children: React.ReactNode }) {
   const session = await auth()
 
-  // Sanitize session to only expose safe data to the client.
-  // If session exists but has no user, treat it as no session.
-  //
-  // SECURITY: narrow `account` to just `{ provider }`. The full account carries
-  // the OAuth `access_token`/`refresh_token`; only the provider name is needed
-  // client-side (e.g. to highlight the current provider on the profile page).
-  // Server-side consumers that need the tokens read them via `auth()`, which is
-  // unaffected — this narrowing applies only to the client-serialized session.
-  const sanitizedSession =
-    session && session.user
-      ? {
-          ...session,
-          user: {
-            name: session.user.name,
-            email: session.user.email,
-            picture: session.user.picture,
-          },
-          // Only the provider name is safe/needed client-side; drop the OAuth
-          // tokens. Cast is required because the client `Session` type still
-          // declares the full `Account` shape.
-          account: session.account
-            ? ({
-                provider: session.account.provider,
-              } as unknown as Session['account'])
-            : undefined,
-        }
-      : null
-
-  // Pass `undefined` (not `null`) when there is no server session.
-  //
-  // NextAuth's SessionProvider treats an explicitly-provided `session` prop —
-  // including `null` — as authoritative: `hasInitialSession = props.session
-  // !== undefined`, and its mount effect skips the `/api/auth/session` fetch
-  // when `_session === null` (see next-auth/react.js). So a `null` that reaches
-  // the client is *sticky*: the header renders signed-out and never
-  // self-corrects until a tab refocus fires `visibilitychange`.
-  //
-  // Under `cacheComponents`, the session is a per-request streamed hole, so a
-  // logged-in user on the same host normally gets the real session here. But
-  // whenever `auth()` returns falsy for a request that actually has a valid
-  // session — e.g. a host-only cookie not sent across subdomains — seeding
-  // `null` would freeze the UI signed-out. Passing `undefined` instead leaves
-  // `hasInitialSession` false, so the client fetches the session on mount and
-  // heals the state. Present sessions are still passed through for SSR (no
-  // signed-out flash on dynamic, authenticated renders).
   return (
-    <SessionProvider session={sanitizedSession ?? undefined}>
+    <SessionProvider session={sanitizeSession(session)}>
       <SessionRefreshOnRestore />
       {children}
     </SessionProvider>

--- a/src/components/providers/SessionProviderWrapper.tsx
+++ b/src/components/providers/SessionProviderWrapper.tsx
@@ -34,8 +34,25 @@ async function SessionLoader({ children }: { children: React.ReactNode }) {
         }
       : null
 
+  // Pass `undefined` (not `null`) when there is no server session.
+  //
+  // NextAuth's SessionProvider treats an explicitly-provided `session` prop —
+  // including `null` — as authoritative: `hasInitialSession = props.session
+  // !== undefined`, and its mount effect skips the `/api/auth/session` fetch
+  // when `_session === null` (see next-auth/react.js). So a `null` that reaches
+  // the client is *sticky*: the header renders signed-out and never
+  // self-corrects until a tab refocus fires `visibilitychange`.
+  //
+  // Under `cacheComponents`, the session is a per-request streamed hole, so a
+  // logged-in user on the same host normally gets the real session here. But
+  // whenever `auth()` returns falsy for a request that actually has a valid
+  // session — e.g. a host-only cookie not sent across subdomains — seeding
+  // `null` would freeze the UI signed-out. Passing `undefined` instead leaves
+  // `hasInitialSession` false, so the client fetches the session on mount and
+  // heals the state. Present sessions are still passed through for SSR (no
+  // signed-out flash on dynamic, authenticated renders).
   return (
-    <SessionProvider session={sanitizedSession}>
+    <SessionProvider session={sanitizedSession ?? undefined}>
       <SessionRefreshOnRestore />
       {children}
     </SessionProvider>


### PR DESCRIPTION
## Symptom

Logged-in users see a **signed-out header / missing profile menu on sub-pages, especially the front page**, and it doesn't self-correct on normal forward navigation (distinct from the back-button/bfcache case fixed in #458). Refocusing the tab makes it reappear.

## Root cause (build-confirmed)

Two-part:

1. **The amplifier (fixed here).** NextAuth v5's `SessionProvider` treats an explicit `session` prop — **including `null`** — as authoritative. In `next-auth/react.js`: `hasInitialSession = props.session !== undefined`, and the mount effect's fetch branch is skipped when the seeded `_session === null` (`if (!event || _session === null) return`). So a `null` handed to the client is **sticky** — the header stays signed-out until a `visibilitychange` refetch (the "refocus fixes it" tell). `SessionProviderWrapper` passed `session={null}` whenever `auth()` returned falsy.

2. **The trigger (follow-up).** Under `cacheComponents` the session is a per-request streamed hole (verified: the prerendered `(main)` shells contain no session/header markers), so same-host logged-in loads normally get the real session. The `null` most plausibly comes from **host-only session cookies not being sent across subdomains** (no `cookies.domain`/`trustHost` in `src/lib/auth.ts`; the app spans per-year subdomains and the `cloudnativebergen.dev → cloudnativedays.no` migration). That cookie-domain change is deployment-specific and tracked separately.

## Fix

In `SessionProviderWrapper`, pass `undefined` instead of `null` when there is no server session (`session={sanitizedSession ?? undefined}`). This leaves `hasInitialSession` false, so the client **fetches `/api/auth/session` on mount and heals the state**. Present sessions still pass through for SSR (no signed-out flash on authenticated dynamic renders).

This removes the stickiness regardless of what produced the `null`, so the header self-corrects on load instead of requiring a tab refocus.

## Test

Adds `SessionProviderWrapper.test.tsx` — asserts a null / user-less session becomes `undefined`, and that a present session passes through sanitized with OAuth tokens stripped.

## Verification

`pnpm typecheck` ✅ · eslint ✅ · prettier ✅ · new test ✅ (3 passing)

## Follow-up (not in this PR)

Cross-subdomain cookie scoping (`cookies.sessionToken.options.domain`) — needs a decision on the production host layout; a shared cookie domain can't bridge two different registrable domains.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a \"sticky signed-out header\" bug by ensuring `null` is never passed as the `session` prop to NextAuth's `SessionProvider`. Instead of `session={sanitizedSession}` (which could be `null`), the fix uses `session={sanitizedSession ?? undefined}`, keeping `hasInitialSession` false so the client always fetches `/api/auth/session` on mount when no server session is available.

- **Core fix** (`SessionProviderWrapper.tsx`): `sanitizedSession ?? undefined` converts `null` to `undefined` before it reaches `SessionProvider`, preventing NextAuth from treating the absence of a session as authoritative and skipping the mount-time fetch.
- **Test coverage** (`SessionProviderWrapper.test.tsx`): Three unit tests directly inspect the resolved React element tree to verify that `null`, a user-less session, and a real session each produce the correct `session` prop value — including that OAuth `access_token`/`refresh_token` are stripped from what reaches the client.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line targeted fix that removes stickiness without altering behaviour for authenticated users.

The fix is minimal and correct: converting null to undefined for the session prop prevents NextAuth from freezing the signed-out state on the client, while authenticated sessions still pass through sanitized for SSR. The token-stripping logic is untouched. The new tests cover the three meaningful cases. The only notes are a minor style simplification in the source and a structural brittleness in the test helper that does not affect current correctness.

No files require special attention; both changed files are straightforward.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/providers/SessionProviderWrapper.tsx | Single-line targeted fix: replaces session={sanitizedSession} with session={sanitizedSession ?? undefined} to prevent null from being treated as an authoritative 'no session' by NextAuth's SessionProvider. Accompanying explanatory comment is thorough and accurate. |
| __tests__/components/providers/SessionProviderWrapper.test.tsx | New test file with 3 cases covering null, user-less session, and a real session. Tests introspect React element tree internals directly rather than rendering to DOM, which works for server components but is structurally brittle if the SessionLoader wrapping layer changes. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js Server
    participant AuthLib as auth()
    participant SP as SessionProvider (client)
    participant NextAuthAPI as /api/auth/session

    Note over NextJS: SessionLoader renders (SSR)
    NextJS->>AuthLib: await auth()
    AuthLib-->>NextJS: "session | null"

    alt "session && session.user (authenticated)"
        NextJS->>SP: "session={sanitizedSession} (tokens stripped)"
        Note over SP: hasInitialSession = true<br/>No mount fetch needed
        SP-->>Browser: Renders signed-in header
    else null / no user (unauthenticated or cookie missing)
        Note over NextJS: sanitizedSession = null to undefined (this PR)
        NextJS->>SP: "session={undefined}"
        Note over SP: hasInitialSession = false<br/>Mount fetch triggered
        SP->>NextAuthAPI: GET /api/auth/session
        NextAuthAPI-->>SP: real session or empty
        SP-->>Browser: Renders correct state (was: frozen signed-out)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextJS as Next.js Server
    participant AuthLib as auth()
    participant SP as SessionProvider (client)
    participant NextAuthAPI as /api/auth/session

    Note over NextJS: SessionLoader renders (SSR)
    NextJS->>AuthLib: await auth()
    AuthLib-->>NextJS: "session | null"

    alt "session && session.user (authenticated)"
        NextJS->>SP: "session={sanitizedSession} (tokens stripped)"
        Note over SP: hasInitialSession = true<br/>No mount fetch needed
        SP-->>Browser: Renders signed-in header
    else null / no user (unauthenticated or cookie missing)
        Note over NextJS: sanitizedSession = null to undefined (this PR)
        NextJS->>SP: "session={undefined}"
        Note over SP: hasInitialSession = false<br/>Mount fetch triggered
        SP->>NextAuthAPI: GET /api/auth/session
        NextAuthAPI-->>SP: real session or empty
        SP-->>Browser: Renders correct state (was: frozen signed-out)
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/providers/SessionProviderWrapper.tsx`, line 17-35 ([link](https://github.com/cloudnativebergen/website/blob/05951bea2e11427b91422938d7b19260eb795b73/src/components/providers/SessionProviderWrapper.tsx#L17-L35)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The intermediate `null` assignment followed by `?? undefined` can be simplified by initialising `sanitizedSession` to `undefined` directly. This removes the two-step conversion, makes the intent self-documenting at the assignment site, and lets TypeScript narrow the type to `Session | undefined` without the extra operator at the JSX call-site.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(auth): heal sticky signed-out header..."](https://github.com/cloudnativebergen/website/commit/05951bea2e11427b91422938d7b19260eb795b73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44591730)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->