### PR TITLE
feat(auth): share session cookie across subdomains via per-request Domain derivation (eTLD+1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "styled-components": "^6.4.3",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.1",
+    "tldts": "^7.4.0",
     "typescript": "^6.0.3",
     "uuid": "^14.0.1",
     "web-push": "^3.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
+      tldts:
+        specifier: ^7.4.0
+        version: 7.4.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -3284,6 +3287,7 @@ packages:
   '@qodo/command@0.36.0':
     resolution: {integrity: sha512-JjnIhH7YCHXjl1RzMvHOZ4SXo4vZi7psrc4h/a4/Gid8KNZlEab3omWQQiNpcyyKQzxMG72+4+t15dAxkrku0Q==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     hasBin: true
 
   '@react-aria/focus@3.22.1':

--- a/src/lib/auth-cookie-domain.test.ts
+++ b/src/lib/auth-cookie-domain.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deriveSessionCookieDomain,
+  SHARED_PARENT_DOMAIN_DENYLIST,
+} from './auth-cookie-domain'
+
+describe('deriveSessionCookieDomain — registrable-domain (eTLD+1) derivation', () => {
+  it('widens a subdomain host to its registrable domain', () => {
+    expect(deriveSessionCookieDomain('admin.cloudnativedays.no')).toBe(
+      '.cloudnativedays.no',
+    )
+    expect(deriveSessionCookieDomain('2026.cloudnativebergen.dev')).toBe(
+      '.cloudnativebergen.dev',
+    )
+    // Deeper nesting still resolves to eTLD+1.
+    expect(deriveSessionCookieDomain('a.b.cloudnativedays.no')).toBe(
+      '.cloudnativedays.no',
+    )
+  })
+
+  it('returns the registrable domain for the apex host itself', () => {
+    // Domain=.cloudnativedays.no on the apex is valid and shares with subdomains.
+    expect(deriveSessionCookieDomain('cloudnativedays.no')).toBe(
+      '.cloudnativedays.no',
+    )
+  })
+
+  it('handles multi-part public suffixes via the PSL, not label counting', () => {
+    // A naive "last two labels" heuristic would derive the PUBLIC suffix
+    // `.co.uk` here — which browsers reject, dropping the whole cookie.
+    expect(deriveSessionCookieDomain('conf.example.co.uk')).toBe(
+      '.example.co.uk',
+    )
+    expect(deriveSessionCookieDomain('www.tickets.example.com.au')).toBe(
+      '.example.com.au',
+    )
+  })
+
+  it('normalizes case, ports, whitespace, and x-forwarded-host chains', () => {
+    expect(deriveSessionCookieDomain('Admin.CloudNativeDays.NO')).toBe(
+      '.cloudnativedays.no',
+    )
+    expect(deriveSessionCookieDomain('admin.cloudnativedays.no:8443')).toBe(
+      '.cloudnativedays.no',
+    )
+    expect(
+      deriveSessionCookieDomain(' admin.cloudnativedays.no , proxy.internal '),
+    ).toBe('.cloudnativedays.no')
+  })
+
+  it('NEVER widens on denylisted platform-shared parents (tenant isolation)', () => {
+    // konf.run: every subdomain is a DIFFERENT tenant — widening would put one
+    // tenant's session cookie in every other tenant's XSS blast radius.
+    expect(deriveSessionCookieDomain('tenant-a.konf.run')).toBeUndefined()
+    expect(deriveSessionCookieDomain('konf.run')).toBeUndefined()
+    expect(
+      deriveSessionCookieDomain('deep.sub.tenant.konf.run'),
+    ).toBeUndefined()
+    // vercel.app previews: subdomains are unrelated projects.
+    expect(deriveSessionCookieDomain('my-app.vercel.app')).toBeUndefined()
+    expect(
+      deriveSessionCookieDomain('website-git-branch-team.vercel.app'),
+    ).toBeUndefined()
+    expect(deriveSessionCookieDomain('vercel.app')).toBeUndefined()
+    // localhost, with and without port.
+    expect(deriveSessionCookieDomain('localhost')).toBeUndefined()
+    expect(deriveSessionCookieDomain('localhost:3000')).toBeUndefined()
+    expect(deriveSessionCookieDomain('app.localhost')).toBeUndefined()
+  })
+
+  it('exports the denylist with the expected shared parents', () => {
+    // Pin the security-critical entries so an accidental removal fails a test.
+    for (const parent of ['konf.run', 'vercel.app', 'localhost']) {
+      expect(SHARED_PARENT_DOMAIN_DENYLIST).toContain(parent)
+    }
+  })
+
+  it('falls back to host-only (undefined) for garbage and non-domains', () => {
+    expect(deriveSessionCookieDomain(undefined)).toBeUndefined()
+    expect(deriveSessionCookieDomain(null)).toBeUndefined()
+    expect(deriveSessionCookieDomain('')).toBeUndefined()
+    expect(deriveSessionCookieDomain('   ')).toBeUndefined()
+    expect(deriveSessionCookieDomain(',')).toBeUndefined()
+    expect(deriveSessionCookieDomain('not a host name')).toBeUndefined()
+    expect(deriveSessionCookieDomain('exa mple.com')).toBeUndefined()
+    // Single-label and bare-suffix hosts have no registrable domain.
+    expect(deriveSessionCookieDomain('intranet')).toBeUndefined()
+    expect(deriveSessionCookieDomain('no')).toBeUndefined()
+    expect(deriveSessionCookieDomain('.no')).toBeUndefined()
+    expect(deriveSessionCookieDomain('co.uk')).toBeUndefined()
+    // IP literals never get a Domain attribute.
+    expect(deriveSessionCookieDomain('127.0.0.1')).toBeUndefined()
+    expect(deriveSessionCookieDomain('127.0.0.1:3000')).toBeUndefined()
+    expect(deriveSessionCookieDomain('[::1]')).toBeUndefined()
+    expect(deriveSessionCookieDomain('[::1]:3000')).toBeUndefined()
+  })
+})

--- a/src/lib/auth-cookie-domain.ts
+++ b/src/lib/auth-cookie-domain.ts
@@ -1,0 +1,93 @@
+import { getDomain } from 'tldts'
+
+/**
+ * Parent domains that are SHARED ACROSS TENANTS — the session cookie must
+ * NEVER be widened to any of these, no matter what eTLD+1 derivation says.
+ *
+ * Rationale (XSS blast radius): a cookie scoped to `Domain=.parent` is sent to
+ * — and can be overwritten from — EVERY subdomain of that parent. On a domain
+ * whose subdomains all belong to ONE tenant (e.g. `cloudnativedays.no`) that is
+ * exactly the point of this feature. But on a platform-shared parent, the
+ * subdomains belong to DIFFERENT tenants: an XSS (or a malicious tenant) on
+ * `evil.konf.run` could read or fixate the session cookie of `victim.konf.run`.
+ * For these hosts we fall back to the default host-only cookie, which the
+ * browser scopes to the exact host that set it.
+ *
+ * Entries are bare registrable/parent domains (no leading dot, lowercase). A
+ * request host matches when it EQUALS an entry or is a subdomain of one.
+ * Extend this list whenever a new shared parent domain enters the platform.
+ */
+export const SHARED_PARENT_DOMAIN_DENYLIST: readonly string[] = [
+  // Future tenant-runtime domain: each subdomain is a DIFFERENT tenant.
+  'konf.run',
+  // Vercel preview/production deploys: subdomains are unrelated projects.
+  // (Also a PSL private-section suffix, but denylisted explicitly — defence in
+  // depth against PSL-data or derivation drift.)
+  'vercel.app',
+  // Local development: host-only cookies, never a Domain attribute.
+  'localhost',
+]
+
+/**
+ * Derive the session-cookie `Domain` attribute for a request host: the host's
+ * REGISTRABLE domain (eTLD+1, per the Public Suffix List via `tldts`) with a
+ * leading dot, so the cookie is shared across all subdomains of the
+ * conference's domain (e.g. host `admin.cloudnativedays.no` →
+ * `.cloudnativedays.no` → apex + www + per-year subdomains). Per-request
+ * derivation means every tenant domain gets the correct scope with ZERO
+ * per-tenant configuration.
+ *
+ * Returns `undefined` — meaning "set no Domain attribute; keep today's
+ * host-only cookie" — for every case where widening is wrong or unsafe:
+ *
+ * - hosts on {@link SHARED_PARENT_DOMAIN_DENYLIST} (see its doc comment),
+ * - IP literals, `localhost`, single-label / unresolvable hosts, and hosts
+ *   that ARE a public suffix (no registrable domain → `getDomain` = null),
+ * - anything unparseable — derivation is FAIL-SAFE: garbage in → host-only
+ *   cookie out, never a malformed `Domain` attribute.
+ *
+ * `allowPrivateDomains: true` matches browser behavior: browsers enforce the
+ * FULL Public Suffix List (private section included), so treating e.g.
+ * `vercel.app` as a suffix here avoids deriving a Domain the browser would
+ * reject (a rejected Set-Cookie drops the ENTIRE cookie, breaking sign-in).
+ */
+export function deriveSessionCookieDomain(
+  host: string | null | undefined,
+): string | undefined {
+  try {
+    if (!host) return undefined
+
+    // `x-forwarded-host` may carry a comma-separated chain — use the first
+    // (client-facing) entry. Strip any port; reject IPv6 literals outright.
+    let hostname = host.split(',')[0].trim().toLowerCase()
+    if (hostname.startsWith('[')) return undefined
+    hostname = hostname.split(':')[0]
+    if (!hostname) return undefined
+
+    if (isDenylistedHost(hostname)) return undefined
+
+    const registrable = getDomain(hostname, { allowPrivateDomains: true })
+    if (!registrable) return undefined
+
+    // Belt and braces: the derived domain must domain-match the request host
+    // (equal or a parent), contain a dot (never a bare TLD), and must not be —
+    // or sit under — a denylisted parent even if PSL data says otherwise.
+    if (registrable !== hostname && !hostname.endsWith(`.${registrable}`)) {
+      return undefined
+    }
+    if (!registrable.includes('.')) return undefined
+    if (isDenylistedHost(registrable)) return undefined
+
+    return `.${registrable}`
+  } catch {
+    // FAIL-SAFE: any unexpected derivation error → host-only cookie.
+    return undefined
+  }
+}
+
+/** True when `hostname` equals or is a subdomain of a denylisted parent. */
+function isDenylistedHost(hostname: string): boolean {
+  return SHARED_PARENT_DOMAIN_DENYLIST.some(
+    (parent) => hostname === parent || hostname.endsWith(`.${parent}`),
+  )
+}

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -63,7 +63,12 @@ vi.mock('@/lib/sanity/client', () => ({
   speakerImageUrl: (src: string) => `img:${src}`,
 }))
 
-import { jwtSignInCallback, signOutHandler, redirectProxyConfig } from './auth'
+import {
+  jwtSignInCallback,
+  signOutHandler,
+  redirectProxyConfig,
+  requestScopedConfig,
+} from './auth'
 import { signLinkIntent, LINK_INTENT_COOKIE } from './auth-link'
 
 const SESSION_COOKIE = 'authjs.session-token'
@@ -555,5 +560,57 @@ describe('redirectProxyConfig — centralized OAuth origin wiring (#619)', () =>
       redirectProxyUrl: 'https://auth.example.no/api/auth',
       trustHost: true,
     })
