### PR TITLE
feat(notifications): 90-day retention cron + privacy wording (N4)

### DIFF
--- a/__tests__/api/cron/cleanup-notifications.test.ts
+++ b/__tests__/api/cron/cleanup-notifications.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment node
+ */
+import { NextRequest } from 'next/server'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockDeleteOlderThan = vi.fn<(...args: any[]) => any>()
+
+vi.mock('@/lib/notification/sanity', () => ({
+  deleteNotificationsOlderThan: (...args: unknown[]) =>
+    mockDeleteOlderThan(...args),
+}))
+
+vi.mock('next/cache', () => ({
+  unstable_noStore: vi.fn(),
+}))
+
+describe('api/cron/cleanup-notifications', () => {
+  beforeAll(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterAll(() => {
+    vi.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = 'test-cron-secret'
+    mockDeleteOlderThan.mockResolvedValue({ deleted: 0 })
+  })
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET
+  })
+
+  function cronRequest(authHeader?: string): NextRequest {
+    return new NextRequest(
+      'http://localhost:3000/api/cron/cleanup-notifications',
+      {
+        headers: authHeader ? { authorization: authHeader } : {},
+      },
+    )
+  }
+
+  describe('Authentication', () => {
+    it('returns 401 without authorization header', async () => {
+      const { GET } = await import('@/app/api/cron/cleanup-notifications/route')
+      const response = await GET(cronRequest())
+      expect(response.status).toBe(401)
+      expect(mockDeleteOlderThan).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 with wrong token', async () => {
+      const { GET } = await import('@/app/api/cron/cleanup-notifications/route')
+      const response = await GET(cronRequest('Bearer wrong-secret'))
+      expect(response.status).toBe(401)
+      expect(mockDeleteOlderThan).not.toHaveBeenCalled()
+    })
+
+    it('returns 500 when CRON_SECRET is not set', async () => {
+      delete process.env.CRON_SECRET
+      const { GET } = await import('@/app/api/cron/cleanup-notifications/route')
+      const response = await GET(cronRequest('Bearer test-cron-secret'))
+      expect(response.status).toBe(500)
+      expect(mockDeleteOlderThan).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Cleanup', () => {
+    it('deletes notifications older than 90 days and returns the count', async () => {
+      mockDeleteOlderThan.mockResolvedValueOnce({ deleted: 7 })
+      const { GET } = await import('@/app/api/cron/cleanup-notifications/route')
+
+      const response = await GET(cronRequest('Bearer test-cron-secret'))
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.success).toBe(true)
+      expect(data.deleted).toBe(7)
+      expect(mockDeleteOlderThan).toHaveBeenCalledWith(90)
+    })
+
+    it('returns 500 and surfaces the error when cleanup throws (errors are not swallowed)', async () => {
+      mockDeleteOlderThan.mockRejectedValueOnce(new Error('sanity down'))
+      const { GET } = await import('@/app/api/cron/cleanup-notifications/route')
+
+      const response = await GET(cronRequest('Bearer test-cron-secret'))
+      expect(response.status).toBe(500)
+
+      const data = await response.json()
+      expect(data.error).toBe('Internal server error')
+      expect(data.details).toBe('sanity down')
+    })
+  })
+})

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -36,6 +36,7 @@ import {
   getUnreadCount,
   markNotificationsRead,
   markAllRead,
+  deleteNotificationsOlderThan,
 } from '@/lib/notification/sanity'
 import type { NotificationInput } from '@/lib/notification/types'
 
