### PR TITLE
refactor(schedule): discriminated-union Slot type at the load boundary (Phase 4a)

### DIFF
--- a/__tests__/lib/schedule/operations.test.ts
+++ b/__tests__/lib/schedule/operations.test.ts
@@ -9,13 +9,14 @@
  *   - moveProposal's duplicate guard considers OTHER days (cross-day dedup).
  */
 import { describe, it, expect } from 'vitest'
-import type {
-  ConferenceSchedule,
-  ScheduleTrack,
-  TrackTalk,
-} from '@/lib/conference/types'
 import type { ProposalExisting } from '@/lib/proposal/types'
-import type { DragItem, DropPosition } from '@/lib/schedule/types'
+import type {
+  DragItem,
+  DropPosition,
+  Slot,
+  EditorTrack,
+  EditorSchedule,
+} from '@/lib/schedule/types'
 import {
   moveProposal,
   moveServiceSession,
@@ -36,25 +37,27 @@ import {
 const proposal = (id: string, format = 'talk_25'): ProposalExisting =>
   ({ _id: id, format }) as unknown as ProposalExisting
 
-const talk = (id: string, start: string, end: string): TrackTalk => ({
+const talk = (id: string, start: string, end: string): Slot => ({
+  kind: 'talk',
   talk: proposal(id),
   startTime: start,
   endTime: end,
 })
 
-const service = (name: string, start: string, end: string): TrackTalk => ({
+const service = (name: string, start: string, end: string): Slot => ({
+  kind: 'service',
   placeholder: name,
   startTime: start,
   endTime: end,
 })
 
-const track = (title: string, ...talks: TrackTalk[]): ScheduleTrack => ({
+const track = (title: string, ...talks: Slot[]): EditorTrack => ({
   trackTitle: title,
   trackDescription: '',
   talks,
 })
 
-const schedule = (...tracks: ScheduleTrack[]): ConferenceSchedule => ({
+const schedule = (...tracks: EditorTrack[]): EditorSchedule => ({
   _id: '',
   date: '2025-09-18',
   tracks,
@@ -446,7 +449,7 @@ describe('classifier ⇔ reducer equivalence', () => {
   const proposalCases: Array<{
     name: string
     build: () => {
-      s: ConferenceSchedule
+      s: EditorSchedule
       d: DragItem
       p: DropPosition
       others?: Set<string>
@@ -546,7 +549,7 @@ describe('classifier ⇔ reducer equivalence', () => {
 
   const serviceCases: Array<{
     name: string
-    build: () => { s: ConferenceSchedule; d: DragItem; p: DropPosition }
+    build: () => { s: EditorSchedule; d: DragItem; p: DropPosition }
   }> = [
     {
       name: 'place a service into a free interval',

--- a/__tests__/lib/schedule/reducer.test.ts
+++ b/__tests__/lib/schedule/reducer.test.ts
@@ -11,13 +11,14 @@
  *      the old code only saved the current day and dropped the rest.
  */
 import { describe, it, expect } from 'vitest'
-import type {
-  ConferenceSchedule,
-  ScheduleTrack,
-  TrackTalk,
-} from '@/lib/conference/types'
+import type { TrackTalk } from '@/lib/conference/types'
 import type { ProposalExisting } from '@/lib/proposal/types'
-import type { DragItem } from '@/lib/schedule/types'
+import type {
+  DragItem,
+  Slot,
+  EditorTrack,
+  EditorSchedule,
+} from '@/lib/schedule/types'
 import {
   scheduleReducer,
   initScheduleEditorState,
@@ -27,13 +28,14 @@ import {
 const proposal = (id: string, format = 'talk_25'): ProposalExisting =>
   ({ _id: id, format }) as unknown as ProposalExisting
 
-const talk = (id: string, start: string, end: string): TrackTalk => ({
+const talk = (id: string, start: string, end: string): Slot => ({
+  kind: 'talk',
   talk: proposal(id),
   startTime: start,
   endTime: end,
 })
 
-const track = (title: string, ...talks: TrackTalk[]): ScheduleTrack => ({
+const track = (title: string, ...talks: Slot[]): EditorTrack => ({
   trackTitle: title,
   trackDescription: '',
   talks,
@@ -41,8 +43,8 @@ const track = (title: string, ...talks: TrackTalk[]): ScheduleTrack => ({
 
 const unsavedDay = (
   date: string,
-  ...tracks: ScheduleTrack[]
-): ConferenceSchedule => ({
+  ...tracks: EditorTrack[]
+): EditorSchedule => ({
   _id: '',
   date,
   tracks,

--- a/__tests__/lib/schedule/slots.test.ts
+++ b/__tests__/lib/schedule/slots.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for the load-boundary converters (src/lib/schedule/types.ts): `toSlot`,
+ * `toEditorTrack`, and `toEditorSchedule`. These construct the discriminated
+ * `Slot` union ONCE at the server boundary and perform the SINGLE editor-side
+ * ghost-strip, so the editor never carries an unremovable/unsavable slot.
+ */
+import { describe, it, expect } from 'vitest'
+import type { ProposalExisting } from '@/lib/proposal/types'
+import type { ConferenceSchedule, TrackTalk } from '@/lib/conference/types'
+import { toSlot, toEditorSchedule } from '@/lib/schedule/types'
+
+const proposal = (id: string): ProposalExisting =>
+  ({ _id: id, format: 'talk_25' }) as unknown as ProposalExisting
+
+describe('toSlot', () => {
+  it('tags a resolved talk reference as a TalkSlot', () => {
+    const slot = toSlot({
+      talk: proposal('t1'),
+      startTime: '09:00',
+      endTime: '09:25',
+    })
+    expect(slot).toEqual({
+      kind: 'talk',
+      talk: proposal('t1'),
+      startTime: '09:00',
+      endTime: '09:25',
+    })
+  })
+
+  it('tags a placeholder as a ServiceSlot', () => {
+    const slot = toSlot({
+      placeholder: 'Lunch',
+      startTime: '12:00',
+      endTime: '13:00',
+    })
+    expect(slot).toEqual({
+      kind: 'service',
+      placeholder: 'Lunch',
+      startTime: '12:00',
+      endTime: '13:00',
+    })
+  })
+
+  it('returns null for a ghost (dangling talk ref, no placeholder)', () => {
+    // The proposal was deleted after being scheduled: `talk` no longer resolves
+    // and there is no placeholder.
+    const ghost = {
+      talk: null,
+      startTime: '10:00',
+      endTime: '10:25',
+    } as unknown as TrackTalk
+    expect(toSlot(ghost)).toBeNull()
+  })
+
+  it('prefers the resolved talk when both are present', () => {
+    const slot = toSlot({
+      talk: proposal('t2'),
+      placeholder: 'ignored',
+      startTime: '09:00',
+      endTime: '09:25',
+    })
+    expect(slot?.kind).toBe('talk')
+  })
+})
+
+describe('toEditorSchedule', () => {
+  it('drops ghost slots while preserving order and fields of the rest', () => {
+    const persisted: ConferenceSchedule = {
+      _id: 'sched-1',
+      _rev: 'rev-1',
+      date: '2026-03-10',
+      tracks: [
+        {
+          trackTitle: 'A',
+          trackDescription: 'first',
+          talks: [
+            { talk: proposal('t1'), startTime: '09:00', endTime: '09:25' },
+            // ghost between two real slots — must be dropped without shifting
+            // the surrounding order.
+            {
+              talk: null,
+              startTime: '10:00',
+              endTime: '10:25',
+            } as unknown as TrackTalk,
+            { placeholder: 'Lunch', startTime: '12:00', endTime: '13:00' },
+          ],
+        },
+        {
+          trackTitle: 'B',
+          trackDescription: 'second',
+          talks: [],
+        },
+      ],
+    }
+
+    const editor = toEditorSchedule(persisted)
+
+    // Top-level day fields are preserved.
+    expect(editor._id).toBe('sched-1')
+    expect(editor._rev).toBe('rev-1')
+    expect(editor.date).toBe('2026-03-10')
+
+    // Track fields and order preserved.
+    expect(editor.tracks.map((t) => t.trackTitle)).toEqual(['A', 'B'])
+    expect(editor.tracks[0].trackDescription).toBe('first')
+
+    // Ghost dropped; the two real slots keep their order and are tagged.
+    const talks = editor.tracks[0].talks
+    expect(talks).toHaveLength(2)
+    expect(talks.map((s) => s.kind)).toEqual(['talk', 'service'])
+    expect(talks[0].talk?._id).toBe('t1')
+    expect(talks[1].placeholder).toBe('Lunch')
+
+    // Empty track converts trivially.
+    expect(editor.tracks[1].talks).toEqual([])
+  })
+})

--- a/src/components/admin/schedule/MobileScheduleView.stories.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.stories.tsx
@@ -6,6 +6,7 @@ import {
   initScheduleEditorState,
 } from '@/lib/schedule/reducer'
 import { computeUnassigned } from '@/lib/schedule/operations'
+import { toEditorSchedule } from '@/lib/schedule/types'
 import { ConferenceSchedule } from '@/lib/conference/types'
 import {
   ProposalExisting,
@@ -115,7 +116,9 @@ function MobileScheduleHarness({
 }) {
   const [state, dispatch] = useReducer(
     scheduleReducer,
-    { schedules: initialSchedules, proposals },
+    // Fixtures are persisted-shaped; resolve them to EditorSchedules at the
+    // (story) load boundary, exactly as `getScheduleData` does in production.
+    { schedules: initialSchedules.map(toEditorSchedule), proposals },
     initScheduleEditorState,
   )
   const unassignedProposals = computeUnassigned(

--- a/src/components/admin/schedule/ScheduleEditor.stories.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.stories.tsx
@@ -14,6 +14,7 @@ import {
   Audience,
   Status,
 } from '@/lib/proposal/types'
+import { toEditorSchedule } from '@/lib/schedule/types'
 import { convertStringToPortableTextBlocks } from '@/lib/proposal'
 
 const createMockProposal = (
@@ -283,7 +284,7 @@ type Story = StoryObj<typeof ScheduleEditor>
 
 export const EmptySchedule: Story = {
   args: {
-    initialSchedules: [emptySchedule],
+    initialSchedules: [emptySchedule].map(toEditorSchedule),
     conference: mockConference,
     initialProposals: allProposals,
   },
@@ -299,7 +300,7 @@ export const EmptySchedule: Story = {
 
 export const SingleDayWithTracks: Story = {
   args: {
-    initialSchedules: [singleDaySchedule],
+    initialSchedules: [singleDaySchedule].map(toEditorSchedule),
     conference: mockConference,
     initialProposals: allProposals,
   },
@@ -315,7 +316,7 @@ export const SingleDayWithTracks: Story = {
 
 export const MultiDay: Story = {
   args: {
-    initialSchedules: multiDaySchedules,
+    initialSchedules: multiDaySchedules.map(toEditorSchedule),
     conference: mockConference,
     initialProposals: allProposals,
   },

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -15,13 +15,8 @@ import {
 } from '@dnd-kit/core'
 import { useState, useReducer, useMemo, useCallback } from 'react'
 import React from 'react'
-import {
-  ScheduleTrack,
-  ConferenceSchedule,
-  TrackTalk,
-  Conference,
-} from '@/lib/conference/types'
-import { DragItem } from '@/lib/schedule/types'
+import { ScheduleTrack, TrackTalk, Conference } from '@/lib/conference/types'
+import { DragItem, type EditorSchedule } from '@/lib/schedule/types'
 import {
   scheduleReducer,
   initScheduleEditorState,
@@ -44,7 +39,7 @@ import { api } from '@/lib/trpc/client'
 import { PlusIcon } from '@heroicons/react/24/outline'
 
 interface ScheduleEditorProps {
-  initialSchedules: ConferenceSchedule[]
+  initialSchedules: EditorSchedule[]
   conference: Conference
   initialProposals: ProposalExisting[]
 }

--- a/src/lib/schedule/operations.ts
+++ b/src/lib/schedule/operations.ts
@@ -7,6 +7,10 @@ import { ProposalExisting } from '@/lib/proposal/types'
 import {
   DragItem,
   DropPosition,
+  EditorSchedule,
+  Slot,
+  TalkSlot,
+  toEditorTrack,
   calculateEndTime,
   getProposalDurationMinutes,
   durationBetween,
@@ -31,11 +35,11 @@ import { withinScheduleEnd } from './time'
 
 /** Result of a transform: the (possibly unchanged) schedule and whether it took. */
 export interface OperationResult {
-  schedule: ConferenceSchedule
+  schedule: EditorSchedule
   ok: boolean
 }
 
-const sortByStart = (a: TrackTalk, b: TrackTalk): number =>
+const sortByStart = (a: Slot, b: Slot): number =>
   a.startTime.localeCompare(b.startTime)
 
 /**
@@ -45,11 +49,11 @@ const sortByStart = (a: TrackTalk, b: TrackTalk): number =>
  * already validated both directions with `canSwapTalks` + `canPlaceDisplacedBack`.
  */
 function performSwap(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   dragItem: DragItem,
-  targetTalk: TrackTalk,
+  targetTalk: TalkSlot,
   dropPosition: DropPosition,
-): ConferenceSchedule {
+): EditorSchedule {
   const proposal = dragItem.proposal!
   const { trackIndex, timeSlot } = dropPosition
 
@@ -59,7 +63,7 @@ function performSwap(
   )
   const targetEndTime = calculateEndTime(
     dragItem.sourceTimeSlot!,
-    getProposalDurationMinutes(targetTalk.talk!),
+    getProposalDurationMinutes(targetTalk.talk),
   )
 
   const newTracks = [...schedule.tracks]
@@ -85,11 +89,12 @@ function performSwap(
   const newTargetTalks = currentTargetTrack.talks.filter(
     (talk) =>
       !(
-        talk.talk?._id === targetTalk.talk!._id &&
+        talk.talk?._id === targetTalk.talk._id &&
         talk.startTime === targetTalk.startTime
       ),
   )
-  const newDraggedTalk: TrackTalk = {
+  const newDraggedTalk: TalkSlot = {
+    kind: 'talk',
     talk: proposal,
     startTime: timeSlot,
     endTime: draggedEndTime,
@@ -103,7 +108,8 @@ function performSwap(
     dragItem.sourceTrackIndex !== undefined &&
     dragItem.sourceTimeSlot !== undefined
   ) {
-    const newTargetTalkAtSource: TrackTalk = {
+    const newTargetTalkAtSource: TalkSlot = {
+      kind: 'talk',
       talk: targetTalk.talk,
       startTime: dragItem.sourceTimeSlot,
       endTime: targetEndTime,
@@ -258,7 +264,7 @@ export function classifyServiceDrop(
  * move/swap so the rule lives in exactly one place.
  */
 export function moveProposal(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   dragItem: DragItem,
   dropPosition: DropPosition,
   otherScheduledProposalIds?: ReadonlySet<string>,
@@ -280,7 +286,10 @@ export function moveProposal(
   if (kind === 'swap') {
     const occupiedTalk = targetTrack.talks.find(
       (talk) => talk.startTime === timeSlot,
-    )!
+    )
+    // classify returned 'swap' ⇒ the occupying slot is a resolved talk; the
+    // `kind` narrow gives performSwap a TalkSlot (no non-null assertion needed).
+    if (occupiedTalk?.kind !== 'talk') return fail
     return {
       schedule: performSwap(schedule, dragItem, occupiedTalk, dropPosition),
       ok: true,
@@ -313,7 +322,8 @@ export function moveProposal(
   }
 
   const finalTargetTrack = newTracks[trackIndex]
-  const newTalk: TrackTalk = {
+  const newTalk: TalkSlot = {
+    kind: 'talk',
     talk: proposal,
     startTime: timeSlot,
     endTime,
@@ -332,7 +342,7 @@ export function moveProposal(
  * check covers both talks and other service sessions).
  */
 export function moveServiceSession(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   dragItem: DragItem,
   dropPosition: DropPosition,
 ): OperationResult {
@@ -373,7 +383,8 @@ export function moveServiceSession(
   }
 
   const finalTargetTrack = newTracks[trackIndex]
-  const newServiceSession: TrackTalk = {
+  const newServiceSession: Slot = {
+    kind: 'service',
     placeholder: serviceSession.placeholder,
     startTime: timeSlot,
     endTime: newEndTime,
@@ -386,20 +397,27 @@ export function moveServiceSession(
   return { schedule: { ...schedule, tracks: newTracks }, ok: true }
 }
 
-/** Append a new track to the day. */
+/**
+ * Append a new track to the day. The UI hands a wide {@link ScheduleTrack}; it is
+ * resolved to an {@link EditorTrack} (a brand-new track's `talks` is empty, so
+ * this converts trivially) so the day stays an {@link EditorSchedule}.
+ */
 export function addTrack(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   track: ScheduleTrack,
 ): OperationResult {
   return {
-    schedule: { ...schedule, tracks: [...schedule.tracks, track] },
+    schedule: {
+      ...schedule,
+      tracks: [...schedule.tracks, toEditorTrack(track)],
+    },
     ok: true,
   }
 }
 
 /** Remove the track at `trackIndex` (no-op if out of range). */
 export function removeTrack(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   trackIndex: number,
 ): OperationResult {
   if (trackIndex < 0 || trackIndex >= schedule.tracks.length) {
@@ -414,9 +432,14 @@ export function removeTrack(
   }
 }
 
-/** Replace the track at `trackIndex` (no-op if out of range). */
+/**
+ * Replace the track at `trackIndex` (no-op if out of range). The UI hands a wide
+ * {@link ScheduleTrack} (title/description edit carrying the existing talks); it
+ * is resolved back to an {@link EditorTrack} — those talks are already ghost-free
+ * so the conversion is 1:1, preserving order and fields.
+ */
 export function updateTrack(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   trackIndex: number,
   track: ScheduleTrack,
 ): OperationResult {
@@ -424,13 +447,13 @@ export function updateTrack(
     return { schedule, ok: false }
   }
   const newTracks = [...schedule.tracks]
-  newTracks[trackIndex] = track
+  newTracks[trackIndex] = toEditorTrack(track)
   return { schedule: { ...schedule, tracks: newTracks }, ok: true }
 }
 
 /** Remove the talk / service session at `talkIndex` in `trackIndex`. */
 export function removeTalk(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   trackIndex: number,
   talkIndex: number,
 ): OperationResult {
@@ -451,7 +474,7 @@ export function removeTalk(
 
 /** Add a service session of `duration` minutes at `startTime` to a track. */
 export function addService(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   trackIndex: number,
   args: { title: string; startTime: string; duration: number },
 ): OperationResult {
@@ -467,7 +490,8 @@ export function addService(
   if (!isTrackIntervalFree(track, args.startTime, endTime)) {
     return { schedule, ok: false }
   }
-  const newSession: TrackTalk = {
+  const newSession: Slot = {
+    kind: 'service',
     placeholder: args.title,
     startTime: args.startTime,
     endTime,
@@ -482,7 +506,7 @@ export function addService(
 
 /** Resize the service session at `talkIndex` to a new duration (in minutes). */
 export function resizeService(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   trackIndex: number,
   talkIndex: number,
   duration: number,
@@ -521,7 +545,7 @@ export function resizeService(
 
 /** Rename the service session at `talkIndex`. */
 export function renameService(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   trackIndex: number,
   talkIndex: number,
   title: string,
@@ -549,10 +573,19 @@ export function renameService(
  * `ok` is true only if the session was copied into at least one track.
  */
 export function duplicateService(
-  schedule: ConferenceSchedule,
+  schedule: EditorSchedule,
   serviceSession: TrackTalk,
   sourceTrackIndex: number,
 ): OperationResult {
+  // The UI dispatches the source slot as a wide TrackTalk; a duplicate is always
+  // a service, so tag it as a ServiceSlot (the `?? ''` only guards the type — a
+  // service session always carries a placeholder).
+  const copy: Slot = {
+    kind: 'service',
+    placeholder: serviceSession.placeholder ?? '',
+    startTime: serviceSession.startTime,
+    endTime: serviceSession.endTime,
+  }
   let changed = false
   const newTracks = schedule.tracks.map((track, trackIndex) => {
     if (trackIndex === sourceTrackIndex) return track
@@ -568,7 +601,7 @@ export function duplicateService(
     changed = true
     return {
       ...track,
-      talks: [...track.talks, { ...serviceSession }].sort(sortByStart),
+      talks: [...track.talks, { ...copy }].sort(sortByStart),
     }
   })
 

--- a/src/lib/schedule/reducer.ts
+++ b/src/lib/schedule/reducer.ts
@@ -1,10 +1,6 @@
-import {
-  ConferenceSchedule,
-  ScheduleTrack,
-  TrackTalk,
-} from '@/lib/conference/types'
+import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import { ProposalExisting } from '@/lib/proposal/types'
-import { DragItem, DropPosition } from './types'
+import { DragItem, DropPosition, EditorSchedule } from './types'
 import * as ops from './operations'
 
 /**
@@ -25,7 +21,7 @@ import * as ops from './operations'
  * `ops.computeUnassigned`, never stored.
  */
 export interface ScheduleEditorState {
-  schedules: ConferenceSchedule[]
+  schedules: EditorSchedule[]
   currentDayIndex: number
   proposals: ProposalExisting[]
   dirty: boolean[]
@@ -73,7 +69,7 @@ export type ScheduleAction =
   | { type: 'saveEnd' }
 
 export function initScheduleEditorState(args: {
-  schedules: ConferenceSchedule[]
+  schedules: EditorSchedule[]
   proposals: ProposalExisting[]
 }): ScheduleEditorState {
   return {

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -57,8 +57,10 @@ export async function saveScheduleToSanity(
         trackDescription: track.trackDescription,
         // Drop ghost slots (neither a resolved talk nor a placeholder) before
         // serializing — otherwise the fallback branch below emits an empty slot
-        // that `validateSchedulePayload` rejects, failing the whole save. Load
-        // already strips these, so this is defense-in-depth for any that slip in.
+        // that `validateSchedulePayload` rejects, failing the whole save. The
+        // editor load path is already ghost-free (`toEditorSchedule`), but this
+        // filter is NOT redundant: the tRPC save path also accepts client-supplied
+        // payloads that never crossed the load boundary, so keep it as-is.
         talks: (track.talks || [])
           .filter((talk) => talk.talk || talk.placeholder)
           .map((talk, talkIndex) => {

--- a/src/lib/schedule/server.ts
+++ b/src/lib/schedule/server.ts
@@ -3,9 +3,10 @@ import { getProposals } from '@/lib/proposal/server'
 import { Status, ProposalExisting } from '@/lib/proposal/types'
 import { ConferenceSchedule } from '@/lib/conference/types'
 import type { Conference } from '@/lib/conference/types'
+import { EditorSchedule, toEditorSchedule } from './types'
 
 export interface ScheduleData {
-  schedules: ConferenceSchedule[]
+  schedules: EditorSchedule[]
   conference: Conference
   proposals: ProposalExisting[]
   error?: string
@@ -63,21 +64,16 @@ export async function getScheduleData(): Promise<ScheduleData> {
 
     schedules.sort((a, b) => a.date.localeCompare(b.date))
 
-    // Drop "ghost" slots — entries whose talk reference no longer resolves (the
-    // proposal was deleted after being scheduled) and which aren't service
-    // placeholders. The projection keeps them as `{ talk: null }` with no
-    // placeholder; in the editor they render invisibly and can't be removed, and
-    // on save the payload validator rejects the whole day ("neither a talk nor a
-    // placeholder"), permanently bricking that day. The public read side already
-    // filters these out, so stripping them here keeps the write side symmetric.
-    for (const schedule of schedules) {
-      schedule.tracks = (schedule.tracks || []).map((track) => ({
-        ...track,
-        talks: (track.talks || []).filter(
-          (slot) => slot.talk || slot.placeholder,
-        ),
-      }))
-    }
+    // Resolve every persisted day into an EditorSchedule at the load boundary.
+    // `toEditorSchedule` tags each slot (talk vs service) AND drops "ghost" slots
+    // — entries whose talk reference no longer resolves (the proposal was deleted
+    // after being scheduled) and which aren't service placeholders. The
+    // projection keeps them as `{ talk: null }` with no placeholder; in the
+    // editor they render invisibly and can't be removed, and on save the payload
+    // validator rejects the whole day ("neither a talk nor a placeholder"),
+    // permanently bricking that day. This is the SINGLE editor-side ghost-strip;
+    // fabricated empty days convert trivially.
+    const editorSchedules: EditorSchedule[] = schedules.map(toEditorSchedule)
 
     const { proposals, proposalsError } = await getProposals({
       conferenceId: conference._id,
@@ -87,7 +83,7 @@ export async function getScheduleData(): Promise<ScheduleData> {
 
     if (proposalsError) {
       return {
-        schedules,
+        schedules: editorSchedules,
         conference,
         proposals: [],
         error: 'Failed to fetch proposals',
@@ -101,7 +97,7 @@ export async function getScheduleData(): Promise<ScheduleData> {
     )
 
     return {
-      schedules,
+      schedules: editorSchedules,
       conference,
       proposals: schedulableProposals,
     }

--- a/src/lib/schedule/types.ts
+++ b/src/lib/schedule/types.ts
@@ -1,3 +1,8 @@
+import {
+  ConferenceSchedule,
+  ScheduleTrack,
+  TrackTalk,
+} from '@/lib/conference/types'
 import { ProposalExisting } from '@/lib/proposal/types'
 
 // Pure time helpers live in ./time and placement rules in ./rules. Re-exported
@@ -27,6 +32,86 @@ export {
 export interface DropPosition {
   trackIndex: number
   timeSlot: string
+}
+
+/**
+ * A schedule slot the EDITOR works with: tagged, with the talk/placeholder
+ * optionality resolved at the load boundary. Structurally assignable to the
+ * persisted {@link TrackTalk} shape (the `kind` tag is an extra property that the
+ * explicit serializer in sanity.ts never writes), so {@link EditorSchedule} flows
+ * into every {@link ConferenceSchedule}-typed consumer unchanged.
+ *
+ * Each variant declares the OTHER content field as `?: undefined` — a closed
+ * discriminated union whose members are mutually property-accessible. That keeps
+ * the unchanged internal ops predicates (`slot.talk?._id`, `slot.placeholder`)
+ * type-checking while the `kind` tag still narrows each variant (e.g. a
+ * {@link TalkSlot}'s `talk` is non-optional after `kind === 'talk'`), which is
+ * how the `!` assertions in operations.ts are retired.
+ */
+export interface TalkSlot {
+  kind: 'talk'
+  talk: ProposalExisting
+  placeholder?: undefined
+  startTime: string
+  endTime: string
+}
+export interface ServiceSlot {
+  kind: 'service'
+  talk?: undefined
+  placeholder: string
+  startTime: string
+  endTime: string
+}
+export type Slot = TalkSlot | ServiceSlot
+export type EditorTrack = Omit<ScheduleTrack, 'talks'> & { talks: Slot[] }
+export type EditorSchedule = Omit<ConferenceSchedule, 'tracks'> & {
+  tracks: EditorTrack[]
+}
+
+/**
+ * Resolve a persisted {@link TrackTalk} into an editor {@link Slot}: a
+ * {@link TalkSlot} when the `talk` reference resolves, a {@link ServiceSlot} when
+ * it is a placeholder, or `null` for a GHOST — a slot whose talk reference no
+ * longer resolves and which is not a placeholder (its proposal was deleted after
+ * being scheduled). Dropping ghosts here is the SINGLE editor-side ghost-strip.
+ */
+export function toSlot(t: TrackTalk): Slot | null {
+  if (t.talk) {
+    return {
+      kind: 'talk',
+      talk: t.talk,
+      startTime: t.startTime,
+      endTime: t.endTime,
+    }
+  }
+  if (t.placeholder) {
+    return {
+      kind: 'service',
+      placeholder: t.placeholder,
+      startTime: t.startTime,
+      endTime: t.endTime,
+    }
+  }
+  return null
+}
+
+/** Convert a persisted track to an editor track, dropping ghost slots. */
+export function toEditorTrack(track: ScheduleTrack): EditorTrack {
+  return {
+    ...track,
+    talks: (track.talks || [])
+      .map(toSlot)
+      .filter((slot): slot is Slot => slot !== null),
+  }
+}
+
+/**
+ * Convert a whole persisted day to an {@link EditorSchedule}, dropping ghost
+ * slots. Constructed once at the server load boundary so the editor never
+ * carries an unremovable/unsavable ghost slot.
+ */
+export function toEditorSchedule(s: ConferenceSchedule): EditorSchedule {
+  return { ...s, tracks: (s.tracks || []).map(toEditorTrack) }
 }
 
 export interface DragItem {


### PR DESCRIPTION
## Summary

Phase 4a of the schedule-editor refactor: introduce a **discriminated-union `Slot` type** the editor engine works with, constructed **once at the server load boundary**. Pure **type-hardening — ZERO behavior change.**

## Design

- **New types** in `src/lib/schedule/types.ts`: `TalkSlot | ServiceSlot = Slot`, `EditorTrack`, `EditorSchedule`. `EditorSchedule` is structurally assignable to the persisted `ConferenceSchedule` (the `kind` tag is an extra property the sanity.ts serializer never writes), so it flows into every wide-typed consumer unchanged.
- **Converters** `toSlot` / `toEditorTrack` / `toEditorSchedule`: `toSlot` tags a resolved talk as a `TalkSlot`, a placeholder as a `ServiceSlot`, and returns `null` for a **ghost** (dangling ref, no placeholder).
- **Single editor-side ghost-strip**: `getScheduleData` now maps each persisted day through `toEditorSchedule` (replacing the inline filter loop). `ScheduleData.schedules`, `ScheduleEditorState.schedules`, `OperationResult.schedule`, and the `ScheduleEditor` `initialSchedules` prop are all now `EditorSchedule[]`.
- **Killed `!` assertions**: the two `targetTalk.talk!` in `performSwap` are retired by narrowing its param to `TalkSlot`; `moveProposal` narrows the occupying slot via its `kind` tag (which also removes the `find(...)!`). Slot-construction sites carry an explicit `kind`.
- **Wide readers untouched**: `classifyProposalDrop`/`classifyServiceDrop`, `computeUnassigned`, `scheduledProposalIdsExcludingDay`, `rules.ts`, `validation.ts` keep their `ScheduleTrack`/`ConferenceSchedule` params — `EditorSchedule` is assignable, so **no UI file needed new types**.
- **sanity.ts keeps its ghost filter**: the tRPC save path accepts client-supplied payloads that never crossed the load boundary, so the filter is **not** redundant (comment updated).

### One deviation from the brief (behavior-neutral)
The literal `TalkSlot`/`ServiceSlot` interfaces cause `TS2339` when the unchanged internal ops predicates read `slot.talk?._id` / `slot.placeholder` on a `Slot` (a property that exists on only one variant). To keep those predicates verbatim (per "internal ops flow unchanged") each variant declares the other content field as `?: undefined` — a **closed** discriminated union whose members stay mutually property-accessible while `kind` still narrows each variant. No runtime behavior changes.

## Verification

- `npx tsc --noEmit`: **0 errors**
- `npx eslint` (touched dirs): **clean**
- `npx vitest run __tests__/lib/schedule/`: **8 files, 120 tests pass** (incl. new converter tests)
- `npx vitest run __tests__/` (repo-wide): **2207 tests pass**; 24 test *files* fail to load on a pre-existing `@digitalbazaar/vc` ESM import error (badge/openbadges/trpc) — identical on `main`, unrelated to this change
- `pnpm shoot`: `OK: 3 card(s) checked, none exceed the 393px viewport`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a discriminated-union `Slot` type (`TalkSlot | ServiceSlot`) at the server load boundary, replacing the optional-field `TrackTalk` in all editor-internal code. It consolidates the ghost-strip into a single `toEditorSchedule` converter and retires the two `targetTalk.talk!` non-null assertions in `performSwap` via kind-narrowing.

- **New types and converters** (`types.ts`): `TalkSlot`, `ServiceSlot`, `Slot`, `EditorTrack`, `EditorSchedule` plus `toSlot`/`toEditorTrack`/`toEditorSchedule`; `EditorSchedule` is structurally assignable to `ConferenceSchedule` so wide-typed consumers are untouched.
- **Operations narrowed** (`operations.ts`): all mutating functions now accept and return `EditorSchedule`; slot construction sites carry an explicit `kind` tag; `moveProposal`'s swap path guards with `kind !== 'talk'` instead of a non-null assertion.
- **Load boundary consolidated** (`server.ts`): the inline ghost-filter loop is replaced by `schedules.map(toEditorSchedule)`; `sanity.ts` keeps its own ghost filter with an updated comment explaining the tRPC path still accepts un-tagged payloads.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive type hardening with zero behaviour change, verified by 2207 passing tests and tsc clean.

Every mutation site that previously relied on optional-chaining or non-null assertions now carries an explicit kind tag or a kind-narrowing guard. The ghost-strip is consolidated to a single point at the load boundary, the sanity.ts filter is correctly kept for the tRPC path, and the new converter tests cover the edge cases.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/schedule/types.ts | Core of the change: adds TalkSlot/ServiceSlot/Slot discriminated union, EditorTrack/EditorSchedule structural aliases, and the three converter functions. Design is sound; closed union with ?: undefined cross-fields is intentional to keep unchanged ops predicates type-checking. |
| src/lib/schedule/operations.ts | All mutating ops narrowed to EditorSchedule; slot-construction sites now carry explicit kind; performSwap param narrowed to TalkSlot; moveProposal swap guard replaces the find(...)! assertion. Remaining dragItem.proposal! / dragItem.sourceTimeSlot! assertions are guarded by classifier invariants. |
| src/lib/schedule/server.ts | Ghost-strip loop replaced by schedules.map(toEditorSchedule); both early-return and success paths now return editorSchedules correctly. |
| src/lib/schedule/reducer.ts | ScheduleEditorState.schedules and initScheduleEditorState updated to EditorSchedule[]; duplicateService action still uses TrackTalk for serviceSession (intentional, explained by comment in operations.ts). |
| __tests__/lib/schedule/slots.test.ts | New tests covering toSlot (talk, service, ghost, talk-wins-over-placeholder) and toEditorSchedule (ghost drop, order preservation, empty track). Good coverage of the converter edge cases. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(schedule): discriminated-union ..."](https://github.com/cloudnativebergen/website/commit/b9d0940c03474e1e94f92f79e2e2fd6d0195f3d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45323377)</sub>

<!-- /greptile_comment -->