### PR TITLE
fix(schedule): engine correctness — end-of-day wrap, swap guards, stale-drag guards (review batch 1)

### DIFF
--- a/__tests__/components/admin/schedule/mobile-placement.test.ts
+++ b/__tests__/components/admin/schedule/mobile-placement.test.ts
@@ -180,10 +180,17 @@ describe('segmentState', () => {
         endTime: '09:15',
       },
     }
+    // The engine now requires the drag source to still exist (F4): track 1 must
+    // actually hold the Break@09:00 the pick-up references.
+    const sourceTrack = track({
+      placeholder: 'Break',
+      startTime: '09:00',
+      endTime: '09:15',
+    })
     expect(
       segmentState(
         placing,
-        [track()],
+        [track(), sourceTrack],
         0,
         openSeg('10:00', '11:00', 60),
         NO_OTHERS,
@@ -192,7 +199,7 @@ describe('segmentState', () => {
     expect(
       segmentState(
         placing,
-        [track(talk('a', '10:00', '10:25'))],
+        [track(talk('a', '10:00', '10:25')), sourceTrack],
         0,
         talkSeg('a', '10:00', '10:25', 25, 0),
         NO_OTHERS,

--- a/__tests__/lib/schedule/operations.test.ts
+++ b/__tests__/lib/schedule/operations.test.ts
@@ -186,8 +186,14 @@ describe('moveProposal — swap (bidirectional validation)', () => {
       talk('a', '10:00', '10:20'),
       talk('c', '10:25', '10:50'),
     )
-    // Target: b@10:00 is 45m; forward fits but b back at 10:00→10:45 hits c.
-    const target = track('B', talk('b', '10:00', '10:45'))
+    // Target: b@10:00 has a 45m FORMAT; forward fits but b back at 10:00→10:45
+    // (its format duration, which performSwap writes) hits c.
+    const target = track('B', {
+      kind: 'talk',
+      talk: proposal('b', 'presentation_45'),
+      startTime: '10:00',
+      endTime: '10:45',
+    })
     const s = schedule(source, target)
     const dragItem: DragItem = {
       type: 'scheduled-talk',
@@ -198,6 +204,141 @@ describe('moveProposal — swap (bidirectional validation)', () => {
     const res = moveProposal(s, dragItem, drop(1, '10:00'))
     expect(res.ok).toBe(false)
     expect(res.schedule).toBe(s)
+  })
+
+  it('REJECTS a swap validated with the stored span but applied with the FORMAT duration (F3)', () => {
+    // Source: a(talk_25)@11:00–11:25 leaving, c@11:30–11:55 staying.
+    const source = track(
+      'A',
+      talk('a', '11:00', '11:25'),
+      talk('c', '11:30', '11:55'),
+    )
+    // Target b is STORED as a 20-min slot (10:00–10:20) but its format is
+    // presentation_45. The old code validated the displaced talk with the stored
+    // span (20m → b back at 11:00–11:20, clears c) then performSwap wrote the 45m
+    // format duration (11:00–11:45, overlapping c). Check-what-you-write ⇒ REJECT.
+    const target = track('B', {
+      kind: 'talk',
+      talk: proposal('b', 'presentation_45'),
+      startTime: '10:00',
+      endTime: '10:20',
+    })
+    const s = schedule(source, target)
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('a', 'talk_25'),
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '11:00',
+    }
+    expect(classifyProposalDrop(s.tracks, dragItem, drop(1, '10:00'))).toBe(
+      'invalid',
+    )
+    const res = moveProposal(s, dragItem, drop(1, '10:00'))
+    expect(res.ok).toBe(false)
+    expect(res.schedule).toBe(s)
+  })
+
+  it('allows a legal SAME-TRACK swap and leaves non-overlapping slots (F6)', () => {
+    // One track: a(talk_25)@09:00, b STORED as a 60-min slot 09:30–10:30 but
+    // FORMAT talk_25. Pre-fix validated the displaced talk with the stored 60-min
+    // span, which self-collided with b's own vacated slot → this legal swap was
+    // wrongly rejected. With the FORMAT duration plus the vacated-slot exclusions
+    // it succeeds: b→09:00–09:25, a→09:30–09:55, non-overlapping.
+    const s = schedule(
+      track('A', talk('a', '09:00', '09:25'), {
+        kind: 'talk',
+        talk: proposal('b', 'talk_25'),
+        startTime: '09:30',
+        endTime: '10:30',
+      }),
+    )
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('a', 'talk_25'),
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '09:00',
+    }
+    expect(classifyProposalDrop(s.tracks, dragItem, drop(0, '09:30'))).toBe(
+      'swap',
+    )
+    const res = moveProposal(s, dragItem, drop(0, '09:30'))
+    expect(res.ok).toBe(true)
+    const slots = res.schedule.tracks[0].talks
+    expect(slots.map((t) => t.talk?._id)).toEqual(['b', 'a'])
+    expect(slots[0]).toMatchObject({ startTime: '09:00', endTime: '09:25' })
+    expect(slots[1]).toMatchObject({ startTime: '09:30', endTime: '09:55' })
+  })
+
+  it('REJECTS a same-track swap whose two talks would overlap EACH OTHER (F6 guard)', () => {
+    // a(talk_25)@09:00 dragged onto b(talk_60)@09:30. Each half-check passes in
+    // isolation (each ignores the other's vacated slot), but the final
+    // a@09:30–09:55 sits inside b@09:00–10:00. The same-track mutual-overlap guard
+    // rejects — the vacated-slot exclusions must not approve a self-overlapping swap.
+    const s = schedule(
+      track('A', talk('a', '09:00', '09:25'), {
+        kind: 'talk',
+        talk: proposal('b', 'talk_60'),
+        startTime: '09:30',
+        endTime: '10:30',
+      }),
+    )
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('a', 'talk_25'),
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '09:00',
+    }
+    expect(classifyProposalDrop(s.tracks, dragItem, drop(0, '09:30'))).toBe(
+      'invalid',
+    )
+    expect(moveProposal(s, dragItem, drop(0, '09:30')).ok).toBe(false)
+  })
+
+  it('REJECTS a same-track swap where the displaced talk lands on a THIRD talk (F6)', () => {
+    // Same track: a(talk_25)@09:00, d(talk_25)@09:35 (stays), b(talk_60)@10:30.
+    // Dragging a onto b displaces b back to 09:00 for its 60-min format
+    // (09:00–10:00), overlapping d@09:35. The reverse half-check (which does NOT
+    // exclude d) rejects — a real third-talk collision is not masked.
+    const s = schedule(
+      track('A', talk('a', '09:00', '09:25'), talk('d', '09:35', '10:00'), {
+        kind: 'talk',
+        talk: proposal('b', 'talk_60'),
+        startTime: '10:30',
+        endTime: '11:30',
+      }),
+    )
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('a', 'talk_25'),
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '09:00',
+    }
+    expect(classifyProposalDrop(s.tracks, dragItem, drop(0, '10:30'))).toBe(
+      'invalid',
+    )
+    expect(moveProposal(s, dragItem, drop(0, '10:30')).ok).toBe(false)
+  })
+
+  it('leaves cross-track swaps unchanged (F6 — same-track guard does not apply)', () => {
+    // Regression guard: the same-track-only mutual-overlap check must not affect a
+    // legal cross-track swap. a(talk_25)@10:00 in track A ↔ b(talk_25)@11:00 in B.
+    const s = schedule(
+      track('A', talk('a', '10:00', '10:25')),
+      track('B', talk('b', '11:00', '11:25')),
+    )
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('a', 'talk_25'),
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '10:00',
+    }
+    expect(classifyProposalDrop(s.tracks, dragItem, drop(1, '11:00'))).toBe(
+      'swap',
+    )
+    const res = moveProposal(s, dragItem, drop(1, '11:00'))
+    expect(res.ok).toBe(true)
+    expect(res.schedule.tracks[1].talks[0].talk?._id).toBe('a')
+    expect(res.schedule.tracks[0].talks[0].talk?._id).toBe('b')
   })
 })
 
@@ -331,6 +472,41 @@ describe('service add/resize/rename', () => {
     const res = renameService(s, 0, 0, 'Coffee Break')
     expect(res.schedule.tracks[0].talks[0].placeholder).toBe('Coffee Break')
   })
+
+  it('addService rejects an empty / whitespace title (F7)', () => {
+    const s = schedule(track('A'))
+    expect(
+      addService(s, 0, { title: '', startTime: '10:00', duration: 15 }).ok,
+    ).toBe(false)
+    expect(
+      addService(s, 0, { title: '   ', startTime: '10:00', duration: 15 }).ok,
+    ).toBe(false)
+  })
+
+  it('addService trims a padded title (F7)', () => {
+    const s = schedule(track('A'))
+    const res = addService(s, 0, {
+      title: '  Coffee  ',
+      startTime: '10:00',
+      duration: 15,
+    })
+    expect(res.ok).toBe(true)
+    expect(res.schedule.tracks[0].talks[0].placeholder).toBe('Coffee')
+  })
+
+  it('renameService rejects an empty / whitespace title (F7)', () => {
+    const s = schedule(track('A', service('Break', '10:00', '10:15')))
+    expect(renameService(s, 0, 0, '').ok).toBe(false)
+    expect(renameService(s, 0, 0, '   ').ok).toBe(false)
+    expect(renameService(s, 0, 0, '   ').schedule).toBe(s)
+  })
+
+  it('renameService trims a padded title (F7)', () => {
+    const s = schedule(track('A', service('Break', '10:00', '10:15')))
+    const res = renameService(s, 0, 0, '  Lunch  ')
+    expect(res.ok).toBe(true)
+    expect(res.schedule.tracks[0].talks[0].placeholder).toBe('Lunch')
+  })
 })
 
 describe('end-of-day clamp (nothing may end after SCHEDULE_END 21:00)', () => {
@@ -390,6 +566,186 @@ describe('end-of-day clamp (nothing may end after SCHEDULE_END 21:00)', () => {
     // Growing to 60 min → 21:30, past 21:00.
     expect(resizeService(s, 0, 0, 60).ok).toBe(false)
   })
+
+  it('rejects a fresh drop whose 24h-WRAPPED end reads as within the day (F1)', () => {
+    // workshop_240 at 20:00 ends at 00:00 (wraps mod 24h). The old
+    // withinScheduleEnd(calculateEndTime(...)) saw 00:00 (0 min) ≤ 21:00 and
+    // wrongly allowed it; endsWithinScheduleDay sums 20:00 + 240 = 24:00 > 21:00.
+    const s = schedule(track('A'))
+    const dragItem: DragItem = {
+      type: 'proposal',
+      proposal: proposal('p', 'workshop_240'),
+    }
+    expect(classifyProposalDrop(s.tracks, dragItem, drop(0, '20:00'))).toBe(
+      'invalid',
+    )
+    expect(moveProposal(s, dragItem, drop(0, '20:00')).ok).toBe(false)
+  })
+
+  it('rejects a MOVE of a scheduled talk whose wrapped end reads as within the day (F1)', () => {
+    // Same wrap, over an existing talk: a workshop_240 dragged to 20:00 must not
+    // classify as a swap/move onto a 20:30 talk just because its end wrapped.
+    const s = schedule(
+      track('A', talk('victim', '20:30', '20:55')),
+      track('B', {
+        kind: 'talk',
+        talk: proposal('w', 'workshop_240'),
+        startTime: '08:00',
+        endTime: '12:00',
+      }),
+    )
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('w', 'workshop_240'),
+      sourceTrackIndex: 1,
+      sourceTimeSlot: '08:00',
+    }
+    expect(classifyProposalDrop(s.tracks, dragItem, drop(0, '20:00'))).toBe(
+      'invalid',
+    )
+    expect(moveProposal(s, dragItem, drop(0, '20:00')).ok).toBe(false)
+  })
+
+  it('addService rejects a huge duration that would wrap past midnight (F1)', () => {
+    const s = schedule(track('A'))
+    // 20:00 + 300 min = 25:00; the wrapped end (01:00) must not read as valid.
+    expect(
+      addService(s, 0, { title: 'Marathon', startTime: '20:00', duration: 300 })
+        .ok,
+    ).toBe(false)
+  })
+
+  it('resizeService rejects a huge duration that would wrap past midnight (F1)', () => {
+    const s = schedule(track('A', service('Break', '20:00', '20:15')))
+    // 20:00 + 300 → 01:00 wrapped; must be rejected, not accepted.
+    expect(resizeService(s, 0, 0, 300).ok).toBe(false)
+  })
+
+  it('moveServiceSession rejects a service whose wrapped end reads as within the day (F1)', () => {
+    const s = schedule(track('A'))
+    const dragItem: DragItem = {
+      type: 'service-session',
+      serviceSession: {
+        placeholder: 'Long',
+        startTime: '08:00',
+        endTime: '12:00', // a 240-min session
+      },
+    }
+    // Dropped at 20:00 → 00:00 wrapped; endsWithinScheduleDay rejects.
+    expect(classifyServiceDrop(s.tracks, dragItem, drop(0, '20:00'))).toBe(
+      'invalid',
+    )
+    expect(moveServiceSession(s, dragItem, drop(0, '20:00')).ok).toBe(false)
+  })
+})
+
+describe('F4 — stale / out-of-range drag source', () => {
+  it('rejects a scheduled-talk drag whose source track index is out of range (no throw)', () => {
+    const s = schedule(track('A', talk('a', '10:00', '10:25')), track('B'))
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('a'),
+      sourceTrackIndex: 9, // out of range
+      sourceTimeSlot: '10:00',
+    }
+    expect(classifyProposalDrop(s.tracks, dragItem, drop(1, '11:00'))).toBe(
+      'invalid',
+    )
+    // The apply path used to index newTracks[9].talks and throw; now it fails soft.
+    expect(() => moveProposal(s, dragItem, drop(1, '11:00'))).not.toThrow()
+    expect(moveProposal(s, dragItem, drop(1, '11:00')).ok).toBe(false)
+  })
+
+  it('rejects a scheduled-talk drag whose source slot is stale (no duplication)', () => {
+    // Source track exists but the talk is no longer at sourceTimeSlot (it was
+    // '09:00', the talk actually sits at '10:00'). Removing nothing then re-adding
+    // would duplicate it; require the source slot to still match.
+    const s = schedule(track('A', talk('a', '10:00', '10:25')), track('B'))
+    const dragItem: DragItem = {
+      type: 'scheduled-talk',
+      proposal: proposal('a'),
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '09:00', // stale
+    }
+    const res = moveProposal(s, dragItem, drop(1, '11:00'))
+    expect(res.ok).toBe(false)
+    expect(res.schedule).toBe(s)
+    // 'a' still appears exactly once, only in track A.
+    const allIds = res.schedule.tracks.flatMap((t) =>
+      t.talks.map((x) => x.talk?._id),
+    )
+    expect(allIds.filter((id) => id === 'a')).toHaveLength(1)
+  })
+
+  it('rejects a scheduled-service drag whose source is out of range (no throw)', () => {
+    const s = schedule(
+      track('A', service('Break', '10:00', '10:15')),
+      track('B'),
+    )
+    const dragItem: DragItem = {
+      type: 'scheduled-service',
+      serviceSession: {
+        placeholder: 'Break',
+        startTime: '10:00',
+        endTime: '10:15',
+      },
+      sourceTrackIndex: 9,
+      sourceTimeSlot: '10:00',
+    }
+    expect(classifyServiceDrop(s.tracks, dragItem, drop(1, '11:00'))).toBe(
+      'invalid',
+    )
+    expect(() =>
+      moveServiceSession(s, dragItem, drop(1, '11:00')),
+    ).not.toThrow()
+    expect(moveServiceSession(s, dragItem, drop(1, '11:00')).ok).toBe(false)
+  })
+
+  it('rejects a scheduled-service drag whose source slot is stale (no duplication)', () => {
+    const s = schedule(
+      track('A', service('Break', '10:00', '10:15')),
+      track('B'),
+    )
+    const dragItem: DragItem = {
+      type: 'scheduled-service',
+      serviceSession: {
+        placeholder: 'Break',
+        startTime: '10:00',
+        endTime: '10:15',
+      },
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '09:00', // stale
+    }
+    const res = moveServiceSession(s, dragItem, drop(1, '11:00'))
+    expect(res.ok).toBe(false)
+    expect(res.schedule).toBe(s)
+    const allPlaceholders = res.schedule.tracks.flatMap((t) =>
+      t.talks.map((x) => x.placeholder),
+    )
+    expect(allPlaceholders.filter((p) => p === 'Break')).toHaveLength(1)
+  })
+})
+
+describe('F5 — service dropped on its own slot is a no-op', () => {
+  it('classifies a same-track same-slot service drop as invalid (not a dirtying move)', () => {
+    const s = schedule(track('A', service('Break', '12:00', '12:15')))
+    const dragItem: DragItem = {
+      type: 'scheduled-service',
+      serviceSession: {
+        placeholder: 'Break',
+        startTime: '12:00',
+        endTime: '12:15',
+      },
+      sourceTrackIndex: 0,
+      sourceTimeSlot: '12:00',
+    }
+    expect(classifyServiceDrop(s.tracks, dragItem, drop(0, '12:00'))).toBe(
+      'invalid',
+    )
+    const res = moveServiceSession(s, dragItem, drop(0, '12:00'))
+    expect(res.ok).toBe(false)
+    expect(res.schedule).toBe(s)
+  })
 })
 
 describe('duplicateService — skips conflicting tracks', () => {
@@ -422,6 +778,40 @@ describe('duplicateService — skips conflicting tracks', () => {
     const res = duplicateService(s, service('Break', '10:00', '10:15'), 0)
     expect(res.ok).toBe(false)
     expect(res.schedule).toBe(s)
+  })
+
+  it('rejects a talk-bearing slot instead of minting placeholder:"" copies (F8)', () => {
+    const s = schedule(track('Source'), track('Free'))
+    // A real talk slot is not a service; duplicating it would copy an untitled
+    // ghost service into the other tracks.
+    const res = duplicateService(s, talk('x', '10:00', '10:25'), 0)
+    expect(res.ok).toBe(false)
+    expect(res.schedule).toBe(s)
+    expect(res.schedule.tracks[1].talks).toHaveLength(0)
+  })
+
+  it('rejects a ghost slot with no placeholder (F8)', () => {
+    const s = schedule(track('Source'), track('Free'))
+    const ghost = { startTime: '10:00', endTime: '10:15' } as unknown as Slot
+    const res = duplicateService(s, ghost, 0)
+    expect(res.ok).toBe(false)
+    expect(res.schedule.tracks[1].talks).toHaveLength(0)
+  })
+
+  it('rejects a session whose stored end runs past the end of the day (F8)', () => {
+    const s = schedule(track('Source'), track('Free'))
+    // Stored 20:00–21:30 (past SCHEDULE_END 21:00); the end-of-day re-check must
+    // reject before copying it into another track.
+    const res = duplicateService(s, service('Late', '20:00', '21:30'), 0)
+    expect(res.ok).toBe(false)
+    expect(res.schedule.tracks[1].talks).toHaveLength(0)
+  })
+
+  it('trims the placeholder on the copies (F8)', () => {
+    const s = schedule(track('Source'), track('Free'))
+    const res = duplicateService(s, service('  Break  ', '10:00', '10:15'), 0)
+    expect(res.ok).toBe(true)
+    expect(res.schedule.tracks[1].talks[0].placeholder).toBe('Break')
   })
 })
 
