### PR TITLE
feat(schedule): mobile time-rail + pick-up→drop editor

### DIFF
--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -142,6 +142,22 @@ describe('MobileScheduleView', () => {
     })
   })
 
+  it('hides the "Service" control while placing (index-shift guard)', () => {
+    setup()
+    // A Service button per track before pick-up.
+    expect(
+      screen.getAllByRole('button', { name: 'Service' }).length,
+    ).toBeGreaterThan(0)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Move Scheduled Keynote Talk' }),
+    )
+    // While placing, adding a service would re-sort track.talks and invalidate
+    // the picked-up talkIndex — so the control is gone.
+    expect(
+      screen.queryByRole('button', { name: 'Service' }),
+    ).not.toBeInTheDocument()
+  })
+
   it('swaps two talks: pick one up, tap the other', () => {
     const dispatch = vi.fn()
     const talkB = makeProposal({

--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -100,41 +100,116 @@ const setup = () => {
 }
 
 describe('MobileScheduleView', () => {
-  it('renders the selected track agenda', () => {
+  it('renders track tabs and the current track rail with a talk card', () => {
     setup()
     expect(screen.getByRole('tab', { name: 'Main Stage' })).toBeInTheDocument()
     expect(
       screen.getByRole('tab', { name: 'Workshop Room' }),
     ).toBeInTheDocument()
+    // Talk card: title, gutter start time, and clamp-proof duration chip.
     expect(screen.getByText('Scheduled Keynote Talk')).toBeInTheDocument()
-    expect(screen.getByText('10:00–10:45')).toBeInTheDocument()
+    expect(screen.getByText('10:00')).toBeInTheDocument()
+    expect(screen.getByText('45m')).toBeInTheDocument()
   })
 
-  it('switches the visible agenda when another track tab is selected', () => {
+  it('selects another track when its tab is tapped', () => {
     setup()
-    fireEvent.click(screen.getByRole('tab', { name: 'Workshop Room' }))
-    expect(
-      screen.getByText('Nothing scheduled in this track yet.'),
-    ).toBeInTheDocument()
+    const workshop = screen.getByRole('tab', { name: 'Workshop Room' })
+    expect(workshop).toHaveAttribute('aria-selected', 'false')
+    fireEvent.click(workshop)
+    expect(workshop).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Main Stage' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
   })
 
-  it('lists unassigned proposals in the assign sheet', () => {
-    setup()
-    fireEvent.click(screen.getByRole('button', { name: 'Assign a talk' }))
-    const dialog = screen.getByRole('dialog')
-    expect(
-      within(dialog).getByText('Unassigned Lightning Talk'),
-    ).toBeInTheDocument()
-  })
-
-  it('dispatches moveProposal when assigning a talk', () => {
+  it('picks up a talk into placing mode and removes it', () => {
     const { dispatch } = setup()
-    fireEvent.click(screen.getByRole('button', { name: 'Assign a talk' }))
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Move Scheduled Keynote Talk' }),
+    )
+    // The placing banner appears as a live region.
+    const banner = screen.getByRole('status')
+    expect(banner).toHaveTextContent(/Moving/)
+    expect(banner).toHaveTextContent(/Scheduled Keynote Talk/)
+
+    fireEvent.click(within(banner).getByRole('button', { name: /Remove/ }))
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'removeTalk',
+      trackIndex: 0,
+      talkIndex: 0,
+    })
+  })
+
+  it('swaps two talks: pick one up, tap the other', () => {
+    const dispatch = vi.fn()
+    const talkB = makeProposal({
+      _id: 'scheduled-2',
+      title: 'Second Talk',
+      format: Format.presentation_25,
+    })
+    const twoTalkSchedule: ConferenceSchedule = {
+      _id: 'day-1',
+      date: '2026-09-01',
+      tracks: [
+        {
+          trackTitle: 'Main Stage',
+          trackDescription: '',
+          talks: [
+            { talk: scheduledProposal, startTime: '10:00', endTime: '10:45' },
+            { talk: talkB, startTime: '11:00', endTime: '11:25' },
+          ],
+        },
+      ],
+    }
+    render(
+      <MobileScheduleView
+        schedules={[twoTalkSchedule]}
+        currentDayIndex={0}
+        unassignedProposals={[]}
+        dispatch={dispatch}
+        onDayChange={vi.fn()}
+        onSave={vi.fn()}
+        onAddTrack={vi.fn()}
+        isSaving={false}
+        saveSuccess={false}
+        error={null}
+      />,
+    )
+
+    // Pick up the keynote, then tap the second talk to swap.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Move Scheduled Keynote Talk' }),
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Swap with Second Talk' }),
+    )
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'moveProposal',
+        dragItem: expect.objectContaining({
+          type: 'scheduled-talk',
+          proposal: expect.objectContaining({ _id: 'scheduled-1' }),
+          sourceTrackIndex: 0,
+          sourceTimeSlot: '10:00',
+        }),
+        dropPosition: { trackIndex: 0, timeSlot: '11:00' },
+      }),
+    )
+  })
+
+  it('assigns a fitting proposal by tapping an open slot', () => {
+    const { dispatch } = setup()
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Assign to open slot 08:00 to 10:00',
+      }),
+    )
 
     const dialog = screen.getByRole('dialog')
     fireEvent.click(within(dialog).getByText('Unassigned Lightning Talk'))
-
-    fireEvent.click(screen.getByRole('button', { name: 'Assign' }))
 
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -143,23 +218,8 @@ describe('MobileScheduleView', () => {
           type: 'proposal',
           proposal: expect.objectContaining({ _id: 'unassigned-1' }),
         }),
-        dropPosition: expect.objectContaining({ trackIndex: 0 }),
+        dropPosition: { trackIndex: 0, timeSlot: '08:00' },
       }),
     )
-  })
-
-  it('dispatches removeTalk from a card action sheet', () => {
-    const { dispatch } = setup()
-    fireEvent.click(
-      screen.getByRole('button', { name: /Scheduled Keynote Talk/ }),
-    )
-    fireEvent.click(
-      screen.getByRole('button', { name: /Remove from schedule/ }),
-    )
-    expect(dispatch).toHaveBeenCalledWith({
-      type: 'removeTalk',
-      trackIndex: 0,
-      talkIndex: 0,
-    })
   })
 })

--- a/__tests__/components/admin/schedule/mobileRail.test.ts
+++ b/__tests__/components/admin/schedule/mobileRail.test.ts
@@ -90,6 +90,21 @@ describe('buildTrackRail', () => {
     expect(talks.map((s) => s.talkIndex)).toEqual([1, 0])
   })
 
