### PR TITLE
fix(schedule): drop ghost slots and guard same-position move

### DIFF
--- a/__tests__/lib/schedule/operations.test.ts
+++ b/__tests__/lib/schedule/operations.test.ts
@@ -131,6 +131,24 @@ describe('moveProposal — moving an already-scheduled talk', () => {
     expect(res.schedule.tracks[1].talks[0].talk?._id).toBe('a')
     expect(res.schedule.tracks[1].talks[0].startTime).toBe('11:00')
   })
+
+  it('treats a move onto the talk OWN slot as a no-op (no duplication)', () => {
+    // Regression: without the same-position guard this falls into the swap
+    // branch (the "occupied" talk is the dragged talk itself) and performSwap
+    // re-adds it at both target and source, silently duplicating it. Reachable
+    // from the mobile Move sheet, which can default the start to the current slot.
+    const s = schedule(track('A', talk('a', '10:00', '10:25')))
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('a'),
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '10:00',
+    }
+    const res = moveProposal(s, dragItem, drop(0, '10:00'))
+    expect(res.ok).toBe(false)
+    expect(res.schedule).toBe(s)
+    expect(res.schedule.tracks[0].talks).toHaveLength(1)
+  })
 })
 
 describe('moveProposal — swap (bidirectional validation)', () => {

--- a/__tests__/lib/schedule/server.test.ts
+++ b/__tests__/lib/schedule/server.test.ts
@@ -64,6 +64,48 @@ describe('getScheduleData day tabs', () => {
     ])
   })
 
