### PR TITLE
feat(schedule): merge add-talk + add-service into one mobile slot-tap flow

### DIFF
--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -201,27 +201,39 @@ describe('MobileScheduleView', () => {
     })
   })
 
-  it('hides the "Service" control while placing (index-shift guard)', () => {
-    setup()
-    // A Service button per track before entering placing mode.
-    expect(
-      screen.getAllByRole('button', { name: 'Service' }).length,
-    ).toBeGreaterThan(0)
+  it('creates a service session from within the slot-tap sheet (merged add flow)', () => {
+    const { dispatch } = setup()
+    // Tap an open slot → the unified "assign a talk OR create a service" sheet.
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'Options for Scheduled Keynote Talk',
+        name: 'Assign to open slot 08:00 to 10:00',
       }),
     )
-    fireEvent.click(
-      within(screen.getByRole('dialog')).getByRole('button', {
-        name: 'Move or swap',
-      }),
-    )
-    // While placing, adding a service would re-sort track.talks and invalidate
-    // the picked-up talkIndex — so the control is gone.
+    const dialog = screen.getByRole('dialog')
+    // Service creation now lives INSIDE the talk-selection sheet (no separate
+    // per-track "Service" button anymore).
     expect(
       screen.queryByRole('button', { name: 'Service' }),
     ).not.toBeInTheDocument()
+    fireEvent.click(
+      within(dialog).getByRole('button', {
+        name: /Create service session here/,
+      }),
+    )
+    // The service form fixes the start time to the tapped slot (08:00).
+    const form = screen.getByRole('dialog')
+    fireEvent.change(within(form).getByLabelText('Session title'), {
+      target: { value: 'Coffee Break' },
+    })
+    fireEvent.click(within(form).getByRole('button', { name: 'Add session' }))
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'addService',
+        trackIndex: 0,
+        title: 'Coffee Break',
+        startTime: '08:00',
+      }),
+    )
   })
 
   it('swaps two talks: options → move or swap → tap the other', () => {

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -18,7 +18,7 @@ import {
   withinScheduleEnd,
 } from '@/lib/schedule/time'
 import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
-import { fitsInTrack } from '@/lib/schedule/rules'
+import { fitsInTrack, isTrackIntervalFree } from '@/lib/schedule/rules'
 import {
   classifyProposalDrop,
   classifyServiceDrop,
@@ -492,13 +492,25 @@ function UnassignedDrawer({
   const [serviceError, setServiceError] = useState<string | null>(null)
 
   // Offer only durations that fit inside the tapped slot's free length, so a
-  // service can never be created longer than the gap the user tapped into.
+  // service can never be created longer than the gap the user tapped into. If
+  // no standard option fits (a sub-5-min gap), fall back to the exact available
+  // minutes rather than a value that would fail the submit guard — otherwise the
+  // form is a dead end (title accepted, "Add session" always errors).
   const durationOptions = useMemo(() => {
     if (!context) return SERVICE_DURATION_OPTIONS
     const fitting = [...SERVICE_DURATION_OPTIONS].filter(
       ([mins]) => Number(mins) <= context.maxDurationMin,
     )
-    return new Map(fitting.length > 0 ? fitting : [['5', '5 minutes']])
+    return new Map(
+      fitting.length > 0
+        ? fitting
+        : [
+            [
+              String(context.maxDurationMin),
+              `${context.maxDurationMin} minutes`,
+            ],
+          ],
+    )
   }, [context])
   const effectiveDuration = durationOptions.has(serviceDuration)
     ? serviceDuration
@@ -520,6 +532,14 @@ function UnassignedDrawer({
       setServiceError('That duration runs past the free slot.')
       return
     }
+    // `maxDurationMin` was snapshotted when the slot was tapped; re-check against
+    // the LIVE track so a schedule change while the sheet is open (another
+    // edit / undo) can't drop a service into a now-occupied interval. The
+    // reducer would reject it too, but this keeps the UI honest.
+    if (track && !isTrackIntervalFree(track, context.startTime, endTime)) {
+      setServiceError('That slot was just taken — pick another.')
+      return
+    }
     dispatch({
       type: 'addService',
       trackIndex: context.trackIndex,
@@ -528,7 +548,7 @@ function UnassignedDrawer({
       duration: dur,
     })
     onClose()
-  }, [context, serviceTitle, effectiveDuration, dispatch, onClose])
+  }, [context, track, serviceTitle, effectiveDuration, dispatch, onClose])
 
   const handlePick = useCallback(
     (proposal: ProposalExisting) => {

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -10,17 +10,15 @@ import {
 import { ProposalExisting } from '@/lib/proposal/types'
 import { ScheduleAction } from '@/lib/schedule/reducer'
 import {
-  SCHEDULE_START,
   SCHEDULE_END,
   calculateEndTime,
   durationBetween,
-  generateTimeSlots,
   getProposalDurationMinutes,
   toMinutes,
   withinScheduleEnd,
 } from '@/lib/schedule/time'
 import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
-import { fitsInTrack, isTrackIntervalFree } from '@/lib/schedule/rules'
+import { fitsInTrack } from '@/lib/schedule/rules'
 import {
   classifyProposalDrop,
   classifyServiceDrop,
@@ -51,6 +49,7 @@ import {
   ChevronDownIcon,
   Cog6ToothIcon,
   DocumentDuplicateIcon,
+  ArrowLeftIcon,
 } from '@heroicons/react/24/outline'
 
 interface MobileScheduleViewProps {
@@ -222,23 +221,6 @@ function segmentState(
   return 'invalid'
 }
 
-/** Every `intervalMinutes` start time whose full footprint is free in `track`. */
-function freeStartTimes(
-  track: ScheduleTrack,
-  durationMinutes: number,
-  intervalMinutes = 5,
-): string[] {
-  const endBound = toMinutes(SCHEDULE_END)
-  return generateTimeSlots(SCHEDULE_START, SCHEDULE_END, intervalMinutes)
-    .map((s) => s.time)
-    .filter((time) => {
-      if (toMinutes(calculateEndTime(time, durationMinutes)) > endBound) {
-        return false
-      }
-      return fitsInTrack(track, time, durationMinutes)
-    })
-}
-
 /* -------------------------------------------------------------------------- */
 /* Bottom sheet                                                               */
 /* -------------------------------------------------------------------------- */
@@ -346,39 +328,6 @@ function BottomSheet({
           {children}
         </div>
       </div>
-    </div>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Time picker                                                                */
-/* -------------------------------------------------------------------------- */
-
-function TimeSelect({
-  id,
-  slots,
-  value,
-  onChange,
-}: {
-  id: string
-  slots: string[]
-  value: string
-  onChange: (value: string) => void
-}) {
-  return (
-    <div className="grid grid-cols-1">
-      <select
-        id={id}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="col-start-1 row-start-1 w-full appearance-none rounded-lg border border-gray-300 bg-white py-2.5 pr-8 pl-3 text-sm text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-      >
-        {slots.map((slot) => (
-          <option key={slot} value={slot}>
-            {slot}
-          </option>
-        ))}
-      </select>
     </div>
   )
 }
@@ -495,138 +444,18 @@ function ServiceEditSheet({
 }
 
 /* -------------------------------------------------------------------------- */
-/* Add service sheet                                                          */
-/* -------------------------------------------------------------------------- */
-
-function AddServiceSheet({
-  track,
-  trackIndex,
-  dispatch,
-  onClose,
-}: {
-  track: ScheduleTrack
-  trackIndex: number
-  dispatch: React.Dispatch<ScheduleAction>
-  onClose: () => void
-}) {
-  const [title, setTitle] = useState('')
-  const [duration, setDuration] = useState('10')
-  const [inlineError, setInlineError] = useState<string | null>(null)
-
-  const slots = useMemo(
-    () => freeStartTimes(track, Number(duration)),
-    [track, duration],
-  )
-  const [startTime, setStartTime] = useState('')
-  const effectiveStart = slots.includes(startTime)
-    ? startTime
-    : (slots[0] ?? '')
-
-  const confirm = useCallback(() => {
-    if (!title.trim() || !effectiveStart) {
-      setInlineError('Enter a title and pick a free start time.')
-      return
-    }
-    const endTime = calculateEndTime(effectiveStart, Number(duration))
-    if (
-      toMinutes(endTime) > toMinutes(SCHEDULE_END) ||
-      !isTrackIntervalFree(track, effectiveStart, endTime)
-    ) {
-      setInlineError('That slot overlaps another item or runs past end of day.')
-      return
-    }
-    dispatch({
-      type: 'addService',
-      trackIndex,
-      title: title.trim(),
-      startTime: effectiveStart,
-      duration: Number(duration),
-    })
-    onClose()
-  }, [title, effectiveStart, duration, track, trackIndex, dispatch, onClose])
-
-  return (
-    <BottomSheet title="Add service session" onClose={onClose}>
-      <label
-        htmlFor="service-title"
-        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-      >
-        Session title
-      </label>
-      <input
-        id="service-title"
-        type="text"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        placeholder="e.g. Coffee Break, Lunch"
-        className="mb-4 w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
-        autoFocus
-      />
-
-      <div className="mb-4">
-        <Dropdown
-          name="new-service-duration"
-          label="Duration (minutes)"
-          options={SERVICE_DURATION_OPTIONS}
-          value={duration}
-          setValue={setDuration}
-        />
-      </div>
-
-      {slots.length > 0 ? (
-        <>
-          <label
-            htmlFor="service-start-time"
-            className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-          >
-            Start time
-          </label>
-          <TimeSelect
-            id="service-start-time"
-            slots={slots}
-            value={effectiveStart}
-            onChange={setStartTime}
-          />
-        </>
-      ) : (
-        <p className="text-sm text-gray-600 dark:text-gray-400">
-          No free time slot of this length in this track.
-        </p>
-      )}
-
-      {inlineError && (
-        <p
-          role="alert"
-          className="mt-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
-        >
-          {inlineError}
-        </p>
-      )}
-
-      <div className="mt-5">
-        <button
-          type="button"
-          onClick={confirm}
-          disabled={!effectiveStart || !title.trim()}
-          className={`w-full ${PRIMARY_BUTTON}`}
-        >
-          Add session
-        </button>
-      </div>
-    </BottomSheet>
-  )
-}
-
-/* -------------------------------------------------------------------------- */
 /* Unassigned drawer                                                          */
 /* -------------------------------------------------------------------------- */
 
 /**
- * The proposal drawer, in two modes:
- *  - `context` set   → contextual "assign here": only proposals that FIT the
- *    open slot are listed, and tapping one drops it straight into that slot.
+ * The unified "add to schedule" drawer, in two modes:
+ *  - `context` set   → tapped an OPEN slot. The user can EITHER assign a fitting
+ *    unassigned talk (tap drops it straight in) OR create a service session in
+ *    place (the start time is fixed to the tapped slot). This merges what used
+ *    to be two separate actions (assign talk vs. the per-track "+ Service").
  *  - `context` null  → the header's Unassigned list: tapping a proposal picks
- *    it up (`onPick`) so the user can then tap a slot.
+ *    it up (`onPick`) so the user can then tap a slot. No service creation here
+ *    because there is no target slot yet.
  */
 function UnassignedDrawer({
   proposals,
@@ -656,9 +485,50 @@ function UnassignedDrawer({
 
   const filters = useProposalFilters(source)
 
-  const title = context
-    ? `Assign at ${context.startTime}`
-    : `Unassigned (${proposals.length})`
+  // Inline service-creation sub-view (only reachable when a slot was tapped).
+  const [creatingService, setCreatingService] = useState(false)
+  const [serviceTitle, setServiceTitle] = useState('')
+  const [serviceDuration, setServiceDuration] = useState('10')
+  const [serviceError, setServiceError] = useState<string | null>(null)
+
+  // Offer only durations that fit inside the tapped slot's free length, so a
+  // service can never be created longer than the gap the user tapped into.
+  const durationOptions = useMemo(() => {
+    if (!context) return SERVICE_DURATION_OPTIONS
+    const fitting = [...SERVICE_DURATION_OPTIONS].filter(
+      ([mins]) => Number(mins) <= context.maxDurationMin,
+    )
+    return new Map(fitting.length > 0 ? fitting : [['5', '5 minutes']])
+  }, [context])
+  const effectiveDuration = durationOptions.has(serviceDuration)
+    ? serviceDuration
+    : (durationOptions.keys().next().value ?? '5')
+
+  const confirmService = useCallback(() => {
+    if (!context) return
+    const trimmed = serviceTitle.trim()
+    if (!trimmed) {
+      setServiceError('Enter a session title.')
+      return
+    }
+    const dur = Number(effectiveDuration)
+    const endTime = calculateEndTime(context.startTime, dur)
+    if (
+      dur > context.maxDurationMin ||
+      toMinutes(endTime) > toMinutes(SCHEDULE_END)
+    ) {
+      setServiceError('That duration runs past the free slot.')
+      return
+    }
+    dispatch({
+      type: 'addService',
+      trackIndex: context.trackIndex,
+      title: trimmed,
+      startTime: context.startTime,
+      duration: dur,
+    })
+    onClose()
+  }, [context, serviceTitle, effectiveDuration, dispatch, onClose])
 
   const handlePick = useCallback(
     (proposal: ProposalExisting) => {
@@ -679,14 +549,104 @@ function UnassignedDrawer({
     [context, dispatch, onPick, onClose],
   )
 
+  // Service-creation sub-view: title + duration, start time fixed to the slot.
+  if (context && creatingService) {
+    return (
+      <BottomSheet
+        title={`New service at ${context.startTime}`}
+        onClose={onClose}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            setCreatingService(false)
+            setServiceError(null)
+          }}
+          className="mb-3 inline-flex min-h-[44px] items-center gap-1 text-sm font-medium text-gray-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-gray-300"
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to talks
+        </button>
+
+        <label
+          htmlFor="slot-service-title"
+          className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Session title
+        </label>
+        <input
+          id="slot-service-title"
+          type="text"
+          value={serviceTitle}
+          onChange={(e) => setServiceTitle(e.target.value)}
+          placeholder="e.g. Coffee Break, Lunch"
+          className="mb-4 w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+          autoFocus
+        />
+
+        <div className="mb-4">
+          <Dropdown
+            name="slot-service-duration"
+            label="Duration (minutes)"
+            options={durationOptions}
+            value={effectiveDuration}
+            setValue={setServiceDuration}
+          />
+        </div>
+
+        <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
+          Starts at {context.startTime} · up to {context.maxDurationMin} min
+          available
+        </p>
+
+        {serviceError && (
+          <p
+            role="alert"
+            className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
+          >
+            {serviceError}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={confirmService}
+          disabled={!serviceTitle.trim()}
+          className={`w-full ${PRIMARY_BUTTON}`}
+        >
+          Add session
+        </button>
+      </BottomSheet>
+    )
+  }
+
+  const title = context
+    ? `Assign at ${context.startTime}`
+    : `Unassigned (${proposals.length})`
+
   return (
     <BottomSheet title={title} onClose={onClose}>
       {context && (
-        <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">
-          Free until{' '}
-          {calculateEndTime(context.startTime, context.maxDurationMin)} ·{' '}
-          {context.maxDurationMin} min available
-        </p>
+        <>
+          <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            Free until{' '}
+            {calculateEndTime(context.startTime, context.maxDurationMin)} ·{' '}
+            {context.maxDurationMin} min available
+          </p>
+          {/* The merged "create a service session" path — same tap-a-slot entry
+              point as assigning a talk, no separate per-track button. */}
+          <button
+            type="button"
+            onClick={() => {
+              setCreatingService(true)
+              setServiceError(null)
+            }}
+            className="mb-4 flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-blue-300 bg-blue-50 px-4 py-2.5 text-sm font-semibold text-blue-700 transition-colors hover:bg-blue-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-blue-700 dark:bg-blue-900/20 dark:text-blue-300 dark:hover:bg-blue-900/40"
+          >
+            <PlusIcon className="h-4 w-4" />
+            Create service session here
+          </button>
+        </>
       )}
       <div className="relative mb-4">
         <ProposalFilters filters={filters} />
@@ -887,7 +847,6 @@ function TrackRail({
   placing,
   otherScheduledProposalIds,
   onSegmentTap,
-  onAddService,
   onTrackOptions,
 }: {
   track: ScheduleTrack
@@ -896,18 +855,17 @@ function TrackRail({
   placing: Placing | null
   otherScheduledProposalIds: ReadonlySet<string>
   onSegmentTap: (trackIndex: number, seg: RailSegment) => void
-  onAddService: (trackIndex: number) => void
   onTrackOptions: (trackIndex: number) => void
 }) {
   const segments = useMemo(() => buildTrackRail(track), [track])
 
   return (
     <div className="pb-8">
-      {/* Hidden while placing: the rail is a target picker, and adding a service
-          re-sorts track.talks, which would shift the picked-up item's stored
-          talkIndex and corrupt a later Remove/Swap. */}
+      {/* Hidden while placing: the rail is a target picker, so the per-track
+          controls would only get in the way. Adding a service now lives in the
+          slot-tap sheet (tap an open slot → "Create service session here"). */}
       {!placing && (
-        <div className="mb-1 flex items-center justify-between">
+        <div className="mb-1 flex items-center">
           <button
             type="button"
             onClick={() => onTrackOptions(trackIndex)}
@@ -916,14 +874,6 @@ function TrackRail({
           >
             <Cog6ToothIcon className="h-4 w-4" />
             Track
-          </button>
-          <button
-            type="button"
-            onClick={() => onAddService(trackIndex)}
-            className="inline-flex min-h-[44px] items-center gap-1 text-sm font-medium text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:text-blue-400"
-          >
-            <PlusIcon className="h-4 w-4" />
-            Service
           </button>
         </div>
       )}
@@ -1376,7 +1326,6 @@ function TrackActionSheet({
 /* -------------------------------------------------------------------------- */
 
 type ActiveSheet =
-  | { kind: 'addService'; trackIndex: number }
   | { kind: 'unassigned'; context: SlotContext | null }
   | { kind: 'track'; trackIndex: number }
   | {
@@ -1637,10 +1586,6 @@ export function MobileScheduleView({
     [effPlacing, tracks, dispatch, otherScheduledProposalIds],
   )
 
-  const openAddService = useCallback((trackIndex: number) => {
-    setSheet({ kind: 'addService', trackIndex })
-  }, [])
-
   const openTrackOptions = useCallback((trackIndex: number) => {
     setSheet({ kind: 'track', trackIndex })
   }, [])
@@ -1666,8 +1611,6 @@ export function MobileScheduleView({
   const tabId = (i: number) => `sched-tab-${i}`
   const panelId = (i: number) => `sched-panel-${i}`
 
-  const addServiceTrack =
-    sheet?.kind === 'addService' ? (tracks[sheet.trackIndex] ?? null) : null
   const trackSheetTrack =
     sheet?.kind === 'track' ? (tracks[sheet.trackIndex] ?? null) : null
   const drawerTrack =
@@ -1832,7 +1775,6 @@ export function MobileScheduleView({
                 placing={effPlacing}
                 otherScheduledProposalIds={otherScheduledProposalIds}
                 onSegmentTap={handleSegmentTap}
-                onAddService={openAddService}
                 onTrackOptions={openTrackOptions}
               />
             </div>
@@ -1841,15 +1783,6 @@ export function MobileScheduleView({
       )}
 
       {/* Sheets */}
-      {sheet?.kind === 'addService' && addServiceTrack && (
-        <AddServiceSheet
-          track={addServiceTrack}
-          trackIndex={sheet.trackIndex}
-          dispatch={dispatch}
-          onClose={closeSheet}
-        />
-      )}
-
       {sheet?.kind === 'unassigned' && (
         <UnassignedDrawer
           proposals={unassignedProposals}


### PR DESCRIPTION
## Why

On mobile, adding a talk and adding a service session were **two separate actions**:

- Tapping an open slot → the talk picker (assign a fitting unassigned talk).
- A separate per-track **"＋ Service"** button → its own sheet with its own start-time picker.

That split is unnatural — you had to choose *what kind* of thing to add before choosing *where*. As requested, this merges them: you just tap where you want, then pick a talk **or** create a service session.

## What

Tapping an open slot now opens one sheet, **"Assign at HH:MM"**, that shows:

- **"＋ Create service session here"** on top, then
- the list of fitting unassigned talks (unchanged).

Choosing *Create service session* swaps the sheet to a compact form:

- Session title + duration, with a **← Back to talks** affordance.
- Start time is **fixed to the tapped slot**; duration options are **capped at the slot's free length** (e.g. a 60-min gap offers up to 60 min, not 90).

The redundant per-track **"＋ Service"** button is removed, and the now-dead `AddServiceSheet` / `TimeSelect` / `freeStartTimes` are deleted — **net −55 lines**.

## Tests & visual QA

- Replaced the obsolete "hides the Service control while placing" test with one that drives the merged flow end-to-end: tap slot → *Create service session here* → fill title → *Add session* → asserts `addService` dispatched with the fixed start time. **134 schedule/mobile tests pass**; tsc/eslint clean.
- Visually verified with Playwright at 393px (iPhone portrait): the assign sheet and the service sub-form both render correctly; duration is correctly capped to the 60-min slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR merges what were previously two separate mobile entry points — tap-a-slot (talk assignment) and the per-track \"+ Service\" button — into a single \"Assign at HH:MM\" drawer. Tapping any open slot now shows a unified sheet where the user can either assign an existing talk or enter a compact inline form to create a service session with the start time fixed to the tapped slot.

- **Deleted code**: `AddServiceSheet`, `TimeSelect`, and `freeStartTimes` are fully removed (net −55 lines); the `addService` sheet kind is dropped from the `ActiveSheet` union; `onAddService` is removed from `TrackRail`.
- **New behaviour**: `UnassignedDrawer` gains three pieces of local state (`creatingService`, `serviceTitle`, `serviceDuration`) and a `confirmService` callback; duration options are capped to the slot's free length via `context.maxDurationMin`; a \"← Back to talks\" button navigates back without closing the sheet.

<h3>Confidence Score: 4/5</h3>

Safe to merge for all normal conference-scheduling usage; two edge cases in the new inline service form are worth addressing before the next iteration.

The core merge-flow logic is correct and well-exercised by the updated test suite. Two small issues live in confirmService / durationOptions: the live isTrackIntervalFree guard that the old AddServiceSheet had at dispatch time is no longer present (replaced by the snapshot maxDurationMin), and the fallback duration option for sub-5-minute free slots presents the user with an option that will always error. Both are uncommon in real conference schedules and neither corrupts data on the happy path.

Focus on the confirmService callback and durationOptions fallback in UnassignedDrawer inside MobileScheduleView.tsx.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/MobileScheduleView.tsx | Removes AddServiceSheet, TimeSelect, and freeStartTimes; merges service-creation into UnassignedDrawer as an inline sub-view keyed on a tapped SlotContext. Two minor edge cases: stale maxDurationMin used instead of live isTrackIntervalFree check, and the sub-5-min fallback duration option produces an unsubmittable form. |
| __tests__/components/admin/schedule/MobileScheduleView.test.tsx | Replaces the old "hides Service control while placing" test with an end-to-end test of the merged tap-slot → create-service flow. Covers the happy path; doesn't exercise Back-to-talks navigation, empty-title guard, or the duration-capping behaviour. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User taps open slot on mobile rail] --> B[UnassignedDrawer opens
'Assign at HH:MM']
    B --> C{User choice}
    C -->|Taps '+ Create service session here'| D[Service sub-view renders
'New service at HH:MM']
    D --> E[Fill in title + pick duration
Start time fixed · duration capped to slot]
    E --> F{Tap 'Add session'}
    F -->|title empty| G[Button disabled]
    F -->|dur > maxDurationMin| H[Inline error shown]
    F -->|valid| I[dispatch addService
trackIndex · title · startTime · duration]
    I --> J[Sheet closes]
    C -->|Taps a proposal| K[dispatch moveProposal
Slot fills with talk]
    K --> J
    D -->|Taps '← Back to talks'| B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User taps open slot on mobile rail] --> B[UnassignedDrawer opens
'Assign at HH:MM']
    B --> C{User choice}
    C -->|Taps '+ Create service session here'| D[Service sub-view renders
'New service at HH:MM']
    D --> E[Fill in title + pick duration
Start time fixed · duration capped to slot]
    E --> F{Tap 'Add session'}
    F -->|title empty| G[Button disabled]
    F -->|dur > maxDurationMin| H[Inline error shown]
    F -->|valid| I[dispatch addService
trackIndex · title · startTime · duration]
    I --> J[Sheet closes]
    C -->|Taps a proposal| K[dispatch moveProposal
Slot fills with talk]
    K --> J
    D -->|Taps '← Back to talks'| B
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(schedule): merge add-talk and add-s..."](https://github.com/cloudnativebergen/website/commit/5907498a462700fee0772d0dde85e2ad59997600) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45318413)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->