### PR TITLE
fix(schedule): interval overlap incl. service sessions + bidirectional swap (Phase 1)

### DIFF
--- a/__tests__/lib/schedule/rules.test.ts
+++ b/__tests__/lib/schedule/rules.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment node
+ *
+ * Truth-table tests for the schedule placement rules (src/lib/schedule/rules.ts).
+ * These pin the CORRECTED behaviour introduced with the extraction: occupancy is
+ * interval-based and includes service sessions, and swaps are validated in both
+ * directions. Regression guards for:
+ *   - talks can no longer be dropped straddling a break/lunch,
+ *   - service sessions no longer bypass collision,
+ *   - a cross-track swap can no longer overlap the source track.
+ */
+import { describe, it, expect } from 'vitest'
+import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
+import type { ProposalExisting } from '@/lib/proposal/types'
+import {
+  isTrackIntervalFree,
+  findAvailableTimeSlot,
+  canSwapTalks,
+  canPlaceDisplacedBack,
+  matchTalk,
+} from '@/lib/schedule/rules'
+
+const talk = (id: string, start: string, end: string): TrackTalk => ({
+  talk: { _id: id } as ProposalExisting,
+  startTime: start,
+  endTime: end,
+})
+const service = (name: string, start: string, end: string): TrackTalk => ({
+  placeholder: name,
+  startTime: start,
+  endTime: end,
+})
+const track = (...talks: TrackTalk[]): ScheduleTrack =>
+  ({ trackTitle: 'T', talks }) as ScheduleTrack
+const proposal = (id: string, format: string): ProposalExisting =>
+  ({ _id: id, format }) as unknown as ProposalExisting
+
+describe('isTrackIntervalFree', () => {
+  it('is free against an empty track and against non-overlapping items', () => {
+    expect(isTrackIntervalFree(track(), '10:00', '10:30')).toBe(true)
+    expect(
+      isTrackIntervalFree(track(talk('a', '09:00', '09:30')), '10:00', '10:30'),
+    ).toBe(true)
+  })
+  it('treats a boundary touch as free (adjacent, not overlapping)', () => {
+    expect(
+      isTrackIntervalFree(track(talk('a', '10:30', '11:00')), '10:00', '10:30'),
+    ).toBe(true)
+  })
+  it('detects overlap with a talk', () => {
+    expect(
+      isTrackIntervalFree(track(talk('a', '10:15', '10:45')), '10:00', '10:30'),
+    ).toBe(false)
+  })
+  it('detects overlap with a SERVICE SESSION (the key fix)', () => {
+    expect(
+      isTrackIntervalFree(
+        track(service('Lunch', '11:30', '12:30')),
+        '12:00',
+        '12:25',
+      ),
+    ).toBe(false)
+  })
+  it('honours the exclude matcher', () => {
+    const t = track(talk('a', '10:00', '10:30'))
+    expect(
+      isTrackIntervalFree(t, '10:00', '10:30', matchTalk('a', '10:00')),
+    ).toBe(true)
+  })
+})
+
+describe('findAvailableTimeSlot', () => {
+  it('returns the slot when the whole footprint is free', () => {
+    expect(
+      findAvailableTimeSlot(track(), proposal('p', 'talk_25'), '10:00'),
+    ).toBe('10:00')
+  })
+  it('returns null when the talk would straddle a service session', () => {
+    // 25-min talk at 12:00 (→12:25) over a 11:30–12:30 lunch.
+    expect(
+      findAvailableTimeSlot(
+        track(service('Lunch', '11:30', '12:30')),
+        proposal('p', 'talk_25'),
+        '12:00',
+      ),
+    ).toBeNull()
+  })
+  it('returns null when it overlaps another talk', () => {
+    expect(
+      findAvailableTimeSlot(
+        track(talk('a', '10:10', '10:40')),
+        proposal('p', 'talk_25'),
+        '10:00',
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('canSwapTalks + canPlaceDisplacedBack (bidirectional)', () => {
+  it('allows a swap when both directions fit', () => {
+    const target = track(talk('b', '10:00', '11:00'))
+    const source = track(talk('a', '10:00', '10:20'))
+    const dragged = proposal('a', 'talk_20')
+    const targetTalk = target.talks[0]
+    expect(canSwapTalks(target, dragged, targetTalk, '10:00')).toBe(true)
+    // b (60min) placed back at 10:00 in the source (only 'a' there, which is leaving) fits.
+    expect(
+      canPlaceDisplacedBack(
+        source,
+        targetTalk,
+        '10:00',
+        matchTalk('a', '10:00'),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects the swap when the displaced talk would overlap the source track', () => {
+    // Source: a@10:00(20m) leaving, plus c@10:25(25m) staying.
+    const source = track(
+      talk('a', '10:00', '10:20'),
+      talk('c', '10:25', '10:50'),
+    )
+    // Target: b@10:00 is 45 min.
+    const targetTalk = talk('b', '10:00', '10:45')
+    const target = track(targetTalk)
+    const dragged = proposal('a', 'talk_20')
+    // Forward fits (a into target excluding b)...
+    expect(canSwapTalks(target, dragged, targetTalk, '10:00')).toBe(true)
+    // ...but b(45m) back at 10:00→10:45 overlaps c@10:25 in the source. REJECT.
+    expect(
+      canPlaceDisplacedBack(
+        source,
+        targetTalk,
+        '10:00',
+        matchTalk('a', '10:00'),
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/hooks/useScheduleEditor.ts
+++ b/src/hooks/useScheduleEditor.ts
@@ -9,9 +9,14 @@ import {
   DragItem,
   DropPosition,
   calculateEndTime,
+  durationBetween,
   getProposalDurationMinutes,
   findAvailableTimeSlot,
   canSwapTalks,
+  canPlaceDisplacedBack,
+  isTrackIntervalFree,
+  matchTalk,
+  matchService,
 } from '@/lib/schedule/types'
 
 export interface UseScheduleEditorReturn {
@@ -279,7 +284,22 @@ export function useScheduleEditor(): UseScheduleEditorReturn {
         dragItem.sourceTrackIndex !== undefined &&
         dragItem.sourceTimeSlot !== undefined
       ) {
-        if (!canSwapTalks(targetTrack, proposal, occupiedTalk, timeSlot)) {
+        const sourceTrack = schedule.tracks[dragItem.sourceTrackIndex]
+        // Validate BOTH directions: the dragged talk must fit in the target
+        // slot AND the displaced talk must fit back into the source track.
+        // Checking only the forward direction let a swap leave the source track
+        // overlapping.
+        const draggedExclude = matchTalk(proposal._id, dragItem.sourceTimeSlot)
+        if (
+          !canSwapTalks(targetTrack, proposal, occupiedTalk, timeSlot) ||
+          !sourceTrack ||
+          !canPlaceDisplacedBack(
+            sourceTrack,
+            occupiedTalk,
+            dragItem.sourceTimeSlot,
+            draggedExclude,
+          )
+        ) {
           return { success: false }
         }
 
@@ -370,11 +390,27 @@ export function useScheduleEditor(): UseScheduleEditorReturn {
       if (trackIndex < 0 || trackIndex >= schedule.tracks.length)
         return { success: false }
 
-      const startTime = new Date(`2000-01-01T${serviceSession.startTime}:00`)
-      const endTime = new Date(`2000-01-01T${serviceSession.endTime}:00`)
-      const durationMinutes =
-        (endTime.getTime() - startTime.getTime()) / (1000 * 60)
+      const durationMinutes = durationBetween(
+        serviceSession.startTime,
+        serviceSession.endTime,
+      )
       const newEndTime = calculateEndTime(timeSlot, durationMinutes)
+
+      // A service session must not be dropped onto an occupied interval (a talk
+      // or another session). Previously service-session moves ran zero overlap
+      // checks and always succeeded, stacking items on top of each other.
+      const targetTrack = schedule.tracks[trackIndex]
+      const excludeExisting =
+        dragItem.type === 'scheduled-service' &&
+        dragItem.sourceTrackIndex === trackIndex &&
+        dragItem.sourceTimeSlot !== undefined
+          ? matchService(serviceSession.placeholder, dragItem.sourceTimeSlot)
+          : undefined
+      if (
+        !isTrackIntervalFree(targetTrack, timeSlot, newEndTime, excludeExisting)
+      ) {
+        return { success: false }
+      }
 
       let updatedSchedule: ConferenceSchedule | null = null
 

--- a/src/lib/schedule/rules.ts
+++ b/src/lib/schedule/rules.ts
@@ -1,0 +1,133 @@
+import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
+import { ProposalExisting } from '@/lib/proposal/types'
+import {
+  calculateEndTime,
+  durationBetween,
+  getProposalDurationMinutes,
+  timesOverlap,
+} from './time'
+
+/**
+ * Scheduling placement rules (pure). Extracted from types.ts during the
+ * refactor and CORRECTED: occupancy is now interval-based and covers BOTH talks
+ * and service sessions (breaks/lunch). Previously the checks only looked at
+ * items with a `.talk` and only at an exact `startTime` match, so a talk could
+ * be dropped straddling lunch, service sessions bypassed collision entirely, and
+ * a cross-track swap could leave the source track overlapping.
+ */
+
+/** Match a specific slot by identity so it can be excluded from a free-check. */
+export type SlotMatcher = (slot: TrackTalk) => boolean
+
+/** Exclude the talk currently occupying `startTime` with the given talk id. */
+export function matchTalk(talkId: string, startTime: string): SlotMatcher {
+  return (slot) => slot.talk?._id === talkId && slot.startTime === startTime
+}
+
+/** Exclude the service session at `startTime` with the given placeholder. */
+export function matchService(
+  placeholder: string,
+  startTime: string,
+): SlotMatcher {
+  return (slot) =>
+    slot.placeholder === placeholder && slot.startTime === startTime
+}
+
+/**
+ * Is the interval `[startTime, endTime)` free in `track`? Every slot that
+ * occupies time is an obstacle — talks AND service sessions — so nothing can be
+ * placed overlapping a break. `exclude` skips a specific slot (the item being
+ * moved out of its own position).
+ */
+export function isTrackIntervalFree(
+  track: ScheduleTrack,
+  startTime: string,
+  endTime: string,
+  exclude?: SlotMatcher,
+): boolean {
+  return !track.talks.some((slot) => {
+    if (exclude?.(slot)) return false
+    return timesOverlap(startTime, endTime, slot.startTime, slot.endTime)
+  })
+}
+
+/** Can an item of `durationMinutes` be placed at `startTime` in `track`? */
+export function fitsInTrack(
+  track: ScheduleTrack,
+  startTime: string,
+  durationMinutes: number,
+  exclude?: SlotMatcher,
+): boolean {
+  return isTrackIntervalFree(
+    track,
+    startTime,
+    calculateEndTime(startTime, durationMinutes),
+    exclude,
+  )
+}
+
+/**
+ * The slot a proposal can occupy at `preferredStartTime` (its whole footprint
+ * must be free), or `null` if it would overlap anything. `excludeTalk` lets a
+ * talk be re-placed at/around its own current slot.
+ */
+export function findAvailableTimeSlot(
+  track: ScheduleTrack,
+  proposal: ProposalExisting,
+  preferredStartTime?: string,
+  excludeTalk?: { talkId: string; startTime: string },
+): string | null {
+  const startTime = preferredStartTime || '08:00'
+  const exclude = excludeTalk
+    ? matchTalk(excludeTalk.talkId, excludeTalk.startTime)
+    : undefined
+  return fitsInTrack(
+    track,
+    startTime,
+    getProposalDurationMinutes(proposal),
+    exclude,
+  )
+    ? startTime
+    : null
+}
+
+/**
+ * Forward half of a swap: does `draggedProposal` fit at `targetStartTime` in
+ * `track` once the talk it displaces is removed? The caller must ALSO check the
+ * reverse (that the displaced talk fits back into the source track) via
+ * {@link canPlaceDisplacedBack} — validating only this direction was the source
+ * of the post-swap-overlap bug.
+ */
+export function canSwapTalks(
+  track: ScheduleTrack,
+  draggedProposal: ProposalExisting,
+  targetTalk: TrackTalk,
+  targetStartTime: string,
+): boolean {
+  if (!targetTalk.talk) return false
+  return fitsInTrack(
+    track,
+    targetStartTime,
+    getProposalDurationMinutes(draggedProposal),
+    matchTalk(targetTalk.talk._id, targetTalk.startTime),
+  )
+}
+
+/**
+ * Reverse half of a swap: does the displaced `targetTalk` fit back into the
+ * source track at `sourceStartTime`, once the dragged talk (which is leaving
+ * that track) is excluded?
+ */
+export function canPlaceDisplacedBack(
+  sourceTrack: ScheduleTrack,
+  targetTalk: TrackTalk,
+  sourceStartTime: string,
+  draggedExclude: SlotMatcher,
+): boolean {
+  return fitsInTrack(
+    sourceTrack,
+    sourceStartTime,
+    durationBetween(targetTalk.startTime, targetTalk.endTime),
+    draggedExclude,
+  )
+}

--- a/src/lib/schedule/types.ts
+++ b/src/lib/schedule/types.ts
@@ -1,13 +1,8 @@
-import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import { ProposalExisting } from '@/lib/proposal/types'
-import {
-  calculateEndTime,
-  getProposalDurationMinutes,
-  timesOverlap,
-} from './time'
 
-// Pure time helpers now live in ./time. Re-exported here so existing importers
-// (`@/lib/schedule/types`) keep working while the module is split up.
+// Pure time helpers live in ./time and placement rules in ./rules. Re-exported
+// here so existing importers (`@/lib/schedule/types`) keep working while the
+// module is split up.
 export {
   toMinutes,
   toHHMM,
@@ -19,6 +14,15 @@ export {
   getProposalDurationMinutes,
   type TimeSlot,
 } from './time'
+export {
+  findAvailableTimeSlot,
+  canSwapTalks,
+  canPlaceDisplacedBack,
+  isTrackIntervalFree,
+  fitsInTrack,
+  matchTalk,
+  matchService,
+} from './rules'
 
 export interface DropPosition {
   trackIndex: number
@@ -39,67 +43,3 @@ export interface DragItem {
 
 export const DRAG_PERFORMANCE_THRESHOLD = 16
 export const BATCH_UPDATE_DELAY = 100
-
-export function findAvailableTimeSlot(
-  track: ScheduleTrack,
-  proposal: ProposalExisting,
-  preferredStartTime?: string,
-  excludeTalk?: { talkId: string; startTime: string },
-): string | null {
-  const durationMinutes = getProposalDurationMinutes(proposal)
-  const startTime = preferredStartTime || '08:00'
-  const proposalEndTime = calculateEndTime(startTime, durationMinutes)
-
-  const hasConflict = track.talks.some((talk) => {
-    if (!talk.talk) return false
-
-    if (
-      excludeTalk &&
-      talk.talk._id === excludeTalk.talkId &&
-      talk.startTime === excludeTalk.startTime
-    ) {
-      return false
-    }
-
-    return timesOverlap(
-      startTime,
-      proposalEndTime,
-      talk.startTime,
-      talk.endTime,
-    )
-  })
-
-  return hasConflict ? null : startTime
-}
-
-export function canSwapTalks(
-  track: ScheduleTrack,
-  draggedProposal: ProposalExisting,
-  targetTalk: TrackTalk,
-  targetStartTime: string,
-): boolean {
-  if (!targetTalk.talk) return false
-
-  const draggedDuration = getProposalDurationMinutes(draggedProposal)
-  const draggedEndTime = calculateEndTime(targetStartTime, draggedDuration)
-
-  const draggedHasConflict = track.talks.some((talk) => {
-    if (!talk.talk) return false
-
-    if (
-      talk.talk._id === targetTalk.talk!._id &&
-      talk.startTime === targetTalk.startTime
-    ) {
-      return false
-    }
-
-    return timesOverlap(
-      targetStartTime,
-      draggedEndTime,
-      talk.startTime,
-      talk.endTime,
-    )
-  })
-
-  return !draggedHasConflict
-}


### PR DESCRIPTION
Phase 1 of the schedule restructure — extracts placement rules into a pure, tested `rules.ts` **and fixes the overlap bugs** that the review traced to one root cause (occupancy was checked only for items with a `.talk`, and only at an exact start-time match).

## Bugs fixed
1. **Talks could be dropped straddling a break/lunch.** `findAvailableTimeSlot` skipped every slot without a `.talk` (i.e. all service sessions) and only looked at exact-start occupancy. Now occupancy is **interval-based** and every time-occupying slot — talk **or** service session — is an obstacle. Because `DroppableTrack.canDrop` calls the same function, this also fixes the **false-positive drop indicator** (slot showed droppable, then the drop silently no-op'd).
2. **Service sessions bypassed collision entirely.** `moveServiceSessionToTrack` ran **zero** overlap checks and always succeeded, stacking items on top of each other. It now rejects a drop onto an occupied interval.
3. **Cross-track swap could leave the *source* track overlapping.** Only the dragged direction was validated. `moveTalkToTrack` now also checks the displaced talk fits back into the source track (`canPlaceDisplacedBack`).

## Structure
- New `src/lib/schedule/rules.ts`: `isTrackIntervalFree` / `fitsInTrack` / `findAvailableTimeSlot` / `canSwapTalks` / `canPlaceDisplacedBack` / `matchTalk` / `matchService` — pure, on top of the Phase-0 `time.ts`.
- `types.ts` re-exports them, so importers (`DroppableTrack`, `useScheduleEditor`) are unchanged in source.
- Also replaces the inline `new Date('2000-01-01T…')` duration math in `moveServiceSessionToTrack` with `durationBetween`.

## Tests
**10 rules truth-table tests** (+ the 14 `time` tests): boundary-touch = free, overlap with talk, **overlap with a service session**, exclude-self, `findAvailableTimeSlot` rejecting a talk over lunch, and the **bidirectional swap** case where the forward direction fits but the displaced talk would overlap the source track.

`tsc` / `eslint` / `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts schedule placement rules into a new pure `rules.ts` module and fixes three related overlap bugs: `findAvailableTimeSlot` now checks interval occupancy for all slot types (talks and service sessions), `moveServiceSessionToTrack` has a collision guard for the first time, and `moveTalkToTrack` validates both directions of a cross-track swap.

- **`src/lib/schedule/rules.ts`** (new): `isTrackIntervalFree` replaces the old exact-startTime + talk-only checks; `canPlaceDisplacedBack` closes the unidirectional swap hole; `matchTalk`/`matchService` provide identity exclusion for in-place moves.
- **`useScheduleEditor.ts`**: bidirectional swap guard added to `moveTalkToTrack`; `isTrackIntervalFree` + `matchService` exclusion added to `moveServiceSessionToTrack`; `durationBetween` replaces inline `new Date` arithmetic.
- **Tests**: 10 truth-table tests pin all three fixed scenarios; `matchService` as an exclude matcher is not yet covered at the unit level.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three overlap bugs are correctly addressed, the pure rule functions are well-tested for the main paths, and no new data mutations were introduced.

The logic in rules.ts and the hook changes is sound and backed by targeted tests. The only gaps are a missing unit test for matchService as an exclude matcher and the SlotMatcher type not being re-exported from the barrel. Neither affects runtime correctness today.

Minor attention to src/lib/schedule/types.ts (missing SlotMatcher re-export) and __tests__/lib/schedule/rules.test.ts (no test for matchService exclusion).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/schedule/rules.ts | New pure-function module. Interval-based occupancy check now covers service sessions; bidirectional swap validation is correct. Logic is clean and well-documented. |
| src/hooks/useScheduleEditor.ts | Two bug fixes applied correctly: bidirectional swap validation added to moveTalkToTrack, and interval overlap guard added to moveServiceSessionToTrack. durationBetween replaces inline Date arithmetic cleanly. |
| src/lib/schedule/types.ts | Barrel re-exports updated to include all new rules functions, but SlotMatcher type is missing from the re-export list. |
| __tests__/lib/schedule/rules.test.ts | Ten truth-table tests covering the three fixed bugs. matchTalk exclusion is tested but matchService exclusion is not, leaving the same-track service session re-position path untested at the unit level. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI (Drag End)
    participant Editor as useScheduleEditor
    participant Rules as rules.ts
    participant State as React State

    UI->>Editor: moveTalkToTrack(dragItem, dropPosition)
    Editor->>Editor: find occupiedTalk by exact startTime
    alt "occupiedTalk is a talk & scheduled-talk drag"
        Editor->>Rules: canSwapTalks(targetTrack, proposal, occupiedTalk, timeSlot)
        Rules->>Rules: fitsInTrack → isTrackIntervalFree (all slots)
        Rules-->>Editor: forward fits?
        Editor->>Rules: canPlaceDisplacedBack(sourceTrack, occupiedTalk, sourceTimeSlot, draggedExclude)
        Rules->>Rules: fitsInTrack → isTrackIntervalFree (excludes dragged talk)
        Rules-->>Editor: backward fits?
        Editor->>State: setSchedule (swap both talks)
    else no occupied talk (or service session at that start)
        Editor->>Rules: findAvailableTimeSlot(targetTrack, proposal, timeSlot)
        Rules->>Rules: fitsInTrack → isTrackIntervalFree (talks + service sessions)
        Rules-->>Editor: slot or null
        Editor->>State: setSchedule (place talk)
    end

    UI->>Editor: moveServiceSessionToTrack(dragItem, dropPosition)
    Editor->>Editor: compute newEndTime via durationBetween
    Editor->>Rules: isTrackIntervalFree(targetTrack, timeSlot, newEndTime, excludeExisting?)
    Rules-->>Editor: free?
    Editor->>State: setSchedule (move service session)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI (Drag End)
    participant Editor as useScheduleEditor
    participant Rules as rules.ts
    participant State as React State

    UI->>Editor: moveTalkToTrack(dragItem, dropPosition)
    Editor->>Editor: find occupiedTalk by exact startTime
    alt "occupiedTalk is a talk & scheduled-talk drag"
        Editor->>Rules: canSwapTalks(targetTrack, proposal, occupiedTalk, timeSlot)
        Rules->>Rules: fitsInTrack → isTrackIntervalFree (all slots)
        Rules-->>Editor: forward fits?
        Editor->>Rules: canPlaceDisplacedBack(sourceTrack, occupiedTalk, sourceTimeSlot, draggedExclude)
        Rules->>Rules: fitsInTrack → isTrackIntervalFree (excludes dragged talk)
        Rules-->>Editor: backward fits?
        Editor->>State: setSchedule (swap both talks)
    else no occupied talk (or service session at that start)
        Editor->>Rules: findAvailableTimeSlot(targetTrack, proposal, timeSlot)
        Rules->>Rules: fitsInTrack → isTrackIntervalFree (talks + service sessions)
        Rules-->>Editor: slot or null
        Editor->>State: setSchedule (place talk)
    end

    UI->>Editor: moveServiceSessionToTrack(dragItem, dropPosition)
    Editor->>Editor: compute newEndTime via durationBetween
    Editor->>Rules: isTrackIntervalFree(targetTrack, timeSlot, newEndTime, excludeExisting?)
    Rules-->>Editor: free?
    Editor->>State: setSchedule (move service session)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): interval-based overlap in..."](https://github.com/cloudnativebergen/website/commit/9955ce772de5c7306d6b83f7a9737774231a6d86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45120919)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->