### PR TITLE
feat(notifications): bell + inbox panel in both shells, unread polling (N2)

### DIFF
--- a/__tests__/components/notifications/NotificationList.test.tsx
+++ b/__tests__/components/notifications/NotificationList.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { NotificationList } from '@/components/notifications/NotificationList'
+import type { NotificationItem } from '@/lib/notification/types'
+
+const baseItems: NotificationItem[] = [
+  {
+    id: '1',
+    type: 'proposal_status_changed',
+    title: 'Accepted',
+    message: 'Your talk was accepted',
+    link: '/cfp/proposal/1',
+    readAt: null,
+    createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+    actor: { _id: 'a', name: 'Committee' },
+  },
+  {
+    id: '2',
+    type: 'system',
+    title: 'Read one',
+    readAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+    createdAt: new Date(Date.now() - 2 * 60 * 60_000).toISOString(),
+    actor: null,
+  },
+]
+
+function renderList(
+  props: Partial<React.ComponentProps<typeof NotificationList>> = {},
+) {
+  return render(
+    <NotificationList
+      items={baseItems}
+      unreadCount={1}
+      onMarkAllRead={vi.fn()}
+      onItemClick={vi.fn()}
+      {...props}
+    />,
+  )
+}
+
+describe('NotificationList', () => {
+  it('renders each item title', () => {
+    renderList()
+    expect(screen.getByText('Accepted')).toBeInTheDocument()
+    expect(screen.getByText('Read one')).toBeInTheDocument()
+  })
+
+  it('renders an unread indicator dot for unread items only', () => {
+    const { container } = renderList()
+    const dots = container.querySelectorAll('.bg-brand-cloud-blue')
+    // One unread item -> exactly one blue dot.
+    expect(dots).toHaveLength(1)
+  })
+
+  it('links notifications that have a link', () => {
+    renderList()
+    const link = screen.getByText('Accepted').closest('a')
+    expect(link).toHaveAttribute('href', '/cfp/proposal/1')
+  })
+
+  it('fires onItemClick when an item is activated', () => {
+    const onItemClick = vi.fn()
+    renderList({ onItemClick })
+    fireEvent.click(screen.getByText('Accepted'))
+    expect(onItemClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: '1' }),
+    )
+  })
+
+  it('enables "Mark all read" when there are unread items', () => {
+    renderList({ unreadCount: 3 })
+    expect(screen.getByRole('button', { name: 'Mark all read' })).toBeEnabled()
+  })
+
+  it('disables "Mark all read" when unreadCount is 0', () => {
+    renderList({ unreadCount: 0 })
+    expect(screen.getByRole('button', { name: 'Mark all read' })).toBeDisabled()
+  })
+
+  it('calls onMarkAllRead when the button is pressed', () => {
+    const onMarkAllRead = vi.fn()
+    renderList({ unreadCount: 2, onMarkAllRead })
+    fireEvent.click(screen.getByRole('button', { name: 'Mark all read' }))
+    expect(onMarkAllRead).toHaveBeenCalledOnce()
+  })
+
+  it('shows the empty state when there are no items', () => {
+    renderList({ items: [], unreadCount: 0 })
+    expect(screen.getByText(/all caught up/i)).toBeInTheDocument()
+  })
+
+  it('shows skeleton rows while loading', () => {
+    const { container } = renderList({ items: [], isLoading: true })
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(
+      0,
+    )
+    expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/lib/notification/format.test.ts
+++ b/__tests__/lib/notification/format.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { formatRelativeTime } from '@/lib/notification/format'
+
+const NOW = new Date('2026-07-09T12:00:00.000Z')
+const at = (ms: number) => new Date(NOW.getTime() - ms).toISOString()
+
+const SEC = 1000
+const MIN = 60 * SEC
+const HOUR = 60 * MIN
+const DAY = 24 * HOUR
+const WEEK = 7 * DAY
+
+describe('formatRelativeTime', () => {
+  it('renders "just now" for sub-minute deltas', () => {
+    expect(formatRelativeTime(at(0), NOW)).toBe('just now')
+    expect(formatRelativeTime(at(59 * SEC), NOW)).toBe('just now')
+  })
+
+  it('renders minutes', () => {
+    expect(formatRelativeTime(at(MIN), NOW)).toBe('1m ago')
+    expect(formatRelativeTime(at(5 * MIN), NOW)).toBe('5m ago')
+    expect(formatRelativeTime(at(59 * MIN), NOW)).toBe('59m ago')
+  })
+
+  it('renders hours', () => {
+    expect(formatRelativeTime(at(HOUR), NOW)).toBe('1h ago')
+    expect(formatRelativeTime(at(23 * HOUR), NOW)).toBe('23h ago')
+  })
+
+  it('renders days', () => {
+    expect(formatRelativeTime(at(DAY), NOW)).toBe('1d ago')
+    expect(formatRelativeTime(at(6 * DAY), NOW)).toBe('6d ago')
+  })
+
+  it('renders weeks', () => {
+    expect(formatRelativeTime(at(WEEK), NOW)).toBe('1w ago')
+    expect(formatRelativeTime(at(4 * WEEK), NOW)).toBe('4w ago')
+  })
+
+  it('treats future timestamps as "just now"', () => {
+    expect(formatRelativeTime(at(-5 * MIN), NOW)).toBe('just now')
+  })
+
+  it('returns empty string for invalid input', () => {
+    expect(formatRelativeTime('not-a-date', NOW)).toBe('')
+  })
+})

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -312,6 +312,47 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                       </ul>
                     </div>
 
+                    {/* In-App Notifications */}
+                    <div className="rounded-lg border border-cyan-200 bg-cyan-50 p-6 dark:border-cyan-800 dark:bg-cyan-900/20">
+                      <h3 className="mb-4 flex items-center text-lg font-semibold text-cyan-800 dark:text-cyan-200">
+                        <ChatBubbleOvalLeftIcon className="mr-3 h-5 w-5" />
+                        In-App Notifications
+                      </h3>
+                      <ul className="space-y-2 text-sm text-cyan-700 dark:text-cyan-300">
+                        <li>
+                          • <strong>Notification content:</strong> The title and
+                          message shown to you (e.g. a proposal status change or
+                          a new comment)
+                        </li>
+                        <li>
+                          • <strong>Recipient:</strong> The speaker or organizer
+                          the notification is delivered to
+                        </li>
+                        <li>
+                          • <strong>Acting user:</strong> The person whose
+                          action triggered the notification, where applicable
+                        </li>
+                        <li>
+                          • <strong>Related proposal reference:</strong> A link
+                          to the proposal the notification relates to, where
+                          applicable
+                        </li>
+                        <li>
+                          • <strong>Read status:</strong> Whether and when you
+                          have read the notification
+                        </li>
+                      </ul>
+                      <div className="mt-3 rounded-lg bg-cyan-100 p-2 dark:bg-cyan-800/30">
+                        <p className="text-xs text-cyan-800 dark:text-cyan-200">
+                          <strong>Purpose:</strong> Keeping speakers and
+                          organizers informed of proposal and conference
+                          activity. <strong>Legal Basis:</strong> Legitimate
+                          interest in conference coordination. These
+                          notifications are retained until deleted.
+                        </p>
+                      </div>
+                    </div>
+
                     {/* Photo Gallery Data */}
                     <div className="rounded-lg border border-pink-200 bg-pink-50 p-6 dark:border-pink-800 dark:bg-pink-900/20">
                       <h3 className="mb-4 flex items-center text-lg font-semibold text-pink-800 dark:text-pink-200">
@@ -1087,6 +1128,25 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                               </span>{' '}
                               Conference documentation and operational
                               continuity
+                            </td>
+                          </tr>
+                          <tr>
+                            <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
+                              In-App Notifications
+                              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                (Content, recipient, acting user, related
+                                proposal, read status)
+                              </div>
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+                              Retained until deleted
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+                              <span className="font-medium text-blue-600 dark:text-blue-400">
+                                Legitimate Interest:
+                              </span>{' '}
+                              Keeping speakers and organizers informed of
+                              proposal and conference activity
                             </td>
                           </tr>
                           <tr>

--- a/src/components/common/DashboardLayout.tsx
+++ b/src/components/common/DashboardLayout.tsx
@@ -15,11 +15,11 @@ import {
   Bars3Icon,
   XMarkIcon,
   MagnifyingGlassIcon,
-  BellIcon,
 } from '@heroicons/react/24/outline'
 import { ConferenceLogo } from '@/components/ConferenceLogo'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { UserMenu } from '@/components/UserMenu'
+import { NotificationBell } from '@/components/notifications/NotificationBell'
 import clsx from 'clsx'
 
 export interface NavigationItem {
@@ -416,6 +416,7 @@ export function DashboardLayout({
 
           <div className="flex items-center gap-x-2" suppressHydrationWarning>
             <ThemeToggle />
+            <NotificationBell />
             <UserMenu
               name={getUserName()}
               picture={getAvatarUrl()}
@@ -455,15 +456,7 @@ export function DashboardLayout({
             >
               <ThemeToggle />
 
-              {mode === 'admin' && (
-                <button
-                  type="button"
-                  className="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-                >
-                  <span className="sr-only">View notifications</span>
-                  <BellIcon aria-hidden="true" className="size-6" />
-                </button>
-              )}
+              <NotificationBell />
 
               <div
                 aria-hidden="true"

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
+import { BellIcon } from '@heroicons/react/24/outline'
+import { api } from '@/lib/trpc/client'
+import { NotificationPanel } from './NotificationPanel'
+
+/**
+ * The notification hub entry point: a bell with an unread badge that opens the
+ * inbox panel. Available in both the admin and speaker shells — the backend
+ * scopes every query to the signed-in speaker, so no client-side role gate is
+ * needed.
+ *
+ * The unread count is polled (30s) and refetched on window focus so the badge
+ * stays live without a socket. The panel (and its `list` query) mounts only
+ * while the Popover is open.
+ */
+export function NotificationBell() {
+  const { data: unreadCount = 0 } = api.notification.unreadCount.useQuery(
+    undefined,
+    {
+      refetchInterval: 30_000,
+      refetchOnWindowFocus: true,
+      staleTime: 10_000,
+    },
+  )
+
+  const hasUnread = unreadCount > 0
+  const badgeLabel = unreadCount > 9 ? '9+' : String(unreadCount)
+
+  return (
+    <Popover className="relative">
+      <PopoverButton
+        aria-label={
+          hasUnread ? `Notifications (${unreadCount} unread)` : 'Notifications'
+        }
+        className="relative -m-2.5 flex h-11 w-11 items-center justify-center rounded-full p-2.5 text-gray-400 transition hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-offset-2 dark:text-gray-500 dark:hover:text-gray-400 dark:focus-visible:ring-offset-gray-950"
+      >
+        <BellIcon aria-hidden="true" className="h-6 w-6" />
+        {hasUnread && (
+          <span className="absolute top-0.5 right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] leading-none font-semibold text-white ring-2 ring-white dark:ring-gray-950">
+            {badgeLabel}
+          </span>
+        )}
+      </PopoverButton>
+
+      <PopoverPanel
+        // Full-width sheet under the top bar on mobile; anchored dropdown on ≥sm.
+        className="fixed inset-x-2 top-16 z-50 max-h-[80vh] overflow-hidden rounded-xl bg-white shadow-lg ring-1 ring-gray-900/5 sm:absolute sm:inset-x-auto sm:top-full sm:right-0 sm:mt-2 sm:w-96 dark:bg-gray-900 dark:ring-white/10"
+      >
+        {({ close }) => (
+          <NotificationPanel unreadCount={unreadCount} onClose={close} />
+        )}
+      </PopoverPanel>
+    </Popover>
+  )
+}

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { NotificationList } from './NotificationList'
+import type { NotificationItem } from '@/lib/notification/types'
+
+// createdAt values are computed relative to render time so the compact relative
+// labels ("5m ago", "2h ago", …) stay realistic in the visual snapshot.
+const minutesAgo = (m: number) =>
+  new Date(Date.now() - m * 60_000).toISOString()
+
+const items: NotificationItem[] = [
+  {
+    id: '1',
+    type: 'proposal_status_changed',
+    title: 'Your proposal was accepted',
+    message:
+      'Congratulations! "Scaling Kubernetes to 10,000 nodes" has been accepted for the main track.',
+    link: '/cfp/proposal/1',
+    readAt: null,
+    createdAt: minutesAgo(4),
+    actor: { _id: 'a1', name: 'Program Committee' },
+  },
+  {
+    id: '2',
+    type: 'proposal_comment',
+    title: 'New comment on your proposal',
+    message: 'Could you clarify the target audience for this session?',
+    link: '/cfp/proposal/2',
+    readAt: null,
+    createdAt: minutesAgo(95),
+    actor: {
+      _id: 'a2',
+      name: 'Maria Jensen',
+      image: '/images/default-avatar.png',
+    },
+  },
+  {
+    id: '3',
+    type: 'travel_support_update',
+    title: 'Travel support approved',
+    message: 'Your travel reimbursement request has been approved.',
+    link: '/cfp/expense',
+    readAt: minutesAgo(60 * 26),
+    createdAt: minutesAgo(60 * 30),
+    actor: null,
+  },
+  {
+    id: '4',
+    type: 'system',
+    title: 'Schedule published',
+    readAt: minutesAgo(60 * 24 * 9),
+    createdAt: minutesAgo(60 * 24 * 10),
+    actor: null,
+  },
+]
+
+const meta = {
+  title: 'Components/Notifications/NotificationList',
+  component: NotificationList,
+  parameters: { layout: 'padded' },
+  args: {
+    onMarkAllRead: fn(),
+    onItemClick: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-sm overflow-hidden rounded-xl bg-white shadow-lg ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-white/10">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof NotificationList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const UnreadAndRead: Story = {
+  args: {
+    items,
+    unreadCount: 2,
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    items: [],
+    unreadCount: 0,
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    items: [],
+    isLoading: true,
+    unreadCount: 0,
+  },
+}

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import Link from 'next/link'
+import Image from 'next/image'
+import { CheckCircleIcon } from '@heroicons/react/24/outline'
+import { formatRelativeTime } from '@/lib/notification/format'
+import type { NotificationItem } from '@/lib/notification/types'
+
+export interface NotificationListProps {
+  /** Items to render, newest first. Ignored while `isLoading` is true. */
+  items: NotificationItem[]
+  /** When true, renders skeleton rows instead of items. */
+  isLoading?: boolean
+  /** Unread total from the polled counter — drives the "Mark all read" state. */
+  unreadCount: number
+  /** Fired when "Mark all read" is pressed. */
+  onMarkAllRead: () => void
+  /** Disables the "Mark all read" button while its mutation is in flight. */
+  isMarkingAll?: boolean
+  /**
+   * Fired when an item is activated (click/Enter). The container marks it read
+   * and closes the panel; navigation (if the item has a `link`) is handled by
+   * the wrapping `<Link>`.
+   */
+  onItemClick: (item: NotificationItem) => void
+}
+
+function SkeletonRow() {
+  return (
+    <div className="flex gap-3 px-4 py-3">
+      <div className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-gray-200 dark:bg-gray-700" />
+      <div className="flex-1 space-y-2">
+        <div className="h-3.5 w-3/4 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+        <div className="h-3 w-1/2 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+      </div>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+      <CheckCircleIcon
+        aria-hidden="true"
+        className="h-10 w-10 text-gray-300 dark:text-gray-600"
+      />
+      <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+        You&apos;re all caught up
+      </p>
+    </div>
+  )
+}
+
+function ItemBody({ item }: { item: NotificationItem }) {
+  const unread = !item.readAt
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className={
+          unread
+            ? 'mt-1.5 h-2 w-2 shrink-0 rounded-full bg-brand-cloud-blue'
+            : 'mt-1.5 h-2 w-2 shrink-0 rounded-full bg-transparent'
+        }
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-baseline justify-between gap-2">
+          <span
+            className={
+              unread
+                ? 'truncate text-sm font-semibold text-gray-900 dark:text-white'
+                : 'truncate text-sm font-medium text-gray-700 dark:text-gray-300'
+            }
+          >
+            {item.title}
+          </span>
+          <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+            {formatRelativeTime(item.createdAt)}
+          </span>
+        </span>
+        {item.message && (
+          <span className="mt-0.5 line-clamp-2 block text-sm text-gray-500 dark:text-gray-400">
+            {item.message}
+          </span>
+        )}
+        {item.actor?.name && (
+          <span className="mt-1 flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500">
+            {item.actor.image && (
+              <Image
+                src={item.actor.image}
+                alt=""
+                width={16}
+                height={16}
+                className="h-4 w-4 rounded-full"
+              />
+            )}
+            <span className="truncate">{item.actor.name}</span>
+          </span>
+        )}
+      </span>
+    </>
+  )
+}
+
+const rowClasses =
+  'flex w-full gap-3 px-4 py-3 text-left transition hover:bg-gray-50 focus-visible:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cloud-blue dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60'
+
+function ListItem({
+  item,
+  onItemClick,
+}: {
+  item: NotificationItem
+  onItemClick: (item: NotificationItem) => void
+}) {
+  const unread = !item.readAt
+  const wrapperClass = `${rowClasses} ${unread ? 'bg-blue-50/40 dark:bg-blue-900/10' : ''}`
+
+  if (item.link) {
+    return (
+      <Link
+        href={item.link}
+        prefetch={false}
+        onClick={() => onItemClick(item)}
+        className={wrapperClass}
+      >
+        <ItemBody item={item} />
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onItemClick(item)}
+      className={wrapperClass}
+    >
+      <ItemBody item={item} />
+    </button>
+  )
+}
+
+/**
+ * Presentational render of the notification inbox: header with a "Mark all
+ * read" control, and the item list / loading / empty states. Pure — all data
+ * and side effects are supplied by the container so this can be storied and
+ * tested without tRPC.
+ */
+export function NotificationList({
+  items,
+  isLoading = false,
+  unreadCount,
+  onMarkAllRead,
+  isMarkingAll = false,
+  onItemClick,
+}: NotificationListProps) {
+  return (
+    <div aria-label="Notifications" className="flex flex-col">
+      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
+          Notifications
+        </h2>
+        <button
+          type="button"
+          onClick={onMarkAllRead}
+          disabled={unreadCount === 0 || isMarkingAll}
+          className="rounded text-xs font-medium text-brand-cloud-blue transition hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:text-gray-300 dark:disabled:text-gray-600"
+        >
+          Mark all read
+        </button>
+      </div>
+
+      <div className="max-h-[70vh] divide-y divide-gray-100 overflow-y-auto dark:divide-gray-800/70">
+        {isLoading ? (
+          <>
+            <SkeletonRow />
+            <SkeletonRow />
+            <SkeletonRow />
+          </>
+        ) : items.length === 0 ? (
+          <EmptyState />
+        ) : (
+          items.map((item) => (
+            <ListItem key={item.id} item={item} onItemClick={onItemClick} />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { api } from '@/lib/trpc/client'
+import type { NotificationItem } from '@/lib/notification/types'
+import { NotificationList } from './NotificationList'
+
+export interface NotificationPanelProps {
+  /** Unread total from the bell's polled counter; drives "Mark all read". */
+  unreadCount: number
+  /** Closes the surrounding Popover (called after an item is activated). */
+  onClose: () => void
+}
+
+/**
+ * Data container for the notification inbox. Headless UI unmounts a closed
+ * `PopoverPanel` by default, so this component only mounts while the panel is
+ * open — the `list` query therefore fires exactly when the user opens the bell,
+ * with no explicit `enabled` gate needed.
+ *
+ * Reads/writes flow through the `notification` tRPC router; every mutation
+ * invalidates both `unreadCount` and `list` so the badge and the panel stay in
+ * sync (the badge poll is only a backstop).
+ */
+export function NotificationPanel({
+  unreadCount,
+  onClose,
+}: NotificationPanelProps) {
+  const utils = api.useUtils()
+
+  const { data: items = [], isLoading } = api.notification.list.useQuery(
+    { limit: 20 },
+    { staleTime: 10_000 },
+  )
+
+  const invalidate = () => {
+    utils.notification.unreadCount.invalidate()
+    utils.notification.list.invalidate()
+  }
+
+  const markRead = api.notification.markRead.useMutation({
+    onSuccess: invalidate,
+  })
+  const markAllRead = api.notification.markAllRead.useMutation({
+    onSuccess: invalidate,
+  })
+
+  const handleItemClick = (item: NotificationItem) => {
+    // Fire-and-forget: mark read on activation, then close. Navigation (if the
+    // item has a link) is handled by the wrapping <Link>.
+    if (!item.readAt) {
+      markRead.mutate({ ids: [item.id] })
+    }
+    onClose()
+  }
+
+  return (
+    <NotificationList
+      items={items}
+      isLoading={isLoading}
+      unreadCount={unreadCount}
+      onMarkAllRead={() => markAllRead.mutate()}
+      isMarkingAll={markAllRead.isPending}
+      onItemClick={handleItemClick}
+    />
+  )
+}

--- a/src/lib/notification/format.ts
+++ b/src/lib/notification/format.ts
@@ -1,0 +1,34 @@
+/**
+ * Compact relative-time formatting for the notification hub UI.
+ *
+ * NOTE: this is deliberately the *compact* form ("5m ago") suited to the narrow
+ * notification panel. `src/lib/time.ts` has a separate, verbose
+ * `formatRelativeTime` ("5 minutes ago") used elsewhere; the two are kept
+ * distinct because the panel's column width can't afford the long form.
+ */
+
+const MINUTE = 60
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+const WEEK = 7 * DAY
+
+/**
+ * Formats an ISO datetime as a compact relative time relative to now:
+ * "just now", "5m ago", "3h ago", "2d ago", "4w ago". Future or invalid
+ * timestamps collapse to "just now".
+ */
+export function formatRelativeTime(
+  iso: string,
+  now: Date = new Date(),
+): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+
+  const diffSeconds = Math.floor((now.getTime() - then) / 1000)
+
+  if (diffSeconds < MINUTE) return 'just now'
+  if (diffSeconds < HOUR) return `${Math.floor(diffSeconds / MINUTE)}m ago`
+  if (diffSeconds < DAY) return `${Math.floor(diffSeconds / HOUR)}h ago`
+  if (diffSeconds < WEEK) return `${Math.floor(diffSeconds / DAY)}d ago`
+  return `${Math.floor(diffSeconds / WEEK)}w ago`
+}


### PR DESCRIPTION
## Notification hub — Phase N2 (UI)

Builds the in-app notification hub UI on top of the N1 backend (`notification` tRPC router, #510). A bell with an unread badge now lives in **both** the admin and speaker shells; it opens an inbox panel that lists recent notifications, marks them read, and stays live via polling.

### What's included
- **`NotificationBell`** — Headless UI `Popover` with a `BellIcon` and a red unread pill (capped at `9+`, hidden at 0), `aria-label` reflecting the unread count. Polls `notification.unreadCount` every 30s with `refetchOnWindowFocus`. The panel is a full-width sheet under the top bar on mobile and a right-anchored `w-96` dropdown on `≥sm`.
- **`NotificationPanel`** — data container. Fetches `notification.list({ limit: 20 })` (only mounts while the Popover is open, since Headless UI unmounts closed panels — no explicit `enabled` gate needed). Handles `markRead` (fire-and-forget on item click) and `markAllRead`; both invalidate `unreadCount` + `list` via `api.useUtils()` so the badge and panel stay in sync.
- **`NotificationList`** — pure presentational split (unread dot, title, line-clamped message, relative time, actor, header with a "Mark all read" control, empty + loading states). Extracted so stories/tests need no tRPC.
- **`DashboardLayout`** — replaced the dead admin-only bell button with `<NotificationBell />` and removed the `mode === 'admin'` gate (backend already scopes per-user); added the bell to the `lg:hidden` mobile bar (44px tap target).
- **`lib/notification/format.ts`** — compact `formatRelativeTime` ("5m ago") suited to the narrow panel. Kept separate from the verbose `formatRelativeTime` in `lib/time.ts` (the panel column can't afford "5 minutes ago").
- **Privacy** — added an "In-App Notifications" card to §2 (what's stored: content, recipient, acting user, related proposal, read status) and a retention row to §7 ("retained until deleted"), per the AGENTS.md data-collection rule.

### Design notes
- **Popover, not Menu** — the panel holds arbitrary content and buttons, so `Popover`/`PopoverPanel` (render-prop `close` passed down for item-click dismissal) rather than menu-item semantics.
- **Poll cadence** — 30s + focus refetch on the badge, `staleTime: 10s`; matches the SponsorCRM precedent.
- **Invalidations** — every mutation invalidates both `unreadCount` and `list`; the poll is only a backstop.
- **Presentational split** — `NotificationList` is dependency-free, so its stories/tests don't touch tRPC.

### Tests & QA
- 16 new tests: `NotificationList` rendering (unread dot count, mark-all state, item-click, empty, loading) + `formatRelativeTime` (now/min/hour/day/week/future/invalid). Full `__tests__/` run: 2310 passed, 24 known `@digitalbazaar/vc` module-load failures.
- `pnpm shoot` at 393px: `NotificationList` unread/read, empty, loading — badge/dots legible, nothing clipped. Bell confirmed in the admin desktop top bar via the `DashboardLayout` story.

### Gaps
- No DashboardLayout-level integration test (heavy session mocking) — the bell is covered by typecheck + the presentational unit tests.
- No live-badge screenshot (needs tRPC/msw mocking, deliberately avoided per the presentational-split guidance); badge markup + `9+` cap reviewed in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the full in-app notification hub UI (Phase N2): a `NotificationBell` with an unread badge in both the admin and speaker shells, an inbox `NotificationPanel` that fetches and marks notifications read via tRPC, and a pure-presentational `NotificationList` with skeleton/empty states. Privacy page is updated with the matching GDPR disclosures.

- **`NotificationBell`** polls `unreadCount` every 30 s + on focus; the panel (and its `list` query) mounts only while the Popover is open — no explicit `enabled` gate needed because Headless UI unmounts closed panels.
- **`NotificationList`** is dependency-free for easy Storybook/unit testing; `formatRelativeTime` in `src/lib/notification/format.ts` provides the compact "5m ago" labels, kept intentionally separate from the verbose form in `src/lib/time.ts`.
- **`DashboardLayout`** replaces the dead admin-only bell stub with `<NotificationBell />` in both the desktop bar and the `lg:hidden` mobile bar, removing the `mode === 'admin'` gate.

<h3>Confidence Score: 4/5</h3>

The feature is well-structured and the core runtime path is safe to merge; the one item that needs fixing before visual snapshot tests can be relied upon is in the Storybook story file.

The notification hub wiring is solid — polling, invalidation on mutation, and the Headless UI unmount-as-enabled-gate all work correctly. The story file does not mock `globalThis.Date`, so `formatRelativeTime` will produce different labels on every Storybook render and any visual snapshot run will produce a diff. Everything else (bell, panel, list, format utility, privacy page, DashboardLayout changes) looks correct.

`src/components/notifications/NotificationList.stories.tsx` needs a `globalThis.Date` stub in `beforeEach` to pin the relative-time labels. The error state gap in `NotificationPanel.tsx` is worth a follow-up but is not blocking.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/notifications/NotificationBell.tsx | New bell component with Headless UI Popover, unread badge (capped at 9+), 30s polling + focus refetch — clean implementation with good a11y on the button. |
| src/components/notifications/NotificationPanel.tsx | Data container for the inbox; mounts only while Popover is open. Error state from the list query is unhandled — falls through to the empty state silently. |
| src/components/notifications/NotificationList.tsx | Pure presentational component with skeleton/empty/item states; aria-label on the root div lacks role="region", so the landmark name is not surfaced to assistive technology. |
| src/components/notifications/NotificationList.stories.tsx | Story items use module-level Date.now() and formatRelativeTime uses new Date() on every render — no globalThis.Date mock, violating the AGENTS.md deterministic-date rule and causing visual snapshot drift. |
| src/lib/notification/format.ts | Compact relative-time formatter ("5m ago"); correctly handles future/invalid timestamps. Well-tested with 7 cases in the accompanying test file. |
| src/components/common/DashboardLayout.tsx | Replaces dead admin-only bell stub with NotificationBell in both the desktop and lg:hidden mobile bars; removes the mode === 'admin' gate cleanly. |
| src/app/(main)/privacy/page.tsx | Adds In-App Notifications card to §2 and a retention row to §7, satisfying the AGENTS.md GDPR data-collection rule for the new feature. |
| __tests__/components/notifications/NotificationList.test.tsx | 9 unit tests covering rendering, unread dots, links, item-click, mark-all-read enable/disable, empty, and loading states — good behavioral coverage of the presentational component. |
| __tests__/lib/notification/format.test.ts | 7 tests against a fixed NOW constant — correctly deterministic, covers all branches including future and invalid inputs. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Shell as DashboardLayout
    participant Bell as NotificationBell
    participant Panel as NotificationPanel
    participant tRPC as tRPC (notification router)

    Shell->>Bell: renders (admin + speaker shells)
    loop every 30s / window focus
        Bell->>tRPC: unreadCount.useQuery()
        tRPC-->>Bell: number
        Bell->>Bell: update badge (capped 9+)
    end

    Bell->>Panel: user opens Popover → Panel mounts
    Panel->>tRPC: "list.useQuery({ limit: 20 })"
    tRPC-->>Panel: NotificationItem[]

    Panel->>Bell: renders NotificationList (unreadCount prop)

    alt item click
        Panel->>tRPC: "markRead.mutate({ ids: [id] })"
        tRPC-->>Panel: success
        Panel->>tRPC: invalidate unreadCount + list
    end

    alt Mark all read click
        Panel->>tRPC: markAllRead.mutate()
        tRPC-->>Panel: success
        Panel->>tRPC: invalidate unreadCount + list
    end

    Bell->>Panel: user closes Popover → Panel unmounts
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Shell as DashboardLayout
    participant Bell as NotificationBell
    participant Panel as NotificationPanel
    participant tRPC as tRPC (notification router)

    Shell->>Bell: renders (admin + speaker shells)
    loop every 30s / window focus
        Bell->>tRPC: unreadCount.useQuery()
        tRPC-->>Bell: number
        Bell->>Bell: update badge (capped 9+)
    end

    Bell->>Panel: user opens Popover → Panel mounts
    Panel->>tRPC: "list.useQuery({ limit: 20 })"
    tRPC-->>Panel: NotificationItem[]

    Panel->>Bell: renders NotificationList (unreadCount prop)

    alt item click
        Panel->>tRPC: "markRead.mutate({ ids: [id] })"
        tRPC-->>Panel: success
        Panel->>tRPC: invalidate unreadCount + list
    end

    alt Mark all read click
        Panel->>tRPC: markAllRead.mutate()
        tRPC-->>Panel: success
        Panel->>tRPC: invalidate unreadCount + list
    end

    Bell->>Panel: user closes Popover → Panel unmounts
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): bell + inbox panel ..."](https://github.com/cloudnativebergen/website/commit/42cc05d273a605d8e4d08f229a0ed95cc759046b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45341603)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->