### PR TITLE
feat(schedule): mobile card action sheet (discoverable move/swap/edit/remove)

### DIFF
--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -124,17 +124,17 @@ describe('MobileScheduleView', () => {
     )
   })
 
-  it('picks up a talk into placing mode and removes it', () => {
+  it('opens the card action sheet and removes a talk', () => {
     const { dispatch } = setup()
     fireEvent.click(
-      screen.getByRole('button', { name: 'Move Scheduled Keynote Talk' }),
+      screen.getByRole('button', {
+        name: 'Options for Scheduled Keynote Talk',
+      }),
     )
-    // The placing banner appears as a live region.
-    const banner = screen.getByRole('status')
-    expect(banner).toHaveTextContent(/Moving/)
-    expect(banner).toHaveTextContent(/Scheduled Keynote Talk/)
-
-    fireEvent.click(within(banner).getByRole('button', { name: /Remove/ }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: /Remove from schedule/ }),
+    )
     expect(dispatch).toHaveBeenCalledWith({
       type: 'removeTalk',
       trackIndex: 0,
@@ -142,14 +142,80 @@ describe('MobileScheduleView', () => {
     })
   })
 
+  it('exposes Rename / Change duration for a service and dispatches rename', () => {
+    const dispatch = vi.fn()
+    const withService: ConferenceSchedule = {
+      _id: 'day-1',
+      date: '2026-09-01',
+      tracks: [
+        {
+          trackTitle: 'Main Stage',
+          trackDescription: '',
+          talks: [
+            {
+              placeholder: 'Coffee Break',
+              startTime: '10:00',
+              endTime: '10:15',
+            },
+          ],
+        },
+      ],
+    }
+    render(
+      <MobileScheduleView
+        schedules={[withService]}
+        currentDayIndex={0}
+        unassignedProposals={[]}
+        dispatch={dispatch}
+        onDayChange={vi.fn()}
+        onSave={vi.fn()}
+        onAddTrack={vi.fn()}
+        isSaving={false}
+        saveSuccess={false}
+        error={null}
+      />,
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Options for Coffee Break' }),
+    )
+    const dialog = screen.getByRole('dialog')
+    // The service actions are discoverable in the sheet.
+    expect(
+      within(dialog).getByRole('button', { name: 'Rename' }),
+    ).toBeInTheDocument()
+    expect(
+      within(dialog).getByRole('button', { name: 'Change duration' }),
+    ).toBeInTheDocument()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Rename' }))
+    const renameSheet = screen.getByRole('dialog')
+    fireEvent.change(within(renameSheet).getByLabelText('Session title'), {
+      target: { value: 'Lunch' },
+    })
+    fireEvent.click(within(renameSheet).getByRole('button', { name: 'Save' }))
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'renameService',
+      trackIndex: 0,
+      talkIndex: 0,
+      title: 'Lunch',
+    })
+  })
+
   it('hides the "Service" control while placing (index-shift guard)', () => {
     setup()
-    // A Service button per track before pick-up.
+    // A Service button per track before entering placing mode.
     expect(
       screen.getAllByRole('button', { name: 'Service' }).length,
     ).toBeGreaterThan(0)
     fireEvent.click(
-      screen.getByRole('button', { name: 'Move Scheduled Keynote Talk' }),
+      screen.getByRole('button', {
+        name: 'Options for Scheduled Keynote Talk',
+      }),
+    )
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Move or swap',
+      }),
     )
     // While placing, adding a service would re-sort track.talks and invalidate
     // the picked-up talkIndex — so the control is gone.