@@ -51,6 +52,7 @@ function installTransaction(commit: () => Promise<unknown> = async () => ({})) {
   const tx = {
     create: vi.fn((_doc?: unknown) => tx),
     patch: vi.fn((_id?: string, _ops?: unknown) => tx),
+    delete: vi.fn((_id?: string) => tx),
     commit: vi.fn(commit),
   }
   writeMock.transaction.mockReturnValue(tx)
@@ -311,5 +313,101 @@ describe('getNotificationsForSpeaker — cursor pagination', () => {
       conferenceId: 'conf-1',
     })
     expect(result).toEqual([])
+  })
+})
+
+describe('deleteNotificationsOlderThan — batched retention cleanup', () => {
+  const BATCH_SIZE = 500
+  const MAX_BATCHES = 20
+  const fullBatch = () => Array.from({ length: BATCH_SIZE }, (_, i) => `n-${i}`)
+
+  it('deletes a single partial batch in ONE transaction and returns the count', async () => {
+    readMock.fetch.mockResolvedValueOnce(['n-1', 'n-2', 'n-3'])
+    const tx = installTransaction()
+
+    const result = await deleteNotificationsOlderThan(90)
+
+    // One fetch, one transaction, one delete per id, one commit.
+    expect(readMock.fetch).toHaveBeenCalledTimes(1)
+    expect(writeMock.transaction).toHaveBeenCalledTimes(1)
+    expect(tx.delete).toHaveBeenCalledTimes(3)
+    expect(tx.delete).toHaveBeenNthCalledWith(1, 'n-1')
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ deleted: 3 })
+  })
+
+  it('queries by a `createdAt < $cutoff` cutoff derived from `days`', async () => {
+    readMock.fetch.mockResolvedValueOnce([])
+    const before = Date.now() - 91 * 24 * 60 * 60 * 1000
+    const after = Date.now() - 89 * 24 * 60 * 60 * 1000
+
+    await deleteNotificationsOlderThan(90)
+
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('_type == "notification"')
+    expect(query).toContain('createdAt < $cutoff')
+    const cutoff = Date.parse((params as { cutoff: string }).cutoff)
+    // ~90 days ago, bracketed to absorb the tiny execution delay.
+    expect(cutoff).toBeGreaterThanOrEqual(before)
+    expect(cutoff).toBeLessThanOrEqual(after)
+  })
+
+  it('is a no-op (no transaction) when nothing is expired', async () => {
+    readMock.fetch.mockResolvedValueOnce([])
+    const tx = installTransaction()
+
+    const result = await deleteNotificationsOlderThan(90)
+
+    expect(result).toEqual({ deleted: 0 })
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+    expect(tx.commit).not.toHaveBeenCalled()
+  })
+
+  it('coalesces a null fetch result to zero deletions', async () => {
+    readMock.fetch.mockResolvedValueOnce(null)
+    const result = await deleteNotificationsOlderThan(90)
+    expect(result).toEqual({ deleted: 0 })
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+  })
+
+  it('loops across batches until a short batch drains the backlog, summing the total', async () => {
+    // A full batch (keep looping) followed by a partial batch (stop).
+    readMock.fetch
+      .mockResolvedValueOnce(fullBatch())
+      .mockResolvedValueOnce(['tail-1', 'tail-2'])
+    const tx = installTransaction()
+
+    const result = await deleteNotificationsOlderThan(90)
+
+    // Two fetches, two transactions/commits; no extra empty fetch after the
+    // short batch.
+    expect(readMock.fetch).toHaveBeenCalledTimes(2)
+    expect(writeMock.transaction).toHaveBeenCalledTimes(2)
+    expect(tx.commit).toHaveBeenCalledTimes(2)
+    expect(tx.delete).toHaveBeenCalledTimes(BATCH_SIZE + 2)
+    expect(result).toEqual({ deleted: BATCH_SIZE + 2 })
+  })
+
+  it('stops at the safety cap when every batch stays full (never spins forever)', async () => {
+    // Always a full batch: only the hard cap can end the loop.
+    readMock.fetch.mockResolvedValue(fullBatch())
+    const tx = installTransaction()
+
+    const result = await deleteNotificationsOlderThan(90)
+
+    expect(readMock.fetch).toHaveBeenCalledTimes(MAX_BATCHES)
+    expect(tx.commit).toHaveBeenCalledTimes(MAX_BATCHES)
+    expect(result).toEqual({ deleted: BATCH_SIZE * MAX_BATCHES })
+  })
+
+  it('PROPAGATES a commit failure (does NOT swallow it, unlike the fan-out paths)', async () => {
+    readMock.fetch.mockResolvedValueOnce(['n-1'])
+    installTransaction(async () => {
+      throw new Error('sanity down')
+    })
+
+    await expect(deleteNotificationsOlderThan(90)).rejects.toThrow(
+      'sanity down',
+    )
   })
 })

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -348,7 +348,8 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                           organizers informed of proposal and conference
                           activity. <strong>Legal Basis:</strong> Legitimate
                           interest in conference coordination. These
-                          notifications are retained until deleted.
+                          notifications are automatically deleted 90 days after
+                          they are created.
                         </p>
                       </div>
                     </div>
