### PR TITLE
test(auth): @auth/core JWT salt ↔ cookie-name contract test (#451)

### DIFF
--- a/__tests__/lib/auth/authjs-jwt-contract.test.ts
+++ b/__tests__/lib/auth/authjs-jwt-contract.test.ts
@@ -102,6 +102,9 @@ describe('@auth/core JWT contract — salt ↔ cookie-name binding', () => {
   })
 
   it('CLI bearer salt equals the bare session-cookie name (getSessionFromBearerToken contract)', async () => {
+    // CLI_JWT_SALT and SESSION_TOKEN_COOKIE_NAMES are declared independently in
+    // auth.ts; this fails if they drift apart (getSessionFromBearerToken must
+    // decode tokens minted under the same salt the session cookie uses).
     expect(CLI_SALT).toBe(DEV_COOKIE)
     const token = await encode({
       token: payload,

--- a/__tests__/lib/auth/authjs-jwt-contract.test.ts
+++ b/__tests__/lib/auth/authjs-jwt-contract.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment node
+ *
+ * CONTRACT test for the `@auth/core` JWT salt ↔ session-cookie-name binding the
+ * app hardcodes — the exact class of assumption that broke during the Phase-2
+ * provider-linking work (#451). It runs a REAL `encode` → `decode` round-trip
+ * through the actual library (bearer.test.ts confirms the crypto is real: the
+ * `jose` alias in vitest.config does not reach `@auth/core`'s internals), so an
+ * Auth.js upgrade that changes salt→key derivation would fail this test instead
+ * of silently breaking session/CLI-token reads in production.
+ *
+ * What it pins:
+ *   - both session-cookie-name salts (`authjs.session-token` bare + the
+ *     `__Secure-` prod form) round-trip;
+ *   - the salt is LOAD-BEARING — a token minted under one salt does NOT decode
+ *     under the other, which is exactly why src/lib/auth.ts `readPriorSessionToken`
+ *     must try each cookie name as its own salt;
+ *   - the CLI bearer salt (`CLI_JWT_SALT`) equals the bare cookie name;
+ *   - a wrong secret is rejected.
+ *
+ * The exact cookie-name STRINGS are asserted as the documented reference
+ * (`@auth/core` is only a transitive dep here, so its `defaultCookies()` can't
+ * be imported directly to diff against — a rename would need this test updated
+ * deliberately alongside src/lib/auth.ts).
+ */
+import { describe, it, expect } from 'vitest'
+import { encode, decode } from 'next-auth/jwt'
+
+const SECRET = 'contract-test-secret-long-enough-for-a256cbc-hs512'
+const OTHER_SECRET = 'a-totally-different-secret-of-sufficient-length!!'
+
+// Mirror of src/lib/auth.ts: salt === session-cookie name. Prod uses the
+// __Secure- prefix (https); dev uses the bare name.
+const DEV_COOKIE = 'authjs.session-token'
+const PROD_COOKIE = '__Secure-authjs.session-token'
+const CLI_SALT = 'authjs.session-token' // CLI_JWT_SALT in auth.ts
+
+const payload = { sub: 'user-1', name: 'Ada', email: 'ada@example.com' }
+
+/** `decode` rejects a bad token by returning null OR throwing; treat both alike. */
+async function tryDecode(token: string, secret: string, salt: string) {
+  try {
+    return await decode({ token, secret, salt })
+  } catch {
+    return null
+  }
+}
+
+describe('@auth/core JWT contract — salt ↔ cookie-name binding', () => {
+  it('round-trips a token minted and read with the bare dev cookie salt', async () => {
+    const token = await encode({
+      token: payload,
+      secret: SECRET,
+      salt: DEV_COOKIE,
+      maxAge: 3600,
+    })
+    const decoded = await decode({ token, secret: SECRET, salt: DEV_COOKIE })
+    expect(decoded?.sub).toBe('user-1')
+  })
+
+  it('round-trips a token minted and read with the __Secure- prod cookie salt', async () => {
+    const token = await encode({
+      token: payload,
+      secret: SECRET,
+      salt: PROD_COOKIE,
+      maxAge: 3600,
+    })
+    const decoded = await decode({ token, secret: SECRET, salt: PROD_COOKIE })
+    expect(decoded?.sub).toBe('user-1')
+  })
+
+  it('binds a token to its salt: a dev-cookie token does NOT decode under the prod-cookie salt', async () => {
+    const token = await encode({
+      token: payload,
+      secret: SECRET,
+      salt: DEV_COOKIE,
+      maxAge: 3600,
+    })
+    expect(await tryDecode(token, SECRET, PROD_COOKIE)).toBeNull()
+  })
+
+  it('binds a token to its salt: a prod-cookie token does NOT decode under the dev-cookie salt', async () => {
+    const token = await encode({
+      token: payload,
+      secret: SECRET,
+      salt: PROD_COOKIE,
+      maxAge: 3600,
+    })
+    expect(await tryDecode(token, SECRET, DEV_COOKIE)).toBeNull()
+  })
+
+  it('rejects a token decoded under the wrong secret', async () => {
+    const token = await encode({
+      token: payload,
+      secret: SECRET,
+      salt: DEV_COOKIE,
+      maxAge: 3600,
+    })
+    expect(await tryDecode(token, OTHER_SECRET, DEV_COOKIE)).toBeNull()
+  })
+
+  it('CLI bearer salt equals the bare session-cookie name (getSessionFromBearerToken contract)', async () => {
+    expect(CLI_SALT).toBe(DEV_COOKIE)
+    const token = await encode({
+      token: payload,
+      secret: SECRET,
+      salt: CLI_SALT,
+      maxAge: 3600,
+    })
+    const decoded = await decode({ token, secret: SECRET, salt: CLI_SALT })
+    expect(decoded?.sub).toBe('user-1')
+  })
+
+  it('documents the exact session-cookie names the app depends on', () => {
+    // If an Auth.js upgrade renames the session cookie, update BOTH
+    // src/lib/auth.ts (readPriorSessionToken baseNames + CLI_JWT_SALT) and this
+    // reference deliberately.
+    expect(DEV_COOKIE).toBe('authjs.session-token')
+    expect(PROD_COOKIE).toBe('__Secure-authjs.session-token')
+  })
+})

--- a/__tests__/lib/auth/authjs-jwt-contract.test.ts
+++ b/__tests__/lib/auth/authjs-jwt-contract.test.ts
@@ -18,22 +18,24 @@
  *   - the CLI bearer salt (`CLI_JWT_SALT`) equals the bare cookie name;
  *   - a wrong secret is rejected.
  *
- * The exact cookie-name STRINGS are asserted as the documented reference
- * (`@auth/core` is only a transitive dep here, so its `defaultCookies()` can't
- * be imported directly to diff against — a rename would need this test updated
- * deliberately alongside src/lib/auth.ts).
+ * The salts are the app's OWN exported constants (`SESSION_TOKEN_COOKIE_NAMES`,
+ * `CLI_JWT_SALT`), imported from src/lib/auth.ts, and asserted against the
+ * known-correct `@auth/core` default strings — so this guards the app, not a
+ * copy. (`@auth/core` is only a transitive dep here, so its `defaultCookies()`
+ * can't be imported to diff automatically; a rename must update auth.ts, which
+ * this test then flags against the reference strings.)
  */
 import { describe, it, expect } from 'vitest'
 import { encode, decode } from 'next-auth/jwt'
+import { SESSION_TOKEN_COOKIE_NAMES, CLI_JWT_SALT } from '@/lib/auth'
 
 const SECRET = 'contract-test-secret-long-enough-for-a256cbc-hs512'
 const OTHER_SECRET = 'a-totally-different-secret-of-sufficient-length!!'
 
-// Mirror of src/lib/auth.ts: salt === session-cookie name. Prod uses the
-// __Secure- prefix (https); dev uses the bare name.
-const DEV_COOKIE = 'authjs.session-token'
-const PROD_COOKIE = '__Secure-authjs.session-token'
-const CLI_SALT = 'authjs.session-token' // CLI_JWT_SALT in auth.ts
+// The REAL constants the app uses (salt === session-cookie name), imported from
+// src/lib/auth.ts so these assertions guard the app — not a copy.
+const [PROD_COOKIE, DEV_COOKIE] = SESSION_TOKEN_COOKIE_NAMES
+const CLI_SALT = CLI_JWT_SALT
 
 const payload = { sub: 'user-1', name: 'Ada', email: 'ada@example.com' }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -45,6 +45,18 @@ function applySpeakerToToken(
 }
 
 /**
+ * `@auth/core`'s default session-token cookie names, most-specific first. Prod
+ * uses the `__Secure-` prefix (https); dev uses the bare name. Salt === cookie
+ * name, so these double as the decode salts. Exported so the contract test
+ * (`__tests__/lib/auth/authjs-jwt-contract.test.ts`) can pin them against a real
+ * encode/decode round-trip and catch an Auth.js rename.
+ */
+export const SESSION_TOKEN_COOKIE_NAMES = [
+  '__Secure-authjs.session-token',
+  'authjs.session-token',
+] as const
+
+/**
  * Decode the browser's PRE-EXISTING NextAuth session token from the request
  * cookies.
  *
@@ -64,9 +76,7 @@ async function readPriorSessionToken(jar: {
   const secret = process.env.AUTH_SECRET
   if (!secret) return null
 
-  // Prod uses the __Secure- prefix; dev uses the bare name. Salt === cookie name.
-  const baseNames = ['__Secure-authjs.session-token', 'authjs.session-token']
-  for (const base of baseNames) {
+  for (const base of SESSION_TOKEN_COOKIE_NAMES) {
     let value = jar.get(base)?.value
     if (!value) {
       const chunks: string[] = []
@@ -428,7 +438,9 @@ export const auth = _auth as typeof _auth &
 
 const SANITY_ID_PATTERN = /^[a-zA-Z0-9_-]+$/
 const MAX_IMPERSONATION_ID_LENGTH = 100
-const CLI_JWT_SALT = 'authjs.session-token'
+// CLI tokens are minted/read with the bare session-cookie salt. Exported so the
+// contract test can assert this equals the bare cookie name (not a magic string).
+export const CLI_JWT_SALT = SESSION_TOKEN_COOKIE_NAMES[1]
 
 function extractBearerToken(headers?: Headers): string | null {
   const value = headers?.get('authorization')

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -49,7 +49,10 @@ function applySpeakerToToken(
  * uses the `__Secure-` prefix (https); dev uses the bare name. Salt === cookie
  * name, so these double as the decode salts. Exported so the contract test
  * (`__tests__/lib/auth/authjs-jwt-contract.test.ts`) can pin them against a real
- * encode/decode round-trip and catch an Auth.js rename.
+ * encode/decode round-trip and against the known reference strings. (It can't
+ * diff `@auth/core`'s own `defaultCookies()` automatically — that's a transitive
+ * dep — so an upstream rename is caught only once these constants are updated to
+ * match; the round-trip still guards the salt→key derivation independently.)
  */
 export const SESSION_TOKEN_COOKIE_NAMES = [
   '__Secure-authjs.session-token',
@@ -438,9 +441,11 @@ export const auth = _auth as typeof _auth &
 
 const SANITY_ID_PATTERN = /^[a-zA-Z0-9_-]+$/
 const MAX_IMPERSONATION_ID_LENGTH = 100
-// CLI tokens are minted/read with the bare session-cookie salt. Exported so the
-// contract test can assert this equals the bare cookie name (not a magic string).
-export const CLI_JWT_SALT = SESSION_TOKEN_COOKIE_NAMES[1]
+// CLI tokens are minted/read with the bare session-cookie salt. Declared as an
+// independent literal (NOT derived from SESSION_TOKEN_COOKIE_NAMES) so the
+// contract test's `CLI_JWT_SALT === <bare cookie name>` assertion actually
+// verifies the two are kept in sync, rather than being true by construction.
+export const CLI_JWT_SALT = 'authjs.session-token'
 
 function extractBearerToken(headers?: Headers): string | null {
   const value = headers?.get('authorization')


### PR DESCRIPTION
The **`@auth/core` contract test** item of #451 — a real `encode` → `decode` round-trip through the actual library, pinning the salt / session-cookie-name assumptions the app hardcodes.

### Why
`src/lib/auth.ts` hardcodes the session-cookie names (`readPriorSessionToken`'s `baseNames`) and the CLI salt (`CLI_JWT_SALT`), relying on **salt === cookie name**. That's the exact class of assumption that broke during Phase-2 provider linking. An Auth.js upgrade that changed salt→key derivation would break session/CLI-token reads **silently** in production. This test turns that into a red build.

The crypto is genuinely real: `bearer.test.ts` already round-trips through `next-auth/jwt`, and the `jose` alias in `vitest.config` does **not** reach `@auth/core`'s internal crypto.

### Pins
- both cookie-name salts round-trip — bare `authjs.session-token` **and** the `__Secure-authjs.session-token` prod form;
- the salt is **load-bearing**: a token minted under one salt does **not** decode under the other (precisely why `readPriorSessionToken` tries each cookie name as its own salt);
- `CLI_JWT_SALT` equals the bare cookie name (the `getSessionFromBearerToken` contract);
- a wrong secret is rejected;
- the exact cookie-name strings, as the documented reference.

### Honest limitation
`@auth/core` is only a **transitive** dep here (unresolvable as a bare specifier; an offline direct-dep add isn't possible in this env), so its `defaultCookies()` can't be imported to diff the names automatically. A cookie **rename** therefore needs `auth.ts` + this test updated together — called out in the test doc. The salt-**derivation** contract (the more upgrade-fragile half) is fully guarded by the real round-trip.

This is **5 of 6** #451 items done; only the Playwright login e2e (large, separate-infra) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a contract test that performs real `encode` → `decode` round-trips through `next-auth/jwt` to pin the salt ↔ session-cookie-name assumptions hardcoded in `src/lib/auth.ts`, turning a silent upgrade regression into a red build. The test correctly exercises the genuine `@auth/core` crypto (the `jose` alias in `vitest.config` is a bare-specifier alias that does not intercept `@auth/core`'s internal JWE operations, as confirmed by the existing `bearer.test.ts` round-trips).

- **Salt-binding tests** (cross-salt decode failure and wrong-secret rejection) are the most valuable part: they genuinely exercise the real encryption and would catch a library change to salt→key derivation.
- **Two assertions are tautological**: `expect(CLI_SALT).toBe(DEV_COOKIE)` on line 103 and the entire "documents exact session-cookie names" test compare locally-defined string constants to their own literal values — they always pass and cannot catch a rename in `auth.ts`. The real guard for the CLI salt is in `bearer.test.ts`, which tests `getSessionFromBearerToken` directly.

<h3>Confidence Score: 4/5</h3>

Safe to merge — this is a test-only addition that adds no production code paths and cannot break existing behaviour.

The salt-binding and wrong-secret round-trip tests are genuinely valuable and correctly implemented. The only gaps are two assertions that compare locally-defined constants to their own literal values, which provide no regression protection against renames in auth.ts — but the existing bearer.test.ts covers those cases. No production code is touched.

Only __tests__/lib/auth/authjs-jwt-contract.test.ts — specifically the tautological CLI-salt assertion and the cookie-name documentation test.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| __tests__/lib/auth/authjs-jwt-contract.test.ts | New contract test exercising real encode→decode round-trips for both session-cookie salts, cross-salt isolation, wrong-secret rejection, and CLI salt equality; two assertions are tautological (locally-defined constants compared to their own literals) and provide no regression protection for changes in auth.ts |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as authjs-jwt-contract.test.ts
    participant JWT as next-auth/jwt (real)
    participant AuthCore as @auth/core (real crypto)

    Note over Test: encode → decode round-trip (dev salt)
    Test->>JWT: "encode({ token, secret, salt: DEV_COOKIE })"
    JWT->>AuthCore: JWE encrypt with PBKDF2(secret, salt)
    AuthCore-->>JWT: encrypted token
    JWT-->>Test: token string
    Test->>JWT: "decode({ token, secret, salt: DEV_COOKIE })"
    JWT->>AuthCore: JWE decrypt with PBKDF2(secret, salt)
    AuthCore-->>JWT: payload
    JWT-->>Test: decoded payload → assert sub

    Note over Test: cross-salt isolation test
    Test->>JWT: "encode({ token, secret, salt: DEV_COOKIE })"
    JWT-->>Test: dev-salt token
    Test->>JWT: "decode({ token, secret, salt: PROD_COOKIE })"
    JWT->>AuthCore: JWE decrypt with PBKDF2(secret, PROD_COOKIE)
    AuthCore-->>JWT: decryption failure
    JWT-->>Test: null / throw → assert null

    Note over Test: wrong-secret rejection
    Test->>JWT: "encode({ token, secret: SECRET, salt })"
    JWT-->>Test: encrypted token
    Test->>JWT: "decode({ token, secret: OTHER_SECRET, salt })"
    JWT->>AuthCore: JWE decrypt with wrong key
    AuthCore-->>JWT: decryption failure
    JWT-->>Test: null / throw → assert null
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as authjs-jwt-contract.test.ts
    participant JWT as next-auth/jwt (real)
    participant AuthCore as @auth/core (real crypto)

    Note over Test: encode → decode round-trip (dev salt)
    Test->>JWT: "encode({ token, secret, salt: DEV_COOKIE })"
    JWT->>AuthCore: JWE encrypt with PBKDF2(secret, salt)
    AuthCore-->>JWT: encrypted token
    JWT-->>Test: token string
    Test->>JWT: "decode({ token, secret, salt: DEV_COOKIE })"
    JWT->>AuthCore: JWE decrypt with PBKDF2(secret, salt)
    AuthCore-->>JWT: payload
    JWT-->>Test: decoded payload → assert sub

    Note over Test: cross-salt isolation test
    Test->>JWT: "encode({ token, secret, salt: DEV_COOKIE })"
    JWT-->>Test: dev-salt token
    Test->>JWT: "decode({ token, secret, salt: PROD_COOKIE })"
    JWT->>AuthCore: JWE decrypt with PBKDF2(secret, PROD_COOKIE)
    AuthCore-->>JWT: decryption failure
    JWT-->>Test: null / throw → assert null

    Note over Test: wrong-secret rejection
    Test->>JWT: "encode({ token, secret: SECRET, salt })"
    JWT-->>Test: encrypted token
    Test->>JWT: "decode({ token, secret: OTHER_SECRET, salt })"
    JWT->>AuthCore: JWE decrypt with wrong key
    AuthCore-->>JWT: decryption failure
    JWT-->>Test: null / throw → assert null
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(auth): @auth/core JWT salt &lt;-&gt; cook..."](https://github.com/cloudnativebergen/website/commit/0e71a254476fbe84abcb2a8e3c850941368a337c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44920861)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->