### PR TITLE
refactor(schedule): extract pure time helpers into a tested time.ts (Phase 0)

### DIFF
--- a/__tests__/lib/schedule/time.test.ts
+++ b/__tests__/lib/schedule/time.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the pure schedule time helpers (src/lib/schedule/time.ts),
+ * extracted from types.ts + five components during the schedule refactor
+ * (Phase 0). Behaviour-preserving: these pin the arithmetic the whole editor
+ * depends on before the rules/reducer phases build on it.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  toMinutes,
+  toHHMM,
+  addMinutes,
+  calculateEndTime,
+  durationBetween,
+  timesOverlap,
+  generateTimeSlots,
+  getProposalDurationMinutes,
+} from '@/lib/schedule/time'
+import type { ProposalExisting } from '@/lib/proposal/types'
+
+describe('toMinutes / toHHMM', () => {
+  it('round-trips HH:MM', () => {
+    for (const t of ['00:00', '08:00', '09:05', '13:30', '21:00', '23:55']) {
+      expect(toHHMM(toMinutes(t))).toBe(t)
+    }
+  })
+  it('toMinutes computes minutes since midnight', () => {
+    expect(toMinutes('00:00')).toBe(0)
+    expect(toMinutes('01:30')).toBe(90)
+    expect(toMinutes('21:00')).toBe(1260)
+  })
+  it('toHHMM wraps at 24h (matches the old Date rollover)', () => {
+    expect(toHHMM(1440)).toBe('00:00')
+    expect(toHHMM(1500)).toBe('01:00')
+    expect(toHHMM(-30)).toBe('23:30')
+  })
+})
+
+describe('addMinutes / calculateEndTime', () => {
+  it('adds minutes within a day', () => {
+    expect(addMinutes('09:00', 25)).toBe('09:25')
+    expect(addMinutes('10:45', 30)).toBe('11:15')
+  })
+  it('wraps past midnight', () => {
+    expect(addMinutes('23:30', 90)).toBe('01:00')
+  })
+  it('calculateEndTime is addMinutes', () => {
+    expect(calculateEndTime('12:00', 45)).toBe('12:45')
+  })
+})
+
+describe('durationBetween', () => {
+  it('returns end - start in minutes', () => {
+    expect(durationBetween('09:00', '09:25')).toBe(25)
+    expect(durationBetween('10:00', '11:30')).toBe(90)
+  })
+})
+
+describe('timesOverlap', () => {
+  it('detects overlapping intervals', () => {
+    expect(timesOverlap('10:00', '10:45', '10:30', '11:00')).toBe(true)
+    expect(timesOverlap('10:00', '11:00', '10:15', '10:30')).toBe(true) // contained
+  })
+  it('treats boundary-touching intervals as NOT overlapping', () => {
+    expect(timesOverlap('10:00', '10:30', '10:30', '11:00')).toBe(false)
+    expect(timesOverlap('10:30', '11:00', '10:00', '10:30')).toBe(false)
+  })
+  it('separate intervals do not overlap', () => {
+    expect(timesOverlap('09:00', '09:30', '10:00', '10:30')).toBe(false)
+  })
+})
+
+describe('generateTimeSlots', () => {
+  it('is inclusive of both bounds at the given interval', () => {
+    const slots = generateTimeSlots('08:00', '08:15', 5)
+    expect(slots.map((s) => s.time)).toEqual([
+      '08:00',
+      '08:05',
+      '08:10',
+      '08:15',
+    ])
+  })
+  it('spans a full day range with the default interval', () => {
+    const slots = generateTimeSlots() // 08:00–21:00 every 5 min
+    expect(slots[0].time).toBe('08:00')
+    expect(slots[slots.length - 1].time).toBe('21:00')
+    expect(slots).toHaveLength((13 * 60) / 5 + 1)
+  })
+})
+
+describe('getProposalDurationMinutes', () => {
+  const p = (format?: string): ProposalExisting =>
+    ({ _id: 'x', format }) as unknown as ProposalExisting
+
+  it('parses the minutes from "<type>_<minutes>"', () => {
+    expect(getProposalDurationMinutes(p('presentation_25'))).toBe(25)
+    expect(getProposalDurationMinutes(p('lightning_10'))).toBe(10)
+    expect(getProposalDurationMinutes(p('workshop_120'))).toBe(120)
+  })
+  it('defaults to 25 for missing or unparseable formats', () => {
+    expect(getProposalDurationMinutes(p(undefined))).toBe(25)
+    expect(getProposalDurationMinutes(p('presentation'))).toBe(25)
+    expect(getProposalDurationMinutes(p('weird_abc'))).toBe(25)
+  })
+})

