### PR TITLE
feat(messaging): conversation UI — threads, inboxes, preferences (M2)

### DIFF
--- a/__tests__/components/messaging/ConversationList.test.tsx
+++ b/__tests__/components/messaging/ConversationList.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ConversationList } from '@/components/messaging'
+import type { ConversationListItem } from '@/lib/messaging/types'
+
+const items: ConversationListItem[] = [
+  {
+    _id: 'conversation.proposal.talk-1',
+    conversationType: 'proposal',
+    subject: 'Scaling Kubernetes',
+    proposalId: 'talk-1',
+    proposalTitle: 'Scaling Kubernetes',
+    createdAt: new Date('2026-07-15T10:00:00Z').toISOString(),
+    lastMessageAt: new Date('2026-07-18T10:00:00Z').toISOString(),
+  },
+  {
+    _id: 'conversation.abc123',
+    conversationType: 'general',
+    subject: 'Travel question',
+    createdAt: new Date('2026-07-15T10:00:00Z').toISOString(),
+    lastMessageAt: new Date('2026-07-18T09:00:00Z').toISOString(),
+  },
+]
+
+function linkFor(title: string): HTMLAnchorElement | null {
+  return screen.getByText(title).closest('a')
+}
+
+describe('ConversationList', () => {
+  it('links to the speaker (cfp) surfaces for a speaker audience', () => {
+    render(<ConversationList items={items} isOrganizer={false} />)
+    // Proposal thread → the proposal page anchor.
+    expect(linkFor('Scaling Kubernetes')).toHaveAttribute(
+      'href',
+      '/cfp/proposal/talk-1#messages',
+    )
+    // General thread → the standalone speaker thread route.
+    expect(linkFor('Travel question')).toHaveAttribute(
+      'href',
+      '/cfp/messages/conversation.abc123',
+    )
+  })
+
+  it('links to the organizer (admin) surfaces for an organizer audience', () => {
+    render(<ConversationList items={items} isOrganizer={true} />)
+    expect(linkFor('Scaling Kubernetes')).toHaveAttribute(
+      'href',
+      '/admin/proposals/talk-1#messages',
+    )
+    expect(linkFor('Travel question')).toHaveAttribute(
+      'href',
+      '/admin/messages/conversation.abc123',
+    )
+  })
+
+  it('renders the empty state when there are no conversations', () => {
+    render(<ConversationList items={[]} isOrganizer={false} />)
+    expect(screen.getByText(/no conversations yet/i)).toBeInTheDocument()
+  })
+
+  it('exposes the inbox as a named region landmark', () => {
+    render(<ConversationList items={items} isOrganizer={false} />)
+    expect(
+      screen.getByRole('region', { name: 'Conversations' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/messaging/ConversationThread.test.tsx
+++ b/__tests__/components/messaging/ConversationThread.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ConversationThreadView } from '@/components/messaging'
+import type { DisplayMessage } from '@/components/messaging'
+import type { ConversationPreference } from '@/lib/messaging/types'
+
+const messages: DisplayMessage[] = [
+  {
+    id: 'm1',
+    authorName: 'Program Committee',
+    isOrganizer: true,
+    isOwn: false,
+    body: 'Could you shorten the abstract?',
+    createdAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+  },
+  {
+    id: 'm2',
+    authorName: 'Åsa Berg',
+    isOrganizer: false,
+    isOwn: true,
+    body: 'Sure — updated now.',
+    createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+  },
+]
+
+const preference: ConversationPreference = {
+  muted: false,
+  emailOverride: 'default',
+}
+
+function renderView(
+  props: Partial<React.ComponentProps<typeof ConversationThreadView>> = {},
+) {
+  return render(
+    <ConversationThreadView
+      messages={messages}
+      emptyText="Start the conversation with the organizers."
+      onSend={vi.fn()}
+      {...props}
+    />,
+  )
+}
+
+describe('ConversationThreadView', () => {
+  it('renders each message body and author', () => {
+    renderView()
+    expect(
+      screen.getByText('Could you shorten the abstract?'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Sure — updated now.')).toBeInTheDocument()
+    expect(screen.getByText('Program Committee')).toBeInTheDocument()
+  })
+
+  it('shows the empty-state copy when there are no messages', () => {
+    renderView({ messages: [] })
+    expect(
+      screen.getByText('Start the conversation with the organizers.'),
+    ).toBeInTheDocument()
+  })
+
+  it('calls onSend with the trimmed body and clears the composer', () => {
+    const onSend = vi.fn()
+    renderView({ onSend })
+    const textarea = screen.getByLabelText(/write a message/i)
+    fireEvent.change(textarea, { target: { value: '  Hello there  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onSend).toHaveBeenCalledWith('Hello there')
+    expect((textarea as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('disables Send when the composer is empty or whitespace', () => {
+    renderView()
+    const sendButton = screen.getByRole('button', { name: 'Send' })
+    expect(sendButton).toBeDisabled()
+    fireEvent.change(screen.getByLabelText(/write a message/i), {
+      target: { value: '   ' },
+    })
+    expect(sendButton).toBeDisabled()
+  })
+
+  it('sends on Cmd/Ctrl+Enter', () => {
+    const onSend = vi.fn()
+    renderView({ onSend })
+    const textarea = screen.getByLabelText(/write a message/i)
+    fireEvent.change(textarea, { target: { value: 'Quick reply' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true })
+    expect(onSend).toHaveBeenCalledWith('Quick reply')
+  })
+
+  it('does not render the preferences bar without onSetMuted', () => {
+    renderView({ preference })
+    expect(
+      screen.queryByRole('button', { name: /mute/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls onSetMuted when the mute toggle is pressed', () => {
+    const onSetMuted = vi.fn()
+    renderView({ preference, onSetMuted })
+    fireEvent.click(screen.getByRole('button', { name: /mute/i }))
+    expect(onSetMuted).toHaveBeenCalledWith(true)
+  })
+
+  it('calls onSetEmailOverride when the email preference changes', () => {
+    const onSetEmailOverride = vi.fn()
+    renderView({ preference, onSetMuted: vi.fn(), onSetEmailOverride })
+    fireEvent.change(
+      screen.getByLabelText(/email notifications for this conversation/i),
+      { target: { value: 'off' } },
+    )
+    expect(onSetEmailOverride).toHaveBeenCalledWith('off')
+  })
+
+  it('renders a distinct error state on load failure', () => {
+    renderView({ messages: [], isError: true })
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /couldn.t load this conversation/i,
+    )
+  })
+})

--- a/src/app/(admin)/admin/messages/[id]/page.tsx
+++ b/src/app/(admin)/admin/messages/[id]/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+import { BackLink } from '@/components/BackButton'
+import { ConversationThread } from '@/components/messaging'
+
+export const metadata: Metadata = {
+  title: 'Conversation',
+  robots: { index: false, follow: false },
+}
+
+interface AdminConversationPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function AdminConversationPage({
+  params,
+}: AdminConversationPageProps) {
+  const { id } = await params
+
+  return (
+    <div className="mx-auto max-w-3xl p-4">
+      <div className="mb-4">
+        <BackLink fallbackUrl="/admin/messages">Back to Messages</BackLink>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <ConversationThread conversationId={id} audience="organizer" />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/messages/page.tsx
+++ b/src/app/(admin)/admin/messages/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next'
+import { MessagesInbox } from '@/components/messaging'
+
+export const metadata: Metadata = {
+  title: 'Messages',
+  robots: { index: false, follow: false },
+}
+
+export default function AdminMessagesPage() {
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <h1 className="font-space-grotesk text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Messages
+        </h1>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Conversations with speakers across the conference.
+        </p>
+      </div>
+
+      <MessagesInbox audience="organizer" />
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/proposals/[id]/page.tsx
+++ b/src/app/(admin)/admin/proposals/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   AudienceFeedbackPanel,
 } from '@/components/admin'
 import { BackLink } from '@/components/BackButton'
+import { ProposalMessagesSection } from '@/components/messaging'
 import { getAuthSession } from '@/lib/auth'
 import { getProposalVideoUrl } from '@/lib/proposal/video'
 
@@ -82,6 +83,13 @@ export default async function ProposalDetailPage({
             </div>
 
             <ProposalDetail proposal={proposal} />
+
+            <div className="mt-6">
+              <ProposalMessagesSection
+                proposalId={proposal._id}
+                audience="organizer"
+              />
+            </div>
           </div>
         </div>
 

--- a/src/app/(cfp)/cfp/messages/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/messages/[id]/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+import { BackLink } from '@/components/BackButton'
+import { ConversationThread } from '@/components/messaging'
+
+export const metadata: Metadata = {
+  title: 'Conversation',
+  robots: { index: false, follow: false },
+}
+
+interface CfpConversationPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function CfpConversationPage({
+  params,
+}: CfpConversationPageProps) {
+  const { id } = await params
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-4">
+        <BackLink fallbackUrl="/cfp/messages">Back to Messages</BackLink>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <ConversationThread conversationId={id} audience="speaker" />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(cfp)/cfp/messages/page.tsx
+++ b/src/app/(cfp)/cfp/messages/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next'
+import { MessagesInbox } from '@/components/messaging'
+
+export const metadata: Metadata = {
+  title: 'Messages',
+  robots: { index: false, follow: false },
+}
+
+export default function CfpMessagesPage() {
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <h1 className="font-space-grotesk text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Messages
+        </h1>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Your conversations with the organizers.
+        </p>
+      </div>
+
+      <MessagesInbox audience="speaker" allowNew />
+    </div>
+  )
+}

--- a/src/app/(cfp)/cfp/proposal/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/proposal/[id]/page.tsx
@@ -12,6 +12,7 @@ import { ProposalGuidanceSidebar } from '@/components/cfp/ProposalGuidanceSideba
 import { PostConferenceVideoPanel } from '@/components/cfp/PostConferenceVideoPanel'
 import { PostConferenceAudienceFeedbackPanel } from '@/components/cfp/PostConferenceAudienceFeedbackPanel'
 import { ProposalAttachmentsPanel } from '@/components/proposal/ProposalAttachmentsPanel'
+import { ProposalMessagesSection } from '@/components/messaging'
 import { isConferenceOver } from '@/lib/conference/state'
 import { BackLink } from '@/components/BackButton'
 import { buildUrlWithImpersonation } from '@/lib/impersonation'
@@ -160,6 +161,10 @@ export default async function ProposalViewPage({
             <ProposalGuidanceSidebar conference={conference} />
           </div>
         </div>
+
+        <div className="mt-6 max-w-4xl">
+          <ProposalMessagesSection proposalId={id} audience="speaker" />
+        </div>
       </div>
     )
   }
@@ -211,6 +216,10 @@ export default async function ProposalViewPage({
             )}
           </div>
         )}
+      </div>
+
+      <div className="mt-6 max-w-4xl">
+        <ProposalMessagesSection proposalId={id} audience="speaker" />
       </div>
     </div>
   )

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -13,6 +13,7 @@ import {
   PresentationChartBarIcon,
   AcademicCapIcon,
   CpuChipIcon,
+  EnvelopeIcon,
 } from '@heroicons/react/24/outline'
 import {
   DashboardLayout,
@@ -28,6 +29,7 @@ const navigation: NavigationSection[] = [
       { name: 'Dashboard', href: '/admin', icon: HomeIcon },
       { name: 'Proposals', href: '/admin/proposals', icon: DocumentTextIcon },
       { name: 'Schedule', href: '/admin/schedule', icon: CalendarDaysIcon },
+      { name: 'Messages', href: '/admin/messages', icon: EnvelopeIcon },
     ],
   },
   {

--- a/src/components/cfp/CFPLayout.tsx
+++ b/src/components/cfp/CFPLayout.tsx
@@ -6,6 +6,7 @@ import {
   PlusIcon,
   ListBulletIcon,
   CreditCardIcon,
+  ChatBubbleLeftRightIcon,
 } from '@heroicons/react/24/outline'
 import { AppEnvironment } from '@/lib/environment/config'
 import {
@@ -44,6 +45,11 @@ export function CFPLayout({ children, conferenceLogos }: CFPLayoutProps) {
       name: 'My Proposals',
       href: `/cfp/list${impersonateQuery}`,
       icon: ListBulletIcon,
+    },
+    {
+      name: 'Messages',
+      href: `/cfp/messages${impersonateQuery}`,
+      icon: ChatBubbleLeftRightIcon,
     },
   ]
 

--- a/src/components/cfp/CFPProfilePage.tsx
+++ b/src/components/cfp/CFPProfilePage.tsx
@@ -289,6 +289,54 @@ export function CFPProfilePage({
             className="space-y-6"
           />
 
+          <section
+            aria-labelledby="messaging-emails-heading"
+            className="border-t border-gray-200 pt-6 dark:border-gray-600"
+          >
+            <h2
+              id="messaging-emails-heading"
+              className="font-space-grotesk text-lg font-semibold text-gray-900 dark:text-white"
+            >
+              Message emails
+            </h2>
+            <div className="mt-3 flex items-start justify-between gap-4">
+              <label
+                htmlFor="messaging-email-default"
+                className="font-inter flex-1 text-sm text-gray-600 dark:text-gray-400"
+              >
+                Email me when an organizer replies in one of my conversations.
+                You can still override this per conversation.
+              </label>
+              <button
+                type="button"
+                role="switch"
+                id="messaging-email-default"
+                aria-checked={speakerData.messagingEmailDefault === true}
+                aria-label="Email me about new messages"
+                onClick={() =>
+                  setSpeakerData((prev) => ({
+                    ...prev,
+                    messagingEmailDefault: !prev.messagingEmailDefault,
+                  }))
+                }
+                className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue ${
+                  speakerData.messagingEmailDefault
+                    ? 'bg-brand-cloud-blue dark:bg-blue-600'
+                    : 'bg-gray-200 dark:bg-gray-600'
+                }`}
+              >
+                <span
+                  aria-hidden="true"
+                  className={`pointer-events-none inline-block h-5 w-5 translate-y-0.5 rounded-full bg-white shadow-sm transition-transform ${
+                    speakerData.messagingEmailDefault
+                      ? 'translate-x-5'
+                      : 'translate-x-0.5'
+                  }`}
+                />
+              </button>
+            </div>
+          </section>
+
           <PushNotificationSettings />
 
           <div className="flex justify-end border-t border-gray-200 pt-6 dark:border-gray-600">

--- a/src/components/messaging/ConversationList.stories.tsx
+++ b/src/components/messaging/ConversationList.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { mockDateBeforeEach } from '@/lib/storybook'
+import { ConversationList } from '@/components/messaging'
+import type { ConversationListItem } from '@/lib/messaging/types'
+
+const minutesAgo = (m: number) =>
+  new Date(Date.now() - m * 60_000).toISOString()
+
+const makeItems = (): ConversationListItem[] => [
+  {
+    _id: 'conversation.proposal.talk-1',
+    conversationType: 'proposal',
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    proposalId: 'talk-1',
+    proposalTitle: 'Scaling Kubernetes to 10,000 nodes',
+    createdAt: minutesAgo(60 * 24 * 3),
+    lastMessageAt: minutesAgo(24),
+  },
+  {
+    _id: 'conversation.abc123',
+    conversationType: 'general',
+    subject: 'Question about speaker travel',
+    createdAt: minutesAgo(60 * 24 * 2),
+    lastMessageAt: minutesAgo(60 * 5),
+  },
+  {
+    _id: 'conversation.proposal.talk-2',
+    conversationType: 'proposal',
+    subject: 'Designing for Failure',
+    proposalId: 'talk-2',
+    proposalTitle: 'Designing for Failure',
+    createdAt: minutesAgo(60 * 24 * 10),
+    lastMessageAt: minutesAgo(60 * 24 * 4),
+  },
+]
+
+const meta = {
+  title: 'Components/Messaging/ConversationList',
+  component: ConversationList,
+  beforeEach: mockDateBeforeEach(new Date('2026-07-18T12:00:00Z')),
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story, ctx) => (
+      <div className={ctx.parameters.dark ? 'dark bg-gray-950 p-4' : ''}>
+        <div className="mx-auto w-full max-w-2xl">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof ConversationList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Speaker inbox — rows link to `/cfp/...`. */
+export const SpeakerInbox: Story = {
+  args: { items: [], isOrganizer: false },
+  render: (args) => <ConversationList {...args} items={makeItems()} />,
+}
+
+/** Organizer inbox — same data, rows link to `/admin/...`. */
+export const OrganizerInbox: Story = {
+  args: { items: [], isOrganizer: true },
+  render: (args) => <ConversationList {...args} items={makeItems()} />,
+}
+
+export const Empty: Story = {
+  args: { items: [], isOrganizer: false },
+}
+
+export const Loading: Story = {
+  args: { items: [], isOrganizer: false, isLoading: true },
+}
+
+export const HasMore: Story = {
+  args: { items: [], isOrganizer: false, hasMore: true },
+  render: (args) => <ConversationList {...args} items={makeItems()} />,
+}
+
+export const SpeakerInboxDark: Story = {
+  args: { items: [], isOrganizer: false },
+  parameters: { dark: true },
+  render: (args) => <ConversationList {...args} items={makeItems()} />,
+}

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import Link from 'next/link'
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline'
+import { conversationLinkPath } from '@/lib/messaging/links'
+import { formatRelativeTime } from '@/lib/notification/format'
+import type { ConversationListItem } from '@/lib/messaging/types'
+
+export interface ConversationListProps {
+  /** Conversations, newest activity first. Ignored while `isLoading`. */
+  items: ConversationListItem[]
+  /**
+   * The viewer's audience. Drives the per-row deep link (organizers → /admin,
+   * speakers → /cfp) via the shared {@link conversationLinkPath} contract.
+   */
+  isOrganizer: boolean
+  isLoading?: boolean
+  isError?: boolean
+  hasMore?: boolean
+  onShowMore?: () => void
+  isLoadingMore?: boolean
+}
+
+function SkeletonRow() {
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3">
+      <div className="h-4 w-2/3 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+      <div className="h-3 w-1/4 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+    </div>
+  )
+}
+
+function conversationTitle(item: ConversationListItem): string {
+  if (item.subject && item.subject.trim().length > 0) return item.subject
+  if (item.proposalTitle && item.proposalTitle.trim().length > 0) {
+    return item.proposalTitle
+  }
+  return 'Conversation'
+}
+
+/**
+ * Presentational inbox: one row per conversation linking to its thread for the
+ * given audience. Pure — the container supplies data and pagination handlers so
+ * this renders without tRPC in Storybook and tests.
+ */
+export function ConversationList({
+  items,
+  isOrganizer,
+  isLoading = false,
+  isError = false,
+  hasMore = false,
+  onShowMore,
+  isLoadingMore = false,
+}: ConversationListProps) {
+  return (
+    <div
+      role="region"
+      aria-label="Conversations"
+      className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200 bg-white dark:divide-gray-800/70 dark:border-gray-700 dark:bg-gray-800"
+    >
+      {isLoading ? (
+        <>
+          <SkeletonRow />
+          <SkeletonRow />
+          <SkeletonRow />
+        </>
+      ) : isError ? (
+        <div
+          role="alert"
+          className="flex flex-col items-center justify-center gap-1 px-6 py-10 text-center"
+        >
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+            Couldn&apos;t load conversations
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Check your connection and try again.
+          </p>
+        </div>
+      ) : items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
+          <ChatBubbleLeftRightIcon
+            aria-hidden="true"
+            className="h-10 w-10 text-gray-300 dark:text-gray-600"
+          />
+          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+            No conversations yet
+          </p>
+        </div>
+      ) : (
+        <>
+          {items.map((item) => (
+            <Link
+              key={item._id}
+              href={conversationLinkPath(item, isOrganizer)}
+              prefetch={false}
+              className="flex items-baseline justify-between gap-3 px-4 py-3 transition hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-semibold text-gray-900 dark:text-white">
+                  {conversationTitle(item)}
+                </span>
+                {item.conversationType === 'proposal' && (
+                  <span className="mt-0.5 block text-xs text-gray-400 dark:text-gray-500">
+                    Proposal thread
+                  </span>
+                )}
+              </span>
+              <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+                {formatRelativeTime(item.lastMessageAt)}
+              </span>
+            </Link>
+          ))}
+          {hasMore && (
+            <div className="p-2">
+              <button
+                type="button"
+                onClick={onShowMore}
+                disabled={isLoadingMore}
+                className="w-full rounded-lg px-4 py-2 text-center text-xs font-medium text-brand-cloud-blue transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset disabled:cursor-not-allowed disabled:text-gray-300 dark:hover:bg-gray-800/60 dark:disabled:text-gray-600"
+              >
+                {isLoadingMore ? 'Loading…' : 'Show more'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/messaging/ConversationThread.stories.tsx
+++ b/src/components/messaging/ConversationThread.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { mockDateBeforeEach } from '@/lib/storybook'
+import {
+  ConversationThreadView,
+  type DisplayMessage,
+} from '@/components/messaging'
+import type { ConversationPreference } from '@/lib/messaging/types'
+
+// createdAt values are computed relative to RENDER time so the compact
+// relative-time labels are deterministic under the pinned Date below.
+const minutesAgo = (m: number) =>
+  new Date(Date.now() - m * 60_000).toISOString()
+
+const makeMessages = (): DisplayMessage[] => [
+  {
+    id: 'm1',
+    authorName: 'Program Committee',
+    isOrganizer: true,
+    isOwn: false,
+    body: 'Hi! Thanks for submitting "Scaling Kubernetes to 10,000 nodes". We loved the topic and have a couple of small questions before the review.',
+    createdAt: minutesAgo(180),
+  },
+  {
+    id: 'm2',
+    authorName: 'Åsa Berg',
+    isOrganizer: false,
+    isOwn: true,
+    body: 'Thanks so much! Happy to help — ask away.',
+    createdAt: minutesAgo(120),
+  },
+  {
+    id: 'm3',
+    authorName: 'Program Committee',
+    isOrganizer: true,
+    isOwn: false,
+    body: 'Could you shorten the abstract to about three sentences so it fits the printed programme?',
+    createdAt: minutesAgo(28),
+  },
+]
+
+const defaultPreference: ConversationPreference = {
+  muted: false,
+  emailOverride: 'default',
+}
+
+const meta = {
+  title: 'Components/Messaging/ConversationThread',
+  component: ConversationThreadView,
+  // AGENTS.md deterministic-dates rule: pin Date so relative-time labels are
+  // fixed for visual snapshots.
+  beforeEach: mockDateBeforeEach(new Date('2026-07-18T12:00:00Z')),
+  parameters: { layout: 'padded' },
+  args: {
+    onSend: fn(),
+    onComposingChange: fn(),
+    onSetMuted: fn(),
+    onSetEmailOverride: fn(),
+    emptyText: 'Start the conversation with the organizers.',
+  },
+  decorators: [
+    // `.dark` is applied at the OUTERMOST node (via `parameters.dark`) so every
+    // `dark:` variant inside the card activates for the dark capture.
+    (Story, ctx) => (
+      <div className={ctx.parameters.dark ? 'dark bg-gray-950 p-4' : ''}>
+        <div className="mx-auto w-full max-w-2xl rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof ConversationThreadView>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** A proposal thread with organizer and own messages, plus the prefs bar. */
+export const WithMessages: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/** The proposal-mount empty state before anyone has posted (composer shows). */
+export const Empty: Story = {
+  args: {
+    messages: [],
+    emptyText: 'Start the conversation with the organizers.',
+    // Mirrors the real proposal mount: no prefs/header until the thread exists.
+    onSetMuted: undefined,
+  },
+}
+
+/** Muted conversation with email delivery forced on. */
+export const MutedWithEmailOn: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: { muted: true, emailOverride: 'on' },
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/** Loading skeletons while the first page fetches. */
+export const Loading: Story = {
+  args: { messages: [], isLoading: true },
+}
+
+/** Older messages remain — a "Show earlier messages" control is offered. */
+export const HasMore: Story = {
+  args: { messages: [], hasMore: true, preference: defaultPreference },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/** Dark theme, with messages. */
+export const WithMessagesDark: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+  },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/** Dark theme, empty state. */
+export const EmptyDark: Story = {
+  args: {
+    messages: [],
+    emptyText: 'Start the conversation with the organizers.',
+    onSetMuted: undefined,
+  },
+  parameters: { dark: true },
+}

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -1,0 +1,475 @@
+'use client'
+
+import { useMemo, useRef, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import {
+  BellIcon,
+  BellSlashIcon,
+  PaperAirplaneIcon,
+} from '@heroicons/react/24/outline'
+import { api } from '@/lib/trpc/client'
+import { proposalConversationId } from '@/lib/messaging/links'
+import { formatRelativeTime } from '@/lib/notification/format'
+import type {
+  ConversationPreference,
+  EmailOverride,
+} from '@/lib/messaging/types'
+
+/** How many messages a single keyset page returns (mirrors the server). */
+const PAGE_SIZE = 20
+
+/** The maximum message body length (mirrors `SendMessageSchema`). */
+const MAX_BODY = 5000
+
+/** A message flattened for display: author identity + own/other alignment. */
+export interface DisplayMessage {
+  id: string
+  authorName: string
+  authorImage?: string
+  isOrganizer: boolean
+  /** True when the current viewer authored the message (right-aligned accent). */
+  isOwn: boolean
+  body: string
+  createdAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Presentational view (pure — storied and tested without tRPC)
+// ---------------------------------------------------------------------------
+
+export interface ConversationThreadViewProps {
+  /** Messages oldest-first (newest at the bottom, chat convention). */
+  messages: DisplayMessage[]
+  isLoading?: boolean
+  isError?: boolean
+  /** A full previous page implies older messages remain. */
+  hasMore?: boolean
+  onShowMore?: () => void
+  isLoadingMore?: boolean
+  /** Empty-state copy (audience-specific "start the conversation …"). */
+  emptyText: string
+  /** Optional thread subject shown above the messages. */
+  subject?: string
+  /** Send a (trimmed, non-empty) message body. */
+  onSend: (body: string) => void
+  isSending?: boolean
+  /** Reports composer focus so the container can pause polling while typing. */
+  onComposingChange?: (composing: boolean) => void
+  /**
+   * The viewer's per-conversation preference. When `onSetMuted` is provided the
+   * preferences bar renders; the proposal mount omits it until the conversation
+   * exists.
+   */
+  preference?: ConversationPreference
+  onSetMuted?: (muted: boolean) => void
+  onSetEmailOverride?: (override: EmailOverride) => void
+  isSavingPreference?: boolean
+}
+
+function MessageSkeleton() {
+  return (
+    <div className="space-y-3" aria-hidden="true">
+      <div className="flex justify-start">
+        <div className="h-12 w-2/3 animate-pulse rounded-2xl bg-gray-100 dark:bg-gray-800" />
+      </div>
+      <div className="flex justify-end">
+        <div className="h-10 w-1/2 animate-pulse rounded-2xl bg-gray-100 dark:bg-gray-800" />
+      </div>
+      <div className="flex justify-start">
+        <div className="h-8 w-1/3 animate-pulse rounded-2xl bg-gray-100 dark:bg-gray-800" />
+      </div>
+    </div>
+  )
+}
+
+function MessageBubble({ message }: { message: DisplayMessage }) {
+  const { isOwn } = message
+  return (
+    <div className={isOwn ? 'flex justify-end' : 'flex justify-start'}>
+      <div className={isOwn ? 'max-w-[80%]' : 'max-w-[80%]'}>
+        <div
+          className={`flex items-baseline gap-2 ${isOwn ? 'justify-end' : 'justify-start'}`}
+        >
+          <span className="text-xs font-semibold text-gray-700 dark:text-gray-200">
+            {message.authorName}
+          </span>
+          {message.isOrganizer && (
+            <span className="rounded-full bg-brand-cloud-blue/10 px-1.5 py-0.5 text-[10px] font-medium text-brand-cloud-blue dark:bg-blue-400/10 dark:text-blue-300">
+              Organizer
+            </span>
+          )}
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            {formatRelativeTime(message.createdAt)}
+          </span>
+        </div>
+        <div
+          className={`mt-1 rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap ${
+            isOwn
+              ? 'bg-brand-cloud-blue text-white dark:bg-blue-600'
+              : 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+          }`}
+        >
+          {message.body}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function PreferencesBar({
+  preference,
+  onSetMuted,
+  onSetEmailOverride,
+  isSavingPreference,
+}: {
+  preference: ConversationPreference
+  onSetMuted: (muted: boolean) => void
+  onSetEmailOverride?: (override: EmailOverride) => void
+  isSavingPreference?: boolean
+}) {
+  const { muted, emailOverride } = preference
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        onClick={() => onSetMuted(!muted)}
+        disabled={isSavingPreference}
+        aria-pressed={muted}
+        title={muted ? 'Muted — click to unmute' : 'Mute this conversation'}
+        className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
+      >
+        {muted ? (
+          <BellSlashIcon className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <BellIcon className="h-4 w-4" aria-hidden="true" />
+        )}
+        {muted ? 'Muted' : 'Mute'}
+      </button>
+
+      <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+        <span>Emails</span>
+        <select
+          value={emailOverride}
+          disabled={isSavingPreference || !onSetEmailOverride}
+          onChange={(e) =>
+            onSetEmailOverride?.(e.target.value as EmailOverride)
+          }
+          aria-label="Email notifications for this conversation"
+          className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 focus:border-brand-cloud-blue focus:outline-none disabled:opacity-50 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200"
+        >
+          <option value="default">Default</option>
+          <option value="on">Always</option>
+          <option value="off">Never</option>
+        </select>
+      </label>
+    </div>
+  )
+}
+
+/**
+ * Presentational thread: a scrollable message list (oldest-first), an optional
+ * preferences bar, and a composer. Pure — every side effect arrives via props so
+ * it renders deterministically in Storybook and unit tests.
+ */
+export function ConversationThreadView({
+  messages,
+  isLoading = false,
+  isError = false,
+  hasMore = false,
+  onShowMore,
+  isLoadingMore = false,
+  emptyText,
+  subject,
+  onSend,
+  isSending = false,
+  onComposingChange,
+  preference,
+  onSetMuted,
+  onSetEmailOverride,
+  isSavingPreference = false,
+}: ConversationThreadViewProps) {
+  const [draft, setDraft] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const submit = () => {
+    const body = draft.trim()
+    if (!body || isSending) return
+    onSend(body)
+    setDraft('')
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault()
+      submit()
+    }
+  }
+
+  return (
+    <div
+      role="region"
+      aria-label={subject ? `Conversation: ${subject}` : 'Conversation'}
+      className="flex flex-col"
+    >
+      {(subject || onSetMuted) && (
+        <div className="flex items-center justify-between gap-3 border-b border-gray-200 pb-3 dark:border-gray-700">
+          {subject ? (
+            <h2 className="truncate text-sm font-semibold text-gray-900 dark:text-white">
+              {subject}
+            </h2>
+          ) : (
+            <span />
+          )}
+          {onSetMuted && preference && (
+            <PreferencesBar
+              preference={preference}
+              onSetMuted={onSetMuted}
+              onSetEmailOverride={onSetEmailOverride}
+              isSavingPreference={isSavingPreference}
+            />
+          )}
+        </div>
+      )}
+
+      <div className="max-h-[60vh] min-h-[8rem] space-y-3 overflow-y-auto py-4">
+        {isLoading ? (
+          <MessageSkeleton />
+        ) : isError ? (
+          <div
+            role="alert"
+            className="flex flex-col items-center justify-center gap-1 py-10 text-center"
+          >
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Couldn&apos;t load this conversation
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Check your connection and try again.
+            </p>
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-1 py-10 text-center">
+            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+              {emptyText}
+            </p>
+          </div>
+        ) : (
+          <>
+            {hasMore && (
+              <div className="flex justify-center">
+                <button
+                  type="button"
+                  onClick={onShowMore}
+                  disabled={isLoadingMore}
+                  className="rounded-lg px-3 py-1.5 text-xs font-medium text-brand-cloud-blue transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:text-gray-300 dark:hover:bg-gray-800/60 dark:disabled:text-gray-600"
+                >
+                  {isLoadingMore ? 'Loading…' : 'Show earlier messages'}
+                </button>
+              </div>
+            )}
+            {messages.map((message) => (
+              <MessageBubble key={message.id} message={message} />
+            ))}
+          </>
+        )}
+      </div>
+
+      <div className="border-t border-gray-200 pt-3 dark:border-gray-700">
+        <label htmlFor="message-composer" className="sr-only">
+          Write a message
+        </label>
+        <textarea
+          id="message-composer"
+          ref={textareaRef}
+          value={draft}
+          maxLength={MAX_BODY}
+          rows={3}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={() => onComposingChange?.(true)}
+          onBlur={() => onComposingChange?.(false)}
+          placeholder="Write a message…"
+          className="block w-full resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-brand-cloud-blue focus:outline-none focus-visible:ring-1 focus-visible:ring-brand-cloud-blue dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder-gray-500"
+        />
+        <div className="mt-2 flex items-center justify-between">
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            {draft.length}/{MAX_BODY} · ⌘/Ctrl+Enter to send
+          </span>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={draft.trim().length === 0 || isSending}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-500"
+          >
+            <PaperAirplaneIcon className="h-4 w-4" aria-hidden="true" />
+            {isSending ? 'Sending…' : 'Send'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Container (wires the presentational view to the `message` tRPC router)
+// ---------------------------------------------------------------------------
+
+function errorCode(error: unknown): string | undefined {
+  return (error as { data?: { code?: string } } | null)?.data?.code
+}
+
+export interface ConversationThreadProps {
+  /** An existing conversation id (general threads, inbox routes). */
+  conversationId?: string
+  /**
+   * A proposal id (proposal mounts). The thread id is the deterministic
+   * `conversation.proposal.<id>`; the conversation is auto-created on first send.
+   */
+  proposalId?: string
+  /** The viewer's audience — only affects the empty-state wording. */
+  audience: 'speaker' | 'organizer'
+}
+
+/**
+ * Data container shared by BOTH audiences. Resolves the conversation id (given
+ * directly, or derived from a proposal id), loads the participant context and
+ * the keyset-paginated messages, and renders {@link ConversationThreadView}.
+ *
+ * PROPOSAL MOUNTS: before anyone has posted, the deterministic conversation does
+ * not exist yet, so `getConversation` / `listMessages` return NOT_FOUND. That is
+ * treated as an empty thread (composer still renders); the first `send` with a
+ * `proposalId` creates the conversation and the queries then resolve.
+ */
+export function ConversationThread({
+  conversationId,
+  proposalId,
+  audience,
+}: ConversationThreadProps) {
+  const { data: session } = useSession()
+  const meId = session?.speaker?._id
+  const utils = api.useUtils()
+  const [isComposing, setIsComposing] = useState(false)
+
+  const convId =
+    conversationId ??
+    (proposalId ? proposalConversationId(proposalId) : undefined)
+
+  // Don't retry a NOT_FOUND (a not-yet-created proposal thread) — it's expected.
+  const retry = (count: number, error: unknown) =>
+    errorCode(error) !== 'NOT_FOUND' && count < 2
+
+  const conversationQuery = api.message.getConversation.useQuery(
+    { id: convId ?? '' },
+    { enabled: !!convId, retry, staleTime: 10_000 },
+  )
+  const conversationExists =
+    !!conversationQuery.data &&
+    errorCode(conversationQuery.error) !== 'NOT_FOUND'
+
+  const messagesQuery = api.message.listMessages.useInfiniteQuery(
+    { conversationId: convId ?? '' },
+    {
+      enabled: !!convId,
+      retry,
+      staleTime: 10_000,
+      // Pause polling while the composer is focused so a refetch can't yank
+      // scroll/state out from under someone mid-message.
+      refetchInterval: isComposing ? false : 20_000,
+      getNextPageParam: (lastPage) =>
+        lastPage.length === PAGE_SIZE
+          ? lastPage[lastPage.length - 1]?.createdAt
+          : undefined,
+      initialCursor: undefined,
+    },
+  )
+  const messagesNotFound = errorCode(messagesQuery.error) === 'NOT_FOUND'
+
+  const participants = conversationQuery.data?.participants
+  const participantById = useMemo(() => {
+    const map = new Map<
+      string,
+      { name: string; image?: string; isOrganizer: boolean }
+    >()
+    for (const p of participants ?? []) map.set(p._id, p)
+    return map
+  }, [participants])
+
+  const pages = messagesQuery.data?.pages
+  const messages: DisplayMessage[] = useMemo(() => {
+    // Server returns newest-first across pages; flatten then reverse to
+    // oldest-first (chat convention, newest at the bottom).
+    const flat = pages?.flat() ?? []
+    return [...flat].reverse().map((msg) => {
+      const p = participantById.get(msg.authorId)
+      return {
+        id: msg._id,
+        authorName: p?.name ?? 'Unknown',
+        authorImage: p?.image,
+        isOrganizer: p?.isOrganizer ?? false,
+        isOwn: !!meId && msg.authorId === meId,
+        body: msg.body,
+        createdAt: msg.createdAt,
+      }
+    })
+  }, [pages, participantById, meId])
+
+  const invalidate = () => {
+    if (convId) {
+      utils.message.listMessages.invalidate({ conversationId: convId })
+      utils.message.getConversation.invalidate({ id: convId })
+    }
+    utils.message.listConversations.invalidate()
+  }
+
+  const sendMutation = api.message.send.useMutation({ onSuccess: invalidate })
+  const preferenceMutation = api.message.setPreference.useMutation({
+    onSuccess: invalidate,
+  })
+
+  const handleSend = (body: string) => {
+    // A not-yet-created proposal thread must be opened via `proposalId`; once it
+    // exists (or for a real conversation id) post directly to the conversation.
+    if (proposalId && !conversationExists) {
+      sendMutation.mutate({ proposalId, body })
+    } else if (convId) {
+      sendMutation.mutate({ conversationId: convId, body })
+    }
+  }
+
+  const emptyText =
+    audience === 'organizer'
+      ? 'Start the conversation with the speakers.'
+      : 'Start the conversation with the organizers.'
+
+  return (
+    <ConversationThreadView
+      messages={messages}
+      isLoading={messagesQuery.isLoading && !messagesNotFound}
+      isError={messagesQuery.isError && !messagesNotFound}
+      hasMore={messagesQuery.hasNextPage}
+      onShowMore={() => messagesQuery.fetchNextPage()}
+      isLoadingMore={messagesQuery.isFetchingNextPage}
+      emptyText={emptyText}
+      subject={conversationQuery.data?.conversation.subject}
+      onSend={handleSend}
+      isSending={sendMutation.isPending}
+      onComposingChange={setIsComposing}
+      preference={conversationQuery.data?.preference}
+      onSetMuted={
+        conversationExists && convId
+          ? (muted) =>
+              preferenceMutation.mutate({ conversationId: convId, muted })
+          : undefined
+      }
+      onSetEmailOverride={
+        conversationExists && convId
+          ? (emailOverride) =>
+              preferenceMutation.mutate({
+                conversationId: convId,
+                emailOverride,
+              })
+          : undefined
+      }
+      isSavingPreference={preferenceMutation.isPending}
+    />
+  )
+}

--- a/src/components/messaging/MessagesInbox.tsx
+++ b/src/components/messaging/MessagesInbox.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState } from 'react'
+import { PlusIcon } from '@heroicons/react/24/outline'
+import { api } from '@/lib/trpc/client'
+import { ConversationList } from './ConversationList'
+import { NewConversationForm } from './NewConversationForm'
+
+/** Page size for the inbox (mirrors the server keyset page). */
+const PAGE_SIZE = 20
+
+export interface MessagesInboxProps {
+  /** The viewer's audience — drives per-row links and the inbox base path. */
+  audience: 'speaker' | 'organizer'
+  /** When true, a "New conversation" affordance (general threads) is shown. */
+  allowNew?: boolean
+}
+
+/**
+ * Inbox container for both audiences: loads the caller's conversations and
+ * renders {@link ConversationList}. Speakers additionally get a
+ * {@link NewConversationForm} to open a general thread with the organizers.
+ */
+export function MessagesInbox({
+  audience,
+  allowNew = false,
+}: MessagesInboxProps) {
+  const isOrganizer = audience === 'organizer'
+  const basePath = isOrganizer ? '/admin/messages' : '/cfp/messages'
+  const [showNew, setShowNew] = useState(false)
+
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = api.message.listConversations.useInfiniteQuery(
+    {},
+    {
+      staleTime: 10_000,
+      getNextPageParam: (lastPage) =>
+        lastPage.length === PAGE_SIZE
+          ? lastPage[lastPage.length - 1]?.lastMessageAt
+          : undefined,
+      initialCursor: undefined,
+    },
+  )
+
+  const items = data?.pages.flat() ?? []
+
+  return (
+    <div className="space-y-4">
+      {allowNew && (
+        <div>
+          {showNew ? (
+            <NewConversationForm
+              basePath={basePath}
+              onCancel={() => setShowNew(false)}
+            />
+          ) : (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => setShowNew(true)}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:bg-blue-600 dark:hover:bg-blue-500"
+              >
+                <PlusIcon className="h-4 w-4" aria-hidden="true" />
+                New conversation
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      <ConversationList
+        items={items}
+        isOrganizer={isOrganizer}
+        isLoading={isLoading}
+        isError={isError}
+        hasMore={hasNextPage}
+        onShowMore={() => fetchNextPage()}
+        isLoadingMore={isFetchingNextPage}
+      />
+    </div>
+  )
+}

--- a/src/components/messaging/NewConversationForm.tsx
+++ b/src/components/messaging/NewConversationForm.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { api } from '@/lib/trpc/client'
+
+const MAX_SUBJECT = 200
+const MAX_BODY = 5000
+
+export interface NewConversationFormProps {
+  /**
+   * The audience inbox base path new threads route to on creation
+   * (e.g. `/cfp/messages`). The created conversation id is appended.
+   */
+  basePath: string
+  /** Optional callback after a thread is created (before navigation). */
+  onCreated?: (conversationId: string) => void
+  /** Optional cancel handler (e.g. to collapse the form). */
+  onCancel?: () => void
+}
+
+/**
+ * Starts a general (non-proposal) conversation: a subject plus a first message.
+ * On success it navigates to the newly created thread.
+ */
+export function NewConversationForm({
+  basePath,
+  onCreated,
+  onCancel,
+}: NewConversationFormProps) {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const [subject, setSubject] = useState('')
+  const [body, setBody] = useState('')
+
+  const sendMutation = api.message.send.useMutation({
+    onSuccess: ({ conversationId }) => {
+      utils.message.listConversations.invalidate()
+      onCreated?.(conversationId)
+      router.push(`${basePath}/${conversationId}`)
+    },
+  })
+
+  const canSubmit =
+    subject.trim().length > 0 &&
+    body.trim().length > 0 &&
+    !sendMutation.isPending
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    sendMutation.mutate({ subject: subject.trim(), body: body.trim() })
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-3 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div>
+        <label
+          htmlFor="new-conversation-subject"
+          className="block text-sm font-medium text-gray-900 dark:text-white"
+        >
+          Subject
+        </label>
+        <input
+          id="new-conversation-subject"
+          type="text"
+          value={subject}
+          maxLength={MAX_SUBJECT}
+          onChange={(e) => setSubject(e.target.value)}
+          placeholder="What's this about?"
+          className="mt-1 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-brand-cloud-blue focus:outline-none focus-visible:ring-1 focus-visible:ring-brand-cloud-blue dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder-gray-500"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="new-conversation-body"
+          className="block text-sm font-medium text-gray-900 dark:text-white"
+        >
+          Message
+        </label>
+        <textarea
+          id="new-conversation-body"
+          value={body}
+          maxLength={MAX_BODY}
+          rows={4}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Write your first message…"
+          className="mt-1 block w-full resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-brand-cloud-blue focus:outline-none focus-visible:ring-1 focus-visible:ring-brand-cloud-blue dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder-gray-500"
+        />
+      </div>
+
+      {sendMutation.isError && (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          Couldn&apos;t start the conversation. Please try again.
+        </p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex items-center rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-500"
+        >
+          {sendMutation.isPending ? 'Starting…' : 'Start conversation'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/messaging/ProposalMessagesSection.tsx
+++ b/src/components/messaging/ProposalMessagesSection.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline'
+import { ConversationThread } from './ConversationThread'
+
+export interface ProposalMessagesSectionProps {
+  proposalId: string
+  /** The viewer's audience — organizer (admin) or speaker (cfp). */
+  audience: 'speaker' | 'organizer'
+}
+
+/**
+ * The "Messages" card mounted on both proposal detail pages, anchored
+ * `#messages` so the notification/email deep links (…/#messages) scroll here.
+ * Renders {@link ConversationThread} for the proposal's (deterministic) thread;
+ * the composer shows even before the thread exists — the first message creates
+ * it (see the router's `proposalId` entry point).
+ */
+export function ProposalMessagesSection({
+  proposalId,
+  audience,
+}: ProposalMessagesSectionProps) {
+  return (
+    <section
+      id="messages"
+      aria-labelledby="proposal-messages-heading"
+      className="scroll-mt-20 rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <ChatBubbleLeftRightIcon
+          className="h-5 w-5 text-brand-cloud-blue dark:text-blue-400"
+          aria-hidden="true"
+        />
+        <h2
+          id="proposal-messages-heading"
+          className="font-space-grotesk text-lg font-semibold text-gray-900 dark:text-white"
+        >
+          Messages
+        </h2>
+      </div>
+      <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        {audience === 'organizer'
+          ? 'Private thread with the speaker(s) on this proposal.'
+          : 'Private thread with the organizers about this proposal.'}
+      </p>
+      <ConversationThread proposalId={proposalId} audience={audience} />
+    </section>
+  )
+}

--- a/src/components/messaging/index.ts
+++ b/src/components/messaging/index.ts
@@ -1,0 +1,20 @@
+export {
+  ConversationThread,
+  ConversationThreadView,
+  type ConversationThreadProps,
+  type ConversationThreadViewProps,
+  type DisplayMessage,
+} from './ConversationThread'
+export {
+  ConversationList,
+  type ConversationListProps,
+} from './ConversationList'
+export {
+  NewConversationForm,
+  type NewConversationFormProps,
+} from './NewConversationForm'
+export { MessagesInbox, type MessagesInboxProps } from './MessagesInbox'
+export {
+  ProposalMessagesSection,
+  type ProposalMessagesSectionProps,
+} from './ProposalMessagesSection'

--- a/src/components/pwa/PushNotificationSettings.tsx
+++ b/src/components/pwa/PushNotificationSettings.tsx
@@ -40,15 +40,19 @@ export type PushSettingsStatus =
   | 'disabled'
   | 'enabled'
 
-// A category with no entry here is intentionally hidden from the settings UI
-// (e.g. `messages` is default-on and gets its toggle in a later phase); the
-// render skips categories without a label.
+// A category with no entry here is intentionally hidden from the settings UI;
+// the render skips categories without a label.
 const CATEGORY_LABELS: Partial<
   Record<PushCategory, { title: string; description: string }>
 > = {
   proposalDecisions: {
     title: 'Proposal decisions',
     description: 'When a talk is accepted, rejected, or waitlisted.',
+  },
+  messages: {
+    title: 'Messages',
+    description:
+      'When an organizer or speaker replies in one of your conversations.',
   },
   talkConfirmed: {
     title: 'Talk confirmed',

--- a/src/lib/messaging/links.ts
+++ b/src/lib/messaging/links.ts
@@ -1,0 +1,42 @@
+/**
+ * Client-safe pure helpers for messaging: the deterministic proposal-thread id
+ * and the per-audience deep-link contract.
+ *
+ * These live OUTSIDE `./sanity` (which is `server-only`) so client components —
+ * the conversation thread and inbox — can derive a proposal thread id and build
+ * inbox links without pulling the server data layer into the browser bundle.
+ * `./sanity` re-exports both so existing server importers are unaffected.
+ */
+
+import type { ConversationWithContext } from './types'
+
+/** Deterministic id for the single conversation attached to a proposal. */
+export function proposalConversationId(proposalId: string): string {
+  return `conversation.proposal.${proposalId}`
+}
+
+/**
+ * The app-relative deep link to a conversation for a given audience. This is the
+ * LINK CONTRACT the M2 routes are built against.
+ *
+ * - proposal + organizer → `/admin/proposals/<proposalId>#messages`
+ * - proposal + speaker   → `/cfp/proposal/<proposalId>#messages`
+ * - general  + organizer → `/admin/messages/<conversationId>`
+ * - general  + speaker   → `/cfp/messages/<conversationId>`
+ */
+export function conversationLinkPath(
+  conversation: Pick<
+    ConversationWithContext,
+    '_id' | 'conversationType' | 'proposalId'
+  >,
+  isOrganizer: boolean,
+): string {
+  if (conversation.conversationType === 'proposal' && conversation.proposalId) {
+    return isOrganizer
+      ? `/admin/proposals/${conversation.proposalId}#messages`
+      : `/cfp/proposal/${conversation.proposalId}#messages`
+  }
+  return isOrganizer
+    ? `/admin/messages/${conversation._id}`
+    : `/cfp/messages/${conversation._id}`
+}

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -13,6 +13,11 @@ import type {
   Message,
 } from './types'
 import { DEFAULT_CONVERSATION_PREFERENCE } from './types'
+import { proposalConversationId, conversationLinkPath } from './links'
+
+// Re-export the client-safe pure helpers so existing server importers keep
+// their `./sanity` import surface (the definitions live in `./links`).
+export { proposalConversationId, conversationLinkPath }
 
 /**
  * Server-only data layer for speaker↔organizer messaging (M1).
@@ -27,11 +32,6 @@ import { DEFAULT_CONVERSATION_PREFERENCE } from './types'
  * proposal speaker refs, organizer ids). No function here trusts a client to
  * say who they are.
  */
-
-/** Deterministic id for the single conversation attached to a proposal. */
-export function proposalConversationId(proposalId: string): string {
-  return `conversation.proposal.${proposalId}`
-}
 
 /** Deterministic id for the single (conversation, speaker) preference doc. */
 export function conversationPreferenceId(
@@ -119,32 +119,6 @@ export function canAccessConversation(
     return conversation.proposalSpeakerIds.includes(speaker._id)
   }
   return conversation.createdById === speaker._id
-}
-
-/**
- * The app-relative deep link to a conversation for a given audience. This is
- * the LINK CONTRACT M2 must implement its routes against.
- *
- * - proposal + organizer → `/admin/proposals/<proposalId>#messages`
- * - proposal + speaker   → `/cfp/proposal/<proposalId>#messages`
- * - general  + organizer → `/admin/messages/<conversationId>`
- * - general  + speaker   → `/cfp/messages/<conversationId>`
- */
-export function conversationLinkPath(
-  conversation: Pick<
-    ConversationWithContext,
-    '_id' | 'conversationType' | 'proposalId'
-  >,
-  isOrganizer: boolean,
-): string {
-  if (conversation.conversationType === 'proposal' && conversation.proposalId) {
-    return isOrganizer
-      ? `/admin/proposals/${conversation.proposalId}#messages`
-      : `/cfp/proposal/${conversation.proposalId}#messages`
-  }
-  return isOrganizer
-    ? `/admin/messages/${conversation._id}`
-    : `/cfp/messages/${conversation._id}`
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/schemas/speaker.ts
+++ b/src/server/schemas/speaker.ts
@@ -64,6 +64,8 @@ export const SpeakerInputSchema = z
     country: z.string().nullable().optional().transform(nullToUndefined),
     consent: SpeakerConsentSchema.optional(),
     company: z.string().nullable().optional().transform(nullToUndefined),
+    // Default email delivery for speaker↔organizer messages (messaging M2).
+    messagingEmailDefault: z.boolean().optional(),
   })
   .refine(
     (data) => {
@@ -107,6 +109,8 @@ const SpeakerInputBaseSchema = z.object({
   country: z.string().nullable().optional().transform(nullToUndefined),
   consent: SpeakerConsentSchema.optional(),
   company: z.string().nullable().optional().transform(nullToUndefined),
+  // Default email delivery for speaker↔organizer messages (messaging M2).
+  messagingEmailDefault: z.boolean().optional(),
 })
 
 // Admin-specific speaker creation (includes email)


### PR DESCRIPTION
## Messaging M2 — conversation UI

Builds the speaker↔organizer messaging UI on top of the M1 `message` tRPC router (#527). Every surface is derived from the M1 LINK CONTRACT (`conversationLinkPath`) and the router's `{conversationId | proposalId | subject}` send entry points.

### Surfaces added
- **`ConversationThread`** (`src/components/messaging/`) — shared by both audiences. Presentational `ConversationThreadView` (message bubbles: own = right/accent, others = neutral, organizer badge, relative time) + a container that resolves the conversation id (given, or derived from a proposal via the deterministic `conversation.proposal.<id>`), loads keyset-paginated messages (`useInfiniteQuery`), polls every 20s (paused while composing), and renders the composer (≤5000 chars, ⌘/Ctrl+Enter, invalidate-on-success) and a prefs bar (mute toggle + email-override select via `setPreference`). NOT_FOUND is treated as an empty thread so the composer shows before the proposal thread exists.
- **`ConversationList`** — inbox rows (subject / proposal title, last-activity relative time, "Proposal thread" hint) linking per audience via the shared contract.
- **`NewConversationForm`** + **`MessagesInbox`** — general-thread creation (speakers) and the inbox container wiring `listConversations`.
- **`ProposalMessagesSection`** — the `#messages`-anchored card mounted on both proposal detail pages.

### Routes
- `/cfp/messages` (inbox + new conversation) and `/cfp/messages/[id]` (thread) in the CFP shell.
- `/admin/messages` and `/admin/messages/[id]` in the admin shell.
- Both rely on the existing shell layouts for auth gating.

### Nav entries
- CFP: **Messages** (chat-bubble icon) added to the speaker sidebar.
- Admin: **Messages** (envelope icon) added to the Core section.

### Proposal-page mounts
- Admin `/admin/proposals/[id]` — section below `ProposalDetail`.
- CFP `/cfp/proposal/[id]` — section in both the editable and read-only render branches.
- Both anchored `id="messages"` with `scroll-mt` so the notification/email deep links land on the thread; composer renders even with no conversation yet (first `{proposalId}` send auto-creates it).

### Preferences wiring
- Unhid the `messages` push category in `PushNotificationSettings`.
- Added a **Message emails** default toggle (`speaker.messagingEmailDefault`) to the CFP profile, saved through the existing `speaker.update` path (extended `SpeakerInputSchema` to accept the boolean).

### Refactor
- Extracted the client-safe pure helpers `proposalConversationId` + `conversationLinkPath` into `src/lib/messaging/links.ts` (out of `server-only` `sanity.ts`, which now re-exports them) so client components can derive ids/links without pulling the server data layer into the bundle.

### Shoot findings (393px, light + dark)
Inspected every PNG. Thread (with-messages, empty), inbox (speaker + organizer), all light and dark: own messages right-aligned blue accent, others neutral, organizer badge, prefs bar, composer with counter + Send, deterministic relative times. Empty state shows the composer (proposal-mount case). No card exceeded the 393px viewport in any capture; dark mode correct throughout.

### Verify
- `tsc --noEmit`: 0 errors
- eslint (touched dirs): clean
- prettier: clean
- knip: exit 0
- `vitest run __tests__/`: 186 files, 2792 passed / 5 skipped, 0 failures (13 new messaging tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the M2 messaging UI layer on top of the M1 tRPC router: speaker↔organizer conversation threads, an inbox, a new-conversation form, proposal-page message sections for both audiences, and per-conversation notification preferences (mute + email override), all wired through keyset-paginated infinite queries with 20 s polling.

- **New surfaces**: `ConversationThread` (presentational view + tRPC container), `ConversationList` (inbox), `MessagesInbox` (container with optional new-thread affordance), `NewConversationForm`, and `ProposalMessagesSection` added to both proposal detail pages.
- **Refactor**: `proposalConversationId` and `conversationLinkPath` extracted from `server-only` `sanity.ts` into a new client-safe `src/lib/messaging/links.ts`; `sanity.ts` re-exports both for backwards compatibility.
- **Schema extension**: `messagingEmailDefault` boolean added to `SpeakerInputSchema` and saved through the existing `speaker.update` path; `messages` push category unhidden in `PushNotificationSettings`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the messaging UI is well-structured and all business logic stays server-side. The three findings are non-blocking quality items.

The implementation is clean and thorough — proper auth gating via existing shell layouts, correct NOT_FOUND-as-empty-thread handling for pre-creation proposal mounts, no XSS surface (message bodies go through React's escaping), and the conversationLinkPath refactor is backwards-compatible. The findings are: a dead ternary (cosmetic), a redundant flag check that doesn't affect behavior, and missing auto-scroll on poll delivery (users won't see new messages land unless they scroll). Nothing blocks the feature from working correctly, but the scroll gap is the most noticeable UX rough edge in production.

src/components/messaging/ConversationThread.tsx — the scroll-to-bottom gap and redundant conversationExists check both live here.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/messaging/ConversationThread.tsx | Core component split into presentational view and tRPC container; NOT_FOUND handled as empty-thread for pre-creation proposal mounts; minor dead ternary in MessageBubble |
| src/components/messaging/MessagesInbox.tsx | Clean inbox container that delegates pagination and rendering to ConversationList; speaker-only new-conversation affordance toggled via local state |
| src/components/messaging/NewConversationForm.tsx | Straightforward form that validates subject + body, calls send mutation, then navigates to the new thread; error state handled correctly |
| src/components/messaging/ConversationList.tsx | Purely presentational inbox list with skeleton, error, and empty states; correctly delegates link construction to conversationLinkPath |
| src/lib/messaging/links.ts | New client-safe module extracting proposalConversationId and conversationLinkPath; sanity.ts re-exports both cleanly |
| src/components/cfp/CFPProfilePage.tsx | Adds messagingEmailDefault toggle; undefined initial state correctly treated as off; toggle flip of undefined uses !undefined === true (correct for first-click enable) |
| src/server/schemas/speaker.ts | messagingEmailDefault added as z.boolean().optional() to both SpeakerInputSchema and SpeakerInputBaseSchema correctly |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Speaker as Speaker (CFP)
    participant CT as ConversationThread
    participant tRPC as tRPC message router
    participant Sanity as Sanity (DB)

    Note over CT: Proposal mount — thread does not exist yet
    CT->>tRPC: getConversation(proposalConversationId)
    tRPC-->>CT: NOT_FOUND → treated as empty thread
    CT->>tRPC: listMessages(proposalConversationId)
    tRPC-->>CT: NOT_FOUND → empty messages, composer shown

    Speaker->>CT: types message, clicks Send
    CT->>tRPC: "send({ proposalId, body })"
    tRPC->>Sanity: ensureProposalConversation + addMessage
    Sanity-->>tRPC: created conversationId
    tRPC-->>CT: "{ conversationId }"
    CT->>tRPC: invalidate getConversation + listMessages
    tRPC->>Sanity: fetch conversation + messages
    Sanity-->>tRPC: conversation data + messages
    tRPC-->>CT: "conversationExists=true, messages shown"

    Note over CT: Subsequent sends use conversationId directly
    Speaker->>CT: types reply, clicks Send
    CT->>tRPC: "send({ conversationId, body })"
    tRPC->>Sanity: addMessage
    Sanity-->>tRPC: ok
    tRPC-->>CT: invalidate → refetch → new message in list

    loop Every 20s (while not composing)
        CT->>tRPC: listMessages refetch
        tRPC-->>CT: latest messages
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Speaker as Speaker (CFP)
    participant CT as ConversationThread
    participant tRPC as tRPC message router
    participant Sanity as Sanity (DB)

    Note over CT: Proposal mount — thread does not exist yet
    CT->>tRPC: getConversation(proposalConversationId)
    tRPC-->>CT: NOT_FOUND → treated as empty thread
    CT->>tRPC: listMessages(proposalConversationId)
    tRPC-->>CT: NOT_FOUND → empty messages, composer shown

    Speaker->>CT: types message, clicks Send
    CT->>tRPC: "send({ proposalId, body })"
    tRPC->>Sanity: ensureProposalConversation + addMessage
    Sanity-->>tRPC: created conversationId
    tRPC-->>CT: "{ conversationId }"
    CT->>tRPC: invalidate getConversation + listMessages
    tRPC->>Sanity: fetch conversation + messages
    Sanity-->>tRPC: conversation data + messages
    tRPC-->>CT: "conversationExists=true, messages shown"

    Note over CT: Subsequent sends use conversationId directly
    Speaker->>CT: types reply, clicks Send
    CT->>tRPC: "send({ conversationId, body })"
    tRPC->>Sanity: addMessage
    Sanity-->>tRPC: ok
    tRPC-->>CT: invalidate → refetch → new message in list

    loop Every 20s (while not composing)
        CT->>tRPC: listMessages refetch
        tRPC-->>CT: latest messages
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/components/messaging/ConversationThread.tsx`, line 1249-1251 ([link](https://github.com/cloudnativebergen/website/blob/155a181d45e312bb9d7467fc131ce166758db27b/src/components/messaging/ConversationThread.tsx#L1249-L1251)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`conversationExists` redundant error check**

   `conversationQuery.error` is always `null` when `conversationQuery.data` is truthy (React Query clears the error field on a successful response). So `errorCode(conversationQuery.error) !== 'NOT_FOUND'` is always `undefined !== 'NOT_FOUND'` (i.e., `true`) whenever the first guard `!!conversationQuery.data` passes. The NOT_FOUND guard here has no effect. The intent is probably `!conversationQuery.isError` or checking `messagesNotFound`, not probing `conversationQuery.error` after data arrived.


2. `src/components/messaging/ConversationThread.tsx`, line 1119 ([link](https://github.com/cloudnativebergen/website/blob/155a181d45e312bb9d7467fc131ce166758db27b/src/components/messaging/ConversationThread.tsx#L1119)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No scroll-to-bottom on new message arrival**

   The message list uses `overflow-y-auto max-h-[60vh]` but has no imperative scroll management. When the 20 s poll delivers new messages, the list re-renders and stays at its current scroll offset — the user never sees the incoming message unless they scroll manually. A `useEffect` that scrolls a bottom-sentinel ref when `messages` changes (only when already near the bottom) is the standard remedy. Without it, polling silently delivers messages that the user cannot see.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): conversation UI — threa..."](https://github.com/cloudnativebergen/website/commit/155a181d45e312bb9d7467fc131ce166758db27b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45378798)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->