### PR TITLE
fix(notifications): review follow-ups — error state, region landmark, deterministic stories

### DIFF
--- a/__tests__/components/notifications/NotificationList.test.tsx
+++ b/__tests__/components/notifications/NotificationList.test.tsx
@@ -99,4 +99,19 @@ describe('NotificationList', () => {
     )
     expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument()
   })
+
+  it('shows a distinct error state on load failure (never "all caught up")', () => {
+    renderList({ items: [], isError: true, unreadCount: 0 })
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /couldn.t load notifications/i,
+    )
+    expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument()
+  })
+
+  it('exposes the inbox as a named region landmark', () => {
+    renderList({ unreadCount: 2 })
+    expect(
+      screen.getByRole('region', { name: 'Notifications' }),
+    ).toBeInTheDocument()
+  })
 })

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -3,12 +3,14 @@ import { fn } from 'storybook/test'
 import { NotificationList } from './NotificationList'
 import type { NotificationItem } from '@/lib/notification/types'
 
-// createdAt values are computed relative to render time so the compact relative
-// labels ("5m ago", "2h ago", …) stay realistic in the visual snapshot.
+// createdAt values are computed relative to RENDER time (the factory below is
+// invoked per story render, not at module load) so the compact relative labels
+// are deterministic in the visual snapshot: "4m ago" is always "4m ago", no
+// matter how long the Storybook module has been loaded.
 const minutesAgo = (m: number) =>
   new Date(Date.now() - m * 60_000).toISOString()
 
