### PR TITLE
feat(notifications): backfill migration for 2026 speaker inbox state

### DIFF
--- a/migrations/040-backfill-notifications-2026/README.md
+++ b/migrations/040-backfill-notifications-2026/README.md
@@ -1,0 +1,137 @@
+# Migration 040: Backfill Notification Hub (2026 speaker inbox state)
+
+## Overview
+
+A one-shot backfill that seeds the in-app **notification hub** with the CURRENT
+2026 state, so speaker inboxes are not empty when the hub launches.
+
+The live emitters
+(`src/lib/events/handlers/persistNotification.ts` and
+`src/server/routers/travelSupport.ts`) only fan notifications out **going
+forward**, from the moment they shipped. Every proposal decision and travel
+support decision made **before** the hub existed produced no notification. This
+migration reconstructs those notifications from the current dataset so a speaker
+opening the inbox at launch sees the decisions that matter to them.
+
+## What this migration does
+
+It resolves the **target conference** (see below) and then creates one
+`notification` document per relevant record:
+
+1. **Proposal decisions** — for every `talk` referencing the conference whose
+   `status` is a speaker-facing decision
+   (`accepted`, `confirmed`, `rejected`, `waitlisted`), one
+   `proposal_status_changed` notification is created **for each referenced
+   speaker**:
+   - `recipient` → the speaker, `conference` → the conference
+   - `title` mirrors the live handler wording:
+     - accepted → `Your proposal "<title>" is now accepted`
+     - rejected → `Your proposal "<title>" is now rejected`
+     - waitlisted → `Your proposal "<title>" is now waitlisted`
+     - confirmed → `Proposal confirmed: "<title>"` (the live system has **no**
+       speaker-facing confirmed title, because confirm is speaker-initiated, so
+       one is minted here)
+   - `link` → `/cfp/proposal/<talkId>`
+   - `relatedProposal` → weak reference to the talk
+2. **Travel support decisions** — for every `travelSupport` referencing the
+   conference whose `status` is a decision (`approved`, `paid`, `rejected`),
+   one `travel_support_update` notification is created for the requesting
+   speaker. Titles mirror `TRAVEL_STATUS_NOTIFY_TITLES` in
+   `src/server/routers/travelSupport.ts`
+   (`Travel support approved` / `Travel support rejected` /
+   `Travel support marked paid`), `link` → `/cfp/expense`.
+
+`createdAt` is the backfill run time for every created document.
+
+## Read-state rule
+
+Backfilled notifications arrive **already read** (`readAt == createdAt`) with a
+single deliberate exception:
+
+- **`accepted` proposals arrive UNREAD** (no `readAt`). An accepted proposal is
+  awaiting the speaker's confirmation, so it is a genuine, still-actionable
+  call-to-action and should light up the unread badge.
+- Every other proposal state (`confirmed` / `rejected` / `waitlisted`) and **all**
+  travel support decisions are informational history, so they arrive read and do
+  not inflate the unread count.
+
+## No organizer backfill (deliberate)
+
+This migration intentionally creates **no** organizer-facing notifications
+(e.g. `proposal_submitted` "new proposal" or "new travel support request"
+notes). Those are transient work-queue signals whose value is at the moment of
+submission; reconstructing a pile of historical "new proposal" notifications
+would spam organizer inboxes with stale, non-actionable items. Only
+speaker-facing decision outcomes are backfilled.
+
+## Target conference
+
+The app resolves the conference by request domain
+(`getConferenceForCurrentDomain`), which is not available inside a migration.
+This migration therefore queries all conferences and picks the one with the
+**latest `startDate`** — the current 2026 edition — and **logs the choice**. To
+pin a specific edition, set `BACKFILL_CONFERENCE_ID=<conferenceId>` in the run
+environment.
+
+## Idempotency
+
+Safe to run multiple times. Two layers:
+
+1. **Deterministic `_id`s** applied via `createIfNotExists`:
+   - proposals → `notification.backfill-2026.<talkId>.<speakerId>`
+   - travel → `notification.backfill-2026.travel.<travelSupportId>`
+
+   A re-run recreates the same ids, so `createIfNotExists` no-ops.
+
+2. **Dedup set** (belt-and-braces) — a pre-pass loads existing `notification`
+   documents for the conference and builds a set keyed by
+   `(recipient, notificationType, relatedProposal | link)`. A candidate is
+   skipped when its key already exists. This catches the case where a **live
+   emitter has already fired** for the same (speaker, decision) with a random
+   `_id` — which the deterministic-id check alone would miss — so no duplicate
+   is created. Skipped counts are logged.
+
+Drafts are skipped (the published document owns the fields).
+
+## Running the migration
+
+Run via the **`Run Sanity Migration`** GitHub Actions workflow
+(`.github/workflows/run-migration.yml`, `workflow_dispatch`):
+
+- **migration**: `040-backfill-notifications-2026`
+- **dataset**: `production` (or the target dataset)
+
+The workflow exports a dataset backup artifact, performs a **dry run** (logging
+every intended creation without writing), and only then applies the migration.
+Review the dry-run log before the apply step — it is the validation gate, since
+the migration cannot be exercised against the real dataset from a PR.
+
+Equivalent local invocation:
+
+```bash
+pnpm sanity migration run 040-backfill-notifications-2026 \
+  --project "$SANITY_STUDIO_PROJECT_ID" --dataset production   # dry run
+pnpm sanity migration run 040-backfill-notifications-2026 \
+  --project "$SANITY_STUDIO_PROJECT_ID" --dataset production --no-dry-run --no-confirm
+```
+
+## Verification
+
+After running, spot-check counts and a sample:
+
+```bash
+# Count backfilled notifications
+npx sanity documents query '*[_type == "notification" && _id in path("notification.backfill-2026.**")] | count'
+
+# Confirm accepted proposals are unread and others are read
+npx sanity documents query '*[_type == "notification" && _id in path("notification.backfill-2026.**")]{title, readAt}[0...10]'
+```
+
+## Rollback
+
+```bash
+# Delete only the documents this migration created (deterministic id prefix)
+npx sanity documents query 'delete *[_type == "notification" && _id in path("notification.backfill-2026.**")]'
+```
+
+Or restore from the backup artifact produced by the workflow.