@@ -519,6 +909,63 @@ describe('classifier ⇔ reducer equivalence', () => {
         p: drop(0, '10:00'),
       }),
     },
+    {
+      name: 'reject a drop whose end wraps past midnight (F1)',
+      build: () => ({
+        s: schedule(track('A')),
+        d: { type: 'proposal', proposal: proposal('p', 'workshop_240') },
+        p: drop(0, '20:00'),
+      }),
+    },
+    {
+      name: 'reject a swap whose displaced talk would run past end of day (F2)',
+      build: () => ({
+        // a(talk_25)@20:35 dragged onto b(talk_45)@10:00; b displaced to 20:35
+        // for its 45m format → 21:20, past 21:00.
+        s: schedule(
+          track('A', talk('a', '20:35', '21:00')),
+          track('B', {
+            kind: 'talk',
+            talk: proposal('b', 'presentation_45'),
+            startTime: '10:00',
+            endTime: '10:45',
+          }),
+        ),
+        d: {
+          type: 'scheduled-talk',
+          proposal: proposal('a', 'talk_25'),
+          sourceTrackIndex: 0,
+          sourceTimeSlot: '20:35',
+        },
+        p: drop(1, '10:00'),
+      }),
+    },
+    {
+      name: 'reject a scheduled-talk drag with an out-of-range source (F4)',
+      build: () => ({
+        s: schedule(track('A', talk('a', '10:00', '10:25')), track('B')),
+        d: {
+          type: 'scheduled-talk',
+          proposal: proposal('a'),
+          sourceTrackIndex: 9,
+          sourceTimeSlot: '10:00',
+        },
+        p: drop(1, '11:00'),
+      }),
+    },
+    {
+      name: 'reject a scheduled-talk drag with a stale source slot (F4)',
+      build: () => ({
+        s: schedule(track('A', talk('a', '10:00', '10:25')), track('B')),
+        d: {
+          type: 'scheduled-talk',
+          proposal: proposal('a'),
+          sourceTrackIndex: 0,
+          sourceTimeSlot: '09:00',
+        },
+        p: drop(1, '11:00'),
+      }),
+    },
   ]
 
   proposalCases.forEach(({ name, build }) => {
@@ -577,6 +1024,47 @@ describe('classifier ⇔ reducer equivalence', () => {
           sourceTimeSlot: '12:00',
         }),
         p: drop(0, '12:05'),
+      }),
+    },
+    {
+      name: 'reject a service whose end wraps past midnight (F1)',
+      build: () => ({
+        s: schedule(track('A')),
+        d: serviceDrag('Long', '08:00', '12:00'), // 240m
+        p: drop(0, '20:00'),
+      }),
+    },
+    {
+      name: 'reject a service dropped on its own slot — no-op (F5)',
+      build: () => ({
+        s: schedule(track('A', service('Break', '12:00', '12:15'))),
+        d: serviceDrag('Break', '12:00', '12:15', {
+          sourceTrackIndex: 0,
+          sourceTimeSlot: '12:00',
+        }),
+        p: drop(0, '12:00'),
+      }),
+    },
+    {
+      name: 'reject a scheduled-service drag with an out-of-range source (F4)',
+      build: () => ({
+        s: schedule(track('A', service('Break', '12:00', '12:15')), track('B')),
+        d: serviceDrag('Break', '12:00', '12:15', {
+          sourceTrackIndex: 9,
+          sourceTimeSlot: '12:00',
+        }),
+        p: drop(1, '13:00'),
+      }),
+    },
+    {
+      name: 'reject a scheduled-service drag with a stale source slot (F4)',
+      build: () => ({
+        s: schedule(track('A', service('Break', '12:00', '12:15')), track('B')),
+        d: serviceDrag('Break', '12:00', '12:15', {
+          sourceTrackIndex: 0,
+          sourceTimeSlot: '09:00',
+        }),
+        p: drop(1, '13:00'),
       }),
     },
   ]

