### PR TITLE
fix(schedule): scope schedule save to the conference + atomic create (CRITICAL)

### DIFF
--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -2,7 +2,11 @@ import { randomUUID } from 'crypto'
 import { clientWrite } from '@/lib/sanity/client'
 import { ConferenceSchedule } from '@/lib/conference/types'
 import { Conference } from '@/lib/conference/types'
-import { generateKey, createReference } from '@/lib/sanity/helpers'
+import {
+  generateKey,
+  createReference,
+  createReferenceWithKey,
+} from '@/lib/sanity/helpers'
 
 export interface SaveScheduleResult {
   schedule?: ConferenceSchedule
@@ -71,14 +75,14 @@ export async function saveScheduleToSanity(
         id: schedule._id,
       })
 
-      if (!target) {
-        return { error: 'Schedule not found' }
-      }
+      // One generic message for missing, wrong-type, and wrong-conference so a
+      // caller can't probe whether an arbitrary document id exists.
       if (
+        !target ||
         target._type !== 'schedule' ||
         target.conferenceRef !== conference._id
       ) {
-        return { error: 'Schedule does not belong to this conference' }
+        return { error: 'Schedule not found or not accessible' }
       }
 
       await clientWrite
@@ -111,7 +115,8 @@ export async function saveScheduleToSanity(
         .patch(conference._id, (patch) =>
           patch
             .setIfMissing({ schedules: [] })
-            .append('schedules', [createReference(newId)]),
+            // Array items need a stable _key, matching other reference arrays.
+            .append('schedules', [createReferenceWithKey(newId, 'schedule')]),
         )
         .commit()
 

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { clientWrite } from '@/lib/sanity/client'
 import { ConferenceSchedule } from '@/lib/conference/types'
 import { Conference } from '@/lib/conference/types'
@@ -57,6 +58,29 @@ export async function saveScheduleToSanity(
     let savedSchedule: ConferenceSchedule
 
     if (schedule._id && schedule._id !== '') {
+      // SECURITY: `schedule._id` comes from the client, and `isOrganizer` is
+      // global across every edition (an organizer of conference A is an
+      // organizer on all domains). Without a scope check, a request could patch
+      // ANOTHER conference's schedule — or any document id at all — overwriting
+      // its `date`/`tracks`. Confirm the target is a `schedule` belonging to the
+      // conference being served before writing.
+      const target = await clientWrite.fetch<{
+        _type: string
+        conferenceRef: string | null
+      } | null>(`*[_id == $id][0]{ _type, "conferenceRef": conference._ref }`, {
+        id: schedule._id,
+      })
+
+      if (!target) {
+        return { error: 'Schedule not found' }
+      }
+      if (
+        target._type !== 'schedule' ||
+        target.conferenceRef !== conference._id
+      ) {
+        return { error: 'Schedule does not belong to this conference' }
+      }
+
       await clientWrite
         .patch(schedule._id)
         .set({
@@ -67,27 +91,33 @@ export async function saveScheduleToSanity(
 
       savedSchedule = schedule
     } else {
+      // Pre-generate the id so the create and the conference-link append run in
+      // ONE atomic transaction. Previously these were two sequential writes: if
+      // the append failed after the create succeeded, the error was swallowed
+      // and the client never learned the new id — orphaning the created
+      // schedule and creating a duplicate on the next save.
+      const newId = randomUUID()
       const newScheduleDoc = {
+        _id: newId,
         _type: 'schedule',
         date: schedule.date,
         tracks: sanitizedTracks,
         conference: createReference(conference._id),
       }
 
-      const createdSchedule = await clientWrite.create(newScheduleDoc)
+      await clientWrite
+        .transaction()
+        .create(newScheduleDoc)
+        .patch(conference._id, (patch) =>
+          patch
+            .setIfMissing({ schedules: [] })
+            .append('schedules', [createReference(newId)]),
+        )
+        .commit()
 
       savedSchedule = {
         ...schedule,
-        _id: createdSchedule._id,
-      }
-
-      const existingScheduleIds = conference.schedules?.map((s) => s._id) || []
-      if (!existingScheduleIds.includes(savedSchedule._id)) {
-        await clientWrite
-          .patch(conference._id)
-          .setIfMissing({ schedules: [] })
-          .append('schedules', [createReference(savedSchedule._id)])
-          .commit()
+        _id: newId,
       }
     }
 


### PR DESCRIPTION
First fix from the adversarial review of the admin schedule editor. **Security / data-loss critical.**

## The bug
`schedule.save` (`src/server/routers/schedule.ts` → `saveScheduleToSanity`) patched a **client-supplied `_id`** with no scope check:

```ts
await clientWrite.patch(schedule._id).set({ date, tracks }).commit()
```

`isOrganizer` is computed **globally** (`_id in *[_type=="conference"].organizers[]._ref`), so an organizer of conference A is an organizer on every domain. Nothing verified that `schedule._id` belonged to the conference being served. An organizer could POST the `_id` of **another edition's** schedule (or literally any document id) plus a `tracks` array, and Sanity would overwrite that document's `date`/`tracks` — silently destroying another conference's schedule or polluting an unrelated doc.

## The fix
- **Scope the update**: load `*[_id==$id][0]{ _type, "conferenceRef": conference._ref }` and reject unless `_type === 'schedule'` **and** `conferenceRef === conference._id` (the current-domain conference).
- **Atomic create**: pre-generate the `_id` and run the document `create` + the conference `schedules` append in **one transaction**. Previously they were two sequential writes; a failure after the create orphaned the new schedule and — because the error was swallowed and the id never returned to the client — produced a **duplicate** schedule on the next save.

## Scope / follow-ups
This PR covers the two contained server-side issues. The review also flagged (tracked for follow-up): no `ifRevisionId` guard (two organizers → silent last-write-wins), no server-side validation of times/overlaps/talk-ids, and `_key`s regenerated every save (defeats history). Those ride with the broader schedule refactor.

No client changes; `tsc`/`eslint`/`prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two server-side security/data-integrity bugs in the schedule save path. Before this change, an organizer could overwrite any Sanity document (including another conference's schedule) by supplying an arbitrary `_id`, and the two-step create+link sequence could orphan a newly created schedule if the second write failed.

- **Scope check on update**: fetches the target document by `_id` before patching and rejects the request unless `_type === 'schedule'` and `conference._ref` matches the current domain's conference, closing the cross-conference overwrite vulnerability.
- **Atomic create**: pre-generates a UUID with `randomUUID()` and wraps the schedule `create` and the conference `schedules` append in a single Sanity transaction, eliminating the orphan/duplicate risk from the previous two-step write sequence.
- **Known follow-ups (out of scope)**: no `ifRevisionId` guard on the update path (last-write-wins under concurrency), no server-side validation of times/overlaps/talk IDs, and `_key`s regenerated on every save.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the two targeted bugs are correctly fixed without any client-side changes, and the new code paths are straightforward.

The scope check and atomic transaction both address their stated goals cleanly. The two remaining observations (fetch-then-patch TOCTOU and non-idempotent append on retry) are pre-acknowledged in the PR description as follow-up work, not regressions introduced here. No new paths are broken.

src/lib/schedule/sanity.ts — specifically the update branch, which will benefit from an ifRevisionId guard once the broader schedule refactor lands.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/schedule/sanity.ts | Adds conference-scoped ownership check before patching an existing schedule, and switches the create path to a single atomic Sanity transaction. The scope check is a two-step fetch-then-patch (no ifRevisionId), leaving a narrow TOCTOU window, and the append in the transaction is not idempotent if a network timeout causes a client retry — but both are noted in the PR as known follow-ups. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant tRPC as tRPC Router
    participant Fn as saveScheduleToSanity
    participant Sanity

    Client->>tRPC: save schedule (schedule._id, tracks)
    tRPC->>Fn: saveScheduleToSanity(schedule, conference)

    alt schedule._id exists (update path)
        Fn->>Sanity: "fetch(*[_id==$id][0]{_type, conferenceRef})"
        Sanity-->>Fn: target doc (or null)
        alt target is null
            Fn-->>tRPC: error Schedule not found
        else "_type != schedule OR conferenceRef != conference._id"
            Fn-->>tRPC: error Schedule does not belong to this conference
        else scope check passes
            Fn->>Sanity: "patch(schedule._id).set({date, tracks}).commit()"
            Sanity-->>Fn: ok
            Fn-->>tRPC: schedule saved
        end
    else no schedule._id (create path)
        Note over Fn: newId = randomUUID()
        Fn->>Sanity: transaction: create + append schedules ref
        Sanity-->>Fn: committed atomically
        Fn-->>tRPC: schedule with new _id
    end

    tRPC-->>Client: result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant tRPC as tRPC Router
    participant Fn as saveScheduleToSanity
    participant Sanity

    Client->>tRPC: save schedule (schedule._id, tracks)
    tRPC->>Fn: saveScheduleToSanity(schedule, conference)

    alt schedule._id exists (update path)
        Fn->>Sanity: "fetch(*[_id==$id][0]{_type, conferenceRef})"
        Sanity-->>Fn: target doc (or null)
        alt target is null
            Fn-->>tRPC: error Schedule not found
        else "_type != schedule OR conferenceRef != conference._id"
            Fn-->>tRPC: error Schedule does not belong to this conference
        else scope check passes
            Fn->>Sanity: "patch(schedule._id).set({date, tracks}).commit()"
            Sanity-->>Fn: ok
            Fn-->>tRPC: schedule saved
        end
    else no schedule._id (create path)
        Note over Fn: newId = randomUUID()
        Fn->>Sanity: transaction: create + append schedules ref
        Sanity-->>Fn: committed atomically
        Fn-->>tRPC: schedule with new _id
    end

    tRPC-->>Client: result
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/schedule/sanity.ts`, line 67-90 ([link](https://github.com/cloudnativebergen/website/blob/3e3de8aea9f5b673f1f1121bce9cab1c6b714f60/src/lib/schedule/sanity.ts#L67-L90)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **TOCTOU window between scope-check fetch and patch**

   The `clientWrite.fetch` and the subsequent `.patch().commit()` are two independent Sanity operations with no revision guard between them. In the (admittedly unlikely) scenario where a schedule document is re-assigned to a different conference between these two calls, the patch would proceed against a now-out-of-scope document. Adding `.ifRevisionId(target._rev)` to the patch (after projecting `_rev` in the GROQ query) would close this window atomically and is the standard Sanity pattern for optimistic concurrency. The PR description already tracks this as a follow-up (`ifRevisionId` guard), so this is a note to make sure it lands before concurrent-organizer scenarios are possible.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): scope schedule save to th..."](https://github.com/cloudnativebergen/website/commit/3e3de8aea9f5b673f1f1121bce9cab1c6b714f60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45114881)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->