### PR TITLE
feat(notifications): persistent notification hub backend — schema, lib, router, emitters (N1)

### DIFF
--- a/__tests__/lib/events/persistNotification.test.ts
+++ b/__tests__/lib/events/persistNotification.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the notification-hub bus handler
+ * (src/lib/events/handlers/persistNotification.ts).
+ *
+ * The data layer is mocked so we assert exactly which recipients get a
+ * notification for each kind of proposal event:
+ * - submit  → all organizers EXCEPT the actor
+ * - accepted/rejected + shouldNotify → each proposal speaker EXCEPT the actor
+ * - shouldNotify=false → nobody
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: vi.fn(async () => {}),
+  getOrganizerSpeakerIds: vi.fn(async () => [] as string[]),
+}))
+
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import { handlePersistNotification } from '@/lib/events/handlers/persistNotification'
+import { Action, Status } from '@/lib/proposal/types'
+import type { ProposalStatusChangeEvent } from '@/lib/events/types'
+import type { NotificationInput } from '@/lib/notification/types'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const createMock = createNotifications as unknown as LooseMock
+const organizersMock = getOrganizerSpeakerIds as unknown as LooseMock
+
+const makeEvent = (
+  overrides: Partial<ProposalStatusChangeEvent> = {},
+  metadataOverrides: Partial<ProposalStatusChangeEvent['metadata']> = {},
+): ProposalStatusChangeEvent =>
+  ({
+    eventType: 'proposal.status.changed',
+    timestamp: new Date(),
+    proposal: { _id: 'prop-1', title: 'My Talk' },
+    previousStatus: Status.submitted,
+    newStatus: Status.accepted,
+    action: Action.accept,
+    conference: { _id: 'conf-1' },
+    speakers: [],
+    metadata: {
+      triggeredBy: { speakerId: 'actor-1', isOrganizer: true },
+      shouldNotify: true,
+      domain: 'example.com',
+      ...metadataOverrides,
+    },
+    ...overrides,
+  }) as unknown as ProposalStatusChangeEvent
+
+const lastItems = (): NotificationInput[] =>
+  createMock.mock.calls[
+    createMock.mock.calls.length - 1
+  ][0] as NotificationInput[]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('submit — organizers minus actor', () => {
+  it('notifies every organizer except the acting organizer', async () => {
+    organizersMock.mockResolvedValue(['org-1', 'actor-1', 'org-2'])
+
+    await handlePersistNotification(
+      makeEvent({ action: Action.submit }, { shouldNotify: false }),
+    )
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const items = lastItems()
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['org-1', 'org-2'])
+    for (const item of items) {
+      expect(item.notificationType).toBe('proposal_submitted')
+      expect(item.title).toBe('New proposal: "My Talk"')
+      expect(item.link).toBe('/admin/proposals/prop-1')
+      expect(item.actorId).toBe('actor-1')
+      expect(item.relatedProposalId).toBe('prop-1')
+      expect(item.conferenceId).toBe('conf-1')
+    }
+  })
+
+  it('fires on submit regardless of shouldNotify (organizer routing is unconditional)', async () => {
+    organizersMock.mockResolvedValue(['org-1'])
+    await handlePersistNotification(
+      makeEvent({ action: Action.submit }, { shouldNotify: false }),
+    )
+    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(lastItems()).toHaveLength(1)
+  })
+})
+
+describe('status change — speakers minus actor, gated by shouldNotify', () => {
+  it('notifies each proposal speaker except the actor on an accepted+shouldNotify event', async () => {
+    await handlePersistNotification(
+      makeEvent({
+        action: Action.accept,
+        newStatus: Status.accepted,
+        speakers: [
+          { _id: 'sp-1' },
+          { _id: 'actor-1' },
+          { _id: 'sp-2' },
+        ] as unknown as ProposalStatusChangeEvent['speakers'],
+      }),
+    )
+
+    expect(organizersMock).not.toHaveBeenCalled()
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const items = lastItems()
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['sp-1', 'sp-2'])
+    for (const item of items) {
+      expect(item.notificationType).toBe('proposal_status_changed')
+      expect(item.title).toContain('accepted')
+      expect(item.link).toBe('/cfp/proposal/prop-1')
+    }
+  })
+
+  it('carries metadata.comment as the message when present', async () => {
+    await handlePersistNotification(
+      makeEvent(
+        {
+          action: Action.reject,
+          newStatus: Status.rejected,
+          speakers: [
+            { _id: 'sp-1' },
+          ] as unknown as ProposalStatusChangeEvent['speakers'],
+        },
+        { comment: 'Not a fit this year' },
+      ),
+    )
+    expect(lastItems()[0].message).toBe('Not a fit this year')
+  })
+
+  it('does NOT notify when shouldNotify is false', async () => {
+    await handlePersistNotification(
+      makeEvent(
+        {
+          action: Action.accept,
+          speakers: [
+            { _id: 'sp-1' },
+          ] as unknown as ProposalStatusChangeEvent['speakers'],
+        },
+        { shouldNotify: false },
+      ),
+    )
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT notify for a non-speaker-facing action even with shouldNotify', async () => {
+    // `withdraw` is not in the speaker-notify action set (mirrors email gating).
+    await handlePersistNotification(
+      makeEvent({
+        action: Action.withdraw,
+        newStatus: Status.withdrawn,
+        speakers: [
+          { _id: 'sp-1' },
+        ] as unknown as ProposalStatusChangeEvent['speakers'],
+      }),
+    )
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -1,0 +1,315 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the notification hub data layer (src/lib/notification/sanity.ts).
+ *
+ * These cover the behaviours the router test cannot (it mocks this module):
+ * - the single-transaction fan-out and the never-throw contract of
+ *   `createNotifications`;
+ * - the SECURITY guard in `markNotificationsRead` (a client must not be able to
+ *   mark another user's notifications read — only recipient-owned ids are
+ *   patched);
+ * - the unread-count query shape and the keyset-cursor argument passing.
+ *
+ * Both Sanity clients are mocked so we assert exactly what is (and is not)
+ * written / queried.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/lib/sanity/helpers', () => ({
+  createReference: (id: string) => ({ _type: 'reference', _ref: id }),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    transaction: vi.fn(),
+  },
+  clientReadUncached: {
+    fetch: vi.fn(),
+  },
+}))
+
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import {
+  createNotifications,
+  getNotificationsForSpeaker,
+  getUnreadCount,
+  markNotificationsRead,
+  markAllRead,
+} from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const writeMock = clientWrite as unknown as { transaction: LooseMock }
+const readMock = clientReadUncached as unknown as { fetch: LooseMock }
+
+/**
+ * A chainable Sanity transaction mock. `create` and `patch` return the same
+ * object; `commit` is configurable per test.
+ */
+function installTransaction(commit: () => Promise<unknown> = async () => ({})) {
+  const tx = {
+    create: vi.fn((_doc?: unknown) => tx),
+    patch: vi.fn((_id?: string, _ops?: unknown) => tx),
+    commit: vi.fn(commit),
+  }
+  writeMock.transaction.mockReturnValue(tx)
+  return tx
+}
+
+const input = (
+  overrides: Partial<NotificationInput> = {},
+): NotificationInput => ({
+  recipientId: 'sp-1',
+  conferenceId: 'conf-1',
+  notificationType: 'proposal_submitted',
+  title: 'New proposal: "Test"',
+  ...overrides,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createNotifications — single-transaction fan-out', () => {
+  it('writes one create per item in exactly one committed transaction', async () => {
+    const tx = installTransaction()
+
+    await createNotifications([
+      input({ recipientId: 'sp-1' }),
+      input({ recipientId: 'sp-2' }),
+      input({ recipientId: 'sp-3' }),
+    ])
+
+    expect(writeMock.transaction).toHaveBeenCalledTimes(1)
+    expect(tx.create).toHaveBeenCalledTimes(3)
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+
+    const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc._type).toBe('notification')
+    expect(doc.recipient).toEqual({ _type: 'reference', _ref: 'sp-1' })
+    expect(doc.conference).toEqual({ _type: 'reference', _ref: 'conf-1' })
+    expect(typeof doc.createdAt).toBe('string')
+  })
+
+  it('is a no-op (no transaction) for an empty list', async () => {
+    const tx = installTransaction()
+    await createNotifications([])
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+    expect(tx.commit).not.toHaveBeenCalled()
+  })
+
+  it('sets optional actor and a WEAK relatedProposal reference only when provided', async () => {
+    const tx = installTransaction()
+
+    await createNotifications([
+      input({
+        actorId: 'actor-1',
+        relatedProposalId: 'prop-1',
+        message: 'hi',
+        link: '/admin/proposals/prop-1',
+      }),
+    ])
+
+    const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.actor).toEqual({ _type: 'reference', _ref: 'actor-1' })
+    expect(doc.relatedProposal).toEqual({
+      _type: 'reference',
+      _ref: 'prop-1',
+      _weak: true,
+    })
+    expect(doc.message).toBe('hi')
+    expect(doc.link).toBe('/admin/proposals/prop-1')
+  })
+
+  it('omits optional fields when not provided', async () => {
+    const tx = installTransaction()
+    await createNotifications([input()])
+    const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
+    expect('actor' in doc).toBe(false)
+    expect('relatedProposal' in doc).toBe(false)
+    expect('message' in doc).toBe(false)
+    expect('link' in doc).toBe(false)
+  })
+
+  it('NEVER throws when the transaction commit fails — it swallows and logs', async () => {
+    installTransaction(async () => {
+      throw new Error('sanity down')
+    })
+
+    await expect(createNotifications([input()])).resolves.toBeUndefined()
+    expect(console.error).toHaveBeenCalled()
+  })
+})
+
+describe('markNotificationsRead — recipient security guard', () => {
+  it('patches ONLY recipient-owned ids (drops a foreign id) and returns the owned count', async () => {
+    // The client asked to mark two ids read; the ownership fetch confirms only
+    // one belongs to this speaker. The foreign id must never be patched.
+    readMock.fetch.mockResolvedValue(['own-1'])
+    const tx = installTransaction()
+
+    const count = await markNotificationsRead({
+      speakerId: 'sp-1',
+      ids: ['own-1', 'foreign-1'],
+    })
+
+    // The ownership query is scoped by recipient._ref == $speakerId.
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('recipient._ref == $speakerId')
+    expect(query).toContain('_id in $ids')
+    expect(params).toEqual({ ids: ['own-1', 'foreign-1'], speakerId: 'sp-1' })
+
+    // Only the verified-own id is patched.
+    expect(tx.patch).toHaveBeenCalledTimes(1)
+    expect(tx.patch).toHaveBeenCalledWith('own-1', {
+      set: { readAt: expect.any(String) },
+    })
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+    expect(count).toBe(1)
+  })
+
+  it('returns 0 and does not fetch or write for an empty id list', async () => {
+    const tx = installTransaction()
+    const count = await markNotificationsRead({ speakerId: 'sp-1', ids: [] })
+    expect(count).toBe(0)
+    expect(readMock.fetch).not.toHaveBeenCalled()
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+    expect(tx.commit).not.toHaveBeenCalled()
+  })
+
+  it('returns 0 and writes nothing when none of the ids are owned', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+
+    const count = await markNotificationsRead({
+      speakerId: 'sp-1',
+      ids: ['foreign-1', 'foreign-2'],
+    })
+
+    expect(count).toBe(0)
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+    expect(tx.patch).not.toHaveBeenCalled()
+  })
+})
+
+describe('markAllRead', () => {
+  it('fetches bounded unread ids for the (speaker, conference) and patches each in one transaction', async () => {
+    readMock.fetch.mockResolvedValue(['n-1', 'n-2'])
+    const tx = installTransaction()
+
+    const count = await markAllRead({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+    })
+
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('recipient._ref == $speakerId')
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(query).toContain('!defined(readAt)')
+    expect(query).toContain('[0...500]')
+    expect(params).toEqual({ speakerId: 'sp-1', conferenceId: 'conf-1' })
+
+    expect(tx.patch).toHaveBeenCalledTimes(2)
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+    expect(count).toBe(2)
+  })
+
+  it('returns 0 and writes nothing when there are no unread notifications', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+    const count = await markAllRead({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+    })
+    expect(count).toBe(0)
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+    expect(tx.commit).not.toHaveBeenCalled()
+  })
+})
+
+describe('getUnreadCount', () => {
+  it('runs a scoped count() query over undefined-readAt docs and returns the number', async () => {
+    readMock.fetch.mockResolvedValue(4)
+
+    const count = await getUnreadCount({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+    })
+
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('count(')
+    expect(query).toContain('recipient._ref == $speakerId')
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(query).toContain('!defined(readAt)')
+    expect(params).toEqual({ speakerId: 'sp-1', conferenceId: 'conf-1' })
+    expect(count).toBe(4)
+  })
+
+  it('coalesces a null count to 0', async () => {
+    readMock.fetch.mockResolvedValue(null)
+    const count = await getUnreadCount({ speakerId: 'sp-1', conferenceId: 'c' })
+    expect(count).toBe(0)
+  })
+})
+
+describe('getNotificationsForSpeaker — cursor pagination', () => {
+  it('omits the cursor clause and passes no `before` param when none is given', async () => {
+    readMock.fetch.mockResolvedValue([])
+
+    await getNotificationsForSpeaker({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+    })
+
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('order(createdAt desc)')
+    expect(query).not.toContain('createdAt < $before')
+    expect(params).toEqual({ speakerId: 'sp-1', conferenceId: 'conf-1' })
+  })
+
+  it('adds the `createdAt < $before` clause and threads the cursor when `before` is given', async () => {
+    readMock.fetch.mockResolvedValue([])
+
+    await getNotificationsForSpeaker({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+      before: '2026-07-01T00:00:00.000Z',
+      limit: 5,
+    })
+
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('createdAt < $before')
+    expect(query).toContain('[0...5]')
+    expect(params).toEqual({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+      before: '2026-07-01T00:00:00.000Z',
+    })
+  })
+
+  it('clamps an out-of-range limit into the slice bound', async () => {
+    readMock.fetch.mockResolvedValue([])
+    await getNotificationsForSpeaker({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+      limit: 9999,
+    })
+    const [query] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('[0...50]')
+  })
+
+  it('coalesces a null result to an empty array', async () => {
+    readMock.fetch.mockResolvedValue(null)
+    const result = await getNotificationsForSpeaker({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+    })
+    expect(result).toEqual([])
+  })
+})

