### PR TITLE
test(auth): cover proxy.ts edge middleware + raise coverage gate off 0

### DIFF
--- a/__tests__/lib/auth/proxy.test.ts
+++ b/__tests__/lib/auth/proxy.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the edge middleware in `src/proxy.ts` — previously ZERO coverage
+ * (its scoped threshold was gated at 0 to keep the gap visible). The middleware
+ * is the app's first auth gate, so its routing and production guards are
+ * security-relevant:
+ *   - path routing: /workshop → WorkOS, protected /cfp|/admin|/cli → NextAuth,
+ *     everything else (incl. bare /cfp) → pass-through.
+ *   - production hard guards: dev-tools 404 gate + impersonation-param strip.
+ *   - unauthenticated → sign-in redirect (preserving callbackUrl).
+ *   - authenticated → forward with the x-url request header.
+ *   - dev test-mode bypass.
+ *
+ * The global `next-auth` mock (see __tests__/mocks/next-auth.ts) populates
+ * `req.auth` from an `x-test-auth-user` header, so "authenticated" here means
+ * "carry a header naming a known test speaker". `@workos-inc/authkit-nextjs`
+ * and `@/lib/environment/config` are mocked so the routing and dev/test gates
+ * are controllable without a real WorkOS client or a fixed NODE_ENV.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { NextRequest, type NextFetchEvent } from 'next/server'
+
+const h = vi.hoisted(() => ({
+  // Mutable environment flags, read via getters on the mocked AppEnvironment.
+  env: { isTestMode: false, isDevelopment: false, isProduction: false },
+  // Sentinel returned by the mocked WorkOS middleware so we can assert routing.
+  workOSResult: { __workos: true },
+  workOSMiddleware: vi.fn(),
+}))
+
+vi.mock('@workos-inc/authkit-nextjs', () => ({
+  authkitMiddleware: vi.fn(() => h.workOSMiddleware),
+}))
+
+vi.mock('@/lib/environment/config', () => ({
+  AppEnvironment: {
+    get isTestMode() {
+      return h.env.isTestMode
+    },
+    get isDevelopment() {
+      return h.env.isDevelopment
+    },
+    get isProduction() {
+      return h.env.isProduction
+    },
+    createMockAuthContext: () => ({ user: { email: 'mock@test' } }),
+  },
+}))
+
+import middleware from '@/proxy'
+
+const ORGANIZER_ID = '08913fe1-4e52-43b9-8b27-6d5febf95dbd'
+
+/** Build a NextRequest, optionally authenticated as a known test speaker. */
+function req(path: string, opts: { authUser?: string } = {}): NextRequest {
+  const headers = new Headers()
+  if (opts.authUser) headers.set('x-test-auth-user', opts.authUser)
+  return new NextRequest(`http://localhost:3000${path}`, { headers })
+}
+
+const event = {} as NextFetchEvent
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.env.isTestMode = false
+  h.env.isDevelopment = false
+  h.env.isProduction = false
+  h.workOSMiddleware.mockReturnValue(h.workOSResult)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('middleware — path routing', () => {
+  it('routes /workshop to the WorkOS middleware', () => {
+    const result = middleware(req('/workshop'), event)
+    expect(h.workOSMiddleware).toHaveBeenCalledOnce()
+    expect(result).toBe(h.workOSResult)
+  })
+
+  it('routes nested /workshop/* to the WorkOS middleware', () => {
+    const result = middleware(req('/workshop/agenda'), event)
+    expect(h.workOSMiddleware).toHaveBeenCalledOnce()
+    expect(result).toBe(h.workOSResult)
+  })
+
+  it('passes through the bare /cfp landing page (not protected)', () => {
+    const res = middleware(req('/cfp'), event) as Response
+    expect(h.workOSMiddleware).not.toHaveBeenCalled()
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+  })
+
+  it('passes through unmatched public paths', () => {
+    const res = middleware(req('/'), event) as Response
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+  })
+})
+
+describe('middleware — NextAuth gate (unauthenticated)', () => {
+  it.each(['/cfp/list', '/admin/sponsors', '/cli/token'])(
+    'redirects an unauthenticated request to %s to sign-in with callbackUrl',
+    (path) => {
+      const res = middleware(req(path), event) as Response
+      expect(res.status).toBe(307)
+      const location = res.headers.get('location')!
+      const url = new URL(location)
+      expect(url.pathname).toBe('/api/auth/signin')
+      expect(url.searchParams.get('callbackUrl')).toBe(
+        `http://localhost:3000${path}`,
+      )
+    },
+  )
+})
+
+describe('middleware — NextAuth gate (authenticated)', () => {
+  it('forwards an authenticated request and sets the x-url header', () => {
+    const res = middleware(
+      req('/admin/sponsors', { authUser: ORGANIZER_ID }),
+      event,
+    ) as Response
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+    expect(res.headers.get('x-middleware-request-x-url')).toBe(
+      'http://localhost:3000/admin/sponsors',
+    )
+  })
+})
+
+describe('middleware — production guards', () => {
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'production')
+  })
+
+  it.each(['/admin/debug', '/admin/clear-storage', '/admin/test-mode'])(
+    'returns 404 for dev-tools path %s in production',
+    (path) => {
+      const res = middleware(
+        req(path, { authUser: ORGANIZER_ID }),
+        event,
+      ) as Response
+      expect(res.status).toBe(404)
+    },
+  )
+
+  it('strips the impersonate param and redirects in production', () => {
+    const res = middleware(
+      req('/admin/sponsors?impersonate=someone', { authUser: ORGANIZER_ID }),
+      event,
+    ) as Response
+    expect(res.status).toBe(307)
+    const url = new URL(res.headers.get('location')!)
+    expect(url.searchParams.has('impersonate')).toBe(false)
+    expect(url.pathname).toBe('/admin/sponsors')
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('[SECURITY] Impersonation attempt blocked'),
+    )
+  })
+
+  it('forwards a clean authenticated admin request in production', () => {
+    const res = middleware(
+      req('/admin/sponsors', { authUser: ORGANIZER_ID }),
+      event,
+    ) as Response
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it('does NOT strip impersonate outside production', () => {
+    // NODE_ENV is stubbed to production in this describe; override back.
+    vi.stubEnv('NODE_ENV', 'development')
+    const res = middleware(
+      req('/admin/sponsors?impersonate=someone', { authUser: ORGANIZER_ID }),
+      event,
+    ) as Response
+    // Authenticated + no production strip → forwarded, not redirected.
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+    expect(console.error).not.toHaveBeenCalled()
+  })
+})
+
+describe('middleware — dev test-mode bypass', () => {
+  it('bypasses auth when dev test-mode is active, even unauthenticated', () => {
+    h.env.isDevelopment = true
+    h.env.isTestMode = true
+    const res = middleware(req('/admin/sponsors'), event) as Response
+    // Bypass → NextResponse.next, no sign-in redirect despite no auth.
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+    expect(res.status).not.toBe(307)
+  })
+
+  it('honours the ?test=true param in development', () => {
+    h.env.isDevelopment = true
+    h.env.isTestMode = false
+    const res = middleware(req('/admin/sponsors?test=true'), event) as Response
+    expect(res.headers.get('x-middleware-next')).toBe('1')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -97,14 +97,15 @@ export default defineConfig({
           functions: 95,
           lines: 85,
         },
-        // proxy.ts currently has no direct tests. Gate at 0 so it stays in the
-        // report (surfacing the gap) without failing the build; raise once
-        // tests are added.
+        // proxy.ts is covered by __tests__/lib/auth/proxy.test.ts (routing,
+        // production dev-tools/impersonation guards, sign-in redirect, test-mode
+        // bypass). Measured 100/~96/100/100 on 2026-07; ratcheted a few points
+        // below to lock in coverage without flakiness.
         'src/proxy.ts': {
-          statements: 0,
-          branches: 0,
-          functions: 0,
-          lines: 0,
+          statements: 95,
+          branches: 90,
+          functions: 90,
+          lines: 95,
         },
       },
     },


### PR DESCRIPTION
Part of the auth/identity test-hardening epic (#451) — the **proxy.ts middleware tests** item.

`src/proxy.ts` is the app's first auth gate but had **zero** test coverage; its scoped coverage threshold was intentionally gated at `0` to keep the gap visible. This adds a focused suite and ratchets the gate off `0`.

### Coverage added
- **Path routing** — `/workshop*` → WorkOS middleware; protected `/cfp/*` (not bare `/cfp`), `/admin/*`, `/cli/*` → NextAuth; bare `/cfp` and unmatched paths → pass-through.
- **Production hard guards** — dev-tools `404` gate (`debug` / `clear-storage` / `test-mode`), impersonation-param strip + redirect (asserts the `[SECURITY]` audit log and that a clean prod request still forwards).
- **Unauthenticated** → sign-in redirect preserving `callbackUrl`.
- **Authenticated** → forward with the `x-url` request header.
- **Dev test-mode bypass** — both `AppEnvironment.isTestMode` and `?test=true`.

### Test infra
- Uses the existing global `next-auth` mock (`x-test-auth-user` header → `req.auth`).
- Mocks `@workos-inc/authkit-nextjs` and `@/lib/environment/config` (mutable getters) so routing and the dev/test gates are controllable without a real WorkOS client or a fixed `NODE_ENV`.

### Threshold
Measured **100% stmts / ~96% branch / 100% funcs / 100% lines**. Ratcheted `src/proxy.ts` from `0` → **95 / 90 / 90 / 95** to lock it in without flakiness.

Remaining #451 items (MSW server, `@auth/core` contract test, testable NextAuth callbacks, Playwright login e2e, standing abuse suite) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a focused test suite for `src/proxy.ts` — the app's first auth gate — which previously had zero coverage, and raises its scoped coverage threshold from `0` to `95/90/90/95`.

- **`__tests__/lib/auth/proxy.test.ts`**: 200-line suite covering WorkOS path routing, NextAuth-protected routes (unauthenticated redirect + authenticated forward), production hard guards (dev-tool `404` + impersonation-param strip with `[SECURITY]` audit log), and the dev test-mode bypass via both `AppEnvironment.isTestMode` and `?test=true`. Uses the existing global `next-auth` mock and `vi.hoisted` to control WorkOS and `AppEnvironment` without a live client.
- **`vitest.config.ts`**: Updates the `src/proxy.ts` per-file threshold from `0/0/0/0` to `95/90/90/95`, consistent with the measured ~100/96/100/100 coverage and leaving a small buffer for inherent branch-coverage variance on the multi-condition dev-tools guard.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive (new tests + threshold increase) and touches no production code paths.

The PR only adds tests and raises a previously-zeroed coverage gate. No production code is modified. The mock setup correctly uses vi.hoisted to control module-level side effects, beforeEach/afterEach teardown is clean, and the hardcoded ORGANIZER_ID matches an entry in the existing testdata.

No files require special attention; both changed files are test/config-only.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| __tests__/lib/auth/proxy.test.ts | New 200-line test suite covering routing, production guards, sign-in redirect, and dev test-mode bypass for the proxy middleware; minor untested branch (`/api/dev/` prefix) is expected and accounted for in the 90% branch threshold. |
| vitest.config.ts | Ratchets `src/proxy.ts` coverage thresholds from 0 to 95/90/90/95 (statements/branches/functions/lines), consistent with the measured 100/~96/100/100; comment updated to explain the rationale. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request enters middleware] --> B{pathname starts with /workshop?}
    B -- yes --> C[workOSMiddleware]
    B -- no --> D{pathname matches /cfp/* /admin/* /cli/*?}
    D -- no --> E[NextResponse.next pass-through]
    D -- yes --> F[nextAuthMiddleware]
    F --> G{NODE_ENV === production?}
    G -- yes --> H{Dev-tool path? debug/clear-storage/test-mode/api/dev/}
    H -- yes --> I[404 Not Found]
    H -- no --> J{Has impersonate param?}
    J -- yes --> K[Log SECURITY error, redirect without param]
    J -- no --> L{isTestModeActive?}
    G -- no --> L
    L -- yes --> M[NextResponse.next bypass]
    L -- no --> N{req.auth set?}
    N -- no --> O[Redirect to /api/auth/signin with callbackUrl]
    N -- yes --> P[Set x-url header, NextResponse.next forward]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Request enters middleware] --> B{pathname starts with /workshop?}
    B -- yes --> C[workOSMiddleware]
    B -- no --> D{pathname matches /cfp/* /admin/* /cli/*?}
    D -- no --> E[NextResponse.next pass-through]
    D -- yes --> F[nextAuthMiddleware]
    F --> G{NODE_ENV === production?}
    G -- yes --> H{Dev-tool path? debug/clear-storage/test-mode/api/dev/}
    H -- yes --> I[404 Not Found]
    H -- no --> J{Has impersonate param?}
    J -- yes --> K[Log SECURITY error, redirect without param]
    J -- no --> L{isTestModeActive?}
    G -- no --> L
    L -- yes --> M[NextResponse.next bypass]
    L -- no --> N{req.auth set?}
    N -- no --> O[Redirect to /api/auth/signin with callbackUrl]
    N -- yes --> P[Set x-url header, NextResponse.next forward]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(auth): cover proxy.ts edge middlewa..."](https://github.com/cloudnativebergen/website/commit/d1d8342c895973f2941647d13fe072a0b78dd3db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44871703)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->