@@ -1139,7 +1140,7 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                               </div>
                             </td>
                             <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
-                              Retained until deleted
+                              90 days after creation
                             </td>
                             <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
                               <span className="font-medium text-blue-600 dark:text-blue-400">

--- a/src/app/api/cron/cleanup-notifications/route.ts
+++ b/src/app/api/cron/cleanup-notifications/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { deleteNotificationsOlderThan } from '@/lib/notification/sanity'
+import { unstable_noStore as noStore } from 'next/cache'
+
+/**
+ * Notification retention period in days before cleanup.
+ * Notifications older than this are permanently deleted by the daily cron,
+ * matching the 90-day retention stated in the privacy policy.
+ */
+const NOTIFICATION_RETENTION_DAYS = 90
+
+export async function GET(request: NextRequest) {
+  noStore()
+  try {
+    const authHeader = request.headers.get('authorization')
+    const cronSecret = process.env.CRON_SECRET
+
+    if (!cronSecret) {
+      console.error('CRON_SECRET environment variable is not set')
+      return NextResponse.json(
+        { error: 'Server configuration error' },
+        { status: 500 },
+      )
+    }
+
+    if (!authHeader || authHeader !== `Bearer ${cronSecret}`) {
+      console.error('Invalid or missing authorization token')
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { deleted } = await deleteNotificationsOlderThan(
+      NOTIFICATION_RETENTION_DAYS,
+    )
+
+    console.log(
+      `Deleted ${deleted} notifications older than ${NOTIFICATION_RETENTION_DAYS} days`,
+    )
+
+    return NextResponse.json({
+      success: true,
+      deleted,
+    })
+  } catch (error) {
+    console.error('Error in cleanup notifications cron job:', error)
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/common/DashboardLayout.stories.tsx
+++ b/src/components/common/DashboardLayout.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { fn } from 'storybook/test'
 import { http, HttpResponse } from 'msw'
+import { mockDateBeforeEach } from '@/lib/storybook'
 import {
   HomeIcon,
   DocumentTextIcon,
@@ -70,6 +71,9 @@ const notificationHandlers = [
 
 const meta = {
   title: 'Components/Layout/DashboardLayout',
+  // AGENTS.md deterministic-dates rule: pin Date so the msw notification
+  // fixtures (and their relative-time labels) are absolutely fixed.
+  beforeEach: mockDateBeforeEach(new Date('2026-07-18T12:00:00Z')),
   decorators: [
     (Story) => (
       <TRPCProvider>

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { fn } from 'storybook/test'
 import { NotificationList } from './NotificationList'
-import { mockDateBeforeEach } from '@/lib/storybook/mockDate'
+import { mockDateBeforeEach } from '@/lib/storybook'
 import type { NotificationItem } from '@/lib/notification/types'
 
 // createdAt values are computed relative to RENDER time (the factory below is

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -208,6 +208,61 @@ export async function markAllRead({
   return ids.length
 }
 
+/** How many expired notifications are fetched and deleted per cleanup batch. */
+const RETENTION_DELETE_BATCH_SIZE = 500
+
+/**
+ * A hard cap on how many batches a single cleanup run performs, so a runaway
+ * query (or a clock/skew bug) can never spin forever. At
+ * {@link RETENTION_DELETE_BATCH_SIZE} per batch this bounds one run to ~10k
+ * deletions; the next daily run picks up any remainder.
+ */
+const RETENTION_MAX_BATCHES = 20
+
+/**
+ * Permanently delete every `notification` document created more than `days` days
+ * ago, in bounded batches — each batch is fetched by id and deleted in ONE
+ * `clientWrite.transaction()` (chained `.delete()`), looping until none remain
+ * or the {@link RETENTION_MAX_BATCHES} safety cap is reached. Returns the total
+ * number of documents deleted.
+ *
+ * CONTRACT: unlike the fan-out write paths, this function MAY throw. It backs a
+ * retention cron route that reports (and should surface) failures rather than
+ * silently swallowing them, so the caller is expected to handle errors.
+ */
+export async function deleteNotificationsOlderThan(
+  days: number,
+): Promise<{ deleted: number }> {
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+
+  let deleted = 0
+  for (let batch = 0; batch < RETENTION_MAX_BATCHES; batch++) {
+    const ids = await clientReadUncached.fetch<string[]>(
+      `*[_type == "notification" && createdAt < $cutoff][0...${RETENTION_DELETE_BATCH_SIZE}]._id`,
+      { cutoff },
+    )
+
+    if (!ids || ids.length === 0) {
+      break
+    }
+
+    const tx = clientWrite.transaction()
+    for (const id of ids) {
+      tx.delete(id)
+    }
+    await tx.commit()
+
+    deleted += ids.length
+
+    // A short batch means the backlog is drained — stop before an empty fetch.
+    if (ids.length < RETENTION_DELETE_BATCH_SIZE) {
+      break
+    }
+  }
+
+  return { deleted }
+}
+
 /**
  * The `_id`s of every organizer speaker. `isOrganizer` is GLOBAL (an organizer
  * of one edition is an organizer everywhere); the conference scoping happens

--- a/src/lib/storybook/index.ts
+++ b/src/lib/storybook/index.ts
@@ -1,0 +1,2 @@
+// Barrel for Storybook-only helpers (AGENTS.md subdirectory-barrel convention).
+export * from './mockDate'

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/contract-reminders",
       "schedule": "0 9 * * *"
+    },
+    {
+      "path": "/api/cron/cleanup-notifications",
+      "schedule": "0 4 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Phase N4 — Notification retention cleanup + privacy wording

Final phase of the notification hub: a daily retention cron that permanently deletes notifications older than 90 days, with the privacy policy updated to match.

### Retention design
- **`deleteNotificationsOlderThan(days)`** (`src/lib/notification/sanity.ts`): GROQ-fetches ids of `notification` docs with `createdAt < $cutoff` in bounded batches (500 per iteration via `clientReadUncached`), deletes each batch in a single `clientWrite.transaction()` of chained `.delete()` calls, and loops until a short/empty batch drains the backlog.
- **Safety cap**: a hard `RETENTION_MAX_BATCHES = 20` ceiling (~10k deletions/run) means a runaway query or clock-skew bug can never spin forever; any remainder is picked up by the next daily run.
- **Throws by contract**: unlike the fan-out write paths (which never throw so a notification failure can't roll back a business mutation), this function propagates errors so the cron route can surface them.
- **Cron route** (`src/app/api/cron/cleanup-notifications/route.ts`): mirrors `cleanup-orphaned-blobs` exactly — `noStore()`, `CRON_SECRET` + `Bearer` auth check with identical 500/401 shapes, calls `deleteNotificationsOlderThan(90)`, returns `{ success, deleted }`, and reports errors as HTTP 500 with details.
- **Schedule** (`vercel.json`): `0 4 * * *` daily — a quiet hour that doesn't collide with the existing 03:00 blob cleanup or 09:00 jobs.

### Privacy alignment
The `/privacy` notifications wording is updated in both places it appears:
- Section 2 (In-App Notifications box): "retained until deleted" → "automatically deleted 90 days after they are created".
- Section 7 retention table row (added in #511): "Retained until deleted" → "90 days after creation".

### Rider (Greptile P2 on #515)
**Skipped** — `src/lib/storybook/` does not exist on the `main` this branch was cut from (#515 unmerged at fetch time), so there is no barrel to add. If #515 merges later, the `src/lib/storybook/index.ts` barrel should be added as a follow-up.

### Tests
- Extended `__tests__/lib/notification/sanity.test.ts`: batched single-transaction delete, cutoff derivation, no-op/null-result paths, multi-batch looping, the 20-batch safety cap, and error propagation (not swallowed).
- Added `__tests__/api/cron/cleanup-notifications.test.ts` (existing cron routes have tests): auth 401/500 paths, delegation to `deleteNotificationsOlderThan(90)`, deleted-count response, and error-surfacing 500.
- Full suite: 2328 tests pass, 0 actual failures (26 known `@digitalbazaar/vc` file-load failures, unrelated). tsc clean, eslint clean, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the notification retention system (Phase N4) by adding a daily cron job that permanently deletes `notification` documents older than 90 days, and updates the privacy policy wording to match the new policy.

- **Retention function** (`deleteNotificationsOlderThan`): GROQ-fetches up to 500 IDs per iteration using `clientReadUncached`, deletes each batch in a single `clientWrite.transaction()`, and loops until the backlog drains or the hard `RETENTION_MAX_BATCHES = 20` safety cap is reached (~10k deletions/run). Errors propagate by contract.
- **Cron route** (`/api/cron/cleanup-notifications`): mirrors the existing `cleanup-orphaned-blobs` pattern — `noStore()`, `CRON_SECRET` Bearer auth, delegates to `deleteNotificationsOlderThan(90)`, schedules at `0 4 * * *` in `vercel.json`.
- **Privacy page**: two occurrences of "retained until deleted" updated to the new 90-day wording, consistent across both the In-App Notifications box and the Section 7 retention table.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the retention function, cron route, schedule, and privacy wording are all consistent and correctly implemented.

The batched delete loop correctly drains the backlog (short-batch break) without ever spinning forever (hard 20-batch cap), the GROQ query is fully parameterized, the cron route mirrors the established cleanup-orphaned-blobs pattern exactly, and the privacy page is updated in both required places. Tests cover every documented contract path including the safety cap and error propagation.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/notification/sanity.ts | Adds deleteNotificationsOlderThan with correct batched-delete loop, GROQ parameterization, safety cap, and error propagation contract. Logic is consistent with existing markAllRead pattern. |
| src/app/api/cron/cleanup-notifications/route.ts | New cron route that faithfully mirrors cleanup-orphaned-blobs: noStore(), CRON_SECRET Bearer auth, delegates to deleteNotificationsOlderThan(90), proper 401/500 shapes. |
| __tests__/lib/notification/sanity.test.ts | Comprehensive test coverage: single batch, cutoff derivation, no-op, null result, multi-batch loop, safety cap, and error propagation. installTransaction mock extended with delete(). |
| __tests__/api/cron/cleanup-notifications.test.ts | New cron route test covering auth 401/500 paths, successful delegation with correct day count, and error surfacing. Follows the same dynamic-import pattern as other cron tests. |
| src/app/(main)/privacy/page.tsx | Two privacy wording updates (Section 2 notifications box, Section 7 retention table) updated consistently to reflect the 90-day retention policy. |
| vercel.json | Adds cleanup-notifications cron at 0 4 * * * — offset from existing 03:00 blob cleanup and 09:00 contract-reminders, correct Vercel cron format. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant V as Vercel Cron (0 4 * * *)
    participant R as /api/cron/cleanup-notifications
    participant S as deleteNotificationsOlderThan(90)
    participant SR as clientReadUncached (Sanity)
    participant SW as clientWrite (Sanity)

    V->>R: GET + Authorization: Bearer CRON_SECRET
    R->>R: Verify CRON_SECRET present + header matches
    R->>S: deleteNotificationsOlderThan(90)
    loop up to 20 batches
        S->>SR: "GROQ fetch expired IDs (createdAt < cutoff)[0...500]"
        SR-->>S: ids[]
        alt ids empty
            S-->>S: break
        else ids present
            S->>SW: transaction().delete(id) x N .commit()
            SW-->>S: committed
            S->>S: "deleted += ids.length"
            alt "ids.length < 500"
                S-->>S: break (backlog drained)
            end
        end
    end
    S-->>R: "{ deleted }"
    R-->>V: "200 { success: true, deleted }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant V as Vercel Cron (0 4 * * *)
    participant R as /api/cron/cleanup-notifications
    participant S as deleteNotificationsOlderThan(90)
    participant SR as clientReadUncached (Sanity)
    participant SW as clientWrite (Sanity)

    V->>R: GET + Authorization: Bearer CRON_SECRET
    R->>R: Verify CRON_SECRET present + header matches
    R->>S: deleteNotificationsOlderThan(90)
    loop up to 20 batches
        S->>SR: "GROQ fetch expired IDs (createdAt < cutoff)[0...500]"
        SR-->>S: ids[]
        alt ids empty
            S-->>S: break
        else ids present
            S->>SW: transaction().delete(id) x N .commit()
            SW-->>S: committed
            S->>S: "deleted += ids.length"
            alt "ids.length < 500"
                S-->>S: break (backlog drained)
            end
        end
    end
    S-->>R: "{ deleted }"
    R-->>V: "200 { success: true, deleted }"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(storybook): add lib/storybook barr..."](https://github.com/cloudnativebergen/website/commit/2e025ff5ed68c4334aee47f3c1882060149a9b77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45346398)</sub>

<!-- /greptile_comment -->