+  it('strips ghost slots (dangling talk ref, no placeholder) on load', async () => {
+    mockGetConference.mockResolvedValue({
+      conference: {
+        _id: 'conf-ghost',
+        startDate: '2026-03-10',
+        endDate: '2026-03-10',
+        schedules: [
+          {
+            _id: 'sched-1',
+            date: '2026-03-10',
+            tracks: [
+              {
+                trackTitle: 'A',
+                talks: [
+                  { talk: { _id: 't1' }, startTime: '09:00', endTime: '09:25' },
+                  // ghost: the referenced proposal was deleted (talk === null),
+                  // and it is not a service placeholder.
+                  { talk: null, startTime: '10:00', endTime: '10:25' },
+                  {
+                    placeholder: 'Lunch',
+                    startTime: '12:00',
+                    endTime: '13:00',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      error: null,
+    })
+
+    const { schedules } = await getScheduleData()
+
+    const talks = schedules[0].tracks[0].talks
+    expect(talks).toHaveLength(2)
+    expect(talks.map((t) => t.talk?._id ?? t.placeholder)).toEqual([
+      't1',
+      'Lunch',
+    ])
+  })
+
   it('never returns a day outside the conference date range', async () => {
     mockGetConference.mockResolvedValue({
       conference: {

--- a/src/components/admin/schedule/DraggableServiceSession.tsx
+++ b/src/components/admin/schedule/DraggableServiceSession.tsx
@@ -4,6 +4,7 @@ import { useDraggable } from '@dnd-kit/core'
 import { useMemo } from 'react'
 import { TrackTalk } from '@/lib/conference/types'
 import { PIXELS_PER_MINUTE } from '@/lib/schedule/geometry'
+import { durationBetween } from '@/lib/schedule/time'
 import { ClockIcon, Bars3Icon } from '@heroicons/react/24/outline'
 
 interface DraggableServiceSessionProps {
@@ -26,9 +27,10 @@ export function DraggableServiceSession({
   isDragging = false,
 }: DraggableServiceSessionProps) {
   const { dragType, durationMinutes, sessionSize, dragId } = useMemo(() => {
-    const startTime = new Date(`2000-01-01T${serviceSession.startTime}:00`)
-    const endTime = new Date(`2000-01-01T${serviceSession.endTime}:00`)
-    const duration = (endTime.getTime() - startTime.getTime()) / (1000 * 60)
+    const duration = durationBetween(
+      serviceSession.startTime,
+      serviceSession.endTime,
+    )
 
     let size: 'short' | 'medium' | 'long' | 'very-long'
     if (duration <= SERVICE_SESSION_THRESHOLDS.SHORT) size = 'short'

--- a/src/lib/schedule/operations.ts
+++ b/src/lib/schedule/operations.ts
@@ -154,6 +154,19 @@ export function moveProposal(
 
   if (trackIndex < 0 || trackIndex >= schedule.tracks.length) return fail
 
+  // A move onto the talk's own current slot is a no-op. Without this guard it
+  // falls into the swap branch below (the "occupied" talk IS the dragged talk),
+  // and `performSwap` re-adds the talk at both the target and the source slot —
+  // silently duplicating it. Reachable from the mobile Move sheet (which can
+  // default the start time to the talk's current slot) and any drop-in-place.
+  if (
+    dragItem.type === 'scheduled-talk' &&
+    dragItem.sourceTrackIndex === trackIndex &&
+    dragItem.sourceTimeSlot === timeSlot
+  ) {
+    return fail
+  }
+
   const targetTrack = schedule.tracks[trackIndex]
   const durationMinutes = getProposalDurationMinutes(proposal)
   const endTime = calculateEndTime(timeSlot, durationMinutes)

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -73,21 +73,16 @@ export async function saveScheduleToSanity(
               }
             }
 
-            if (talk.talk) {
-              const talkId =
-                talk.talk._id ||
-                (talk.talk as unknown as { _ref?: string })._ref ||
-                ''
-              return {
-                _key: generateKey(`${baseKey}-${talkId}`),
-                talk: createReference(talkId),
-                startTime: talk.startTime,
-                endTime: talk.endTime,
-              }
-            }
-
+            // The filter above guarantees a resolved talk reaches this point
+            // (ghost slots — neither talk nor placeholder — are dropped), so this
+            // is the exhaustive final case, no fallback needed.
+            const talkId =
+              talk.talk?._id ||
+              (talk.talk as unknown as { _ref?: string })?._ref ||
+              ''
             return {
-              _key: generateKey(`${baseKey}-fallback`),
+              _key: generateKey(`${baseKey}-${talkId}`),
+              talk: createReference(talkId),
               startTime: talk.startTime,
               endTime: talk.endTime,
             }

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -55,37 +55,43 @@ export async function saveScheduleToSanity(
         _key: generateKey(`track-${trackIndex}`),
         trackTitle: track.trackTitle,
         trackDescription: track.trackDescription,
-        talks: (track.talks || []).map((talk, talkIndex) => {
-          const baseKey = `talk-${trackIndex}-${talkIndex}-${talk.startTime.replace(':', '')}`
+        // Drop ghost slots (neither a resolved talk nor a placeholder) before
+        // serializing — otherwise the fallback branch below emits an empty slot
+        // that `validateSchedulePayload` rejects, failing the whole save. Load
+        // already strips these, so this is defense-in-depth for any that slip in.
+        talks: (track.talks || [])
+          .filter((talk) => talk.talk || talk.placeholder)
+          .map((talk, talkIndex) => {
+            const baseKey = `talk-${trackIndex}-${talkIndex}-${talk.startTime.replace(':', '')}`
 
-          if (talk.placeholder) {
+            if (talk.placeholder) {
+              return {
+                _key: generateKey(`${baseKey}-service`),
+                placeholder: talk.placeholder,
+                startTime: talk.startTime,
+                endTime: talk.endTime,
+              }
+            }
+
+            if (talk.talk) {
+              const talkId =
+                talk.talk._id ||
+                (talk.talk as unknown as { _ref?: string })._ref ||
+                ''
+              return {
+                _key: generateKey(`${baseKey}-${talkId}`),
+                talk: createReference(talkId),
+                startTime: talk.startTime,
+                endTime: talk.endTime,
+              }
+            }
+
             return {
-              _key: generateKey(`${baseKey}-service`),
-              placeholder: talk.placeholder,
+              _key: generateKey(`${baseKey}-fallback`),
               startTime: talk.startTime,
               endTime: talk.endTime,
             }
-          }
-
-          if (talk.talk) {
-            const talkId =
-              talk.talk._id ||
-              (talk.talk as unknown as { _ref?: string })._ref ||
-              ''
-            return {
-              _key: generateKey(`${baseKey}-${talkId}`),
-              talk: createReference(talkId),
-              startTime: talk.startTime,
-              endTime: talk.endTime,
-            }
-          }
-
-          return {
-            _key: generateKey(`${baseKey}-fallback`),
-            startTime: talk.startTime,
-            endTime: talk.endTime,
-          }
-        }),
+          }),
       }),
     )
 

--- a/src/lib/schedule/server.ts
+++ b/src/lib/schedule/server.ts
@@ -63,6 +63,22 @@ export async function getScheduleData(): Promise<ScheduleData> {
 
     schedules.sort((a, b) => a.date.localeCompare(b.date))
 
+    // Drop "ghost" slots — entries whose talk reference no longer resolves (the
+    // proposal was deleted after being scheduled) and which aren't service
+    // placeholders. The projection keeps them as `{ talk: null }` with no
+    // placeholder; in the editor they render invisibly and can't be removed, and
+    // on save the payload validator rejects the whole day ("neither a talk nor a
+    // placeholder"), permanently bricking that day. The public read side already
+    // filters these out, so stripping them here keeps the write side symmetric.
+    for (const schedule of schedules) {
+      schedule.tracks = (schedule.tracks || []).map((track) => ({
+        ...track,
+        talks: (track.talks || []).filter(
+          (slot) => slot.talk || slot.placeholder,
+        ),
+      }))
+    }
+
     const { proposals, proposalsError } = await getProposals({
       conferenceId: conference._id,
       returnAll: true,


### PR DESCRIPTION
## Summary

Two **data-integrity** fixes surfaced by the final adversarial review of the reworked schedule editor, plus one cleanup.

### 1. Same-position move duplicates a talk (HIGH)
`moveProposal` now treats a move onto a talk's **own** current slot as a no-op. Previously it fell into the swap branch — the "occupied" talk being the dragged talk itself — and `performSwap` re-added it at **both** the target and the source, silently **duplicating** the talk (and marking the day dirty → saved). Reachable from the mobile Move sheet, whose start-time picker can default to the talk's current slot, so confirming "Move here" without changing anything corrupted the schedule.

### 2. Ghost slot bricks a day's save (HIGH)
A "ghost" slot — a talk ref whose proposal was deleted after scheduling, with no placeholder — was **invisible and unremovable** in the editor, **blocked drops** onto its time, and made the whole day **un-saveable**: `validateSchedulePayload` rejects a slot with neither talk nor placeholder, so the router threw `BAD_REQUEST` and that day plus every later day in the save loop failed to persist.

Now stripped on **load** (`server.ts`) and defensively during **save serialization** (`sanity.ts`). The public read side already filters dangling refs; this makes the write side symmetric.

### 3. Cleanup
`DraggableServiceSession` now uses the extracted `durationBetween` instead of leftover `new Date()` arithmetic, completing the time-helper consolidation.

## Tests
- `operations.test.ts`: same-position move is a no-op (no duplication); genuine swaps and normal moves still work.
- `server.test.ts`: load strips ghost slots, keeps real talks + placeholders.

All schedule suites green; tsc/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two data-integrity bugs in the schedule editor and completes a time-helper consolidation. The fixes are well-targeted and the new tests cover the primary regression paths.

- **Same-position move guard** (`operations.ts`): A new early-return in `moveProposal` now catches the case where a `scheduled-talk` is dropped onto its own current slot, preventing it from reaching the swap branch and silently duplicating the talk entry in both the target and source positions.
- **Ghost slot stripping** (`server.ts` + `sanity.ts`): Dangling talk refs (deleted proposals that remain as `{ talk: null }` in Sanity) are now filtered on load and again as defense-in-depth during save serialization, so they can no longer brick an entire day's save via `validateSchedulePayload`.
- **Cleanup** (`DraggableServiceSession.tsx`): Duration calculation now delegates to `durationBetween()` from `time.ts`, eliminating the last remaining ad-hoc `new Date()` arithmetic in the editor.

<h3>Confidence Score: 4/5</h3>

Safe to merge — both targeted fixes have regression tests and the changes are narrowly scoped to the editor's load and save paths.

The same-position guard and ghost-slot stripping are correct and well-tested. The only rough edge is the now-unreachable fallback branch in sanity.ts, which is dead code rather than a defect and carries no runtime risk.

src/lib/schedule/sanity.ts — the unreachable fallback branch inside the .map() could be cleaned up for clarity.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/schedule/operations.ts | Adds a same-position no-op guard in moveProposal; logic is correct and covered by the new regression test. |
| src/lib/schedule/server.ts | Ghost slot stripping loop is correct and symmetric with the public read side; covered by the new server test. |
| src/lib/schedule/sanity.ts | Ghost slot filter added as defense-in-depth before serialization; the fallback branch inside the map is now dead code but not harmful. |
| src/components/admin/schedule/DraggableServiceSession.tsx | Clean refactor from ad-hoc Date arithmetic to durationBetween(); behavior is identical for valid HH:MM times. |
| __tests__/lib/schedule/operations.test.ts | New regression test correctly verifies same-position move is a no-op and the schedule object is unchanged. |
| __tests__/lib/schedule/server.test.ts | New test accurately simulates a ghost slot (talk: null, no placeholder) and asserts it is stripped while real talks and placeholders survive. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[moveProposal called] --> B{dragItem.proposal?}
    B -- No --> FAIL[return fail]
    B -- Yes --> C{trackIndex in range?}
    C -- No --> FAIL
    C -- Yes --> D{scheduled-talk AND same track AND same timeSlot?}
    D -- Yes --> FAIL
    D -- No --> E{withinScheduleEnd?}
    E -- No --> FAIL
    E -- Yes --> F{Fresh drop?}
    F -- Yes --> G{Already scheduled?}
    G -- Yes --> FAIL
    G -- No --> H
    F -- No --> H{Slot occupied?}
    H -- Yes + scheduled-talk --> I{canSwapTalks AND canPlaceDisplacedBack?}
    I -- No --> FAIL
    I -- Yes --> J[performSwap ok:true]
    H -- Yes + other --> FAIL
    H -- No --> K{findAvailableTimeSlot == timeSlot?}
    K -- No --> FAIL
    K -- Yes --> L[Place talk ok:true]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[moveProposal called] --> B{dragItem.proposal?}
    B -- No --> FAIL[return fail]
    B -- Yes --> C{trackIndex in range?}
    C -- No --> FAIL
    C -- Yes --> D{scheduled-talk AND same track AND same timeSlot?}
    D -- Yes --> FAIL
    D -- No --> E{withinScheduleEnd?}
    E -- No --> FAIL
    E -- Yes --> F{Fresh drop?}
    F -- Yes --> G{Already scheduled?}
    G -- Yes --> FAIL
    G -- No --> H
    F -- No --> H{Slot occupied?}
    H -- Yes + scheduled-talk --> I{canSwapTalks AND canPlaceDisplacedBack?}
    I -- No --> FAIL
    I -- Yes --> J[performSwap ok:true]
    H -- Yes + other --> FAIL
    H -- No --> K{findAvailableTimeSlot == timeSlot?}
    K -- No --> FAIL
    K -- Yes --> L[Place talk ok:true]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): drop ghost slots and guar..."](https://github.com/cloudnativebergen/website/commit/38b9731d75975a21581351ab1337c07463262154) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45168996)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->