### PR TITLE
feat(messaging): speaker↔organizer conversations backend (M1)

### DIFF
--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -1,0 +1,284 @@
+/**
+ * @vitest-environment node
+ *
+ * Router-level tests for `message.*` (src/server/routers/message.ts):
+ * - authorization: a non-participant speaker is blocked from get/list/send/pref;
+ * - conversation auto-create: a proposalId converges on the deterministic id
+ *   (idempotent), a subject starts a general thread, neither is a BAD_REQUEST;
+ * - the actor and conference are always server-derived.
+ *
+ * The data layer is mocked (IO functions only); the pure authz helper runs for
+ * real so the FORBIDDEN paths exercise the true rule.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  createAuthenticatedCaller,
+  createAdminCaller,
+  speakers,
+} from '../../helpers/trpc'
+import type { ConversationWithContext } from '@/lib/messaging/types'
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: vi.fn(async () => ({
+    conference: { _id: 'conf-1', domains: ['cndn.no'] },
+    domain: 'cndn.no',
+    error: null,
+  })),
+}))
+
+vi.mock('@/lib/messaging/notify', () => ({
+  notifyNewMessage: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/messaging/sanity', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/messaging/sanity')>()
+  return {
+    ...actual, // keep the real canAccessConversation
+    getConversationById: vi.fn(),
+    getConversationParticipants: vi.fn(async () => []),
+    getConversationPreference: vi.fn(async () => ({
+      muted: false,
+      emailOverride: 'default',
+    })),
+    listConversationsForSpeaker: vi.fn(async () => []),
+    listMessages: vi.fn(async () => []),
+    addMessage: vi.fn(async () => ({
+      _id: 'message.1',
+      conversationId: 'conversation.proposal.prop-1',
+      authorId: 'a',
+      body: 'hi',
+      createdAt: '2026-01-02T00:00:00.000Z',
+    })),
+    ensureProposalConversation: vi.fn(
+      async () => 'conversation.proposal.prop-1',
+    ),
+    createGeneralConversation: vi.fn(async () => 'conversation.gen-1'),
+    getProposalForConversation: vi.fn(),
+    setConversationPreference: vi.fn(async () => ({
+      muted: true,
+      emailOverride: 'default',
+    })),
+  }
+})
+
+import {
+  getConversationById,
+  listConversationsForSpeaker,
+  ensureProposalConversation,
+  createGeneralConversation,
+  getProposalForConversation,
+  addMessage,
+} from '@/lib/messaging/sanity'
+import { notifyNewMessage } from '@/lib/messaging/notify'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const getById = getConversationById as unknown as LooseMock
+const listConvs = listConversationsForSpeaker as unknown as LooseMock
+const ensureProposal = ensureProposalConversation as unknown as LooseMock
+const createGeneral = createGeneralConversation as unknown as LooseMock
+const getProposal = getProposalForConversation as unknown as LooseMock
+const addMsg = addMessage as unknown as LooseMock
+const notifyMock = notifyNewMessage as unknown as LooseMock
+
+const speaker1 = speakers[0]._id // John, not an organizer
+const organizerId = speakers.find((s) => s.isOrganizer)!._id
+
+const strangerProposalConv: ConversationWithContext = {
+  _id: 'conversation.proposal.prop-1',
+  conferenceId: 'conf-1',
+  conversationType: 'proposal',
+  proposalId: 'prop-1',
+  proposalTitle: 'T',
+  proposalSpeakerIds: ['someone-else'],
+  createdById: 'someone-else',
+  subject: 'T',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastMessageAt: '2026-01-01T00:00:00.000Z',
+}
+
+const ownProposalConv: ConversationWithContext = {
+  ...strangerProposalConv,
+  proposalSpeakerIds: [speaker1],
+  createdById: speaker1,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('authorization', () => {
+  it('blocks a non-participant speaker from getConversation (FORBIDDEN)', async () => {
+    getById.mockResolvedValue(strangerProposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.getConversation({ id: 'conversation.proposal.prop-1' }),
+    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+  })
+
+  it('blocks a non-participant speaker from listMessages (FORBIDDEN)', async () => {
+    getById.mockResolvedValue(strangerProposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.listMessages({
+        conversationId: 'conversation.proposal.prop-1',
+      }),
+    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+  })
+
+  it('blocks a non-participant speaker from sending to an existing thread', async () => {
+    getById.mockResolvedValue(strangerProposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.send({
+        conversationId: 'conversation.proposal.prop-1',
+        body: 'hi',
+      }),
+    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+    expect(addMsg).not.toHaveBeenCalled()
+  })
+
+  it('404s when the conversation does not exist', async () => {
+    getById.mockResolvedValue(null)
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.getConversation({ id: 'nope' }),
+    ).rejects.toThrow(/NOT_FOUND|not found/)
+  })
+
+  it('an organizer can access any conversation', async () => {
+    getById.mockResolvedValue(strangerProposalConv)
+    const caller = createAdminCaller()
+    const result = await caller.message.getConversation({
+      id: 'conversation.proposal.prop-1',
+    })
+    expect(result.conversation._id).toBe('conversation.proposal.prop-1')
+  })
+
+  it('rejects an unauthenticated caller', async () => {
+    const { createAnonymousCaller } = await import('../../helpers/trpc')
+    const caller = createAnonymousCaller()
+    await expect(caller.message.listConversations({})).rejects.toThrow(
+      /UNAUTHORIZED|Authentication required/,
+    )
+  })
+})
+
+describe('listConversations — scope by role', () => {
+  it('passes isOrganizer=false for a speaker', async () => {
+    const caller = createAuthenticatedCaller(speaker1)
+    await caller.message.listConversations({})
+    expect(listConvs.mock.calls[0][0]).toMatchObject({
+      speakerId: speaker1,
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+    })
+  })
+
+  it('passes isOrganizer=true for an organizer', async () => {
+    const caller = createAdminCaller()
+    await caller.message.listConversations({})
+    expect(listConvs.mock.calls[0][0]).toMatchObject({ isOrganizer: true })
+  })
+})
+
+describe('send — conversation creation', () => {
+  it('auto-creates the proposal thread (deterministic id) and is idempotent', async () => {
+    getProposal.mockResolvedValue({
+      conferenceId: 'conf-1',
+      title: 'My Talk',
+      speakerIds: [speaker1],
+    })
+    getById.mockResolvedValue(ownProposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+
+    const first = await caller.message.send({
+      proposalId: 'prop-1',
+      body: 'one',
+    })
+    const second = await caller.message.send({
+      proposalId: 'prop-1',
+      body: 'two',
+    })
+
+    expect(first.conversationId).toBe('conversation.proposal.prop-1')
+    expect(second.conversationId).toBe('conversation.proposal.prop-1')
+    expect(ensureProposal).toHaveBeenCalledTimes(2)
+    expect(addMsg).toHaveBeenCalledTimes(2)
+    expect(notifyMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks starting a proposal thread for a proposal the speaker is not on', async () => {
+    getProposal.mockResolvedValue({
+      conferenceId: 'conf-1',
+      title: 'My Talk',
+      speakerIds: ['other'],
+    })
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.send({ proposalId: 'prop-1', body: 'hi' }),
+    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+    expect(ensureProposal).not.toHaveBeenCalled()
+  })
+
+  it('404s a proposal that belongs to another conference', async () => {
+    getProposal.mockResolvedValue({
+      conferenceId: 'other-conf',
+      title: 'X',
+      speakerIds: [speaker1],
+    })
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.send({ proposalId: 'prop-1', body: 'hi' }),
+    ).rejects.toThrow(/NOT_FOUND|not found/)
+  })
+
+  it('starts a general thread from a subject', async () => {
+    getById.mockResolvedValue({
+      _id: 'conversation.gen-1',
+      conferenceId: 'conf-1',
+      conversationType: 'general',
+      proposalSpeakerIds: [],
+      createdById: speaker1,
+      subject: 'Question',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      lastMessageAt: '2026-01-01T00:00:00.000Z',
+    })
+    const caller = createAuthenticatedCaller(speaker1)
+    const result = await caller.message.send({
+      subject: 'Question',
+      body: 'hi',
+    })
+    expect(createGeneral).toHaveBeenCalledTimes(1)
+    expect(result.conversationId).toBe('conversation.gen-1')
+  })
+
+  it('rejects a send with neither conversationId, proposalId, nor subject', async () => {
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(caller.message.send({ body: 'hi' })).rejects.toThrow(
+      /BAD_REQUEST|Provide a/,
+    )
+  })
+})
+
+describe('setPreference', () => {
+  it('is authz-checked and binds to the caller', async () => {
+    getById.mockResolvedValue(ownProposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    const result = await caller.message.setPreference({
+      conversationId: 'conversation.proposal.prop-1',
+      muted: true,
+    })
+    expect(result).toEqual({ muted: true, emailOverride: 'default' })
+  })
+
+  it('blocks a non-participant from setting a preference', async () => {
+    getById.mockResolvedValue(strangerProposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.setPreference({
+        conversationId: 'conversation.proposal.prop-1',
+        muted: true,
+      }),
+    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+  })
+})

--- a/__tests__/api/trpc/push.test.ts
+++ b/__tests__/api/trpc/push.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/lib/push/sanity', () => ({
     proposalDecisions: true,
     talkConfirmed: true,
     coSpeakerInvites: true,
+    messages: true,
     otherUpdates: true,
   }),
   setPushPreferences: vi.fn().mockImplementation(async (_id, prefs) => prefs),
@@ -93,6 +94,7 @@ describe('push router', () => {
       proposalDecisions: true,
       talkConfirmed: false,
       coSpeakerInvites: true,
+      messages: true,
       otherUpdates: false,
     }
     await caller.push.setPreferences(prefs)

--- a/__tests__/lib/messaging/notify.test.ts
+++ b/__tests__/lib/messaging/notify.test.ts
@@ -1,0 +1,287 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the messaging fan-out (src/lib/messaging/notify.ts):
+ * - HUB items are per-recipient (organizer → /admin link, speaker → /cfp link);
+ * - muted recipients are excluded from every channel;
+ * - EMAIL fires only for recipients whose effective email pref is ON;
+ * - SLACK fires only when the author is NOT an organizer;
+ * - the fan-out NEVER throws (never-fail contract).
+ *
+ * The pure helpers (resolveRecipients / conversationLinkPath) run for real; only
+ * the IO boundaries (hub write, preference read, email, slack) are mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: vi.fn(async () => {}),
+  getOrganizerSpeakerIds: vi.fn(async () => ['org-1']),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: vi.fn() },
+  clientWrite: { transaction: vi.fn(), create: vi.fn() },
+}))
+
+vi.mock('@/lib/messaging/email', () => ({
+  sendMessageEmails: vi.fn(async () => 1),
+}))
+
+vi.mock('@/lib/slack/notify', () => ({
+  notifyNewSpeakerMessage: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/messaging/sanity', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/messaging/sanity')>()
+  return {
+    ...actual,
+    getConversationPreferencesFor: vi.fn(async () => new Map()),
+  }
+})
+
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import { clientReadUncached } from '@/lib/sanity/client'
+import { getConversationPreferencesFor } from '@/lib/messaging/sanity'
+import { sendMessageEmails } from '@/lib/messaging/email'
+import { notifyNewSpeakerMessage } from '@/lib/slack/notify'
+import { notifyNewMessage } from '@/lib/messaging/notify'
+import type { NotificationInput } from '@/lib/notification/types'
+import type { ConversationWithContext, Message } from '@/lib/messaging/types'
+import type { Conference } from '@/lib/conference/types'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const createMock = createNotifications as unknown as LooseMock
+const organizersMock = getOrganizerSpeakerIds as unknown as LooseMock
+const fetchMock = (clientReadUncached as unknown as { fetch: LooseMock }).fetch
+const prefsMock = getConversationPreferencesFor as unknown as LooseMock
+const emailMock = sendMessageEmails as unknown as LooseMock
+const slackMock = notifyNewSpeakerMessage as unknown as LooseMock
+
+const proposalConv: ConversationWithContext = {
+  _id: 'conversation.proposal.prop-1',
+  conferenceId: 'conf-1',
+  conversationType: 'proposal',
+  proposalId: 'prop-1',
+  proposalTitle: 'My Talk',
+  proposalSpeakerIds: ['sp-1', 'sp-2'],
+  createdById: 'sp-1',
+  subject: 'My Talk',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastMessageAt: '2026-01-01T00:00:00.000Z',
+}
+
+const message: Message = {
+  _id: 'message.1',
+  conversationId: proposalConv._id,
+  authorId: 'sp-1',
+  body: 'Hello there, this is the body',
+  createdAt: '2026-01-02T00:00:00.000Z',
+}
+
+const conference = {
+  _id: 'conf-1',
+  title: 'CNDN',
+  organizer: 'CNDN',
+  cfpEmail: 'cfp@cndn.no',
+  city: 'Bergen',
+  country: 'Norway',
+  startDate: '2026-09-01',
+  domains: ['cndn.no'],
+  socialLinks: [],
+} as unknown as Conference
+
+const speakerRows = [
+  {
+    _id: 'sp-1',
+    name: 'Alice',
+    email: 'alice@x.no',
+    messagingEmailDefault: false,
+  },
+  { _id: 'sp-2', name: 'Bob', email: 'bob@x.no', messagingEmailDefault: true },
+  {
+    _id: 'org-1',
+    name: 'Olga',
+    email: 'olga@x.no',
+    messagingEmailDefault: false,
+  },
+]
+
+const lastItems = (): NotificationInput[] =>
+  createMock.mock.calls[
+    createMock.mock.calls.length - 1
+  ][0] as NotificationInput[]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  organizersMock.mockResolvedValue(['org-1'])
+  fetchMock.mockResolvedValue(speakerRows)
+  prefsMock.mockResolvedValue(new Map())
+  emailMock.mockResolvedValue(1)
+})
+
+describe('HUB fan-out — per-recipient links, actor excluded', () => {
+  it('emits message_received to each recipient with an audience-specific link', async () => {
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference,
+    })
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const items = lastItems()
+    // Author (sp-1) excluded; recipients are org-1 and sp-2.
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['org-1', 'sp-2'])
+
+    const byId = Object.fromEntries(items.map((i) => [i.recipientId, i]))
+    expect(byId['org-1'].link).toBe('/admin/proposals/prop-1#messages')
+    expect(byId['sp-2'].link).toBe('/cfp/proposal/prop-1#messages')
+
+    for (const item of items) {
+      expect(item.notificationType).toBe('message_received')
+      expect(item.title).toBe('New message from Alice')
+      expect(item.actorId).toBe('sp-1')
+      expect(item.relatedProposalId).toBe('prop-1')
+      expect(item.message).toContain('Hello there')
+    }
+  })
+})
+
+describe('muting — excluded from every channel', () => {
+  it('drops a muted recipient from the hub items', async () => {
+    prefsMock.mockResolvedValue(
+      new Map([['org-1', { muted: true, emailOverride: 'default' }]]),
+    )
+
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference,
+    })
+
+    const items = lastItems()
+    expect(items.map((i) => i.recipientId)).toEqual(['sp-2'])
+  })
+})
+
+describe('EMAIL — opt-in only', () => {
+  it('emails only recipients whose effective pref is ON', async () => {
+    // sp-2 has messagingEmailDefault true (default→on); org-1 does not.
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference,
+    })
+
+    expect(emailMock).toHaveBeenCalledTimes(1)
+    const [recipients] = emailMock.mock.calls[0]
+    expect(recipients.map((r: { email: string }) => r.email)).toEqual([
+      'bob@x.no',
+    ])
+    // Speaker recipient → absolute cfp link.
+    expect(recipients[0].replyUrl).toBe(
+      'https://cndn.no/cfp/proposal/prop-1#messages',
+    )
+  })
+
+  it("respects a per-conversation 'on' override even when the speaker default is off", async () => {
+    prefsMock.mockResolvedValue(
+      new Map([['org-1', { muted: false, emailOverride: 'on' }]]),
+    )
+
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference,
+    })
+
+    const [recipients] = emailMock.mock.calls[0]
+    // org-1 forced on, plus sp-2 default-on.
+    expect(recipients.map((r: { email: string }) => r.email).sort()).toEqual([
+      'bob@x.no',
+      'olga@x.no',
+    ])
+  })
+
+  it('sends no email when nobody is opted in', async () => {
+    fetchMock.mockResolvedValue([
+      {
+        _id: 'sp-1',
+        name: 'Alice',
+        email: 'alice@x.no',
+        messagingEmailDefault: false,
+      },
+      {
+        _id: 'sp-2',
+        name: 'Bob',
+        email: 'bob@x.no',
+        messagingEmailDefault: false,
+      },
+      {
+        _id: 'org-1',
+        name: 'Olga',
+        email: 'olga@x.no',
+        messagingEmailDefault: false,
+      },
+    ])
+
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference,
+    })
+
+    expect(emailMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('SLACK — speaker-authored only', () => {
+  it('posts to Slack when the author is NOT an organizer', async () => {
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference,
+    })
+    expect(slackMock).toHaveBeenCalledTimes(1)
+    const [payload] = slackMock.mock.calls[0]
+    expect(payload.authorName).toBe('Alice')
+    expect(payload.adminPath).toBe('/admin/proposals/prop-1#messages')
+  })
+
+  it('does NOT post to Slack when an organizer authored the message', async () => {
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message: { ...message, authorId: 'org-1' },
+      authorId: 'org-1',
+      conference,
+    })
+    expect(slackMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('never-fail contract', () => {
+  it('resolves (and logs) when a dependency throws', async () => {
+    organizersMock.mockRejectedValue(new Error('sanity down'))
+
+    await expect(
+      notifyNewMessage({
+        conversation: proposalConv,
+        message,
+        authorId: 'sp-1',
+        conference,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(createMock).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalled()
+  })
+})

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -1,0 +1,302 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the messaging data layer (src/lib/messaging/sanity.ts):
+ * - deterministic ids (proposal conversation + preference doc-per-pair);
+ * - the single-transaction addMessage (create + lastMessageAt bump);
+ * - createIfNotExists race-safety for proposal threads and preferences;
+ * - the pure authz / recipient / link helpers.
+ *
+ * Both Sanity clients are mocked so we assert exactly what is written / queried.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/sanity/helpers', () => ({
+  createReference: (id: string) => ({ _type: 'reference', _ref: id }),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { transaction: vi.fn(), create: vi.fn() },
+  clientReadUncached: { fetch: vi.fn() },
+}))
+
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn(async () => [] as string[]),
+}))
+
+// Deterministic ids so we can assert the message/general-conversation shapes.
+vi.mock('nanoid', () => ({ nanoid: () => 'FIXED' }))
+
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import {
+  proposalConversationId,
+  conversationPreferenceId,
+  resolveParticipantIds,
+  resolveRecipients,
+  canAccessConversation,
+  conversationLinkPath,
+  addMessage,
+  ensureProposalConversation,
+  createGeneralConversation,
+  setConversationPreference,
+  getConversationPreferencesFor,
+} from '@/lib/messaging/sanity'
+import type { ConversationWithContext } from '@/lib/messaging/types'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const writeMock = clientWrite as unknown as {
+  transaction: LooseMock
+  create: LooseMock
+}
+const readMock = clientReadUncached as unknown as { fetch: LooseMock }
+
+function installTransaction(commit: () => Promise<unknown> = async () => ({})) {
+  const tx = {
+    create: vi.fn((_doc?: unknown) => tx),
+    createIfNotExists: vi.fn((_doc?: unknown) => tx),
+    patch: vi.fn((_id?: string, _ops?: unknown) => tx),
+    commit: vi.fn(commit),
+  }
+  writeMock.transaction.mockReturnValue(tx)
+  return tx
+}
+
+const proposalConv: ConversationWithContext = {
+  _id: 'conversation.proposal.prop-1',
+  conferenceId: 'conf-1',
+  conversationType: 'proposal',
+  proposalId: 'prop-1',
+  proposalTitle: 'My Talk',
+  proposalSpeakerIds: ['sp-1', 'sp-2'],
+  createdById: 'sp-1',
+  subject: 'My Talk',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastMessageAt: '2026-01-01T00:00:00.000Z',
+}
+
+const generalConv: ConversationWithContext = {
+  _id: 'conversation.gen-1',
+  conferenceId: 'conf-1',
+  conversationType: 'general',
+  proposalSpeakerIds: [],
+  createdById: 'sp-9',
+  subject: 'A question',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastMessageAt: '2026-01-01T00:00:00.000Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('deterministic ids', () => {
+  it('derives a stable proposal conversation id', () => {
+    expect(proposalConversationId('prop-1')).toBe(
+      'conversation.proposal.prop-1',
+    )
+  })
+  it('derives a stable per-pair preference id', () => {
+    expect(conversationPreferenceId('conversation.gen-1', 'sp-3')).toBe(
+      'convpref.conversation.gen-1.sp-3',
+    )
+  })
+})
+
+describe('resolveParticipantIds', () => {
+  it('proposal thread → proposal speakers ∪ organizers, de-duplicated', () => {
+    const ids = resolveParticipantIds(proposalConv, ['org-1', 'sp-1']).sort()
+    // sp-1 is both a speaker and an organizer → appears once.
+    expect(ids).toEqual(['org-1', 'sp-1', 'sp-2'])
+  })
+  it('general thread → creator ∪ organizers', () => {
+    expect(resolveParticipantIds(generalConv, ['org-1']).sort()).toEqual([
+      'org-1',
+      'sp-9',
+    ])
+  })
+})
+
+describe('resolveRecipients — excludes the actor', () => {
+  it('drops the author from a proposal thread fan-out', () => {
+    expect(resolveRecipients(proposalConv, 'sp-1', ['org-1']).sort()).toEqual([
+      'org-1',
+      'sp-2',
+    ])
+  })
+  it('drops an organizer author from a general thread fan-out', () => {
+    expect(resolveRecipients(generalConv, 'org-1', ['org-1', 'org-2'])).toEqual(
+      ['sp-9', 'org-2'].sort((a, b) => a.localeCompare(b)),
+    )
+  })
+})
+
+describe('canAccessConversation — authz matrix', () => {
+  it('any organizer can access any conversation', () => {
+    expect(
+      canAccessConversation(proposalConv, { _id: 'x', isOrganizer: true }),
+    ).toBe(true)
+    expect(
+      canAccessConversation(generalConv, { _id: 'x', isOrganizer: true }),
+    ).toBe(true)
+  })
+  it('a proposal-speaker can access their proposal thread; a stranger cannot', () => {
+    expect(canAccessConversation(proposalConv, { _id: 'sp-2' })).toBe(true)
+    expect(canAccessConversation(proposalConv, { _id: 'sp-99' })).toBe(false)
+  })
+  it('only the creator can access a general thread', () => {
+    expect(canAccessConversation(generalConv, { _id: 'sp-9' })).toBe(true)
+    expect(canAccessConversation(generalConv, { _id: 'sp-1' })).toBe(false)
+  })
+})
+
+describe('conversationLinkPath — M2 link contract', () => {
+  it('proposal thread links to /admin or /cfp proposal #messages', () => {
+    expect(conversationLinkPath(proposalConv, true)).toBe(
+      '/admin/proposals/prop-1#messages',
+    )
+    expect(conversationLinkPath(proposalConv, false)).toBe(
+      '/cfp/proposal/prop-1#messages',
+    )
+  })
+  it('general thread links to /admin or /cfp messages/<conversationId>', () => {
+    expect(conversationLinkPath(generalConv, true)).toBe(
+      '/admin/messages/conversation.gen-1',
+    )
+    expect(conversationLinkPath(generalConv, false)).toBe(
+      '/cfp/messages/conversation.gen-1',
+    )
+  })
+})
+
+describe('addMessage — single transaction (create + lastMessageAt bump)', () => {
+  it('creates the message and patches the conversation in ONE transaction', async () => {
+    const tx = installTransaction()
+
+    const message = await addMessage({
+      conversationId: 'conversation.gen-1',
+      authorId: 'sp-9',
+      body: 'hello',
+    })
+
+    expect(writeMock.transaction).toHaveBeenCalledTimes(1)
+    expect(tx.create).toHaveBeenCalledTimes(1)
+    expect(tx.patch).toHaveBeenCalledTimes(1)
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+
+    const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc._type).toBe('message')
+    expect(doc.conversation).toEqual({
+      _type: 'reference',
+      _ref: 'conversation.gen-1',
+    })
+    expect(doc.author).toEqual({ _type: 'reference', _ref: 'sp-9' })
+    expect(doc.body).toBe('hello')
+
+    // The returned message mirrors what was written (same createdAt used for the bump).
+    expect(message.body).toBe('hello')
+    expect(message.conversationId).toBe('conversation.gen-1')
+    expect(typeof message.createdAt).toBe('string')
+    expect(message._id).toBe('message.FIXED')
+  })
+})
+
+describe('ensureProposalConversation — race-safe createIfNotExists', () => {
+  it('creates the deterministic-id doc and returns that id', async () => {
+    const tx = installTransaction()
+
+    const id = await ensureProposalConversation({
+      conferenceId: 'conf-1',
+      proposalId: 'prop-1',
+      proposalTitle: 'My Talk',
+      createdById: 'sp-1',
+    })
+
+    expect(id).toBe('conversation.proposal.prop-1')
+    expect(tx.createIfNotExists).toHaveBeenCalledTimes(1)
+    const doc = tx.createIfNotExists.mock.calls[0][0] as Record<string, unknown>
+    expect(doc._id).toBe('conversation.proposal.prop-1')
+    expect(doc.conversationType).toBe('proposal')
+    expect(doc.subject).toBe('My Talk')
+    expect(doc.proposal).toEqual({
+      _type: 'reference',
+      _ref: 'prop-1',
+      _weak: true,
+    })
+  })
+})
+
+describe('createGeneralConversation', () => {
+  it('creates a random-id general conversation with an explicit subject', async () => {
+    const id = await createGeneralConversation({
+      conferenceId: 'conf-1',
+      createdById: 'sp-9',
+      subject: 'A question',
+    })
+    expect(id).toBe('conversation.FIXED')
+    const doc = writeMock.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.conversationType).toBe('general')
+    expect(doc.subject).toBe('A question')
+    expect('proposal' in doc).toBe(false)
+  })
+})
+
+describe('setConversationPreference — doc-per-pair upsert (no array RMW)', () => {
+  it('createIfNotExists seeds defaults then patches only provided fields', async () => {
+    const tx = installTransaction()
+    readMock.fetch.mockResolvedValue({ muted: true, emailOverride: 'off' })
+
+    const pref = await setConversationPreference({
+      conversationId: 'conversation.gen-1',
+      speakerId: 'sp-3',
+      muted: true,
+    })
+
+    const seed = tx.createIfNotExists.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >
+    expect(seed._id).toBe('convpref.conversation.gen-1.sp-3')
+    expect(seed.muted).toBe(false)
+    expect(seed.emailOverride).toBe('default')
+
+    // Only `muted` was provided → the patch sets just that.
+    expect(tx.patch).toHaveBeenCalledTimes(1)
+    expect(tx.patch.mock.calls[0][0]).toBe('convpref.conversation.gen-1.sp-3')
+    expect(pref).toEqual({ muted: true, emailOverride: 'off' })
+  })
+
+  it('skips the patch entirely when no fields are provided', async () => {
+    const tx = installTransaction()
+    readMock.fetch.mockResolvedValue(null)
+
+    await setConversationPreference({
+      conversationId: 'conversation.gen-1',
+      speakerId: 'sp-3',
+    })
+
+    expect(tx.createIfNotExists).toHaveBeenCalledTimes(1)
+    expect(tx.patch).not.toHaveBeenCalled()
+  })
+})
+
+describe('getConversationPreferencesFor — batched, normalized', () => {
+  it('is a no-op for an empty recipient set', async () => {
+    const map = await getConversationPreferencesFor('conversation.gen-1', [])
+    expect(map.size).toBe(0)
+    expect(readMock.fetch).not.toHaveBeenCalled()
+  })
+
+  it('maps rows by speaker id and normalizes a bad emailOverride to default', async () => {
+    readMock.fetch.mockResolvedValue([
+      { speakerId: 'sp-1', muted: true, emailOverride: 'on' },
+      { speakerId: 'sp-2', muted: false, emailOverride: 'weird' },
+    ])
+    const map = await getConversationPreferencesFor('conversation.gen-1', [
+      'sp-1',
+      'sp-2',
+    ])
+    expect(map.get('sp-1')).toEqual({ muted: true, emailOverride: 'on' })
+    expect(map.get('sp-2')).toEqual({ muted: false, emailOverride: 'default' })
+  })
+})

--- a/__tests__/lib/push/send-bridge.test.ts
+++ b/__tests__/lib/push/send-bridge.test.ts
@@ -35,6 +35,7 @@ const ALL_ON = {
   proposalDecisions: true,
   talkConfirmed: true,
   coSpeakerInvites: true,
+  messages: true,
   otherUpdates: true,
 }
 
@@ -87,6 +88,10 @@ describe('pushCategoryForNotificationType', () => {
     expect(pushCategoryForNotificationType('cospeaker_response')).toBe(
       'coSpeakerInvites',
     )
+  })
+
+  it('maps message_received → messages', () => {
+    expect(pushCategoryForNotificationType('message_received')).toBe('messages')
   })
 
   it.each([

--- a/__tests__/server/schemas/message.test.ts
+++ b/__tests__/server/schemas/message.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the message router input schemas (src/server/schemas/message.ts) —
+ * the first gate a client payload passes, including the body/subject caps.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  SendMessageSchema,
+  SetPreferenceSchema,
+  GetConversationSchema,
+} from '@/server/schemas/message'
+
+describe('SendMessageSchema', () => {
+  it('accepts a body of 1..5000 chars', () => {
+    expect(SendMessageSchema.safeParse({ body: 'x' }).success).toBe(true)
+    expect(
+      SendMessageSchema.safeParse({ body: 'x'.repeat(5000) }).success,
+    ).toBe(true)
+  })
+
+  it('rejects an empty body and a body over 5000 chars', () => {
+    expect(SendMessageSchema.safeParse({ body: '' }).success).toBe(false)
+    expect(
+      SendMessageSchema.safeParse({ body: 'x'.repeat(5001) }).success,
+    ).toBe(false)
+  })
+
+  it('caps the subject at 200 chars', () => {
+    expect(
+      SendMessageSchema.safeParse({ subject: 'x'.repeat(200), body: 'hi' })
+        .success,
+    ).toBe(true)
+    expect(
+      SendMessageSchema.safeParse({ subject: 'x'.repeat(201), body: 'hi' })
+        .success,
+    ).toBe(false)
+  })
+})
+
+describe('SetPreferenceSchema', () => {
+  it('requires at least one of muted / emailOverride', () => {
+    expect(SetPreferenceSchema.safeParse({ conversationId: 'c' }).success).toBe(
+      false,
+    )
+    expect(
+      SetPreferenceSchema.safeParse({ conversationId: 'c', muted: true })
+        .success,
+    ).toBe(true)
+  })
+
+  it('constrains emailOverride to the enum', () => {
+    expect(
+      SetPreferenceSchema.safeParse({
+        conversationId: 'c',
+        emailOverride: 'on',
+      }).success,
+    ).toBe(true)
+    expect(
+      SetPreferenceSchema.safeParse({
+        conversationId: 'c',
+        emailOverride: 'sometimes',
+      }).success,
+    ).toBe(false)
+  })
+})
+
+describe('GetConversationSchema', () => {
+  it('requires a non-empty id', () => {
+    expect(GetConversationSchema.safeParse({ id: '' }).success).toBe(false)
+    expect(GetConversationSchema.safeParse({ id: 'conv-1' }).success).toBe(true)
+  })
+})

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -4,8 +4,11 @@ import { fileAttachment, urlAttachment } from './schemaTypes/attachment'
 import blockContent from './schemaTypes/blockContent'
 import conference from './schemaTypes/conference'
 import contractTemplate from './schemaTypes/contractTemplate'
+import conversation from './schemaTypes/conversation'
+import conversationPreference from './schemaTypes/conversationPreference'
 import coSpeakerInvitation from './schemaTypes/coSpeakerInvitation'
 import dashboardConfig from './schemaTypes/dashboardConfig'
+import message from './schemaTypes/message'
 import dataProcessingConsent from './schemaTypes/dataProcessingConsent'
 import imageGallery from './schemaTypes/imageGallery'
 import notification from './schemaTypes/notification'
@@ -42,6 +45,9 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     volunteer,
     staff,
     notification,
+    conversation,
+    message,
+    conversationPreference,
 
     // Topics & Talks
     talk,

--- a/sanity/schemaTypes/conversation.ts
+++ b/sanity/schemaTypes/conversation.ts
@@ -1,0 +1,118 @@
+import { defineField, defineType } from 'sanity'
+
+/**
+ * A speaker↔organizer conversation thread (messaging M1).
+ *
+ * Two shapes:
+ * - `proposal` threads hang off a single proposal (talk). There is AT MOST ONE
+ *   per proposal: the router enforces this with a deterministic document id
+ *   (`conversation.proposal.<proposalId>`) written via `createIfNotExists`, so a
+ *   race between two starters is harmless (both converge on the same doc).
+ * - `general` threads are free-standing (creator ↔ organizers) with a random id.
+ *
+ * `subject` is stored EXPLICITLY even for proposal threads (defaulted to the
+ * proposal title at creation) so a thread can render without resolving the
+ * proposal, and so a later proposal-title edit doesn't silently rewrite history.
+ */
+export default defineType({
+  name: 'conversation',
+  title: 'Conversation',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'conference',
+      title: 'Conference',
+      type: 'reference',
+      to: [{ type: 'conference' }],
+      description: 'The conference edition this conversation belongs to.',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'conversationType',
+      title: 'Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Proposal', value: 'proposal' },
+          { title: 'General', value: 'general' },
+        ],
+        layout: 'radio',
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'proposal',
+      title: 'Proposal',
+      type: 'reference',
+      to: [{ type: 'talk' }],
+      // Weak so deleting the proposal does not orphan-block or fail the delete.
+      weak: true,
+      description:
+        'The proposal (talk) this thread is about. Required for proposal threads.',
+      validation: (Rule) =>
+        Rule.custom((value, context) => {
+          const type = (context.parent as { conversationType?: string })
+            ?.conversationType
+          if (type === 'proposal' && !value) {
+            return 'A proposal reference is required for proposal threads'
+          }
+          return true
+        }),
+    }),
+    defineField({
+      name: 'createdBy',
+      title: 'Created By',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      description: 'The speaker who started this conversation.',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'subject',
+      title: 'Subject',
+      type: 'string',
+      description:
+        'Thread subject. For proposal threads this defaults to the proposal title at creation and is stored explicitly.',
+      validation: (Rule) => Rule.required().max(200),
+    }),
+    defineField({
+      name: 'createdAt',
+      title: 'Created At',
+      type: 'datetime',
+      validation: (Rule) => Rule.required(),
+      initialValue: () => new Date().toISOString(),
+    }),
+    defineField({
+      name: 'lastMessageAt',
+      title: 'Last Message At',
+      type: 'datetime',
+      description:
+        'Timestamp of the most recent message; bumped in the same transaction that adds a message. Drives the inbox ordering.',
+      validation: (Rule) => Rule.required(),
+      initialValue: () => new Date().toISOString(),
+    }),
+  ],
+  preview: {
+    select: {
+      subject: 'subject',
+      conversationType: 'conversationType',
+      lastMessageAt: 'lastMessageAt',
+    },
+    prepare({ subject, conversationType, lastMessageAt }) {
+      const when = lastMessageAt
+        ? new Date(lastMessageAt).toLocaleDateString()
+        : 'Unknown date'
+      return {
+        title: subject || 'Conversation',
+        subtitle: `${conversationType || 'general'} · last activity ${when}`,
+      }
+    },
+  },
+  orderings: [
+    {
+      title: 'Last Message (Newest first)',
+      name: 'lastMessageAtDesc',
+      by: [{ field: 'lastMessageAt', direction: 'desc' }],
+    },
+  ],
+})

