### PR TITLE
fix(migrations): conference targeting for the notification backfill

### DIFF
--- a/.github/workflows/run-migration.yml
+++ b/.github/workflows/run-migration.yml
@@ -20,6 +20,10 @@ on:
         required: true
         type: string
         default: 'production'
+      conference_id:
+        description: 'Optional conference _id override (exported as BACKFILL_CONFERENCE_ID for migrations that target a conference)'
+        required: false
+        type: string
 
 # Never run two migrations against the same dataset concurrently
 concurrency:
@@ -36,6 +40,7 @@ jobs:
       SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
       SANITY_STUDIO_PROJECT_ID: ${{ vars.SANITY_STUDIO_PROJECT_ID }}
       SANITY_STUDIO_DATASET: ${{ inputs.dataset }}
+      BACKFILL_CONFERENCE_ID: ${{ inputs.conference_id }}
 
     steps:
       - name: Checkout code

--- a/migrations/040-backfill-notifications-2026/index.ts
+++ b/migrations/040-backfill-notifications-2026/index.ts
@@ -159,6 +159,17 @@ export default defineMigration({
       return
     }
 
+    // Always list every candidate so the operator can identify the right
+    // edition from a dry-run — the production dataset contains test/dummy
+    // conference docs (e.g. far-future startDates) that break the
+    // latest-startDate heuristic.
+    console.log('  Conference candidates:')
+    for (const c of conferences) {
+      console.log(
+        `    - ${c._id}  startDate=${c.startDate ?? '—'}  ${c.title ?? '—'}`,
+      )
+    }
+
     let conference: ConferenceRow | undefined
     if (CONFERENCE_OVERRIDE) {
       conference = conferences.find((c) => c._id === CONFERENCE_OVERRIDE)


### PR DESCRIPTION
The first production run of `040-backfill-notifications-2026` was a functional no-op: the latest-`startDate` heuristic selected a dummy conference (**AwesomeCon, startDate 2030-01-01**) present in the production dataset, so 0 notifications were created.

- The migration now **logs every conference candidate** (id / startDate / title) so a dry-run identifies the correct edition.
- `run-migration.yml` gains an optional **`conference_id`** input, exported as `BACKFILL_CONFERENCE_ID`, to pin the target explicitly (the override path already existed in the migration).

Re-run plan: dry-run → read candidates → dispatch with the 2026 id pinned. Idempotency makes the earlier no-op run harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production no-op in the `040-backfill-notifications-2026` migration caused by a dummy "AwesomeCon" conference (startDate 2030-01-01) beating the latest-startDate heuristic. It adds two targeted changes: candidate-listing logs before the conference-selection step so a dry-run reveals the correct document ID, and an optional `conference_id` workflow-dispatch input that exports `BACKFILL_CONFERENCE_ID` so the operator can pin the target explicitly on re-run.

- **`migrations/040-backfill-notifications-2026/index.ts`**: Adds a `for…of` logging loop over all queried `ConferenceRow` candidates immediately before the override/heuristic branch; control flow and idempotency logic are unchanged.
- **`.github/workflows/run-migration.yml`**: Adds an optional `conference_id` dispatch input forwarded as the `BACKFILL_CONFERENCE_ID` job-level env var, wiring into the existing override path in the migration.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely additive (logging and an optional workflow input) with no modifications to write paths, idempotency logic, or existing migration behaviour.

The migration's data-write, dedup, and conference-selection logic are entirely unchanged. The new logging block is read-only and runs before any yield. The workflow input is optional and defaults to an empty string, which the migration's existing truthiness guard handles correctly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| migrations/040-backfill-notifications-2026/index.ts | Adds a candidate-listing log loop before the conference selection branch; no logic, idempotency, or data-write paths are altered. |
| .github/workflows/run-migration.yml | Adds an optional workflow-dispatch input `conference_id` forwarded as `BACKFILL_CONFERENCE_ID` job env var; existing steps and concurrency guard are untouched. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): conference targeting fo..."](https://github.com/cloudnativebergen/website/commit/3c2205ab1192c5ff908da5a7011785fc36b047cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45353870)</sub>

<!-- /greptile_comment -->