### PR TITLE
refactor(schedule): single placement predicate shared by engine + both UIs

### DIFF
--- a/__tests__/lib/schedule/operations.test.ts
+++ b/__tests__/lib/schedule/operations.test.ts
@@ -19,6 +19,8 @@ import type { DragItem, DropPosition } from '@/lib/schedule/types'
 import {
   moveProposal,
   moveServiceSession,
+  classifyProposalDrop,
+  classifyServiceDrop,
   addTrack,
   removeTrack,
   updateTrack,
@@ -431,5 +433,156 @@ describe('computeUnassigned', () => {
   it('returns all proposals when nothing is scheduled', () => {
     const proposals = [proposal('p1'), proposal('p2')]
     expect(computeUnassigned(proposals, [schedule(track('A'))])).toHaveLength(2)
+  })
+})
+
+// The drop indicators in BOTH UIs (desktop `TimeSlotDropZone.canDrop`, mobile
+// `segmentState`) call the classifiers, while the actual drop calls the reducer
+// ops. If the two ever diverge, the UI promises a drop the reducer then rejects
+// (or vice-versa). These tests pin the classifier's verdict to the op's outcome
+// on identical fixtures, so any future edit to one without the other fails here.
+describe('classifier ⇔ reducer equivalence', () => {
+  const proposalCases: Array<{
+    name: string
+    build: () => {
+      s: ConferenceSchedule
+      d: DragItem
+      p: DropPosition
+      others?: Set<string>
+      expectSwap?: boolean
+    }
+  }> = [
+    {
+      name: 'move into a free slot',
+      build: () => ({
+        s: schedule(track('A'), track('B')),
+        d: { type: 'proposal', proposal: proposal('p') },
+        p: drop(1, '11:00'),
+      }),
+    },
+    {
+      name: 'reject an out-of-bounds track index',
+      build: () => ({
+        s: schedule(track('A')),
+        d: { type: 'proposal', proposal: proposal('p') },
+        p: drop(5, '10:00'),
+      }),
+    },
+    {
+      name: 'reject a proposal already scheduled elsewhere (duplicate guard)',
+      build: () => ({
+        s: schedule(track('A')),
+        d: { type: 'proposal', proposal: proposal('p') },
+        p: drop(0, '10:00'),
+        others: new Set(['p']),
+      }),
+    },
+    {
+      name: 'reject a drop that runs past the end of the day',
+      build: () => ({
+        s: schedule(track('A')),
+        d: { type: 'proposal', proposal: proposal('p') },
+        p: drop(0, '20:45'),
+      }),
+    },
+    {
+      name: 'swap two talks across tracks',
+      build: () => ({
+        s: schedule(
+          track('A', talk('a', '10:00', '10:25')),
+          track('B', talk('b', '11:00', '11:25')),
+        ),
+        d: {
+          type: 'scheduled-talk',
+          proposal: proposal('a'),
+          sourceTrackIndex: 0,
+          sourceTimeSlot: '10:00',
+        },
+        p: drop(1, '11:00'),
+        expectSwap: true,
+      }),
+    },
+    {
+      name: 'reject dropping a talk back onto its own slot (no-op)',
+      build: () => ({
+        s: schedule(track('A', talk('a', '10:00', '10:25'))),
+        d: {
+          type: 'scheduled-talk',
+          proposal: proposal('a'),
+          sourceTrackIndex: 0,
+          sourceTimeSlot: '10:00',
+        },
+        p: drop(0, '10:00'),
+      }),
+    },
+  ]
+
+  proposalCases.forEach(({ name, build }) => {
+    it(`proposal: ${name}`, () => {
+      const { s, d, p, others, expectSwap } = build()
+      const kind = classifyProposalDrop(s.tracks, d, p, others)
+      const op = moveProposal(s, d, p, others)
+      expect(kind !== 'invalid').toBe(op.ok)
+      if (expectSwap) {
+        expect(kind).toBe('swap')
+        // A swap displaces the target talk back to the source rather than
+        // dropping it: the target track keeps exactly one talk.
+        expect(op.schedule.tracks[p.trackIndex].talks).toHaveLength(1)
+      }
+    })
+  })
+
+  const serviceDrag = (
+    placeholder: string,
+    start: string,
+    end: string,
+    extra: Partial<DragItem> = {},
+  ): DragItem => ({
+    type: 'service-session',
+    serviceSession: { placeholder, startTime: start, endTime: end },
+    ...extra,
+  })
+
+  const serviceCases: Array<{
+    name: string
+    build: () => { s: ConferenceSchedule; d: DragItem; p: DropPosition }
+  }> = [
+    {
+      name: 'place a service into a free interval',
+      build: () => ({
+        s: schedule(track('A')),
+        d: serviceDrag('Lunch', '12:00', '13:00'),
+        p: drop(0, '12:00'),
+      }),
+    },
+    {
+      name: 'reject a service overlapping an existing talk',
+      build: () => ({
+        s: schedule(track('A', talk('x', '12:30', '12:55'))),
+        d: serviceDrag('Lunch', '12:00', '13:00'),
+        p: drop(0, '12:00'),
+      }),
+    },
+    {
+      name: 'move an existing service, excluding its own slot',
+      build: () => ({
+        s: schedule(track('A', service('Break', '12:00', '12:15'))),
+        d: serviceDrag('Break', '12:00', '12:15', {
+          type: 'scheduled-service',
+          sourceTrackIndex: 0,
+          sourceTimeSlot: '12:00',
+        }),
+        p: drop(0, '12:05'),
+      }),
+    },
+  ]
+
+  serviceCases.forEach(({ name, build }) => {
+    it(`service: ${name}`, () => {
+      const { s, d, p } = build()
+      const kind = classifyServiceDrop(s.tracks, d, p)
+      const op = moveServiceSession(s, d, p)
+      expect(kind === 'move').toBe(op.ok)
+    })
   })
 })

--- a/__tests__/lib/schedule/operations.test.ts
+++ b/__tests__/lib/schedule/operations.test.ts
@@ -21,6 +21,7 @@ import {
   moveServiceSession,
   classifyProposalDrop,
   classifyServiceDrop,
+  scheduledProposalIdsExcludingDay,
   addTrack,
   removeTrack,
   updateTrack,
@@ -584,5 +585,30 @@ describe('classifier ⇔ reducer equivalence', () => {
       const op = moveServiceSession(s, d, p)
       expect(kind === 'move').toBe(op.ok)
     })
+  })
+
+  it('cross-day set: the guard rejects a proposal scheduled on another day', () => {
+    // Same fixtures both callers use: reducer computes the set, then the UIs
+    // read the SAME set from context/props, so classify must agree with the op.
+    const days = [
+      schedule(track('Day1', talk('p', '10:00', '10:25'))),
+      schedule(track('Day2')),
+    ]
+    const others = scheduledProposalIdsExcludingDay(days, 1)
+    expect(others.has('p')).toBe(true)
+
+    const d: DragItem = { type: 'proposal', proposal: proposal('p') }
+    const p = drop(0, '11:00')
+    // Day 2 has room, but `p` already lives on day 1 → both must refuse.
+    expect(classifyProposalDrop(days[1].tracks, d, p, others)).toBe('invalid')
+    expect(moveProposal(days[1], d, p, others).ok).toBe(false)
+    // Without the set the SAME drop is legal — proving the set is the only
+    // reason it fails, i.e. a UI omitting it would light up a rejected slot.
+    expect(classifyProposalDrop(days[1].tracks, d, p)).toBe('move')
+  })
+
+  it('cross-day set: EXCLUDES the queried day so same-day talks do not self-block', () => {
+    const days = [schedule(track('Day1', talk('p', '10:00', '10:25')))]
+    expect(scheduledProposalIdsExcludingDay(days, 0).has('p')).toBe(false)
   })
 })

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -20,14 +20,12 @@ import {
   withinScheduleEnd,
 } from '@/lib/schedule/time'
 import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