--- a/sanity/schemaTypes/conversationPreference.ts
+++ b/sanity/schemaTypes/conversationPreference.ts
@@ -1,0 +1,70 @@
+import { defineField, defineType } from 'sanity'
+
+/**
+ * A single participant's per-conversation delivery preference (messaging M1).
+ *
+ * There is EXACTLY ONE document per (conversation, speaker) pair, addressed by a
+ * deterministic `_id` (`convpref.<conversationId>.<speakerId>`) written via
+ * `createIfNotExists` + a follow-up patch. This doc-per-pair model exists
+ * precisely to AVOID a read-modify-write race on a shared array — two
+ * participants (or two devices) editing their own preference can never clobber
+ * each other.
+ */
+export default defineType({
+  name: 'conversationPreference',
+  title: 'Conversation Preference',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'conversation',
+      title: 'Conversation',
+      type: 'reference',
+      to: [{ type: 'conversation' }],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'speaker',
+      title: 'Speaker',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'muted',
+      title: 'Muted',
+      type: 'boolean',
+      description:
+        'When true, this participant receives no notifications (hub, push, or email) for the conversation.',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'emailOverride',
+      title: 'Email Override',
+      type: 'string',
+      description:
+        "Per-conversation email override: 'default' follows the speaker's messagingEmailDefault, 'on'/'off' force it.",
+      options: {
+        list: [
+          { title: 'Default (follow speaker setting)', value: 'default' },
+          { title: 'Always email', value: 'on' },
+          { title: 'Never email', value: 'off' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'default',
+    }),
+  ],
+  preview: {
+    select: {
+      speaker: 'speaker.name',
+      muted: 'muted',
+      emailOverride: 'emailOverride',
+    },
+    prepare({ speaker, muted, emailOverride }) {
+      return {
+        title: speaker || 'Unknown speaker',
+        subtitle: `${muted ? 'muted' : 'active'} · email: ${emailOverride || 'default'}`,
+      }
+    },
+  },
+})

