### PR TITLE
feat(notifications): bell in the public header for signed-in users

### DIFF
--- a/__tests__/components/PublicHeaderBell.test.tsx
+++ b/__tests__/components/PublicHeaderBell.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import type { Session } from 'next-auth'
+
+// Mutable session the mocked `useSession()` returns; each test sets it.
+let mockSession: Session | null = null
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: mockSession,
+    status: mockSession ? 'authenticated' : 'unauthenticated',
+  }),
+}))
+
+// Stub the bell so the gate can be tested without a tRPC/QueryClient provider.
+vi.mock('@/components/notifications/NotificationBell', () => ({
+  NotificationBell: () => <div data-testid="notification-bell" />,
+}))
+
+import { PublicHeaderBell } from '@/components/PublicHeaderBell'
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  mockSession = null
+})
+
+describe('PublicHeaderBell', () => {
+  it('renders nothing when signed out', () => {
+    mockSession = null
+    const { container } = render(<PublicHeaderBell />)
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByTestId('notification-bell')).toBeNull()
+  })
+
+  it('renders nothing when a session exists but has no speaker', () => {
+    // e.g. a session mid-onboarding without a speaker profile yet.
+    mockSession = {
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      user: { name: 'No Speaker' },
+      // no `speaker`
+    } as unknown as Session
+    const { container } = render(<PublicHeaderBell />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the bell for a signed-in speaker', () => {
+    mockSession = {
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      user: { name: 'Jane Doe' },
+      speaker: { _id: 'spk-1', name: 'Jane Doe', isOrganizer: false },
+    } as unknown as Session
+    render(<PublicHeaderBell />)
+    expect(screen.getByTestId('notification-bell')).toBeInTheDocument()
+  })
+})

--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -1,11 +1,56 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { mockDateBeforeEach } from '@/lib/storybook'
 import { Container } from '@/components/Container'
 import { DiamondIcon } from '@/components/DiamondIcon'
 import { ConferenceLogo } from '@/components/ConferenceLogo'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { UserCircleIcon } from '@heroicons/react/24/solid'
 import { UserMenu } from '@/components/UserMenu'
+import { TRPCProvider } from '@/components/providers/TRPCProvider'
+import { NotificationBell } from '@/components/notifications/NotificationBell'
 import type { Speaker } from '@/lib/speaker/types'
