### PR TITLE
feat(schedule): compact 2-row mobile toolbar (day dropdown + action cluster)

### DIFF
--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -26,6 +26,7 @@ import {
   matchTalk,
   matchService,
 } from '@/lib/schedule/rules'
+import { formatConferenceDate } from '@/lib/time'
 import { buildTrackRail, type RailSegment } from './mobileRail'
 import { StatusBadge, LevelIndicator } from '@/lib/proposal'
 import { Status } from '@/lib/proposal/types'
@@ -48,7 +49,6 @@ import {
   ArrowsUpDownIcon,
   InboxStackIcon,
   ChevronDownIcon,
-  CheckIcon,
 } from '@heroicons/react/24/outline'
 
 interface MobileScheduleViewProps {
@@ -765,7 +765,9 @@ function UnassignedDrawer({
 /* -------------------------------------------------------------------------- */
 
 function dayLabel(schedule: ConferenceSchedule, index: number): string {
-  const date = new Date(schedule.date).toLocaleDateString('en-US', {
+  // Project convention: format YYYY-MM-DD via the shared, timezone-safe helper
+  // (no raw `new Date(date)` for display — see AGENTS.md).
+  const date = formatConferenceDate(schedule.date, {
     month: 'short',
     day: 'numeric',
   })
@@ -773,9 +775,11 @@ function dayLabel(schedule: ConferenceSchedule, index: number): string {
 }
 
 /**
- * Day selector as a compact dropdown (replaces the day-chip row). A single-day
- * schedule renders as static text. Frees a full row of top chrome and scales to
- * any number of days.
+ * Day selector (replaces the day-chip row). A single-day schedule renders as
+ * static text; multi-day uses a NATIVE styled <select> — this gives full
+ * keyboard + screen-reader support and the native mobile picker for free, with
+ * none of the focus/keyboard pitfalls of a hand-rolled listbox. Frees a full row
+ * of top chrome and scales to any number of days.
  */
 function DaySelect({
   schedules,
@@ -786,7 +790,6 @@ function DaySelect({
   currentDayIndex: number
   onSelect: (dayIndex: number) => void
 }) {
-  const [open, setOpen] = useState(false)
   const current = schedules[currentDayIndex]
 
   if (schedules.length <= 1) {
@@ -799,67 +802,22 @@ function DaySelect({
 
   return (
     <div className="relative min-w-0">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        className="inline-flex min-h-[44px] max-w-full items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+      <select
+        aria-label="Select day"
+        value={currentDayIndex}
+        onChange={(e) => onSelect(Number(e.target.value))}
+        className="min-h-[44px] max-w-full appearance-none truncate rounded-lg border border-gray-300 bg-white py-2 pr-9 pl-3 text-sm font-semibold text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
       >
-        <span className="truncate">
-          {current ? dayLabel(current, currentDayIndex) : 'Select day'}
-        </span>
-        <ChevronDownIcon className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
-      </button>
-      {open && (
-        <>
-          <button
-            type="button"
-            aria-hidden="true"
-            tabIndex={-1}
-            onClick={() => setOpen(false)}
-            className="fixed inset-0 z-30 cursor-default"
-          />
-          <ul
-            role="listbox"
-            aria-label="Select day"
-            className="absolute left-0 z-40 mt-1 w-60 max-w-[80vw] rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
-          >
-            {schedules.map((day, index) => {
-              const isActive = index === currentDayIndex
-              return (
-                <li key={`${index}-${day.date}`}>
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={isActive}
-                    onClick={() => {
-                      onSelect(index)
-                      setOpen(false)
-                    }}
-                    className={clsx(
-                      'flex min-h-[44px] w-full items-center gap-2 px-3 text-left text-sm transition-colors',
-                      isActive
-                        ? 'font-semibold text-blue-700 dark:text-blue-300'
-                        : 'text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700',
-                    )}
-                  >
-                    <CheckIcon
-                      className={clsx(
-                        'h-4 w-4 shrink-0',
-                        isActive
-                          ? 'text-blue-600 dark:text-blue-300'
-                          : 'invisible',
-                      )}
-                    />
-                    {dayLabel(day, index)}
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        </>
-      )}
+        {schedules.map((day, index) => (
+          <option key={`${index}-${day.date}`} value={index}>
+            {dayLabel(day, index)}
+          </option>
+        ))}
+      </select>
+      <ChevronDownIcon
+        aria-hidden="true"
+        className="pointer-events-none absolute top-1/2 right-2.5 h-4 w-4 -translate-y-1/2 text-gray-500 dark:text-gray-400"
+      />
     </div>
   )
 }

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -47,6 +47,8 @@ import {
   PencilIcon,
   ArrowsUpDownIcon,
   InboxStackIcon,
+  ChevronDownIcon,
+  CheckIcon,
 } from '@heroicons/react/24/outline'
 
 interface MobileScheduleViewProps {
@@ -762,6 +764,106 @@ function UnassignedDrawer({
 /* Legend disclosure                                                          */
 /* -------------------------------------------------------------------------- */
 
+function dayLabel(schedule: ConferenceSchedule, index: number): string {
+  const date = new Date(schedule.date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+  return `Day ${index + 1} · ${date}`
+}
+
+/**
+ * Day selector as a compact dropdown (replaces the day-chip row). A single-day
+ * schedule renders as static text. Frees a full row of top chrome and scales to
+ * any number of days.
+ */
+function DaySelect({
+  schedules,
+  currentDayIndex,
+  onSelect,
+}: {
+  schedules: ConferenceSchedule[]
+  currentDayIndex: number
+  onSelect: (dayIndex: number) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const current = schedules[currentDayIndex]
+
+  if (schedules.length <= 1) {
+    return (
+      <span className="min-w-0 truncate text-base font-semibold text-gray-900 dark:text-white">
+        {current ? dayLabel(current, currentDayIndex) : 'Schedule'}
+      </span>
+    )
+  }
+
+  return (
+    <div className="relative min-w-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className="inline-flex min-h-[44px] max-w-full items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+      >
+        <span className="truncate">
+          {current ? dayLabel(current, currentDayIndex) : 'Select day'}
+        </span>
+        <ChevronDownIcon className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
+      </button>
+      {open && (
+        <>
+          <button
+            type="button"
+            aria-hidden="true"
+            tabIndex={-1}
+            onClick={() => setOpen(false)}
+            className="fixed inset-0 z-30 cursor-default"
+          />
+          <ul
+            role="listbox"
+            aria-label="Select day"
+            className="absolute left-0 z-40 mt-1 w-60 max-w-[80vw] rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+          >
+            {schedules.map((day, index) => {
+              const isActive = index === currentDayIndex
+              return (
+                <li key={`${index}-${day.date}`}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isActive}
+                    onClick={() => {
+                      onSelect(index)
+                      setOpen(false)
+                    }}
+                    className={clsx(
+                      'flex min-h-[44px] w-full items-center gap-2 px-3 text-left text-sm transition-colors',
+                      isActive
+                        ? 'font-semibold text-blue-700 dark:text-blue-300'
+                        : 'text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700',
+                    )}
+                  >
+                    <CheckIcon
+                      className={clsx(
+                        'h-4 w-4 shrink-0',
+                        isActive
+                          ? 'text-blue-600 dark:text-blue-300'
+                          : 'invisible',
+                      )}
+                    />
+                    {dayLabel(day, index)}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}
+
 function LegendDisclosure() {
   const [open, setOpen] = useState(false)
   return (
@@ -1431,10 +1533,12 @@ export function MobileScheduleView({
       {/* Header */}
       <header className="shrink-0 border-b border-gray-200 bg-white px-4 pt-3 dark:border-gray-700 dark:bg-gray-900">
         <div className="flex items-center justify-between gap-2">
-          <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
-            Schedule
-          </h1>
-          <div className="flex items-center gap-1">
+          <DaySelect
+            schedules={schedules}
+            currentDayIndex={currentDayIndex}
+            onSelect={handleDayChange}
+          />
+          <div className="flex shrink-0 items-center gap-1">
             <button
               type="button"
               onClick={() => setSheet({ kind: 'unassigned', context: null })}
@@ -1469,38 +1573,6 @@ export function MobileScheduleView({
             </button>
           </div>
         </div>
-
-        {schedules.length > 1 && (
-          <div
-            className="-mx-4 mt-2 flex gap-1.5 overflow-x-auto px-4 pb-1"
-            role="group"
-            aria-label="Select day"
-          >
-            {schedules.map((day, index) => {
-              const isActive = index === currentDayIndex
-              const label = new Date(day.date).toLocaleDateString('en-US', {
-                month: 'short',
-                day: 'numeric',
-              })
-              return (
-                <button
-                  key={`${index}-${day.date}`}
-                  type="button"
-                  onClick={() => handleDayChange(index)}
-                  aria-pressed={isActive}
-                  className={clsx(
-                    'min-h-[44px] shrink-0 rounded-lg border px-3 py-1 text-sm font-medium whitespace-nowrap transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500',
-                    isActive
-                      ? 'border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
-                      : 'border-gray-300 bg-white text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300',
-                  )}
-                >
-                  Day {index + 1} · {label}
-                </button>
-              )
-            })}
-          </div>
-        )}
 
         {/* Fixed track tab strip (synced to the carousel below). */}
         {tracks.length > 0 ? (


### PR DESCRIPTION
## What

Restructures the crowded **3-row** mobile top toolbar into a compact **2-row** header (your pick, Option A):

- The `Schedule` title → a **day dropdown** (`DaySelect`). Single-day schedules render as static text; multi-day opens a listbox of days. This removes the separate day-chip row.
- A tight right-hand **action cluster**: Unassigned badge · Legend · Save.
- Track tabs unchanged (row 2).

Net: one fewer row of chrome → more vertical space for the rail.

## QA
- **Visually inspected** via `pnpm shoot` (screenshot shared): compact 2-row header; the day dropdown opens to `Day 1 / Day 2`.
- 16 schedule component/rail tests green; tsc/eslint/prettier clean.

Next (queued): (1) another adversarial architecture review of the editor; (2) investigate sharing more between the desktop & mobile views + ensuring feature parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the mobile schedule header from three rows to two by replacing the static `Schedule` title and the horizontal day-chip row with a single `DaySelect` dropdown. The action cluster (unassigned badge, legend, save) stays in the same row as the new dropdown.

- **New `DaySelect` component** renders either static text (single-day) or a floating listbox (multi-day), freeing a full row of chrome on mobile.
- **`dayLabel` helper** uses raw `new Date()` for display instead of `formatConferenceDate` from `src/lib/time.ts`, violating the project rule and introducing a UTC-offset date display bug.
- **Accessibility gaps**: the custom listbox has no Escape-key dismissal and no arrow-key navigation, which diverges from the WAI-ARIA listbox interaction model.

<h3>Confidence Score: 3/5</h3>

The mobile header restructuring is straightforward, but the new dayLabel helper will display wrong dates for any user whose browser timezone is behind UTC — a real display bug for an international admin audience.

The dayLabel function constructs a date label by passing the Sanity YYYY-MM-DD string directly to new Date(), which treats it as UTC midnight. Any organizer running a browser at UTC-1 or further west will see the day label show the previous calendar date. The project already has formatConferenceDate in src/lib/time.ts that parses components directly to avoid exactly this problem, and AGENTS.md explicitly bans raw new Date() for display — the fix is a one-liner once the import is added.

src/components/admin/schedule/MobileScheduleView.tsx — specifically the dayLabel helper and the DaySelect listbox keyboard handling.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/MobileScheduleView.tsx | Replaces the 3-row mobile header with a compact 2-row layout by introducing a DaySelect dropdown component; contains a timezone bug and rule violation in dayLabel (raw new Date() instead of formatConferenceDate), plus two accessibility gaps (no Escape handler, no arrow-key navigation on the listbox). |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MobileScheduleView (header row 1)"] --> B{schedules.length <= 1?}
    B -- Yes --> C["Static text span\n(dayLabel)"]
    B -- No --> D["DaySelect button\n(aria-haspopup=listbox)"]
    D -->|click| E{open?}
    E -- true --> F["Backdrop overlay (z-30)\n+ ul role=listbox (z-40)"]
    F -->|click option| G["onSelect(index)\nsetOpen(false)"]
    F -->|click backdrop| H["setOpen(false)"]
    E -- false --> I["Dropdown hidden"]
    D & C --> J["Action cluster\n(Unassigned · Legend · Save)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["MobileScheduleView (header row 1)"] --> B{schedules.length <= 1?}
    B -- Yes --> C["Static text span\n(dayLabel)"]
    B -- No --> D["DaySelect button\n(aria-haspopup=listbox)"]
    D -->|click| E{open?}
    E -- true --> F["Backdrop overlay (z-30)\n+ ul role=listbox (z-40)"]
    F -->|click option| G["onSelect(index)\nsetOpen(false)"]
    F -->|click backdrop| H["setOpen(false)"]
    E -- false --> I["Dropdown hidden"]
    D & C --> J["Action cluster\n(Unassigned · Legend · Save)"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(schedule): compact 2-row mobile too..."](https://github.com/cloudnativebergen/website/commit/e40d0d6c93cebf6341d85ca75b36364d1ee2f411) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45307344)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->