### PR TITLE
feat(schedule): mobile parity — track rename/remove + service duplicate + top spacing

### DIFF
--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -350,7 +350,11 @@ describe('MobileScheduleView', () => {
         name: 'Remove track',
       }),
     )
-    // confirm step
+    // No removal yet — the menu button only opens the confirm step.
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'removeTrack' }),
+    )
+    // Confirm.
     fireEvent.click(
       within(screen.getByRole('dialog')).getByRole('button', {
         name: 'Remove',

--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -311,4 +311,106 @@ describe('MobileScheduleView', () => {
       }),
     )
   })
+
+  it('renames a track (preserving its talks) via track options', () => {
+    const { dispatch } = setup()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Track options' })[0])
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Rename track',
+      }),
+    )
+    const sheet = screen.getByRole('dialog')
+    fireEvent.change(within(sheet).getByLabelText('Track name'), {
+      target: { value: 'Keynote Hall' },
+    })
+    fireEvent.click(within(sheet).getByRole('button', { name: 'Save' }))
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'updateTrack',
+        trackIndex: 0,
+        track: expect.objectContaining({
+          trackTitle: 'Keynote Hall',
+          // talks must be preserved on rename
+          talks: expect.arrayContaining([
+            expect.objectContaining({
+              talk: expect.objectContaining({ _id: 'scheduled-1' }),
+            }),
+          ]),
+        }),
+      }),
+    )
+  })
+
+  it('removes a track only after the confirm step', () => {
+    const { dispatch } = setup()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Track options' })[0])
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Remove track',
+      }),
+    )
+    // confirm step
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Remove',
+      }),
+    )
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'removeTrack',
+      trackIndex: 0,
+    })
+  })
+
+  it('duplicates a service to all tracks from the card sheet', () => {
+    const dispatch = vi.fn()
+    const withService: ConferenceSchedule = {
+      _id: 'day-1',
+      date: '2026-09-01',
+      tracks: [
+        {
+          trackTitle: 'Main Stage',
+          trackDescription: '',
+          talks: [
+            {
+              placeholder: 'Coffee Break',
+              startTime: '10:00',
+              endTime: '10:15',
+            },
+          ],
+        },
+      ],
+    }
+    render(
+      <MobileScheduleView
+        schedules={[withService]}
+        currentDayIndex={0}
+        unassignedProposals={[]}
+        dispatch={dispatch}
+        onDayChange={vi.fn()}
+        onSave={vi.fn()}
+        onAddTrack={vi.fn()}
+        isSaving={false}
+        saveSuccess={false}
+        error={null}
+      />,
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Options for Coffee Break' }),
+    )
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Duplicate to all tracks',
+      }),
+    )
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'duplicateService',
+        sourceTrackIndex: 0,
+        serviceSession: expect.objectContaining({
+          placeholder: 'Coffee Break',
+        }),
+      }),
+    )
+  })
 })

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -50,6 +50,8 @@ import {
   ArrowsUpDownIcon,
   InboxStackIcon,
   ChevronDownIcon,
+  Cog6ToothIcon,
+  DocumentDuplicateIcon,
 } from '@heroicons/react/24/outline'
 
 interface MobileScheduleViewProps {
@@ -881,6 +883,7 @@ function TrackRail({
   placing,
   onSegmentTap,
   onAddService,
+  onTrackOptions,
 }: {
   track: ScheduleTrack
   trackIndex: number
@@ -888,6 +891,7 @@ function TrackRail({
   placing: Placing | null
   onSegmentTap: (trackIndex: number, seg: RailSegment) => void
   onAddService: (trackIndex: number) => void
+  onTrackOptions: (trackIndex: number) => void
 }) {
   const segments = useMemo(() => buildTrackRail(track), [track])
 
@@ -897,7 +901,16 @@ function TrackRail({
           re-sorts track.talks, which would shift the picked-up item's stored
           talkIndex and corrupt a later Remove/Swap. */}
       {!placing && (
-        <div className="mb-1 flex items-center justify-end">
+        <div className="mb-1 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => onTrackOptions(trackIndex)}
+            aria-label="Track options"
+            className="inline-flex min-h-[44px] items-center gap-1 rounded-lg px-2 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-gray-400 dark:hover:bg-gray-800"
+          >
+            <Cog6ToothIcon className="h-4 w-4" />
+            Track
+          </button>
           <button
             type="button"
             onClick={() => onAddService(trackIndex)}
@@ -1138,6 +1151,7 @@ function CardActionSheet({
   onMove,
   onRename,
   onDuration,
+  onDuplicate,
   onRemove,
   onClose,
 }: {
@@ -1145,6 +1159,7 @@ function CardActionSheet({
   onMove: () => void
   onRename: () => void
   onDuration: () => void
+  onDuplicate: () => void
   onRemove: () => void
   onClose: () => void
 }) {
@@ -1174,6 +1189,10 @@ function CardActionSheet({
               <ArrowsUpDownIcon className="h-5 w-5" />
               Change duration
             </button>
+            <button type="button" onClick={onDuplicate} className={action}>
+              <DocumentDuplicateIcon className="h-5 w-5" />
+              Duplicate to all tracks
+            </button>
           </>
         )}
         <button
@@ -1190,12 +1209,157 @@ function CardActionSheet({
 }
 
 /* -------------------------------------------------------------------------- */
+/* Track action sheet (rename / remove a track)                               */
+/* -------------------------------------------------------------------------- */
+
+function TrackActionSheet({
+  track,
+  trackIndex,
+  dispatch,
+  onClose,
+}: {
+  track: ScheduleTrack
+  trackIndex: number
+  dispatch: React.Dispatch<ScheduleAction>
+  onClose: () => void
+}) {
+  const [mode, setMode] = useState<'menu' | 'rename' | 'confirmRemove'>('menu')
+  const [title, setTitle] = useState(track.trackTitle ?? '')
+  const [description, setDescription] = useState(track.trackDescription ?? '')
+  const name = track.trackTitle || `Track ${trackIndex + 1}`
+  const talkCount = track.talks.length
+  const action =
+    'inline-flex min-h-[44px] w-full items-center justify-start gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+
+  if (mode === 'rename') {
+    const save = () => {
+      if (!title.trim()) return
+      dispatch({
+        type: 'updateTrack',
+        trackIndex,
+        track: {
+          ...track,
+          trackTitle: title.trim(),
+          trackDescription: description.trim(),
+        },
+      })
+      onClose()
+    }
+    return (
+      <BottomSheet title="Edit track" onClose={onClose}>
+        <label
+          htmlFor="track-title"
+          className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Track name
+        </label>
+        <input
+          id="track-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+          autoFocus
+        />
+        <label
+          htmlFor="track-description"
+          className="mt-4 mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Description (optional)
+        </label>
+        <input
+          id="track-description"
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        />
+        <div className="mt-5 flex gap-3">
+          <button
+            type="button"
+            onClick={save}
+            disabled={!title.trim()}
+            className={`flex-1 ${PRIMARY_BUTTON}`}
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('menu')}
+            className={`flex-1 ${SECONDARY_BUTTON}`}
+          >
+            Cancel
+          </button>
+        </div>
+      </BottomSheet>
+    )
+  }
+
+  if (mode === 'confirmRemove') {
+    return (
+      <BottomSheet title="Remove track?" onClose={onClose}>
+        <p className="mb-5 text-sm text-gray-600 dark:text-gray-300">
+          Remove <span className="font-semibold">{name}</span>?
+          {talkCount > 0
+            ? ` Its ${talkCount} item${talkCount === 1 ? '' : 's'} return to unassigned.`
+            : ''}
+        </p>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              dispatch({ type: 'removeTrack', trackIndex })
+              onClose()
+            }}
+            className="inline-flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500"
+          >
+            <TrashIcon className="h-5 w-5" />
+            Remove
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('menu')}
+            className={`flex-1 ${SECONDARY_BUTTON}`}
+          >
+            Cancel
+          </button>
+        </div>
+      </BottomSheet>
+    )
+  }
+
+  return (
+    <BottomSheet title={name} onClose={onClose}>
+      <div className="space-y-2">
+        <button
+          type="button"
+          onClick={() => setMode('rename')}
+          className={action}
+        >
+          <PencilIcon className="h-5 w-5" />
+          Rename track
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('confirmRemove')}
+          className="inline-flex min-h-[44px] w-full items-center justify-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 dark:border-red-900 dark:bg-red-900/30 dark:text-red-300 dark:hover:bg-red-900/50"
+        >
+          <TrashIcon className="h-5 w-5" />
+          Remove track
+        </button>
+      </div>
+    </BottomSheet>
+  )
+}
+
+/* -------------------------------------------------------------------------- */
 /* Main view                                                                  */
 /* -------------------------------------------------------------------------- */
 
 type ActiveSheet =
   | { kind: 'addService'; trackIndex: number }
   | { kind: 'unassigned'; context: SlotContext | null }
+  | { kind: 'track'; trackIndex: number }
   | {
       kind: 'card'
       trackIndex: number
@@ -1444,6 +1608,10 @@ export function MobileScheduleView({
     setSheet({ kind: 'addService', trackIndex })
   }, [])
 
+  const openTrackOptions = useCallback((trackIndex: number) => {
+    setSheet({ kind: 'track', trackIndex })
+  }, [])
+
   // Whether the CURRENT panel offers any legal drop for the pick-up (drives the
   // "no room here" hint).
   const hasValidTargetHere = useMemo(() => {
@@ -1461,6 +1629,8 @@ export function MobileScheduleView({
 
   const addServiceTrack =
     sheet?.kind === 'addService' ? (tracks[sheet.trackIndex] ?? null) : null
+  const trackSheetTrack =
+    sheet?.kind === 'track' ? (tracks[sheet.trackIndex] ?? null) : null
   const drawerTrack =
     sheet?.kind === 'unassigned' && sheet.context
       ? (tracks[sheet.context.trackIndex] ?? null)
@@ -1469,7 +1639,7 @@ export function MobileScheduleView({
   return (
     <div className="flex h-[calc(100dvh-4rem)] flex-col bg-gray-50 dark:bg-gray-950">
       {/* Header */}
-      <header className="shrink-0 border-b border-gray-200 bg-white px-4 pt-3 dark:border-gray-700 dark:bg-gray-900">
+      <header className="shrink-0 border-b border-gray-200 bg-white px-4 pt-5 dark:border-gray-700 dark:bg-gray-900">
         <div className="flex items-center justify-between gap-2">
           <DaySelect
             schedules={schedules}
@@ -1623,6 +1793,7 @@ export function MobileScheduleView({
                 placing={effPlacing}
                 onSegmentTap={handleSegmentTap}
                 onAddService={openAddService}
+                onTrackOptions={openTrackOptions}
               />
             </div>
           ))}
@@ -1671,6 +1842,14 @@ export function MobileScheduleView({
           onDuration={() =>
             setSheet({ ...sheet, kind: 'serviceEdit', mode: 'duration' })
           }
+          onDuplicate={() => {
+            dispatch({
+              type: 'duplicateService',
+              serviceSession: sheet.talk,
+              sourceTrackIndex: sheet.trackIndex,
+            })
+            closeSheet()
+          }}
           onRemove={() => {
             dispatch({
               type: 'removeTalk',
@@ -1679,6 +1858,15 @@ export function MobileScheduleView({
             })
             closeSheet()
           }}
+          onClose={closeSheet}
+        />
+      )}
+
+      {sheet?.kind === 'track' && trackSheetTrack && (
+        <TrackActionSheet
+          track={trackSheetTrack}
+          trackIndex={sheet.trackIndex}
+          dispatch={dispatch}
           onClose={closeSheet}
         />
       )}

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -1163,7 +1163,9 @@ function CardActionSheet({
   onRemove: () => void
   onClose: () => void
 }) {
-  const isService = !talk.talk
+  // A real service session has a placeholder; a talk-less slot without one
+  // (defensive) must not surface the service-only actions.
+  const isService = !talk.talk && !!talk.placeholder
   const title = talk.talk?.title ?? talk.placeholder ?? 'Untitled'
   const action =
     'inline-flex min-h-[44px] w-full items-center justify-start gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
@@ -1227,7 +1229,11 @@ function TrackActionSheet({
   const [title, setTitle] = useState(track.trackTitle ?? '')
   const [description, setDescription] = useState(track.trackDescription ?? '')
   const name = track.trackTitle || `Track ${trackIndex + 1}`
-  const talkCount = track.talks.length
+  // Removing a track un-schedules its real talks (they return to the unassigned
+  // list) but permanently DELETES its service sessions — word the confirm
+  // accordingly so it doesn't overstate recoverability.
+  const talkCount = track.talks.filter((t) => t.talk).length
+  const serviceCount = track.talks.length - talkCount
   const action =
     'inline-flex min-h-[44px] w-full items-center justify-start gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
 
@@ -1300,9 +1306,10 @@ function TrackActionSheet({
       <BottomSheet title="Remove track?" onClose={onClose}>
         <p className="mb-5 text-sm text-gray-600 dark:text-gray-300">
           Remove <span className="font-semibold">{name}</span>?
-          {talkCount > 0
-            ? ` Its ${talkCount} item${talkCount === 1 ? '' : 's'} return to unassigned.`
-            : ''}
+          {talkCount > 0 &&
+            ` Its ${talkCount} talk${talkCount === 1 ? '' : 's'} return to unassigned.`}
+          {serviceCount > 0 &&
+            ` ${serviceCount} service session${serviceCount === 1 ? '' : 's'} will be deleted.`}
         </p>
         <div className="flex gap-3">
           <button


### PR DESCRIPTION
## Phase 1.5 — feature parity gaps

The architecture review found three operations the **desktop** editor had but **mobile** didn't (the engine ops already existed — only mobile UI was missing). Closed here:

- **Track options** — each track panel gets a ⚙ **Track** button → action sheet with:
  - **Rename track** (title + description → `updateTrack`, **preserving the track's talks**)
  - **Remove track** (with a **confirm** step — "its N items return to unassigned" → `removeTrack`)
- **Duplicate to all tracks** — added to the service card sheet → `duplicateService`.

## Also (Hans on-device feedback)
- A little **top spacing** (header `pt-3` → `pt-5`) so the day/track toolbar doesn't butt against the app's top bar.

## QA
- Tests for all three: rename **preserves talks**, remove requires the **confirm** step, duplicate dispatches `duplicateService`. 10 mobile component tests green; tsc/eslint/prettier clean.
- **Visually inspected** via `pnpm shoot` (track sheet + service sheet screenshots shared).

Next: the **loading-skeletons** sweep (separate task) and continuing the refactor sequence — the shared placement predicate, the `mobile/` split, the `Slot` union, then the add-talk/add-service unification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes mobile feature parity gaps by adding track rename/remove via a new `TrackActionSheet` component and a "Duplicate to all tracks" option to the service card sheet. It also adjusts the header top padding for better spacing on device.

- **Track options**: A gear button on each `TrackRail` header opens a three-mode `TrackActionSheet` — a menu, a rename form (spreads `...track` to preserve talks), and a `confirmRemove` step before dispatching `removeTrack`.
- **Duplicate service**: `onDuplicate` wired into `CardActionSheet`, gated behind the existing `isService` guard, dispatches `duplicateService` with the current `TrackTalk` and `trackIndex`.
- **Top spacing**: `pt-3` → `pt-5` on the main view header.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the new features, but the remove-track confirmation dialog shows users a misleading count that should be fixed before shipping.

The rename and duplicate paths are solid. The remove-track flow has a real defect: the confirmation dialog counts service sessions alongside actual proposals and tells the user all of them "return to unassigned," but service sessions are permanently deleted by the underlying operation. A track with only service sessions would show "Its 3 items return to unassigned" when in fact 0 items do — incorrect user-facing information on a destructive action.

The talkCount derivation inside TrackActionSheet in MobileScheduleView.tsx needs attention — it should filter to only proposal-backed slots before computing the count shown in the confirmation message.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/MobileScheduleView.tsx | Adds TrackActionSheet (rename/remove) and duplicate-service to CardActionSheet. The remove confirmation message counts all track slots including service sessions, but only actual proposal assignments are returned to unassigned — service sessions are silently deleted. |
| __tests__/components/admin/schedule/MobileScheduleView.test.tsx | Adds 3 targeted tests for rename (verifies talks preserved), remove (verifies confirm step required), and duplicate-service. Tests are well-structured and cover the stated requirements. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant TrackRail
    participant TrackActionSheet
    participant Reducer

    User->>TrackRail: tap Track button
    TrackRail->>TrackActionSheet: "open (mode=menu)"

    alt Rename
        User->>TrackActionSheet: tap Rename track
        TrackActionSheet->>TrackActionSheet: setMode rename
        User->>TrackActionSheet: edit title/description, tap Save
        TrackActionSheet->>Reducer: dispatch updateTrack
        TrackActionSheet->>TrackActionSheet: onClose
    else Remove
        User->>TrackActionSheet: tap Remove track
        TrackActionSheet->>TrackActionSheet: setMode confirmRemove
        User->>TrackActionSheet: tap Remove confirm
        TrackActionSheet->>Reducer: dispatch removeTrack
        TrackActionSheet->>TrackActionSheet: onClose
    end

    participant CardActionSheet
    User->>CardActionSheet: tap service session card
    CardActionSheet-->>User: show Duplicate to all tracks
    User->>CardActionSheet: tap Duplicate to all tracks
    CardActionSheet->>Reducer: dispatch duplicateService
    CardActionSheet->>CardActionSheet: closeSheet
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant TrackRail
    participant TrackActionSheet
    participant Reducer

    User->>TrackRail: tap Track button
    TrackRail->>TrackActionSheet: "open (mode=menu)"

    alt Rename
        User->>TrackActionSheet: tap Rename track
        TrackActionSheet->>TrackActionSheet: setMode rename
        User->>TrackActionSheet: edit title/description, tap Save
        TrackActionSheet->>Reducer: dispatch updateTrack
        TrackActionSheet->>TrackActionSheet: onClose
    else Remove
        User->>TrackActionSheet: tap Remove track
        TrackActionSheet->>TrackActionSheet: setMode confirmRemove
        User->>TrackActionSheet: tap Remove confirm
        TrackActionSheet->>Reducer: dispatch removeTrack
        TrackActionSheet->>TrackActionSheet: onClose
    end

    participant CardActionSheet
    User->>CardActionSheet: tap service session card
    CardActionSheet-->>User: show Duplicate to all tracks
    User->>CardActionSheet: tap Duplicate to all tracks
    CardActionSheet->>Reducer: dispatch duplicateService
    CardActionSheet->>CardActionSheet: closeSheet
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(schedule): mobile parity — track re..."](https://github.com/cloudnativebergen/website/commit/8a2505f0ad9aa72991a1008bbbc68c353ef50ed0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45313344)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->