+
+// Deterministic tRPC responses for the REAL NotificationBell rendered in the
+// signed-in header states. Mirrors the pattern in DashboardLayout.stories:
+// splits httpBatchLink's comma-batched GET paths so `notification.unreadCount`
+// resolves to 3 (badge) and `notification.list` to a small inbox.
+const notificationItems = () => [
+  {
+    id: 'n1',
+    type: 'proposal_status_changed',
+    title: 'Your proposal was accepted',
+    message: 'Congratulations! "Scaling Kubernetes" was accepted.',
+    link: '/cfp/proposal/1',
+    readAt: null,
+    createdAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+    actor: { _id: 'a1', name: 'Program Committee' },
+  },
+  {
+    id: 'n2',
+    type: 'travel_support_update',
+    title: 'Travel support approved',
+    readAt: null,
+    createdAt: new Date(Date.now() - 90 * 60_000).toISOString(),
+    actor: null,
+  },
+]
+
+const notificationHandlers = [
+  http.get('/api/trpc/:procs', ({ params }) =>
+    HttpResponse.json(
+      String(params.procs)
+        .split(',')
+        .map((proc) =>
+          proc === 'notification.list'
+            ? { result: { data: notificationItems() } }
+            : proc === 'notification.unreadCount'
+              ? { result: { data: 3 } }
+              : { result: { data: null } },
+        ),
+    ),
+  ),
+]
 
 const mockSpeaker: Speaker = {
   _id: 'spk-1',
@@ -20,12 +65,26 @@ const mockSpeaker: Speaker = {
 
 const meta = {
   title: 'Components/Layout/Header',
+  // Pin Date so the msw notification fixtures (and their relative-time labels)
+  // are deterministic, per the AGENTS.md deterministic-dates rule.
+  beforeEach: mockDateBeforeEach(new Date('2026-07-18T12:00:00Z')),
+  // Wrap in the real (httpBatchLink) TRPCProvider so the bell's queries are
+  // comma-batched into a single request that `notificationHandlers` splits —
+  // matching the DashboardLayout.stories pattern.
+  decorators: [
+    (Story) => (
+      <TRPCProvider>
+        <Story />
+      </TRPCProvider>
+    ),
+  ],
   parameters: {
+    msw: { handlers: notificationHandlers },
     layout: 'fullscreen',
     docs: {
       description: {
         component:
-          'Main site header with conference logo, date/location info, registration button, theme toggle, and the role-aware user avatar menu (see `Components/Layout/UserMenu`). Uses `useSession` for authentication state — stories use a mock wrapper to demonstrate logged-out, signed-in speaker, and organizer states.',
+          'Main site header with conference logo, date/location info, registration button, theme toggle, the notification bell (signed-in only), and the role-aware user avatar menu (see `Components/Layout/UserMenu`). Uses `useSession` for authentication state — stories use a mock wrapper to demonstrate logged-out, signed-in speaker, and organizer states. In production the bell is gated by `PublicHeaderBell` on `session?.speaker`; the mock shell below gates on the `isLoggedIn` prop, and the gate itself is covered by the `PublicHeaderBell` unit test.',
       },
     },
   },
@@ -90,6 +149,12 @@ function MockHeader({
         <div className="mt-10 ml-10 sm:flex lg:mt-0 lg:ml-4">
           <div className="flex items-center gap-4">
             <ThemeToggle />
+            {/* The REAL NotificationBell, shown only in signed-in states — its
+                unreadCount/list queries are stubbed by the msw handlers above.
+                Production gates this via PublicHeaderBell on `session?.speaker`;
+                here the mock shell gates on the `isLoggedIn` prop so the
+                signed-out variants render no bell (no layout shift). */}
+            {isLoggedIn && <NotificationBell />}
             {isLoggedIn ? (
               <UserMenu
                 name="Jane Doe"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,6 +16,7 @@ import {
 import { formatDatesSafe } from '@/lib/time'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { UserMenu } from '@/components/UserMenu'
+import { PublicHeaderBell } from '@/components/PublicHeaderBell'
 
 export function Header({ c }: { c: Conference }) {
   const { data: session } = useSession()
@@ -85,6 +86,11 @@ export function Header({ c }: { c: Conference }) {
         <div className="mt-10 ml-10 sm:flex lg:mt-0 lg:ml-4">
           <div className="flex items-center gap-4">
             <ThemeToggle />
+            {/* Bell self-gates on `session?.speaker`; renders nothing (and
+                mounts no query) for signed-out visitors. Lives in this single
+                cluster which is present on both the mobile and desktop header,
+                so one placement covers every breakpoint. */}
+            <PublicHeaderBell />
             {session ? (
               <UserMenu
                 name={session.user.name}

--- a/src/components/PublicHeaderBell.tsx
+++ b/src/components/PublicHeaderBell.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { NotificationBell } from '@/components/notifications/NotificationBell'
+
+/**
+ * Public-site header wrapper around {@link NotificationBell}.
+ *
+ * The installed PWA boots to the public landing page, so a signed-in
+ * speaker/organizer must be able to see their unread badge there. This gate
+ * ensures the bell — and, crucially, its polling `unreadCount` tRPC query —
+ * only mounts when there is a session with a speaker. Signed-out visitors
+ * render nothing: no layout shift, and no unauthenticated (401-spamming)
+ * requests, because the query lives inside `NotificationBell` which never
+ * mounts until the gate passes.
+ *
+ * The public header already sits inside the root layout's `SessionProvider`
+ * and `TRPCProvider` (see `src/app/layout.tsx`), so no extra provider wiring
+ * is needed here.
+ */
+export function PublicHeaderBell() {
+  const { data: session } = useSession()
+
+  if (!session?.speaker) {
+    return null
+  }
+
+  return <NotificationBell />
+}


### PR DESCRIPTION
## What

Adds the notification bell to the **public site header** (`Header.tsx`) for signed-in speakers/organizers. The installed PWA boots to the public landing page, so a signed-in user must be able to see their unread badge there — not only inside the admin/CFP shells.

## Survey findings

- **`src/components/Header.tsx`** is already a client component (`'use client'`) and already reads `useSession()` (it renders `UserMenu` when `session` is truthy, else a login avatar).
- **Providers are already global.** The root `src/app/layout.tsx` mounts **both** `TRPCProvider` and `SessionProviderWrapper` around all children, so every public route already has tRPC + session context. `/cfp` and `/admin` inherit the same global providers. No new provider wiring was required.
- The header has a single right-hand cluster (`<div className="flex items-center gap-4">` holding `ThemeToggle` + user menu) that is present at **every** breakpoint (mobile and desktop) — so one insertion point covers phones and desktop; there is no separate mobile header markup for this region.
- The public header sits on the page background (white in light / `gray-950` in dark), and `NotificationBell`'s badge already uses `ring-white dark:ring-gray-950` — which happens to match the public header background exactly, so no color adaptation of the bell was needed.

## Provider approach

**No provider changes.** Both `TRPCProvider` and `SessionProvider` are already mounted at the root layout level (global), covering public routes. The new `PublicHeaderBell` self-gates on `session?.speaker` and only then renders `<NotificationBell />`, so the polling `unreadCount` query never mounts for signed-out visitors (no 401 spam, no layout shift).

## Changes

- **`src/components/PublicHeaderBell.tsx`** (new): `'use client'` wrapper that returns `null` unless `session?.speaker` is present, otherwise renders `<NotificationBell />`. Kept outside `src/components/notifications/` to avoid touching components shaped by a recent PR.
- **`src/components/Header.tsx`**: mounts `<PublicHeaderBell />` in the existing theme-toggle/user cluster (covers mobile + desktop).
- **`src/components/Header.stories.tsx`**: renders the real `NotificationBell` in the signed-in mock states, with `msw` handlers (comma-batched tRPC split, copied from `DashboardLayout.stories`), a real `TRPCProvider` decorator (httpBatchLink so the batched handler matches), and `mockDateBeforeEach` for deterministic relative-time labels.
- **`__tests__/components/PublicHeaderBell.test.tsx`** (new): asserts the gate — renders nothing signed-out, nothing when a session has no speaker, and the bell for a signed-in speaker (mocks `next-auth/react`).

## Placement screenshots (visual QA via `pnpm shoot`)

- **Light, desktop 1440**: bell with red `3` badge sits between the theme toggle and the JD avatar; badge legible on white.
- **Dark, mobile 393×852**: bell + red `3` badge clearly legible against the `gray-950` navy header; the badge's `dark:ring-gray-950` ring blends into the public dark background. 44px tap target (`h-11 w-11`).
- **Signed-out, mobile 393×852**: only theme toggle + login avatar render — no bell, no layout shift.

## Verify

- `tsc --noEmit`: 0
- eslint (changed files): clean
- prettier: clean
- knip: exit 0
- `vitest run __tests__/`: 2335 tests passed, 0 assertion failures (26 files fail to load on missing optional deps — the known environmental load-failure set, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `PublicHeaderBell` gate component to the public site header so signed-in speakers see the notification bell (with unread badge) while browsing the public pages — which is where the PWA boots. The underlying `NotificationBell` and its polling tRPC query only mount when `session?.speaker` is truthy, keeping public pages clean for signed-out visitors.

- **`PublicHeaderBell.tsx`** (new): thin `'use client'` wrapper that checks `session?.speaker` and returns `null` for signed-out visitors; renders `<NotificationBell />` otherwise. No new provider wiring needed since `TRPCProvider` and `SessionProviderWrapper` are already global in the root layout.
- **`Header.tsx`**: inserts `<PublicHeaderBell />` in the single theme-toggle/user cluster that is present at every breakpoint.
- **`Header.stories.tsx`**: adds MSW handlers, a real `TRPCProvider` decorator, and `mockDateBeforeEach` so signed-in story states render a live bell with deterministic fixtures — consistent with the `DashboardLayout.stories` pattern.
- **`PublicHeaderBell.test.tsx`** (new): unit tests covering the three gate conditions (signed-out, session without speaker, session with speaker).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, well-gated addition with no modifications to existing logic paths.

The gate component is minimal and correct: it delegates entirely to the existing NotificationBell, adds no new state or side-effects of its own, and the null-return path ensures neither layout shift nor unauthenticated queries for signed-out visitors. The root layout already supplies both required providers globally, so no provider wiring was needed. The useNotificationSafe design in NotificationBell already handles the absence of a NotificationProvider on public pages gracefully. Tests cover all three gate conditions, and the Storybook story follows the established DashboardLayout pattern for MSW + TRPCProvider.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/PublicHeaderBell.tsx | New gate component — correctly uses useSession(), returns null for signed-out/no-speaker sessions, and delegates to the existing NotificationBell. Clean and minimal. |
| src/components/Header.tsx | Single-line insertion of <PublicHeaderBell /> in the shared mobile/desktop cluster; no structural changes to the component. |
| src/components/Header.stories.tsx | Adds TRPCProvider decorator, MSW notification handlers with lazy date construction (respects mockDateBeforeEach), and conditional NotificationBell rendering in signed-in story states. Pattern mirrors DashboardLayout.stories correctly. |
| __tests__/components/PublicHeaderBell.test.tsx | Three targeted tests covering signed-out, session-without-speaker, and signed-in-speaker cases. Correctly stubs NotificationBell to avoid tRPC/QueryClient dependencies in unit tests. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Public page renders Header.tsx] --> B[PublicHeaderBell mounts]
    B --> C{useSession}
    C -->|status: loading| D[return null\nno bell, no query]
    C -->|status: unauthenticated| D
    C -->|authenticated, no speaker| D
    C -->|authenticated + session.speaker| E[NotificationBell mounts]
    E --> F[api.notification.unreadCount\npoll every 30s]
    F --> G{unreadCount > 0}
    G -->|yes| H[Show red badge]
    G -->|no| I[Bell icon, no badge]
    E --> J{useNotificationSafe}
    J -->|NotificationProvider absent on public pages| K[notify = undefined\nno toast bridging]
    J -->|NotificationProvider present in admin/CFP shell| L[Toast on new notification]
    H --> M[User clicks bell]
    I --> M
    M --> N[PopoverPanel opens\nNotificationPanel renders\nnotification.list query fires]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Public page renders Header.tsx] --> B[PublicHeaderBell mounts]
    B --> C{useSession}
    C -->|status: loading| D[return null\nno bell, no query]
    C -->|status: unauthenticated| D
    C -->|authenticated, no speaker| D
    C -->|authenticated + session.speaker| E[NotificationBell mounts]
    E --> F[api.notification.unreadCount\npoll every 30s]
    F --> G{unreadCount > 0}
    G -->|yes| H[Show red badge]
    G -->|no| I[Bell icon, no badge]
    E --> J{useNotificationSafe}
    J -->|NotificationProvider absent on public pages| K[notify = undefined\nno toast bridging]
    J -->|NotificationProvider present in admin/CFP shell| L[Toast on new notification]
    H --> M[User clicks bell]
    I --> M
    M --> N[PopoverPanel opens\nNotificationPanel renders\nnotification.list query fires]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): bell in the public ..."](https://github.com/cloudnativebergen/website/commit/7c80af3b87515eeb5c13d792a2ab630312b41617) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45351286)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->