### PR TITLE
feat(notifications): integration wave A — confirm/withdraw, co-speaker, volunteer, expense emitters + deep links

### DIFF
--- a/__tests__/api/trpc/proposal-invitation.test.ts
+++ b/__tests__/api/trpc/proposal-invitation.test.ts
@@ -7,6 +7,7 @@ import {
   sendInvitationEmail,
   sendResponseNotificationEmail,
 } from '@/lib/cospeaker/server'
+import { createNotifications } from '@/lib/notification/sanity'
 import { clientWrite } from '@/lib/sanity/client'
 import { Status, Format } from '@/lib/proposal/types'
 import { speakers } from '../../helpers/trpc'
@@ -39,6 +40,9 @@ vi.mock('@/lib/sanity/client', () => ({
 vi.mock('@/lib/proposal/data/sanity')
 vi.mock('@/lib/cospeaker/sanity')
 vi.mock('@/lib/cospeaker/server')
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock('@/lib/conference/sanity', () => ({
   getConferenceForCurrentDomain: vi.fn().mockResolvedValue({
     conference: {
@@ -415,6 +419,56 @@ describe('proposal.invitation router', () => {
           respondentEmail: invitedSpeaker.email,
         }),
       )
+
+      // In-app mirror to the inviter
+      expect(createNotifications).toHaveBeenCalledTimes(1)
+      const notifyItems = vi.mocked(createNotifications).mock.calls[0][0]
+      expect(notifyItems).toHaveLength(1)
+      expect(notifyItems[0]).toMatchObject({
+        recipientId: regularSpeaker._id,
+        conferenceId: 'conf-1',
+        notificationType: 'system',
+        title: `${invitedSpeaker.name} accepted your co-speaker invitation`,
+        actorId: invitedSpeaker._id,
+        link: '/cfp/proposal/proposal-1',
+      })
+    })
+
+    it('sends the inviter an in-app decline notification', async () => {
+      vi.mocked(getInvitationByToken).mockResolvedValue(mockInvitation as any)
+
+      const caller = createCaller(invitedSpeaker)
+      await caller.proposal.invitation.respond({
+        token: 'valid-token',
+        accept: false,
+        declineReason: 'Too busy',
+      })
+
+      expect(createNotifications).toHaveBeenCalledTimes(1)
+      const notifyItems = vi.mocked(createNotifications).mock.calls[0][0]
+      expect(notifyItems[0]).toMatchObject({
+        recipientId: regularSpeaker._id,
+        notificationType: 'system',
+        title: `${invitedSpeaker.name} declined your co-speaker invitation`,
+        actorId: invitedSpeaker._id,
+        link: '/cfp/proposal/proposal-1',
+      })
+    })
+
+    it('skips the in-app inviter notification when the inviter id is missing', async () => {
+      vi.mocked(getInvitationByToken).mockResolvedValue({
+        ...mockInvitation,
+        invitedBy: undefined,
+      } as any)
+
+      const caller = createCaller(invitedSpeaker)
+      const result = await caller.proposal.invitation.respond({
+        token: 'valid-token',
+        accept: false,
+      })
+
+      expect(result.success).toBe(true)
+      expect(createNotifications).not.toHaveBeenCalled()
     })
 
     it('should reject if the email does not match (bug fix)', async () => {

--- a/__tests__/api/trpc/sponsor-stage-notification.test.ts
+++ b/__tests__/api/trpc/sponsor-stage-notification.test.ts
@@ -111,7 +111,7 @@ describe('sponsor.crm.moveStage — organizer notifications', () => {
     for (const item of items) {
       expect(item.notificationType).toBe('sponsor_activity')
       expect(item.title).toBe('Sponsor Acme moved to closed-lost')
-      expect(item.link).toBe('/admin/sponsors/crm')
+      expect(item.link).toBe('/admin/sponsors/crm?sponsor=sfc-1')
       expect(item.actorId).toBe('actor-1')
       expect(item.conferenceId).toBe('conf-1')
     }

--- a/__tests__/api/trpc/travel-support-notification.test.ts
+++ b/__tests__/api/trpc/travel-support-notification.test.ts
@@ -15,13 +15,15 @@ import {
   getTravelSupportById,
   submitTravelSupport,
   updateTravelSupportStatus,
+  updateExpenseStatus,
+  getTravelExpenseRef,
 } from '@/lib/travel-support/sanity'
 import { authorizeTravelSupportOperation } from '@/lib/travel-support/auth'
 import {
   createNotifications,
   getOrganizerSpeakerIds,
 } from '@/lib/notification/sanity'
-import { TravelSupportStatus } from '@/lib/travel-support/types'
+import { TravelSupportStatus, ExpenseStatus } from '@/lib/travel-support/types'
 import type { NotificationInput } from '@/lib/notification/types'
 
 vi.mock('@/lib/travel-support/sanity')
@@ -98,7 +100,7 @@ describe('travelSupport.submit — organizer notifications', () => {
     for (const item of items) {
       expect(item.notificationType).toBe('travel_support_update')
       expect(item.title).toBe('Travel support request from Acting Organizer')
-      expect(item.link).toBe('/admin/speakers/travel-support')
+      expect(item.link).toBe('/admin/speakers/travel-support?request=ts-1')
       expect(item.actorId).toBe('actor-1')
       expect(item.conferenceId).toBe('conf-1')
     }
@@ -188,6 +190,92 @@ describe('travelSupport.admin.updateStatus — affected-speaker notifications', 
       travelSupportId: 'ts-1',
       status: TravelSupportStatus.APPROVED,
     })
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('travelSupport.admin.updateExpenseStatus — affected-speaker notifications', () => {
+  const mockOwner = (speakerId = 'sp-1') => {
+    vi.mocked(getTravelExpenseRef).mockResolvedValue({
+      travelSupport: { _ref: 'ts-1' },
+    })
+    vi.mocked(getTravelSupportById).mockResolvedValue({
+      travelSupport: {
+        _id: 'ts-1',
+        status: TravelSupportStatus.SUBMITTED,
+        speaker: { _id: speakerId, name: 'Jane Speaker', email: 'j@test.com' },
+        conference: { _id: 'conf-1', name: 'Test Conf' },
+        expenses: [],
+      } as never,
+      error: null,
+    })
+  }
+
+  beforeEach(() => {
+    vi.mocked(updateExpenseStatus).mockResolvedValue({
+      success: true,
+      error: null,
+    } as never)
+  })
+
+  it('notifies the affected speaker when an expense is approved, carrying reviewNotes', async () => {
+    mockOwner()
+
+    await createCaller(actor).travelSupport.admin.updateExpenseStatus({
+      expenseId: 'exp-1',
+      status: ExpenseStatus.APPROVED,
+      reviewNotes: 'Within policy',
+    })
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const item = lastItems()[0]
+    expect(item.recipientId).toBe('sp-1')
+    expect(item.notificationType).toBe('travel_support_update')
+    expect(item.title).toBe('Expense approved')
+    expect(item.message).toBe('Within policy')
+    expect(item.link).toBe('/cfp/expense')
+    expect(item.actorId).toBe('actor-1')
+    expect(item.conferenceId).toBe('conf-1')
+  })
+
+  it('titles a rejected expense', async () => {
+    mockOwner()
+    await createCaller(actor).travelSupport.admin.updateExpenseStatus({
+      expenseId: 'exp-1',
+      status: ExpenseStatus.REJECTED,
+    })
+    expect(lastItems()[0].title).toBe('Expense rejected')
+  })
+
+  it('does NOT notify for the pending echo status', async () => {
+    mockOwner()
+    await createCaller(actor).travelSupport.admin.updateExpenseStatus({
+      expenseId: 'exp-1',
+      status: ExpenseStatus.PENDING,
+    })
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT notify when the affected speaker is the actor', async () => {
+    mockOwner('actor-1')
+    await createCaller(actor).travelSupport.admin.updateExpenseStatus({
+      expenseId: 'exp-1',
+      status: ExpenseStatus.APPROVED,
+    })
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fail the mutation when the owner lookup throws', async () => {
+    vi.mocked(getTravelExpenseRef).mockRejectedValue(new Error('boom'))
+
+    const result = await createCaller(
+      actor,
+    ).travelSupport.admin.updateExpenseStatus({
+      expenseId: 'exp-1',
+      status: ExpenseStatus.APPROVED,
+    })
+
+    expect(result).toEqual({ success: true })
     expect(createMock).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/api/trpc/volunteer.test.ts
+++ b/__tests__/api/trpc/volunteer.test.ts
@@ -20,6 +20,11 @@ vi.mock('@/lib/slack/notify', () => ({
   notifyNewVolunteer: vi.fn().mockResolvedValue(undefined),
 }))
 
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: vi.fn().mockResolvedValue(undefined),
+  getOrganizerSpeakerIds: vi.fn().mockResolvedValue([]),
+}))
+
 vi.mock('@/lib/email/volunteer', () => ({
   sendVolunteerApprovalEmail: vi.fn().mockResolvedValue({ success: true }),
 }))
@@ -38,6 +43,10 @@ import {
 } from '../../helpers/trpc'
 import { createVolunteer, getVolunteerById } from '@/lib/volunteer/sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
 import { Occupation, TShirtSize, VolunteerStatus } from '@/lib/volunteer/types'
 
 const mockConference = {
@@ -100,6 +109,43 @@ describe('volunteer router', () => {
           }),
         }),
       )
+    })
+
+    it('should mirror the signup to organizers as an in-app notification', async () => {
+      vi.mocked(createVolunteer).mockResolvedValue({
+        volunteer: { _id: 'vol-1', name: 'Test Volunteer' } as any,
+        error: null,
+      })
+      vi.mocked(getOrganizerSpeakerIds).mockResolvedValue(['org-1', 'org-2'])
+
+      const caller = createAnonymousCaller()
+      await caller.volunteer.create(validVolunteerInput)
+
+      expect(createNotifications).toHaveBeenCalledTimes(1)
+      const items = vi.mocked(createNotifications).mock.calls[0][0]
+      expect(items.map((i) => i.recipientId).sort()).toEqual(['org-1', 'org-2'])
+      for (const item of items) {
+        expect(item.notificationType).toBe('system')
+        expect(item.title).toBe('New volunteer signup: Test Volunteer')
+        expect(item.link).toBe('/admin/volunteers')
+        expect(item.conferenceId).toBe('conf-1')
+        // Public endpoint: no actor to attribute.
+        expect(item.actorId).toBeUndefined()
+      }
+    })
+
+    it('does not fail the signup when the organizer-id fetch throws', async () => {
+      vi.mocked(createVolunteer).mockResolvedValue({
+        volunteer: { _id: 'vol-1', name: 'Test Volunteer' } as any,
+        error: null,
+      })
+      vi.mocked(getOrganizerSpeakerIds).mockRejectedValue(new Error('boom'))
+
+      const caller = createAnonymousCaller()
+      const result = await caller.volunteer.create(validVolunteerInput)
+
+      expect(result).toEqual({ success: true, volunteerId: 'vol-1' })
+      expect(createNotifications).not.toHaveBeenCalled()
     })
 
     it('should throw on creation failure', async () => {

--- a/__tests__/api/trpc/volunteer.test.ts
+++ b/__tests__/api/trpc/volunteer.test.ts
@@ -69,12 +69,19 @@ const validVolunteerInput = {
 
 describe('volunteer router', () => {
   beforeEach(() => {
-    vi.restoreAllMocks()
+    // clearAllMocks (not restoreAllMocks): since Vitest 3, restoreAllMocks
+    // only touches vi.spyOn spies — it no longer clears vi.fn() factory
+    // mocks, so call history would accumulate across tests. clearAllMocks
+    // resets history while keeping the factory implementations.
+    vi.clearAllMocks()
     vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
       conference: mockConference as any,
       domain: 'localhost',
       error: null,
     })
+    // Re-pin the default: per-test mockResolvedValue/mockRejectedValue
+    // overrides survive clearAllMocks and would otherwise leak forward.
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValue([])
   })
 
   describe('create', () => {

--- a/__tests__/lib/events/persistNotification.test.ts
+++ b/__tests__/lib/events/persistNotification.test.ts
@@ -148,8 +148,10 @@ describe('status change — speakers minus actor, gated by shouldNotify', () => 
     expect(createMock).not.toHaveBeenCalled()
   })
 
-  it('does NOT notify for a non-speaker-facing action even with shouldNotify', async () => {
-    // `withdraw` is not in the speaker-notify action set (mirrors email gating).
+  it('does NOT notify the proposal speakers for confirm/withdraw (that is organizer routing)', async () => {
+    // confirm/withdraw are not in the speaker-notify action set — they route to
+    // organizers instead (asserted below), never to the proposal speakers.
+    organizersMock.mockResolvedValue(['org-1'])
     await handlePersistNotification(
       makeEvent({
         action: Action.withdraw,
@@ -159,6 +161,74 @@ describe('status change — speakers minus actor, gated by shouldNotify', () => 
         ] as unknown as ProposalStatusChangeEvent['speakers'],
       }),
     )
-    expect(createMock).not.toHaveBeenCalled()
+    // The proposal speaker (sp-1) is never a recipient — only organizers are.
+    const recipients = lastItems().map((i) => i.recipientId)
+    expect(recipients).not.toContain('sp-1')
+    expect(recipients).toEqual(['org-1'])
+  })
+})
+
+describe('confirm / withdraw — organizers minus actor', () => {
+  it('notifies every organizer except the actor when a speaker confirms', async () => {
+    organizersMock.mockResolvedValue(['org-1', 'actor-1', 'org-2'])
+
+    await handlePersistNotification(
+      makeEvent(
+        { action: Action.confirm, newStatus: Status.confirmed },
+        { shouldNotify: false },
+      ),
+    )
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const items = lastItems()
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['org-1', 'org-2'])
+    for (const item of items) {
+      expect(item.notificationType).toBe('proposal_status_changed')
+      expect(item.title).toBe('Speaker confirmed: "My Talk"')
+      expect(item.link).toBe('/admin/proposals/prop-1')
+      expect(item.actorId).toBe('actor-1')
+      expect(item.relatedProposalId).toBe('prop-1')
+      expect(item.conferenceId).toBe('conf-1')
+      expect(item.message).toBeUndefined()
+    }
+  })
+
+  it('titles a withdrawal and carries metadata.reason as the message', async () => {
+    organizersMock.mockResolvedValue(['org-1'])
+
+    await handlePersistNotification(
+      makeEvent(
+        { action: Action.withdraw, newStatus: Status.withdrawn },
+        { reason: 'Speaker fell ill' },
+      ),
+    )
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const item = lastItems()[0]
+    expect(item.recipientId).toBe('org-1')
+    expect(item.title).toBe('Proposal withdrawn: "My Talk"')
+    expect(item.message).toBe('Speaker fell ill')
+    expect(item.link).toBe('/admin/proposals/prop-1')
+  })
+
+  it('omits the message when a withdrawal has no reason', async () => {
+    organizersMock.mockResolvedValue(['org-1'])
+
+    await handlePersistNotification(
+      makeEvent({ action: Action.withdraw, newStatus: Status.withdrawn }),
+    )
+
+    expect(lastItems()[0].message).toBeUndefined()
+  })
+
+  it('fires on confirm/withdraw regardless of shouldNotify', async () => {
+    organizersMock.mockResolvedValue(['org-1'])
+    await handlePersistNotification(
+      makeEvent(
+        { action: Action.confirm, newStatus: Status.confirmed },
+        { shouldNotify: false },
+      ),
+    )
+    expect(createMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -40,9 +40,11 @@ export default defineType({
             title: 'Proposal Status Changed',
             value: 'proposal_status_changed',
           },
+          // Reserved for future use — no emitter yet.
           { title: 'Proposal Comment', value: 'proposal_comment' },
           { title: 'Travel Support Update', value: 'travel_support_update' },
           { title: 'Sponsor Activity', value: 'sponsor_activity' },
+          // Reserved for future use — no emitter yet.
           { title: 'Schedule Update', value: 'schedule_update' },
           { title: 'Gallery Tagged', value: 'gallery_tagged' },
           { title: 'System', value: 'system' },

--- a/src/components/travel-support/TravelSupportAdminPage.tsx
+++ b/src/components/travel-support/TravelSupportAdminPage.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { api } from '@/lib/trpc/client'
 import {
@@ -19,7 +20,13 @@ import { useExchangeRates } from '@/hooks/useExchangeRates'
 import { ReceiptViewer } from './ReceiptViewer'
 
 export function TravelSupportAdminPage() {
-  const [selectedRequest, setSelectedRequest] = useState<string | null>(null)
+  const searchParams = useSearchParams()
+  // Read-once from the `request` deep-link param (emitted by the travel-support
+  // notification links) so a notification can open straight to a request. No
+  // URL sync-back — subsequent selection is plain local state.
+  const [selectedRequest, setSelectedRequest] = useState<string | null>(() =>
+    searchParams.get('request'),
+  )
   const { data: session } = useSession()
 
   const {

--- a/src/lib/events/handlers/persistNotification.ts
+++ b/src/lib/events/handlers/persistNotification.ts
@@ -24,6 +24,9 @@ const SPEAKER_NOTIFY_ACTIONS: readonly Action[] = [
  *
  * - `submit`: notify every organizer (except the actor) that a new proposal
  *   arrived.
+ * - `confirm` / `withdraw`: notify every organizer (except the actor) that a
+ *   speaker confirmed or withdrew — mirrors the Slack organizer alert
+ *   (`slackNotification.ts`), which the in-app hub previously lacked.
  * - status change (mirroring the email handler's gating): notify each speaker
  *   on the proposal (except the actor) of the new status.
  *
@@ -47,6 +50,33 @@ export async function handlePersistNotification(
         conferenceId,
         notificationType: 'proposal_submitted',
         title: `New proposal: "${proposalTitle}"`,
+        actorId,
+        relatedProposalId: proposalId,
+        link: `/admin/proposals/${proposalId}`,
+      }))
+    await createNotifications(items)
+    return
+  }
+
+  if (event.action === Action.confirm || event.action === Action.withdraw) {
+    // Organizer routing is unconditional (like submit) — it mirrors the Slack
+    // organizer alert, not the email-gated speaker notification.
+    const isWithdraw = event.action === Action.withdraw
+    const organizerIds = await getOrganizerSpeakerIds()
+    const title = isWithdraw
+      ? `Proposal withdrawn: "${proposalTitle}"`
+      : `Speaker confirmed: "${proposalTitle}"`
+    // The mandatory withdrawal reason (#212) becomes the message when present.
+    const message =
+      isWithdraw && event.metadata.reason ? event.metadata.reason : undefined
+    const items: NotificationInput[] = organizerIds
+      .filter((id) => id && id !== actorId)
+      .map((id): NotificationInput => ({
+        recipientId: id,
+        conferenceId,
+        notificationType: 'proposal_status_changed',
+        title,
+        message,
         actorId,
         relatedProposalId: proposalId,
         link: `/admin/proposals/${proposalId}`,

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -8,9 +8,11 @@
 export type NotificationType =
   | 'proposal_submitted'
   | 'proposal_status_changed'
+  // Reserved for future use — no emitter yet.
   | 'proposal_comment'
   | 'travel_support_update'
   | 'sponsor_activity'
+  // Reserved for future use — no emitter yet.
   | 'schedule_update'
   | 'gallery_tagged'
   | 'system'

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -1790,6 +1790,46 @@ export const proposalRouter = router({
             )
           })
 
+          // Mirror the inviter email with an in-app notification. Guarded like
+          // the other router-inline emitters: the response is already
+          // persisted, so a failure here (e.g. the conference fetch) must not
+          // surface as a respond error. The invitation projection dereferences
+          // `invitedBy`, so a resolvable inviter carries an `_id`.
+          const inviterId =
+            invitation.invitedBy &&
+            typeof invitation.invitedBy === 'object' &&
+            '_id' in invitation.invitedBy
+              ? invitation.invitedBy._id
+              : undefined
+          if (inviterId) {
+            try {
+              const { conference: notifyConference } =
+                await getConferenceForCurrentDomain()
+              if (notifyConference) {
+                const responderName = ctx.speaker.name || ctx.speaker.email
+                await createNotifications([
+                  {
+                    recipientId: inviterId,
+                    conferenceId: notifyConference._id,
+                    notificationType: 'system',
+                    title: `${responderName} ${
+                      input.accept ? 'accepted' : 'declined'
+                    } your co-speaker invitation`,
+                    actorId: ctx.speaker._id,
+                    ...(proposalId
+                      ? { link: `/cfp/proposal/${proposalId}` }
+                      : {}),
+                  },
+                ])
+              }
+            } catch (notifyError) {
+              console.error(
+                'Failed to notify inviter of co-speaker response:',
+                notifyError,
+              )
+            }
+          }
+
           return { success: true, status }
         } catch (error) {
           if (error instanceof TRPCError) throw error

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -1125,7 +1125,7 @@ export const sponsorRouter = router({
                       ? `Sponsor ${sponsorName} moved to ${input.newStatus}`
                       : `Sponsor moved to ${input.newStatus}`,
                     actorId: userId,
-                    link: '/admin/sponsors/crm',
+                    link: `/admin/sponsors/crm?sponsor=${input.id}`,
                   })),
               )
             }

--- a/src/server/routers/travelSupport.ts
+++ b/src/server/routers/travelSupport.ts
@@ -46,7 +46,7 @@ import {
   getOrganizerSpeakerIds,
 } from '@/lib/notification/sanity'
 import type { NotificationInput } from '@/lib/notification/types'
-import { TravelSupportStatus } from '@/lib/travel-support/types'
+import { TravelSupportStatus, ExpenseStatus } from '@/lib/travel-support/types'
 
 /**
  * Human-readable notification titles for the travel support statuses that
@@ -60,6 +60,16 @@ const TRAVEL_STATUS_NOTIFY_TITLES: Partial<
   [TravelSupportStatus.APPROVED]: 'Travel support approved',
   [TravelSupportStatus.REJECTED]: 'Travel support rejected',
   [TravelSupportStatus.PAID]: 'Travel support marked paid',
+}
+
+/**
+ * Notification titles for the individual-expense decisions that warrant
+ * notifying the affected speaker. The pending status is intentionally absent —
+ * only an organizer approve/reject decision produces a notification.
+ */
+const EXPENSE_STATUS_NOTIFY_TITLES: Partial<Record<ExpenseStatus, string>> = {
+  [ExpenseStatus.APPROVED]: 'Expense approved',
+  [ExpenseStatus.REJECTED]: 'Expense rejected',
 }
 
 export const travelSupportRouter = router({
@@ -293,7 +303,7 @@ export const travelSupportRouter = router({
                   notificationType: 'travel_support_update',
                   title: `Travel support request from ${ctx.speaker.name}`,
                   actorId: ctx.speaker._id,
-                  link: '/admin/speakers/travel-support',
+                  link: `/admin/speakers/travel-support?request=${input.travelSupportId}`,
                 })),
             )
           }
@@ -776,6 +786,47 @@ export const travelSupportRouter = router({
               message: 'Failed to update expense status',
               cause: error,
             })
+          }
+
+          // Notify the affected speaker of an approve/reject decision (pending
+          // echoes are skipped), unless they made the change themselves. Mirrors
+          // the updateStatus emitter above and shares createNotifications'
+          // never-fail contract: the expense status is already persisted, so a
+          // failure here must not surface as an update error.
+          try {
+            const statusTitle = EXPENSE_STATUS_NOTIFY_TITLES[input.status]
+            if (statusTitle) {
+              const expenseRef = await getTravelExpenseRef(input.expenseId)
+              const travelSupportId = expenseRef?.travelSupport?._ref
+              if (travelSupportId) {
+                const { travelSupport } =
+                  await getTravelSupportById(travelSupportId)
+                const affectedSpeakerId = travelSupport?.speaker?._id
+                const conferenceId = travelSupport?.conference?._id
+                if (
+                  affectedSpeakerId &&
+                  conferenceId &&
+                  affectedSpeakerId !== ctx.speaker._id
+                ) {
+                  await createNotifications([
+                    {
+                      recipientId: affectedSpeakerId,
+                      conferenceId,
+                      notificationType: 'travel_support_update',
+                      title: statusTitle,
+                      message: input.reviewNotes || undefined,
+                      actorId: ctx.speaker._id,
+                      link: '/cfp/expense',
+                    },
+                  ])
+                }
+              }
+            }
+          } catch (notifyError) {
+            console.error(
+              'Failed to notify speaker of expense status change:',
+              notifyError,
+            )
           }
 
           return { success: true }

--- a/src/server/routers/volunteer.ts
+++ b/src/server/routers/volunteer.ts
@@ -26,6 +26,11 @@ import { sendVolunteerApprovalEmail } from '@/lib/email/volunteer'
 import { PRIVACY_POLICY_VERSION } from '@/lib/privacy/config'
 import { notifyNewVolunteer } from '@/lib/slack/notify'
 import { getCurrentDateTime } from '@/lib/time'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
 
 export const volunteerRouter = router({
   create: publicProcedure
@@ -73,6 +78,23 @@ export const volunteerRouter = router({
           const { conference, error } = await getConferenceForCurrentDomain()
           if (!error && conference) {
             void notifyNewVolunteer(result.volunteer, conference)
+
+            // In-app mirror for organizers. This is a public endpoint, so
+            // there is no actor to exclude. Shares createNotifications'
+            // never-fail contract: the volunteer record is already created.
+            const volunteerName = result.volunteer.name
+            const organizerIds = await getOrganizerSpeakerIds()
+            await createNotifications(
+              organizerIds
+                .filter((id) => id)
+                .map((id): NotificationInput => ({
+                  recipientId: id,
+                  conferenceId: conference._id,
+                  notificationType: 'system',
+                  title: `New volunteer signup: ${volunteerName}`,
+                  link: '/admin/volunteers',
+                })),
+            )
           }
         } catch {
           // Ignore notification errors


### PR DESCRIPTION
## Notification hub integration — Wave A

Server-side in-app notification emitters and deep links, closing gaps where Slack/email already notified but the persistent in-app hub did not. Every emitter fans out via `createNotifications` (never-throws), excludes the actor where applicable, and is wrapped in a guarded `try/catch` so a notification failure never fails the business mutation.

### A1 — Speaker confirm/withdraw → organizers (HIGH)
`persistNotification` bus handler now has an organizer branch for `Action.confirm` / `Action.withdraw` (previously only Slack alerted organizers). Recipients: `getOrganizerSpeakerIds()` minus the actor; type `proposal_status_changed`; titles `Speaker confirmed: "<title>"` / `Proposal withdrawn: "<title>"`; the mandatory withdrawal reason becomes the message when present; link `/admin/proposals/<id>`. Routing is unconditional like `submit`.

### A2 — Co-speaker invitation response → inviter (MED-HIGH)
`proposal.invitation.respond` now mirrors the inviter email with an in-app notification to `invitedBy` (skipped if the inviter id is missing): type `system`, title `<responder> accepted/declined your co-speaker invitation`, actor = responder, link `/cfp/proposal/<proposalId>` (omitted if the proposal no longer resolves).

### A3 — Volunteer signup → organizers (MED)
`volunteer.create` now mirrors the Slack alert in-app to all organizers (public endpoint, no actor to exclude): type `system`, title `New volunteer signup: <name>`, link `/admin/volunteers`.

### A4 — Travel-support expense decision → speaker (LOW-MED)
`travelSupport.admin.updateExpenseStatus` now notifies the affected speaker (not the actor) on approve/reject outcomes (pending echoes skipped): type `travel_support_update`, titles `Expense approved` / `Expense rejected`, `reviewNotes` as message, link `/cfp/expense`. Owner/conference resolved via `getTravelExpenseRef` → `getTravelSupportById`. Mirrors the existing `updateStatus` emitter.

### A5 — Sponsor deep link (MED)
`sponsor.crm.moveStage` emitter link now `/admin/sponsors/crm?sponsor=<id>` (the sponsor-for-conference id the CRM pipeline reads from the `sponsor` search param).

### A6 — Travel-support deep link (MED-HIGH)
Organizer-facing submit emitter link now carries `?request=<travelSupportId>`. `TravelSupportAdminPage` initializes its selection read-once from the `request` URL param on mount (no URL sync-back). The admin route is dynamically rendered (auth in the layout), so `useSearchParams` needs no Suspense boundary — consistent with existing admin components.

### A7 — Dormant types annotated (LOW)
`proposal_comment` and `schedule_update` marked reserved-for-future in `types.ts` and the Sanity schema options. Not removed.

### Tests
- `persistNotification.test.ts`: confirm/withdraw → organizer fan-out, withdraw reason as message, reason-absent omission, shouldNotify independence, actor exclusion, speakers-not-notified.
- Router tests extended (N3 pattern) for A2/A3/A4 and updated links for A5/A6.
- `npx vitest run __tests__/`: 2320 passed, 0 actual failures. 26 suites fail to load locally due to the known `@digitalbazaar/vc` missing-package issue (not installed in the shared node_modules; CI installs it and runs them). The 4 router suites touched here are among those — they typecheck (tsc 0) and run in CI.
- No story exists for the travel-support admin page, so A6 was verified via tsc + pattern-consistency rather than `pnpm shoot`.

### Verification
tsc 0 · eslint (source) clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up server-side in-app notification emitters for five previously-missing event types: organizer alerts on proposal confirm/withdraw, co-speaker invitation response to the inviter, volunteer signups to organizers, and individual expense approve/reject decisions to the affected speaker. It also improves two existing deep links (sponsor CRM, travel-support admin) and annotates two dormant notification types as reserved.

- **A1–A4**: New `createNotifications` fan-outs added in `persistNotification.ts`, `proposal.ts`, `travelSupport.ts`, and `volunteer.ts`; each is guarded in a try/catch so notification failures never fail the business mutation.
- **A5–A6**: Sponsor CRM link now carries `?sponsor=<id>` and the travel-support admin link carries `?request=<travelSupportId>`; `TravelSupportAdminPage` reads the `request` param once at mount to pre-select the deep-linked request.
- **A7**: `proposal_comment` and `schedule_update` types annotated as reserved-for-future in `types.ts` and the Sanity schema.

<h3>Confidence Score: 4/5</h3>

Safe to merge — every new emitter is wrapped in a guarded try/catch so notification failures cannot break the underlying business mutation, and the test suite comprehensively covers fan-out, actor exclusion, and resilience cases.

The volunteer signup notification catch block silently swallows errors with no log, unlike every other emitter added in this PR. The useSearchParams() call in TravelSupportAdminPage also lacks a Suspense boundary, which is harmless today but brittle against future rendering strategy changes.

src/server/routers/volunteer.ts — notification errors swallowed silently; src/components/travel-support/TravelSupportAdminPage.tsx — useSearchParams without Suspense boundary.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/events/handlers/persistNotification.ts | Adds confirm/withdraw → organizer fan-out with correct actor exclusion and unconditional routing, consistent with the existing submit path; event-bus try-catch provides the outer safety net. |
| src/server/routers/volunteer.ts | In-app organizer notification added to the public signup path; errors are silently swallowed with no log (unlike parallel patterns in travelSupport.ts/sponsor.ts), making notification failures invisible in production. |
| src/server/routers/proposal.ts | Co-speaker invitation response notification to inviter added; correctly guarded in a dedicated try/catch, actor and inviter are separate people by design, conference fetched on-demand. |
| src/server/routers/travelSupport.ts | Expense approve/reject → affected-speaker notification and deep-link added; correctly skips pending status and self-notifications; requires two extra Sanity fetches per updateExpenseStatus call. |
| src/components/travel-support/TravelSupportAdminPage.tsx | Deep-link selection via useSearchParams() added at component root; works for a dynamically-rendered admin route but lacks a Suspense boundary, which would be silently required if the route ever gains static/PPR rendering. |
| src/server/routers/sponsor.ts | CRM notification link updated to include ?sponsor=<id> deep-link parameter; minimal, correct change. |
| src/lib/notification/types.ts | Reserved-for-future annotations added to proposal_comment and schedule_update; no behavioral change. |
| sanity/schemaTypes/notification.ts | Matching reserved-for-future comments added to the Sanity schema options; no behavioral change. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Speaker
    participant OrganizerAdmin as Organizer/Admin
    participant Router as tRPC Router
    participant EventBus as Event Bus
    participant PersistHandler as persistNotification handler
    participant Sanity as Sanity (notifications)

    Note over Speaker,Sanity: A1 — Proposal confirm/withdraw
    Speaker->>Router: proposal action (confirm/withdraw)
    Router->>EventBus: publish proposal.status.changed
    EventBus->>PersistHandler: handlePersistNotification
    PersistHandler->>Sanity: getOrganizerSpeakerIds()
    PersistHandler->>Sanity: createNotifications([...organizers minus actor])
    Sanity-->>OrganizerAdmin: in-app notification

    Note over Speaker,Sanity: A2 — Co-speaker invitation response
    Speaker->>Router: proposal.invitation.respond
    Router->>Sanity: persist accept/decline
    Router->>Speaker: sendResponseNotificationEmail (async)
    Router->>Sanity: getConferenceForCurrentDomain()
    Router->>Sanity: createNotifications([invitedBy])
    Sanity-->>OrganizerAdmin: in-app notification (inviter)

    Note over Speaker,Sanity: A3 — Volunteer signup
    Speaker->>Router: volunteer.create (public)
    Router->>Sanity: createVolunteer()
    Router->>Sanity: getConferenceForCurrentDomain()
    Router->>Router: void notifyNewVolunteer (Slack, fire-forget)
    Router->>Sanity: getOrganizerSpeakerIds()
    Router->>Sanity: createNotifications([...organizers])
    Sanity-->>OrganizerAdmin: in-app notification

    Note over Speaker,Sanity: A4 — Expense decision
    OrganizerAdmin->>Router: travelSupport.admin.updateExpenseStatus
    Router->>Sanity: updateExpenseStatus()
    Router->>Sanity: getTravelExpenseRef(expenseId)
    Router->>Sanity: getTravelSupportById(travelSupportId)
    Router->>Sanity: createNotifications([affectedSpeaker])
    Sanity-->>Speaker: in-app notification
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Speaker
    participant OrganizerAdmin as Organizer/Admin
    participant Router as tRPC Router
    participant EventBus as Event Bus
    participant PersistHandler as persistNotification handler
    participant Sanity as Sanity (notifications)

    Note over Speaker,Sanity: A1 — Proposal confirm/withdraw
    Speaker->>Router: proposal action (confirm/withdraw)
    Router->>EventBus: publish proposal.status.changed
    EventBus->>PersistHandler: handlePersistNotification
    PersistHandler->>Sanity: getOrganizerSpeakerIds()
    PersistHandler->>Sanity: createNotifications([...organizers minus actor])
    Sanity-->>OrganizerAdmin: in-app notification

    Note over Speaker,Sanity: A2 — Co-speaker invitation response
    Speaker->>Router: proposal.invitation.respond
    Router->>Sanity: persist accept/decline
    Router->>Speaker: sendResponseNotificationEmail (async)
    Router->>Sanity: getConferenceForCurrentDomain()
    Router->>Sanity: createNotifications([invitedBy])
    Sanity-->>OrganizerAdmin: in-app notification (inviter)

    Note over Speaker,Sanity: A3 — Volunteer signup
    Speaker->>Router: volunteer.create (public)
    Router->>Sanity: createVolunteer()
    Router->>Sanity: getConferenceForCurrentDomain()
    Router->>Router: void notifyNewVolunteer (Slack, fire-forget)
    Router->>Sanity: getOrganizerSpeakerIds()
    Router->>Sanity: createNotifications([...organizers])
    Sanity-->>OrganizerAdmin: in-app notification

    Note over Speaker,Sanity: A4 — Expense decision
    OrganizerAdmin->>Router: travelSupport.admin.updateExpenseStatus
    Router->>Sanity: updateExpenseStatus()
    Router->>Sanity: getTravelExpenseRef(expenseId)
    Router->>Sanity: getTravelSupportById(travelSupportId)
    Router->>Sanity: createNotifications([affectedSpeaker])
    Sanity-->>Speaker: in-app notification
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/server/routers/volunteer.ts`, line 99-101 ([link](https://github.com/cloudnativebergen/website/blob/4a5894685ead835c8ea58ef423ecdb694e47ea49/src/server/routers/volunteer.ts#L99-L101)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent notification failures on the public signup path**

   The outer catch swallows all errors with no log, including failures from `getOrganizerSpeakerIds()` and `createNotifications()`. Every other notification try/catch introduced in this PR (sponsor, travelSupport, proposal) logs via `console.error` so failures are traceable. Because this is a public endpoint it sees the most traffic, and a persistent Sanity connectivity problem here would be completely invisible in production logs — contrasting with the sibling emitters that do surface errors.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): integration wave A ..."](https://github.com/cloudnativebergen/website/commit/4a5894685ead835c8ea58ef423ecdb694e47ea49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45349078)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->