### PR TITLE
feat(push): self-serve test notification

### DIFF
--- a/__tests__/api/trpc/push.test.ts
+++ b/__tests__/api/trpc/push.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   createAuthenticatedCaller,
   createAnonymousCaller,
@@ -9,8 +9,11 @@ import {
   removePushSubscription,
   getPushPreferences,
   setPushPreferences,
+  getSpeakerPushState,
+  prunePushSubscription,
 } from '@/lib/push/sanity'
-import { getVapidPublicKey } from '@/lib/push/vapid'
+import { getVapidPublicKey, isPushConfigured } from '@/lib/push/vapid'
+import { sendPush } from '@/lib/push/send'
 import { DEFAULT_PUSH_PREFERENCES } from '@/lib/push/types'
 
 vi.mock('@/lib/push/sanity', () => ({
@@ -25,14 +28,36 @@ vi.mock('@/lib/push/sanity', () => ({
     otherUpdates: true,
   }),
   setPushPreferences: vi.fn().mockImplementation(async (_id, prefs) => prefs),
+  getSpeakerPushState: vi.fn().mockResolvedValue({
+    subscriptions: [],
+    preferences: {
+      proposalDecisions: true,
+      talkConfirmed: true,
+      coSpeakerInvites: true,
+      otherUpdates: true,
+    },
+  }),
+  prunePushSubscription: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('@/lib/push/vapid', () => ({
   getVapidPublicKey: vi.fn().mockReturnValue('test-public-key'),
+  isPushConfigured: vi.fn().mockReturnValue(true),
+}))
+// Mock the transport so no real web-push/network is touched (this suite also
+// avoids importing the server-only send module for real).
+vi.mock('@/lib/push/send', () => ({
+  sendPush: vi
+    .fn()
+    .mockResolvedValue({ ok: true, statusCode: 201, gone: false }),
 }))
 
 const mockAdd = vi.mocked(addPushSubscription)
 const mockRemove = vi.mocked(removePushSubscription)
 const mockSetPrefs = vi.mocked(setPushPreferences)
+const mockGetState = vi.mocked(getSpeakerPushState)
+const mockPrune = vi.mocked(prunePushSubscription)
+const mockIsConfigured = vi.mocked(isPushConfigured)
+const mockSendPush = vi.mocked(sendPush)
 
 const SUBSCRIPTION_INPUT = {
   endpoint: 'https://push.example/endpoint-1',
@@ -122,5 +147,111 @@ describe('push router', () => {
       caller.push.subscribe({ endpoint: 'not-a-url', keys: {} }),
     ).rejects.toThrow()
     expect(mockAdd).not.toHaveBeenCalled()
+  })
+
+  describe('sendTest', () => {
+    const SUB = {
+      endpoint: 'https://fcm.googleapis.com/fcm/send/device-1',
+      keys: { p256dh: 'p256dh-value', auth: 'auth-value' },
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }
+
+    // Monotonic fake clock: each test runs 60s after the previous, so the
+    // module-scoped per-speaker cooldown from a prior test is always expired.
+    // (Resetting to real `Date.now()` each test would NOT — the whole suite
+    // runs within a few ms of wall-clock, well inside the 10s window.)
+    let clock = Date.parse('2026-06-01T00:00:00.000Z')
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      clock += 60_000
+      vi.setSystemTime(clock)
+      mockIsConfigured.mockReturnValue(true)
+      mockGetState.mockResolvedValue({
+        subscriptions: [SUB],
+        preferences: DEFAULT_PUSH_PREFERENCES,
+      })
+      mockSendPush.mockResolvedValue({ ok: true, statusCode: 201, gone: false })
+      mockPrune.mockResolvedValue(undefined)
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('sends to every subscription and returns counts (happy path)', async () => {
+      mockGetState.mockResolvedValue({
+        subscriptions: [
+          SUB,
+          { ...SUB, endpoint: 'https://fcm.googleapis.com/fcm/send/device-2' },
+        ],
+        preferences: DEFAULT_PUSH_PREFERENCES,
+      })
+      const caller = createAuthenticatedCaller(speakerA)
+      const result = await caller.push.sendTest()
+
+      expect(result).toEqual({ sent: 2, gone: 0, configured: true })
+      expect(mockGetState).toHaveBeenCalledWith(speakerA)
+      expect(mockSendPush).toHaveBeenCalledTimes(2)
+      // Uses the production payload shape: deep link + collapse tag, bypassing
+      // per-category preferences (explicit user action).
+      const [, payload] = mockSendPush.mock.calls[0]
+      expect(payload).toMatchObject({
+        title: 'Test notification',
+        url: '/cfp/profile',
+        tag: 'test-notification',
+      })
+      expect(mockPrune).not.toHaveBeenCalled()
+    })
+
+    it('returns configured:false when push is not configured', async () => {
+      mockIsConfigured.mockReturnValue(false)
+      const caller = createAuthenticatedCaller(speakerA)
+      const result = await caller.push.sendTest()
+
+      expect(result).toEqual({ sent: 0, gone: 0, configured: false })
+      expect(mockGetState).not.toHaveBeenCalled()
+      expect(mockSendPush).not.toHaveBeenCalled()
+    })
+
+    it('returns zero counts when the caller has no subscriptions', async () => {
+      mockGetState.mockResolvedValue({
+        subscriptions: [],
+        preferences: DEFAULT_PUSH_PREFERENCES,
+      })
+      const caller = createAuthenticatedCaller(speakerA)
+      const result = await caller.push.sendTest()
+
+      expect(result).toEqual({ sent: 0, gone: 0, configured: true })
+      expect(mockSendPush).not.toHaveBeenCalled()
+    })
+
+    it('prunes a gone (404/410) subscription exactly like production', async () => {
+      mockSendPush.mockResolvedValue({ ok: false, statusCode: 410, gone: true })
+      const caller = createAuthenticatedCaller(speakerA)
+      const result = await caller.push.sendTest()
+
+      expect(result).toEqual({ sent: 0, gone: 1, configured: true })
+      expect(mockPrune).toHaveBeenCalledWith(speakerA, SUB.endpoint)
+    })
+
+    it('refuses a second test within the cooldown window', async () => {
+      const caller = createAuthenticatedCaller(speakerA)
+      await caller.push.sendTest()
+      // No time advance → still inside the 10s per-speaker cooldown.
+      await expect(caller.push.sendTest()).rejects.toThrow(
+        /wait a few seconds|TOO_MANY_REQUESTS/,
+      )
+      // The refused call never reached the transport a second time.
+      expect(mockSendPush).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects an unauthenticated caller', async () => {
+      const caller = createAnonymousCaller()
+      await expect(caller.push.sendTest()).rejects.toThrow(
+        /Authentication required|UNAUTHORIZED/,
+      )
+      expect(mockSendPush).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/components/pwa/PushNotificationSettings.stories.tsx
+++ b/src/components/pwa/PushNotificationSettings.stories.tsx
@@ -20,6 +20,7 @@ const meta = {
     preferences: DEFAULT_PUSH_PREFERENCES,
     onToggleMaster: fn(),
     onToggleCategory: fn(),
+    onSendTest: fn(),
   },
   argTypes: {
     status: {
@@ -48,6 +49,43 @@ export const Disabled: Story = {
 /** Subscribed — master on, per-category toggles revealed. */
 export const Enabled: Story = {
   args: { status: 'enabled' },
+}
+
+/**
+ * Subscribed, with the self-serve "Send test notification" button revealed
+ * (only shown when `onSendTest` is wired and the master toggle is on).
+ */
+export const EnabledWithTestButton: Story = {
+  args: { status: 'enabled' },
+}
+
+/** Test send in flight — button disabled with a spinner. */
+export const EnabledSendingTest: Story = {
+  args: { status: 'enabled', sendTestPending: true },
+}
+
+/** Test delivered to two devices — success feedback via role="status". */
+export const EnabledTestSent: Story = {
+  args: {
+    status: 'enabled',
+    sendTestResult: { sent: 2, gone: 0, configured: true },
+  },
+}
+
+/** Test attempted but no devices are subscribed on this account yet. */
+export const EnabledTestNoDevices: Story = {
+  args: {
+    status: 'enabled',
+    sendTestResult: { sent: 0, gone: 0, configured: true },
+  },
+}
+
+/** Test delivered, and an expired subscription was pruned in the process. */
+export const EnabledTestWithExpired: Story = {
+  args: {
+    status: 'enabled',
+    sendTestResult: { sent: 1, gone: 1, configured: true },
+  },
 }
 
 /** Subscribed but two categories (co-speaker + other updates) turned off. */

--- a/src/components/pwa/PushNotificationSettings.tsx
+++ b/src/components/pwa/PushNotificationSettings.tsx
@@ -98,6 +98,16 @@ function Toggle({ checked, onChange, disabled, label, id }: ToggleProps) {
   )
 }
 
+/** Result of a `push.sendTest` round-trip, surfaced as inline feedback. */
+export interface PushTestResult {
+  /** Devices the push service accepted. */
+  sent: number
+  /** Dead/invalid subscriptions pruned during the send. */
+  gone: number
+  /** Whether the server has VAPID keys configured at all. */
+  configured: boolean
+}
+
 export interface PushNotificationSettingsViewProps {
   status: PushSettingsStatus
   preferences: PushPreferences
@@ -108,6 +118,55 @@ export interface PushNotificationSettingsViewProps {
   error?: string | null
   onToggleMaster: (enable: boolean) => void
   onToggleCategory: (category: PushCategory, next: boolean) => void
+  /** Fire a self-serve test notification. Omit to hide the test button. */
+  onSendTest?: () => void
+  /** The test send is in flight (button disabled + spinner). */
+  sendTestPending?: boolean
+  /** Result of the last test send, or null if none attempted this session. */
+  sendTestResult?: PushTestResult | null
+  /** True when the last test send threw (network / server error). */
+  sendTestError?: boolean
+}
+
+/** Human-readable feedback for the last test-notification send. */
+function testFeedback(
+  result: PushTestResult | null | undefined,
+  error: boolean | undefined,
+): { text: string; tone: 'success' | 'muted' | 'warn' } | null {
+  if (error) {
+    return {
+      text: 'Could not send a test notification. Please try again.',
+      tone: 'warn',
+    }
+  }
+  if (!result) return null
+  if (!result.configured) {
+    return {
+      text: 'Push notifications aren’t available right now.',
+      tone: 'muted',
+    }
+  }
+  if (result.sent === 0 && result.gone === 0) {
+    return {
+      text: 'No devices are subscribed on this account yet. Enable notifications on a device first.',
+      tone: 'muted',
+    }
+  }
+  const devices = `${result.sent} device${result.sent === 1 ? '' : 's'}`
+  const base =
+    result.sent > 0
+      ? `Sent to ${devices} — check for the notification.`
+      : 'No active devices received the test.'
+  const expired =
+    result.gone > 0
+      ? ` Removed ${result.gone} expired subscription${
+          result.gone === 1 ? '' : 's'
+        }.`
+      : ''
+  return {
+    text: base + expired,
+    tone: result.sent > 0 ? 'success' : 'warn',
+  }
 }
 
 /**
@@ -123,8 +182,13 @@ export function PushNotificationSettingsView({
   error,
   onToggleMaster,
   onToggleCategory,
+  onSendTest,
+  sendTestPending,
+  sendTestResult,
+  sendTestError,
 }: PushNotificationSettingsViewProps) {
   const enabled = status === 'enabled'
+  const feedback = testFeedback(sendTestResult, sendTestError)
 
   return (
     <section
@@ -263,6 +327,34 @@ export function PushNotificationSettingsView({
                 ))}
               </fieldset>
             )}
+
+            {enabled && onSendTest && (
+              <div className="space-y-2">
+                <button
+                  type="button"
+                  onClick={onSendTest}
+                  disabled={sendTestPending}
+                  className="font-inter inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                >
+                  {sendTestPending && <LoadingSpinner size="sm" />}
+                  {sendTestPending ? 'Sending test…' : 'Send test notification'}
+                </button>
+                {feedback && (
+                  <p
+                    role="status"
+                    className={`font-inter text-sm ${
+                      feedback.tone === 'success'
+                        ? 'text-green-700 dark:text-green-400'
+                        : feedback.tone === 'warn'
+                          ? 'text-amber-700 dark:text-amber-400'
+                          : 'text-gray-500 dark:text-gray-400'
+                    }`}
+                  >
+                    {feedback.text}
+                  </p>
+                )}
+              </div>
+            )}
           </div>
         )}
 
@@ -303,6 +395,22 @@ export function PushNotificationSettings() {
   const setPreferencesMutation = api.push.setPreferences.useMutation({
     onSuccess: () => utils.push.getPreferences.invalidate(),
   })
+
+  const [testResult, setTestResult] = useState<PushTestResult | null>(null)
+  const [testError, setTestError] = useState(false)
+  const sendTestMutation = api.push.sendTest.useMutation()
+
+  const handleSendTest = useCallback(async () => {
+    setTestError(false)
+    setTestResult(null)
+    try {
+      setTestResult(await sendTestMutation.mutateAsync())
+    } catch {
+      // Covers the cooldown (TOO_MANY_REQUESTS) and any transport error — the
+      // inline status shows a generic retry hint.
+      setTestError(true)
+    }
+  }, [sendTestMutation])
 
   // Server-side push availability: an empty VAPID public key means no keys are
   // configured in the environment, so subscribing can never work. Wait for the
@@ -416,6 +524,10 @@ export function PushNotificationSettings() {
       error={error}
       onToggleMaster={handleToggleMaster}
       onToggleCategory={handleToggleCategory}
+      onSendTest={handleSendTest}
+      sendTestPending={sendTestMutation.isPending}
+      sendTestResult={testResult}
+      sendTestError={testError}
     />
   )
 }

--- a/src/server/routers/push.ts
+++ b/src/server/routers/push.ts
@@ -10,8 +10,48 @@ import {
   removePushSubscription,
   getPushPreferences,
   setPushPreferences,
+  getSpeakerPushState,
+  prunePushSubscription,
 } from '@/lib/push/sanity'
-import { getVapidPublicKey } from '@/lib/push/vapid'
+import { getVapidPublicKey, isPushConfigured } from '@/lib/push/vapid'
+import { sendPush } from '@/lib/push/send'
+import { isValidPushEndpoint } from '@/lib/push/validate'
+import type { PushMessagePayload } from '@/lib/push/types'
+
+/**
+ * Best-effort, per-speaker cooldown for `sendTest` so an accidental double-tap
+ * can't hammer the push services. Lives in module memory, so on serverless it is
+ * PER-INSTANCE only — a retry routed to a different (or cold) instance won't see
+ * a prior send. That's acceptable: the endpoint is self-targeted and the push
+ * services rate-limit further downstream. The map is size-capped so it can never
+ * grow without bound (oldest-active entry evicted on overflow).
+ */
+const TEST_COOLDOWN_MS = 10_000
+const MAX_COOLDOWN_ENTRIES = 10_000
+const lastTestSentAt = new Map<string, number>()
+
+/**
+ * Record a test send for `speakerId` and report whether it is allowed right now.
+ * Returns false when the speaker sent a test within {@link TEST_COOLDOWN_MS};
+ * otherwise stamps the current time and returns true.
+ */
+function claimTestCooldown(speakerId: string): boolean {
+  const now = Date.now()
+  const previous = lastTestSentAt.get(speakerId)
+  if (previous !== undefined && now - previous < TEST_COOLDOWN_MS) {
+    return false
+  }
+  // Bound memory: a Map iterates in insertion order, so the first key is the
+  // least-recently-active. Delete-then-set keeps the just-active speaker at the
+  // tail, so eviction always targets the genuinely oldest entry.
+  lastTestSentAt.delete(speakerId)
+  if (lastTestSentAt.size >= MAX_COOLDOWN_ENTRIES) {
+    const oldest = lastTestSentAt.keys().next().value
+    if (oldest !== undefined) lastTestSentAt.delete(oldest)
+  }
+  lastTestSentAt.set(speakerId, now)
+  return true
+}
 
 /**
  * Web push subscription + preference management (issue #444).
@@ -94,4 +134,107 @@ export const pushRouter = router({
         })
       }
     }),
+
+  /**
+   * Send a test notification to the CALLER'S OWN subscriptions so a speaker can
+   * verify their push setup end-to-end (keys → subscription → SW display → deep
+   * link) with one tap.
+   *
+   * SECURITY: self-targeted only — no input, the recipient is always
+   * `ctx.speaker._id`. Like every other procedure here it can never read or
+   * write another speaker's subscriptions, so it needs no extra authz beyond
+   * `protectedProcedure`.
+   *
+   * Returns `{ sent, gone, configured }`:
+   *   - `configured`: whether the server has VAPID keys at all;
+   *   - `sent`: how many of the caller's devices the push service accepted;
+   *   - `gone`: how many dead/invalid subscriptions were pruned in the process.
+   */
+  sendTest: protectedProcedure.mutation(async ({ ctx }) => {
+    // No VAPID keys → push can never work; report it rather than pretending.
+    if (!isPushConfigured()) {
+      return { sent: 0, gone: 0, configured: false }
+    }
+
+    // Best-effort guard against accidental hammering (see claimTestCooldown).
+    if (!claimTestCooldown(ctx.speaker._id)) {
+      throw new TRPCError({
+        code: 'TOO_MANY_REQUESTS',
+        message: 'Please wait a few seconds before sending another test.',
+      })
+    }
+
+    let state
+    try {
+      state = await getSpeakerPushState(ctx.speaker._id)
+    } catch (error) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to load push subscriptions',
+        cause: error,
+      })
+    }
+
+    if (state.subscriptions.length === 0) {
+      return { sent: 0, gone: 0, configured: true }
+    }
+
+    // A deliberate, explicit user action — so it BYPASSES per-category
+    // preferences entirely (unlike sendPushForNotifications, which gates each
+    // notification on the speaker's category prefs). If a speaker taps "send
+    // test", they get the test regardless of which categories they've muted.
+    const payload: PushMessagePayload = {
+      title: 'Test notification',
+      body: 'Push notifications are working on this device 🎉',
+      url: '/cfp/profile',
+      tag: 'test-notification',
+    }
+
+    let sent = 0
+    let gone = 0
+
+    // Same transport as production (`sendPush`) and the SAME prune helper
+    // (`prunePushSubscription`) on a 404/410, so this exercises the real path.
+    const results = await Promise.allSettled(
+      state.subscriptions.map(async (subscription) => {
+        // Defense in depth against SSRF, mirroring send.ts: never POST to a
+        // stored endpoint that no longer passes public-https validation. Prune
+        // and skip it (counts as gone) rather than requesting it.
+        if (!isValidPushEndpoint(subscription.endpoint)) {
+          await prunePushSubscription(
+            ctx.speaker._id,
+            subscription.endpoint,
+          ).catch((error) => {
+            console.error(
+              `Failed to prune invalid push subscription for speaker ${ctx.speaker._id}:`,
+              error,
+            )
+          })
+          return { ok: false, gone: true }
+        }
+
+        const result = await sendPush(subscription, payload)
+        if (result.gone) {
+          await prunePushSubscription(
+            ctx.speaker._id,
+            subscription.endpoint,
+          ).catch((error) => {
+            console.error(
+              `Failed to prune dead push subscription for speaker ${ctx.speaker._id}:`,
+              error,
+            )
+          })
+        }
+        return result
+      }),
+    )
+
+    for (const r of results) {
+      if (r.status !== 'fulfilled') continue
+      if (r.value.ok) sent += 1
+      if (r.value.gone) gone += 1
+    }
+
+    return { sent, gone, configured: true }
+  }),
 })


### PR DESCRIPTION
## Self-serve "Send test notification"

Lets a signed-in speaker/organizer verify their web-push setup end-to-end — **keys → subscription → SW display → deep link** — with one tap, straight from the notification settings panel.

### What it verifies
- Server VAPID keys are configured (`isPushConfigured()`).
- The caller has at least one live subscription on their speaker doc.
- The `web-push` transport actually delivers (same `sendPush` used in production).
- The service worker renders the notification and the click deep-links to `/cfp/profile`.
- Dead/expired subscriptions get pruned along the way (same `prunePushSubscription` path).

### `push.sendTest` (protectedProcedure, no input)
- Self-targeted only — recipient is always `ctx.speaker._id`, no client-supplied id, so it needs no extra authz beyond `protectedProcedure`.
- Returns `{ sent, gone, configured }`:
  - not configured → `{ sent: 0, gone: 0, configured: false }`
  - no subscriptions → `{ sent: 0, gone: 0, configured: true }`
  - otherwise counts accepted devices (`sent`) and pruned dead/invalid subs (`gone`).
- Reuses the production transport (`sendPush`), the SSRF endpoint re-validation (`isValidPushEndpoint`), and the prune helper (`prunePushSubscription`) — this exercises the real send path, not a mock of it.

### Preference bypass (intentional)
The test send **deliberately ignores per-category preferences**. Unlike `sendPushForNotifications`, which gates each notification on the speaker's category prefs, a test is an explicit user action: if a speaker taps "send test" they should get it regardless of which categories they've muted. Commented at the call site.

### Cooldown note
A lightweight in-memory per-speaker cooldown (1 test / 10s) guards against accidental double-taps hammering the push services. It's a module-scope `Map` with a size cap; on serverless it is **per-instance / best-effort** only (a retry routed to another instance won't see a prior send) — acceptable because the endpoint is self-targeted and the push services rate-limit downstream. A refused call throws `TOO_MANY_REQUESTS`.

### UI
When the master toggle is enabled, a secondary **"Send test notification"** button appears. On click it calls the mutation and shows inline `role="status"` feedback: success (`Sent to N device(s) — check for the notification`), zero-subscriptions hint, not-configured note, and an "expired subscriptions removed" note when `gone > 0`. Disabled with a spinner while pending. Matches the panel's existing styling/state/a11y patterns.

### Tests & QA
- Extended `__tests__/api/trpc/push.test.ts`: happy-path counts, no-subscriptions, unconfigured, cooldown refusal, gone-pruning, and unauth rejection. Full `__tests__/` suite: **2731 passed, 5 skipped, 0 failures**.
- Added story variants (button, sending, sent, no-devices, expired-pruned).
- Visual QA via `pnpm shoot` at 393×852 — button and feedback render cleanly, no viewport overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a self-serve \"Send test notification\" button to the push notification settings panel, letting signed-in speakers verify their full push stack end-to-end with one tap. The server adds a `sendTest` protectedProcedure that reuses the production `sendPush` transport, applies the same SSRF endpoint validation, prunes dead subscriptions, and guards against accidental hammering with an in-memory per-speaker cooldown.

- The new `sendTest` mutation is self-targeted only (always `ctx.speaker._id`), uses `protectedProcedure`, and returns `{sent, gone, configured}` counts.
- A `testFeedback` helper in the UI renders inline `role=\"status\"` feedback for success, no-devices, unconfigured, and error states; the test button is hidden when `onSendTest` is omitted, preserving backward compatibility for Storybook.
- Five new Storybook stories and a comprehensive test extension cover the main paths, but the response shape for \"no subscriptions\" and \"all sends fail with non-gone errors\" is identical, causing the wrong feedback message to appear when the push service is temporarily unavailable.

<h3>Confidence Score: 3/5</h3>

Safe to merge once the ambiguous {sent:0,gone:0} response shape is resolved; the feature is well-contained and self-targeted with no cross-user risk.

The router and the UI feedback helper share a response shape that conflates two distinct outcomes — no subscriptions and all-sends-failed-with-non-gone-errors — so a transient push-service error (500, 429, network timeout) during the test send will display 'No devices are subscribed on this account yet. Enable notifications on a device first.' to a speaker who does have subscriptions. That actively misleads the user. Everything else in the PR — cooldown logic, SSRF validation, prune path, auth scoping, Storybook stories — is solid.

src/server/routers/push.ts (sendTest return shape) and src/components/pwa/PushNotificationSettings.tsx (testFeedback branch for sent===0 && gone===0) need attention to distinguish the no-subscription case from delivery failures.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/push.ts | Adds `sendTest` protectedProcedure with in-memory cooldown, SSRF validation, and production `sendPush` transport. Well-structured, but returns `{sent:0,gone:0,configured:true}` for two distinct situations — no subscriptions and all-non-gone send failures — giving the client no way to distinguish them. |
| src/components/pwa/PushNotificationSettings.tsx | Adds `PushTestResult` type, `testFeedback` helper, and wires `sendTest` mutation with local result/error state. The `testFeedback` condition for `sent===0 && gone===0` incorrectly shows "No devices subscribed" even when subscriptions exist but delivery failed. |
| __tests__/api/trpc/push.test.ts | Extends push router tests with good coverage: happy path, unconfigured, no-subscriptions, 410-pruning, cooldown refusal, and unauth rejection. Missing a case where all subscriptions have valid endpoints but `sendPush` returns non-gone failures. |
| src/components/pwa/PushNotificationSettings.stories.tsx | Adds five well-chosen Storybook story variants covering the main UI states of the test button. Missing story for `{sent:0, gone:1}` (all subscriptions expired) vs. `{sent:1, gone:1}` (partial success with pruning), but not blocking. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as PushNotificationSettings
    participant tRPC as push.sendTest
    participant Cooldown as claimTestCooldown
    participant Sanity as getSpeakerPushState
    participant Send as sendPush
    participant Prune as prunePushSubscription

    UI->>tRPC: sendTest() [mutateAsync]
    tRPC->>tRPC: isPushConfigured()?
    alt not configured
        tRPC-->>UI: "{sent:0, gone:0, configured:false}"
    else configured
        tRPC->>Cooldown: claimTestCooldown(speakerId)
        alt within cooldown window
            tRPC-->>UI: TRPCError TOO_MANY_REQUESTS
        else cooldown cleared
            tRPC->>Sanity: getSpeakerPushState(speakerId)
            Sanity-->>tRPC: "{subscriptions, preferences}"
            alt no subscriptions
                tRPC-->>UI: "{sent:0, gone:0, configured:true}"
            else has subscriptions
                loop each subscription (Promise.allSettled)
                    tRPC->>tRPC: isValidPushEndpoint(endpoint)?
                    alt invalid endpoint
                        tRPC->>Prune: prunePushSubscription(speakerId, endpoint)
                    else valid endpoint
                        tRPC->>Send: sendPush(subscription, payload)
                        Send-->>tRPC: "{ok, statusCode, gone}"
                        alt result.gone
                            tRPC->>Prune: prunePushSubscription(speakerId, endpoint)
                        end
                    end
                end
                tRPC-->>UI: "{sent, gone, configured:true}"
            end
        end
    end
    UI->>UI: testFeedback(result, error) → inline status
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as PushNotificationSettings
    participant tRPC as push.sendTest
    participant Cooldown as claimTestCooldown
    participant Sanity as getSpeakerPushState
    participant Send as sendPush
    participant Prune as prunePushSubscription

    UI->>tRPC: sendTest() [mutateAsync]
    tRPC->>tRPC: isPushConfigured()?
    alt not configured
        tRPC-->>UI: "{sent:0, gone:0, configured:false}"
    else configured
        tRPC->>Cooldown: claimTestCooldown(speakerId)
        alt within cooldown window
            tRPC-->>UI: TRPCError TOO_MANY_REQUESTS
        else cooldown cleared
            tRPC->>Sanity: getSpeakerPushState(speakerId)
            Sanity-->>tRPC: "{subscriptions, preferences}"
            alt no subscriptions
                tRPC-->>UI: "{sent:0, gone:0, configured:true}"
            else has subscriptions
                loop each subscription (Promise.allSettled)
                    tRPC->>tRPC: isValidPushEndpoint(endpoint)?
                    alt invalid endpoint
                        tRPC->>Prune: prunePushSubscription(speakerId, endpoint)
                    else valid endpoint
                        tRPC->>Send: sendPush(subscription, payload)
                        Send-->>tRPC: "{ok, statusCode, gone}"
                        alt result.gone
                            tRPC->>Prune: prunePushSubscription(speakerId, endpoint)
                        end
                    end
                end
                tRPC-->>UI: "{sent, gone, configured:true}"
            end
        end
    end
    UI->>UI: testFeedback(result, error) → inline status
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(push): self-serve test notification"](https://github.com/cloudnativebergen/website/commit/fd3ffe399f77a82f03cc67cea58318f2de945326) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45374560)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->