### PR TITLE
refactor(schedule): extract mobile rail pure core into a mobile/ subtree (Phase 3a)

### DIFF
--- a/__tests__/components/admin/schedule/mobile-placement.test.ts
+++ b/__tests__/components/admin/schedule/mobile-placement.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the mobile rail's pure placement machine (mobile/placement.ts).
+ * `segmentState` drives the rail's valid-target highlighting; it defers legality
+ * to the shared engine classifiers, so these tests pin the parts it OWNS: source
+ * detection, the min-open-slot gate, break/open/talk branch selection, and that
+ * the cross-day set flows through for a fresh proposal.
+ */
+import { describe, it, expect } from 'vitest'
+import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
+import type { ProposalExisting } from '@/lib/proposal/types'
+import type { RailSegment } from '@/components/admin/schedule/mobileRail'
+import type { Placing } from '@/components/admin/schedule/mobile/types'
+import { segmentState } from '@/components/admin/schedule/mobile/placement'
+
+const proposal = (id: string, format = 'talk_25'): ProposalExisting =>
+  ({ _id: id, format }) as unknown as ProposalExisting
+
+const talk = (id: string, start: string, end: string): TrackTalk => ({
+  talk: proposal(id),
+  startTime: start,
+  endTime: end,
+})
+
+const track = (...talks: TrackTalk[]): ScheduleTrack => ({
+  trackTitle: 'A',
+  trackDescription: '',
+  talks,
+})
+
+const openSeg = (start: string, end: string, dur: number): RailSegment => ({
+  kind: 'open',
+  startTime: start,
+  endTime: end,
+  durationMin: dur,
+})
+
+const talkSeg = (
+  id: string,
+  start: string,
+  end: string,
+  dur: number,
+  idx: number,
+): RailSegment => ({
+  kind: 'talk',
+  talk: talk(id, start, end),
+  talkIndex: idx,
+  startTime: start,
+  endTime: end,
+  durationMin: dur,
+})
+
+const breakSeg = (
+  start: string,
+  end: string,
+  dur: number,
+  idx: number,
+): RailSegment => ({
+  kind: 'break',
+  talk: { placeholder: 'Lunch', startTime: start, endTime: end },
+  talkIndex: idx,
+  startTime: start,
+  endTime: end,
+  durationMin: dur,
+})
+
+const NO_OTHERS = new Set<string>()
+
+describe('segmentState', () => {
+  it("marks the pick-up's own segment as source", () => {
+    const placing: Placing = {
+      kind: 'scheduled',
+      trackIndex: 0,
+      talkIndex: 0,
+      talk: talk('a', '10:00', '10:25'),
+    }
+    const seg = talkSeg('a', '10:00', '10:25', 25, 0)
+    expect(
+      segmentState(
+        placing,
+        [track(talk('a', '10:00', '10:25'))],
+        0,
+        seg,
+        NO_OTHERS,
+      ),
+    ).toBe('source')
+  })
+
+  it('proposal → an open slot that fits is a valid move', () => {
+    const placing: Placing = { kind: 'proposal', proposal: proposal('p') }
+    expect(
+      segmentState(
+        placing,
+        [track()],
+        0,
+        openSeg('10:00', '11:00', 60),
+        NO_OTHERS,
+      ),
+    ).toBe('valid')
+  })
+
+  it('proposal → an open slot shorter than the minimum is invalid', () => {
+    const placing: Placing = { kind: 'proposal', proposal: proposal('p') }
+    expect(
+      segmentState(
+        placing,
+        [track()],
+        0,
+        openSeg('10:00', '10:05', 5),
+        NO_OTHERS,
+      ),
+    ).toBe('invalid')
+  })
+
+  it('proposal → a break segment is never a target', () => {
+    const placing: Placing = { kind: 'proposal', proposal: proposal('p') }
+    expect(
+      segmentState(
+        placing,
+        [track()],
+        0,
+        breakSeg('12:00', '12:30', 30, 0),
+        NO_OTHERS,
+      ),
+    ).toBe('invalid')
+  })
+
+  it('a fresh proposal scheduled on another day is rejected (cross-day set flows through)', () => {
+    const placing: Placing = { kind: 'proposal', proposal: proposal('p') }
+    expect(
+      segmentState(
+        placing,
+        [track()],
+        0,
+        openSeg('10:00', '11:00', 60),
+        new Set(['p']),
+      ),
+    ).toBe('invalid')
+  })
+
+  it('scheduled talk → an occupied talk that can swap is valid', () => {
+    const placing: Placing = {
+      kind: 'scheduled',
+      trackIndex: 1,
+      talkIndex: 0,
+      talk: talk('a', '10:00', '10:25'),
+    }
+    const tracks = [
+      track(talk('b', '10:00', '10:25')),
+      track(talk('a', '10:00', '10:25')),
+    ]
+    expect(
+      segmentState(
+        placing,
+        tracks,
+        0,
+        talkSeg('b', '10:00', '10:25', 25, 0),
+        NO_OTHERS,
+      ),
+    ).toBe('valid')
+  })
+
+  it('scheduled service → an open slot is valid, onto a talk is invalid', () => {
+    const placing: Placing = {
+      kind: 'scheduled',
+      trackIndex: 1,
+      talkIndex: 0,
+      talk: { placeholder: 'Break', startTime: '09:00', endTime: '09:15' },
+    }
+    expect(
+      segmentState(
+        placing,
+        [track()],
+        0,
+        openSeg('10:00', '11:00', 60),
+        NO_OTHERS,
+      ),
+    ).toBe('valid')
+    expect(
+      segmentState(
+        placing,
+        [track(talk('a', '10:00', '10:25'))],
+        0,
+        talkSeg('a', '10:00', '10:25', 25, 0),
+        NO_OTHERS,
+      ),
+    ).toBe('invalid')
+  })
+})

