### PR TITLE
fix(schedule): stop mobile card title overflow + full-width panels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,5 +49,10 @@ Project uses [mise](https://mise.jdx.sh/). Key commands:
 - **Storybook** is the single source of truth for UI/UX.
   - Component stories go in `Components/` or `Systems/{SystemName}/`.
   - **Deterministic Dates:** Mock `globalThis.Date` in Storybook `beforeEach` to fix relative dates (prevents visual diff thrashing).
+- **Visual inspection is MANDATORY for UI work.** Whenever you create or change a component/layout, **look at the rendered result** — never conclude "it works" from code review, measurements, or unit tests alone (they miss overflow, truncation, spacing, and responsive bugs). Workflow:
+  - Ensure the component has a Storybook story (add one if missing) so it's inspectable in isolation.
+  - Screenshot it with **`rtk pnpm shoot <story-id> [width] [height]`** (`scripts/shoot-story.mjs`) — defaults to iPhone-portrait (393×852, DPR 3), auto-starts Storybook, flattens decorator insets so the capture maps 1:1 to the app, and prints a hard per-card viewport-overflow check. Then actually view the PNG.
+  - For full-screen/mobile views set `parameters.layout: 'fullscreen'` on the story so captures aren't inset.
+  - Prefer isolated Storybook capture over trusting a deployed URL — a stale **PWA service worker** can serve an old bundle (see `public/sw.js` / `scripts/stamp-sw.mjs`); a Safari **Private tab** bypasses the SW when checking production.
 - **Testing (Vitest):** Test behavior over implementation. Prefer integration tests. Mock at boundaries.
 - **Storybook Interaction:** Use `play` functions for interactive tests (`storybook/test`).

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "generate-badge-ed25519-key": "tsx scripts/generate-badge-ed25519-key.ts",
     "audit-sponsor-health": "tsx scripts/audit-sponsor-health.ts",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "shoot": "node scripts/shoot-story.mjs"
   },
   "browserslist": "defaults, not ie <= 11",
   "dependencies": {

--- a/scripts/shoot-story.mjs
+++ b/scripts/shoot-story.mjs
@@ -35,10 +35,20 @@ async function storybookUp() {
   }
 }
 
