### PR TITLE
feat(schedule): functional mobile tap-to-assign editor view

### DIFF
--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MobileScheduleView } from '@/components/admin/schedule/MobileScheduleView'
+import {
+  ProposalExisting,
+  Format,
+  Language,
+  Level,
+  Audience,
+  Status,
+} from '@/lib/proposal/types'
+import { ConferenceSchedule } from '@/lib/conference/types'
+
+const makeProposal = (
+  overrides: Partial<ProposalExisting> & { _id: string; title: string },
+): ProposalExisting => ({
+  _rev: '1',
+  _type: 'talk',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+  description: [],
+  language: Language.english,
+  format: Format.presentation_45,
+  level: Level.intermediate,
+  audiences: [Audience.developer],
+  status: Status.confirmed,
+  outline: '',
+  topics: [],
+  tos: true,
+  speakers: [
+    {
+      _id: `speaker-${overrides._id}`,
+      _rev: '1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      slug: 'jane-doe',
+    },
+  ],
+  conference: { _type: 'reference', _ref: 'conf-1' },
+  attachments: [],
+  ...overrides,
+})
+
+const scheduledProposal = makeProposal({
+  _id: 'scheduled-1',
+  title: 'Scheduled Keynote Talk',
+})
+
+const unassignedProposal = makeProposal({
+  _id: 'unassigned-1',
+  title: 'Unassigned Lightning Talk',
+  format: Format.lightning_10,
+  level: Level.beginner,
+})
+
+const schedule: ConferenceSchedule = {
+  _id: 'day-1',
+  date: '2026-09-01',
+  tracks: [
+    {
+      trackTitle: 'Main Stage',
+      trackDescription: '',
+      talks: [
+        {
+          talk: scheduledProposal,
+          startTime: '10:00',
+          endTime: '10:45',
+        },
+      ],
+    },
+    {
+      trackTitle: 'Workshop Room',
+      trackDescription: '',
+      talks: [],
+    },
+  ],
+}
+
+const setup = () => {
+  const dispatch = vi.fn()
+  render(
+    <MobileScheduleView
+      schedules={[schedule]}
+      currentDayIndex={0}
+      unassignedProposals={[unassignedProposal]}
+      dispatch={dispatch}
+      onSave={vi.fn()}
+      onAddTrack={vi.fn()}
+      isSaving={false}
+      saveSuccess={false}
+      error={null}
+    />,
+  )
+  return { dispatch }
+}
+
+describe('MobileScheduleView', () => {
+  it('renders the selected track agenda', () => {
+    setup()
+    expect(
+      screen.getByRole('heading', { name: 'Main Stage' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Scheduled Keynote Talk')).toBeInTheDocument()
+    expect(screen.getByText('10:00–10:45')).toBeInTheDocument()
+  })
+
+  it('lists unassigned proposals in the assign sheet', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button', { name: 'Assign a talk' }))
+    const dialog = screen.getByRole('dialog')
+    expect(
+      within(dialog).getByText('Unassigned Lightning Talk'),
+    ).toBeInTheDocument()
+  })
+
+  it('dispatches moveProposal when assigning a talk', () => {
+    const { dispatch } = setup()
+    fireEvent.click(screen.getByRole('button', { name: 'Assign a talk' }))
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByText('Unassigned Lightning Talk'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Assign' }))
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'moveProposal',
+        dragItem: expect.objectContaining({
+          type: 'proposal',
+          proposal: expect.objectContaining({ _id: 'unassigned-1' }),
+        }),
+        dropPosition: expect.objectContaining({ trackIndex: 0 }),
+      }),
+    )
+  })
+
+  it('dispatches removeTalk from a card action sheet', () => {
+    const { dispatch } = setup()
+    fireEvent.click(
+      screen.getByRole('button', { name: /Scheduled Keynote Talk/ }),
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: /Remove from schedule/ }),
+    )
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'removeTalk',
+      trackIndex: 0,
+      talkIndex: 0,
+    })
+  })
+})