+  })
+})
+
+describe('requestScopedConfig — per-request session-cookie Domain (#462)', () => {
+  const reqFor = (headers: Record<string, string>) =>
+    ({ headers: new Headers(headers) }) as unknown as Parameters<
+      typeof requestScopedConfig
+    >[0]
+
+  it('derives the Domain from the request host (registrable domain)', () => {
+    const config = requestScopedConfig(
+      reqFor({ host: 'admin.cloudnativedays.no' }),
+    )
+    expect(config.cookies).toEqual({
+      sessionToken: { options: { domain: '.cloudnativedays.no' } },
+    })
+  })
+
+  it('prefers x-forwarded-host over host', () => {
+    const config = requestScopedConfig(
+      reqFor({
+        host: 'internal.upstream.example',
+        'x-forwarded-host': '2026.cloudnativebergen.dev',
+      }),
+    )
+    expect(config.cookies).toEqual({
+      sessionToken: { options: { domain: '.cloudnativebergen.dev' } },
+    })
+  })
+
+  it('returns the base config UNCHANGED (no cookies key) when derivation declines', () => {
+    // No request at all (e.g. `auth()` from a server component).
+    expect(requestScopedConfig(undefined).cookies).toBeUndefined()
+    // Denylisted shared parents and localhost → host-only cookie.
+    for (const host of [
+      'tenant.konf.run',
+      'my-app.vercel.app',
+      'localhost:3000',
+      '127.0.0.1:3000',
+    ]) {
+      const config = requestScopedConfig(reqFor({ host }))
+      expect(config.cookies, host).toBeUndefined()
+    }
+  })
+
+  it('overrides ONLY the sessionToken domain, leaving other options to @auth/core defaults', () => {
+    const config = requestScopedConfig(reqFor({ host: 'cloudnativedays.no' }))
+    expect(config.cookies?.sessionToken?.options).toEqual({
+      domain: '.cloudnativedays.no',
+    })
+    // Same providers/callbacks object as the static config — a shallow overlay.
+    expect(config.providers).toBe(requestScopedConfig(undefined).providers)
   })
 })

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -12,6 +12,7 @@ process.env.AUTH_SECRET = 'auth-callback-test-secret'
 type Jar = {
   store: Map<string, string>
   get: (name: string) => { value: string } | undefined
+  getAll: () => { name: string; value: string }[]
   set: (name: string, value: string) => void
   delete: ReturnType<typeof vi.fn>
 }
