### PR TITLE
feat(notifications): integration wave B — live toast bridge, impersonation guard, pagination, docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,16 @@ Project uses [mise](https://mise.jdx.sh/). Key commands:
   - Prefer isolated Storybook capture over trusting a deployed URL — a stale **PWA service worker** can serve an old bundle (see `public/sw.js` / `scripts/stamp-sw.mjs`); a Safari **Private tab** bypasses the SW when checking production.
 - **Testing (Vitest):** Test behavior over implementation. Prefer integration tests. Mock at boundaries.
 - **Storybook Interaction:** Use `play` functions for interactive tests (`storybook/test`).
+
+## In-app notifications
+
+The persistent notification hub (`src/lib/notification/*`, `src/server/routers/notification.ts`, `src/components/notifications/*`) is a durable, per-recipient inbox — surfaced by the `NotificationBell`. **Name-collision warning:** this is NOT the ephemeral toast system in `src/components/admin/NotificationProvider.tsx` (`useNotification()` / `showNotification()`), which shows transient, in-memory alerts and persists nothing. Keep the two straight — the bell may _bridge_ a new persistent notification into a toast, but they are separate systems.
+
+- **Never-fail contract:** a notification write must NEVER fail (or roll back) the business mutation that triggered it. `createNotifications` catches and logs its own errors and never throws into the caller — do not wrap it expecting to react to failures. A submitted proposal stays submitted even if the organizer notification write fails.
+- **Actor exclusion:** never notify the actor about their own action. Exclude `actorId` from the recipient set when fanning out.
+- **Per-recipient fan-out in ONE transaction:** fan out one `notification` document PER recipient (read state is per-user), and write the whole batch in a single `clientWrite.transaction()`.
+- **Link conventions:** link to the most-specific page for the audience — `/admin/...` for organizers, `/cfp/...` for speakers (e.g. `/cfp/proposal/<id>`, `/admin/proposals/<id>`). Same event to both audiences → two inputs with different links.
+- **Bus-handler vs router-inline:** emit from a domain **bus handler** when multiple call sites raise the same event or the emit is cross-cutting; emit **inline in the router/mutation** only when the notification is a one-off tightly coupled to that single mutation.
+- **Retention:** notifications older than **90 days are hard-deleted** by a daily cron — **including unread ones**. The hub is not an archive; anything that must persist longer belongs in its own record.
+
+See `docs/ADMIN_NOTIFICATION_SYSTEM.md` for the ephemeral toast system it is often confused with.

--- a/__tests__/components/notifications/NotificationList.test.tsx
+++ b/__tests__/components/notifications/NotificationList.test.tsx
@@ -114,4 +114,36 @@ describe('NotificationList', () => {
       screen.getByRole('region', { name: 'Notifications' }),
     ).toBeInTheDocument()
   })
