### PR TITLE
fix(pwa): stamp service-worker version per deploy so updates ship

### DIFF
--- a/__tests__/pwa/stamp-sw.test.ts
+++ b/__tests__/pwa/stamp-sw.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @vitest-environment node
+ *
+ * Guards the service-worker version stamp. `scripts/stamp-sw.mjs` rewrites the
+ * `CACHE_VERSION` declaration in `public/sw.js` at build time so `/sw.js` changes
+ * every deploy (otherwise the PWA never updates). If the declaration's shape ever
+ * drifts, the stamp would silently no-op — this test fails first, before a deploy
+ * ships a service worker that can never update.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { CACHE_VERSION_PATTERN } from '../../scripts/stamp-sw.mjs'
+
+const swSource = readFileSync(
+  path.resolve(process.cwd(), 'public/sw.js'),
+  'utf8',
+)
+
+describe('service-worker version stamp target', () => {
+  it('public/sw.js contains a stampable CACHE_VERSION declaration', () => {
+    expect(CACHE_VERSION_PATTERN.test(swSource)).toBe(true)
+  })
+
+  it('the stamp replacement produces a changed, versioned CACHE_VERSION', () => {
+    const stamped = swSource.replace(
+      CACHE_VERSION_PATTERN,
+      `const CACHE_VERSION = 'cndn-abc12345'`,
+    )
+    expect(stamped).not.toBe(swSource)
+    expect(stamped).toContain("const CACHE_VERSION = 'cndn-abc12345'")
+  })
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.24.0",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "node scripts/stamp-sw.mjs && next build",
     "build:clean": "rm -rf .next && pnpm run build",
     "start": "next start",
     "check": "concurrently -n typecheck,lint,knip,format -c blue,green,yellow,magenta --kill-others-on-fail \"pnpm run typecheck\" \"pnpm run lint\" \"pnpm run knip\" \"pnpm run format:check\"",

--- a/public/sw.js
+++ b/public/sw.js
@@ -27,9 +27,10 @@
  * banner, which posts { type: 'SKIP_WAITING' }.
  */
 
-// STAMPED AT BUILD TIME with the commit SHA (see scripts/stamp-sw.mjs). The
-// `cndn-dev` default is only used for local builds; every deploy replaces it so
-// the bytes change and the browser installs a fresh worker.
+// STAMPED AT BUILD TIME with the commit SHA (see scripts/stamp-sw.mjs). Any
+// build that exposes a commit SHA (Vercel/CI deploys) replaces this so the bytes
+// change and the browser installs a fresh worker; builds without a SHA (local)
+// keep the `cndn-dev` default unchanged.
 const CACHE_VERSION = 'cndn-dev'
 const PRECACHE = `${CACHE_VERSION}-precache`
 const RUNTIME = `${CACHE_VERSION}-runtime`

--- a/public/sw.js
+++ b/public/sw.js
@@ -19,15 +19,18 @@
  *   - Only GET is handled; everything else passes through untouched.
  *
  * Update flow: this file lives at the stable URL `/sw.js` and is served with
- * `Cache-Control: no-cache`. Changing its bytes (e.g. bumping CACHE_VERSION)
- * is what triggers the browser to install a new worker. We do NOT call
- * skipWaiting() on install — the new worker waits until the user clicks
- * "Reload" in the update banner, which posts { type: 'SKIP_WAITING' }.
+ * `Cache-Control: no-cache`. Changing its bytes is what triggers the browser to
+ * install a new worker. `CACHE_VERSION` is STAMPED with the deploy's commit SHA
+ * at build time (scripts/stamp-sw.mjs), so `/sw.js` differs every deploy — that
+ * is what makes the update lifecycle actually run. We do NOT call skipWaiting()
+ * on install — the new worker waits until the user clicks "Reload" in the update
+ * banner, which posts { type: 'SKIP_WAITING' }.
  */
 
-// Bump this to invalidate the precache and force an update. The changed bytes
-// are what the browser diffs to detect a new worker.
-const CACHE_VERSION = 'cndn-v1'
+// STAMPED AT BUILD TIME with the commit SHA (see scripts/stamp-sw.mjs). The
+// `cndn-dev` default is only used for local builds; every deploy replaces it so
+// the bytes change and the browser installs a fresh worker.
+const CACHE_VERSION = 'cndn-dev'
 const PRECACHE = `${CACHE_VERSION}-precache`
 const RUNTIME = `${CACHE_VERSION}-runtime`
 

--- a/scripts/stamp-sw.mjs
+++ b/scripts/stamp-sw.mjs
@@ -1,0 +1,44 @@
+/**
+ * Stamp the service worker's CACHE_VERSION with the deploy's commit SHA.
+ *
+ * `public/sw.js` is a static file. The browser only installs a NEW worker when
+ * the bytes of `/sw.js` change — so with a hardcoded `CACHE_VERSION` the file is
+ * byte-identical across deploys, no new worker ever installs, and the
+ * "update available" banner never fires. Users get stuck on a stale bundle.
+ *
+ * Run before `next build`. On Vercel/CI a commit SHA is in the env; stamping it
+ * into CACHE_VERSION makes `/sw.js` change every deploy, which is what drives the
+ * update lifecycle (new worker → banner → reload). Locally (no SHA) it's a no-op
+ * so the committed file stays `cndn-dev` and the working tree stays clean.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const sha = process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || ''
+
+if (!sha) {
+  console.log(
+    '[stamp-sw] no commit SHA in env — leaving CACHE_VERSION unchanged',
+  )
+  process.exit(0)
+}
+
+try {
+  const swPath = path.resolve(process.cwd(), 'public/sw.js')
+  const src = readFileSync(swPath, 'utf8')
+  const version = `cndn-${sha.slice(0, 8)}`
+  const next = src.replace(
+    /const CACHE_VERSION = '[^']*'/,
+    `const CACHE_VERSION = '${version}'`,
+  )
+  if (next === src) {
+    console.warn('[stamp-sw] CACHE_VERSION line not found — nothing stamped')
+  } else {
+    writeFileSync(swPath, next)
+    console.log(`[stamp-sw] CACHE_VERSION → ${version}`)
+  }
+} catch (err) {
+  // Never fail the build over the stamp; a stale-but-working SW beats no deploy.
+  console.warn('[stamp-sw] non-fatal:', err && err.message)
+}
+process.exit(0)

--- a/scripts/stamp-sw.mjs
+++ b/scripts/stamp-sw.mjs
@@ -13,32 +13,53 @@
  */
 import { readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
-const sha = process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || ''
+// Tolerant of quote style and spacing so a prettier reformat of sw.js can't
+// silently defeat the stamp. Shared shape asserted by __tests__/pwa/stamp-sw.
+export const CACHE_VERSION_PATTERN =
+  /const\s+CACHE_VERSION\s*=\s*['"][^'"]*['"]/
 
-if (!sha) {
-  console.log(
-    '[stamp-sw] no commit SHA in env — leaving CACHE_VERSION unchanged',
-  )
-  process.exit(0)
-}
+function stampServiceWorker() {
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || ''
 
-try {
+  if (!sha) {
+    console.log(
+      '[stamp-sw] no commit SHA in env — leaving CACHE_VERSION unchanged',
+    )
+    return
+  }
+
   const swPath = path.resolve(process.cwd(), 'public/sw.js')
   const src = readFileSync(swPath, 'utf8')
+
+  // FAIL LOUDLY if the target moved: a silent miss would ship a service worker
+  // whose bytes never change → back to "PWA never updates", undetected. Better
+  // to break the build so the declaration/regex is fixed. (The unit test guards
+  // this too, so it's normally caught before a deploy.)
+  if (!CACHE_VERSION_PATTERN.test(src)) {
+    console.error(
+      '[stamp-sw] CACHE_VERSION declaration not found in public/sw.js — the ' +
+        'stamp target changed. Refusing to ship a service worker that can never ' +
+        'update. Fix the declaration or CACHE_VERSION_PATTERN.',
+    )
+    process.exit(1)
+  }
+
   const version = `cndn-${sha.slice(0, 8)}`
   const next = src.replace(
-    /const CACHE_VERSION = '[^']*'/,
+    CACHE_VERSION_PATTERN,
     `const CACHE_VERSION = '${version}'`,
   )
-  if (next === src) {
-    console.warn('[stamp-sw] CACHE_VERSION line not found — nothing stamped')
-  } else {
-    writeFileSync(swPath, next)
-    console.log(`[stamp-sw] CACHE_VERSION → ${version}`)
-  }
-} catch (err) {
-  // Never fail the build over the stamp; a stale-but-working SW beats no deploy.
-  console.warn('[stamp-sw] non-fatal:', err && err.message)
+  writeFileSync(swPath, next)
+  console.log(`[stamp-sw] CACHE_VERSION → ${version}`)
 }
-process.exit(0)
+
+// Only run when invoked directly (`node scripts/stamp-sw.mjs`), so importing the
+// pattern from a test doesn't execute the stamp or call process.exit.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  stampServiceWorker()
+}


### PR DESCRIPTION
## The bug: "PWA not updating"

The service worker only installs a **new worker when the bytes of `/sw.js` change**. But `CACHE_VERSION` was **hardcoded (`'cndn-v1'`)** and `public/sw.js` is a static file — so `/sw.js` was **byte-identical across every deploy**. Result:

- The browser never detected a new worker after the first install.
- The **"update available" banner never fired** for anyone (the whole `ServiceWorkerRegistrar` → `UpdateBanner` flow was effectively dead).
- Clients stayed pinned to a **stale bundle** — e.g. reporting that a shipped UI fix "isn't showing up," even on the production URL, because their old worker kept serving cached chunks and never handed over.

The server/domain and the app code were fine — I confirmed the production domain serves the current deploy and the code renders correctly; the blocker was purely this SW update gap.

## The fix

`scripts/stamp-sw.mjs` rewrites `CACHE_VERSION` to `cndn-<commit-sha>` **before `next build`** (wired into the `build` script). So `/sw.js` changes every deploy, which revives the existing, already-built update lifecycle: new worker installs → banner → user reloads. Going forward the banner fires on **every** deploy, and currently-stuck clients pick up the new versioned worker on their next visit.

- **No caching-strategy change** — navigations stay network-first, static assets stale-while-revalidate.
- **No-op locally** — without a commit SHA in the env the script leaves the `cndn-dev` default untouched, so local builds don't dirty the working tree.
- Served headers (`no-cache`) and `updateViaCache: 'none'` were already correct; this supplies the missing per-deploy byte change.

## Files
- `scripts/stamp-sw.mjs` (new) — the stamper.
- `package.json` — `build` now runs the stamper first.
- `public/sw.js` — `CACHE_VERSION` default → `cndn-dev`; comment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a PWA update lifecycle bug where `CACHE_VERSION` was hardcoded in a static `public/sw.js`, making the file byte-identical across every deploy and preventing the browser from ever detecting a new service worker.

- A new `scripts/stamp-sw.mjs` script rewrites `CACHE_VERSION` to `cndn-<8-char-sha>` before `next build`, ensuring `/sw.js` changes on every deploy and the existing update banner flow fires correctly.
- The stamper is a no-op locally (no SHA in env), preserving clean local builds, and errors during stamping are intentionally non-fatal so a deploy is never blocked.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix correctly wires a per-deploy SHA into the service worker and the no-op local path keeps the dev experience clean.

The stamper has one silent-failure path: if the CACHE_VERSION regex misses after a future reformatting of sw.js, the script prints a warning but exits 0 and updates quietly stop working again. Everything else — the regex, SHA slicing, early exit when no SHA, cache cleanup on activate — looks correct.

scripts/stamp-sw.mjs — specifically the if (next === src) no-match branch and the in-place mutation of a tracked source file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/stamp-sw.mjs | New build-time stamper that replaces CACHE_VERSION in public/sw.js with a short commit SHA; silently no-ops locally. The catch block intentionally swallows errors, but a regex no-match only warns rather than failing the build. |
| public/sw.js | CACHE_VERSION default changed from 'cndn-v1' to 'cndn-dev'; comments updated to describe the stamping mechanism. No caching logic changes. |
| package.json | build script now runs stamp-sw.mjs before next build; build:clean inherits this automatically. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pwa): stamp service-worker version p..."](https://github.com/cloudnativebergen/website/commit/9f87c8867baa4ff125cce52e0d42d792a67d77ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45296621)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->