@@ -27,6 +28,8 @@ function createJar(initial: Record<string, string> = {}): Jar {
       const value = store.get(name)
       return value === undefined ? undefined : { value }
     },
+    getAll: () =>
+      Array.from(store.entries(), ([name, value]) => ({ name, value })),
     set: (name: string, value: string) => {
       store.set(name, value)
     },
@@ -364,6 +367,29 @@ describe('signOutHandler — clears link-flow state', () => {
     await signOutHandler()
 
     expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
+  })
+
+  it('deletes RESIDUAL host-only session cookies (incl. chunked parts) on sign-out', async () => {
+    // @auth/core's own clear targets the Domain-scoped cookie; a pre-widening
+    // HOST-ONLY cookie of the same name must be deleted separately or the user
+    // stays signed in on that host after sign-out.
+    currentJar = createJar({
+      'authjs.session-token': 'stale',
+      '__Secure-authjs.session-token.0': 'chunk0',
+      '__Secure-authjs.session-token.1': 'chunk1',
+      'unrelated-cookie': 'keep',
+    })
+
+    await signOutHandler()
+
+    expect(currentJar.delete).toHaveBeenCalledWith('authjs.session-token')
+    expect(currentJar.delete).toHaveBeenCalledWith(
+      '__Secure-authjs.session-token.0',
+    )
+    expect(currentJar.delete).toHaveBeenCalledWith(
+      '__Secure-authjs.session-token.1',
+    )
+    expect(currentJar.delete).not.toHaveBeenCalledWith('unrelated-cookie')
   })
 })
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,7 @@ import type { Account, NextAuthConfig, Profile, Session, User } from 'next-auth'
 import { decode } from 'next-auth/jwt'
 import { NextRequest } from 'next/server'
 import { getOrCreateSpeaker } from '@/lib/speaker/sanity'
