### PR TITLE
feat(pwa): platform-aware /install instructions page (#455)

### DIFF
--- a/__tests__/components/pwa/InstallGuidePanel.test.tsx
+++ b/__tests__/components/pwa/InstallGuidePanel.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Behavioural tests for the presentational install panels
+ * (src/components/pwa/InstallGuide.tsx `InstallGuidePanel`). The pure
+ * platform -> view mapping is covered in installView.test.ts; this pins that
+ * each resolved view renders the right guidance and that the Chromium view's
+ * button invokes the install callback.
+ */
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { InstallGuidePanel } from '@/components/pwa/InstallGuide'
+
+afterEach(cleanup)
+
+describe('InstallGuidePanel', () => {
+  it('installed: confirms and shows no install control', () => {
+    render(<InstallGuidePanel view="installed" />)
+    expect(screen.getByText(/you.?re all set/i)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /install/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('chromium: renders an Install button that invokes onInstall', () => {
+    const onInstall = vi.fn()
+    render(<InstallGuidePanel view="chromium" onInstall={onInstall} />)
+    const button = screen.getByRole('button', {
+      name: /install cloud native days/i,
+    })
+    fireEvent.click(button)
+    expect(onInstall).toHaveBeenCalledOnce()
+  })
+
+  it('ios-safari: shows the three-step Add-to-Home-Screen walkthrough', () => {
+    render(<InstallGuidePanel view="ios-safari" />)
+    expect(screen.getByText(/add to your home screen/i)).toBeInTheDocument()
+    // Three ordered steps.
+    expect(screen.getAllByRole('listitem').length).toBeGreaterThanOrEqual(3)
+    expect(screen.getByLabelText('Share')).toBeInTheDocument()
+  })
+
+  it('ios-other: tells the user to open in Safari', () => {
+    render(<InstallGuidePanel view="ios-other" />)
+    expect(screen.getByText(/open in safari to install/i)).toBeInTheDocument()
+  })
+
+  it('desktop-generic: points at the browser install affordance', () => {
+    render(<InstallGuidePanel view="desktop-generic" />)
+    expect(screen.getByText(/install from your browser/i)).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/pwa/detectBrowser.test.ts
+++ b/__tests__/components/pwa/detectBrowser.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for detectBrowser (src/components/pwa/installView.ts) — the client UA
+ * sniffing that decides which install COPY the `/install` page shows. The key
+ * correctness property: iOS in-app webviews (Facebook, Instagram, …) carry a
+ * "Safari" token but CANNOT Add-to-Home-Screen, so they must NOT be classified
+ * as Safari (they should get the "open in Safari" guidance instead).
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { detectBrowser } from '@/components/pwa/installView'
+
+function setUA(ua: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  })
+}
+
+const UA = {
+  iosSafari:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  iosChrome:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0 Mobile/15E148 Safari/604.1',
+  iosFacebook:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1 [FBAN/FBIOS;FBAV/440.0]',
+  desktopChrome:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+  desktopSafari:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+}
+
+afterEach(() => {
+  setUA('') // reset between cases
+})
+
+describe('detectBrowser', () => {
+  it('classifies real iOS Safari as iOS + Safari', () => {
+    setUA(UA.iosSafari)
+    expect(detectBrowser()).toEqual({ isIOS: true, isSafari: true })
+  })
+
+  it('classifies iOS Chrome (CriOS) as iOS but NOT Safari', () => {
+    setUA(UA.iosChrome)
+    expect(detectBrowser()).toEqual({ isIOS: true, isSafari: false })
+  })
+
+  it('does NOT treat an iOS in-app webview (Facebook) as Safari', () => {
+    setUA(UA.iosFacebook)
+    const result = detectBrowser()
+    expect(result.isIOS).toBe(true)
+    // Even though the UA carries "Safari" + "Version/", the FBAN token means
+    // it cannot Add-to-Home-Screen → must not be Safari.
+    expect(result.isSafari).toBe(false)
+  })
+
+  it('classifies desktop Chrome as neither iOS nor Safari', () => {
+    setUA(UA.desktopChrome)
+    expect(detectBrowser()).toEqual({ isIOS: false, isSafari: false })
+  })
+
+  it('classifies desktop Safari as Safari', () => {
+    setUA(UA.desktopSafari)
+    // Note: the Mac-vs-iPad split relies on touch support, which jsdom always
+    // reports as present, so isIOS is not asserted here (it is false on a real
+    // non-touch Mac). The meaningful signal for desktop Safari is isSafari.
+    expect(detectBrowser().isSafari).toBe(true)
+  })
+})

--- a/__tests__/components/pwa/installView.test.ts
+++ b/__tests__/components/pwa/installView.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the pure platform -> install-view mapping that drives the
+ * `/install` page (src/components/pwa/installView.ts). Kept free of React so
+ * every state — including the precedence rules between them — is pinned.
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveInstallView } from '@/components/pwa/installView'
+
+const base = {
+  platform: null as 'chromium' | 'ios' | null,
+  isStandalone: false,
+  isIOS: false,
+  isSafari: false,
+}
+
+describe('resolveInstallView', () => {
+  it('shows the installed state whenever running standalone (wins over all)', () => {
+    expect(
+      resolveInstallView({ ...base, isStandalone: true, platform: 'chromium' }),
+    ).toBe('installed')
+    expect(
+      resolveInstallView({
+        ...base,
+        isStandalone: true,
+        isIOS: true,
+        isSafari: true,
+      }),
+    ).toBe('installed')
+  })
+
+  it('prefers the Chromium prompt when one was captured', () => {
+    expect(resolveInstallView({ ...base, platform: 'chromium' })).toBe(
+      'chromium',
+    )
+  })
+
+  it('shows the iOS Safari Add-to-Home-Screen steps', () => {
+    expect(
+      resolveInstallView({
+        ...base,
+        platform: 'ios',
+        isIOS: true,
+        isSafari: true,
+      }),
+    ).toBe('ios-safari')
+  })
+
+  it('tells iOS non-Safari users to open in Safari (cannot install)', () => {
+    expect(
+      resolveInstallView({
+        ...base,
+        platform: 'ios',
+        isIOS: true,
+        isSafari: false,
+      }),
+    ).toBe('ios-other')
+  })
+
+  it('treats a detected iOS device as iOS even if platform is still null', () => {
+    // Provider may not have marked platform yet on the first render.
+    expect(resolveInstallView({ ...base, isIOS: true, isSafari: true })).toBe(
+      'ios-safari',
+    )
+    expect(resolveInstallView({ ...base, isIOS: true, isSafari: false })).toBe(
+      'ios-other',
+    )
+  })
+
+  it('falls back to generic desktop guidance otherwise', () => {
+    expect(resolveInstallView(base)).toBe('desktop-generic')
+    expect(
+      resolveInstallView({ ...base, isSafari: true }), // desktop Safari
+    ).toBe('desktop-generic')
+  })
+})

--- a/src/app/(main)/install/page.tsx
+++ b/src/app/(main)/install/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next'
+import { BackgroundImage } from '@/components/BackgroundImage'
+import { Container } from '@/components/Container'
+import { InstallGuide } from '@/components/pwa/InstallGuide'
+import { canonicalAlternates } from '@/lib/seo/canonical'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Install the app - Cloud Native Days Norway',
+    description:
+      'Install Cloud Native Days on your phone or computer for fast, full-screen, offline-ready access to the schedule — with step-by-step instructions for your device.',
+    alternates: await canonicalAlternates('/install'),
+  }
+}
+
+export default function InstallPage() {
+  return (
+    <div className="relative py-20 sm:pt-36 sm:pb-24">
+      <BackgroundImage className="-top-36 -bottom-14" />
+      <Container className="relative">
+        <div className="mx-auto max-w-2xl text-center">
+          <h1 className="font-jetbrains text-4xl font-bold tracking-tighter text-brand-cloud-blue sm:text-6xl dark:text-blue-400">
+            Get the app
+          </h1>
+          <p className="font-inter mt-6 text-lg text-brand-slate-gray dark:text-gray-300">
+            Add Cloud Native Days to your device for a faster, full-screen,
+            offline-ready experience. Follow the steps for your browser below.
+          </p>
+        </div>
+        <div className="mt-12">
+          <InstallGuide />
+        </div>
+      </Container>
+    </div>
+  )
+}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -109,21 +109,12 @@ export interface UserMenuProps {
  * accessible and focus-visible; dark-mode and mobile aware.
  */
 export function UserMenu({ name, picture, speaker, account }: UserMenuProps) {
-  const { canInstall, platform, promptInstall, requestHint } = usePwaInstall()
+  const { canInstall } = usePwaInstall()
 
   const isOrganizer = Boolean(speaker?.isOrganizer)
   const slug = speaker?.slug
   const provider = account?.provider
   const providerMeta = provider ? PROVIDER_META[provider] : undefined
-
-  const handleInstall = () => {
-    if (platform === 'ios') {
-      // iOS Safari has no install prompt — surface the A2HS hint instead.
-      requestHint()
-      return
-    }
-    void promptInstall()
-  }
 
   return (
     <Menu as="div" className="relative">
@@ -173,16 +164,11 @@ export function UserMenu({ name, picture, speaker, account }: UserMenuProps) {
         <Divider />
 
         {canInstall && (
-          <MenuItem>
-            <button
-              type="button"
-              onClick={handleInstall}
-              className={itemClasses}
-            >
-              <ArrowDownTrayIcon className="h-5 w-5 shrink-0 text-gray-400 dark:text-gray-500" />
-              <span className="flex-1">Install app</span>
-            </button>
-          </MenuItem>
+          <LinkItem
+            href="/install"
+            label="Install app"
+            icon={ArrowDownTrayIcon}
+          />
         )}
 
         {providerMeta && (

--- a/src/components/pwa/InstallGuide.stories.tsx
+++ b/src/components/pwa/InstallGuide.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { InstallGuidePanel } from './InstallGuide'
+
+const meta = {
+  title: 'Components/PWA/InstallGuidePanel',
+  component: InstallGuidePanel,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Presentational, platform-aware install guidance rendered on the `/install` page. The `InstallGuide` container resolves which view to show from the shared install capability (`usePwaInstall`) plus light UA detection; this pure panel renders one resolved view so every state is inspectable in isolation.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    onInstall: fn(),
+  },
+  argTypes: {
+    view: {
+      control: 'radio',
+      options: [
+        'installed',
+        'chromium',
+        'ios-safari',
+        'ios-other',
+        'desktop-generic',
+      ],
+      description: 'Which resolved install view to render',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-lg ring-1 ring-gray-900/5 sm:p-8 dark:bg-gray-800 dark:ring-white/10">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InstallGuidePanel>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Chromium (Android / desktop): a real one-tap Install button. */
+export const Chromium: Story = {
+  args: { view: 'chromium' },
+}
+
+/** iOS Safari: the manual Add-to-Home-Screen walkthrough. */
+export const IOSSafari: Story = {
+  args: { view: 'ios-safari' },
+}
+
+/** iOS in a non-Safari browser: cannot install, open in Safari. */
+export const IOSOther: Story = {
+  args: { view: 'ios-other' },
+}
+
+/** Desktop / other: best-effort browser-menu guidance. */
+export const DesktopGeneric: Story = {
+  args: { view: 'desktop-generic' },
+}
+
+/** Already installed / running standalone. */
+export const Installed: Story = {
+  args: { view: 'installed' },
+}

--- a/src/components/pwa/InstallGuide.tsx
+++ b/src/components/pwa/InstallGuide.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import {
+  ArrowDownTrayIcon,
+  ArrowUpOnSquareIcon,
+  CheckCircleIcon,
+  PlusSmallIcon,
+  BoltIcon,
+  WifiIcon,
+  DevicePhoneMobileIcon,
+} from '@heroicons/react/24/outline'
+import { usePwaInstall } from './PwaInstallProvider'
+import {
+  detectBrowser,
+  resolveInstallView,
+  type InstallView,
+} from './installView'
+
+/** Why someone would install — shown above the manual/actionable flows. */
+function Benefits() {
+  const items = [
+    {
+      icon: BoltIcon,
+      text: 'Launches full-screen, straight from your home screen',
+    },
+    { icon: WifiIcon, text: 'Works offline — the schedule stays available' },
+    {
+      icon: DevicePhoneMobileIcon,
+      text: 'Enables push notifications for schedule changes (iOS: install first)',
+    },
+  ]
+  return (
+    <ul className="mt-6 space-y-3 text-left">
+      {items.map(({ icon: Icon, text }) => (
+        <li key={text} className="flex items-start gap-3">
+          <Icon
+            className="mt-0.5 size-5 flex-none text-brand-cloud-blue"
+            aria-hidden="true"
+          />
+          <span className="text-sm text-gray-600 dark:text-gray-300">
+            {text}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/** One numbered step in the iOS Add-to-Home-Screen walkthrough. */
+function Step({ n, children }: { n: number; children: ReactNode }) {
+  return (
+    <li className="flex items-start gap-4">
+      <span
+        className="flex size-8 flex-none items-center justify-center rounded-full bg-brand-cloud-blue/10 text-sm font-bold text-brand-cloud-blue dark:bg-brand-cloud-blue/20"
+        aria-hidden="true"
+      >
+        {n}
+      </span>
+      <span className="pt-1 text-sm text-gray-700 dark:text-gray-200">
+        {children}
+      </span>
+    </li>
+  )
+}
+
+export interface InstallGuidePanelProps {
+  view: InstallView
+  /** Invoked by the Chromium Install button. */
+  onInstall?: () => void
+}
+
+/**
+ * Presentational install guidance for a resolved {@link InstallView}. Free of
+ * any browser-event or context access so every state can be rendered directly
+ * (Storybook, tests). The container {@link InstallGuide} picks the view.
+ */
+export function InstallGuidePanel({ view, onInstall }: InstallGuidePanelProps) {
+  if (view === 'installed') {
+    return (
+      <div className="text-center">
+        <CheckCircleIcon
+          className="mx-auto size-14 text-green-500"
+          aria-hidden="true"
+        />
+        <h2 className="mt-4 text-xl font-bold text-gray-900 dark:text-white">
+          You&rsquo;re all set
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          Cloud Native Days is installed. Launch it from your home screen or app
+          launcher any time.
+        </p>
+      </div>
+    )
+  }
+
+  if (view === 'chromium') {
+    return (
+      <div className="text-center">
+        <div className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-brand-cloud-blue/10 text-brand-cloud-blue dark:bg-brand-cloud-blue/20">
+          <ArrowDownTrayIcon className="size-7" aria-hidden="true" />
+        </div>
+        <h2 className="mt-4 text-xl font-bold text-gray-900 dark:text-white">
+          Install the app
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          One tap adds Cloud Native Days to your device.
+        </p>
+        <button
+          type="button"
+          onClick={onInstall}
+          className="mt-6 inline-flex items-center gap-2 rounded-xl bg-brand-cloud-blue px-6 py-3 text-base font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+        >
+          <ArrowDownTrayIcon className="size-5" aria-hidden="true" />
+          Install Cloud Native Days
+        </button>
+        <Benefits />
+      </div>
+    )
+  }
+
+  if (view === 'ios-safari') {
+    return (
+      <div>
+        <h2 className="text-center text-xl font-bold text-gray-900 dark:text-white">
+          Add to your Home Screen
+        </h2>
+        <p className="mt-2 text-center text-sm text-gray-600 dark:text-gray-300">
+          iOS installs from Safari&rsquo;s Share menu — it only takes three
+          taps.
+        </p>
+        <ol className="mt-6 space-y-4">
+          <Step n={1}>
+            Tap the{' '}
+            <span className="inline-flex items-center gap-1 font-semibold text-gray-900 dark:text-white">
+              Share
+              <ArrowUpOnSquareIcon
+                className="inline size-4 align-text-bottom"
+                aria-label="Share"
+              />
+            </span>{' '}
+            icon in the Safari toolbar.
+          </Step>
+          <Step n={2}>
+            Scroll down and choose{' '}
+            <span className="inline-flex items-center gap-1 font-semibold text-gray-900 dark:text-white">
+              Add to Home Screen
+              <PlusSmallIcon
+                className="inline size-4 rounded border border-current align-text-bottom"
+                aria-hidden="true"
+              />
+            </span>
+            .
+          </Step>
+          <Step n={3}>
+            Tap{' '}
+            <span className="font-semibold text-gray-900 dark:text-white">
+              Add
+            </span>{' '}
+            in the top-right corner. The app appears on your Home Screen.
+          </Step>
+        </ol>
+        <Benefits />
+      </div>
+    )
+  }
+
+  if (view === 'ios-other') {
+    return (
+      <div className="text-center">
+        <div className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400">
+          <ArrowUpOnSquareIcon className="size-7" aria-hidden="true" />
+        </div>
+        <h2 className="mt-4 text-xl font-bold text-gray-900 dark:text-white">
+          Open in Safari to install
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          On iPhone and iPad, only <span className="font-semibold">Safari</span>{' '}
+          can add apps to your Home Screen. Open this page in Safari, then use
+          Share → Add to Home Screen.
+        </p>
+      </div>
+    )
+  }
+
+  // desktop-generic
+  return (
+    <div className="text-center">
+      <div className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-brand-cloud-blue/10 text-brand-cloud-blue dark:bg-brand-cloud-blue/20">
+        <ArrowDownTrayIcon className="size-7" aria-hidden="true" />
+      </div>
+      <h2 className="mt-4 text-xl font-bold text-gray-900 dark:text-white">
+        Install from your browser
+      </h2>
+      <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+        Look for an <span className="font-semibold">install icon</span> in the
+        address bar, or open your browser menu and choose{' '}
+        <span className="font-semibold">Install Cloud Native Days</span>.
+        Available in Chrome, Edge, and other Chromium browsers.
+      </p>
+      <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+        Firefox and desktop Safari don&rsquo;t support installing this app — you
+        can still use it in the browser, or install it on your phone.
+      </p>
+      <Benefits />
+    </div>
+  )
+}
+
+/**
+ * The `/install` container: reads the shared install capability from
+ * {@link usePwaInstall} (which owns the single `beforeinstallprompt` capture),
+ * adds light UA detection for copy only, and renders the matching
+ * {@link InstallGuidePanel}. On Chromium the button drives the real deferred
+ * prompt; `appinstalled` flips the provider to standalone and this re-renders
+ * into the success state automatically.
+ */
+export function InstallGuide() {
+  const { platform, isStandalone, promptInstall } = usePwaInstall()
+  const [browser, setBrowser] = useState({ isIOS: false, isSafari: false })
+
+  useEffect(() => {
+    // Client-only UA detection (used for copy only); runs once after mount so
+    // SSR and the first client render agree on the neutral default.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- client-only capability detection
+    setBrowser(detectBrowser())
+  }, [])
+
+  const view = resolveInstallView({
+    platform,
+    isStandalone,
+    isIOS: browser.isIOS,
+    isSafari: browser.isSafari,
+  })
+
+  return (
+    <div className="mx-auto max-w-md rounded-2xl bg-white p-6 shadow-lg ring-1 ring-gray-900/5 sm:p-8 dark:bg-gray-800 dark:ring-white/10">
+      <InstallGuidePanel view={view} onInstall={() => void promptInstall()} />
+    </div>
+  )
+}

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -1,6 +1,14 @@
 export { InstallBanner } from './InstallBanner'
 export type { InstallBannerProps } from './InstallBanner'
 export { InstallPrompt } from './InstallPrompt'
+export { InstallGuide, InstallGuidePanel } from './InstallGuide'
+export type { InstallGuidePanelProps } from './InstallGuide'
+export {
+  resolveInstallView,
+  detectBrowser,
+  type InstallView,
+  type InstallViewInput,
+} from './installView'
 export { UpdateBanner } from './UpdateBanner'
 export type { UpdateBannerProps } from './UpdateBanner'
 export { ServiceWorkerRegistrar } from './ServiceWorkerRegistrar'

--- a/src/components/pwa/installView.ts
+++ b/src/components/pwa/installView.ts
@@ -60,9 +60,17 @@ export function detectBrowser(): { isIOS: boolean; isSafari: boolean } {
     (/macintosh/i.test(ua) &&
       typeof document !== 'undefined' &&
       'ontouchend' in document)
-  // Safari's UA contains "Safari" but so do Chrome/Firefox/Edge on iOS; those
-  // add their own tokens (CriOS/FxiOS/EdgiOS) plus Chrome/Android on other OSes.
+  // Safari's UA contains "Safari" but so do many others: Chrome/Firefox/Edge
+  // (CriOS/FxiOS/EdgiOS + Chrome/Android), and in-app webviews (Facebook/
+  // Instagram/WeChat/Line/Google app) which CANNOT Add-to-Home-Screen. Excluding
+  // those routes them to the "open in Safari" guidance instead of A2HS steps
+  // that would not work. A true-standalone-capable Safari also carries a
+  // "Version/" token, which in-app WKWebViews typically omit.
+  const isInAppOrOtherBrowser =
+    /chrome|crios|android|fxios|edgios|edg\/|fban|fbav|instagram|line\/|micromessenger|gsa\//i.test(
+      ua,
+    )
   const isSafari =
-    /safari/i.test(ua) && !/chrome|crios|android|fxios|edgios|edg\//i.test(ua)
+    /safari/i.test(ua) && /version\//i.test(ua) && !isInAppOrOtherBrowser
   return { isIOS, isSafari }
 }

--- a/src/components/pwa/installView.ts
+++ b/src/components/pwa/installView.ts
@@ -1,0 +1,68 @@
+import type { InstallPlatform } from './PwaInstallProvider'
+
+/**
+ * The distinct install experiences `/install` renders. Kept as a pure,
+ * serialisable enum (no React) so the platform → view mapping is unit-testable
+ * and the presentational panels can be driven directly in Storybook.
+ *
+ * - `installed` — already running standalone; show a confirmation, no CTA.
+ * - `chromium` — a `beforeinstallprompt` was captured; show a one-tap Install.
+ * - `ios-safari` — iOS/iPadOS Safari; show the manual Add-to-Home-Screen steps
+ *   (Safari has no install API).
+ * - `ios-other` — iOS in a non-Safari browser, which cannot install a
+ *   standalone PWA; tell the user to open the page in Safari.
+ * - `desktop-generic` — anything else (desktop Chromium before the prompt
+ *   fires, Firefox, desktop Safari…); show best-effort browser-menu guidance.
+ */
+export type InstallView =
+  'installed' | 'chromium' | 'ios-safari' | 'ios-other' | 'desktop-generic'
+
+export interface InstallViewInput {
+  platform: InstallPlatform
+  isStandalone: boolean
+  isIOS: boolean
+  isSafari: boolean
+}
+
+/**
+ * Map the shared install capability (+ light UA hints) to the panel `/install`
+ * should show. Order matters: an already-installed app wins over everything; a
+ * live Chromium prompt beats the manual flows; iOS is split by browser because
+ * only Safari can Add-to-Home-Screen.
+ */
+export function resolveInstallView({
+  platform,
+  isStandalone,
+  isIOS,
+  isSafari,
+}: InstallViewInput): InstallView {
+  if (isStandalone) return 'installed'
+  if (platform === 'chromium') return 'chromium'
+  if (isIOS || platform === 'ios') {
+    return isSafari ? 'ios-safari' : 'ios-other'
+  }
+  return 'desktop-generic'
+}
+
+/**
+ * Client-only browser sniffing used ONLY to choose install COPY (never to gate
+ * the actual `beforeinstallprompt` capture, which lives in PwaInstallProvider).
+ * Returns all-false during SSR so the first client render can refine it.
+ */
+export function detectBrowser(): { isIOS: boolean; isSafari: boolean } {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return { isIOS: false, isSafari: false }
+  }
+  const ua = navigator.userAgent
+  const isIOS =
+    /iphone|ipad|ipod/i.test(ua) ||
+    // iPadOS 13+ reports as desktop Safari; disambiguate via touch support.
+    (/macintosh/i.test(ua) &&
+      typeof document !== 'undefined' &&
+      'ontouchend' in document)
+  // Safari's UA contains "Safari" but so do Chrome/Firefox/Edge on iOS; those
+  // add their own tokens (CriOS/FxiOS/EdgiOS) plus Chrome/Android on other OSes.
+  const isSafari =
+    /safari/i.test(ua) && !/chrome|crios|android|fxios|edgios|edg\//i.test(ua)
+  return { isIOS, isSafari }
+}


### PR DESCRIPTION
Completes the PWA epic (#445) — the **dedicated, discoverable, platform-aware install surface**. It's what "Get the app" CTAs link to, and where the #444 iOS push-enable flow points (push needs an installed PWA first).

## New `/install` route
A public page that resolves the right guidance from the **shared** install capability (`usePwaInstall`, which already owns the single `beforeinstallprompt` capture — **no duplicated event handling**) plus light UA detection used only to pick copy:

| Client | Panel |
|---|---|
| **Chromium** (deferred prompt captured) | one-tap **Install** button wired to the real prompt; `appinstalled` → success state automatically |
| **iOS Safari** | 3-step Add-to-Home-Screen walkthrough (Share → Add to Home Screen → Add) with the iOS Share glyph |
| **iOS non-Safari** | "open in Safari" note (other iOS browsers can't install a standalone PWA) |
| **Already standalone** | installed confirmation, no CTA |
| **Desktop / other** | best-effort browser-menu guidance |

## Structure (matches the existing `InstallBanner`/`InstallPrompt` split)
- `installView.ts` — a **pure** `resolveInstallView()` (platform → view, with precedence rules) + `detectBrowser()`. Unit-tested.
- `InstallGuidePanel` — **presentational**, one view at a time. Storybook story per state + RTL behaviour test (incl. the Install-click wiring).
- `InstallGuide` — the container that reads the hook, detects the browser, and renders the panel.

## Integration
- The user-menu **"Install app"** item now **links to `/install`** instead of duplicating the prompt/hint logic (removes `handleInstall`/`platform`/`promptInstall`/`requestHint` from `UserMenu`).
- `/install` uses `canonicalAlternates()` for its canonical URL, consistent with the other static pages.

## Quality
- Accessible: real `<h2>`/`<ol>` steps, labelled Share glyph, `focus-visible` rings, dark-mode correct.
- Full local suite green (bar the pre-existing `@digitalbazaar/vc` env dep); prettier + eslint clean; `tsc` clean (bar a stale generated `.next/types` entry for a parked #457 route).

### Reviewer note
Worth a quick **visual pass on a real iOS Safari device** (the one thing that can't be fully asserted in CI) — the Storybook `InstallGuidePanel` stories cover every state for desktop review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the dedicated `/install` page that completes the PWA epic — a discoverable, platform-aware install surface that replaces the inline install logic in `UserMenu` and covers Chromium one-tap, iOS Safari walkthrough, iOS non-Safari redirect, standalone confirmation, and desktop fallback states.

- `installView.ts` introduces a pure, unit-tested `resolveInstallView()` + `detectBrowser()` pair; `InstallGuide.tsx` splits container (hook/UA reads) from the presentational `InstallGuidePanel` (directly testable and exercised in Storybook for all five states).
- `UserMenu` is simplified: the `handleInstall`/`requestHint` inline logic is replaced by a single `LinkItem` to `/install`, reducing the menu's surface area and removing duplicated platform branching.
- All five `InstallView` states have both unit tests and Storybook stories; the `resolveInstallView` precedence rules (standalone wins, then Chromium prompt, then iOS split, then fallback) are explicitly covered.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is additive (new route + presentational components) with no mutations to existing data flows beyond the UserMenu simplification.

The new `/install` container always renders `desktop-generic` on SSR and the first client paint because both `platform` (from the provider) and `browser` (from the local `useEffect`) start at their neutral defaults; on a slow iOS Safari connection this briefly shows the wrong guidance. The iOS detection logic is also duplicated between `detectBrowser()` and `PwaInstallProvider.detectIOS()`, creating a quiet divergence risk. Neither blocks the feature, but both are worth addressing before the page gets heavy traffic.

src/components/pwa/InstallGuide.tsx (initial render flash) and src/components/pwa/installView.ts (duplicated iOS detection)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/pwa/installView.ts | Pure platform→view mapping + browser detection; logic is correct but iOS detection partially duplicates PwaInstallProvider's detectIOS(). |
| src/components/pwa/InstallGuide.tsx | Container + presentational component, well-structured; initial render always shows desktop-generic before useEffect runs client-side UA detection. |
| src/app/(main)/install/page.tsx | New /install route — straightforward Server Component with metadata; correct use of canonicalAlternates. |
| src/components/UserMenu.tsx | Cleanly removes handleInstall/requestHint logic, replaces inline button with LinkItem to /install; canInstall guard preserved. |
| __tests__/components/pwa/installView.test.ts | Good coverage of all resolveInstallView branches including precedence rules and the platform-null-but-isIOS-true edge case. |
| __tests__/components/pwa/InstallGuidePanel.test.tsx | Behavioral tests for all five view states; correctly isolates the presentational component from browser context. |
| src/components/pwa/InstallGuide.stories.tsx | Storybook stories cover all five InstallView states; placed under Components/PWA/ consistent with AGENTS.md conventions. |
| src/components/pwa/index.ts | Barrel exports updated correctly for all new symbols; ordering is consistent with existing entries. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/install page loads"] --> B["InstallGuide renders\n(SSR + first paint)"]
    B --> C{{"isStandalone?\n(PwaInstallProvider)"}}
    C -- "true (after useEffect)" --> D["view = installed\n✅ Already set up"]
    C -- "false (initial default)" --> E{{"platform === 'chromium'?\n(PwaInstallProvider)"}}
    E -- "true (after beforeinstallprompt)" --> F["view = chromium\n🔵 One-tap Install button"]
    E -- "false (initial default)" --> G{{"isIOS || platform === 'ios'?\n(detectBrowser + Provider)"}}
    G -- "true (after useEffect)" --> H{{"isSafari?"}}
    H -- "true" --> I["view = ios-safari\n📱 3-step walkthrough"]
    H -- "false" --> J["view = ios-other\n⚠️ Open in Safari"]
    G -- "false (or initial render)" --> K["view = desktop-generic\n💻 Browser menu guidance"]

    style K fill:#fef9c3,stroke:#ca8a04
    style B fill:#dbeafe,stroke:#3b82f6
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["/install page loads"] --> B["InstallGuide renders\n(SSR + first paint)"]
    B --> C{{"isStandalone?\n(PwaInstallProvider)"}}
    C -- "true (after useEffect)" --> D["view = installed\n✅ Already set up"]
    C -- "false (initial default)" --> E{{"platform === 'chromium'?\n(PwaInstallProvider)"}}
    E -- "true (after beforeinstallprompt)" --> F["view = chromium\n🔵 One-tap Install button"]
    E -- "false (initial default)" --> G{{"isIOS || platform === 'ios'?\n(detectBrowser + Provider)"}}
    G -- "true (after useEffect)" --> H{{"isSafari?"}}
    H -- "true" --> I["view = ios-safari\n📱 3-step walkthrough"]
    H -- "false" --> J["view = ios-other\n⚠️ Open in Safari"]
    G -- "false (or initial render)" --> K["view = desktop-generic\n💻 Browser menu guidance"]

    style K fill:#fef9c3,stroke:#ca8a04
    style B fill:#dbeafe,stroke:#3b82f6
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(pwa): platform-aware /install instr..."](https://github.com/cloudnativebergen/website/commit/3679709d595262f6ebf4309ef2c103212285e909) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44904997)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->