### PR TITLE
feat(seo): per-host dynamic sitemap.ts (#394)

### DIFF
--- a/__tests__/lib/seo/sitemap.test.ts
+++ b/__tests__/lib/seo/sitemap.test.ts
@@ -71,6 +71,17 @@ describe('buildSitemap', () => {
     expect(adaEntries).toHaveLength(1)
   })
 
+  it('drops whitespace-only slugs and trims real ones', () => {
+    const map = buildSitemap(HOST, {
+      speakers: [{ slug: '   ' }, { slug: '  ada  ' }],
+    })
+    const speakerUrls = map
+      .map((e) => e.url)
+      .filter((u) => u.includes('/speaker/'))
+    // The blank slug produces no entry; the padded one is trimmed.
+    expect(speakerUrls).toEqual([`${BASE}/speaker/ada`])
+  })
+
   it('URL-encodes speaker slugs', () => {
     const map = buildSitemap(HOST, { speakers: [{ slug: 'josé garcía' }] })
     expect(

--- a/__tests__/lib/seo/sitemap.test.ts
+++ b/__tests__/lib/seo/sitemap.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the per-host sitemap builder (src/lib/seo/sitemap.ts). Pins the
+ * acceptance criteria of #394: valid entries on the host's origin, speaker
+ * pages enumerated for the edition, and NO disallowed/noindex URL present.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildSitemap,
+  isDisallowed,
+  PUBLIC_STATIC_PATHS,
+} from '@/lib/seo/sitemap'
+import { DISALLOWED_PATHS } from '@/lib/seo/robots'
+
+const HOST = '2026.cloudnativedays.no'
+const BASE = 'https://2026.cloudnativedays.no'
+
+describe('isDisallowed', () => {
+  it('matches a disallowed path and its descendants', () => {
+    expect(isDisallowed('/admin')).toBe(true)
+    expect(isDisallowed('/admin/sponsors')).toBe(true)
+    expect(isDisallowed('/cfp/list')).toBe(true)
+    expect(isDisallowed('/sponsor/portal/abc')).toBe(true)
+  })
+
+  it('does NOT match the public prefixes that share a segment', () => {
+    // Bare /cfp and /sponsor are public; only their private sub-paths disallow.
+    expect(isDisallowed('/cfp')).toBe(false)
+    expect(isDisallowed('/sponsor')).toBe(false)
+    expect(isDisallowed('/sponsor/terms')).toBe(false)
+    expect(isDisallowed('/speaker/ada-lovelace')).toBe(false)
+  })
+})
+
+describe('buildSitemap', () => {
+  it('emits the public static pages on the host origin, home first', () => {
+    const map = buildSitemap(HOST)
+    expect(map[0]).toMatchObject({ url: `${BASE}/`, priority: 1 })
+    const urls = map.map((e) => e.url)
+    expect(urls).toContain(`${BASE}/program`)
+    expect(urls).toContain(`${BASE}/speaker`)
+    expect(urls).toContain(`${BASE}/tickets`)
+    // Every entry is an absolute URL on the requested host.
+    expect(urls.every((u) => u.startsWith(`${BASE}/`))).toBe(true)
+  })
+
+  it('enumerates public speaker profiles with lastModified', () => {
+    const map = buildSitemap(HOST, {
+      speakers: [
+        { slug: 'ada-lovelace', lastModified: '2026-01-02T00:00:00.000Z' },
+        { slug: 'alan-turing' },
+      ],
+    })
+    const ada = map.find((e) => e.url === `${BASE}/speaker/ada-lovelace`)
+    expect(ada).toBeDefined()
+    expect(ada?.lastModified).toBe('2026-01-02T00:00:00.000Z')
+    expect(map.some((e) => e.url === `${BASE}/speaker/alan-turing`)).toBe(true)
+  })
+
+  it('skips speakers without a slug and de-dupes repeats', () => {
+    const map = buildSitemap(HOST, {
+      speakers: [
+        { slug: 'ada' },
+        { slug: undefined },
+        { slug: '' },
+        { slug: 'ada' },
+      ],
+    })
+    const adaEntries = map.filter((e) => e.url === `${BASE}/speaker/ada`)
+    expect(adaEntries).toHaveLength(1)
+  })
+
+  it('URL-encodes speaker slugs', () => {
+    const map = buildSitemap(HOST, { speakers: [{ slug: 'josé garcía' }] })
+    expect(
+      map.some((e) => e.url === `${BASE}/speaker/jos%C3%A9%20garc%C3%ADa`),
+    ).toBe(true)
+  })
+
+  it('NEVER emits a disallowed/noindex URL (acceptance criteria)', () => {
+    const map = buildSitemap(HOST, {
+      // A speaker whose slug would collide with a disallowed prefix is still
+      // fine (it lives under /speaker/), but assert the whole set is clean.
+      speakers: [{ slug: 'real-speaker' }],
+    })
+    for (const entry of map) {
+      const path = new URL(entry.url).pathname
+      for (const raw of DISALLOWED_PATHS) {
+        const prefix = raw.replace(/\/$/, '')
+        expect(path === prefix || path.startsWith(`${prefix}/`)).toBe(false)
+      }
+    }
+  })
+
+  it('applies the protocol from getBaseUrl (http for localhost)', () => {
+    const map = buildSitemap('localhost:3000')
+    expect(map[0].url).toBe('http://localhost:3000/')
+  })
+
+  it('keeps the curated static list free of disallowed paths', () => {
+    // Guards against someone adding a private path to PUBLIC_STATIC_PATHS.
+    for (const path of PUBLIC_STATIC_PATHS) {
+      expect(isDisallowed(path)).toBe(false)
+    }
+  })
+})

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from 'next'
+import { headers } from 'next/headers'
+
+import { getConferenceForDomain } from '@/lib/conference/sanity'
+import { getSpeakers } from '@/lib/speaker/sanity'
+import { buildSitemap } from '@/lib/seo/sitemap'
+
+/**
+ * Per-host `sitemap.xml` (Next.js file convention). Resolves the conference for
+ * the incoming host — the same derivation `robots.ts` / `layout.tsx` use — then
+ * enumerates the public static pages plus each confirmed speaker's profile page.
+ * Disallowed/noindex paths are filtered inside `buildSitemap`.
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const host = (await headers()).get('host') || 'localhost:3000'
+
+  const { conference } = await getConferenceForDomain(host)
+
+  // No conference resolves for this host → emit only the static public pages.
+  if (!conference?._id) {
+    return buildSitemap(host)
+  }
+
+  const { speakers } = await getSpeakers(conference._id)
+
+  return buildSitemap(host, {
+    speakers: (speakers ?? []).map((speaker) => ({
+      slug: speaker.slug,
+      lastModified: speaker._updatedAt,
+    })),
+  })
+}

--- a/src/lib/seo/sitemap.ts
+++ b/src/lib/seo/sitemap.ts
@@ -1,0 +1,89 @@
+import type { MetadataRoute } from 'next'
+import { DISALLOWED_PATHS, getBaseUrl } from './robots'
+
+/**
+ * Crawlable, public static paths included in the sitemap. Curated (not derived
+ * from the filesystem) so private/thin routes are never emitted by accident;
+ * every entry is cross-checked against `DISALLOWED_PATHS` at build time via
+ * {@link isDisallowed}. `''` is the home page.
+ */
+export const PUBLIC_STATIC_PATHS = [
+  '',
+  '/program',
+  '/speaker',
+  '/sponsor',
+  '/sponsor/terms',
+  '/tickets',
+  '/conduct',
+  '/privacy',
+  '/terms',
+  '/info',
+  '/install',
+  '/cfp',
+  '/volunteer',
+] as const
+
+/** A speaker whose public profile page (`/speaker/<slug>`) should be listed. */
+export interface SitemapSpeaker {
+  slug?: string
+  /** ISO timestamp for `<lastmod>` (Sanity `_updatedAt`). */
+  lastModified?: string
+}
+
+export interface BuildSitemapInput {
+  speakers?: SitemapSpeaker[]
+  /** Fallback `<lastmod>` for static pages (e.g. the conference `_updatedAt`). */
+  lastModified?: string | Date
+}
+
+/**
+ * True when `path` is (or lives under) a `robots.ts`-disallowed prefix. Trailing
+ * slashes on disallow entries are normalised so `/cfp` (public) is NOT matched
+ * by the `/cfp/list` disallow, while `/cfp/list` itself is.
+ */
+export function isDisallowed(path: string): boolean {
+  return DISALLOWED_PATHS.some((raw) => {
+    const prefix = raw.replace(/\/$/, '')
+    return path === prefix || path.startsWith(`${prefix}/`)
+  })
+}
+
+/**
+ * Build the per-host sitemap: the curated public static pages plus one entry per
+ * public speaker profile, all on `host`'s origin. Any path that `robots.ts`
+ * disallows is filtered out (defence-in-depth), so no disallowed/noindex URL can
+ * appear even if the static list drifts.
+ */
+export function buildSitemap(
+  host: string,
+  { speakers = [], lastModified }: BuildSitemapInput = {},
+): MetadataRoute.Sitemap {
+  const baseUrl = getBaseUrl(host)
+
+  const staticEntries: MetadataRoute.Sitemap = PUBLIC_STATIC_PATHS.filter(
+    (path) => !isDisallowed(path),
+  ).map((path) => ({
+    url: `${baseUrl}${path || '/'}`,
+    ...(lastModified ? { lastModified } : {}),
+    changeFrequency: 'weekly',
+    priority: path === '' ? 1 : 0.7,
+  }))
+
+  const seen = new Set<string>()
+  const speakerEntries: MetadataRoute.Sitemap = speakers
+    .filter((speaker): speaker is SitemapSpeaker & { slug: string } => {
+      if (!speaker.slug) return false
+      const path = `/speaker/${speaker.slug}`
+      if (isDisallowed(path) || seen.has(speaker.slug)) return false
+      seen.add(speaker.slug)
+      return true
+    })
+    .map((speaker) => ({
+      url: `${baseUrl}/speaker/${encodeURIComponent(speaker.slug)}`,
+      ...(speaker.lastModified ? { lastModified: speaker.lastModified } : {}),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    }))
+
+  return [...staticEntries, ...speakerEntries]
+}

--- a/src/lib/seo/sitemap.ts
+++ b/src/lib/seo/sitemap.ts
@@ -71,6 +71,9 @@ export function buildSitemap(
 
   const seen = new Set<string>()
   const speakerEntries: MetadataRoute.Sitemap = speakers
+    // Normalise first: a blank / whitespace-only slug (seen historically, see
+    // the slug-repair migration) is not a real profile URL and must be dropped.
+    .map((speaker) => ({ ...speaker, slug: speaker.slug?.trim() }))
     .filter((speaker): speaker is SitemapSpeaker & { slug: string } => {
       if (!speaker.slug) return false
       const path = `/speaker/${speaker.slug}`


### PR DESCRIPTION
Part of the SEO epic (#391) — the **P0 dynamic sitemap** (#394). Complements the existing `robots.ts` (which already points at `/sitemap.xml` — this makes that real).

## What it emits (per host)
- **Public static pages** — home, `/program`, `/speaker`, `/sponsor` (+ `/sponsor/terms`), `/tickets`, `/conduct`, `/privacy`, `/terms`, `/info`, `/install`, `/cfp`, `/volunteer`.
- **Dynamic** — one entry per **confirmed speaker's** public profile (`/speaker/<slug>`), `lastModified` from the speaker's Sanity `_updatedAt`. (`speaker/[slug]` is the only public dynamic route — there is no public talk-detail page.)

## Design
- Pure builder in `src/lib/seo/sitemap.ts` (mirrors `src/lib/seo/robots.ts`), wired by `src/app/sitemap.ts` using the same host derivation as `robots.ts` / `layout.tsx`.
- **Every** path is filtered through `robots.ts`'s `DISALLOWED_PATHS` (trailing-slash-normalised), so no disallowed/noindex URL can appear — even if the static list drifts. Bare `/cfp` and `/sponsor` stay in; their private sub-paths are excluded.
- Slugs are URL-encoded and de-duped. When no conference resolves for the host, only the static pages are emitted.

## Tests (9)
Cover the #394 acceptance criteria: entries are absolute URLs on the requested host, home first, speaker pages enumerated with `lastModified`, slugless speakers skipped, repeats de-duped, slugs encoded, `getBaseUrl` protocol respected, and — asserted exhaustively — **no disallowed URL ever appears**, plus a guard that the curated static list stays clean.

Note: the hub-vs-edition split (#392, apex→hub) isn't done, so this serves the resolved conference for whatever host is requested — correct for the edition host today and forward-compatible once #392 defines a hub conference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a per-host dynamic `sitemap.xml` for the SEO epic: a pure builder (`src/lib/seo/sitemap.ts`) wired by a Next.js App Router entry (`src/app/sitemap.ts`), which resolves the conference for the incoming `host` header and emits curated static pages plus confirmed-speaker profile URLs. Disallowed paths are filtered via `robots.ts`'s `DISALLOWED_PATHS`, closing the loop that `robots.ts` already pointed at `/sitemap.xml`.

- `buildSitemap` curates a fixed static-path list, URL-encodes and deduplicates speaker slugs, and cross-checks every entry against `isDisallowed` as defence-in-depth.
- `src/app/sitemap.ts` follows the AGENTS.md wrapper pattern — reads `headers()` in the outer function and delegates to `getConferenceForDomain`/`getSpeakers`, both of which carry their own `'use cache'` + `cacheLife` wrappers.
- Nine Vitest tests cover the full acceptance criteria exhaustively, including the "no disallowed URL ever appears" invariant.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the sitemap degrades gracefully to static-only pages on any Sanity error, and the disallowed-path guard means no private URLs can leak into the index.

The builder logic, deduplication, URL-encoding, and disallow filtering are all correct and well-tested. The only gap is in `src/app/sitemap.ts`: both `error` from `getConferenceForDomain` and `err` from `getSpeakers` are silently discarded with no logging, so a Sanity outage would produce a speaker-less sitemap with no server-side signal.

src/app/sitemap.ts — error fields from both Sanity calls are never logged

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/seo/sitemap.ts | Pure sitemap builder; `isDisallowed` logic, deduplication, URL-encoding, and priority assignments all look correct |
| src/app/sitemap.ts | Wires the builder correctly and follows the AGENTS.md header/cache pattern, but both error fields from `getConferenceForDomain` and `getSpeakers` are silently discarded |
| __tests__/lib/seo/sitemap.test.ts | Comprehensive tests covering all acceptance criteria: absolute URLs, speaker enumeration, slug-less skip, dedup, encoding, disallowed-path guard, and localhost protocol |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Search Engine / Crawler
    participant Route as src/app/sitemap.ts
    participant Conf as getConferenceForDomain (use cache, hours)
    participant Spk as getSpeakers (use cache, hours)
    participant Builder as buildSitemap
    participant Robots as DISALLOWED_PATHS

    Client->>Route: GET /sitemap.xml
    Route->>Route: headers().get('host')
    Route->>Conf: getConferenceForDomain(host)
    Conf-->>Route: "{ conference, error }"
    alt conference._id exists
        Route->>Spk: getSpeakers(conference._id)
        Spk-->>Route: "{ speakers, err }"
        Route->>Builder: "buildSitemap(host, { speakers })"
    else no conference
        Route->>Builder: buildSitemap(host)
    end
    Builder->>Robots: isDisallowed(path) per entry
    Robots-->>Builder: true / false
    Builder-->>Route: MetadataRoute.Sitemap[]
    Route-->>Client: sitemap.xml
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Search Engine / Crawler
    participant Route as src/app/sitemap.ts
    participant Conf as getConferenceForDomain (use cache, hours)
    participant Spk as getSpeakers (use cache, hours)
    participant Builder as buildSitemap
    participant Robots as DISALLOWED_PATHS

    Client->>Route: GET /sitemap.xml
    Route->>Route: headers().get('host')
    Route->>Conf: getConferenceForDomain(host)
    Conf-->>Route: "{ conference, error }"
    alt conference._id exists
        Route->>Spk: getSpeakers(conference._id)
        Spk-->>Route: "{ speakers, err }"
        Route->>Builder: "buildSitemap(host, { speakers })"
    else no conference
        Route->>Builder: buildSitemap(host)
    end
    Builder->>Robots: isDisallowed(path) per entry
    Robots-->>Builder: true / false
    Builder-->>Route: MetadataRoute.Sitemap[]
    Route-->>Client: sitemap.xml
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(seo): per-host dynamic sitemap.ts (..."](https://github.com/cloudnativebergen/website/commit/c590c6ae04493ef7e380a4aafa140020fbdb698f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45107141)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->