### PR TITLE
fix(schedule): save integrity — lost-update guard, create/update races, payload validation (review batch 2)

### DIFF
--- a/__tests__/lib/schedule/reducer.test.ts
+++ b/__tests__/lib/schedule/reducer.test.ts
@@ -241,6 +241,7 @@ describe('save lifecycle + dirty tracking', () => {
       type: 'saveDaySucceeded',
       index: 0,
       _id: 'server-id-0',
+      saved: state.schedules[0],
     })
     expect(state.schedules[0]._id).toBe('server-id-0')
     expect(state.dirty).toEqual([false, true])
@@ -249,6 +250,7 @@ describe('save lifecycle + dirty tracking', () => {
       type: 'saveDaySucceeded',
       index: 1,
       _id: 'server-id-1',
+      saved: state.schedules[1],
     })
     expect(state.schedules[1]._id).toBe('server-id-1')
     expect(state.dirty).toEqual([false, false])
@@ -264,6 +266,7 @@ describe('save lifecycle + dirty tracking', () => {
       index: 0,
       _id: 'server-id-0',
       _rev: 'rev-abc',
+      saved: state.schedules[0],
     })
     expect(state.schedules[0]._rev).toBe('rev-abc')
 
@@ -273,8 +276,97 @@ describe('save lifecycle + dirty tracking', () => {
       type: 'saveDaySucceeded',
       index: 0,
       _id: 'server-id-0',
+      saved: state.schedules[0],
     })
     expect(state.schedules[0]._rev).toBe('rev-abc')