--- a/__tests__/server/schemas/notification.test.ts
+++ b/__tests__/server/schemas/notification.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the notification router input schemas
+ * (src/server/schemas/notification.ts) — the first gate a client payload passes.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  ListNotificationsSchema,
+  MarkReadSchema,
+} from '@/server/schemas/notification'
+
+describe('ListNotificationsSchema', () => {
+  it('defaults limit to 20 when omitted', () => {
+    const result = ListNotificationsSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.limit).toBe(20)
+    }
+  })
+
+  it('accepts limits within 1..50 and a valid ISO datetime cursor', () => {
+    expect(
+      ListNotificationsSchema.safeParse({
+        limit: 50,
+        before: '2026-07-01T00:00:00.000Z',
+      }).success,
+    ).toBe(true)
+    expect(ListNotificationsSchema.safeParse({ limit: 1 }).success).toBe(true)
+  })
+
+  it('rejects a limit above 50, below 1, or non-integer', () => {
+    expect(ListNotificationsSchema.safeParse({ limit: 51 }).success).toBe(false)
+    expect(ListNotificationsSchema.safeParse({ limit: 0 }).success).toBe(false)
+    expect(ListNotificationsSchema.safeParse({ limit: 2.5 }).success).toBe(
+      false,
+    )
+  })
+
+  it('rejects a non-datetime cursor', () => {
+    expect(
+      ListNotificationsSchema.safeParse({ before: 'not-a-date' }).success,
+    ).toBe(false)
+  })
+})
+
+describe('MarkReadSchema', () => {
+  it('accepts 1..100 ids', () => {
+    expect(MarkReadSchema.safeParse({ ids: ['a'] }).success).toBe(true)
+    expect(
+      MarkReadSchema.safeParse({
+        ids: Array.from({ length: 100 }, (_, i) => `id-${i}`),
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects an empty id list', () => {
+    expect(MarkReadSchema.safeParse({ ids: [] }).success).toBe(false)
+  })
+
+  it('rejects more than 100 ids', () => {
+    expect(
+      MarkReadSchema.safeParse({
+        ids: Array.from({ length: 101 }, (_, i) => `id-${i}`),
+      }).success,
+    ).toBe(false)
+  })
+})

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -8,6 +8,7 @@ import coSpeakerInvitation from './schemaTypes/coSpeakerInvitation'
 import dashboardConfig from './schemaTypes/dashboardConfig'
 import dataProcessingConsent from './schemaTypes/dataProcessingConsent'
 import imageGallery from './schemaTypes/imageGallery'
+import notification from './schemaTypes/notification'
 import review from './schemaTypes/review'
 import schedule from './schemaTypes/schedule'
 import speaker from './schemaTypes/speaker'
@@ -40,6 +41,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     imageGallery,
     volunteer,
     staff,
+    notification,
 
     // Topics & Talks
     talk,

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -1,0 +1,131 @@
+import { defineField, defineType } from 'sanity'
+
+/**
+ * A single persisted in-app notification for one recipient. Notifications are
+ * fanned out per-recipient (one document each) rather than shared, so read state
+ * (`readAt`) is naturally per-user and queries stay a simple recipient filter.
+ *
+ * NOTE: distinct from the ephemeral toast system (`NotificationProvider` /
+ * `NotificationToast`). This is the durable notification hub.
+ */
+export default defineType({
+  name: 'notification',
+  title: 'Notification',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'recipient',
+      title: 'Recipient',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      description: 'The speaker who receives this notification.',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'conference',
+      title: 'Conference',
+      type: 'reference',
+      to: [{ type: 'conference' }],
+      description: 'The conference edition this notification belongs to.',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'notificationType',
+      title: 'Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Proposal Submitted', value: 'proposal_submitted' },
+          {
+            title: 'Proposal Status Changed',
+            value: 'proposal_status_changed',
+          },
+          { title: 'Proposal Comment', value: 'proposal_comment' },
+          { title: 'Travel Support Update', value: 'travel_support_update' },
+          { title: 'Sponsor Activity', value: 'sponsor_activity' },
+          { title: 'Schedule Update', value: 'schedule_update' },
+          { title: 'System', value: 'system' },
+        ],
+        layout: 'dropdown',
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required().max(200),
+    }),
+    defineField({
+      name: 'message',
+      title: 'Message',
+      type: 'text',
+      rows: 3,
+    }),
+    defineField({
+      name: 'link',
+      title: 'Link',
+      type: 'string',
+      description:
+        'App-relative deep link, e.g. /cfp/proposal/<id> or /admin/proposals/<id>.',
+    }),
+    defineField({
+      name: 'actor',
+      title: 'Actor',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      description:
+        'The speaker whose action triggered this notification. Omitted for system-generated notifications.',
+    }),
+    defineField({
+      name: 'relatedProposal',
+      title: 'Related Proposal',
+      type: 'reference',
+      to: [{ type: 'talk' }],
+      // Weak so deleting the proposal does not orphan-block or fail the delete;
+      // the notification simply ends up with a dangling reference.
+      weak: true,
+    }),
+    defineField({
+      name: 'readAt',
+      title: 'Read At',
+      type: 'datetime',
+      description: 'When the recipient read this notification. Unset = unread.',
+    }),
+    defineField({
+      name: 'createdAt',
+      title: 'Created At',
+      type: 'datetime',
+      validation: (Rule) => Rule.required(),
+      initialValue: () => new Date().toISOString(),
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      recipient: 'recipient.name',
+      createdAt: 'createdAt',
+    },
+    prepare({ title, recipient, createdAt }) {
+      const when = createdAt
+        ? new Date(createdAt).toLocaleDateString()
+        : 'Unknown date'
+      return {
+        title: title || 'Notification',
+        subtitle: `To ${recipient || 'Unknown'} on ${when}`,
+      }
+    },
+  },
+  orderings: [
+    {
+      title: 'Created Date (Newest first)',
+      name: 'createdAtDesc',
+      by: [{ field: 'createdAt', direction: 'desc' }],
+    },
+    {
+      title: 'Created Date (Oldest first)',
+      name: 'createdAtAsc',
+      by: [{ field: 'createdAt', direction: 'asc' }],
+    },
+  ],
+})

