### PR TITLE
fix(schedule): configure dnd-kit sensors so touch drag doesn't hijack scroll

### DIFF
--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -7,6 +7,11 @@ import {
   DragOverlay,
   DragStartEvent,
   pointerWithin,
+  useSensor,
+  useSensors,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
 } from '@dnd-kit/core'
 import { useEffect, useState, useRef, useMemo, useCallback } from 'react'
 import React from 'react'
@@ -860,9 +865,23 @@ export function ScheduleEditor({
     return null
   }, [activeItem])
 
+  // Explicit sensors so touch drag coexists with scrolling. Without any sensors
+  // dnd-kit's default PointerSensor has NO activation constraint, so on a phone
+  // the first move of a scroll swipe starts a drag and the board/list can't be
+  // scrolled. Mouse drags stay instant (tiny distance); touch requires a short
+  // press-and-hold (delay) so a quick swipe scrolls instead of dragging.
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 8 },
+    }),
+    useSensor(KeyboardSensor),
+  )
+
   return (
     <div className={LAYOUT_CLASSES.container}>
       <DndContext
+        sensors={sensors}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         collisionDetection={pointerWithin}


### PR DESCRIPTION
The `DndContext` had **no `sensors` prop**, so dnd-kit used its default `PointerSensor` with **no `activationConstraint`**. On a touch device the first move of a scroll swipe immediately started a drag — so the board and the unassigned list **couldn't be scrolled** (the classic dnd-kit mobile failure).

## Fix
Explicit per-input sensors:
- **`MouseSensor`** — 4px distance, so desktop drags stay instant.
- **`TouchSensor`** — 200ms delay + 8px tolerance: a quick swipe **scrolls**, a deliberate press-and-hold starts a drag (matches native mobile reorder).
- **`KeyboardSensor`** — preserved.

Splitting Mouse/Touch (rather than one `PointerSensor`) lets each input get the right constraint — a *distance* constraint on touch would still conflict with scrolling, whereas a *delay* doesn't.

Fixes drag-vs-scroll on phones, tablets, and touch-laptops. Single-file, `tsc`/`eslint`/`prettier` clean.

## Follow-up (not in this PR)
The full **phone** experience — the board is still a fixed-pixel, side-by-side layout with a 320px sidebar and hover-only controls — needs a larger change. The review recommends **gating the drag board behind `md`/`lg`** and giving phones a **tap-to-assign** view rather than making the pixel-timeline finger-friendly. That's a UX-direction decision I'll confirm before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the classic dnd-kit touch-scroll conflict by replacing the implicit default `PointerSensor` (no activation constraint) with explicit `MouseSensor` (4 px distance), `TouchSensor` (200 ms delay + 8 px tolerance), and `KeyboardSensor` registrations passed to `DndContext`. The change is scoped to a single file and is a direct application of dnd-kit's recommended approach for co-existing drag and scroll on touch devices.

- **Sensor split (Mouse vs Touch):** Splitting `PointerSensor` into separate `MouseSensor`/`TouchSensor` instances lets each input type receive a different activation constraint, which is the correct fix — a distance constraint on touch still hijacks scroll, so only the delay variant solves the phone/tablet case.
- **`KeyboardSensor` addition:** The sensor was previously provided implicitly via dnd-kit defaults; it is now explicitly declared with no `coordinateGetter`, so keyboard navigation behaviour is unchanged from before this PR.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-file change with no logic side-effects, only improving touch-device UX.

The change is a narrow, additive fix: five new imports and twelve lines that wire up explicitly configured sensors to the existing DndContext. The selected values (4 px mouse distance, 200 ms + 8 px touch delay/tolerance) are the recommended dnd-kit defaults for this use-case and pose no risk to existing desktop behaviour. KeyboardSensor is unchanged from its implicit-default state. No data flow, API calls, or rendering logic is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/ScheduleEditor.tsx | Adds explicit dnd-kit sensors (MouseSensor, TouchSensor, KeyboardSensor) to DndContext, resolving touch-scroll conflict on mobile devices. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Input Event] --> B{Input Type?}
    B -->|Mouse| C[MouseSensor\ndistance: 4px]
    B -->|Touch| D[TouchSensor\ndelay: 200ms\ntolerance: 8px]
    B -->|Keyboard| E[KeyboardSensor]

    C --> F{Move >= 4px?}
    F -->|Yes| G[Activate Drag]
    F -->|No| H[Native Click/Scroll]

    D --> I{Hold >= 200ms AND move < 8px?}
    I -->|Yes| G
    I -->|No - quick swipe| J[Native Scroll]

    E --> G

    G --> K[DndContext handles drag]
    K --> L[onDragStart / onDragEnd callbacks]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User Input Event] --> B{Input Type?}
    B -->|Mouse| C[MouseSensor\ndistance: 4px]
    B -->|Touch| D[TouchSensor\ndelay: 200ms\ntolerance: 8px]
    B -->|Keyboard| E[KeyboardSensor]

    C --> F{Move >= 4px?}
    F -->|Yes| G[Activate Drag]
    F -->|No| H[Native Click/Scroll]

    D --> I{Hold >= 200ms AND move < 8px?}
    I -->|Yes| G
    I -->|No - quick swipe| J[Native Scroll]

    E --> G

    G --> K[DndContext handles drag]
    K --> L[onDragStart / onDragEnd callbacks]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): configure dnd-kit sensors..."](https://github.com/cloudnativebergen/website/commit/b9d50352eb9c437a493148588d6711d137a7fb11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45121520)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->