### PR TITLE
fix(notifications): story-mock parity + emitter polish

### DIFF
--- a/src/components/common/DashboardLayout.stories.tsx
+++ b/src/components/common/DashboardLayout.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { fn } from 'storybook/test'
+import { http, HttpResponse } from 'msw'
 import {
   HomeIcon,
   DocumentTextIcon,
@@ -7,20 +8,77 @@ import {
   CalendarDaysIcon,
   Cog6ToothIcon,
   MagnifyingGlassIcon,
-  BellIcon,
   ChevronDownIcon,
 } from '@heroicons/react/24/outline'
 import { ConferenceLogo } from '@/components/ConferenceLogo'
 import { ThemeToggle } from '@/components/ThemeToggle'
+import { TRPCProvider } from '@/components/providers/TRPCProvider'
+import { NotificationBell } from '@/components/notifications/NotificationBell'
 import clsx from 'clsx'
 import type {
   NavigationSection,
   NavigationItem,
 } from '@/components/common/DashboardLayout'
 
+// Deterministic tRPC responses for the REAL NotificationBell the mock shell
+// mounts: 3 unread (badge) and a small inbox. Handles httpBatchLink's
+// comma-batched GET paths generically.
+const notificationItems = () => [
+  {
+    id: 'n1',
+    type: 'proposal_status_changed',
+    title: 'Your proposal was accepted',
+    message: 'Congratulations! "Scaling Kubernetes" was accepted.',
+    link: '/cfp/proposal/1',
+    readAt: null,
+    createdAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+    actor: { _id: 'a1', name: 'Program Committee' },
+  },
+  {
+    id: 'n2',
+    type: 'travel_support_update',
+    title: 'Travel support approved',
+    readAt: null,
+    createdAt: new Date(Date.now() - 90 * 60_000).toISOString(),
+    actor: null,
+  },
+  {
+    id: 'n3',
+    type: 'system',
+    title: 'Schedule published',
+    readAt: new Date().toISOString(),
+    createdAt: new Date(Date.now() - 86_400_000).toISOString(),
+    actor: null,
+  },
+]
+
+const notificationHandlers = [
+  http.get('/api/trpc/:procs', ({ params }) =>
+    HttpResponse.json(
+      String(params.procs)
+        .split(',')
+        .map((proc) =>
+          proc === 'notification.list'
+            ? { result: { data: notificationItems() } }
+            : proc === 'notification.unreadCount'
+              ? { result: { data: 3 } }
+              : { result: { data: null } },
+        ),
+    ),
+  ),
+]
+
 const meta = {
   title: 'Components/Layout/DashboardLayout',
+  decorators: [
+    (Story) => (
+      <TRPCProvider>
+        <Story />
+      </TRPCProvider>
+    ),
+  ],
   parameters: {
+    msw: { handlers: notificationHandlers },
     layout: 'fullscreen',
     docs: {
       description: {
@@ -190,14 +248,10 @@ function MockDashboard({
           </div>
           <div className="flex items-center gap-x-4 lg:gap-x-6">
             <ThemeToggle />
-            {mode === 'admin' && (
-              <button
-                type="button"
-                className="-m-2.5 p-2.5 text-gray-400 hover:text-gray-500 dark:text-gray-500"
-              >
-                <BellIcon aria-hidden="true" className="size-6" />
-              </button>
-            )}
+            {/* The REAL bell (kept in sync with DashboardLayout post-#511):
+                needs a TRPCProvider (meta decorator); its queries are stubbed
+                by msw/route interception in visual QA. */}
+            <NotificationBell />
             <div className="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-200 dark:bg-gray-700" />
             <button className="-m-1.5 flex items-center p-1.5">
               <img

--- a/src/lib/events/handlers/galleryTagPersistNotification.ts
+++ b/src/lib/events/handlers/galleryTagPersistNotification.ts
@@ -38,7 +38,7 @@ export async function handleGalleryTagPersistNotification(
       conferenceId,
       notificationType: 'gallery_tagged',
       title: 'You were tagged in a conference photo',
-      actorId: actorId || undefined,
+      actorId,
       link,
     })
   }

--- a/src/server/routers/travelSupport.ts
+++ b/src/server/routers/travelSupport.ts
@@ -279,19 +279,24 @@ export const travelSupportRouter = router({
         // submitted, so a failure here (e.g. the organizer-id fetch) must not
         // surface as a submit error to the speaker.
         try {
-          const organizerIds = await getOrganizerSpeakerIds()
-          await createNotifications(
-            organizerIds
-              .filter((id) => id && id !== ctx.speaker._id)
-              .map((id): NotificationInput => ({
-                recipientId: id,
-                conferenceId: travelSupport.conference._id,
-                notificationType: 'travel_support_update',
-                title: `Travel support request from ${ctx.speaker.name}`,
-                actorId: ctx.speaker._id,
-                link: '/admin/speakers/travel-support',
-              })),
-          )
+          // Defensive: mirror sponsor.ts — skip the fan-out entirely if the
+          // conference ref is missing rather than writing a broken reference.
+          const conferenceId = travelSupport.conference?._id
+          if (conferenceId) {
+            const organizerIds = await getOrganizerSpeakerIds()
+            await createNotifications(
+              organizerIds
+                .filter((id) => id && id !== ctx.speaker._id)
+                .map((id): NotificationInput => ({
+                  recipientId: id,
+                  conferenceId,
+                  notificationType: 'travel_support_update',
+                  title: `Travel support request from ${ctx.speaker.name}`,
+                  actorId: ctx.speaker._id,
+                  link: '/admin/speakers/travel-support',
+                })),
+            )
+          }
         } catch (notifyError) {
           console.error(
             'Failed to notify organizers of travel support request:',


### PR DESCRIPTION
## Visual-validation findings

Ran the full notification-UI state matrix (Playwright + MSW, light/dark × mobile/desktop). Key finding: **the DashboardLayout story mock still rendered the old dead `BellIcon`** — the integrated bell had never been visually validated through it. The mock now mounts the **real `NotificationBell`** (TRPCProvider decorator + deterministic msw handlers, comma-batch-safe), so badge + panel states are visible in Storybook and covered by Chromatic.

Also applies the two Greptile P2s from #513 (redundant `|| undefined`; defensive `conferenceId` guard matching the sponsor.ts pattern).

## States validated (screenshots inspected)

- List: unread/read mix, empty, loading, load-error — light + dark @393px ✅
- Live badge (3) on desktop admin bar; open panel anchored right with items ✅
- Dark-mode open panel ✅; speaker-shell bell + badge (gate removal) ✅

Known story-mock gaps (not product gaps; real `DashboardLayout` code-verified): the mock has no mobile top bar; the `9+` badge cap is covered by unit logic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the real `NotificationBell` into the `DashboardLayout` story mock (replacing a dead `BellIcon` placeholder), adds MSW + `TRPCProvider` scaffolding to stub the tRPC notification queries, and applies two small backend clean-ups from the previous review cycle.

- **Story mock** (`DashboardLayout.stories.tsx`): real `NotificationBell` with `TRPCProvider` decorator and MSW handlers for `notification.list` / `notification.unreadCount`; the mode-based bell gate is removed so the bell renders in both admin and speaker shells.
- **Backend clean-ups**: redundant `|| undefined` coercion removed from `galleryTagPersistNotification.ts`; defensive `conferenceId` null guard added in `travelSupport.ts` before the organizer notification fan-out, mirroring the existing `sponsor.ts` pattern.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the backend changes are small and defensive, and the story wiring is additive.

The two backend files are straightforward clean-ups with no behavioral risk. The story file works correctly but its notificationItems() factory uses live Date.now() calls, so every Storybook render produces different createdAt values — any relative-time rendering in NotificationPanel will produce Chromatic snapshot diffs on each run, which undermines the visual-QA goal the PR is trying to achieve. The SpeakerMode story description is also stale. Neither issue blocks functionality.

src/components/common/DashboardLayout.stories.tsx — the notification item timestamps should use a fixed epoch rather than live Date.now() calls.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/common/DashboardLayout.stories.tsx | Replaces the dead BellIcon placeholder with the real NotificationBell, adds TRPCProvider decorator and MSW handlers — but the notificationItems() factory uses live Date.now() calls that will produce non-deterministic createdAt values on every render, risking Chromatic diff noise; the SpeakerMode story description is also stale. |
| src/lib/events/handlers/galleryTagPersistNotification.ts | Removes the redundant `|| undefined` on actorId — actorId is typed as optional (string | undefined) so the coercion was a no-op. Clean simplification. |
| src/server/routers/travelSupport.ts | Adds a defensive conferenceId guard before the notification fan-out, mirroring the sponsor.ts pattern. Safe change — the outer try/catch already prevents notification failures from surfacing to the user. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SB as Storybook
    participant MSW as MSW Handler
    participant TRPC as TRPCProvider
    participant Bell as NotificationBell
    participant Panel as NotificationPanel

    SB->>TRPC: render with TRPCProvider decorator
    TRPC->>Bell: mount NotificationBell
    Bell->>MSW: GET /api/trpc/notification.unreadCount
    MSW-->>Bell: "{ result: { data: 3 } }"
    Bell->>Bell: show badge 3
    Bell->>Panel: open panel (on click)
    Panel->>MSW: GET /api/trpc/notification.list,notification.unreadCount
    MSW-->>Panel: array of notification items
    Panel->>Panel: render 3 notification items
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SB as Storybook
    participant MSW as MSW Handler
    participant TRPC as TRPCProvider
    participant Bell as NotificationBell
    participant Panel as NotificationPanel

    SB->>TRPC: render with TRPCProvider decorator
    TRPC->>Bell: mount NotificationBell
    Bell->>MSW: GET /api/trpc/notification.unreadCount
    MSW-->>Bell: "{ result: { data: 3 } }"
    Bell->>Bell: show badge 3
    Bell->>Panel: open panel (on click)
    Panel->>MSW: GET /api/trpc/notification.list,notification.unreadCount
    MSW-->>Panel: array of notification items
    Panel->>Panel: render 3 notification items
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/common/DashboardLayout.stories.tsx`, line 309-326 ([link](https://github.com/cloudnativebergen/website/blob/7da064acca90c910bfc3376567e0a0bb6917715e/src/components/common/DashboardLayout.stories.tsx#L309-L326)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `SpeakerMode` story description still says "No search bar or notification bell", but the `NotificationBell` is now rendered unconditionally (the `mode === 'admin'` gate was removed). The bell will be visible in this story, making the description misleading.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): story-mock parity + ..."](https://github.com/cloudnativebergen/website/commit/7da064acca90c910bfc3376567e0a0bb6917715e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45344359)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->