### PR TITLE
fix(schedule): server-side payload validation + optimistic-concurrency save

### DIFF
--- a/__tests__/api/trpc/schedule.test.ts
+++ b/__tests__/api/trpc/schedule.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the schedule.save tRPC mutation (src/server/routers/schedule.ts).
+ * Guards the two hardening behaviours: the router (1) validates the payload and
+ * rejects a malformed/foreign-ref schedule with BAD_REQUEST BEFORE persisting,
+ * and (2) maps an optimistic-concurrency `conflict` from the data layer to a
+ * 409 CONFLICT. The pure validator is exercised in full in
+ * __tests__/lib/schedule/validation.test.ts; here we assert the wiring.
+ */
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: vi.fn(),
+}))
+
+vi.mock('@/lib/schedule/sanity', () => ({
+  saveScheduleToSanity: vi.fn(),
+  getValidTalkIds: vi.fn(),
+}))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { initTRPC } from '@trpc/server'
+import type { Context } from '@/server/trpc'
+import { scheduleRouter } from '@/server/routers/schedule'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { saveScheduleToSanity, getValidTalkIds } from '@/lib/schedule/sanity'
+
+// Build a caller from the schedule router alone (not the full appRouter) so this
+// suite does not import unrelated routers — notably the badge router, whose
+// `@digitalbazaar/vc` dependency is absent in this environment.
+const t = initTRPC.context<Context>().create()
+const createCaller = t.createCallerFactory(scheduleRouter)
+
+function baseCtx(): Context {
+  return {
+    req: {
+      headers: new Headers(),
+      url: 'http://localhost:3000',
+    } as unknown as Context['req'],
+    session: null,
+    speaker: undefined,
+    user: undefined,
+    ipAddress: '',
+  }
+}
+
+function createAdminCaller() {
+  return createCaller({
+    ...baseCtx(),
+    session: {
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      user: { email: 'admin@example.com', name: 'Admin' },
+      speaker: { _id: 'admin-1', isOrganizer: true },
+    } as unknown as Context['session'],
+  })
+}
+
+function createAuthenticatedCaller() {
+  return createCaller({
+    ...baseCtx(),
+    session: {
+      expires: new Date(Date.now() + 86400000).toISOString(),
+      user: { email: 'user@example.com', name: 'User' },
+      speaker: { _id: 'user-1', isOrganizer: false },
+    } as unknown as Context['session'],
+  })
+}
+
+const conference = { _id: 'conf-1', title: 'CND 2026' }
+
+const validDay = {
+  _id: 'sched-1',
+  _rev: 'rev-1',
+  date: '2026-06-15',
+  tracks: [
+    {
+      trackTitle: 'Track A',
+      trackDescription: '',
+      talks: [
+        { talk: { _id: 'talk-1' }, startTime: '09:00', endTime: '09:30' },
+      ],
+    },
+  ],
+}
+
+describe('schedule.save', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
+      conference: conference as never,
+      domain: 'localhost',
+    } as never)
+    vi.mocked(getValidTalkIds).mockResolvedValue(new Set(['talk-1', 'talk-2']))
+    vi.mocked(saveScheduleToSanity).mockResolvedValue({
+      schedule: { ...validDay, _rev: 'rev-2' } as never,
+    })
+  })
+
+  it('requires an admin', async () => {
+    const caller = createAuthenticatedCaller()
+    await expect(caller.save(validDay)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+  })
+
+  it('persists a valid payload and returns the schedule with new _rev', async () => {
+    const caller = createAdminCaller()
+    const result = await caller.save(validDay)
+    expect(result.schedule._rev).toBe('rev-2')
+    expect(saveScheduleToSanity).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a foreign talk ref with BAD_REQUEST before persisting', async () => {
+    const caller = createAdminCaller()
+    const bad = {
+      ...validDay,
+      tracks: [
+        {
+          trackTitle: 'Track A',
+          trackDescription: '',
+          talks: [
+            { talk: { _id: 'not-mine' }, startTime: '09:00', endTime: '09:30' },
+          ],
+        },
+      ],
+    }
+    await expect(caller.save(bad)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    })
+    expect(saveScheduleToSanity).not.toHaveBeenCalled()
+  })
+
+  it('rejects overlapping slots with BAD_REQUEST before persisting', async () => {
+    const caller = createAdminCaller()
+    const bad = {
+      ...validDay,
+      tracks: [
+        {
+          trackTitle: 'Track A',
+          trackDescription: '',
+          talks: [
+            { talk: { _id: 'talk-1' }, startTime: '09:00', endTime: '09:45' },
+            { talk: { _id: 'talk-2' }, startTime: '09:30', endTime: '10:00' },
+          ],
+        },
+      ],
+    }
+    await expect(caller.save(bad)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    })
+    expect(saveScheduleToSanity).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non HH:MM time at the schema boundary', async () => {
+    const caller = createAdminCaller()
+    const bad = {
+      ...validDay,
+      tracks: [
+        {
+          trackTitle: 'Track A',
+          trackDescription: '',
+          talks: [
+            { talk: { _id: 'talk-1' }, startTime: '9:00', endTime: '09:30' },
+          ],
+        },
+      ],
+    }
+    await expect(caller.save(bad)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    })
+  })
+
+  it('maps a data-layer conflict to CONFLICT', async () => {
+    vi.mocked(saveScheduleToSanity).mockResolvedValue({
+      conflict: true,
+      error: 'This day was changed elsewhere since you loaded it.',
+    })
+    const caller = createAdminCaller()
+    await expect(caller.save(validDay)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    })
+  })
+})

