### PR TITLE
ci: auto-deploy Sanity Studio after merges touching studio files

### DIFF
--- a/.github/workflows/deploy-studio.yml
+++ b/.github/workflows/deploy-studio.yml
@@ -1,0 +1,78 @@
+name: Deploy Sanity Studio
+
+# Auto-deploys the standalone Studio (appId pinned in sanity.cli.ts) whenever
+# studio-relevant files land on main, so new/changed schema types (e.g. the
+# `notification` document) become visible in the hosted Studio without a manual
+# `sanity deploy`. Main only advances through the merge queue with green CI, so
+# a push to main IS the "CI succeeded" signal.
+#
+# Data migrations stay deliberately manual via run-migration.yml (backup +
+# dry-run gates, human-controlled timing).
+#
+# Required repository configuration (already used by run-migration.yml):
+#   secrets.SANITY_AUTH_TOKEN        - token with deploy access to the project
+#   vars.SANITY_STUDIO_PROJECT_ID    - the Sanity project id
+#   vars.SANITY_STUDIO_DATASET       - (optional) dataset, defaults to production
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'sanity/**'
+      - 'sanity.config.ts'
+      - 'sanity.cli.ts'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-studio.yml'
+  workflow_dispatch:
+
+# One studio deploy at a time; a newer push supersedes an in-flight deploy.
+concurrency:
+  group: sanity-studio-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy-studio:
+    name: Deploy Studio
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+      SANITY_STUDIO_PROJECT_ID: ${{ vars.SANITY_STUDIO_PROJECT_ID }}
+      SANITY_STUDIO_DATASET: ${{ vars.SANITY_STUDIO_DATASET || 'production' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # ratchet:pnpm/action-setup@v4
+        with:
+          version: 10.24.0
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy Studio
+        # Non-interactive: the deployment target is pinned via
+        # `deployment.appId` in sanity.cli.ts, so no hostname prompt occurs.
+        run: pnpm sanity deploy


### PR DESCRIPTION
Implements the "always deploy the Studio after CI on main succeeds" proposal:

- **Trigger**: push to `main` with a paths filter (`sanity/**`, `sanity.config.ts`, `sanity.cli.ts`, lockfile) + manual `workflow_dispatch`. Since main only advances through the merge queue with green CI, push-to-main *is* the CI-success signal — no `workflow_run` chaining needed.
- **Non-interactive**: the deploy target is pinned via `deployment.appId` in `sanity.cli.ts`, so `pnpm sanity deploy` runs without prompts.
- **Secrets**: reuses `secrets.SANITY_AUTH_TOKEN` + `vars.SANITY_STUDIO_PROJECT_ID` already configured for `run-migration.yml` — no new repository setup needed (the token must have deploy permission; if the migration token is write-only to the dataset, it may need a scope bump).
- **Concurrency**: one deploy at a time, newer pushes supersede in-flight ones.
- **Migrations stay manual** by design (`run-migration.yml` with backup + dry-run gates) — auto-running dataset mutations on merge is risk without benefit.

Immediate payoff: the `notification` schema type (#510) and any future schema changes become visible in the hosted Studio automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new GitHub Actions workflow that automatically deploys the Sanity Studio to its hosted URL whenever studio-relevant files land on `main`, replacing the previously manual `pnpm sanity deploy` step.

- Triggers on `push` to `main` with a paths filter covering `sanity/**`, config files, and the lockfile, plus a manual `workflow_dispatch` escape hatch. The non-interactive deploy is made possible by the `deployment.appId` already pinned in `sanity.cli.ts`.
- Reuses the existing `SANITY_AUTH_TOKEN` / `SANITY_STUDIO_PROJECT_ID` secrets from `run-migration.yml`, with a noted caveat in the PR description that the token may need a deploy-permission scope bump.
- Concurrency is correctly set to `cancel-in-progress: true` so rapid successive merges do not queue up stale deploys.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both findings are minor improvements rather than blockers.

The workflow is straightforward and correctly structured. The missing permissions block leaves GITHUB_TOKEN with broader access than needed, and the package.json path trigger fires a Studio deploy on any dependency change rather than only Sanity-related ones — both are easy to address but neither breaks anything today.

.github/workflows/deploy-studio.yml — the two suggestions above are worth applying before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-studio.yml | New workflow: auto-deploys Sanity Studio on push to main when studio-relevant files change. Missing `permissions` block; `package.json` path trigger is broader than strictly necessary. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant MQ as Merge Queue
    participant Main as main branch
    participant GHA as GitHub Actions
    participant Sanity as Sanity Cloud

    Dev->>MQ: Open PR
    MQ->>GHA: Run CI checks (pr-checks.yml)
    GHA-->>MQ: CI passes
    MQ->>Main: Merge to main
    Main->>GHA: push event (paths filter)
    Note over GHA: deploy-studio.yml triggers if sanity/** changed
    GHA->>GHA: Checkout + Setup Node/pnpm
    GHA->>GHA: pnpm install --frozen-lockfile
    GHA->>Sanity: pnpm sanity deploy (appId pinned)
    Sanity-->>GHA: Deploy complete
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant MQ as Merge Queue
    participant Main as main branch
    participant GHA as GitHub Actions
    participant Sanity as Sanity Cloud

    Dev->>MQ: Open PR
    MQ->>GHA: Run CI checks (pr-checks.yml)
    GHA-->>MQ: CI passes
    MQ->>Main: Merge to main
    Main->>GHA: push event (paths filter)
    Note over GHA: deploy-studio.yml triggers if sanity/** changed
    GHA->>GHA: Checkout + Setup Node/pnpm
    GHA->>GHA: pnpm install --frozen-lockfile
    GHA->>Sanity: pnpm sanity deploy (appId pinned)
    Sanity-->>GHA: Deploy complete
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: auto-deploy Sanity Studio on studio-..."](https://github.com/cloudnativebergen/website/commit/4cf2564da250d4d2e8fad03b8711c18f327241e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45348588)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->