### PR TITLE
fix(admin): loading skeletons mirror their new mobile layouts

### DIFF
--- a/src/components/admin/LoadingSkeleton.tsx
+++ b/src/components/admin/LoadingSkeleton.tsx
@@ -50,8 +50,10 @@ export function SkeletonTable({
 }) {
   return (
     <div className={`animate-pulse ${className}`}>
+      {/* Column header exists only in the md+ table; the mobile view is a card
+          list, so hide it below md to match the real pages. */}
       <div
-        className="grid gap-4 border-b border-gray-200 pb-3 dark:border-gray-700"
+        className="hidden gap-4 border-b border-gray-200 pb-3 md:grid dark:border-gray-700"
         style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
       >
         {[...Array(columns)].map((_, i) => (
@@ -59,22 +61,29 @@ export function SkeletonTable({
         ))}
       </div>
 
-      <div className="space-y-3 pt-3">
+      <div className="space-y-3 md:pt-3">
         {[...Array(rows)].map((_, rowIndex) => (
-          <div
-            key={rowIndex}
-            className="grid gap-4"
-            style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
-          >
-            {[...Array(columns)].map((_, colIndex) => (
-              <div
-                key={colIndex}
-                className="h-4 rounded bg-gray-200 dark:bg-gray-700"
-                style={{
-                  width: colIndex === columns - 1 ? '60%' : '100%',
-                }}
-              />
-            ))}
+          <div key={rowIndex}>
+            {/* Mobile: a stacked card mirroring the real `md:hidden` card list. */}
+            <div className="rounded-lg border border-gray-100 p-3 md:hidden dark:border-gray-800">
+              <div className="h-4 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
+              <div className="mt-2 h-3 w-1/3 rounded bg-gray-200 dark:bg-gray-700" />
+            </div>
+            {/* md+: a table row. */}
+            <div
+              className="hidden gap-4 md:grid"
+              style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+            >
+              {[...Array(columns)].map((_, colIndex) => (
+                <div
+                  key={colIndex}
+                  className="h-4 rounded bg-gray-200 dark:bg-gray-700"
+                  style={{
+                    width: colIndex === columns - 1 ? '60%' : '100%',
+                  }}
+                />
+              ))}
+            </div>
           </div>
         ))}
       </div>
@@ -357,6 +366,20 @@ export function SkeletonModal({
   )
 }
 
+// Responsive column classes keyed by the desktop column count. Full literal
+// strings so Tailwind's JIT picks them up (dynamic `grid-cols-${n}` would not).
+// Every skeleton stacks toward a single column on phones so it mirrors the real
+// pages, which collapse their multi-column grids at small widths instead of
+// cramming N columns into 320px.
+const SKELETON_GRID_COLS: Record<number, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-1 sm:grid-cols-2',
+  3: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+  4: 'grid-cols-2 sm:grid-cols-2 lg:grid-cols-4',
+  5: 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-5',
+  6: 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-6',
+}
+
 export function SkeletonGrid({
   className = '',
   items = 4,
@@ -368,11 +391,10 @@ export function SkeletonGrid({
   columns?: number
   cardHeight?: string
 }) {
+  const colClass =
+    SKELETON_GRID_COLS[columns] ?? 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-4'
   return (
-    <div
-      className={`grid animate-pulse gap-4 ${className}`}
-      style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
-    >
+    <div className={`grid animate-pulse gap-4 ${colClass} ${className}`}>
       {[...Array(items)].map((_, i) => (
         <div
           key={i}

--- a/src/components/admin/LoadingSkeleton.tsx
+++ b/src/components/admin/LoadingSkeleton.tsx
@@ -368,14 +368,14 @@ export function SkeletonModal({
 
 // Responsive column classes keyed by the desktop column count. Full literal
 // strings so Tailwind's JIT picks them up (dynamic `grid-cols-${n}` would not).
-// Every skeleton stacks toward a single column on phones so it mirrors the real
-// pages, which collapse their multi-column grids at small widths instead of
-// cramming N columns into 320px.
+// Every skeleton stacks toward one or two columns on phones so it mirrors the
+// real pages, which collapse their multi-column grids at small widths instead
+// of cramming N columns into 320px.
 const SKELETON_GRID_COLS: Record<number, string> = {
   1: 'grid-cols-1',
   2: 'grid-cols-1 sm:grid-cols-2',
   3: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
-  4: 'grid-cols-2 sm:grid-cols-2 lg:grid-cols-4',
+  4: 'grid-cols-2 lg:grid-cols-4',
   5: 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-5',
   6: 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-6',
 }

--- a/src/components/admin/PageLoadingSkeleton.stories.tsx
+++ b/src/components/admin/PageLoadingSkeleton.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import type { ReactNode } from 'react'
+import {
+  AdminPageLoading,
+  AdminTablePageLoading,
+  AdminDashboardLoading,
+  AdminScheduleLoading,
+} from './PageLoadingSkeleton'
+
+/**
+ * Full-page admin loading skeletons (the `loading.tsx` route fallbacks). These
+ * must mirror their real page at BOTH mobile and desktop widths — use the
+ * Storybook viewport toolbar (or `pnpm shoot`) to check the phone layout, which
+ * is where the schedule/table skeletons previously diverged from the real UI.
+ */
+const meta = {
+  title: 'Admin/Feedback/PageLoadingSkeleton',
+  component: AdminTablePageLoading,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof AdminTablePageLoading>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// The admin route layout pads its content `p-2 py-8 sm:p-4 lg:p-8`; wrap each
+// skeleton in it so the story matches the real `loading.tsx` context. (The
+// schedule skeleton cancels this with negative margins to go full-bleed, which
+// is exactly why it needs the same padded frame here to look right.)
+const AdminFrame = ({ children }: { children: ReactNode }) => (
+  <div className="min-h-screen bg-gray-50 p-2 py-8 sm:p-4 lg:p-8 dark:bg-gray-900">
+    {children}
+  </div>
+)
+
+/**
+ * The schedule editor's fallback. Below `md` it mirrors MobileScheduleView's
+ * time-rail carousel (sticky header + track pills + a single full-width panel
+ * with a left time gutter); at `md+` it is the desktop sidebar + track board.
+ */
+export const Schedule: Story = {
+  render: () => (
+    <AdminFrame>
+      <AdminScheduleLoading />
+    </AdminFrame>
+  ),
+}
+
+/** Table pages: stat cards + a table on desktop, a stacked card list on mobile. */
+export const TablePage: Story = {
+  render: () => (
+    <AdminFrame>
+      <AdminTablePageLoading />
+    </AdminFrame>
+  ),
+}
+
+/** Dashboard: widget grid that stacks toward one column on phones. */
+export const Dashboard: Story = {
+  render: () => (
+    <AdminFrame>
+      <AdminDashboardLoading />
+    </AdminFrame>
+  ),
+}
+
+/** Generic header + stacked cards page fallback. */
+export const Page: Story = {
+  render: () => (
+    <AdminFrame>
+      <AdminPageLoading />
+    </AdminFrame>
+  ),
+}

--- a/src/components/admin/PageLoadingSkeleton.tsx
+++ b/src/components/admin/PageLoadingSkeleton.tsx
@@ -15,9 +15,9 @@ export function AdminPageLoading() {
         <div className="animate-pulse">
           <div className="flex items-center gap-3">
             <div className="h-8 w-8 rounded bg-gray-200 dark:bg-gray-700" />
-            <div>
-              <div className="h-8 w-64 rounded bg-gray-200 dark:bg-gray-700" />
-              <div className="mt-2 h-4 w-96 rounded bg-gray-200 dark:bg-gray-700" />
+            <div className="min-w-0">
+              <div className="h-8 w-44 rounded bg-gray-200 sm:w-64 dark:bg-gray-700" />
+              <div className="mt-2 h-4 w-56 max-w-full rounded bg-gray-200 sm:w-96 dark:bg-gray-700" />
             </div>
           </div>
         </div>
@@ -37,14 +37,14 @@ export function AdminTablePageLoading() {
       <div className="pb-6">
         <div className="animate-pulse">
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="h-8 w-8 rounded bg-gray-200 dark:bg-gray-700" />
-              <div>
-                <div className="h-8 w-48 rounded bg-gray-200 dark:bg-gray-700" />
-                <div className="mt-2 h-4 w-80 rounded bg-gray-200 dark:bg-gray-700" />
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="h-8 w-8 shrink-0 rounded bg-gray-200 dark:bg-gray-700" />
+              <div className="min-w-0">
+                <div className="h-8 w-40 rounded bg-gray-200 sm:w-48 dark:bg-gray-700" />
+                <div className="mt-2 h-4 w-48 max-w-full rounded bg-gray-200 sm:w-80 dark:bg-gray-700" />
               </div>
             </div>
-            <div className="h-10 w-32 rounded bg-gray-200 dark:bg-gray-700" />
+            <div className="h-10 w-24 shrink-0 rounded bg-gray-200 sm:w-32 dark:bg-gray-700" />
           </div>
         </div>
       </div>
@@ -67,8 +67,8 @@ export function AdminDashboardLoading() {
     <div className="space-y-6">
       <div className="pb-6">
         <div className="animate-pulse">
-          <div className="h-8 w-48 rounded bg-gray-200 dark:bg-gray-700" />
-          <div className="mt-2 h-4 w-96 rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-8 w-40 rounded bg-gray-200 sm:w-48 dark:bg-gray-700" />
+          <div className="mt-2 h-4 w-56 max-w-full rounded bg-gray-200 sm:w-96 dark:bg-gray-700" />
         </div>
       </div>
 
@@ -89,8 +89,8 @@ export function AdminFormPageLoading() {
     <div className="mx-auto max-w-4xl">
       <div className="pb-6">
         <div className="animate-pulse">
-          <div className="h-8 w-64 rounded bg-gray-200 dark:bg-gray-700" />
-          <div className="mt-2 h-4 w-80 rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-8 w-44 rounded bg-gray-200 sm:w-64 dark:bg-gray-700" />
+          <div className="mt-2 h-4 w-48 max-w-full rounded bg-gray-200 sm:w-80 dark:bg-gray-700" />
         </div>
       </div>
 

--- a/src/components/admin/PageLoadingSkeleton.tsx
+++ b/src/components/admin/PageLoadingSkeleton.tsx
@@ -150,8 +150,8 @@ export function AdminScheduleLoading() {
         </div>
 
         <div className="flex flex-1 gap-2 overflow-hidden px-3 pt-2">
-          {/* Left time gutter (~52px), matching the rail. */}
-          <div className="w-13 shrink-0 animate-pulse space-y-8 pt-2">
+          {/* Left time gutter — 52px matches MobileScheduleView's GUTTER_PX. */}
+          <div className="w-[52px] shrink-0 animate-pulse space-y-8 pt-2">
             {[...Array(6)].map((_, i) => (
               <div
                 key={i}

--- a/src/components/admin/PageLoadingSkeleton.tsx
+++ b/src/components/admin/PageLoadingSkeleton.tsx
@@ -125,7 +125,55 @@ export function AdminDetailPageLoading() {
 export function AdminScheduleLoading() {
   return (
     <div className="-mx-2 -my-8 sm:-mx-4 lg:-mx-8">
-      <div className="flex h-[calc(100vh-5rem)]">
+      {/* Mobile (<md): the time-rail carousel shape from MobileScheduleView —
+          a sticky header (day selector + actions, then track pills) over a
+          single full-width track panel with a left time gutter. The old
+          skeleton showed a desktop sidebar + track grid that never renders on
+          a phone. */}
+      <div className="flex h-[calc(100dvh-4rem)] flex-col bg-gray-50 md:hidden dark:bg-gray-950">
+        <div className="shrink-0 animate-pulse border-b border-gray-200 bg-white px-4 pt-5 pb-3 dark:border-gray-700 dark:bg-gray-900">
+          <div className="flex items-center justify-between gap-2">
+            <div className="h-11 w-32 rounded-lg bg-gray-200 dark:bg-gray-700" />
+            <div className="flex items-center gap-2">
+              <div className="h-11 w-28 rounded-lg bg-gray-200 dark:bg-gray-700" />
+              <div className="h-11 w-16 rounded-lg bg-gray-200 dark:bg-gray-700" />
+            </div>
+          </div>
+          <div className="mt-3 flex gap-1">
+            {[...Array(3)].map((_, i) => (
+              <div
+                key={i}
+                className="h-11 flex-1 rounded-full bg-gray-200 dark:bg-gray-700"
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-1 gap-2 overflow-hidden px-3 pt-2">
+          {/* Left time gutter (~52px), matching the rail. */}
+          <div className="w-13 shrink-0 animate-pulse space-y-8 pt-2">
+            {[...Array(6)].map((_, i) => (
+              <div
+                key={i}
+                className="h-3 w-10 rounded bg-gray-200 dark:bg-gray-700"
+              />
+            ))}
+          </div>
+          {/* Stacked segment cards of varying heights. */}
+          <div className="flex-1 animate-pulse space-y-2">
+            {[...Array(5)].map((_, i) => (
+              <div
+                key={i}
+                className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+                style={{ height: `${64 + (i % 3) * 28}px` }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Desktop (md+): the drag board — sidebar + track columns. */}
+      <div className="hidden h-[calc(100vh-5rem)] md:flex">
         {/* Sidebar skeleton */}
         <div className="w-64 shrink-0 border-r border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800">
           <div className="animate-pulse space-y-3 p-4">


### PR DESCRIPTION
## Why

An audit of every admin/CFP/main `loading.tsx` against its real page found the loading skeletons had drifted from the layouts they cover — most visibly on mobile, where several pages were recently redesigned:

- **Schedule** (`AdminScheduleLoading`) rendered the desktop drag board only — a fixed `w-64` sidebar + a horizontal 3-track grid with **no responsive breakpoints**. On a phone the real page is `MobileScheduleView`'s time-rail carousel (sticky header + track pills + a single full-width panel with a left time gutter), so the skeleton showed chrome that never appears.
- The shared `SkeletonGrid` / `SkeletonTable` primitives hard-coded `gridTemplateColumns: repeat(N, 1fr)` with **no breakpoints**, so every table/grid skeleton crammed N columns into 320px while the real pages (`SpeakerTable`, `OrdersTableWithSearch`, …) collapse to a `md:hidden` card list.
- The shared skeleton headers used fixed `w-80` / `w-96` (320–384px) subtitle bars that overflow a phone's content width.

## What

- `AdminScheduleLoading`: add a `<md` time-rail skeleton (header + track pills + gutter + stacked segment cards); gate the existing board behind `md:flex`.
- `SkeletonGrid`: responsive column classes (stacks toward one column on phones) keyed by the desktop count, via full literal Tailwind strings so JIT picks them up.
- `SkeletonTable`: render a stacked **card list** below `md` (mirroring the real `md:hidden` cards) and the N-column table at `md+`.
- Header bars: responsive widths so they fit at 320px.
- Add `PageLoadingSkeleton.stories.tsx` (schedule / table / dashboard / page) wrapped in the admin layout padding — inspectable via `pnpm shoot`, covered by Chromatic going forward.

## Visual verification

`pnpm shoot` at **393px** (iPhone portrait) and **1280px** (desktop), no horizontal overflow at either width:
- Schedule → time-rail carousel on mobile, sidebar + 3-track board on desktop.
- Table → 2-col stat grid + stacked card list on mobile.

Pages already responsive (tickets, workshops, proposal detail, CFP, speaker, form/settings) were checked and left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes responsive-layout drift in admin loading skeletons, where skeleton components had drifted from the actual pages they cover — particularly on mobile.

- **`AdminScheduleLoading`**: Adds a full `md:hidden` mobile skeleton (sticky header + track pills + time-gutter + stacked segment cards) that mirrors `MobileScheduleView`; gates the existing desktop board behind `md:flex`. Uses `100dvh` for the mobile height calculation to handle browser chrome correctly.
- **`SkeletonTable`**: Now renders a stacked card list below `md` (matching the real `md:hidden` card list) and an N-column table row grid at `md+`; the column header is hidden on mobile with `hidden md:grid`.
- **`SkeletonGrid`**: Replaces the inline `gridTemplateColumns` style with a `SKELETON_GRID_COLS` lookup of full literal Tailwind strings so JIT picks them up; each entry stacks toward fewer columns on phones rather than cramming N columns into 320 px.
- **Header bars** across all page-level skeletons gain responsive widths (`w-44 sm:w-64`, `max-w-full`) so they no longer overflow at 320 px.
- **`PageLoadingSkeleton.stories.tsx`** (new): four Storybook stories wrapped in `AdminFrame` (replicating the real route padding) to make both mobile and desktop layouts inspectable via `pnpm shoot`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely presentational loading skeletons with no data-fetching, routing, or business logic.

All three files contain only skeleton UI markup. The responsive fixes are straightforward Tailwind class changes, the SKELETON_GRID_COLS lookup correctly uses full literal strings for JIT, and the new Storybook stories faithfully replicate the real route padding. The one minor finding (redundant sm:grid-cols-2 for the 4-column entry) has no visual or functional impact.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/LoadingSkeleton.tsx | Adds responsive breakpoints to SkeletonTable (mobile card list vs md+ table rows) and replaces inline gridTemplateColumns with a Tailwind-JIT-safe SKELETON_GRID_COLS lookup. The entry for 4 columns carries a redundant sm:grid-cols-2 class. |
| src/components/admin/PageLoadingSkeleton.tsx | Fixes overflowing fixed-width header bars and adds a full mobile skeleton for AdminScheduleLoading (dvh-based time-rail shape gated with md:hidden) alongside the existing desktop board (now md:flex). All changes are straightforward responsive fixes. |
| src/components/admin/PageLoadingSkeleton.stories.tsx | New Storybook file exporting four stories (Schedule, TablePage, Dashboard, Page) wrapped in an AdminFrame that mirrors the real route padding. Clean and consistent with the visual-inspection workflow described in AGENTS.md. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser width] --> B{≥ md\n768px?}

    B -- No / Mobile --> C[AdminScheduleLoading\nmd:hidden block]
    C --> C1[100dvh − 4rem flex-col\nSticky header: day selector + track pills]
    C1 --> C2[Body: left time gutter w-13\n+ stacked segment cards]

    B -- Yes / Desktop --> D[AdminScheduleLoading\nhidden md:flex block]
    D --> D1[100vh − 5rem\nLeft sidebar w-64]
    D1 --> D2[Main area: toolbar\n+ 3 track columns]

    E[SkeletonTable] --> F{≥ md?}
    F -- No --> G[Column header hidden\nEach row → mobile card\n2-line skeleton]
    F -- Yes --> H[Column header visible\nEach row → N-col grid row]

    I[SkeletonGrid\ncolumns=N] --> J[SKELETON_GRID_COLS lookup]
    J --> J1["1 → grid-cols-1"]
    J --> J2["2 → grid-cols-1 sm:grid-cols-2"]
    J --> J3["3 → grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"]
    J --> J4["4 → grid-cols-2 lg:grid-cols-4"]
    J --> J5["5 → grid-cols-2 sm:grid-cols-3 lg:grid-cols-5"]
    J --> J6["6 → grid-cols-2 sm:grid-cols-3 lg:grid-cols-6"]
    J --> J7["other → fallback 2/3/4"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Browser width] --> B{≥ md\n768px?}

    B -- No / Mobile --> C[AdminScheduleLoading\nmd:hidden block]
    C --> C1[100dvh − 4rem flex-col\nSticky header: day selector + track pills]
    C1 --> C2[Body: left time gutter w-13\n+ stacked segment cards]

    B -- Yes / Desktop --> D[AdminScheduleLoading\nhidden md:flex block]
    D --> D1[100vh − 5rem\nLeft sidebar w-64]
    D1 --> D2[Main area: toolbar\n+ 3 track columns]

    E[SkeletonTable] --> F{≥ md?}
    F -- No --> G[Column header hidden\nEach row → mobile card\n2-line skeleton]
    F -- Yes --> H[Column header visible\nEach row → N-col grid row]

    I[SkeletonGrid\ncolumns=N] --> J[SKELETON_GRID_COLS lookup]
    J --> J1["1 → grid-cols-1"]
    J --> J2["2 → grid-cols-1 sm:grid-cols-2"]
    J --> J3["3 → grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"]
    J --> J4["4 → grid-cols-2 lg:grid-cols-4"]
    J --> J5["5 → grid-cols-2 sm:grid-cols-3 lg:grid-cols-5"]
    J --> J6["6 → grid-cols-2 sm:grid-cols-3 lg:grid-cols-6"]
    J --> J7["other → fallback 2/3/4"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): mobile-safe skeleton headers..."](https://github.com/cloudnativebergen/website/commit/b267eaacd1018b969287bb2330cfe134d0f86715) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45316515)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->