### PR TITLE
fix(program): correct schedule load/render read-side bugs

### DIFF
--- a/__tests__/components/program/TalkCard.test.tsx
+++ b/__tests__/components/program/TalkCard.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render } from '@testing-library/react'
+import { TalkCard } from '@/components/program/TalkCard'
+import { BookmarksProvider } from '@/contexts/BookmarksContext'
+import type { TrackTalk } from '@/lib/conference/types'
+
+type CardTalk = TrackTalk & {
+  scheduleDate: string
+  trackTitle: string
+  trackIndex: number
+}
+
+const baseSlot = {
+  startTime: '09:00',
+  endTime: '09:30',
+  scheduleDate: '2026-03-10',
+  trackTitle: 'Track A',
+  trackIndex: 0,
+}
+
+function renderCard(talk: CardTalk) {
+  return render(
+    <BookmarksProvider>
+      <TalkCard talk={talk} />
+    </BookmarksProvider>,
+  )
+}
+
+describe('TalkCard service session vs dangling reference', () => {
+  it('renders a genuine service session (placeholder, no talk ref)', () => {
+    const { container } = renderCard({
+      ...baseSlot,
+      placeholder: 'Lunch Break',
+    })
+
+    expect(container.textContent).toContain('Lunch Break')
+  })
+
+  it('falls back to "Service Session" for a placeholder-less slot with no talk ref', () => {
+    const { container } = renderCard({ ...baseSlot })
+
+    expect(container.textContent).toContain('Service Session')
+  })
+
+  it('renders nothing for a dangling talk reference (proposal deleted)', () => {
+    // hasTalkRef true but the reference did not resolve (talk is undefined):
+    // the proposal was deleted. This must NOT be mislabelled as a service
+    // session — it should be dropped entirely.
+    const { container } = renderCard({
+      ...baseSlot,
+      hasTalkRef: true,
+    })
+
+    expect(container.firstChild).toBeNull()
+    expect(container.textContent).not.toContain('Service Session')
+  })
+})

--- a/__tests__/lib/schedule/server.test.ts
+++ b/__tests__/lib/schedule/server.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for getScheduleData day-tab generation.
+ *
+ * Regression guard: a single-day conference with one saved schedule must NOT
+ * fabricate a synthetic extra day at baseDate + 1. Day tabs must come only from
+ * the real conference date range.
+ */
+import { getScheduleData } from '@/lib/schedule/server'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = (...args: any[]) => any
+
+const mockGetConference = vi.fn<AnyFn>()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    mockGetConference(...args),
+}))
+
+const mockGetProposals = vi.fn<AnyFn>()
+vi.mock('@/lib/proposal/server', () => ({
+  getProposals: (...args: unknown[]) => mockGetProposals(...args),
+}))
+
+describe('getScheduleData day tabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetProposals.mockResolvedValue({ proposals: [], proposalsError: null })
+  })
+
+  it('does not fabricate an out-of-range day for a single-day conference', async () => {
+    mockGetConference.mockResolvedValue({
+      conference: {
+        _id: 'conf-1',
+        startDate: '2026-03-10',
+        endDate: '2026-03-10',
+        schedules: [{ _id: 'sched-1', date: '2026-03-10', tracks: [] }],
+      },
+      error: null,
+    })
+
+    const { schedules, error } = await getScheduleData()
+
+    expect(error).toBeUndefined()
+    expect(schedules.map((s) => s.date)).toEqual(['2026-03-10'])
+  })
+
+  it('produces exactly one tab per day in the conference range', async () => {
+    mockGetConference.mockResolvedValue({
+      conference: {
+        _id: 'conf-2',
+        startDate: '2026-03-10',
+        endDate: '2026-03-12',
+        schedules: [{ _id: 'sched-1', date: '2026-03-11', tracks: [] }],
+      },
+      error: null,
+    })
+
+    const { schedules } = await getScheduleData()
+
+    expect(schedules.map((s) => s.date)).toEqual([
+      '2026-03-10',
+      '2026-03-11',
+      '2026-03-12',
+    ])
+  })
+
+  it('never returns a day outside the conference date range', async () => {
+    mockGetConference.mockResolvedValue({
+      conference: {
+        _id: 'conf-3',
+        startDate: '2026-03-10',
+        endDate: '2026-03-11',
+        schedules: [
+          { _id: 'sched-1', date: '2026-03-10', tracks: [] },
+          { _id: 'sched-2', date: '2026-03-11', tracks: [] },
+        ],
+      },
+      error: null,
+    })
+
+    const { schedules } = await getScheduleData()
+
+    for (const s of schedules) {
+      expect(s.date >= '2026-03-10' && s.date <= '2026-03-11').toBe(true)
+    }
+    expect(schedules).toHaveLength(2)
+  })
+})