--- a/__tests__/components/admin/schedule/mobile-placement.test.ts
+++ b/__tests__/components/admin/schedule/mobile-placement.test.ts
@@ -11,8 +11,8 @@ import { describe, it, expect } from 'vitest'
 import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import type { ProposalExisting } from '@/lib/proposal/types'
 import type { RailSegment } from '@/components/admin/schedule/mobileRail'
-import type { Placing } from '@/components/admin/schedule/mobile/types'
-import { segmentState } from '@/components/admin/schedule/mobile/placement'
+import type { Placing } from '@/components/admin/schedule/mobile'
+import { segmentState } from '@/components/admin/schedule/mobile'
 
 const proposal = (id: string, format = 'talk_25'): ProposalExisting =>
   ({ _id: id, format }) as unknown as ProposalExisting

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -53,16 +53,17 @@ import {
   TAP_TARGET,
   GUTTER_PX,
   MIN_OPEN_SLOT_MIN,
-} from './mobile/constants'
+  segmentHeight,
+  segmentLabel,
+  segmentState,
+} from './mobile'
 import type {
   ActiveSheet,
   MobileScheduleViewProps,
   Placing,
   SegmentState,
   SlotContext,
-} from './mobile/types'
-import { segmentHeight, segmentLabel } from './mobile/railGeometry'
-import { segmentState } from './mobile/placement'
+} from './mobile'
 
 /* -------------------------------------------------------------------------- */
 /* Bottom sheet                                                               */

--- a/src/components/admin/schedule/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.tsx
@@ -19,12 +19,7 @@ import {
 } from '@/lib/schedule/time'
 import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
 import { fitsInTrack, isTrackIntervalFree } from '@/lib/schedule/rules'
-import {
-  classifyProposalDrop,
-  classifyServiceDrop,
-  scheduledProposalIdsExcludingDay,
-} from '@/lib/schedule/operations'
-import type { DragItem } from '@/lib/schedule/types'
+import { scheduledProposalIdsExcludingDay } from '@/lib/schedule/operations'
 import { formatConferenceDate } from '@/lib/time'
 import { buildTrackRail, type RailSegment } from './mobileRail'
 import { StatusBadge, LevelIndicator } from '@/lib/proposal'
@@ -52,174 +47,22 @@ import {
   ArrowLeftIcon,
 } from '@heroicons/react/24/outline'
 
