### PR TITLE
fix(schedule): harden mobile sheet a11y and move-sheet defaults

### DIFF
--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -88,6 +88,7 @@ const setup = () => {
       currentDayIndex={0}
       unassignedProposals={[unassignedProposal]}
       dispatch={dispatch}
+      onDayChange={vi.fn()}
       onSave={vi.fn()}
       onAddTrack={vi.fn()}
       isSaving={false}

--- a/src/components/admin/schedule/MobileScheduleView.stories.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.stories.tsx
@@ -129,6 +129,7 @@ function MobileScheduleHarness({
       currentDayIndex={state.currentDayIndex}
       unassignedProposals={unassignedProposals}
       dispatch={dispatch}
+      onDayChange={(dayIndex) => dispatch({ type: 'changeDay', dayIndex })}
       onSave={() => {}}
       onAddTrack={() => {}}
       isSaving={state.ui.isSaving}

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -190,13 +190,14 @@ function BottomSheet({
       const first = items[0]
       const last = items[items.length - 1]
       const active = document.activeElement
-      if (
-        e.shiftKey &&
-        (active === first || !dialogRef.current?.contains(active))
-      ) {
+      const outside = !dialogRef.current?.contains(active)
+      if (e.shiftKey && (active === first || outside)) {
+        // Wrap backwards to the last element (or pull stray focus back in).
         e.preventDefault()
         last.focus()
-      } else if (!e.shiftKey && active === last) {
+      } else if (!e.shiftKey && (active === last || outside)) {
+        // Wrap forwards to the first element; also pull focus back in if it
+        // somehow escaped the dialog, so Tab can't advance into the background.
         e.preventDefault()
         first.focus()
       }

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -52,6 +52,7 @@ interface MobileScheduleViewProps {
   currentDayIndex: number
   unassignedProposals: ProposalExisting[]
   dispatch: React.Dispatch<ScheduleAction>
+  onDayChange: (dayIndex: number) => void
   onSave: () => void
   onAddTrack: () => void
   isSaving: boolean
@@ -128,7 +129,10 @@ function useSwipeNavigation(onSwipe: (direction: 1 | -1) => void) {
       const dx = touch.clientX - start.current.x
       const dy = touch.clientY - start.current.y
       start.current = null
-      if (Math.abs(dx) > 60 && Math.abs(dx) > Math.abs(dy) * 1.5) {
+      // Require a clearly horizontal gesture: past the distance threshold AND
+      // at least twice as horizontal as vertical, so a near-diagonal drag
+      // during vertical agenda scrolling doesn't switch tracks.
+      if (Math.abs(dx) > 60 && Math.abs(dx) > Math.abs(dy) * 2) {
         onSwipe(dx < 0 ? 1 : -1)
       }
     },
@@ -152,13 +156,57 @@ function BottomSheet({
     () => `sheet-${title.replace(/\s+/g, '-').toLowerCase()}`,
     [title],
   )
+  const dialogRef = useRef<HTMLDivElement>(null)
 
+  // Escape to close, plus a focus trap and body-scroll lock so this
+  // `aria-modal` sheet actually behaves modally: keyboard/screen-reader users
+  // can't Tab into the covered background, and the page behind doesn't scroll.
   useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    const { overflow } = document.body.style
+    document.body.style.overflow = 'hidden'
+
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      )
+
+    // Move focus into the sheet on open.
+    ;(focusables()[0] ?? dialogRef.current)?.focus()
+
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab') return
+      const items = focusables()
+      if (items.length === 0) {
+        e.preventDefault()
+        return
+      }
+      const first = items[0]
+      const last = items[items.length - 1]
+      const active = document.activeElement
+      if (
+        e.shiftKey &&
+        (active === first || !dialogRef.current?.contains(active))
+      ) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
     }
     document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = overflow
+      previouslyFocused?.focus?.()
+    }
   }, [onClose])
 
   return (
@@ -170,10 +218,12 @@ function BottomSheet({
         className="absolute inset-0 bg-black/50"
       />
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
-        className="relative flex max-h-[85dvh] flex-col rounded-t-2xl bg-white shadow-xl dark:bg-gray-900"
+        tabIndex={-1}
+        className="relative flex max-h-[85dvh] flex-col rounded-t-2xl bg-white shadow-xl focus:outline-none dark:bg-gray-900"
       >
         <div className="flex shrink-0 items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
           <h2
@@ -522,12 +572,17 @@ function MoveSheet({
   ])
 
   // `startTime` starts empty and is only ever set by the user; the effective
-  // value falls back to the first free slot so we never need a setState-in-effect
-  // to "reset" it when the track (and its slot list) changes.
+  // value falls back to the talk's CURRENT slot (kept free by the same-track
+  // exclude above) so opening the sheet and tapping "Move here" without picking
+  // a time is a no-op instead of silently relocating the talk to the earliest
+  // free slot. When that time isn't offered (a different track), fall back to
+  // the first free slot. No setState-in-effect needed to "reset" on track change.
   const [startTime, setStartTime] = useState('')
   const effectiveStart = slots.includes(startTime)
     ? startTime
-    : (slots[0] ?? '')
+    : slots.includes(talk.startTime)
+      ? talk.startTime
+      : (slots[0] ?? '')
 
   const confirm = useCallback(() => {
     if (!effectiveStart) return
@@ -1047,6 +1102,7 @@ export function MobileScheduleView({
   currentDayIndex,
   unassignedProposals,
   dispatch,
+  onDayChange,
   onSave,
   onAddTrack,
   isSaving,
@@ -1096,11 +1152,13 @@ export function MobileScheduleView({
 
   const handleDayChange = useCallback(
     (dayIndex: number) => {
-      dispatch({ type: 'changeDay', dayIndex })
+      // Delegate to the parent so the "Saved" indicator (parent state) is
+      // cleared consistently with the desktop view; then reset local UI.
+      onDayChange(dayIndex)
       setSelectedTrackIndex(0)
       setSheet(null)
     },
-    [dispatch],
+    [onDayChange],
   )
 
   // The action sheet stores a talkIndex into the SORTED list; translate it back

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -385,6 +385,7 @@ export function ScheduleEditor({
           currentDayIndex={currentDayIndex}
           unassignedProposals={unassignedProposals}
           dispatch={dispatch}
+          onDayChange={handleDayChange}
           onSave={handleSave}
           onAddTrack={handleShowAddTrackModal}
           isSaving={isSaving}


### PR DESCRIPTION
## Summary

Mobile-view fixes from the final adversarial review of the schedule editor.

### MoveSheet default (MED)
The Move sheet now defaults the start time to the talk's **current** slot (kept free by the same-track exclude) instead of the earliest free slot. Previously, opening the sheet to inspect a talk and tapping **Move here** without picking a time silently relocated it to 08:00 (or the first gap). Combined with the same-position no-op guard in #488, confirming an unchanged Move is now a true no-op.

### BottomSheet a11y (MED)
The bottom sheet now behaves like a real modal: focus moves into the sheet on open, **Tab is trapped** inside it, focus is **restored** to the trigger on close, and **body scroll is locked**. Previously an `aria-modal` dialog let keyboard/screen-reader users Tab straight into the covered background, and the page behind could scroll.

### Sticky "Saved" on day change (LOW)
Day switching now delegates to the parent's `handleDayChange` via a new `onDayChange` prop, so the green **Saved** indicator (parent state) clears consistently with the desktop view instead of sticking across a day change.

### Swipe threshold (LOW)
Swipe-to-switch-track now requires a clearly horizontal gesture (**2× ratio**, up from 1.5×) so a near-diagonal drag during vertical agenda scrolling doesn't hijack track navigation.

## Tests
- `MobileScheduleView.test.tsx` and the story updated for the new `onDayChange` prop; all mobile tests green.
- tsc/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the mobile schedule editor with four targeted fixes: proper focus trap and body-scroll lock in the `BottomSheet` component, a sensible default start-time in `MoveSheet` (current slot rather than earliest free slot), delegation of day-change to the parent to clear the "Saved" indicator, and a tighter swipe-to-switch-track threshold.

- **`BottomSheet` a11y**: `useEffect` now captures the previously-focused element, locks `document.body.style.overflow`, traps Tab/Shift-Tab within `dialogRef`, and restores focus and scroll on unmount — turning the `aria-modal` declaration into actual modal behaviour.
- **`MoveSheet` default**: `effectiveStart` falls back to `talk.startTime` (kept free by the same-track exclude) before falling back to `slots[0]`, so opening the sheet and confirming without picking a time is a true no-op.
- **Day-change and swipe**: `handleDayChange` delegates to `onDayChange` (parent), and the swipe ratio guard tightened from 1.5× to 2×.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the a11y and UX fixes are well-scoped and the onDayChange delegation is straightforward.

The focus trap, scroll lock, and focus-restoration logic in BottomSheet are sound for the common paths. The one nuance is that the cleanup unconditionally fires focus restoration on every unmount — including transitions between sheets (card action → move) — relying on screen-reader debounce behaviour rather than an explicit guard. In practice this is imperceptible, but it's worth a follow-up to either skip restoration when the element is no longer connected to the DOM, or to track the real trigger at the parent level.

src/components/admin/schedule/MobileScheduleView.tsx — specifically the BottomSheet useEffect cleanup around focus restoration.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/MobileScheduleView.tsx | Core changes: BottomSheet gains focus trap + scroll lock, MoveSheet defaults to current slot, handleDayChange delegates to onDayChange prop. Focus cleanup on unmount can briefly return focus to the original trigger when navigating between sheets (card → move), but both effects fire synchronously in the same commit phase so in practice screen readers will not announce the intermediate state. |
| src/components/admin/schedule/ScheduleEditor.tsx | Passes existing handleDayChange (which already calls setSaveSuccess(false)) to MobileScheduleView via the new onDayChange prop — minimal, correct wiring. |
| __tests__/components/admin/schedule/MobileScheduleView.test.tsx | Adds the required onDayChange={vi.fn()} prop to the test harness; no new tests cover the a11y behaviour (focus trap, scroll lock) which is expected since jsdom cannot exercise real browser focus APIs meaningfully. |
| src/components/admin/schedule/MobileScheduleView.stories.tsx | Wires onDayChange to dispatch a changeDay action in the story harness, consistent with the ScheduleEditor integration. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant AgendaCard
    participant CardActionSheet as CardActionSheet (BottomSheet)
    participant MoveSheet as MoveSheet (BottomSheet)
    participant DOM as DOM / Screen Reader

    User->>AgendaCard: tap
    AgendaCard->>CardActionSheet: "setSheet({kind:'card'})"
    Note over CardActionSheet: useEffect mounts<br/>previouslyFocused = AgendaCard<br/>overflow = hidden<br/>focus → first button
    User->>CardActionSheet: tap "Move to another track"
    CardActionSheet->>MoveSheet: "setSheet({kind:'move'})"
    Note over CardActionSheet: cleanup runs<br/>overflow restored<br/>AgendaCard.focus() ← brief flash
    Note over MoveSheet: useEffect mounts<br/>previouslyFocused = AgendaCard<br/>overflow = hidden<br/>focus → time picker
    DOM-->>User: announces MoveSheet (debounced)
    User->>MoveSheet: "pick time & confirm"
    MoveSheet->>DOM: dispatch moveProposal
    MoveSheet->>MoveSheet: onClose → setSheet(null)
    Note over MoveSheet: cleanup runs<br/>overflow restored<br/>AgendaCard.focus()
    DOM-->>User: focus returned to AgendaCard
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant AgendaCard
    participant CardActionSheet as CardActionSheet (BottomSheet)
    participant MoveSheet as MoveSheet (BottomSheet)
    participant DOM as DOM / Screen Reader

    User->>AgendaCard: tap
    AgendaCard->>CardActionSheet: "setSheet({kind:'card'})"
    Note over CardActionSheet: useEffect mounts<br/>previouslyFocused = AgendaCard<br/>overflow = hidden<br/>focus → first button
    User->>CardActionSheet: tap "Move to another track"
    CardActionSheet->>MoveSheet: "setSheet({kind:'move'})"
    Note over CardActionSheet: cleanup runs<br/>overflow restored<br/>AgendaCard.focus() ← brief flash
    Note over MoveSheet: useEffect mounts<br/>previouslyFocused = AgendaCard<br/>overflow = hidden<br/>focus → time picker
    DOM-->>User: announces MoveSheet (debounced)
    User->>MoveSheet: "pick time & confirm"
    MoveSheet->>DOM: dispatch moveProposal
    MoveSheet->>MoveSheet: onClose → setSheet(null)
    Note over MoveSheet: cleanup runs<br/>overflow restored<br/>AgendaCard.focus()
    DOM-->>User: focus returned to AgendaCard
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): harden mobile sheet a11y ..."](https://github.com/cloudnativebergen/website/commit/5e6724fb3bb995e4d9090d8e48c9e9260a795d99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45171043)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->