### PR TITLE
fix(mobile): privacy-table clip + sponsor-prospectus grid at 375px

### DIFF
--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -989,7 +989,7 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                       its purpose and legal requirements:
                     </p>
 
-                    <div className="my-6 overflow-hidden rounded-lg border border-gray-200 shadow-sm dark:border-gray-700 print:overflow-visible print:rounded-none print:border-black print:shadow-none">
+                    <div className="my-6 overflow-x-auto rounded-lg border border-gray-200 shadow-sm dark:border-gray-700 print:overflow-visible print:rounded-none print:border-black print:shadow-none">
                       <table className="w-full border-collapse print:text-sm">
                         <thead>
                           <tr className="bg-gray-50 dark:bg-gray-800 print:bg-white">

--- a/src/components/sponsor/SponsorProspectus.tsx
+++ b/src/components/sponsor/SponsorProspectus.tsx
@@ -100,7 +100,7 @@ export function SponsorProspectus({
         {conference.vanityMetrics && conference.vanityMetrics.length > 0 && (
           <Container className="relative z-10 mt-16">
             <div className="rounded-xl border border-gray-200 bg-white p-2 shadow-lg dark:border-gray-700 dark:bg-gray-900">
-              <div className="grid grid-cols-3 gap-1">
+              <div className="grid grid-cols-2 gap-1 sm:grid-cols-3">
                 {conference.vanityMetrics.map((metric, index) => (
                   <div
                     key={metric.label}


### PR DESCRIPTION
A deliberate **375px mobile audit** across the public-facing surface and the whole authenticated admin/CRM surface. Headline: the codebase is genuinely mobile-first and holds up well — only **two** verified breakages, both on the public marketing surface.

## Fixes

**1. Privacy data-retention table was clipped (not scrollable)** — `src/app/(main)/privacy/page.tsx`
The 3-column `w-full` table (each cell `px-6`) sits in a wrapper that was `overflow-hidden`. At 375px the table overflows and the third column ("Legal Basis & Reason") is **cut off with no way to scroll to it**. Changed the wrapper to `overflow-x-auto` so the table scrolls inside its own container (the correct pattern for wide content). `print:overflow-visible` is preserved.

**2. Sponsor prospectus vanity-metrics grid never collapsed** — `src/components/sponsor/SponsorProspectus.tsx`
`grid-cols-3` with no responsive collapse → the `text-[10px]` uppercase labels clip at ~90px/cell on the public `/sponsor` page. Now `grid-cols-2 sm:grid-cols-3`, matching the Hero / ProgramHighlights stat grids.

## Audit scope & result
- **Public pages / shared components** — front page, hero, header/footer, featured speakers, program, sponsors, tickets, pricing, photo grid, carousels: all already `grid-cols-1` base with `sm:`/`lg:` bumps, headings down-scaled (`text-4xl … sm:text-6xl`), shelves use `overflow-x-auto`. Clean apart from the two above.
- **Admin / sponsor-CRM / CFP** — the #463/#465 sponsor redesign, data tables (mobile card fallbacks + `overflow-x-auto`), dialogs (full-width on mobile), filter bar, and kanban (intentional snap-scroll) all verified responsive at 375px. **No confirmed breakage.**
- One borderline item (`AudienceFeedbackPanel` edit-mode 3-col input grid) was left alone — it very likely fits and warrants a screenshot before any change rather than a speculative fix.

No logic changes — Tailwind classNames only; prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two verified 375px mobile breakages — neither change touches logic, only Tailwind class names. Both fixes are minimal and match existing responsive patterns in the codebase.

- **Privacy page** (`privacy/page.tsx`): the 3-column data-retention table wrapper's `overflow-hidden` is replaced with `overflow-x-auto`, enabling horizontal scrolling on narrow viewports while preserving the existing `print:overflow-visible` modifier.
- **Sponsor prospectus** (`SponsorProspectus.tsx`): the vanity-metrics grid gains a `grid-cols-2` base with `sm:grid-cols-3`, consistent with the Hero and ProgramHighlights stat grids; this prevents the three cells from being squashed to ~90px each at 375px.

<h3>Confidence Score: 5/5</h3>

Safe to merge — two isolated Tailwind class tweaks with no logic changes and no risk of regression.

Both changes are single-class substitutions that fix confirmed mobile clipping with no behavioural side-effects. The privacy fix swaps overflow-hidden for overflow-x-auto while keeping the print:overflow-visible modifier intact. The sponsor grid fix adds a grid-cols-2 base breakpoint that matches the established responsive pattern elsewhere in the codebase. Nothing in the rendering pipeline, data flow, or print stylesheet is disrupted.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(main)/privacy/page.tsx | Single-class change: `overflow-hidden` → `overflow-x-auto` on the data-retention table wrapper; `print:overflow-visible` preserved. Correct fix for mobile clipping. |
| src/components/sponsor/SponsorProspectus.tsx | Single-class change: `grid-cols-3` → `grid-cols-2 sm:grid-cols-3` on the vanity-metrics grid. Aligns with responsive pattern used in Hero/ProgramHighlights; no logic affected. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[375px viewport] --> B{Which component?}
    B --> C[Privacy table wrapper]
    B --> D[SponsorProspectus vanity grid]

    C --> C1["Before: overflow-hidden\n(3rd column clipped, no scroll)"]
    C --> C2["After: overflow-x-auto\n(horizontal scroll available)"]
    C2 --> C3["print:overflow-visible preserved"]

    D --> D1["Before: grid-cols-3\n(~90px/cell, labels clip)"]
    D --> D2["After: grid-cols-2\n(2 cols on mobile, 3 on sm+)"]
    D2 --> D3["Matches Hero / ProgramHighlights pattern"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[375px viewport] --> B{Which component?}
    B --> C[Privacy table wrapper]
    B --> D[SponsorProspectus vanity grid]

    C --> C1["Before: overflow-hidden\n(3rd column clipped, no scroll)"]
    C --> C2["After: overflow-x-auto\n(horizontal scroll available)"]
    C2 --> C3["print:overflow-visible preserved"]

    D --> D1["Before: grid-cols-3\n(~90px/cell, labels clip)"]
    D --> D2["After: grid-cols-2\n(2 cols on mobile, 3 on sm+)"]
    D2 --> D3["Matches Hero / ProgramHighlights pattern"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(mobile): stop 375px clipping on priv..."](https://github.com/cloudnativebergen/website/commit/e9ce085d465b7b7933c7cd6798b70e7d40868948) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44902199)</sub>

<!-- /greptile_comment -->