+import { deriveSessionCookieDomain } from '@/lib/auth-cookie-domain'
 import { speakerImageUrl } from '@/lib/sanity/client'
 import { AppEnvironment } from '@/lib/environment/config'
 import type { Speaker } from '@/lib/speaker/types'
@@ -492,7 +493,55 @@ export const providerMap = config.providers.map((provider: Provider) => {
   }
 })
 
-export const { handlers, auth: _auth, signIn } = NextAuth(config)
+/**
+ * Per-request NextAuth config (Auth.js "lazy initialization"): the static
+ * `config` plus a session-cookie `Domain` derived from the REQUEST HOST's
+ * registrable domain (eTLD+1) — host `admin.cloudnativedays.no` →
+ * `Domain=.cloudnativedays.no` — so a signed-in user stays signed in across
+ * apex + www + per-year subdomains instead of being dropped by the default
+ * host-only cookie. Deriving per request (rather than from a deploy-wide env
+ * var) makes this scale to every tenant domain with zero configuration.
+ *
+ * `deriveSessionCookieDomain` is FAIL-SAFE and tenant-aware: localhost, IP
+ * literals, previews on `vercel.app`, platform-shared parents (`konf.run`),
+ * public suffixes, and unparseable hosts all yield `undefined` → NO override →
+ * today's host-only cookie. See `SHARED_PARENT_DOMAIN_DENYLIST` for the
+ * security rationale. The same derivation runs in the route handlers AND the
+ * `auth`-wrapped middleware, so set / refresh / clear all carry an identical
+ * Domain attribute.
+ *
+ * Only the `domain` option is set — @auth/core deep-merges it onto the
+ * defaults, so httpOnly / secure / sameSite=lax / path and the `__Secure-`
+ * name prefix are preserved (that prefix permits a Domain attribute, unlike
+ * `__Host-`). The CSRF cookie deliberately stays host-only (`__Host-`), which
+ * is fine as the sign-in POST happens on a single host. `x-forwarded-host` is
+ * preferred over `host` (Vercel sets it authoritatively; Auth.js itself trusts
+ * it under `trustHost`); a spoofed value cannot widen the cookie beyond the
+ * denylist checks, and the browser drops any Set-Cookie whose Domain does not
+ * cover the real request host. No request (e.g. `auth()` in a server
+ * component, which cannot write cookies anyway) → static config unchanged.
+ *
+ * Exported for unit tests; referenced in-file by `NextAuth(...)` below.
+ */
+export function requestScopedConfig(
+  req: Pick<NextRequest, 'headers'> | undefined,
+): NextAuthConfig {
+  const host =
+    req?.headers.get('x-forwarded-host') ?? req?.headers.get('host') ?? null
+  const domain = deriveSessionCookieDomain(host)
+  if (!domain) return config
+
+  return {
+    ...config,
+    cookies: {
+      sessionToken: {
+        options: { domain },
+      },
+    },
+  }
+}
+
+export const { handlers, auth: _auth, signIn } = NextAuth(requestScopedConfig)
 
 export const auth = _auth as typeof _auth &
   (<HandlerResponse extends Response | Promise<Response>>(

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -128,9 +128,29 @@ export async function signOutHandler(): Promise<void> {
   try {
     const { LINK_INTENT_COOKIE } = await import('@/lib/auth-link')
     const { cookies } = await import('next/headers')
-    ;(await cookies()).delete(LINK_INTENT_COOKIE)
+    const jar = await cookies()
+    jar.delete(LINK_INTENT_COOKIE)
+
+    // RESIDUAL HOST-ONLY COOKIE CLEANUP: @auth/core clears the session cookie
+    // using the CURRENT cookie options — since the per-request Domain widening
+    // (`requestScopedConfig`), that clear targets the Domain-scoped cookie. A
+    // browser can additionally hold a HOST-ONLY cookie of the same name (set
+    // before the widening shipped, or across a denylist change); a Set-Cookie
+    // with a Domain attribute can never remove it, so it would SURVIVE sign-out
+    // and keep the user signed in on that host. Delete every session-token
+    // cookie (including chunked `<name>.0`, `.1`, … parts) host-only as well —
+    // the two deletes target different cookies, so both are needed.
+    for (const { name } of jar.getAll()) {
+      if (
+        SESSION_TOKEN_COOKIE_NAMES.some(
+          (base) => name === base || name.startsWith(`${base}.`),
+        )
+      ) {
+        jar.delete(name)
+      }
+    }
   } catch (err) {
-    console.error('Failed to clear link-intent cookie on sign-out', err)
+    console.error('Failed to clear auth cookies on sign-out', err)
   }
 }
 

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -341,10 +341,10 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
       { missing: 'JWT signing/verification breaks — no one can sign in' },
     ),
   )