--- a/src/lib/schedule/time.ts
+++ b/src/lib/schedule/time.ts
@@ -1,0 +1,97 @@
+import { ProposalExisting } from '@/lib/proposal/types'
+
+/**
+ * Pure time helpers for the schedule editor. Previously this arithmetic was
+ * re-implemented with `new Date('2000-01-01T…')` in five different files
+ * (types.ts, DroppableTrack, DraggableProposal, DraggableServiceSession,
+ * useScheduleEditor); centralising it here removes the duplication and makes the
+ * most-reused logic in the feature unit-testable.
+ *
+ * All times are `HH:MM` on a single day. Arithmetic wraps at 24h (mod 1440),
+ * matching the previous `Date`-based behaviour; end-of-day CLAMPING is a
+ * scheduling RULE handled elsewhere, not a property of these primitives.
+ */
+
+export interface TimeSlot {
+  time: string
+  displayTime: string
+}
+
+/** `HH:MM` → minutes since midnight. */
+export function toMinutes(hhmm: string): number {
+  const [hours, minutes] = hhmm.split(':').map(Number)
+  return hours * 60 + minutes
+}
+
+/** Minutes since midnight → `HH:MM`, wrapping at 24h (matches Date rollover). */
+export function toHHMM(minutes: number): string {
+  const wrapped = ((Math.round(minutes) % 1440) + 1440) % 1440
+  const hours = Math.floor(wrapped / 60)
+  const mins = wrapped % 60
+  return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`
+}
+
+/** Add (or subtract) minutes to a `HH:MM` time. */
+export function addMinutes(hhmm: string, delta: number): string {
+  return toHHMM(toMinutes(hhmm) + delta)
+}
+
+/** End time of a slot starting at `startTime` lasting `durationMinutes`. */
+export function calculateEndTime(
+  startTime: string,
+  durationMinutes: number,
+): string {
+  return addMinutes(startTime, durationMinutes)
+}
+
+/** Minutes between two same-day `HH:MM` times (`end - start`). */
+export function durationBetween(start: string, end: string): number {
+  return toMinutes(end) - toMinutes(start)
+}
+
+/**
+ * Do intervals `[start1,end1)` and `[start2,end2)` overlap? Strict `<`, so items
+ * that merely touch at a boundary (one ends exactly when the next begins) do NOT
+ * overlap.
+ */
+export function timesOverlap(
+  start1: string,
+  end1: string,
+  start2: string,
+  end2: string,
+): boolean {
+  return (
+    toMinutes(start1) < toMinutes(end2) && toMinutes(start2) < toMinutes(end1)
+  )
+}
+
+/** Inclusive list of `HH:MM` slots from `startTime` to `endTime` every `interval`. */
+export function generateTimeSlots(
+  startTime: string = '08:00',
+  endTime: string = '21:00',
+  intervalMinutes: number = 5,
+): TimeSlot[] {
+  const slots: TimeSlot[] = []
+  const endMin = toMinutes(endTime)
+  for (let m = toMinutes(startTime); m <= endMin; m += intervalMinutes) {
+    const time = toHHMM(m)
+    slots.push({ time, displayTime: time })
+  }
+  return slots
+}
+
+/**
+ * Talk duration in minutes, parsed from `proposal.format` (`"<type>_<minutes>"`,
+ * e.g. `presentation_25`). Defaults to 25 for a missing/unparseable format.
+ */
+export function getProposalDurationMinutes(proposal: ProposalExisting): number {
+  const DEFAULT = 25
+  if (!proposal.format) return DEFAULT
+
+  const split = proposal.format.split('_')
+  if (split.length >= 2) {
+    const parsed = parseInt(split[1], 10)
+    if (!isNaN(parsed)) return parsed
+  }
+  return DEFAULT
+}

--- a/src/lib/schedule/types.ts
+++ b/src/lib/schedule/types.ts
@@ -1,5 +1,24 @@
 import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import { ProposalExisting } from '@/lib/proposal/types'
+import {
+  calculateEndTime,
+  getProposalDurationMinutes,
+  timesOverlap,
+} from './time'
+
+// Pure time helpers now live in ./time. Re-exported here so existing importers
+// (`@/lib/schedule/types`) keep working while the module is split up.
+export {
+  toMinutes,
+  toHHMM,
+  addMinutes,
+  durationBetween,
+  calculateEndTime,
+  timesOverlap,
+  generateTimeSlots,
+  getProposalDurationMinutes,
+  type TimeSlot,
+} from './time'
 
 export interface DropPosition {
   trackIndex: number
@@ -18,87 +37,8 @@ export interface DragItem {
   sourceTimeSlot?: string
 }
 
-export interface TimeSlot {
-  time: string
-  displayTime: string
-}
-
 export const DRAG_PERFORMANCE_THRESHOLD = 16
 export const BATCH_UPDATE_DELAY = 100
-
-const memoCache = new Map<string, number>()
-
-export function getProposalDurationMinutes(proposal: ProposalExisting): number {
-  const cacheKey = `duration-${proposal._id}-${proposal.format}`
-  const cached = memoCache.get(cacheKey)
-  if (cached !== undefined) {
-    return cached
-  }
-
-  // Handle null or undefined format
-  if (!proposal.format) {
-    const defaultDuration = 25
-    memoCache.set(cacheKey, defaultDuration)
-    return defaultDuration
-  }
-
-  const split = proposal.format.split('_')
-  let duration = 25
-
-  if (split.length >= 2) {
-    const parsed = parseInt(split[1], 10)
-    if (!isNaN(parsed)) {
-      duration = parsed
-    }
-  }
-
-  memoCache.set(cacheKey, duration)
-  return duration
-}
-
-export function generateTimeSlots(
-  startTime: string = '08:00',
-  endTime: string = '21:00',
-  intervalMinutes: number = 5,
-): TimeSlot[] {
-  const slots: TimeSlot[] = []
-  const start = new Date(`2000-01-01T${startTime}:00`)
-  const end = new Date(`2000-01-01T${endTime}:00`)
-
-  while (start <= end) {
-    const timeString = start.toTimeString().slice(0, 5)
-    slots.push({
-      time: timeString,
-      displayTime: timeString,
-    })
-    start.setMinutes(start.getMinutes() + intervalMinutes)
-  }
-
-  return slots
-}
-
-export function calculateEndTime(
-  startTime: string,
-  durationMinutes: number,
-): string {
-  const start = new Date(`2000-01-01T${startTime}:00`)
-  start.setMinutes(start.getMinutes() + durationMinutes)
-  return start.toTimeString().slice(0, 5)
-}
-
-export function timesOverlap(
-  start1: string,
-  end1: string,
-  start2: string,
-  end2: string,
-): boolean {
-  const s1 = new Date(`2000-01-01T${start1}:00`)
-  const e1 = new Date(`2000-01-01T${end1}:00`)
-  const s2 = new Date(`2000-01-01T${start2}:00`)
-  const e2 = new Date(`2000-01-01T${end2}:00`)
-
-  return s1 < e2 && s2 < e1
-}
 
 export function findAvailableTimeSlot(
   track: ScheduleTrack,


### PR DESCRIPTION
First step of the schedule-editor restructure (behaviour-preserving groundwork).

## Problem
The `HH:MM` arithmetic was re-implemented with `new Date('2000-01-01T…')` in **five** files (`types.ts`, `DroppableTrack`, `DraggableProposal`, `DraggableServiceSession`, `useScheduleEditor`), and `types.ts` — despite its name — held domain logic plus a **module-level `memoCache` Map that is never cleared**.

## This PR
Extracts the pure time functions into `src/lib/schedule/time.ts`:
`toMinutes` / `toHHMM` / `addMinutes` / `calculateEndTime` / `durationBetween` / `timesOverlap` / `generateTimeSlots` / `getProposalDurationMinutes`.

- **Behaviour-preserving** — the 24h wrap matches the old `Date` rollover; `timesOverlap` keeps strict `<` (touching boundaries don't overlap).
- **Drops the `memoCache`** (keyed by `_id`+`format`; recomputation is trivial string parsing).
- `types.ts` **re-exports** these from `./time`, so every existing `@/lib/schedule/types` importer keeps working unchanged. `findAvailableTimeSlot` / `canSwapTalks` stay put — they move to `rules.ts` in Phase 1.
- **14 unit tests** pin the arithmetic the whole editor depends on (round-trips, midnight wrap, overlap boundaries, slot generation, duration parsing) before the rules/reducer phases build on it.

Replacing the remaining inline `Date` duplicates inside the components is a mechanical follow-up; this PR establishes the tested home for them.

Part of the schedule-editor review/restructure. `tsc` / `eslint` / `prettier` clean; the extraction typechecks against all existing importers via the re-export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the schedule editor's `HH:MM` time arithmetic from `types.ts` (which carried a module-level `memoCache` that was never cleared) into a new, standalone `src/lib/schedule/time.ts` module, backed by 14 unit tests. The extraction is behaviour-preserving: `types.ts` re-exports everything from `./time`, so no existing importer needs to change.

- **`src/lib/schedule/time.ts`** — eight pure functions (`toMinutes`, `toHHMM`, `addMinutes`, `calculateEndTime`, `durationBetween`, `timesOverlap`, `generateTimeSlots`, `getProposalDurationMinutes`) implemented with integer arithmetic instead of `new Date(…)`, removing any timezone/DST sensitivity.
- **`src/lib/schedule/types.ts`** — drops the `memoCache`, all `Date`-based implementations, and re-exports the helpers from `./time`; `findAvailableTimeSlot` and `canSwapTalks` stay put pending Phase 1.
- **`__tests__/lib/schedule/time.test.ts`** — covers round-trips, midnight wrap, overlap boundaries, slot generation, and duration parsing; one gap is a `durationBetween(end < start)` test to document the intentional negative-result contract.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the `generateTimeSlots` zero-interval guard is addressed; all other changes are additive or deletions of dead code.

The refactor is clean and the re-export shim keeps backward compatibility intact. The one real defect is `generateTimeSlots` accepting `intervalMinutes = 0`, which produces an infinite loop on the changed code path — the old `while` loop had the same flaw, but the new function is now the explicit public API with tests, making the unguarded case more reachable. Everything else is a test-coverage suggestion.

`src/lib/schedule/time.ts` — specifically the `generateTimeSlots` loop guard. The other two files are straightforward.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/schedule/time.ts | New pure time-helpers module; logic is correct, but `generateTimeSlots` has no guard against a zero/negative `intervalMinutes`, which would infinite-loop. |
| src/lib/schedule/types.ts | Cleanly strips the old `memoCache` + Date-based implementations and re-exports everything from `./time`; existing importers are unaffected. |
| __tests__/lib/schedule/time.test.ts | Good coverage of the happy paths and boundary cases; missing a test for `durationBetween` when `end < start` (negative result) and for `generateTimeSlots` with a zero/negative interval. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["src/lib/schedule/time.ts\n(new – pure helpers)"] -->|"re-exported via"| B["src/lib/schedule/types.ts\n(updated)"]
    B -->|"consumed by"| C["findAvailableTimeSlot\ncanSwapTalks\n(remain in types.ts)"]
    B -->|"re-exported to"| D["Existing importers\n@/lib/schedule/types"]
    A -->|"tested by"| E["__tests__/lib/schedule/time.test.ts\n(new – 14 unit tests)"]

    subgraph "Removed from types.ts"
        F["memoCache Map (unbounded)"]
        G["Date-based implementations\ngenerateTimeSlots / calculateEndTime\ntimesOverlap / getProposalDurationMinutes"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["src/lib/schedule/time.ts\n(new – pure helpers)"] -->|"re-exported via"| B["src/lib/schedule/types.ts\n(updated)"]
    B -->|"consumed by"| C["findAvailableTimeSlot\ncanSwapTalks\n(remain in types.ts)"]
    B -->|"re-exported to"| D["Existing importers\n@/lib/schedule/types"]
    A -->|"tested by"| E["__tests__/lib/schedule/time.test.ts\n(new – 14 unit tests)"]

    subgraph "Removed from types.ts"
        F["memoCache Map (unbounded)"]
        G["Date-based implementations\ngenerateTimeSlots / calculateEndTime\ntimesOverlap / getProposalDurationMinutes"]
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(schedule): extract pure time he..."](https://github.com/cloudnativebergen/website/commit/d3995969a850fa3e6056e79cabc6daf2ae1d341b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45118145)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->