### PR TITLE
fix(auth): close open-redirect in the NextAuth redirect callback (+ testable callbacks)

### DIFF
--- a/__tests__/lib/auth/callbacks.test.ts
+++ b/__tests__/lib/auth/callbacks.test.ts
@@ -6,8 +6,8 @@
  * which is passed to the globally-mocked `next-auth`, so the real logic never
  * ran in tests. They are now exported named functions referenced from the
  * config, making the security-critical behaviour directly testable:
- *   - `redirectCallback`: the OPEN-REDIRECT guard (`url.startsWith(baseUrl)`)
- *     and the Phase-2 `linkResult` param append (same-origin only).
+ *   - `redirectCallback`: the OPEN-REDIRECT guard (same-origin check on the
+ *     parsed URL) and the Phase-2 `linkResult` param append (same-origin only).
  *   - `sessionCallback`: the exact client-visible session shape (trimmed user +
  *     speaker/account lifted off the JWT).
  *
@@ -32,6 +32,14 @@ describe('redirectCallback — open-redirect guard', () => {
     expect(target).toBe(`${BASE}/cfp/list`)
   })
 
+  it('allows a relative URL by resolving it onto baseUrl', async () => {
+    const target = await redirectCallback({
+      url: '/cfp/list',
+      baseUrl: BASE,
+    })
+    expect(target).toBe(`${BASE}/cfp/list`)
+  })
+
   it('rejects an off-site absolute URL, falling back to baseUrl', async () => {
     const target = await redirectCallback({
       url: 'https://evil.example.com/steal',
@@ -45,13 +53,15 @@ describe('redirectCallback — open-redirect guard', () => {
       url: '//evil.example.com/steal',
       baseUrl: BASE,
     })
-    // Does not start with baseUrl → must fall back, never leak to the other host.
+    // Resolves to a different origin (https://evil.example.com) → must fall
+    // back, never leak to the other host.
     expect(target).toBe(BASE)
   })
 
   it('rejects a look-alike host that only prefixes the base host', async () => {
-    // `https://2026.cloudnativedays.no.evil.com` shares the base as a substring
-    // but not as a prefix of the full origin URL string — must be rejected.
+    // `https://2026.cloudnativedays.no.evil.com` IS a string prefix of the base
+    // URL — exactly what the old `startsWith(baseUrl)` guard leaked — but its
+    // parsed origin differs, so the origin check rejects it.
     const target = await redirectCallback({
       url: 'https://2026.cloudnativedays.no.evil.com/x',
       baseUrl: BASE,

--- a/__tests__/lib/auth/callbacks.test.ts
+++ b/__tests__/lib/auth/callbacks.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the extracted NextAuth `session` and `redirect` callbacks
+ * (src/lib/auth.ts). These bodies used to live inline in `config.callbacks`,
+ * which is passed to the globally-mocked `next-auth`, so the real logic never
+ * ran in tests. They are now exported named functions referenced from the
+ * config, making the security-critical behaviour directly testable:
+ *   - `redirectCallback`: the OPEN-REDIRECT guard (`url.startsWith(baseUrl)`)
+ *     and the Phase-2 `linkResult` param append (same-origin only).
+ *   - `sessionCallback`: the exact client-visible session shape (trimmed user +
+ *     speaker/account lifted off the JWT).
+ *
+ * `@/lib/auth-link` is the real module here (not mocked); `redirectCallback`
+ * dynamically imports it and reads `linkResultStore`, so the link-result cases
+ * run the callback inside `linkResultStore.run(...)`.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Session } from 'next-auth'
+import type { JWT } from 'next-auth/jwt'
+import { redirectCallback, sessionCallback } from '@/lib/auth'
+import { linkResultStore, LINK_RESULT_PARAM } from '@/lib/auth-link'
+
+const BASE = 'https://2026.cloudnativedays.no'
+
+describe('redirectCallback — open-redirect guard', () => {
+  it('allows a same-origin absolute URL under baseUrl', async () => {
+    const target = await redirectCallback({
+      url: `${BASE}/cfp/list`,
+      baseUrl: BASE,
+    })
+    expect(target).toBe(`${BASE}/cfp/list`)
+  })
+
+  it('rejects an off-site absolute URL, falling back to baseUrl', async () => {
+    const target = await redirectCallback({
+      url: 'https://evil.example.com/steal',
+      baseUrl: BASE,
+    })
+    expect(target).toBe(BASE)
+  })
+
+  it('rejects a protocol-relative URL (//evil.com)', async () => {
+    const target = await redirectCallback({
+      url: '//evil.example.com/steal',
+      baseUrl: BASE,
+    })
+    // Does not start with baseUrl → must fall back, never leak to the other host.
+    expect(target).toBe(BASE)
+  })
+
+  it('rejects a look-alike host that only prefixes the base host', async () => {
+    // `https://2026.cloudnativedays.no.evil.com` shares the base as a substring
+    // but not as a prefix of the full origin URL string — must be rejected.
+    const target = await redirectCallback({
+      url: 'https://2026.cloudnativedays.no.evil.com/x',
+      baseUrl: BASE,
+    })
+    expect(target).toBe(BASE)
+  })
+})
+
+describe('redirectCallback — Phase-2 link-result append', () => {
+  it('appends the linkResult param on a same-origin redirect', async () => {
+    const target = await linkResultStore.run({ result: 'linked' }, () =>
+      redirectCallback({ url: `${BASE}/profile`, baseUrl: BASE }),
+    )
+    const url = new URL(target)
+    expect(url.origin).toBe(BASE)
+    expect(url.pathname).toBe('/profile')
+    expect(url.searchParams.get(LINK_RESULT_PARAM)).toBe('linked')
+  })
+
+  it('does NOT append when there is no link result in the store', async () => {
+    const target = await linkResultStore.run({}, () =>
+      redirectCallback({ url: `${BASE}/profile`, baseUrl: BASE }),
+    )
+    expect(target).toBe(`${BASE}/profile`)
+  })
+
+  it('appends onto the safe baseUrl fallback after an off-site attempt', async () => {
+    // Even when the requested URL is rejected, the (safe) baseUrl still carries
+    // the outcome so the profile banner shows — but only ever on baseUrl.
+    const target = await linkResultStore.run({ result: 'already-linked' }, () =>
+      redirectCallback({ url: 'https://evil.example.com', baseUrl: BASE }),
+    )
+    const url = new URL(target)
+    expect(url.origin).toBe(BASE)
+    expect(url.searchParams.get(LINK_RESULT_PARAM)).toBe('already-linked')
+  })
+})
+
+describe('sessionCallback — client-visible shape', () => {
+  const baseSession = {
+    expires: '2099-01-01T00:00:00.000Z',
+    user: { name: 'stale', email: 'stale@old', image: 'old.jpg' },
+  } as unknown as Session
+
+  const token = {
+    sub: 'sub-123',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    picture: 'https://cdn/ada.jpg',
+    speaker: { _id: 'spk-1', isOrganizer: true },
+    account: { provider: 'github', providerAccountId: '42', type: 'oauth' },
+  } as unknown as JWT
+
+  it('lifts speaker + account off the token and trims the user', async () => {
+    const result = await sessionCallback({ session: baseSession, token })
+    expect(result.speaker).toEqual({ _id: 'spk-1', isOrganizer: true })
+    expect(result.account).toEqual({
+      provider: 'github',
+      providerAccountId: '42',
+      type: 'oauth',
+    })
+    expect(result.user).toEqual({
+      sub: 'sub-123',
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      picture: 'https://cdn/ada.jpg',
+    })
+  })
+
+  it('preserves non-user session fields (expires) via spread', async () => {
+    const result = await sessionCallback({ session: baseSession, token })
+    expect(result.expires).toBe('2099-01-01T00:00:00.000Z')
+  })
+
+  it('carries through an undefined speaker/account without throwing', async () => {
+    const bare = { sub: 'sub-9', name: 'X', email: 'x@y', picture: '' } as JWT
+    const result = await sessionCallback({ session: baseSession, token: bare })
+    expect(result.speaker).toBeUndefined()
+    expect(result.account).toBeUndefined()
+    expect(result.user.sub).toBe('sub-9')
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -278,6 +278,82 @@ export async function jwtSignInCallback({
   return token
 }
 
+/**
+ * The `session` callback body: project the JWT's speaker/account and a trimmed
+ * user onto the client-visible session. Extracted (and exported) so the shape
+ * the browser receives is directly unit-testable. Referenced from
+ * `config.callbacks.session`.
+ */
+export async function sessionCallback({
+  session,
+  token,
+}: {
+  session: Session
+  token: JWT
+}): Promise<Session> {
+  const speaker = token.speaker
+  const account = token.account
+
+  return {
+    ...session,
+    user: {
+      sub: token.sub,
+      name: token.name,
+      email: token.email,
+      picture: token.picture,
+    },
+    speaker,
+    account,
+  } as Session
+}
+
+/**
+ * The `redirect` callback body. Extracted (and exported) so the security-
+ * critical OPEN-REDIRECT guard (`url.startsWith(baseUrl)`) and the Phase-2
+ * link-result param append are directly unit-testable. Referenced from
+ * `config.callbacks.redirect`.
+ */
+export async function redirectCallback({
+  url,
+  baseUrl,
+}: {
+  url: string
+  baseUrl: string
+}): Promise<string> {
+  // OPEN-REDIRECT GUARD: only ever return a URL on baseUrl's own origin.
+  // Compare parsed ORIGINS — a bare `url.startsWith(baseUrl)` is unsafe because a
+  // look-alike host such as `https://<base>.evil.com` is a string prefix of the
+  // base and would slip through. Relative URLs resolve onto baseUrl; anything
+  // else (off-site, protocol-relative `//evil`, unparseable) falls back to base.
+  let target: string
+  try {
+    const resolved = new URL(url, baseUrl)
+    target =
+      resolved.origin === new URL(baseUrl).origin
+        ? resolved.toString()
+        : baseUrl
+  } catch {
+    target = baseUrl
+  }
+
+  // Phase 2: append the link outcome (set by the jwt callback in the same
+  // request) so the profile page can show a success / already-linked banner.
+  // `target` is guaranteed same-origin above, so the append is always safe.
+  const { linkResultStore, LINK_RESULT_PARAM } = await import('@/lib/auth-link')
+  const result = linkResultStore.getStore()?.result
+  if (result) {
+    try {
+      const resolved = new URL(target, baseUrl)
+      resolved.searchParams.set(LINK_RESULT_PARAM, result)
+      target = resolved.toString()
+    } catch {
+      // Leave target unchanged on any URL parsing issue.
+    }
+  }
+
+  return target
+}
+
 const config = {
   providers: [
     GitHub({
@@ -305,47 +381,15 @@ const config = {
   },
 
   callbacks: {
-    async session({ session, token }) {
-      const speaker = token.speaker
-      const account = token.account
-
-      return {
-        ...session,
-        user: {
-          sub: token.sub,
-          name: token.name,
-          email: token.email,
-          picture: token.picture,
-        },
-        speaker,
-        account,
-      } as Session
+    async session(params) {
+      return sessionCallback(params)
     },
 
     async jwt(params) {
       return jwtSignInCallback(params)
     },
-    async redirect({ url, baseUrl }) {
-      let target = url.startsWith(baseUrl) ? url : baseUrl
-
-      // Phase 2: append the link outcome (set by the jwt callback in the same
-      // request) so the profile page can show a success / already-linked banner.
-      const { linkResultStore, LINK_RESULT_PARAM } =
-        await import('@/lib/auth-link')
-      const result = linkResultStore.getStore()?.result
-      if (result) {
-        try {
-          const resolved = new URL(target, baseUrl)
-          if (resolved.origin === new URL(baseUrl).origin) {
-            resolved.searchParams.set(LINK_RESULT_PARAM, result)
-            target = resolved.toString()
-          }
-        } catch {
-          // Leave target unchanged on any URL parsing issue.
-        }
-      }
-
-      return target
+    async redirect(params) {
+      return redirectCallback(params)
     },
   },
 } satisfies NextAuthConfig

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -309,8 +309,8 @@ export async function sessionCallback({
 
 /**
  * The `redirect` callback body. Extracted (and exported) so the security-
- * critical OPEN-REDIRECT guard (`url.startsWith(baseUrl)`) and the Phase-2
- * link-result param append are directly unit-testable. Referenced from
+ * critical OPEN-REDIRECT guard (same-origin check on the parsed URL) and the
+ * Phase-2 link-result param append are directly unit-testable. Referenced from
  * `config.callbacks.redirect`.
  */
 export async function redirectCallback({


### PR DESCRIPTION
**Security fix** surfaced while implementing the "testable NextAuth callbacks" item of the auth test-hardening epic (#451). The test written to pin the open-redirect guard immediately caught a real hole.

## The bug
The `redirect` callback chose the post-login/logout destination with:

```ts
let target = url.startsWith(baseUrl) ? url : baseUrl
```

`startsWith` is a **string-prefix** check. A look-alike host is a string prefix of the base:

```
'https://2026.cloudnativedays.no.evil.com/x'.startsWith('https://2026.cloudnativedays.no') === true
```

…so the callback returns the **attacker URL**. This is an open redirect reachable via a crafted `?callbackUrl=` (phishing / auth-flow token-leak vector). Every `callbackUrl` flow in the app funnels through this one callback, so the weak guard undermined them all centrally.

## The fix
Compare parsed **origins**, resolving relative URLs onto `baseUrl`:

```ts
const resolved = new URL(url, baseUrl)
target = resolved.origin === new URL(baseUrl).origin ? resolved.toString() : baseUrl
```

- relative (`/cfp/list`) → allowed (resolves same-origin)
- off-site absolute, protocol-relative (`//evil`), look-alike host, unparseable → fall back to `baseUrl`

## Test hardening (the #451 item)
The inline `session` / `redirect` callbacks lived in `config.callbacks`, which is handed to the **globally-mocked** `next-auth` — so their real bodies never executed under test. Extracted them into exported `sessionCallback` / `redirectCallback` (mirroring the existing `jwtSignInCallback`) and added `callbacks.test.ts`:

- open-redirect guard incl. the look-alike-host case **that caught this bug**, off-site, and protocol-relative
- Phase-2 `linkResult` append (same-origin only; safe-baseUrl fallback still carries the outcome)
- `sessionCallback` projection shape (trimmed user + speaker/account off the JWT, preserved `expires`, undefined speaker/account tolerated)

## Notes
- No behavioural change for legitimate internal redirects (relative paths and same-origin absolutes are preserved, normalised via `URL.toString()`).
- Full suite green; auth.ts coverage rises (callbacks now execute).
- Flagging for **adversarial security review** per our auth-PR discipline — this touches the auth redirect path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an open-redirect vulnerability in the NextAuth `redirect` callback where a bare `url.startsWith(baseUrl)` check could be bypassed by a look-alike host (e.g. `https://2026.cloudnativedays.no.evil.com`) that is a string prefix of the real origin. The fix replaces the string comparison with a parsed-origin comparison via the `URL` constructor.

- **Security fix (`src/lib/auth.ts`):** `redirectCallback` now resolves the input URL against `baseUrl` and compares parsed origins; relative paths, off-site absolutes, protocol-relative URLs, and malformed inputs are all handled correctly. The `sessionCallback` body is extracted into a named export in the same change.
- **Test hardening (`callbacks.test.ts`):** New unit tests cover the four critical redirect cases (same-origin, off-site, protocol-relative, look-alike host) plus the Phase-2 link-result append and the session projection shape; callbacks that previously only ran against the globally-mocked `next-auth` are now directly exercisable.

<h3>Confidence Score: 4/5</h3>

The redirect fix is correct and well-tested for the attack vectors that motivated it; safe to merge with a small test gap to address.

The core origin-comparison logic is sound and handles all documented attack vectors. The only gap is that relative URL inputs — the most common real-world callbackUrl — have no corresponding test, even though the PR description explicitly names them as a supported case. The production code path for relative URLs is correct, but the missing test leaves a regression surface unguarded.

__tests__/lib/auth/callbacks.test.ts — add a test for a relative URL input (e.g. `/cfp/list`) to complete the redirect-guard coverage described in the PR.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/auth.ts | Extracts `sessionCallback` and `redirectCallback` into exported named functions; replaces the unsafe `url.startsWith(baseUrl)` open-redirect guard with a parsed-origin comparison — fix is correct and handles look-alike hosts, protocol-relative URLs, and unparseable inputs. |
| __tests__/lib/auth/callbacks.test.ts | New test file covering the open-redirect guard and link-result append in `redirectCallback`, plus the session-projection shape in `sessionCallback`; covers the critical attack vectors but is missing a test for relative-URL inputs, which is an explicitly documented supported case. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["redirectCallback(url, baseUrl)"] --> B["try: new URL(url, baseUrl)"]
    B -->|parse succeeds| C{"resolved.origin\n=== new URL(baseUrl).origin?"}
    B -->|parse throws| D["target = baseUrl"]
    C -->|yes — same-origin| E["target = resolved.toString()"]
    C -->|no — off-site / look-alike| D
    E --> F["import linkResultStore"]
    D --> F
    F --> G{"linkResultStore\n.getStore()?.result?"}
    G -->|no result| H["return target"]
    G -->|result exists| I["try: append LINK_RESULT_PARAM"]
    I -->|success| J["target = resolved.toString()"]
    I -->|throws| K["leave target unchanged"]
    J --> H
    K --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["redirectCallback(url, baseUrl)"] --> B["try: new URL(url, baseUrl)"]
    B -->|parse succeeds| C{"resolved.origin\n=== new URL(baseUrl).origin?"}
    B -->|parse throws| D["target = baseUrl"]
    C -->|yes — same-origin| E["target = resolved.toString()"]
    C -->|no — off-site / look-alike| D
    E --> F["import linkResultStore"]
    D --> F
    F --> G{"linkResultStore\n.getStore()?.result?"}
    G -->|no result| H["return target"]
    G -->|result exists| I["try: append LINK_RESULT_PARAM"]
    I -->|success| J["target = resolved.toString()"]
    I -->|throws| K["leave target unchanged"]
    J --> H
    K --> H
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): close open-redirect in the Ne..."](https://github.com/cloudnativebergen/website/commit/734f3b025a1dc26110b9b66b260c879848de7078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44873856)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->