--- a/__tests__/lib/schedule/reducer.test.ts
+++ b/__tests__/lib/schedule/reducer.test.ts
@@ -255,6 +255,26 @@ describe('save lifecycle + dirty tracking', () => {
     expect(state.ui.isSaving).toBe(false)
   })
 
+  it('saveDaySucceeded stores the new _rev for optimistic concurrency', () => {
+    let state = scheduleReducer(twoDirtyDays(), { type: 'saveStart' })
+    state = scheduleReducer(state, {
+      type: 'saveDaySucceeded',
+      index: 0,
+      _id: 'server-id-0',
+      _rev: 'rev-abc',
+    })
+    expect(state.schedules[0]._rev).toBe('rev-abc')
+
+    // A save that returns no _rev keeps whatever revision was already stored
+    // (rather than wiping it to undefined and forcing an unconditional write).
+    state = scheduleReducer(state, {
+      type: 'saveDaySucceeded',
+      index: 0,
+      _id: 'server-id-0',
+    })
+    expect(state.schedules[0]._rev).toBe('rev-abc')
+  })
+
   it('saveError records the message and stops saving', () => {
     let state = scheduleReducer(twoDirtyDays(), { type: 'saveStart' })
     state = scheduleReducer(state, { type: 'saveError', message: 'boom' })

--- a/__tests__/lib/schedule/validation.test.ts
+++ b/__tests__/lib/schedule/validation.test.ts
@@ -1,0 +1,209 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the server-side SAVE payload validator
+ * (src/lib/schedule/validation.ts). This is the last gate before a schedule is
+ * persisted, so it must reject every shape that would corrupt the public
+ * program: malformed/out-of-bounds/mis-ordered times, in-track overlaps,
+ * ambiguous slots (both or neither talk+placeholder), and dangling/foreign
+ * talk references.
+ */
+import { describe, it, expect } from 'vitest'
+import type { ConferenceSchedule, TrackTalk } from '@/lib/conference/types'
+import { validateSchedulePayload } from '@/lib/schedule/validation'
+
+const VALID_IDS = new Set(['talk-1', 'talk-2'])
+
+const talkSlot = (start: string, end: string, id = 'talk-1'): TrackTalk =>
+  ({
+    talk: { _id: id },
+    startTime: start,
+    endTime: end,
+  }) as unknown as TrackTalk
+
+const serviceSlot = (start: string, end: string): TrackTalk => ({
+  placeholder: 'Lunch',
+  startTime: start,
+  endTime: end,
+})
+
+const schedule = (...slots: TrackTalk[]): ConferenceSchedule => ({
+  _id: 'sched-1',
+  date: '2026-06-15',
+  tracks: [{ trackTitle: 'Track A', trackDescription: '', talks: slots }],
+})
+
+describe('validateSchedulePayload', () => {
+  it('accepts a well-formed schedule (talks + service session, no overlap)', () => {
+    const result = validateSchedulePayload(
+      schedule(
+        talkSlot('09:00', '09:30', 'talk-1'),
+        serviceSlot('09:30', '10:00'),
+        talkSlot('10:00', '10:30', 'talk-2'),
+      ),
+      VALID_IDS,
+    )
+    expect(result).toBeNull()
+  })
+
+  it('accepts an empty schedule with no tracks', () => {
+    expect(
+      validateSchedulePayload(
+        { _id: 's', date: '2026-06-15', tracks: [] },
+        VALID_IDS,
+      ),
+    ).toBeNull()
+  })
+
+  it('resolves talk refs via _ref as well as _id', () => {
+    const slot = {
+      talk: { _ref: 'talk-2' },
+      startTime: '09:00',
+      endTime: '09:30',
+    } as unknown as TrackTalk
+    expect(validateSchedulePayload(schedule(slot), VALID_IDS)).toBeNull()
+  })
+
+  describe('time format', () => {
+    it('rejects a non HH:MM time', () => {
+      expect(
+        validateSchedulePayload(schedule(talkSlot('9:00', '09:30')), VALID_IDS),
+      ).toMatch(/HH:MM/)
+    })
+
+    it('rejects an out-of-range hour', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(talkSlot('24:00', '24:30')),
+          VALID_IDS,
+        ),
+      ).toMatch(/HH:MM/)
+    })
+  })
+
+  describe('ordering and bounds', () => {
+    it('rejects endTime equal to startTime', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(talkSlot('09:00', '09:00')),
+          VALID_IDS,
+        ),
+      ).toMatch(/end after it starts/)
+    })
+
+    it('rejects endTime before startTime', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(talkSlot('10:00', '09:00')),
+          VALID_IDS,
+        ),
+      ).toMatch(/end after it starts/)
+    })
+
+    it('rejects a slot starting before SCHEDULE_START', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(talkSlot('07:30', '08:30')),
+          VALID_IDS,
+        ),
+      ).toMatch(/starts before 08:00/)
+    })
+
+    it('rejects a slot ending after SCHEDULE_END', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(talkSlot('20:30', '21:30')),
+          VALID_IDS,
+        ),
+      ).toMatch(/ends after 21:00/)
+    })
+
+    it('accepts a slot exactly at the grid boundaries', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(talkSlot('08:00', '08:30'), talkSlot('20:30', '21:00')),
+          VALID_IDS,
+        ),
+      ).toBeNull()
+    })
+  })
+
+  describe('overlap within a track', () => {
+    it('rejects two overlapping talks', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(
+            talkSlot('09:00', '09:45', 'talk-1'),
+            talkSlot('09:30', '10:00', 'talk-2'),
+          ),
+          VALID_IDS,
+        ),
+      ).toMatch(/overlap/)
+    })
+
+    it('rejects a talk overlapping a service session', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(serviceSlot('12:00', '13:00'), talkSlot('12:30', '13:00')),
+          VALID_IDS,
+        ),
+      ).toMatch(/overlap/)
+    })
+
+    it('allows back-to-back slots that merely touch at a boundary', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(
+            talkSlot('09:00', '09:30'),
+            talkSlot('09:30', '10:00', 'talk-2'),
+          ),
+          VALID_IDS,
+        ),
+      ).toBeNull()
+    })
+  })
+
+  describe('exactly one of talk / placeholder', () => {
+    it('rejects a slot with both a talk and a placeholder', () => {
+      const slot = {
+        talk: { _id: 'talk-1' },
+        placeholder: 'Lunch',
+        startTime: '09:00',
+        endTime: '09:30',
+      } as unknown as TrackTalk
+      expect(validateSchedulePayload(schedule(slot), VALID_IDS)).toMatch(
+        /both a talk and a placeholder/,
+      )
+    })
+
+    it('rejects a slot with neither a talk nor a placeholder', () => {
+      const slot = {
+        startTime: '09:00',
+        endTime: '09:30',
+      } as unknown as TrackTalk
+      expect(validateSchedulePayload(schedule(slot), VALID_IDS)).toMatch(
+        /neither a talk nor a placeholder/,
+      )
+    })
+  })
+
+  describe('talk reference validity', () => {
+    it('rejects a talk id not belonging to this conference', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(talkSlot('09:00', '09:30', 'foreign-talk')),
+          VALID_IDS,
+        ),
+      ).toMatch(/does not belong to this conference/)
+    })
+
+    it('rejects a dangling ref when the valid set is empty', () => {
+      expect(
+        validateSchedulePayload(
+          schedule(talkSlot('09:00', '09:30', 'talk-1')),
+          new Set<string>(),
+        ),
+      ).toMatch(/does not belong to this conference/)
+    })
+  })
+})

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -442,7 +442,12 @@ export function ScheduleEditor({
 
         const { schedule } = await saveMutation.mutateAsync(daySchedule)
         if (schedule) {
-          dispatch({ type: 'saveDaySucceeded', index, _id: schedule._id })
+          dispatch({
+            type: 'saveDaySucceeded',
+            index,
+            _id: schedule._id,
+            _rev: schedule._rev,
+          })
         }
       }
 
@@ -450,8 +455,16 @@ export function ScheduleEditor({
       setSaveSuccess(true)
       setTimeout(() => setSaveSuccess(false), 3000)
     } catch (err) {
+      // A CONFLICT means another organizer changed this day since it was loaded.
+      // Don't clobber the user's in-progress edits — stop and tell them to
+      // reload. Any other error keeps its original message.
+      const code = (err as { data?: { code?: string } })?.data?.code
       const message =
-        err instanceof Error ? err.message : 'Failed to save schedule'
+        code === 'CONFLICT'
+          ? 'This day was changed elsewhere — reload to get the latest before saving.'
+          : err instanceof Error
+            ? err.message
+            : 'Failed to save schedule'
       dispatch({ type: 'saveError', message })
     }
   }, [state.dirty, state.schedules, currentDayIndex, saveMutation])

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -167,6 +167,7 @@ export async function getConferenceForDomain(
         schedule
           ? `schedules[]-> {
       ...,
+      _rev,
       tracks[]{
         trackTitle,
         trackDescription,

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -34,6 +34,13 @@ export interface ScheduleTrack {
 }
 export interface ConferenceSchedule {
   _id: string
+  /**
+   * Sanity document revision, threaded through load→edit→save for optimistic
+   * concurrency: the SAVE patches with `ifRevisionId` so a stale write (another
+   * organizer edited the same day since it was loaded) is rejected instead of
+   * silently clobbering their changes. Absent for a not-yet-persisted day.
+   */
+  _rev?: string
   date: string
   tracks: Array<ScheduleTrack>
   conference?: { _id: string }

--- a/src/lib/schedule/reducer.ts
+++ b/src/lib/schedule/reducer.ts
@@ -68,7 +68,7 @@ export type ScheduleAction =
     }
   | { type: 'changeDay'; dayIndex: number }
   | { type: 'saveStart' }
-  | { type: 'saveDaySucceeded'; index: number; _id: string }
+  | { type: 'saveDaySucceeded'; index: number; _id: string; _rev?: string }
   | { type: 'saveError'; message: string }
   | { type: 'saveEnd' }
 
@@ -249,6 +249,9 @@ export function scheduleReducer(
       schedules[action.index] = {
         ...schedules[action.index],
         _id: action._id,
+        // Store the NEW revision returned by the write so a second save in the
+        // same session patches against the current `_rev` (not a false conflict).
+        _rev: action._rev ?? schedules[action.index]._rev,
       }
       const dirty = [...state.dirty]
       dirty[action.index] = false

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -11,6 +11,36 @@ import {
 export interface SaveScheduleResult {
   schedule?: ConferenceSchedule
   error?: string
+  /**
+   * Set when the update was rejected by optimistic-concurrency: the day was
+   * changed elsewhere since it was loaded (`ifRevisionId` mismatch). Distinct
+   * from a generic `error` so the router can map it to a 409 CONFLICT and the UI
+   * can tell the organizer to reload rather than retry blindly.
+   */
+  conflict?: boolean
+}
+
+/**
+ * The set of `talk` document ids belonging to `conferenceId`. The SAVE validator
+ * asserts every referenced talk is in this set, rejecting dangling refs (deleted
+ * talks) and foreign refs (talks from another edition). Fetched once per save.
+ */
+export async function getValidTalkIds(
+  conferenceId: string,
+): Promise<Set<string>> {
+  const ids = await clientWrite.fetch<string[]>(
+    `*[_type == "talk" && conference._ref == $conferenceId]._id`,
+    { conferenceId },
+  )
+  return new Set(ids || [])
+}
+
+/** True when a Sanity write failed because `ifRevisionId` did not match (409). */
+function isRevisionMismatch(error: unknown): boolean {
+  const statusCode = (error as { statusCode?: number })?.statusCode
+  if (statusCode === 409) return true
+  const message = error instanceof Error ? error.message.toLowerCase() : ''
+  return message.includes('revision') && message.includes('mismatch')
 }
 
 export async function saveScheduleToSanity(
@@ -85,15 +115,25 @@ export async function saveScheduleToSanity(
         return { error: 'Schedule not found or not accessible' }
       }
 
-      await clientWrite
-        .patch(schedule._id)
+      // Optimistic concurrency: when the client carried a `_rev`, patch with
+      // `ifRevisionId` so a save is rejected if the day changed since it was
+      // loaded (two organizers editing the same day). Sanity throws a 409 on
+      // mismatch, which we surface as a distinct `conflict` result. The commit
+      // returns the persisted document, so we thread the NEW `_rev` back to the
+      // client — a second save in the same session then isn't a false conflict.
+      let patch = clientWrite.patch(schedule._id)
+      if (schedule._rev) {
+        patch = patch.ifRevisionId(schedule._rev)
+      }
+
+      const committed = await patch
         .set({
           date: schedule.date,
           tracks: sanitizedTracks,
         })
         .commit()
 
-      savedSchedule = schedule
+      savedSchedule = { ...schedule, _rev: committed._rev }
     } else {
       // Pre-generate the id so the create and the conference-link append run in
       // ONE atomic transaction. Previously these were two sequential writes: if
@@ -120,9 +160,18 @@ export async function saveScheduleToSanity(
         )
         .commit()
 
+      // Read back the created document's `_rev` so a follow-up save in the same
+      // session carries a revision and participates in optimistic concurrency
+      // (rather than always taking the unconditional-write path).
+      const created = await clientWrite.fetch<{ _rev: string } | null>(
+        `*[_id == $id][0]{ _rev }`,
+        { id: newId },
+      )
+
       savedSchedule = {
         ...schedule,
         _id: newId,
+        _rev: created?._rev,
       }
     }
 
@@ -130,6 +179,13 @@ export async function saveScheduleToSanity(
 
     return { schedule: savedSchedule }
   } catch (error) {
+    if (isRevisionMismatch(error)) {
+      console.warn('Schedule save conflict (stale revision):', schedule._id)
+      return {
+        conflict: true,
+        error: 'This day was changed elsewhere since you loaded it.',
+      }
+    }
     console.error('Error saving schedule to Sanity:', error)
     return {
       error: error instanceof Error ? error.message : 'Failed to save schedule',

--- a/src/lib/schedule/time.ts
+++ b/src/lib/schedule/time.ts
@@ -27,6 +27,10 @@ export interface TimeSlot {
 export const SCHEDULE_START = '08:00'
 export const SCHEDULE_END = '21:00'
 
+/** `HH:MM` in 24h (00:00–23:59), anchored so no surrounding junk is accepted.
+ *  Single source of truth for the schema boundary gate and the server validator. */
+export const HHMM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/
+
 /** `HH:MM` → minutes since midnight. */
 export function toMinutes(hhmm: string): number {
   const [hours, minutes] = hhmm.split(':').map(Number)

--- a/src/lib/schedule/validation.ts
+++ b/src/lib/schedule/validation.ts
@@ -1,0 +1,92 @@
+import type { ConferenceSchedule, TrackTalk } from '@/lib/conference/types'
+import { toMinutes, timesOverlap, SCHEDULE_START, SCHEDULE_END } from './time'
+
+/**
+ * Server-side payload validation for an admin schedule SAVE (pure, so it is
+ * unit-testable without touching Sanity). The client sends whatever its editor
+ * state holds; a malformed or hostile payload must be REJECTED before it is
+ * persisted, because a bad write silently corrupts the public program (a slot
+ * ending after the grid renders below it, an overlap double-books a track, a
+ * dangling/foreign `talk` ref points the program at a talk from another edition).
+ *
+ * `validTalkIds` is the set of `talk` document ids that belong to THIS
+ * conference — the caller fetches it once and every referenced id must be in it.
+ * Returns a human-readable error string on the FIRST problem found, or `null`
+ * when the whole payload is valid.
+ */
+
+/** `HH:MM` in 24h (00:00–23:59). Anchored so no surrounding junk is accepted. */
+const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/
+
+/** The referenced talk id on a slot, from either `_id` or a Sanity `_ref`. */
+function talkRefId(slot: TrackTalk): string | undefined {
+  const talk = slot.talk as
+    { _id?: string | null; _ref?: string | null } | undefined | null
+  if (!talk) return undefined
+  return talk._id || talk._ref || undefined
+}
+
+export function validateSchedulePayload(
+  schedule: ConferenceSchedule,
+  validTalkIds: ReadonlySet<string>,
+): string | null {
+  const startBound = toMinutes(SCHEDULE_START)
+  const endBound = toMinutes(SCHEDULE_END)
+
+  for (const track of schedule.tracks || []) {
+    const slots = track.talks || []
+    const label = track.trackTitle || 'Untitled track'
+
+    for (const slot of slots) {
+      if (!HHMM.test(slot.startTime) || !HHMM.test(slot.endTime)) {
+        return `Track "${label}": times must be HH:MM (24h), got "${slot.startTime}"–"${slot.endTime}".`
+      }
+
+      const start = toMinutes(slot.startTime)
+      const end = toMinutes(slot.endTime)
+
+      if (end <= start) {
+        return `Track "${label}": slot ${slot.startTime}–${slot.endTime} must end after it starts.`
+      }
+      if (start < startBound) {
+        return `Track "${label}": slot ${slot.startTime}–${slot.endTime} starts before ${SCHEDULE_START}.`
+      }
+      if (end > endBound) {
+        return `Track "${label}": slot ${slot.startTime}–${slot.endTime} ends after ${SCHEDULE_END}.`
+      }
+
+      const refId = talkRefId(slot)
+      const hasTalk = Boolean(refId)
+      const hasPlaceholder = Boolean(slot.placeholder)
+
+      if (hasTalk && hasPlaceholder) {
+        return `Track "${label}": slot ${slot.startTime}–${slot.endTime} has both a talk and a placeholder.`
+      }
+      if (!hasTalk && !hasPlaceholder) {
+        return `Track "${label}": slot ${slot.startTime}–${slot.endTime} has neither a talk nor a placeholder.`
+      }
+
+      if (hasTalk && !validTalkIds.has(refId!)) {
+        return `Track "${label}": slot ${slot.startTime}–${slot.endTime} references a talk that does not belong to this conference.`
+      }
+    }
+
+    // Overlap within a single track (talks AND placeholders both occupy time).
+    for (let i = 0; i < slots.length; i++) {
+      for (let j = i + 1; j < slots.length; j++) {
+        if (
+          timesOverlap(
+            slots[i].startTime,
+            slots[i].endTime,
+            slots[j].startTime,
+            slots[j].endTime,
+          )
+        ) {
+          return `Track "${label}": slots ${slots[i].startTime}–${slots[i].endTime} and ${slots[j].startTime}–${slots[j].endTime} overlap.`
+        }
+      }
+    }
+  }
+
+  return null
+}

--- a/src/lib/schedule/validation.ts
+++ b/src/lib/schedule/validation.ts
@@ -1,5 +1,11 @@
 import type { ConferenceSchedule, TrackTalk } from '@/lib/conference/types'
-import { toMinutes, timesOverlap, SCHEDULE_START, SCHEDULE_END } from './time'
+import {
+  toMinutes,
+  timesOverlap,
+  SCHEDULE_START,
+  SCHEDULE_END,
+  HHMM_PATTERN,
+} from './time'
 
 /**
  * Server-side payload validation for an admin schedule SAVE (pure, so it is
@@ -14,9 +20,6 @@ import { toMinutes, timesOverlap, SCHEDULE_START, SCHEDULE_END } from './time'
  * Returns a human-readable error string on the FIRST problem found, or `null`
  * when the whole payload is valid.
  */
-
-/** `HH:MM` in 24h (00:00–23:59). Anchored so no surrounding junk is accepted. */
-const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/
 
 /** The referenced talk id on a slot, from either `_id` or a Sanity `_ref`. */
 function talkRefId(slot: TrackTalk): string | undefined {
@@ -38,7 +41,10 @@ export function validateSchedulePayload(
     const label = track.trackTitle || 'Untitled track'
 
     for (const slot of slots) {
-      if (!HHMM.test(slot.startTime) || !HHMM.test(slot.endTime)) {
+      if (
+        !HHMM_PATTERN.test(slot.startTime) ||
+        !HHMM_PATTERN.test(slot.endTime)
+      ) {
         return `Track "${label}": times must be HH:MM (24h), got "${slot.startTime}"–"${slot.endTime}".`
       }
 

--- a/src/server/routers/schedule.ts
+++ b/src/server/routers/schedule.ts
@@ -1,7 +1,8 @@
 import { TRPCError } from '@trpc/server'
 import { router, adminProcedure } from '@/server/trpc'
 import { SaveScheduleSchema } from '@/server/schemas/schedule'
-import { saveScheduleToSanity } from '@/lib/schedule/sanity'
+import { saveScheduleToSanity, getValidTalkIds } from '@/lib/schedule/sanity'
+import { validateSchedulePayload } from '@/lib/schedule/validation'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { revalidateTag } from 'next/cache'
 import type { ConferenceSchedule } from '@/lib/conference/types'
@@ -18,10 +19,31 @@ export const scheduleRouter = router({
       })
     }
 
-    const { schedule, error: saveError } = await saveScheduleToSanity(
-      input as ConferenceSchedule,
-      conference,
-    )
+    const payload = input as ConferenceSchedule
+
+    // Validate the incoming payload BEFORE persisting: reject malformed times,
+    // out-of-bounds/overlapping slots, ambiguous slots (both/neither talk and
+    // placeholder), and dangling/foreign talk refs. The talk-id set is fetched
+    // once and passed to the pure validator.
+    const validTalkIds = await getValidTalkIds(conference._id)
+    const validationError = validateSchedulePayload(payload, validTalkIds)
+    if (validationError) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: validationError })
+    }
+
+    const {
+      schedule,
+      error: saveError,
+      conflict,
+    } = await saveScheduleToSanity(payload, conference)
+
+    if (conflict) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message:
+          saveError || 'This day was changed elsewhere since you loaded it.',
+      })
+    }
 
     if (saveError || !schedule) {
       throw new TRPCError({

--- a/src/server/schemas/schedule.ts
+++ b/src/server/schemas/schedule.ts
@@ -1,9 +1,7 @@
 import { z } from 'zod'
+import { HHMM_PATTERN } from '@/lib/schedule/time'
 
-// `HH:MM` in 24h. A cheap first gate at the schema boundary; the router's
-// validateSchedulePayload enforces the richer rules (ordering, bounds, overlap).
-const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/
-const timeString = z.string().regex(HHMM, 'Time must be HH:MM (24h)')
+const timeString = z.string().regex(HHMM_PATTERN, 'Time must be HH:MM (24h)')
 
 const TrackTalkSchema = z.object({
   talk: z

--- a/src/server/schemas/schedule.ts
+++ b/src/server/schemas/schedule.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
 
+// `HH:MM` in 24h. A cheap first gate at the schema boundary; the router's
+// validateSchedulePayload enforces the richer rules (ordering, bounds, overlap).
+const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/
+const timeString = z.string().regex(HHMM, 'Time must be HH:MM (24h)')
+
 const TrackTalkSchema = z.object({
   talk: z
     .object({
@@ -10,8 +15,8 @@ const TrackTalkSchema = z.object({
     .optional()
     .nullable(),
   placeholder: z.string().optional().nullable(),
-  startTime: z.string(),
-  endTime: z.string(),
+  startTime: timeString,
+  endTime: timeString,
 })
 
 const ScheduleTrackSchema = z.object({
@@ -22,6 +27,9 @@ const ScheduleTrackSchema = z.object({
 
 export const SaveScheduleSchema = z.object({
   _id: z.string(),
+  // Optimistic-concurrency token from the loaded document; the SAVE patches with
+  // `ifRevisionId` when present so a stale write is rejected. Absent for a new day.
+  _rev: z.string().optional(),
   date: z.string(),
   tracks: z.array(ScheduleTrackSchema),
   conference: z


### PR DESCRIPTION
Hardens the schedule SAVE path — two persistence gaps from the review.

## 1. Server-side payload validation
The save router accepted any shape-valid payload. Added a pure `validateSchedulePayload(schedule, validTalkIds)` (`src/lib/schedule/validation.ts`), called in the router after fetching the conference's valid talk ids; rejects with `TRPCError({code:'BAD_REQUEST'})` before any write when:
1. a slot `startTime`/`endTime` isn't `HH:MM` 24h,
2. `endTime <= startTime`,
3. a slot starts before `SCHEDULE_START` (08:00) or ends after `SCHEDULE_END` (21:00),
4. two slots **overlap** within a track (`rules.timesOverlap`; back-to-back is allowed),
5. a slot has **both** a talk ref and a placeholder, or **neither**,
6. a talk ref (`_id`/`_ref`) is **not** a talk belonging to this conference (dangling/foreign refs).

Schema also gets a cheap `HH:MM` regex first-gate. So even a buggy client (or a crafted request) can no longer persist overlapping/malformed/foreign-ref schedules.

## 2. Optimistic concurrency (`ifRevisionId`)
Two organizers editing the same day was silent last-write-wins. Threaded the Sanity `_rev` end to end:
- `_rev` added to `ConferenceSchedule` + the `schedules[]->` projection → reaches the reducer's `schedules`.
- Each day carries `_rev` in reducer state; `handleSave` sends it; the update patch uses `.ifRevisionId(_rev)`.
- A revision mismatch (Sanity 409) returns a distinct `{ conflict: true }` → router maps to `TRPCError({code:'CONFLICT'})` → the editor shows a **"this day was changed elsewhere — reload"** message **without clobbering the user's edits**.
- The write returns the **new** `_rev`, stored by `saveDaySucceeded`, so a second same-session save isn't a false conflict.

(Agent caught a footgun: `@sanity/client`'s key is `ifRevisionID` (capital ID) — a lowercase object key is silently ignored — so the fluent `.ifRevisionId()` method is used.)

## Verified (independently re-run)
`vitest` (schedule + trpc schedule + admin/schedule) → **99 passed** (new `validation.test.ts` truth-table, a `scheduleRouter` caller test, extended reducer tests); `tsc`/`eslint`/`prettier --check`/`knip` → clean.

Completes the persistence items from the review. On the merged reducer + mobile base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the schedule save path with two improvements: a pure server-side payload validator that rejects malformed times, out-of-bounds slots, overlaps, ambiguous talk/placeholder slots, and foreign talk references before any write; and optimistic-concurrency control using Sanity's `ifRevisionId`, threading `_rev` end-to-end so concurrent edits by two organizers produce a 409 CONFLICT rather than a silent last-write-wins clobber.

- `validateSchedulePayload` (`validation.ts`) is a pure function called in the router after fetching the conference's valid talk IDs; rejects six distinct bad-payload shapes with `BAD_REQUEST` before touching Sanity.
- `ifRevisionId` is applied to update patches; a Sanity 409 is surfaced as a distinct `conflict` result, mapped to `TRPCError({ code: 'CONFLICT' })`, and displayed to the organizer without clobbering in-progress edits.
- The new `_rev` is stored back in reducer state after each successful save so a second same-session save is not a false conflict.

<h3>Confidence Score: 3/5</h3>

The validation and conflict-detection logic is correct and well-tested, but the post-transaction `_rev` fetch for new schedules introduces a new failure mode that can leave Sanity in an inconsistent state relative to what the client knows.

If the post-transaction `_rev` fetch throws, the client concludes the save failed, retries with `_id: ''`, and the server creates a duplicate orphan document — the same class of bug the prior atomic-transaction fix was designed to prevent.

src/lib/schedule/sanity.ts — specifically the `_rev` fetch block in the new-schedule creation path (lines 163–175).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/schedule/sanity.ts | Adds `getValidTalkIds`, `isRevisionMismatch`, and `ifRevisionId` patch; new post-transaction `_rev` fetch introduces a failure point that can produce orphan duplicate schedules on retry. |
| src/lib/schedule/validation.ts | New pure validator; logic is correct and well-tested. HHMM regex is duplicated from schemas/schedule.ts (minor DRY violation). |
| src/server/routers/schedule.ts | Correctly wires validation to save to conflict mapping; CONFLICT and BAD_REQUEST codes are valid tRPC codes and handled in the right order. |
| src/server/schemas/schedule.ts | Adds HH:MM regex to `timeString` and `_rev` field; schema changes are additive and correct. |
| src/components/admin/schedule/ScheduleEditor.tsx | Threads `_rev` to `saveDaySucceeded` and adds CONFLICT-specific error message; error message does not identify which day conflicted in a multi-day save. |
| src/lib/schedule/reducer.ts | Correctly preserves existing `_rev` when a save returns no new revision using nullish coalescing. |
| src/lib/conference/sanity.ts | Adds `_rev` to the GROQ projection; safe and correct. |
| src/lib/conference/types.ts | Adds optional `_rev` to `ConferenceSchedule`; well-documented and non-breaking. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Editor as ScheduleEditor
    participant Router as tRPC Router
    participant Validator as validateSchedulePayload
    participant Sanity as Sanity (clientWrite)

    Editor->>Router: "save({ _id, _rev, tracks, ... })"
    Router->>Sanity: getValidTalkIds(conference._id)
    Sanity-->>Router: "Set<talkId>"
    Router->>Validator: validateSchedulePayload(payload, validTalkIds)
    alt invalid payload
        Validator-->>Router: error string
        Router-->>Editor: TRPCError(BAD_REQUEST)
    else valid payload
        Validator-->>Router: null
        Router->>Sanity: saveScheduleToSanity(payload, conference)
        alt existing schedule (_id present)
            Sanity->>Sanity: fetch target doc (scope check)
            Sanity->>Sanity: patch(_id).ifRevisionId(_rev).set(...).commit()
            alt _rev mismatch (409)
                Sanity-->>Router: "{ conflict: true }"
                Router-->>Editor: TRPCError(CONFLICT)
                Editor->>Editor: show reload message, keep edits
            else success
                Sanity-->>Router: "{ schedule: { ...newRev } }"
                Router-->>Editor: "{ schedule }"
                Editor->>Editor: dispatch saveDaySucceeded(_id, _rev)
            end
        else new schedule (_id empty)
            Sanity->>Sanity: transaction().create().patch().commit()
            Sanity->>Sanity: "fetch({ _rev }) for newId"
            Sanity-->>Router: "{ schedule: { _id: newId, _rev? } }"
            Router-->>Editor: "{ schedule }"
            Editor->>Editor: dispatch saveDaySucceeded(_id, _rev)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Editor as ScheduleEditor
    participant Router as tRPC Router
    participant Validator as validateSchedulePayload
    participant Sanity as Sanity (clientWrite)

    Editor->>Router: "save({ _id, _rev, tracks, ... })"
    Router->>Sanity: getValidTalkIds(conference._id)
    Sanity-->>Router: "Set<talkId>"
    Router->>Validator: validateSchedulePayload(payload, validTalkIds)
    alt invalid payload
        Validator-->>Router: error string
        Router-->>Editor: TRPCError(BAD_REQUEST)
    else valid payload
        Validator-->>Router: null
        Router->>Sanity: saveScheduleToSanity(payload, conference)
        alt existing schedule (_id present)
            Sanity->>Sanity: fetch target doc (scope check)
            Sanity->>Sanity: patch(_id).ifRevisionId(_rev).set(...).commit()
            alt _rev mismatch (409)
                Sanity-->>Router: "{ conflict: true }"
                Router-->>Editor: TRPCError(CONFLICT)
                Editor->>Editor: show reload message, keep edits
            else success
                Sanity-->>Router: "{ schedule: { ...newRev } }"
                Router-->>Editor: "{ schedule }"
                Editor->>Editor: dispatch saveDaySucceeded(_id, _rev)
            end
        else new schedule (_id empty)
            Sanity->>Sanity: transaction().create().patch().commit()
            Sanity->>Sanity: "fetch({ _rev }) for newId"
            Sanity-->>Router: "{ schedule: { _id: newId, _rev? } }"
            Router-->>Editor: "{ schedule }"
            Editor->>Editor: dispatch saveDaySucceeded(_id, _rev)
        end
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(schedule): centralize the HH:MM..."](https://github.com/cloudnativebergen/website/commit/79759f005848828834b5ff8dc00fa041d3d9e1cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45152088)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->