--- a/migrations/040-backfill-notifications-2026/index.ts
+++ b/migrations/040-backfill-notifications-2026/index.ts
@@ -1,0 +1,346 @@
+import { defineMigration, createIfNotExists } from 'sanity/migrate'
+import type { SanityDocument } from '@sanity/types'
+
+/**
+ * One-shot backfill of the in-app notification hub with the CURRENT 2026 state,
+ * so speaker inboxes are not empty when the hub launches.
+ *
+ * WHY: the live emitters (`src/lib/events/handlers/persistNotification.ts` and
+ * `src/server/routers/travelSupport.ts`) only fan out notifications going
+ * FORWARD, from the moment they shipped. Every proposal decision and travel
+ * support decision made BEFORE the hub existed produced no notification, so a
+ * speaker opening the new inbox at launch would see nothing about the very
+ * decisions that matter most to them. This migration reconstructs those
+ * notifications from the current dataset state.
+ *
+ * SCOPE (source documents this migration reads):
+ *  1. `talk` documents for the target conference whose status is a
+ *     speaker-facing decision (accepted / confirmed / rejected / waitlisted).
+ *     One `proposal_status_changed` notification per referenced speaker.
+ *  2. `travelSupport` documents for the target conference whose status is a
+ *     decision (approved / paid / rejected). One `travel_support_update`
+ *     notification to the requesting speaker.
+ *  NO organizer backfill — see README ("No organizer backfill").
+ *
+ * READ-STATE RULE: backfilled notifications arrive already READ
+ * (`readAt == createdAt`) EXCEPT `accepted` proposals, which arrive UNREAD.
+ * An accepted proposal is awaiting the speaker's confirmation, so its
+ * notification is a genuine, still-actionable call-to-action; every other
+ * state is informational history, so it should not light up the unread badge.
+ *
+ * IDEMPOTENCY (see README): every created document has a deterministic `_id`
+ * (`notification.backfill-2026.<...>`) applied via `createIfNotExists`, and a
+ * pre-pass builds a dedup set keyed by
+ * (recipient, notificationType, relatedProposal|link) from the existing
+ * `notification` documents. A candidate is skipped when either its `_id` or its
+ * key already exists — so a re-run, OR a live emitter that already fired for the
+ * same (speaker, decision), can never produce a duplicate.
+ */
+
+/** Conference id prefix for every backfilled notification's deterministic id. */
+const ID_PREFIX = 'notification.backfill-2026'
+
+/** Optional operator override to pin the target conference explicitly. */
+const CONFERENCE_OVERRIDE = process.env.BACKFILL_CONFERENCE_ID
+
+/**
+ * Proposal statuses that warrant a speaker-facing status notification. Values
+ * mirror the `Status` enum in `src/lib/proposal/types.ts` (note the spelling
+ * `waitlisted`). `confirmed` is included even though the live handler never
+ * emits for it (confirm is speaker-initiated) — see `proposalTitle`.
+ */
+const PROPOSAL_NOTIFY_STATUSES = [
+  'accepted',
+  'confirmed',
+  'rejected',
+  'waitlisted',
+] as const
+type ProposalNotifyStatus = (typeof PROPOSAL_NOTIFY_STATUSES)[number]
+
+/**
+ * Travel support statuses that warrant notifying the requesting speaker. Values
+ * mirror the `TravelSupportStatus` enum in `src/lib/travel-support/types.ts`.
+ */
+const TRAVEL_NOTIFY_STATUSES = ['approved', 'paid', 'rejected'] as const
+type TravelNotifyStatus = (typeof TRAVEL_NOTIFY_STATUSES)[number]
+
+/**
+ * Travel support notification titles. Mirrors `TRAVEL_STATUS_NOTIFY_TITLES` in
+ * `src/server/routers/travelSupport.ts` verbatim.
+ */
+const TRAVEL_TITLES: Record<TravelNotifyStatus, string> = {
+  approved: 'Travel support approved',
+  rejected: 'Travel support rejected',
+  paid: 'Travel support marked paid',
+}
+
+const TRAVEL_LINK = '/cfp/expense'
+
+/**
+ * Proposal notification title for a status.
+ *
+ * accept / reject / waitlist mirror the live handler
+ * (`handlePersistNotification`) wording: `Your proposal "<title>" is now
+ * <status>`. `confirmed` has no live speaker-facing title — confirm is
+ * speaker-initiated, so the live system never emits one — so we mint an
+ * explicit `Proposal confirmed: "<title>"`.
+ */
+function proposalTitle(
+  status: ProposalNotifyStatus,
+  talkTitle: string,
+): string {
+  if (status === 'confirmed') {
+    return `Proposal confirmed: "${talkTitle}"`
+  }
+  return `Your proposal "${talkTitle}" is now ${status}`
+}
+
+interface ConferenceRow {
+  _id: string
+  title?: string
+  startDate?: string
+}
+
+interface ExistingNotificationRow {
+  recipientRef?: string
+  notificationType?: string
+  relatedProposalRef?: string
+  link?: string
+}
+
+interface TalkDoc extends SanityDocument {
+  title?: string
+  status?: string
+  conference?: { _ref?: string }
+  speakers?: Array<{ _ref?: string } | null>
+}
+
+interface TravelSupportDoc extends SanityDocument {
+  status?: string
+  conference?: { _ref?: string }
+  speaker?: { _ref?: string }
+}
+
+const isDraft = (id: string): boolean => id.startsWith('drafts.')
+
+/** Dedup key: matches on (recipient, notificationType, relatedProposal|link). */
+function proposalKey(recipientRef: string, proposalRef: string): string {
+  return `${recipientRef}::proposal_status_changed::${proposalRef}`
+}
+function travelKey(recipientRef: string): string {
+  return `${recipientRef}::travel_support_update::${TRAVEL_LINK}`
+}
+
+export default defineMigration({
+  title: 'Backfill notification hub with current 2026 speaker inbox state',
+  description:
+    'Creates in-app notification documents reconstructing the current ' +
+    'proposal-decision and travel-support-decision state for the latest ' +
+    'conference, so speaker inboxes are not empty at hub launch. Accepted ' +
+    'proposals arrive unread (call-to-action); everything else arrives read. ' +
+    'No organizer backfill. Idempotent via deterministic ids + a dedup set.',
+  documentTypes: ['talk', 'travelSupport'],
+
+  async *migrate(documents, context) {
+    // Single backfill timestamp for createdAt (and readAt where read-on-arrival).
+    const now = new Date().toISOString()
+
+    // --- Pre-pass 1: resolve the target conference ---------------------------
+    // The app scopes the conference by request domain (getConferenceForCurrentDomain),
+    // which is unavailable in a migration. So we pick the latest edition by
+    // startDate — the CURRENT 2026 conference — logging the choice. An operator
+    // can pin a specific edition via BACKFILL_CONFERENCE_ID.
+    const conferences = await context.client.fetch<ConferenceRow[]>(
+      `*[_type == "conference" && !(_id in path("drafts.**"))]{ _id, title, startDate } | order(startDate desc)`,
+    )
+
+    if (!conferences || conferences.length === 0) {
+      console.warn('  ⚠ No conference documents found — nothing to backfill.')
+      return
+    }
+
+    let conference: ConferenceRow | undefined
+    if (CONFERENCE_OVERRIDE) {
+      conference = conferences.find((c) => c._id === CONFERENCE_OVERRIDE)
+      if (!conference) {
+        console.warn(
+          `  ⚠ BACKFILL_CONFERENCE_ID=${CONFERENCE_OVERRIDE} not found — aborting.`,
+        )
+        return
+      }
+      console.log(
+        `  → Target conference (pinned): ${conference.title ?? '—'} (${conference._id}, startDate ${conference.startDate ?? '—'})`,
+      )
+    } else {
+      conference = conferences[0]
+      console.log(
+        `  → Target conference (latest startDate): ${conference.title ?? '—'} (${conference._id}, startDate ${conference.startDate ?? '—'})`,
+      )
+      if (conferences.length > 1) {
+        console.log(
+          `    (${conferences.length} conferences total; chose the one with the latest startDate. Set BACKFILL_CONFERENCE_ID to override.)`,
+        )
+      }
+    }
+    const conferenceId = conference._id
+
+    // --- Pre-pass 2: build the dedup set from existing notifications ----------
+    // Catches BOTH prior runs of this migration AND live emitters that already
+    // fired for the same (recipient, type, relatedProposal|link).
+    const existingRows = await context.client.fetch<ExistingNotificationRow[]>(
+      `*[_type == "notification" && conference._ref == $conferenceId
+          && notificationType in ["proposal_status_changed", "travel_support_update"]]{
+        "recipientRef": recipient._ref,
+        notificationType,
+        "relatedProposalRef": relatedProposal._ref,
+        link
+      }`,
+      { conferenceId },
+    )
+
+    const existingKeys = new Set<string>()
+    for (const row of existingRows ?? []) {
+      if (!row.recipientRef) continue
+      if (row.notificationType === 'proposal_status_changed') {
+        existingKeys.add(
+          proposalKey(row.recipientRef, row.relatedProposalRef ?? ''),
+        )
+      } else if (row.notificationType === 'travel_support_update') {
+        // Travel notifications carry no relatedProposal; dedup on the link.
+        if (row.link === TRAVEL_LINK)
+          existingKeys.add(travelKey(row.recipientRef))
+      }
+    }
+    console.log(
+      `  → ${existingKeys.size} existing notification key(s) for this conference will be skipped if re-encountered.`,
+    )
+
+    // --- Stream the source documents and yield creates -----------------------
+    let proposalCreated = 0
+    let proposalSkipped = 0
+    let travelCreated = 0
+    let travelSkipped = 0
+
+    for await (const rawDoc of documents()) {
+      const doc = rawDoc as TalkDoc | TravelSupportDoc
+
+      // Drafts inherit the published document's fields on publish; the
+      // published document is the source of truth for the backfill.
+      if (isDraft(doc._id)) continue
+      if (doc.conference?._ref !== conferenceId) continue
+
+      // ---------------- Proposal decisions (talk) ----------------
+      if (doc._type === 'talk') {
+        const talk = doc as TalkDoc
+        const status = talk.status
+        if (
+          !status ||
+          !(PROPOSAL_NOTIFY_STATUSES as readonly string[]).includes(status)
+        ) {
+          continue
+        }
+        const notifyStatus = status as ProposalNotifyStatus
+        const talkTitle = talk.title ?? 'your proposal'
+
+        // De-dup speakers within the talk (mirrors the live handler).
+        const seen = new Set<string>()
+        for (const speaker of talk.speakers ?? []) {
+          const recipientRef = speaker?._ref
+          if (!recipientRef || seen.has(recipientRef)) continue
+          seen.add(recipientRef)
+
+          const key = proposalKey(recipientRef, talk._id)
+          if (existingKeys.has(key)) {
+            proposalSkipped++
+            continue
+          }
+          existingKeys.add(key)
+
+          // Read-state rule: accepted arrives UNREAD; all others arrive read.
+          const readAt = notifyStatus === 'accepted' ? undefined : now
+
+          const _id = `${ID_PREFIX}.${talk._id}.${recipientRef}`
+          console.log(
+            `  ✓ proposal ${notifyStatus} → ${recipientRef} (talk ${talk._id})${readAt ? '' : ' [unread]'}`,
+          )
+          yield [
+            createIfNotExists({
+              _id,
+              _type: 'notification',
+              recipient: { _type: 'reference', _ref: recipientRef },
+              conference: { _type: 'reference', _ref: conferenceId },
+              notificationType: 'proposal_status_changed',
+              title: proposalTitle(notifyStatus, talkTitle),
+              link: `/cfp/proposal/${talk._id}`,
+              // Weak: a later proposal deletion must not orphan-block the note.
+              relatedProposal: {
+                _type: 'reference',
+                _ref: talk._id,
+                _weak: true,
+              },
+              createdAt: now,
+              ...(readAt ? { readAt } : {}),
+            }),
+          ]
+          proposalCreated++
+        }
+        continue
+      }
+
+      // ---------------- Travel support decisions ----------------
+      if (doc._type === 'travelSupport') {
+        const travel = doc as TravelSupportDoc
+        const status = travel.status
+        if (
+          !status ||
+          !(TRAVEL_NOTIFY_STATUSES as readonly string[]).includes(status)
+        ) {
+          continue
+        }
+        const travelStatus = status as TravelNotifyStatus
+        const recipientRef = travel.speaker?._ref
+        if (!recipientRef) {
+          console.warn(
+            `  ⚠ travelSupport ${travel._id} has no speaker ref — skipping.`,
+          )
+          continue
+        }
+
+        const key = travelKey(recipientRef)
+        if (existingKeys.has(key)) {
+          travelSkipped++
+          continue
+        }
+        existingKeys.add(key)
+
+        const _id = `${ID_PREFIX}.travel.${travel._id}`
+        console.log(
+          `  ✓ travel ${travelStatus} → ${recipientRef} (travelSupport ${travel._id})`,
+        )
+        yield [
+          createIfNotExists({
+            _id,
+            _type: 'notification',
+            recipient: { _type: 'reference', _ref: recipientRef },
+            conference: { _type: 'reference', _ref: conferenceId },
+            notificationType: 'travel_support_update',
+            title: TRAVEL_TITLES[travelStatus],
+            link: TRAVEL_LINK,
+            // Decisions are informational — arrive already read.
+            createdAt: now,
+            readAt: now,
+          }),
+        ]
+        travelCreated++
+      }
+    }
+
+    console.log('\n=== Backfill summary ===')
+    console.log(
+      `  Proposal notifications: ${proposalCreated} created, ${proposalSkipped} skipped (already present)`,
+    )
+    console.log(
+      `  Travel notifications:   ${travelCreated} created, ${travelSkipped} skipped (already present)`,
+    )
+  },
+})


