### PR TITLE
fix(dashboard): stop the mobile avatar from signing users out on tap

### DIFF
--- a/src/components/common/DashboardLayout.tsx
+++ b/src/components/common/DashboardLayout.tsx
@@ -421,22 +421,44 @@ export function DashboardLayout({
 
           <div className="flex items-center gap-x-2" suppressHydrationWarning>
             <ThemeToggle />
-            <button
-              onClick={() => signOut({ callbackUrl: '/' })}
-              className="focus:outline-none"
-            >
-              <span className="sr-only">Sign out</span>
-              <Image
-                alt=""
-                src={getAvatarUrl()}
-                width={32}
-                height={32}
-                className={clsx(
-                  'size-8 rounded-full transition-opacity hover:opacity-80',
-                  mode === 'speaker' ? 'bg-brand-cloud-blue' : 'bg-gray-800',
-                )}
-              />
-            </button>
+            {/*
+              Avatar opens a menu rather than signing out directly — a bare
+              onClick={signOut} here (the previous behaviour) meant tapping your
+              own profile photo instantly logged you out and bounced you to `/`,
+              which read as a mysterious "logged out on the landing page" bug.
+              Mirrors the desktop header's user menu below.
+            */}
+            <Menu as="div" className="relative">
+              <MenuButton
+                className="flex items-center focus:outline-none"
+                suppressHydrationWarning
+              >
+                <span className="sr-only">Open user menu</span>
+                <Image
+                  alt=""
+                  src={getAvatarUrl()}
+                  width={32}
+                  height={32}
+                  className={clsx(
+                    'size-8 rounded-full transition-opacity hover:opacity-80',
+                    mode === 'speaker' ? 'bg-brand-cloud-blue' : 'bg-gray-800',
+                  )}
+                />
+              </MenuButton>
+              <MenuItems
+                transition
+                className="absolute right-0 z-10 mt-2.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 transition focus:outline-none data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-900 dark:ring-white/10"
+              >
+                <MenuItem>
+                  <button
+                    onClick={() => signOut({ callbackUrl: '/' })}
+                    className="block w-full px-3 py-1 text-left text-sm leading-6 text-gray-900 data-focus:bg-gray-50 dark:text-white dark:data-focus:bg-gray-800"
+                  >
+                    Sign out
+                  </button>
+                </MenuItem>
+              </MenuItems>
+            </Menu>
           </div>
         </div>
 


### PR DESCRIPTION
## The actual bug behind "logged out on the landing page"

On the CFP/admin dashboard (`DashboardLayout`, used by `/cfp/*` via `CFPLayout`), the header renders the profile photo two different ways:

- **Desktop (`lg:`)** — a proper headless-ui `Menu`: tapping the avatar opens a dropdown, and *Sign out* is a menu item.
- **Narrow (`<lg`)** — the avatar was a **bare `<button onClick={signOut({ callbackUrl: '/' })}>`** with only an `sr-only` "Sign out" label.

So on a phone/tablet/narrow window, **tapping your own profile photo instantly signed you out** and redirected to `/`, where you appeared logged out and had to sign in again. That exactly matches the report: "logged in on /cfp/list → click profile photo → sent to / → logged out."

This is **not** a session/cookie/caching issue — it's the click itself. (It's independent of the earlier bfcache fix #458 and the SessionProvider-null fix #461, and unrelated to the cross-subdomain cookie work in #462, which does not apply to a single-subdomain flow.)

## Fix

Replace the narrow-viewport bare button with the **same `Menu` the desktop header already uses**, so the avatar opens a menu and *Sign out* is a deliberate second step. No behavioural change to session, cookies, or caching — purely the header affordance, and now consistent across breakpoints.

## Verification
`pnpm typecheck` ✅ · eslint ✅ · prettier ✅. Diff is one component; no logic/data changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX bug where tapping the profile avatar on narrow viewports (mobile/tablet) immediately signed the user out and redirected to `/`, because the mobile header rendered the avatar as a bare `button` with `onClick={signOut(…)}` instead of a dropdown menu.

- **Root cause fixed**: The narrow-viewport avatar button (inside the top mobile header bar) called `signOut` directly on click; it is now replaced with the same headless-ui `Menu`/`MenuButton`/`MenuItems` pattern already used by the desktop header, so sign-out becomes a deliberate second step.
- **Scope**: One component file, UI-only change; no session, cookie, or data logic is touched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a focused UI fix replacing a single errant click handler with the same proven Menu pattern already in use on desktop.

The change is a direct, minimal fix to one component. The new mobile menu is a near-verbatim copy of the desktop menu that already works correctly: same headless-ui primitives, same signOut call, same MenuItems class string. No session logic, API calls, or data paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/common/DashboardLayout.tsx | Mobile avatar replaced with a proper headless-ui Menu matching the existing desktop implementation; fix is minimal, correct, and consistent. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant MobileHeader
    participant Menu
    participant NextAuth

    Note over MobileHeader: Before fix
    User->>MobileHeader: Tap avatar
    MobileHeader->>NextAuth: "signOut({ callbackUrl: '/' })"
    NextAuth-->>User: Redirect to / (logged out)

    Note over MobileHeader: After fix
    User->>MobileHeader: Tap avatar
    MobileHeader->>Menu: Open dropdown
    Menu-->>User: Show Sign out item
    User->>Menu: Click Sign out
    Menu->>NextAuth: "signOut({ callbackUrl: '/' })"
    NextAuth-->>User: Redirect to / (logged out)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant MobileHeader
    participant Menu
    participant NextAuth

    Note over MobileHeader: Before fix
    User->>MobileHeader: Tap avatar
    MobileHeader->>NextAuth: "signOut({ callbackUrl: '/' })"
    NextAuth-->>User: Redirect to / (logged out)

    Note over MobileHeader: After fix
    User->>MobileHeader: Tap avatar
    MobileHeader->>Menu: Open dropdown
    Menu-->>User: Show Sign out item
    User->>Menu: Click Sign out
    Menu->>NextAuth: "signOut({ callbackUrl: '/' })"
    NextAuth-->>User: Redirect to / (logged out)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): stop the mobile avatar f..."](https://github.com/cloudnativebergen/website/commit/078a94cd8315a4d13181ce0cb7b1d2cb25ca760e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44714400)</sub>

<!-- /greptile_comment -->