-interface MobileScheduleViewProps {
-  schedules: ConferenceSchedule[]
-  currentDayIndex: number
-  unassignedProposals: ProposalExisting[]
-  dispatch: React.Dispatch<ScheduleAction>
-  onDayChange: (dayIndex: number) => void
-  onSave: () => void
-  onAddTrack: () => void
-  isSaving: boolean
-  saveSuccess: boolean
-  error: string | null
-}
-
-const TAP_TARGET = 'min-h-[44px]'
-
-const PRIMARY_BUTTON =
-  'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600'
-
-const SECONDARY_BUTTON =
-  'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
-
-/* -------------------------------------------------------------------------- */
-/* Rail geometry                                                              */
-/* -------------------------------------------------------------------------- */
-
-// Card heights are content-driven with a small floor; duration adds only a
-// GENTLE, hard-capped proportional nudge so a long workshop reads slightly
-// taller without producing a bulky, mostly-empty card that dominates the panel
-// and fights the swipe. The duration CHIP carries the exact length. Applied as
-// a `minHeight` on the card itself (never via a flex-stretched row).
-const PX_PER_MIN = 0.55
-const SEG_MIN_HEIGHT = 56
-const SEG_MAX_HEIGHT = 112
-const OPEN_MAX_HEIGHT = 72
-// Open gaps shorter than this can't hold a talk, so they render as a slim,
-// non-interactive divider rather than an "assign here" target.
-const MIN_OPEN_SLOT_MIN = 10
-// Left time gutter width (~52px) — the rail line sits at its right edge.
-const GUTTER_PX = 52
-
-function segmentHeight(seg: RailSegment): number {
-  const max = seg.kind === 'open' ? OPEN_MAX_HEIGHT : SEG_MAX_HEIGHT
-  return Math.min(
-    max,
-    Math.max(SEG_MIN_HEIGHT, Math.round(seg.durationMin * PX_PER_MIN)),
-  )
-}
-
-/* -------------------------------------------------------------------------- */
-/* Placement model                                                            */
-/* -------------------------------------------------------------------------- */
-
-/**
- * A picked-up item awaiting a drop. Persists across track swipes, so dropping
- * into another track is "swipe, then tap a slot". A `scheduled` pick-up carries
- * the ORIGINAL `track.talks` index so reducer actions target the right slot.
- */
-type Placing =
-  | {
-      kind: 'scheduled'
-      trackIndex: number
-      talkIndex: number
-      talk: TrackTalk
-    }
-  | { kind: 'proposal'; proposal: ProposalExisting }
-
-/** The open interval a contextual "assign here" drawer was opened for. */
-interface SlotContext {
-  trackIndex: number
-  startTime: string
-  maxDurationMin: number
-}
-
-type SegmentState = 'default' | 'source' | 'valid' | 'invalid'
-
-/** Does `seg` represent the currently picked-up scheduled item? */
-function isPlacingSource(
-  placing: Placing,
-  panelTrackIndex: number,
-  seg: RailSegment,
-): boolean {
-  return (
-    placing.kind === 'scheduled' &&
-    (seg.kind === 'talk' || seg.kind === 'break') &&
-    panelTrackIndex === placing.trackIndex &&
-    seg.talkIndex === placing.talkIndex
-  )
-}
-
-/**
- * Whether `seg` in panel `T` is a legal drop target for the current pick-up.
- * Mirrors `operations.moveProposal` / `moveServiceSession` exactly (same
- * fitsInTrack / interval-free / swap checks + end-of-day guard) so the UI never
- * offers a drop the reducer would reject.
- */
-/** The engine DragItem for the current pick-up (proposal / scheduled talk /
- * scheduled service), so the UI can defer every legality question to the shared
- * classifiers instead of re-deriving the rule. */
-function placingDragItem(placing: Placing): DragItem {
-  if (placing.kind === 'proposal') {
-    return { type: 'proposal', proposal: placing.proposal }
-  }
-  const src = placing.talk
-  if (src.talk) {
-    return {
-      type: 'scheduled-talk',
-      proposal: src.talk,
-      sourceTrackIndex: placing.trackIndex,
-      sourceTimeSlot: src.startTime,
-    }
-  }
-  return {
-    type: 'scheduled-service',
-    serviceSession: {
-      placeholder: src.placeholder ?? '',
-      startTime: src.startTime,
-      endTime: src.endTime,
-    },
-    sourceTrackIndex: placing.trackIndex,
-    sourceTimeSlot: src.startTime,
-  }
-}
-
-function segmentState(
-  placing: Placing,
-  tracks: ScheduleTrack[],
-  T: number,
-  seg: RailSegment,
-  otherScheduledProposalIds: ReadonlySet<string>,
-): SegmentState {
-  if (isPlacingSource(placing, T, seg)) return 'source'
-  if (!tracks[T]) return 'invalid'
-
-  const dragItem = placingDragItem(placing)
-  const dropPosition = { trackIndex: T, timeSlot: seg.startTime }
-
-  // Service pick-up: only moves into open slots (services never swap).
-  if (dragItem.type === 'scheduled-service') {
-    if (seg.kind !== 'open' || seg.durationMin < MIN_OPEN_SLOT_MIN) {
-      return 'invalid'
-    }
-    return classifyServiceDrop(tracks, dragItem, dropPosition) === 'move'
-      ? 'valid'
-      : 'invalid'
-  }
-
-  // Proposal / scheduled talk: an open slot is a MOVE, an occupied talk a SWAP.
-  // The cross-day duplicate set is only consulted for a FRESH proposal drop
-  // (moving an already-scheduled talk bypasses the guard), matching the reducer.
-  if (seg.kind === 'open') {
-    if (seg.durationMin < MIN_OPEN_SLOT_MIN) return 'invalid'
-    return classifyProposalDrop(
-      tracks,
-      dragItem,
-      dropPosition,
-      otherScheduledProposalIds,
-    ) === 'move'
-      ? 'valid'
-      : 'invalid'
-  }
-  if (seg.kind === 'talk') {
-    return classifyProposalDrop(tracks, dragItem, dropPosition) === 'swap'
-      ? 'valid'
-      : 'invalid'
-  }
-  // `break` targets are never a valid drop.
-  return 'invalid'
-}
+import {
+  PRIMARY_BUTTON,
+  SECONDARY_BUTTON,
+  TAP_TARGET,
+  GUTTER_PX,
+  MIN_OPEN_SLOT_MIN,
+} from './mobile/constants'
+import type {
+  ActiveSheet,
+  MobileScheduleViewProps,
+  Placing,
+  SegmentState,
+  SlotContext,
+} from './mobile/types'
+import { segmentHeight, segmentLabel } from './mobile/railGeometry'
+import { segmentState } from './mobile/placement'
 
 /* -------------------------------------------------------------------------- */
 /* Bottom sheet                                                               */
