### PR TITLE
fix(schedule): subtle drag/drop UX bugs (drop animation, stuck swap, id)

### DIFF
--- a/src/components/admin/schedule/DraggableServiceSession.tsx
+++ b/src/components/admin/schedule/DraggableServiceSession.tsx
@@ -38,7 +38,7 @@ export function DraggableServiceSession({
 
     const type =
       sourceTrackIndex !== undefined ? 'scheduled-service' : 'service-session'
-    const id = `${type}-${serviceSession.startTime}-${sourceTrackIndex || 'unassigned'}-${sourceTimeSlot || 'new'}`
+    const id = `${type}-${serviceSession.startTime}-${sourceTrackIndex ?? 'unassigned'}-${sourceTimeSlot || 'new'}`
 
     return {
       dragType: type,

--- a/src/components/admin/schedule/DroppableTrack.tsx
+++ b/src/components/admin/schedule/DroppableTrack.tsx
@@ -468,8 +468,12 @@ const TimeSlotDropZone = ({
 
     if (isSwapOperation && !isSelfSwap) {
       onSwapHover(timeSlot.time)
-    } else if (isOver) {
-      onSwapHover(null)
+      // Clear when this slot stops being the swap target — including when the
+      // pointer leaves the track entirely (isOver → false). Without this
+      // cleanup the amber "SWAP" ring stayed stuck on the talk because the old
+      // code only cleared inside the `else if (isOver)` branch, which never runs
+      // once the slot is no longer hovered.
+      return () => onSwapHover(null)
     }
   }, [isOver, timeSlot.time, track.talks, activeDragItem, onSwapHover])
 

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -899,7 +899,11 @@ export function ScheduleEditor({
           </div>
         </div>
 
-        <DragOverlay>{dragOverlay}</DragOverlay>
+        {/* dropAnimation={null}: on a successful drop the source card unmounts
+            (the talk moves to its new slot / leaves the sidebar), so dnd-kit's
+            default animation of the overlay BACK to the origin rect reads as a
+            snap-back/"didn't take" even though the move succeeded. */}
+        <DragOverlay dropAnimation={null}>{dragOverlay}</DragOverlay>
       </DndContext>
 
       {showAddTrackModal && (


### PR DESCRIPTION
Second PR from the schedule-editor review — the contained, user-visible **subtle drag/drop** fixes you called out.

### 1. Successful moves no longer "snap back" — `dropAnimation={null}`
On a successful drop the source card unmounts (a scheduled talk leaves its old slot; an unassigned proposal leaves the sidebar). dnd-kit's **default** drop animation then animates the `DragOverlay` from the cursor **back to the origin's** last-measured rect before releasing — while the real card has already appeared at the destination. It reads as "it flew back / didn't take" even though the move succeeded. `dropAnimation={null}` makes the item appear at its destination immediately.

### 2. Stuck "SWAP" highlight
The `isOver` effect set the hovered-swap slot but only cleared it inside an `else if (isOver)` branch, which never runs once the slot stops being hovered — so the amber pulsing **SWAP** ring stayed stuck on a talk after you dragged off the track. Now cleared from the effect's cleanup, so it clears the moment the slot stops being the swap target (including leaving the track).

### 3. Service-session id mislabels track 0
`` `...-${sourceTrackIndex || 'unassigned'}-...` `` treated **track index 0** as `'unassigned'` (0 is falsy) — a latent id-collision hazard. Changed to `??`.

### Deferred (ride with the component refactor)
The heavier DnD items from the review — a presentational `DragOverlay` card (kills the "draggable id already registered" warning + fixes overlay measurement), keyboard-drag accessibility (listeners are on a non-focusable handle), and an item-sized drop placeholder instead of the 12px sliver — land during the component split so they aren't rewritten twice.

`tsc` / `eslint` / `prettier` clean. Storybook stories exist for these components as regression guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three contained drag-and-drop UX bugs in the schedule editor: a snap-back animation on successful drops, a stuck "SWAP" highlight after dragging off a slot, and a falsy-zero id collision for track 0.

- **`DragOverlay dropAnimation={null}`** (`ScheduleEditor.tsx`): disables dnd-kit's default drop animation, which was flying the overlay back to the origin rect even after the item had already appeared at its destination, creating a misleading \"snap-back\" effect.
- **Effect cleanup for swap hover** (`DroppableTrack.tsx`): moves the `onSwapHover(null)` reset into the `useEffect` cleanup function so the amber SWAP ring is cleared the moment `isOver` goes false, rather than being stuck until the next render cycle happened to enter the `else if (isOver)` branch.
- **`??` instead of `||` for track index** (`DraggableServiceSession.tsx`): fixes the drag id for track 0, which `||` was incorrectly treating as falsy and replacing with the string `'unassigned'`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three changes are narrow, well-scoped bug fixes with no functional regressions introduced.

`dropAnimation={null}` removes the return animation for cancelled drags (Escape / invalid drop) as a side-effect of fixing successful drops, which slightly degrades the cancel UX. The other two changes (`??` and effect cleanup) are straightforwardly correct.

`ScheduleEditor.tsx` — the `dropAnimation={null}` change is the one worth a second look if the cancel-drag experience is important to the team.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/DraggableServiceSession.tsx | Single-character fix: `||` → `??` for `sourceTrackIndex` so track 0 no longer produces an `unassigned` id segment, eliminating a latent drag-id collision. |
| src/components/admin/schedule/DroppableTrack.tsx | Swap-hover fix: moves the `onSwapHover(null)` clear into the `useEffect` cleanup, so the amber SWAP ring is correctly removed when the pointer leaves the hovered slot or the track entirely. |
| src/components/admin/schedule/ScheduleEditor.tsx | Adds `dropAnimation={null}` to `DragOverlay` to prevent the snap-back illusion on successful drops; the trade-off is that the return animation on cancelled drags is also disabled. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant DragOverlay
    participant TimeSlotDropZone
    participant ScheduleEditor

    Note over User,ScheduleEditor: Successful drop (BEFORE fix)
    User->>ScheduleEditor: drops card on target slot
    ScheduleEditor->>ScheduleEditor: item moves to destination
    DragOverlay->>DragOverlay: animates back to origin rect ❌ (looks like snap-back)

    Note over User,ScheduleEditor: Successful drop (AFTER fix — dropAnimation=null)
    User->>ScheduleEditor: drops card on target slot
    ScheduleEditor->>ScheduleEditor: item moves to destination
    DragOverlay->>DragOverlay: disappears immediately ✅

    Note over User,TimeSlotDropZone: SWAP hover (BEFORE fix)
    User->>TimeSlotDropZone: "drags over occupied slot (isOver=true)"
    TimeSlotDropZone->>ScheduleEditor: onSwapHover(time) — amber ring shown
    User->>TimeSlotDropZone: "pointer leaves slot (isOver=false)"
    Note over TimeSlotDropZone: else-if(isOver) never runs ❌ ring stays stuck

    Note over User,TimeSlotDropZone: SWAP hover (AFTER fix — cleanup fn)
    User->>TimeSlotDropZone: "drags over occupied slot (isOver=true)"
    TimeSlotDropZone->>ScheduleEditor: onSwapHover(time) — amber ring shown
    TimeSlotDropZone-->>TimeSlotDropZone: registers cleanup: onSwapHover(null)
    User->>TimeSlotDropZone: "pointer leaves slot (isOver=false)"
    TimeSlotDropZone->>ScheduleEditor: cleanup fires → onSwapHover(null) ✅
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant DragOverlay
    participant TimeSlotDropZone
    participant ScheduleEditor

    Note over User,ScheduleEditor: Successful drop (BEFORE fix)
    User->>ScheduleEditor: drops card on target slot
    ScheduleEditor->>ScheduleEditor: item moves to destination
    DragOverlay->>DragOverlay: animates back to origin rect ❌ (looks like snap-back)

    Note over User,ScheduleEditor: Successful drop (AFTER fix — dropAnimation=null)
    User->>ScheduleEditor: drops card on target slot
    ScheduleEditor->>ScheduleEditor: item moves to destination
    DragOverlay->>DragOverlay: disappears immediately ✅

    Note over User,TimeSlotDropZone: SWAP hover (BEFORE fix)
    User->>TimeSlotDropZone: "drags over occupied slot (isOver=true)"
    TimeSlotDropZone->>ScheduleEditor: onSwapHover(time) — amber ring shown
    User->>TimeSlotDropZone: "pointer leaves slot (isOver=false)"
    Note over TimeSlotDropZone: else-if(isOver) never runs ❌ ring stays stuck

    Note over User,TimeSlotDropZone: SWAP hover (AFTER fix — cleanup fn)
    User->>TimeSlotDropZone: "drags over occupied slot (isOver=true)"
    TimeSlotDropZone->>ScheduleEditor: onSwapHover(time) — amber ring shown
    TimeSlotDropZone-->>TimeSlotDropZone: registers cleanup: onSwapHover(null)
    User->>TimeSlotDropZone: "pointer leaves slot (isOver=false)"
    TimeSlotDropZone->>ScheduleEditor: cleanup fires → onSwapHover(null) ✅
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): subtle drag/drop UX bugs ..."](https://github.com/cloudnativebergen/website/commit/b6a39cf47c2fe3143ea34d459c5a72ea29d1aac8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45115584)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->