### PR TITLE
fix(schedule): UI review batch — drag lifecycle, confirmations, dirty indication, modal a11y

### DIFF
--- a/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
+++ b/__tests__/components/admin/schedule/MobileScheduleView.test.tsx
@@ -94,6 +94,7 @@ const setup = () => {
       onAddTrack={vi.fn()}
       isSaving={false}
       saveSuccess={false}
+      hasUnsavedChanges={false}
       error={null}
     />,
   )
@@ -173,6 +174,7 @@ describe('MobileScheduleView', () => {
         onAddTrack={vi.fn()}
         isSaving={false}
         saveSuccess={false}
+        hasUnsavedChanges={false}
         error={null}
       />,
     )
@@ -269,6 +271,7 @@ describe('MobileScheduleView', () => {
         onAddTrack={vi.fn()}
         isSaving={false}
         saveSuccess={false}
+        hasUnsavedChanges={false}
         error={null}
       />,
     )
@@ -409,6 +412,7 @@ describe('MobileScheduleView', () => {
         onAddTrack={vi.fn()}
         isSaving={false}
         saveSuccess={false}
+        hasUnsavedChanges={false}
         error={null}
       />,
     )
@@ -429,5 +433,55 @@ describe('MobileScheduleView', () => {
         }),
       }),
     )