+import { fitsInTrack, isTrackIntervalFree } from '@/lib/schedule/rules'
 import {
-  fitsInTrack,
-  isTrackIntervalFree,
-  canSwapTalks,
-  canPlaceDisplacedBack,
-  matchTalk,
-  matchService,
-} from '@/lib/schedule/rules'
+  classifyProposalDrop,
+  classifyServiceDrop,
+} from '@/lib/schedule/operations'
+import type { DragItem } from '@/lib/schedule/types'
 import { formatConferenceDate } from '@/lib/time'
 import { buildTrackRail, type RailSegment } from './mobileRail'
 import { StatusBadge, LevelIndicator } from '@/lib/proposal'
@@ -149,6 +147,34 @@ function isPlacingSource(
  * fitsInTrack / interval-free / swap checks + end-of-day guard) so the UI never
  * offers a drop the reducer would reject.
  */
+/** The engine DragItem for the current pick-up (proposal / scheduled talk /
+ * scheduled service), so the UI can defer every legality question to the shared
+ * classifiers instead of re-deriving the rule. */
+function placingDragItem(placing: Placing): DragItem {
+  if (placing.kind === 'proposal') {
+    return { type: 'proposal', proposal: placing.proposal }
+  }
+  const src = placing.talk
+  if (src.talk) {
+    return {
+      type: 'scheduled-talk',
+      proposal: src.talk,
+      sourceTrackIndex: placing.trackIndex,
+      sourceTimeSlot: src.startTime,
+    }
+  }
+  return {
+    type: 'scheduled-service',
+    serviceSession: {
+      placeholder: src.placeholder ?? '',
+      startTime: src.startTime,
+      endTime: src.endTime,
+    },
+    sourceTrackIndex: placing.trackIndex,
+    sourceTimeSlot: src.startTime,
+  }
+}
+
 function segmentState(
   placing: Placing,
   tracks: ScheduleTrack[],
@@ -156,64 +182,33 @@ function segmentState(
   seg: RailSegment,
 ): SegmentState {
   if (isPlacingSource(placing, T, seg)) return 'source'
-  const target = tracks[T]
-  if (!target) return 'invalid'
+  if (!tracks[T]) return 'invalid'
 
-  if (seg.kind === 'open') {
-    if (seg.durationMin < MIN_OPEN_SLOT_MIN) return 'invalid'
-    if (placing.kind === 'proposal') {
-      const dur = getProposalDurationMinutes(placing.proposal)
-      const end = calculateEndTime(seg.startTime, dur)
-      return withinScheduleEnd(end) && fitsInTrack(target, seg.startTime, dur)
-        ? 'valid'
-        : 'invalid'
+  const dragItem = placingDragItem(placing)
+  const dropPosition = { trackIndex: T, timeSlot: seg.startTime }
+
+  // Service pick-up: only moves into open slots (services never swap).
+  if (dragItem.type === 'scheduled-service') {
+    if (seg.kind !== 'open' || seg.durationMin < MIN_OPEN_SLOT_MIN) {
+      return 'invalid'
     }
-    const src = placing.talk
-    const sameTrack = T === placing.trackIndex
-    if (src.talk) {
-      const dur = getProposalDurationMinutes(src.talk)
-      const end = calculateEndTime(seg.startTime, dur)
-      const exclude = sameTrack
-        ? matchTalk(src.talk._id, src.startTime)
-        : undefined
-      return withinScheduleEnd(end) &&
-        fitsInTrack(target, seg.startTime, dur, exclude)
-        ? 'valid'
-        : 'invalid'
-    }
-    const dur = durationBetween(src.startTime, src.endTime)
-    const end = calculateEndTime(seg.startTime, dur)
-    const exclude = sameTrack
-      ? matchService(src.placeholder ?? '', src.startTime)
-      : undefined
-    return withinScheduleEnd(end) &&
-      isTrackIntervalFree(target, seg.startTime, end, exclude)
+    return classifyServiceDrop(tracks, dragItem, dropPosition) === 'move'
       ? 'valid'
       : 'invalid'
   }
 
-  if (seg.kind === 'talk') {
-    // Occupied talk => SWAP, only when a scheduled TALK is being placed.
-    if (placing.kind !== 'scheduled' || !placing.talk.talk) return 'invalid'
-    const src = placing.talk
-    const sourceTrack = tracks[placing.trackIndex]
-    if (!sourceTrack) return 'invalid'
-    const draggedEnd = calculateEndTime(
-      seg.startTime,
-      getProposalDurationMinutes(src.talk!),
-    )
-    const ok =
-      withinScheduleEnd(draggedEnd) &&
-      canSwapTalks(target, src.talk!, seg.talk, seg.startTime) &&
-      canPlaceDisplacedBack(
-        sourceTrack,
-        seg.talk,
-        src.startTime,
-        matchTalk(src.talk!._id, src.startTime),
-      )
-    return ok ? 'valid' : 'invalid'
+  // Proposal / scheduled talk: an open slot is a MOVE, an occupied talk a SWAP.
+  if (seg.kind === 'open') {
+    if (seg.durationMin < MIN_OPEN_SLOT_MIN) return 'invalid'
+    return classifyProposalDrop(tracks, dragItem, dropPosition) === 'move'
+      ? 'valid'
+      : 'invalid'
   }
-
+  if (seg.kind === 'talk') {
+    return classifyProposalDrop(tracks, dragItem, dropPosition) === 'swap'
+      ? 'valid'
+      : 'invalid'
+  }
   // `break` targets are never a valid drop.
   return 'invalid'
 }

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -24,6 +24,7 @@ import { fitsInTrack, isTrackIntervalFree } from '@/lib/schedule/rules'
 import {
   classifyProposalDrop,
   classifyServiceDrop,
+  scheduledProposalIdsExcludingDay,
 } from '@/lib/schedule/operations'
 import type { DragItem } from '@/lib/schedule/types'
 import { formatConferenceDate } from '@/lib/time'
@@ -180,6 +181,7 @@ function segmentState(
   tracks: ScheduleTrack[],
   T: number,
   seg: RailSegment,
+  otherScheduledProposalIds: ReadonlySet<string>,
 ): SegmentState {
   if (isPlacingSource(placing, T, seg)) return 'source'
   if (!tracks[T]) return 'invalid'
@@ -198,9 +200,16 @@ function segmentState(
   }
 
   // Proposal / scheduled talk: an open slot is a MOVE, an occupied talk a SWAP.
+  // The cross-day duplicate set is only consulted for a FRESH proposal drop
+  // (moving an already-scheduled talk bypasses the guard), matching the reducer.
   if (seg.kind === 'open') {
     if (seg.durationMin < MIN_OPEN_SLOT_MIN) return 'invalid'
-    return classifyProposalDrop(tracks, dragItem, dropPosition) === 'move'
+    return classifyProposalDrop(
+      tracks,
+      dragItem,
+      dropPosition,
+      otherScheduledProposalIds,
+    ) === 'move'
       ? 'valid'
       : 'invalid'
   }
@@ -876,6 +885,7 @@ function TrackRail({
   trackIndex,
   tracks,
   placing,
+  otherScheduledProposalIds,
   onSegmentTap,
   onAddService,
   onTrackOptions,
@@ -884,6 +894,7 @@ function TrackRail({
   trackIndex: number
   tracks: ScheduleTrack[]
   placing: Placing | null
+  otherScheduledProposalIds: ReadonlySet<string>
   onSegmentTap: (trackIndex: number, seg: RailSegment) => void
   onAddService: (trackIndex: number) => void
   onTrackOptions: (trackIndex: number) => void
@@ -928,7 +939,13 @@ function TrackRail({
           {segments.map((seg, i) => {
             const height = segmentHeight(seg)
             const state: SegmentState = placing
-              ? segmentState(placing, tracks, trackIndex, seg)
+              ? segmentState(
+                  placing,
+                  tracks,
+                  trackIndex,
+                  seg,
+                  otherScheduledProposalIds,
+                )
               : 'default'
 
             // Slim, non-interactive divider for gaps too small to hold a talk.
@@ -1392,6 +1409,14 @@ export function MobileScheduleView({
   const schedule = schedules[currentDayIndex] ?? null
   const tracks = useMemo(() => schedule?.tracks ?? [], [schedule])
 
+  // Proposals scheduled on OTHER days — the cross-day duplicate set. Passed into
+  // `segmentState` so the rail's valid-target highlighting applies the SAME
+  // guard the reducer's `moveProposal` does and can't offer a rejected drop.
+  const otherScheduledProposalIds = useMemo(
+    () => scheduledProposalIdsExcludingDay(schedules, currentDayIndex),
+    [schedules, currentDayIndex],
+  )
+
   const [selectedTrackIndex, setSelectedTrackIndex] = useState(0)
   const [placing, setPlacing] = useState<Placing | null>(null)
   const [sheet, setSheet] = useState<ActiveSheet>(null)
@@ -1535,7 +1560,13 @@ export function MobileScheduleView({
         return
       }
 
-      const state = segmentState(active, tracks, panelTrackIndex, seg)
+      const state = segmentState(
+        active,
+        tracks,
+        panelTrackIndex,
+        seg,
+        otherScheduledProposalIds,
+      )
       if (state === 'source') {
         setPlacing(null)
         return
@@ -1603,7 +1634,7 @@ export function MobileScheduleView({
       }
       setPlacing(null)
     },
-    [effPlacing, tracks, dispatch],
+    [effPlacing, tracks, dispatch, otherScheduledProposalIds],
   )
 
   const openAddService = useCallback((trackIndex: number) => {
@@ -1622,9 +1653,15 @@ export function MobileScheduleView({
     if (!track) return false
     return buildTrackRail(track).some(
       (seg) =>
-        segmentState(effPlacing, tracks, safeTrackIndex, seg) === 'valid',
+        segmentState(
+          effPlacing,
+          tracks,
+          safeTrackIndex,
+          seg,
+          otherScheduledProposalIds,
+        ) === 'valid',
     )
-  }, [effPlacing, tracks, safeTrackIndex])
+  }, [effPlacing, tracks, safeTrackIndex, otherScheduledProposalIds])
 
   const tabId = (i: number) => `sched-tab-${i}`
   const panelId = (i: number) => `sched-panel-${i}`
@@ -1793,6 +1830,7 @@ export function MobileScheduleView({
                 trackIndex={trackIndex}
                 tracks={tracks}
                 placing={effPlacing}
+                otherScheduledProposalIds={otherScheduledProposalIds}
                 onSegmentTap={handleSegmentTap}
                 onAddService={openAddService}
                 onTrackOptions={openTrackOptions}

--- a/src/components/admin/schedule/ScheduleContext.tsx
+++ b/src/components/admin/schedule/ScheduleContext.tsx
@@ -13,11 +13,15 @@ import type { ScheduleAction } from '@/lib/schedule/reducer'
  * - `activeDragItem` — the item currently being dragged (null when idle).
  * - `schedule` — the whole current day, needed by `TimeSlotDropZone.canDrop` to
  *   validate the REVERSE half of a swap (see `rules.canPlaceDisplacedBack`).
+ * - `otherScheduledProposalIds` — proposals scheduled on OTHER days, so
+ *   `canDrop` applies the SAME cross-day duplicate guard as the reducer and can
+ *   never light up a slot the reducer would then reject.
  * - `dispatch` — the reducer dispatch, so leaves can request mutations directly.
  */
 interface ScheduleContextValue {
   activeDragItem: DragItem | null
   schedule: ConferenceSchedule | null
+  otherScheduledProposalIds: ReadonlySet<string>
   dispatch: Dispatch<ScheduleAction>
 }
 
@@ -26,6 +30,7 @@ const noop: Dispatch<ScheduleAction> = () => {}
 const ScheduleContext = createContext<ScheduleContextValue>({
   activeDragItem: null,
   schedule: null,
+  otherScheduledProposalIds: new Set(),
   dispatch: noop,
 })
 

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -26,7 +26,10 @@ import {
   scheduleReducer,
   initScheduleEditorState,
 } from '@/lib/schedule/reducer'
-import { computeUnassigned } from '@/lib/schedule/operations'
+import {
+  computeUnassigned,
+  scheduledProposalIdsExcludingDay,
+} from '@/lib/schedule/operations'
 import { ProposalExisting } from '@/lib/proposal/types'
 import { UnassignedProposals } from './UnassignedProposals'
 import { MemoizedDroppableTrack as DroppableTrack } from './DroppableTrack'
@@ -340,11 +343,25 @@ export function ScheduleEditor({
 
   const hasTracks = Boolean(schedule?.tracks && schedule.tracks.length > 0)
 
+  // Ids scheduled on OTHER days — the cross-day duplicate set the reducer feeds
+  // `moveProposal`. Threading it through context lets `canDrop` apply the exact
+  // same guard so the indicator can't promise a drop the reducer rejects.
+  const otherScheduledProposalIds = useMemo(
+    () => scheduledProposalIdsExcludingDay(state.schedules, currentDayIndex),
+    [state.schedules, currentDayIndex],
+  )
+
   // Ambient board state for the leaf drop targets (see ScheduleContext): the
-  // active drag, the whole current day (for the swap reverse-check) and dispatch.
+  // active drag, the whole current day (for the swap reverse-check), the
+  // cross-day duplicate set, and dispatch.
   const scheduleContextValue = useMemo(
-    () => ({ activeDragItem: activeItem, schedule: currentSchedule, dispatch }),
-    [activeItem, currentSchedule],
+    () => ({
+      activeDragItem: activeItem,
+      schedule: currentSchedule,
+      otherScheduledProposalIds,
+      dispatch,
+    }),
+    [activeItem, currentSchedule, otherScheduledProposalIds],
   )
 
   const dragOverlay = useMemo(() => {

--- a/src/components/admin/schedule/track/TimeSlotDropZone.tsx
+++ b/src/components/admin/schedule/track/TimeSlotDropZone.tsx
@@ -5,13 +5,8 @@ import { useDroppable } from '@dnd-kit/core'
 import { ScheduleTrack } from '@/lib/conference/types'
 import { TimeSlot } from '@/lib/schedule/types'
 import { addMinutes } from '@/lib/schedule/time'
-import {
-  findAvailableTimeSlot,
-  canSwapTalks,
-  canPlaceDisplacedBack,
-  isTrackIntervalFree,
-  matchTalk,
-} from '@/lib/schedule/rules'
+import { isTrackIntervalFree } from '@/lib/schedule/rules'
+import { classifyProposalDrop } from '@/lib/schedule/operations'
 import {
   calculateTimePosition,
   shouldShowTimeLabel,
@@ -80,74 +75,19 @@ export const TimeSlotDropZone = ({
 
   const canDrop = useMemo(() => {
     if (!activeDragItem) return true
-
+    // Service drags aren't validated here (the reducer does); only proposals.
     if (!activeDragItem.proposal) return true
-
-    const occupiedTalk = track.talks.find(
-      (talk) => talk.startTime === timeSlot.time,
-    )
-
-    if (occupiedTalk && occupiedTalk.talk) {
-      if (
-        activeDragItem.type === 'scheduled-talk' &&
-        activeDragItem.sourceTrackIndex !== undefined &&
-        activeDragItem.sourceTimeSlot !== undefined
-      ) {
-        if (
-          activeDragItem.proposal._id === occupiedTalk.talk._id &&
-          activeDragItem.sourceTimeSlot === timeSlot.time
-        ) {
-          return false
-        }
-
-        // Validate BOTH directions of the swap so the indicator matches what the
-        // reducer's `moveProposal` will actually do: the dragged talk must fit
-        // the target slot AND the displaced talk must fit back into the source
-        // track. Checking only the forward `canSwapTalks` let the UI show a swap
-        // as droppable that the drop then rejected.
-        const sourceTrack = schedule?.tracks[activeDragItem.sourceTrackIndex]
-        const draggedExclude = matchTalk(
-          activeDragItem.proposal._id,
-          activeDragItem.sourceTimeSlot,
-        )
-        return (
-          canSwapTalks(
-            track,
-            activeDragItem.proposal,
-            occupiedTalk,
-            timeSlot.time,
-          ) &&
-          !!sourceTrack &&
-          canPlaceDisplacedBack(
-            sourceTrack,
-            occupiedTalk,
-            activeDragItem.sourceTimeSlot,
-            draggedExclude,
-          )
-        )
-      }
-
-      return false
-    }
-
-    const excludeTalk =
-      activeDragItem.type === 'scheduled-talk' &&
-      activeDragItem.sourceTrackIndex === trackIndex
-        ? {
-            talkId: activeDragItem.proposal._id,
-            startTime: activeDragItem.sourceTimeSlot!,
-          }
-        : undefined
-
+    if (!schedule) return true
+    // Defer to the shared predicate so the drop indicator matches EXACTLY what
+    // the reducer's `moveProposal` will do — fit, bidirectional swap, and the
+    // end-of-day guard (which this inline check previously omitted).
     return (
-      findAvailableTimeSlot(
-        track,
-        activeDragItem.proposal,
-        timeSlot.time,
-        excludeTalk,
-      ) === timeSlot.time
+      classifyProposalDrop(schedule.tracks, activeDragItem, {
+        trackIndex,
+        timeSlot: timeSlot.time,
+      }) !== 'invalid'
     )
-  }, [activeDragItem, track, timeSlot.time, trackIndex, schedule])
+  }, [activeDragItem, schedule, trackIndex, timeSlot.time])
 
   // Gate on the WHOLE slot interval, not just an exact start-time match, so the
   // "＋ Service" button never appears on a 5-min slot that falls INSIDE an

--- a/src/components/admin/schedule/track/TimeSlotDropZone.tsx
+++ b/src/components/admin/schedule/track/TimeSlotDropZone.tsx
@@ -33,7 +33,8 @@ export const TimeSlotDropZone = ({
   // `activeDragItem` and the whole-day `schedule` come from context instead of
   // being prop-drilled through TracksGrid → DroppableTrack. The schedule lets
   // `canDrop` validate the REVERSE half of a swap (see below).
-  const { activeDragItem, schedule } = useScheduleContext()
+  const { activeDragItem, schedule, otherScheduledProposalIds } =
+    useScheduleContext()
 
   const { setNodeRef, isOver } = useDroppable({
     id: `track-${trackIndex}-time-${timeSlot.time}`,
@@ -82,12 +83,20 @@ export const TimeSlotDropZone = ({
     // the reducer's `moveProposal` will do — fit, bidirectional swap, and the
     // end-of-day guard (which this inline check previously omitted).
     return (
-      classifyProposalDrop(schedule.tracks, activeDragItem, {
-        trackIndex,
-        timeSlot: timeSlot.time,
-      }) !== 'invalid'
+      classifyProposalDrop(
+        schedule.tracks,
+        activeDragItem,
+        { trackIndex, timeSlot: timeSlot.time },
+        otherScheduledProposalIds,
+      ) !== 'invalid'
     )
-  }, [activeDragItem, schedule, trackIndex, timeSlot.time])
+  }, [
+    activeDragItem,
+    schedule,
+    trackIndex,
+    timeSlot.time,
+    otherScheduledProposalIds,
+  ])
 
   // Gate on the WHOLE slot interval, not just an exact start-time match, so the
   // "＋ Service" button never appears on a 5-min slot that falls INSIDE an

--- a/src/lib/schedule/operations.ts
+++ b/src/lib/schedule/operations.ts
@@ -121,55 +121,50 @@ function performSwap(
 }
 
 /**
- * Place / move a proposal into a track slot (pure port of `moveTalkToTrack`).
- *
- * Duplicate guard: a FRESH drop (not a `scheduled-talk` move) is rejected if the
- * proposal is already scheduled on THIS day or — via `otherScheduledProposalIds`
- * — on ANY other day. This is the cross-day duplicate fix; the old check only
- * looked at the current day so the same talk could be scheduled twice across
- * days.
+ * What a proposal drop would do: `move` into an empty slot, `swap` with the
+ * occupied talk, or `invalid`. SINGLE SOURCE OF TRUTH for "is this drop legal?"
+ * — `moveProposal` applies it, and both UIs (desktop `TimeSlotDropZone.canDrop`,
+ * mobile `segmentState`) call it so they can never offer a drop the reducer
+ * rejects. Pure, no mutation.
  */
-export function moveProposal(
-  schedule: ConferenceSchedule,
+export type DropClassification = 'move' | 'swap' | 'invalid'
+
+export function classifyProposalDrop(
+  tracks: readonly ScheduleTrack[],
   dragItem: DragItem,
   dropPosition: DropPosition,
   otherScheduledProposalIds?: ReadonlySet<string>,
-): OperationResult {
-  const fail: OperationResult = { schedule, ok: false }
-  if (!dragItem.proposal) return fail
-
+): DropClassification {
+  if (!dragItem.proposal) return 'invalid'
   const { proposal } = dragItem
   const { trackIndex, timeSlot } = dropPosition
 
-  if (trackIndex < 0 || trackIndex >= schedule.tracks.length) return fail
+  if (trackIndex < 0 || trackIndex >= tracks.length) return 'invalid'
 
-  // A move onto the talk's own current slot is a no-op. Without this guard it
-  // falls into the swap branch below (the "occupied" talk IS the dragged talk),
-  // and `performSwap` re-adds the talk at both the target and the source slot —
-  // silently duplicating it. Reachable from the mobile Move sheet (which can
-  // default the start time to the talk's current slot) and any drop-in-place.
+  // A move onto the talk's own current slot is a no-op — without this it falls
+  // into the swap branch (the "occupied" talk IS the dragged one) and duplicates.
   if (
     dragItem.type === 'scheduled-talk' &&
     dragItem.sourceTrackIndex === trackIndex &&
     dragItem.sourceTimeSlot === timeSlot
   ) {
-    return fail
+    return 'invalid'
   }
 
-  const targetTrack = schedule.tracks[trackIndex]
+  const targetTrack = tracks[trackIndex]
   const durationMinutes = getProposalDurationMinutes(proposal)
   const endTime = calculateEndTime(timeSlot, durationMinutes)
+  if (!withinScheduleEnd(endTime)) return 'invalid'
 
-  // The dragged talk always lands ending at `endTime` (both for a fresh drop and
-  // as the forward half of a swap), so a single end-of-day guard covers both.
-  if (!withinScheduleEnd(endTime)) return fail
-
+  // Duplicate guard: a FRESH drop (not a `scheduled-talk` move) is rejected if
+  // the proposal is already scheduled on THIS day or — via
+  // `otherScheduledProposalIds` — on ANY other day.
   if (dragItem.type !== 'scheduled-talk') {
-    const scheduledHere = schedule.tracks.some((track) =>
+    const scheduledHere = tracks.some((track) =>
       track.talks.some((talk) => talk.talk?._id === proposal._id),
     )
     if (scheduledHere || otherScheduledProposalIds?.has(proposal._id)) {
-      return fail
+      return 'invalid'
     }
   }
 
@@ -184,29 +179,22 @@ export function moveProposal(
     dragItem.sourceTrackIndex !== undefined &&
     dragItem.sourceTimeSlot !== undefined
   ) {
-    const sourceTrack = schedule.tracks[dragItem.sourceTrackIndex]
-    // Validate BOTH directions of the swap: the dragged talk must fit the target
-    // slot AND the displaced talk must fit back into the source track.
+    const sourceTrack = tracks[dragItem.sourceTrackIndex]
+    // Validate BOTH directions of the swap.
     const draggedExclude = matchTalk(proposal._id, dragItem.sourceTimeSlot)
-    if (
-      !canSwapTalks(targetTrack, proposal, occupiedTalk, timeSlot) ||
-      !sourceTrack ||
-      !canPlaceDisplacedBack(
+    return canSwapTalks(targetTrack, proposal, occupiedTalk, timeSlot) &&
+      sourceTrack &&
+      canPlaceDisplacedBack(
         sourceTrack,
         occupiedTalk,
         dragItem.sourceTimeSlot,
         draggedExclude,
       )
-    ) {
-      return fail
-    }
-    return {
-      schedule: performSwap(schedule, dragItem, occupiedTalk, dropPosition),
-      ok: true,
-    }
+      ? 'swap'
+      : 'invalid'
   }
 
-  if (occupiedTalk) return fail
+  if (occupiedTalk) return 'invalid'
 
   const excludeTalk =
     dragItem.type === 'scheduled-talk' &&
@@ -220,8 +208,84 @@ export function moveProposal(
     timeSlot,
     excludeTalk,
   )
-  if (!availableTime || availableTime !== timeSlot) return fail
+  return availableTime === timeSlot ? 'move' : 'invalid'
+}
 
+/**
+ * Whether a service-session drop is legal (services never swap, so `move` or
+ * `invalid`). Single source of truth shared by `moveServiceSession` and the UIs.
+ */
+export function classifyServiceDrop(
+  tracks: readonly ScheduleTrack[],
+  dragItem: DragItem,
+  dropPosition: DropPosition,
+): 'move' | 'invalid' {
+  if (!dragItem.serviceSession) return 'invalid'
+  const { serviceSession } = dragItem
+  const { trackIndex, timeSlot } = dropPosition
+
+  if (trackIndex < 0 || trackIndex >= tracks.length) return 'invalid'
+
+  const durationMinutes = durationBetween(
+    serviceSession.startTime,
+    serviceSession.endTime,
+  )
+  const newEndTime = calculateEndTime(timeSlot, durationMinutes)
+  if (!withinScheduleEnd(newEndTime)) return 'invalid'
+
+  const targetTrack = tracks[trackIndex]
+  const excludeExisting =
+    dragItem.type === 'scheduled-service' &&
+    dragItem.sourceTrackIndex === trackIndex &&
+    dragItem.sourceTimeSlot !== undefined
+      ? matchService(serviceSession.placeholder, dragItem.sourceTimeSlot)
+      : undefined
+
+  return isTrackIntervalFree(targetTrack, timeSlot, newEndTime, excludeExisting)
+    ? 'move'
+    : 'invalid'
+}
+
+/**
+ * Place / move a proposal into a track slot. Legality is decided by
+ * {@link classifyProposalDrop}; this function only applies the resulting
+ * move/swap so the rule lives in exactly one place.
+ */
+export function moveProposal(
+  schedule: ConferenceSchedule,
+  dragItem: DragItem,
+  dropPosition: DropPosition,
+  otherScheduledProposalIds?: ReadonlySet<string>,
+): OperationResult {
+  const fail: OperationResult = { schedule, ok: false }
+  const kind = classifyProposalDrop(
+    schedule.tracks,
+    dragItem,
+    dropPosition,
+    otherScheduledProposalIds,
+  )
+  if (kind === 'invalid') return fail
+
+  // classify returned non-invalid ⇒ dragItem.proposal is present.
+  const proposal = dragItem.proposal!
+  const { trackIndex, timeSlot } = dropPosition
+  const targetTrack = schedule.tracks[trackIndex]
+
+  if (kind === 'swap') {
+    const occupiedTalk = targetTrack.talks.find(
+      (talk) => talk.startTime === timeSlot,
+    )!
+    return {
+      schedule: performSwap(schedule, dragItem, occupiedTalk, dropPosition),
+      ok: true,
+    }
+  }
+
+  // kind === 'move': drop into the (now-known-free) slot, clearing the source.
+  const endTime = calculateEndTime(
+    timeSlot,
+    getProposalDurationMinutes(proposal),
+  )
   const newTracks = [...schedule.tracks]
 
   if (
@@ -267,34 +331,20 @@ export function moveServiceSession(
   dropPosition: DropPosition,
 ): OperationResult {
   const fail: OperationResult = { schedule, ok: false }
-  if (!dragItem.serviceSession) return fail
+  if (
+    classifyServiceDrop(schedule.tracks, dragItem, dropPosition) === 'invalid'
+  ) {
+    return fail
+  }
 
-  const { serviceSession } = dragItem
+  // classify returned non-invalid ⇒ dragItem.serviceSession is present.
+  const serviceSession = dragItem.serviceSession!
   const { trackIndex, timeSlot } = dropPosition
-
-  if (trackIndex < 0 || trackIndex >= schedule.tracks.length) return fail
-
   const durationMinutes = durationBetween(
     serviceSession.startTime,
     serviceSession.endTime,
   )
   const newEndTime = calculateEndTime(timeSlot, durationMinutes)
-
-  if (!withinScheduleEnd(newEndTime)) return fail
-
-  const targetTrack = schedule.tracks[trackIndex]
-  const excludeExisting =
-    dragItem.type === 'scheduled-service' &&
-    dragItem.sourceTrackIndex === trackIndex &&
-    dragItem.sourceTimeSlot !== undefined
-      ? matchService(serviceSession.placeholder, dragItem.sourceTimeSlot)
-      : undefined
-
-  if (
-    !isTrackIntervalFree(targetTrack, timeSlot, newEndTime, excludeExisting)
-  ) {
-    return fail
-  }
 
   const newTracks = [...schedule.tracks]
 

--- a/src/lib/schedule/operations.ts
+++ b/src/lib/schedule/operations.ts
@@ -126,6 +126,12 @@ function performSwap(
  * — `moveProposal` applies it, and both UIs (desktop `TimeSlotDropZone.canDrop`,
  * mobile `segmentState`) call it so they can never offer a drop the reducer
  * rejects. Pure, no mutation.
+ *
+ * `otherScheduledProposalIds` is the cross-day duplicate set (a fresh proposal
+ * already scheduled on another day is rejected). It is OPTIONAL only so callers
+ * that never place fresh proposals can omit it; every real caller — the reducer
+ * (via {@link scheduledProposalIdsExcludingDay}) AND both UIs — passes it, so
+ * the "no rejected drop is ever offered" guarantee holds for cross-day dups too.
  */
 export type DropClassification = 'move' | 'swap' | 'invalid'
 
@@ -589,4 +595,26 @@ export function computeUnassigned(
     ),
   )
   return proposals.filter((proposal) => !scheduledIds.has(proposal._id))
+}
+
+/**
+ * Ids of proposals scheduled on days OTHER than `dayIndex` — the cross-day
+ * duplicate set. Passed as `otherScheduledProposalIds` to
+ * {@link classifyProposalDrop} so both the reducer and the drop indicators
+ * reject placing a proposal that already lives on another day.
+ */
+export function scheduledProposalIdsExcludingDay(
+  schedules: readonly ConferenceSchedule[],
+  dayIndex: number,
+): Set<string> {
+  const ids = new Set<string>()
+  schedules.forEach((schedule, index) => {
+    if (index === dayIndex) return
+    schedule.tracks?.forEach((track) =>
+      track.talks.forEach((talk) => {
+        if (talk.talk?._id) ids.add(talk.talk._id)
+      }),
+    )
+  })
+  return ids
 }

--- a/src/lib/schedule/reducer.ts
+++ b/src/lib/schedule/reducer.ts
@@ -85,23 +85,6 @@ export function initScheduleEditorState(args: {
   }
 }
 
-/** Ids of talks scheduled on days OTHER than `dayIndex` (cross-day dup guard). */
-function scheduledIdsExcludingDay(
-  schedules: ConferenceSchedule[],
-  dayIndex: number,
-): Set<string> {
-  const ids = new Set<string>()
-  schedules.forEach((schedule, index) => {
-    if (index === dayIndex) return
-    schedule.tracks?.forEach((track) =>
-      track.talks.forEach((talk) => {
-        if (talk.talk?._id) ids.add(talk.talk._id)
-      }),
-    )
-  })
-  return ids
-}
-
 /**
  * Apply a day-level transform result to the current day: on success, replace
  * `schedules[currentDayIndex]` and mark it dirty; on failure, return state
@@ -128,7 +111,7 @@ export function scheduleReducer(
   switch (action.type) {
     case 'moveProposal': {
       if (!current) return state
-      const otherIds = scheduledIdsExcludingDay(
+      const otherIds = ops.scheduledProposalIdsExcludingDay(
         state.schedules,
         state.currentDayIndex,
       )


### PR DESCRIPTION
## Why

Placement legality (can this proposal/service drop here?) was implemented **three times**:

- `moveProposal` / `moveServiceSession` in the pure reducer
- `TimeSlotDropZone.canDrop` on the desktop drag board
- `segmentState` on the mobile pick-up→drop view

They had already **drifted**: the desktop `canDrop` re-implemented the swap/fit logic inline but was missing the **end-of-day guard** and the **cross-day duplicate guard** the reducer enforces — so it would highlight a slot as droppable that the reducer then silently rejected on drop.

## What

Extract the decision into two pure functions in `operations.ts` as the single source of truth:

- `classifyProposalDrop(tracks, dragItem, dropPosition, otherScheduledProposalIds?) → 'move' | 'swap' | 'invalid'`
- `classifyServiceDrop(tracks, dragItem, dropPosition) → 'move' | 'invalid'`

`moveProposal` / `moveServiceSession` now only **apply** the verdict (perform the swap or the move); both UIs call the same classifiers for their highlighting. The indicators can no longer promise a drop the reducer refuses, and the desktop guards are restored for free.

## Tests

- Added a `classifier ⇔ reducer equivalence` block: identical fixtures run through both the classifier and the op, asserting `classify !== 'invalid'` ⇔ `op.ok` (and `swap` preserves the displaced target). A future edit to one without the other fails here.
- 132 schedule tests pass; `tsc`, `eslint`, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates three separate (and drifted) implementations of placement legality by extracting `classifyProposalDrop` and `classifyServiceDrop` as pure, exported functions in `operations.ts`. Both UIs and both reducer ops now share the same predicates, so desktop drop indicators gain the end-of-day and bidirectional-swap guards they were previously missing.

- **`operations.ts`**: `classifyProposalDrop` / `classifyServiceDrop` become the single source of truth; `moveProposal` and `moveServiceSession` now just apply the verdict instead of re-deriving it.
- **`TimeSlotDropZone.tsx` / `MobileScheduleView.tsx`**: Both UIs replace their inline logic with calls to the shared classifiers, with a new `placingDragItem` helper in mobile to bridge the `Placing` → `DragItem` conversion.
- **`operations.test.ts`**: A new `classifier ⇔ reducer equivalence` suite pins 9 fixtures through both the classifier and the op, ensuring future drift fails a test.

<h3>Confidence Score: 3/5</h3>

The refactor is structurally sound and cleans up genuine pre-existing bugs, but leaves one drop-acceptance case where both drop-zone UIs show valid and the reducer silently rejects the drop.

The new shared classifier correctly consolidates all guards — end-of-day, bidirectional swap, same-day duplicate — and the reducer now delegates to it cleanly. The one gap is that otherScheduledProposalIds is never forwarded from either UI to classifyProposalDrop, so a proposal already scheduled on a different conference day still lights up as droppable on desktop and mobile while the reducer silently rejects the actual drop. This is exactly the class of indicator-reducer divergence the PR set out to close, and it remains open for the cross-day path.

TimeSlotDropZone.tsx and the segmentState call-site in MobileScheduleView.tsx — both need otherScheduledProposalIds forwarded so the classifier and the reducer agree on cross-day duplicate proposals.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/schedule/operations.ts | Core change: extracts `classifyProposalDrop` and `classifyServiceDrop` as pure single-source-of-truth predicates; `moveProposal` and `moveServiceSession` now delegate to them. Logic is correct, well-guarded, and DRY. |
| src/components/admin/schedule/track/TimeSlotDropZone.tsx | Desktop drop indicator now correctly uses the shared `classifyProposalDrop`, fixing swap/fit/end-of-day divergences. However, `otherScheduledProposalIds` is not passed to the classifier, leaving the cross-day duplicate guard absent from the visual indicator. |
| src/components/admin/schedule/MobileScheduleView.tsx | Mobile `segmentState` is cleanly simplified through the new `placingDragItem` helper and shared classifiers. A stale JSDoc block from the old `segmentState` comment was accidentally left orphaned above `placingDragItem`. |
| __tests__/lib/schedule/operations.test.ts | New `classifier ⇔ reducer equivalence` suite pins classification to reducer outcomes across 9 cases. Cross-day duplicate scenario (where `others` is the only rejection reason from the UI call site) is not covered. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI (Desktop / Mobile)
    participant CL as classifyProposalDrop / classifyServiceDrop
    participant OP as moveProposal / moveServiceSession
    participant RD as Reducer

    Note over UI: Hover / pick-up highlight
    UI->>CL: classifyProposalDrop(tracks, dragItem, dropPos)
    CL-->>UI: "'move' | 'swap' | 'invalid'"
    UI->>UI: render valid / swap / invalid indicator

    Note over RD: Actual drop dispatched
    RD->>OP: moveProposal(schedule, dragItem, dropPos, otherIds)
    OP->>CL: classifyProposalDrop(tracks, dragItem, dropPos, otherIds)
    CL-->>OP: "'move' | 'swap' | 'invalid'"
    OP-->>RD: "OperationResult { ok, schedule }"

    Note over UI,RD: UI call omits otherIds — cross-day duplicate can still diverge
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI (Desktop / Mobile)
    participant CL as classifyProposalDrop / classifyServiceDrop
    participant OP as moveProposal / moveServiceSession
    participant RD as Reducer

    Note over UI: Hover / pick-up highlight
    UI->>CL: classifyProposalDrop(tracks, dragItem, dropPos)
    CL-->>UI: "'move' | 'swap' | 'invalid'"
    UI->>UI: render valid / swap / invalid indicator

    Note over RD: Actual drop dispatched
    RD->>OP: moveProposal(schedule, dragItem, dropPos, otherIds)
    OP->>CL: classifyProposalDrop(tracks, dragItem, dropPos, otherIds)
    CL-->>OP: "'move' | 'swap' | 'invalid'"
    OP-->>RD: "OperationResult { ok, schedule }"

    Note over UI,RD: UI call omits otherIds — cross-day duplicate can still diverge
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/admin/schedule/MobileScheduleView.tsx`, line 144-153 ([link](https://github.com/cloudnativebergen/website/blob/893b2f13a2da2c1dc0677a45faecbee2f0c61c75/src/components/admin/schedule/MobileScheduleView.tsx#L144-L153)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Stale JSDoc block left dangling above `placingDragItem`. The comment originally documented `segmentState` and says "Mirrors … exactly," which is now inaccurate (the new code delegates to classifiers rather than mirroring them). It is not attached to any function by TypeScript and will mislead readers.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["refactor(schedule): single placement pre..."](https://github.com/cloudnativebergen/website/commit/893b2f13a2da2c1dc0677a45faecbee2f0c61c75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45315191)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->