-const items: NotificationItem[] = [
+const makeItems = (): NotificationItem[] => [
   {
     id: '1',
     type: 'proposal_status_changed',
@@ -77,9 +79,12 @@ type Story = StoryObj<typeof meta>
 
 export const UnreadAndRead: Story = {
   args: {
-    items,
+    // Placeholder for typing; the render below rebuilds items at render time so
+    // the relative-time labels are stable.
+    items: [],
     unreadCount: 2,
   },
+  render: (args) => <NotificationList {...args} items={makeItems()} />,
 }
 
 export const Empty: Story = {
@@ -93,6 +98,14 @@ export const Loading: Story = {
   args: {
     items: [],
     isLoading: true,
+    unreadCount: 0,
+  },
+}
+
+export const LoadError: Story = {
+  args: {
+    items: [],
+    isError: true,
     unreadCount: 0,
   },
 }

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -11,6 +11,8 @@ export interface NotificationListProps {
   items: NotificationItem[]
   /** When true, renders skeleton rows instead of items. */
   isLoading?: boolean
+  /** When true, renders a load-failure state (distinct from the empty state). */
+  isError?: boolean
   /** Unread total from the polled counter — drives the "Mark all read" state. */
   unreadCount: number
   /** Fired when "Mark all read" is pressed. */
@@ -46,6 +48,26 @@ function EmptyState() {
       />
       <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
         You&apos;re all caught up
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Load-failure state, deliberately DISTINCT from the empty state: a failed
+ * fetch must not read as "you're all caught up".
+ */
+function ErrorState() {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center justify-center gap-2 px-6 py-10 text-center"
+    >
+      <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+        Couldn&apos;t load notifications
+      </p>
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Check your connection and reopen the panel to retry.
       </p>
     </div>
   )
@@ -148,13 +170,16 @@ function ListItem({
 export function NotificationList({
   items,
   isLoading = false,
+  isError = false,
   unreadCount,
   onMarkAllRead,
   isMarkingAll = false,
   onItemClick,
 }: NotificationListProps) {
   return (
-    <div aria-label="Notifications" className="flex flex-col">
+    // `role="region"` makes the aria-label an actual named landmark — on a
+    // generic div the label is not exposed to assistive tech at all.
+    <div role="region" aria-label="Notifications" className="flex flex-col">
       <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800">
         <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
           Notifications
@@ -176,6 +201,8 @@ export function NotificationList({
             <SkeletonRow />
             <SkeletonRow />
           </>
+        ) : isError ? (
+          <ErrorState />
         ) : items.length === 0 ? (
           <EmptyState />
         ) : (

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -27,10 +27,11 @@ export function NotificationPanel({
 }: NotificationPanelProps) {
   const utils = api.useUtils()
 
-  const { data: items = [], isLoading } = api.notification.list.useQuery(
-    { limit: 20 },
-    { staleTime: 10_000 },
-  )
+  const {
+    data: items = [],
+    isLoading,
+    isError,
+  } = api.notification.list.useQuery({ limit: 20 }, { staleTime: 10_000 })
 
   const invalidate = () => {
     utils.notification.unreadCount.invalidate()
@@ -57,6 +58,7 @@ export function NotificationPanel({
     <NotificationList
       items={items}
       isLoading={isLoading}
+      isError={isError}
       unreadCount={unreadCount}
       onMarkAllRead={() => markAllRead.mutate()}
       isMarkingAll={markAllRead.isPending}


### PR DESCRIPTION
Addresses the three Greptile P2s posted on #511 after it merged:

1. **Error ≠ empty**: a failed `list` fetch now renders a distinct "Couldn't load notifications" state (`role="alert"`) instead of the "You're all caught up" empty state.
2. **Named landmark**: the inbox container gets `role="region"` so its `aria-label` is actually exposed (a generic div's label is ignored by assistive tech).
3. **Deterministic stories**: story items are built at render time via a factory, keeping relative-time labels stable regardless of module lifetime; adds a `LoadError` story.

34/34 notification tests (2 new); error state shoot-verified at 393px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three accessibility and correctness follow-ups from #511: a distinct error state so a failed fetch never reads as "You're all caught up", a `role="region"` landmark so the `aria-label` is actually exposed to assistive tech, and a `makeItems()` factory in stories to keep relative-time labels deterministic at render time.

- **Error state**: `NotificationList` gains an `isError` prop; when set, `ErrorState` (with `role="alert"`) renders in place of the empty state. `NotificationPanel` wires `isError` from the `useQuery` result straight through.
- **Named landmark**: the root `<div>` gains `role="region"`, which is required for `aria-label` to be surfaced as a landmark by screen readers.
- **Stories / tests**: `makeItems()` is called per-render so snapshot labels are stable; a `LoadError` story and two new unit tests cover the new branches.

<h3>Confidence Score: 5/5</h3>

All four changed files are tightly scoped to the notification panel; the changes add new branches without touching any existing logic paths.

The three changes are each minimal and self-contained. The isLoading → isError → empty → items guard order correctly matches React Query's state machine (the two states never fire simultaneously on the same query). The role="region" addition follows the ARIA spec requirement for a named landmark. New tests cover both additions with direct assertions. No existing behavior is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/notifications/NotificationList.tsx | Adds `isError` prop, `ErrorState` component with `role="alert"`, and `role="region"` on the root wrapper — all three fixes are logically correct and well-scoped. |
| src/components/notifications/NotificationPanel.tsx | Destructures `isError` from the `useQuery` result and passes it down to `NotificationList`; minimal, correct wiring change. |
| __tests__/components/notifications/NotificationList.test.tsx | Two new tests covering the error state (via `role="alert"`) and the named region landmark; both tests are direct and correctly target the new behavior. |
| src/components/notifications/NotificationList.stories.tsx | Refactors static `items` array into a `makeItems()` factory called at story render time, adds a `LoadError` story; the pattern is sound and the comment explains the intent. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    NP[NotificationPanel] -->|"isLoading, isError, items"| NL[NotificationList]
    NL --> C{State?}
    C -->|isLoading| SK[SkeletonRows]
    C -->|isError| ER["ErrorState\n(role=alert)"]
    C -->|items.length === 0| ES[EmptyState]
    C -->|items.length > 0| IL[Item List]
    NL -->|"role=region\naria-label=Notifications"| LANDMARK[Named Landmark]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    NP[NotificationPanel] -->|"isLoading, isError, items"| NL[NotificationList]
    NL --> C{State?}
    C -->|isLoading| SK[SkeletonRows]
    C -->|isError| ER["ErrorState\n(role=alert)"]
    C -->|items.length === 0| ES[EmptyState]
    C -->|items.length > 0| IL[Item List]
    NL -->|"role=region\naria-label=Notifications"| LANDMARK[Named Landmark]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): review follow-ups — ..."](https://github.com/cloudnativebergen/website/commit/b5bca0f31297e407cd174436138e3e1f7688b356) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45342739)</sub>

<!-- /greptile_comment -->