--- a/src/components/admin/schedule/MobileScheduleView.stories.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.stories.tsx
@@ -1,0 +1,180 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useReducer } from 'react'
+import { MobileScheduleView } from './MobileScheduleView'
+import {
+  scheduleReducer,
+  initScheduleEditorState,
+} from '@/lib/schedule/reducer'
+import { computeUnassigned } from '@/lib/schedule/operations'
+import { ConferenceSchedule } from '@/lib/conference/types'
+import {
+  ProposalExisting,
+  Format,
+  Language,
+  Level,
+  Audience,
+  Status,
+} from '@/lib/proposal/types'
+import { convertStringToPortableTextBlocks } from '@/lib/proposal'
+
+const makeProposal = (
+  overrides: Partial<ProposalExisting> & { _id: string; title: string },
+): ProposalExisting => ({
+  _rev: '1',
+  _type: 'talk',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+  description: convertStringToPortableTextBlocks('A talk.'),
+  language: Language.english,
+  format: Format.presentation_45,
+  level: Level.intermediate,
+  audiences: [Audience.developer],
+  status: Status.confirmed,
+  outline: '',
+  topics: [],
+  tos: true,
+  speakers: [
+    {
+      _id: `sp-${overrides._id}`,
+      _rev: '1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      slug: 'jane-doe',
+    },
+  ],
+  conference: { _type: 'reference', _ref: 'conf-1' },
+  attachments: [],
+  ...overrides,
+})
+
+const scheduledA = makeProposal({
+  _id: 'sched-a',
+  title: 'Building Scalable Kubernetes Applications',
+})
+const scheduledB = makeProposal({
+  _id: 'sched-b',
+  title: 'Service Mesh Deep Dive',
+  format: Format.presentation_25,
+  level: Level.advanced,
+})
+
+const unassigned: ProposalExisting[] = [
+  makeProposal({
+    _id: 'un-1',
+    title: 'Cloud Native CI/CD Pipelines',
+    format: Format.lightning_10,
+    level: Level.beginner,
+  }),
+  makeProposal({
+    _id: 'un-2',
+    title: 'Observability with OpenTelemetry',
+    format: Format.presentation_45,
+    status: Status.accepted,
+  }),
+  makeProposal({
+    _id: 'un-3',
+    title: 'Platform Engineering 101',
+    format: Format.presentation_25,
+    level: Level.beginner,
+    audiences: [Audience.manager],
+  }),
+]
+
+const schedules: ConferenceSchedule[] = [
+  {
+    _id: 'day-1',
+    date: '2026-09-01',
+    tracks: [
+      {
+        trackTitle: 'Main Stage',
+        trackDescription: '',
+        talks: [
+          { talk: scheduledA, startTime: '09:00', endTime: '09:45' },
+          { placeholder: 'Coffee Break', startTime: '09:45', endTime: '10:00' },
+          { talk: scheduledB, startTime: '10:00', endTime: '10:25' },
+        ],
+      },
+      { trackTitle: 'Workshop Room', trackDescription: '', talks: [] },
+    ],
+  },
+  {
+    _id: 'day-2',
+    date: '2026-09-02',
+    tracks: [{ trackTitle: 'Main Stage', trackDescription: '', talks: [] }],
+  },
+]
+
+function MobileScheduleHarness({
+  initialSchedules,
+  proposals,
+}: {
+  initialSchedules: ConferenceSchedule[]
+  proposals: ProposalExisting[]
+}) {
+  const [state, dispatch] = useReducer(
+    scheduleReducer,
+    { schedules: initialSchedules, proposals },
+    initScheduleEditorState,
+  )
+  const unassignedProposals = computeUnassigned(
+    state.proposals,
+    state.schedules,
+  )
+
+  return (
+    <MobileScheduleView
+      schedules={state.schedules}
+      currentDayIndex={state.currentDayIndex}
+      unassignedProposals={unassignedProposals}
+      dispatch={dispatch}
+      onSave={() => {}}
+      onAddTrack={() => {}}
+      isSaving={state.ui.isSaving}
+      saveSuccess={false}
+      error={state.ui.error}
+    />
+  )
+}
+
+const meta: Meta<typeof MobileScheduleHarness> = {
+  title: 'Systems/Program/Admin/MobileScheduleView',
+  component: MobileScheduleHarness,
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+    docs: {
+      description: {
+        component:
+          'Tap-to-assign mobile schedule editor rendered below the `md` breakpoint. One track at a time, agenda cards, and bottom sheets for assigning talks, moving them, and managing service sessions. Wired to the real schedule reducer so interactions mutate state.',
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof MobileScheduleHarness>
+
+export const Default: Story = {
+  args: { initialSchedules: schedules, proposals: unassigned },
+}
+
+export const EmptyTrack: Story = {
+  args: {
+    initialSchedules: [
+      {
+        _id: 'day-1',
+        date: '2026-09-01',
+        tracks: [{ trackTitle: 'Main Stage', trackDescription: '', talks: [] }],
+      },
+    ],
+    proposals: unassigned,
+  },
+}
+
+export const NoTracks: Story = {
+  args: {
+    initialSchedules: [{ _id: 'day-1', date: '2026-09-01', tracks: [] }],
+    proposals: unassigned,
+  },
+}

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -1,0 +1,1302 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ConferenceSchedule,
+  ScheduleTrack,
+  TrackTalk,
+} from '@/lib/conference/types'
+import { ProposalExisting } from '@/lib/proposal/types'
+import { ScheduleAction } from '@/lib/schedule/reducer'
+import {
+  SCHEDULE_START,
+  SCHEDULE_END,
+  calculateEndTime,
+  durationBetween,
+  generateTimeSlots,
+  getProposalDurationMinutes,
+  toMinutes,
+} from '@/lib/schedule/time'
+import {
+  fitsInTrack,
+  isTrackIntervalFree,
+  matchTalk,
+} from '@/lib/schedule/rules'
+import { StatusBadge, LevelIndicator } from '@/lib/proposal'
+import { Status } from '@/lib/proposal/types'
+import { formatSpeakerNames } from '@/lib/speaker/formatSpeakerNames'
+import type { Speaker } from '@/lib/speaker/types'
+import { Dropdown } from '@/components/Form'
+import { useProposalFilters } from './useProposalFilters'
+import { ProposalFilters } from './ProposalFilters'
+import {
+  PlusIcon,
+  BookmarkIcon,
+  CheckCircleIcon,
+  XMarkIcon,
+  ClockIcon,
+  UserIcon,
+  InformationCircleIcon,
+  ArrowLeftIcon,
+  ArrowsRightLeftIcon,
+  TrashIcon,
+  PencilIcon,
+  ArrowsUpDownIcon,
+} from '@heroicons/react/24/outline'
+
+interface MobileScheduleViewProps {
+  schedules: ConferenceSchedule[]
+  currentDayIndex: number
+  unassignedProposals: ProposalExisting[]
+  dispatch: React.Dispatch<ScheduleAction>
+  onSave: () => void
+  onAddTrack: () => void
+  isSaving: boolean
+  saveSuccess: boolean
+  error: string | null
+}
+
+const SERVICE_DURATION_OPTIONS = new Map([
+  ['5', '5 minutes'],
+  ['10', '10 minutes'],
+  ['15', '15 minutes'],
+  ['20', '20 minutes'],
+  ['30', '30 minutes'],
+  ['45', '45 minutes'],
+  ['60', '60 minutes'],
+  ['90', '90 minutes'],
+])
+
+const TAP_TARGET = 'min-h-[44px]'
+
+const PRIMARY_BUTTON =
+  'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600'
+
+const SECONDARY_BUTTON =
+  'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+
+/** Every `intervalMinutes` start time whose full footprint is free in `track`. */
+function freeStartTimes(
+  track: ScheduleTrack,
+  durationMinutes: number,
+  exclude?: (slot: TrackTalk) => boolean,
+  intervalMinutes = 5,
+): string[] {
+  const endBound = toMinutes(SCHEDULE_END)
+  return generateTimeSlots(SCHEDULE_START, SCHEDULE_END, intervalMinutes)
+    .map((s) => s.time)
+    .filter((time) => {
+      if (toMinutes(calculateEndTime(time, durationMinutes)) > endBound) {
+        return false
+      }
+      return fitsInTrack(track, time, durationMinutes, exclude)
+    })
+}
+
+function speakerNamesOf(proposal: ProposalExisting): string | null {
+  const populated = Array.isArray(proposal.speakers)
+    ? (proposal.speakers.filter(
+        (s) => s && typeof s === 'object' && 'name' in s,
+      ) as Speaker[])
+    : []
+  return populated.length > 0 ? formatSpeakerNames(populated) : null
+}
+
+/* -------------------------------------------------------------------------- */
+/* Bottom sheet                                                               */
+/* -------------------------------------------------------------------------- */
+
+function BottomSheet({
+  title,
+  onClose,
+  children,
+}: {
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+}) {
+  const titleId = useMemo(
+    () => `sheet-${title.replace(/\s+/g, '-').toLowerCase()}`,
+    [title],
+  )
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col justify-end">
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/50"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative flex max-h-[85dvh] flex-col rounded-t-2xl bg-white shadow-xl dark:bg-gray-900"
+      >
+        <div className="flex shrink-0 items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+          <h2
+            id={titleId}
+            className="text-base font-semibold text-gray-900 dark:text-white"
+          >
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close sheet"
+            className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:bg-gray-800"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto overscroll-contain p-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Agenda card                                                                */
+/* -------------------------------------------------------------------------- */
+
+function AgendaCard({ talk, onTap }: { talk: TrackTalk; onTap: () => void }) {
+  const isService = !talk.talk
+  const proposal = talk.talk
+  const duration = durationBetween(talk.startTime, talk.endTime)
+  const title = proposal?.title ?? talk.placeholder ?? 'Untitled'
+  const speakers = proposal ? speakerNamesOf(proposal) : null
+
+  return (
+    <button
+      type="button"
+      onClick={onTap}
+      className={`flex w-full ${TAP_TARGET} flex-col gap-1 rounded-lg border p-3 text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+        isService
+          ? 'border-dashed border-gray-300 bg-gray-50 dark:border-gray-600 dark:bg-gray-800/60'
+          : 'border-gray-200 bg-white hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+        <span className="tabular-nums">
+          {talk.startTime}–{talk.endTime}
+        </span>
+        <span className="inline-flex items-center gap-1 tabular-nums">
+          <ClockIcon className="h-3.5 w-3.5" />
+          {duration}m
+        </span>
+      </div>
+
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          {title}
+        </h3>
+        {proposal && (
+          <LevelIndicator
+            level={proposal.level}
+            size="xs"
+            className="mt-0.5 shrink-0"
+          />
+        )}
+      </div>
+
+      {isService ? (
+        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+          Service session
+        </span>
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          {proposal && (
+            <StatusBadge status={proposal.status} variant="compact" />
+          )}
+          {speakers && (
+            <span className="inline-flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400">
+              <UserIcon className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{speakers}</span>
+            </span>
+          )}
+        </div>
+      )}
+    </button>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Time picker (shared by assign + move)                                      */
+/* -------------------------------------------------------------------------- */
+
+function TimeSelect({
+  id,
+  slots,
+  value,
+  onChange,
+}: {
+  id: string
+  slots: string[]
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="grid grid-cols-1">
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="col-start-1 row-start-1 w-full appearance-none rounded-lg border border-gray-300 bg-white py-2.5 pr-8 pl-3 text-sm text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+      >
+        {slots.map((slot) => (
+          <option key={slot} value={slot}>
+            {slot}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Assign sheet                                                               */
+/* -------------------------------------------------------------------------- */
+
+function AssignSheet({
+  track,
+  trackTitle,
+  trackIndex,
+  proposals,
+  dispatch,
+  onClose,
+}: {
+  track: ScheduleTrack
+  trackTitle: string
+  trackIndex: number
+  proposals: ProposalExisting[]
+  dispatch: React.Dispatch<ScheduleAction>
+  onClose: () => void
+}) {
+  const filters = useProposalFilters(proposals)
+  const [selected, setSelected] = useState<ProposalExisting | null>(null)
+  const [startTime, setStartTime] = useState('')
+  const [inlineError, setInlineError] = useState<string | null>(null)
+
+  const duration = selected ? getProposalDurationMinutes(selected) : 0
+  const slots = useMemo(
+    () => (selected ? freeStartTimes(track, duration) : []),
+    [track, selected, duration],
+  )
+
+  const pickProposal = useCallback(
+    (proposal: ProposalExisting) => {
+      setSelected(proposal)
+      setInlineError(null)
+      const free = freeStartTimes(track, getProposalDurationMinutes(proposal))
+      if (free.length === 0) {
+        setInlineError('No free time slot for this talk in this track.')
+        setStartTime('')
+      } else {
+        setStartTime(free[0])
+      }
+    },
+    [track],
+  )
+
+  const confirm = useCallback(() => {
+    if (!selected || !startTime) return
+    const endTime = calculateEndTime(startTime, duration)
+    if (
+      toMinutes(endTime) > toMinutes(SCHEDULE_END) ||
+      !fitsInTrack(track, startTime, duration)
+    ) {
+      setInlineError('That slot overlaps another item or runs past end of day.')
+      return
+    }
+    dispatch({
+      type: 'moveProposal',
+      dragItem: { type: 'proposal', proposal: selected },
+      dropPosition: { trackIndex, timeSlot: startTime },
+    })
+    onClose()
+  }, [selected, startTime, duration, track, trackIndex, dispatch, onClose])
+
+  if (selected) {
+    return (
+      <BottomSheet title="Pick a start time" onClose={onClose}>
+        <button
+          type="button"
+          onClick={() => setSelected(null)}
+          className="mb-3 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400"
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to talks
+        </button>
+
+        <p className="mb-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
+          {selected.title}
+        </p>
+        <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
+          {duration} min · into {trackTitle}
+        </p>
+
+        {slots.length > 0 ? (
+          <>
+            <label
+              htmlFor="assign-start-time"
+              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Start time
+            </label>
+            <TimeSelect
+              id="assign-start-time"
+              slots={slots}
+              value={startTime}
+              onChange={setStartTime}
+            />
+          </>
+        ) : (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            No free time slot for this talk in this track.
+          </p>
+        )}
+
+        {inlineError && (
+          <p
+            role="alert"
+            className="mt-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
+          >
+            {inlineError}
+          </p>
+        )}
+
+        <div className="mt-5 flex gap-3">
+          <button
+            type="button"
+            onClick={confirm}
+            disabled={!startTime}
+            className={`flex-1 ${PRIMARY_BUTTON}`}
+          >
+            Assign
+          </button>
+        </div>
+      </BottomSheet>
+    )
+  }
+
+  return (
+    <BottomSheet title="Assign a talk" onClose={onClose}>
+      <div className="relative mb-4">
+        <ProposalFilters filters={filters} />
+      </div>
+      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+        {filters.statsText}
+      </p>
+
+      {filters.filteredProposals.length === 0 ? (
+        <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+          {proposals.length === 0
+            ? 'No unassigned talks left.'
+            : 'No talks match your filters.'}
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {filters.filteredProposals.map((proposal) => {
+            const speakers = speakerNamesOf(proposal)
+            return (
+              <li key={proposal._id}>
+                <button
+                  type="button"
+                  onClick={() => pickProposal(proposal)}
+                  className={`flex w-full ${TAP_TARGET} flex-col gap-1 rounded-lg border border-gray-200 bg-white p-3 text-left transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                      {proposal.title}
+                    </span>
+                    <LevelIndicator
+                      level={proposal.level}
+                      size="xs"
+                      className="mt-0.5 shrink-0"
+                    />
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusBadge status={proposal.status} variant="compact" />
+                    <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                      <ClockIcon className="h-3.5 w-3.5" />
+                      {getProposalDurationMinutes(proposal)}m
+                    </span>
+                    {speakers && (
+                      <span className="inline-flex items-center gap-1 truncate text-xs text-gray-600 dark:text-gray-400">
+                        <UserIcon className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">{speakers}</span>
+                      </span>
+                    )}
+                  </div>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </BottomSheet>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Move sheet (scheduled talk -> another track/time)                          */
+/* -------------------------------------------------------------------------- */
+
+function MoveSheet({
+  tracks,
+  sourceTrackIndex,
+  talk,
+  dispatch,
+  onClose,
+}: {
+  tracks: ScheduleTrack[]
+  sourceTrackIndex: number
+  talk: TrackTalk
+  dispatch: React.Dispatch<ScheduleAction>
+  onClose: () => void
+}) {
+  const proposal = talk.talk!
+  const duration = getProposalDurationMinutes(proposal)
+  const [targetTrackIndex, setTargetTrackIndex] = useState(sourceTrackIndex)
+  const [inlineError, setInlineError] = useState<string | null>(null)
+
+  const slots = useMemo(() => {
+    const target = tracks[targetTrackIndex]
+    if (!target) return []
+    const exclude =
+      targetTrackIndex === sourceTrackIndex
+        ? matchTalk(proposal._id, talk.startTime)
+        : undefined
+    return freeStartTimes(target, duration, exclude)
+  }, [
+    tracks,
+    targetTrackIndex,
+    sourceTrackIndex,
+    proposal._id,
+    talk.startTime,
+    duration,
+  ])
+
+  // `startTime` starts empty and is only ever set by the user; the effective
+  // value falls back to the first free slot so we never need a setState-in-effect
+  // to "reset" it when the track (and its slot list) changes.
+  const [startTime, setStartTime] = useState('')
+  const effectiveStart = slots.includes(startTime)
+    ? startTime
+    : (slots[0] ?? '')
+
+  const confirm = useCallback(() => {
+    if (!effectiveStart) return
+    dispatch({
+      type: 'moveProposal',
+      dragItem: {
+        type: 'scheduled-talk',
+        proposal,
+        sourceTrackIndex,
+        sourceTimeSlot: talk.startTime,
+      },
+      dropPosition: { trackIndex: targetTrackIndex, timeSlot: effectiveStart },
+    })
+    onClose()
+  }, [
+    effectiveStart,
+    proposal,
+    sourceTrackIndex,
+    talk.startTime,
+    targetTrackIndex,
+    dispatch,
+    onClose,
+  ])
+
+  return (
+    <BottomSheet title="Move talk" onClose={onClose}>
+      <p className="mb-4 text-sm font-semibold text-gray-900 dark:text-gray-100">
+        {proposal.title}
+      </p>
+
+      <label
+        htmlFor="move-track"
+        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        Track
+      </label>
+      <div className="mb-4 grid grid-cols-1">
+        <select
+          id="move-track"
+          value={targetTrackIndex}
+          onChange={(e) => {
+            setTargetTrackIndex(Number(e.target.value))
+            setInlineError(null)
+          }}
+          className="col-start-1 row-start-1 w-full appearance-none rounded-lg border border-gray-300 bg-white py-2.5 pr-8 pl-3 text-sm text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        >
+          {tracks.map((track, index) => (
+            <option key={index} value={index}>
+              {track.trackTitle || `Track ${index + 1}`}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {slots.length > 0 ? (
+        <>
+          <label
+            htmlFor="move-start-time"
+            className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Start time
+          </label>
+          <TimeSelect
+            id="move-start-time"
+            slots={slots}
+            value={effectiveStart}
+            onChange={setStartTime}
+          />
+        </>
+      ) : (
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          No free time slot in this track.
+        </p>
+      )}
+
+      {inlineError && (
+        <p
+          role="alert"
+          className="mt-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
+        >
+          {inlineError}
+        </p>
+      )}
+
+      <div className="mt-5">
+        <button
+          type="button"
+          onClick={confirm}
+          disabled={!effectiveStart}
+          className={`w-full ${PRIMARY_BUTTON}`}
+        >
+          Move here
+        </button>
+      </div>
+    </BottomSheet>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Card action sheet                                                          */
+/* -------------------------------------------------------------------------- */
+
+function CardActionSheet({
+  talk,
+  trackIndex,
+  talkIndex,
+  dispatch,
+  onClose,
+  onMove,
+}: {
+  talk: TrackTalk
+  trackIndex: number
+  talkIndex: number
+  dispatch: React.Dispatch<ScheduleAction>
+  onClose: () => void
+  onMove: () => void
+}) {
+  const isService = !talk.talk
+  const [mode, setMode] = useState<'menu' | 'rename' | 'duration'>('menu')
+  const [renameValue, setRenameValue] = useState(talk.placeholder ?? '')
+  const [durationValue, setDurationValue] = useState(
+    String(durationBetween(talk.startTime, talk.endTime)),
+  )
+  const title = talk.talk?.title ?? talk.placeholder ?? 'Untitled'
+
+  const remove = useCallback(() => {
+    dispatch({ type: 'removeTalk', trackIndex, talkIndex })
+    onClose()
+  }, [dispatch, trackIndex, talkIndex, onClose])
+
+  const saveRename = useCallback(() => {
+    if (!renameValue.trim()) return
+    dispatch({
+      type: 'renameService',
+      trackIndex,
+      talkIndex,
+      title: renameValue.trim(),
+    })
+    onClose()
+  }, [dispatch, trackIndex, talkIndex, renameValue, onClose])
+
+  const saveDuration = useCallback(() => {
+    dispatch({
+      type: 'resizeService',
+      trackIndex,
+      talkIndex,
+      duration: Number(durationValue),
+    })
+    onClose()
+  }, [dispatch, trackIndex, talkIndex, durationValue, onClose])
+
+  if (mode === 'rename') {
+    return (
+      <BottomSheet title="Rename session" onClose={onClose}>
+        <label
+          htmlFor="rename-service"
+          className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Session title
+        </label>
+        <input
+          id="rename-service"
+          type="text"
+          value={renameValue}
+          onChange={(e) => setRenameValue(e.target.value)}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+          autoFocus
+        />
+        <div className="mt-5 flex gap-3">
+          <button
+            type="button"
+            onClick={saveRename}
+            className={`flex-1 ${PRIMARY_BUTTON}`}
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('menu')}
+            className={`flex-1 ${SECONDARY_BUTTON}`}
+          >
+            Cancel
+          </button>
+        </div>
+      </BottomSheet>
+    )
+  }
+
+  if (mode === 'duration') {
+    return (
+      <BottomSheet title="Change duration" onClose={onClose}>
+        <Dropdown
+          name="service-duration"
+          label="Duration (minutes)"
+          options={SERVICE_DURATION_OPTIONS}
+          value={durationValue}
+          setValue={setDurationValue}
+        />
+        <div className="mt-5 flex gap-3">
+          <button
+            type="button"
+            onClick={saveDuration}
+            className={`flex-1 ${PRIMARY_BUTTON}`}
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('menu')}
+            className={`flex-1 ${SECONDARY_BUTTON}`}
+          >
+            Cancel
+          </button>
+        </div>
+      </BottomSheet>
+    )
+  }
+
+  return (
+    <BottomSheet title={title} onClose={onClose}>
+      <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
+        {talk.startTime}–{talk.endTime}
+        {isService ? ' · Service session' : ''}
+      </p>
+      <div className="space-y-2">
+        {!isService && (
+          <button
+            type="button"
+            onClick={onMove}
+            className={`w-full justify-start ${SECONDARY_BUTTON}`}
+          >
+            <ArrowsRightLeftIcon className="h-5 w-5" />
+            Move to another track / time
+          </button>
+        )}
+        {isService && (
+          <>
+            <button
+              type="button"
+              onClick={() => setMode('rename')}
+              className={`w-full justify-start ${SECONDARY_BUTTON}`}
+            >
+              <PencilIcon className="h-5 w-5" />
+              Rename session
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode('duration')}
+              className={`w-full justify-start ${SECONDARY_BUTTON}`}
+            >
+              <ArrowsUpDownIcon className="h-5 w-5" />
+              Change duration
+            </button>
+          </>
+        )}
+        <button
+          type="button"
+          onClick={remove}
+          className="inline-flex min-h-[44px] w-full items-center justify-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:border-red-900 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50"
+        >
+          <TrashIcon className="h-5 w-5" />
+          Remove from schedule
+        </button>
+      </div>
+    </BottomSheet>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Add service sheet                                                          */
+/* -------------------------------------------------------------------------- */
+
+function AddServiceSheet({
+  track,
+  trackIndex,
+  dispatch,
+  onClose,
+}: {
+  track: ScheduleTrack
+  trackIndex: number
+  dispatch: React.Dispatch<ScheduleAction>
+  onClose: () => void
+}) {
+  const [title, setTitle] = useState('')
+  const [duration, setDuration] = useState('10')
+  const [inlineError, setInlineError] = useState<string | null>(null)
+
+  const slots = useMemo(
+    () => freeStartTimes(track, Number(duration)),
+    [track, duration],
+  )
+  const [startTime, setStartTime] = useState('')
+  const effectiveStart = slots.includes(startTime)
+    ? startTime
+    : (slots[0] ?? '')
+
+  const confirm = useCallback(() => {
+    if (!title.trim() || !effectiveStart) {
+      setInlineError('Enter a title and pick a free start time.')
+      return
+    }
+    const endTime = calculateEndTime(effectiveStart, Number(duration))
+    if (
+      toMinutes(endTime) > toMinutes(SCHEDULE_END) ||
+      !isTrackIntervalFree(track, effectiveStart, endTime)
+    ) {
+      setInlineError('That slot overlaps another item or runs past end of day.')
+      return
+    }
+    dispatch({
+      type: 'addService',
+      trackIndex,
+      title: title.trim(),
+      startTime: effectiveStart,
+      duration: Number(duration),
+    })
+    onClose()
+  }, [title, effectiveStart, duration, track, trackIndex, dispatch, onClose])
+
+  return (
+    <BottomSheet title="Add service session" onClose={onClose}>
+      <label
+        htmlFor="service-title"
+        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        Session title
+      </label>
+      <input
+        id="service-title"
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="e.g. Coffee Break, Lunch"
+        className="mb-4 w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+        autoFocus
+      />
+
+      <div className="mb-4">
+        <Dropdown
+          name="new-service-duration"
+          label="Duration (minutes)"
+          options={SERVICE_DURATION_OPTIONS}
+          value={duration}
+          setValue={setDuration}
+        />
+      </div>
+
+      {slots.length > 0 ? (
+        <>
+          <label
+            htmlFor="service-start-time"
+            className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Start time
+          </label>
+          <TimeSelect
+            id="service-start-time"
+            slots={slots}
+            value={effectiveStart}
+            onChange={setStartTime}
+          />
+        </>
+      ) : (
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          No free time slot of this length in this track.
+        </p>
+      )}
+
+      {inlineError && (
+        <p
+          role="alert"
+          className="mt-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
+        >
+          {inlineError}
+        </p>
+      )}
+
+      <div className="mt-5">
+        <button
+          type="button"
+          onClick={confirm}
+          disabled={!effectiveStart || !title.trim()}
+          className={`w-full ${PRIMARY_BUTTON}`}
+        >
+          Add session
+        </button>
+      </div>
+    </BottomSheet>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Unassigned drawer                                                          */
+/* -------------------------------------------------------------------------- */
+
+function UnassignedDrawer({
+  proposals,
+  onClose,
+}: {
+  proposals: ProposalExisting[]
+  onClose: () => void
+}) {
+  const filters = useProposalFilters(proposals)
+  return (
+    <BottomSheet title={`Unassigned (${proposals.length})`} onClose={onClose}>
+      <div className="relative mb-4">
+        <ProposalFilters filters={filters} />
+      </div>
+      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+        {filters.statsText}
+      </p>
+      {filters.filteredProposals.length === 0 ? (
+        <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+          {proposals.length === 0
+            ? 'Every talk has been scheduled.'
+            : 'No talks match your filters.'}
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {filters.filteredProposals.map((proposal) => {
+            const speakers = speakerNamesOf(proposal)
+            return (
+              <li
+                key={proposal._id}
+                className={`flex ${TAP_TARGET} flex-col gap-1 rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    {proposal.title}
+                  </span>
+                  <LevelIndicator
+                    level={proposal.level}
+                    size="xs"
+                    className="mt-0.5 shrink-0"
+                  />
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusBadge status={proposal.status} variant="compact" />
+                  <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                    <ClockIcon className="h-3.5 w-3.5" />
+                    {getProposalDurationMinutes(proposal)}m
+                  </span>
+                  {speakers && (
+                    <span className="inline-flex items-center gap-1 truncate text-xs text-gray-600 dark:text-gray-400">
+                      <UserIcon className="h-3.5 w-3.5 shrink-0" />
+                      <span className="truncate">{speakers}</span>
+                    </span>
+                  )}
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </BottomSheet>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Legend disclosure                                                          */
+/* -------------------------------------------------------------------------- */
+
+function LegendDisclosure() {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:bg-gray-800"
+        aria-label="Legend"
+      >
+        <InformationCircleIcon className="h-5 w-5" />
+      </button>
+      {open && (
+        <div className="absolute right-0 z-40 mt-1 w-64 rounded-lg border border-gray-200 bg-white p-3 text-xs shadow-lg dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-2 font-semibold text-gray-700 dark:text-gray-200">
+            Legend
+          </h3>
+          <ul className="space-y-1.5 text-gray-600 dark:text-gray-400">
+            <li className="flex items-center gap-2">
+              <StatusBadge status={Status.confirmed} variant="compact" />
+              Confirmed talk
+            </li>
+            <li className="flex items-center gap-2">
+              <StatusBadge status={Status.accepted} variant="compact" />
+              Accepted, not confirmed
+            </li>
+            <li className="flex items-center gap-2">
+              <span className="rounded border border-dashed border-gray-400 px-1.5 py-0.5 dark:border-gray-500">
+                Service
+              </span>
+              Break / lunch session
+            </li>
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Main view                                                                  */
+/* -------------------------------------------------------------------------- */
+
+type ActiveSheet =
+  | { kind: 'assign' }
+  | { kind: 'addService' }
+  | { kind: 'unassigned' }
+  | { kind: 'card'; talkIndex: number }
+  | { kind: 'move'; talkIndex: number }
+  | null
+
+export function MobileScheduleView({
+  schedules,
+  currentDayIndex,
+  unassignedProposals,
+  dispatch,
+  onSave,
+  onAddTrack,
+  isSaving,
+  saveSuccess,
+  error,
+}: MobileScheduleViewProps) {
+  const schedule = schedules[currentDayIndex] ?? null
+  const tracks = useMemo(() => schedule?.tracks ?? [], [schedule])
+
+  const [selectedTrackIndex, setSelectedTrackIndex] = useState(0)
+  const [sheet, setSheet] = useState<ActiveSheet>(null)
+
+  // Keep the selected track valid when the day (and therefore the track list)
+  // changes underneath us.
+  const safeTrackIndex =
+    tracks.length === 0 ? 0 : Math.min(selectedTrackIndex, tracks.length - 1)
+  const prevTrackCount = useRef(tracks.length)
+  useEffect(() => {
+    if (prevTrackCount.current !== tracks.length) {
+      prevTrackCount.current = tracks.length
+      setSelectedTrackIndex((i) => Math.min(i, Math.max(0, tracks.length - 1)))
+    }
+  }, [tracks.length])
+
+  const currentTrack = tracks[safeTrackIndex] ?? null
+
+  const sortedTalks = useMemo(() => {
+    if (!currentTrack) return []
+    return [...currentTrack.talks].sort((a, b) =>
+      a.startTime.localeCompare(b.startTime),
+    )
+  }, [currentTrack])
+
+  const closeSheet = useCallback(() => setSheet(null), [])
+
+  const handleDayChange = useCallback(
+    (dayIndex: number) => {
+      dispatch({ type: 'changeDay', dayIndex })
+      setSelectedTrackIndex(0)
+      setSheet(null)
+    },
+    [dispatch],
+  )
+
+  // The action sheet stores a talkIndex into the SORTED list; translate it back
+  // to the real index in `currentTrack.talks` for reducer actions.
+  const realTalkIndex = useCallback(
+    (talk: TrackTalk): number =>
+      currentTrack
+        ? currentTrack.talks.findIndex(
+            (t) => t.startTime === talk.startTime && t.endTime === talk.endTime,
+          )
+        : -1,
+    [currentTrack],
+  )
+
+  const sheetTalk =
+    sheet && (sheet.kind === 'card' || sheet.kind === 'move')
+      ? sortedTalks[sheet.talkIndex]
+      : null
+
+  return (
+    <div className="flex h-[calc(100dvh-4rem)] flex-col bg-gray-50 dark:bg-gray-950">
+      {/* Header */}
+      <header className="shrink-0 border-b border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-900">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Schedule
+          </h1>
+          <div className="flex items-center gap-2">
+            <LegendDisclosure />
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={isSaving}
+              className={`${PRIMARY_BUTTON} ${
+                saveSuccess ? 'bg-green-600 hover:bg-green-700' : ''
+              }`}
+            >
+              {saveSuccess ? (
+                <>
+                  <CheckCircleIcon className="h-5 w-5" />
+                  Saved
+                </>
+              ) : (
+                <>
+                  <BookmarkIcon className="h-5 w-5" />
+                  {isSaving ? 'Saving…' : 'Save'}
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {schedules.length > 1 && (
+          <div
+            className="mt-3 flex flex-wrap gap-1.5"
+            role="group"
+            aria-label="Select day"
+          >
+            {schedules.map((day, index) => {
+              const isActive = index === currentDayIndex
+              const label = new Date(day.date).toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+              })
+              return (
+                <button
+                  key={`${index}-${day.date}`}
+                  type="button"
+                  onClick={() => handleDayChange(index)}
+                  aria-pressed={isActive}
+                  className={`min-h-[44px] rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 ${
+                    isActive
+                      ? 'border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+                      : 'border-gray-300 bg-white text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300'
+                  }`}
+                >
+                  Day {index + 1} · {label}
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Track switcher */}
+        <div className="mt-3 flex items-center gap-2">
+          <label htmlFor="mobile-track" className="sr-only">
+            Select track
+          </label>
+          <div className="grid flex-1 grid-cols-1">
+            <select
+              id="mobile-track"
+              value={safeTrackIndex}
+              onChange={(e) => setSelectedTrackIndex(Number(e.target.value))}
+              disabled={tracks.length === 0}
+              className="col-start-1 row-start-1 w-full appearance-none rounded-lg border border-gray-300 bg-white py-2.5 pr-8 pl-3 text-sm font-medium text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+            >
+              {tracks.length === 0 ? (
+                <option value={0}>No tracks yet</option>
+              ) : (
+                tracks.map((track, index) => (
+                  <option key={index} value={index}>
+                    {track.trackTitle || `Track ${index + 1}`}
+                  </option>
+                ))
+              )}
+            </select>
+          </div>
+          <button
+            type="button"
+            onClick={onAddTrack}
+            className={SECONDARY_BUTTON}
+            aria-label="Add track"
+          >
+            <PlusIcon className="h-5 w-5" />
+            Track
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setSheet({ kind: 'unassigned' })}
+          className="mt-3 inline-flex min-h-[44px] w-full items-center justify-center gap-2 rounded-lg border border-gray-300 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+        >
+          Unassigned ({unassignedProposals.length})
+        </button>
+      </header>
+
+      {error && (
+        <div className="shrink-0 border-b border-red-200 bg-red-50 px-4 py-2 dark:border-red-800 dark:bg-red-900/20">
+          <p className="text-sm text-red-800 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {/* Agenda */}
+      <main className="flex-1 overflow-y-auto px-4 py-4">
+        {tracks.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No tracks created yet.
+            </p>
+            <button
+              type="button"
+              onClick={onAddTrack}
+              className={PRIMARY_BUTTON}
+            >
+              <PlusIcon className="h-5 w-5" />
+              Create first track
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                {currentTrack?.trackTitle || `Track ${safeTrackIndex + 1}`}
+              </h2>
+              <button
+                type="button"
+                onClick={() => setSheet({ kind: 'addService' })}
+                className="text-sm font-medium text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-blue-400"
+              >
+                + Service
+              </button>
+            </div>
+
+            {sortedTalks.length === 0 ? (
+              <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                Nothing scheduled in this track yet.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {sortedTalks.map((talk, index) => (
+                  <li key={`${talk.startTime}-${talk.endTime}-${index}`}>
+                    <AgendaCard
+                      talk={talk}
+                      onTap={() => setSheet({ kind: 'card', talkIndex: index })}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setSheet({ kind: 'assign' })}
+              className={`mt-4 w-full ${PRIMARY_BUTTON}`}
+            >
+              <PlusIcon className="h-5 w-5" />
+              Assign a talk
+            </button>
+          </>
+        )}
+      </main>
+
+      {/* Sheets */}
+      {sheet?.kind === 'assign' && currentTrack && (
+        <AssignSheet
+          track={currentTrack}
+          trackTitle={currentTrack.trackTitle || `Track ${safeTrackIndex + 1}`}
+          trackIndex={safeTrackIndex}
+          proposals={unassignedProposals}
+          dispatch={dispatch}
+          onClose={closeSheet}
+        />
+      )}
+
+      {sheet?.kind === 'addService' && currentTrack && (
+        <AddServiceSheet
+          track={currentTrack}
+          trackIndex={safeTrackIndex}
+          dispatch={dispatch}
+          onClose={closeSheet}
+        />
+      )}
+
+      {sheet?.kind === 'unassigned' && (
+        <UnassignedDrawer
+          proposals={unassignedProposals}
+          onClose={closeSheet}
+        />
+      )}
+
+      {sheet?.kind === 'card' && sheetTalk && (
+        <CardActionSheet
+          talk={sheetTalk}
+          trackIndex={safeTrackIndex}
+          talkIndex={realTalkIndex(sheetTalk)}
+          dispatch={dispatch}
+          onClose={closeSheet}
+          onMove={() => setSheet({ kind: 'move', talkIndex: sheet.talkIndex })}
+        />
+      )}
+
+      {sheet?.kind === 'move' && sheetTalk && sheetTalk.talk && (
+        <MoveSheet
+          tracks={tracks}
+          sourceTrackIndex={safeTrackIndex}
+          talk={sheetTalk}
+          dispatch={dispatch}
+          onClose={closeSheet}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/schedule/ProposalFilters.tsx
+++ b/src/components/admin/schedule/ProposalFilters.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import {
+  FunnelIcon,
+  XMarkIcon,
+  AdjustmentsHorizontalIcon,
+} from '@heroicons/react/24/outline'
+import { SearchInput } from '@/components/SearchInput'
+import { FilterSelect } from '@/components/FilterSelect'
+import type { ProposalFilterState } from './useProposalFilters'
+
+const SEARCH_INPUT_CLASSES =
+  'w-full rounded-lg border border-gray-200 bg-gray-50 py-2.5 pl-10 pr-4 text-sm text-gray-900 placeholder:text-gray-500 focus:border-transparent focus:bg-white focus:ring-2 focus:ring-blue-500 focus:outline-none transition-all dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:bg-gray-600'
+
+const FormatFilter = ({
+  selectedFormat,
+  availableFormats,
+  onFormatChange,
+}: {
+  selectedFormat: string
+  availableFormats: string[]
+  onFormatChange: (value: string) => void
+}) => (
+  <FilterSelect
+    icon={FunnelIcon}
+    value={selectedFormat}
+    onChange={onFormatChange}
+    ariaLabel="Filter by format"
+    options={
+      new Map(
+        availableFormats.map((format) => [
+          format,
+          format.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
+        ]),
+      )
+    }
+    allLabel="All formats"
+  />
+)
+
+const LevelFilter = ({
+  selectedLevel,
+  availableLevels,
+  onLevelChange,
+}: {
+  selectedLevel: string
+  availableLevels: string[]
+  onLevelChange: (value: string) => void
+}) => (
+  <FilterSelect
+    icon={AdjustmentsHorizontalIcon}
+    value={selectedLevel}
+    onChange={onLevelChange}
+    ariaLabel="Filter by level"
+    options={
+      new Map(
+        availableLevels.map((level) => [
+          level,
+          level.charAt(0).toUpperCase() + level.slice(1),
+        ]),
+      )
+    }
+    allLabel="All levels"
+  />
+)
+
+/**
+ * Search + format + level filter controls, driven by {@link ProposalFilterState}
+ * from `useProposalFilters`. Shared by the desktop `UnassignedProposals` sidebar
+ * and the mobile assign sheet so the filter UX stays identical.
+ */
+export function ProposalFilters({
+  filters,
+  clearButtonClassName,
+}: {
+  filters: ProposalFilterState
+  clearButtonClassName?: string
+}) {
+  return (
+    <div className="space-y-3">
+      {filters.hasActiveFilters && (
+        <button
+          onClick={filters.clearFilters}
+          className={
+            clearButtonClassName ??
+            'absolute top-2 right-2 inline-flex items-center gap-1 rounded-md border border-gray-200 bg-white/90 px-2 py-1 text-xs font-medium text-gray-600 shadow-sm backdrop-blur-sm transition-all hover:bg-white hover:text-gray-800 focus:ring-2 focus:ring-gray-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800/90 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100'
+          }
+          type="button"
+          title="Clear all filters"
+        >
+          <XMarkIcon className="h-3 w-3" />
+          Clear
+        </button>
+      )}
+
+      <SearchInput
+        value={filters.searchQuery}
+        onChange={filters.setSearchQuery}
+        placeholder="Search talks or speakers..."
+        inputClassName={SEARCH_INPUT_CLASSES}
+      />
+
+      <FormatFilter
+        selectedFormat={filters.selectedFormat}
+        availableFormats={filters.availableFormats}
+        onFormatChange={filters.setSelectedFormat}
+      />
+
+      <LevelFilter
+        selectedLevel={filters.selectedLevel}
+        availableLevels={filters.availableLevels}
+        onLevelChange={filters.setSelectedLevel}
+      />
+    </div>
+  )
+}

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -32,6 +32,8 @@ import { UnassignedProposals } from './UnassignedProposals'
 import { MemoizedDroppableTrack as DroppableTrack } from './DroppableTrack'
 import { DraggableProposal } from './DraggableProposal'
 import { DraggableServiceSession } from './DraggableServiceSession'
+import { MobileScheduleView } from './MobileScheduleView'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { api } from '@/lib/trpc/client'
 import {
   PlusIcon,
@@ -392,6 +394,12 @@ export function ScheduleEditor({
   const [showAddTrackModal, setShowAddTrackModal] = useState(false)
   const [saveSuccess, setSaveSuccess] = useState(false)
 
+  // Desktop is the SSR default (`true`), so wide screens never flash the mobile
+  // layout and there is no hydration mismatch; phones flip to the tap-driven
+  // view after mount. The two layouts are mutually exclusive so the drag board's
+  // DndContext (and its touch sensors) is never mounted on a phone.
+  const isDesktop = useMediaQuery('(min-width: 768px)', true)
+
   const saveMutation = api.schedule.save.useMutation()
 
   // Single reducer over ALL days. The active day is `state.currentDayIndex`
@@ -589,6 +597,30 @@ export function ScheduleEditor({
     }),
     useSensor(KeyboardSensor),
   )
+
+  if (!isDesktop) {
+    return (
+      <>
+        <MobileScheduleView
+          schedules={state.schedules}
+          currentDayIndex={currentDayIndex}
+          unassignedProposals={unassignedProposals}
+          dispatch={dispatch}
+          onSave={handleSave}
+          onAddTrack={handleShowAddTrackModal}
+          isSaving={isSaving}
+          saveSuccess={saveSuccess}
+          error={error}
+        />
+        {showAddTrackModal && (
+          <AddTrackModal
+            onAdd={handleAddTrack}
+            onCancel={handleHideAddTrackModal}
+          />
+        )}
+      </>
+    )
+  }
 
   return (
     <div className={LAYOUT_CLASSES.container}>

--- a/src/components/admin/schedule/UnassignedProposals.tsx
+++ b/src/components/admin/schedule/UnassignedProposals.tsx
@@ -4,14 +4,9 @@ import { ProposalExisting } from '@/lib/proposal/types'
 import { LevelIndicator } from '@/lib/proposal'
 import { Level } from '@/lib/proposal/types'
 import { DraggableProposal } from './DraggableProposal'
-import {
-  FunnelIcon,
-  XMarkIcon,
-  AdjustmentsHorizontalIcon,
-} from '@heroicons/react/24/outline'
-import { SearchInput } from '@/components/SearchInput'
-import { FilterSelect } from '@/components/FilterSelect'
 import { useState, useMemo, useCallback } from 'react'
+import { useProposalFilters } from './useProposalFilters'
+import { ProposalFilters } from './ProposalFilters'
 
 interface UnassignedProposalsProps {
   proposals: ProposalExisting[]
@@ -19,84 +14,6 @@ interface UnassignedProposalsProps {
 
 const VIRTUAL_SCROLL_THRESHOLD = 50
 const PROPOSAL_HEIGHT = 120
-
-const FILTER_STYLES = {
-  container: 'space-y-3',
-  clearButton:
-    'absolute top-2 right-2 inline-flex items-center gap-1 rounded-md bg-white/90 backdrop-blur-sm px-2 py-1 text-xs font-medium text-gray-600 hover:bg-white hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-500 transition-all shadow-sm border border-gray-200 dark:bg-gray-800/90 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100 dark:border-gray-600',
-} as const
-
-const FormatFilter = ({
-  selectedFormat,
-  availableFormats,
-  onFormatChange,
-}: {
-  selectedFormat: string
-  availableFormats: string[]
-  onFormatChange: (value: string) => void
-}) => (
-  <FilterSelect
-    icon={FunnelIcon}
-    value={selectedFormat}
-    onChange={onFormatChange}
-    options={
-      new Map(
-        availableFormats.map((format) => [
-          format,
-          format.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
-        ]),
-      )
-    }
-    allLabel="All formats"
-  />
-)
-
-const LevelFilter = ({
-  selectedLevel,
-  availableLevels,
-  onLevelChange,
-}: {
-  selectedLevel: string
-  availableLevels: string[]
-  onLevelChange: (value: string) => void
-}) => (
-  <FilterSelect
-    icon={AdjustmentsHorizontalIcon}
-    value={selectedLevel}
-    onChange={onLevelChange}
-    options={
-      new Map(
-        availableLevels.map((level) => [
-          level,
-          level.charAt(0).toUpperCase() + level.slice(1),
-        ]),
-      )
-    }
-    allLabel="All levels"
-  />
-)
-
-const ClearFiltersButton = ({
-  onClear,
-  hasActiveFilters,
-}: {
-  onClear: () => void
-  hasActiveFilters: boolean
-}) => {
-  if (!hasActiveFilters) return null
-
-  return (
-    <button
-      onClick={onClear}
-      className={FILTER_STYLES.clearButton}
-      type="button"
-      title="Clear all filters"
-    >
-      <XMarkIcon className="h-3 w-3" />
-      Clear
-    </button>
-  )
-}
 
 const EmptyState = ({ hasProposals }: { hasProposals: boolean }) => (
   <div className="flex h-full items-center justify-center p-8 text-center">
@@ -112,89 +29,8 @@ const EmptyState = ({ hasProposals }: { hasProposals: boolean }) => (
 )
 
 export function UnassignedProposals({ proposals }: UnassignedProposalsProps) {
-  const [searchQuery, setSearchQuery] = useState('')
-  const [selectedFormat, setSelectedFormat] = useState<string>('')
-  const [selectedLevel, setSelectedLevel] = useState<string>('')
-
-  const filterOptions = useMemo(() => {
-    const formats = new Set(proposals.map((p) => p.format).filter(Boolean))
-    const levels = new Set(proposals.map((p) => p.level).filter(Boolean))
-
-    return {
-      formats: Array.from(formats).sort(),
-      levels: Array.from(levels).sort(),
-    }
-  }, [proposals])
-
-  const filteredProposals = useMemo(() => {
-    if (!searchQuery && !selectedFormat && !selectedLevel) {
-      return proposals
-    }
-
-    return proposals.filter((proposal) => {
-      if (searchQuery) {
-        const query = searchQuery.toLowerCase().trim()
-        // Null-guard every field: a proposal with a missing title/format or a
-        // speaker with no name must not throw and blank the whole panel.
-        const titleMatch = proposal.title?.toLowerCase().includes(query)
-
-        const speakerMatch =
-          proposal.speakers &&
-          Array.isArray(proposal.speakers) &&
-          proposal.speakers.some(
-            (speaker) =>
-              typeof speaker === 'object' &&
-              'name' in speaker &&
-              speaker.name?.toLowerCase().includes(query),
-          )
-
-        const formatMatch = proposal.format?.toLowerCase().includes(query)
-
-        if (!titleMatch && !speakerMatch && !formatMatch) {
-          return false
-        }
-      }
-
-      if (selectedFormat && proposal.format !== selectedFormat) {
-        return false
-      }
-
-      if (selectedLevel && proposal.level !== selectedLevel) {
-        return false
-      }
-
-      return true
-    })
-  }, [proposals, searchQuery, selectedFormat, selectedLevel])
-
-  const handleSearchChange = useCallback((value: string) => {
-    setSearchQuery(value)
-  }, [])
-
-  const handleFormatChange = useCallback((value: string) => {
-    setSelectedFormat(value)
-  }, [])
-
-  const handleLevelChange = useCallback((value: string) => {
-    setSelectedLevel(value)
-  }, [])
-
-  const handleClearFilters = useCallback(() => {
-    setSearchQuery('')
-    setSelectedFormat('')
-    setSelectedLevel('')
-  }, [])
-
-  const hasActiveFilters = useMemo(() => {
-    return Boolean(searchQuery || selectedFormat || selectedLevel)
-  }, [searchQuery, selectedFormat, selectedLevel])
-
-  const statsText = useMemo(() => {
-    if (filteredProposals.length === proposals.length) {
-      return `${proposals.length} ${proposals.length === 1 ? 'talk' : 'talks'}`
-    }
-    return `${filteredProposals.length} of ${proposals.length} talks`
-  }, [filteredProposals.length, proposals.length])
+  const filters = useProposalFilters(proposals)
+  const { filteredProposals, statsText } = filters
 
   const useVirtualScrolling =
     filteredProposals.length > VIRTUAL_SCROLL_THRESHOLD
@@ -241,31 +77,7 @@ export function UnassignedProposals({ proposals }: UnassignedProposalsProps) {
           </p>
         </div>
 
-        <ClearFiltersButton
-          onClear={handleClearFilters}
-          hasActiveFilters={hasActiveFilters}
-        />
-
-        <div className={FILTER_STYLES.container}>
-          <SearchInput
-            value={searchQuery}
-            onChange={handleSearchChange}
-            placeholder="Search talks or speakers..."
-            inputClassName="w-full rounded-lg border border-gray-200 bg-gray-50 py-2.5 pl-10 pr-4 text-sm text-gray-900 placeholder:text-gray-500 focus:border-transparent focus:bg-white focus:ring-2 focus:ring-blue-500 focus:outline-none transition-all dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:bg-gray-600"
-          />
-
-          <FormatFilter
-            selectedFormat={selectedFormat}
-            availableFormats={filterOptions.formats}
-            onFormatChange={handleFormatChange}
-          />
-
-          <LevelFilter
-            selectedLevel={selectedLevel}
-            availableLevels={filterOptions.levels}
-            onLevelChange={handleLevelChange}
-          />
-        </div>
+        <ProposalFilters filters={filters} />
       </div>
 
       <div

--- a/src/components/admin/schedule/useProposalFilters.ts
+++ b/src/components/admin/schedule/useProposalFilters.ts
@@ -1,0 +1,112 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { ProposalExisting } from '@/lib/proposal/types'
+
+/**
+ * Search + format + level filtering for a list of proposals. Extracted from
+ * `UnassignedProposals` so the desktop sidebar and the mobile assign sheet share
+ * ONE implementation instead of duplicating the (null-guarded) matching logic.
+ */
+export interface ProposalFilterState {
+  searchQuery: string
+  selectedFormat: string
+  selectedLevel: string
+  availableFormats: string[]
+  availableLevels: string[]
+  filteredProposals: ProposalExisting[]
+  hasActiveFilters: boolean
+  statsText: string
+  setSearchQuery: (value: string) => void
+  setSelectedFormat: (value: string) => void
+  setSelectedLevel: (value: string) => void
+  clearFilters: () => void
+}
+
+export function useProposalFilters(
+  proposals: ProposalExisting[],
+): ProposalFilterState {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedFormat, setSelectedFormat] = useState('')
+  const [selectedLevel, setSelectedLevel] = useState('')
+
+  const { availableFormats, availableLevels } = useMemo(() => {
+    const formats = new Set(proposals.map((p) => p.format).filter(Boolean))
+    const levels = new Set(proposals.map((p) => p.level).filter(Boolean))
+    return {
+      availableFormats: Array.from(formats).sort(),
+      availableLevels: Array.from(levels).sort(),
+    }
+  }, [proposals])
+
+  const filteredProposals = useMemo(() => {
+    if (!searchQuery && !selectedFormat && !selectedLevel) {
+      return proposals
+    }
+
+    return proposals.filter((proposal) => {
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase().trim()
+        // Null-guard every field: a proposal with a missing title/format or a
+        // speaker with no name must not throw and blank the whole list.
+        const titleMatch = proposal.title?.toLowerCase().includes(query)
+
+        const speakerMatch =
+          proposal.speakers &&
+          Array.isArray(proposal.speakers) &&
+          proposal.speakers.some(
+            (speaker) =>
+              typeof speaker === 'object' &&
+              'name' in speaker &&
+              speaker.name?.toLowerCase().includes(query),
+          )
+
+        const formatMatch = proposal.format?.toLowerCase().includes(query)
+
+        if (!titleMatch && !speakerMatch && !formatMatch) {
+          return false
+        }
+      }
+
+      if (selectedFormat && proposal.format !== selectedFormat) {
+        return false
+      }
+
+      if (selectedLevel && proposal.level !== selectedLevel) {
+        return false
+      }
+
+      return true
+    })
+  }, [proposals, searchQuery, selectedFormat, selectedLevel])
+
+  const clearFilters = useCallback(() => {
+    setSearchQuery('')
+    setSelectedFormat('')
+    setSelectedLevel('')
+  }, [])
+
+  const hasActiveFilters = Boolean(
+    searchQuery || selectedFormat || selectedLevel,
+  )
+
+  const statsText =
+    filteredProposals.length === proposals.length
+      ? `${proposals.length} ${proposals.length === 1 ? 'talk' : 'talks'}`
+      : `${filteredProposals.length} of ${proposals.length} talks`
+
+  return {
+    searchQuery,
+    selectedFormat,
+    selectedLevel,
+    availableFormats,
+    availableLevels,
+    filteredProposals,
+    hasActiveFilters,
+    statsText,
+    setSearchQuery,
+    setSelectedFormat,
+    setSelectedLevel,
+    clearFilters,
+  }
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Subscribe to a CSS media query and return whether it currently matches.
+ *
+ * `defaultValue` is the value used for the server render and the very first
+ * client render (before the effect runs), so it must equal what the server
+ * would produce to avoid a hydration mismatch. Callers that want the desktop
+ * layout to be the SSR default (and therefore never flash on wide screens)
+ * pass `true` for a `min-width` query.
+ */
+export function useMediaQuery(query: string, defaultValue = false): boolean {
+  const [matches, setMatches] = useState(defaultValue)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+
+    const mediaQuery = window.matchMedia(query)
+    const update = () => setMatches(mediaQuery.matches)
+
+    update()
+    mediaQuery.addEventListener('change', update)
+    return () => mediaQuery.removeEventListener('change', update)
+  }, [query])
+
+  return matches
+}


### PR DESCRIPTION
Gives the admin schedule editor a real **phone** UI. The desktop @dnd-kit drag board (fixed 320px tracks, pixel timeline, hover-only controls, `w-80` sidebar) is unusable on a phone — the sidebar filled the screen and the board was off-screen. Per the locked decision, the drag board is gated to `md`+ and phones get a dedicated **tap-to-assign** flow driving the same reducer.

## How
- `ScheduleEditor` adds `isDesktop = useMediaQuery('(min-width:768px)', true)` (SSR default desktop → no hydration flash) and early-returns `<MobileScheduleView>` on `< md`. The desktop board is **byte-for-byte unchanged** and its `DndContext`/touch sensors never mount on a phone.
- `MobileScheduleView` consumes the **same reducer** `state` + `dispatch` — no new mutation logic, all placement goes through the merged `operations`/`rules` (overlap + end-of-day validation apply).

## The flow (no drag)
- **Header (wraps):** day chips (`changeDay`), a one-track-at-a-time `<select>` + "＋ Track" (reuses AddTrack modal), Save (reuses `handleSave`), an "Unassigned (N)" button, and the Legend collapsed into a popover.
- **Agenda:** the selected track's talks/breaks as ≥44px full-width cards (time · title · duration · status · level · speakers) — no pixel positioning.
- **＋ Assign a talk** → bottom sheet with the shared search/filter listing unassigned proposals → pick one → free-slot start-time `<select>` (computed via `fitsInTrack` + end-of-day guard) → `dispatch(moveProposal)`. Invalid slots pre-validated with an inline alert.
- **Tap a card → action sheet:** Move (track+time → `moveProposal` as `scheduled-talk`), Remove (`removeTalk`); service sessions add Rename/Change-duration (`renameService`/`resizeService`); "＋ Service" → `addService`.
- **Unassigned** is a closed-by-default drawer.
- Accessible (`role="dialog"` sheets, `aria-labelledby`, Escape-to-close, focus-visible, ≥44px), dark-mode, `100dvh`/safe-area sizing.

## Reuse, not duplication
Extracted the sidebar's filtering into shared `useProposalFilters` + `ProposalFilters` (now used by both `UnassignedProposals` and the mobile view); reuses `StatusBadge`/`LevelIndicator`, the AddTrack/ServiceSession modals, and all `time`/`rules` helpers.

## Verified (independently re-run)
`vitest` (admin/schedule + schedule) → **75 passed** (incl. 4 new MobileScheduleView interaction tests asserting the dispatched actions); `tsc`/`eslint`/`prettier --check`/`knip` → clean. 3 Storybook stories on the mobile viewport.

> Worth a real-device visual pass — the interaction logic is tested, but the on-phone feel is best confirmed by you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a dedicated mobile schedule editor (`MobileScheduleView`) that replaces the unusable desktop drag-board below the `md` breakpoint with a tap-to-assign flow driven by the same shared reducer. It also extracts the sidebar's filtering into a reusable `useProposalFilters` hook and `ProposalFilters` component consumed by both the desktop sidebar and the new mobile view.

- **New `MobileScheduleView`**: full-screen mobile layout with a day-chip header, per-track agenda, and bottom sheets for assigning, moving, renaming, resizing, and removing talks — all dispatching through the existing reducer so overlap/end-of-day rules apply unchanged.
- **`useMediaQuery` hook**: SSR-safe (defaults to desktop) so wide screens never flash the mobile layout; the desktop `DndContext` never mounts on a phone.
- **`useProposalFilters` + `ProposalFilters`**: extracted from `UnassignedProposals` to eliminate duplication; the desktop sidebar is refactored to use the shared hook with no behaviour change.

<h3>Confidence Score: 3/5</h3>

Mostly safe for desktop users; mobile users in UTC-negative timezones will see day-chip labels that are one day off, a visible correctness issue.

The day-chip date labels use raw new Date() which shows the wrong date for anyone west of UTC. The fix is a one-line swap to formatConferenceDate() from src/lib/time.ts. The rest of the feature — reducer integration, slot validation, accessibility, shared hook extraction — is well-structured and the 75 passing tests give good confidence in the interaction logic.

src/components/admin/schedule/MobileScheduleView.tsx — the date formatting call and the dead inlineError state in MoveSheet both need attention before the mobile view ships to real users.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/MobileScheduleView.tsx | New 1300-line mobile tap-to-assign view; uses raw `new Date()` for day-chip labels (timezone bug + AGENTS.md violation), has dead `inlineError` state in MoveSheet, and an unreliable CSS class merge for the save-success button colour |
| src/hooks/useMediaQuery.ts | New hook; correctly subscribes to a CSS media query, uses a configurable SSR default to avoid hydration mismatches, and removes the listener on cleanup |
| src/components/admin/schedule/useProposalFilters.ts | Extracted shared filtering hook; null-guards speaker/title/format, memoizes derived values, and keeps callbacks stable with useCallback |
| src/components/admin/schedule/ProposalFilters.tsx | Extracted shared filter UI; reduces duplication between desktop sidebar and mobile assign sheet, adds ariaLabel props that were missing in the original per-component implementation |
| src/components/admin/schedule/ScheduleEditor.tsx | Adds early-return path rendering MobileScheduleView when isDesktop is false; desktop board and DndContext are byte-for-byte unchanged |
| src/components/admin/schedule/UnassignedProposals.tsx | Replaces ~90 lines of inline filter state/logic with the shared useProposalFilters + ProposalFilters; parent container already has relative positioning so the absolute clear button anchors correctly |
| __tests__/components/admin/schedule/MobileScheduleView.test.tsx | Four new interaction tests covering render, assign-sheet proposal listing, moveProposal dispatch, and removeTalk dispatch; uses vi.fn() dispatch mocks |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant ScheduleEditor
  participant MobileScheduleView
  participant AssignSheet
  participant CardActionSheet
  participant MoveSheet
  participant Reducer as scheduleReducer

  ScheduleEditor->>ScheduleEditor: useMediaQuery('(min-width:768px)', true)
  alt "isDesktop === false"
    ScheduleEditor->>MobileScheduleView: render with state + dispatch
  end

  User->>MobileScheduleView: tap Assign a talk
  MobileScheduleView->>AssignSheet: open (track, trackIndex, unassignedProposals)
  User->>AssignSheet: select proposal
  AssignSheet->>AssignSheet: freeStartTimes(track, duration) via fitsInTrack + rules
  User->>AssignSheet: pick start time, tap Assign
  AssignSheet->>Reducer: "dispatch(moveProposal {type:proposal, trackIndex, timeSlot})"
  Reducer-->>MobileScheduleView: updated schedules state

  User->>MobileScheduleView: tap agenda card
  MobileScheduleView->>CardActionSheet: open (talk, trackIndex, talkIndex)
  User->>CardActionSheet: tap Move to another track / time
  CardActionSheet->>MoveSheet: transition (tracks, sourceTrackIndex, talk)
  User->>MoveSheet: select target track + time, tap Move here
  MoveSheet->>Reducer: "dispatch(moveProposal {type:scheduled-talk, sourceTrack, targetTrack})"
  Reducer-->>MobileScheduleView: updated schedules state

  User->>CardActionSheet: tap Remove from schedule
  CardActionSheet->>Reducer: "dispatch(removeTalk {trackIndex, talkIndex})"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant ScheduleEditor
  participant MobileScheduleView
  participant AssignSheet
  participant CardActionSheet
  participant MoveSheet
  participant Reducer as scheduleReducer

  ScheduleEditor->>ScheduleEditor: useMediaQuery('(min-width:768px)', true)
  alt "isDesktop === false"
    ScheduleEditor->>MobileScheduleView: render with state + dispatch
  end

  User->>MobileScheduleView: tap Assign a talk
  MobileScheduleView->>AssignSheet: open (track, trackIndex, unassignedProposals)
  User->>AssignSheet: select proposal
  AssignSheet->>AssignSheet: freeStartTimes(track, duration) via fitsInTrack + rules
  User->>AssignSheet: pick start time, tap Assign
  AssignSheet->>Reducer: "dispatch(moveProposal {type:proposal, trackIndex, timeSlot})"
  Reducer-->>MobileScheduleView: updated schedules state

  User->>MobileScheduleView: tap agenda card
  MobileScheduleView->>CardActionSheet: open (talk, trackIndex, talkIndex)
  User->>CardActionSheet: tap Move to another track / time
  CardActionSheet->>MoveSheet: transition (tracks, sourceTrackIndex, talk)
  User->>MoveSheet: select target track + time, tap Move here
  MoveSheet->>Reducer: "dispatch(moveProposal {type:scheduled-talk, sourceTrack, targetTrack})"
  Reducer-->>MobileScheduleView: updated schedules state

  User->>CardActionSheet: tap Remove from schedule
  CardActionSheet->>Reducer: "dispatch(removeTalk {trackIndex, talkIndex})"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(schedule): mobile tap-to-assign edi..."](https://github.com/cloudnativebergen/website/commit/650b577180a3ae2dddaf7f4ef57be0378721195b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45146595)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->