+
+  it('does not render "Show more" when hasMore is false', () => {
+    renderList({ hasMore: false })
+    expect(
+      screen.queryByRole('button', { name: /show more/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders "Show more" and fires onShowMore when hasMore is true', () => {
+    const onShowMore = vi.fn()
+    renderList({ hasMore: true, onShowMore })
+    const button = screen.getByRole('button', { name: /show more/i })
+    fireEvent.click(button)
+    expect(onShowMore).toHaveBeenCalledOnce()
+  })
+
+  it('shows a loading label and disables "Show more" while loading the next page', () => {
+    renderList({ hasMore: true, isLoadingMore: true })
+    const button = screen.getByRole('button', { name: /loading/i })
+    expect(button).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: /^show more$/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('hides "Mark all read" and shows a read-only hint in read-only mode', () => {
+    renderList({ readOnly: true, unreadCount: 3 })
+    expect(
+      screen.queryByRole('button', { name: 'Mark all read' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument()
+  })
 })

--- a/docs/ADMIN_NOTIFICATION_SYSTEM.md
+++ b/docs/ADMIN_NOTIFICATION_SYSTEM.md
@@ -1,5 +1,7 @@
 # Admin Notification System
 
+> **Not the notification hub.** This document covers the **ephemeral toast** system (`src/components/admin/NotificationProvider.tsx`, `useNotification()` / `showNotification()`): transient, in-memory, auto-dismissing alerts that persist **nothing**. It is a different system from the **persistent in-app notification hub** (`src/lib/notification/*`, `src/components/notifications/*`, the `NotificationBell`), which is a durable, per-recipient inbox backed by Sanity. They share the word "notification" but nothing else — see the "In-app notifications" section in `AGENTS.md` for the hub. The bell _may_ bridge a newly arrived hub notification into a toast, but the two systems are otherwise independent.
+
 ## Overview
 
 The admin notification system provides a user-friendly toast notification system to replace browser `alert()` calls throughout the admin interface. This system provides better UX with styled notifications that match the brand design and automatically dismiss after a set duration.

--- a/src/components/admin/NotificationProvider.tsx
+++ b/src/components/admin/NotificationProvider.tsx
@@ -120,3 +120,13 @@ export function useNotification() {
   }
   return context
 }
+
+/**
+ * Non-throwing variant of {@link useNotification}: returns `undefined` when no
+ * `NotificationProvider` is mounted instead of throwing. Use this from
+ * components that render across multiple shells and must stay resilient if the
+ * toast provider happens to be absent (e.g. the notification bell).
+ */
+export function useNotificationSafe(): NotificationContextType | undefined {
+  return useContext(NotificationContext)
+}

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,8 +1,11 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
+import { useSession } from 'next-auth/react'
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/react'
 import { BellIcon } from '@heroicons/react/24/outline'
 import { api } from '@/lib/trpc/client'
+import { useNotificationSafe } from '@/components/admin/NotificationProvider'
 import { NotificationPanel } from './NotificationPanel'
 
 /**
@@ -16,14 +19,48 @@ import { NotificationPanel } from './NotificationPanel'
  * while the Popover is open.
  */
 export function NotificationBell() {
-  const { data: unreadCount = 0 } = api.notification.unreadCount.useQuery(
-    undefined,
-    {
-      refetchInterval: 30_000,
-      refetchOnWindowFocus: true,
-      staleTime: 10_000,
-    },
-  )
+  const { data, isSuccess } = api.notification.unreadCount.useQuery(undefined, {
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    staleTime: 10_000,
+  })
+  const unreadCount = data ?? 0
+
+  // Bridge a rising unread count to the ephemeral toast system so a live
+  // notification surfaces even when the bell is closed. `useNotificationSafe`
+  // returns `undefined` (rather than throwing) if the toast provider isn't
+  // mounted, keeping the bell resilient in any shell.
+  const notify = useNotificationSafe()
+  const { data: session } = useSession()
+  const isImpersonating = session?.isImpersonating === true
+
+  // Previous RESOLVED unread count. `null` until the first successful fetch, so
+  // login / first-load never fires a toast — only a subsequent increase does.
+  const prevUnreadRef = useRef<number | null>(null)
+  useEffect(() => {
+    if (!isSuccess) {
+      return
+    }
+    const prev = prevUnreadRef.current
+    prevUnreadRef.current = unreadCount
+    if (prev === null) {
+      // First resolved value: establish the baseline, don't toast.
+      return
+    }
+    // Only a genuine increase toasts — never a decrease (mark-read) or an
+    // unchanged refetch. Suppressed entirely while impersonating a speaker.
+    if (unreadCount > prev && !isImpersonating) {
+      const delta = unreadCount - prev
+      notify?.showNotification({
+        type: 'info',
+        title: 'You have new notifications',
+        message:
+          delta === 1
+            ? 'You have 1 new notification.'
+            : `You have ${delta} new notifications.`,
+      })
+    }
+  }, [isSuccess, unreadCount, isImpersonating, notify])
 
   const hasUnread = unreadCount > 0
   const badgeLabel = unreadCount > 9 ? '9+' : String(unreadCount)

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -113,3 +113,25 @@ export const LoadError: Story = {
     unreadCount: 0,
   },
 }
+
+// A full page was returned, so keyset pagination offers a "Show more" button.
+export const HasMore: Story = {
+  args: {
+    items: [],
+    unreadCount: 2,
+    hasMore: true,
+    onShowMore: fn(),
+  },
+  render: (args) => <NotificationList {...args} items={makeItems()} />,
+}
+
+// While an admin impersonates a speaker the panel is read-only: "Mark all read"
+// is replaced by a subtle hint and no read-state mutations can fire.
+export const ReadOnlyImpersonating: Story = {
+  args: {
+    items: [],
+    unreadCount: 2,
+    readOnly: true,
+  },
+  render: (args) => <NotificationList {...args} items={makeItems()} />,
+}

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -25,6 +25,18 @@ export interface NotificationListProps {
    * the wrapping `<Link>`.
    */
   onItemClick: (item: NotificationItem) => void
+  /** Fired when "Show more" is pressed to load the next page. */
+  onShowMore?: () => void
+  /** When true, a "Show more" button is rendered under the list. */
+  hasMore?: boolean
+  /** Puts the "Show more" button in a loading state while the next page loads. */
+  isLoadingMore?: boolean
+  /**
+   * Read-only mode (e.g. an admin impersonating a speaker): hides "Mark all
+   * read" and shows a subtle hint that read state is untouched. Item activation
+   * still navigates; the container is responsible for not marking read.
+   */
+  readOnly?: boolean
 }
 
 function SkeletonRow() {
@@ -175,6 +187,10 @@ export function NotificationList({
   onMarkAllRead,
   isMarkingAll = false,
   onItemClick,
+  onShowMore,
+  hasMore = false,
+  isLoadingMore = false,
+  readOnly = false,
 }: NotificationListProps) {
   return (
     // `role="region"` makes the aria-label an actual named landmark — on a
@@ -184,14 +200,23 @@ export function NotificationList({
         <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
           Notifications
         </h2>
-        <button
-          type="button"
-          onClick={onMarkAllRead}
-          disabled={unreadCount === 0 || isMarkingAll}
-          className="rounded text-xs font-medium text-brand-cloud-blue transition hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:text-gray-300 dark:disabled:text-gray-600"
-        >
-          Mark all read
-        </button>
+        {readOnly ? (
+          <span
+            title="Viewing as speaker — read state is left untouched"
+            className="ml-2 shrink-0 text-xs font-medium whitespace-nowrap text-gray-400 dark:text-gray-500"
+          >
+            Speaker view · read-only
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={onMarkAllRead}
+            disabled={unreadCount === 0 || isMarkingAll}
+            className="rounded text-xs font-medium text-brand-cloud-blue transition hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:text-gray-300 dark:disabled:text-gray-600"
+          >
+            Mark all read
+          </button>
+        )}
       </div>
 
       <div className="max-h-[70vh] divide-y divide-gray-100 overflow-y-auto dark:divide-gray-800/70">
@@ -206,9 +231,23 @@ export function NotificationList({
         ) : items.length === 0 ? (
           <EmptyState />
         ) : (
-          items.map((item) => (
-            <ListItem key={item.id} item={item} onItemClick={onItemClick} />
-          ))
+          <>
+            {items.map((item) => (
+              <ListItem key={item.id} item={item} onItemClick={onItemClick} />
+            ))}
+            {hasMore && (
+              <div className="p-2">
+                <button
+                  type="button"
+                  onClick={onShowMore}
+                  disabled={isLoadingMore}
+                  className="w-full rounded-lg px-4 py-2 text-center text-xs font-medium text-brand-cloud-blue transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset disabled:cursor-not-allowed disabled:text-gray-300 dark:hover:bg-gray-800/60 dark:disabled:text-gray-600"
+                >
+                  {isLoadingMore ? 'Loading…' : 'Show more'}
+                </button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -1,8 +1,12 @@
 'use client'
 
+import { useSession } from 'next-auth/react'
 import { api } from '@/lib/trpc/client'
 import type { NotificationItem } from '@/lib/notification/types'
 import { NotificationList } from './NotificationList'
+
+/** Page size for the inbox list; a full page implies another page may exist. */
+const PAGE_SIZE = 20
 
 export interface NotificationPanelProps {
   /** Unread total from the bell's polled counter; drives "Mark all read". */
@@ -20,18 +24,43 @@ export interface NotificationPanelProps {
  * Reads/writes flow through the `notification` tRPC router; every mutation
  * invalidates both `unreadCount` and `list` so the badge and the panel stay in
  * sync (the badge poll is only a backstop).
+ *
+ * IMPERSONATION: while an admin impersonates a speaker (`session.isImpersonating`)
+ * every query is scoped to the SPEAKER's inbox, so marking items read would
+ * silently destroy the speaker's real unread state. In that mode the panel is
+ * rendered read-only: no `markRead` / `markAllRead` mutations fire and item
+ * activation still navigates (via the wrapping `<Link>`) without marking.
  */
 export function NotificationPanel({
   unreadCount,
   onClose,
 }: NotificationPanelProps) {
   const utils = api.useUtils()
+  const { data: session } = useSession()
+  const isImpersonating = session?.isImpersonating === true
 
   const {
-    data: items = [],
+    data,
     isLoading,
     isError,
-  } = api.notification.list.useQuery({ limit: 20 }, { staleTime: 10_000 })
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = api.notification.list.useInfiniteQuery(
+    { limit: PAGE_SIZE },
+    {
+      staleTime: 10_000,
+      // tRPC injects this value into the input's `cursor` field for the next
+      // page. A short final page means there's nothing more to fetch.
+      getNextPageParam: (lastPage) =>
+        lastPage.length === PAGE_SIZE
+          ? lastPage[lastPage.length - 1]?.createdAt
+          : undefined,
+      initialCursor: undefined,
+    },
+  )
+
+  const items = data?.pages.flat() ?? []
 
   const invalidate = () => {
     utils.notification.unreadCount.invalidate()
@@ -47,8 +76,9 @@ export function NotificationPanel({
 
   const handleItemClick = (item: NotificationItem) => {
     // Fire-and-forget: mark read on activation, then close. Navigation (if the
-    // item has a link) is handled by the wrapping <Link>.
-    if (!item.readAt) {
+    // item has a link) is handled by the wrapping <Link>. While impersonating we
+    // must NOT mutate the speaker's read state — just close (and navigate).
+    if (!isImpersonating && !item.readAt) {
       markRead.mutate({ ids: [item.id] })
     }
     onClose()
@@ -63,6 +93,10 @@ export function NotificationPanel({
       onMarkAllRead={() => markAllRead.mutate()}
       isMarkingAll={markAllRead.isPending}
       onItemClick={handleItemClick}
+      onShowMore={() => fetchNextPage()}
+      hasMore={hasNextPage}
+      isLoadingMore={isFetchingNextPage}
+      readOnly={isImpersonating}
     />
   )
 }

--- a/src/server/routers/notification.ts
+++ b/src/server/routers/notification.ts
@@ -25,7 +25,8 @@ export const notificationRouter = router({
         speakerId: ctx.speaker._id,
         conferenceId,
         limit: input.limit,
-        before: input.before,
+        // `cursor` is the `useInfiniteQuery` alias of `before` (see schema).
+        before: input.before ?? input.cursor,
       })
     }),
 

--- a/src/server/schemas/notification.ts
+++ b/src/server/schemas/notification.ts
@@ -8,6 +8,12 @@ import { z } from 'zod'
 export const ListNotificationsSchema = z.object({
   limit: z.number().int().min(1).max(50).default(20),
   before: z.string().datetime().optional(),
+  // Alias of `before` for tRPC's `useInfiniteQuery`: its react-query integration
+  // injects the value returned by `getNextPageParam` into an input field named
+  // literally `cursor`. Keeping `before` as well is backward compatible for
+  // direct callers; the router treats `before` as the canonical field and falls
+  // back to `cursor`.
+  cursor: z.string().datetime().optional(),
 })
 
 /**


### PR DESCRIPTION
Wave B of the notification-hub integration: client UX + docs. No changes to Wave A's routers/handlers/lib emitters or the travel-support admin page. The only server touch is a backward-compatible `cursor` alias on the notification list schema (required by tRPC's `useInfiniteQuery`).

## B1 — Live toast bridge (MED-HIGH)
`NotificationBell` bridges a *rising* polled unread count into the ephemeral toast system (`showNotification`). The previous **resolved** count is tracked via a ref and the **first** resolved value is skipped, so login / first-load never toasts — only a genuine increase fires (never a mark-read decrease or an unchanged refetch). To stay resilient across shells, access goes through a new `useNotificationSafe()` that returns `undefined` instead of throwing when no toast provider is mounted.

## B2 — Impersonation read-state guard (MED)
`NotificationPanel` reads `useSession()`. When `session.isImpersonating`, the panel operates on the **speaker's** inbox, so it is rendered **read-only**: no `markRead` / `markAllRead` mutations fire, item activation still navigates (via the wrapping `<Link>`) without marking, and "Mark all read" is replaced by a subtle `Speaker view · read-only` hint (full explanation in a `title`). B1's toast is suppressed while impersonating.

## B3 — "Show more" pagination (MED)
The panel query is converted to `useInfiniteQuery` with `getNextPageParam` (a full page → the last item's `createdAt` cursor, else `undefined`). Because tRPC injects the next-page param into an input field named literally `cursor`, an **optional `cursor` alias of `before`** was added to `ListNotificationsSchema` (backward compatible; `before` stays canonical, router falls back to `cursor`). The presentational split is preserved: `NotificationList` gains `onShowMore` / `hasMore` / `isLoadingMore` and renders a loading-aware "Show more" button.

## B4 — Docs (MED)
New **"In-app notifications"** section in `AGENTS.md`: never-fail contract, actor exclusion, per-recipient single-transaction fan-out, link conventions (`/admin/...` organizers, `/cfp/...` speakers, most-specific page), bus-handler vs router-inline rule, 90-day retention (unread included), and the ephemeral-toast-vs-persistent-hub name-collision warning. `docs/ADMIN_NOTIFICATION_SYSTEM.md` gets a cross-linked paragraph distinguishing the two systems.

## Tests / stories / visual QA
- `NotificationList.test.tsx`: added coverage for Show-more render/callback/loading-disabled and read-only mode. 15/15 pass.
- Stories: `HasMore` and `ReadOnlyImpersonating` variants (deterministic dates via `mockDateBeforeEach`).
- Visual QA (`pnpm shoot`, 393×852): Show-more button renders centered below a full page; read-only header shows the hint on one clean line with "Mark all read" hidden.

## Verify
- `tsc --noEmit`: 0
- eslint (touched dirs): clean · prettier: clean
- `vitest run __tests__/`: 2332 passed, 0 actual failures (26 known load failures from the missing `@digitalbazaar/vc` optional dep)
- `knip`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wave B adds client-side UX on top of the Wave A notification hub: a live toast bridge in `NotificationBell`, an impersonation read-only guard in `NotificationPanel`, keyset-pagination via `useInfiniteQuery`, and documentation. The server touch is a minimal backward-compatible `cursor` alias on `ListNotificationsSchema`.

- **Toast bridge (B1):** `NotificationBell` tracks the previous resolved unread count via `useRef`, skipping the first value so login never toasts; only a genuine count increase fires `showNotification`, and it's suppressed while impersonating.
- **Impersonation guard (B2):** `NotificationPanel` reads `useSession`; when `isImpersonating`, `markRead`/`markAllRead` mutations are blocked at the `handleItemClick` and `readOnly` levels, and the "Mark all read" button is replaced by a "Speaker view · read-only" hint.
- **Pagination (B3):** `useQuery` is replaced by `useInfiniteQuery` with `getNextPageParam` keyed on `createdAt`; `NotificationList` gains `hasMore`/`onShowMore`/`isLoadingMore` props and a loading-aware "Show more" button.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all core mutation paths are correctly guarded and the pagination logic is sound.

The toast bridge, impersonation guard, and pagination are all implemented correctly. Two minor defensive-coding gaps — the unstable NotificationProvider context reference causing extra effect runs in NotificationBell, and the unguarded onMarkAllRead callback that relies solely on the readOnly UI prop — neither causes incorrect behavior today but could become subtle issues under future refactors.

src/components/admin/NotificationProvider.tsx (context value memoization) and src/components/notifications/NotificationPanel.tsx (onMarkAllRead callback guard)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/notifications/NotificationBell.tsx | Adds toast bridge via useEffect + prevUnreadRef; impersonation suppression is correct but notify's unstable reference causes extra effect runs on every toast. |
| src/components/notifications/NotificationPanel.tsx | Migrates list query to useInfiniteQuery and adds impersonation guard; onMarkAllRead callback is not itself guarded against isImpersonating, relying solely on the readOnly UI prop. |
| src/components/notifications/NotificationList.tsx | Adds hasMore/onShowMore/isLoadingMore/readOnly props; presentational component is clean and well-guarded. |
| src/server/schemas/notification.ts | Adds optional cursor alias for tRPC useInfiniteQuery; backward-compatible, well-documented, router correctly prefers `before` over `cursor`. |
| src/components/admin/NotificationProvider.tsx | Adds useNotificationSafe(); context value object literal is not memoized, causing unnecessary effect re-runs in NotificationBell. |
| src/server/routers/notification.ts | Single-line addition: before ?? cursor fallback is correct and well-commented. |
| __tests__/components/notifications/NotificationList.test.tsx | Adds 4 new tests covering Show-more, loading-disabled, and read-only mode; all assertions are clear and well-targeted. |
| src/components/notifications/NotificationList.stories.tsx | Adds HasMore and ReadOnlyImpersonating stories; clean, deterministic. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Bell as NotificationBell
    participant Query as tRPC unreadCount
    participant Ref as prevUnreadRef
    participant Toast as NotificationProvider (toast)
    participant Panel as NotificationPanel
    participant Router as notification router

    Bell->>Query: poll every 30s / window focus
    Query-->>Bell: "isSuccess=true, unreadCount=N"

    Note over Bell,Ref: First resolved value — set baseline, no toast
    Bell->>Ref: "prevUnreadRef.current = N (was null)"

    Query-->>Bell: "refetch → unreadCount=N+2"
    Bell->>Ref: read prev (N), write N+2
    alt "!isImpersonating && unreadCount > prev"
        Bell->>Toast: showNotification(2 new notifications)
    else isImpersonating
        Note over Bell,Toast: suppressed
    end

    Bell->>Panel: open popover → mounts NotificationPanel
    Panel->>Router: "useInfiniteQuery({ limit: 20 }) → page 1"
    Router-->>Panel: "items[0..19], length === PAGE_SIZE → hasNextPage=true"

    Panel-->>Bell: "renders NotificationList with hasMore=true"

    Note over Panel,Router: User clicks Show more
    Panel->>Router: "fetchNextPage → cursor=items[19].createdAt"
    Router-->>Panel: "items[20..39], length < PAGE_SIZE → hasNextPage=false"

    Note over Panel,Router: User clicks item (non-impersonating)
    Panel->>Router: "markRead.mutate({ ids: [item.id] })"
    Panel->>Bell: onClose() → panel unmounts

    Note over Panel,Router: Admin impersonating speaker
    Panel-->>Bell: "readOnly=true (no markRead/markAllRead mutations fire)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Bell as NotificationBell
    participant Query as tRPC unreadCount
    participant Ref as prevUnreadRef
    participant Toast as NotificationProvider (toast)
    participant Panel as NotificationPanel
    participant Router as notification router

    Bell->>Query: poll every 30s / window focus
    Query-->>Bell: "isSuccess=true, unreadCount=N"

    Note over Bell,Ref: First resolved value — set baseline, no toast
    Bell->>Ref: "prevUnreadRef.current = N (was null)"

    Query-->>Bell: "refetch → unreadCount=N+2"
    Bell->>Ref: read prev (N), write N+2
    alt "!isImpersonating && unreadCount > prev"
        Bell->>Toast: showNotification(2 new notifications)
    else isImpersonating
        Note over Bell,Toast: suppressed
    end

    Bell->>Panel: open popover → mounts NotificationPanel
    Panel->>Router: "useInfiniteQuery({ limit: 20 }) → page 1"
    Router-->>Panel: "items[0..19], length === PAGE_SIZE → hasNextPage=true"

    Panel-->>Bell: "renders NotificationList with hasMore=true"

    Note over Panel,Router: User clicks Show more
    Panel->>Router: "fetchNextPage → cursor=items[19].createdAt"
    Router-->>Panel: "items[20..39], length < PAGE_SIZE → hasNextPage=false"

    Note over Panel,Router: User clicks item (non-impersonating)
    Panel->>Router: "markRead.mutate({ ids: [item.id] })"
    Panel->>Bell: onClose() → panel unmounts

    Note over Panel,Router: Admin impersonating speaker
    Panel-->>Bell: "readOnly=true (no markRead/markAllRead mutations fire)"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/components/admin/NotificationProvider.tsx`, line 3 ([link](https://github.com/cloudnativebergen/website/blob/f02cfdd62a3b7920f76c0f85608e579c0533518d/src/components/admin/NotificationProvider.tsx#L3)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The context value object `{ showNotification, removeNotification }` is a fresh object literal on every render of `NotificationProvider`. Because `NotificationBell` includes `notify` (the result of `useNotificationSafe()`) in its `useEffect` dependency array — correctly, since the rules of hooks require it — the effect re-executes on every toast show/dismiss cycle. The `unreadCount > prev` guard makes this safe today, but memoising the context value removes the unnecessary churn and future-proofs the contract.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `src/components/admin/NotificationProvider.tsx`, line 33 ([link](https://github.com/cloudnativebergen/website/blob/f02cfdd62a3b7920f76c0f85608e579c0533518d/src/components/admin/NotificationProvider.tsx#L33)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Continuing the memoization fix — wrap both handlers in `useCallback` and the context value in `useMemo` so the reference is stable across re-renders.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): integration wave B ..."](https://github.com/cloudnativebergen/website/commit/f02cfdd62a3b7920f76c0f85608e579c0533518d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45348849)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->