### PR TITLE
fix(stories): correct no-devices push fixture + delivery-failure variant

### DIFF
--- a/src/components/pwa/PushNotificationSettings.stories.tsx
+++ b/src/components/pwa/PushNotificationSettings.stories.tsx
@@ -76,7 +76,15 @@ export const EnabledTestSent: Story = {
 export const EnabledTestNoDevices: Story = {
   args: {
     status: 'enabled',
-    sendTestResult: { sent: 0, gone: 0, total: 1, configured: true },
+    sendTestResult: { sent: 0, gone: 0, total: 0, configured: true },
+  },
+}
+
+/** Devices exist but every send failed — distinct from having no devices. */
+export const EnabledTestDeliveryFailed: Story = {
+  args: {
+    ...EnabledTestNoDevices.args,
+    sendTestResult: { sent: 0, gone: 0, total: 2, configured: true },
   },
 }
 


### PR DESCRIPTION
Greptile P2 on #525: the fixture updater gave `EnabledTestNoDevices` `total: 1`, which renders the delivery-failure warning instead of the no-devices hint — contradicting the story label. Fixed to `total: 0`, and added an explicit `EnabledTestDeliveryFailed` variant so both branches of the new distinction are storied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a fixture bug in `PushNotificationSettings.stories.tsx` where `EnabledTestNoDevices` had `total: 1`, causing it to render the delivery-failure warning instead of the no-devices hint — the wrong branch of `testFeedback`. It corrects the value to `total: 0` and adds a new `EnabledTestDeliveryFailed` story to explicitly cover the delivery-failure path (devices exist but every send failed).

- `EnabledTestNoDevices`: `total` corrected from `1` to `0`, so it now hits the `result.total === 0` branch in `testFeedback` and shows the muted "no devices subscribed" hint as its label promises.
- `EnabledTestDeliveryFailed` (new): `total: 2, sent: 0, gone: 0` correctly exercises the `sent === 0 && gone === 0` branch that renders the amber delivery-failure warning.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to Storybook fixtures and add no runtime logic.

Both changes are story-only: the `total: 0` correction makes `EnabledTestNoDevices` hit the intended branch of `testFeedback`, and the new `EnabledTestDeliveryFailed` variant covers the previously-unstoried delivery-failure path. No component logic, types, or API contracts are touched. The only open item is a minor stylistic coupling in the new story's `args` spread.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/pwa/PushNotificationSettings.stories.tsx | Corrects EnabledTestNoDevices fixture (total: 1 → 0) so it exercises the right branch, and adds EnabledTestDeliveryFailed to cover the distinct delivery-failure path. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[testFeedback called] --> B{error?}
    B -- yes --> E["warn: 'Could not send'"]
    B -- no --> C{result?}
    C -- null --> D[return null]
    C -- present --> F{configured?}
    F -- false --> G["muted: 'not available'"]
    F -- true --> H{total === 0?}
    H -- yes --> I["muted: 'No devices subscribed'\n✅ EnabledTestNoDevices\ntotal=0"]
    H -- no --> J{sent===0 && gone===0?}
    J -- yes --> K["warn: 'Could not deliver'\n✅ EnabledTestDeliveryFailed\ntotal=2, sent=0, gone=0"]
    J -- no --> L{sent > 0?}
    L -- yes --> M["success: 'Sent to N devices'\n✅ EnabledTestSent\ntotal=2, sent=2, gone=0"]
    L -- no --> N["warn: 'No active devices'\n✅ EnabledTestWithExpired\nsent=1, gone=1"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[testFeedback called] --> B{error?}
    B -- yes --> E["warn: 'Could not send'"]
    B -- no --> C{result?}
    C -- null --> D[return null]
    C -- present --> F{configured?}
    F -- false --> G["muted: 'not available'"]
    F -- true --> H{total === 0?}
    H -- yes --> I["muted: 'No devices subscribed'\n✅ EnabledTestNoDevices\ntotal=0"]
    H -- no --> J{sent===0 && gone===0?}
    J -- yes --> K["warn: 'Could not deliver'\n✅ EnabledTestDeliveryFailed\ntotal=2, sent=0, gone=0"]
    J -- no --> L{sent > 0?}
    L -- yes --> M["success: 'Sent to N devices'\n✅ EnabledTestSent\ntotal=2, sent=2, gone=0"]
    L -- no --> N["warn: 'No active devices'\n✅ EnabledTestWithExpired\nsent=1, gone=1"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(stories): correct no-devices push fi..."](https://github.com/cloudnativebergen/website/commit/a0de47d8ab701acd4736fa4a4836f7ff502e8154) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45376626)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->