-  // NOTE: AUTH_COOKIE_DOMAIN (the prod subdomain-cookie fix) is NOT read as an
-  // env var anywhere in the codebase today, so there is nothing to surface.
-  // If it is later wired as a `process.env.AUTH_COOKIE_DOMAIN` read, add a plain
-  // check here that warns when unset.
+  // NOTE: the cross-subdomain session cookie needs NO env check: its Domain
+  // attribute is derived per request from the request host's registrable domain
+  // (`deriveSessionCookieDomain` in `src/lib/auth-cookie-domain.ts`), so there
+  // is no configuration to surface here.
   //
   // Centralized OAuth origin (#619). Informational: 'ok' when configured (opt-in
   // multi-domain OAuth), 'off' when absent (today's single-domain default). Not


### PR DESCRIPTION
## Problem

Signing in on one subdomain (e.g. `cloudnativedays.no`) and navigating to another (`www.` / `2026.` / `admin.`) drops the session: the NextAuth session cookie is host-only by default, so each subdomain gets its own (empty) cookie jar.

## Approach: per-request Domain derivation (reworked)

An earlier revision of this PR introduced an `AUTH_COOKIE_DOMAIN` env var (it was never set in prod). That approach is **replaced**: a deploy-wide env var cannot serve multiple tenant domains from one deployment. Instead, NextAuth is now initialized **lazily** (`NextAuth(requestScopedConfig)`), and for each request the session cookie's `Domain` is derived from the request host's **registrable domain** (eTLD+1):