--- a/src/components/program/ProgramScheduleView.tsx
+++ b/src/components/program/ProgramScheduleView.tsx
@@ -6,7 +6,11 @@ import {
   ChevronRightIcon,
 } from '@heroicons/react/24/outline'
 import { FilteredProgramData } from '@/hooks/useProgramFilter'
-import { ConferenceSchedule, ScheduleTrack } from '@/lib/conference/types'
+import {
+  ConferenceSchedule,
+  ScheduleTrack,
+  TrackTalk,
+} from '@/lib/conference/types'
 import { TalkCard } from './TalkCard'
 import { getTalkStatusKey, isScheduleInPast } from '@/lib/program/time-utils'
 import type { TalkStatus, CurrentPosition } from '@/lib/program/time-utils'
@@ -43,10 +47,17 @@ const getAllTimeSlots = (tracks: ScheduleTrack[]): string[] => {
 // stacks co-starting slots in one cell. A duration-aware, row-spanning layout
 // (talks occupying multiple time rows based on end time) would render overlaps
 // more faithfully but is a larger change tracked separately.
+// A slot whose talk reference no longer resolves (proposal deleted after
+// scheduling) renders nothing — drop it here so neither the desktop grid cell
+// nor the mobile list leaves an empty wrapper/gap. Genuine service sessions
+// (a real placeholder, no talk ref) are kept.
+const isDanglingRef = (talk: TrackTalk) =>
+  talk.hasTalkRef === true && !talk.talk
+
 const getTalksAtTime = (track: ScheduleTrack, startTime: string) =>
   track.talks
     .map((talk, index) => ({ talk, index }))
-    .filter(({ talk }) => talk.startTime === startTime)
+    .filter(({ talk }) => talk.startTime === startTime && !isDanglingRef(talk))
 
 // Sort talks by start time while preserving each talk's original index, so
 // desktop and mobile render slots in the same order without breaking the
@@ -54,6 +65,7 @@ const getTalksAtTime = (track: ScheduleTrack, startTime: string) =>
 const sortTalksWithIndex = (track: ScheduleTrack) =>
   track.talks
     .map((talk, index) => ({ talk, index }))
+    .filter(({ talk }) => !isDanglingRef(talk))
     .sort((a, b) => a.talk.startTime.localeCompare(b.talk.startTime))
 
 const ScheduleTabbed = React.memo(function ScheduleTabbed({

--- a/src/components/program/ProgramScheduleView.tsx
+++ b/src/components/program/ProgramScheduleView.tsx
@@ -34,9 +34,27 @@ const getAllTimeSlots = (tracks: ScheduleTrack[]): string[] => {
   return Array.from(timeSlots).sort()
 }
 
-const getTalkAtTime = (track: ScheduleTrack, startTime: string) => {
-  return track.talks.find((talk) => talk.startTime === startTime)
-}
+// Return EVERY talk in a track that starts at the given time, paired with its
+// original index in `track.talks` (used for status keys and the live-scroll
+// target). Previously this returned only the first match, so a second slot
+// sharing a start time was silently dropped from the desktop grid while it
+// still rendered on mobile.
+// TODO(duration-spanning): the desktop grid keys rows purely off start time and
+// stacks co-starting slots in one cell. A duration-aware, row-spanning layout
+// (talks occupying multiple time rows based on end time) would render overlaps
+// more faithfully but is a larger change tracked separately.
+const getTalksAtTime = (track: ScheduleTrack, startTime: string) =>
+  track.talks
+    .map((talk, index) => ({ talk, index }))
+    .filter(({ talk }) => talk.startTime === startTime)
+
+// Sort talks by start time while preserving each talk's original index, so
+// desktop and mobile render slots in the same order without breaking the
+// index-based status keys / live-scroll targeting.
+const sortTalksWithIndex = (track: ScheduleTrack) =>
+  track.talks
+    .map((talk, index) => ({ talk, index }))
+    .sort((a, b) => a.talk.startTime.localeCompare(b.talk.startTime))
 
 const ScheduleTabbed = React.memo(function ScheduleTabbed({
   tracks,
@@ -218,7 +236,7 @@ const ScheduleTabbed = React.memo(function ScheduleTabbed({
             className="ui-not-focus-visible:outline-none"
           >
             <div className="space-y-3">
-              {track.talks.map((talk, talkIndex) => {
+              {sortTalksWithIndex(track).map(({ talk, index: talkIndex }) => {
                 const talkData = {
                   ...talk,
                   scheduleDate: date,
@@ -322,44 +340,43 @@ const ScheduleStatic = React.memo(function ScheduleStatic({
               </div>
 
               {tracks.map((track, trackIndex) => {
-                const talk = getTalkAtTime(track, timeSlot)
-                const talkIndex = talk
-                  ? track.talks.findIndex((t) => t.startTime === talk.startTime)
-                  : -1
-                const isScrollTarget =
-                  talk &&
-                  talkIndex !== -1 &&
-                  currentPosition &&
-                  currentPosition.scheduleIndex === scheduleIndex &&
-                  currentPosition.trackIndex === trackIndex &&
-                  currentPosition.talkIndex === talkIndex
+                const cellTalks = getTalksAtTime(track, timeSlot)
+                const isScrollTarget = cellTalks.some(
+                  ({ index }) =>
+                    currentPosition &&
+                    currentPosition.scheduleIndex === scheduleIndex &&
+                    currentPosition.trackIndex === trackIndex &&
+                    currentPosition.talkIndex === index,
+                )
 
                 return (
                   <div
                     key={`${timeSlot}-track-${trackIndex}-${track.trackTitle}`}
-                    className="min-h-15"
+                    className="min-h-15 space-y-2"
                     ref={isScrollTarget ? scrollTargetRef : undefined}
                   >
-                    {talk ? (
-                      <TalkCard
-                        key={`talk-${timeSlot}-${trackIndex}-${talk.talk?._id || talk.placeholder || 'empty'}`}
-                        talk={{
-                          ...talk,
-                          scheduleDate: date,
-                          trackTitle: track.trackTitle,
-                          trackIndex,
-                        }}
-                        status={talkStatusMap?.get(
-                          getTalkStatusKey(
-                            date,
-                            talk.startTime,
+                    {cellTalks.length > 0 ? (
+                      cellTalks.map(({ talk, index: talkIndex }) => (
+                        <TalkCard
+                          key={`talk-${timeSlot}-${trackIndex}-${talkIndex}-${talk.talk?._id || talk.placeholder || 'empty'}`}
+                          talk={{
+                            ...talk,
+                            scheduleDate: date,
+                            trackTitle: track.trackTitle,
                             trackIndex,
-                            talk.talk?._id,
-                          ),
-                        )}
-                        compact={true}
-                        fixedHeight={true}
-                      />
+                          }}
+                          status={talkStatusMap?.get(
+                            getTalkStatusKey(
+                              date,
+                              talk.startTime,
+                              trackIndex,
+                              talk.talk?._id,
+                            ),
+                          )}
+                          compact={true}
+                          fixedHeight={true}
+                        />
+                      ))
                     ) : (
                       <div className="h-full min-h-15" />
                     )}

--- a/src/components/program/TalkCard.tsx
+++ b/src/components/program/TalkCard.tsx
@@ -96,6 +96,13 @@ export function TalkCard({
   const isHappeningSoon = status === 'happening-soon'
 
   if (!talk.talk) {
+    // The slot HAD a `talk` reference that no longer resolves (the proposal was
+    // deleted). This is NOT a service session, so drop it rather than mislabel
+    // it as one and render a phantom entry at the old time.
+    if (talk.hasTalkRef) {
+      return null
+    }
+
     return (
       <div className="relative">
         <StatusIndicator status={status} />

--- a/src/components/stream/NextTalkDisplay.tsx
+++ b/src/components/stream/NextTalkDisplay.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import clsx from 'clsx'
 import { ClockIcon, CalendarIcon } from '@heroicons/react/24/outline'
 import type { ConferenceSchedule, TrackTalk } from '@/lib/conference/types'
+import { isInactiveProposal } from '@/lib/proposal/types'
 import {
   getCurrentConferenceTime,
   getTalkStatus,
@@ -30,6 +31,23 @@ interface CurrentTalkData {
   talk: TrackTalk
   scheduleDate: string
   status: TalkStatus
+}
+
+/**
+ * A slot must not surface on the live stream when it is either:
+ *  - a cancelled talk: a resolved proposal whose status is withdrawn/rejected/
+ *    deleted (the stream reads with confirmedTalksOnly:false, so these resolve),
+ *    which otherwise renders with a "LIVE NOW"/"UP NEXT" badge; or
+ *  - a dangling reference: the slot HAD a talk reference that no longer resolves
+ *    (the proposal was deleted), which is indistinguishable from a genuine
+ *    service session and would otherwise render as a phantom "Service Session".
+ * Genuine service sessions (no talk reference, with a placeholder) stay visible.
+ */
+function isHiddenFromStream(talk: TrackTalk): boolean {
+  if (talk.talk) {
+    return isInactiveProposal(talk.talk.status)
+  }
+  return talk.hasTalkRef === true
 }
 
 function StatusBadge({ status }: { status: TalkStatus }) {
@@ -88,7 +106,7 @@ export default function NextTalkDisplay({
       currentTime,
     )
 
-    if (currentPosition) {
+    if (currentPosition && !isHiddenFromStream(currentPosition.talk)) {
       const schedule = sortedSchedules[currentPosition.scheduleIndex]
       const track = schedule.tracks[currentPosition.trackIndex]
 
@@ -126,6 +144,7 @@ export default function NextTalkDisplay({
 
       for (const talk of sortedTalks) {
         if (!talk.startTime || !talk.endTime) continue
+        if (isHiddenFromStream(talk)) continue
 
         const status = getTalkStatus(talk, schedule.date, currentTime)
 
@@ -161,6 +180,7 @@ export default function NextTalkDisplay({
 
         for (const talk of sortedTalks) {
           if (!talk.startTime || !talk.endTime) continue
+          if (isHiddenFromStream(talk)) continue
 
           // Find any session (talk or service) that starts at or after the given time
           if (talk.startTime >= afterTime) {

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -174,6 +174,7 @@ export async function getConferenceForDomain(
         startTime,
         endTime,
         placeholder,
+        "hasTalkRef": defined(talk),
         talk->{
           _id,
           title,

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -18,6 +18,14 @@ export interface TrackTalk {
   placeholder?: string
   startTime: string
   endTime: string
+  /**
+   * True when the persisted slot HAD a `talk` reference, regardless of whether
+   * that reference still resolves. Lets renderers tell a genuine service
+   * session (no ref + placeholder) apart from a dangling reference whose
+   * proposal was deleted (`hasTalkRef` true but `talk` unresolved), so the
+   * latter is not mislabelled as a "Service Session".
+   */
+  hasTalkRef?: boolean
 }
 export interface ScheduleTrack {
   trackTitle: string

--- a/src/lib/schedule/server.ts
+++ b/src/lib/schedule/server.ts
@@ -61,23 +61,6 @@ export async function getScheduleData(): Promise<ScheduleData> {
       }
     }
 
-    if (schedules.length === 1 && conferenceDates.length === 1) {
-      const baseDate = new Date(schedules[0].date)
-      const secondDay = new Date(baseDate)
-      secondDay.setDate(secondDay.getDate() + 1)
-
-      schedules.push({
-        _id: '',
-        date: secondDay.toISOString().split('T')[0],
-        tracks: [],
-      })
-
-      console.log(
-        'Added second day schedule:',
-        secondDay.toISOString().split('T')[0],
-      )
-    }
-
     schedules.sort((a, b) => a.date.localeCompare(b.date))
 
     const { proposals, proposalsError } = await getProposals({


### PR DESCRIPTION
From the deeper adversarial review — the schedule editor's bugs propagate to how schedules are **loaded and rendered** on the public program & stream. Four verified read-side fixes (separate files from the editor/reducer work).

1. **Fabricated out-of-range day removed** — `src/lib/schedule/server.ts`. `getScheduleData` invented a synthetic day at `baseDate + 1` for single-day conferences; saving that tab persisted a `schedule` dated **outside** the conference range, which then showed on the public program. Deleted; day tabs now come only from `generateConferenceDates(startDate, endDate)`.
2. **Stream no longer shows withdrawn/deleted talks as "LIVE NOW"** — `NextTalkDisplay.tsx`. Added an `isHiddenFromStream` guard (reusing `isInactiveProposal`) in all three selection paths, so withdrawn/rejected/deleted talks and dangling refs are skipped during current/next selection. (Public/stream read with `confirmedTalksOnly:false`, so these otherwise resolved and rendered live.)
3. **Dangling talk ref no longer renders as a phantom "Service Session"** — projection (`conference/sanity.ts`) now surfaces `"hasTalkRef": defined(talk)` (+ `hasTalkRef?` on `TrackTalk`); `TalkCard` drops a slot whose ref is present-but-unresolved (proposal deleted) instead of labelling it a service session. Only a real `placeholder` with no ref renders as a service session. The new projected field is never persisted back (the writer reconstructs each talk explicitly).
4. **Desktop program grid no longer drops same-start-time slots** — `ProgramScheduleView.tsx`. `getTalkAtTime` (first-match) → `getTalksAtTime` (all co-starting slots, stacked), and talks sorted by start time on **both** desktop and mobile for consistent ordering. This is the no-drop + consistent-order interim; full duration-aware row-spanning is marked `// TODO(duration-spanning)` (larger/riskier, deferred).

Independently verified: `tsc` / `eslint` / `prettier --check` / `knip` clean; new `server.test.ts` (day tabs match conference range) + `TalkCard.test.tsx` (dangling-ref guard) pass.

Part of the schedule solidity push. No overlap with the reducer PR (#481).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four read-side bugs in the schedule/program/stream rendering: a fabricated out-of-range day tab for single-day conferences, withdrawn/deleted talks showing as \"LIVE NOW\" on the stream, dangling talk references rendering as phantom \"Service Sessions\", and the desktop program grid silently dropping co-starting-time slots.

- **`server.ts`**: Removes the synthetic `baseDate + 1` day; day tabs now come solely from `generateConferenceDates(startDate, endDate)`, with new regression tests.
- **`NextTalkDisplay.tsx`**: Adds `isHiddenFromStream` guard (reusing `isInactiveProposal`) across all three talk-selection paths.
- **`TalkCard.tsx` + `sanity.ts` + `types.ts`**: GROQ projects `hasTalkRef: defined(talk)` so renderers distinguish genuine service sessions from dangling refs; `TalkCard` returns `null` for the latter.
- **`ProgramScheduleView.tsx`**: `getTalkAtTime` (first-match) replaced with `getTalksAtTime` (all co-starting slots); talks sorted by start time on both desktop and mobile.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all four targeted bugs are addressed with well-scoped changes and new regression tests.

The four fixes are logically correct and well-tested. The one subtle assumption — that Sanity's GROQ evaluates `defined(talk)` against the raw reference rather than the dereferenced result — is almost certainly correct per GROQ spec, but is undocumented in the code. A comment there would eliminate any future ambiguity.

`src/lib/conference/sanity.ts` warrants a second look on the `"hasTalkRef": defined(talk)` projection to confirm the GROQ evaluation order matches the assumption (raw reference, not dereferenced document).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/schedule/server.ts | Removes the synthetic `baseDate + 1` day that caused out-of-range schedule tabs; day list now comes exclusively from `generateConferenceDates`. Clean. |
| src/components/stream/NextTalkDisplay.tsx | Adds `isHiddenFromStream` guard across all three talk-selection paths; correctly skips withdrawn/deleted proposals and dangling refs. Minor edge case with co-starting hidden/visible slots (still produces correct output). |
| src/components/program/TalkCard.tsx | Adds early-return `null` when `hasTalkRef` is true but `talk` is unresolved, preventing phantom "Service Session" labels for deleted proposals. |
| src/components/program/ProgramScheduleView.tsx | Replaces first-match `getTalkAtTime` with `getTalksAtTime` (all co-starting slots) and adds `sortTalksWithIndex` for consistent ordering; original indices preserved for status-key and scroll-target compatibility. |
| src/lib/conference/sanity.ts | Adds `"hasTalkRef": defined(talk)` projection; relies on GROQ evaluating `defined()` against the raw reference field (correct behavior), but the assumption is implicit. |
| src/lib/conference/types.ts | Adds `hasTalkRef?: boolean` to `TrackTalk` with a clear JSDoc explaining the tristate semantics. |
| __tests__/lib/schedule/server.test.ts | Good regression tests for the day-tab fix; covers single-day, multi-day, and exact-range scenarios. |
| __tests__/components/program/TalkCard.test.tsx | Covers the three relevant TalkCard cases: genuine service session, placeholder-less fallback, and dangling-ref null return. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Schedule slot from GROQ] --> B{hasTalkRef?}
    B -- false --> C[Genuine service session\nno reference + placeholder]
    B -- true --> D{talk resolved?}
    D -- yes --> E{isInactiveProposal\nwithdrawn/rejected/deleted?}
    D -- no --> F[Dangling ref\nproposal deleted]
    E -- yes --> G[Hidden from stream\nNextTalkDisplay skips]
    E -- no --> H[Active talk — render normally]
    F --> I[TalkCard returns null\nNextTalkDisplay skips]
    C --> J[Render placeholder / Service Session]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Schedule slot from GROQ] --> B{hasTalkRef?}
    B -- false --> C[Genuine service session\nno reference + placeholder]
    B -- true --> D{talk resolved?}
    D -- yes --> E{isInactiveProposal\nwithdrawn/rejected/deleted?}
    D -- no --> F[Dangling ref\nproposal deleted]
    E -- yes --> G[Hidden from stream\nNextTalkDisplay skips]
    E -- no --> H[Active talk — render normally]
    F --> I[TalkCard returns null\nNextTalkDisplay skips]
    C --> J[Render placeholder / Service Session]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/stream/NextTalkDisplay.tsx`, line 109-126 ([link](https://github.com/cloudnativebergen/website/blob/48f991dda4ca575d112ed4febca85c6e666fbc50/src/components/stream/NextTalkDisplay.tsx#L109-L126)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`findCurrentTalkPosition` fallthrough when hidden talk is in the target room**

   When `findCurrentTalkPosition` returns a position in the correct room but on a hidden slot, execution falls through to the manual loop, which re-scans from the start and will correctly find any visible co-starting talk. The end result is correct, but with the co-starting-time fix also landing in this PR the scenario (hidden + visible co-starting slot in the same room) is now more plausible. The manual loop will surface the visible one, so no incorrect output occurs.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(program): filter dangling talk refs ..."](https://github.com/cloudnativebergen/website/commit/48f991dda4ca575d112ed4febca85c6e666fbc50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45134366)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->