### PR TITLE
fix(schedule): dedup end-of-day/speaker/duration helpers + desktop day-label TZ bug

### DIFF
--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -8,8 +8,7 @@ import { getProposalDurationMinutes } from '@/lib/schedule/types'
 import { PIXELS_PER_MINUTE } from '@/lib/schedule/geometry'
 import { Topic } from '@/lib/topic/types'
 import { LevelIndicator, getLevelConfig } from '@/lib/proposal'
-import { formatSpeakerNames } from '@/lib/speaker/formatSpeakerNames'
-import type { Speaker } from '@/lib/speaker/types'
+import { populatedSpeakerNames } from '@/lib/speaker/formatSpeakerNames'
 import {
   ClockIcon,
   UserIcon,
@@ -72,26 +71,12 @@ export function DraggableProposal({
       else if (duration <= TALK_THRESHOLDS.MEDIUM) size = 'medium'
       else size = 'long'
 
-      const populatedSpeakers = Array.isArray(proposal.speakers)
-        ? (proposal.speakers.filter(
-            (s) =>
-              s &&
-              typeof s === 'object' &&
-              'name' in s &&
-              typeof s.name === 'string',
-          ) as Speaker[])
-        : []
-      const speaker =
-        populatedSpeakers.length > 0
-          ? formatSpeakerNames(populatedSpeakers)
-          : null
-
       return {
         dragType: type,
         durationMinutes: duration,
         talkSize: size,
         dragId: id,
-        speakerInfo: speaker,
+        speakerInfo: populatedSpeakerNames(proposal),
       }
     }, [proposal, sourceTrackIndex, sourceTimeSlot])
 

--- a/src/components/admin/schedule/HeaderSection.tsx
+++ b/src/components/admin/schedule/HeaderSection.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from 'react'
 import { ConferenceSchedule } from '@/lib/conference/types'
+import { formatConferenceDate } from '@/lib/time'
 import {
   PlusIcon,
   BookmarkIcon,
@@ -54,9 +55,11 @@ const HeaderSectionComponent = ({
         <div className="flex rounded-lg border border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-800">
           {schedules.map((daySchedule, index) => {
             const isActive = index === currentDayIndex
-            const dayDate = new Date(daySchedule.date)
             const dayLabel = `Day ${index + 1}`
-            const dateLabel = dayDate.toLocaleDateString('en-US', {
+            // Format the YYYY-MM-DD date via the shared, timezone-safe helper —
+            // a raw `new Date(date)` here is parsed as UTC midnight and can show
+            // the previous day in western timezones (see AGENTS.md).
+            const dateLabel = formatConferenceDate(daySchedule.date, {
               month: 'short',
               day: 'numeric',
             })

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -17,7 +17,9 @@ import {
   generateTimeSlots,
   getProposalDurationMinutes,
   toMinutes,
+  withinScheduleEnd,
 } from '@/lib/schedule/time'
+import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
 import {
   fitsInTrack,
   isTrackIntervalFree,
@@ -30,8 +32,7 @@ import { formatConferenceDate } from '@/lib/time'
 import { buildTrackRail, type RailSegment } from './mobileRail'
 import { StatusBadge, LevelIndicator } from '@/lib/proposal'
 import { Status } from '@/lib/proposal/types'
-import { formatSpeakerNames } from '@/lib/speaker/formatSpeakerNames'
-import type { Speaker } from '@/lib/speaker/types'
+import { populatedSpeakerNames } from '@/lib/speaker/formatSpeakerNames'
 import { Dropdown } from '@/components/Form'
 import { useProposalFilters } from './useProposalFilters'
 import { ProposalFilters } from './ProposalFilters'
@@ -63,17 +64,6 @@ interface MobileScheduleViewProps {
   saveSuccess: boolean
   error: string | null
 }
-
-const SERVICE_DURATION_OPTIONS = new Map([
-  ['5', '5 minutes'],
-  ['10', '10 minutes'],
-  ['15', '15 minutes'],
-  ['20', '20 minutes'],
-  ['30', '30 minutes'],
-  ['45', '45 minutes'],
-  ['60', '60 minutes'],
-  ['90', '90 minutes'],
-])
 
 const TAP_TARGET = 'min-h-[44px]'
 
@@ -109,9 +99,6 @@ function segmentHeight(seg: RailSegment): number {
     Math.max(SEG_MIN_HEIGHT, Math.round(seg.durationMin * PX_PER_MIN)),
   )
 }
-
-const withinEnd = (endTime: string): boolean =>
-  toMinutes(endTime) <= toMinutes(SCHEDULE_END)
 
 /* -------------------------------------------------------------------------- */
 /* Placement model                                                            */
@@ -175,7 +162,7 @@ function segmentState(
     if (placing.kind === 'proposal') {
       const dur = getProposalDurationMinutes(placing.proposal)
       const end = calculateEndTime(seg.startTime, dur)
-      return withinEnd(end) && fitsInTrack(target, seg.startTime, dur)
+      return withinScheduleEnd(end) && fitsInTrack(target, seg.startTime, dur)
         ? 'valid'
         : 'invalid'
     }
@@ -187,7 +174,8 @@ function segmentState(
       const exclude = sameTrack
         ? matchTalk(src.talk._id, src.startTime)
         : undefined
-      return withinEnd(end) && fitsInTrack(target, seg.startTime, dur, exclude)
+      return withinScheduleEnd(end) &&
+        fitsInTrack(target, seg.startTime, dur, exclude)
         ? 'valid'
         : 'invalid'
     }
@@ -196,7 +184,7 @@ function segmentState(
     const exclude = sameTrack
       ? matchService(src.placeholder ?? '', src.startTime)
       : undefined
-    return withinEnd(end) &&
+    return withinScheduleEnd(end) &&
       isTrackIntervalFree(target, seg.startTime, end, exclude)
       ? 'valid'
       : 'invalid'
@@ -213,7 +201,7 @@ function segmentState(
       getProposalDurationMinutes(src.talk!),
     )
     const ok =
-      withinEnd(draggedEnd) &&
+      withinScheduleEnd(draggedEnd) &&
       canSwapTalks(target, src.talk!, seg.talk, seg.startTime) &&
       canPlaceDisplacedBack(
         sourceTrack,
@@ -226,15 +214,6 @@ function segmentState(
 
   // `break` targets are never a valid drop.
   return 'invalid'
-}
-
-function speakerNamesOf(proposal: ProposalExisting): string | null {
-  const populated = Array.isArray(proposal.speakers)
-    ? (proposal.speakers.filter(
-        (s) => s && typeof s === 'object' && 'name' in s,
-      ) as Speaker[])
-    : []
-  return populated.length > 0 ? formatSpeakerNames(populated) : null
 }
 
 /** Every `intervalMinutes` start time whose full footprint is free in `track`. */
@@ -663,7 +642,8 @@ function UnassignedDrawer({
     return proposals.filter((p) => {
       const dur = getProposalDurationMinutes(p)
       if (dur > context.maxDurationMin) return false
-      if (!withinEnd(calculateEndTime(context.startTime, dur))) return false
+      if (!withinScheduleEnd(calculateEndTime(context.startTime, dur)))
+        return false
       return fitsInTrack(track, context.startTime, dur)
     })
   }, [proposals, context, track])
@@ -719,7 +699,7 @@ function UnassignedDrawer({
       ) : (
         <ul className="space-y-2">
           {filters.filteredProposals.map((proposal) => {
-            const speakers = speakerNamesOf(proposal)
+            const speakers = populatedSpeakerNames(proposal)
             return (
               <li key={proposal._id}>
                 <button
@@ -1060,7 +1040,7 @@ function RailBody({ seg }: { seg: RailSegment }) {
     )
   }
 
-  const speakers = proposal ? speakerNamesOf(proposal) : null
+  const speakers = proposal ? populatedSpeakerNames(proposal) : null
   return (
     <>
       <div className="flex items-start justify-between gap-2">

--- a/src/components/admin/schedule/track/ServiceSessionModal.tsx
+++ b/src/components/admin/schedule/track/ServiceSessionModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useState } from 'react'
 import { Dropdown } from '@/components/Form'
+import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
 
 interface ServiceSessionModalProps {
   isOpen: boolean
@@ -73,18 +74,7 @@ export const ServiceSessionModal = ({
             <Dropdown
               name="duration"
               label="Duration (minutes)"
-              options={
-                new Map([
-                  ['5', '5 minutes'],
-                  ['10', '10 minutes'],
-                  ['15', '15 minutes'],
-                  ['20', '20 minutes'],
-                  ['30', '30 minutes'],
-                  ['45', '45 minutes'],
-                  ['60', '60 minutes'],
-                  ['90', '90 minutes'],
-                ])
-              }
+              options={SERVICE_DURATION_OPTIONS}
               value={String(duration)}
               setValue={(val) => setDuration(Number(val))}
             />

--- a/src/lib/schedule/constants.ts
+++ b/src/lib/schedule/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Duration choices (value → label) offered when creating or resizing a service
+ * session. Shared by the desktop `ServiceSessionModal` and the mobile add/edit
+ * sheets so the option list stays in sync in one place.
+ */
+export const SERVICE_DURATION_OPTIONS = new Map([
+  ['5', '5 minutes'],
+  ['10', '10 minutes'],
+  ['15', '15 minutes'],
+  ['20', '20 minutes'],
+  ['30', '30 minutes'],
+  ['45', '45 minutes'],
+  ['60', '60 minutes'],
+  ['90', '90 minutes'],
+])

--- a/src/lib/schedule/operations.ts
+++ b/src/lib/schedule/operations.ts
@@ -16,9 +16,8 @@ import {
   isTrackIntervalFree,
   matchTalk,
   matchService,
-  toMinutes,
 } from './types'
-import { SCHEDULE_END } from './time'
+import { withinScheduleEnd } from './time'
 
 /**
  * Pure schedule transforms, lifted verbatim (behaviour-preserving) from the old
@@ -38,16 +37,6 @@ export interface OperationResult {
 
 const sortByStart = (a: TrackTalk, b: TrackTalk): number =>
   a.startTime.localeCompare(b.startTime)
-
-/**
- * Does a placement ending at `endTime` fit within the schedule's end-of-day
- * bound? Nothing may extend past {@link SCHEDULE_END}; without this guard an item
- * dropped/created/resized near the bottom of the grid renders below it. Shared by
- * move/create/resize so the rule lives in one place.
- */
-function withinScheduleEnd(endTime: string): boolean {
-  return toMinutes(endTime) <= toMinutes(SCHEDULE_END)
-}
 
 /**
  * Swap the dragged talk with the talk occupying the target slot. Pure port of

--- a/src/lib/schedule/time.ts
+++ b/src/lib/schedule/time.ts
@@ -64,6 +64,16 @@ export function durationBetween(start: string, end: string): number {
 }
 
 /**
+ * Does a placement ending at `endTime` fit within the schedule's end-of-day
+ * bound? Nothing may extend past {@link SCHEDULE_END}. Shared by the pure
+ * operations and the mobile placement UI so the end-of-day rule lives in one
+ * place.
+ */
+export function withinScheduleEnd(endTime: string): boolean {
+  return toMinutes(endTime) <= toMinutes(SCHEDULE_END)
+}
+
+/**
  * Do intervals `[start1,end1)` and `[start2,end2)` overlap? Strict `<`, so items
  * that merely touch at a boundary (one ends exactly when the next begins) do NOT
  * overlap.

--- a/src/lib/speaker/formatSpeakerNames.ts
+++ b/src/lib/speaker/formatSpeakerNames.ts
@@ -1,4 +1,4 @@
-import { Speaker } from './types'
+import type { Speaker } from './types'
 import type { ProposalExisting } from '@/lib/proposal/types'
 
 /**

--- a/src/lib/speaker/formatSpeakerNames.ts
+++ b/src/lib/speaker/formatSpeakerNames.ts
@@ -1,4 +1,27 @@
 import { Speaker } from './types'
+import type { ProposalExisting } from '@/lib/proposal/types'
+
+/**
+ * Speaker names for a proposal, or `null` when none are populated. Filters
+ * `proposal.speakers` down to fully-populated speaker objects (a reference that
+ * wasn't expanded has no `name`) before formatting. Shared by the schedule
+ * editor's desktop card and mobile rail so the populated-speaker filtering lives
+ * in one place.
+ */
+export function populatedSpeakerNames(
+  proposal: ProposalExisting,
+): string | null {
+  const populated = Array.isArray(proposal.speakers)
+    ? (proposal.speakers.filter(
+        (s) =>
+          s &&
+          typeof s === 'object' &&
+          'name' in s &&
+          typeof s.name === 'string',
+      ) as Speaker[])
+    : []
+  return populated.length > 0 ? formatSpeakerNames(populated) : null
+}
 
 export function formatSpeakerNames(speakers: Speaker[]): string {
   if (speakers.length === 0) return ''


### PR DESCRIPTION
Small, low-risk cleanup for the schedule editor: one bug fix plus three de-duplications. Behavior is preserved except for the timezone bug fix.

## Changes

1. **Bug: desktop day-label timezone off-by-one.** `HeaderSection.tsx` formatted each day button's `YYYY-MM-DD` date with raw `new Date(date).toLocaleDateString('en-US', …)`, which parses the string as UTC midnight and can render the previous day in western timezones. Now uses the shared timezone-safe `formatConferenceDate(date, { month: 'short', day: 'numeric' })` from `@/lib/time` (AGENTS.md forbids raw `new Date()` for display). Same visible label; correct date.

2. **Dedup end-of-day guard.** `withinScheduleEnd(endTime)` was defined identically in `operations.ts` and in `MobileScheduleView.tsx` (as `withinEnd`). Hoisted one canonical version into `src/lib/schedule/time.ts`; both now import it.

3. **Dedup speaker-name extraction.** The "filter to populated speakers, then `formatSpeakerNames`" logic lived both in `MobileScheduleView`'s `speakerNamesOf` and inline in `DraggableProposal`. Extracted `populatedSpeakerNames(proposal): string | null` into `src/lib/speaker/formatSpeakerNames.ts`; both call sites now use it. Uses the stricter `typeof s.name === 'string'` filter (superset of the two originals).

4. **Dedup `SERVICE_DURATION_OPTIONS`.** The identical duration `Map` was defined in `MobileScheduleView.tsx` and inline in `ServiceSessionModal.tsx`. Hoisted one shared constant into `src/lib/schedule/constants.ts`.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run __tests__/lib/schedule/ __tests__/components/admin/schedule/` — 8 files, 107 tests passed
- `npx eslint` on all touched files — clean
- `npx prettier --check` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a timezone off-by-one bug in the desktop day-label and de-duplicates three helpers (`withinScheduleEnd`, `populatedSpeakerNames`, `SERVICE_DURATION_OPTIONS`) that were previously copy-pasted across two or more files each. All behaviour is preserved except for the intentional timezone correction in `HeaderSection`.

- **Timezone fix** (`HeaderSection.tsx`): `new Date(date).toLocaleDateString` parsed `YYYY-MM-DD` as UTC midnight and could display the previous calendar day for users in western timezones; replaced with the existing `formatConferenceDate` helper which splits the string directly and forces `Europe/Oslo` display, matching AGENTS.md guidance.
- **Three de-duplications**: `withinScheduleEnd` promoted to `src/lib/schedule/time.ts` (exported), `populatedSpeakerNames` extracted to `src/lib/speaker/formatSpeakerNames.ts` (uses the stricter `typeof s.name === 'string'` guard that `DraggableProposal` already had), and `SERVICE_DURATION_OPTIONS` moved to a new `src/lib/schedule/constants.ts` — all original call sites updated to import from the single source.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the bug fix is correct and all three de-duplications are behaviour-preserving refactors.

The timezone fix correctly replaces UTC-midnight parsing with the project's established formatConferenceDate helper. Each de-duplication replaces local copies with the canonical shared version using identical logic (or a strictly safer filter in the speaker-name case). No new runtime branches, no schema changes, and the verification checklist (typecheck, 107 tests, lint, format) was run clean.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/HeaderSection.tsx | Replaces UTC-midnight new Date(date).toLocaleDateString with formatConferenceDate, fixing the off-by-one day in western timezones. |
| src/lib/schedule/time.ts | Adds exported withinScheduleEnd helper, hoisted from the private version in operations.ts; no logic change. |
| src/lib/speaker/formatSpeakerNames.ts | Adds populatedSpeakerNames, extracted from both consumers; uses the stricter typeof s.name === 'string' guard (superset of the two originals). |
| src/lib/schedule/constants.ts | New file exporting the shared SERVICE_DURATION_OPTIONS Map, previously duplicated in MobileScheduleView and ServiceSessionModal. |
| src/components/admin/schedule/MobileScheduleView.tsx | Removes local duplicates (withinEnd, speakerNamesOf, SERVICE_DURATION_OPTIONS) and replaces all call sites with the shared imports. |
| src/lib/schedule/operations.ts | Removes now-redundant private withinScheduleEnd and imports the canonical version from ./time; all callers unaffected. |
| src/components/admin/schedule/DraggableProposal.tsx | Replaces the inline populated-speakers filter + formatSpeakerNames call with populatedSpeakerNames; behavior is identical (used the stricter filter already). |
| src/components/admin/schedule/track/ServiceSessionModal.tsx | Replaces inline new Map([...]) with the shared SERVICE_DURATION_OPTIONS constant. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): dedup end-of-day/speaker/..."](https://github.com/cloudnativebergen/website/commit/89563d72901a943c8b29d52c7b5a283955ef9c63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45311896)</sub>

<!-- /greptile_comment -->