- `admin.cloudnativedays.no` → `Domain=.cloudnativedays.no`
- `conf.example.co.uk` → `Domain=.example.co.uk`
- every tenant domain gets the correct scope with **zero per-tenant configuration** — multi-tenant from day one.

The same derivation runs in the auth route handlers **and** the `auth`-wrapped proxy middleware (next-auth's lazy-config path forwards the request in both), so cookie set / refresh / clear all carry an identical `Domain`. Only the `domain` option is overridden; `@auth/core` deep-merges it, preserving `httpOnly` / `secure` / `SameSite=Lax` / `path` and the `__Secure-` prefix.

### Public Suffix List: why `tldts`

eTLD+1 requires the PSL — a naive "last two labels" heuristic derives the **public suffix** itself on multi-part TLDs (`.co.uk`, `.com.au`, …), and browsers respond to `Domain=<public suffix>` by **dropping the entire Set-Cookie**, silently breaking sign-in. `tldts` was already in our dependency tree (transitively via `tough-cookie`); it is promoted to a direct dependency (zero deps, actively maintained, works in edge and Node runtimes). Derivation uses `allowPrivateDomains: true` so our view of the PSL matches the browsers' (which enforce the private section too, e.g. `vercel.app`).

### Security containment (`SHARED_PARENT_DOMAIN_DENYLIST`)

`src/lib/auth-cookie-domain.ts` exports a documented denylist of **platform-shared parent domains whose subdomains belong to different tenants** — `konf.run` (future tenant runtime), `vercel.app`, `localhost`. The cookie is **never** widened there (host-only fallback): widening would put one tenant's session cookie inside every other tenant's XSS blast radius. The list is designed to be extended, and a test pins the entries.

**Fail-safe:** any derivation failure — garbage host, IP literal, single-label host, bare public suffix, unparseable input — yields *no* `Domain` attribute (today's host-only behavior), never a malformed one.

### Sign-out hardening

With a Domain-scoped cookie, `@auth/core`'s sign-out clear targets the Domain cookie only; a pre-migration **host-only** cookie of the same name (incl. chunked `.0`/`.1` parts) would survive sign-out and keep the user signed in on that host. `signOutHandler` now also deletes all session-token cookies host-only.

## Tests & verification

- `src/lib/auth-cookie-domain.test.ts`: derivation for normal domains, subdomain + apex hosts, multi-part TLDs, denylisted parents (`konf.run` / `vercel.app` / `localhost` → no Domain), garbage/IP/suffix hosts → host-only, port/case/x-forwarded-host-chain normalization, denylist pinning.
- `src/lib/auth.test.ts`: `requestScopedConfig` overlay shape (derives Domain, prefers `x-forwarded-host`, returns base config untouched when derivation declines, only the `domain` option overridden), residual host-only cookie cleanup on sign-out.
- Verified end-to-end against the **real** `@auth/core` handler (`Set-Cookie` inspection per host class): tenant hosts get `Domain=.<registrable>`, denylisted/garbage hosts stay host-only, other attributes preserved.
- Full suite: 349 files / 4504 tests green; lint, typecheck, format, knip green; production build green.
