### PR TITLE
fix(admin): tighten mobile density (filter row, top gap, action menu)

### DIFF
--- a/src/components/admin/AdminActionBar.tsx
+++ b/src/components/admin/AdminActionBar.tsx
@@ -39,6 +39,28 @@ interface AdminActionBarProps {
   conference: Conference
 }
 
+type ActionColor =
+  'blue' | 'green' | 'orange' | 'red' | 'purple' | 'yellow' | undefined
+
+interface ActionItem {
+  key: string
+  label: string
+  icon: typeof CheckIcon
+  color?: ActionColor
+  onClick: () => void
+  title?: string
+}
+
+/** Icon accent per action colour, for the mobile dropdown menu items. */
+const MENU_ACCENT: Record<NonNullable<ActionColor>, string> = {
+  blue: 'text-blue-500',
+  green: 'text-green-500',
+  orange: 'text-orange-500',
+  red: 'text-red-500',
+  purple: 'text-purple-500',
+  yellow: 'text-yellow-500',
+}
+
 export function AdminActionBar({
   proposal,
   domain,
@@ -162,16 +184,6 @@ export function AdminActionBar({
   // Single source of truth for the available actions, rendered as an inline
   // button row on sm+ and as a compact dropdown menu on mobile (where the wide
   // colored buttons previously wrapped awkwardly across several rows).
-  type ActionColor =
-    'blue' | 'green' | 'orange' | 'red' | 'purple' | 'yellow' | undefined
-  interface ActionItem {
-    key: string
-    label: string
-    icon: typeof CheckIcon
-    color?: ActionColor
-    onClick: () => void
-    title?: string
-  }
   const actions: ActionItem[] = [
     {
       key: 'edit',
@@ -274,15 +286,6 @@ export function AdminActionBar({
         ]
       : []),
   ]
-
-  const menuAccent: Record<NonNullable<ActionColor>, string> = {
-    blue: 'text-blue-500',
-    green: 'text-green-500',
-    orange: 'text-orange-500',
-    red: 'text-red-500',
-    purple: 'text-purple-500',
-    yellow: 'text-yellow-500',
-  }
 
   return (
     <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
@@ -408,13 +411,14 @@ export function AdminActionBar({
                   <button
                     type="button"
                     onClick={action.onClick}
+                    title={action.title}
                     className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left font-medium text-gray-700 transition-colors data-focus:bg-gray-100 dark:text-gray-200 dark:data-focus:bg-gray-700"
                   >
                     <action.icon
                       className={clsx(
                         'h-4 w-4 shrink-0',
                         action.color
-                          ? menuAccent[action.color]
+                          ? MENU_ACCENT[action.color]
                           : 'text-gray-400 dark:text-gray-500',
                       )}
                     />

--- a/src/components/admin/AdminActionBar.tsx
+++ b/src/components/admin/AdminActionBar.tsx
@@ -15,7 +15,10 @@ import {
   PencilIcon,
   EyeIcon,
   ArrowUturnLeftIcon,
+  ChevronDownIcon,
 } from '@heroicons/react/20/solid'
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
+import clsx from 'clsx'
 import { ProposalExisting, Action } from '@/lib/proposal/types'
 import { ProposalStatusBadge } from '@/lib/proposal/ui'
 import { extractSpeakersFromProposal } from '@/lib/proposal/utils'
@@ -156,6 +159,131 @@ export function AdminActionBar({
     requiresTravelSupport,
   } = indicators
 
+  // Single source of truth for the available actions, rendered as an inline
+  // button row on sm+ and as a compact dropdown menu on mobile (where the wide
+  // colored buttons previously wrapped awkwardly across several rows).
+  type ActionColor =
+    'blue' | 'green' | 'orange' | 'red' | 'purple' | 'yellow' | undefined
+  interface ActionItem {
+    key: string
+    label: string
+    icon: typeof CheckIcon
+    color?: ActionColor
+    onClick: () => void
+    title?: string
+  }
+  const actions: ActionItem[] = [
+    {
+      key: 'edit',
+      label: 'Edit',
+      icon: PencilIcon,
+      onClick: handleEditProposal,
+      title: 'Edit proposal (⌘E)',
+    },
+    ...(speakers.length > 0
+      ? [
+          {
+            key: 'preview',
+            label: 'Preview',
+            icon: EyeIcon,
+            color: 'purple' as const,
+            onClick: handlePreviewSpeaker,
+            title:
+              speakers.length > 1
+                ? `Preview first speaker profile of ${speakers.length} speakers (⌘P)`
+                : 'Preview speaker profile (⌘P)',
+          },
+        ]
+      : []),
+    ...(speakers.length > 0 && speakers.some((speaker) => speaker.email)
+      ? [
+          {
+            key: 'email',
+            label: 'Email',
+            icon: EnvelopeIcon,
+            color: 'blue' as const,
+            onClick: handleEmailSpeakers,
+            title: 'Email speaker (⌘M)',
+          },
+        ]
+      : []),
+    ...(canApprove
+      ? [
+          {
+            key: 'approve',
+            label: 'Approve',
+            icon: CheckIcon,
+            color: 'green' as const,
+            onClick: () => handleAction(Action.accept),
+          },
+        ]
+      : []),
+    ...(canConfirm
+      ? [
+          {
+            key: 'confirm',
+            label: 'Confirm',
+            icon: CheckIcon,
+            color: 'green' as const,
+            onClick: () => handleAction(Action.confirm),
+          },
+        ]
+      : []),
+    ...(canWaitlist
+      ? [
+          {
+            key: 'waitlist',
+            label: 'Waitlist',
+            icon: ClockIcon,
+            color: 'orange' as const,
+            onClick: () => handleAction(Action.waitlist),
+          },
+        ]
+      : []),
+    ...(canRemind
+      ? [
+          {
+            key: 'remind',
+            label: 'Remind',
+            icon: BellIcon,
+            color: 'yellow' as const,
+            onClick: () => handleAction(Action.remind),
+          },
+        ]
+      : []),
+    ...(canReject
+      ? [
+          {
+            key: 'reject',
+            label: 'Reject',
+            icon: XMarkIcon,
+            color: 'red' as const,
+            onClick: () => handleAction(Action.reject),
+          },
+        ]
+      : []),
+    ...(canWithdraw
+      ? [
+          {
+            key: 'withdraw',
+            label: 'Withdraw',
+            icon: ArrowUturnLeftIcon,
+            color: 'red' as const,
+            onClick: () => handleAction(Action.withdraw),
+          },
+        ]
+      : []),
+  ]
+
+  const menuAccent: Record<NonNullable<ActionColor>, string> = {
+    blue: 'text-blue-500',
+    green: 'text-green-500',
+    orange: 'text-orange-500',
+    red: 'text-red-500',
+    purple: 'text-purple-500',
+    yellow: 'text-yellow-500',
+  }
+
   return (
     <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
@@ -248,105 +376,55 @@ export function AdminActionBar({
           )}
         </div>
 
-        <div className="flex flex-wrap items-center gap-1.5 sm:shrink-0">
-          <AdminButton
-            size="xs"
-            onClick={handleEditProposal}
-            title="Edit proposal (⌘E)"
-          >
-            <PencilIcon className="h-3 w-3" />
-            Edit
-          </AdminButton>
-
-          {speakers.length > 0 && (
+        {/* Desktop (sm+): inline button row. */}
+        <div className="hidden flex-wrap items-center gap-1.5 sm:flex sm:shrink-0">
+          {actions.map((action) => (
             <AdminButton
-              color="purple"
+              key={action.key}
+              color={action.color}
               size="xs"
-              onClick={handlePreviewSpeaker}
-              title={
-                speakers.length > 1
-                  ? `Preview first speaker profile of ${speakers.length} speakers (⌘P)`
-                  : 'Preview speaker profile (⌘P)'
-              }
+              onClick={action.onClick}
+              title={action.title}
             >
-              <EyeIcon className="h-3 w-3" />
-              Preview
+              <action.icon className="h-3 w-3" />
+              {action.label}
             </AdminButton>
-          )}
-
-          {speakers.length > 0 && speakers.some((speaker) => speaker.email) && (
-            <AdminButton
-              color="blue"
-              size="xs"
-              onClick={handleEmailSpeakers}
-              title={`Email speaker (⌘M)`}
-            >
-              <EnvelopeIcon className="h-3 w-3" />
-              Email
-            </AdminButton>
-          )}
-
-          {canApprove && (
-            <AdminButton
-              color="green"
-              size="xs"
-              onClick={() => handleAction(Action.accept)}
-            >
-              <CheckIcon className="h-3 w-3" />
-              Approve
-            </AdminButton>
-          )}
-          {canConfirm && (
-            <AdminButton
-              color="green"
-              size="xs"
-              onClick={() => handleAction(Action.confirm)}
-            >
-              <CheckIcon className="h-3 w-3" />
-              Confirm
-            </AdminButton>
-          )}
-          {canWaitlist && (
-            <AdminButton
-              color="orange"
-              size="xs"
-              onClick={() => handleAction(Action.waitlist)}
-            >
-              <ClockIcon className="h-3 w-3" />
-              Waitlist
-            </AdminButton>
-          )}
-          {canRemind && (
-            <AdminButton
-              color="yellow"
-              size="xs"
-              onClick={() => handleAction(Action.remind)}
-            >
-              <BellIcon className="h-3 w-3" />
-              Remind
-            </AdminButton>
-          )}
-          {canReject && (
-            <AdminButton
-              color="red"
-              size="xs"
-              onClick={() => handleAction(Action.reject)}
-            >
-              <XMarkIcon className="h-3 w-3" />
-              Reject
-            </AdminButton>
-          )}
-          {canWithdraw && (
-            <AdminButton
-              color="red"
-              size="xs"
-              onClick={() => handleAction(Action.withdraw)}
-            >
-              <ArrowUturnLeftIcon className="h-3 w-3" />
-              Withdraw
-            </AdminButton>
-          )}
+          ))}
         </div>
+
+        {/* Mobile: a single "Actions" dropdown instead of wrapping buttons. */}
+        {actions.length > 0 && (
+          <Menu as="div" className="relative sm:hidden">
+            <MenuButton className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-indigo-600 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800">
+              Actions
+              <ChevronDownIcon className="h-4 w-4" />
+            </MenuButton>
+            <MenuItems
+              anchor="bottom end"
+              className="z-50 mt-1 w-56 origin-top-right rounded-lg bg-white p-1 text-sm shadow-lg ring-1 ring-gray-900/5 focus:outline-none dark:bg-gray-800 dark:ring-white/10"
+            >
+              {actions.map((action) => (
+                <MenuItem key={action.key}>
+                  <button
+                    type="button"
+                    onClick={action.onClick}
+                    className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-left font-medium text-gray-700 transition-colors data-focus:bg-gray-100 dark:text-gray-200 dark:data-focus:bg-gray-700"
+                  >
+                    <action.icon
+                      className={clsx(
+                        'h-4 w-4 shrink-0',
+                        action.color
+                          ? menuAccent[action.color]
+                          : 'text-gray-400 dark:text-gray-500',
+                      )}
+                    />
+                    {action.label}
+                  </button>
+                </MenuItem>
+              ))}
+            </MenuItems>
+          </Menu>
+        )}
       </div>
 
       {showEmailModal && speakersWithEmail.length > 0 && (

--- a/src/components/admin/AdminFilterBar.tsx
+++ b/src/components/admin/AdminFilterBar.tsx
@@ -218,7 +218,12 @@ export function AdminFilterBar({
       )}
     >
       <div className="flex flex-row items-center gap-2 lg:justify-between lg:gap-3">
-        <div className="flex flex-1 items-center gap-2 lg:flex-none">
+        <div
+          className={clsx(
+            'flex items-center gap-2 lg:flex-none',
+            search && 'flex-1',
+          )}
+        >
           {search && (
             <div className="relative w-full lg:w-64">
               <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />

--- a/src/components/admin/AdminFilterBar.tsx
+++ b/src/components/admin/AdminFilterBar.tsx
@@ -217,8 +217,8 @@ export function AdminFilterBar({
         className,
       )}
     >
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-row items-center gap-2 lg:justify-between lg:gap-3">
+        <div className="flex flex-1 items-center gap-2 lg:flex-none">
           {search && (
             <div className="relative w-full lg:w-64">
               <MagnifyingGlassIcon className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400" />

--- a/src/components/common/DashboardLayout.tsx
+++ b/src/components/common/DashboardLayout.tsx
@@ -480,7 +480,7 @@ export function DashboardLayout({
           </div>
         </div>
 
-        <main className="py-10 lg:pl-20">
+        <main className="py-4 lg:py-10 lg:pl-20">
           <div className="px-2 sm:px-4 lg:px-8">{children}</div>
         </main>
       </div>


### PR DESCRIPTION
Three mobile admin UX fixes from the proposals screens (reported with screenshots).

### 1. Filter + search on one row — `AdminFilterBar`
The `card` variant stacked the free-text search **above** the Filters button on mobile. Now they share a row (search flexes to fill, Filters button beside it), reclaiming a row of vertical space. Desktop layout (search left, filters right via `justify-between`) is unchanged. Only `ProposalsFilter` uses the `card` variant with search; the other two usages are `variant="bare"` and unaffected.

### 2. Reduce top nav → content gap — `DashboardLayout`
`<main>` used `py-10` at all breakpoints, leaving a large gap under the sticky mobile top bar. Now `py-4 lg:py-10` — tighter on mobile across all admin/cfp pages, unchanged on desktop.

### 3. Action buttons → dropdown on mobile — `AdminActionBar`
The proposal-detail status card rendered up to **nine** colored action buttons (Edit/Preview/Email/Approve/Confirm/Waitlist/Remind/Reject/Withdraw) that wrapped across 2–3 rows on mobile. Now:
- **Desktop (sm+):** the same inline button row as before.
- **Mobile:** a single full-width **"Actions"** dropdown (Headless UI `Menu`) listing the available actions with their accent-colored icons.

The actions are now defined once in a data array and both renderings map over it, so they can't drift. `AdminActionBar` is only used on `admin/proposals/[id]`, so the blast radius is contained.

No logic/behavior changes to the actions themselves — same handlers, same conditional availability, same keyboard shortcuts. Typecheck / lint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Three focused mobile admin UX fixes addressing layout density issues on the proposals screens. No logic or behavior changes — the same handlers, conditions, and keyboard shortcuts remain in place.

- **AdminActionBar**: Actions are consolidated into a single data array and rendered as an inline button row on `sm+` and a Headless UI `Menu` dropdown on mobile, replacing up to nine individually-conditional colored buttons that previously wrapped across several rows.
- **AdminFilterBar**: The search input and Filters button now share a single flex row on mobile (`flex-1` search + shrink-to-fit button) instead of stacking vertically, recovering a row of vertical space.
- **DashboardLayout**: Top/bottom padding on `<main>` reduced from `py-10` to `py-4` on mobile, preserving `lg:py-10` on desktop.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three changes are purely presentational and scoped to mobile breakpoints, with desktop behaviour unchanged.

The action refactor in AdminActionBar is well-contained: the same handlers fire, the same conditional flags gate availability, and Headless UI handles focus/keyboard for the new dropdown. The two style notes (type definitions inside the function body and a redundant length guard) are cosmetic and carry no runtime risk.

AdminActionBar.tsx — the `type ActionColor` / `interface ActionItem` declarations and the always-true `actions.length > 0` guard are minor follow-ups worth cleaning up.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/AdminActionBar.tsx | Introduces a shared actions data array rendered as inline buttons on desktop and a Headless UI Menu dropdown on mobile; type/interface definitions are placed inside the function body (style), and the `actions.length > 0` guard is always true since Edit is unconditional |
| src/components/admin/AdminFilterBar.tsx | Tightens mobile layout so search and Filters button share a row by switching from flex-col to flex-row with flex-1 on the search container; clean and correct change |
| src/components/common/DashboardLayout.tsx | Single-line change reducing top/bottom padding from py-10 to py-4 on mobile while preserving lg:py-10 on desktop |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    AB["AdminActionBar renders"]
    AB --> BUILD["Build actions[] array\n(edit + conditional items)"]
    BUILD --> DESKTOP["sm+ breakpoint\n→ hidden div sm:flex\nInline AdminButton row"]
    BUILD --> MOBILE["< sm breakpoint\nHeadless UI Menu dropdown\n'Actions' button"]
    MOBILE --> SHEET["MenuItems panel\nMaps actions[]\nwith accent-colored icons"]
    DESKTOP --> BTNS["Maps actions[]\nas AdminButton xs"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    AB["AdminActionBar renders"]
    AB --> BUILD["Build actions[] array\n(edit + conditional items)"]
    BUILD --> DESKTOP["sm+ breakpoint\n→ hidden div sm:flex\nInline AdminButton row"]
    BUILD --> MOBILE["< sm breakpoint\nHeadless UI Menu dropdown\n'Actions' button"]
    MOBILE --> SHEET["MenuItems panel\nMaps actions[]\nwith accent-colored icons"]
    DESKTOP --> BTNS["Maps actions[]\nas AdminButton xs"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): tighten mobile density (filt..."](https://github.com/cloudnativebergen/website/commit/9b62737ee544ac50d25c1600c9a57f6756d9174d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45106473)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->