+// Use the package manager that invoked us, defaulting to pnpm (this repo's
+// declared packageManager). `.cmd` on Windows so spawn can find it.
+const ua = process.env.npm_config_user_agent || ''
+const pm = ua.startsWith('npm')
+  ? 'npm'
+  : ua.startsWith('yarn')
+    ? 'yarn'
+    : 'pnpm'
+const pmBin = process.platform === 'win32' ? `${pm}.cmd` : pm
+
 let started
 if (!(await storybookUp())) {
-  console.log('[shoot] starting Storybook on :6006 …')
-  started = spawn('npm', ['run', 'storybook', '--', '--ci', '--quiet'], {
+  console.log(`[shoot] starting Storybook on :6006 (via ${pm}) …`)
+  started = spawn(pmBin, ['run', 'storybook', '--', '--ci', '--quiet'], {
     stdio: 'ignore',
     detached: true,
   })
@@ -122,17 +132,24 @@ try {
     ),
   )
   const cut = info.cards.filter((c) => c.cut).length
+  // Note the count so a zero (e.g. the aria-label selector drifted and matched
+  // nothing) reads as "0 cards checked", not a false all-clear.
   console.log(
     cut
       ? `[shoot] WARNING: ${cut} card(s) exceed the ${width}px viewport`
-      : `[shoot] OK: every card fits within the ${width}px viewport`,
+      : `[shoot] OK: ${info.cards.length} card(s) checked, none exceed the ${width}px viewport`,
   )
 } finally {
   await browser.close()
-  // Only stop Storybook if this script started it.
-  if (started) {
+  // Only stop Storybook if this script started it. Kill the whole process group
+  // (detached) on POSIX; fall back to the single pid (e.g. Windows).
+  if (started?.pid) {
     try {
-      process.kill(-started.pid)
-    } catch {}
+      process.kill(process.platform === 'win32' ? started.pid : -started.pid)
+    } catch {
+      try {
+        started.kill()
+      } catch {}
+    }
   }
 }

--- a/scripts/shoot-story.mjs
+++ b/scripts/shoot-story.mjs
@@ -1,0 +1,138 @@
+/**
+ * Dev tool: screenshot a Storybook story at iPhone-portrait size for visual QA.
+ *
+ * Usage:
+ *   node scripts/shoot-story.mjs [storyId] [width] [height]
+ *   npm run shoot -- <storyId> [width] [height]
+ *
+ * Defaults: the MobileScheduleView story at 393×852 (iPhone 15/16 Pro portrait),
+ * DPR 3. Starts Storybook on :6006 if it isn't already running, renders the
+ * story's iframe at the viewport, resets the track carousel to its first panel,
+ * writes a PNG (SHOOT_OUT dir, default cwd), and prints panel/card widths plus a
+ * hard overflow check (cards wider than the viewport = layout bug).
+ */
+import { chromium } from 'playwright'
+import { spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+import path from 'node:path'
+
+const [
+  storyId = 'systems-program-admin-mobilescheduleview--default',
+  wArg,
+  hArg,
+] = process.argv.slice(2)
+const width = Number(wArg) || 393 // iPhone 15/16 Pro portrait (CSS px)
+const height = Number(hArg) || 852
+const PORT = 6006
+const BASE = `http://localhost:${PORT}`
+
+async function storybookUp() {
+  try {
+    const r = await fetch(`${BASE}/index.json`)
+    return r.ok
+  } catch {
+    return false
+  }
+}
+
+let started
+if (!(await storybookUp())) {
+  console.log('[shoot] starting Storybook on :6006 …')
+  started = spawn('npm', ['run', 'storybook', '--', '--ci', '--quiet'], {
+    stdio: 'ignore',
+    detached: true,
+  })
+  for (let i = 0; i < 45; i++) {
+    if (await storybookUp()) break
+    await sleep(2000)
+  }
+  if (!(await storybookUp())) {
+    console.error('[shoot] Storybook did not come up on :6006')
+    process.exit(1)
+  }
+}
+
+const out = path.resolve(process.env.SHOOT_OUT || '.', `${storyId}.png`)
+const browser = await chromium.launch()
+try {
+  const page = await browser.newPage({
+    viewport: { width, height },
+    deviceScaleFactor: 3,
+  })
+  await page.goto(`${BASE}/iframe.html?id=${storyId}&viewMode=story`, {
+    waitUntil: 'networkidle',
+  })
+  await page.waitForTimeout(1000)
+  // Zero any Storybook wrapper/decorator insets between <body> and the app root
+  // so the viewport maps 1:1 to the app (a decorator's padding otherwise shrinks
+  // the scroll container and makes viewport-relative panels look cut off).
+  await page.addStyleTag({
+    content:
+      'html,body,#storybook-root,#root{margin:0!important;padding:0!important}',
+  })
+  await page.evaluate(() => {
+    // Walk up from the component's full-height root and flatten every ancestor.
+    const root =
+      document.querySelector('.snap-x')?.closest('[class*="100dvh"]') ||
+      document.querySelector('[class*="100dvh"]')
+    let el = root?.parentElement
+    while (el && el !== document.body) {
+      el.style.padding = '0'
+      el.style.margin = '0'
+      el = el.parentElement
+    }
+  })
+  // Reset the track carousel to the first panel for a deterministic shot.
+  await page.evaluate(() => {
+    const s = document.querySelector('.snap-x')
+    if (s) s.scrollLeft = 0
+  })
+  await page.waitForTimeout(300)
+
+  const info = await page.evaluate((vw) => {
+    const panel = document.querySelector('[role=tabpanel]')
+    const pr = panel && panel.getBoundingClientRect()
+    const cards = [...document.querySelectorAll('button[aria-label]')]
+      .filter((e) =>
+        /^Move |^Assign to open/.test(e.getAttribute('aria-label') || ''),
+      )
+      .map((e) => {
+        const r = e.getBoundingClientRect()
+        return {
+          w: Math.round(r.width),
+          right: Math.round(r.right),
+          // Only a card that STARTS on-screen but runs past the edge is a real
+          // overflow; cards belonging to the next (off-screen) track panel start
+          // beyond the viewport and are not counted.
+          cut: r.left < vw && r.right > vw + 1,
+        }
+      })
+    return {
+      panel: pr && { w: Math.round(pr.width), right: Math.round(pr.right) },
+      cards,
+    }
+  }, width)
+
+  await page.screenshot({ path: out })
+  console.log(`[shoot] ${width}×${height} (DPR 3) → ${out}`)
+  console.log('[shoot] panel', JSON.stringify(info.panel))
+  info.cards.forEach((c) =>
+    console.log(
+      `  card w=${c.w} right=${c.right}${c.cut ? '  <-- CUT off viewport' : ''}`,
+    ),
+  )
+  const cut = info.cards.filter((c) => c.cut).length
+  console.log(
+    cut
+      ? `[shoot] WARNING: ${cut} card(s) exceed the ${width}px viewport`
+      : `[shoot] OK: every card fits within the ${width}px viewport`,
+  )
+} finally {
+  await browser.close()
+  // Only stop Storybook if this script started it.
+  if (started) {
+    try {
+      process.kill(-started.pid)
+    } catch {}
+  }
+}

--- a/src/components/admin/schedule/MobileScheduleView.stories.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.stories.tsx
@@ -143,6 +143,9 @@ const meta: Meta<typeof MobileScheduleHarness> = {
   title: 'Systems/Program/Admin/MobileScheduleView',
   component: MobileScheduleHarness,
   parameters: {
+    // Full-screen: this is a full-viewport mobile view, so drop Storybook's
+    // default story padding (which otherwise insets it and skews visual QA).
+    layout: 'fullscreen',
     viewport: { defaultViewport: 'mobile1' },
     docs: {
       description: {

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -931,7 +931,7 @@ function TrackRail({
                   style={{ left: 0 }}
                   aria-hidden="true"
                 />
-                <div className="flex-1 pb-2 pl-4">
+                <div className="min-w-0 flex-1 pb-2 pl-4">
                   <button
                     type="button"
                     disabled={disabled}
@@ -987,7 +987,7 @@ function RailBody({ seg }: { seg: RailSegment }) {
     return (
       <>
         <div className="flex items-center justify-between gap-2">
-          <h3 className="inline-flex items-center gap-1.5 truncate text-sm font-medium text-gray-600 dark:text-gray-300">
+          <h3 className="inline-flex min-w-0 items-center gap-1.5 truncate text-sm font-medium text-gray-600 dark:text-gray-300">
             <ClockIcon className="h-4 w-4 shrink-0" />
             {title}
           </h3>
@@ -1004,7 +1004,7 @@ function RailBody({ seg }: { seg: RailSegment }) {
   return (
     <>
       <div className="flex items-start justify-between gap-2">
-        <h3 className="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+        <h3 className="min-w-0 truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
           {title}
         </h3>
         <div className="flex shrink-0 items-center gap-1.5">
@@ -1585,7 +1585,7 @@ export function MobileScheduleView({
         <div
           ref={scrollerRef}
           onScroll={handleScroll}
-          className="flex flex-1 snap-x snap-mandatory gap-0 overflow-x-auto overflow-y-hidden overscroll-x-contain scroll-smooth px-[7vw] [&::-webkit-scrollbar]:hidden"
+          className="flex flex-1 snap-x snap-mandatory gap-0 overflow-x-auto overflow-y-hidden overscroll-x-contain scroll-smooth [&::-webkit-scrollbar]:hidden"
           style={{ scrollbarWidth: 'none' }}
         >
           {tracks.map((track, trackIndex) => (
@@ -1597,10 +1597,10 @@ export function MobileScheduleView({
               role="tabpanel"
               id={panelId(trackIndex)}
               aria-labelledby={tabId(trackIndex)}
-              // `snap-always` (scroll-snap-stop) forces exactly one track per
-              // fling so a fast swipe can't skip past a track — each is a
-              // distinct context (Trello/kanban column-swipe guidance).
-              className="shrink-0 basis-[86vw] snap-center snap-always overflow-y-auto px-1 pt-2"
+              // Full-width panels (no side peek) so each track's cards use the
+              // whole screen width. `snap-always` (scroll-snap-stop) forces
+              // exactly one track per fling so a fast swipe can't skip a track.
+              className="shrink-0 basis-[100vw] snap-center snap-always overflow-y-auto px-3 pt-2"
             >
               <TrackRail
                 track={track}


### PR DESCRIPTION
## The actual bug

The mobile talk cards were **overflowing horizontally** — long titles didn't truncate, so a card grew wider than its `86vw` track panel and spilled past it. That's what was "breaking the swiping": a card wider than its panel breaks the horizontal scroll-snap carousel. (Not a height issue — the earlier height work was real but not the cause.)

## Fixes
- **Truncation:** add `min-w-0` to the rail card body and to the talk/break `<h3>` so titles ellipsize (`Building Scalable Kubernet…`) instead of pushing the card wide. A `truncate` element inside a flex row can't shrink without `min-w-0`.
- **Full-width panels (per request):** dropped the side peek — panels are now `basis-[100vw]` with no scroller `px-[7vw]`, so each track's cards use the whole screen width.

## Visual-QA tooling (requested — make inspections easy/reliable)
- `scripts/shoot-story.mjs` + **`npm run shoot`**: screenshots a Storybook story at **iPhone-portrait** size (default 393×852, DPR 3), starts Storybook if needed, **flattens Storybook decorator insets** so the capture maps 1:1 to the real app, resets the carousel to the first track, and prints a **per-card viewport-overflow check** (catches this class of bug automatically).
- The `MobileScheduleView` story now renders `layout: 'fullscreen'` (it *is* a full-screen view), so captures aren't inset.

Verified render at 393px: cards **301px wide, right edge 381px — inside the viewport**, titles truncate, chips/durations visible (screenshot shared with reviewer).

All schedule tests green; tsc/eslint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes horizontal overflow on mobile talk cards by adding `min-w-0` to the flex rail-body container and both `h3` title elements, letting `truncate` actually shrink them. It also widens track panels from `basis-[86vw]` to `basis-[100vw]` (removing the scroller's `px-[7vw]` peek) and ships a new `scripts/shoot-story.mjs` dev tool for visual QA screenshots.

- **`MobileScheduleView.tsx`** — four targeted class additions/removals; the `min-w-0` + `truncate` combination correctly prevents cards from growing wider than their panel, and the `basis-[100vw]` / `px-3` swap is clean.
- **`scripts/shoot-story.mjs`** — new Playwright-based screenshot helper; uses `npm` to start Storybook instead of the project's `pnpm`, and the card-detection regex only matches labels from the default (non-placing) state.
- **`MobileScheduleView.stories.tsx`** — correctly adds `layout: 'fullscreen'` so Storybook drops its decorator padding for this full-viewport story.

<h3>Confidence Score: 4/5</h3>

The core layout fixes in MobileScheduleView.tsx are correct and self-contained; the new QA script has minor issues that only affect developer tooling, not the shipped UI.

The production component changes are straightforward Tailwind fixes with no logic risk. The new shoot-story.mjs script spawns npm in a project that enforces pnpm, so the auto-start path will fail in many environments, and its card-detection regex will silently skip cards in any placing-mode story variant — but these only affect the local dev tool, not the app itself.

scripts/shoot-story.mjs — npm vs pnpm spawn and brittle aria-label card selector.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/MobileScheduleView.tsx | Adds `min-w-0` to the flex-1 rail body and to both h3 title elements so `truncate` can shrink below flex-item minimum; removes scroller `px-[7vw]` and widens panels from `basis-[86vw]` to `basis-[100vw]` with `px-3` inner padding. |
| scripts/shoot-story.mjs | New dev-QA script. Two issues: Storybook auto-start uses `npm` instead of the project's `pnpm`, and the card detection regex only matches aria-labels from the default (non-placing) state. |
| src/components/admin/schedule/MobileScheduleView.stories.tsx | Adds `layout: 'fullscreen'` to the story meta so Storybook drops its default padding; correct change for a full-viewport mobile story. |
| package.json | Adds `"shoot": "node scripts/shoot-story.mjs"` script entry; minimal and correct. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MobileScheduleView renders] --> B{tracks.length > 0?}
    B -- No --> C[Empty state]
    B -- Yes --> D[Scroll container flex snap-x snap-mandatory]
    D --> E[Track panel basis-100vw snap-center px-3]
    E --> F[TrackRail]
    F --> G[Rail body div min-w-0 flex-1]
    G --> H{seg.kind}
    H -- break --> I[h3 min-w-0 truncate]
    H -- talk --> J[h3 min-w-0 truncate]
    I --> K[Title ellipsizes inside 100vw panel]
    J --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[MobileScheduleView renders] --> B{tracks.length > 0?}
    B -- No --> C[Empty state]
    B -- Yes --> D[Scroll container flex snap-x snap-mandatory]
    D --> E[Track panel basis-100vw snap-center px-3]
    E --> F[TrackRail]
    F --> G[Rail body div min-w-0 flex-1]
    G --> H{seg.kind}
    H -- break --> I[h3 min-w-0 truncate]
    H -- talk --> J[h3 min-w-0 truncate]
    I --> K[Title ellipsizes inside 100vw panel]
    J --> K
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): stop mobile card title ov..."](https://github.com/cloudnativebergen/website/commit/c60266e0b1760779918bef2d638516e9954fd314) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45304429)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->