### PR TITLE
feat(notifications): travel-support, sponsor-stage and gallery-tag emitters (N3)

### DIFF
--- a/__tests__/api/trpc/sponsor-stage-notification.test.ts
+++ b/__tests__/api/trpc/sponsor-stage-notification.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests the in-app notification fan-out emitted inline by
+ * `sponsor.crm.moveStage` (src/server/routers/sponsor.ts). The notification
+ * data layer is mocked so we assert exactly which organizers are notified, and
+ * that a failing organizer-id fetch never escapes the mutation path.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { appRouter } from '@/server/_app'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import {
+  getSponsorForConference,
+  updateSponsorForConference,
+} from '@/lib/sponsor-crm/sanity'
+import { logStageChange } from '@/lib/sponsor-crm/activity'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
+import type { NotificationInput } from '@/lib/notification/types'
+
+vi.mock('@/lib/conference/sanity')
+vi.mock('@/lib/sponsor-crm/sanity')
+vi.mock('@/lib/sponsor-crm/activity')
+vi.mock('@/lib/notification/sanity')
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
+
+const mockOrganizer = {
+  _id: 'actor-1',
+  name: 'Acting Organizer',
+  email: 'org@test.com',
+  isOrganizer: true,
+}
+const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+
+function makeSfc(
+  overrides: Partial<SponsorForConferenceExpanded> = {},
+): SponsorForConferenceExpanded {
+  return {
+    _id: 'sfc-1',
+    _createdAt: '',
+    _updatedAt: '',
+    sponsor: {
+      _id: 's1',
+      name: 'Acme',
+      website: 'https://acme.test',
+      logo: '',
+    },
+    conference: { _id: 'conf-1', title: 'Test Conf' },
+    contractStatus: 'none',
+    status: 'negotiating',
+    contractCurrency: 'NOK',
+    invoiceStatus: 'not-sent',
+    ...overrides,
+  } as SponsorForConferenceExpanded
+}
+
+const createCaller = (speaker: typeof mockOrganizer) =>
+  appRouter.createCaller({
+    session: { user: { email: speaker.email }, speaker },
+    speaker,
+    user: { email: speaker.email },
+  } as unknown as Parameters<typeof appRouter.createCaller>[0])
+
+const createMock = createNotifications as unknown as ReturnType<typeof vi.fn>
+const lastItems = (): NotificationInput[] =>
+  createMock.mock.calls[
+    createMock.mock.calls.length - 1
+  ][0] as NotificationInput[]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
+    conference: mockConference as never,
+    domain: 'test.com',
+    error: null,
+  })
+  vi.mocked(getSponsorForConference).mockResolvedValue({
+    sponsorForConference: makeSfc(),
+    error: undefined,
+  })
+  vi.mocked(updateSponsorForConference).mockResolvedValue({
+    sponsorForConference: makeSfc({ status: 'closed-lost' }),
+    error: undefined,
+  })
+  vi.mocked(logStageChange).mockResolvedValue(undefined as never)
+  vi.mocked(getOrganizerSpeakerIds).mockResolvedValue([
+    'org-1',
+    'actor-1',
+    'org-2',
+  ])
+  vi.mocked(createNotifications).mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('sponsor.crm.moveStage — organizer notifications', () => {
+  it('notifies every organizer except the acting organizer', async () => {
+    await createCaller(mockOrganizer).sponsor.crm.moveStage({
+      id: 'sfc-1',
+      newStatus: 'closed-lost',
+    })
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const items = lastItems()
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['org-1', 'org-2'])
+    for (const item of items) {
+      expect(item.notificationType).toBe('sponsor_activity')
+      expect(item.title).toBe('Sponsor Acme moved to closed-lost')
+      expect(item.link).toBe('/admin/sponsors/crm')
+      expect(item.actorId).toBe('actor-1')
+      expect(item.conferenceId).toBe('conf-1')
+    }
+  })
+
+  it('falls back to a generic title when the sponsor name is missing', async () => {
+    vi.mocked(getSponsorForConference).mockResolvedValue({
+      sponsorForConference: makeSfc({
+        sponsor: undefined as never,
+      }),
+      error: undefined,
+    })
+
+    await createCaller(mockOrganizer).sponsor.crm.moveStage({
+      id: 'sfc-1',
+      newStatus: 'closed-lost',
+    })
+
+    expect(lastItems()[0].title).toBe('Sponsor moved to closed-lost')
+  })
+
+  it('does not fail the stage move when the organizer-id fetch throws', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockRejectedValue(new Error('boom'))
+
+    const result = await createCaller(mockOrganizer).sponsor.crm.moveStage({
+      id: 'sfc-1',
+      newStatus: 'closed-lost',
+    })
+
+    // Mutation still succeeds; the notification failure is swallowed.
+    expect(result).toBeDefined()
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/api/trpc/travel-support-notification.test.ts
+++ b/__tests__/api/trpc/travel-support-notification.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests the in-app notification fan-out emitted inline by the travel-support
+ * router (src/server/routers/travelSupport.ts):
+ * - `submit`            → all organizers EXCEPT the actor
+ * - `admin.updateStatus`→ the affected speaker, gated to approved/rejected/paid
+ *
+ * The notification and travel-support data layers are mocked so we assert the
+ * exact recipients/types and that a failing id fetch never escapes the mutation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { appRouter } from '@/server/_app'
+import {
+  getTravelSupportById,
+  submitTravelSupport,
+  updateTravelSupportStatus,
+} from '@/lib/travel-support/sanity'
+import { authorizeTravelSupportOperation } from '@/lib/travel-support/auth'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import { TravelSupportStatus } from '@/lib/travel-support/types'
+import type { NotificationInput } from '@/lib/notification/types'
+
+vi.mock('@/lib/travel-support/sanity')
+vi.mock('@/lib/travel-support/auth')
+vi.mock('@/lib/notification/sanity')
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
+
+const actor = {
+  _id: 'actor-1',
+  name: 'Acting Organizer',
+  email: 'org@test.com',
+  isOrganizer: true,
+}
+
+const bankingDetails = {
+  beneficiaryName: 'Jane Speaker',
+  bankName: 'Bank',
+  swiftCode: 'SWIFT',
+  country: 'NO',
+  iban: 'NO123',
+}
+
+const createCaller = (speaker: typeof actor) =>
+  appRouter.createCaller({
+    session: { user: { email: speaker.email }, speaker },
+    speaker,
+    user: { email: speaker.email },
+  } as unknown as Parameters<typeof appRouter.createCaller>[0])
+
+const createMock = createNotifications as unknown as ReturnType<typeof vi.fn>
+const lastItems = (): NotificationInput[] =>
+  createMock.mock.calls[
+    createMock.mock.calls.length - 1
+  ][0] as NotificationInput[]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(createNotifications).mockResolvedValue(undefined)
+  vi.mocked(getOrganizerSpeakerIds).mockResolvedValue([
+    'org-1',
+    'actor-1',
+    'org-2',
+  ])
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('travelSupport.submit — organizer notifications', () => {
+  beforeEach(() => {
+    vi.mocked(authorizeTravelSupportOperation).mockResolvedValue({
+      authorized: true,
+      travelSupport: {
+        _id: 'ts-1',
+        status: TravelSupportStatus.DRAFT,
+        bankingDetails,
+        speaker: { _id: 'sp-1', name: 'Jane Speaker', email: 'j@test.com' },
+        conference: { _id: 'conf-1', name: 'Test Conf' },
+      } as never,
+    })
+    vi.mocked(submitTravelSupport).mockResolvedValue({
+      success: true,
+      error: null,
+    } as never)
+  })
+
+  it('notifies every organizer except the actor with the right shape', async () => {
+    await createCaller(actor).travelSupport.submit({ travelSupportId: 'ts-1' })
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const items = lastItems()
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['org-1', 'org-2'])
+    for (const item of items) {
+      expect(item.notificationType).toBe('travel_support_update')
+      expect(item.title).toBe('Travel support request from Acting Organizer')
+      expect(item.link).toBe('/admin/speakers/travel-support')
+      expect(item.actorId).toBe('actor-1')
+      expect(item.conferenceId).toBe('conf-1')
+    }
+  })
+
+  it('does not fail the submission when the organizer-id fetch throws', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockRejectedValue(new Error('boom'))
+
+    const result = await createCaller(actor).travelSupport.submit({
+      travelSupportId: 'ts-1',
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('travelSupport.admin.updateStatus — affected-speaker notifications', () => {
+  const mockFetched = (status: TravelSupportStatus, speakerId = 'sp-1') =>
+    vi.mocked(getTravelSupportById).mockResolvedValue({
+      travelSupport: {
+        _id: 'ts-1',
+        status: TravelSupportStatus.SUBMITTED,
+        speaker: { _id: speakerId, name: 'Jane Speaker', email: 'j@test.com' },
+        conference: { _id: 'conf-1', name: 'Test Conf' },
+        expenses: [],
+      } as never,
+      error: null,
+    })
+
+  beforeEach(() => {
+    vi.mocked(authorizeTravelSupportOperation).mockResolvedValue({
+      authorized: true,
+    } as never)
+    vi.mocked(updateTravelSupportStatus).mockResolvedValue({
+      success: true,
+      error: null,
+    } as never)
+  })
+
+  it('notifies the affected speaker on approval, carrying reviewNotes as message', async () => {
+    mockFetched(TravelSupportStatus.APPROVED)
+
+    await createCaller(actor).travelSupport.admin.updateStatus({
+      travelSupportId: 'ts-1',
+      status: TravelSupportStatus.APPROVED,
+      reviewNotes: 'Looks good',
+    })
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const item = lastItems()[0]
+    expect(item.recipientId).toBe('sp-1')
+    expect(item.notificationType).toBe('travel_support_update')
+    expect(item.title).toBe('Travel support approved')
+    expect(item.message).toBe('Looks good')
+    expect(item.link).toBe('/cfp/expense')
+    expect(item.actorId).toBe('actor-1')
+  })
+
+  it.each([
+    [TravelSupportStatus.REJECTED, 'Travel support rejected'],
+    [TravelSupportStatus.PAID, 'Travel support marked paid'],
+  ])('maps %s to a human title', async (status, title) => {
+    mockFetched(status)
+    await createCaller(actor).travelSupport.admin.updateStatus({
+      travelSupportId: 'ts-1',
+      status,
+    })
+    expect(lastItems()[0].title).toBe(title)
+  })
+
+  it.each([TravelSupportStatus.DRAFT, TravelSupportStatus.SUBMITTED])(
+    'does NOT notify for the %s echo status',
+    async (status) => {
+      mockFetched(status)
+      await createCaller(actor).travelSupport.admin.updateStatus({
+        travelSupportId: 'ts-1',
+        status,
+      })
+      expect(createMock).not.toHaveBeenCalled()
+    },
+  )
+
+  it('does NOT notify when the affected speaker is the actor', async () => {
+    mockFetched(TravelSupportStatus.APPROVED, 'actor-1')
+    await createCaller(actor).travelSupport.admin.updateStatus({
+      travelSupportId: 'ts-1',
+      status: TravelSupportStatus.APPROVED,
+    })
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/lib/events/galleryTagPersistNotification.test.ts
+++ b/__tests__/lib/events/galleryTagPersistNotification.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the gallery-tag notification-hub bus handler
+ * (src/lib/events/handlers/galleryTagPersistNotification.ts).
+ *
+ * The data layer is mocked so we assert exactly which recipients get an in-app
+ * notification when speakers are tagged in a gallery image:
+ * - every tagged speaker (de-duplicated) gets a 'gallery_tagged' notification
+ * - the actor (metadata.taggedBy), when present, is excluded
+ * - an undefined taggedBy (the current survey TODO) is handled gracefully
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: vi.fn(async () => {}),
+}))
+
+import { createNotifications } from '@/lib/notification/sanity'
+import { handleGalleryTagPersistNotification } from '@/lib/events/handlers/galleryTagPersistNotification'
+import type { GallerySpeakerTaggedEvent } from '@/lib/events/types'
+import type { NotificationInput } from '@/lib/notification/types'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const createMock = createNotifications as unknown as LooseMock
+
+const makeEvent = (
+  speakerIds: string[],
+  metadataOverrides: Partial<GallerySpeakerTaggedEvent['metadata']> = {},
+): GallerySpeakerTaggedEvent =>
+  ({
+    eventType: 'gallery.speaker.tagged',
+    timestamp: new Date(),
+    image: { _id: 'img-1' },
+    conference: { _id: 'conf-1', title: 'Test Conf' },
+    speakers: speakerIds.map((id) => ({ _id: id, name: id })),
+    metadata: {
+      domain: 'example.com',
+      ...metadataOverrides,
+    },
+  }) as unknown as GallerySpeakerTaggedEvent
+
+const lastItems = (): NotificationInput[] =>
+  createMock.mock.calls[
+    createMock.mock.calls.length - 1
+  ][0] as NotificationInput[]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('gallery tag persistence — one notification per tagged speaker', () => {
+  it('notifies every tagged speaker with the right type/title/link', async () => {
+    await handleGalleryTagPersistNotification(makeEvent(['sp-1', 'sp-2']))
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const items = lastItems()
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['sp-1', 'sp-2'])
+    for (const item of items) {
+      expect(item.notificationType).toBe('gallery_tagged')
+      expect(item.title).toBe('You were tagged in a conference photo')
+      expect(item.link).toBe('/#gallery?img=img-1')
+      expect(item.conferenceId).toBe('conf-1')
+    }
+  })
+
+  it('de-duplicates a repeated speaker id', async () => {
+    await handleGalleryTagPersistNotification(
+      makeEvent(['sp-1', 'sp-1', 'sp-2']),
+    )
+    expect(
+      lastItems()
+        .map((i) => i.recipientId)
+        .sort(),
+    ).toEqual(['sp-1', 'sp-2'])
+  })
+
+  it('excludes the actor and sets actorId when taggedBy is present', async () => {
+    await handleGalleryTagPersistNotification(
+      makeEvent(['sp-1', 'actor-1', 'sp-2'], { taggedBy: 'actor-1' }),
+    )
+    const items = lastItems()
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['sp-1', 'sp-2'])
+    for (const item of items) {
+      expect(item.actorId).toBe('actor-1')
+    }
+  })
+
+  it('handles an undefined taggedBy gracefully (no actorId, nobody excluded)', async () => {
+    await handleGalleryTagPersistNotification(makeEvent(['sp-1', 'sp-2']))
+    const items = lastItems()
+    expect(items).toHaveLength(2)
+    for (const item of items) {
+      expect(item.actorId).toBeUndefined()
+    }
+  })
+})

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -44,6 +44,7 @@ export default defineType({
           { title: 'Travel Support Update', value: 'travel_support_update' },
           { title: 'Sponsor Activity', value: 'sponsor_activity' },
           { title: 'Schedule Update', value: 'schedule_update' },
+          { title: 'Gallery Tagged', value: 'gallery_tagged' },
           { title: 'System', value: 'system' },
         ],
         layout: 'dropdown',

--- a/src/lib/events/handlers/galleryTagPersistNotification.ts
+++ b/src/lib/events/handlers/galleryTagPersistNotification.ts
@@ -1,0 +1,47 @@
+import { GallerySpeakerTaggedEvent } from '@/lib/events/types'
+import { createNotifications } from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
+
+/**
+ * Persists an in-app notification for each speaker tagged in a gallery image,
+ * mirroring the email side effect (`handleGalleryTagNotification`). The link
+ * mirrors the email's `galleryUrl` (`buildGalleryImageUrl`) in app-relative
+ * form.
+ *
+ * All fan-out goes through `createNotifications`, which never throws — a failed
+ * notification write must not fail the tagging mutation that produced the event.
+ *
+ * NOTE: `metadata.taggedBy` is currently undefined (a survey TODO), so there is
+ * usually no actor. We handle its absence gracefully: the notification is
+ * emitted without an `actorId`, and the actor is only excluded from the
+ * recipients when it is actually present.
+ */
+export async function handleGalleryTagPersistNotification(
+  event: GallerySpeakerTaggedEvent,
+): Promise<void> {
+  const conferenceId = event.conference._id
+  const actorId = event.metadata.taggedBy
+  const link = `/#gallery?img=${event.image._id}`
+
+  // De-duplicate by speaker id and skip the actor (if known — a speaker who
+  // tags themselves does not need to be told about it).
+  const seen = new Set<string>()
+  const items: NotificationInput[] = []
+  for (const speaker of event.speakers || []) {
+    const id = speaker?._id
+    if (!id || id === actorId || seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    items.push({
+      recipientId: id,
+      conferenceId,
+      notificationType: 'gallery_tagged',
+      title: 'You were tagged in a conference photo',
+      actorId: actorId || undefined,
+      link,
+    })
+  }
+
+  await createNotifications(items)
+}

--- a/src/lib/events/registry.ts
+++ b/src/lib/events/registry.ts
@@ -3,6 +3,7 @@ import { handleEmailNotification } from './handlers/emailNotification'
 import { handleSlackNotification } from './handlers/slackNotification'
 import { handleAudienceUpdate } from './handlers/audienceUpdate'
 import { handleGalleryTagNotification } from './handlers/galleryTagNotification'
+import { handleGalleryTagPersistNotification } from './handlers/galleryTagPersistNotification'
 import { handlePersistNotification } from './handlers/persistNotification'
 
 let registered = false
@@ -16,8 +17,12 @@ export function registerEventHandlers(): void {
   eventBus.subscribe('proposal.status.changed', handleAudienceUpdate)
   eventBus.subscribe('proposal.status.changed', handlePersistNotification)
 
-  // Register gallery speaker tagged handler
+  // Register gallery speaker tagged handlers (email + in-app persistence)
   eventBus.subscribe('gallery.speaker.tagged', handleGalleryTagNotification)
+  eventBus.subscribe(
+    'gallery.speaker.tagged',
+    handleGalleryTagPersistNotification,
+  )
 }
 
 registerEventHandlers()

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -12,6 +12,7 @@ export type NotificationType =
   | 'travel_support_update'
   | 'sponsor_activity'
   | 'schedule_update'
+  | 'gallery_tagged'
   | 'system'
 
 /**

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -70,6 +70,11 @@ import {
   deleteSponsorActivity,
 } from '@/lib/sponsor-crm/activity'
 import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
+import {
   SponsorForConferenceInputSchema,
   SponsorForConferenceUpdateSchema,
   SponsorForConferenceIdSchema,
@@ -1098,6 +1103,37 @@ export const sponsorRouter = router({
             await logStageChange(input.id, oldStatus, input.newStatus, userId)
           } catch (logError) {
             console.error('Failed to log stage change activity:', logError)
+          }
+
+          // Notify organizers (except the actor) of the stage move. Shares
+          // createNotifications' never-fail contract: the move is already
+          // persisted, so a failure here (e.g. the organizer-id fetch) must not
+          // surface as a moveStage error.
+          try {
+            const conferenceId = existing.conference?._id
+            if (conferenceId) {
+              const sponsorName = existing.sponsor?.name
+              const organizerIds = await getOrganizerSpeakerIds()
+              await createNotifications(
+                organizerIds
+                  .filter((id) => id && id !== userId)
+                  .map((id): NotificationInput => ({
+                    recipientId: id,
+                    conferenceId,
+                    notificationType: 'sponsor_activity',
+                    title: sponsorName
+                      ? `Sponsor ${sponsorName} moved to ${input.newStatus}`
+                      : `Sponsor moved to ${input.newStatus}`,
+                    actorId: userId,
+                    link: '/admin/sponsors/crm',
+                  })),
+              )
+            }
+          } catch (notifyError) {
+            console.error(
+              'Failed to notify organizers of sponsor stage move:',
+              notifyError,
+            )
           }
         }
 

--- a/src/server/routers/travelSupport.ts
+++ b/src/server/routers/travelSupport.ts
@@ -41,6 +41,26 @@ import {
   canAddExpenses,
   verifyTravelSupportOwnership,
 } from '@/lib/travel-support/auth'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
+import { TravelSupportStatus } from '@/lib/travel-support/types'
+
+/**
+ * Human-readable notification titles for the travel support statuses that
+ * warrant notifying the affected speaker. The draft/submitted statuses are
+ * intentionally absent — they are the speaker's own echoes, not an organizer
+ * decision, so no notification is produced for them.
+ */
+const TRAVEL_STATUS_NOTIFY_TITLES: Partial<
+  Record<TravelSupportStatus, string>
+> = {
+  [TravelSupportStatus.APPROVED]: 'Travel support approved',
+  [TravelSupportStatus.REJECTED]: 'Travel support rejected',
+  [TravelSupportStatus.PAID]: 'Travel support marked paid',
+}
 
 export const travelSupportRouter = router({
   getMine: protectedProcedure.query(async ({ ctx }) => {
@@ -252,6 +272,31 @@ export const travelSupportRouter = router({
             message: 'Failed to submit travel support request',
             cause: error,
           })
+        }
+
+        // Notify organizers (except the actor) of the new request. Shares
+        // createNotifications' never-fail contract: the request is already
+        // submitted, so a failure here (e.g. the organizer-id fetch) must not
+        // surface as a submit error to the speaker.
+        try {
+          const organizerIds = await getOrganizerSpeakerIds()
+          await createNotifications(
+            organizerIds
+              .filter((id) => id && id !== ctx.speaker._id)
+              .map((id): NotificationInput => ({
+                recipientId: id,
+                conferenceId: travelSupport.conference._id,
+                notificationType: 'travel_support_update',
+                title: `Travel support request from ${ctx.speaker.name}`,
+                actorId: ctx.speaker._id,
+                link: '/admin/speakers/travel-support',
+              })),
+          )
+        } catch (notifyError) {
+          console.error(
+            'Failed to notify organizers of travel support request:',
+            notifyError,
+          )
         }
 
         return { success: true }
@@ -652,6 +697,38 @@ export const travelSupportRouter = router({
               message: 'Failed to update travel support status',
               cause: error,
             })
+          }
+
+          // Notify the affected speaker of a decision (approved/rejected/paid
+          // only — draft/submitted echoes are skipped), unless they made the
+          // change themselves. Shares createNotifications' never-fail contract:
+          // the status is already persisted, so a failure here must not surface
+          // as an update error.
+          try {
+            const statusTitle = TRAVEL_STATUS_NOTIFY_TITLES[input.status]
+            const affectedSpeakerId = travelSupport.speaker._id
+            if (
+              statusTitle &&
+              affectedSpeakerId &&
+              affectedSpeakerId !== ctx.speaker._id
+            ) {
+              await createNotifications([
+                {
+                  recipientId: affectedSpeakerId,
+                  conferenceId: travelSupport.conference._id,
+                  notificationType: 'travel_support_update',
+                  title: statusTitle,
+                  message: input.reviewNotes || undefined,
+                  actorId: ctx.speaker._id,
+                  link: '/cfp/expense',
+                },
+              ])
+            }
+          } catch (notifyError) {
+            console.error(
+              'Failed to notify speaker of travel support status change:',
+              notifyError,
+            )
           }
 
           return { success: true }


### PR DESCRIPTION
Phase N3 of the notification hub: three additional server-side emitters that fan out persistent in-app notifications. Every fan-out is failure-isolated so it can never fail the business mutation that produced it (guarded id-fetches + `createNotifications`' never-throw contract).

## 1. Travel support (`src/server/routers/travelSupport.ts`)
- **`submit`** (protectedProcedure): after a successful submission, notifies all organizers except the actor. Type `travel_support_update`, title `Travel support request from <speaker name>` (from `ctx.speaker.name`), link `/admin/speakers/travel-support`. `conferenceId` taken from the already-authorized `travelSupport.conference._id` (no extra fetch).
- **`admin.updateStatus`** (adminProcedure): after a successful status change, notifies the affected speaker (`travelSupport.speaker._id`) unless they are the actor. Gated by a status→title map — only `approved` (`Travel support approved`), `rejected` (`Travel support rejected`), `paid` (`Travel support marked paid`) notify; `draft`/`submitted` echoes produce nothing. `reviewNotes` carried as the message when present. Link `/cfp/expense` (the speaker-facing travel-support page; there is no `/cfp/travel-support` route).

## 2. Sponsor stage (`src/server/routers/sponsor.ts` `crm.moveStage`)
- After a successful stage move, notifies all organizers except the actor. Type `sponsor_activity`, title `Sponsor <name> moved to <newStage>` (name from the already-fetched `existing.sponsor?.name`; falls back to `Sponsor moved to <newStage>` when absent), link `/admin/sponsors/crm`. `conferenceId` from `existing.conference?._id`.

## 3. Gallery tag (`src/lib/events/handlers/galleryTagPersistNotification.ts`)
- New bus handler on `gallery.speaker.tagged`, registered alongside the existing email handler in `registry.ts`. Notifies each tagged speaker (de-duplicated). New `gallery_tagged` member added to the `NotificationType` union and the Sanity schema options list. Title `You were tagged in a conference photo`, link `/#gallery?img=<imageId>` (mirrors the email's `buildGalleryImageUrl`). `metadata.taggedBy` is currently undefined (survey TODO) so `actorId` is usually absent — handled gracefully (no actor, nobody excluded); when present, the actor is excluded from recipients.

## Tests
- `__tests__/lib/events/galleryTagPersistNotification.test.ts` — fan-out, de-dup, actor exclusion, undefined-taggedBy handling (4 tests, runs locally).
- `__tests__/api/trpc/sponsor-stage-notification.test.ts` — organizers-minus-actor fan-out, generic-title fallback, isolation (organizer-id fetch throwing does not fail the move).
- `__tests__/api/trpc/travel-support-notification.test.ts` — submit fan-out + isolation; updateStatus recipient/title/message, status-map gating (no notification on draft/submitted), actor exclusion.

The two tRPC-caller tests import `@/server/_app` and therefore share the repo's known `@digitalbazaar/vc` load failure locally (same as `sponsor-move-stage.test.ts` and every other tRPC test); they run in CI. Full suite: 2314 tests pass, 0 actual failures; 26 suites fail to load on the known vc issue (24 pre-existing + these 2).

tsc clean, eslint clean, prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Phase N3 of the notification hub wires three new server-side emitters — travel support (submit + status-change), sponsor CRM stage moves, and gallery photo tags — all fanning out persistent in-app notifications through the existing `createNotifications` never-throw contract so no emitter can fail its parent mutation.

- **Travel support** (`travelSupport.ts`): `submit` fans out to all organizers (excluding the actor); `admin.updateStatus` notifies the affected speaker for `approved`/`rejected`/`paid` decisions only, carrying `reviewNotes` as the message.
- **Sponsor CRM** (`sponsor.ts`): `crm.moveStage` fans out to all organizers whenever the status actually changes; title falls back gracefully when `sponsor.name` is absent.
- **Gallery tag** (`galleryTagPersistNotification.ts`): new bus handler on `gallery.speaker.tagged`, de-duplicating by speaker id and excluding the tagger when known; `gallery_tagged` added to both the TypeScript union and the Sanity schema dropdown.

<h3>Confidence Score: 4/5</h3>

The three new emitters are well-isolated — every notification fan-out sits inside its own try/catch so no notification failure can surface as a mutation error. The `conferenceId` values all come from server-fetched objects rather than client input, preserving multi-tenant isolation.

The changes are focused and the isolation pattern is applied consistently across all three emitters. The only notable asymmetry is that `travelSupport.ts` accesses `travelSupport.conference._id` without the optional-chain guard that `sponsor.ts` uses, meaning a missing `conference` field would silently swallow the notification rather than explicitly skipping it. This doesn't affect end-users but makes the skip behaviour less obvious during debugging.

src/server/routers/travelSupport.ts — the bare `travelSupport.conference._id` accesses in both notification blocks are worth a second look for consistency with the sponsor router's defensive pattern.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/events/handlers/galleryTagPersistNotification.ts | New bus handler that persists in-app notifications for each tagged speaker; de-duplication and actor-exclusion logic is correct, and the handler correctly defers to `createNotifications`' never-throw contract. |
| src/server/routers/travelSupport.ts | Adds organizer fan-out after `submit` and speaker notification after `admin.updateStatus`; both wrapped in isolation try/catch. Minor: accesses `travelSupport.conference._id` directly (no optional-chain guard), unlike the equivalent pattern in sponsor.ts. |
| src/server/routers/sponsor.ts | Adds organizer notification after `crm.moveStage`; correctly guarded by `conferenceId` optional-chain + null check, isolated in try/catch, and scoped to status-changing moves only. |
| src/lib/events/registry.ts | Registers `handleGalleryTagPersistNotification` alongside the existing email handler for `gallery.speaker.tagged`; straightforward and correct. |
| src/lib/notification/types.ts | Adds `gallery_tagged` to the `NotificationType` union, consistent with the new schema option and all call sites. |
| sanity/schemaTypes/notification.ts | Adds `gallery_tagged` option to the Sanity schema dropdown; value matches the TypeScript union and all notification writes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): travel-support, spo..."](https://github.com/cloudnativebergen/website/commit/8d40ee537193c1854452ed6f2e546d868cb7d7a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45343306)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->