+  })
+
+  it('clears an active placing and any open sheet when the day changes', () => {
+    const dayTwo: ConferenceSchedule = {
+      _id: 'day-2',
+      date: '2026-09-02',
+      tracks: [
+        { trackTitle: 'Day Two Stage', trackDescription: '', talks: [] },
+      ],
+    }
+    const props = {
+      schedules: [toEditorSchedule(schedule), toEditorSchedule(dayTwo)],
+      unassignedProposals: [unassignedProposal],
+      dispatch: vi.fn(),
+      onDayChange: vi.fn(),
+      onSave: vi.fn(),
+      onAddTrack: vi.fn(),
+      isSaving: false,
+      saveSuccess: false,
+      hasUnsavedChanges: false,
+      error: null,
+    }
+    const { rerender } = render(
+      <MobileScheduleView {...props} currentDayIndex={0} />,
+    )
+
+    // Pick up the scheduled talk → the placing banner (role=status) appears.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Options for Scheduled Keynote Talk',
+      }),
+    )
+    fireEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: 'Move or swap',
+      }),
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Moving “Scheduled Keynote Talk”',
+    )
+
+    // Also open a sheet on top of the pick-up (the header Unassigned drawer).
+    fireEvent.click(screen.getByRole('button', { name: 'Unassigned (1)' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // Day changes via parent state → both the pick-up and the sheet are stale
+    // per-day UI and must be cleared.
+    rerender(<MobileScheduleView {...props} currentDayIndex={1} />)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/__tests__/components/admin/schedule/ServiceEditSheet.test.tsx
+++ b/__tests__/components/admin/schedule/ServiceEditSheet.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { ServiceEditSheet } from '@/components/admin/schedule/mobile/sheets/ServiceEditSheet'
+import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
+
+const session: TrackTalk = {
+  placeholder: 'Coffee Break',
+  startTime: '10:00',
+  endTime: '10:15',
+}
+
+const trackWith = (
+  blockerStart: string,
+  blockerEnd: string,
+): ScheduleTrack => ({
+  trackTitle: 'Main Stage',
+  trackDescription: '',
+  talks: [
+    session,
+    { placeholder: 'Blocker', startTime: blockerStart, endTime: blockerEnd },
+  ],
+})
+
+describe('ServiceEditSheet duration mode', () => {
+  it('filters options to the surrounding gap and keeps a non-standard current duration selectable', () => {
+    render(
+      <ServiceEditSheet
+        talk={{
+          placeholder: 'Odd Break',
+          startTime: '10:00',
+          endTime: '10:25',
+        }}
+        trackIndex={0}
+        talkIndex={0}
+        track={{
+          trackTitle: 'Main Stage',
+          trackDescription: '',
+          talks: [
+            { placeholder: 'Odd Break', startTime: '10:00', endTime: '10:25' },
+            { placeholder: 'Blocker', startTime: '10:30', endTime: '11:00' },
+          ],
+        }}
+        mode="duration"
+        dispatch={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    const select = screen.getByLabelText('Duration (minutes)')
+    const options = within(select as HTMLElement)
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+    // 25 is not a standard option but is the session's CURRENT duration.
+    expect(options).toContain('25 minutes')
+    // 30 ends exactly at the 10:30 blocker (legal); 45 would overlap it.
+    expect(options).toContain('30 minutes')
+    expect(options).not.toContain('45 minutes')
+  })
+
+  it('shows an inline error and does not close when the chosen duration no longer fits', () => {
+    const dispatch = vi.fn()
+    const onClose = vi.fn()
+    const props = {
+      talk: session,
+      trackIndex: 0,
+      talkIndex: 0,
+      mode: 'duration' as const,
+      dispatch,
+      onClose,
+    }
+    const { rerender } = render(
+      <ServiceEditSheet {...props} track={trackWith('11:00', '11:30')} />,
+    )
+
+    // 45 minutes fits while the blocker sits at 11:00…
+    fireEvent.change(screen.getByLabelText('Duration (minutes)'), {
+      target: { value: '45' },
+    })
+
+    // …but the schedule changes underneath the open sheet (blocker → 10:30).
+    rerender(
+      <ServiceEditSheet {...props} track={trackWith('10:30', '11:00')} />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    // The rejected resize surfaces inline instead of closing as if it worked.
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'That duration no longer fits',
+    )
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/admin/schedule/TimeSlotDropZone.test.tsx
+++ b/__tests__/components/admin/schedule/TimeSlotDropZone.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render } from '@testing-library/react'
+import { TimeSlotDropZone } from '@/components/admin/schedule/track/TimeSlotDropZone'
+import { ScheduleProvider } from '@/components/admin/schedule/ScheduleContext'
+import { ScheduleTrack, ConferenceSchedule } from '@/lib/conference/types'
+import { toEditorSchedule, type DragItem } from '@/lib/schedule/types'
+
+// Force `isOver` so the drop indicator classes render without a real dnd-kit
+// drag in flight (the unit under test is `canDrop`, not the sensor pipeline).
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>()
+  return {
+    ...actual,
+    useDroppable: () => ({ setNodeRef: () => {}, isOver: true }),
+  }
+})
+
+const track: ScheduleTrack = {
+  trackTitle: 'Main Stage',
+  trackDescription: '',
+  talks: [{ placeholder: 'Lunch', startTime: '10:00', endTime: '10:45' }],
+}
+
+const schedule: ConferenceSchedule = {
+  _id: 'day-1',
+  date: '2026-09-01',
+  tracks: [track],
+}
+
+// A fresh 30-minute service session being dragged from the palette.
+const serviceDrag: DragItem = {
+  type: 'service-session',
+  serviceSession: {
+    placeholder: 'Coffee Break',
+    startTime: '09:00',
+    endTime: '09:30',
+  },
+}
+
+const renderZone = (time: string) =>
+  render(
+    <ScheduleProvider
+      value={{
+        activeDragItem: serviceDrag,
+        schedule: toEditorSchedule(schedule),
+        otherScheduledProposalIds: new Set(),
+        dispatch: () => {},
+      }}
+    >
+      <TimeSlotDropZone
+        timeSlot={{ time, displayTime: time }}
+        trackIndex={0}
+        track={track}
+        onCreateServiceSession={vi.fn()}
+      />
+    </ScheduleProvider>,
+  )
+
+describe('TimeSlotDropZone service-drag indicator', () => {
+  it('shows the not-allowed indicator over an occupied interval', () => {
+    const { container } = renderZone('10:00')
+    const zone = container.firstElementChild as HTMLElement
+    // canDrop=false + isOver → the red not-allowed classes, not the blue ones.
+    expect(zone.className).toContain('bg-red-100')
+    expect(zone.className).not.toContain('bg-blue-100')
+  })
+
+  it('shows the droppable indicator over a free interval', () => {
+    const { container } = renderZone('12:00')
+    const zone = container.firstElementChild as HTMLElement
+    expect(zone.className).toContain('bg-blue-100')
+    expect(zone.className).not.toContain('bg-red-100')
+  })
+})

--- a/__tests__/components/admin/schedule/UnassignedDrawer.test.tsx
+++ b/__tests__/components/admin/schedule/UnassignedDrawer.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { UnassignedDrawer } from '@/components/admin/schedule/mobile/sheets/UnassignedDrawer'
+import { ScheduleTrack } from '@/lib/conference/types'
+
+const track: ScheduleTrack = {
+  trackTitle: 'Main Stage',
+  trackDescription: '',
+  talks: [
+    // The tapped gap is 10:00–10:04 (a sub-5-minute sliver before this talk).
+    { placeholder: 'Standup', startTime: '10:04', endTime: '10:30' },
+  ],
+}
+
+describe('UnassignedDrawer service creation', () => {
+  it('falls back to the exact available minutes when no standard duration fits a sub-5-min gap', () => {
+    render(
+      <UnassignedDrawer
+        proposals={[]}
+        context={{ trackIndex: 0, startTime: '10:00', maxDurationMin: 4 }}
+        track={track}
+        dispatch={vi.fn()}
+        onPick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Create service session here/ }),
+    )
+
+    // No standard SERVICE_DURATION_OPTIONS entry (5..90) fits 4 free minutes,
+    // so the dropdown must offer the exact gap instead of a dead-end form.
+    const select = screen.getByLabelText('Duration (minutes)')
+    const options = within(select as HTMLElement)
+      .getAllByRole('option')
+      .map((o) => o.textContent)
+    expect(options).toContain('4 minutes')
+    expect(options).not.toContain('5 minutes')
+  })
+})

--- a/src/components/admin/schedule/AddTrackModal.tsx
+++ b/src/components/admin/schedule/AddTrackModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
+import { useModalA11y } from './useModalA11y'
 
 const CANCEL_BUTTON_STYLE =
   'flex-1 rounded-md bg-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 dark:bg-gray-600 dark:text-gray-300 dark:hover:bg-gray-500'
@@ -14,6 +15,12 @@ export const AddTrackModal = ({
 }) => {
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Modal semantics: Escape closes, focus moves in (preferring the autoFocus
+  // title input) and is restored on close, Tab is trapped. Shared with
+  // ServiceSessionModal and the mobile BottomSheet.
+  useModalA11y(dialogRef, onCancel)
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -40,9 +47,18 @@ export const AddTrackModal = ({
   )
 
   return (
-    <div className="bg-opacity-50 fixed inset-0 z-50 flex items-center justify-center bg-black">
-      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 dark:bg-gray-800">
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-track-modal-title"
+        className="mx-4 w-full max-w-md rounded-lg bg-white p-6 dark:bg-gray-800"
+      >
+        <h3
+          id="add-track-modal-title"
+          className="mb-4 text-lg font-semibold text-gray-900 dark:text-white"
+        >
           Add New Track
         </h3>
 

--- a/src/components/admin/schedule/DraggableProposal.tsx
+++ b/src/components/admin/schedule/DraggableProposal.tsx
@@ -152,7 +152,10 @@ export function DraggableProposal({
     transform,
     isDragging: isBeingDragged,
   } = useDraggable({
-    id: dragId,
+    // The DragOverlay renders this same component (`isDragging`) while the
+    // source card is still mounted; suffix the overlay's id so its useDraggable
+    // registration can't clobber the source card's in dnd-kit's registry.
+    id: isDragging ? `${dragId}-overlay` : dragId,
     data: dragItem,
   })
 
@@ -369,19 +372,26 @@ export function DraggableProposal({
           height: `${durationMinutes * PIXELS_PER_MINUTE}px`,
         }}
         title={tooltipContent}
-        {...attributes}
       >
         <div
           className="pointer-events-none absolute inset-0 z-0"
           style={backgroundStyle}
         />
         <div className="relative z-10 flex min-h-4 items-center gap-1">
-          <div
+          {/* Drag handle: dnd-kit's attributes AND listeners live together on
+              this real button so the keyboard-focusable element is the one
+              whose Enter/Space actually starts the drag. (Keyboard drops
+              remain a known gap: `pointerWithin` collision detection has no
+              pointer during a keyboard drag.) */}
+          <button
+            type="button"
+            aria-label={`Drag ${proposal.title}`}
             className="shrink-0 cursor-grab rounded p-0.5 transition-colors hover:cursor-grabbing hover:bg-gray-100 dark:hover:bg-gray-700"
+            {...attributes}
             {...listeners}
           >
             <Bars3Icon className="h-3 w-3 text-gray-400 dark:text-gray-500" />
-          </div>
+          </button>
 
           <div className="flex min-w-0 flex-1 items-center gap-1">
             <div className="min-w-0 flex-1">{TitleComponent}</div>

--- a/src/components/admin/schedule/DraggableServiceSession.tsx
+++ b/src/components/admin/schedule/DraggableServiceSession.tsx
@@ -72,7 +72,10 @@ export function DraggableServiceSession({
     transform,
     isDragging: isBeingDragged,
   } = useDraggable({
-    id: dragId,
+    // The DragOverlay renders this same component (`isDragging`) while the
+    // source card is still mounted; suffix the overlay's id so its useDraggable
+    // registration can't clobber the source card's in dnd-kit's registry.
+    id: isDragging ? `${dragId}-overlay` : dragId,
     data: dragItem,
   })
 
@@ -126,15 +129,22 @@ export function DraggableServiceSession({
         height: `${durationMinutes * PIXELS_PER_MINUTE}px`,
       }}
       className={containerClasses}
-      {...attributes}
     >
       <div className="flex min-h-[16px] items-center gap-1">
-        <div
+        {/* Drag handle: dnd-kit's attributes AND listeners live together on
+            this real button so the keyboard-focusable element is the one whose
+            Enter/Space actually starts the drag. (Keyboard drops remain a
+            known gap: `pointerWithin` collision detection has no pointer
+            during a keyboard drag.) */}
+        <button
+          type="button"
+          aria-label={`Drag ${serviceSession.placeholder || 'Service Session'}`}
           className="shrink-0 cursor-grab rounded p-0.5 transition-colors hover:cursor-grabbing hover:bg-gray-200 dark:hover:bg-gray-600"
+          {...attributes}
           {...listeners}
         >
           <Bars3Icon className="h-3 w-3 text-gray-500 dark:text-gray-400" />
-        </div>
+        </button>
 
         <div className="min-w-0 flex-1">{TitleComponent}</div>
 

--- a/src/components/admin/schedule/DroppableTrack.tsx
+++ b/src/components/admin/schedule/DroppableTrack.tsx
@@ -246,6 +246,7 @@ function DroppableTrack({
       <ServiceSessionModal
         isOpen={showServiceModal}
         timeSlot={selectedTimeSlot}
+        track={track}
         onClose={handleCloseServiceModal}
         onSave={handleSaveServiceSession}
       />

--- a/src/components/admin/schedule/HeaderSection.tsx
+++ b/src/components/admin/schedule/HeaderSection.tsx
@@ -27,6 +27,7 @@ const HeaderSectionComponent = ({
   onSave,
   isSaving,
   saveSuccess,
+  hasUnsavedChanges,
 }: {
   schedule: ConferenceSchedule | null
   schedules: ConferenceSchedule[]
@@ -36,6 +37,7 @@ const HeaderSectionComponent = ({
   onSave: () => void
   isSaving: boolean
   saveSuccess: boolean
+  hasUnsavedChanges: boolean
 }) => {
   const trackCount = useMemo(
     () => schedule?.tracks?.length || 0,
@@ -115,6 +117,11 @@ const HeaderSectionComponent = ({
           <button
             onClick={onSave}
             disabled={isSaving}
+            aria-label={
+              !saveSuccess && !isSaving && hasUnsavedChanges
+                ? 'Save — you have unsaved changes'
+                : undefined
+            }
             className={`${PRIMARY_BUTTON} transition-all duration-300 ${
               saveSuccess
                 ? 'bg-green-600 hover:bg-green-700 focus:ring-green-500'
@@ -131,6 +138,13 @@ const HeaderSectionComponent = ({
               <>
                 <BookmarkIcon className="h-4 w-4" />
                 {isSaving ? 'Saving...' : 'Save'}
+                {/* Unsaved-changes dot: any dirty day, not just the visible one. */}
+                {hasUnsavedChanges && !isSaving && (
+                  <span
+                    aria-hidden="true"
+                    className="h-2 w-2 rounded-full bg-amber-300"
+                  />
+                )}
               </>
             )}
           </button>

--- a/src/components/admin/schedule/MobileScheduleView.stories.tsx
+++ b/src/components/admin/schedule/MobileScheduleView.stories.tsx
@@ -137,6 +137,7 @@ function MobileScheduleHarness({
       onAddTrack={() => {}}
       isSaving={state.ui.isSaving}
       saveSuccess={false}
+      hasUnsavedChanges={false}
       error={state.ui.error}
     />
   )

--- a/src/components/admin/schedule/ScheduleEditor.tsx
+++ b/src/components/admin/schedule/ScheduleEditor.tsx
@@ -13,7 +13,14 @@ import {
   TouchSensor,
   KeyboardSensor,
 } from '@dnd-kit/core'
-import { useState, useReducer, useMemo, useCallback } from 'react'
+import {
+  useState,
+  useReducer,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react'
 import React from 'react'
 import { ScheduleTrack, TrackTalk, Conference } from '@/lib/conference/types'
 import { DragItem, type EditorSchedule } from '@/lib/schedule/types'
@@ -173,6 +180,37 @@ export function ScheduleEditor({
   const isSaving = state.ui.isSaving
   const error = state.ui.error
 
+  // ANY dirty day means unsaved work — surfaced on both headers' Save button
+  // and guarding navigation below.
+  const hasUnsavedChanges = state.dirty.some(Boolean)
+
+  // Warn before a tab close / hard navigation while any day is dirty. (In-app
+  // route changes aren't guarded here — the editor is a single page.)
+  useEffect(() => {
+    if (!hasUnsavedChanges) return
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      // Chrome requires returnValue to be set for the prompt to show.
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [hasUnsavedChanges])
+
+  // The saved-flash timeout is stored so a new save (or unmount) cancels the
+  // previous one instead of leaking it / clearing the wrong flash.
+  const saveSuccessTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
+  useEffect(
+    () => () => {
+      if (saveSuccessTimeoutRef.current !== null) {
+        clearTimeout(saveSuccessTimeoutRef.current)
+      }
+    },
+    [],
+  )
+
   // Unassigned proposals are DERIVED from all days, never stored.
   const unassignedProposals = useMemo(
     () => computeUnassigned(state.proposals, state.schedules),
@@ -182,6 +220,10 @@ export function ScheduleEditor({
   const handleSave = useCallback(async () => {
     dispatch({ type: 'saveStart' })
     setSaveSuccess(false)
+    if (saveSuccessTimeoutRef.current !== null) {
+      clearTimeout(saveSuccessTimeoutRef.current)
+      saveSuccessTimeoutRef.current = null
+    }
 
     // Persist every DIRTY day so edits on non-current days are not dropped. If
     // nothing is dirty, fall back to saving the current day (matches the old
@@ -214,7 +256,10 @@ export function ScheduleEditor({
 
       dispatch({ type: 'saveEnd' })
       setSaveSuccess(true)
-      setTimeout(() => setSaveSuccess(false), 3000)
+      saveSuccessTimeoutRef.current = setTimeout(() => {
+        setSaveSuccess(false)
+        saveSuccessTimeoutRef.current = null
+      }, 3000)
     } catch (err) {
       // A CONFLICT means another organizer changed this day since it was loaded.
       // Don't clobber the user's in-progress edits — stop and tell them to
@@ -233,6 +278,13 @@ export function ScheduleEditor({
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const { active } = event
     setActiveItem(active.data.current as DragItem)
+  }, [])
+
+  // An Escape-cancelled drag must clear the active item too, or the board is
+  // left thinking a drag is still in flight (every "+ Service" button hidden,
+  // stale canDrop indicators) until the next successful drag.
+  const handleDragCancel = useCallback(() => {
+    setActiveItem(null)
   }, [])
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
@@ -406,6 +458,7 @@ export function ScheduleEditor({
           onAddTrack={handleShowAddTrackModal}
           isSaving={isSaving}
           saveSuccess={saveSuccess}
+          hasUnsavedChanges={hasUnsavedChanges}
           error={error}
         />
         {showAddTrackModal && (
@@ -425,6 +478,7 @@ export function ScheduleEditor({
           sensors={sensors}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
           collisionDetection={pointerWithin}
         >
           <UnassignedProposals proposals={unassignedProposals} />
@@ -439,6 +493,7 @@ export function ScheduleEditor({
               onSave={handleSave}
               isSaving={isSaving}
               saveSuccess={saveSuccess}
+              hasUnsavedChanges={hasUnsavedChanges}
             />
 
             {error && <ErrorBanner error={error} />}

--- a/src/components/admin/schedule/UX.md
+++ b/src/components/admin/schedule/UX.md
@@ -72,12 +72,16 @@ Mobiscroll's min-row-height.
 
 With multiple tracks (columns) on one phone screen:
 
-- **Peek the adjacent track** (~7vw each side via a scroll-snap carousel of
-  `basis-[86vw]` panels). A peeking neighbour is the single strongest cue that the
-  panel swipes _and_ that another column exists — swipe is otherwise invisible.
+- **Full-width panels** (a scroll-snap carousel of `basis-full` panels — sized
+  against the scroll container, not the viewport, so a scrollbar can't clip the
+  panel edge). The shipped design deliberately drops the earlier ~86vw side-peek
+  (locked decision, PR #493): on a phone every horizontal pixel goes to the
+  track's cards, and swipe/next-column **discoverability is carried by the fixed
+  tab strip** instead of a peeking neighbour.
 - **Fixed, all-visible tab strip** synced to the carousel: the active tab updates
   _live_ as you swipe past a track's midpoint (it should track the drag, not jump on
-  release). Tabs are the accessible, non-swipe equivalent.
+  release). Tabs are the accessible, non-swipe equivalent — and, with no peek, the
+  primary cue that more tracks exist.
 - `scroll-snap-stop: always` — one track per fling; a fast swipe can't skip a track.
 - **Never auto-advance** columns.
 

--- a/src/components/admin/schedule/mobile/BottomSheet.tsx
+++ b/src/components/admin/schedule/mobile/BottomSheet.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
+import { useModalA11y } from '../useModalA11y'
 
 /* -------------------------------------------------------------------------- */
 /* Bottom sheet                                                               */
@@ -25,54 +26,9 @@ export function BottomSheet({
   // Escape to close, plus a focus trap and body-scroll lock so this
   // `aria-modal` sheet actually behaves modally: keyboard/screen-reader users
   // can't Tab into the covered background, and the page behind doesn't scroll.
-  useEffect(() => {
-    const previouslyFocused = document.activeElement as HTMLElement | null
-    const { overflow } = document.body.style
-    document.body.style.overflow = 'hidden'
-
-    const focusables = (): HTMLElement[] =>
-      Array.from(
-        dialogRef.current?.querySelectorAll<HTMLElement>(
-          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ) ?? [],
-      )
-
-    // Move focus into the sheet on open.
-    ;(focusables()[0] ?? dialogRef.current)?.focus()
-
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose()
-        return
-      }
-      if (e.key !== 'Tab') return
-      const items = focusables()
-      if (items.length === 0) {
-        e.preventDefault()
-        return
-      }
-      const first = items[0]
-      const last = items[items.length - 1]
-      const active = document.activeElement
-      const outside = !dialogRef.current?.contains(active)
-      if (e.shiftKey && (active === first || outside)) {
-        // Wrap backwards to the last element (or pull stray focus back in).
-        e.preventDefault()
-        last.focus()
-      } else if (!e.shiftKey && (active === last || outside)) {
-        // Wrap forwards to the first element; also pull focus back in if it
-        // somehow escaped the dialog, so Tab can't advance into the background.
-        e.preventDefault()
-        first.focus()
-      }
-    }
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('keydown', onKey)
-      document.body.style.overflow = overflow
-      previouslyFocused?.focus?.()
-    }
-  }, [onClose])
+  // Initial focus prefers an `autoFocus` input over the first focusable (the
+  // header Close button), so typing sheets open ready to type.
+  useModalA11y(dialogRef, onClose)
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col justify-end">

--- a/src/components/admin/schedule/mobile/MobileScheduleView.tsx
+++ b/src/components/admin/schedule/mobile/MobileScheduleView.tsx
@@ -35,6 +35,7 @@ export function MobileScheduleView({
   onAddTrack,
   isSaving,
   saveSuccess,
+  hasUnsavedChanges,
   error,
 }: MobileScheduleViewProps) {
   const schedule = schedules[currentDayIndex] ?? null
@@ -72,13 +73,34 @@ export function MobileScheduleView({
   const closeSheet = useCallback(() => setSheet(null), [])
 
   // Live view of the picked-up scheduled item: derived from current `tracks` so
-  // a rename/resize while placing is reflected, and the ORIGINAL talkIndex keeps
-  // reducer actions correct. Falls back to the snapshot if the index drifts.
+  // a resize while placing is reflected, and the ORIGINAL talkIndex keeps
+  // reducer actions correct. The index alone isn't identity — if the slot at
+  // that index no longer matches the picked-up item (same startTime AND same
+  // talk id / placeholder), the pick-up is DANGLING (the item was removed or
+  // replaced underneath us) and must be cancelled rather than silently
+  // retargeting whatever now sits at that index or acting on a stale snapshot.
   const effPlacing = useMemo<Placing | null>(() => {
     if (!placing || placing.kind !== 'scheduled') return placing
     const live = tracks[placing.trackIndex]?.talks[placing.talkIndex]
-    return live ? { ...placing, talk: live } : placing
+    const sameIdentity =
+      live &&
+      live.startTime === placing.talk.startTime &&
+      (placing.talk.talk
+        ? live.talk?._id === placing.talk.talk._id
+        : live.placeholder === placing.talk.placeholder)
+    return sameIdentity ? { ...placing, talk: live } : null
   }, [placing, tracks])
+
+  // Cancel a dangling pick-up (see above) so the placing banner doesn't stay
+  // half-alive with state that can no longer be acted on. Guarded + convergent:
+  // it fires at most once per dangling pick-up (setting `placing` to null makes
+  // the condition false), so no cascading renders.
+  useEffect(() => {
+    if (placing && placing.kind === 'scheduled' && !effPlacing) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPlacing(null)
+    }
+  }, [placing, effPlacing])
 
   const goToTrack = useCallback((index: number) => {
     setSelectedTrackIndex(index)
@@ -329,6 +351,11 @@ export function MobileScheduleView({
               type="button"
               onClick={onSave}
               disabled={isSaving}
+              aria-label={
+                !saveSuccess && !isSaving && hasUnsavedChanges
+                  ? 'Save — you have unsaved changes'
+                  : undefined
+              }
               className={`inline-flex min-h-[44px] items-center justify-center gap-1.5 rounded-lg px-3 text-sm font-semibold text-white transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 ${
                 saveSuccess
                   ? 'bg-green-600 hover:bg-green-700'
@@ -344,6 +371,13 @@ export function MobileScheduleView({
                 <>
                   <BookmarkIcon className="h-5 w-5" />
                   {isSaving ? 'Saving…' : 'Save'}
+                  {/* Unsaved-changes dot: any dirty day, not just the visible one. */}
+                  {hasUnsavedChanges && !isSaving && (
+                    <span
+                      aria-hidden="true"
+                      className="h-2 w-2 rounded-full bg-amber-300"
+                    />
+                  )}
                 </>
               )}
             </button>
@@ -450,9 +484,12 @@ export function MobileScheduleView({
               id={panelId(trackIndex)}
               aria-labelledby={tabId(trackIndex)}
               // Full-width panels (no side peek) so each track's cards use the
-              // whole screen width. `snap-always` (scroll-snap-stop) forces
-              // exactly one track per fling so a fast swipe can't skip a track.
-              className="shrink-0 basis-[100vw] snap-center snap-always overflow-y-auto px-3 pt-2"
+              // whole screen width. `basis-full` sizes against the scroll
+              // container (not the viewport, which includes any scrollbar
+              // width and clips the panel edge). `snap-always`
+              // (scroll-snap-stop) forces exactly one track per fling so a
+              // fast swipe can't skip a track.
+              className="shrink-0 basis-full snap-center snap-always overflow-y-auto px-3 pt-2"
             >
               <TrackRail
                 track={track}
@@ -535,6 +572,7 @@ export function MobileScheduleView({
           talk={sheet.talk}
           trackIndex={sheet.trackIndex}
           talkIndex={sheet.talkIndex}
+          track={tracks[sheet.trackIndex] ?? null}
           mode={sheet.mode}
           dispatch={dispatch}
           onClose={closeSheet}

--- a/src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx
+++ b/src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx
@@ -1,9 +1,14 @@
 'use client'
 
-import React, { useCallback, useState } from 'react'
-import { TrackTalk } from '@/lib/conference/types'
+import React, { useCallback, useMemo, useState } from 'react'
+import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import { ScheduleAction } from '@/lib/schedule/reducer'
-import { durationBetween } from '@/lib/schedule/time'
+import {
+  calculateEndTime,
+  durationBetween,
+  withinScheduleEnd,
+} from '@/lib/schedule/time'
+import { isTrackIntervalFree, matchService } from '@/lib/schedule/rules'
 import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
 import { Dropdown } from '@/components/Form'
 
@@ -18,6 +23,7 @@ export function ServiceEditSheet({
   talk,
   trackIndex,
   talkIndex,
+  track,
   mode,
   dispatch,
   onClose,
@@ -25,6 +31,8 @@ export function ServiceEditSheet({
   talk: TrackTalk
   trackIndex: number
   talkIndex: number
+  /** The live track, for filtering durations to what actually fits. */
+  track: ScheduleTrack | null
   mode: 'rename' | 'duration'
   dispatch: React.Dispatch<ScheduleAction>
   onClose: () => void
@@ -33,6 +41,7 @@ export function ServiceEditSheet({
   const [durationValue, setDurationValue] = useState(
     String(durationBetween(talk.startTime, talk.endTime)),
   )
+  const [durationError, setDurationError] = useState<string | null>(null)
 
   const saveRename = useCallback(() => {
     if (!renameValue.trim()) return
@@ -45,15 +54,57 @@ export function ServiceEditSheet({
     onClose()
   }, [dispatch, trackIndex, talkIndex, renameValue, onClose])
 
+  // Whether `dur` minutes from this session's start stays inside the day and
+  // clear of the surrounding items (excluding the session itself) — the exact
+  // checks the reducer's `resizeService` applies, so the sheet never offers or
+  // submits a duration the reducer would silently reject.
+  const durationFits = useCallback(
+    (dur: number): boolean => {
+      const end = calculateEndTime(talk.startTime, dur)
+      if (!withinScheduleEnd(end)) return false
+      if (!track) return true
+      return isTrackIntervalFree(
+        track,
+        talk.startTime,
+        end,
+        matchService(talk.placeholder ?? '', talk.startTime),
+      )
+    },
+    [track, talk.startTime, talk.placeholder],
+  )
+
+  // Standard options that fit the surrounding gap, plus the CURRENT duration
+  // when it isn't a standard option (the Dropdown needs a valid selection for
+  // e.g. a hand-resized 25-min break).
+  const currentDuration = durationBetween(talk.startTime, talk.endTime)
+  const durationOptions = useMemo(() => {
+    const entries = [...SERVICE_DURATION_OPTIONS].filter(([mins]) =>
+      durationFits(Number(mins)),
+    )
+    if (!entries.some(([mins]) => Number(mins) === currentDuration)) {
+      entries.push([String(currentDuration), `${currentDuration} minutes`])
+      entries.sort((a, b) => Number(a[0]) - Number(b[0]))
+    }
+    return new Map(entries)
+  }, [durationFits, currentDuration])
+
   const saveDuration = useCallback(() => {
+    const dur = Number(durationValue)
+    // Re-validate against the LIVE track: the schedule can change while the
+    // sheet is open, and a rejected resize must surface here instead of the
+    // sheet closing as if it had worked.
+    if (!dur || !durationFits(dur)) {
+      setDurationError('That duration no longer fits — pick a shorter one.')
+      return
+    }
     dispatch({
       type: 'resizeService',
       trackIndex,
       talkIndex,
-      duration: Number(durationValue),
+      duration: dur,
     })
     onClose()
-  }, [dispatch, trackIndex, talkIndex, durationValue, onClose])
+  }, [dispatch, trackIndex, talkIndex, durationValue, durationFits, onClose])
 
   if (mode === 'rename') {
     return (
@@ -97,10 +148,21 @@ export function ServiceEditSheet({
       <Dropdown
         name="service-duration"
         label="Duration (minutes)"
-        options={SERVICE_DURATION_OPTIONS}
+        options={durationOptions}
         value={durationValue}
-        setValue={setDurationValue}
+        setValue={(val) => {
+          setDurationValue(val)
+          setDurationError(null)
+        }}
       />
+      {durationError && (
+        <p
+          role="alert"
+          className="mt-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
+        >
+          {durationError}
+        </p>
+      )}
       <div className="mt-5 flex gap-3">
         <button
           type="button"

--- a/src/components/admin/schedule/mobile/types.ts
+++ b/src/components/admin/schedule/mobile/types.ts
@@ -13,6 +13,8 @@ export interface MobileScheduleViewProps {
   onAddTrack: () => void
   isSaving: boolean
   saveSuccess: boolean
+  /** Any day dirty since its last save — drives the Save button's unsaved dot. */
+  hasUnsavedChanges: boolean
   error: string | null
 }
 

--- a/src/components/admin/schedule/track/ServiceSessionModal.tsx
+++ b/src/components/admin/schedule/track/ServiceSessionModal.tsx
@@ -1,12 +1,22 @@
 'use client'
 
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { ScheduleTrack } from '@/lib/conference/types'
 import { Dropdown } from '@/components/Form'
 import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
+import {
+  SCHEDULE_END,
+  calculateEndTime,
+  endsWithinScheduleDay,
+  toMinutes,
+} from '@/lib/schedule/time'
+import { isTrackIntervalFree } from '@/lib/schedule/rules'
+import { useModalA11y } from '../useModalA11y'
 
 interface ServiceSessionModalProps {
   isOpen: boolean
   timeSlot: string
+  track: ScheduleTrack
   onClose: () => void
   onSave: (title: string, duration: number) => void
 }
@@ -14,40 +24,116 @@ interface ServiceSessionModalProps {
 export const ServiceSessionModal = ({
   isOpen,
   timeSlot,
+  track,
   onClose,
   onSave,
 }: ServiceSessionModalProps) => {
+  // The dialog is an inner component so its hooks (modal a11y, per-open state)
+  // only run while the modal is actually open.
+  if (!isOpen) return null
+  return (
+    <ServiceSessionDialog
+      timeSlot={timeSlot}
+      track={track}
+      onClose={onClose}
+      onSave={onSave}
+    />
+  )
+}
+
+const ServiceSessionDialog = ({
+  timeSlot,
+  track,
+  onClose,
+  onSave,
+}: Omit<ServiceSessionModalProps, 'isOpen'>) => {
   const [title, setTitle] = useState('')
-  const [duration, setDuration] = useState(10)
+  const [duration, setDuration] = useState('10')
+  const [error, setError] = useState<string | null>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Modal semantics: Escape closes, focus moves in (preferring the autoFocus
+  // title input) and is restored on close, Tab is trapped. Shared with
+  // AddTrackModal and the mobile BottomSheet.
+  useModalA11y(dialogRef, onClose)
+
+  // Free minutes from the chosen start until the next talk/session (or the end
+  // of the day). Recomputed from the LIVE track so a schedule change while the
+  // modal is open can't offer a duration the reducer would reject.
+  const maxDurationMin = useMemo(() => {
+    const start = toMinutes(timeSlot)
+    let limit = toMinutes(SCHEDULE_END)
+    for (const t of track.talks) {
+      const s = toMinutes(t.startTime)
+      const e = toMinutes(t.endTime)
+      // The start itself sits inside an existing item — nothing fits.
+      if (s <= start && e > start) return 0
+      if (s > start) limit = Math.min(limit, s)
+    }
+    return limit - start
+  }, [track, timeSlot])
+
+  // Offer only durations that fit the free gap (mirrors the mobile
+  // UnassignedDrawer). If no standard option fits but SOME time is free, fall
+  // back to the exact available minutes so the form isn't a dead end.
+  const durationOptions = useMemo(() => {
+    const fitting = [...SERVICE_DURATION_OPTIONS].filter(
+      ([mins]) => Number(mins) <= maxDurationMin,
+    )
+    if (fitting.length > 0) return new Map(fitting)
+    if (maxDurationMin > 0) {
+      return new Map([[String(maxDurationMin), `${maxDurationMin} minutes`]])
+    }
+    return new Map<string, string>()
+  }, [maxDurationMin])
+
+  const effectiveDuration = durationOptions.has(duration)
+    ? duration
+    : (durationOptions.keys().next().value ?? '')
+
+  const nothingFits = durationOptions.size === 0
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault()
-      if (title.trim()) {
-        onSave(title.trim(), duration)
-        setTitle('')
-        setDuration(10)
+      const trimmed = title.trim()
+      if (!trimmed) return
+      const dur = Number(effectiveDuration)
+      // Re-validate against the live track with the reducer's own rules
+      // (end-of-day + interval free) so a rejected add can't silently close
+      // the modal — surface an inline error instead.
+      if (!dur || !endsWithinScheduleDay(timeSlot, dur)) {
+        setError('That duration runs past the free slot.')
+        return
       }
+      const endTime = calculateEndTime(timeSlot, dur)
+      if (!isTrackIntervalFree(track, timeSlot, endTime)) {
+        setError('That slot was just taken — pick another.')
+        return
+      }
+      onSave(trimmed, dur)
     },
-    [title, duration, onSave],
+    [title, effectiveDuration, timeSlot, track, onSave],
   )
 
-  const handleClose = useCallback(() => {
-    setTitle('')
-    setDuration(10)
-    onClose()
-  }, [onClose])
-
-  if (!isOpen) return null
-
   return (
-    <div className="bg-opacity-50 fixed inset-0 z-50 flex items-center justify-center bg-black">
-      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 dark:bg-gray-800">
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="service-session-modal-title"
+        className="mx-4 w-full max-w-md rounded-lg bg-white p-6 dark:bg-gray-800"
+      >
+        <h3
+          id="service-session-modal-title"
+          className="mb-4 text-lg font-semibold text-gray-900 dark:text-white"
+        >
           Create Service Session
         </h3>
         <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
           Starting at {timeSlot}
+          {maxDurationMin > 0 && ` · up to ${maxDurationMin} min available`}
         </p>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -74,22 +160,38 @@ export const ServiceSessionModal = ({
             <Dropdown
               name="duration"
               label="Duration (minutes)"
-              options={SERVICE_DURATION_OPTIONS}
-              value={String(duration)}
-              setValue={(val) => setDuration(Number(val))}
+              options={durationOptions}
+              value={effectiveDuration}
+              setValue={(val) => {
+                setDuration(val)
+                setError(null)
+              }}
+              disabled={nothingFits}
             />
           </div>
+
+          {(error || nothingFits) && (
+            <p
+              role="alert"
+              className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
+            >
+              {nothingFits
+                ? 'This slot is no longer free — close and pick another.'
+                : error}
+            </p>
+          )}
 
           <div className="flex gap-3 pt-4">
             <button
               type="submit"
-              className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:bg-blue-700 dark:hover:bg-blue-600"
+              disabled={nothingFits}
+              className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
             >
               Create Session
             </button>
             <button
               type="button"
-              onClick={handleClose}
+              onClick={onClose}
               className="flex-1 rounded-md bg-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-400 focus:ring-2 focus:ring-gray-500 focus:outline-none dark:bg-gray-600 dark:text-gray-300 dark:hover:bg-gray-500"
             >
               Cancel

--- a/src/components/admin/schedule/track/TimeSlotDropZone.tsx
+++ b/src/components/admin/schedule/track/TimeSlotDropZone.tsx
@@ -6,7 +6,10 @@ import { ScheduleTrack } from '@/lib/conference/types'
 import { TimeSlot } from '@/lib/schedule/types'
 import { addMinutes } from '@/lib/schedule/time'
 import { isTrackIntervalFree } from '@/lib/schedule/rules'
-import { classifyProposalDrop } from '@/lib/schedule/operations'
+import {
+  classifyProposalDrop,
+  classifyServiceDrop,
+} from '@/lib/schedule/operations'
 import {
   calculateTimePosition,
   shouldShowTimeLabel,
@@ -76,12 +79,20 @@ export const TimeSlotDropZone = ({
 
   const canDrop = useMemo(() => {
     if (!activeDragItem) return true
-    // Service drags aren't validated here (the reducer does); only proposals.
-    if (!activeDragItem.proposal) return true
     if (!schedule) return true
-    // Defer to the shared predicate so the drop indicator matches EXACTLY what
-    // the reducer's `moveProposal` will do — fit, bidirectional swap, and the
-    // end-of-day guard (which this inline check previously omitted).
+    // Defer to the shared predicates so the drop indicator matches EXACTLY
+    // what the reducer will do. Services get the same treatment as proposals
+    // (fit, end-of-day, same-position no-op) — previously a service drag
+    // showed every slot as droppable and let the reducer silently reject.
+    if (activeDragItem.serviceSession) {
+      return (
+        classifyServiceDrop(schedule.tracks, activeDragItem, {
+          trackIndex,
+          timeSlot: timeSlot.time,
+        }) !== 'invalid'
+      )
+    }
+    // Proposal drags: fit, bidirectional swap, and the end-of-day guard.
     return (
       classifyProposalDrop(
         schedule.tracks,

--- a/src/components/admin/schedule/track/TrackHeader.tsx
+++ b/src/components/admin/schedule/track/TrackHeader.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { useState } from 'react'
 import { ScheduleTrack } from '@/lib/conference/types'
 import { PencilIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { calculateTalkContentMinutes } from '@/lib/schedule/geometry'
+import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 
 export const TrackHeader = ({
   track,
@@ -29,6 +31,21 @@ export const TrackHeader = ({
 }) => {
   const talkContentMinutes = calculateTalkContentMinutes(track)
   const realTalks = track.talks.filter((talk) => talk.talk).length
+  const [confirmingRemove, setConfirmingRemove] = useState(false)
+
+  // Removing a track un-schedules its real talks (they return to the unassigned
+  // list) but permanently DELETES its service sessions — mirror the mobile
+  // TrackActionSheet's confirm step and wording so one click can't destroy them.
+  const serviceCount = track.talks.length - realTalks
+  const name = track.trackTitle || 'this track'
+  const removeMessage =
+    `Remove ${name}?` +
+    (realTalks > 0
+      ? ` Its ${realTalks} talk${realTalks === 1 ? '' : 's'} return to unassigned.`
+      : '') +
+    (serviceCount > 0
+      ? ` ${serviceCount} service session${serviceCount === 1 ? '' : 's'} will be deleted.`
+      : '')
 
   return (
     <div className="rounded-t-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
@@ -97,7 +114,7 @@ export const TrackHeader = ({
               <PencilIcon className="h-4 w-4" />
             </button>
             <button
-              onClick={onRemoveTrack}
+              onClick={() => setConfirmingRemove(true)}
               className="rounded p-1 text-gray-400 transition-colors hover:text-red-600 focus:ring-2 focus:ring-red-500 focus:outline-none dark:text-gray-500 dark:hover:text-red-400"
               title="Remove track"
               type="button"
@@ -107,6 +124,19 @@ export const TrackHeader = ({
           </div>
         </div>
       )}
+
+      <ConfirmationModal
+        isOpen={confirmingRemove}
+        onClose={() => setConfirmingRemove(false)}
+        onConfirm={() => {
+          setConfirmingRemove(false)
+          onRemoveTrack()
+        }}
+        title="Remove track?"
+        message={removeMessage}
+        confirmButtonText="Remove"
+        variant="danger"
+      />
     </div>
   )
 }

--- a/src/components/admin/schedule/track/useServiceSessionResize.ts
+++ b/src/components/admin/schedule/track/useServiceSessionResize.ts
@@ -3,7 +3,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
 import { PIXELS_PER_MINUTE, SLOT_INTERVAL } from '@/lib/schedule/geometry'
-import { SCHEDULE_END, calculateEndTime, toMinutes } from '@/lib/schedule/time'
+import {
+  SCHEDULE_END,
+  calculateEndTime,
+  durationBetween,
+  toMinutes,
+} from '@/lib/schedule/time'
 import { isTrackIntervalFree, matchService } from '@/lib/schedule/rules'
 
 const MIN_DURATION = 5
@@ -41,6 +46,25 @@ export function useServiceSessionResize({
   const [isResizing, setIsResizing] = useState(false)
   const startYRef = useRef(0)
   const startHeightRef = useRef(0)
+  // Duration when the resize started, so Escape can revert to it.
+  const originalDurationRef = useRef(0)
+  // Last duration actually dispatched, so pointermove only dispatches CHANGES
+  // (not one resizeService per pixel of movement).
+  const lastDispatchedRef = useRef<number | null>(null)
+  // Capture target + pointer id, so Escape / unmount can release the capture
+  // (pointer events keep streaming to the handle until released).
+  const captureElRef = useRef<Element | null>(null)
+  const capturePointerIdRef = useRef<number | null>(null)
+
+  const releaseCapture = useCallback(() => {
+    const el = captureElRef.current
+    const pointerId = capturePointerIdRef.current
+    if (el && pointerId !== null && el.hasPointerCapture?.(pointerId)) {
+      el.releasePointerCapture(pointerId)
+    }
+    captureElRef.current = null
+    capturePointerIdRef.current = null
+  }, [])
 
   // Largest duration (quantized to the slot interval, within [MIN, MAX]) whose
   // end stays free and inside the schedule — i.e. clamp `requested` down until
@@ -70,11 +94,18 @@ export function useServiceSessionResize({
       e.preventDefault()
       e.stopPropagation()
       e.currentTarget.setPointerCapture(e.pointerId)
+      captureElRef.current = e.currentTarget
+      capturePointerIdRef.current = e.pointerId
       startYRef.current = e.clientY
       startHeightRef.current = height
+      originalDurationRef.current = durationBetween(
+        talk.startTime,
+        talk.endTime,
+      )
+      lastDispatchedRef.current = originalDurationRef.current
       setIsResizing(true)
     },
-    [height],
+    [height, talk.startTime, talk.endTime],
   )
 
   const handlePointerMove = useCallback(
@@ -89,7 +120,11 @@ export function useServiceSessionResize({
         SLOT_INTERVAL
 
       const duration = clampDuration(rawDuration)
-      if (duration >= MIN_DURATION) {
+      // Only dispatch when the quantized duration actually CHANGED — a
+      // pointermove fires per pixel and would otherwise flood the reducer with
+      // identical resizeService actions.
+      if (duration >= MIN_DURATION && duration !== lastDispatchedRef.current) {
+        lastDispatchedRef.current = duration
         onUpdateSession(talkIndex, duration)
       }
     },
@@ -101,18 +136,32 @@ export function useServiceSessionResize({
     if (e.currentTarget.hasPointerCapture(e.pointerId)) {
       e.currentTarget.releasePointerCapture(e.pointerId)
     }
+    captureElRef.current = null
+    capturePointerIdRef.current = null
+    lastDispatchedRef.current = null
     setIsResizing(false)
   }, [])
 
-  // Escape cancels an in-progress resize (parity with the old mouse handler).
+  // Escape CANCELS an in-progress resize: revert to the duration the resize
+  // started from and release the pointer capture (otherwise moves keep
+  // streaming to the handle and the "cancel" left the intermediate size).
   useEffect(() => {
     if (!isResizing) return
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsResizing(false)
+      if (e.key !== 'Escape') return
+      if (lastDispatchedRef.current !== originalDurationRef.current) {
+        onUpdateSession(talkIndex, originalDurationRef.current)
+      }
+      lastDispatchedRef.current = null
+      releaseCapture()
+      setIsResizing(false)
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [isResizing])
+  }, [isResizing, talkIndex, onUpdateSession, releaseCapture])
+
+  // If the handle unmounts mid-resize, don't leave the pointer captured.
+  useEffect(() => releaseCapture, [releaseCapture])
 
   return {
     isResizing,

--- a/src/components/admin/schedule/useModalA11y.ts
+++ b/src/components/admin/schedule/useModalA11y.ts
@@ -90,6 +90,5 @@ export function useModalA11y(
       previouslyFocused?.focus?.()
     }
     // Mount-only (dialogRef is a stable ref object; onClose via the latest-ref).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dialogRef])
 }

--- a/src/components/admin/schedule/useModalA11y.ts
+++ b/src/components/admin/schedule/useModalA11y.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, type RefObject } from 'react'
+import { useEffect, useRef, type RefObject } from 'react'
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
@@ -25,6 +25,15 @@ export function useModalA11y(
   dialogRef: RefObject<HTMLElement | null>,
   onClose: () => void,
 ) {
+  // Latest-ref for `onClose` so a caller passing a non-memoized callback (an
+  // inline arrow) doesn't re-run the whole effect mid-open — the cleanup would
+  // restore focus and unlock scroll while the dialog is still up. The effect
+  // itself runs once per mount; Escape always sees the current callback.
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
   useEffect(() => {
     const previouslyFocused = document.activeElement as HTMLElement | null
     const { overflow } = document.body.style
@@ -50,7 +59,7 @@ export function useModalA11y(
 
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onClose()
+        onCloseRef.current()
         return
       }
       if (e.key !== 'Tab') return
@@ -80,5 +89,7 @@ export function useModalA11y(
       document.body.style.overflow = overflow
       previouslyFocused?.focus?.()
     }
-  }, [dialogRef, onClose])
+    // Mount-only (dialogRef is a stable ref object; onClose via the latest-ref).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dialogRef])
 }

--- a/src/components/admin/schedule/useModalA11y.ts
+++ b/src/components/admin/schedule/useModalA11y.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import { useEffect, type RefObject } from 'react'
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/**
+ * Modal dialog a11y behaviour shared by the schedule editor's overlays
+ * (AddTrackModal, ServiceSessionModal, mobile/BottomSheet):
+ *
+ * - moves focus INTO the dialog on open — preferring an `autofocus` element so
+ *   the initial focus isn't stolen from an input by whatever happens to be the
+ *   first focusable (e.g. a header Close button) — and restores focus to the
+ *   previously focused element on close/unmount;
+ * - Escape closes;
+ * - Tab is trapped in both directions (wraps, and pulls stray focus back in);
+ * - body scroll is locked while open.
+ *
+ * The caller renders the dialog element itself (with `role="dialog"`,
+ * `aria-modal="true"` and `aria-labelledby`) and passes its ref here. Only call
+ * this from a component that is mounted exclusively while the dialog is open.
+ */
+export function useModalA11y(
+  dialogRef: RefObject<HTMLElement | null>,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    const { overflow } = document.body.style
+    document.body.style.overflow = 'hidden'
+
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ??
+          [],
+      )
+
+    // Move focus into the dialog on open. Prefer the caller's `autoFocus`
+    // element; if focus already landed inside the dialog (React can apply
+    // `autoFocus` before this effect runs), leave it alone; else fall back to
+    // the first focusable.
+    const autoFocusTarget =
+      dialogRef.current?.querySelector<HTMLElement>('[autofocus]')
+    if (autoFocusTarget) {
+      autoFocusTarget.focus()
+    } else if (!dialogRef.current?.contains(document.activeElement)) {
+      ;(focusables()[0] ?? dialogRef.current)?.focus()
+    }
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+      if (e.key !== 'Tab') return
+      const items = focusables()
+      if (items.length === 0) {
+        e.preventDefault()
+        return
+      }
+      const first = items[0]
+      const last = items[items.length - 1]
+      const active = document.activeElement
+      const outside = !dialogRef.current?.contains(active)
+      if (e.shiftKey && (active === first || outside)) {
+        // Wrap backwards to the last element (or pull stray focus back in).
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && (active === last || outside)) {
+        // Wrap forwards to the first element; also pull focus back in if it
+        // somehow escaped the dialog, so Tab can't advance into the background.
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = overflow
+      previouslyFocused?.focus?.()
+    }
+  }, [dialogRef, onClose])
+}


### PR DESCRIPTION
UI/a11y/parity batch from the full schedule-editor code review (follows the engine batches #507/#508). One section per finding; scope is `src/components/admin/schedule/**`, `UX.md`, and the schedule component tests — no `src/lib/schedule/**` or server changes.

## F1 (high) — Escape-cancelled drag left the board stuck
`DndContext` had no `onDragCancel`, so an Escape-cancelled drag kept `activeItem` set: every "+ Service" button stayed hidden and stale `canDrop` indicators lingered until the next drag. Added `onDragCancel` → `setActiveItem(null)` in `ScheduleEditor`.

## F2 (high) — Desktop remove-track was one unconfirmed click
The desktop trash icon removed the track immediately — permanently deleting its service sessions. It now opens the shared `ConfirmationModal` with the same information mobile's TrackActionSheet gives: how many talks return to unassigned and how many service sessions will be deleted.

## F3 (high) — No unsaved-changes indication or navigation guard
- `hasUnsavedChanges` (`state.dirty.some(Boolean)`) is threaded to both headers: the Save button shows an amber dot plus an `aria-label` mentioning unsaved changes (desktop `HeaderSection` and the mobile header).
- `ScheduleEditor` registers a `beforeunload` guard while any day is dirty (active for both views).

## F4 (med) — Service drags always showed "droppable"
`TimeSlotDropZone.canDrop` returned `true` for any non-proposal drag. Service drags now defer to `classifyServiceDrop` (post-#508: fit, end-of-day, same-position no-op, stale-source), so the indicator matches exactly what the reducer will accept. Covered by a new unit test.

## F5 (med) — DragOverlay dragId collided with the source card
The overlay renders the same Draggable component as the source card, registering the same dragId twice in dnd-kit's registry. Overlay renders (`isDragging`) now suffix the id with `-overlay` in both `DraggableProposal` and `DraggableServiceSession`.

## F6 (med) — Keyboard focus and keyboard activator lived on different elements
`{...attributes}` (role/tabIndex) was on the outer card div while `{...listeners}` (incl. the keyboard activator) was on the drag-handle icon, so the focusable element couldn't start a drag. Both are now co-located on the handle, which is a real `<button>` with an aria-label ("Drag <title>"), in both Draggables. A code comment notes the remaining known gap: `pointerWithin` collision detection can't target drops for keyboard drags (collisionDetection unchanged).

## F7 (med) — Resize dispatched per pointermove; Escape didn't cancel
`useServiceSessionResize` now keeps the last dispatched duration in a ref and dispatches only on change; Escape dispatches a final `resizeService` back to the duration captured at resize start and releases the pointer capture; unmount cleanup also releases capture.

## F8 (med) — Opaque modal backdrops, no dialog semantics
`AddTrackModal` and `ServiceSessionModal` used Tailwind-v4-dead `bg-opacity-50`, giving a fully opaque black backdrop; they also had no dialog semantics. Backdrops are now `bg-black/50`, both modals have `role="dialog" aria-modal aria-labelledby`, and a new shared hook `useModalA11y` (extracted from `BottomSheet`'s pattern) provides Escape-to-close, focus-in on open / restore on close, Tab trap, and body-scroll lock. `BottomSheet` itself was refactored onto the hook (small diff, identical behavior apart from F10's fix). Verified in the running story: focus lands on the autoFocus input, Escape closes, backdrop dims.

## F9 (med) — Silent duration failures
- Desktop `ServiceSessionModal`: duration options are filtered to the free gap from the chosen start (computed against the live track, mirroring mobile's UnassignedDrawer, incl. the exact-minutes fallback for sub-5-minute gaps); submit re-validates with the reducer's own rules and shows an inline error instead of closing on rejection.
- Mobile `ServiceEditSheet` (change duration): options are filtered to the surrounding gap (excluding the session itself, up to the next obstacle / end of day); a current duration that isn't a standard option is included so the Dropdown has a valid selection; a rejected resize shows the drawer's inline error style and does not close. Covered by new tests.

## F10 (low) — BottomSheet stole focus from autoFocus inputs
Initial focus preferred the first focusable (the header Close button). The shared hook now prefers `[autofocus]`, leaves focus alone if it's already inside the dialog (React applies `autoFocus` before the effect), and only then falls back to the first focusable.

## F11 (low) — Carousel panels sized against the viewport
`basis-[100vw]` → `basis-full`: panels size against the scroll container instead of the viewport (which includes scrollbar width and clipped the panel edge). Verified with `pnpm shoot`: panel width 393/393, 3 cards checked, none cut.

## F12 (low) — Stale pick-up silently retargeted by index
`effPlacing` re-derived the picked-up slot by index with no identity check. The live lookup now verifies identity (same `startTime` and same `talk._id`/`placeholder`); a mismatch means the pick-up is dangling and it is cancelled via an effect rather than retargeting whatever now sits at that index.

## F13 (low) — saveSuccess timeout leaked
The 3s saved-flash `setTimeout` id is stored in a ref, cleared on a new save and on unmount.

## F14 (doc) — UX.md §7 contradicted the shipped design
§7 still mandated ~86vw side-peek panels. It now documents the locked full-width decision (PR #493) and its rationale: discoverability is carried by the fixed tab strip, and every horizontal pixel goes to the track's cards.

## Tests
Four new/extended tests (all in `__tests__/components/admin/schedule/`):
1. `MobileScheduleView`: a day change clears an active placing **and** an open sheet.
2. `UnassignedDrawer`: a sub-5-minute gap (`maxDurationMin=4`) offers the exact-minutes fallback option "4 minutes".
3. `TimeSlotDropZone` under `ScheduleProvider`: a service drag over an occupied interval shows the not-allowed indicator (red class), and the droppable indicator over a free one.
4. `ServiceEditSheet`: a rejected resize shows the inline error and does not close (and non-standard current durations stay selectable).

## Verification
- `npx tsc --noEmit` — 0 errors
- `eslint src/components/admin/schedule/` — clean
- `prettier --check` on touched dirs — clean
- `vitest run __tests__/lib/schedule/ __tests__/components/admin/schedule/` — 14 files, 192/192 passing
- `pnpm shoot` (mobile 393×852) — `OK: 3 card(s) checked`, panel 393/393, screenshot inspected
- Desktop story at 1280×800 screenshotted; AddTrackModal opened via Playwright: backdrop dims at 50 %, focus lands on the title input, Escape closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a comprehensive UI/a11y batch fixing 14 independent issues in the schedule editor: drag lifecycle (Escape cancel, DragOverlay id collision), desktop track removal without confirmation, unsaved-changes indication and beforeunload guard, service-drag drop indicators, drag-handle keyboard a11y, resize dispatch throttling and Escape revert, opaque modal backdrops and missing dialog semantics, silent duration failures on both desktop and mobile, and carousel panel sizing.

- **New shared `useModalA11y` hook** extracted from `BottomSheet`'s existing focus-trap code and applied to `AddTrackModal`, `ServiceSessionModal`, and `BottomSheet`; fixes `bg-opacity-50` (always opaque) → `bg-black/50` and adds `role=\"dialog\"` semantics to the two desktop modals.
- **`ScheduleEditor`** gains `onDragCancel` → `setActiveItem(null)`, `hasUnsavedChanges` threaded to both headers, a `beforeunload` guard, and a ref-tracked `saveSuccess` timeout to prevent leaks.
- **Duration filtering** in both `ServiceSessionModal` and `ServiceEditSheet` now computes the live free gap, offers an exact-minutes fallback for sub-5-minute gaps, and re-validates on submit with an inline error instead of silently closing.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the two findings are minor UX polish items with no runtime breakage risk.

All 14 fixes are well-scoped, tested, and consistent with the existing codebase. The two flagged issues are both non-blocking: the useModalA11y onClose dependency concern is latent and pre-existed in BottomSheet's original code; the ServiceSessionModal error-persistence issue is a cosmetic UX gap. Neither affects correctness or data integrity.

src/components/admin/schedule/useModalA11y.ts and src/components/admin/schedule/track/ServiceSessionModal.tsx

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/useModalA11y.ts | New shared hook for modal a11y (Escape, focus trap, body-scroll lock, autofocus preference). onClose in the effect dependency array is a minor risk if any caller passes an unstable reference, causing a transient focus-restoration event. |
| src/components/admin/schedule/track/ServiceSessionModal.tsx | Refactored to ServiceSessionDialog inner component; adds live gap filtering, inline error display on rejected submit, and modal a11y via useModalA11y. Minor UX gap: error state not cleared when user edits only the title. |
| src/components/admin/schedule/ScheduleEditor.tsx | Adds onDragCancel handler (F1), hasUnsavedChanges computed from dirty state (F3), beforeunload guard, and saveSuccess timeout stored in a ref to prevent leak on rapid saves or unmount. |
| src/components/admin/schedule/mobile/MobileScheduleView.tsx | effPlacing now validates scheduled-placing identity (startTime + id/placeholder) instead of blindly following index; dangling pick-ups are cancelled via a guarded effect; basis-[100vw] → basis-full fixes carousel clipping. |
| src/components/admin/schedule/track/useServiceSessionResize.ts | Escape now reverts to originalDurationRef and releases pointer capture; dispatch is gated by lastDispatchedRef to avoid per-pixel flooding; unmount cleanup releases capture via a stable useCallback ref. |
| src/components/admin/schedule/track/TrackHeader.tsx | Desktop trash icon now gates on a ConfirmationModal before calling onRemoveTrack, matching mobile parity. removeMessage accurately reports real-talk count and service-session count. |
| src/components/admin/schedule/DraggableProposal.tsx | Drag handle promoted to a real button with aria-label; attributes+listeners co-located on the handle; DragOverlay renders with ${dragId}-overlay suffix to avoid dnd-kit registry collision. |
| src/components/admin/schedule/DraggableServiceSession.tsx | Same drag-handle and overlay-id pattern as DraggableProposal applied here; outer container no longer carries dnd-kit attributes. |
| src/components/admin/schedule/track/TimeSlotDropZone.tsx | Service drags now validate via classifyServiceDrop (returns 'move'|'invalid') instead of always showing droppable; correctly distinguishes occupied vs free slots. |
| src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx | Duration options filtered to the live surrounding gap; non-standard current duration preserved as a valid selection; rejected resize shows inline error without closing. |
| src/components/admin/schedule/mobile/BottomSheet.tsx | Refactored onto shared useModalA11y hook, removing ~54 lines of inline focus-trap code. Behaviour is identical apart from the improved autoFocus preference from F10. |
| src/components/admin/schedule/AddTrackModal.tsx | bg-opacity-50 → bg-black/50 fixes the opaque backdrop; role=dialog, aria-modal, aria-labelledby added; useModalA11y provides focus trap and Escape-to-close. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant DragHandle as Drag Handle (button)
    participant DndContext
    participant ScheduleEditor
    participant TimeSlotDropZone
    participant Reducer

    User->>DragHandle: pointerdown / Enter
    DragHandle->>DndContext: onDragStart (attributes+listeners co-located)
    DndContext->>ScheduleEditor: setActiveItem(dragItem)
    Note over TimeSlotDropZone: classifyServiceDrop() or classifyProposalDrop()
    TimeSlotDropZone-->>User: canDrop indicator (blue/red)

    alt Drop on valid slot
        User->>DndContext: pointerup
        DndContext->>ScheduleEditor: onDragEnd
        ScheduleEditor->>Reducer: dispatch(moveProposal/moveServiceSession)
    else Escape pressed
        User->>DndContext: Escape key
        DndContext->>ScheduleEditor: onDragCancel (NEW)
        ScheduleEditor->>ScheduleEditor: setActiveItem(null)
        Note over TimeSlotDropZone: canDrop indicators cleared
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant DragHandle as Drag Handle (button)
    participant DndContext
    participant ScheduleEditor
    participant TimeSlotDropZone
    participant Reducer

    User->>DragHandle: pointerdown / Enter
    DragHandle->>DndContext: onDragStart (attributes+listeners co-located)
    DndContext->>ScheduleEditor: setActiveItem(dragItem)
    Note over TimeSlotDropZone: classifyServiceDrop() or classifyProposalDrop()
    TimeSlotDropZone-->>User: canDrop indicator (blue/red)

    alt Drop on valid slot
        User->>DndContext: pointerup
        DndContext->>ScheduleEditor: onDragEnd
        ScheduleEditor->>Reducer: dispatch(moveProposal/moveServiceSession)
    else Escape pressed
        User->>DndContext: Escape key
        DndContext->>ScheduleEditor: onDragCancel (NEW)
        ScheduleEditor->>ScheduleEditor: setActiveItem(null)
        Note over TimeSlotDropZone: canDrop indicators cleared
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/admin/schedule/track/ServiceSessionModal.tsx`, line 151 ([link](https://github.com/cloudnativebergen/website/blob/c17ac2401fa7e2516dc8a43f799112fe9a960560/src/components/admin/schedule/track/ServiceSessionModal.tsx#L151)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Slot-availability error persists after the user edits only the title**

   `setError(null)` is called when the duration Dropdown changes, but not when the title input changes. If a submit fails with "That slot was just taken", the error banner stays visible even after the user edits the title — it only disappears when the duration changes. Adding `setError(null)` to the title `onChange` keeps the alert in sync with what the user is actually modifying.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): UI review batch — drag li..."](https://github.com/cloudnativebergen/website/commit/c17ac2401fa7e2516dc8a43f799112fe9a960560) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45332325)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->