+  it('drops ghost slots (dangling ref: no talk, no placeholder) into open time', () => {
+    const rail = buildTrackRail(
+      track(
+        // ghost: has times but neither a resolved talk nor a placeholder
+        { startTime: '10:00', endTime: '10:25' } as TrackTalk,
+        talk('y', '11:00', '11:25'),
+      ),
+    )
+    expect(shape(rail)).toEqual([
+      'open:08:00-11:00',
+      'talk:11:00-11:25',
+      'open:11:25-21:00',
+    ])
+  })
+
   it('skips malformed slots without emitting a negative-width gap', () => {
     const rail = buildTrackRail(
       track(

--- a/__tests__/components/admin/schedule/mobileRail.test.ts
+++ b/__tests__/components/admin/schedule/mobileRail.test.ts
@@ -82,12 +82,12 @@ describe('buildTrackRail', () => {
     const rail = buildTrackRail(
       track(talk('late', '14:00', '14:25'), talk('early', '10:00', '10:25')),
     )
+    // `filter` narrows to the talk/break variant (inferred type predicate), so
+    // `talkIndex` is available directly.
     const talks = rail.filter((s) => s.kind !== 'open')
     expect(talks.map((s) => s.startTime)).toEqual(['10:00', '14:00'])
     // 'early' is index 1 in the original array, 'late' is index 0
-    expect(talks.map((s) => (s.kind !== 'open' ? s.talkIndex : -1))).toEqual([
-      1, 0,
-    ])
+    expect(talks.map((s) => s.talkIndex)).toEqual([1, 0])
   })
 
   it('skips malformed slots without emitting a negative-width gap', () => {

--- a/__tests__/components/admin/schedule/mobileRail.test.ts
+++ b/__tests__/components/admin/schedule/mobileRail.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the mobile time-rail builder (buildTrackRail). It turns a track into
+ * a chronological list of talk/break/open segments spanning the schedule day,
+ * with `open` segments for every uncovered interval (the editor's tappable free
+ * time).
+ */
+import { describe, it, expect } from 'vitest'
+import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
+import type { ProposalExisting } from '@/lib/proposal/types'
+import { buildTrackRail } from '@/components/admin/schedule/mobileRail'
+
+const proposal = (id: string): ProposalExisting =>
+  ({ _id: id, format: 'talk_25' }) as unknown as ProposalExisting
+
+const talk = (id: string, start: string, end: string): TrackTalk => ({
+  talk: proposal(id),
+  startTime: start,
+  endTime: end,
+})
+
+const service = (name: string, start: string, end: string): TrackTalk => ({
+  placeholder: name,
+  startTime: start,
+  endTime: end,
+})
+
+const track = (...talks: TrackTalk[]): ScheduleTrack => ({
+  trackTitle: 'A',
+  trackDescription: '',
+  talks,
+})
+
+const shape = (s: ReturnType<typeof buildTrackRail>) =>
+  s.map((seg) => `${seg.kind}:${seg.startTime}-${seg.endTime}`)
+
+describe('buildTrackRail', () => {
+  it('collapses an empty track to a single full-day open segment', () => {
+    expect(shape(buildTrackRail(track()))).toEqual(['open:08:00-21:00'])
+  })
+
+  it('wraps a lone talk with leading and trailing open time', () => {
+    expect(shape(buildTrackRail(track(talk('x', '09:00', '09:25'))))).toEqual([
+      'open:08:00-09:00',
+      'talk:09:00-09:25',
+      'open:09:25-21:00',
+    ])
+  })
+
+  it('emits no open gap between back-to-back items', () => {
+    const rail = buildTrackRail(
+      track(talk('x', '08:00', '08:25'), service('Break', '08:25', '08:40')),
+    )
+    expect(shape(rail)).toEqual([
+      'talk:08:00-08:25',
+      'break:08:25-08:40',
+      'open:08:40-21:00',
+    ])
+  })
+
+  it('classifies placeholder slots as break and talk slots as talk', () => {
+    const rail = buildTrackRail(
+      track(service('Lunch', '12:00', '13:00'), talk('y', '13:00', '13:25')),
+    )
+    expect(rail[0].kind).toBe('open')
+    expect(rail[1].kind).toBe('break')
+    expect(rail[2].kind).toBe('talk')
+  })
+
+  it('drops leading open time when a talk starts at SCHEDULE_START', () => {
+    const rail = buildTrackRail(track(talk('x', '08:00', '08:25')))
+    expect(rail[0].kind).toBe('talk')
+  })
+
+  it('drops trailing open time when the last item ends at SCHEDULE_END', () => {
+    const rail = buildTrackRail(track(talk('x', '20:35', '21:00')))
+    expect(shape(rail)).toEqual(['open:08:00-20:35', 'talk:20:35-21:00'])
+  })
+
+  it('sorts out-of-order talks and preserves original talkIndex', () => {
+    const rail = buildTrackRail(
+      track(talk('late', '14:00', '14:25'), talk('early', '10:00', '10:25')),
+    )
+    const talks = rail.filter((s) => s.kind !== 'open')
+    expect(talks.map((s) => s.startTime)).toEqual(['10:00', '14:00'])
+    // 'early' is index 1 in the original array, 'late' is index 0
+    expect(talks.map((s) => (s.kind !== 'open' ? s.talkIndex : -1))).toEqual([
+      1, 0,
+    ])
+  })
+
+  it('skips malformed slots without emitting a negative-width gap', () => {
+    const rail = buildTrackRail(
+      track(
+        { talk: proposal('x'), startTime: '', endTime: '' } as TrackTalk,
+        talk('y', '10:00', '10:25'),
+      ),
+    )
+    expect(shape(rail)).toEqual([
+      'open:08:00-10:00',
+      'talk:10:00-10:25',
+      'open:10:25-21:00',
+    ])
+  })
+})

--- a/src/components/admin/schedule/MobileScheduleView.stories.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.stories.tsx
@@ -147,7 +147,7 @@ const meta: Meta<typeof MobileScheduleHarness> = {
     docs: {
       description: {
         component:
-          'Tap-to-assign mobile schedule editor rendered below the `md` breakpoint. A light top nav (Schedule title, unassigned/legend/save cluster, scrollable day chips) sits above a swipeable track tab strip — swipe or tap between tracks, with a trailing “＋” chip to add one. Agenda cards and bottom sheets handle assigning talks, moving them, and managing service sessions. Wired to the real schedule reducer so interactions mutate state.',
+          'Pick-up → drop mobile schedule editor rendered below the `md` breakpoint. A light top nav (Schedule title, unassigned/legend/save cluster, scrollable day chips) sits above a fixed track tab strip synced to a scroll-snap carousel — swipe between tracks (the neighbour peeks) or tap a tab. Each track is a hybrid time-rail: tap a talk/break to pick it up, then tap a valid open slot to move it (or another talk to swap); tap an open slot directly to assign a fitting unassigned proposal. Wired to the real schedule reducer so interactions mutate state.',
       },
     },
   },

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -1201,6 +1201,9 @@ export function MobileScheduleView({
       prevDayRef.current = currentDayIndex
       setSelectedTrackIndex(0)
       setPlacing(null)
+      // Also close any open sheet — if the day changed via parent state (not
+      // handleDayChange) a sheet could otherwise linger with stale context.
+      setSheet(null)
     }
     const scroller = scrollerRef.current
     if (scroller) scroller.scrollLeft = 0

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/react'
 import clsx from 'clsx'
 import {
   ConferenceSchedule,
@@ -22,8 +21,12 @@ import {
 import {
   fitsInTrack,
   isTrackIntervalFree,
+  canSwapTalks,
+  canPlaceDisplacedBack,
   matchTalk,
+  matchService,
 } from '@/lib/schedule/rules'
+import { buildTrackRail, type RailSegment } from './mobileRail'
 import { StatusBadge, LevelIndicator } from '@/lib/proposal'
 import { Status } from '@/lib/proposal/types'
 import { formatSpeakerNames } from '@/lib/speaker/formatSpeakerNames'
@@ -39,7 +42,6 @@ import {
   ClockIcon,
   UserIcon,
   InformationCircleIcon,
-  ArrowLeftIcon,
   ArrowsRightLeftIcon,
   TrashIcon,
   PencilIcon,
@@ -79,22 +81,147 @@ const PRIMARY_BUTTON =
 const SECONDARY_BUTTON =
   'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
 
-/** Every `intervalMinutes` start time whose full footprint is free in `track`. */
-function freeStartTimes(
-  track: ScheduleTrack,
-  durationMinutes: number,
-  exclude?: (slot: TrackTalk) => boolean,
-  intervalMinutes = 5,
-): string[] {
-  const endBound = toMinutes(SCHEDULE_END)
-  return generateTimeSlots(SCHEDULE_START, SCHEDULE_END, intervalMinutes)
-    .map((s) => s.time)
-    .filter((time) => {
-      if (toMinutes(calculateEndTime(time, durationMinutes)) > endBound) {
-        return false
-      }
-      return fitsInTrack(track, time, durationMinutes, exclude)
-    })
+/* -------------------------------------------------------------------------- */
+/* Rail geometry                                                              */
+/* -------------------------------------------------------------------------- */
+
+// Duration-proportional heights, CLAMPED so short items stay tappable and long
+// ones don't dominate the rail. See the redesign spec: 1.4px/min, floor 56px
+// (touch target), ceilings 168px for talk/break and 120px for open gaps.
+const PX_PER_MIN = 1.4
+const SEG_MIN_HEIGHT = 56
+const SEG_MAX_HEIGHT = 168
+const OPEN_MAX_HEIGHT = 120
+// Open gaps shorter than this can't hold a talk, so they render as a slim,
+// non-interactive divider rather than an "assign here" target.
+const MIN_OPEN_SLOT_MIN = 10
+// Left time gutter width (~52px) — the rail line sits at its right edge.
+const GUTTER_PX = 52
+
+function segmentHeight(seg: RailSegment): number {
+  const max = seg.kind === 'open' ? OPEN_MAX_HEIGHT : SEG_MAX_HEIGHT
+  return Math.min(
+    max,
+    Math.max(SEG_MIN_HEIGHT, Math.round(seg.durationMin * PX_PER_MIN)),
+  )
+}
+
+const withinEnd = (endTime: string): boolean =>
+  toMinutes(endTime) <= toMinutes(SCHEDULE_END)
+
+/* -------------------------------------------------------------------------- */
+/* Placement model                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A picked-up item awaiting a drop. Persists across track swipes, so dropping
+ * into another track is "swipe, then tap a slot". A `scheduled` pick-up carries
+ * the ORIGINAL `track.talks` index so reducer actions target the right slot.
+ */
+type Placing =
+  | {
+      kind: 'scheduled'
+      trackIndex: number
+      talkIndex: number
+      talk: TrackTalk
+    }
+  | { kind: 'proposal'; proposal: ProposalExisting }
+
+/** The open interval a contextual "assign here" drawer was opened for. */
+interface SlotContext {
+  trackIndex: number
+  startTime: string
+  maxDurationMin: number
+}
+
+type SegmentState = 'default' | 'source' | 'valid' | 'invalid'
+
+/** Does `seg` represent the currently picked-up scheduled item? */
+function isPlacingSource(
+  placing: Placing,
+  panelTrackIndex: number,
+  seg: RailSegment,
+): boolean {
+  return (
+    placing.kind === 'scheduled' &&
+    (seg.kind === 'talk' || seg.kind === 'break') &&
+    panelTrackIndex === placing.trackIndex &&
+    seg.talkIndex === placing.talkIndex
+  )
+}
+
+/**
+ * Whether `seg` in panel `T` is a legal drop target for the current pick-up.
+ * Mirrors `operations.moveProposal` / `moveServiceSession` exactly (same
+ * fitsInTrack / interval-free / swap checks + end-of-day guard) so the UI never
+ * offers a drop the reducer would reject.
+ */
+function segmentState(
+  placing: Placing,
+  tracks: ScheduleTrack[],
+  T: number,
+  seg: RailSegment,
+): SegmentState {
+  if (isPlacingSource(placing, T, seg)) return 'source'
+  const target = tracks[T]
+  if (!target) return 'invalid'
+
+  if (seg.kind === 'open') {
+    if (seg.durationMin < MIN_OPEN_SLOT_MIN) return 'invalid'
+    if (placing.kind === 'proposal') {
+      const dur = getProposalDurationMinutes(placing.proposal)
+      const end = calculateEndTime(seg.startTime, dur)
+      return withinEnd(end) && fitsInTrack(target, seg.startTime, dur)
+        ? 'valid'
+        : 'invalid'
+    }
+    const src = placing.talk
+    const sameTrack = T === placing.trackIndex
+    if (src.talk) {
+      const dur = getProposalDurationMinutes(src.talk)
+      const end = calculateEndTime(seg.startTime, dur)
+      const exclude = sameTrack
+        ? matchTalk(src.talk._id, src.startTime)
+        : undefined
+      return withinEnd(end) && fitsInTrack(target, seg.startTime, dur, exclude)
+        ? 'valid'
+        : 'invalid'
+    }
+    const dur = durationBetween(src.startTime, src.endTime)
+    const end = calculateEndTime(seg.startTime, dur)
+    const exclude = sameTrack
+      ? matchService(src.placeholder ?? '', src.startTime)
+      : undefined
+    return withinEnd(end) &&
+      isTrackIntervalFree(target, seg.startTime, end, exclude)
+      ? 'valid'
+      : 'invalid'
+  }
+
+  if (seg.kind === 'talk') {
+    // Occupied talk => SWAP, only when a scheduled TALK is being placed.
+    if (placing.kind !== 'scheduled' || !placing.talk.talk) return 'invalid'
+    const src = placing.talk
+    const sourceTrack = tracks[placing.trackIndex]
+    if (!sourceTrack) return 'invalid'
+    const draggedEnd = calculateEndTime(
+      seg.startTime,
+      getProposalDurationMinutes(src.talk!),
+    )
+    const ok =
+      withinEnd(draggedEnd) &&
+      canSwapTalks(target, src.talk!, seg.talk, seg.startTime) &&
+      canPlaceDisplacedBack(
+        sourceTrack,
+        seg.talk,
+        src.startTime,
+        matchTalk(src.talk!._id, src.startTime),
+      )
+    return ok ? 'valid' : 'invalid'
+  }
+
+  // `break` targets are never a valid drop.
+  return 'invalid'
 }
 
 function speakerNamesOf(proposal: ProposalExisting): string | null {
@@ -106,37 +233,21 @@ function speakerNamesOf(proposal: ProposalExisting): string | null {
   return populated.length > 0 ? formatSpeakerNames(populated) : null
 }
 
-/** Talks in a track ordered by start time (does not mutate the source array). */
-function sortTalks(track: ScheduleTrack): TrackTalk[] {
-  return [...track.talks].sort((a, b) => a.startTime.localeCompare(b.startTime))
-}
-
-/**
- * Horizontal swipe detector for track navigation. Fires `onSwipe(1)` on a
- * left swipe (next track) and `onSwipe(-1)` on a right swipe, but only when the
- * gesture is clearly horizontal so it never hijacks vertical agenda scrolling.
- */
-function useSwipeNavigation(onSwipe: (direction: 1 | -1) => void) {
-  const start = useRef<{ x: number; y: number } | null>(null)
-  return {
-    onTouchStart: (e: React.TouchEvent) => {
-      const touch = e.touches[0]
-      start.current = { x: touch.clientX, y: touch.clientY }
-    },
-    onTouchEnd: (e: React.TouchEvent) => {
-      if (!start.current) return
-      const touch = e.changedTouches[0]
-      const dx = touch.clientX - start.current.x
-      const dy = touch.clientY - start.current.y
-      start.current = null
-      // Require a clearly horizontal gesture: past the distance threshold AND
-      // at least twice as horizontal as vertical, so a near-diagonal drag
-      // during vertical agenda scrolling doesn't switch tracks.
-      if (Math.abs(dx) > 60 && Math.abs(dx) > Math.abs(dy) * 2) {
-        onSwipe(dx < 0 ? 1 : -1)
+/** Every `intervalMinutes` start time whose full footprint is free in `track`. */
+function freeStartTimes(
+  track: ScheduleTrack,
+  durationMinutes: number,
+  intervalMinutes = 5,
+): string[] {
+  const endBound = toMinutes(SCHEDULE_END)
+  return generateTimeSlots(SCHEDULE_START, SCHEDULE_END, intervalMinutes)
+    .map((s) => s.time)
+    .filter((time) => {
+      if (toMinutes(calculateEndTime(time, durationMinutes)) > endBound) {
+        return false
       }
-    },
-  }
+      return fitsInTrack(track, time, durationMinutes)
+    })
 }
 
 /* -------------------------------------------------------------------------- */
@@ -251,72 +362,7 @@ function BottomSheet({
 }
 
 /* -------------------------------------------------------------------------- */
-/* Agenda card                                                                */
-/* -------------------------------------------------------------------------- */
-
-function AgendaCard({ talk, onTap }: { talk: TrackTalk; onTap: () => void }) {
-  const isService = !talk.talk
-  const proposal = talk.talk
-  const duration = durationBetween(talk.startTime, talk.endTime)
-  const title = proposal?.title ?? talk.placeholder ?? 'Untitled'
-  const speakers = proposal ? speakerNamesOf(proposal) : null
-
-  return (
-    <button
-      type="button"
-      onClick={onTap}
-      className={`flex w-full ${TAP_TARGET} flex-col gap-1 rounded-lg border p-3 text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
-        isService
-          ? 'border-dashed border-gray-300 bg-gray-50 dark:border-gray-600 dark:bg-gray-800/60'
-          : 'border-gray-200 bg-white hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700'
-      }`}
-    >
-      <div className="flex items-center justify-between gap-2 text-xs font-medium text-gray-500 dark:text-gray-400">
-        <span className="tabular-nums">
-          {talk.startTime}–{talk.endTime}
-        </span>
-        <span className="inline-flex items-center gap-1 tabular-nums">
-          <ClockIcon className="h-3.5 w-3.5" />
-          {duration}m
-        </span>
-      </div>
-
-      <div className="flex items-start justify-between gap-2">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-          {title}
-        </h3>
-        {proposal && (
-          <LevelIndicator
-            level={proposal.level}
-            size="xs"
-            className="mt-0.5 shrink-0"
-          />
-        )}
-      </div>
-
-      {isService ? (
-        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
-          Service session
-        </span>
-      ) : (
-        <div className="flex flex-wrap items-center gap-2">
-          {proposal && (
-            <StatusBadge status={proposal.status} variant="compact" />
-          )}
-          {speakers && (
-            <span className="inline-flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400">
-              <UserIcon className="h-3.5 w-3.5 shrink-0" />
-              <span className="truncate">{speakers}</span>
-            </span>
-          )}
-        </div>
-      )}
-    </button>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Time picker (shared by assign + move)                                      */
+/* Time picker                                                                */
 /* -------------------------------------------------------------------------- */
 
 function TimeSelect({
@@ -349,370 +395,28 @@ function TimeSelect({
 }
 
 /* -------------------------------------------------------------------------- */
-/* Assign sheet                                                               */
+/* Service edit sheet (rename / duration)                                     */
 /* -------------------------------------------------------------------------- */
 
-function AssignSheet({
-  track,
-  trackTitle,
-  trackIndex,
-  proposals,
-  dispatch,
-  onClose,
-}: {
-  track: ScheduleTrack
-  trackTitle: string
-  trackIndex: number
-  proposals: ProposalExisting[]
-  dispatch: React.Dispatch<ScheduleAction>
-  onClose: () => void
-}) {
-  const filters = useProposalFilters(proposals)
-  const [selected, setSelected] = useState<ProposalExisting | null>(null)
-  const [startTime, setStartTime] = useState('')
-  const [inlineError, setInlineError] = useState<string | null>(null)
-
-  const duration = selected ? getProposalDurationMinutes(selected) : 0
-  const slots = useMemo(
-    () => (selected ? freeStartTimes(track, duration) : []),
-    [track, selected, duration],
-  )
-
-  const pickProposal = useCallback(
-    (proposal: ProposalExisting) => {
-      setSelected(proposal)
-      setInlineError(null)
-      const free = freeStartTimes(track, getProposalDurationMinutes(proposal))
-      if (free.length === 0) {
-        setInlineError('No free time slot for this talk in this track.')
-        setStartTime('')
-      } else {
-        setStartTime(free[0])
-      }
-    },
-    [track],
-  )
-
-  const confirm = useCallback(() => {
-    if (!selected || !startTime) return
-    const endTime = calculateEndTime(startTime, duration)
-    if (
-      toMinutes(endTime) > toMinutes(SCHEDULE_END) ||
-      !fitsInTrack(track, startTime, duration)
-    ) {
-      setInlineError('That slot overlaps another item or runs past end of day.')
-      return
-    }
-    dispatch({
-      type: 'moveProposal',
-      dragItem: { type: 'proposal', proposal: selected },
-      dropPosition: { trackIndex, timeSlot: startTime },
-    })
-    onClose()
-  }, [selected, startTime, duration, track, trackIndex, dispatch, onClose])
-
-  if (selected) {
-    return (
-      <BottomSheet title="Pick a start time" onClose={onClose}>
-        <button
-          type="button"
-          onClick={() => setSelected(null)}
-          className="mb-3 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400"
-        >
-          <ArrowLeftIcon className="h-4 w-4" />
-          Back to talks
-        </button>
-
-        <p className="mb-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
-          {selected.title}
-        </p>
-        <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
-          {duration} min · into {trackTitle}
-        </p>
-
-        {slots.length > 0 ? (
-          <>
-            <label
-              htmlFor="assign-start-time"
-              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Start time
-            </label>
-            <TimeSelect
-              id="assign-start-time"
-              slots={slots}
-              value={startTime}
-              onChange={setStartTime}
-            />
-          </>
-        ) : (
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            No free time slot for this talk in this track.
-          </p>
-        )}
-
-        {inlineError && (
-          <p
-            role="alert"
-            className="mt-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
-          >
-            {inlineError}
-          </p>
-        )}
-
-        <div className="mt-5 flex gap-3">
-          <button
-            type="button"
-            onClick={confirm}
-            disabled={!startTime}
-            className={`flex-1 ${PRIMARY_BUTTON}`}
-          >
-            Assign
-          </button>
-        </div>
-      </BottomSheet>
-    )
-  }
-
-  return (
-    <BottomSheet title="Assign a talk" onClose={onClose}>
-      <div className="relative mb-4">
-        <ProposalFilters filters={filters} />
-      </div>
-      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-        {filters.statsText}
-      </p>
-
-      {filters.filteredProposals.length === 0 ? (
-        <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
-          {proposals.length === 0
-            ? 'No unassigned talks left.'
-            : 'No talks match your filters.'}
-        </p>
-      ) : (
-        <ul className="space-y-2">
-          {filters.filteredProposals.map((proposal) => {
-            const speakers = speakerNamesOf(proposal)
-            return (
-              <li key={proposal._id}>
-                <button
-                  type="button"
-                  onClick={() => pickProposal(proposal)}
-                  className={`flex w-full ${TAP_TARGET} flex-col gap-1 rounded-lg border border-gray-200 bg-white p-3 text-left transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700`}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                      {proposal.title}
-                    </span>
-                    <LevelIndicator
-                      level={proposal.level}
-                      size="xs"
-                      className="mt-0.5 shrink-0"
-                    />
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <StatusBadge status={proposal.status} variant="compact" />
-                    <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
-                      <ClockIcon className="h-3.5 w-3.5" />
-                      {getProposalDurationMinutes(proposal)}m
-                    </span>
-                    {speakers && (
-                      <span className="inline-flex items-center gap-1 truncate text-xs text-gray-600 dark:text-gray-400">
-                        <UserIcon className="h-3.5 w-3.5 shrink-0" />
-                        <span className="truncate">{speakers}</span>
-                      </span>
-                    )}
-                  </div>
-                </button>
-              </li>
-            )
-          })}
-        </ul>
-      )}
-    </BottomSheet>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Move sheet (scheduled talk -> another track/time)                          */
-/* -------------------------------------------------------------------------- */
-
-function MoveSheet({
-  tracks,
-  sourceTrackIndex,
-  talk,
-  dispatch,
-  onClose,
-}: {
-  tracks: ScheduleTrack[]
-  sourceTrackIndex: number
-  talk: TrackTalk
-  dispatch: React.Dispatch<ScheduleAction>
-  onClose: () => void
-}) {
-  const proposal = talk.talk!
-  const duration = getProposalDurationMinutes(proposal)
-  const [targetTrackIndex, setTargetTrackIndex] = useState(sourceTrackIndex)
-  const [inlineError, setInlineError] = useState<string | null>(null)
-
-  const slots = useMemo(() => {
-    const target = tracks[targetTrackIndex]
-    if (!target) return []
-    const exclude =
-      targetTrackIndex === sourceTrackIndex
-        ? matchTalk(proposal._id, talk.startTime)
-        : undefined
-    return freeStartTimes(target, duration, exclude)
-  }, [
-    tracks,
-    targetTrackIndex,
-    sourceTrackIndex,
-    proposal._id,
-    talk.startTime,
-    duration,
-  ])
-
-  // `startTime` starts empty and is only ever set by the user; the effective
-  // value falls back to the talk's CURRENT slot (kept free by the same-track
-  // exclude above) so opening the sheet and tapping "Move here" without picking
-  // a time is a no-op instead of silently relocating the talk to the earliest
-  // free slot. When that time isn't offered (a different track), fall back to
-  // the first free slot. No setState-in-effect needed to "reset" on track change.
-  const [startTime, setStartTime] = useState('')
-  const effectiveStart = slots.includes(startTime)
-    ? startTime
-    : slots.includes(talk.startTime)
-      ? talk.startTime
-      : (slots[0] ?? '')
-
-  const confirm = useCallback(() => {
-    if (!effectiveStart) return
-    dispatch({
-      type: 'moveProposal',
-      dragItem: {
-        type: 'scheduled-talk',
-        proposal,
-        sourceTrackIndex,
-        sourceTimeSlot: talk.startTime,
-      },
-      dropPosition: { trackIndex: targetTrackIndex, timeSlot: effectiveStart },
-    })
-    onClose()
-  }, [
-    effectiveStart,
-    proposal,
-    sourceTrackIndex,
-    talk.startTime,
-    targetTrackIndex,
-    dispatch,
-    onClose,
-  ])
-
-  return (
-    <BottomSheet title="Move talk" onClose={onClose}>
-      <p className="mb-4 text-sm font-semibold text-gray-900 dark:text-gray-100">
-        {proposal.title}
-      </p>
-
-      <label
-        htmlFor="move-track"
-        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-      >
-        Track
-      </label>
-      <div className="mb-4 grid grid-cols-1">
-        <select
-          id="move-track"
-          value={targetTrackIndex}
-          onChange={(e) => {
-            setTargetTrackIndex(Number(e.target.value))
-            setInlineError(null)
-          }}
-          className="col-start-1 row-start-1 w-full appearance-none rounded-lg border border-gray-300 bg-white py-2.5 pr-8 pl-3 text-sm text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-        >
-          {tracks.map((track, index) => (
-            <option key={index} value={index}>
-              {track.trackTitle || `Track ${index + 1}`}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {slots.length > 0 ? (
-        <>
-          <label
-            htmlFor="move-start-time"
-            className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-          >
-            Start time
-          </label>
-          <TimeSelect
-            id="move-start-time"
-            slots={slots}
-            value={effectiveStart}
-            onChange={setStartTime}
-          />
-        </>
-      ) : (
-        <p className="text-sm text-gray-600 dark:text-gray-400">
-          No free time slot in this track.
-        </p>
-      )}
-
-      {inlineError && (
-        <p
-          role="alert"
-          className="mt-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
-        >
-          {inlineError}
-        </p>
-      )}
-
-      <div className="mt-5">
-        <button
-          type="button"
-          onClick={confirm}
-          disabled={!effectiveStart}
-          className={`w-full ${PRIMARY_BUTTON}`}
-        >
-          Move here
-        </button>
-      </div>
-    </BottomSheet>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Card action sheet                                                          */
-/* -------------------------------------------------------------------------- */
-
-function CardActionSheet({
+function ServiceEditSheet({
   talk,
   trackIndex,
   talkIndex,
+  mode,
   dispatch,
   onClose,
-  onMove,
 }: {
   talk: TrackTalk
   trackIndex: number
   talkIndex: number
+  mode: 'rename' | 'duration'
   dispatch: React.Dispatch<ScheduleAction>
   onClose: () => void
-  onMove: () => void
 }) {
-  const isService = !talk.talk
-  const [mode, setMode] = useState<'menu' | 'rename' | 'duration'>('menu')
   const [renameValue, setRenameValue] = useState(talk.placeholder ?? '')
   const [durationValue, setDurationValue] = useState(
     String(durationBetween(talk.startTime, talk.endTime)),
   )
-  const title = talk.talk?.title ?? talk.placeholder ?? 'Untitled'
-
-  const remove = useCallback(() => {
-    dispatch({ type: 'removeTalk', trackIndex, talkIndex })
-    onClose()
-  }, [dispatch, trackIndex, talkIndex, onClose])
 
   const saveRename = useCallback(() => {
     if (!renameValue.trim()) return
@@ -762,37 +466,7 @@ function CardActionSheet({
           </button>
           <button
             type="button"
-            onClick={() => setMode('menu')}
-            className={`flex-1 ${SECONDARY_BUTTON}`}
-          >
-            Cancel
-          </button>
-        </div>
-      </BottomSheet>
-    )
-  }
-
-  if (mode === 'duration') {
-    return (
-      <BottomSheet title="Change duration" onClose={onClose}>
-        <Dropdown
-          name="service-duration"
-          label="Duration (minutes)"
-          options={SERVICE_DURATION_OPTIONS}
-          value={durationValue}
-          setValue={setDurationValue}
-        />
-        <div className="mt-5 flex gap-3">
-          <button
-            type="button"
-            onClick={saveDuration}
-            className={`flex-1 ${PRIMARY_BUTTON}`}
-          >
-            Save
-          </button>
-          <button
-            type="button"
-            onClick={() => setMode('menu')}
+            onClick={onClose}
             className={`flex-1 ${SECONDARY_BUTTON}`}
           >
             Cancel
@@ -803,49 +477,28 @@ function CardActionSheet({
   }
 
   return (
-    <BottomSheet title={title} onClose={onClose}>
-      <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
-        {talk.startTime}–{talk.endTime}
-        {isService ? ' · Service session' : ''}
-      </p>
-      <div className="space-y-2">
-        {!isService && (
-          <button
-            type="button"
-            onClick={onMove}
-            className={`w-full justify-start ${SECONDARY_BUTTON}`}
-          >
-            <ArrowsRightLeftIcon className="h-5 w-5" />
-            Move to another track / time
-          </button>
-        )}
-        {isService && (
-          <>
-            <button
-              type="button"
-              onClick={() => setMode('rename')}
-              className={`w-full justify-start ${SECONDARY_BUTTON}`}
-            >
-              <PencilIcon className="h-5 w-5" />
-              Rename session
-            </button>
-            <button
-              type="button"
-              onClick={() => setMode('duration')}
-              className={`w-full justify-start ${SECONDARY_BUTTON}`}
-            >
-              <ArrowsUpDownIcon className="h-5 w-5" />
-              Change duration
-            </button>
-          </>
-        )}
+    <BottomSheet title="Change duration" onClose={onClose}>
+      <Dropdown
+        name="service-duration"
+        label="Duration (minutes)"
+        options={SERVICE_DURATION_OPTIONS}
+        value={durationValue}
+        setValue={setDurationValue}
+      />
+      <div className="mt-5 flex gap-3">
         <button
           type="button"
-          onClick={remove}
-          className="inline-flex min-h-[44px] w-full items-center justify-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:border-red-900 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50"
+          onClick={saveDuration}
+          className={`flex-1 ${PRIMARY_BUTTON}`}
         >
-          <TrashIcon className="h-5 w-5" />
-          Remove from schedule
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className={`flex-1 ${SECONDARY_BUTTON}`}
+        >
+          Cancel
         </button>
       </div>
     </BottomSheet>
@@ -979,16 +632,72 @@ function AddServiceSheet({
 /* Unassigned drawer                                                          */
 /* -------------------------------------------------------------------------- */
 
+/**
+ * The proposal drawer, in two modes:
+ *  - `context` set   → contextual "assign here": only proposals that FIT the
+ *    open slot are listed, and tapping one drops it straight into that slot.
+ *  - `context` null  → the header's Unassigned list: tapping a proposal picks
+ *    it up (`onPick`) so the user can then tap a slot.
+ */
 function UnassignedDrawer({
   proposals,
+  context,
+  track,
+  dispatch,
+  onPick,
   onClose,
 }: {
   proposals: ProposalExisting[]
+  context: SlotContext | null
+  track: ScheduleTrack | null
+  dispatch: React.Dispatch<ScheduleAction>
+  onPick: (proposal: ProposalExisting) => void
   onClose: () => void
 }) {
-  const filters = useProposalFilters(proposals)
+  const source = useMemo(() => {
+    if (!context || !track) return proposals
+    return proposals.filter((p) => {
+      const dur = getProposalDurationMinutes(p)
+      if (dur > context.maxDurationMin) return false
+      if (!withinEnd(calculateEndTime(context.startTime, dur))) return false
+      return fitsInTrack(track, context.startTime, dur)
+    })
+  }, [proposals, context, track])
+
+  const filters = useProposalFilters(source)
+
+  const title = context
+    ? `Assign at ${context.startTime}`
+    : `Unassigned (${proposals.length})`
+
+  const handlePick = useCallback(
+    (proposal: ProposalExisting) => {
+      if (context) {
+        dispatch({
+          type: 'moveProposal',
+          dragItem: { type: 'proposal', proposal },
+          dropPosition: {
+            trackIndex: context.trackIndex,
+            timeSlot: context.startTime,
+          },
+        })
+        onClose()
+        return
+      }
+      onPick(proposal)
+    },
+    [context, dispatch, onPick, onClose],
+  )
+
   return (
-    <BottomSheet title={`Unassigned (${proposals.length})`} onClose={onClose}>
+    <BottomSheet title={title} onClose={onClose}>
+      {context && (
+        <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">
+          Free until{' '}
+          {calculateEndTime(context.startTime, context.maxDurationMin)} ·{' '}
+          {context.maxDurationMin} min available
+        </p>
+      )}
       <div className="relative mb-4">
         <ProposalFilters filters={filters} />
       </div>
@@ -997,8 +706,10 @@ function UnassignedDrawer({
       </p>
       {filters.filteredProposals.length === 0 ? (
         <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
-          {proposals.length === 0
-            ? 'Every talk has been scheduled.'
+          {source.length === 0
+            ? context
+              ? 'No unassigned talk fits this open slot.'
+              : 'Every talk has been scheduled.'
             : 'No talks match your filters.'}
         </p>
       ) : (
@@ -1006,33 +717,36 @@ function UnassignedDrawer({
           {filters.filteredProposals.map((proposal) => {
             const speakers = speakerNamesOf(proposal)
             return (
-              <li
-                key={proposal._id}
-                className={`flex ${TAP_TARGET} flex-col gap-1 rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800`}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-                    {proposal.title}
-                  </span>
-                  <LevelIndicator
-                    level={proposal.level}
-                    size="xs"
-                    className="mt-0.5 shrink-0"
-                  />
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <StatusBadge status={proposal.status} variant="compact" />
-                  <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
-                    <ClockIcon className="h-3.5 w-3.5" />
-                    {getProposalDurationMinutes(proposal)}m
-                  </span>
-                  {speakers && (
-                    <span className="inline-flex items-center gap-1 truncate text-xs text-gray-600 dark:text-gray-400">
-                      <UserIcon className="h-3.5 w-3.5 shrink-0" />
-                      <span className="truncate">{speakers}</span>
+              <li key={proposal._id}>
+                <button
+                  type="button"
+                  onClick={() => handlePick(proposal)}
+                  className={`flex w-full ${TAP_TARGET} flex-col gap-1 rounded-lg border border-gray-200 bg-white p-3 text-left transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                      {proposal.title}
                     </span>
-                  )}
-                </div>
+                    <LevelIndicator
+                      level={proposal.level}
+                      size="xs"
+                      className="mt-0.5 shrink-0"
+                    />
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusBadge status={proposal.status} variant="compact" />
+                    <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                      <ClockIcon className="h-3.5 w-3.5" />
+                      {`${getProposalDurationMinutes(proposal)}m`}
+                    </span>
+                    {speakers && (
+                      <span className="inline-flex items-center gap-1 truncate text-xs text-gray-600 dark:text-gray-400">
+                        <UserIcon className="h-3.5 w-3.5 shrink-0" />
+                        <span className="truncate">{speakers}</span>
+                      </span>
+                    )}
+                  </div>
+                </button>
               </li>
             )
           })}
@@ -1087,15 +801,338 @@ function LegendDisclosure() {
 }
 
 /* -------------------------------------------------------------------------- */
+/* Rail segment body                                                          */
+/* -------------------------------------------------------------------------- */
+
+function DurationChip({ minutes }: { minutes: number }) {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium text-gray-600 tabular-nums dark:bg-gray-700 dark:text-gray-300">
+      <ClockIcon className="h-3 w-3" />
+      {`${minutes}m`}
+    </span>
+  )
+}
+
+function segmentLabel(
+  seg: RailSegment,
+  placing: Placing | null,
+  state: SegmentState,
+): string {
+  if (seg.kind === 'open') {
+    return `Assign to open slot ${seg.startTime} to ${seg.endTime}`
+  }
+  const title = seg.talk.talk?.title ?? seg.talk.placeholder ?? 'Untitled'
+  if (!placing) return `Move ${title}`
+  if (state === 'source') return `Cancel moving ${title}`
+  return seg.kind === 'talk' ? `Swap with ${title}` : title
+}
+
+/**
+ * One track's hybrid time-rail: a continuous gutter line with a node per
+ * segment, and duration-proportional (clamped) bodies. When `placing` is set the
+ * rail is a target picker — only valid segments are enabled and highlighted.
+ */
+function TrackRail({
+  track,
+  trackIndex,
+  tracks,
+  placing,
+  onSegmentTap,
+  onAddService,
+}: {
+  track: ScheduleTrack
+  trackIndex: number
+  tracks: ScheduleTrack[]
+  placing: Placing | null
+  onSegmentTap: (trackIndex: number, seg: RailSegment) => void
+  onAddService: (trackIndex: number) => void
+}) {
+  const segments = useMemo(() => buildTrackRail(track), [track])
+
+  return (
+    <div className="pb-8">
+      <div className="mb-2 flex items-center justify-end">
+        <button
+          type="button"
+          onClick={() => onAddService(trackIndex)}
+          className="inline-flex min-h-[44px] items-center gap-1 text-sm font-medium text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-blue-400"
+        >
+          <PlusIcon className="h-4 w-4" />
+          Service
+        </button>
+      </div>
+
+      <div className="relative" style={{ paddingLeft: GUTTER_PX }}>
+        {/* One continuous rail line behind all the rows. */}
+        <div
+          className="absolute top-3 bottom-3 w-px bg-gray-200 dark:bg-gray-700"
+          style={{ left: GUTTER_PX }}
+          aria-hidden="true"
+        />
+        <ul>
+          {segments.map((seg, i) => {
+            const height = segmentHeight(seg)
+            const state: SegmentState = placing
+              ? segmentState(placing, tracks, trackIndex, seg)
+              : 'default'
+
+            // Slim, non-interactive divider for gaps too small to hold a talk.
+            if (seg.kind === 'open' && seg.durationMin < MIN_OPEN_SLOT_MIN) {
+              return (
+                <li key={i} className="relative flex" style={{ minHeight: 28 }}>
+                  <span
+                    className="absolute top-0 w-[46px] text-right text-xs text-gray-400 tabular-nums dark:text-gray-500"
+                    style={{ left: -GUTTER_PX }}
+                  >
+                    {seg.startTime}
+                  </span>
+                  <span
+                    className="absolute top-2 h-1.5 w-1.5 -translate-x-1/2 rounded-full bg-gray-200 dark:bg-gray-700"
+                    style={{ left: 0 }}
+                    aria-hidden="true"
+                  />
+                  <div className="flex-1 pl-4">
+                    <div className="mt-1 text-[11px] text-gray-400 tabular-nums dark:text-gray-500">
+                      {`${seg.durationMin} min`}
+                    </div>
+                  </div>
+                </li>
+              )
+            }
+
+            // When not placing, every talk/break/open (>=10) is tappable. When
+            // placing, only valid targets and the source stay interactive.
+            const disabled = state === 'invalid'
+
+            return (
+              <li
+                key={i}
+                className="relative flex"
+                style={{ minHeight: height }}
+              >
+                <span
+                  className="absolute top-0 w-[46px] text-right text-xs text-gray-500 tabular-nums dark:text-gray-400"
+                  style={{ left: -GUTTER_PX }}
+                >
+                  {seg.startTime}
+                </span>
+                <span
+                  className={clsx(
+                    'absolute top-1.5 h-2 w-2 -translate-x-1/2 rounded-full',
+                    state === 'valid'
+                      ? 'bg-blue-500'
+                      : state === 'source'
+                        ? 'bg-blue-600'
+                        : 'bg-gray-300 dark:bg-gray-600',
+                  )}
+                  style={{ left: 0 }}
+                  aria-hidden="true"
+                />
+                <div className="flex-1 pb-1.5 pl-4">
+                  <button
+                    type="button"
+                    disabled={disabled}
+                    aria-label={segmentLabel(seg, placing, state)}
+                    onClick={() => onSegmentTap(trackIndex, seg)}
+                    className={clsx(
+                      'flex h-full w-full flex-col gap-1 rounded-lg border p-3 text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
+                      state === 'source' &&
+                        'border-blue-500 bg-blue-50 ring-2 ring-blue-500 dark:border-blue-500 dark:bg-blue-900/30',
+                      state === 'valid' &&
+                        'border-blue-400 bg-blue-50 ring-2 ring-blue-400 dark:border-blue-500 dark:bg-blue-900/20',
+                      state === 'invalid' && 'opacity-40',
+                      state === 'default' &&
+                        seg.kind === 'talk' &&
+                        'border-gray-200 bg-white hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700',
+                      state === 'default' &&
+                        seg.kind === 'break' &&
+                        'border-dashed border-gray-300 bg-gray-50 dark:border-gray-600 dark:bg-gray-800/60',
+                      state === 'default' &&
+                        seg.kind === 'open' &&
+                        'border-dashed border-blue-300 bg-blue-50/40 hover:bg-blue-50 dark:border-blue-800 dark:bg-blue-900/10 dark:hover:bg-blue-900/20',
+                    )}
+                  >
+                    <RailBody seg={seg} />
+                  </button>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function RailBody({ seg }: { seg: RailSegment }) {
+  if (seg.kind === 'open') {
+    return (
+      <span className="flex h-full items-center text-sm font-medium text-blue-700 dark:text-blue-300">
+        <PlusIcon className="mr-1.5 h-4 w-4 shrink-0" />
+        <span className="tabular-nums">
+          Assign here · {seg.startTime}–{seg.endTime} · {seg.durationMin} min
+          free
+        </span>
+      </span>
+    )
+  }
+
+  const proposal = seg.talk.talk
+  const title = proposal?.title ?? seg.talk.placeholder ?? 'Untitled'
+
+  if (seg.kind === 'break') {
+    return (
+      <>
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="inline-flex items-center gap-1.5 truncate text-sm font-medium text-gray-600 dark:text-gray-300">
+            <ClockIcon className="h-4 w-4 shrink-0" />
+            {title}
+          </h3>
+          <DurationChip minutes={seg.durationMin} />
+        </div>
+        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+          Service session
+        </span>
+      </>
+    )
+  }
+
+  const speakers = proposal ? speakerNamesOf(proposal) : null
+  return (
+    <>
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+          {title}
+        </h3>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <DurationChip minutes={seg.durationMin} />
+          {proposal && (
+            <LevelIndicator
+              level={proposal.level}
+              size="xs"
+              className="mt-0.5"
+            />
+          )}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {proposal && <StatusBadge status={proposal.status} variant="compact" />}
+        {speakers && (
+          <span className="inline-flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400">
+            <UserIcon className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{speakers}</span>
+          </span>
+        )}
+      </div>
+    </>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Placing banner                                                             */
+/* -------------------------------------------------------------------------- */
+
+function PlacingBanner({
+  placing,
+  hasValidTarget,
+  onRemove,
+  onRename,
+  onDuration,
+  onCancel,
+}: {
+  placing: Placing
+  hasValidTarget: boolean
+  onRemove: () => void
+  onRename: () => void
+  onDuration: () => void
+  onCancel: () => void
+}) {
+  const isProposal = placing.kind === 'proposal'
+  const isService = placing.kind === 'scheduled' && !placing.talk.talk
+  const title = isProposal
+    ? placing.proposal.title
+    : (placing.talk.talk?.title ?? placing.talk.placeholder ?? 'Untitled')
+
+  const message = isProposal
+    ? `Placing “${title}” — tap an open slot`
+    : isService
+      ? `Moving “${title}” — tap an open slot to move`
+      : `Moving “${title}” — tap a slot to move, or a talk to swap`
+
+  return (
+    <div
+      role="status"
+      className="shrink-0 border-b border-blue-200 bg-blue-50 px-4 py-2 dark:border-blue-800 dark:bg-blue-900/40"
+    >
+      <div className="flex items-center gap-2">
+        <ArrowsRightLeftIcon className="h-5 w-5 shrink-0 text-blue-600 dark:text-blue-300" />
+        <p className="flex-1 text-sm font-medium text-blue-900 dark:text-blue-100">
+          {message}
+        </p>
+      </div>
+      {!hasValidTarget && (
+        <p className="mt-1 pl-7 text-xs text-blue-700 dark:text-blue-300">
+          No room here — swipe to another track.
+        </p>
+      )}
+      <div className="mt-2 flex flex-wrap gap-2">
+        {placing.kind === 'scheduled' && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-red-300 bg-white px-3 text-sm font-medium text-red-700 transition-colors hover:bg-red-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:border-red-800 dark:bg-gray-900 dark:text-red-300 dark:hover:bg-red-900/30"
+          >
+            <TrashIcon className="h-4 w-4" />
+            Remove
+          </button>
+        )}
+        {isService && (
+          <>
+            <button
+              type="button"
+              onClick={onRename}
+              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-blue-300 bg-white px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300 dark:hover:bg-blue-900/30"
+            >
+              <PencilIcon className="h-4 w-4" />
+              Rename
+            </button>
+            <button
+              type="button"
+              onClick={onDuration}
+              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-blue-300 bg-white px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300 dark:hover:bg-blue-900/30"
+            >
+              <ArrowsUpDownIcon className="h-4 w-4" />
+              Duration
+            </button>
+          </>
+        )}
+        <button
+          type="button"
+          onClick={onCancel}
+          className="ml-auto inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-blue-300 bg-white px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300 dark:hover:bg-blue-900/30"
+        >
+          <XMarkIcon className="h-4 w-4" />
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
 /* Main view                                                                  */
 /* -------------------------------------------------------------------------- */
 
 type ActiveSheet =
-  | { kind: 'assign' }
-  | { kind: 'addService' }
-  | { kind: 'unassigned' }
-  | { kind: 'card'; talkIndex: number }
-  | { kind: 'move'; talkIndex: number }
+  | { kind: 'addService'; trackIndex: number }
+  | { kind: 'unassigned'; context: SlotContext | null }
+  | {
+      kind: 'serviceEdit'
+      trackIndex: number
+      talkIndex: number
+      talk: TrackTalk
+      mode: 'rename' | 'duration'
+    }
   | null
 
 export function MobileScheduleView({
@@ -1114,7 +1151,13 @@ export function MobileScheduleView({
   const tracks = useMemo(() => schedule?.tracks ?? [], [schedule])
 
   const [selectedTrackIndex, setSelectedTrackIndex] = useState(0)
+  const [placing, setPlacing] = useState<Placing | null>(null)
   const [sheet, setSheet] = useState<ActiveSheet>(null)
+
+  const scrollerRef = useRef<HTMLDivElement>(null)
+  const panelRefs = useRef<(HTMLDivElement | null)[]>([])
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const rafRef = useRef<number | null>(null)
 
   // Keep the selected track valid when the day (and therefore the track list)
   // changes underneath us.
@@ -1128,66 +1171,247 @@ export function MobileScheduleView({
     }
   }, [tracks.length])
 
-  const currentTrack = tracks[safeTrackIndex] ?? null
-
-  const sortedTalks = useMemo(
-    () => (currentTrack ? sortTalks(currentTrack) : []),
-    [currentTrack],
-  )
-
   const closeSheet = useCallback(() => setSheet(null), [])
 
-  const goToTrack = useCallback(
-    (index: number) => {
-      if (index >= 0 && index < tracks.length) setSelectedTrackIndex(index)
-    },
-    [tracks.length],
-  )
+  // Live view of the picked-up scheduled item: derived from current `tracks` so
+  // a rename/resize while placing is reflected, and the ORIGINAL talkIndex keeps
+  // reducer actions correct. Falls back to the snapshot if the index drifts.
+  const effPlacing = useMemo<Placing | null>(() => {
+    if (!placing || placing.kind !== 'scheduled') return placing
+    const live = tracks[placing.trackIndex]?.talks[placing.talkIndex]
+    return live ? { ...placing, talk: live } : placing
+  }, [placing, tracks])
 
-  const swipe = useSwipeNavigation(
-    useCallback(
-      (direction: 1 | -1) => goToTrack(safeTrackIndex + direction),
-      [goToTrack, safeTrackIndex],
-    ),
+  const goToTrack = useCallback((index: number) => {
+    setSelectedTrackIndex(index)
+    panelRefs.current[index]?.scrollIntoView?.({
+      behavior: 'smooth',
+      inline: 'center',
+      block: 'nearest',
+    })
+  }, [])
+
+  // On day change, reset per-day UI (first track, no pending pick-up) and jump
+  // the carousel back to the first track. Guarded by a ref so the state resets
+  // are conditional (matching the track-count effect above) rather than a
+  // top-level setState-in-effect.
+  const prevDayRef = useRef(currentDayIndex)
+  useEffect(() => {
+    if (prevDayRef.current !== currentDayIndex) {
+      prevDayRef.current = currentDayIndex
+      setSelectedTrackIndex(0)
+      setPlacing(null)
+    }
+    const scroller = scrollerRef.current
+    if (scroller) scroller.scrollLeft = 0
+  }, [currentDayIndex])
+
+  // Live-update the active tab as the user swipes: pick the panel whose
+  // horizontal centre is nearest the scroller's centre. Never scrolls
+  // programmatically, so it doesn't fight the drag. Throttled with rAF.
+  const handleScroll = useCallback(() => {
+    if (rafRef.current != null) return
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null
+      const scroller = scrollerRef.current
+      if (!scroller) return
+      const rect = scroller.getBoundingClientRect()
+      const centre = rect.left + rect.width / 2
+      let nearest = 0
+      let best = Infinity
+      panelRefs.current.forEach((el, i) => {
+        if (!el) return
+        const r = el.getBoundingClientRect()
+        const c = r.left + r.width / 2
+        const d = Math.abs(c - centre)
+        if (d < best) {
+          best = d
+          nearest = i
+        }
+      })
+      setSelectedTrackIndex((prev) => (prev === nearest ? prev : nearest))
+    })
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    },
+    [],
   )
 
   const handleDayChange = useCallback(
     (dayIndex: number) => {
-      // Delegate to the parent so the "Saved" indicator (parent state) is
-      // cleared consistently with the desktop view; then reset local UI.
       onDayChange(dayIndex)
       setSelectedTrackIndex(0)
+      setPlacing(null)
       setSheet(null)
     },
     [onDayChange],
   )
 
-  // The action sheet stores a talkIndex into the SORTED list; translate it back
-  // to the real index in `currentTrack.talks` for reducer actions.
-  const realTalkIndex = useCallback(
-    (talk: TrackTalk): number =>
-      currentTrack
-        ? currentTrack.talks.findIndex(
-            (t) => t.startTime === talk.startTime && t.endTime === talk.endTime,
-          )
-        : -1,
-    [currentTrack],
+  const onTabKeyDown = useCallback(
+    (e: React.KeyboardEvent, index: number) => {
+      if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return
+      e.preventDefault()
+      const delta = e.key === 'ArrowRight' ? 1 : -1
+      const next = Math.min(Math.max(index + delta, 0), tracks.length - 1)
+      goToTrack(next)
+      tabRefs.current[next]?.focus()
+    },
+    [goToTrack, tracks.length],
   )
 
-  const sheetTalk =
-    sheet && (sheet.kind === 'card' || sheet.kind === 'move')
-      ? sortedTalks[sheet.talkIndex]
+  // Central tap router: pick up when idle, drop/swap/cancel when placing.
+  const handleSegmentTap = useCallback(
+    (panelTrackIndex: number, seg: RailSegment) => {
+      const active = effPlacing
+      if (!active) {
+        if (seg.kind === 'open') {
+          setSheet({
+            kind: 'unassigned',
+            context: {
+              trackIndex: panelTrackIndex,
+              startTime: seg.startTime,
+              maxDurationMin: seg.durationMin,
+            },
+          })
+        } else {
+          setPlacing({
+            kind: 'scheduled',
+            trackIndex: panelTrackIndex,
+            talkIndex: seg.talkIndex,
+            talk: seg.talk,
+          })
+        }
+        return
+      }
+
+      const state = segmentState(active, tracks, panelTrackIndex, seg)
+      if (state === 'source') {
+        setPlacing(null)
+        return
+      }
+      if (state !== 'valid') return
+
+      if (seg.kind === 'open') {
+        if (active.kind === 'proposal') {
+          dispatch({
+            type: 'moveProposal',
+            dragItem: { type: 'proposal', proposal: active.proposal },
+            dropPosition: {
+              trackIndex: panelTrackIndex,
+              timeSlot: seg.startTime,
+            },
+          })
+        } else if (active.talk.talk) {
+          dispatch({
+            type: 'moveProposal',
+            dragItem: {
+              type: 'scheduled-talk',
+              proposal: active.talk.talk,
+              sourceTrackIndex: active.trackIndex,
+              sourceTimeSlot: active.talk.startTime,
+            },
+            dropPosition: {
+              trackIndex: panelTrackIndex,
+              timeSlot: seg.startTime,
+            },
+          })
+        } else {
+          dispatch({
+            type: 'moveService',
+            dragItem: {
+              type: 'scheduled-service',
+              serviceSession: {
+                placeholder: active.talk.placeholder ?? '',
+                startTime: active.talk.startTime,
+                endTime: active.talk.endTime,
+              },
+              sourceTrackIndex: active.trackIndex,
+              sourceTimeSlot: active.talk.startTime,
+            },
+            dropPosition: {
+              trackIndex: panelTrackIndex,
+              timeSlot: seg.startTime,
+            },
+          })
+        }
+      } else if (seg.kind === 'talk' && active.kind === 'scheduled') {
+        // Swap the picked-up talk with the occupied target slot.
+        dispatch({
+          type: 'moveProposal',
+          dragItem: {
+            type: 'scheduled-talk',
+            proposal: active.talk.talk,
+            sourceTrackIndex: active.trackIndex,
+            sourceTimeSlot: active.talk.startTime,
+          },
+          dropPosition: {
+            trackIndex: panelTrackIndex,
+            timeSlot: seg.startTime,
+          },
+        })
+      }
+      setPlacing(null)
+    },
+    [effPlacing, tracks, dispatch],
+  )
+
+  const openAddService = useCallback((trackIndex: number) => {
+    setSheet({ kind: 'addService', trackIndex })
+  }, [])
+
+  // Whether the CURRENT panel offers any legal drop for the pick-up (drives the
+  // "no room here" hint).
+  const hasValidTargetHere = useMemo(() => {
+    if (!effPlacing) return true
+    const track = tracks[safeTrackIndex]
+    if (!track) return false
+    return buildTrackRail(track).some(
+      (seg) =>
+        segmentState(effPlacing, tracks, safeTrackIndex, seg) === 'valid',
+    )
+  }, [effPlacing, tracks, safeTrackIndex])
+
+  const removePlacing = useCallback(() => {
+    if (effPlacing?.kind !== 'scheduled') return
+    dispatch({
+      type: 'removeTalk',
+      trackIndex: effPlacing.trackIndex,
+      talkIndex: effPlacing.talkIndex,
+    })
+    setPlacing(null)
+  }, [effPlacing, dispatch])
+
+  const openServiceEdit = useCallback(
+    (mode: 'rename' | 'duration') => {
+      if (effPlacing?.kind !== 'scheduled') return
+      setSheet({
+        kind: 'serviceEdit',
+        trackIndex: effPlacing.trackIndex,
+        talkIndex: effPlacing.talkIndex,
+        talk: effPlacing.talk,
+        mode,
+      })
+    },
+    [effPlacing],
+  )
+
+  const tabId = (i: number) => `sched-tab-${i}`
+  const panelId = (i: number) => `sched-panel-${i}`
+
+  const addServiceTrack =
+    sheet?.kind === 'addService' ? (tracks[sheet.trackIndex] ?? null) : null
+  const drawerTrack =
+    sheet?.kind === 'unassigned' && sheet.context
+      ? (tracks[sheet.context.trackIndex] ?? null)
       : null
 
   return (
-    <TabGroup
-      as="div"
-      className="flex h-[calc(100dvh-4rem)] flex-col bg-gray-50 dark:bg-gray-950"
-      selectedIndex={safeTrackIndex}
-      onChange={setSelectedTrackIndex}
-    >
+    <div className="flex h-[calc(100dvh-4rem)] flex-col bg-gray-50 dark:bg-gray-950">
       {/* Header */}
-      <header className="shrink-0 border-b border-gray-200 bg-white px-4 pt-3 dark:border-gray-700 dark:bg-gray-900">
+      <header className="shrink-0 border-b border-gray-200 bg-white px-4 pt-4 dark:border-gray-700 dark:bg-gray-900">
         <div className="flex items-center justify-between gap-2">
           <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
             Schedule
@@ -1195,7 +1419,7 @@ export function MobileScheduleView({
           <div className="flex items-center gap-1">
             <button
               type="button"
-              onClick={() => setSheet({ kind: 'unassigned' })}
+              onClick={() => setSheet({ kind: 'unassigned', context: null })}
               aria-label={`Unassigned (${unassignedProposals.length})`}
               className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
             >
@@ -1260,32 +1484,52 @@ export function MobileScheduleView({
           </div>
         )}
 
-        {/* Swipeable track tabs */}
+        {/* Fixed track tab strip (synced to the carousel below). */}
         {tracks.length > 0 ? (
-          <TabList className="-mx-4 mt-3 flex gap-2 overflow-x-auto px-4 pb-3">
-            {tracks.map((track, index) => (
-              <Tab
-                key={index}
-                className={clsx(
-                  'min-h-[44px] shrink-0 rounded-full border px-4 text-sm font-medium whitespace-nowrap transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
-                  index === safeTrackIndex
-                    ? 'border-blue-600 bg-blue-600 text-white dark:border-blue-500 dark:bg-blue-600'
-                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
-                )}
-              >
-                {track.trackTitle || `Track ${index + 1}`}
-              </Tab>
-            ))}
+          <div className="mt-3 flex items-stretch gap-2 pb-3">
+            <div
+              role="tablist"
+              aria-label="Select track"
+              className="flex min-w-0 flex-1 gap-1 overflow-x-auto"
+            >
+              {tracks.map((track, index) => {
+                const isActive = index === safeTrackIndex
+                return (
+                  <button
+                    key={index}
+                    ref={(el) => {
+                      tabRefs.current[index] = el
+                    }}
+                    type="button"
+                    role="tab"
+                    id={tabId(index)}
+                    aria-selected={isActive}
+                    aria-controls={panelId(index)}
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => goToTrack(index)}
+                    onKeyDown={(e) => onTabKeyDown(e, index)}
+                    className={clsx(
+                      'min-h-[44px] min-w-0 flex-1 truncate rounded-full border px-3 text-center text-sm font-medium transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500',
+                      isActive
+                        ? 'border-blue-600 bg-blue-600 text-white dark:border-blue-500 dark:bg-blue-600'
+                        : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
+                    )}
+                  >
+                    {track.trackTitle || `Track ${index + 1}`}
+                  </button>
+                )
+              })}
+            </div>
             <button
               type="button"
               onClick={onAddTrack}
               aria-label="Add track"
-              className="inline-flex min-h-[44px] shrink-0 items-center gap-1 rounded-full border border-dashed border-gray-300 bg-white px-4 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+              className="inline-flex min-h-[44px] shrink-0 items-center gap-1 rounded-full border border-dashed border-gray-300 bg-white px-3 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
             >
               <PlusIcon className="h-4 w-4" />
               Track
             </button>
-          </TabList>
+          </div>
         ) : (
           <div className="pb-3" />
         )}
@@ -1297,7 +1541,19 @@ export function MobileScheduleView({
         </div>
       )}
 
-      {/* Agenda */}
+      {/* Placing banner */}
+      {effPlacing && (
+        <PlacingBanner
+          placing={effPlacing}
+          hasValidTarget={hasValidTargetHere}
+          onRemove={removePlacing}
+          onRename={() => openServiceEdit('rename')}
+          onDuration={() => openServiceEdit('duration')}
+          onCancel={() => setPlacing(null)}
+        />
+      )}
+
+      {/* Carousel */}
       {tracks.length === 0 ? (
         <main className="flex-1 overflow-y-auto px-4 py-4">
           <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
@@ -1315,76 +1571,44 @@ export function MobileScheduleView({
           </div>
         </main>
       ) : (
-        <TabPanels
-          as="main"
-          className="flex-1 overflow-y-auto px-4 py-4"
-          onTouchStart={swipe.onTouchStart}
-          onTouchEnd={swipe.onTouchEnd}
+        <div
+          ref={scrollerRef}
+          onScroll={handleScroll}
+          className="flex flex-1 snap-x snap-mandatory gap-0 overflow-x-auto overflow-y-hidden overscroll-x-contain scroll-smooth px-[7vw] [&::-webkit-scrollbar]:hidden"
+          style={{ scrollbarWidth: 'none' }}
         >
-          {tracks.map((track, trackIndex) => {
-            const talks = sortTalks(track)
-            return (
-              <TabPanel key={trackIndex} className="focus:outline-none">
-                <div className="mb-3 flex items-center justify-end">
-                  <button
-                    type="button"
-                    onClick={() => setSheet({ kind: 'addService' })}
-                    className="inline-flex min-h-[44px] items-center gap-1 text-sm font-medium text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-blue-400"
-                  >
-                    <PlusIcon className="h-4 w-4" />
-                    Service
-                  </button>
-                </div>
-
-                {talks.length === 0 ? (
-                  <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
-                    Nothing scheduled in this track yet.
-                  </p>
-                ) : (
-                  <ul className="space-y-2">
-                    {talks.map((talk, index) => (
-                      <li key={`${talk.startTime}-${talk.endTime}-${index}`}>
-                        <AgendaCard
-                          talk={talk}
-                          onTap={() =>
-                            setSheet({ kind: 'card', talkIndex: index })
-                          }
-                        />
-                      </li>
-                    ))}
-                  </ul>
-                )}
-
-                <button
-                  type="button"
-                  onClick={() => setSheet({ kind: 'assign' })}
-                  className={`mt-4 w-full ${PRIMARY_BUTTON}`}
-                >
-                  <PlusIcon className="h-5 w-5" />
-                  Assign a talk
-                </button>
-              </TabPanel>
-            )
-          })}
-        </TabPanels>
+          {tracks.map((track, trackIndex) => (
+            <div
+              key={trackIndex}
+              ref={(el) => {
+                panelRefs.current[trackIndex] = el
+              }}
+              role="tabpanel"
+              id={panelId(trackIndex)}
+              aria-labelledby={tabId(trackIndex)}
+              // `snap-always` (scroll-snap-stop) forces exactly one track per
+              // fling so a fast swipe can't skip past a track — each is a
+              // distinct context (Trello/kanban column-swipe guidance).
+              className="shrink-0 basis-[86vw] snap-center snap-always overflow-y-auto px-1 pt-3"
+            >
+              <TrackRail
+                track={track}
+                trackIndex={trackIndex}
+                tracks={tracks}
+                placing={effPlacing}
+                onSegmentTap={handleSegmentTap}
+                onAddService={openAddService}
+              />
+            </div>
+          ))}
+        </div>
       )}
 
       {/* Sheets */}
-      {sheet?.kind === 'assign' && currentTrack && (
-        <AssignSheet
-          track={currentTrack}
-          trackTitle={currentTrack.trackTitle || `Track ${safeTrackIndex + 1}`}
-          trackIndex={safeTrackIndex}
-          proposals={unassignedProposals}
-          dispatch={dispatch}
-          onClose={closeSheet}
-        />
-      )}
-
-      {sheet?.kind === 'addService' && currentTrack && (
+      {sheet?.kind === 'addService' && addServiceTrack && (
         <AddServiceSheet
-          track={currentTrack}
-          trackIndex={safeTrackIndex}
+          track={addServiceTrack}
+          trackIndex={sheet.trackIndex}
           dispatch={dispatch}
           onClose={closeSheet}
         />
@@ -1393,30 +1617,27 @@ export function MobileScheduleView({
       {sheet?.kind === 'unassigned' && (
         <UnassignedDrawer
           proposals={unassignedProposals}
+          context={sheet.context}
+          track={drawerTrack}
+          dispatch={dispatch}
+          onPick={(proposal) => {
+            setPlacing({ kind: 'proposal', proposal })
+            closeSheet()
+          }}
           onClose={closeSheet}
         />
       )}
 
-      {sheet?.kind === 'card' && sheetTalk && (
-        <CardActionSheet
-          talk={sheetTalk}
-          trackIndex={safeTrackIndex}
-          talkIndex={realTalkIndex(sheetTalk)}
-          dispatch={dispatch}
-          onClose={closeSheet}
-          onMove={() => setSheet({ kind: 'move', talkIndex: sheet.talkIndex })}
-        />
-      )}
-
-      {sheet?.kind === 'move' && sheetTalk && sheetTalk.talk && (
-        <MoveSheet
-          tracks={tracks}
-          sourceTrackIndex={safeTrackIndex}
-          talk={sheetTalk}
+      {sheet?.kind === 'serviceEdit' && (
+        <ServiceEditSheet
+          talk={sheet.talk}
+          trackIndex={sheet.trackIndex}
+          talkIndex={sheet.talkIndex}
+          mode={sheet.mode}
           dispatch={dispatch}
           onClose={closeSheet}
         />
       )}
-    </TabGroup>
+    </div>
   )
 }

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -851,16 +851,21 @@ function TrackRail({
 
   return (
     <div className="pb-8">
-      <div className="mb-2 flex items-center justify-end">
-        <button
-          type="button"
-          onClick={() => onAddService(trackIndex)}
-          className="inline-flex min-h-[44px] items-center gap-1 text-sm font-medium text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-blue-400"
-        >
-          <PlusIcon className="h-4 w-4" />
-          Service
-        </button>
-      </div>
+      {/* Hidden while placing: the rail is a target picker, and adding a service
+          re-sorts track.talks, which would shift the picked-up item's stored
+          talkIndex and corrupt a later Remove/Swap. */}
+      {!placing && (
+        <div className="mb-2 flex items-center justify-end">
+          <button
+            type="button"
+            onClick={() => onAddService(trackIndex)}
+            className="inline-flex min-h-[44px] items-center gap-1 text-sm font-medium text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-blue-400"
+          >
+            <PlusIcon className="h-4 w-4" />
+            Service
+          </button>
+        </div>
+      )}
 
       <div className="relative" style={{ paddingLeft: GUTTER_PX }}>
         {/* One continuous rail line behind all the rows. */}
@@ -1048,7 +1053,12 @@ function PlacingBanner({
   onCancel: () => void
 }) {
   const isProposal = placing.kind === 'proposal'
-  const isService = placing.kind === 'scheduled' && !placing.talk.talk
+  // A real service session has a placeholder; require it so a talk-less slot
+  // without one (defensively) never surfaces Rename/Duration.
+  const isService =
+    placing.kind === 'scheduled' &&
+    !placing.talk.talk &&
+    !!placing.talk.placeholder
   const title = isProposal
     ? placing.proposal.title
     : (placing.talk.talk?.title ?? placing.talk.placeholder ?? 'Untitled')

--- a/src/components/admin/schedule/UX.md
+++ b/src/components/admin/schedule/UX.md
@@ -1,0 +1,106 @@
+# Schedule editor — UX principles
+
+The design north-star for the admin schedule editor (`src/components/admin/schedule/*`).
+Change the editor freely, but treat the **principles** below as invariants: they
+encode research and deliberate product decisions, and quietly regressing them is a
+regression even when the code still compiles. Each principle notes _why_ and, where
+relevant, the evidence.
+
+## 1. The editor's job is to reveal where the open time is
+
+Scheduling is a planning task: the organizer is looking for _free space_ to drop a
+talk into. A flat list "shows commitments, not the free space around them" — so the
+editor must always make **duration, breaks, and gaps visible**, and make open time a
+**first-class, tappable target**, not an absence. This is why both the desktop grid
+and the mobile time-rail render empty time explicitly.
+
+## 2. Two surfaces, one engine
+
+All scheduling logic lives in the pure, tested core (`src/lib/schedule/`:
+`reducer`, `operations`, `rules`, `time`, `validation`). The desktop drag board and
+the mobile view are **thin UIs over that engine** — they never re-implement overlap,
+swap, or placement rules. Any placement a UI offers must be one the reducer accepts;
+mirror `operations.moveProposal` (e.g. `fitsInTrack` / `canSwapTalks` /
+`canPlaceDisplacedBack` + the end-of-day guard) rather than inventing a parallel check.
+
+## 3. Desktop drags; mobile taps — deliberately
+
+Below `md` (< 768px) the pixel-drag board is replaced by a tap-driven view
+(`MobileScheduleView`). The two layouts are mutually exclusive so the DnD context and
+touch sensors never mount on a phone. **Do not** try to make the fine-grained pixel
+timeline finger-friendly — touch drag on a dense timeline is imprecise and hijacks
+scrolling. Locked decision (2026-07).
+
+## 4. The four core operations, and how each is reachable
+
+Every common operation must have a clear, non-drag path on mobile:
+
+| Operation                                | Model                                                                                        |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **Add** (unassigned → slot)              | tap an open slot → drawer of _fitting_ talks → tap one; or Unassigned → pick up → tap a slot |
+| **Move / adjust** (change time or track) | pick up a talk → tap an open slot (any track, after swiping)                                 |
+| **Swap** two talks                       | pick up a talk → tap another talk                                                            |
+| **Remove**                               | pick up → **Remove** (explicit; destructive actions are never a "drop")                      |
+
+**Pick-up → drop is the unifying model**: drag is just "pick up, then drop", so on
+touch it becomes two taps where **the drop target decides the operation** (empty slot
+= move/add, occupied talk = swap). This maps 1:1 onto `moveProposal`, needs no engine
+change, and — critically — restores **swap**, which the earlier sheet-based flow could
+not express (its pickers only offered free slots).
+
+## 5. Mode must be loud, and only valid targets are offered
+
+"Placing mode" is a mode, and hidden modes are a classic usability failure. So it is
+**always visible**: a sticky banner naming what's being placed, with Cancel/Remove
+(and Rename/Duration for services) always in reach. While placing, the rail becomes a
+target picker where **only legal targets are enabled** (validity computed from the
+same rules the reducer uses) and invalid ones are dimmed — the UI never lets you
+attempt a drop that would silently fail. Tapping the source cancels.
+
+## 6. Convey duration and gaps without the pixel-timeline's costs
+
+The mobile agenda is a **clamped, gap-collapsing time-rail**, not a uniform card list
+and not a literal pixel timeline. Card height is proportional to duration but
+`clamp(min, …, max)` — a floor (≥ touch target, ~56px) keeps a 5-minute break tappable,
+a ceiling stops a 90-minute workshop from dominating the scroll. A **duration chip**
+carries the exact length when heights hit the clamp. Breaks render as their own muted
+segments; open time renders as dashed "assign here" slots; sub-10-minute gaps collapse
+to a slim divider (too small to hold a talk). Models: Fantastical's DayTicker,
+Mobiscroll's min-row-height.
+
+## 7. Column switching must look and feel swipeable
+
+With multiple tracks (columns) on one phone screen:
+
+- **Peek the adjacent track** (~7vw each side via a scroll-snap carousel of
+  `basis-[86vw]` panels). A peeking neighbour is the single strongest cue that the
+  panel swipes _and_ that another column exists — swipe is otherwise invisible.
+- **Fixed, all-visible tab strip** synced to the carousel: the active tab updates
+  _live_ as you swipe past a track's midpoint (it should track the drag, not jump on
+  release). Tabs are the accessible, non-swipe equivalent.
+- `scroll-snap-stop: always` — one track per fling; a fast swipe can't skip a track.
+- **Never auto-advance** columns.
+
+## 8. Accessibility is not optional
+
+- Every swipe has a tap/keyboard equivalent (the tab strip: `role=tab/tabpanel`,
+  roving `tabindex`, arrow keys).
+- Bottom sheets are real modals: focus moves in on open, **Tab is trapped** (both
+  directions), focus is restored on close, and body scroll is locked.
+- Touch targets ≥ 44px; visible `focus-visible` outlines; placing banner is a
+  `role="status"`; rail buttons carry descriptive `aria-label`s.
+
+## 9. Persistence is safe by construction
+
+- Saves are conference-scoped and use optimistic concurrency (`ifRevisionId`); a
+  stale write surfaces as a distinct conflict, never a silent last-write-wins.
+- The client can't produce a payload the server rejects (shared rules); ghost slots
+  (dangling talk refs) are stripped on load and on save so they can't brick a day.
+- Every dirty day is persisted on save — never just the visible one.
+
+---
+
+_Evidence for the mobile decisions (peek/affordances, time-rail vs list, Trello-style
+column swipe) comes from NN/g, Baymard, Material 3, Apple HIG, and teardowns of
+Google/Apple Calendar, Fantastical, and Trello. See the redesign PRs for the cited
+research briefs._

--- a/src/components/admin/schedule/mobileRail.ts
+++ b/src/components/admin/schedule/mobileRail.ts
@@ -1,0 +1,81 @@
+import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
+import {
+  SCHEDULE_START,
+  SCHEDULE_END,
+  toMinutes,
+  durationBetween,
+} from '@/lib/schedule/time'
+
+/**
+ * One row of the mobile time-rail. Assigned talks and service breaks each become
+ * their own segment; every uncovered interval between them (and at the head/tail
+ * of the day) becomes an `open` segment — the tappable "assign here" time that
+ * makes the editor's free space visible on a phone.
+ *
+ * `talkIndex` on a talk/break segment is its index into the ORIGINAL
+ * `track.talks` array (not the sorted order), so callers can dispatch reducer
+ * actions (removeTalk, resizeService, …) without re-deriving it.
+ */
+export type RailSegment =
+  | {
+      kind: 'talk' | 'break'
+      talk: TrackTalk
+      talkIndex: number
+      startTime: string
+      endTime: string
+      durationMin: number
+    }
+  | { kind: 'open'; startTime: string; endTime: string; durationMin: number }
+
+/**
+ * Build the vertical time-rail for one track: a chronological, gap-aware list of
+ * segments spanning `[SCHEDULE_START, SCHEDULE_END]`. Talks are visited in start
+ * order; the running `cursor` tracks the latest covered minute so back-to-back
+ * items produce no gap while non-contiguous ones yield an `open` segment. A fully
+ * empty track collapses to a single open segment covering the whole day.
+ *
+ * Malformed slots (missing times) are skipped; overlaps (which shouldn't occur
+ * post-validation) never emit a negative-width open segment.
+ */
+export function buildTrackRail(track: ScheduleTrack): RailSegment[] {
+  const indexed = (track.talks ?? []).map((talk, talkIndex) => ({
+    talk,
+    talkIndex,
+  }))
+  const ordered = indexed
+    .filter(({ talk }) => talk.startTime && talk.endTime)
+    .sort((a, b) => a.talk.startTime.localeCompare(b.talk.startTime))
+
+  const segments: RailSegment[] = []
+  let cursor = SCHEDULE_START
+
+  for (const { talk, talkIndex } of ordered) {
+    if (toMinutes(talk.startTime) > toMinutes(cursor)) {
+      segments.push(openSegment(cursor, talk.startTime))
+    }
+    segments.push({
+      kind: talk.placeholder ? 'break' : 'talk',
+      talk,
+      talkIndex,
+      startTime: talk.startTime,
+      endTime: talk.endTime,
+      durationMin: durationBetween(talk.startTime, talk.endTime),
+    })
+    if (toMinutes(talk.endTime) > toMinutes(cursor)) cursor = talk.endTime
+  }
+
+  if (toMinutes(cursor) < toMinutes(SCHEDULE_END)) {
+    segments.push(openSegment(cursor, SCHEDULE_END))
+  }
+
+  return segments
+}
+
+function openSegment(startTime: string, endTime: string): RailSegment {
+  return {
+    kind: 'open',
+    startTime,
+    endTime,
+    durationMin: durationBetween(startTime, endTime),
+  }
+}

--- a/src/components/admin/schedule/mobileRail.ts
+++ b/src/components/admin/schedule/mobileRail.ts
@@ -43,7 +43,16 @@ export function buildTrackRail(track: ScheduleTrack): RailSegment[] {
     talkIndex,
   }))
   const ordered = indexed
-    .filter(({ talk }) => talk.startTime && talk.endTime)
+    // Drop malformed slots (missing times) and "ghost" slots — a dangling talk
+    // ref with neither a resolved `talk` nor a `placeholder`. The loader/saver
+    // already strip ghosts, but filtering here keeps the rail robust: a ghost
+    // must never become a pick-up-able segment (it has no title, can't be
+    // renamed/resized, and can't be a valid move/swap source). Its interval
+    // simply becomes open, tappable time instead.
+    .filter(
+      ({ talk }) =>
+        talk.startTime && talk.endTime && (talk.talk || talk.placeholder),
+    )
     .sort((a, b) => a.talk.startTime.localeCompare(b.talk.startTime))
 
   const segments: RailSegment[] = []


### PR DESCRIPTION
## Summary

A ground-up redesign of the **mobile** schedule editor, driven by UX research (briefs below) and a design-thinking pass on the four core scheduling operations. Desktop is unchanged; **no engine changes** — the mobile UI is a thin layer over the existing reducer/rules.

### 1. Hybrid time-rail agenda (replaces the uniform card list)
A left **time gutter + continuous rail**; each card's height is **duration-proportional but clamped** (min ~56px touch floor, max ceilings) with a **duration chip** so exact length survives the clamp. Breaks render as muted segments; sub-10-min gaps as slim dividers; **open time as dashed tap-to-assign slots**. The old flat list structurally hid duration, breaks, and the day's flow — an editor needs to *show where the free time is*.

### 2. Pick-up → drop interaction (restores swap)
Tap a talk to **pick it up** (sticky placing banner); then tap an **open slot to move** or **another talk to swap** — the drop target decides the operation, mapping 1:1 onto `moveProposal`. This **restores swap**, which the previous sheet-based flow *could not do at all* (its pickers only offered free slots). Only **legal targets are enabled** (validity mirrors `operations.moveProposal`); Remove + service Rename/Duration live in the banner; placing **persists across track swipes** so a cross-track move is swipe-then-tap.

| Operation | Path |
|---|---|
| Add | tap open slot → drawer of *fitting* talks → tap; or Unassigned → pick up → tap slot |
| Move/adjust | pick up → tap an open slot (any track) |
| Swap | pick up → tap another talk |
| Remove | pick up → Remove |

### 3. Column navigation
Scroll-snap carousel with **~7vw edge-peek** of the adjacent track (the strongest swipe affordance), a **fixed all-visible tab strip synced live** to scroll position, `scroll-snap-stop: always` (one track per fling), roving `tabindex` + arrow keys. Replaces the manual swipe-threshold hack (native axis-locking fixes the swipe-vs-scroll conflict).

### 4. Top air
Header `pt-3 → pt-4` so it doesn't crowd the top nav.

## New / notable files
- `mobileRail.ts` — pure, unit-tested rail builder.
- `UX.md` — **UX principles doc** for the editor (design invariants + rationale + citations), so future changes don't quietly regress these decisions.

## Tests
- `mobileRail.test.ts` (8) — segment building, gaps, break/talk classification, ordering, malformed slots.
- `MobileScheduleView.test.tsx` (5) — tabs + rail render, tab switching, pick-up→remove, **swap**, contextual assign.
- All schedule suites green (104); tsc/eslint/prettier clean. Bottom-sheet focus trap preserved.

## Research briefs behind this
Mobile swipe affordances (NN/g, Baymard, Material 3, Apple HIG) · agenda time-rail vs list (Google/Apple Calendar, Fantastical, Mobiscroll) · Trello/kanban column-swipe feel.

> ⚠️ Best reviewed on a **phone-width preview** (Vercel) — the whole point is the touch experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a ground-up redesign of the mobile schedule editor: a duration-proportional time-rail with a pick-up → drop interaction model (replacing the sheet-only flow), a scroll-snap track carousel with synced tab strip, and a new `mobileRail.ts` utility with full unit coverage.

- **`mobileRail.ts`** — pure rail builder converting a track's `talks` array into a chronological `talk | break | open` segment list, with correct gap detection, overlap safety, and malformed-slot skipping.
- **Pick-up → drop** — tap any talk/break to enter placing mode; tap a valid open slot to move, another talk to swap, or use the banner's Remove button. The `segmentState` function mirrors reducer validity checks so only legal targets are offered.
- **Carousel** — scroll-snap with `~7 vw` edge-peek, `scroll-snap-stop: always` (one track per fling), live scroll-position sync to the tab strip, and roving `tabindex` arrow-key navigation.

<h3>Confidence Score: 3/5</h3>

Safe to review on a phone preview branch; not ready to merge until the talkIndex corruption path is addressed.

The `openAddService` callback is reachable while placing is active — tapping "+ Service" on the same track, adding a session before the picked-up talk, causes `addService` to re-sort the talks array. The stored `placing.talkIndex` becomes stale and now points at the adjacent item; every subsequent Remove or Swap in the banner targets the wrong talk, silently corrupting the schedule.

src/components/admin/schedule/MobileScheduleView.tsx — specifically the interaction between `openAddService` and the active `placing` state, and the absence of a corresponding test case for this flow.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/MobileScheduleView.tsx | Ground-up mobile rewrite adding scroll-snap carousel, pick-up→drop placement model, and time-rail UI. Core pick-up/drop/swap logic is well-structured, but the "+Service" button is reachable while placing is active, and addService re-sorts talks — shifting the stored talkIndex and causing Remove/Swap to target the wrong item. |
| src/components/admin/schedule/mobileRail.ts | New pure rail-builder: chronological segment list with open/talk/break kinds, correct cursor-based gap detection, overlap safety, and malformed-slot filtering. All 8 unit tests pass. |
| __tests__/components/admin/schedule/MobileScheduleView.test.tsx | New integration tests cover tab rendering, tab switching, pick-up→remove, swap, and contextual assign. Missing: a test for adding a service while a talk is picked up (the scenario that can corrupt talkIndex). |
| __tests__/components/admin/schedule/mobileRail.test.ts | Comprehensive unit tests for buildTrackRail covering empty tracks, leading/trailing gaps, back-to-back items, sort order, talkIndex preservation, and malformed-slot skipping. |
| src/components/admin/schedule/MobileScheduleView.stories.tsx | Minor one-line change; stories updated to use the real reducer harness. Default, EmptyTrack, and NoTracks stories are comprehensive for mobile preview. |
| src/components/admin/schedule/UX.md | New UX principles document capturing design invariants, interaction rationale, and citations. A useful guardrail for future changes. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant TrackRail
    participant MobileScheduleView
    participant Reducer

    User->>TrackRail: Tap talk/break card
    TrackRail->>MobileScheduleView: onSegmentTap(trackIndex, seg)
    MobileScheduleView->>MobileScheduleView: "setPlacing({kind:'scheduled', talkIndex, talk})"
    MobileScheduleView->>TrackRail: re-render with placing state (valid/invalid/source highlights)

    alt Drop on open slot (Move)
        User->>TrackRail: "Tap open slot (state='valid')"
        TrackRail->>MobileScheduleView: onSegmentTap(targetTrackIndex, openSeg)
        MobileScheduleView->>Reducer: dispatch moveProposal (scheduled-talk to open slot)
        MobileScheduleView->>MobileScheduleView: setPlacing(null)
    else Drop on talk (Swap)
        User->>TrackRail: "Tap another talk (state='valid')"
        TrackRail->>MobileScheduleView: onSegmentTap(targetTrackIndex, talkSeg)
        MobileScheduleView->>Reducer: dispatch moveProposal (swap)
        MobileScheduleView->>MobileScheduleView: setPlacing(null)
    else Remove from PlacingBanner
        User->>MobileScheduleView: Tap Remove in banner
        MobileScheduleView->>Reducer: dispatch removeTalk(trackIndex, talkIndex)
        MobileScheduleView->>MobileScheduleView: setPlacing(null)
    else Cancel
        User->>MobileScheduleView: Tap Cancel in banner
        MobileScheduleView->>MobileScheduleView: setPlacing(null)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant TrackRail
    participant MobileScheduleView
    participant Reducer

    User->>TrackRail: Tap talk/break card
    TrackRail->>MobileScheduleView: onSegmentTap(trackIndex, seg)
    MobileScheduleView->>MobileScheduleView: "setPlacing({kind:'scheduled', talkIndex, talk})"
    MobileScheduleView->>TrackRail: re-render with placing state (valid/invalid/source highlights)

    alt Drop on open slot (Move)
        User->>TrackRail: "Tap open slot (state='valid')"
        TrackRail->>MobileScheduleView: onSegmentTap(targetTrackIndex, openSeg)
        MobileScheduleView->>Reducer: dispatch moveProposal (scheduled-talk to open slot)
        MobileScheduleView->>MobileScheduleView: setPlacing(null)
    else Drop on talk (Swap)
        User->>TrackRail: "Tap another talk (state='valid')"
        TrackRail->>MobileScheduleView: onSegmentTap(targetTrackIndex, talkSeg)
        MobileScheduleView->>Reducer: dispatch moveProposal (swap)
        MobileScheduleView->>MobileScheduleView: setPlacing(null)
    else Remove from PlacingBanner
        User->>MobileScheduleView: Tap Remove in banner
        MobileScheduleView->>Reducer: dispatch removeTalk(trackIndex, talkIndex)
        MobileScheduleView->>MobileScheduleView: setPlacing(null)
    else Cancel
        User->>MobileScheduleView: Tap Cancel in banner
        MobileScheduleView->>MobileScheduleView: setPlacing(null)
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(schedule): mobile time-rail + pick-..."](https://github.com/cloudnativebergen/website/commit/0f7c26c4223eb222a4d11d3e4968f8d37ba36066) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45213246)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->