--- a/src/lib/events/handlers/persistNotification.ts
+++ b/src/lib/events/handlers/persistNotification.ts
@@ -1,0 +1,85 @@
+import { ProposalStatusChangeEvent } from '@/lib/events/types'
+import { Action } from '@/lib/proposal/types'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
+
+/**
+ * The set of actions that produce a speaker-facing status notification. Mirrors
+ * the gating in `handleEmailNotification` (accept / reject / waitlist / remind)
+ * so the in-app notification and the email stay in lockstep — a speaker is
+ * notified in-app exactly when they'd be emailed about a status change.
+ */
+const SPEAKER_NOTIFY_ACTIONS: readonly Action[] = [
+  Action.accept,
+  Action.reject,
+  Action.waitlist,
+  Action.remind,
+]
+
+/**
+ * Persists in-app notifications when a proposal's status changes.
+ *
+ * - `submit`: notify every organizer (except the actor) that a new proposal
+ *   arrived.
+ * - status change (mirroring the email handler's gating): notify each speaker
+ *   on the proposal (except the actor) of the new status.
+ *
+ * All fan-out goes through `createNotifications`, which never throws — a failed
+ * notification write must not fail the proposal mutation.
+ */
+export async function handlePersistNotification(
+  event: ProposalStatusChangeEvent,
+): Promise<void> {
+  const actorId = event.metadata.triggeredBy?.speakerId
+  const conferenceId = event.conference._id
+  const proposalId = event.proposal._id
+  const proposalTitle = event.proposal.title
+
+  if (event.action === Action.submit) {
+    const organizerIds = await getOrganizerSpeakerIds()
+    const items: NotificationInput[] = organizerIds
+      .filter((id) => id && id !== actorId)
+      .map((id): NotificationInput => ({
+        recipientId: id,
+        conferenceId,
+        notificationType: 'proposal_submitted',
+        title: `New proposal: "${proposalTitle}"`,
+        actorId,
+        relatedProposalId: proposalId,
+        link: `/admin/proposals/${proposalId}`,
+      }))
+    await createNotifications(items)
+    return
+  }
+
+  if (
+    event.metadata.shouldNotify &&
+    SPEAKER_NOTIFY_ACTIONS.includes(event.action)
+  ) {
+    // De-duplicate by speaker id in case a proposal carries a duplicated
+    // speaker, and skip the actor (they triggered the change themselves).
+    const seen = new Set<string>()
+    const items: NotificationInput[] = []
+    for (const speaker of event.speakers || []) {
+      const id = speaker?._id
+      if (!id || id === actorId || seen.has(id)) {
+        continue
+      }
+      seen.add(id)
+      items.push({
+        recipientId: id,
+        conferenceId,
+        notificationType: 'proposal_status_changed',
+        title: `Your proposal "${proposalTitle}" is now ${event.newStatus}`,
+        message: event.metadata.comment || undefined,
+        actorId,
+        relatedProposalId: proposalId,
+        link: `/cfp/proposal/${proposalId}`,
+      })
+    }
+    await createNotifications(items)
+  }
+}

