### PR TITLE
fix(scripts): shoot auto-start broken by Storybook 10 arg parsing

### DIFF
--- a/scripts/shoot-story.mjs
+++ b/scripts/shoot-story.mjs
@@ -48,7 +48,13 @@ const pmBin = process.platform === 'win32' ? `${pm}.cmd` : pm
 let started
 if (!(await storybookUp())) {
   console.log(`[shoot] starting Storybook on :6006 (via ${pm}) …`)
-  started = spawn(pmBin, ['run', 'storybook', '--', '--ci', '--quiet'], {
+  // npm needs `--` to forward flags to the script; pnpm/yarn forward them as-is
+  // and pass a literal `--` through to the storybook CLI, which Storybook 10
+  // rejects ("too many arguments for 'dev'"). Only insert it for npm.
+  const runArgs = ['run', 'storybook']
+  if (pm === 'npm') runArgs.push('--')
+  runArgs.push('--ci', '--quiet')
+  started = spawn(pmBin, runArgs, {
     stdio: 'ignore',
     detached: true,
   })


### PR DESCRIPTION
Found during Phase 3b verification: `pnpm shoot`'s Storybook auto-start spawns `pnpm run storybook -- --ci --quiet`, and pnpm forwards the literal `--` to the `storybook` CLI, which Storybook 10 rejects ("too many arguments for 'dev'"). The mandated visual-QA tool therefore only worked if Storybook was already running.

Fix: insert the `--` separator only for npm (which requires it); pnpm/yarn forward flags as-is.

Verified cold — with nothing listening on :6006, `pnpm shoot` now auto-starts Storybook and completes: `OK: 3 card(s) checked, none exceed the 393px viewport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a one-line regression in `scripts/shoot-story.mjs` where the Storybook auto-start command always included a `--` separator that pnpm forwards verbatim to the storybook CLI, causing Storybook 10's `dev` subcommand to reject it with "too many arguments".

- **Root cause fixed**: the `--` arg separator is now only inserted when the detected package manager is `npm` (which requires it to pass extra flags through `npm run`); pnpm and yarn both forward flags directly without needing it.
- **Detection logic unchanged**: the existing `npm_config_user_agent`-based PM detection remains untouched; the fix simply plumbs its result into `runArgs` construction.
- **Verified cold-start**: the author confirmed `pnpm shoot` auto-starts Storybook and completes the viewport-overflow check with nothing pre-running on `:6006`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single conditional in the spawn args construction with no side effects outside the auto-start path.

The change is a 7-line diff that adds a guard around one runArgs.push('--') call. All three package-manager branches (npm, yarn, pnpm) are handled correctly, the default path (direct node invocation) falls through to pnpm with no separator, and the rest of the script is untouched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/shoot-story.mjs | Minimal targeted fix: conditionally omits `--` from the pnpm/yarn Storybook spawn args to resolve Storybook 10 argument-parsing rejection. Logic is straightforward and correct for all three detected package managers. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm shoot] --> B{storybookUp on :6006?}
    B -- yes --> G[Launch Playwright]
    B -- no --> C[Detect package manager via npm_config_user_agent]
    C --> D{pm === 'npm'?}
    D -- yes --> E["runArgs = ['run','storybook','--','--ci','--quiet']"]
    D -- no --> F["runArgs = ['run','storybook','--ci','--quiet']"]
    E --> H[spawn pmBin with runArgs]
    F --> H
    H --> I[Poll :6006 every 2s up to 45 attempts]
    I --> J{Storybook up?}
    J -- no --> K[Exit 1]
    J -- yes --> G
    G --> L[Screenshot story / Print overflow check]
    L --> M[Kill spawned Storybook if we started it]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pnpm shoot] --> B{storybookUp on :6006?}
    B -- yes --> G[Launch Playwright]
    B -- no --> C[Detect package manager via npm_config_user_agent]
    C --> D{pm === 'npm'?}
    D -- yes --> E["runArgs = ['run','storybook','--','--ci','--quiet']"]
    D -- no --> F["runArgs = ['run','storybook','--ci','--quiet']"]
    E --> H[spawn pmBin with runArgs]
    F --> H
    H --> I[Poll :6006 every 2s up to 45 attempts]
    I --> J{Storybook up?}
    J -- no --> K[Exit 1]
    J -- yes --> G
    G --> L[Screenshot story / Print overflow check]
    L --> M[Kill spawned Storybook if we started it]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(scripts): shoot auto-start broken by..."](https://github.com/cloudnativebergen/website/commit/37f3f5c27ee19bc1ee9b17be844b41c36e8c7905) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45321644)</sub>

<!-- /greptile_comment -->