### PR TITLE
fix(push): distinguish no-devices from all-sends-failed in test feedback

### DIFF
--- a/__tests__/api/trpc/push.test.ts
+++ b/__tests__/api/trpc/push.test.ts
@@ -190,7 +190,7 @@ describe('push router', () => {
       const caller = createAuthenticatedCaller(speakerA)
       const result = await caller.push.sendTest()
 
-      expect(result).toEqual({ sent: 2, gone: 0, configured: true })
+      expect(result).toEqual({ sent: 2, gone: 0, total: 2, configured: true })
       expect(mockGetState).toHaveBeenCalledWith(speakerA)
       expect(mockSendPush).toHaveBeenCalledTimes(2)
       // Uses the production payload shape: deep link + collapse tag, bypassing
@@ -209,7 +209,7 @@ describe('push router', () => {
       const caller = createAuthenticatedCaller(speakerA)
       const result = await caller.push.sendTest()
 
-      expect(result).toEqual({ sent: 0, gone: 0, configured: false })
+      expect(result).toEqual({ sent: 0, gone: 0, total: 0, configured: false })
       expect(mockGetState).not.toHaveBeenCalled()
       expect(mockSendPush).not.toHaveBeenCalled()
     })
@@ -222,7 +222,7 @@ describe('push router', () => {
       const caller = createAuthenticatedCaller(speakerA)
       const result = await caller.push.sendTest()
 
-      expect(result).toEqual({ sent: 0, gone: 0, configured: true })
+      expect(result).toEqual({ sent: 0, gone: 0, total: 0, configured: true })
       expect(mockSendPush).not.toHaveBeenCalled()
     })
 
@@ -231,7 +231,7 @@ describe('push router', () => {
       const caller = createAuthenticatedCaller(speakerA)
       const result = await caller.push.sendTest()
 
-      expect(result).toEqual({ sent: 0, gone: 1, configured: true })
+      expect(result).toEqual({ sent: 0, gone: 1, total: 1, configured: true })
       expect(mockPrune).toHaveBeenCalledWith(speakerA, SUB.endpoint)
     })
 

--- a/src/components/pwa/PushNotificationSettings.stories.tsx
+++ b/src/components/pwa/PushNotificationSettings.stories.tsx
@@ -68,7 +68,7 @@ export const EnabledSendingTest: Story = {
 export const EnabledTestSent: Story = {
   args: {
     status: 'enabled',
-    sendTestResult: { sent: 2, gone: 0, configured: true },
+    sendTestResult: { sent: 2, gone: 0, total: 2, configured: true },
   },
 }
 
@@ -76,7 +76,7 @@ export const EnabledTestSent: Story = {
 export const EnabledTestNoDevices: Story = {
   args: {
     status: 'enabled',
-    sendTestResult: { sent: 0, gone: 0, configured: true },
+    sendTestResult: { sent: 0, gone: 0, total: 1, configured: true },
   },
 }
 
@@ -84,7 +84,7 @@ export const EnabledTestNoDevices: Story = {
 export const EnabledTestWithExpired: Story = {
   args: {
     status: 'enabled',
-    sendTestResult: { sent: 1, gone: 1, configured: true },
+    sendTestResult: { sent: 1, gone: 1, total: 2, configured: true },
   },
 }
 

--- a/src/components/pwa/PushNotificationSettings.tsx
+++ b/src/components/pwa/PushNotificationSettings.tsx
@@ -106,6 +106,8 @@ export interface PushTestResult {
   gone: number
   /** Whether the server has VAPID keys configured at all. */
   configured: boolean
+  /** Total subscriptions on the account when the test ran. */
+  total: number
 }
 
 export interface PushNotificationSettingsViewProps {
@@ -146,10 +148,18 @@ function testFeedback(
       tone: 'muted',
     }
   }
-  if (result.sent === 0 && result.gone === 0) {
+  if (result.total === 0) {
     return {
       text: 'No devices are subscribed on this account yet. Enable notifications on a device first.',
       tone: 'muted',
+    }
+  }
+  if (result.sent === 0 && result.gone === 0) {
+    // Devices exist but every send failed (non-gone transport errors) — a
+    // different situation from having no devices at all.
+    return {
+      text: 'Could not deliver to your devices right now. Please try again shortly.',
+      tone: 'warn',
     }
   }
   const devices = `${result.sent} device${result.sent === 1 ? '' : 's'}`

--- a/src/server/routers/push.ts
+++ b/src/server/routers/push.ts
@@ -153,7 +153,7 @@ export const pushRouter = router({
   sendTest: protectedProcedure.mutation(async ({ ctx }) => {
     // No VAPID keys → push can never work; report it rather than pretending.
     if (!isPushConfigured()) {
-      return { sent: 0, gone: 0, configured: false }
+      return { sent: 0, gone: 0, total: 0, configured: false }
     }
 
     // Best-effort guard against accidental hammering (see claimTestCooldown).
@@ -176,7 +176,7 @@ export const pushRouter = router({
     }
 
     if (state.subscriptions.length === 0) {
-      return { sent: 0, gone: 0, configured: true }
+      return { sent: 0, gone: 0, total: 0, configured: true }
     }
 
     // A deliberate, explicit user action — so it BYPASSES per-category
@@ -235,6 +235,8 @@ export const pushRouter = router({
       if (r.value.gone) gone += 1
     }
 
-    return { sent, gone, configured: true }
+    // `total` lets the client distinguish "no devices subscribed" (total 0)
+    // from "devices exist but every send failed" (total > 0, sent 0).
+    return { sent, gone, total: state.subscriptions.length, configured: true }
   }),
 })


### PR DESCRIPTION
Addresses the Greptile P2 on #524: `{sent:0, gone:0, configured:true}` conflated "no subscriptions on the account" with "devices exist but every send failed". `sendTest` now returns `total` (subscription count at send time); the settings card shows the no-devices hint only when `total === 0`, and a "could not deliver — try again" warning when devices exist but nothing was delivered. Tests + story fixtures aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `total` field to the `sendTest` mutation response so the client can distinguish "no subscriptions exist" (`total === 0`) from "subscriptions exist but every send failed" (`total > 0, sent === 0, gone === 0`). The `testFeedback` helper in the settings card is updated accordingly, and the new delivery-failure path surfaces a "could not deliver" warning.

- **`push.ts`**: `total: state.subscriptions.length` added to every return site in `sendTest` (two early returns + the final path); all four unit-test assertions updated to match.
- **`PushNotificationSettings.tsx`**: `PushTestResult` gains a `total` field; `testFeedback` now gates the "no devices" hint on `total === 0` and adds a new `warn` branch for the all-sends-failed case.
- **`PushNotificationSettings.stories.tsx`**: The `EnabledTestNoDevices` fixture was updated to `total: 1`, which actually exercises the new "could not deliver" path — not the "no devices" path the story is named for.

<h3>Confidence Score: 4/5</h3>

The server and component logic are correct; only the Storybook fixture for the "no devices" story is broken, rendering the wrong message and leaving the `total === 0` UI branch without any story coverage.

The router and component changes are internally consistent and the unit tests validate all four return paths. The one concrete defect is in the stories file: `EnabledTestNoDevices` sets `total: 1`, so it renders "Could not deliver" instead of "No devices subscribed" — the branch its name and JSDoc describe is entirely untested visually, and the new delivery-failure path has no named story of its own.

src/components/pwa/PushNotificationSettings.stories.tsx — the EnabledTestNoDevices fixture needs total: 0, and a new story should cover the all-sends-failed case.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/push.ts | Adds `total: state.subscriptions.length` to every early-return and final return in `sendTest`, correctly letting clients distinguish "no subscriptions" from "all sends failed". |
| src/components/pwa/PushNotificationSettings.tsx | Adds `total` to `PushTestResult` interface and rewires `testFeedback` to gate the "no devices" hint on `total === 0` while a new "could not deliver" warning covers the `sent===0 && gone===0 && total>0` case. |
| src/components/pwa/PushNotificationSettings.stories.tsx | `EnabledTestNoDevices` has `total: 1`, so it renders the "could not deliver" warning instead of the "no devices" hint — the story does not exercise the branch its name describes, and the `total === 0` path has no story at all. |
| __tests__/api/trpc/push.test.ts | All four existing assertions updated to include `total` in the expected shape; values are consistent with the server logic. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sendTest called] --> B{isPushConfigured?}
    B -- No --> C[return sent:0, gone:0, total:0, configured:false]
    B -- Yes --> D{cooldown OK?}
    D -- No --> E[throw TOO_MANY_REQUESTS]
    D -- Yes --> F[getSpeakerPushState]
    F --> G{subscriptions.length === 0?}
    G -- Yes --> H[return sent:0, gone:0, total:0, configured:true]
    G -- No --> I[sendPush to each subscription]
    I --> J[tally sent / gone]
    J --> K[return sent, gone, total=subscriptions.length, configured:true]
    K --> L[testFeedback in UI]
    L --> M{configured?}
    M -- No --> N[Push not available]
    M -- Yes --> O{total === 0?}
    O -- Yes --> P[No devices subscribed hint]
    O -- No --> Q{sent===0 and gone===0?}
    Q -- Yes --> R[Could not deliver warning - NEW]
    Q -- No --> S[sent/gone summary]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[sendTest called] --> B{isPushConfigured?}
    B -- No --> C[return sent:0, gone:0, total:0, configured:false]
    B -- Yes --> D{cooldown OK?}
    D -- No --> E[throw TOO_MANY_REQUESTS]
    D -- Yes --> F[getSpeakerPushState]
    F --> G{subscriptions.length === 0?}
    G -- Yes --> H[return sent:0, gone:0, total:0, configured:true]
    G -- No --> I[sendPush to each subscription]
    I --> J[tally sent / gone]
    J --> K[return sent, gone, total=subscriptions.length, configured:true]
    K --> L[testFeedback in UI]
    L --> M{configured?}
    M -- No --> N[Push not available]
    M -- Yes --> O{total === 0?}
    O -- Yes --> P[No devices subscribed hint]
    O -- No --> Q{sent===0 and gone===0?}
    Q -- Yes --> R[Could not deliver warning - NEW]
    Q -- No --> S[sent/gone summary]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(push): distinguish no-devices from a..."](https://github.com/cloudnativebergen/website/commit/ceeadf3c79fb4939a76a77ed1dcf2112d6f0b00d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45375887)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->