### PR TITLE
test(schedule): unit tests for saveScheduleToSanity (security scope, conflict, ghost-drop)

### DIFF
--- a/__tests__/lib/schedule/sanity.test.ts
+++ b/__tests__/lib/schedule/sanity.test.ts
@@ -1,0 +1,373 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the schedule SAVE data layer (src/lib/schedule/sanity.ts).
+ *
+ * This is the highest-stakes code in the schedule feature: it is the only place
+ * a client-supplied `schedule._id` becomes a Sanity write. The tRPC test
+ * (__tests__/api/trpc/schedule.test.ts) only exercises the router with this
+ * module MOCKED, so the behaviours below — the security scope check, optimistic
+ * concurrency, the atomic create transaction, and ghost-slot dropping — are
+ * otherwise untested. Here `@/lib/sanity/client` is mocked so we assert exactly
+ * what is (and is not) written for each case.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Deterministic key generation so assertions on serialized payloads don't
+// depend on nanoid randomness. References keep their real (trivial) shape.
+vi.mock('@/lib/sanity/helpers', () => ({
+  generateKey: (prefix = 'item') => `${prefix}-key`,
+  createReference: (id: string) => ({ _type: 'reference', _ref: id }),
+  createReferenceWithKey: (id: string, prefix = 'ref') => ({
+    _type: 'reference',
+    _ref: id,
+    _key: `${prefix}-key`,
+  }),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    fetch: vi.fn(),
+    patch: vi.fn(),
+    transaction: vi.fn(),
+  },
+}))
+
+import { clientWrite } from '@/lib/sanity/client'
+import { saveScheduleToSanity, getValidTalkIds } from '@/lib/schedule/sanity'
+import type { ConferenceSchedule } from '@/lib/conference/types'
+import type { Conference } from '@/lib/conference/types'
+
+const conference = { _id: 'conf-1', title: 'CND 2026' } as unknown as Conference
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asAny = (x: unknown) => x as any
+
+// The real `clientWrite.fetch` is heavily overloaded; view the mock through a
+// loose shape so per-test `mockResolvedValue` / `mock.calls` reads stay simple.
+type LooseMock = ReturnType<typeof vi.fn>
+const mockClient = clientWrite as unknown as {
+  fetch: LooseMock
+  patch: LooseMock
+  transaction: LooseMock
+}
+
+/**
+ * A chainable Sanity patch-builder mock. `patch()`, `ifRevisionId()` and
+ * `set()` all return the same object so both the with-`_rev` and without-`_rev`
+ * paths chain cleanly; `commit` is configurable per test.
+ */
+function installPatch(commit: () => Promise<unknown>) {
+  const builder = {
+    ifRevisionId: vi.fn((_rev?: unknown) => builder),
+    set: vi.fn((_value?: unknown) => builder),
+    commit: vi.fn(commit),
+  }
+  mockClient.patch.mockReturnValue(builder)
+  return builder
+}
+
+/**
+ * A chainable Sanity transaction mock. The conference-link `patch(id, fn)` call
+ * receives a builder function; we invoke it against a captured patch object so
+ * the append can be asserted.
+ */
+function installTransaction(commit: () => Promise<unknown> = async () => ({})) {
+  const confPatch = {
+    setIfMissing: vi.fn((_value?: unknown) => confPatch),
+    append: vi.fn((_field?: unknown, _items?: unknown) => confPatch),
+  }
+  const tx = {
+    create: vi.fn((_doc?: unknown) => tx),
+    patch: vi.fn((_id: string, fn?: (p: typeof confPatch) => unknown) => {
+      if (fn) fn(confPatch)
+      return tx
+    }),
+    commit: vi.fn(commit),
+  }
+  mockClient.transaction.mockReturnValue(tx)
+  return { tx, confPatch }
+}
+
+const track = (talks: ConferenceSchedule['tracks'][number]['talks']) => ({
+  trackTitle: 'Track A',
+  trackDescription: '',
+  talks,
+})
+
+const updateDay = (
+  overrides: Partial<ConferenceSchedule> = {},
+): ConferenceSchedule => ({
+  _id: 'sched-1',
+  _rev: 'rev-1',
+  date: '2026-06-15',
+  tracks: [
+    track([
+      {
+        talk: asAny({ _id: 'talk-1' }),
+        startTime: '09:00',
+        endTime: '09:30',
+      },
+    ]),
+  ],
+  ...overrides,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('saveScheduleToSanity — security scope check (update path)', () => {
+  const REJECT = 'Schedule not found or not accessible'
+
+  it('rejects when the target id does not exist (fetch → null) without writing', async () => {
+    mockClient.fetch.mockResolvedValue(null)
+    const patch = installPatch(async () => ({ _rev: 'new' }))
+
+    const result = await saveScheduleToSanity(updateDay(), conference)
+
+    expect(result).toEqual({ error: REJECT })
+    expect(clientWrite.patch).not.toHaveBeenCalled()
+    expect(patch.commit).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the target document is not a schedule without writing', async () => {
+    mockClient.fetch.mockResolvedValue({
+      _type: 'talk',
+      conferenceRef: 'conf-1',
+    })
+    const patch = installPatch(async () => ({ _rev: 'new' }))
+
+    const result = await saveScheduleToSanity(updateDay(), conference)
+
+    expect(result).toEqual({ error: REJECT })
+    expect(clientWrite.patch).not.toHaveBeenCalled()
+    expect(patch.commit).not.toHaveBeenCalled()
+  })
+
+  it('rejects a cross-conference target without writing', async () => {
+    mockClient.fetch.mockResolvedValue({
+      _type: 'schedule',
+      conferenceRef: 'conf-OTHER',
+    })
+    const patch = installPatch(async () => ({ _rev: 'new' }))
+
+    const result = await saveScheduleToSanity(updateDay(), conference)
+
+    expect(result).toEqual({ error: REJECT })
+    expect(clientWrite.patch).not.toHaveBeenCalled()
+    expect(patch.commit).not.toHaveBeenCalled()
+  })
+
+  it('returns the SAME generic message for all three reject reasons (no existence probe)', async () => {
+    const messages: (string | undefined)[] = []
+    for (const target of [
+      null,
+      { _type: 'talk', conferenceRef: 'conf-1' },
+      { _type: 'schedule', conferenceRef: 'conf-OTHER' },
+    ]) {
+      mockClient.fetch.mockResolvedValue(target)
+      installPatch(async () => ({ _rev: 'new' }))
+      const result = await saveScheduleToSanity(updateDay(), conference)
+      messages.push(result.error)
+    }
+    expect(messages).toEqual([REJECT, REJECT, REJECT])
+  })
+})
+
+describe('saveScheduleToSanity — update happy path', () => {
+  beforeEach(() => {
+    mockClient.fetch.mockResolvedValue({
+      _type: 'schedule',
+      conferenceRef: 'conf-1',
+    })
+  })
+
+  it('patches a valid target with ifRevisionId + set + commit and threads the new _rev back', async () => {
+    const patch = installPatch(async () => ({ _rev: 'new' }))
+
+    const result = await saveScheduleToSanity(updateDay(), conference)
+
+    expect(clientWrite.patch).toHaveBeenCalledWith('sched-1')
+    expect(patch.ifRevisionId).toHaveBeenCalledWith('rev-1')
+
+    const setArg = patch.set.mock.calls[0][0] as {
+      date: string
+      tracks: unknown[]
+    }
+    expect(setArg.date).toBe('2026-06-15')
+    expect(Array.isArray(setArg.tracks)).toBe(true)
+
+    expect(patch.commit).toHaveBeenCalledTimes(1)
+    expect(result.error).toBeUndefined()
+    expect(result.schedule?._rev).toBe('new')
+    expect(result.schedule?._id).toBe('sched-1')
+  })
+
+  it('skips ifRevisionId when the schedule carries no _rev (unconditional write)', async () => {
+    const patch = installPatch(async () => ({ _rev: 'new' }))
+
+    const result = await saveScheduleToSanity(
+      updateDay({ _rev: undefined }),
+      conference,
+    )
+
+    expect(patch.ifRevisionId).not.toHaveBeenCalled()
+    expect(patch.set).toHaveBeenCalledTimes(1)
+    expect(patch.commit).toHaveBeenCalledTimes(1)
+    expect(result.schedule?._rev).toBe('new')
+  })
+})
+
+describe('saveScheduleToSanity — optimistic concurrency', () => {
+  beforeEach(() => {
+    mockClient.fetch.mockResolvedValue({
+      _type: 'schedule',
+      conferenceRef: 'conf-1',
+    })
+  })
+
+  it('maps a 409 statusCode from commit to a distinct conflict result', async () => {
+    const patch = installPatch(async () => {
+      throw Object.assign(new Error('Conflict'), { statusCode: 409 })
+    })
+
+    const result = await saveScheduleToSanity(updateDay(), conference)
+
+    expect(result.conflict).toBe(true)
+    expect(result.error).toBeTruthy()
+    expect(result.schedule).toBeUndefined()
+    expect(patch.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps a revision-mismatch message from commit to a conflict result', async () => {
+    installPatch(async () => {
+      throw new Error('The revision id does not match (mismatch)')
+    })
+
+    const result = await saveScheduleToSanity(updateDay(), conference)
+
+    expect(result.conflict).toBe(true)
+  })
+
+  it('a non-concurrency error is a generic error, not a conflict', async () => {
+    installPatch(async () => {
+      throw new Error('network down')
+    })
+
+    const result = await saveScheduleToSanity(updateDay(), conference)
+
+    expect(result.conflict).toBeUndefined()
+    expect(result.error).toBe('network down')
+  })
+})
+
+describe('saveScheduleToSanity — create path (no _id)', () => {
+  it('runs one atomic transaction: create schedule + append conference link, then reads back _rev', async () => {
+    const { tx, confPatch } = installTransaction()
+    mockClient.fetch.mockResolvedValue({ _rev: 'created-rev' })
+
+    const newDay = updateDay({ _id: '', _rev: undefined })
+    const result = await saveScheduleToSanity(newDay, conference)
+
+    // Exactly one transaction, committed once. No standalone patch() write.
+    expect(clientWrite.transaction).toHaveBeenCalledTimes(1)
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+    expect(clientWrite.patch).not.toHaveBeenCalled()
+
+    // The created doc is a schedule for this conference with a generated id.
+    const created = tx.create.mock.calls[0][0] as {
+      _id: string
+      _type: string
+      conference: { _ref: string }
+    }
+    expect(created._type).toBe('schedule')
+    expect(typeof created._id).toBe('string')
+    expect(created._id.length).toBeGreaterThan(0)
+    expect(created.conference._ref).toBe('conf-1')
+
+    // The conference link is appended to `schedules` as a keyed reference to the
+    // SAME new id.
+    expect(tx.patch).toHaveBeenCalledWith('conf-1', expect.any(Function))
+    expect(confPatch.setIfMissing).toHaveBeenCalledWith({ schedules: [] })
+    const appendArgs = confPatch.append.mock.calls[0]
+    expect(appendArgs[0]).toBe('schedules')
+    expect(appendArgs[1]).toEqual([
+      expect.objectContaining({ _ref: created._id, _type: 'reference' }),
+    ])
+
+    // The result carries the generated id and the read-back revision.
+    expect(result.schedule?._id).toBe(created._id)
+    expect(result.schedule?._rev).toBe('created-rev')
+  })
+})
+
+describe('saveScheduleToSanity — ghost-slot drop', () => {
+  beforeEach(() => {
+    mockClient.fetch.mockResolvedValue({
+      _type: 'schedule',
+      conferenceRef: 'conf-1',
+    })
+  })
+
+  it('drops a slot with neither talk nor placeholder while keeping real refs and placeholders', async () => {
+    const patch = installPatch(async () => ({ _rev: 'new' }))
+
+    const day = updateDay({
+      tracks: [
+        track([
+          { talk: asAny({ _id: 't1' }), startTime: '09:00', endTime: '09:25' },
+          // ghost slot: no talk, no placeholder — must be dropped.
+          { startTime: '10:00', endTime: '10:25' } as never,
+          { placeholder: 'Lunch', startTime: '12:00', endTime: '13:00' },
+        ]),
+      ],
+    })
+
+    await saveScheduleToSanity(day, conference)
+
+    const setArg = patch.set.mock.calls[0][0] as {
+      tracks: Array<{ talks: Array<Record<string, unknown>> }>
+    }
+    const talks = setArg.tracks[0].talks
+
+    expect(talks).toHaveLength(2)
+    // The real talk ref is preserved.
+    expect(talks[0]).toMatchObject({
+      talk: { _ref: 't1', _type: 'reference' },
+      startTime: '09:00',
+    })
+    // The placeholder is preserved.
+    expect(talks[1]).toMatchObject({ placeholder: 'Lunch', startTime: '12:00' })
+    // Nothing timed at 10:00 (the ghost) survives.
+    expect(talks.some((t) => t.startTime === '10:00')).toBe(false)
+  })
+})
+
+describe('getValidTalkIds', () => {
+  it('queries talk ids scoped to the conference and returns them as a Set', async () => {
+    mockClient.fetch.mockResolvedValue(['talk-1', 'talk-2'])
+
+    const ids = await getValidTalkIds('conf-1')
+
+    expect(ids).toBeInstanceOf(Set)
+    expect([...ids].sort()).toEqual(['talk-1', 'talk-2'])
+
+    const [query, params] = mockClient.fetch.mock.calls[0]
+    expect(query).toContain('_type == "talk"')
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(params).toEqual({ conferenceId: 'conf-1' })
+  })
+
+  it('returns an empty Set when the query yields nothing (null)', async () => {
+    mockClient.fetch.mockResolvedValue(null)
+
+    const ids = await getValidTalkIds('conf-1')
+
+    expect(ids).toBeInstanceOf(Set)
+    expect(ids.size).toBe(0)
+  })
+})

--- a/__tests__/lib/schedule/sanity.test.ts
+++ b/__tests__/lib/schedule/sanity.test.ts
@@ -11,7 +11,7 @@
  * otherwise untested. Here `@/lib/sanity/client` is mocked so we assert exactly
  * what is (and is not) written for each case.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Deterministic key generation so assertions on serialized payloads don't
 // depend on nanoid randomness. References keep their real (trivial) shape.
@@ -118,6 +118,11 @@ beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(() => {})
   vi.spyOn(console, 'warn').mockImplementation(() => {})
   vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  // Restore the console spies so they don't stack across tests.
+  vi.restoreAllMocks()
 })
 
 describe('saveScheduleToSanity — security scope check (update path)', () => {
@@ -295,8 +300,14 @@ describe('saveScheduleToSanity — create path (no _id)', () => {
     expect(confPatch.setIfMissing).toHaveBeenCalledWith({ schedules: [] })
     const appendArgs = confPatch.append.mock.calls[0]
     expect(appendArgs[0]).toBe('schedules')
+    // A keyed reference (createReferenceWithKey) — array items MUST carry a
+    // `_key`, so assert it, not just the `_ref`.
     expect(appendArgs[1]).toEqual([
-      expect.objectContaining({ _ref: created._id, _type: 'reference' }),
+      expect.objectContaining({
+        _ref: created._id,
+        _type: 'reference',
+        _key: 'schedule-key',
+      }),
     ])
 
     // The result carries the generated id and the read-back revision.


### PR DESCRIPTION
Adds a direct unit suite for `src/lib/schedule/sanity.ts` — the schedule SAVE data layer. This is the only place a client-supplied `schedule._id` becomes a Sanity write, and it previously had no direct test (only indirectly via the tRPC test, which mocks this module out entirely).

`@/lib/sanity/client` (`clientWrite`) and `@/lib/sanity/helpers` are mocked so each test asserts exactly what is — and is not — written.

## Coverage (13 cases)

- **Security scope check (update path):** when `schedule._id` is set, `saveScheduleToSanity` first fetches `{_type, conferenceRef}` and MUST reject with the generic `{ error: 'Schedule not found or not accessible' }` and perform NO write when the target (a) doesn't exist, (b) isn't a `schedule`, or (c) belongs to another conference. Also asserts the SAME message for all three so a caller can't probe document existence.
- **Update happy path:** valid target patches with `.ifRevisionId(_rev)` + `.set({date, tracks})` + `.commit()`, and threads the NEW `_rev` back into the result. Also covers the no-`_rev` unconditional-write path (no `ifRevisionId`).
- **Optimistic concurrency:** a 409 `statusCode` and a "revision mismatch" message both map to `{ conflict: true }` (distinct from a generic error); an unrelated error stays a generic error.
- **Create path (no `_id`):** runs ONE atomic transaction — `.create(newDoc)` (generated id + `_type:'schedule'` + conference ref) plus a keyed reference appended to the conference `schedules` array — then reads back `_rev`; result carries the new `_id` and `_rev`.
- **Ghost-slot drop:** a slot with neither a `talk` nor a `placeholder` is filtered out of the serialized `tracks`, while real talk refs and placeholders are kept.
- **`getValidTalkIds`:** queries talks scoped to `conference._ref == $conferenceId` and returns a `Set` (empty on null).

Tests only — no source changes.

## Verification

- `npx vitest run __tests__/lib/schedule/sanity.test.ts` → 13 passed
- `npx tsc --noEmit` → 0 errors
- `npx prettier --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a direct unit suite for `src/lib/schedule/sanity.ts`, filling a gap left by the tRPC integration tests which mock this module entirely. The 13 test cases cover the security-critical paths (scope check, cross-conference rejection, optimistic concurrency) as well as the atomic create transaction and ghost-slot filtering.

- **Security scope tests** assert that all three rejection reasons (missing doc, wrong `_type`, wrong conference) return the same generic error and perform no write — directly testing the anti-probing invariant that was previously uncovered.
- **Optimistic concurrency** verifies both the 409 `statusCode` and the Sanity \"revision mismatch\" error message map to `{ conflict: true }`, while unrelated errors stay generic.
- **Create path** verifies the single atomic transaction (`.create()` + `.patch()` in one `.commit()`) and the subsequent `_rev` read-back, guarding against the orphaned-schedule regression fixed in the source.

<h3>Confidence Score: 4/5</h3>

Test-only PR adding direct coverage for security-critical and concurrency-sensitive write paths; no source changes, safe to merge.

The suite correctly exercises the three security rejection branches, the atomic create transaction, and the two conflict signals, each with meaningful write-suppression assertions. Two tests have narrower assertions than their sibling cases — the revision-mismatch test omits the error and schedule checks present in the 409 test, and the update happy path only verifies tracks is an array rather than checking track structure. Neither gap hides a current defect, but they leave small regression blind spots.

No files require special attention beyond the minor assertion gaps noted in the review comments.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| __tests__/lib/schedule/sanity.test.ts | New test file with 13 cases covering security scope check, optimistic concurrency, atomic create transaction, ghost-slot dropping, and getValidTalkIds; minor completeness gaps in two assertions. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[saveScheduleToSanity called] --> B{schedule._id set?}
    B -- No --> C[Generate randomUUID]
    C --> D[Build newScheduleDoc]
    D --> E[transaction.create + patch.append]
    E --> F[transaction.commit]
    F --> G[fetch read-back _rev]
    G --> H[return schedule with new _id + _rev]
    B -- Yes --> I[fetch target doc]
    I --> J{target valid?}
    J -- null / wrong type / wrong conf --> K[return error]
    J -- Valid --> L[clientWrite.patch _id]
    L --> M{schedule._rev?}
    M -- Yes --> N[patch.ifRevisionId _rev]
    M -- No --> O[skip ifRevisionId]
    N --> P[patch.set date + tracks]
    O --> P
    P --> Q[patch.commit]
    Q --> R{Revision mismatch?}
    R -- Yes --> S[return conflict: true + error]
    R -- No error --> T[return schedule with new _rev]
    R -- Other error --> U[return generic error]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[saveScheduleToSanity called] --> B{schedule._id set?}
    B -- No --> C[Generate randomUUID]
    C --> D[Build newScheduleDoc]
    D --> E[transaction.create + patch.append]
    E --> F[transaction.commit]
    F --> G[fetch read-back _rev]
    G --> H[return schedule with new _id + _rev]
    B -- Yes --> I[fetch target doc]
    I --> J{target valid?}
    J -- null / wrong type / wrong conf --> K[return error]
    J -- Valid --> L[clientWrite.patch _id]
    L --> M{schedule._rev?}
    M -- Yes --> N[patch.ifRevisionId _rev]
    M -- No --> O[skip ifRevisionId]
    N --> P[patch.set date + tracks]
    O --> P
    P --> Q[patch.commit]
    Q --> R{Revision mismatch?}
    R -- Yes --> S[return conflict: true + error]
    R -- No error --> T[return schedule with new _rev]
    R -- Other error --> U[return generic error]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(schedule): unit tests for saveSched..."](https://github.com/cloudnativebergen/website/commit/acec7c92c3b098a07f4f0b5a50db8d3969b5c2fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45311977)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->