### PR TITLE
test(auth): MSW node server for HTTP interception (#451)

### DIFF
--- a/__tests__/lib/profile/github.test.ts
+++ b/__tests__/lib/profile/github.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment node
+ *
+ * Exercises `verifiedEmails` (src/lib/profile/github.ts) THROUGH the MSW node
+ * server (__tests__/mocks/msw). This is the reference test proving HTTP
+ * interception works: the GitHub `/user/emails` call is served by MSW, never
+ * the real network, and per-case overrides via `server.use(...)` drive the
+ * error/edge branches deterministically.
+ */
+import { describe, it, expect } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import type { Account } from 'next-auth'
+import { server } from '../../mocks/msw/server'
+import { verifiedEmails } from '@/lib/profile/github'
+
+const account = {
+  provider: 'github',
+  providerAccountId: '1',
+  type: 'oauth',
+  access_token: 'gho_test-token',
+} as Account
+
+describe('verifiedEmails — GitHub /user/emails via MSW', () => {
+  it('returns only the verified emails from the default handler', async () => {
+    const { error, emails } = await verifiedEmails(account)
+    expect(error).toBeNull()
+    // The default handler returns two verified + one unverified; the unverified
+    // one must be filtered out.
+    expect(emails.map((e) => e.email)).toEqual([
+      'primary@example.com',
+      'secondary@example.com',
+    ])
+    expect(emails.every((e) => e.verified)).toBe(true)
+  })
+
+  it('forwards the OAuth access token as a Bearer credential', async () => {
+    let seenAuth: string | null = null
+    server.use(
+      http.get('https://api.github.com/user/emails', ({ request }) => {
+        seenAuth = request.headers.get('authorization')
+        return HttpResponse.json([
+          { email: 'a@b.com', primary: true, verified: true },
+        ])
+      }),
+    )
+    await verifiedEmails(account)
+    expect(seenAuth).toBe('Bearer gho_test-token')
+  })
+
+  it('returns an error (no throw) on a non-OK response', async () => {
+    server.use(
+      http.get('https://api.github.com/user/emails', () =>
+        HttpResponse.json({ message: 'Bad credentials' }, { status: 401 }),
+      ),
+    )
+    const { error, emails } = await verifiedEmails(account)
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toContain('401')
+    expect(emails).toEqual([])
+  })
+
+  it('returns an error (no throw) when the request fails at the network layer', async () => {
+    server.use(
+      http.get('https://api.github.com/user/emails', () =>
+        HttpResponse.error(),
+      ),
+    )
+    const { error, emails } = await verifiedEmails(account)
+    expect(error).toBeInstanceOf(Error)
+    expect(emails).toEqual([])
+  })
+})

--- a/__tests__/mocks/msw/handlers.ts
+++ b/__tests__/mocks/msw/handlers.ts
@@ -1,0 +1,38 @@
+import { http, HttpResponse } from 'msw'
+
+/**
+ * Default MSW request handlers for the external HTTP the auth/identity and
+ * ticketing paths call. Until now `__tests__/mocks/*` were module ALIASES, not
+ * a network server — GitHub (`/user/emails`), LinkedIn userinfo, and the
+ * Checkin.no GraphQL API weren't intercepted, so any test exercising those
+ * paths would hit the real network. These handlers make those paths
+ * deterministic. Individual tests override a handler with `server.use(...)` to
+ * exercise error/edge responses (see __tests__/lib/profile/github.test.ts).
+ *
+ * The server is registered with `onUnhandledRequest: 'bypass'` (see
+ * vitest.setup.ts), so adding these handlers does NOT change the behaviour of
+ * the ~2000 existing tests that make no outbound requests — it only intercepts
+ * these specific hosts.
+ */
+
+/** A stable, verified GitHub email set returned by the default handler. */
+export const DEFAULT_GITHUB_EMAILS = [
+  { email: 'primary@example.com', primary: true, verified: true },
+  { email: 'secondary@example.com', primary: false, verified: true },
+  { email: 'unverified@example.com', primary: false, verified: false },
+]
+
+export const handlers = [
+  // GitHub verified-emails API (src/lib/profile/github.ts). The OAuth userinfo
+  // only exposes a verified primary email, so the app reads the full verified
+  // set from here to power verified-email account matching.
+  http.get('https://api.github.com/user/emails', () => {
+    return HttpResponse.json(DEFAULT_GITHUB_EMAILS)
+  }),
+
+  // Checkin.no GraphQL ticketing API (src/lib/tickets/graphql-client.ts).
+  // Default to an empty-but-well-formed GraphQL envelope; ticket tests override.
+  http.post('https://api.checkin.no/graphql', () => {
+    return HttpResponse.json({ data: {} })
+  }),
+]

--- a/__tests__/mocks/msw/handlers.ts
+++ b/__tests__/mocks/msw/handlers.ts
@@ -3,11 +3,13 @@ import { http, HttpResponse } from 'msw'
 /**
  * Default MSW request handlers for the external HTTP the auth/identity and
  * ticketing paths call. Until now `__tests__/mocks/*` were module ALIASES, not
- * a network server — GitHub (`/user/emails`), LinkedIn userinfo, and the
- * Checkin.no GraphQL API weren't intercepted, so any test exercising those
- * paths would hit the real network. These handlers make those paths
- * deterministic. Individual tests override a handler with `server.use(...)` to
- * exercise error/edge responses (see __tests__/lib/profile/github.test.ts).
+ * a network server — outbound HTTP (GitHub `/user/emails`, LinkedIn userinfo,
+ * the Checkin.no GraphQL API) wasn't intercepted, so any test exercising those
+ * paths would hit the real network. The handlers below cover the endpoints
+ * currently reached in tests — GitHub `/user/emails` and Checkin.no GraphQL;
+ * add a LinkedIn userinfo handler here when a test first needs one. Individual
+ * tests override a handler with `server.use(...)` to exercise error/edge
+ * responses (see __tests__/lib/profile/github.test.ts).
  *
  * The server is registered with `onUnhandledRequest: 'bypass'` (see
  * vitest.setup.ts), so adding these handlers does NOT change the behaviour of

--- a/__tests__/mocks/msw/server.ts
+++ b/__tests__/mocks/msw/server.ts
@@ -1,0 +1,10 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+/**
+ * MSW node server for HTTP interception in vitest. Started once in
+ * vitest.setup.ts. Tests add per-case behaviour with `server.use(...)` and the
+ * global `afterEach` resets to the default handlers, so overrides never leak
+ * between tests.
+ */
+export const server = setupServer(...handlers)

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,9 +1,19 @@
 import '@testing-library/jest-dom/vitest'
 import dotenv from 'dotenv'
+import { afterAll, afterEach, beforeAll } from 'vitest'
+import { server } from './__tests__/mocks/msw/server'
 
 dotenv.config({ path: ['.env', '.env.local', '.env.test'] })
 
 process.env.INVITATION_TOKEN_SECRET ??= 'test-invitation-token-secret'
+
+// MSW node server for HTTP interception (GitHub /user/emails, Checkin.no
+// GraphQL, …). `onUnhandledRequest: 'bypass'` so the many existing tests that
+// make no outbound requests are unaffected — only the explicitly-handled hosts
+// are intercepted. `resetHandlers` clears any per-test `server.use(...)`.
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 const originalWarn = console.warn
 console.warn = (msg, ...args) => {


### PR DESCRIPTION
Part of the auth/identity test-hardening epic (#451) — the **MSW node server** item, the foundation for the standing abuse suite and the login e2e.

## Problem
`__tests__/mocks/*` were module **aliases**, not a network server. The external HTTP the auth/identity and ticketing paths make — GitHub `/user/emails` (verified-email account matching), LinkedIn userinfo, Checkin.no GraphQL — was **not intercepted**, so any test reaching those paths would hit the real network (non-deterministic, offline-fragile).

## What this adds
`msw` is **already a devDependency** (used by Storybook) — no new dep.

- `__tests__/mocks/msw/handlers.ts` — default handlers for GitHub `/user/emails` and the Checkin.no GraphQL endpoint.
- `__tests__/mocks/msw/server.ts` — `setupServer(...handlers)`.
- `vitest.setup.ts` — `listen` / `resetHandlers` / `close`, with **`onUnhandledRequest: 'bypass'`** so the ~2000 existing tests that make no outbound requests are completely unaffected; only the explicitly-handled hosts are intercepted.

## Reference test
`__tests__/lib/profile/github.test.ts` drives `verifiedEmails()` through the server — default verified-set filtering, Bearer-token forwarding, non-OK (401) response, and network-layer failure — proving both interception and per-test `server.use(...)` overrides work. (Also gives `src/lib/profile/github.ts` its first coverage.)

## Safety
- Full local suite: no regressions. Every failing file is the pre-existing `@digitalbazaar/vc` missing-dep (openbadges crypto), unrelated to this change and green on CI.
- The two intercepted hosts have no existing outbound-fetch tests; the inbound checkin **webhook** test mocks its own collaborators and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up an MSW node server as the HTTP interception layer for the Vitest suite, replacing the module-alias approach that left outbound GitHub and Checkin.no requests hitting the real network. The change is non-breaking: `onUnhandledRequest: 'bypass'` ensures the ~2000 existing tests are completely unaffected.

- `__tests__/mocks/msw/` adds default handlers for the GitHub `/user/emails` and Checkin.no GraphQL endpoints, plus a shared `setupServer` export; `vitest.setup.ts` wires up `listen`/`resetHandlers`/`close` globally.
- `__tests__/lib/profile/github.test.ts` is a reference test that exercises `verifiedEmails()` end-to-end through MSW, covering the happy path, Bearer-token forwarding, non-OK HTTP responses, and network-layer failures — proving both interception and per-test `server.use(...)` overrides work correctly.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are purely test infrastructure, isolated from production code paths.

The implementation is correct — lifecycle hooks, handler reset, and `onUnhandledRequest: 'bypass'` are all wired up properly. The one minor issue is a misleading comment in `handlers.ts` that implies LinkedIn is now intercepted when it isn't; a future author writing a LinkedIn test could be misled into thinking their requests will be intercepted. No production or test-correctness regressions are introduced.

The `handlers.ts` comment should be clarified before it causes confusion when a LinkedIn handler is eventually added.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| __tests__/lib/profile/github.test.ts | New reference test for `verifiedEmails` driven through MSW; covers happy path, Bearer-token forwarding, non-OK response, and network-layer failure. Logic is correct and test isolation relies properly on the global `afterEach(resetHandlers)` from `vitest.setup.ts`. |
| __tests__/mocks/msw/handlers.ts | Provides default MSW handlers for GitHub `/user/emails` and Checkin.no GraphQL. The jsdoc comment implies LinkedIn is also now intercepted, but no LinkedIn handler is added; minor documentation inaccuracy flagged. |
| __tests__/mocks/msw/server.ts | Minimal `setupServer` wrapper; correctly exported for both the global setup file and individual test overrides via `server.use(...).` |
| vitest.setup.ts | Adds `beforeAll`/`afterEach`/`afterAll` lifecycle hooks with `onUnhandledRequest: 'bypass'`; non-breaking and correctly scoped. Existing tests are unaffected. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test
    participant S as MSW Server
    participant G as github.ts (verifiedEmails)
    participant GH as GitHub API (intercepted)
    participant LI as LinkedIn (bypassed)

    Note over S: beforeAll — server.listen({ onUnhandledRequest: 'bypass' })

    T->>G: verifiedEmails(account)
    G->>GH: fetch /user/emails (Bearer token)
    S-->>GH: intercept — return DEFAULT_GITHUB_EMAILS
    GH-->>G: "[{email, verified}, ...]"
    G-->>T: "{error: null, emails: [verified only]}"

    Note over T: per-test override
    T->>S: server.use(http.get(..., customHandler))
    T->>G: verifiedEmails(account)
    G->>GH: fetch /user/emails
    S-->>GH: intercept — custom response (e.g. 401)
    GH-->>G: 401 Unauthorized
    G-->>T: "{error: Error('401'), emails: []}"

    Note over S: afterEach — server.resetHandlers()
    Note over S: afterAll — server.close()

    Note over LI: No handler → request bypasses MSW to real network
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test
    participant S as MSW Server
    participant G as github.ts (verifiedEmails)
    participant GH as GitHub API (intercepted)
    participant LI as LinkedIn (bypassed)

    Note over S: beforeAll — server.listen({ onUnhandledRequest: 'bypass' })

    T->>G: verifiedEmails(account)
    G->>GH: fetch /user/emails (Bearer token)
    S-->>GH: intercept — return DEFAULT_GITHUB_EMAILS
    GH-->>G: "[{email, verified}, ...]"
    G-->>T: "{error: null, emails: [verified only]}"

    Note over T: per-test override
    T->>S: server.use(http.get(..., customHandler))
    T->>G: verifiedEmails(account)
    G->>GH: fetch /user/emails
    S-->>GH: intercept — custom response (e.g. 401)
    GH-->>G: 401 Unauthorized
    G-->>T: "{error: Error('401'), emails: []}"

    Note over S: afterEach — server.resetHandlers()
    Note over S: afterAll — server.close()

    Note over LI: No handler → request bypasses MSW to real network
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(auth): stand up MSW node server for..."](https://github.com/cloudnativebergen/website/commit/0166ddd8c39a4c9daeec33b35fa8d9a08e77eaa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44901743)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->