### PR TITLE
feat(dashboard): unify on the shared role-aware UserMenu across all headers

### DIFF
--- a/src/components/common/DashboardLayout.tsx
+++ b/src/components/common/DashboardLayout.tsx
@@ -3,28 +3,23 @@
 import { useState, useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
-import Image from 'next/image'
-import { useSession, signOut } from 'next-auth/react'
+import { useSession } from 'next-auth/react'
 import { useTheme } from 'next-themes'
 import {
   Dialog,
   DialogBackdrop,
   DialogPanel,
   TransitionChild,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuItems,
 } from '@headlessui/react'
 import {
   Bars3Icon,
   XMarkIcon,
-  ChevronDownIcon,
   MagnifyingGlassIcon,
   BellIcon,
 } from '@heroicons/react/24/outline'
 import { ConferenceLogo } from '@/components/ConferenceLogo'
 import { ThemeToggle } from '@/components/ThemeToggle'
+import { UserMenu } from '@/components/UserMenu'
 import clsx from 'clsx'
 
 export interface NavigationItem {
@@ -421,22 +416,12 @@ export function DashboardLayout({
 
           <div className="flex items-center gap-x-2" suppressHydrationWarning>
             <ThemeToggle />
-            <button
-              onClick={() => signOut({ callbackUrl: '/' })}
-              className="focus:outline-none"
-            >
-              <span className="sr-only">Sign out</span>
-              <Image
-                alt=""
-                src={getAvatarUrl()}
-                width={32}
-                height={32}
-                className={clsx(
-                  'size-8 rounded-full transition-opacity hover:opacity-80',
-                  mode === 'speaker' ? 'bg-brand-cloud-blue' : 'bg-gray-800',
-                )}
-              />
-            </button>
+            <UserMenu
+              name={getUserName()}
+              picture={getAvatarUrl()}
+              speaker={session?.speaker}
+              account={session?.account}
+            />
           </div>
         </div>
 
@@ -485,46 +470,12 @@ export function DashboardLayout({
                 className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-200 dark:bg-gray-700"
               />
 
-              <Menu as="div" className="relative">
-                <MenuButton
-                  className="-m-1.5 flex items-center p-1.5"
-                  suppressHydrationWarning
-                >
-                  <span className="sr-only">Open user menu</span>
-                  <Image
-                    alt=""
-                    src={getAvatarUrl()}
-                    width={32}
-                    height={32}
-                    className="size-8 rounded-full bg-gray-50 dark:bg-gray-800"
-                  />
-                  <span className="hidden lg:flex lg:items-center">
-                    <span
-                      aria-hidden="true"
-                      className="ml-4 text-sm leading-6 font-semibold text-gray-900 dark:text-white"
-                    >
-                      {getUserName()}
-                    </span>
-                    <ChevronDownIcon
-                      aria-hidden="true"
-                      className="ml-2 size-5 text-gray-400 dark:text-gray-500"
-                    />
-                  </span>
-                </MenuButton>
-                <MenuItems
-                  transition
-                  className="absolute right-0 z-10 mt-2.5 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 transition focus:outline-none data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in dark:bg-gray-900 dark:ring-white/10"
-                >
-                  <MenuItem>
-                    <button
-                      onClick={() => signOut({ callbackUrl: '/' })}
-                      className="block w-full px-3 py-1 text-left text-sm leading-6 text-gray-900 data-focus:bg-gray-50 dark:text-white dark:data-focus:bg-gray-800"
-                    >
-                      Sign out
-                    </button>
-                  </MenuItem>
-                </MenuItems>
-              </Menu>
+              <UserMenu
+                name={getUserName()}
+                picture={getAvatarUrl()}
+                speaker={session?.speaker}
+                account={session?.account}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Goal
Use the **same context-aware user menu from the profile photo on every page.**

The main site header already uses the shared role-aware `UserMenu` (#443/#456) — speaker links, an organizer-gated Admin section, install, current sign-in provider, and Sign out. But the **CFP/admin dashboard** (`DashboardLayout`, used by `/cfp/*` and `/admin/*`) still rolled its own avatar menus:

- **Narrow viewports:** a bare `<button onClick={signOut}>` — tapping your own photo signed you out and bounced you to `/` (the bug reported as "logged out on the landing page").
- **Desktop:** a Sign-out-only dropdown, with no speaker/admin navigation.

## Change
Adopt `UserMenu` in both dashboard header slots (mobile + desktop), passing `name` / `picture` (the existing initials-avatar fallback via `getAvatarUrl()`) / `speaker` / `account` from the session. Now the identical role-aware menu opens from the avatar everywhere.

- **Supersedes #464** — UserMenu opens a proper menu, so the one-tap-signout bug is gone by construction. (I'll close #464.)
- No new providers: `UserMenu` takes session via props and reads the PwaInstall/session context already in the root layout.
- Removes the now-dead `Menu`/`MenuItem`/`ChevronDownIcon`/`Image`/`signOut` imports (−63/+14).

## Visual notes for your inspection
- The dashboard avatar trigger is now the shared 40px avatar (was 32px) and, on desktop, no longer shows the name + chevron beside it — trading that dashboard-specific flourish for a consistent trigger across the app. The menu itself is now much richer (dashboard/proposals/profile/expenses, admin section for organizers).

## Verification
`pnpm typecheck` ✅ · eslint ✅ · prettier ✅. Single-component diff.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the two custom avatar triggers in `DashboardLayout` (a bare sign-out button on mobile and a sign-out-only dropdown on desktop) with the shared `UserMenu` component that already powers the main site header. The fix eliminates a reported bug where tapping the avatar on narrow viewports immediately signed the user out.

- **Mobile header** (`lg:hidden`): swaps the `<button onClick={signOut}>` / `<Image>` combo for `<UserMenu>`, so the avatar now opens the rich menu instead of signing out on first tap.
- **Desktop header**: replaces the `Menu`/`MenuButton`/`MenuItems` one-item dropdown (sign-out only) with `<UserMenu>`, gaining speaker links, an organizer-gated Admin section, install prompt, and provider label — matching the main-site experience.

<h3>Confidence Score: 4/5</h3>

Safe to merge — fixes a real UX bug (tap-to-sign-out) and consolidates behaviour with the existing main-site header.

The change is a focused, well-scoped component swap. The one nuance: UserMenu always renders speaker CFP links regardless of whether a speaker profile exists, so an organizer-only account would see CFP links that may lead to empty states in the admin dashboard. This pre-existed on the main-site header and is not introduced here.

No files require special attention. The single changed file is a straightforward import swap with clean dead-code removal.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/common/DashboardLayout.tsx | Removes custom mobile sign-out button and desktop sign-out dropdown; replaces both with the shared UserMenu component, passing name/picture/speaker/account from session. Dead imports (Image, signOut, Menu*, ChevronDownIcon) cleaned up correctly. The colorSchemes.avatar.background config remains in use via getAvatarUrl(), so no dead code is introduced. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): use the shared role-awa..."](https://github.com/cloudnativebergen/website/commit/e59d8614daf8e6507a24fbe824cf41c446f8f002) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44716604)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->