--- a/__tests__/lib/schedule/rules.test.ts
+++ b/__tests__/lib/schedule/rules.test.ts
@@ -97,11 +97,25 @@ describe('findAvailableTimeSlot', () => {
 })
 
 describe('canSwapTalks + canPlaceDisplacedBack (bidirectional)', () => {
+  // The displaced talk's landing duration is its FORMAT duration (what
+  // performSwap writes), so target talks carry a format matching their intended
+  // span — check-what-you-write.
+  const targetTalkWithFormat = (
+    id: string,
+    format: string,
+    start: string,
+    end: string,
+  ): TrackTalk => ({
+    talk: proposal(id, format),
+    startTime: start,
+    endTime: end,
+  })
+
   it('allows a swap when both directions fit', () => {
-    const target = track(talk('b', '10:00', '11:00'))
+    const targetTalk = targetTalkWithFormat('b', 'talk_60', '10:00', '11:00')
+    const target = track(targetTalk)
     const source = track(talk('a', '10:00', '10:20'))
     const dragged = proposal('a', 'talk_20')
-    const targetTalk = target.talks[0]
     expect(canSwapTalks(target, dragged, targetTalk, '10:00')).toBe(true)
     // b (60min) placed back at 10:00 in the source (only 'a' there, which is leaving) fits.
     expect(
@@ -120,8 +134,13 @@ describe('canSwapTalks + canPlaceDisplacedBack (bidirectional)', () => {
       talk('a', '10:00', '10:20'),
       talk('c', '10:25', '10:50'),
     )
-    // Target: b@10:00 is 45 min.
-    const targetTalk = talk('b', '10:00', '10:45')
+    // Target: b@10:00 is a 45-min FORMAT (presentation_45).
+    const targetTalk = targetTalkWithFormat(
+      'b',
+      'presentation_45',
+      '10:00',
+      '10:45',
+    )
     const target = track(targetTalk)
     const dragged = proposal('a', 'talk_20')
     // Forward fits (a into target excluding b)...
@@ -133,6 +152,51 @@ describe('canSwapTalks + canPlaceDisplacedBack (bidirectional)', () => {
         targetTalk,
         '10:00',
         matchTalk('a', '10:00'),
+      ),
+    ).toBe(false)
+  })
+
+  it('validates the displaced talk with its FORMAT duration, not the stored slot span', () => {
+    // Regression (F3): b is STORED as a 20-min slot (10:00–10:20) but its format
+    // is presentation_45. Validating with the stored span (20m) would pass while
+    // performSwap writes the 45m format duration, overlapping c. Must use the
+    // format duration and REJECT.
+    const source = track(
+      talk('a', '10:00', '10:20'),
+      talk('c', '10:30', '10:55'),
+    )
+    const targetTalk = targetTalkWithFormat(
+      'b',
+      'presentation_45',
+      '10:00',
+      '10:20',
+    )
+    expect(
+      canPlaceDisplacedBack(
+        source,
+        targetTalk,
+        '10:00',
+        matchTalk('a', '10:00'),
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects the swap when the displaced talk would run past the end of the day (F2)', () => {
+    // Source slot at 20:45; the displaced 45-min talk would land 20:45→21:30,
+    // past SCHEDULE_END (21:00) — even though the source track is otherwise empty.
+    const source = track()
+    const targetTalk = targetTalkWithFormat(
+      'b',
+      'presentation_45',
+      '20:45',
+      '21:30',
+    )
+    expect(
+      canPlaceDisplacedBack(
+        source,
+        targetTalk,
+        '20:45',
+        matchTalk('a', '20:45'),
       ),
     ).toBe(false)
   })

--- a/src/lib/schedule/operations.ts
+++ b/src/lib/schedule/operations.ts
@@ -14,6 +14,7 @@ import {
   calculateEndTime,
   getProposalDurationMinutes,
   durationBetween,
+  timesOverlap,
   findAvailableTimeSlot,
   canSwapTalks,
   canPlaceDisplacedBack,
@@ -21,7 +22,7 @@ import {
   matchTalk,
   matchService,
 } from './types'
-import { withinScheduleEnd } from './time'
+import { endsWithinScheduleDay } from './time'
 
 /**
  * Pure schedule transforms, lifted verbatim (behaviour-preserving) from the old
@@ -156,10 +157,30 @@ export function classifyProposalDrop(
     return 'invalid'
   }
 
+  // A `scheduled-talk` drag must still find its source slot exactly where the
+  // drag claims it is. Out of range → the apply path indexes
+  // `newTracks[sourceTrackIndex]` on `undefined` and the reducer throws; stale
+  // but in range → the source removal (by id + startTime) matches nothing while
+  // the re-add proceeds, duplicating the talk (the fresh-drop dup guard below is
+  // skipped for scheduled-talk). Reject before either can happen.
+  if (dragItem.type === 'scheduled-talk') {
+    const sourceTrack = tracks[dragItem.sourceTrackIndex]
+    const sourcePresent =
+      sourceTrack?.talks.some(
+        (slot) =>
+          slot.talk?._id === proposal._id &&
+          slot.startTime === dragItem.sourceTimeSlot,
+      ) ?? false
+    if (!sourcePresent) return 'invalid'
+  }
+
   const targetTrack = tracks[trackIndex]
   const durationMinutes = getProposalDurationMinutes(proposal)
-  const endTime = calculateEndTime(timeSlot, durationMinutes)
-  if (!withinScheduleEnd(endTime)) return 'invalid'
+  // Root end-of-day gate: `endsWithinScheduleDay` sums start + duration in raw
+  // minutes, so a long talk (e.g. workshop_240 at 20:00) can't wrap past
+  // midnight and read as ending before 21:00 the way
+  // `withinScheduleEnd(calculateEndTime(...))` did.
+  if (!endsWithinScheduleDay(timeSlot, durationMinutes)) return 'invalid'
 
   // Duplicate guard: a FRESH drop (not a `scheduled-talk` move) is rejected if
   // the proposal is already scheduled on THIS day or — via
@@ -185,18 +206,55 @@ export function classifyProposalDrop(
     dragItem.sourceTimeSlot !== undefined
   ) {
     const sourceTrack = tracks[dragItem.sourceTrackIndex]
-    // Validate BOTH directions of the swap.
+    if (!sourceTrack) return 'invalid'
+    // Validate BOTH directions of the swap. `draggedExclude` skips the dragged
+    // talk's own source slot: on a SAME-TRACK swap that slot is still in the
+    // track, so both halves must ignore it (forward via `canSwapTalks`, reverse
+    // via `canPlaceDisplacedBack`) or the check self-collides and rejects a legal
+    // swap. Cross-track: the dragged talk isn't in either track being probed, so
+    // the exclusion is a harmless no-op.
     const draggedExclude = matchTalk(proposal._id, dragItem.sourceTimeSlot)
-    return canSwapTalks(targetTrack, proposal, occupiedTalk, timeSlot) &&
-      sourceTrack &&
+    const bothDirectionsFit =
+      canSwapTalks(
+        targetTrack,
+        proposal,
+        occupiedTalk,
+        timeSlot,
+        draggedExclude,
+      ) &&
       canPlaceDisplacedBack(
         sourceTrack,
         occupiedTalk,
         dragItem.sourceTimeSlot,
         draggedExclude,
       )
-      ? 'swap'
-      : 'invalid'
+    if (!bothDirectionsFit) return 'invalid'
+
+    // Same-track swap: each half-check validates one talk with the OTHER removed
+    // (via the vacated-slot exclusions), so neither sees the two talks in their
+    // FINAL positions. In a single track that lets a long displaced talk land
+    // over the dragged talk's new slot and still pass both halves. Reject when
+    // the two swapped footprints (both at their FORMAT durations, what
+    // performSwap writes) overlap each other. Cross-track swaps land in separate
+    // tracks, so there is nothing to check here.
+    if (dragItem.sourceTrackIndex === trackIndex) {
+      const draggedEnd = calculateEndTime(timeSlot, durationMinutes)
+      const displacedEnd = calculateEndTime(
+        dragItem.sourceTimeSlot,
+        getProposalDurationMinutes(occupiedTalk.talk),
+      )
+      if (
+        timesOverlap(
+          timeSlot,
+          draggedEnd,
+          dragItem.sourceTimeSlot,
+          displacedEnd,
+        )
+      ) {
+        return 'invalid'
+      }
+    }
+    return 'swap'
   }
 
   if (occupiedTalk) return 'invalid'
@@ -231,12 +289,39 @@ export function classifyServiceDrop(
 
   if (trackIndex < 0 || trackIndex >= tracks.length) return 'invalid'
 
+  // A service dropped back onto its own slot is a no-op — mirror the talk path,
+  // else `excludeExisting` matches the session against itself and it reports as a
+  // legal 'move', marking the day dirty for an identical state.
+  if (
+    dragItem.type === 'scheduled-service' &&
+    dragItem.sourceTrackIndex === trackIndex &&
+    dragItem.sourceTimeSlot === timeSlot
+  ) {
+    return 'invalid'
+  }
+
+  // Mirror the scheduled-talk stale-source guard: an out-of-range source makes
+  // the reducer index `undefined.talks` and throw; a stale-but-in-range source
+  // removes nothing then re-adds, duplicating the session. Require the source
+  // service to still exist exactly where the drag claims it.
+  if (dragItem.type === 'scheduled-service') {
+    const sourceTrack = tracks[dragItem.sourceTrackIndex]
+    const sourcePresent =
+      sourceTrack?.talks.some(
+        (slot) =>
+          slot.placeholder === serviceSession.placeholder &&
+          slot.startTime === dragItem.sourceTimeSlot,
+      ) ?? false
+    if (!sourcePresent) return 'invalid'
+  }
+
   const durationMinutes = durationBetween(
     serviceSession.startTime,
     serviceSession.endTime,
   )
+  // Root end-of-day gate (see classifyProposalDrop) — no wrap possible.
+  if (!endsWithinScheduleDay(timeSlot, durationMinutes)) return 'invalid'
   const newEndTime = calculateEndTime(timeSlot, durationMinutes)
-  if (!withinScheduleEnd(newEndTime)) return 'invalid'
 
   const targetTrack = tracks[trackIndex]
   const excludeExisting =
@@ -483,9 +568,17 @@ export function addService(
   if (trackIndex < 0 || trackIndex >= schedule.tracks.length) {
     return { schedule, ok: false }
   }
+  // Reject an empty/whitespace title: an untitled placeholder is a ghost slot
+  // that toEditorSchedule silently strips on the next load (invisible data loss).
+  const title = args.title.trim()
+  if (!title) return { schedule, ok: false }
   const track = schedule.tracks[trackIndex]
+  // Root end-of-day gate (see classifyProposalDrop) — sums start + duration so a
+  // huge duration can't wrap past midnight and read as within the day.
+  if (!endsWithinScheduleDay(args.startTime, args.duration)) {
+    return { schedule, ok: false }
+  }
   const endTime = calculateEndTime(args.startTime, args.duration)
-  if (!withinScheduleEnd(endTime)) return { schedule, ok: false }
   // Reject a new service session that would overlap an existing talk/session
   // (the UI's ＋ button only gates on an exact-start match, so a session can be
   // created inside/over an existing item).
@@ -494,7 +587,7 @@ export function addService(
   }
   const newSession: Slot = {
     kind: 'service',
-    placeholder: args.title,
+    placeholder: title,
     startTime: args.startTime,
     endTime,
   }
@@ -520,8 +613,11 @@ export function resizeService(
   const talk = track.talks[talkIndex]
   if (!talk || !talk.placeholder) return { schedule, ok: false }
 
+  // Root end-of-day gate (see classifyProposalDrop) — no wrap possible.
+  if (!endsWithinScheduleDay(talk.startTime, duration)) {
+    return { schedule, ok: false }
+  }
   const newEnd = calculateEndTime(talk.startTime, duration)
-  if (!withinScheduleEnd(newEnd)) return { schedule, ok: false }
   // Reject a resize that would grow the session over a following talk/session
   // (exclude the session being resized from the check).
   if (
@@ -559,8 +655,12 @@ export function renameService(
   const talk = track.talks[talkIndex]
   if (!talk || !talk.placeholder) return { schedule, ok: false }
 
+  // Reject an empty/whitespace rename — an untitled placeholder becomes a ghost
+  // slot that the next load silently strips (see addService).
+  const trimmed = title.trim()
+  if (!trimmed) return { schedule, ok: false }
   const newTalks = [...track.talks]
-  newTalks[talkIndex] = { ...talk, placeholder: title }
+  newTalks[talkIndex] = { ...talk, placeholder: trimmed }
   const newTracks = [...schedule.tracks]
   newTracks[trackIndex] = { ...track, talks: newTalks }
   return { schedule: { ...schedule, tracks: newTracks }, ok: true }
@@ -579,12 +679,26 @@ export function duplicateService(
   serviceSession: TrackTalk,
   sourceTrackIndex: number,
 ): OperationResult {
-  // The UI dispatches the source slot as a wide TrackTalk; a duplicate is always
-  // a service, so tag it as a ServiceSlot (the `?? ''` only guards the type — a
-  // service session always carries a placeholder).
+  // The UI dispatches the source slot as a wide TrackTalk. Only an actual
+  // service session may be duplicated: a talk-bearing slot or a ghost (no
+  // placeholder) would otherwise mint `placeholder: ''` copies — untitled ghost
+  // sessions the next load strips. Guard both, mirroring the other constructors.
+  const placeholder = serviceSession.placeholder?.trim()
+  if (serviceSession.talk || !placeholder) return { schedule, ok: false }
+
+  // End-of-day guard, mirroring addService/resizeService: never copy a session
+  // that runs past SCHEDULE_END into a track.
+  const duration = durationBetween(
+    serviceSession.startTime,
+    serviceSession.endTime,
+  )
+  if (!endsWithinScheduleDay(serviceSession.startTime, duration)) {
+    return { schedule, ok: false }
+  }
+
   const copy: Slot = {
     kind: 'service',
-    placeholder: serviceSession.placeholder ?? '',
+    placeholder,
     startTime: serviceSession.startTime,
     endTime: serviceSession.endTime,
   }

--- a/src/lib/schedule/rules.ts
+++ b/src/lib/schedule/rules.ts
@@ -2,7 +2,7 @@ import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import { ProposalExisting } from '@/lib/proposal/types'
 import {
   calculateEndTime,
-  durationBetween,
+  endsWithinScheduleDay,
   getProposalDurationMinutes,
   timesOverlap,
 } from './time'
@@ -31,6 +31,13 @@ export function matchService(
 ): SlotMatcher {
   return (slot) =>
     slot.placeholder === placeholder && slot.startTime === startTime
+}
+
+/** Compose matchers: a slot is excluded if ANY of the matchers claim it. */
+export function anyMatch(
+  ...matchers: Array<SlotMatcher | undefined>
+): SlotMatcher {
+  return (slot) => matchers.some((match) => match?.(slot))
 }
 
 /**
@@ -97,19 +104,29 @@ export function findAvailableTimeSlot(
  * reverse (that the displaced talk fits back into the source track) via
  * {@link canPlaceDisplacedBack} — validating only this direction was the source
  * of the post-swap-overlap bug.
+ *
+ * `draggedExclude` skips the dragged talk's OWN source slot: on a SAME-TRACK
+ * swap the dragged talk is still sitting in this track at its source position,
+ * so without excluding it the forward check self-collides and rejects every
+ * legal same-track swap. Omitted for cross-track swaps (the dragged talk lives
+ * in a different track, so there is nothing of its to exclude here).
  */
 export function canSwapTalks(
   track: ScheduleTrack,
   draggedProposal: ProposalExisting,
   targetTalk: TrackTalk,
   targetStartTime: string,
+  draggedExclude?: SlotMatcher,
 ): boolean {
   if (!targetTalk.talk) return false
   return fitsInTrack(
     track,
     targetStartTime,
     getProposalDurationMinutes(draggedProposal),
-    matchTalk(targetTalk.talk._id, targetTalk.startTime),
+    anyMatch(
+      matchTalk(targetTalk.talk._id, targetTalk.startTime),
+      draggedExclude,
+    ),
   )
 }
 
@@ -117,6 +134,21 @@ export function canSwapTalks(
  * Reverse half of a swap: does the displaced `targetTalk` fit back into the
  * source track at `sourceStartTime`, once the dragged talk (which is leaving
  * that track) is excluded?
+ *
+ * The displaced talk's landing duration is its FORMAT duration
+ * ({@link getProposalDurationMinutes}) — the value `performSwap` actually writes
+ * — NOT the stored slot span. Validating with the stored span while the write
+ * uses the format duration let a swap pass here then overlap a neighbour after
+ * the write (when stored < format). Check-what-you-write.
+ *
+ * Two guards beyond interval-freedom:
+ *  - end-of-day: the displaced talk must not run past {@link SCHEDULE_END} at
+ *    its landing slot (the dragged talk's own end was checked by the caller, but
+ *    the displaced talk's was not — a short talk could push a long one off-grid);
+ *  - it excludes the TARGET's own old slot as well as the dragged source, so a
+ *    SAME-TRACK swap (source === target track, target still present at its old
+ *    position) does not self-collide. Cross-track: the target's old slot is in
+ *    another track, so excluding it here is a harmless no-op.
  */
 export function canPlaceDisplacedBack(
   sourceTrack: ScheduleTrack,
@@ -124,10 +156,16 @@ export function canPlaceDisplacedBack(
   sourceStartTime: string,
   draggedExclude: SlotMatcher,
 ): boolean {
+  if (!targetTalk.talk) return false
+  const displacedDuration = getProposalDurationMinutes(targetTalk.talk)
+  if (!endsWithinScheduleDay(sourceStartTime, displacedDuration)) return false
   return fitsInTrack(
     sourceTrack,
     sourceStartTime,
-    durationBetween(targetTalk.startTime, targetTalk.endTime),
-    draggedExclude,
+    displacedDuration,
+    anyMatch(
+      draggedExclude,
+      matchTalk(targetTalk.talk._id, targetTalk.startTime),
+    ),
   )
 }

--- a/src/lib/schedule/time.ts
+++ b/src/lib/schedule/time.ts
@@ -68,9 +68,31 @@ export function durationBetween(start: string, end: string): number {
  * bound? Nothing may extend past {@link SCHEDULE_END}. Shared by the pure
  * operations and the mobile placement UI so the end-of-day rule lives in one
  * place.
+ *
+ * DANGER: only pass an end time that is known to be on the SAME day as its
+ * start. `calculateEndTime` wraps mod 24h, so `withinScheduleEnd(calculateEnd
+ * Time('20:00', 240))` sees `'00:00'` (0 min) and wrongly passes — an item that
+ * runs to midnight then reads as ending before 08:00. Placement gates that take
+ * a start + duration MUST use {@link endsWithinScheduleDay} instead; reserve
+ * this for callers that already hold a valid same-day end time.
  */
 export function withinScheduleEnd(endTime: string): boolean {
   return toMinutes(endTime) <= toMinutes(SCHEDULE_END)
+}
+
+/**
+ * Does a placement STARTING at `startTime` for `durationMinutes` fit within the
+ * schedule's end-of-day bound {@link SCHEDULE_END}? Computes the end in raw
+ * minutes (no `toHHMM` round-trip) so a duration that would push the end past
+ * midnight can never wrap back under the bound — the wrap hole that
+ * `withinScheduleEnd(calculateEndTime(...))` has. This is the end-of-day gate
+ * for every start+duration placement (drops, swaps, added/resized services).
+ */
+export function endsWithinScheduleDay(
+  startTime: string,
+  durationMinutes: number,
+): boolean {
+  return toMinutes(startTime) + durationMinutes <= toMinutes(SCHEDULE_END)
 }
 
 /**

--- a/src/lib/schedule/types.ts
+++ b/src/lib/schedule/types.ts
@@ -17,6 +17,7 @@ export {
   timesOverlap,
   generateTimeSlots,
   getProposalDurationMinutes,
+  endsWithinScheduleDay,
   type TimeSlot,
 } from './time'
 export {


### PR DESCRIPTION
Correctness fixes for the schedule-editor **engine** (`src/lib/schedule/{time,rules,operations}.ts`), from a full review. Scope is strictly the pure engine + its tests — no reducer/sanity/server/component changes. Both UIs (desktop `TimeSlotDropZone.canDrop`, mobile `segmentState`) defer to the classifiers, so the stricter semantics also fix the drop indicators for free.

## F1 (HIGH) — 24h wrap defeats end-of-day + overlap checks
**Repro:** `calculateEndTime('20:00', 240)` wraps mod 1440 → `'00:00'`; `withinScheduleEnd('00:00')` passes, so a `workshop_240` dropped at 20:00 over an existing 20:30 talk classified as a legal placement.
**Fix:** new `endsWithinScheduleDay(startTime, durationMinutes)` in `time.ts` sums start+duration in raw minutes (no wrap). Every start+duration placement gate now uses it: `classifyProposalDrop`, `classifyServiceDrop`, `addService`, `resizeService` (and `duplicateService`, see F8). `withinScheduleEnd` kept for callers holding a known same-day end time, with a DANGER note.
**Tests:** fresh drop / scheduled-talk move / `addService` / `resizeService` / `moveServiceSession` all reject wrapped ends; equivalence suite gets proposal + service wrap cases.

## F2 (HIGH) — swap never end-of-day-checks the displaced talk
**Repro:** talk a (talk_25)@20:35–21:00 dragged onto b (talk_45) elsewhere → b lands 20:35–21:20, past 21:00.
**Fix:** `canPlaceDisplacedBack` (the single place both UIs + reducer share) now requires `endsWithinScheduleDay(sourceStartTime, displacedDuration)`.
**Tests:** rules-level end-of-day reject; equivalence swap case a@20:35 ↔ b(45m).

## F3 (HIGH) — swap validated with stored slot duration but applied with format duration
**Repro:** displaced talk validated via `durationBetween(stored start,end)` while `performSwap` writes `getProposalDurationMinutes(format)`; when stored < format the write overlaps a neighbor.
**Fix:** `canPlaceDisplacedBack` now uses the format-derived duration (check-what-you-write).
**Tests:** kept the format-recompute application test; added the mismatch repro (b stored @10:00–10:20 but format presentation_45; a↔b rejected). Two pre-existing fixtures that implicitly assumed stored==format were updated to carry an explicit format (called out below).

## F4 (MED) — out-of-range/stale drag source crashes or duplicates
**Repro:** a `scheduled-talk`/`scheduled-service` drag with an out-of-range `sourceTrackIndex` made the reducer index `undefined.talks` → TypeError; a stale in-range source removed nothing then re-added → same-day duplicate.
**Fix:** `classifyProposalDrop` / `classifyServiceDrop` return `invalid` unless the source slot still exists exactly where the drag claims (id/placeholder + startTime).
**Tests:** out-of-range → invalid + op fails without throwing; stale → invalid with no duplication; equivalence cases for both drag kinds.

## F5 (MED) — service dropped on its own slot is a dirty-marking no-op
**Repro:** a `scheduled-service` dropped on its own slot returned `move` (its own slot excluded), dirtying the day for identical state.
**Fix:** mirror the talk path — same track + same timeSlot for a `scheduled-service` → `invalid`.
**Tests:** classify+op no-op; equivalence case.

## F6 (MED) — same-track swaps falsely rejected
**Repro:** neither swap direction excluded the other moving slot's vacated position, so same-track swaps self-collided and were always rejected.
**Fix:** `canSwapTalks` gained an optional `draggedExclude` (dragged talk's own source slot); `canPlaceDisplacedBack` now also excludes the target's old slot. Both are harmless no-ops cross-track. Added an explicit same-track **mutual-overlap guard**: the two half-checks each validate one talk with the other removed, so on a single track a long displaced talk could land over the dragged talk's new slot and pass both halves — the guard rejects when the two final footprints overlap. (This is the correct completion of F6; the vacated-slot exclusions alone would otherwise approve a self-overlapping swap. Flagged as a deliberate superset of the literal finding.)
**Tests:** legal same-track swap (displaced stored longer than its format) succeeds non-overlapping; mutual-overlap guard rejects; displaced-lands-on-third-talk rejects; cross-track swap unchanged; all pre-existing cross-track tests stay green.

## F7 (MED) — empty/whitespace service titles create silent ghosts
**Fix:** `addService` and `renameService` trim the title and return `{ok:false}` when empty; the stored placeholder is the trimmed value.
**Tests:** empty/whitespace rejected + trimming for both.

## F8 (LOW) — duplicateService gaps
**Fix:** reject a non-service arg (talk-bearing or ghost with no placeholder) with `ok:false` instead of minting `placeholder:''` copies; re-check `endsWithinScheduleDay` before copying; trim the copied placeholder. Skip-on-overlap semantics preserved.
**Tests:** talk-bearing rejected, ghost rejected, past-end-of-day rejected, trimming.

---

### Notes / deviations
- `src/lib/schedule/types.ts` got a one-line barrel re-export of `endsWithinScheduleDay` (kept minimal; edge of scope).
- Two pre-existing swap fixtures (`rules.test.ts` + `operations.test.ts`) that relied on stored==format were updated to carry an explicit format so they still exercise the intended overlap under F3. One mobile test (`mobile-placement.test.ts`) was updated to supply a valid drag source track (it previously referenced an out-of-range source, which F4 now correctly rejects).
- F6 includes the extra same-track mutual-overlap guard described above.

**Verification:** `tsc --noEmit` 0 errors · `eslint src/lib/schedule/` clean · `vitest __tests__/lib/schedule __tests__/components/admin/schedule` 179 passed / 11 files · `pnpm shoot` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies a focused correctness batch to the schedule-editor engine (`time.ts`, `rules.ts`, `operations.ts`) — eight distinct bugs in placement validation, swap logic, drag-source integrity, and service-slot construction. All changes are pure, test-covered, and stay within the declared engine scope.

- **F1–F3 (end-of-day + swap correctness):** new `endsWithinScheduleDay` replaces the `withinScheduleEnd(calculateEndTime(...))` mod-1440 wrap hole at every placement gate; `canPlaceDisplacedBack` now validates with the format-derived duration plus an end-of-day check for the displaced talk.
- **F4–F6 (drag-source and same-track swap integrity):** stale/out-of-range source guards added to both classifiers; same-slot service drop returns `invalid`; vacated-slot exclusions and a mutual-overlap post-check correct same-track swaps.
- **F7–F8 (service ghost prevention):** `addService`, `renameService`, and `duplicateService` now trim and reject empty/whitespace titles; `duplicateService` guards against talk-bearing or ghost source slots.

<h3>Confidence Score: 3/5</h3>

The engine is correct and safe, but the mobile UnassignedDrawer component still uses the old wrap-vulnerable end-of-day pattern, creating a broken UX on the mobile scheduling path after this PR.

The engine changes are well-hardened with 179 passing tests. However, UnassignedDrawer.tsx was not updated: its proposal-filter and service-submit checks still diverge from the stricter gate the reducer now enforces — long talks appear in the slot drawer as eligible but tapping silently does nothing, and very-long services appear to submit but are silently dropped.

src/components/admin/schedule/mobile/sheets/UnassignedDrawer.tsx — both its end-of-day filter (line 66) and service-submit guard (line 116) need to switch from withinScheduleEnd(calculateEndTime(...)) to endsWithinScheduleDay to match the engine.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/schedule/time.ts | Adds endsWithinScheduleDay that avoids the mod-1440 wrap hole; withinScheduleEnd kept with a DANGER doc comment |
| src/lib/schedule/rules.ts | Adds anyMatch helper, updates canSwapTalks with optional draggedExclude, rewrites canPlaceDisplacedBack with format-derived duration and end-of-day guard |
| src/lib/schedule/operations.ts | Comprehensive correctness fixes across all placement operations; one now-dead sourceTrack null-check in the swap branch is the only minor nit |
| src/lib/schedule/types.ts | One-line barrel re-export of endsWithinScheduleDay; safe minimal change |
| __tests__/lib/schedule/operations.test.ts | Targeted regression tests covering all eight fix classes plus equivalence suite extensions |
| __tests__/lib/schedule/rules.test.ts | New tests for F2 and F3; pre-existing fixtures updated with explicit formats |
| __tests__/components/admin/schedule/mobile-placement.test.ts | Adds sourceTrack fixture to satisfy the new F4 stale-source guard |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    DROP([Drag drop event]) --> CPD[classifyProposalDrop]
    DROP --> CSD[classifyServiceDrop]
    CPD --> OWN{own slot?}
    OWN -- yes --> INV1[invalid]
    OWN -- no --> STALE{source still exists? F4}
    STALE -- no --> INV2[invalid]
    STALE -- yes --> EOD{endsWithinScheduleDay? F1}
    EOD -- no --> INV3[invalid]
    EOD -- yes --> OCCUPIED{slot occupied by talk?}
    OCCUPIED -- yes --> SWAP_CHECK[canSwapTalks + canPlaceDisplacedBack F2 F3 F6]
    SWAP_CHECK -- fail --> INV4[invalid]
    SWAP_CHECK -- pass --> SAMETRACK{same track? F6}
    SAMETRACK -- mutual overlap --> INV5[invalid]
    SAMETRACK -- no overlap --> SWAP[swap]
    OCCUPIED -- no --> FIT[findAvailableTimeSlot]
    FIT -- fits --> MOVE[move]
    FIT -- blocked --> INV6[invalid]
    CSD --> OWNSLOT{own slot? F5}
    OWNSLOT -- yes --> INV7[invalid]
    OWNSLOT -- no --> STALE2{source still exists? F4}
    STALE2 -- no --> INV8[invalid]
    STALE2 -- yes --> EOD2{endsWithinScheduleDay? F1}
    EOD2 -- no --> INV9[invalid]
    EOD2 -- yes --> FREE{interval free?}
    FREE -- yes --> SMOVE[move]
    FREE -- no --> INV10[invalid]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    DROP([Drag drop event]) --> CPD[classifyProposalDrop]
    DROP --> CSD[classifyServiceDrop]
    CPD --> OWN{own slot?}
    OWN -- yes --> INV1[invalid]
    OWN -- no --> STALE{source still exists? F4}
    STALE -- no --> INV2[invalid]
    STALE -- yes --> EOD{endsWithinScheduleDay? F1}
    EOD -- no --> INV3[invalid]
    EOD -- yes --> OCCUPIED{slot occupied by talk?}
    OCCUPIED -- yes --> SWAP_CHECK[canSwapTalks + canPlaceDisplacedBack F2 F3 F6]
    SWAP_CHECK -- fail --> INV4[invalid]
    SWAP_CHECK -- pass --> SAMETRACK{same track? F6}
    SAMETRACK -- mutual overlap --> INV5[invalid]
    SAMETRACK -- no overlap --> SWAP[swap]
    OCCUPIED -- no --> FIT[findAvailableTimeSlot]
    FIT -- fits --> MOVE[move]
    FIT -- blocked --> INV6[invalid]
    CSD --> OWNSLOT{own slot? F5}
    OWNSLOT -- yes --> INV7[invalid]
    OWNSLOT -- no --> STALE2{source still exists? F4}
    STALE2 -- no --> INV8[invalid]
    STALE2 -- yes --> EOD2{endsWithinScheduleDay? F1}
    EOD2 -- no --> INV9[invalid]
    EOD2 -- yes --> FREE{interval free?}
    FREE -- yes --> SMOVE[move]
    FREE -- no --> INV10[invalid]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): engine correctness — end-..."](https://github.com/cloudnativebergen/website/commit/81601ac9e0ff424584ea4c7283cf8f25f7a6963d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45329488)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->