### PR DESCRIPTION
## What

One-shot Sanity content migration (`040-backfill-notifications-2026`) that seeds the new in-app **notification hub** with the CURRENT 2026 state, so speaker inboxes are not empty at launch. The live emitters only fan out notifications going forward; every proposal/travel-support decision made before the hub shipped produced nothing. This reconstructs them from the current dataset.

Scope is `migrations/` only (disjoint from #518/#519). No product code touched.

**Sources → notifications created for the target conference:**
- `talk` with status in {accepted, confirmed, rejected, waitlisted} → one `proposal_status_changed` per referenced speaker. Titles mirror the live handler (`Your proposal "<title>" is now <status>`); `confirmed` has no live speaker-facing title (confirm is speaker-initiated), so `Proposal confirmed: "<title>"` is minted. `link` → `/cfp/proposal/<id>`, weak `relatedProposal` ref.
- `travelSupport` with status in {approved, paid, rejected} → one `travel_support_update` to the requesting speaker. Titles mirror `TRAVEL_STATUS_NOTIFY_TITLES`; `link` → `/cfp/expense`.

## Read-state rule

Backfilled notifications arrive **already read** (`readAt == createdAt`) — **except `accepted` proposals, which arrive UNREAD**. An accepted proposal is awaiting the speaker's confirmation, so it is a genuine, still-actionable call-to-action and should light up the unread badge; every other state (and all travel decisions) is informational history and should not inflate the unread count.

## No organizer backfill (deliberate)

No organizer-facing notifications are created. Historical "new proposal / new travel request" work-queue signals have value only at submission time; reconstructing a pile of them would spam organizer inboxes with stale, non-actionable items. Documented in the migration README.

## Idempotency

Two layers, so a re-run — or a live emitter that already fired — cannot duplicate:
1. **Deterministic `_id`s** via `createIfNotExists` (`notification.backfill-2026.<talkId>.<speakerId>` / `notification.backfill-2026.travel.<travelSupportId>`).
2. **Dedup set** (belt-and-braces): a pre-pass loads existing `notification` docs for the conference and keys them by `(recipient, notificationType, relatedProposal | link)`; a candidate whose key already exists is skipped (catches live-emitted docs with random `_id`s that the id check alone would miss). Skipped counts are logged.

Target conference is resolved by latest `startDate` (the 2026 edition), logged at runtime; pin with `BACKFILL_CONFERENCE_ID` if needed. Drafts are skipped.

## Verification

- `tsc --noEmit`: clean (migrations are type-checked via `**/*.ts`).
- ESLint + Prettier on the new files: clean.
- Repo has no migration test harness, so logic was exercised via a throwaway smoke test driving the generator against a mocked Sanity client: read-state rule, minted `confirmed` title, weak refs, per-talk speaker dedup, conference filtering, draft skip, live-emitter dedup, and travel titles/links all verified. The workflow's **dry-run step is the real-dataset validation gate**.

## How to run (NOT auto-run)

Trigger the **Run Sanity Migration** workflow (`.github/workflows/run-migration.yml`, `workflow_dispatch`) with:
- **migration**: `040-backfill-notifications-2026`
- **dataset**: `production`

The workflow exports a dataset backup artifact, performs a dry run (logging every intended creation), then applies. Review the dry-run log before the apply step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a one-shot Sanity content migration (`040-backfill-notifications-2026`) that seeds the new notification hub with the pre-existing 2026 speaker decisions (proposal statuses and travel support outcomes), so inboxes are not empty at hub launch.

- **Proposal backfill**: streams `talk` documents for the target conference, creates one `proposal_status_changed` notification per speaker for each of the four decision statuses; `accepted` arrives unread (still-actionable CTA), all others arrive pre-read.
- **Travel support backfill**: streams `travelSupport` documents, creates one `travel_support_update` per speaker for `approved`/`paid`/`rejected` statuses, using the same titles as the live router.
- **Idempotency**: two-layer approach — deterministic document IDs via `createIfNotExists` plus a pre-pass dedup set keyed by `(recipient, type, relatedProposal|link)` to catch live-emitter duplicates with random IDs.

<h3>Confidence Score: 4/5</h3>

Safe to merge with care: this is a dry-run-gated, one-shot migration that creates no product code changes. The dry-run workflow step acts as the real validation gate before any writes land in production.

The idempotency design is solid (deterministic IDs + pre-pass dedup set). The two findings are both informational: a `confirmed`-status notification is sent to every speaker including the one who triggered the confirmation (no actor data is available in the stored document to exclude them), and an empty-string `talk.title` would produce a malformed notification title. Neither affects the unread count or causes data loss.

migrations/040-backfill-notifications-2026/index.ts — specifically the `confirmed` fan-out and the `talkTitle` null-coalescing operator.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| migrations/040-backfill-notifications-2026/index.ts | One-shot Sanity migration using the async-generator pattern to seed notifications for accepted/confirmed/rejected/waitlisted talks and approved/paid/rejected travel support. Idempotency is well-designed (deterministic IDs + dedup set). Minor: `confirmed` notifications are sent to all speakers including the actor who confirmed, violating the AGENTS.md actor-exclusion rule; and the `talkTitle` empty-string edge case is not guarded. |
| migrations/040-backfill-notifications-2026/README.md | Thorough documentation of the migration: scope, read-state rule, idempotency layers, target conference resolution, rollback procedure, and verification queries. No issues. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start migration] --> B[Pre-pass 1: resolve target conference]
    B --> C{CONFERENCE_OVERRIDE set?}
    C -- yes --> D[Pin by env var]
    C -- no --> E[Pick latest startDate]
    D --> F[Pre-pass 2: load existing notifications]
    E --> F
    F --> G[Build dedup key set]
    G --> H[Stream talk + travelSupport docs]
    H --> I{Draft?}
    I -- yes --> H
    I -- no --> J{Conference matches?}
    J -- no --> H
    J -- yes --> K{doc._type?}
    K -- talk --> L{status in accepted/confirmed/rejected/waitlisted?}
    L -- no --> H
    L -- yes --> M[For each speaker ref]
    M --> N{Key in dedup set?}
    N -- yes --> O[Skip + increment counter]
    N -- no --> P[Add key to set]
    P --> Q{status == accepted?}
    Q -- yes --> R[readAt = undefined - UNREAD]
    Q -- no --> S[readAt = now - pre-read]
    R --> T[yield createIfNotExists notification]
    S --> T
    T --> H
    K -- travelSupport --> U{status in approved/paid/rejected?}
    U -- no --> H
    U -- yes --> V{speaker ref present?}
    V -- no --> W[warn + skip]
    V -- yes --> X{travelKey in dedup set?}
    X -- yes --> Y[Skip + increment counter]
    X -- no --> Z[Add key + yield createIfNotExists travel notification]
    Z --> H
    W --> H
    O --> H
    Y --> H
    H --> AA[Log summary counts]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Start migration] --> B[Pre-pass 1: resolve target conference]
    B --> C{CONFERENCE_OVERRIDE set?}
    C -- yes --> D[Pin by env var]
    C -- no --> E[Pick latest startDate]
    D --> F[Pre-pass 2: load existing notifications]
    E --> F
    F --> G[Build dedup key set]
    G --> H[Stream talk + travelSupport docs]
    H --> I{Draft?}
    I -- yes --> H
    I -- no --> J{Conference matches?}
    J -- no --> H
    J -- yes --> K{doc._type?}
    K -- talk --> L{status in accepted/confirmed/rejected/waitlisted?}
    L -- no --> H
    L -- yes --> M[For each speaker ref]
    M --> N{Key in dedup set?}
    N -- yes --> O[Skip + increment counter]
    N -- no --> P[Add key to set]
    P --> Q{status == accepted?}
    Q -- yes --> R[readAt = undefined - UNREAD]
    Q -- no --> S[readAt = now - pre-read]
    R --> T[yield createIfNotExists notification]
    S --> T
    T --> H
    K -- travelSupport --> U{status in approved/paid/rejected?}
    U -- no --> H
    U -- yes --> V{speaker ref present?}
    V -- no --> W[warn + skip]
    V -- yes --> X{travelKey in dedup set?}
    X -- yes --> Y[Skip + increment counter]
    X -- no --> Z[Add key + yield createIfNotExists travel notification]
    Z --> H
    W --> H
    O --> H
    Y --> H
    H --> AA[Log summary counts]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): backfill migration ..."](https://github.com/cloudnativebergen/website/commit/1e587a558ff951fcff541b9c0ecd9843e1f7123a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45350663)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))
- Context used - Custom context ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->