### PR TITLE
test(auth): standing abuse suite for provider-link-intent tokens (#451)

### DIFF
--- a/__tests__/lib/auth/auth-link-abuse.test.ts
+++ b/__tests__/lib/auth/auth-link-abuse.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @vitest-environment node
+ *
+ * Standing auth-abuse suite for the provider-link-intent tokens
+ * (src/lib/auth-link.ts `signLinkIntent` / `verifyLinkIntent`) — part of #451.
+ * These HMAC-signed, short-lived tokens bind an already-authenticated speaker to
+ * a provider they are about to link; a forged/replayed/mis-bound one is the
+ * "link-cookie takeover" class this suite guards against permanently.
+ *
+ * Both functions take injectable `secret` and `now`, so every case is pure — no
+ * env or timer mocking. `forge()` mints tokens with an arbitrary payload but a
+ * VALID signature (using the known secret) to prove the SEMANTIC checks reject
+ * bad payloads even past the integrity layer (defence in depth).
+ */
+import { describe, it, expect } from 'vitest'
+import { createHmac } from 'crypto'
+import {
+  signLinkIntent,
+  verifyLinkIntent,
+  LINK_INTENT_TTL_SECONDS,
+} from '@/lib/auth-link'
+
+const SECRET = 'test-auth-secret-long-enough-abcdefghijklmnop'
+const OTHER_SECRET = 'a-different-secret-of-similar-length-qrstuvwx'
+const NOW = 1_700_000_000_000 // fixed epoch ms
+
+const validInput = {
+  speakerId: 'speaker-1',
+  provider: 'github' as const,
+  initiatorSub: 'sub-initiator-1',
+}
+
+/** Build `<payloadB64>.<hmac>` with a VALID signature over an arbitrary body. */
+function forge(payload: Record<string, unknown>, secret = SECRET): string {
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  const sig = createHmac('sha256', secret)
+    .update(payloadB64)
+    .digest('base64url')
+  return `${payloadB64}.${sig}`
+}
+
+describe('signLinkIntent', () => {
+  it('mints a token that round-trips through verifyLinkIntent', () => {
+    const token = signLinkIntent(validInput, SECRET, NOW)
+    const result = verifyLinkIntent(token, 'github', SECRET, NOW)
+    expect(result).toEqual({
+      speakerId: 'speaker-1',
+      provider: 'github',
+      initiatorSub: 'sub-initiator-1',
+    })
+  })
+
+  it('fails closed when AUTH_SECRET is missing', () => {
+    expect(() => signLinkIntent(validInput, undefined, NOW)).toThrow(
+      /AUTH_SECRET/,
+    )
+  })
+
+  it('refuses to mint without a speaker id', () => {
+    expect(() =>
+      signLinkIntent({ ...validInput, speakerId: '' }, SECRET, NOW),
+    ).toThrow(/speaker id/)
+  })
+
+  it('refuses to mint without an initiating session', () => {
+    expect(() =>
+      signLinkIntent({ ...validInput, initiatorSub: '' }, SECRET, NOW),
+    ).toThrow(/initiating session/)
+  })
+
+  it('is non-deterministic (per-mint nonce) so tokens are not reusable structurally', () => {
+    const a = signLinkIntent(validInput, SECRET, NOW)
+    const b = signLinkIntent(validInput, SECRET, NOW)
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('verifyLinkIntent — happy path & expiry boundary', () => {
+  it('accepts a token exactly at its expiry instant', () => {
+    const token = signLinkIntent(validInput, SECRET, NOW)
+    const expMs = (Math.floor(NOW / 1000) + LINK_INTENT_TTL_SECONDS) * 1000
+    // Reject is `exp*1000 < now`, so now === exp*1000 is still valid.
+    expect(verifyLinkIntent(token, 'github', SECRET, expMs)).not.toBeNull()
+    expect(verifyLinkIntent(token, 'github', SECRET, expMs + 1)).toBeNull()
+  })
+})
+
+describe('verifyLinkIntent — abuse cases (all reject to null)', () => {
+  it('rejects a missing / empty token', () => {
+    expect(verifyLinkIntent(undefined, 'github', SECRET, NOW)).toBeNull()
+    expect(verifyLinkIntent(null, 'github', SECRET, NOW)).toBeNull()
+    expect(verifyLinkIntent('', 'github', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects when no secret is configured', () => {
+    const token = signLinkIntent(validInput, SECRET, NOW)
+    expect(verifyLinkIntent(token, 'github', undefined, NOW)).toBeNull()
+  })
+
+  it('rejects malformed tokens (no dot, empty payload, empty sig)', () => {
+    expect(verifyLinkIntent('not-a-token', 'github', SECRET, NOW)).toBeNull()
+    expect(verifyLinkIntent('.sig', 'github', SECRET, NOW)).toBeNull()
+    expect(verifyLinkIntent('payload.', 'github', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects a tampered payload (HMAC no longer matches)', () => {
+    const token = signLinkIntent(validInput, SECRET, NOW)
+    const [payloadB64, sig] = token.split('.')
+    const flipped = (payloadB64[0] === 'A' ? 'B' : 'A') + payloadB64.slice(1)
+    expect(
+      verifyLinkIntent(`${flipped}.${sig}`, 'github', SECRET, NOW),
+    ).toBeNull()
+  })
+
+  it('rejects a tampered signature', () => {
+    const token = signLinkIntent(validInput, SECRET, NOW)
+    const [payloadB64, sig] = token.split('.')
+    const flipped = (sig[0] === 'A' ? 'B' : 'A') + sig.slice(1)
+    expect(
+      verifyLinkIntent(`${payloadB64}.${flipped}`, 'github', SECRET, NOW),
+    ).toBeNull()
+  })
+
+  it('rejects a token forged with the wrong secret', () => {
+    const token = signLinkIntent(validInput, OTHER_SECRET, NOW)
+    expect(verifyLinkIntent(token, 'github', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects an expired token', () => {
+    const token = signLinkIntent(validInput, SECRET, NOW)
+    const wayLater = NOW + (LINK_INTENT_TTL_SECONDS + 60) * 1000
+    expect(verifyLinkIntent(token, 'github', SECRET, wayLater)).toBeNull()
+  })
+
+  it('rejects a token bound to a DIFFERENT provider than expected', () => {
+    const token = signLinkIntent(validInput, SECRET, NOW) // github
+    expect(verifyLinkIntent(token, 'linkedin', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects a validly-signed token carrying a non-linkable provider', () => {
+    const token = forge({
+      speakerId: 'speaker-1',
+      provider: 'evil',
+      initiatorSub: 'sub-1',
+      exp: Math.floor(NOW / 1000) + 60,
+      nonce: 'x',
+    })
+    expect(verifyLinkIntent(token, 'evil', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects a validly-signed token with an empty speakerId', () => {
+    const token = forge({
+      speakerId: '',
+      provider: 'github',
+      initiatorSub: 'sub-1',
+      exp: Math.floor(NOW / 1000) + 60,
+      nonce: 'x',
+    })
+    expect(verifyLinkIntent(token, 'github', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects a validly-signed token missing the initiating session', () => {
+    const token = forge({
+      speakerId: 'speaker-1',
+      provider: 'github',
+      exp: Math.floor(NOW / 1000) + 60,
+      nonce: 'x',
+    })
+    expect(verifyLinkIntent(token, 'github', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects a validly-signed token with a non-numeric exp', () => {
+    const token = forge({
+      speakerId: 'speaker-1',
+      provider: 'github',
+      initiatorSub: 'sub-1',
+      exp: 'not-a-number',
+      nonce: 'x',
+    })
+    expect(verifyLinkIntent(token, 'github', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects a signature that is valid for a DIFFERENT payload (swap)', () => {
+    const good = forge({
+      speakerId: 'speaker-1',
+      provider: 'github',
+      initiatorSub: 'sub-1',
+      exp: Math.floor(NOW / 1000) + 60,
+      nonce: 'x',
+    })
+    const evil = forge({
+      speakerId: 'attacker',
+      provider: 'github',
+      initiatorSub: 'sub-attacker',
+      exp: Math.floor(NOW / 1000) + 60,
+      nonce: 'y',
+    })
+    const swapped = `${evil.split('.')[0]}.${good.split('.')[1]}`
+    expect(verifyLinkIntent(swapped, 'github', SECRET, NOW)).toBeNull()
+  })
+
+  it('rejects a length-mismatched signature without throwing', () => {
+    const token = signLinkIntent(validInput, SECRET, NOW)
+    const payloadB64 = token.split('.')[0]
+    expect(
+      verifyLinkIntent(`${payloadB64}.short`, 'github', SECRET, NOW),
+    ).toBeNull()
+  })
+
+  it('rejects payload that is not valid base64url JSON', () => {
+    // Valid signature over a payload that does not JSON-parse.
+    const payloadB64 = Buffer.from('}{not json', 'utf8').toString('base64url')
+    const sig = createHmac('sha256', SECRET)
+      .update(payloadB64)
+      .digest('base64url')
+    expect(
+      verifyLinkIntent(`${payloadB64}.${sig}`, 'github', SECRET, NOW),
+    ).toBeNull()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,11 +79,14 @@ export default defineConfig({
           functions: 60,
           lines: 70,
         },
+        // Covered by auth-link-abuse.test.ts (signLinkIntent/verifyLinkIntent
+        // integrity, expiry, provider-binding, forgery) plus the jwt-callback
+        // path. Measured ~98/93/83/98 on 2026-07; ratcheted up a few points.
         'src/lib/auth-link.ts': {
-          statements: 85,
-          branches: 83,
+          statements: 92,
+          branches: 88,
           functions: 80,
-          lines: 85,
+          lines: 92,
         },
         'src/lib/speaker/sanity.ts': {
           statements: 61,


### PR DESCRIPTION
The **standing auth-abuse suite** item of #451 — now unblocked, and targeting the biggest gap: `signLinkIntent` / `verifyLinkIntent` (`src/lib/auth-link.ts`) had **zero** direct tests.

These HMAC-signed, short-lived tokens bind an already-authenticated speaker to a provider they're about to link — the exact "link-cookie takeover" surface flagged in earlier reviews. This adds **21 permanent regression guards** across the negative/abuse space:

- **Integrity** — tampered payload, tampered signature, wrong secret, a signature valid for a *different* payload (swap), length-mismatched signature (exercises the constant-time compare path).
- **Expiry** — exact-instant boundary (accepted) + expired (rejected).
- **Provider binding** — a token bound to `github` rejected when `linkedin` is expected.
- **Semantic defence-in-depth** — validly-signed but malicious payloads (non-linkable provider, empty `speakerId`, missing `initiatorSub`, non-numeric `exp`, non-JSON body) are all rejected *past* the signature layer.
- **Malformed inputs** — missing/empty token, no secret, no dot, empty payload/sig.
- **Mint guards** — `signLinkIntent` fails closed without secret / speakerId / initiatorSub; per-mint nonce makes tokens structurally non-reusable.

Both functions take injectable `secret` and `now`, so every case is pure — no env or timer mocking, no flakiness.

**Coverage:** `auth-link.ts` rises to ~98% statements / 93% branch. Ratcheted its gate `85/83/80/85 → 92/88/80/92`.

Full suite green (bar the pre-existing `@digitalbazaar/vc` env dep). No source changes — tests + threshold only.

Part of #451; complements the CLI-bearer abuse cases (`bearer.test.ts`), impersonation/privilege-escalation guards (`impersonation.test.ts`), and the open-redirect guard (#467).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a standing auth-abuse regression suite (`auth-link-abuse.test.ts`) covering the previously untested `signLinkIntent` / `verifyLinkIntent` functions in `src/lib/auth-link.ts`, and ratchets the corresponding coverage gates in `vitest.config.ts`. No source code changes are included.

- **21 tests** span integrity (tampered payload/signature, wrong secret, signature-swap, length-mismatched sig), expiry boundary, provider-binding, semantic defense-in-depth (forged-but-validly-signed payloads carrying bad providers, empty IDs, non-numeric `exp`, non-JSON body), malformed inputs, and mint-time guards — all via injectable `secret`/`now` so the suite is fully deterministic.
- **Coverage thresholds** for `src/lib/auth-link.ts` are raised from `85/83/80/85` to `92/88/80/92` (statements/branches/functions/lines), reflecting measured coverage of approximately `98/93/83/98`; the `functions` gate is intentionally left at `80` since `isLinkResult` is exercised elsewhere.

<h3>Confidence Score: 5/5</h3>

Pure test addition with no source changes; all new assertions match the implementation's documented behaviour.

Every test case was cross-checked against src/lib/auth-link.ts. The expiry boundary arithmetic, the constant-time-comparison length-mismatch path, the HMAC swap attack, and the JSON-serialisation edge cases (NaN/Infinity to null in JSON prevents a theoretical bypass) all behave exactly as the tests assert. Coverage threshold increases are proportional to the measured improvement and follow the existing ratchet pattern in the file.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| __tests__/lib/auth/auth-link-abuse.test.ts | New 220-line abuse suite covering signLinkIntent/verifyLinkIntent; all test logic verified correct against the implementation. |
| vitest.config.ts | Ratchets auth-link.ts coverage thresholds from 85/83/80/85 to 92/88/80/92; comment documents measured values; no other config changes. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Test Suite
    participant Sign as signLinkIntent
    participant Verify as verifyLinkIntent
    participant Forge as forge() helper

    Note over Test,Verify: Happy path & mint guards
    Test->>Sign: signLinkIntent(validInput, SECRET, NOW)
    Sign-->>Test: token (payloadB64.hmac)
    Test->>Verify: verifyLinkIntent(token, 'github', SECRET, NOW)
    Verify-->>Test: "{ speakerId, provider, initiatorSub }"

    Note over Test,Sign: Mint-time guards (throw)
    Test->>Sign: no secret
    Test->>Sign: empty speakerId
    Test->>Sign: empty initiatorSub

    Note over Test,Verify: Integrity abuse cases
    Test->>Verify: tampered payload (HMAC mismatch)
    Test->>Verify: tampered signature
    Test->>Verify: wrong secret
    Test->>Verify: signature swap attack
    Test->>Verify: length-mismatched sig

    Note over Test,Verify: Semantic abuse via forge()
    Test->>Forge: build valid HMAC over malicious payload
    Forge-->>Test: validly-signed token
    Test->>Verify: non-linkable provider
    Test->>Verify: empty speakerId
    Test->>Verify: missing initiatorSub
    Test->>Verify: non-numeric exp
    Test->>Verify: non-JSON body

    Note over Test,Verify: Expiry & provider-binding
    Test->>Verify: expired token
    Test->>Verify: github token vs linkedin expected
    Test->>Verify: token at exact expiry epoch
    Test->>Verify: token at expiry+1ms
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Test Suite
    participant Sign as signLinkIntent
    participant Verify as verifyLinkIntent
    participant Forge as forge() helper

    Note over Test,Verify: Happy path & mint guards
    Test->>Sign: signLinkIntent(validInput, SECRET, NOW)
    Sign-->>Test: token (payloadB64.hmac)
    Test->>Verify: verifyLinkIntent(token, 'github', SECRET, NOW)
    Verify-->>Test: "{ speakerId, provider, initiatorSub }"

    Note over Test,Sign: Mint-time guards (throw)
    Test->>Sign: no secret
    Test->>Sign: empty speakerId
    Test->>Sign: empty initiatorSub

    Note over Test,Verify: Integrity abuse cases
    Test->>Verify: tampered payload (HMAC mismatch)
    Test->>Verify: tampered signature
    Test->>Verify: wrong secret
    Test->>Verify: signature swap attack
    Test->>Verify: length-mismatched sig

    Note over Test,Verify: Semantic abuse via forge()
    Test->>Forge: build valid HMAC over malicious payload
    Forge-->>Test: validly-signed token
    Test->>Verify: non-linkable provider
    Test->>Verify: empty speakerId
    Test->>Verify: missing initiatorSub
    Test->>Verify: non-numeric exp
    Test->>Verify: non-JSON body

    Note over Test,Verify: Expiry & provider-binding
    Test->>Verify: expired token
    Test->>Verify: github token vs linkedin expected
    Test->>Verify: token at exact expiry epoch
    Test->>Verify: token at expiry+1ms
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(auth): standing abuse suite for pro..."](https://github.com/cloudnativebergen/website/commit/fb5aa8b903344c2e166a4897956a286773c4e33b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44907116)</sub>

<!-- /greptile_comment -->