--- a/src/lib/events/registry.ts
+++ b/src/lib/events/registry.ts
@@ -3,6 +3,7 @@ import { handleEmailNotification } from './handlers/emailNotification'
 import { handleSlackNotification } from './handlers/slackNotification'
 import { handleAudienceUpdate } from './handlers/audienceUpdate'
 import { handleGalleryTagNotification } from './handlers/galleryTagNotification'
+import { handlePersistNotification } from './handlers/persistNotification'
 
 let registered = false
 
@@ -13,6 +14,7 @@ export function registerEventHandlers(): void {
   eventBus.subscribe('proposal.status.changed', handleEmailNotification)
   eventBus.subscribe('proposal.status.changed', handleSlackNotification)
   eventBus.subscribe('proposal.status.changed', handleAudienceUpdate)
+  eventBus.subscribe('proposal.status.changed', handlePersistNotification)
 
   // Register gallery speaker tagged handler
   eventBus.subscribe('gallery.speaker.tagged', handleGalleryTagNotification)

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -1,0 +1,221 @@
+/**
+ * Server-only data layer for the persistent notification hub.
+ *
+ * Design:
+ * - Notifications are fanned out PER RECIPIENT (one document each), so read
+ *   state is per-user and reads are a simple recipient filter.
+ * - A fan-out writes all recipients in ONE transaction.
+ * - `createNotifications` NEVER throws into the caller: a failed notification
+ *   must not fail the business mutation that produced it (see its doc).
+ * - Inbox reads use `clientReadUncached`: for a notification inbox, freshness
+ *   (read-your-writes after marking read / a new notification) matters more
+ *   than CDN caching.
+ */
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { createReference } from '@/lib/sanity/helpers'
+import type { NotificationInput, NotificationItem } from './types'
+
+/**
+ * Persist one `notification` document per input, all in a SINGLE
+ * `clientWrite.transaction()`.
+ *
+ * CONTRACT: this function NEVER throws into the caller's flow. A failure to
+ * persist notifications is caught and logged (`console.error`) — a broken
+ * notification write must not roll back or fail the business mutation that
+ * triggered it (a submitted proposal is still submitted even if the organizer
+ * notification write fails). Callers therefore do not (and must not) wrap this
+ * in a try/catch expecting to react to failures.
+ */
+export async function createNotifications(
+  items: NotificationInput[],
+): Promise<void> {
+  if (items.length === 0) {
+    return
+  }
+
+  try {
+    const createdAt = new Date().toISOString()
+    const tx = clientWrite.transaction()
+
+    for (const item of items) {
+      const doc: { _type: string; [key: string]: unknown } = {
+        _type: 'notification',
+        recipient: createReference(item.recipientId),
+        conference: createReference(item.conferenceId),
+        notificationType: item.notificationType,
+        title: item.title,
+        createdAt,
+      }
+      if (item.message) {
+        doc.message = item.message
+      }
+      if (item.link) {
+        doc.link = item.link
+      }
+      if (item.actorId) {
+        doc.actor = createReference(item.actorId)
+      }
+      if (item.relatedProposalId) {
+        // Weak reference so a later proposal deletion doesn't orphan-block.
+        doc.relatedProposal = {
+          ...createReference(item.relatedProposalId),
+          _weak: true,
+        }
+      }
+      tx.create(doc)
+    }
+
+    await tx.commit()
+  } catch (error) {
+    // Never propagate — see the contract above.
+    console.error('Failed to create notifications:', error)
+  }
+}
+
+/**
+ * A recipient's notifications for a conference, newest first. Supports keyset
+ * pagination via `before` (a `createdAt` cursor): pass the `createdAt` of the
+ * last item on the previous page to fetch the next page.
+ */
+export async function getNotificationsForSpeaker({
+  speakerId,
+  conferenceId,
+  limit = 20,
+  before,
+}: {
+  speakerId: string
+  conferenceId: string
+  limit?: number
+  before?: string
+}): Promise<NotificationItem[]> {
+  // `limit` is inlined into the GROQ slice (slice bounds must be literals), so
+  // clamp it to a safe integer range — it never reaches the query as free text.
+  const safeLimit = Math.min(Math.max(1, Math.floor(limit) || 20), 50)
+
+  const params: Record<string, unknown> = { speakerId, conferenceId }
+  let cursor = ''
+  if (before) {
+    cursor = ' && createdAt < $before'
+    params.before = before
+  }
+
+  const query = `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId${cursor}] | order(createdAt desc) [0...${safeLimit}] {
+    "id": _id,
+    "type": notificationType,
+    title,
+    message,
+    link,
+    readAt,
+    createdAt,
+    actor->{
+      _id,
+      name,
+      "image": coalesce(image.asset->url, imageURL)
+    }
+  }`
+
+  const results = await clientReadUncached.fetch<NotificationItem[]>(
+    query,
+    params,
+  )
+  return results || []
+}
+
+/** Count of unread notifications (no `readAt`) for a recipient in a conference. */
+export async function getUnreadCount({
+  speakerId,
+  conferenceId,
+}: {
+  speakerId: string
+  conferenceId: string
+}): Promise<number> {
+  const count = await clientReadUncached.fetch<number>(
+    `count(*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && !defined(readAt)])`,
+    { speakerId, conferenceId },
+  )
+  return count || 0
+}
+
+/**
+ * Mark the given notification ids as read for `speakerId`, returning how many
+ * were actually patched.
+ *
+ * SECURITY: the ids come from the client, so a caller must not be able to mark
+ * ANOTHER user's notifications read. We first fetch the subset of ids whose
+ * `recipient._ref == speakerId` and patch ONLY that verified set — a foreign id
+ * is silently dropped rather than patched.
+ */
+export async function markNotificationsRead({
+  speakerId,
+  ids,
+}: {
+  speakerId: string
+  ids: string[]
+}): Promise<number> {
+  if (ids.length === 0) {
+    return 0
+  }
+
+  const ownedIds = await clientReadUncached.fetch<string[]>(
+    `*[_type == "notification" && _id in $ids && recipient._ref == $speakerId]._id`,
+    { ids, speakerId },
+  )
+
+  if (!ownedIds || ownedIds.length === 0) {
+    return 0
+  }
+
+  const now = new Date().toISOString()
+  const tx = clientWrite.transaction()
+  for (const id of ownedIds) {
+    tx.patch(id, { set: { readAt: now } })
+  }
+  await tx.commit()
+
+  return ownedIds.length
+}
+
+/** The maximum number of notifications marked read in one `markAllRead` call. */
+const MARK_ALL_READ_LIMIT = 500
+
+/**
+ * Mark all unread notifications for a recipient in a conference as read (bounded
+ * to the first {@link MARK_ALL_READ_LIMIT}), returning how many were patched.
+ */
+export async function markAllRead({
+  speakerId,
+  conferenceId,
+}: {
+  speakerId: string
+  conferenceId: string
+}): Promise<number> {
+  const ids = await clientReadUncached.fetch<string[]>(
+    `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && !defined(readAt)][0...${MARK_ALL_READ_LIMIT}]._id`,
+    { speakerId, conferenceId },
+  )
+
+  if (!ids || ids.length === 0) {
+    return 0
+  }
+
+  const now = new Date().toISOString()
+  const tx = clientWrite.transaction()
+  for (const id of ids) {
+    tx.patch(id, { set: { readAt: now } })
+  }
+  await tx.commit()
+
+  return ids.length
+}
+
+/**
+ * The `_id`s of every organizer speaker. `isOrganizer` is GLOBAL (an organizer
+ * of one edition is an organizer everywhere); the conference scoping happens
+ * implicitly because the created notification carries the conference ref.
+ */
+export async function getOrganizerSpeakerIds(): Promise<string[]> {
+  const ids = await clientReadUncached.fetch<string[]>(
+    `*[_type == "speaker" && isOrganizer == true]._id`,
+  )
+  return ids || []
+}

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -1,0 +1,54 @@
+/**
+ * The persistent in-app notification hub types.
+ *
+ * NOTE: unrelated to the ephemeral toast system (`NotificationProvider` /
+ * `NotificationToast`). This is the durable, per-recipient notification store.
+ */
+
+export type NotificationType =
+  | 'proposal_submitted'
+  | 'proposal_status_changed'
+  | 'proposal_comment'
+  | 'travel_support_update'
+  | 'sponsor_activity'
+  | 'schedule_update'
+  | 'system'
+
+/**
+ * The write-side shape used to fan a notification out to a single recipient.
+ * One of these is produced per recipient; `createNotifications` turns each into
+ * one `notification` document in a single transaction.
+ */
+export interface NotificationInput {
+  recipientId: string
+  conferenceId: string
+  notificationType: NotificationType
+  title: string
+  message?: string
+  /** App-relative deep link, e.g. /cfp/proposal/<id> or /admin/proposals/<id>. */
+  link?: string
+  /** Speaker whose action triggered this. Omitted for system notifications. */
+  actorId?: string
+  /** Weakly referenced proposal (talk) id, if the notification relates to one. */
+  relatedProposalId?: string
+}
+
+/** The actor sub-object projected for the client. */
+export interface NotificationActor {
+  _id: string
+  name: string
+  image?: string
+}
+
+/** The read-side shape returned to the client (from `getNotificationsForSpeaker`). */
+export interface NotificationItem {
+  id: string
+  type: NotificationType
+  title: string
+  message?: string
+  link?: string
+  /** ISO datetime; unset/null means unread. */
+  readAt?: string | null
+  createdAt: string
+  actor?: NotificationActor | null
+}

--- a/src/server/_app.ts
+++ b/src/server/_app.ts
@@ -14,6 +14,7 @@ import { signingRouter } from './routers/signing'
 import { scheduleRouter } from './routers/schedule'
 import { statusRouter } from './routers/status'
 import { agentsRouter } from './routers/agents'
+import { notificationRouter } from './routers/notification'
 
 export const appRouter = router({
   badge: badgeRouter,
@@ -31,6 +32,7 @@ export const appRouter = router({
   schedule: scheduleRouter,
   status: statusRouter,
   agents: agentsRouter,
+  notification: notificationRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/server/routers/notification.ts
+++ b/src/server/routers/notification.ts
@@ -1,0 +1,55 @@
+import { router, protectedProcedure, resolveConferenceId } from '@/server/trpc'
+import {
+  ListNotificationsSchema,
+  MarkReadSchema,
+} from '@/server/schemas/notification'
+import {
+  getNotificationsForSpeaker,
+  getUnreadCount,
+  markNotificationsRead,
+  markAllRead,
+} from '@/lib/notification/sanity'
+
+/**
+ * The persistent notification hub. Delivery is via polling (`list` /
+ * `unreadCount`); the shape is kept SSE-friendly for a later phase. Recipient
+ * identity is always `ctx.speaker._id` and the conference is resolved from the
+ * current domain — a client can never read or mutate another user's inbox.
+ */
+export const notificationRouter = router({
+  list: protectedProcedure
+    .input(ListNotificationsSchema)
+    .query(async ({ ctx, input }) => {
+      const conferenceId = await resolveConferenceId()
+      return getNotificationsForSpeaker({
+        speakerId: ctx.speaker._id,
+        conferenceId,
+        limit: input.limit,
+        before: input.before,
+      })
+    }),
+
+  unreadCount: protectedProcedure.query(async ({ ctx }) => {
+    const conferenceId = await resolveConferenceId()
+    return getUnreadCount({ speakerId: ctx.speaker._id, conferenceId })
+  }),
+
+  markRead: protectedProcedure
+    .input(MarkReadSchema)
+    .mutation(async ({ ctx, input }) => {
+      const count = await markNotificationsRead({
+        speakerId: ctx.speaker._id,
+        ids: input.ids,
+      })
+      return { count }
+    }),
+
+  markAllRead: protectedProcedure.mutation(async ({ ctx }) => {
+    const conferenceId = await resolveConferenceId()
+    const count = await markAllRead({
+      speakerId: ctx.speaker._id,
+      conferenceId,
+    })
+    return { count }
+  }),
+})

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -324,12 +324,16 @@ export const proposalRouter = router({
         // Slack/email handlers and change existing create behaviour (out of
         // scope for the notification hub).
         if (initialStatus === Status.submitted) {
-          const organizerIds = await getOrganizerSpeakerIds()
-          await createNotifications(
-            organizerIds
-              .filter((id) => id && id !== ctx.speaker._id)
-              .map(
-                (id): NotificationInput => ({
+          // The whole notify block shares createNotifications' never-fail
+          // contract: the proposal is already created at this point, so a
+          // failure here (e.g. the organizer-id fetch) must not surface as a
+          // create error to the submitting speaker.
+          try {
+            const organizerIds = await getOrganizerSpeakerIds()
+            await createNotifications(
+              organizerIds
+                .filter((id) => id && id !== ctx.speaker._id)
+                .map((id): NotificationInput => ({
                   recipientId: id,
                   conferenceId: conference._id,
                   notificationType: 'proposal_submitted',
@@ -337,9 +341,14 @@ export const proposalRouter = router({
                   actorId: ctx.speaker._id,
                   relatedProposalId: proposal._id,
                   link: `/admin/proposals/${proposal._id}`,
-                }),
-              ),
-          )
+                })),
+            )
+          } catch (notifyError) {
+            console.error(
+              'Failed to notify organizers of new proposal:',
+              notifyError,
+            )
+          }
         }
 
         return proposal

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -48,6 +48,11 @@ import {
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { clientWrite } from '@/lib/sanity/client'
 import { createReference, createReferenceWithKey } from '@/lib/sanity/helpers'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
 import type { ProposalInput, ProposalExisting } from '@/lib/proposal/types'
 import { Action, Status, isInactiveProposal } from '@/lib/proposal/types'
 import { actionStateMachine } from '@/lib/proposal'
@@ -309,6 +314,32 @@ export const proposalRouter = router({
             message: 'Failed to create proposal',
             cause: err,
           })
+        }
+
+        // Notify organizers of a genuinely NEW submission (not a saved draft).
+        // INTENTIONAL ASYMMETRY: this create path does not publish a
+        // `proposal.status.changed` bus event, so the `persistNotification`
+        // bus handler never fires here — we fan out directly instead. We do
+        // NOT publish a bus event on purpose: that would also trigger the
+        // Slack/email handlers and change existing create behaviour (out of
+        // scope for the notification hub).
+        if (initialStatus === Status.submitted) {
+          const organizerIds = await getOrganizerSpeakerIds()
+          await createNotifications(
+            organizerIds
+              .filter((id) => id && id !== ctx.speaker._id)
+              .map(
+                (id): NotificationInput => ({
+                  recipientId: id,
+                  conferenceId: conference._id,
+                  notificationType: 'proposal_submitted',
+                  title: `New proposal: "${proposal.title}"`,
+                  actorId: ctx.speaker._id,
+                  relatedProposalId: proposal._id,
+                  link: `/admin/proposals/${proposal._id}`,
+                }),
+              ),
+          )
         }
 
         return proposal

--- a/src/server/schemas/notification.ts
+++ b/src/server/schemas/notification.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+/**
+ * Input for `notification.list`. `before` is a `createdAt` keyset cursor: the
+ * `createdAt` of the last item on the previous page. `limit` is bounded so a
+ * client can't request an unbounded page.
+ */
+export const ListNotificationsSchema = z.object({
+  limit: z.number().int().min(1).max(50).default(20),
+  before: z.string().datetime().optional(),
+})
+
+/**
+ * Input for `notification.markRead`. Bounded at 100 ids per call; the data layer
+ * additionally verifies each id belongs to the caller before patching.
+ */
+export const MarkReadSchema = z.object({
+  ids: z.array(z.string()).min(1).max(100),
+})


### PR DESCRIPTION
## Phase N1 — Notification hub backend

Backend foundation for a stateful in-app notification hub for organizers + speakers. **No UI in this phase.** Storage is Sanity documents; delivery is tRPC polling (the read shape is kept SSE-friendly for a later phase).

Distinct from the existing ephemeral toast system (`NotificationProvider` / `NotificationToast`) — this is the durable hub under `notification` (schema/router/lib). Those are untouched.

### What's here

**Sanity schema** — `sanity/schemaTypes/notification.ts` (registered in `sanity/schema.ts`): `recipient`→speaker, `conference`→conference, `notificationType`, `title`, `message`, `link`, `actor`→speaker, `relatedProposal`→talk (**weak** so proposal deletion doesn't orphan-block), `readAt` (unset = unread), `createdAt`. Orderings + preview (title → recipient), modeled on `sponsorActivity`.

**Data layer** — `src/lib/notification/sanity.ts` (+ `types.ts`):
- **Per-recipient docs, single-transaction fan-out**: `createNotifications` writes one `create` per recipient in ONE `clientWrite.transaction()`.
- **Never-fail contract**: `createNotifications` catches + `console.error`s — a failed notification write must never fail the business mutation that triggered it. Callers do not wrap it.
- `getNotificationsForSpeaker` (keyset cursor via `before`), `getUnreadCount`, `markNotificationsRead`, `markAllRead` (bounded 500) — inbox reads use `clientReadUncached` (freshness > CDN cache).
- **Security guard on markRead**: client-supplied ids are first filtered to those whose `recipient._ref == speakerId`; only the verified-own subset is patched, so a client can't mark another user's notifications read.

**tRPC router** — `src/server/routers/notification.ts` (registered in `_app.ts`), zod in `src/server/schemas/notification.ts`: `list`, `unreadCount`, `markRead` (max 100 ids), `markAllRead`. All `protectedProcedure`, always scoped to `ctx.speaker._id` + `resolveConferenceId()`.

**Emitters**:
- Bus handler `src/lib/events/handlers/persistNotification.ts` (subscribed to `proposal.status.changed` in `registry.ts`): on **submit** → notify all organizers except the actor; on speaker-facing status changes (gated on `metadata.shouldNotify` + the same action set as the email handler: accept/reject/waitlist/remind) → notify each proposal speaker except the actor.
- **Create-path asymmetry**: `proposalRouter.create` bypasses the bus, so it calls `createNotifications` directly for the organizer audience when a proposal is created already-submitted (not draft). It deliberately does **not** publish a bus event there — doing so would also fire the Slack/email handlers and change existing create behavior (out of scope). A comment marks the intentional asymmetry.

### Tests
`__tests__/lib/notification/sanity.test.ts`, `__tests__/lib/events/persistNotification.test.ts`, `__tests__/server/schemas/notification.test.ts` — 29 new tests, all green. Cover the single-transaction fan-out, the never-throw contract, the markRead security guard, query shapes, cursor pagination, emitter audience selection (organizers/speakers minus actor, shouldNotify gating), and zod bounds.

### Verification
- `tsc --noEmit`: 0 errors
- `eslint` on touched dirs: clean
- `prettier`: formatted
- `vitest run __tests__/`: 2294 passed, 0 actual test failures (the 24 failed files are the pre-existing `@digitalbazaar/vc` module-load failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a durable per-recipient notification hub (Sanity schema, data layer, tRPC router, and bus emitter) as a backend-only foundation. The implementation is well-structured: multi-tenant isolation is enforced via server-side `resolveConferenceId()`, the `markRead` ownership guard prevents cross-user writes, and the single-transaction fan-out keeps Sanity writes atomic.

- **Sanity schema + data layer** (`notification.ts`, `src/lib/notification/sanity.ts`): per-recipient documents with weak proposal reference, keyset-cursor pagination, and a never-throw `createNotifications` contract.
- **tRPC router** (`src/server/routers/notification.ts`): four `protectedProcedure` endpoints (list, unreadCount, markRead, markAllRead) always scoped to `ctx.speaker._id` and a server-resolved conference.
- **Bus handler + direct fan-out** (`persistNotification.ts`, `proposal.ts`): submit events notify organizers; speaker-facing status changes (accept/reject/waitlist/remind) mirror the existing email handler's gating. The intentional asymmetry on the create path is documented.

<h3>Confidence Score: 3/5</h3>

The notification hub itself is safe to ship, but the direct fan-out in `proposal.ts` has an unguarded async call that can make a successful proposal creation appear to fail to the submitter.

The `proposal.create` mutation calls `getOrganizerSpeakerIds()` inside the outer try/catch after the proposal is already committed to Sanity. Because `getOrganizerSpeakerIds` has no never-throw contract, a transient Sanity API error during that fetch surfaces as an `INTERNAL_SERVER_ERROR` to the user — the proposal exists in the database but the client sees a failure. The missing privacy page update is a stated policy requirement from AGENTS.md that should also be addressed.

src/server/routers/proposal.ts (notification block needs its own try/catch) and the absence of a privacy page update for the new notification data collection.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/routers/proposal.ts | Adds direct notification fan-out on proposal creation; `getOrganizerSpeakerIds()` can throw inside the outer try/catch, causing a false failure response after the proposal is already saved. |
| src/lib/notification/sanity.ts | New data layer: single-transaction fan-out, recipient ownership guard on markRead, keyset cursor pagination — well-designed; uncached organizer lookup on every submit event is worth revisiting. |
| src/server/routers/notification.ts | tRPC router with four protected procedures; conference ID always resolved server-side, recipient identity always from ctx — multi-tenant isolation satisfied. |
| sanity/schemaTypes/notification.ts | New Sanity document type storing per-recipient notification data; stores personal data (recipient, actor, proposal ref) without a corresponding privacy page update. |
| src/lib/events/handlers/persistNotification.ts | Bus handler for proposal status changes; correctly mirrors email handler gating, deduplicates speakers, filters the actor — logic is sound. |
| src/server/schemas/notification.ts | Zod schemas for list and markRead inputs; bounds correctly enforced (limit 1–50, ids 1–100), datetime cursor validated. |
| src/lib/notification/types.ts | Clean type definitions for NotificationInput (write side) and NotificationItem (read side); NotificationType union matches Sanity schema values. |
| __tests__/lib/notification/sanity.test.ts | Thorough unit tests: single-transaction fan-out, never-throw contract, markRead security guard, cursor pagination, and null coalescing — good coverage. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant PR as proposalRouter.create
    participant EB as EventBus
    participant PN as handlePersistNotification
    participant NL as notification/sanity
    participant SD as Sanity

    C->>PR: "create(proposal, status=submitted)"
    PR->>SD: createProposal() — commit
    SD-->>PR: proposal doc
    PR->>NL: getOrganizerSpeakerIds()
    NL->>SD: fetch organizers (uncached)
    SD-->>NL: [id1, id2, ...]
    PR->>NL: createNotifications([...]) — never throws
    NL->>SD: transaction.create x N then commit
    PR-->>C: proposal

    Note over EB,PN: Status-change path (submit/accept/reject)
    EB->>PN: proposal.status.changed
    PN->>NL: getOrganizerSpeakerIds() [submit only]
    PN->>NL: createNotifications([...]) — never throws
    NL->>SD: transaction.create x N then commit

    C->>PR: notification.list / unreadCount
    PR->>NL: getNotificationsForSpeaker / getUnreadCount
    NL->>SD: clientReadUncached.fetch (keyset cursor)
    SD-->>NL: NotificationItem[]
    NL-->>C: items

    C->>PR: notification.markRead(ids)
    PR->>NL: markNotificationsRead(speakerId, ids)
    NL->>SD: fetch owned ids (recipient guard)
    NL->>SD: transaction.patch x owned then commit
    NL-->>C: count
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant PR as proposalRouter.create
    participant EB as EventBus
    participant PN as handlePersistNotification
    participant NL as notification/sanity
    participant SD as Sanity

    C->>PR: "create(proposal, status=submitted)"
    PR->>SD: createProposal() — commit
    SD-->>PR: proposal doc
    PR->>NL: getOrganizerSpeakerIds()
    NL->>SD: fetch organizers (uncached)
    SD-->>NL: [id1, id2, ...]
    PR->>NL: createNotifications([...]) — never throws
    NL->>SD: transaction.create x N then commit
    PR-->>C: proposal

    Note over EB,PN: Status-change path (submit/accept/reject)
    EB->>PN: proposal.status.changed
    PN->>NL: getOrganizerSpeakerIds() [submit only]
    PN->>NL: createNotifications([...]) — never throws
    NL->>SD: transaction.create x N then commit

    C->>PR: notification.list / unreadCount
    PR->>NL: getNotificationsForSpeaker / getUnreadCount
    NL->>SD: clientReadUncached.fetch (keyset cursor)
    SD-->>NL: NotificationItem[]
    NL-->>C: items

    C->>PR: notification.markRead(ids)
    PR->>NL: markNotificationsRead(speakerId, ids)
    NL->>SD: fetch owned ids (recipient guard)
    NL->>SD: transaction.patch x owned then commit
    NL-->>C: count
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/notification/sanity.ts`, line 1053-1058 ([link](https://github.com/cloudnativebergen/website/blob/54a809edc4dee5ba32a263f40de4a697356064f6/src/lib/notification/sanity.ts#L1053-L1058)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`getOrganizerSpeakerIds` uses uncached client on every proposal-submit event**

   The function unconditionally calls `clientReadUncached.fetch` — bypassing the CDN cache — to read all organizers. This runs once per proposal submission via the bus handler and once via the direct `proposal.ts` path. The organizer list changes infrequently, so hitting the uncached endpoint every time adds unnecessary Sanity API latency on the hot path. Consider caching this query (e.g., with a short TTL or Next.js `'use cache'` wrapper) so that organizer lookups only bypass the cache after a real organizer change.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): failure-isolate the ..."](https://github.com/cloudnativebergen/website/commit/54a809edc4dee5ba32a263f40de4a697356064f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45339460)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->