+  })
+
+  // F1 — LOST-UPDATE RACE. `handleSave` captures a snapshot of the day and sends
+  // it; when the response lands, the reducer must clear `dirty` only if that
+  // exact snapshot is still the current day. An edit made while the save was in
+  // flight replaces the day object, so identity no longer matches and the day
+  // must stay dirty (its newer edits weren't part of the save).
+  describe('saveDaySucceeded — lost-update guard (F1)', () => {
+    it('clears dirty when no edit landed between saveStart and success', () => {
+      let state = scheduleReducer(twoDirtyDays(), { type: 'saveStart' })
+      // The snapshot handleSave would have sent is the current day object.
+      const snapshot = state.schedules[0]
+      state = scheduleReducer(state, {
+        type: 'saveDaySucceeded',
+        index: 0,
+        _id: 'server-id-0',
+        _rev: 'rev-1',
+        saved: snapshot,
+      })
+      expect(state.dirty[0]).toBe(false)
+      expect(state.schedules[0]._id).toBe('server-id-0')
+      expect(state.schedules[0]._rev).toBe('rev-1')
+    })
+
+    it('keeps the day dirty (and still updates _rev) when an edit lands mid-save', () => {
+      // saveStart captures the snapshot handleSave sends to the server.
+      let state = scheduleReducer(twoDirtyDays(), { type: 'saveStart' })
+      const snapshot = state.schedules[0]
+
+      // An edit lands on day 0 WHILE the save is in flight — switch to day 0 and
+      // edit it; the reducer replaces the day object, so it is no longer
+      // identical to the snapshot the save sent.
+      state = scheduleReducer(state, { type: 'changeDay', dayIndex: 0 })
+      state = scheduleReducer(state, { type: 'addTrack', track: track('C') })
+      expect(state.schedules[0]).not.toBe(snapshot)
+      const interleaved = state.schedules[0]
+
+      // The (now stale) save response lands.
+      state = scheduleReducer(state, {
+        type: 'saveDaySucceeded',
+        index: 0,
+        _id: 'server-id-0',
+        _rev: 'rev-2',
+        saved: snapshot,
+      })
+
+      // Dirty STAYS true: the interleaved edit was not part of this save.
+      expect(state.dirty[0]).toBe(true)
+      // But the doc really advanced, so the new _rev is threaded in — otherwise
+      // the next save would be a false conflict.
+      expect(state.schedules[0]._rev).toBe('rev-2')
+      expect(state.schedules[0]._id).toBe('server-id-0')
+      // The interleaved edit's content is preserved (only _id/_rev changed).
+      expect(state.schedules[0].tracks).toBe(interleaved.tracks)
+    })
+
+    it('the next save then persists the newer state (fresh _rev, still dirty)', () => {
+      let state = scheduleReducer(twoDirtyDays(), { type: 'saveStart' })
+      const snapshot = state.schedules[0]
+      // Interleaved edit on day 0.
+      state = scheduleReducer(state, { type: 'changeDay', dayIndex: 0 })
+      state = scheduleReducer(state, { type: 'addTrack', track: track('C') })
+      // Stale response lands: day stays dirty, _rev advances to rev-2.
+      state = scheduleReducer(state, {
+        type: 'saveDaySucceeded',
+        index: 0,
+        _id: 'server-id-0',
+        _rev: 'rev-2',
+        saved: snapshot,
+      })
+
+      // The next save sends the CURRENT (newer) day carrying the fresh _rev, so it
+      // doesn't false-conflict — model it as a second saveStart + success whose
+      // snapshot is the current day.
+      const nextSnapshot = state.schedules[0]
+      expect(nextSnapshot._rev).toBe('rev-2')
+      state = scheduleReducer(state, { type: 'saveStart' })
+      state = scheduleReducer(state, {
+        type: 'saveDaySucceeded',
+        index: 0,
+        _id: 'server-id-0',
+        _rev: 'rev-3',
+        saved: nextSnapshot,
+      })
+      // No further edit interleaved this time, so the newer state is now clean.
+      expect(state.dirty[0]).toBe(false)
+      expect(state.schedules[0]._rev).toBe('rev-3')
+    })
   })
 
   it('saveError records the message and stops saving', () => {

--- a/__tests__/lib/schedule/sanity.test.ts
+++ b/__tests__/lib/schedule/sanity.test.ts
@@ -212,7 +212,8 @@ describe('saveScheduleToSanity — update happy path', () => {
     expect(result.schedule?._id).toBe('sched-1')
   })
 
-  it('skips ifRevisionId when the schedule carries no _rev (unconditional write)', async () => {
+  it('rejects an UPDATE that carries no _rev (F3 — no unconditional last-write-wins)', async () => {
+    // The security-scope fetch must NOT even be reached; the _rev guard is first.
     const patch = installPatch(async () => ({ _rev: 'new' }))
 
     const result = await saveScheduleToSanity(
@@ -220,8 +221,19 @@ describe('saveScheduleToSanity — update happy path', () => {
       conference,
     )
 
-    expect(patch.ifRevisionId).not.toHaveBeenCalled()
-    expect(patch.set).toHaveBeenCalledTimes(1)
+    expect(result.error).toMatch(/revision/i)
+    expect(result.schedule).toBeUndefined()
+    expect(mockClient.fetch).not.toHaveBeenCalled()
+    expect(clientWrite.patch).not.toHaveBeenCalled()
+    expect(patch.commit).not.toHaveBeenCalled()
+  })
+
+  it('always patches with ifRevisionId now that _rev is required for updates', async () => {
+    const patch = installPatch(async () => ({ _rev: 'new' }))
+
+    const result = await saveScheduleToSanity(updateDay(), conference)
+
+    expect(patch.ifRevisionId).toHaveBeenCalledWith('rev-1')
     expect(patch.commit).toHaveBeenCalledTimes(1)
     expect(result.schedule?._rev).toBe('new')
   })
@@ -273,7 +285,11 @@ describe('saveScheduleToSanity — optimistic concurrency', () => {
 describe('saveScheduleToSanity — create path (no _id)', () => {
   it('runs one atomic transaction: create schedule + append conference link, then reads back _rev', async () => {
     const { tx, confPatch } = installTransaction()
-    mockClient.fetch.mockResolvedValue({ _rev: 'created-rev' })
+    // First fetch is the duplicate-day existence check (none exists → null);
+    // the second is the post-create read-back of the new _rev.
+    mockClient.fetch
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ _rev: 'created-rev' })
 
     const newDay = updateDay({ _id: '', _rev: undefined })
     const result = await saveScheduleToSanity(newDay, conference)
@@ -313,6 +329,31 @@ describe('saveScheduleToSanity — create path (no _id)', () => {
     // The result carries the generated id and the read-back revision.
     expect(result.schedule?._id).toBe(created._id)
     expect(result.schedule?._rev).toBe('created-rev')
+  })
+
+  it('returns a conflict (no create) when a schedule for this (conference, date) already exists (F2)', async () => {
+    // The duplicate-day existence check finds a doc for this date.
+    mockClient.fetch.mockResolvedValueOnce('existing-sched-id')
+    const { tx } = installTransaction()
+
+    const newDay = updateDay({ _id: '', _rev: undefined, date: '2026-06-15' })
+    const result = await saveScheduleToSanity(newDay, conference)
+
+    // Surfaced as the same conflict shape as a revision mismatch.
+    expect(result.conflict).toBe(true)
+    expect(result.error).toMatch(/reload/i)
+    expect(result.schedule).toBeUndefined()
+
+    // No create happened.
+    expect(clientWrite.transaction).not.toHaveBeenCalled()
+    expect(tx.create).not.toHaveBeenCalled()
+
+    // The existence check queried by (conference, date).
+    const [query, params] = mockClient.fetch.mock.calls[0]
+    expect(query).toContain('_type == "schedule"')
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(query).toContain('date == $date')
+    expect(params).toEqual({ conferenceId: 'conf-1', date: '2026-06-15' })
   })
 })
 
@@ -355,6 +396,35 @@ describe('saveScheduleToSanity — ghost-slot drop', () => {
     expect(talks[1]).toMatchObject({ placeholder: 'Lunch', startTime: '12:00' })
     // Nothing timed at 10:00 (the ghost) survives.
     expect(talks.some((t) => t.startTime === '10:00')).toBe(false)
+  })
+
+  it('drops a slot whose talk resolves to an empty id instead of serializing {_ref:""} (F7)', async () => {
+    const patch = installPatch(async () => ({ _rev: 'new' }))
+
+    const day = updateDay({
+      tracks: [
+        track([
+          { talk: asAny({ _id: 't1' }), startTime: '09:00', endTime: '09:25' },
+          // A malformed talk object: present but with neither `_id` nor `_ref`.
+          // The old fallback would emit `talk: {_ref: ''}`; it must be dropped.
+          { talk: asAny({}), startTime: '10:00', endTime: '10:25' },
+        ]),
+      ],
+    })
+
+    await saveScheduleToSanity(day, conference)
+
+    const setArg = patch.set.mock.calls[0][0] as {
+      tracks: Array<{ talks: Array<Record<string, unknown>> }>
+    }
+    const talks = setArg.tracks[0].talks
+
+    // Only the real ref survives; no empty reference is ever serialized.
+    expect(talks).toHaveLength(1)
+    expect(talks[0]).toMatchObject({ talk: { _ref: 't1' } })
+    expect(
+      talks.some((t) => (t.talk as { _ref?: string } | undefined)?._ref === ''),
+    ).toBe(false)
   })
 })
 

--- a/__tests__/lib/schedule/server.test.ts
+++ b/__tests__/lib/schedule/server.test.ts
@@ -106,6 +106,34 @@ describe('getScheduleData day tabs', () => {
     ])
   })
 
+  it('does not mutate conference.schedules in place (F8 — no fabricated days / reorder leak)', async () => {
+    // A multi-day conference whose only saved day is the LAST one: fabricating
+    // the earlier days and sorting would, if done in place, both grow and
+    // reorder the shared cached array.
+    const original = [{ _id: 'sched-1', date: '2026-03-12', tracks: [] }]
+    const conference = {
+      _id: 'conf-mut',
+      startDate: '2026-03-10',
+      endDate: '2026-03-12',
+      schedules: original,
+    }
+    mockGetConference.mockResolvedValue({ conference, error: null })
+
+    const { schedules } = await getScheduleData()
+
+    // The returned view has all three days, sorted.
+    expect(schedules.map((s) => s.date)).toEqual([
+      '2026-03-10',
+      '2026-03-11',
+      '2026-03-12',
+    ])
+
+    // The input array is untouched: same reference, same single element.
+    expect(conference.schedules).toBe(original)
+    expect(conference.schedules).toHaveLength(1)
+    expect(conference.schedules[0].date).toBe('2026-03-12')
+  })
+
   it('never returns a day outside the conference date range', async () => {
     mockGetConference.mockResolvedValue({
       conference: {

--- a/__tests__/server/schemas/schedule.test.ts
+++ b/__tests__/server/schemas/schedule.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the SAVE payload zod schema (src/server/schemas/schedule.ts).
+ *
+ * The router uses this schema as its tRPC input, so these are the FIRST gate a
+ * client payload passes. Guards the review-batch-2 hardening:
+ *   F3 — an existing schedule (non-empty `_id`) must carry its `_rev`.
+ *   F4 — `date` must be a real YYYY-MM-DD calendar date.
+ *   F5 — size caps on titles/descriptions/arrays reject oversized payloads.
+ */
+import { describe, it, expect } from 'vitest'
+import { SaveScheduleSchema } from '@/server/schemas/schedule'
+
+const validTrack = () => ({
+  trackTitle: 'Track A',
+  trackDescription: '',
+  talks: [
+    { talk: { _id: 't1' }, startTime: '09:00', endTime: '09:30' },
+    { placeholder: 'Lunch', startTime: '12:00', endTime: '13:00' },
+  ],
+})
+
+const base = (overrides: Record<string, unknown> = {}) => ({
+  _id: 'sched-1',
+  _rev: 'rev-1',
+  date: '2026-06-15',
+  tracks: [validTrack()],
+  ...overrides,
+})
+
+describe('SaveScheduleSchema — happy path', () => {
+  it('accepts a well-formed update payload', () => {
+    expect(SaveScheduleSchema.safeParse(base()).success).toBe(true)
+  })
+
+  it('accepts a create payload (empty _id, no _rev)', () => {
+    const result = SaveScheduleSchema.safeParse(
+      base({ _id: '', _rev: undefined }),
+    )
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('SaveScheduleSchema — _rev required for updates (F3)', () => {
+  it('rejects an update (non-empty _id) without a _rev', () => {
+    const result = SaveScheduleSchema.safeParse(base({ _rev: undefined }))
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['_rev'])
+    }
+  })
+
+  it('rejects an update with an empty-string _rev', () => {
+    const result = SaveScheduleSchema.safeParse(base({ _rev: '' }))
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('SaveScheduleSchema — date validation (F4)', () => {
+  it('accepts a real calendar date', () => {
+    expect(
+      SaveScheduleSchema.safeParse(base({ date: '2026-02-28' })).success,
+    ).toBe(true)
+  })
+
+  it('rejects a malformed date shape', () => {
+    expect(
+      SaveScheduleSchema.safeParse(base({ date: '2026-6-1' })).success,
+    ).toBe(false)
+    expect(
+      SaveScheduleSchema.safeParse(base({ date: 'not-a-date' })).success,
+    ).toBe(false)
+  })
+
+  it('rejects an impossible calendar date (Feb 30 / month 13)', () => {
+    expect(
+      SaveScheduleSchema.safeParse(base({ date: '2026-02-30' })).success,
+    ).toBe(false)
+    expect(
+      SaveScheduleSchema.safeParse(base({ date: '2026-13-01' })).success,
+    ).toBe(false)
+  })
+})
+
+describe('SaveScheduleSchema — size bounds (F5)', () => {
+  it('rejects a track title over 200 chars', () => {
+    const bad = base({
+      tracks: [{ ...validTrack(), trackTitle: 'x'.repeat(201) }],
+    })
+    expect(SaveScheduleSchema.safeParse(bad).success).toBe(false)
+  })
+
+  it('rejects a trackDescription over 2000 chars', () => {
+    const bad = base({
+      tracks: [{ ...validTrack(), trackDescription: 'x'.repeat(2001) }],
+    })
+    expect(SaveScheduleSchema.safeParse(bad).success).toBe(false)
+  })
+
+  it('rejects a placeholder over 200 chars', () => {
+    const bad = base({
+      tracks: [
+        {
+          ...validTrack(),
+          talks: [
+            {
+              placeholder: 'x'.repeat(201),
+              startTime: '12:00',
+              endTime: '13:00',
+            },
+          ],
+        },
+      ],
+    })
+    expect(SaveScheduleSchema.safeParse(bad).success).toBe(false)
+  })
+
+  it('rejects more than 30 tracks', () => {
+    const bad = base({ tracks: Array.from({ length: 31 }, validTrack) })
+    expect(SaveScheduleSchema.safeParse(bad).success).toBe(false)
+  })
+
+  it('rejects more than 300 talks in a track', () => {
+    const slot = { placeholder: 'x', startTime: '09:00', endTime: '09:05' }
+    const bad = base({
+      tracks: [
+        { ...validTrack(), talks: Array.from({ length: 301 }, () => slot) },
+      ],
+    })
+    expect(SaveScheduleSchema.safeParse(bad).success).toBe(false)
+  })
+})

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -204,6 +204,10 @@ export function ScheduleEditor({
             index,
             _id: schedule._id,
             _rev: schedule._rev,
+            // Pass the EXACT object we sent so the reducer can identity-compare
+            // it against the current day and detect an edit made mid-save (which
+            // must stay dirty rather than be marked clean and lost).
+            saved: daySchedule,
           })
         }
       }

--- a/src/lib/schedule/reducer.ts
+++ b/src/lib/schedule/reducer.ts
@@ -64,7 +64,17 @@ export type ScheduleAction =
     }
   | { type: 'changeDay'; dayIndex: number }
   | { type: 'saveStart' }
-  | { type: 'saveDaySucceeded'; index: number; _id: string; _rev?: string }
+  | {
+      type: 'saveDaySucceeded'
+      index: number
+      _id: string
+      _rev?: string
+      // The EXACT day object that was sent to the server for this save. Every
+      // reducer edit REPLACES the day object, so an identity compare against the
+      // current `schedules[index]` tells us whether an edit landed while the save
+      // was in flight (see the case handler for the lost-update guard).
+      saved: EditorSchedule
+    }
   | { type: 'saveError'; message: string }
   | { type: 'saveEnd' }
 
@@ -225,15 +235,25 @@ export function scheduleReducer(
         return state
       }
       const schedules = [...state.schedules]
+      const currentDay = schedules[action.index]
+      // The document really advanced on the server, so ALWAYS thread the new
+      // `_id`/`_rev` — even when an edit landed mid-save. Keeping a stale `_rev`
+      // would make the NEXT save a false `ifRevisionId` conflict; carrying the
+      // fresh one lets that save re-send the newer state and actually persist it.
       schedules[action.index] = {
-        ...schedules[action.index],
+        ...currentDay,
         _id: action._id,
-        // Store the NEW revision returned by the write so a second save in the
-        // same session patches against the current `_rev` (not a false conflict).
-        _rev: action._rev ?? schedules[action.index]._rev,
+        _rev: action._rev ?? currentDay._rev,
       }
       const dirty = [...state.dirty]
-      dirty[action.index] = false
+      // LOST-UPDATE GUARD: clear `dirty[index]` ONLY if nothing changed since the
+      // snapshot we sent. Every edit replaces the day object, so identity still
+      // matching (`currentDay === action.saved`) means no interleaved edit — the
+      // save covered the current state. If they differ, an edit landed while the
+      // save was in flight; keep the day dirty so the next save re-sends it.
+      if (currentDay === action.saved) {
+        dirty[action.index] = false
+      }
       return { ...state, schedules, dirty }
     }
 

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -35,6 +35,19 @@ export async function getValidTalkIds(
   return new Set(ids || [])
 }
 
+/**
+ * The referenced talk id on a slot, resolved from either the projected `_id` or
+ * a raw Sanity `_ref`. Returns '' when the slot carries no resolvable talk (no
+ * `talk` at all, or a malformed `talk` object with neither field) — the caller
+ * treats a '' result on a non-placeholder slot as a ghost and drops it, so a
+ * `createReference('')` is never serialized.
+ */
+function resolveTalkId(talk: {
+  talk?: { _id?: string | null; _ref?: string | null } | null
+}): string {
+  return talk.talk?._id || talk.talk?._ref || ''
+}
+
 /** True when a Sanity write failed because `ifRevisionId` did not match (409). */
 function isRevisionMismatch(error: unknown): boolean {
   const statusCode = (error as { statusCode?: number })?.statusCode
@@ -48,21 +61,32 @@ export async function saveScheduleToSanity(
   conference: Conference,
 ): Promise<SaveScheduleResult> {
   try {
-    console.log('Saving schedule to Sanity:', schedule)
+    // Compact save log — the full payload used to be dumped every save, leaking
+    // the entire schedule into logs. Log only what's useful for tracing a write.
+    const slotCount = (schedule.tracks || []).reduce(
+      (n, track) => n + (track.talks?.length || 0),
+      0,
+    )
+    console.log(
+      `Saving schedule ${schedule._id || '(new)'} date=${schedule.date} tracks=${(schedule.tracks || []).length} slots=${slotCount}`,
+    )
 
     const sanitizedTracks = (schedule.tracks || []).map(
       (track, trackIndex) => ({
         _key: generateKey(`track-${trackIndex}`),
         trackTitle: track.trackTitle,
         trackDescription: track.trackDescription,
-        // Drop ghost slots (neither a resolved talk nor a placeholder) before
-        // serializing — otherwise the fallback branch below emits an empty slot
-        // that `validateSchedulePayload` rejects, failing the whole save. The
-        // editor load path is already ghost-free (`toEditorSchedule`), but this
-        // filter is NOT redundant: the tRPC save path also accepts client-supplied
-        // payloads that never crossed the load boundary, so keep it as-is.
+        // Drop ghost slots before serializing — otherwise the talk branch below
+        // emits an empty `{_ref:''}` that `validateSchedulePayload` rejects,
+        // failing the whole save. A ghost is a slot that is neither a placeholder
+        // NOR a resolvable talk: `resolveTalkId` returns '' for a slot with no
+        // talk at all AND for a malformed `talk` object carrying neither `_id`
+        // nor `_ref`. The editor load path is already ghost-free
+        // (`toEditorSchedule`), but this filter is NOT redundant: the tRPC save
+        // path also accepts client-supplied payloads that never crossed the load
+        // boundary, so keep it.
         talks: (track.talks || [])
-          .filter((talk) => talk.talk || talk.placeholder)
+          .filter((talk) => talk.placeholder || resolveTalkId(talk) !== '')
           .map((talk, talkIndex) => {
             const baseKey = `talk-${trackIndex}-${talkIndex}-${talk.startTime.replace(':', '')}`
 
@@ -75,13 +99,9 @@ export async function saveScheduleToSanity(
               }
             }
 
-            // The filter above guarantees a resolved talk reaches this point
-            // (ghost slots — neither talk nor placeholder — are dropped), so this
-            // is the exhaustive final case, no fallback needed.
-            const talkId =
-              talk.talk?._id ||
-              (talk.talk as unknown as { _ref?: string })?._ref ||
-              ''
+            // The filter above guarantees a resolvable talk id (non-empty) reaches
+            // this point, so this is the exhaustive final case — no empty ref.
+            const talkId = resolveTalkId(talk)
             return {
               _key: generateKey(`${baseKey}-${talkId}`),
               talk: createReference(talkId),
@@ -95,6 +115,17 @@ export async function saveScheduleToSanity(
     let savedSchedule: ConferenceSchedule
 
     if (schedule._id && schedule._id !== '') {
+      // An UPDATE without a revision would patch UNCONDITIONALLY — a silent
+      // last-write-wins that clobbers a concurrent organizer's edit. The editor
+      // always loads `_rev` (projected on load), so a missing one means a
+      // malformed or hostile payload: reject it rather than degrade to LWW.
+      if (!schedule._rev) {
+        return {
+          error:
+            'Missing revision for this update — reload the day and try again.',
+        }
+      }
+
       // SECURITY: `schedule._id` comes from the client, and `isOrganizer` is
       // global across every edition (an organizer of conference A is an
       // organizer on all domains). Without a scope check, a request could patch
@@ -118,18 +149,16 @@ export async function saveScheduleToSanity(
         return { error: 'Schedule not found or not accessible' }
       }
 
-      // Optimistic concurrency: when the client carried a `_rev`, patch with
-      // `ifRevisionId` so a save is rejected if the day changed since it was
-      // loaded (two organizers editing the same day). Sanity throws a 409 on
-      // mismatch, which we surface as a distinct `conflict` result. The commit
-      // returns the persisted document, so we thread the NEW `_rev` back to the
-      // client — a second save in the same session then isn't a false conflict.
-      let patch = clientWrite.patch(schedule._id)
-      if (schedule._rev) {
-        patch = patch.ifRevisionId(schedule._rev)
-      }
-
-      const committed = await patch
+      // Optimistic concurrency: `_rev` is guaranteed present (rejected above),
+      // so ALWAYS patch with `ifRevisionId` — a save is rejected if the day
+      // changed since it was loaded (two organizers editing the same day).
+      // Sanity throws a 409 on mismatch, which we surface as a distinct
+      // `conflict` result. The commit returns the persisted document, so we
+      // thread the NEW `_rev` back to the client — a second save in the same
+      // session then isn't a false conflict.
+      const committed = await clientWrite
+        .patch(schedule._id)
+        .ifRevisionId(schedule._rev)
         .set({
           date: schedule.date,
           tracks: sanitizedTracks,
@@ -138,6 +167,25 @@ export async function saveScheduleToSanity(
 
       savedSchedule = { ...schedule, _rev: committed._rev }
     } else {
+      // DUPLICATE-DAY GUARD: any payload with `_id: ''` creates a fresh schedule
+      // doc and appends it to `conference.schedules`. Two organizers saving the
+      // same fabricated empty day — or a client retry after a lost response —
+      // would each create a doc for one date, producing duplicate day tabs and
+      // forked edits. Check for an existing schedule for this (conference, date)
+      // first; if one exists, surface the same conflict UX as a revision mismatch
+      // so the client tells the organizer to reload rather than fork the day.
+      const existingId = await clientWrite.fetch<string | null>(
+        `*[_type == "schedule" && conference._ref == $conferenceId && date == $date][0]._id`,
+        { conferenceId: conference._id, date: schedule.date },
+      )
+      if (existingId) {
+        return {
+          conflict: true,
+          error:
+            'A schedule for this date was just created — reload to continue.',
+        }
+      }
+
       // Pre-generate the id so the create and the conference-link append run in
       // ONE atomic transaction. Previously these were two sequential writes: if
       // the append failed after the create succeeded, the error was swallowed

--- a/src/lib/schedule/server.ts
+++ b/src/lib/schedule/server.ts
@@ -43,7 +43,10 @@ export async function getScheduleData(): Promise<ScheduleData> {
       }
     }
 
-    const schedules: ConferenceSchedule[] = conference.schedules || []
+    // Operate on a COPY: fabricating empty days and sorting must never mutate
+    // the cached `conference.schedules` array in place (that leaks synthetic
+    // days and a reordering back into the shared, cached conference object).
+    const schedules: ConferenceSchedule[] = [...(conference.schedules ?? [])]
 
     const conferenceDates = generateConferenceDates(
       conference.startDate,
@@ -59,6 +62,9 @@ export async function getScheduleData(): Promise<ScheduleData> {
           date: date,
           tracks: [],
         })
+        // Keep the set in step with what we've fabricated so a duplicate date in
+        // `conferenceDates` can't fabricate the same day twice.
+        existingDates.add(date)
       }
     }
 

--- a/src/server/schemas/schedule.ts
+++ b/src/server/schemas/schedule.ts
@@ -3,6 +3,22 @@ import { HHMM_PATTERN } from '@/lib/schedule/time'
 
 const timeString = z.string().regex(HHMM_PATTERN, 'Time must be HH:MM (24h)')
 
+// A real calendar date in YYYY-MM-DD: the regex fixes the SHAPE, the refine
+// rejects impossible dates (e.g. 2026-02-30, 2026-13-01) by round-tripping
+// through `Date` — an invalid day rolls over, so its ISO date no longer matches.
+// Deliberately NOT range-checked against the conference dates: fabricated empty
+// days already match, and out-of-range future flexibility is fine.
+const dateString = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD')
+  .refine((value) => {
+    const parsed = new Date(`${value}T00:00:00Z`)
+    return (
+      !Number.isNaN(parsed.getTime()) &&
+      parsed.toISOString().slice(0, 10) === value
+    )
+  }, 'Date must be a real calendar date')
+
 const TrackTalkSchema = z.object({
   talk: z
     .object({
@@ -12,29 +28,43 @@ const TrackTalkSchema = z.object({
     })
     .optional()
     .nullable(),
-  placeholder: z.string().optional().nullable(),
+  // Bounded so a hostile/oversized payload can't be persisted (a placeholder is
+  // a short service label like "Lunch").
+  placeholder: z.string().max(200).optional().nullable(),
   startTime: timeString,
   endTime: timeString,
 })
 
 const ScheduleTrackSchema = z.object({
-  trackTitle: z.string(),
-  trackDescription: z.string().optional().nullable(),
-  talks: z.array(TrackTalkSchema),
+  trackTitle: z.string().max(200),
+  trackDescription: z.string().max(2000).optional().nullable(),
+  // A single track holds far fewer than 300 slots in practice; the cap only
+  // rejects abuse, not real schedules.
+  talks: z.array(TrackTalkSchema).max(300),
 })
 
-export const SaveScheduleSchema = z.object({
-  _id: z.string(),
-  // Optimistic-concurrency token from the loaded document; the SAVE patches with
-  // `ifRevisionId` when present so a stale write is rejected. Absent for a new day.
-  _rev: z.string().optional(),
-  date: z.string(),
-  tracks: z.array(ScheduleTrackSchema),
-  conference: z
-    .object({
-      _id: z.string().optional(),
-      _ref: z.string().optional(),
-      _type: z.string().optional(),
-    })
-    .optional(),
-})
+export const SaveScheduleSchema = z
+  .object({
+    _id: z.string(),
+    // Optimistic-concurrency token from the loaded document; the SAVE patches
+    // with `ifRevisionId` when present so a stale write is rejected. Absent for a
+    // new day (`_id: ''`); REQUIRED for an update — enforced by the refine below.
+    _rev: z.string().optional(),
+    date: dateString,
+    // A conference has a handful of tracks; the cap only rejects abuse.
+    tracks: z.array(ScheduleTrackSchema).max(30),
+    conference: z
+      .object({
+        _id: z.string().optional(),
+        _ref: z.string().optional(),
+        _type: z.string().optional(),
+      })
+      .optional(),
+  })
+  // An UPDATE (non-empty `_id`) MUST carry its `_rev`: without it the server
+  // would patch unconditionally (silent last-write-wins). The create path
+  // (`_id: ''`) legitimately has no revision yet.
+  .refine((value) => value._id === '' || Boolean(value._rev), {
+    message: 'An existing schedule must carry its revision (_rev) to be saved.',
+    path: ['_rev'],
+  })


### PR DESCRIPTION
Full code review of the schedule-editor **persistence / save path**. Each finding was verified against the code, then fixed with a regression test. Scope was strictly the save seam: `src/lib/schedule/{reducer,sanity,server}.ts`, `src/server/schemas/schedule.ts`, the `handleSave`/`saveDaySucceeded` seam in `ScheduleEditor.tsx`, and tests.

## F1 (HIGH) — Lost-update race: mid-save edits marked clean but never persisted
**Repro:** `handleSave` iterates a closure snapshot. When a response lands, `saveDaySucceeded` unconditionally cleared `dirty[index]` on the *current* state — which may hold edits made after the snapshot — and threaded the new `_rev`, so the next save wouldn't even conflict. Those edits were silently lost.
**Fix:** Identity compare. Every reducer edit replaces the day object, so `handleSave` now includes the exact object it sent (`saved: EditorSchedule`). The reducer clears `dirty[index]` **only** if `state.schedules[index] === action.saved` (nothing changed since the snapshot), but **always** updates `_id`/`_rev` (the doc really advanced — a stale `_rev` would false-conflict the next save, which then correctly re-sends the newer state).
**Test:** `reducer.test.ts` — (1) no interleaved edit → dirty cleared; (2) edit dispatched between `saveStart` and `saveDaySucceeded` → dirty stays true, `_rev` updated; (3) next save persists the newer state (fresh `_rev`, then clean).

## F2 (MED) — Duplicate-day create race
**Repro:** Any payload with `_id:''` unconditionally created a schedule doc and appended it to `conference.schedules`. Two organizers saving the same fabricated empty day (or a client retry after a lost response) produced two docs for one date → duplicate day tabs, forked edits.
**Fix:** In `saveScheduleToSanity`'s create path, query for an existing schedule with this `(conference, date)` before creating; if found, return the same `conflict`-shaped result used for revision mismatches ("A schedule for this date was just created — reload to continue.").
**Test:** `sanity.test.ts` — create with pre-existing `(conference, date)` → conflict, no `transaction`/`create` call; existence query asserted.

## F3 (MED) — `_rev`-less update was unconditional last-write-wins
**Repro:** `_rev` was optional, so an update lacking it patched unconditionally, silently clobbering a concurrent edit.
**Fix:** Reject an UPDATE (non-empty `_id`) without `_rev` server-side in `saveScheduleToSanity` (before any write), and enforce it in the zod schema via a refine (`_rev` required when `_id` present). `ifRevisionId` is now always applied on updates.
**Test:** `sanity.test.ts` — update without `_rev` → rejected, no fetch/patch. `schema` test — update without/empty `_rev` → rejected on `_rev` path.

## F4 (MED) — `date` entirely unvalidated
**Repro:** `date` was a bare `z.string()`; any garbage persisted.
**Fix:** `date` regex `^\d{4}-\d{2}-\d{2}$` **plus** a real-calendar-date refine (round-trips through `Date` so `2026-02-30` / `2026-13-01` are rejected). Deliberately not range-checked against conference dates (fabricated days already match; future flexibility is fine).
**Test:** `schema` test — accepts real dates; rejects malformed shapes and impossible calendar dates.

## F5 (MED) — No size bounds
**Repro:** No maxima on strings/arrays — an oversized payload could be persisted.
**Fix:** zod caps: `trackTitle` ≤ 200, `trackDescription` ≤ 2000, `placeholder` ≤ 200, `tracks` ≤ 30, `talks` per track ≤ 300.
**Test:** `schema` test — one rejection per bound.

## F6 (LOW) — Full payload dumped to logs every save
**Repro:** `console.log('Saving schedule to Sanity:', schedule)` dumped the entire payload on every save.
**Fix:** Compact line: `Saving schedule <id|(new)> date=… tracks=… slots=…`.
**Test:** covered indirectly (console spied in `sanity.test.ts`); no payload dump.

## F7 (LOW) — Latent `createReference('')`
**Repro:** The `talkId … || ''` fallback would serialize `{_ref:''}` if a caller skipped validation (a `talk` object with neither `_id` nor `_ref`).
**Fix:** The serializer resolves the talk id up front (`resolveTalkId`) and the ghost filter now drops any non-placeholder slot whose id resolves to `''`, so an empty ref is never emitted.
**Test:** `sanity.test.ts` — a slot with `talk:{}` (no id/ref) is dropped; no `{_ref:''}` serialized.

## F8 (LOW) — `getScheduleData` mutated `conference.schedules` in place
**Repro:** Fabricated empty days were pushed onto — and the array sorted in place on — the cached conference object, leaking synthetic days and a reordering into shared cache.
**Fix:** Operate on a copy (`[...(conference.schedules ?? [])]`); update the `existingDates` set as fabricated days are added (defensive against duplicate fabrication). Behavior otherwise identical.
**Test:** `server.test.ts` — input array reference/length unchanged after a fabricate+sort call.

## Verification
- `npx tsc --noEmit` — 0 errors
- eslint (touched source) — clean; prettier — clean
- `vitest run` scoped suites — 55/55 green (`reducer`, `sanity`, `server`, `schema`, tRPC `schedule`)
- `pnpm shoot` (SHOOT_OUT=/tmp) — editor boots and renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the schedule editor's save path against eight classes of bugs found in a structured code review: a lost-update race in the reducer, a duplicate-day create race, unconditional last-write-wins updates, unvalidated dates, missing size bounds, a noisy log, a latent empty reference, and an in-place mutation of the cached conference object.

- **F1 (reducer):** `saveDaySucceeded` now carries the exact day snapshot sent to the server; the reducer clears `dirty` only when that snapshot still matches the current day (identity compare), while always threading the new `_rev` to prevent false conflicts on the next save.
- **F2–F3 (sanity):** Creates check for an existing `(conference, date)` before inserting, and updates without `_rev` are rejected before any write — both enforced at the schema layer (F3 zod refine) and the service layer.
- **F4–F5 (schema):** `date` is validated with a regex + real-calendar-date refine, and string/array size caps prevent oversized payload persistence.
- **F6–F8 (misc):** Log compacted, empty-ref slots dropped before serialization, and `getScheduleData` operates on a copy so fabricated days don't leak into the shared cache.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all eight targeted bugs are correctly fixed and regression-tested, with changes isolated to the schedule save path.

The identity-compare guard, schema enforcement, and server-side rejection of revision-less updates are all correctly implemented and well-tested. The one remaining gap is a narrow TOCTOU window in the duplicate-day guard: the existence fetch and the create transaction are separate round-trips to Sanity, so two truly simultaneous creates can still slip through. This is a known platform limitation rather than an implementation mistake, and the common-case attack surface is now closed.

src/lib/schedule/sanity.ts — the duplicate-day guard (lines 177–187) contains a residual non-atomic check-then-create window that a future maintainer should be aware of.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/schedule/reducer.ts | Adds `saved: EditorSchedule` to the `saveDaySucceeded` action and uses identity comparison to guard against lost updates; always threads new `_id`/`_rev` regardless of mid-save edits. |
| src/lib/schedule/sanity.ts | F2–F3/F6/F7 fixes are all correct. Minor residual TOCTOU window between the existence-check fetch and the create transaction (unavoidable without Sanity-side unique constraints, and the common case is now closed). |
| src/lib/schedule/server.ts | Operates on a copy of `conference.schedules` and updates `existingDates` after each fabrication; neither change mutates the shared cached array. |
| src/server/schemas/schedule.ts | Adds date-shape regex + real-calendar-date refine, `_rev` cross-field constraint, and size caps on strings/arrays. |
| src/components/admin/schedule/ScheduleEditor.tsx | Passes the pre-await `daySchedule` snapshot as `saved` to `saveDaySucceeded`; correctly wires the F1 identity guard from the component side. |
| __tests__/lib/schedule/reducer.test.ts | New lost-update guard describe block covers all three F1 scenarios; existing tests updated to supply the now-required `saved` field. |
| __tests__/lib/schedule/sanity.test.ts | Tests for duplicate-day conflict and empty-ref drop added; create-path test updated for the new existence-check fetch. |
| __tests__/lib/schedule/server.test.ts | New test verifies input array reference and length are unchanged after a fabricate+sort call. |
| __tests__/server/schemas/schedule.test.ts | New test file covering F3–F5: _rev constraint, date validation, and size caps. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as ScheduleEditor
    participant R as Reducer
    participant tRPC as tRPC Router
    participant S as saveScheduleToSanity
    participant DB as Sanity

    UI->>R: dispatch saveStart
    UI->>UI: snapshot daySchedule (closure)
    UI->>tRPC: mutateAsync(daySchedule)
    Note over tRPC,S: Schema validates date, _rev, size caps
    tRPC->>S: saveScheduleToSanity(schedule)
    alt Update (_id present)
        S->>S: reject if _rev missing (F3)
        S->>DB: fetch scope-check
        S->>DB: patch().ifRevisionId(_rev).commit()
        DB-->>S: committed._rev
    else Create (_id empty)
        S->>DB: fetch existence check (F2)
        alt Already exists
            S-->>tRPC: conflict true
        else New
            S->>DB: transaction create + patch commit
            S->>DB: fetch _rev read-back
        end
    end
    S-->>UI: schedule
    alt No mid-save edit (F1)
        UI->>R: "saveDaySucceeded saved=snapshot"
        Note over R: currentDay===saved, dirty=false
    else Edit landed mid-save (F1)
        UI->>R: "saveDaySucceeded saved=old snapshot"
        Note over R: currentDay!==saved, dirty stays true, _rev updated
    end
    UI->>R: dispatch saveEnd
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as ScheduleEditor
    participant R as Reducer
    participant tRPC as tRPC Router
    participant S as saveScheduleToSanity
    participant DB as Sanity

    UI->>R: dispatch saveStart
    UI->>UI: snapshot daySchedule (closure)
    UI->>tRPC: mutateAsync(daySchedule)
    Note over tRPC,S: Schema validates date, _rev, size caps
    tRPC->>S: saveScheduleToSanity(schedule)
    alt Update (_id present)
        S->>S: reject if _rev missing (F3)
        S->>DB: fetch scope-check
        S->>DB: patch().ifRevisionId(_rev).commit()
        DB-->>S: committed._rev
    else Create (_id empty)
        S->>DB: fetch existence check (F2)
        alt Already exists
            S-->>tRPC: conflict true
        else New
            S->>DB: transaction create + patch commit
            S->>DB: fetch _rev read-back
        end
    end
    S-->>UI: schedule
    alt No mid-save edit (F1)
        UI->>R: "saveDaySucceeded saved=snapshot"
        Note over R: currentDay===saved, dirty=false
    else Edit landed mid-save (F1)
        UI->>R: "saveDaySucceeded saved=old snapshot"
        Note over R: currentDay!==saved, dirty stays true, _rev updated
    end
    UI->>R: dispatch saveEnd
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): save integrity — lost-upd..."](https://github.com/cloudnativebergen/website/commit/a2b6d66de2c299cf3be94cdd3fe12507a1404d32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45328797)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->