--- a/sanity/schemaTypes/message.ts
+++ b/sanity/schemaTypes/message.ts
@@ -1,0 +1,67 @@
+import { defineField, defineType } from 'sanity'
+
+/**
+ * A single message within a {@link conversation} (messaging M1).
+ *
+ * Messages are append-only; adding one also bumps the parent conversation's
+ * `lastMessageAt` in the SAME transaction (see `src/lib/messaging/sanity.ts`).
+ */
+export default defineType({
+  name: 'message',
+  title: 'Message',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'conversation',
+      title: 'Conversation',
+      type: 'reference',
+      to: [{ type: 'conversation' }],
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'author',
+      title: 'Author',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      description: 'The speaker (or organizer) who wrote this message.',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'text',
+      rows: 4,
+      validation: (Rule) => Rule.required().max(5000),
+    }),
+    defineField({
+      name: 'createdAt',
+      title: 'Created At',
+      type: 'datetime',
+      validation: (Rule) => Rule.required(),
+      initialValue: () => new Date().toISOString(),
+    }),
+  ],
+  preview: {
+    select: {
+      body: 'body',
+      author: 'author.name',
+      createdAt: 'createdAt',
+    },
+    prepare({ body, author, createdAt }) {
+      const when = createdAt
+        ? new Date(createdAt).toLocaleString()
+        : 'Unknown date'
+      return {
+        title: body ? String(body).slice(0, 80) : 'Message',
+        subtitle: `By ${author || 'Unknown'} · ${when}`,
+      }
+    },
+  },
+  orderings: [
+    {
+      title: 'Created Date (Oldest first)',
+      name: 'createdAtAsc',
+      by: [{ field: 'createdAt', direction: 'asc' }],
+    },
+  ],
+})

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -42,6 +42,7 @@ export default defineType({
           },
           // Reserved for future use — no emitter yet.
           { title: 'Proposal Comment', value: 'proposal_comment' },
+          { title: 'Message Received', value: 'message_received' },
           { title: 'Co-Speaker Response', value: 'cospeaker_response' },
           { title: 'Travel Support Update', value: 'travel_support_update' },
           { title: 'Sponsor Activity', value: 'sponsor_activity' },

--- a/sanity/schemaTypes/speaker.ts
+++ b/sanity/schemaTypes/speaker.ts
@@ -342,6 +342,12 @@ export default defineType({
           initialValue: true,
         }),
         defineField({
+          name: 'messages',
+          title: 'Messages',
+          type: 'boolean',
+          initialValue: true,
+        }),
+        defineField({
           name: 'otherUpdates',
           title: 'Other Updates',
           type: 'boolean',
@@ -356,6 +362,18 @@ export default defineType({
           )
         )
       },
+    }),
+    // Messaging (M1). Opt-IN by default: when true, the speaker receives an email
+    // for new conversation messages whose per-conversation override is 'default'.
+    // Absent/unset means false (no email unless the speaker opts in, or a
+    // conversation override forces 'on'). Additive/optional — no migration.
+    defineField({
+      name: 'messagingEmailDefault',
+      title: 'Messaging Email (default)',
+      type: 'boolean',
+      description:
+        'Default email delivery for new conversation messages. Off by default; per-conversation overrides can force on/off.',
+      initialValue: false,
     }),
   ],
   preview: {

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -360,6 +360,41 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                       </div>
                     </div>
 
+                    {/* Messages */}
+                    <div className="rounded-lg border border-sky-200 bg-sky-50 p-6 dark:border-sky-800 dark:bg-sky-900/20">
+                      <h3 className="mb-4 flex items-center text-lg font-semibold text-sky-800 dark:text-sky-200">
+                        <ChatBubbleLeftRightIcon className="mr-3 h-5 w-5" />
+                        Messages
+                      </h3>
+                      <ul className="space-y-2 text-sm text-sky-700 dark:text-sky-300">
+                        <li>
+                          • <strong>Message content:</strong> The text you write
+                          in a conversation with organizers or co-speakers
+                        </li>
+                        <li>
+                          • <strong>Author &amp; timestamps:</strong> Who sent
+                          each message and when
+                        </li>
+                        <li>
+                          • <strong>Conversation preferences:</strong> Your
+                          per-conversation mute and email delivery settings
+                        </li>
+                      </ul>
+                      <div className="mt-3 rounded-lg bg-sky-100 p-2 dark:bg-sky-800/30">
+                        <p className="text-xs text-sky-800 dark:text-sky-200">
+                          <strong>Visibility:</strong> Messages in a proposal
+                          thread are visible to that proposal&apos;s speakers
+                          and all conference organizers; messages in a general
+                          thread are visible to their author and all conference
+                          organizers. <strong>Purpose:</strong> Coordinating
+                          proposals and conference logistics.{' '}
+                          <strong>Legal Basis:</strong> Legitimate interest in
+                          conference coordination. Messages are retained until
+                          deleted.
+                        </p>
+                      </div>
+                    </div>
+
                     {/* Photo Gallery Data */}
                     <div className="rounded-lg border border-pink-200 bg-pink-50 p-6 dark:border-pink-800 dark:bg-pink-900/20">
                       <h3 className="mb-4 flex items-center text-lg font-semibold text-pink-800 dark:text-pink-200">
@@ -1154,6 +1189,25 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                               </span>{' '}
                               Keeping speakers and organizers informed of
                               proposal and conference activity
+                            </td>
+                          </tr>
+                          <tr>
+                            <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
+                              Messages
+                              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                (Content, author, timestamps, conversation
+                                preferences)
+                              </div>
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+                              Until deleted
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-700 dark:text-gray-300">
+                              <span className="font-medium text-blue-600 dark:text-blue-400">
+                                Legitimate Interest:
+                              </span>{' '}
+                              Speaker↔organizer coordination of proposals and
+                              conference logistics
                             </td>
                           </tr>
                           <tr>

--- a/src/components/email/MessageNotificationTemplate.tsx
+++ b/src/components/email/MessageNotificationTemplate.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import { BaseEmailTemplate } from './BaseEmailTemplate'
+import {
+  EmailSection,
+  EmailSectionHeader,
+  EmailText,
+  EmailButton,
+} from './EmailComponents'
+
+export interface MessageNotificationTemplateProps {
+  recipientName: string
+  authorName: string
+  subject: string
+  excerpt: string
+  replyUrl: string
+  eventName: string
+  eventLocation: string
+  eventDate: string
+  eventUrl: string
+  socialLinks?: string[]
+}
+
+/**
+ * Speaker↔organizer new-message email (messaging M1). House style via
+ * {@link BaseEmailTemplate}; the CTA deep-links straight into the thread.
+ */
+export function MessageNotificationTemplate({
+  recipientName,
+  authorName,
+  subject,
+  excerpt,
+  replyUrl,
+  eventName,
+  eventLocation,
+  eventDate,
+  eventUrl,
+  socialLinks = [],
+}: MessageNotificationTemplateProps) {
+  const customContent = {
+    heading: 'New message',
+    body: (
+      <>
+        <div style={{ marginBottom: '24px' }}>
+          <EmailText>
+            <strong>{authorName}</strong> sent you a new message about{' '}
+            <strong>&quot;{subject}&quot;</strong>.
+          </EmailText>
+        </div>
+
+        <EmailSection backgroundColor="#F8FAFC" borderColor="#E5E7EB">
+          <EmailSectionHeader>Message</EmailSectionHeader>
+          <EmailText size="14px" color="#475569">
+            {excerpt}
+          </EmailText>
+        </EmailSection>
+
+        <div
+          style={{
+            textAlign: 'center',
+            marginTop: '24px',
+            marginBottom: '24px',
+          }}
+        >
+          <EmailButton href={replyUrl}>Reply in app</EmailButton>
+        </div>
+
+        <EmailText size="14px" color="#64748B">
+          You can manage message emails for this conversation from its
+          notification settings.
+        </EmailText>
+      </>
+    ),
+  }
+
+  return (
+    <BaseEmailTemplate
+      speakerName={recipientName}
+      eventName={eventName}
+      eventLocation={eventLocation}
+      eventDate={eventDate}
+      eventUrl={eventUrl}
+      socialLinks={socialLinks}
+      customContent={customContent}
+    />
+  )
+}

--- a/src/components/pwa/PushNotificationSettings.tsx
+++ b/src/components/pwa/PushNotificationSettings.tsx
@@ -40,9 +40,11 @@ export type PushSettingsStatus =
   | 'disabled'
   | 'enabled'
 
-const CATEGORY_LABELS: Record<
-  PushCategory,
-  { title: string; description: string }
+// A category with no entry here is intentionally hidden from the settings UI
+// (e.g. `messages` is default-on and gets its toggle in a later phase); the
+// render skips categories without a label.
+const CATEGORY_LABELS: Partial<
+  Record<PushCategory, { title: string; description: string }>
 > = {
   proposalDecisions: {
     title: 'Proposal decisions',
@@ -236,31 +238,35 @@ export function PushNotificationSettingsView({
                 <legend className="font-inter text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
                   Notify me about
                 </legend>
-                {PUSH_CATEGORIES.map((category) => (
-                  <div
-                    key={category}
-                    className="flex items-center justify-between gap-4"
-                  >
-                    <div>
-                      <label
-                        htmlFor={`push-cat-${category}`}
-                        className="font-inter text-sm font-medium text-gray-900 dark:text-white"
-                      >
-                        {CATEGORY_LABELS[category].title}
-                      </label>
-                      <p className="font-inter text-xs text-gray-500 dark:text-gray-400">
-                        {CATEGORY_LABELS[category].description}
-                      </p>
+                {PUSH_CATEGORIES.map((category) => {
+                  const label = CATEGORY_LABELS[category]
+                  if (!label) return null
+                  return (
+                    <div
+                      key={category}
+                      className="flex items-center justify-between gap-4"
+                    >
+                      <div>
+                        <label
+                          htmlFor={`push-cat-${category}`}
+                          className="font-inter text-sm font-medium text-gray-900 dark:text-white"
+                        >
+                          {label.title}
+                        </label>
+                        <p className="font-inter text-xs text-gray-500 dark:text-gray-400">
+                          {label.description}
+                        </p>
+                      </div>
+                      <Toggle
+                        id={`push-cat-${category}`}
+                        label={label.title}
+                        checked={preferences[category]}
+                        disabled={savingPreferences}
+                        onChange={(next) => onToggleCategory(category, next)}
+                      />
                     </div>
-                    <Toggle
-                      id={`push-cat-${category}`}
-                      label={CATEGORY_LABELS[category].title}
-                      checked={preferences[category]}
-                      disabled={savingPreferences}
-                      onChange={(next) => onToggleCategory(category, next)}
-                    />
-                  </div>
-                ))}
+                  )
+                })}
               </fieldset>
             )}
           </div>

--- a/src/lib/messaging/email.ts
+++ b/src/lib/messaging/email.ts
@@ -1,0 +1,95 @@
+import 'server-only'
+import React from 'react'
+import {
+  resend,
+  retryWithBackoff,
+  delay,
+  EMAIL_CONFIG,
+} from '@/lib/email/config'
+import { MessageNotificationTemplate } from '@/components/email/MessageNotificationTemplate'
+import type { Conference } from '@/lib/conference/types'
+import { formatDate } from '@/lib/time'
+
+/** One email recipient for a new-message notification. */
+export interface MessageEmailRecipient {
+  email: string
+  name: string
+  /** Absolute deep link into the thread for THIS recipient's surface. */
+  replyUrl: string
+}
+
+/**
+ * Send the new-message email to a single recipient. Never throws — an email
+ * failure must not fail the (already committed) message write.
+ */
+async function sendOne(
+  recipient: MessageEmailRecipient,
+  {
+    authorName,
+    subject,
+    excerpt,
+    conference,
+  }: {
+    authorName: string
+    subject: string
+    excerpt: string
+    conference: Conference
+  },
+): Promise<boolean> {
+  try {
+    await retryWithBackoff(async () => {
+      const result = await resend.emails.send({
+        from: `${conference.organizer} <${conference.cfpEmail}>`,
+        to: [recipient.email],
+        subject: `New message about "${subject}"`,
+        react: React.createElement(MessageNotificationTemplate, {
+          recipientName: recipient.name,
+          authorName,
+          subject,
+          excerpt,
+          replyUrl: recipient.replyUrl,
+          eventName: conference.title,
+          eventLocation: `${conference.city}, ${conference.country}`,
+          eventDate: conference.startDate
+            ? formatDate(conference.startDate)
+            : '',
+          eventUrl: conference.domains?.[0]
+            ? `https://${conference.domains[0]}`
+            : '',
+          socialLinks: conference.socialLinks || [],
+        }),
+      })
+      if (result.error) {
+        throw new Error(`Failed to send email: ${result.error.message}`)
+      }
+      return result
+    })
+    return true
+  } catch (error) {
+    console.error('Failed to send message notification email:', error)
+    return false
+  }
+}
+
+/**
+ * Send new-message emails to several recipients, sequentially with the shared
+ * rate-limit delay between sends (mirrors the other email senders). Never
+ * throws; returns how many were delivered.
+ */
+export async function sendMessageEmails(
+  recipients: MessageEmailRecipient[],
+  context: {
+    authorName: string
+    subject: string
+    excerpt: string
+    conference: Conference
+  },
+): Promise<number> {
+  let sent = 0
+  for (let i = 0; i < recipients.length; i++) {
+    if (i > 0) await delay(EMAIL_CONFIG.RATE_LIMIT_DELAY)
+    const ok = await sendOne(recipients[i], context)
+    if (ok) sent++
+  }
+  return sent
+}

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -1,0 +1,155 @@
+import 'server-only'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import { clientReadUncached } from '@/lib/sanity/client'
+import { notifyNewSpeakerMessage } from '@/lib/slack/notify'
+import type { NotificationInput } from '@/lib/notification/types'
+import type { Conference } from '@/lib/conference/types'
+import {
+  resolveRecipients,
+  getConversationPreferencesFor,
+  conversationLinkPath,
+} from './sanity'
+import { sendMessageEmails, type MessageEmailRecipient } from './email'
+import type { ConversationWithContext, Message } from './types'
+
+/** How many characters of the message body ride into the notification/email. */
+const EXCERPT_LENGTH = 140
+
+/** A single-line excerpt of a message body, capped and ellipsised. */
+export function messageExcerpt(body: string, max = EXCERPT_LENGTH): string {
+  const flat = body.replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max).trimEnd()}…` : flat
+}
+
+function absoluteLink(
+  conversation: ConversationWithContext,
+  isOrganizer: boolean,
+  conference: Conference,
+): string {
+  const path = conversationLinkPath(conversation, isOrganizer)
+  const domain = conference.domains?.[0]
+  return domain ? `https://${domain}${path}` : path
+}
+
+interface SpeakerRow {
+  _id: string
+  name?: string
+  email?: string
+  messagingEmailDefault?: boolean
+}
+
+/**
+ * Fan a newly-added message out across every channel. Called AFTER a successful
+ * `addMessage`, and wrapped in the never-fail contract: any failure here is
+ * caught and logged — it must never fail the (already committed) message write.
+ *
+ * Channels:
+ * - HUB: one `message_received` notification per non-muted recipient, with a
+ *   PER-RECIPIENT link (organizers → /admin, speakers → /cfp). Web push rides
+ *   along inside `createNotifications` (category `messages`).
+ * - EMAIL: only to non-muted recipients whose effective email pref is ON
+ *   (override 'on', or 'default' + speaker.messagingEmailDefault).
+ * - SLACK: only when the author is NOT an organizer (speaker-authored).
+ */
+export async function notifyNewMessage({
+  conversation,
+  message,
+  authorId,
+  conference,
+}: {
+  conversation: ConversationWithContext
+  message: Message
+  authorId: string
+  conference: Conference
+}): Promise<void> {
+  try {
+    const organizerIds = await getOrganizerSpeakerIds()
+    const organizerSet = new Set(organizerIds)
+    const authorIsOrganizer = organizerSet.has(authorId)
+    const recipientIds = resolveRecipients(conversation, authorId, organizerIds)
+    const excerpt = messageExcerpt(message.body)
+
+    // One read for every speaker we need to name / email (author + recipients).
+    const speakerIds = Array.from(new Set([authorId, ...recipientIds]))
+    const speakerRows = await clientReadUncached.fetch<SpeakerRow[]>(
+      `*[_type == "speaker" && _id in $ids]{ _id, name, email, messagingEmailDefault }`,
+      { ids: speakerIds },
+      { cache: 'no-store' },
+    )
+    const speakers = new Map<string, SpeakerRow>(
+      (speakerRows ?? []).map((s) => [s._id, s]),
+    )
+    const authorName = speakers.get(authorId)?.name ?? 'Someone'
+
+    if (recipientIds.length > 0) {
+      const prefs = await getConversationPreferencesFor(
+        conversation._id,
+        recipientIds,
+      )
+      // Muted participants get NO notifications on any channel.
+      const active = recipientIds.filter((id) => !prefs.get(id)?.muted)
+
+      // HUB (+ push): per-recipient link by audience.
+      const items: NotificationInput[] = active.map((id) => ({
+        recipientId: id,
+        conferenceId: conversation.conferenceId,
+        notificationType: 'message_received',
+        title: `New message from ${authorName}`,
+        message: excerpt,
+        link: conversationLinkPath(conversation, organizerSet.has(id)),
+        actorId: authorId,
+        ...(conversation.proposalId
+          ? { relatedProposalId: conversation.proposalId }
+          : {}),
+      }))
+      await createNotifications(items)
+
+      // EMAIL: opt-in only.
+      const emailRecipients: MessageEmailRecipient[] = []
+      for (const id of active) {
+        const sp = speakers.get(id)
+        if (!sp?.email) continue
+        const override = prefs.get(id)?.emailOverride ?? 'default'
+        const wantsEmail =
+          override === 'on' ||
+          (override === 'default' && sp.messagingEmailDefault === true)
+        if (!wantsEmail) continue
+        emailRecipients.push({
+          email: sp.email,
+          name: sp.name ?? 'there',
+          replyUrl: absoluteLink(
+            conversation,
+            organizerSet.has(id),
+            conference,
+          ),
+        })
+      }
+      if (emailRecipients.length > 0) {
+        await sendMessageEmails(emailRecipients, {
+          authorName,
+          subject: conversation.subject,
+          excerpt,
+          conference,
+        })
+      }
+    }
+
+    // SLACK: speaker-authored messages only.
+    if (!authorIsOrganizer) {
+      await notifyNewSpeakerMessage(
+        {
+          authorName,
+          subject: conversation.subject,
+          excerpt,
+          adminPath: conversationLinkPath(conversation, true),
+        },
+        conference,
+      )
+    }
+  } catch (error) {
+    console.error('Failed to fan out new-message notifications:', error)
+  }
+}

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -1,0 +1,499 @@
+import 'server-only'
+import { nanoid } from 'nanoid'
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { createReference } from '@/lib/sanity/helpers'
+import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import type {
+  AccessSpeaker,
+  ConversationListItem,
+  ConversationParticipant,
+  ConversationPreference,
+  ConversationWithContext,
+  EmailOverride,
+  Message,
+} from './types'
+import { DEFAULT_CONVERSATION_PREFERENCE } from './types'
+
+/**
+ * Server-only data layer for speaker↔organizer messaging (M1).
+ *
+ * DETERMINISTIC IDS (race-safe):
+ * - a proposal thread has id `conversation.proposal.<proposalId>` and is created
+ *   with `createIfNotExists`, so two concurrent starters converge on one doc;
+ * - a preference has id `convpref.<conversationId>.<speakerId>` — ONE doc per
+ *   pair, created with `createIfNotExists` + patch, so no array RMW race.
+ *
+ * SECURITY: actor/recipient ids are ALWAYS server-derived (`ctx.speaker._id`,
+ * proposal speaker refs, organizer ids). No function here trusts a client to
+ * say who they are.
+ */
+
+/** Deterministic id for the single conversation attached to a proposal. */
+export function proposalConversationId(proposalId: string): string {
+  return `conversation.proposal.${proposalId}`
+}
+
+/** Deterministic id for the single (conversation, speaker) preference doc. */
+export function conversationPreferenceId(
+  conversationId: string,
+  speakerId: string,
+): string {
+  return `convpref.${conversationId}.${speakerId}`
+}
+
+/** How many conversations / messages a single list page returns. */
+const PAGE_SIZE = 20
+
+const CONVERSATION_PROJECTION = `{
+  "_id": _id,
+  "conferenceId": conference._ref,
+  conversationType,
+  "proposalId": proposal._ref,
+  "proposalTitle": proposal->title,
+  "proposalSpeakerIds": coalesce(proposal->speakers[]._ref, []),
+  "createdById": createdBy._ref,
+  subject,
+  createdAt,
+  lastMessageAt
+}`
+
+// ---------------------------------------------------------------------------
+// Pure helpers (authz + recipient resolution). Server-derived ids only.
+// ---------------------------------------------------------------------------
+
+/**
+ * Every participant of a conversation:
+ * - proposal thread → the proposal's speakers ∪ organizers;
+ * - general thread  → the creator ∪ organizers.
+ * De-duplicated (a speaker who is also an organizer appears once).
+ */
+export function resolveParticipantIds(
+  conversation: Pick<
+    ConversationWithContext,
+    'conversationType' | 'proposalSpeakerIds' | 'createdById'
+  >,
+  organizerIds: string[],
+): string[] {
+  const ids = new Set<string>(organizerIds)
+  if (conversation.conversationType === 'proposal') {
+    for (const id of conversation.proposalSpeakerIds) ids.add(id)
+  } else {
+    ids.add(conversation.createdById)
+  }
+  return Array.from(ids)
+}
+
+/**
+ * The recipients of a new message: all participants EXCEPT the actor (an actor
+ * is never notified about their own message — mirrors the hub's actor-exclusion
+ * rule).
+ */
+export function resolveRecipients(
+  conversation: Pick<
+    ConversationWithContext,
+    'conversationType' | 'proposalSpeakerIds' | 'createdById'
+  >,
+  actorId: string,
+  organizerIds: string[],
+): string[] {
+  return resolveParticipantIds(conversation, organizerIds).filter(
+    (id) => id !== actorId,
+  )
+}
+
+/**
+ * Whether `speaker` may read/write `conversation`:
+ * - any organizer; OR
+ * - a proposal thread where the speaker is on the proposal; OR
+ * - a general thread the speaker created.
+ */
+export function canAccessConversation(
+  conversation: Pick<
+    ConversationWithContext,
+    'conversationType' | 'proposalSpeakerIds' | 'createdById'
+  >,
+  speaker: AccessSpeaker,
+): boolean {
+  if (speaker.isOrganizer) return true
+  if (conversation.conversationType === 'proposal') {
+    return conversation.proposalSpeakerIds.includes(speaker._id)
+  }
+  return conversation.createdById === speaker._id
+}
+
+/**
+ * The app-relative deep link to a conversation for a given audience. This is
+ * the LINK CONTRACT M2 must implement its routes against.
+ *
+ * - proposal + organizer → `/admin/proposals/<proposalId>#messages`
+ * - proposal + speaker   → `/cfp/proposal/<proposalId>#messages`
+ * - general  + organizer → `/admin/messages/<conversationId>`
+ * - general  + speaker   → `/cfp/messages/<conversationId>`
+ */
+export function conversationLinkPath(
+  conversation: Pick<
+    ConversationWithContext,
+    '_id' | 'conversationType' | 'proposalId'
+  >,
+  isOrganizer: boolean,
+): string {
+  if (conversation.conversationType === 'proposal' && conversation.proposalId) {
+    return isOrganizer
+      ? `/admin/proposals/${conversation.proposalId}#messages`
+      : `/cfp/proposal/${conversation.proposalId}#messages`
+  }
+  return isOrganizer
+    ? `/admin/messages/${conversation._id}`
+    : `/cfp/messages/${conversation._id}`
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/** The proposal fields needed to authorize + seed a proposal conversation. */
+export async function getProposalForConversation(proposalId: string): Promise<{
+  conferenceId: string | null
+  title: string | null
+  speakerIds: string[]
+} | null> {
+  const result = await clientReadUncached.fetch<{
+    conferenceId: string | null
+    title: string | null
+    speakerIds: string[] | null
+  } | null>(
+    `*[_type == "talk" && _id == $proposalId][0]{
+      "conferenceId": conference._ref,
+      title,
+      "speakerIds": coalesce(speakers[]._ref, [])
+    }`,
+    { proposalId },
+    { cache: 'no-store' },
+  )
+  if (!result) return null
+  return {
+    conferenceId: result.conferenceId,
+    title: result.title,
+    speakerIds: result.speakerIds ?? [],
+  }
+}
+
+/** A single conversation with its authorization/recipient context. */
+export async function getConversationById(
+  id: string,
+): Promise<ConversationWithContext | null> {
+  const result = await clientReadUncached.fetch<ConversationWithContext | null>(
+    `*[_type == "conversation" && _id == $id][0]${CONVERSATION_PROJECTION}`,
+    { id },
+    { cache: 'no-store' },
+  )
+  if (!result) return null
+  return { ...result, proposalSpeakerIds: result.proposalSpeakerIds ?? [] }
+}
+
+/**
+ * The participant speaker docs for a conversation (id, name, image, organizer
+ * flag), used to render a thread header.
+ */
+export async function getConversationParticipants(
+  conversation: ConversationWithContext,
+): Promise<ConversationParticipant[]> {
+  const organizerIds = await getOrganizerSpeakerIds()
+  const ids = resolveParticipantIds(conversation, organizerIds)
+  if (ids.length === 0) return []
+  const organizerSet = new Set(organizerIds)
+  const speakers = await clientReadUncached.fetch<
+    { _id: string; name: string; image?: string }[]
+  >(
+    `*[_type == "speaker" && _id in $ids]{
+      _id,
+      name,
+      "image": coalesce(image.asset->url, imageURL)
+    }`,
+    { ids },
+    { cache: 'no-store' },
+  )
+  return (speakers ?? []).map((s) => ({
+    _id: s._id,
+    name: s.name,
+    image: s.image,
+    isOrganizer: organizerSet.has(s._id),
+  }))
+}
+
+/**
+ * A speaker's inbox, newest activity first, keyset-paginated by `before` (the
+ * `lastMessageAt` of the last item on the previous page).
+ *
+ * - organizers see EVERY conversation for the conference;
+ * - a speaker sees only conversations they created or are a proposal-speaker on.
+ */
+export async function listConversationsForSpeaker({
+  speakerId,
+  isOrganizer,
+  conferenceId,
+  before,
+}: {
+  speakerId: string
+  isOrganizer: boolean
+  conferenceId: string
+  before?: string
+}): Promise<ConversationListItem[]> {
+  const params: Record<string, unknown> = { conferenceId }
+  let cursor = ''
+  if (before) {
+    cursor = ' && lastMessageAt < $before'
+    params.before = before
+  }
+
+  let scope = ''
+  if (!isOrganizer) {
+    scope =
+      ' && (createdBy._ref == $speakerId || $speakerId in proposal->speakers[]._ref)'
+    params.speakerId = speakerId
+  }
+
+  const query = `*[_type == "conversation" && conference._ref == $conferenceId${scope}${cursor}] | order(lastMessageAt desc) [0...${PAGE_SIZE}] {
+    "_id": _id,
+    conversationType,
+    subject,
+    "proposalId": proposal._ref,
+    "proposalTitle": proposal->title,
+    createdAt,
+    lastMessageAt
+  }`
+
+  const results = await clientReadUncached.fetch<ConversationListItem[]>(
+    query,
+    params,
+    { cache: 'no-store' },
+  )
+  return results ?? []
+}
+
+/**
+ * A conversation's messages, NEWEST first, keyset-paginated by `before` (the
+ * `createdAt` of the last item on the previous page). M2 reverses for display.
+ */
+export async function listMessages({
+  conversationId,
+  before,
+}: {
+  conversationId: string
+  before?: string
+}): Promise<Message[]> {
+  const params: Record<string, unknown> = { conversationId }
+  let cursor = ''
+  if (before) {
+    cursor = ' && createdAt < $before'
+    params.before = before
+  }
+
+  const query = `*[_type == "message" && conversation._ref == $conversationId${cursor}] | order(createdAt desc) [0...${PAGE_SIZE}] {
+    "_id": _id,
+    "conversationId": conversation._ref,
+    "authorId": author._ref,
+    body,
+    createdAt
+  }`
+
+  const results = await clientReadUncached.fetch<Message[]>(query, params, {
+    cache: 'no-store',
+  })
+  return results ?? []
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure the single proposal conversation exists (deterministic id +
+ * `createIfNotExists`, so the create is race-safe) and return its id. `subject`
+ * is stored explicitly, defaulted to the proposal title.
+ */
+export async function ensureProposalConversation({
+  conferenceId,
+  proposalId,
+  proposalTitle,
+  createdById,
+}: {
+  conferenceId: string
+  proposalId: string
+  proposalTitle: string
+  createdById: string
+}): Promise<string> {
+  const id = proposalConversationId(proposalId)
+  const now = new Date().toISOString()
+  await clientWrite
+    .transaction()
+    .createIfNotExists({
+      _id: id,
+      _type: 'conversation',
+      conference: createReference(conferenceId),
+      conversationType: 'proposal',
+      proposal: { ...createReference(proposalId), _weak: true },
+      createdBy: createReference(createdById),
+      subject: (proposalTitle || 'Proposal').slice(0, 200),
+      createdAt: now,
+      lastMessageAt: now,
+    })
+    .commit()
+  return id
+}
+
+/** Create a free-standing general conversation (random id) and return its id. */
+export async function createGeneralConversation({
+  conferenceId,
+  createdById,
+  subject,
+}: {
+  conferenceId: string
+  createdById: string
+  subject: string
+}): Promise<string> {
+  const id = `conversation.${nanoid()}`
+  const now = new Date().toISOString()
+  await clientWrite.create({
+    _id: id,
+    _type: 'conversation',
+    conference: createReference(conferenceId),
+    conversationType: 'general',
+    createdBy: createReference(createdById),
+    subject: subject.slice(0, 200),
+    createdAt: now,
+    lastMessageAt: now,
+  })
+  return id
+}
+
+/**
+ * Append a message AND bump the parent conversation's `lastMessageAt` in ONE
+ * transaction (the two must never drift apart). Returns the created message.
+ */
+export async function addMessage({
+  conversationId,
+  authorId,
+  body,
+}: {
+  conversationId: string
+  authorId: string
+  body: string
+}): Promise<Message> {
+  const now = new Date().toISOString()
+  const messageId = `message.${nanoid()}`
+
+  await clientWrite
+    .transaction()
+    .create({
+      _id: messageId,
+      _type: 'message',
+      conversation: createReference(conversationId),
+      author: createReference(authorId),
+      body,
+      createdAt: now,
+    })
+    .patch(conversationId, (patch) => patch.set({ lastMessageAt: now }))
+    .commit()
+
+  return { _id: messageId, conversationId, authorId, body, createdAt: now }
+}
+
+// ---------------------------------------------------------------------------
+// Preferences (doc-per-pair; no array RMW)
+// ---------------------------------------------------------------------------
+
+function normalizePreference(
+  raw: { muted?: boolean; emailOverride?: string } | null | undefined,
+): ConversationPreference {
+  const emailOverride = raw?.emailOverride
+  return {
+    muted: raw?.muted ?? DEFAULT_CONVERSATION_PREFERENCE.muted,
+    emailOverride:
+      emailOverride === 'on' || emailOverride === 'off'
+        ? emailOverride
+        : DEFAULT_CONVERSATION_PREFERENCE.emailOverride,
+  }
+}
+
+/** One participant's (normalized) preference for a conversation. */
+export async function getConversationPreference(
+  conversationId: string,
+  speakerId: string,
+): Promise<ConversationPreference> {
+  const id = conversationPreferenceId(conversationId, speakerId)
+  const raw = await clientReadUncached.fetch<{
+    muted?: boolean
+    emailOverride?: string
+  } | null>(
+    `*[_type == "conversationPreference" && _id == $id][0]{ muted, emailOverride }`,
+    { id },
+    { cache: 'no-store' },
+  )
+  return normalizePreference(raw)
+}
+
+/**
+ * The preferences of MANY participants in ONE query (used by the fan-out to
+ * decide mute/email per recipient). Returns a map keyed by speaker id;
+ * participants without a doc are simply absent (caller falls back to default).
+ */
+export async function getConversationPreferencesFor(
+  conversationId: string,
+  speakerIds: string[],
+): Promise<Map<string, ConversationPreference>> {
+  const map = new Map<string, ConversationPreference>()
+  if (speakerIds.length === 0) return map
+  const rows = await clientReadUncached.fetch<
+    { speakerId: string; muted?: boolean; emailOverride?: string }[]
+  >(
+    `*[_type == "conversationPreference" && conversation._ref == $conversationId && speaker._ref in $speakerIds]{
+      "speakerId": speaker._ref,
+      muted,
+      emailOverride
+    }`,
+    { conversationId, speakerIds },
+    { cache: 'no-store' },
+  )
+  for (const row of rows ?? []) {
+    map.set(row.speakerId, normalizePreference(row))
+  }
+  return map
+}
+
+/**
+ * Upsert a participant's preference: `createIfNotExists` seeds the single
+ * doc-per-pair with defaults, then a patch sets only the provided fields. This
+ * is the race-safe alternative to editing a shared preferences array.
+ */
+export async function setConversationPreference({
+  conversationId,
+  speakerId,
+  muted,
+  emailOverride,
+}: {
+  conversationId: string
+  speakerId: string
+  muted?: boolean
+  emailOverride?: EmailOverride
+}): Promise<ConversationPreference> {
+  const id = conversationPreferenceId(conversationId, speakerId)
+  const set: Record<string, unknown> = {}
+  if (muted !== undefined) set.muted = muted
+  if (emailOverride !== undefined) set.emailOverride = emailOverride
+
+  const tx = clientWrite.transaction().createIfNotExists({
+    _id: id,
+    _type: 'conversationPreference',
+    conversation: createReference(conversationId),
+    speaker: createReference(speakerId),
+    muted: false,
+    emailOverride: 'default',
+  })
+  if (Object.keys(set).length > 0) {
+    tx.patch(id, (patch) => patch.set(set))
+  }
+  await tx.commit()
+
+  return getConversationPreference(conversationId, speakerId)
+}

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Speaker↔organizer messaging domain types (messaging M1).
+ *
+ * The thread model has two shapes (`proposal` / `general`); see
+ * `sanity/schemaTypes/conversation.ts`. Access and recipient resolution are
+ * always derived from SERVER-side ids (never trust a client-supplied speaker
+ * id) — see `canAccessConversation` / `resolveRecipients` in `./sanity`.
+ */
+
+export type ConversationType = 'proposal' | 'general'
+
+/** Per-conversation email delivery override. */
+export type EmailOverride = 'default' | 'on' | 'off'
+
+/** A speaker as needed for authorization decisions (server-derived). */
+export interface AccessSpeaker {
+  _id: string
+  isOrganizer?: boolean
+}
+
+/**
+ * A conversation plus the context needed to authorize access, resolve
+ * recipients, and render a thread without a second round-trip.
+ *
+ * `proposalSpeakerIds` are the speaker `_ref`s on the referenced proposal
+ * (empty for general threads). `createdById` is the thread starter.
+ */
+export interface ConversationWithContext {
+  _id: string
+  conferenceId: string
+  conversationType: ConversationType
+  proposalId?: string
+  proposalTitle?: string
+  proposalSpeakerIds: string[]
+  createdById: string
+  subject: string
+  createdAt: string
+  lastMessageAt: string
+}
+
+/** A conversation as listed in an inbox. */
+export interface ConversationListItem {
+  _id: string
+  conversationType: ConversationType
+  subject: string
+  proposalId?: string
+  proposalTitle?: string
+  createdAt: string
+  lastMessageAt: string
+}
+
+/** A single message in a thread. */
+export interface Message {
+  _id: string
+  conversationId: string
+  authorId: string
+  body: string
+  createdAt: string
+}
+
+/** A participant sub-object projected for a conversation view. */
+export interface ConversationParticipant {
+  _id: string
+  name: string
+  image?: string
+  isOrganizer: boolean
+}
+
+/** A participant's per-conversation preference (normalized; never null). */
+export interface ConversationPreference {
+  muted: boolean
+  emailOverride: EmailOverride
+}
+
+export const DEFAULT_CONVERSATION_PREFERENCE: ConversationPreference = {
+  muted: false,
+  emailOverride: 'default',
+}

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -10,6 +10,8 @@ export type NotificationType =
   | 'proposal_status_changed'
   // Reserved for future use — no emitter yet.
   | 'proposal_comment'
+  // Speaker↔organizer conversation message (messaging M1).
+  | 'message_received'
   | 'cospeaker_response'
   | 'travel_support_update'
   | 'sponsor_activity'

--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -79,6 +79,7 @@ export async function sendPush(
  *       (speaker accept/reject/waitlist AND organizer-facing confirm/withdraw
  *        notifications both carry this type)
  *   - `cospeaker_response`       → `coSpeakerInvites`
+ *   - `message_received`         → `messages`
  *   - everything else            → `otherUpdates`
  *       (`proposal_submitted`, `travel_support_update`, `sponsor_activity`,
  *        `gallery_tagged`, `schedule_update`, `proposal_comment`, `system`)
@@ -95,6 +96,8 @@ export function pushCategoryForNotificationType(
       return 'proposalDecisions'
     case 'cospeaker_response':
       return 'coSpeakerInvites'
+    case 'message_received':
+      return 'messages'
     default:
       return 'otherUpdates'
   }

--- a/src/lib/push/types.ts
+++ b/src/lib/push/types.ts
@@ -11,6 +11,7 @@ export const PUSH_CATEGORIES = [
   'proposalDecisions',
   'talkConfirmed',
   'coSpeakerInvites',
+  'messages',
   'otherUpdates',
 ] as const
 
@@ -24,6 +25,8 @@ export interface PushPreferences {
   talkConfirmed: boolean
   /** Co-speaker activity (an invitation to co-present, or a response to yours). */
   coSpeakerInvites: boolean
+  /** New messages in a speaker↔organizer conversation (messaging M1). */
+  messages: boolean
   /**
    * Everything else the notification hub emits (a new submission for organizers,
    * travel-support and sponsor updates, gallery tags, and other system
@@ -40,6 +43,7 @@ export const DEFAULT_PUSH_PREFERENCES: PushPreferences = {
   proposalDecisions: true,
   talkConfirmed: true,
   coSpeakerInvites: true,
+  messages: true,
   otherUpdates: true,
 }
 
@@ -94,6 +98,7 @@ export function normalizePushPreferences(
       value?.talkConfirmed ?? DEFAULT_PUSH_PREFERENCES.talkConfirmed,
     coSpeakerInvites:
       value?.coSpeakerInvites ?? DEFAULT_PUSH_PREFERENCES.coSpeakerInvites,
+    messages: value?.messages ?? DEFAULT_PUSH_PREFERENCES.messages,
     otherUpdates: value?.otherUpdates ?? DEFAULT_PUSH_PREFERENCES.otherUpdates,
   }
 }

--- a/src/lib/slack/notify.ts
+++ b/src/lib/slack/notify.ts
@@ -222,6 +222,69 @@ export async function notifyNewProposal(
   await sendSlackNotification(message, conference)
 }
 
+/**
+ * Speaker-authored conversation message → organizer Slack channel (messaging
+ * M1). Mirrors {@link notifyNewProposal}: only fires for SPEAKER-authored
+ * messages (organizer-authored messages don't ping the organizer channel). The
+ * admin deep link is provided by the caller (proposal vs general thread).
+ */
+export async function notifyNewSpeakerMessage(
+  {
+    authorName,
+    subject,
+    excerpt,
+    adminPath,
+  }: {
+    authorName: string
+    subject: string
+    excerpt: string
+    adminPath: string
+  },
+  conference: Conference,
+) {
+  const domain = getDomainFromConference(conference)
+
+  const blocks: SlackBlock[] = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: '💬 New Speaker Message',
+        emoji: true,
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: `*From:*\n${authorName}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Subject:*\n${subject}`,
+        },
+      ],
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Message:*\n${excerpt}`,
+      },
+    },
+  ]
+
+  if (domain) {
+    blocks.push(
+      createAdminLinkButton(domain, adminPath, 'View in Admin', 'view_message'),
+    )
+  }
+
+  const message = { blocks }
+  await sendSlackNotification(message, conference)
+}
+
 export async function notifyNewVolunteer(
   volunteer: Volunteer,
   conference: Conference,

--- a/src/lib/speaker/types.ts
+++ b/src/lib/speaker/types.ts
@@ -122,6 +122,12 @@ export interface Speaker extends SpeakerBase {
    * {@link normalizePushPreferences}. Additive/optional; no migration required.
    */
   pushPreferences?: PushPreferences
+  /**
+   * Messaging email opt-in (M1). When true, the speaker is emailed for new
+   * conversation messages whose per-conversation override is 'default'. Absent
+   * means FALSE (email opt-in only). Additive/optional; no migration required.
+   */
+  messagingEmailDefault?: boolean
 }
 
 export interface SpeakerWithTalks extends Speaker {

--- a/src/server/_app.ts
+++ b/src/server/_app.ts
@@ -16,6 +16,7 @@ import { statusRouter } from './routers/status'
 import { agentsRouter } from './routers/agents'
 import { notificationRouter } from './routers/notification'
 import { pushRouter } from './routers/push'
+import { messageRouter } from './routers/message'
 
 export const appRouter = router({
   badge: badgeRouter,
@@ -35,6 +36,7 @@ export const appRouter = router({
   agents: agentsRouter,
   notification: notificationRouter,
   push: pushRouter,
+  message: messageRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -1,0 +1,210 @@
+import { TRPCError } from '@trpc/server'
+import { router, protectedProcedure, resolveConferenceId } from '@/server/trpc'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import {
+  ListConversationsSchema,
+  GetConversationSchema,
+  ListMessagesSchema,
+  SendMessageSchema,
+  SetPreferenceSchema,
+} from '@/server/schemas/message'
+import {
+  listConversationsForSpeaker,
+  getConversationById,
+  getConversationParticipants,
+  getConversationPreference,
+  listMessages,
+  addMessage,
+  ensureProposalConversation,
+  createGeneralConversation,
+  getProposalForConversation,
+  setConversationPreference,
+  canAccessConversation,
+} from '@/lib/messaging/sanity'
+import { notifyNewMessage } from '@/lib/messaging/notify'
+import type { ConversationWithContext } from '@/lib/messaging/types'
+
+/**
+ * Speaker↔organizer messaging (M1). Every procedure derives the actor from
+ * `ctx.speaker` and the conference from the domain; a client can never target
+ * another user or another conference. Read/write access to a conversation is
+ * gated by `canAccessConversation` (organizer, proposal-speaker, or creator).
+ */
+export const messageRouter = router({
+  /** The caller's conversation inbox (organizers see all; speakers see theirs). */
+  listConversations: protectedProcedure
+    .input(ListConversationsSchema)
+    .query(async ({ ctx, input }) => {
+      const conferenceId = await resolveConferenceId()
+      return listConversationsForSpeaker({
+        speakerId: ctx.speaker._id,
+        isOrganizer: ctx.speaker.isOrganizer === true,
+        conferenceId,
+        before: input.cursor,
+      })
+    }),
+
+  /** A single conversation + participants + the caller's own preference. */
+  getConversation: protectedProcedure
+    .input(GetConversationSchema)
+    .query(async ({ ctx, input }) => {
+      const conversation = await getConversationById(input.id)
+      if (!conversation) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Conversation not found',
+        })
+      }
+      if (!canAccessConversation(conversation, ctx.speaker)) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
+      }
+      const [participants, preference] = await Promise.all([
+        getConversationParticipants(conversation),
+        getConversationPreference(conversation._id, ctx.speaker._id),
+      ])
+      return { conversation, participants, preference }
+    }),
+
+  /** A conversation's messages, newest first, keyset-paginated. Authz-checked. */
+  listMessages: protectedProcedure
+    .input(ListMessagesSchema)
+    .query(async ({ ctx, input }) => {
+      const conversation = await getConversationById(input.conversationId)
+      if (!conversation) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Conversation not found',
+        })
+      }
+      if (!canAccessConversation(conversation, ctx.speaker)) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
+      }
+      return listMessages({
+        conversationId: conversation._id,
+        before: input.cursor,
+      })
+    }),
+
+  /**
+   * Send a message, creating the conversation when needed:
+   * - `conversationId` → post to an existing thread (authz-checked);
+   * - `proposalId`     → look up / create the proposal thread (race-safe id);
+   * - `subject` only   → start a general thread.
+   * Then adds the message and fires the (never-fail) fan-out.
+   */
+  send: protectedProcedure
+    .input(SendMessageSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { conference, error } = await getConferenceForCurrentDomain()
+      if (error || !conference?._id) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Could not resolve conference from domain',
+        })
+      }
+      const conferenceId = conference._id
+      const actorId = ctx.speaker._id
+      const isOrganizer = ctx.speaker.isOrganizer === true
+
+      let conversation: ConversationWithContext
+
+      if (input.conversationId) {
+        const existing = await getConversationById(input.conversationId)
+        if (!existing) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Conversation not found',
+          })
+        }
+        if (!canAccessConversation(existing, ctx.speaker)) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
+        }
+        conversation = existing
+      } else if (input.proposalId) {
+        const proposal = await getProposalForConversation(input.proposalId)
+        if (!proposal || proposal.conferenceId !== conferenceId) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Proposal not found',
+          })
+        }
+        // Only an organizer or a speaker ON the proposal may open its thread.
+        if (!isOrganizer && !proposal.speakerIds.includes(actorId)) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
+        }
+        const id = await ensureProposalConversation({
+          conferenceId,
+          proposalId: input.proposalId,
+          proposalTitle: proposal.title ?? 'Proposal',
+          createdById: actorId,
+        })
+        const created = await getConversationById(id)
+        if (!created) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Failed to load conversation',
+          })
+        }
+        conversation = created
+      } else if (input.subject) {
+        const id = await createGeneralConversation({
+          conferenceId,
+          createdById: actorId,
+          subject: input.subject,
+        })
+        const created = await getConversationById(id)
+        if (!created) {
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Failed to load conversation',
+          })
+        }
+        conversation = created
+      } else {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Provide a conversationId, a proposalId, or a subject to start a conversation',
+        })
+      }
+
+      const message = await addMessage({
+        conversationId: conversation._id,
+        authorId: actorId,
+        body: input.body,
+      })
+
+      // Fan-out is fire-and-forget within the request: it never throws, and a
+      // failure must not fail the (committed) message write.
+      await notifyNewMessage({
+        conversation,
+        message,
+        authorId: actorId,
+        conference,
+      })
+
+      return { conversationId: conversation._id, message }
+    }),
+
+  /** Set the caller's mute / email preference for a conversation. Authz-checked. */
+  setPreference: protectedProcedure
+    .input(SetPreferenceSchema)
+    .mutation(async ({ ctx, input }) => {
+      const conversation = await getConversationById(input.conversationId)
+      if (!conversation) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Conversation not found',
+        })
+      }
+      if (!canAccessConversation(conversation, ctx.speaker)) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
+      }
+      return setConversationPreference({
+        conversationId: conversation._id,
+        speakerId: ctx.speaker._id,
+        muted: input.muted,
+        emailOverride: input.emailOverride,
+      })
+    }),
+})

--- a/src/server/schemas/message.ts
+++ b/src/server/schemas/message.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+
+/**
+ * Zod schemas for the `message` tRPC router (messaging M1).
+ *
+ * NOTE: no schema carries a conferenceId or a speaker id — the conference is
+ * resolved from the domain and the actor is always `ctx.speaker._id`, never
+ * client input (multi-tenant isolation rule).
+ */
+
+/** Cursor pages use the `lastMessageAt` / `createdAt` of the last item seen. */
+const cursor = z.string().datetime().optional()
+
+export const ListConversationsSchema = z.object({
+  cursor,
+})
+
+export const GetConversationSchema = z.object({
+  id: z.string().min(1).max(200),
+})
+
+export const ListMessagesSchema = z.object({
+  conversationId: z.string().min(1).max(200),
+  cursor,
+})
+
+/**
+ * Send a message. Exactly one of two entry points:
+ * - an existing `conversationId`, OR
+ * - a `proposalId` (auto-creates/looks up the proposal thread), OR
+ * - a `subject` with no proposalId (starts a general thread).
+ * The router enforces the precedence; the body cap mirrors the schema (≤5000).
+ */
+export const SendMessageSchema = z.object({
+  conversationId: z.string().min(1).max(200).optional(),
+  proposalId: z.string().min(1).max(200).optional(),
+  subject: z.string().min(1).max(200).optional(),
+  body: z.string().min(1).max(5000),
+})
+
+export const SetPreferenceSchema = z
+  .object({
+    conversationId: z.string().min(1).max(200),
+    muted: z.boolean().optional(),
+    emailOverride: z.enum(['default', 'on', 'off']).optional(),
+  })
+  .refine((v) => v.muted !== undefined || v.emailOverride !== undefined, {
+    message: 'Provide at least one of muted or emailOverride',
+  })

--- a/src/server/schemas/push.ts
+++ b/src/server/schemas/push.ts
@@ -32,5 +32,6 @@ export const PushPreferencesSchema = z.object({
   proposalDecisions: z.boolean(),
   talkConfirmed: z.boolean(),
   coSpeakerInvites: z.boolean(),
+  messages: z.boolean(),
   otherUpdates: z.boolean(),
 })


### PR DESCRIPTION
## Messaging M1 — speaker↔organizer conversations (backend only)

Backend for a speaker↔organizer messaging system, riding the shipped notification hub + web-push rail. **No UI** in this phase — M2 builds the surfaces against the link contracts below.

### Thread model
- **`conversation`** — `proposal` or `general`. A proposal thread is capped at **one per proposal** via a deterministic id (`conversation.proposal.<proposalId>`) written with `createIfNotExists`, so a race between two starters is harmless (both converge on the same doc). General threads get a random id. `subject` is stored **explicitly** (defaulted to the proposal title) so a thread renders without resolving the proposal.
- **`message`** — append-only; `addMessage` creates the message and bumps `conversation.lastMessageAt` in **one transaction**.

### Preference model (doc-per-pair — race avoidance)
- **`conversationPreference`** — exactly **one document per (conversation, speaker)** at a deterministic id (`convpref.<conversationId>.<speakerId>`), upserted with `createIfNotExists` + patch. This doc-per-pair shape exists precisely to avoid a read-modify-write race on a shared array (the push-subscriptions lesson). Fields: `muted` (default false), `emailOverride` `default|on|off` (default `default`).
- Speaker gains **`messagingEmailDefault`** (default **false** — email is opt-in).

### Channel matrix (fan-out after a successful send; never-fail contract)
| Channel | Who | Notes |
|---|---|---|
| **Hub** | recipients minus muted | new `NotificationType` `message_received`; **per-recipient** link by audience; muted read in one GROQ |
| **Push** | rides the hub | new category **`messages`**, **default ON** (works before the M2 toggle exists) |
| **Email** | opted-in, non-muted | `emailOverride === 'on'`, or `'default'` + `messagingEmailDefault` true; house react-email template, sequential with the shared rate-limit delay |
| **Slack** | speaker-authored only | mirrors `notifyNewProposal`; organizer-authored messages don't ping the channel |

Recipients: proposal thread → proposal speakers ∪ organizers − actor; general → creator ∪ organizers − actor. Muted participants are excluded from **every** channel. The whole fan-out is wrapped so a failure can never fail the (committed) message write.

### Router (`message.*`)
`listConversations`, `getConversation` (authz), `listMessages` (authz), `send` (creates the thread when needed — proposal: deterministic `createIfNotExists`; general: requires subject), `setPreference` (authz). Actor is always `ctx.speaker._id`; conference always resolved from the domain — never client input. Non-participant speakers are rejected from get/list/send/pref.

### Link contracts for M2 to implement
- proposal + organizer → `/admin/proposals/<proposalId>#messages`
- proposal + speaker → `/cfp/proposal/<proposalId>#messages`
- general + organizer → `/admin/messages/<conversationId>`
- general + speaker → `/cfp/messages/<conversationId>`

Email deep links are the absolute (`https://<domain>…`) form of the same paths, per recipient audience.

### Privacy
`/privacy` updated: a new **Messages** data-collection card (content, author, timestamps, per-conversation preferences; proposal-thread visibility = proposal speakers + organizers; general = author + organizers) and a **retention row** (retained until deleted).

### Verification
- `tsc` 0 · eslint (touched) clean · prettier · knip exit 0
- `vitest run`: **197 files, 2909 passed, 5 skipped, 0 failures**
- New suites: messaging lib (transaction shapes, deterministic ids, recipient/authz/link matrix, preference upsert), notify fan-out (per-recipient links, mute exclusion, email opt-in, slack speaker-only, never-throw), router (authz rejections + proposal auto-create idempotency), schema caps, plus `message_received → messages` push mapping.

### Deviation
- `resolveRecipients(conversation, actorId, organizerIds)` takes `organizerIds` as an explicit third arg (rather than fetching internally) so the recipient logic stays pure/testable; `notifyNewMessage` fetches organizers once and passes them. Behavior is unchanged from the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the backend for a speaker↔organizer messaging system (M1) — new Sanity schemas (`conversation`, `message`, `conversationPreference`), a data layer with race-safe deterministic IDs, a tRPC `message.*` router, and a multi-channel fan-out (hub+push, email, Slack) all riding the existing notification rail.

- **Thread model**: proposal threads use `createIfNotExists` with a fixed `conversation.proposal.<proposalId>` ID (race-safe); general threads use `nanoid`. Preferences are stored one doc-per-pair to avoid array RMW races.
- **Authorization**: actor and conference are always server-derived; the `proposalId` path correctly validates conference ownership; however, the `conversationId` path in `send`, and the `getConversation`, `listMessages`, and `setPreference` procedures do not verify the fetched conversation's `conferenceId` against the current domain's conference, allowing an organizer to cross conference boundaries.
- **Fan-out**: mute filtering applies correctly to hub and email, but the Slack notification fires outside the mute check, contradicting the stated "excluded from every channel" contract.

<h3>Confidence Score: 3/5</h3>

The core business logic (message write, race-safe conversation creation, preference upsert) is solid, but the router skips the conference-ownership check on four of its five procedures, creating a cross-conference data-access gap for organizers that should be fixed before production traffic reaches this router.

The fan-out, auth, and transaction design are well thought out, and most read paths are guarded. The conference boundary is validated on the proposal-creation path but consistently missing on every direct-by-ID fetch (`getConversation`, `listMessages`, `setPreference`, and the existing-conversation branch of `send`). Since proposal conversation IDs are deterministic and predictable, an organizer on one conference can construct and query another conference's conversation IDs.

src/server/routers/message.ts — all four procedures that fetch a conversation by client-supplied ID need a conference boundary check against the fetched conversation's `conferenceId`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/message.ts | New tRPC router for the messaging system; authz is correctly checked for most paths but `getConversation`, `listMessages`, `setPreference`, and the `conversationId` branch of `send` do not validate the conversation's conference against the current domain, allowing cross-conference reads/writes by organizers. |
| src/lib/messaging/sanity.ts | Data layer with deterministic IDs, race-safe writes (`createIfNotExists`), and pure authz helpers; dot-separated preference ID construction is potentially ambiguous for IDs containing dots, and `canAccessConversation` does not check conference membership. |
| src/lib/messaging/notify.ts | Fan-out handler with correct never-fail wrapping, per-recipient hub links, email opt-in logic, and actor exclusion; Slack fires outside the mute check, contradicting the stated "excluded from every channel" contract. |
| src/lib/messaging/email.ts | Sequential email sender with retry/backoff and rate-limit delay; mirrors the existing email sender pattern; no issues found. |
| src/lib/messaging/types.ts | Domain types for conversations, messages, preferences, and participants; well-structured with a shared `AccessSpeaker` for authz; no issues. |
| src/server/schemas/message.ts | Zod schemas for the message router; cursor validated as ISO datetime, body capped at 5000, no client-supplied actor or conference — matches multi-tenant isolation rule. |
| sanity/schemaTypes/conversation.ts | New `conversation` Sanity document type with weak proposal reference, required subject, and `lastMessageAt` ordering; correctly mirrors the runtime model. |
| sanity/schemaTypes/conversationPreference.ts | New doc-per-pair preference schema with correct references and radio options; no issues. |
| src/lib/push/send.ts | Adds `message_received → messages` push category mapping; existing push bridge logic unchanged; mapping is correct and tested. |
| src/lib/slack/notify.ts | Adds `notifyNewSpeakerMessage` alongside existing Slack notifiers; follows the same Slack block pattern and is properly gated in the caller. |
| src/lib/notification/types.ts | Adds `message_received` to the `NotificationType` union; change is minimal and correct. |
| src/lib/push/types.ts | Adds `messages` push category with default ON; correctly integrated into `PushPreferences` and `normalizePushPreferences`. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as message.ts router
    participant SanityLib as messaging/sanity.ts
    participant NotifyLib as messaging/notify.ts
    participant Hub as createNotifications (hub)
    participant Push as sendPushForNotifications
    participant Email as sendMessageEmails
    participant Slack as notifyNewSpeakerMessage

    Client->>Router: "send({ proposalId | conversationId | subject, body })"
    Router->>Router: resolveConferenceId() + ctx.speaker._id

    alt proposalId branch
        Router->>SanityLib: getProposalForConversation(proposalId)
        SanityLib-->>Router: "{ conferenceId, speakerIds }"
        Router->>Router: check conferenceId match + authz
        Router->>SanityLib: ensureProposalConversation() [createIfNotExists]
    else conversationId branch
        Router->>SanityLib: getConversationById(conversationId)
        Router->>Router: canAccessConversation() [no conference check]
    else subject branch
        Router->>SanityLib: createGeneralConversation()
    end

    Router->>SanityLib: addMessage() [transaction: message + lastMessageAt bump]
    SanityLib-->>Router: Message

    Router->>NotifyLib: notifyNewMessage() [never-fail]
    activate NotifyLib
    NotifyLib->>SanityLib: getOrganizerSpeakerIds()
    NotifyLib->>SanityLib: getConversationPreferencesFor(recipientIds)
    Note over NotifyLib: Filter muted recipients to active[]

    NotifyLib->>Hub: createNotifications(per-recipient items with audience links)
    Hub->>Push: sendPushForNotifications(items) [category: messages]

    NotifyLib->>Email: sendMessageEmails(opted-in, non-muted)

    alt speaker-authored
        NotifyLib->>Slack: notifyNewSpeakerMessage() [no mute check]
    end
    deactivate NotifyLib

    Router-->>Client: "{ conversationId, message }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as message.ts router
    participant SanityLib as messaging/sanity.ts
    participant NotifyLib as messaging/notify.ts
    participant Hub as createNotifications (hub)
    participant Push as sendPushForNotifications
    participant Email as sendMessageEmails
    participant Slack as notifyNewSpeakerMessage

    Client->>Router: "send({ proposalId | conversationId | subject, body })"
    Router->>Router: resolveConferenceId() + ctx.speaker._id

    alt proposalId branch
        Router->>SanityLib: getProposalForConversation(proposalId)
        SanityLib-->>Router: "{ conferenceId, speakerIds }"
        Router->>Router: check conferenceId match + authz
        Router->>SanityLib: ensureProposalConversation() [createIfNotExists]
    else conversationId branch
        Router->>SanityLib: getConversationById(conversationId)
        Router->>Router: canAccessConversation() [no conference check]
    else subject branch
        Router->>SanityLib: createGeneralConversation()
    end

    Router->>SanityLib: addMessage() [transaction: message + lastMessageAt bump]
    SanityLib-->>Router: Message

    Router->>NotifyLib: notifyNewMessage() [never-fail]
    activate NotifyLib
    NotifyLib->>SanityLib: getOrganizerSpeakerIds()
    NotifyLib->>SanityLib: getConversationPreferencesFor(recipientIds)
    Note over NotifyLib: Filter muted recipients to active[]

    NotifyLib->>Hub: createNotifications(per-recipient items with audience links)
    Hub->>Push: sendPushForNotifications(items) [category: messages]

    NotifyLib->>Email: sendMessageEmails(opted-in, non-muted)

    alt speaker-authored
        NotifyLib->>Slack: notifyNewSpeakerMessage() [no mute check]
    end
    deactivate NotifyLib

    Router-->>Client: "{ conversationId, message }"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): speaker↔organizer conve..."](https://github.com/cloudnativebergen/website/commit/b1e8c2e25f102b23b7566c85cc8e8972a38647d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45376770)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->