### PR TITLE
refactor(schedule): discriminated-union DragItem + narrow editor UI types (Phase 4b)

### DIFF
--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -12,6 +12,7 @@ import {
   Status,
 } from '@/lib/proposal/types'
 import { ConferenceSchedule } from '@/lib/conference/types'
+import { toEditorSchedule } from '@/lib/schedule/types'
 
 const makeProposal = (
   overrides: Partial<ProposalExisting> & { _id: string; title: string },
@@ -84,7 +85,7 @@ const setup = () => {
   const dispatch = vi.fn()
   render(
     <MobileScheduleView
-      schedules={[schedule]}
+      schedules={[toEditorSchedule(schedule)]}
       currentDayIndex={0}
       unassignedProposals={[unassignedProposal]}
       dispatch={dispatch}
@@ -163,7 +164,7 @@ describe('MobileScheduleView', () => {
     }
     render(
       <MobileScheduleView
-        schedules={[withService]}
+        schedules={[toEditorSchedule(withService)]}
         currentDayIndex={0}
         unassignedProposals={[]}
         dispatch={dispatch}
@@ -259,7 +260,7 @@ describe('MobileScheduleView', () => {
     }
     render(
       <MobileScheduleView
-        schedules={[twoTalkSchedule]}
+        schedules={[toEditorSchedule(twoTalkSchedule)]}
         currentDayIndex={0}
         unassignedProposals={[]}
         dispatch={dispatch}
@@ -399,7 +400,7 @@ describe('MobileScheduleView', () => {
     }
     render(
       <MobileScheduleView
-        schedules={[withService]}
+        schedules={[toEditorSchedule(withService)]}
         currentDayIndex={0}
         unassignedProposals={[]}
         dispatch={dispatch}

--- a/__tests__/components/admin/schedule/mobile-placement.test.ts
+++ b/__tests__/components/admin/schedule/mobile-placement.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest'
 import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import type { ProposalExisting } from '@/lib/proposal/types'
+import type { Slot } from '@/lib/schedule/types'
 import type { RailSegment } from '@/components/admin/schedule/mobile'
 import type { Placing } from '@/components/admin/schedule/mobile'
 import { segmentState } from '@/components/admin/schedule/mobile'
@@ -17,7 +18,8 @@ import { segmentState } from '@/components/admin/schedule/mobile'
 const proposal = (id: string, format = 'talk_25'): ProposalExisting =>
   ({ _id: id, format }) as unknown as ProposalExisting
 
-const talk = (id: string, start: string, end: string): TrackTalk => ({
+const talk = (id: string, start: string, end: string): Slot => ({
+  kind: 'talk',
   talk: proposal(id),
   startTime: start,
   endTime: end,
@@ -58,7 +60,12 @@ const breakSeg = (
   idx: number,
 ): RailSegment => ({
   kind: 'break',
-  talk: { placeholder: 'Lunch', startTime: start, endTime: end },
+  talk: {
+    kind: 'service',
+    placeholder: 'Lunch',
+    startTime: start,
+    endTime: end,
+  },
   talkIndex: idx,
   startTime: start,
   endTime: end,
@@ -166,7 +173,12 @@ describe('segmentState', () => {
       kind: 'scheduled',
       trackIndex: 1,
       talkIndex: 0,
-      talk: { placeholder: 'Break', startTime: '09:00', endTime: '09:15' },
+      talk: {
+        kind: 'service',
+        placeholder: 'Break',
+        startTime: '09:00',
+        endTime: '09:15',
+      },
     }
     expect(
       segmentState(

--- a/__tests__/components/admin/schedule/mobileRail.test.ts
+++ b/__tests__/components/admin/schedule/mobileRail.test.ts
@@ -7,26 +7,31 @@
  * time).
  */
 import { describe, it, expect } from 'vitest'
-import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import type { ProposalExisting } from '@/lib/proposal/types'
+import type { EditorTrack, Slot } from '@/lib/schedule/types'
 import { buildTrackRail } from '@/components/admin/schedule/mobile'
 
 const proposal = (id: string): ProposalExisting =>
   ({ _id: id, format: 'talk_25' }) as unknown as ProposalExisting
 
-const talk = (id: string, start: string, end: string): TrackTalk => ({
+const talk = (id: string, start: string, end: string): Slot => ({
+  kind: 'talk',
   talk: proposal(id),
   startTime: start,
   endTime: end,
 })
 
-const service = (name: string, start: string, end: string): TrackTalk => ({
+const service = (name: string, start: string, end: string): Slot => ({
+  kind: 'service',
   placeholder: name,
   startTime: start,
   endTime: end,
 })
 
-const track = (...talks: TrackTalk[]): ScheduleTrack => ({
+// Fixtures pass raw slots (including deliberately malformed ghost slots) so
+// buildTrackRail's OWN filtering is exercised — hence the loose `Slot[]` here
+// rather than converting via toEditorTrack (which would strip ghosts first).
+const track = (...talks: Slot[]): EditorTrack => ({
   trackTitle: 'A',
   trackDescription: '',
   talks,
@@ -94,7 +99,7 @@ describe('buildTrackRail', () => {
     const rail = buildTrackRail(
       track(
         // ghost: has times but neither a resolved talk nor a placeholder
-        { startTime: '10:00', endTime: '10:25' } as TrackTalk,
+        { startTime: '10:00', endTime: '10:25' } as unknown as Slot,
         talk('y', '11:00', '11:25'),
       ),
     )
@@ -108,7 +113,7 @@ describe('buildTrackRail', () => {
   it('skips malformed slots without emitting a negative-width gap', () => {
     const rail = buildTrackRail(
       track(
-        { talk: proposal('x'), startTime: '', endTime: '' } as TrackTalk,
+        { talk: proposal('x'), startTime: '', endTime: '' } as unknown as Slot,
         talk('y', '10:00', '10:25'),
       ),
     )

--- a/__tests__/lib/schedule/operations.test.ts
+++ b/__tests__/lib/schedule/operations.test.ts
@@ -206,12 +206,13 @@ describe('moveServiceSession', () => {
     placeholder: string,
     start: string,
     end: string,
-    extra: Partial<DragItem> = {},
-  ): DragItem => ({
-    type: 'service-session',
-    serviceSession: { placeholder, startTime: start, endTime: end },
-    ...extra,
-  })
+    source?: { sourceTrackIndex: number; sourceTimeSlot: string },
+  ): DragItem => {
+    const serviceSession = { placeholder, startTime: start, endTime: end }
+    return source
+      ? { type: 'scheduled-service', serviceSession, ...source }
+      : { type: 'service-session', serviceSession }
+  }
 
   it('places a service session into a free interval', () => {
     const s = schedule(track('A'))
@@ -238,7 +239,6 @@ describe('moveServiceSession', () => {
   it('moves an existing service, excluding its own slot from the check', () => {
     const s = schedule(track('A', service('Break', '12:00', '12:15')))
     const dragItem = serviceDrag('Break', '12:00', '12:15', {
-      type: 'scheduled-service',
       sourceTrackIndex: 0,
       sourceTimeSlot: '12:00',
     })
@@ -540,12 +540,13 @@ describe('classifier ⇔ reducer equivalence', () => {
     placeholder: string,
     start: string,
     end: string,
-    extra: Partial<DragItem> = {},
-  ): DragItem => ({
-    type: 'service-session',
-    serviceSession: { placeholder, startTime: start, endTime: end },
-    ...extra,
-  })
+    source?: { sourceTrackIndex: number; sourceTimeSlot: string },
+  ): DragItem => {
+    const serviceSession = { placeholder, startTime: start, endTime: end }
+    return source
+      ? { type: 'scheduled-service', serviceSession, ...source }
+      : { type: 'service-session', serviceSession }
+  }
 
   const serviceCases: Array<{
     name: string
@@ -572,7 +573,6 @@ describe('classifier ⇔ reducer equivalence', () => {
       build: () => ({
         s: schedule(track('A', service('Break', '12:00', '12:15'))),
         d: serviceDrag('Break', '12:00', '12:15', {
-          type: 'scheduled-service',
           sourceTrackIndex: 0,
           sourceTimeSlot: '12:00',
         }),

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -4,7 +4,7 @@ import { useDraggable } from '@dnd-kit/core'
 import { useMemo } from 'react'
 import { ProposalExisting, Status } from '@/lib/proposal/types'
 import { formats, audiences } from '@/lib/proposal/types'
-import { getProposalDurationMinutes } from '@/lib/schedule/types'
+import { getProposalDurationMinutes, type DragItem } from '@/lib/schedule/types'
 import { PIXELS_PER_MINUTE } from '@/lib/schedule/geometry'
 import { Topic } from '@/lib/topic/types'
 import { LevelIndicator, getLevelConfig } from '@/lib/proposal'
@@ -58,12 +58,21 @@ export function DraggableProposal({
 }: DraggableProposalProps) {
   const levelConfig = getLevelConfig(proposal.level)
 
-  const { dragType, durationMinutes, talkSize, dragId, speakerInfo } =
+  const { dragItem, durationMinutes, talkSize, dragId, speakerInfo } =
     useMemo(() => {
       const duration = getProposalDurationMinutes(proposal)
-      const type =
-        sourceTrackIndex !== undefined ? 'scheduled-talk' : 'proposal'
-      const id = `${type}-${proposal._id}-${sourceTimeSlot || 'unassigned'}`
+      // A scheduled talk is dragged FROM a slot (both source fields are always
+      // passed together by ScheduledTalk); an unassigned proposal carries none.
+      const item: DragItem =
+        sourceTrackIndex !== undefined && sourceTimeSlot !== undefined
+          ? {
+              type: 'scheduled-talk',
+              proposal,
+              sourceTrackIndex,
+              sourceTimeSlot,
+            }
+          : { type: 'proposal', proposal }
+      const id = `${item.type}-${proposal._id}-${sourceTimeSlot || 'unassigned'}`
 
       let size: 'very-short' | 'short' | 'medium' | 'long'
       if (duration <= TALK_THRESHOLDS.VERY_SHORT) size = 'very-short'
@@ -72,7 +81,7 @@ export function DraggableProposal({
       else size = 'long'
 
       return {
-        dragType: type,
+        dragItem: item,
         durationMinutes: duration,
         talkSize: size,
         dragId: id,
@@ -144,12 +153,7 @@ export function DraggableProposal({
     isDragging: isBeingDragged,
   } = useDraggable({
     id: dragId,
-    data: {
-      type: dragType,
-      proposal,
-      sourceTrackIndex,
-      sourceTimeSlot,
-    },
+    data: dragItem,
   })
 
   const transformStyle = useMemo(() => {

--- a/src/components/admin/schedule/DraggableServiceSession.tsx
+++ b/src/components/admin/schedule/DraggableServiceSession.tsx
@@ -3,6 +3,7 @@
 import { useDraggable } from '@dnd-kit/core'
 import { useMemo } from 'react'
 import { TrackTalk } from '@/lib/conference/types'
+import type { DragItem } from '@/lib/schedule/types'
 import { PIXELS_PER_MINUTE } from '@/lib/schedule/geometry'
 import { durationBetween } from '@/lib/schedule/time'
 import { ClockIcon, Bars3Icon } from '@heroicons/react/24/outline'
@@ -26,7 +27,7 @@ export function DraggableServiceSession({
   sourceTimeSlot,
   isDragging = false,
 }: DraggableServiceSessionProps) {
-  const { dragType, durationMinutes, sessionSize, dragId } = useMemo(() => {
+  const { dragItem, durationMinutes, sessionSize, dragId } = useMemo(() => {
     const duration = durationBetween(
       serviceSession.startTime,
       serviceSession.endTime,
@@ -38,12 +39,26 @@ export function DraggableServiceSession({
     else if (duration <= SERVICE_SESSION_THRESHOLDS.LONG) size = 'long'
     else size = 'very-long'
 
-    const type =
-      sourceTrackIndex !== undefined ? 'scheduled-service' : 'service-session'
-    const id = `${type}-${serviceSession.startTime}-${sourceTrackIndex ?? 'unassigned'}-${sourceTimeSlot || 'new'}`
+    const session = {
+      placeholder: serviceSession.placeholder || 'Service Session',
+      startTime: serviceSession.startTime,
+      endTime: serviceSession.endTime,
+    }
+    // A scheduled service is dragged FROM a slot (both source fields are always
+    // passed together by ServiceSession); a fresh service carries none.
+    const item: DragItem =
+      sourceTrackIndex !== undefined && sourceTimeSlot !== undefined
+        ? {
+            type: 'scheduled-service',
+            serviceSession: session,
+            sourceTrackIndex,
+            sourceTimeSlot,
+          }
+        : { type: 'service-session', serviceSession: session }
+    const id = `${item.type}-${serviceSession.startTime}-${sourceTrackIndex ?? 'unassigned'}-${sourceTimeSlot || 'new'}`
 
     return {
-      dragType: type,
+      dragItem: item,
       durationMinutes: duration,
       sessionSize: size,
       dragId: id,
@@ -58,16 +73,7 @@ export function DraggableServiceSession({
     isDragging: isBeingDragged,
   } = useDraggable({
     id: dragId,
-    data: {
-      type: dragType,
-      serviceSession: {
-        placeholder: serviceSession.placeholder || 'Service Session',
-        startTime: serviceSession.startTime,
-        endTime: serviceSession.endTime,
-      },
-      sourceTrackIndex,
-      sourceTimeSlot,
-    },
+    data: dragItem,
   })
 
   const transformStyle = useMemo(() => {

--- a/src/components/admin/schedule/ScheduleContext.tsx
+++ b/src/components/admin/schedule/ScheduleContext.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { createContext, useContext, type Dispatch } from 'react'
-import type { ConferenceSchedule } from '@/lib/conference/types'
-import type { DragItem } from '@/lib/schedule/types'
+import type { DragItem, EditorSchedule } from '@/lib/schedule/types'
 import type { ScheduleAction } from '@/lib/schedule/reducer'
 
 /**
@@ -20,7 +19,7 @@ import type { ScheduleAction } from '@/lib/schedule/reducer'
  */
 interface ScheduleContextValue {
   activeDragItem: DragItem | null
-  schedule: ConferenceSchedule | null
+  schedule: EditorSchedule | null
   otherScheduledProposalIds: ReadonlySet<string>
   dispatch: Dispatch<ScheduleAction>
 }

--- a/src/components/admin/schedule/mobile/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/mobile/MobileScheduleView.tsx
@@ -250,7 +250,7 @@ export function MobileScheduleView({
       } else if (
         seg.kind === 'talk' &&
         active.kind === 'scheduled' &&
-        active.talk.talk
+        active.talk.kind === 'talk'
       ) {
         // Swap the picked-up talk with the occupied target slot.
         dispatch({

--- a/src/components/admin/schedule/mobile/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/mobile/MobileScheduleView.tsx
@@ -247,7 +247,11 @@ export function MobileScheduleView({
             },
           })
         }
-      } else if (seg.kind === 'talk' && active.kind === 'scheduled') {
+      } else if (
+        seg.kind === 'talk' &&
+        active.kind === 'scheduled' &&
+        active.talk.talk
+      ) {
         // Swap the picked-up talk with the occupied target slot.
         dispatch({
           type: 'moveProposal',

--- a/src/components/admin/schedule/mobile/TrackRail.tsx
+++ b/src/components/admin/schedule/mobile/TrackRail.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react'
 import clsx from 'clsx'
 import { ScheduleTrack } from '@/lib/conference/types'
+import type { EditorTrack } from '@/lib/schedule/types'
 import { StatusBadge, LevelIndicator } from '@/lib/proposal'
 import { populatedSpeakerNames } from '@/lib/speaker/formatSpeakerNames'
 import {
@@ -37,7 +38,7 @@ export function TrackRail({
   onSegmentTap,
   onTrackOptions,
 }: {
-  track: ScheduleTrack
+  track: EditorTrack
   trackIndex: number
   tracks: ScheduleTrack[]
   placing: Placing | null

--- a/src/components/admin/schedule/mobile/rail.ts
+++ b/src/components/admin/schedule/mobile/rail.ts
@@ -1,4 +1,4 @@
-import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
+import type { EditorTrack, Slot } from '@/lib/schedule/types'
 import {
   SCHEDULE_START,
   SCHEDULE_END,
@@ -19,7 +19,7 @@ import {
 export type RailSegment =
   | {
       kind: 'talk' | 'break'
-      talk: TrackTalk
+      talk: Slot
       talkIndex: number
       startTime: string
       endTime: string
@@ -37,7 +37,7 @@ export type RailSegment =
  * Malformed slots (missing times) are skipped; overlaps (which shouldn't occur
  * post-validation) never emit a negative-width open segment.
  */
-export function buildTrackRail(track: ScheduleTrack): RailSegment[] {
+export function buildTrackRail(track: EditorTrack): RailSegment[] {
   const indexed = (track.talks ?? []).map((talk, talkIndex) => ({
     talk,
     talkIndex,

--- a/src/components/admin/schedule/mobile/types.ts
+++ b/src/components/admin/schedule/mobile/types.ts
@@ -1,10 +1,10 @@
 import type React from 'react'
-import type { ConferenceSchedule, TrackTalk } from '@/lib/conference/types'
 import type { ProposalExisting } from '@/lib/proposal/types'
+import type { EditorSchedule, Slot } from '@/lib/schedule/types'
 import type { ScheduleAction } from '@/lib/schedule/reducer'
 
 export interface MobileScheduleViewProps {
-  schedules: ConferenceSchedule[]
+  schedules: EditorSchedule[]
   currentDayIndex: number
   unassignedProposals: ProposalExisting[]
   dispatch: React.Dispatch<ScheduleAction>
@@ -26,7 +26,7 @@ export type Placing =
       kind: 'scheduled'
       trackIndex: number
       talkIndex: number
-      talk: TrackTalk
+      talk: Slot
     }
   | { kind: 'proposal'; proposal: ProposalExisting }
 
@@ -47,13 +47,13 @@ export type ActiveSheet =
       kind: 'card'
       trackIndex: number
       talkIndex: number
-      talk: TrackTalk
+      talk: Slot
     }
   | {
       kind: 'serviceEdit'
       trackIndex: number
       talkIndex: number
-      talk: TrackTalk
+      talk: Slot
       mode: 'rename' | 'duration'
     }
   | null

--- a/src/lib/schedule/operations.ts
+++ b/src/lib/schedule/operations.ts
@@ -50,11 +50,11 @@ const sortByStart = (a: Slot, b: Slot): number =>
  */
 function performSwap(
   schedule: EditorSchedule,
-  dragItem: DragItem,
+  dragItem: Extract<DragItem, { type: 'scheduled-talk' }>,
   targetTalk: TalkSlot,
   dropPosition: DropPosition,
 ): EditorSchedule {
-  const proposal = dragItem.proposal!
+  const { proposal, sourceTrackIndex, sourceTimeSlot } = dragItem
   const { trackIndex, timeSlot } = dropPosition
 
   const draggedEndTime = calculateEndTime(
@@ -62,24 +62,20 @@ function performSwap(
     getProposalDurationMinutes(proposal),
   )
   const targetEndTime = calculateEndTime(
-    dragItem.sourceTimeSlot!,
+    sourceTimeSlot,
     getProposalDurationMinutes(targetTalk.talk),
   )
 
   const newTracks = [...schedule.tracks]
 
-  if (
-    dragItem.sourceTrackIndex !== undefined &&
-    dragItem.sourceTimeSlot !== undefined
-  ) {
-    const sourceTrack = newTracks[dragItem.sourceTrackIndex]
-    newTracks[dragItem.sourceTrackIndex] = {
+  {
+    const sourceTrack = newTracks[sourceTrackIndex]
+    newTracks[sourceTrackIndex] = {
       ...sourceTrack,
       talks: sourceTrack.talks.filter(
         (talk) =>
           !(
-            talk.talk?._id === proposal._id &&
-            talk.startTime === dragItem.sourceTimeSlot
+            talk.talk?._id === proposal._id && talk.startTime === sourceTimeSlot
           ),
       ),
     }
@@ -104,18 +100,15 @@ function performSwap(
     talks: [...newTargetTalks, newDraggedTalk].sort(sortByStart),
   }
 
-  if (
-    dragItem.sourceTrackIndex !== undefined &&
-    dragItem.sourceTimeSlot !== undefined
-  ) {
+  {
     const newTargetTalkAtSource: TalkSlot = {
       kind: 'talk',
       talk: targetTalk.talk,
-      startTime: dragItem.sourceTimeSlot,
+      startTime: sourceTimeSlot,
       endTime: targetEndTime,
     }
-    const finalSourceTrack = newTracks[dragItem.sourceTrackIndex]
-    newTracks[dragItem.sourceTrackIndex] = {
+    const finalSourceTrack = newTracks[sourceTrackIndex]
+    newTracks[sourceTrackIndex] = {
       ...finalSourceTrack,
       talks: [...finalSourceTrack.talks, newTargetTalkAtSource].sort(
         sortByStart,
@@ -211,7 +204,7 @@ export function classifyProposalDrop(
   const excludeTalk =
     dragItem.type === 'scheduled-talk' &&
     dragItem.sourceTrackIndex === trackIndex
-      ? { talkId: proposal._id, startTime: dragItem.sourceTimeSlot! }
+      ? { talkId: proposal._id, startTime: dragItem.sourceTimeSlot }
       : undefined
 
   const availableTime = findAvailableTimeSlot(
@@ -276,10 +269,12 @@ export function moveProposal(
     dropPosition,
     otherScheduledProposalIds,
   )
-  if (kind === 'invalid') return fail
+  // classify returned non-invalid ⇒ dragItem.proposal is present; the truthiness
+  // narrow (never independently true here — classify rejects a proposal-less drag)
+  // proves it to TS, retiring the old `dragItem.proposal!`.
+  if (kind === 'invalid' || !dragItem.proposal) return fail
 
-  // classify returned non-invalid ⇒ dragItem.proposal is present.
-  const proposal = dragItem.proposal!
+  const { proposal } = dragItem
   const { trackIndex, timeSlot } = dropPosition
   const targetTrack = schedule.tracks[trackIndex]
 
@@ -290,6 +285,9 @@ export function moveProposal(
     // classify returned 'swap' ⇒ the occupying slot is a resolved talk; the
     // `kind` narrow gives performSwap a TalkSlot (no non-null assertion needed).
     if (occupiedTalk?.kind !== 'talk') return fail
+    // classify returned 'swap' ⇒ dragItem is a `scheduled-talk` (the only variant
+    // that swaps); this narrow gives performSwap its `scheduled-talk` param.
+    if (dragItem.type !== 'scheduled-talk') return fail
     return {
       schedule: performSwap(schedule, dragItem, occupiedTalk, dropPosition),
       ok: true,
@@ -347,14 +345,18 @@ export function moveServiceSession(
   dropPosition: DropPosition,
 ): OperationResult {
   const fail: OperationResult = { schedule, ok: false }
+  // classify returned non-invalid ⇒ dragItem.serviceSession is present; the
+  // truthiness narrow (never independently true — classify rejects a
+  // session-less drag) proves it to TS, retiring the old `dragItem.serviceSession!`.
   if (
-    classifyServiceDrop(schedule.tracks, dragItem, dropPosition) === 'invalid'
+    classifyServiceDrop(schedule.tracks, dragItem, dropPosition) ===
+      'invalid' ||
+    !dragItem.serviceSession
   ) {
     return fail
   }
 
-  // classify returned non-invalid ⇒ dragItem.serviceSession is present.
-  const serviceSession = dragItem.serviceSession!
+  const { serviceSession } = dragItem
   const { trackIndex, timeSlot } = dropPosition
   const durationMinutes = durationBetween(
     serviceSession.startTime,

--- a/src/lib/schedule/types.ts
+++ b/src/lib/schedule/types.ts
@@ -114,14 +114,48 @@ export function toEditorSchedule(s: ConferenceSchedule): EditorSchedule {
   return { ...s, tracks: (s.tracks || []).map(toEditorTrack) }
 }
 
-export interface DragItem {
-  type: 'proposal' | 'scheduled-talk' | 'service-session' | 'scheduled-service'
-  proposal?: ProposalExisting
-  serviceSession?: {
-    placeholder: string
-    startTime: string
-    endTime: string
-  }
-  sourceTrackIndex?: number
-  sourceTimeSlot?: string
+/** The service-session payload a service drag carries (a break/lunch, etc.). */
+export interface DragServiceSession {
+  placeholder: string
+  startTime: string
+  endTime: string
 }
+
+/**
+ * A drag payload the editor moves around. A CLOSED discriminated union on
+ * `type`, mirroring {@link Slot}: each variant declares the content fields it
+ * does NOT carry as `?: undefined`, so wide reads (`dragItem.proposal?._id`) keep
+ * compiling in the classify predicates while `type` narrows each variant. The
+ * `scheduled-*` variants carry a non-optional source (`sourceTrackIndex` +
+ * `sourceTimeSlot`); the fresh (`proposal` / `service-session`) variants never
+ * do — which is how the `!` assertions in operations.ts are retired.
+ */
+export type DragItem =
+  | {
+      type: 'proposal'
+      proposal: ProposalExisting
+      serviceSession?: undefined
+      sourceTrackIndex?: undefined
+      sourceTimeSlot?: undefined
+    }
+  | {
+      type: 'scheduled-talk'
+      proposal: ProposalExisting
+      serviceSession?: undefined
+      sourceTrackIndex: number
+      sourceTimeSlot: string
+    }
+  | {
+      type: 'service-session'
+      proposal?: undefined
+      serviceSession: DragServiceSession
+      sourceTrackIndex?: undefined
+      sourceTimeSlot?: undefined
+    }
+  | {
+      type: 'scheduled-service'
+      proposal?: undefined
+      serviceSession: DragServiceSession
+      sourceTrackIndex: number
+      sourceTimeSlot: string
+    }


### PR DESCRIPTION
## Phase 4b — discriminated-union `DragItem` + narrowed editor UI types

Follows Phase 4a (#505), which made `Slot = TalkSlot | ServiceSlot` a closed discriminated union. This phase applies the SAME closed-union style to `DragItem` and narrows the schedule-editor UI to the editor types, retiring the last non-null assertions in `operations.ts`. **Zero behavior change** — type plumbing plus mechanical narrowing only.

### What narrowed

- **`DragItem` (src/lib/schedule/types.ts)** — the single interface (`type` four-string-union + optional `proposal`/`serviceSession`/`sourceTrackIndex`/`sourceTimeSlot`) is now a **closed** four-variant union on `type`, mirroring `Slot`. Each variant declares the content field it does NOT carry as `?: undefined`, so the classify predicates' wide reads (`dragItem.proposal?._id`) keep compiling while `type` narrows. The `scheduled-*` variants carry a non-optional source (`sourceTrackIndex: number` + `sourceTimeSlot: string`); the fresh variants declare both as `?: undefined`. Extracted the payload shape as a named `DragServiceSession` interface.
- **`ScheduleContext.schedule`**: `ConferenceSchedule | null` → `EditorSchedule | null`.
- **mobile/types.ts**: `MobileScheduleViewProps.schedules: EditorSchedule[]`; `Placing.talk` / `ActiveSheet` card+serviceEdit `talk`: `TrackTalk` → `Slot`.
- **mobile/rail.ts**: `buildTrackRail(track: EditorTrack)`; `RailSegment` talk/break variant `talk: Slot`. (The rail's `kind: 'talk' | 'break'` stays independent of `Slot.kind` — `talk.placeholder ? 'break' : 'talk'` works unchanged on the closed union.)
- **mobile/TrackRail.tsx**: `track: EditorTrack` (only what `buildTrackRail` forces; `tracks: ScheduleTrack[]` left as-is).
- **Desktop dnd payloads** (`DraggableProposal.tsx`, `DraggableServiceSession.tsx`): the `useDraggable({ data })` literals are now built as a typed `const item: DragItem` (conditional on the source fields, which the render sites always pass paired), so the payloads conform to the union rather than being loosely typed.

The desktop `track/*`, `DroppableTrack.tsx`, `HeaderSection.tsx`, `chrome.tsx`, `sheets/*` needed **no** changes — `Slot`/`EditorTrack`/`EditorSchedule` are structurally assignable to the wide persisted types, so tsc forced nothing further. Cascade stayed within 6 source files + 4 test files (well under the 15-file stop threshold).

### The 5 killed assertion sites (src/lib/schedule/operations.ts)

**1 + 2. `performSwap` (was `dragItem.proposal!` and `dragItem.sourceTimeSlot!`)** — param narrowed to the `scheduled-talk` variant; the two `sourceTrackIndex !== undefined && sourceTimeSlot !== undefined` runtime guards became unconditional blocks (the variant guarantees them, and `performSwap` is only reachable via a `swap` classification which requires `scheduled-talk`):

```diff
-  dragItem: DragItem,
+  dragItem: Extract<DragItem, { type: 'scheduled-talk' }>,
 ) {
-  const proposal = dragItem.proposal!
+  const { proposal, sourceTrackIndex, sourceTimeSlot } = dragItem
...
-  const targetEndTime = calculateEndTime(dragItem.sourceTimeSlot!, ...)
+  const targetEndTime = calculateEndTime(sourceTimeSlot, ...)
```

**3. `classifyProposalDrop` (was `dragItem.sourceTimeSlot!`)** — the ternary sits behind `dragItem.type === 'scheduled-talk'`, which now narrows `sourceTimeSlot` to `string`:

```diff
-      ? { talkId: proposal._id, startTime: dragItem.sourceTimeSlot! }
+      ? { talkId: proposal._id, startTime: dragItem.sourceTimeSlot }
```

**4. `moveProposal` (was `dragItem.proposal!`)** — a truthiness narrow (never independently true — `classifyProposalDrop` rejects a proposal-less drag) proves presence; plus a `type` narrow before `performSwap`:

```diff
-  if (kind === 'invalid') return fail
-  const proposal = dragItem.proposal!
+  if (kind === 'invalid' || !dragItem.proposal) return fail
+  const { proposal } = dragItem
...
   if (occupiedTalk?.kind !== 'talk') return fail
+  if (dragItem.type !== 'scheduled-talk') return fail
   return { schedule: performSwap(schedule, dragItem, occupiedTalk, dropPosition), ok: true }
```

**5. `moveServiceSession` (was `dragItem.serviceSession!`)** — same truthiness-narrow pattern:

```diff
-  if (classifyServiceDrop(...) === 'invalid') return fail
-  const serviceSession = dragItem.serviceSession!
+  if (classifyServiceDrop(...) === 'invalid' || !dragItem.serviceSession) return fail
+  const { serviceSession } = dragItem
```

The added `|| !dragItem.proposal` / `|| !dragItem.serviceSession` / `type !== 'scheduled-talk'` guards can never independently fire (the classifier already rejects those cases), so they only prove presence to TS — no runtime behavior change.

### Deviations / notes

- **No variant-widening was needed** — every construction site fit one of the four variants cleanly. The `scheduled-*` sites (mobile `MobileScheduleView`/`placement`, desktop `ScheduledTalk`/`ServiceSession`) always pass `sourceTrackIndex` and `sourceTimeSlot` together, matching the union.
- **One extra UI narrow** (`MobileScheduleView.tsx` swap branch): added `&& active.talk.talk` to the existing `seg.kind === 'talk' && active.kind === 'scheduled'` guard so the inline `scheduled-talk` payload gets a non-optional `proposal`. Behavior-preserving: a service pick-up onto a talk segment is already classified `invalid` upstream (so it's unreachable here), and a `moveProposal` with no proposal is a no-op anyway.
- **Test fixtures**: `operations.test.ts`'s `serviceDrag` helper now takes an optional `source` arg and builds the correct variant (instead of spreading a `Partial<DragItem>`). `mobileRail.test.ts` / `mobile-placement.test.ts` tag their `talk()`/`service()`/break fixtures with `kind` (kept as raw `Slot[]` so the rail's own ghost/malformed filtering is still exercised). `MobileScheduleView.test.tsx` converts its `ConferenceSchedule` fixtures with `toEditorSchedule(...)` at the render boundary — production parity with the stories.

### Verification

- `npx tsc --noEmit` — clean.
- eslint on touched source dirs — 0 errors (test files are eslint-ignored by repo config).
- prettier — all touched files formatted.
- `npx vitest run __tests__/lib/schedule/ __tests__/components/admin/schedule/` — **146 passed**.
- `npx vitest run __tests__/` — **2207 tests passed**, 0 actual failures (24 test *files* fail to load on the pre-existing `@digitalbazaar/vc` module-resolution issue, known on main).
- `SHOOT_OUT=/tmp pnpm shoot` — `OK: 3 card(s) checked, none exceed the 393px viewport`.
- `SHOOT_OUT=/tmp pnpm shoot systems-program-admin-scheduleeditor--single-day-with-tracks 1280 800` — `OK: 0 card(s) checked, none exceed the 1280px viewport` (0 is expected — the card check is mobile-specific); the desktop editor renders correctly (both tracks, service sessions, breaks, talks, legend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Converts `DragItem` from a single interface with four optional fields into a closed four-variant discriminated union mirroring `Slot`, and narrows the schedule-editor UI types (`ScheduleContext.schedule`, mobile props/rail/placement) from the wide persisted types to their `EditorSchedule`/`Slot` equivalents. Zero behavior change — five non-null assertions in `operations.ts` are retired by structural type guarantees and truthiness guards that can never independently fire.

- **`DragItem` union** — each variant marks the content fields it does NOT carry as `?: undefined`; `scheduled-*` variants require both source fields non-optionally, while fresh variants declare them as `?: undefined`; `DragServiceSession` is extracted as a named interface.
- **Drag payload construction** (`DraggableProposal`, `DraggableServiceSession`) — both components now build a typed `const item: DragItem` conditional on the source fields, so the `useDraggable` `data` object is a valid union member rather than a loose object literal.
- **`performSwap` narrowing** — parameter narrowed to `Extract<DragItem, {type:'scheduled-talk'}>`, dropping the two redundant `sourceTrackIndex/sourceTimeSlot !== undefined` guards to plain blocks; the same cleanup was not applied to the analogous blocks in `moveProposal`'s 'move' branch, `moveServiceSession`, `classifyProposalDrop`, and `classifyServiceDrop`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — every change is type-level with zero runtime behavior change; 2207 tests pass and tsc is clean.

The refactor is methodical and internally consistent. The only findings are style-level inconsistencies: `performSwap` was cleaned up to drop its now-dead `!== undefined` guards, but `moveProposal`'s 'move' branch, `moveServiceSession`, `classifyProposalDrop`, and `classifyServiceDrop` still carry the same redundant checks. No logic is wrong. The swap-branch guard in `MobileScheduleView` also uses a property truthiness check (`active.talk.talk`) where the new `kind` discriminant would be more direct.

`src/lib/schedule/operations.ts` has a few redundant `!== undefined` checks that could be tidied for consistency with how `performSwap` was updated in this same PR.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/schedule/types.ts | Replaces the single `DragItem` interface with a correct closed four-variant discriminated union; extracts `DragServiceSession` interface; each variant marks the fields it does NOT carry as `?: undefined` so wide optional reads still compile while narrowing works. |
| src/lib/schedule/operations.ts | Removes 5 non-null assertions; `performSwap` narrowed to `Extract<DragItem, {type:'scheduled-talk'}>` and its redundant undefined guards dropped to plain blocks; residual `!== undefined` checks in classifyProposalDrop, classifyServiceDrop, moveProposal move branch, and moveServiceSession are now permanently dead. |
| src/components/admin/schedule/DraggableProposal.tsx | Builds a typed `DragItem` const instead of a loose object literal, correctly choosing `scheduled-talk` only when both source fields are defined. |
| src/components/admin/schedule/DraggableServiceSession.tsx | Same pattern as `DraggableProposal`: builds a typed `DragItem` const; `session` object extracted before the conditional so the `DragServiceSession` payload is shared between both variants. |
| src/components/admin/schedule/mobile/MobileScheduleView.tsx | Adds `active.talk.talk` guard to the swap branch so the `scheduled-talk` payload is only dispatched when the picked-up item has a resolved proposal. |
| src/components/admin/schedule/mobile/rail.ts | Type updated from `ScheduleTrack`/`TrackTalk` to `EditorTrack`/`Slot`; `kind` assignment (`talk.placeholder ? 'break' : 'talk'`) still works correctly against the closed union. |
| src/components/admin/schedule/mobile/types.ts | Narrows `MobileScheduleViewProps.schedules`, `Placing.talk`, and `ActiveSheet` card/serviceEdit `talk` from `ConferenceSchedule`/`TrackTalk` to `EditorSchedule`/`Slot`. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/schedule/operations.ts`, line 304-320 ([link](https://github.com/cloudnativebergen/website/blob/3ea7a25a2599ed262a06c87c11c73567e358bdde/src/lib/schedule/operations.ts#L304-L320)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> After narrowing to `dragItem.type === 'scheduled-talk'`, both `sourceTrackIndex` and `sourceTimeSlot` are non-optional on the union variant — the `!== undefined` checks are permanently dead. `performSwap` (same file, same PR) was updated to plain `{ }` blocks precisely because those guards are redundant once the type is narrowed; the 'move' branch wasn't cleaned up the same way.


2. `src/lib/schedule/operations.ts`, line 369-385 ([link](https://github.com/cloudnativebergen/website/blob/3ea7a25a2599ed262a06c87c11c73567e358bdde/src/lib/schedule/operations.ts#L369-L385)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same redundant pattern in `moveServiceSession`: `dragItem.type === 'scheduled-service'` guarantees both source fields are `string`/`number`, so the extra `!== undefined` guards are dead. The analogous block in `classifyServiceDrop` (the ternary condition `dragItem.sourceTimeSlot !== undefined`) has the same issue.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["refactor(schedule): discriminated-union ..."](https://github.com/cloudnativebergen/website/commit/3ea7a25a2599ed262a06c87c11c73567e358bdde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45326050)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->