@@ -841,20 +684,6 @@ function DurationChip({ minutes }: { minutes: number }) {
   )
 }
 
-function segmentLabel(
-  seg: RailSegment,
-  placing: Placing | null,
-  state: SegmentState,
-): string {
-  if (seg.kind === 'open') {
-    return `Assign to open slot ${seg.startTime} to ${seg.endTime}`
-  }
-  const title = seg.talk.talk?.title ?? seg.talk.placeholder ?? 'Untitled'
-  if (!placing) return `Options for ${title}`
-  if (state === 'source') return `Cancel moving ${title}`
-  return seg.kind === 'talk' ? `Swap with ${title}` : title
-}
-
 /**
  * One track's hybrid time-rail: a continuous gutter line with a node per
  * segment, and duration-proportional (clamped) bodies. When `placing` is set the
@@ -1344,24 +1173,6 @@ function TrackActionSheet({
 /* -------------------------------------------------------------------------- */
 /* Main view                                                                  */
 /* -------------------------------------------------------------------------- */
-
-type ActiveSheet =
-  | { kind: 'unassigned'; context: SlotContext | null }
-  | { kind: 'track'; trackIndex: number }
-  | {
-      kind: 'card'
-      trackIndex: number
-      talkIndex: number
-      talk: TrackTalk
-    }
-  | {
-      kind: 'serviceEdit'
-      trackIndex: number
-      talkIndex: number
-      talk: TrackTalk
-      mode: 'rename' | 'duration'
-    }
-  | null
 
 export function MobileScheduleView({
   schedules,

--- a/src/components/admin/schedule/mobile/constants.ts
+++ b/src/components/admin/schedule/mobile/constants.ts
@@ -1,0 +1,26 @@
+// Shared constants for the mobile schedule editor: tap-target + button styles
+// and the rail geometry tuning. Pure values, no React — safe to import anywhere
+// in the `mobile/` subtree (and unit-testable).
+
+export const TAP_TARGET = 'min-h-[44px]'
+
+export const PRIMARY_BUTTON =
+  'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600'
+
+export const SECONDARY_BUTTON =
+  'inline-flex min-h-[44px] items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+
+// Rail geometry (see railGeometry.ts). Card heights are content-driven with a
+// small floor; duration adds only a GENTLE, hard-capped proportional nudge so a
+// long workshop reads slightly taller without producing a bulky, mostly-empty
+// card that dominates the panel and fights the swipe. The duration CHIP carries
+// the exact length.
+export const PX_PER_MIN = 0.55
+export const SEG_MIN_HEIGHT = 56
+export const SEG_MAX_HEIGHT = 112
+export const OPEN_MAX_HEIGHT = 72
+// Open gaps shorter than this can't hold a talk, so they render as a slim,
+// non-interactive divider rather than an "assign here" target.
+export const MIN_OPEN_SLOT_MIN = 10
+// Left time gutter width (~52px) — the rail line sits at its right edge.
+export const GUTTER_PX = 52

--- a/src/components/admin/schedule/mobile/index.ts
+++ b/src/components/admin/schedule/mobile/index.ts
@@ -1,0 +1,9 @@
+// Public surface of the mobile schedule-editor subtree. Import from
+// `./mobile` (or `@/components/admin/schedule/mobile`) rather than reaching into
+// deep file paths, per the AGENTS.md barrel convention — so internal file names
+// can move without churning every call site. Phase 3b will add the sheet / rail
+// / chrome components and MobileScheduleView itself here.
+export * from './constants'
+export * from './types'
+export * from './railGeometry'
+export * from './placement'

--- a/src/components/admin/schedule/mobile/placement.ts
+++ b/src/components/admin/schedule/mobile/placement.ts
@@ -1,0 +1,104 @@
+import type { ScheduleTrack } from '@/lib/conference/types'
+import type { DragItem } from '@/lib/schedule/types'
+import {
+  classifyProposalDrop,
+  classifyServiceDrop,
+} from '@/lib/schedule/operations'
+import type { RailSegment } from '../mobileRail'
+import { MIN_OPEN_SLOT_MIN } from './constants'
+import type { Placing, SegmentState } from './types'
+
+/** Does `seg` represent the currently picked-up scheduled item? */
+export function isPlacingSource(
+  placing: Placing,
+  panelTrackIndex: number,
+  seg: RailSegment,
+): boolean {
+  return (
+    placing.kind === 'scheduled' &&
+    (seg.kind === 'talk' || seg.kind === 'break') &&
+    panelTrackIndex === placing.trackIndex &&
+    seg.talkIndex === placing.talkIndex
+  )
+}
+
+/**
+ * The engine DragItem for the current pick-up (proposal / scheduled talk /
+ * scheduled service), so the UI can defer every legality question to the shared
+ * classifiers instead of re-deriving the rule.
+ */
+export function placingDragItem(placing: Placing): DragItem {
+  if (placing.kind === 'proposal') {
+    return { type: 'proposal', proposal: placing.proposal }
+  }
+  const src = placing.talk
+  if (src.talk) {
+    return {
+      type: 'scheduled-talk',
+      proposal: src.talk,
+      sourceTrackIndex: placing.trackIndex,
+      sourceTimeSlot: src.startTime,
+    }
+  }
+  return {
+    type: 'scheduled-service',
+    serviceSession: {
+      placeholder: src.placeholder ?? '',
+      startTime: src.startTime,
+      endTime: src.endTime,
+    },
+    sourceTrackIndex: placing.trackIndex,
+    sourceTimeSlot: src.startTime,
+  }
+}
+
+/**
+ * Whether `seg` in panel `T` is a legal drop target for the current pick-up.
+ * Defers to the shared `classifyProposalDrop` / `classifyServiceDrop` engine
+ * predicates so the UI never offers a drop the reducer would reject. The
+ * cross-day duplicate set is only consulted for a FRESH proposal drop (moving
+ * an already-scheduled talk bypasses the guard), matching the reducer.
+ */
+export function segmentState(
+  placing: Placing,
+  tracks: ScheduleTrack[],
+  T: number,
+  seg: RailSegment,
+  otherScheduledProposalIds: ReadonlySet<string>,
+): SegmentState {
+  if (isPlacingSource(placing, T, seg)) return 'source'
+  if (!tracks[T]) return 'invalid'
+
+  const dragItem = placingDragItem(placing)
+  const dropPosition = { trackIndex: T, timeSlot: seg.startTime }
+
+  // Service pick-up: only moves into open slots (services never swap).
+  if (dragItem.type === 'scheduled-service') {
+    if (seg.kind !== 'open' || seg.durationMin < MIN_OPEN_SLOT_MIN) {
+      return 'invalid'
+    }
+    return classifyServiceDrop(tracks, dragItem, dropPosition) === 'move'
+      ? 'valid'
+      : 'invalid'
+  }
+
+  // Proposal / scheduled talk: an open slot is a MOVE, an occupied talk a SWAP.
+  if (seg.kind === 'open') {
+    if (seg.durationMin < MIN_OPEN_SLOT_MIN) return 'invalid'
+    return classifyProposalDrop(
+      tracks,
+      dragItem,
+      dropPosition,
+      otherScheduledProposalIds,
+    ) === 'move'
+      ? 'valid'
+      : 'invalid'
+  }
+  if (seg.kind === 'talk') {
+    return classifyProposalDrop(tracks, dragItem, dropPosition) === 'swap'
+      ? 'valid'
+      : 'invalid'
+  }
+  // `break` targets are never a valid drop.
+  return 'invalid'
+}

--- a/src/components/admin/schedule/mobile/railGeometry.ts
+++ b/src/components/admin/schedule/mobile/railGeometry.ts
@@ -1,0 +1,32 @@
+import type { RailSegment } from '../mobileRail'
+import type { Placing, SegmentState } from './types'
+import {
+  OPEN_MAX_HEIGHT,
+  PX_PER_MIN,
+  SEG_MAX_HEIGHT,
+  SEG_MIN_HEIGHT,
+} from './constants'
+
+/** Clamped, duration-proportional pixel height for a rail segment's card. */
+export function segmentHeight(seg: RailSegment): number {
+  const max = seg.kind === 'open' ? OPEN_MAX_HEIGHT : SEG_MAX_HEIGHT
+  return Math.min(
+    max,
+    Math.max(SEG_MIN_HEIGHT, Math.round(seg.durationMin * PX_PER_MIN)),
+  )
+}
+
+/** Accessible label for a rail segment, context-aware of the current pick-up. */
+export function segmentLabel(
+  seg: RailSegment,
+  placing: Placing | null,
+  state: SegmentState,
+): string {
+  if (seg.kind === 'open') {
+    return `Assign to open slot ${seg.startTime} to ${seg.endTime}`
+  }
+  const title = seg.talk.talk?.title ?? seg.talk.placeholder ?? 'Untitled'
+  if (!placing) return `Options for ${title}`
+  if (state === 'source') return `Cancel moving ${title}`
+  return seg.kind === 'talk' ? `Swap with ${title}` : title
+}

--- a/src/components/admin/schedule/mobile/types.ts
+++ b/src/components/admin/schedule/mobile/types.ts
@@ -1,0 +1,59 @@
+import type React from 'react'
+import type { ConferenceSchedule, TrackTalk } from '@/lib/conference/types'
+import type { ProposalExisting } from '@/lib/proposal/types'
+import type { ScheduleAction } from '@/lib/schedule/reducer'
+
+export interface MobileScheduleViewProps {
+  schedules: ConferenceSchedule[]
+  currentDayIndex: number
+  unassignedProposals: ProposalExisting[]
+  dispatch: React.Dispatch<ScheduleAction>
+  onDayChange: (dayIndex: number) => void
+  onSave: () => void
+  onAddTrack: () => void
+  isSaving: boolean
+  saveSuccess: boolean
+  error: string | null
+}
+
+/**
+ * A picked-up item awaiting a drop. Persists across track swipes, so dropping
+ * into another track is "swipe, then tap a slot". A `scheduled` pick-up carries
+ * the ORIGINAL `track.talks` index so reducer actions target the right slot.
+ */
+export type Placing =
+  | {
+      kind: 'scheduled'
+      trackIndex: number
+      talkIndex: number
+      talk: TrackTalk
+    }
+  | { kind: 'proposal'; proposal: ProposalExisting }
+
+/** The open interval a contextual "assign here" drawer was opened for. */
+export interface SlotContext {
+  trackIndex: number
+  startTime: string
+  maxDurationMin: number
+}
+
+export type SegmentState = 'default' | 'source' | 'valid' | 'invalid'
+
+/** Which bottom sheet (if any) is currently open over the rail. */
+export type ActiveSheet =
+  | { kind: 'unassigned'; context: SlotContext | null }
+  | { kind: 'track'; trackIndex: number }
+  | {
+      kind: 'card'
+      trackIndex: number
+      talkIndex: number
+      talk: TrackTalk
+    }
+  | {
+      kind: 'serviceEdit'
+      trackIndex: number
+      talkIndex: number
+      talk: TrackTalk
+      mode: 'rename' | 'duration'
+    }
+  | null


### PR DESCRIPTION
First stage of splitting the ~1880-line `MobileScheduleView` god component (Phase 3 of the schedule-editor restructure).

## What

Move the **pure, React-free core** out of the component into a `mobile/` subtree so it has clear module boundaries and is independently unit-testable:

| File | Contents |
|---|---|
| `mobile/constants.ts` | tap-target + button style strings, rail geometry tuning (`PX_PER_MIN`, `SEG_*`, `MIN_OPEN_SLOT_MIN`, `GUTTER_PX`) |
| `mobile/types.ts` | `MobileScheduleViewProps`, `Placing`, `SlotContext`, `SegmentState`, `ActiveSheet` |
| `mobile/railGeometry.ts` | `segmentHeight`, `segmentLabel` |
| `mobile/placement.ts` | `isPlacingSource`, `placingDragItem`, `segmentState` — the valid-target state machine, deferring legality to the shared engine classifiers |

`MobileScheduleView.tsx` now imports these (**1879 → 1690 lines**). **No behaviour change** — pure move.

## Tests

Adds `mobile-placement.test.ts` (7 cases) pinning `segmentState`'s own logic now that it's isolated: source detection, the min-open-slot gate, break/open/talk branch selection, cross-day-set flow-through, and service-vs-talk targets. **141 schedule/mobile tests pass**; tsc/eslint/prettier clean.

## Next

Phase 3b will move the sheet / rail / chrome **components** (`BottomSheet`, the `sheets/*`, `TrackRail`, day/legend/banner chrome) into the same subtree with barrels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is the first stage of breaking up the ~1880-line `MobileScheduleView` god component. It moves the pure, React-free core — tap-target/button constants, rail-geometry constants and functions, placement types, and the `segmentState` state machine — into a `mobile/` subtree, then re-imports them from `MobileScheduleView.tsx`. Seven new unit tests pin `segmentState`'s own logic independently.

- **`mobile/{constants,types,railGeometry,placement}.ts`** — verbatim extractions of inlined blocks; no logic change, no behaviour difference at runtime.
- **`mobile-placement.test.ts`** — exercises `segmentState` directly using the real engine classifiers (no mocks), covering source detection, the min-open-slot gate, break/open/talk branching, the cross-day duplicate guard, and service vs. talk targeting.
- **`MobileScheduleView.tsx`** — shrinks by ~190 lines; now imports everything from the new subtree.

<h3>Confidence Score: 4/5</h3>

This is a pure structural move with no runtime behaviour change — safe to merge.

All moved code is identical to what was inlined; the new unit tests pass and confirm the state machine works in isolation. The only gap is that the `mobile/` subtree has no barrel export yet, meaning consumers import from deep paths, which makes the module boundary a little fragile until Phase 3b lands the barrels.

No files need special attention for correctness; `mobile/constants.ts` is the natural home for the eventual `index.ts` barrel when Phase 3b lands.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/mobile/constants.ts | New file — extracts tap-target strings, button-style strings, and rail-geometry constants verbatim from MobileScheduleView.tsx. Values are identical to what was inlined; no logic change. |
| src/components/admin/schedule/mobile/types.ts | New file — lifts MobileScheduleViewProps, Placing, SlotContext, SegmentState, and ActiveSheet type declarations out of MobileScheduleView.tsx unchanged. Imports React type-only for Dispatch. |
| src/components/admin/schedule/mobile/railGeometry.ts | New file — moves segmentHeight and segmentLabel pure functions from MobileScheduleView.tsx; logic is identical, imports constants from the sibling constants.ts file. |
| src/components/admin/schedule/mobile/placement.ts | New file — moves isPlacingSource, placingDragItem, and segmentState pure functions unchanged; two stacked JSDoc comments from the original that were confusingly ordered are now properly separated. |
| src/components/admin/schedule/MobileScheduleView.tsx | Reduced from ~1879 to ~1690 lines by replacing inlined type/constant/function blocks with imports from the new mobile/ subtree; net behavior is identical. |
| __tests__/components/admin/schedule/mobile-placement.test.ts | New test file — 7 unit cases covering segmentState's own logic (source detection, min-slot gate, break/open/talk branching, cross-day guard, service vs talk targets) using real engine classifiers, no mocks. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    MSV["MobileScheduleView.tsx"]

    subgraph mobile["mobile/ (new subtree)"]
        C["constants.ts\n(TAP_TARGET, buttons,\nPX_PER_MIN, GUTTER_PX…)"]
        T["types.ts\n(MobileScheduleViewProps,\nPlacing, SlotContext,\nSegmentState, ActiveSheet)"]
        RG["railGeometry.ts\n(segmentHeight,\nsegmentLabel)"]
        PL["placement.ts\n(isPlacingSource,\nplacingDragItem,\nsegmentState)"]
    end

    OPS["@/lib/schedule/operations\n(classifyProposalDrop,\nclassifyServiceDrop,\nscheduledProposalIdsExcludingDay)"]
    RAIL["mobileRail.ts\n(buildTrackRail, RailSegment)"]

    MSV -->|imports from| C
    MSV -->|imports from| T
    MSV -->|imports from| RG
    MSV -->|imports from| PL
    MSV -->|imports from| OPS

    RG -->|imports| C
    RG -->|imports type| RAIL
    PL -->|imports| C
    PL -->|imports type| RAIL
    PL -->|imports| OPS

    TEST["mobile-placement.test.ts"]
    TEST -->|tests| PL
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    MSV["MobileScheduleView.tsx"]

    subgraph mobile["mobile/ (new subtree)"]
        C["constants.ts\n(TAP_TARGET, buttons,\nPX_PER_MIN, GUTTER_PX…)"]
        T["types.ts\n(MobileScheduleViewProps,\nPlacing, SlotContext,\nSegmentState, ActiveSheet)"]
        RG["railGeometry.ts\n(segmentHeight,\nsegmentLabel)"]
        PL["placement.ts\n(isPlacingSource,\nplacingDragItem,\nsegmentState)"]
    end

    OPS["@/lib/schedule/operations\n(classifyProposalDrop,\nclassifyServiceDrop,\nscheduledProposalIdsExcludingDay)"]
    RAIL["mobileRail.ts\n(buildTrackRail, RailSegment)"]

    MSV -->|imports from| C
    MSV -->|imports from| T
    MSV -->|imports from| RG
    MSV -->|imports from| PL
    MSV -->|imports from| OPS

    RG -->|imports| C
    RG -->|imports type| RAIL
    PL -->|imports| C
    PL -->|imports type| RAIL
    PL -->|imports| OPS

    TEST["mobile-placement.test.ts"]
    TEST -->|tests| PL
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(schedule): extract mobile rail ..."](https://github.com/cloudnativebergen/website/commit/45e2a393b0577fdce78d57094f1c8adee7e021e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45319767)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->