@@ -158,7 +224,7 @@ describe('MobileScheduleView', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('swaps two talks: pick one up, tap the other', () => {
+  it('swaps two talks: options → move or swap → tap the other', () => {
     const dispatch = vi.fn()
     const talkB = makeProposal({
       _id: 'scheduled-2',
@@ -194,9 +260,16 @@ describe('MobileScheduleView', () => {
       />,
     )
 
-    // Pick up the keynote, then tap the second talk to swap.
+    // Open the keynote's sheet, choose Move or swap, then tap the second talk.
     fireEvent.click(
-      screen.getByRole('button', { name: 'Move Scheduled Keynote Talk' }),
+      screen.getByRole('button', {
+        name: 'Options for Scheduled Keynote Talk',
+      }),
+    )
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Move or swap',
+      }),
     )
     fireEvent.click(
       screen.getByRole('button', { name: 'Swap with Second Talk' }),

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -824,7 +824,7 @@ function segmentLabel(
     return `Assign to open slot ${seg.startTime} to ${seg.endTime}`
   }
   const title = seg.talk.talk?.title ?? seg.talk.placeholder ?? 'Untitled'
-  if (!placing) return `Move ${title}`
+  if (!placing) return `Options for ${title}`
   if (state === 'source') return `Cancel moving ${title}`
   return seg.kind === 'talk' ? `Swap with ${title}` : title
 }
@@ -1038,21 +1038,13 @@ function RailBody({ seg }: { seg: RailSegment }) {
 function PlacingBanner({
   placing,
   hasValidTarget,
-  onRemove,
-  onRename,
-  onDuration,
   onCancel,
 }: {
   placing: Placing
   hasValidTarget: boolean
-  onRemove: () => void
-  onRename: () => void
-  onDuration: () => void
   onCancel: () => void
 }) {
   const isProposal = placing.kind === 'proposal'
-  // A real service session has a placeholder; require it so a talk-less slot
-  // without one (defensively) never surfaces Rename/Duration.
   const isService =
     placing.kind === 'scheduled' &&
     !placing.talk.talk &&
@@ -1061,10 +1053,12 @@ function PlacingBanner({
     ? placing.proposal.title
     : (placing.talk.talk?.title ?? placing.talk.placeholder ?? 'Untitled')
 
+  // The banner is now purely the "choose where" step — move/swap/remove/edit
+  // are chosen up front in the card action sheet. So this only guides the drop.
   const message = isProposal
     ? `Placing “${title}” — tap an open slot`
     : isService
-      ? `Moving “${title}” — tap an open slot to move`
+      ? `Moving “${title}” — tap an open slot`
       : `Moving “${title}” — tap a slot to move, or a talk to swap`
 
   return (
@@ -1077,53 +1071,81 @@ function PlacingBanner({
         <p className="flex-1 text-sm font-medium text-blue-900 dark:text-blue-100">
           {message}
         </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex min-h-[44px] shrink-0 items-center gap-1.5 rounded-lg border border-blue-300 bg-white px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300 dark:hover:bg-blue-900/30"
+        >
+          <XMarkIcon className="h-4 w-4" />
+          Cancel
+        </button>
       </div>
       {!hasValidTarget && (
         <p className="mt-1 pl-7 text-xs text-blue-700 dark:text-blue-300">
           No room here — swipe to another track.
         </p>
       )}
-      <div className="mt-2 flex flex-wrap gap-2">
-        {placing.kind === 'scheduled' && (
-          <button
-            type="button"
-            onClick={onRemove}
-            className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-red-300 bg-white px-3 text-sm font-medium text-red-700 transition-colors hover:bg-red-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:border-red-800 dark:bg-gray-900 dark:text-red-300 dark:hover:bg-red-900/30"
-          >
-            <TrashIcon className="h-4 w-4" />
-            Remove
-          </button>
-        )}
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
+/* Card action sheet (tap a scheduled talk/service)                           */
+/* -------------------------------------------------------------------------- */
+
+function CardActionSheet({
+  talk,
+  onMove,
+  onRename,
+  onDuration,
+  onRemove,
+  onClose,
+}: {
+  talk: TrackTalk
+  onMove: () => void
+  onRename: () => void
+  onDuration: () => void
+  onRemove: () => void
+  onClose: () => void
+}) {
+  const isService = !talk.talk
+  const title = talk.talk?.title ?? talk.placeholder ?? 'Untitled'
+  const action =
+    'inline-flex min-h-[44px] w-full items-center justify-start gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+
+  return (
+    <BottomSheet title={title} onClose={onClose}>
+      <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
+        {talk.startTime}–{talk.endTime}
+        {isService ? ' · Service session' : ''}
+      </p>
+      <div className="space-y-2">
+        <button type="button" onClick={onMove} className={action}>
+          <ArrowsRightLeftIcon className="h-5 w-5" />
+          {isService ? 'Move to another slot' : 'Move or swap'}
+        </button>
         {isService && (
           <>
-            <button
-              type="button"
-              onClick={onRename}
-              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-blue-300 bg-white px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300 dark:hover:bg-blue-900/30"
-            >
-              <PencilIcon className="h-4 w-4" />
+            <button type="button" onClick={onRename} className={action}>
+              <PencilIcon className="h-5 w-5" />
               Rename
             </button>
-            <button
-              type="button"
-              onClick={onDuration}
-              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-blue-300 bg-white px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300 dark:hover:bg-blue-900/30"
-            >
-              <ArrowsUpDownIcon className="h-4 w-4" />
-              Duration
+            <button type="button" onClick={onDuration} className={action}>
+              <ArrowsUpDownIcon className="h-5 w-5" />
+              Change duration
             </button>
           </>
         )}
         <button
           type="button"
-          onClick={onCancel}
-          className="ml-auto inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-blue-300 bg-white px-3 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300 dark:hover:bg-blue-900/30"
+          onClick={onRemove}
+          className="inline-flex min-h-[44px] w-full items-center justify-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:border-red-900 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50"
         >
-          <XMarkIcon className="h-4 w-4" />
-          Cancel
+          <TrashIcon className="h-5 w-5" />
+          Remove from schedule
         </button>
       </div>
-    </div>
+    </BottomSheet>
   )
 }
 
@@ -1134,6 +1156,12 @@ function PlacingBanner({
 type ActiveSheet =
   | { kind: 'addService'; trackIndex: number }
   | { kind: 'unassigned'; context: SlotContext | null }
+  | {
+      kind: 'card'
+      trackIndex: number
+      talkIndex: number
+      talk: TrackTalk
+    }
   | {
       kind: 'serviceEdit'
       trackIndex: number
@@ -1288,8 +1316,11 @@ export function MobileScheduleView({
             },
           })
         } else {
-          setPlacing({
-            kind: 'scheduled',
+          // Tap a talk/break → a self-describing action sheet (Move/Swap for
+          // talks, Rename/Duration for services, Remove). Surfaces edit/remove
+          // that were previously hidden behind the placing banner.
+          setSheet({
+            kind: 'card',
             trackIndex: panelTrackIndex,
             talkIndex: seg.talkIndex,
             talk: seg.talk,
@@ -1384,30 +1415,6 @@ export function MobileScheduleView({
         segmentState(effPlacing, tracks, safeTrackIndex, seg) === 'valid',
     )
   }, [effPlacing, tracks, safeTrackIndex])
-
-  const removePlacing = useCallback(() => {
-    if (effPlacing?.kind !== 'scheduled') return
-    dispatch({
-      type: 'removeTalk',
-      trackIndex: effPlacing.trackIndex,
-      talkIndex: effPlacing.talkIndex,
-    })
-    setPlacing(null)
-  }, [effPlacing, dispatch])
-
-  const openServiceEdit = useCallback(
-    (mode: 'rename' | 'duration') => {
-      if (effPlacing?.kind !== 'scheduled') return
-      setSheet({
-        kind: 'serviceEdit',
-        trackIndex: effPlacing.trackIndex,
-        talkIndex: effPlacing.talkIndex,
-        talk: effPlacing.talk,
-        mode,
-      })
-    },
-    [effPlacing],
-  )
 
   const tabId = (i: number) => `sched-tab-${i}`
   const panelId = (i: number) => `sched-panel-${i}`
@@ -1557,9 +1564,6 @@ export function MobileScheduleView({
         <PlacingBanner
           placing={effPlacing}
           hasValidTarget={hasValidTargetHere}
-          onRemove={removePlacing}
-          onRename={() => openServiceEdit('rename')}
-          onDuration={() => openServiceEdit('duration')}
           onCancel={() => setPlacing(null)}
         />
       )}
@@ -1633,6 +1637,36 @@ export function MobileScheduleView({
           dispatch={dispatch}
           onPick={(proposal) => {
             setPlacing({ kind: 'proposal', proposal })
+            closeSheet()
+          }}
+          onClose={closeSheet}
+        />
+      )}
+
+      {sheet?.kind === 'card' && (
+        <CardActionSheet
+          talk={sheet.talk}
+          onMove={() => {
+            setPlacing({
+              kind: 'scheduled',
+              trackIndex: sheet.trackIndex,
+              talkIndex: sheet.talkIndex,
+              talk: sheet.talk,
+            })
+            closeSheet()
+          }}
+          onRename={() =>
+            setSheet({ ...sheet, kind: 'serviceEdit', mode: 'rename' })
+          }
+          onDuration={() =>
+            setSheet({ ...sheet, kind: 'serviceEdit', mode: 'duration' })
+          }
+          onRemove={() => {
+            dispatch({
+              type: 'removeTalk',
+              trackIndex: sheet.trackIndex,
+              talkIndex: sheet.talkIndex,
+            })
             closeSheet()
           }}
           onClose={closeSheet}


### PR DESCRIPTION
## Why

You flagged that **creating/editing service sessions felt unsupported** on mobile. They were wired, but **editing was hidden**: tapping a card silently entered "placing" mode and the Rename/Duration/Remove actions lived in the placing banner — nobody would find them.

## What

Tapping a scheduled talk/service now opens a **self-describing action sheet**:
- **Talk:** Move or swap · Remove from schedule
- **Service:** Move to another slot · **Rename** · **Change duration** · Remove from schedule

"Move or swap" enters the existing **pick-up → drop** flow (open slot = move, another talk = swap) — nothing regresses. The placing banner is now purely the "choose where" step (guidance + Cancel). Idle-tap aria-label is `Options for <title>`.

Create is unchanged (the "+ Service" button per track).

## Tests / QA
- Updated the flow tests + added a **service rename** test (options → Rename → save → `renameService`). 107 schedule tests green; tsc/eslint/prettier clean.
- **Visually inspected** the rendered sheets via `pnpm shoot` (screenshot shared with reviewer): service sheet shows Move/Rename/Change duration/Remove; talk sheet shows Move or swap/Remove.

Next (separate): restructure the crowded top toolbar — will bring layout options as `shoot` mockups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the hidden "enter placing mode then find the banner" edit flow on mobile with a self-describing **card action sheet** that opens immediately when a user taps a scheduled talk or service session. The `PlacingBanner` is now purely a "choose where to drop" guide with a single Cancel button.

- **`CardActionSheet` component added**: shows Move or swap / Rename / Change duration / Remove from schedule depending on whether the card is a talk or a service session. Transition from the card sheet to `serviceEdit` is done via a clean discriminated-union spread (`{ ...sheet, kind: 'serviceEdit', mode }`) which TypeScript validates correctly.
- **`PlacingBanner` simplified**: `onRemove`, `onRename`, and `onDuration` props removed; the Cancel button is now inline with the message rather than in a separate button row; the `removePlacing` and `openServiceEdit` callbacks in the main view are deleted.
- **Tests updated and extended**: four tests now exercise the new action-sheet path; a new test verifies the full card → Rename → Save → `renameService` dispatch chain for service sessions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the action sheet is additive, the removing/editing dispatch calls are identical to what the banner previously issued, and the state transitions are type-checked discriminated-union spreads with no data loss.

The change is well-scoped: the new CardActionSheet introduces no new reducer actions and reuses the existing ServiceEditSheet and placing flow unchanged. The talk snapshot stored in sheet state is used only for display and for correctly referencing trackIndex/talkIndex on dispatch, which is safe. The 107 passing tests and clean tsc/eslint/prettier run further support confidence in the change.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/MobileScheduleView.tsx | New CardActionSheet component wired correctly; PlacingBanner simplified; segmentLabel aria-label updated from 'Move …' to 'Options for …'; discriminated-union spread for card→serviceEdit transition is type-safe. |
| __tests__/components/admin/schedule/MobileScheduleView.test.tsx | All existing tests updated to go through the action-sheet path; new test covers service rename end-to-end; the Change duration path is not separately tested but its ServiceEditSheet logic is unchanged. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant RailCard as Rail Card Button
    participant CardSheet as CardActionSheet
    participant PlacingBanner
    participant ServiceEditSheet
    participant Reducer

    User->>RailCard: tap (idle)
    RailCard->>CardSheet: "setSheet({ kind: 'card', trackIndex, talkIndex, talk })"

    alt Move or Swap
        User->>CardSheet: tap "Move or swap"
        CardSheet->>PlacingBanner: "setPlacing({ kind: 'scheduled', … }) + closeSheet()"
        User->>RailCard: tap target slot / talk
        RailCard->>Reducer: moveTalk / swapTalks
        Reducer-->>PlacingBanner: setPlacing(null)
    else Rename (service only)
        User->>CardSheet: tap "Rename"
        CardSheet->>ServiceEditSheet: "setSheet({ …card, kind: 'serviceEdit', mode: 'rename' })"
        User->>ServiceEditSheet: edit title, tap Save
        ServiceEditSheet->>Reducer: renameService
        ServiceEditSheet->>ServiceEditSheet: onClose → setSheet(null)
    else Change Duration (service only)
        User->>CardSheet: tap "Change duration"
        CardSheet->>ServiceEditSheet: "setSheet({ …card, kind: 'serviceEdit', mode: 'duration' })"
        User->>ServiceEditSheet: pick duration, tap Save
        ServiceEditSheet->>Reducer: resizeService
        ServiceEditSheet->>ServiceEditSheet: onClose → setSheet(null)
    else Remove from schedule
        User->>CardSheet: tap "Remove from schedule"
        CardSheet->>Reducer: removeTalk
        CardSheet->>CardSheet: closeSheet()
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant RailCard as Rail Card Button
    participant CardSheet as CardActionSheet
    participant PlacingBanner
    participant ServiceEditSheet
    participant Reducer

    User->>RailCard: tap (idle)
    RailCard->>CardSheet: "setSheet({ kind: 'card', trackIndex, talkIndex, talk })"

    alt Move or Swap
        User->>CardSheet: tap "Move or swap"
        CardSheet->>PlacingBanner: "setPlacing({ kind: 'scheduled', … }) + closeSheet()"
        User->>RailCard: tap target slot / talk
        RailCard->>Reducer: moveTalk / swapTalks
        Reducer-->>PlacingBanner: setPlacing(null)
    else Rename (service only)
        User->>CardSheet: tap "Rename"
        CardSheet->>ServiceEditSheet: "setSheet({ …card, kind: 'serviceEdit', mode: 'rename' })"
        User->>ServiceEditSheet: edit title, tap Save
        ServiceEditSheet->>Reducer: renameService
        ServiceEditSheet->>ServiceEditSheet: onClose → setSheet(null)
    else Change Duration (service only)
        User->>CardSheet: tap "Change duration"
        CardSheet->>ServiceEditSheet: "setSheet({ …card, kind: 'serviceEdit', mode: 'duration' })"
        User->>ServiceEditSheet: pick duration, tap Save
        ServiceEditSheet->>Reducer: resizeService
        ServiceEditSheet->>ServiceEditSheet: onClose → setSheet(null)
    else Remove from schedule
        User->>CardSheet: tap "Remove from schedule"
        CardSheet->>Reducer: removeTalk
        CardSheet->>CardSheet: closeSheet()
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(schedule): mobile card action sheet..."](https://github.com/cloudnativebergen/website/commit/3566f2f16ebb31c62518ae76f41075f5de6a4680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45306352)</sub>

<!-- /greptile_comment -->