### PR TITLE
feat(messaging): organizer-initiated threads, mark-read-by-link, unread counts (M3a)

### DIFF
--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/lib/messaging/sanity', async (importActual) => {
       async () => 'conversation.proposal.prop-1',
     ),
     createGeneralConversation: vi.fn(async () => 'conversation.gen-1'),
+    speakerExists: vi.fn(async () => true),
     getProposalForConversation: vi.fn(),
     setConversationPreference: vi.fn(async () => ({
       muted: true,
@@ -67,6 +68,7 @@ import {
   ensureProposalConversation,
   createGeneralConversation,
   getProposalForConversation,
+  speakerExists,
   addMessage,
 } from '@/lib/messaging/sanity'
 import { notifyNewMessage } from '@/lib/messaging/notify'
@@ -77,6 +79,7 @@ const listConvs = listConversationsForSpeaker as unknown as LooseMock
 const ensureProposal = ensureProposalConversation as unknown as LooseMock
 const createGeneral = createGeneralConversation as unknown as LooseMock
 const getProposal = getProposalForConversation as unknown as LooseMock
+const speakerExistsMock = speakerExists as unknown as LooseMock
 const addMsg = addMessage as unknown as LooseMock
 const notifyMock = notifyNewMessage as unknown as LooseMock
 
@@ -257,6 +260,73 @@ describe('send — conversation creation', () => {
     await expect(caller.message.send({ body: 'hi' })).rejects.toThrow(
       /BAD_REQUEST|Provide a/,
     )
+  })
+})
+
+describe('send — organizer-initiated general threads (subjectSpeaker)', () => {
+  const organizerGeneralConv: ConversationWithContext = {
+    _id: 'conversation.gen-1',
+    conferenceId: 'conf-1',
+    conversationType: 'general',
+    proposalSpeakerIds: [],
+    createdById: organizerId,
+    subjectSpeakerId: 'sp-target',
+    subject: 'About your talk',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastMessageAt: '2026-01-01T00:00:00.000Z',
+  }
+
+  it('FORBIDS a non-organizer who supplies recipientSpeakerId (never honored)', async () => {
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.send({
+        subject: 'Q',
+        recipientSpeakerId: 'sp-target',
+        body: 'hi',
+      }),
+    ).rejects.toThrow(/FORBIDDEN|organizer/)
+    expect(createGeneral).not.toHaveBeenCalled()
+    expect(addMsg).not.toHaveBeenCalled()
+  })
+
+  it('rejects an organizer starting a general thread WITHOUT recipientSpeakerId', async () => {
+    const caller = createAdminCaller()
+    await expect(
+      caller.message.send({ subject: 'Q', body: 'hi' }),
+    ).rejects.toThrow(/BAD_REQUEST|required/)
+    expect(createGeneral).not.toHaveBeenCalled()
+  })
+
+  it('404s when the organizer recipientSpeakerId does not resolve to a speaker', async () => {
+    speakerExistsMock.mockResolvedValue(false)
+    const caller = createAdminCaller()
+    await expect(
+      caller.message.send({
+        subject: 'Q',
+        recipientSpeakerId: 'ghost',
+        body: 'hi',
+      }),
+    ).rejects.toThrow(/NOT_FOUND|does not resolve/)
+    expect(createGeneral).not.toHaveBeenCalled()
+  })
+
+  it('creates an organizer general thread that persists the subjectSpeaker', async () => {
+    speakerExistsMock.mockResolvedValue(true)
+    getById.mockResolvedValue(organizerGeneralConv)
+    const caller = createAdminCaller()
+
+    const result = await caller.message.send({
+      subject: 'About your talk',
+      recipientSpeakerId: 'sp-target',
+      body: 'hi',
+    })
+
+    expect(speakerExistsMock).toHaveBeenCalledWith('sp-target')
+    expect(createGeneral).toHaveBeenCalledWith(
+      expect.objectContaining({ subjectSpeakerId: 'sp-target' }),
+    )
+    expect(result.conversationId).toBe('conversation.gen-1')
+    expect(addMsg).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/__tests__/components/messaging/ConversationList.test.tsx
+++ b/__tests__/components/messaging/ConversationList.test.tsx
@@ -15,6 +15,7 @@ const items: ConversationListItem[] = [
     proposalTitle: 'Scaling Kubernetes',
     createdAt: new Date('2026-07-15T10:00:00Z').toISOString(),
     lastMessageAt: new Date('2026-07-18T10:00:00Z').toISOString(),
+    unreadCount: 0,
   },
   {
     _id: 'conversation.abc123',
@@ -22,6 +23,7 @@ const items: ConversationListItem[] = [
     subject: 'Travel question',
     createdAt: new Date('2026-07-15T10:00:00Z').toISOString(),
     lastMessageAt: new Date('2026-07-18T09:00:00Z').toISOString(),
+    unreadCount: 0,
   },
 ]
 

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -40,6 +40,8 @@ import {
   createGeneralConversation,
   setConversationPreference,
   getConversationPreferencesFor,
+  listConversationsForSpeaker,
+  speakerExists,
 } from '@/lib/messaging/sanity'
 import type { ConversationWithContext } from '@/lib/messaging/types'
 
@@ -85,6 +87,19 @@ const generalConv: ConversationWithContext = {
   lastMessageAt: '2026-01-01T00:00:00.000Z',
 }
 
+// An ORGANIZER-initiated general thread: created by an organizer, ABOUT sp-7.
+const organizerGeneralConv: ConversationWithContext = {
+  _id: 'conversation.gen-2',
+  conferenceId: 'conf-1',
+  conversationType: 'general',
+  proposalSpeakerIds: [],
+  createdById: 'org-1',
+  subjectSpeakerId: 'sp-7',
+  subject: 'About your talk',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastMessageAt: '2026-01-01T00:00:00.000Z',
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -115,6 +130,12 @@ describe('resolveParticipantIds', () => {
       'sp-9',
     ])
   })
+  it('organizer-initiated general thread → creator ∪ subjectSpeaker ∪ organizers, de-duplicated', () => {
+    // org-1 is both creator and organizer → appears once; sp-7 is the subject.
+    expect(
+      resolveParticipantIds(organizerGeneralConv, ['org-1', 'org-2']).sort(),
+    ).toEqual(['org-1', 'org-2', 'sp-7'])
+  })
 })
 
 describe('resolveRecipients — excludes the actor', () => {
@@ -128,6 +149,15 @@ describe('resolveRecipients — excludes the actor', () => {
     expect(resolveRecipients(generalConv, 'org-1', ['org-1', 'org-2'])).toEqual(
       ['sp-9', 'org-2'].sort((a, b) => a.localeCompare(b)),
     )
+  })
+  it('organizer-initiated general thread → subjectSpeaker ∪ other organizers (author excluded, de-duplicated)', () => {
+    // org-1 authored → excluded; the subject sp-7 and the other organizer remain.
+    expect(
+      resolveRecipients(organizerGeneralConv, 'org-1', [
+        'org-1',
+        'org-2',
+      ]).sort(),
+    ).toEqual(['org-2', 'sp-7'])
   })
 })
 
@@ -147,6 +177,16 @@ describe('canAccessConversation — authz matrix', () => {
   it('only the creator can access a general thread', () => {
     expect(canAccessConversation(generalConv, { _id: 'sp-9' })).toBe(true)
     expect(canAccessConversation(generalConv, { _id: 'sp-1' })).toBe(false)
+  })
+  it('the subjectSpeaker of an organizer-initiated general thread can access it; a stranger cannot', () => {
+    // Neither creator nor a proposal-speaker, but the subject → allowed.
+    expect(canAccessConversation(organizerGeneralConv, { _id: 'sp-7' })).toBe(
+      true,
+    )
+    // Some other speaker who is neither creator nor subject → denied.
+    expect(canAccessConversation(organizerGeneralConv, { _id: 'sp-8' })).toBe(
+      false,
+    )
   })
 })
 
@@ -238,6 +278,116 @@ describe('createGeneralConversation', () => {
     expect(doc.conversationType).toBe('general')
     expect(doc.subject).toBe('A question')
     expect('proposal' in doc).toBe(false)
+    // A speaker-created general thread carries NO subjectSpeaker.
+    expect('subjectSpeaker' in doc).toBe(false)
+  })
+
+  it('sets subjectSpeaker when an organizer targets a recipient speaker', async () => {
+    await createGeneralConversation({
+      conferenceId: 'conf-1',
+      createdById: 'org-1',
+      subject: 'About your talk',
+      subjectSpeakerId: 'sp-7',
+    })
+    const doc = writeMock.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.subjectSpeaker).toEqual({ _type: 'reference', _ref: 'sp-7' })
+  })
+})
+
+describe('speakerExists — server-side recipient validation', () => {
+  it('returns true when a speaker doc with the id exists', async () => {
+    readMock.fetch.mockResolvedValue('sp-7')
+    expect(await speakerExists('sp-7')).toBe(true)
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('_type == "speaker"')
+    expect(params).toEqual({ speakerId: 'sp-7' })
+  })
+  it('returns false when no such speaker exists', async () => {
+    readMock.fetch.mockResolvedValue(null)
+    expect(await speakerExists('ghost')).toBe(false)
+  })
+})
+
+describe('listConversationsForSpeaker — unread counts per conversation', () => {
+  const rows = [
+    {
+      _id: 'conversation.proposal.prop-1',
+      conversationType: 'proposal' as const,
+      subject: 'T',
+      proposalId: 'prop-1',
+      proposalTitle: 'T',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      lastMessageAt: '2026-01-02T00:00:00.000Z',
+    },
+    {
+      _id: 'conversation.gen-1',
+      conversationType: 'general' as const,
+      subject: 'Q',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      lastMessageAt: '2026-01-01T00:00:00.000Z',
+    },
+  ]
+
+  it('counts a speaker unread message_received notifications matching the /cfp link variant', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce(rows) // conversations page
+      .mockResolvedValueOnce([
+        '/cfp/proposal/prop-1#messages',
+        '/cfp/proposal/prop-1#messages',
+      ]) // caller's unread message links
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'sp-1',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+    })
+
+    expect(
+      result.find((r) => r._id === 'conversation.proposal.prop-1')!.unreadCount,
+    ).toBe(2)
+    expect(
+      result.find((r) => r._id === 'conversation.gen-1')!.unreadCount,
+    ).toBe(0)
+
+    // The unread query is scoped to the caller, the conference, message_received,
+    // and unread only (read notifications are never fetched, so never counted).
+    const [query, params] = readMock.fetch.mock.calls[1]
+    expect(query).toContain('recipient._ref == $speakerId')
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(query).toContain('notificationType == "message_received"')
+    expect(query).toContain('!defined(readAt)')
+    expect(params).toEqual({ speakerId: 'sp-1', conferenceId: 'conf-1' })
+  })
+
+  it('counts an organizer unread notifications matching the /admin link variant', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce(rows)
+      .mockResolvedValueOnce(['/admin/messages/conversation.gen-1'])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+    })
+
+    // The general thread's /admin variant matched → 1; the proposal thread → 0.
+    expect(
+      result.find((r) => r._id === 'conversation.gen-1')!.unreadCount,
+    ).toBe(1)
+    expect(
+      result.find((r) => r._id === 'conversation.proposal.prop-1')!.unreadCount,
+    ).toBe(0)
+  })
+
+  it('returns [] and runs NO unread query when the page is empty', async () => {
+    readMock.fetch.mockResolvedValueOnce([])
+    const result = await listConversationsForSpeaker({
+      speakerId: 'sp-1',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+    })
+    expect(result).toEqual([])
+    expect(readMock.fetch).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -35,6 +35,7 @@ import {
   getNotificationsForSpeaker,
   getUnreadCount,
   markNotificationsRead,
+  markNotificationsReadByLinks,
   markAllRead,
   deleteNotificationsOlderThan,
 } from '@/lib/notification/sanity'
@@ -197,6 +198,66 @@ describe('markNotificationsRead — recipient security guard', () => {
     expect(count).toBe(0)
     expect(writeMock.transaction).not.toHaveBeenCalled()
     expect(tx.patch).not.toHaveBeenCalled()
+  })
+})
+
+describe('markNotificationsReadByLinks — link-matched read (recipient guard)', () => {
+  it('fetches the caller unread matching-link ids and patches ONLY those', async () => {
+    // The ownership + unread + link filter IS the guard: only the caller's own
+    // unread notifications whose link matches are ever returned and patched.
+    readMock.fetch.mockResolvedValue(['own-1', 'own-2'])
+    const tx = installTransaction()
+
+    const count = await markNotificationsReadByLinks({
+      speakerId: 'sp-1',
+      links: ['/cfp/messages/c1'],
+    })
+
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('recipient._ref == $speakerId')
+    expect(query).toContain('!defined(readAt)')
+    expect(query).toContain('link in $links')
+    expect(params).toEqual({ speakerId: 'sp-1', links: ['/cfp/messages/c1'] })
+
+    expect(tx.patch).toHaveBeenCalledTimes(2)
+    expect(tx.patch).toHaveBeenCalledWith('own-1', {
+      set: { readAt: expect.any(String) },
+    })
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+    expect(count).toBe(2)
+  })
+
+  it('returns 0 and writes nothing when no unread notification matches a link', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+
+    const count = await markNotificationsReadByLinks({
+      speakerId: 'sp-1',
+      links: ['/cfp/messages/none'],
+    })
+
+    expect(count).toBe(0)
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+    expect(tx.patch).not.toHaveBeenCalled()
+  })
+
+  it('returns 0 and does not fetch for an empty link list', async () => {
+    const count = await markNotificationsReadByLinks({
+      speakerId: 'sp-1',
+      links: [],
+    })
+    expect(count).toBe(0)
+    expect(readMock.fetch).not.toHaveBeenCalled()
+  })
+
+  it('defensively bounds the query to at most 8 links', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const links = Array.from({ length: 12 }, (_, i) => `/cfp/messages/c${i}`)
+
+    await markNotificationsReadByLinks({ speakerId: 'sp-1', links })
+
+    const [, params] = readMock.fetch.mock.calls[0]
+    expect((params as { links: string[] }).links).toHaveLength(8)
   })
 })
 

--- a/__tests__/server/schemas/notification.test.ts
+++ b/__tests__/server/schemas/notification.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest'
 import {
   ListNotificationsSchema,
   MarkReadSchema,
+  MarkReadByLinkSchema,
 } from '@/server/schemas/notification'
 
 describe('ListNotificationsSchema', () => {
@@ -61,6 +62,53 @@ describe('MarkReadSchema', () => {
       MarkReadSchema.safeParse({
         ids: Array.from({ length: 101 }, (_, i) => `id-${i}`),
       }).success,
+    ).toBe(false)
+  })
+})
+
+describe('MarkReadByLinkSchema', () => {
+  it('accepts 1..8 app-relative links', () => {
+    expect(
+      MarkReadByLinkSchema.safeParse({ links: ['/cfp/messages/c1'] }).success,
+    ).toBe(true)
+    expect(
+      MarkReadByLinkSchema.safeParse({
+        links: Array.from({ length: 8 }, (_, i) => `/cfp/messages/c${i}`),
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects an empty list and more than 8 links', () => {
+    expect(MarkReadByLinkSchema.safeParse({ links: [] }).success).toBe(false)
+    expect(
+      MarkReadByLinkSchema.safeParse({
+        links: Array.from({ length: 9 }, (_, i) => `/cfp/messages/c${i}`),
+      }).success,
+    ).toBe(false)
+  })
+
+  it('rejects an absolute URL, a protocol-relative host, a backslash path, and a non-slash path', () => {
+    expect(
+      MarkReadByLinkSchema.safeParse({ links: ['https://evil.com/x'] }).success,
+    ).toBe(false)
+    // A single bad link taints the whole array.
+    expect(
+      MarkReadByLinkSchema.safeParse({
+        links: ['/cfp/messages/c1', 'http://evil.com'],
+      }).success,
+    ).toBe(false)
+    expect(
+      MarkReadByLinkSchema.safeParse({ links: ['\\\\server\\share'] }).success,
+    ).toBe(false)
+    expect(
+      MarkReadByLinkSchema.safeParse({ links: ['cfp/messages/c1'] }).success,
+    ).toBe(false)
+  })
+
+  it('rejects a link longer than 300 chars', () => {
+    expect(
+      MarkReadByLinkSchema.safeParse({ links: [`/${'x'.repeat(300)}`] })
+        .success,
     ).toBe(false)
   })
 })

--- a/sanity/schemaTypes/conversation.ts
+++ b/sanity/schemaTypes/conversation.ts
@@ -68,6 +68,14 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'subjectSpeaker',
+      title: 'Subject Speaker',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      description:
+        'The speaker a general conversation is ABOUT/with. Set when an ORGANIZER initiates a general thread targeting a speaker; speaker-created threads leave this unset (the creator IS the speaker). Unused for proposal threads.',
+    }),
+    defineField({
       name: 'subject',
       title: 'Subject',
       type: 'string',

--- a/src/components/messaging/ConversationList.stories.tsx
+++ b/src/components/messaging/ConversationList.stories.tsx
@@ -15,6 +15,7 @@ const makeItems = (): ConversationListItem[] => [
     proposalTitle: 'Scaling Kubernetes to 10,000 nodes',
     createdAt: minutesAgo(60 * 24 * 3),
     lastMessageAt: minutesAgo(24),
+    unreadCount: 0,
   },
   {
     _id: 'conversation.abc123',
@@ -22,6 +23,7 @@ const makeItems = (): ConversationListItem[] => [
     subject: 'Question about speaker travel',
     createdAt: minutesAgo(60 * 24 * 2),
     lastMessageAt: minutesAgo(60 * 5),
+    unreadCount: 0,
   },
   {
     _id: 'conversation.proposal.talk-2',
@@ -31,6 +33,7 @@ const makeItems = (): ConversationListItem[] => [
     proposalTitle: 'Designing for Failure',
     createdAt: minutesAgo(60 * 24 * 10),
     lastMessageAt: minutesAgo(60 * 24 * 4),
+    unreadCount: 0,
   },
 ]
 

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -86,7 +86,7 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
   const { isOwn } = message
   return (
     <div className={isOwn ? 'flex justify-end' : 'flex justify-start'}>
-      <div className={isOwn ? 'max-w-[80%]' : 'max-w-[80%]'}>
+      <div className="max-w-[80%]">
         <div
           className={`flex items-baseline gap-2 ${isOwn ? 'justify-end' : 'justify-start'}`}
         >

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -52,6 +52,7 @@ const CONVERSATION_PROJECTION = `{
   "proposalTitle": proposal->title,
   "proposalSpeakerIds": coalesce(proposal->speakers[]._ref, []),
   "createdById": createdBy._ref,
+  "subjectSpeakerId": subjectSpeaker._ref,
   subject,
   createdAt,
   lastMessageAt
@@ -64,13 +65,18 @@ const CONVERSATION_PROJECTION = `{
 /**
  * Every participant of a conversation:
  * - proposal thread → the proposal's speakers ∪ organizers;
- * - general thread  → the creator ∪ organizers.
- * De-duplicated (a speaker who is also an organizer appears once).
+ * - general thread  → the creator ∪ subjectSpeaker ∪ organizers.
+ * De-duplicated (a speaker who is also an organizer appears once). A general
+ * thread's `subjectSpeaker` is the speaker an organizer targeted; it is absent
+ * on speaker-created threads (where the creator IS the subject).
  */
 export function resolveParticipantIds(
   conversation: Pick<
     ConversationWithContext,
-    'conversationType' | 'proposalSpeakerIds' | 'createdById'
+    | 'conversationType'
+    | 'proposalSpeakerIds'
+    | 'createdById'
+    | 'subjectSpeakerId'
   >,
   organizerIds: string[],
 ): string[] {
@@ -79,6 +85,7 @@ export function resolveParticipantIds(
     for (const id of conversation.proposalSpeakerIds) ids.add(id)
   } else {
     ids.add(conversation.createdById)
+    if (conversation.subjectSpeakerId) ids.add(conversation.subjectSpeakerId)
   }
   return Array.from(ids)
 }
@@ -91,7 +98,10 @@ export function resolveParticipantIds(
 export function resolveRecipients(
   conversation: Pick<
     ConversationWithContext,
-    'conversationType' | 'proposalSpeakerIds' | 'createdById'
+    | 'conversationType'
+    | 'proposalSpeakerIds'
+    | 'createdById'
+    | 'subjectSpeakerId'
   >,
   actorId: string,
   organizerIds: string[],
@@ -105,12 +115,16 @@ export function resolveRecipients(
  * Whether `speaker` may read/write `conversation`:
  * - any organizer; OR
  * - a proposal thread where the speaker is on the proposal; OR
- * - a general thread the speaker created.
+ * - a general thread the speaker created OR is the subject speaker of (an
+ *   organizer-initiated general thread targets a `subjectSpeaker`).
  */
 export function canAccessConversation(
   conversation: Pick<
     ConversationWithContext,
-    'conversationType' | 'proposalSpeakerIds' | 'createdById'
+    | 'conversationType'
+    | 'proposalSpeakerIds'
+    | 'createdById'
+    | 'subjectSpeakerId'
   >,
   speaker: AccessSpeaker,
 ): boolean {
@@ -118,7 +132,10 @@ export function canAccessConversation(
   if (conversation.conversationType === 'proposal') {
     return conversation.proposalSpeakerIds.includes(speaker._id)
   }
-  return conversation.createdById === speaker._id
+  return (
+    conversation.createdById === speaker._id ||
+    conversation.subjectSpeakerId === speaker._id
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -200,7 +217,14 @@ export async function getConversationParticipants(
  * `lastMessageAt` of the last item on the previous page).
  *
  * - organizers see EVERY conversation for the conference;
- * - a speaker sees only conversations they created or are a proposal-speaker on.
+ * - a speaker sees only conversations they created, are a proposal-speaker on,
+ *   or are the subject speaker of (an organizer-initiated general thread).
+ *
+ * Each row carries the caller's `unreadCount`: their unread `message_received`
+ * notifications for that conversation. Rather than N per-row subqueries we run
+ * ONE extra fetch of the caller's unread message links for the conference and
+ * count them in JS against each row's two audience link variants (the caller
+ * only ever received one variant, so matching both is simplest and correct).
  */
 export async function listConversationsForSpeaker({
   speakerId,
@@ -223,7 +247,7 @@ export async function listConversationsForSpeaker({
   let scope = ''
   if (!isOrganizer) {
     scope =
-      ' && (createdBy._ref == $speakerId || $speakerId in proposal->speakers[]._ref)'
+      ' && (createdBy._ref == $speakerId || subjectSpeaker._ref == $speakerId || $speakerId in proposal->speakers[]._ref)'
     params.speakerId = speakerId
   }
 
@@ -237,12 +261,31 @@ export async function listConversationsForSpeaker({
     lastMessageAt
   }`
 
-  const results = await clientReadUncached.fetch<ConversationListItem[]>(
-    query,
-    params,
+  const results = await clientReadUncached.fetch<
+    Omit<ConversationListItem, 'unreadCount'>[]
+  >(query, params, { cache: 'no-store' })
+  const rows = results ?? []
+  if (rows.length === 0) return []
+
+  // ONE extra read: the caller's unread message_received notification links for
+  // this conference. Counted in JS per conversation below.
+  const unreadLinks = await clientReadUncached.fetch<(string | null)[]>(
+    `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt)].link`,
+    { speakerId, conferenceId },
     { cache: 'no-store' },
   )
-  return results ?? []
+  const linkCounts = new Map<string, number>()
+  for (const link of unreadLinks ?? []) {
+    if (link) linkCounts.set(link, (linkCounts.get(link) ?? 0) + 1)
+  }
+
+  return rows.map((row) => {
+    // Match EITHER audience variant; the caller received only one of them.
+    const unreadCount =
+      (linkCounts.get(conversationLinkPath(row, true)) ?? 0) +
+      (linkCounts.get(conversationLinkPath(row, false)) ?? 0)
+    return { ...row, unreadCount }
+  })
 }
 
 /**
@@ -316,15 +359,23 @@ export async function ensureProposalConversation({
   return id
 }
 
-/** Create a free-standing general conversation (random id) and return its id. */
+/**
+ * Create a free-standing general conversation (random id) and return its id.
+ *
+ * `subjectSpeakerId` is set ONLY when an organizer initiates a thread targeting
+ * a speaker — it records who the conversation is ABOUT/with. Speaker-created
+ * threads omit it (the creator IS the subject speaker).
+ */
 export async function createGeneralConversation({
   conferenceId,
   createdById,
   subject,
+  subjectSpeakerId,
 }: {
   conferenceId: string
   createdById: string
   subject: string
+  subjectSpeakerId?: string
 }): Promise<string> {
   const id = `conversation.${nanoid()}`
   const now = new Date().toISOString()
@@ -334,11 +385,24 @@ export async function createGeneralConversation({
     conference: createReference(conferenceId),
     conversationType: 'general',
     createdBy: createReference(createdById),
+    ...(subjectSpeakerId
+      ? { subjectSpeaker: createReference(subjectSpeakerId) }
+      : {}),
     subject: subject.slice(0, 200),
     createdAt: now,
     lastMessageAt: now,
   })
   return id
+}
+
+/** Whether a speaker document with this id exists (server-side validation). */
+export async function speakerExists(speakerId: string): Promise<boolean> {
+  const id = await clientReadUncached.fetch<string | null>(
+    `*[_type == "speaker" && _id == $speakerId][0]._id`,
+    { speakerId },
+    { cache: 'no-store' },
+  )
+  return Boolean(id)
 }
 
 /**

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -24,6 +24,10 @@ export interface AccessSpeaker {
  *
  * `proposalSpeakerIds` are the speaker `_ref`s on the referenced proposal
  * (empty for general threads). `createdById` is the thread starter.
+ *
+ * `subjectSpeakerId` is the speaker a general conversation is ABOUT/with, set
+ * only when an ORGANIZER initiates the thread; speaker-created threads leave it
+ * unset (the creator IS the subject speaker). Unused for proposal threads.
  */
 export interface ConversationWithContext {
   _id: string
@@ -33,6 +37,7 @@ export interface ConversationWithContext {
   proposalTitle?: string
   proposalSpeakerIds: string[]
   createdById: string
+  subjectSpeakerId?: string
   subject: string
   createdAt: string
   lastMessageAt: string
@@ -47,6 +52,12 @@ export interface ConversationListItem {
   proposalTitle?: string
   createdAt: string
   lastMessageAt: string
+  /**
+   * The caller's unread `message_received` notification count for this
+   * conversation (matches either audience link variant; the caller only ever
+   * received one).
+   */
+  unreadCount: number
 }
 
 /** A single message in a thread. */

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -188,6 +188,52 @@ export async function markNotificationsRead({
   return ownedIds.length
 }
 
+/** The maximum number of distinct links accepted by `markNotificationsReadByLinks`. */
+const MARK_READ_BY_LINKS_LIMIT = 8
+
+/**
+ * Mark every UNREAD notification whose `link` is one of `links` read for
+ * `speakerId`, returning how many were patched. Used to auto-clear a
+ * conversation's message notifications when the recipient opens the thread
+ * (they navigate by the same deep link the notification carries).
+ *
+ * SECURITY: mirrors {@link markNotificationsRead}. The recipient filter
+ * (`recipient._ref == $speakerId`) IS the ownership guard — only the caller's
+ * own notifications are ever fetched and patched, so a foreign link can clear
+ * nothing but the caller's own matching notifications. `links` is bounded to
+ * {@link MARK_READ_BY_LINKS_LIMIT} defensively (the router also caps it).
+ */
+export async function markNotificationsReadByLinks({
+  speakerId,
+  links,
+}: {
+  speakerId: string
+  links: string[]
+}): Promise<number> {
+  const boundedLinks = links.slice(0, MARK_READ_BY_LINKS_LIMIT)
+  if (boundedLinks.length === 0) {
+    return 0
+  }
+
+  const ids = await clientReadUncached.fetch<string[]>(
+    `*[_type == "notification" && recipient._ref == $speakerId && !defined(readAt) && link in $links]._id`,
+    { speakerId, links: boundedLinks },
+  )
+
+  if (!ids || ids.length === 0) {
+    return 0
+  }
+
+  const now = new Date().toISOString()
+  const tx = clientWrite.transaction()
+  for (const id of ids) {
+    tx.patch(id, { set: { readAt: now } })
+  }
+  await tx.commit()
+
+  return ids.length
+}
+
 /** The maximum number of notifications marked read in one `markAllRead` call. */
 const MARK_ALL_READ_LIMIT = 500
 

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -20,6 +20,7 @@ import {
   getProposalForConversation,
   setConversationPreference,
   canAccessConversation,
+  speakerExists,
 } from '@/lib/messaging/sanity'
 import { notifyNewMessage } from '@/lib/messaging/notify'
 import type { ConversationWithContext } from '@/lib/messaging/types'
@@ -91,6 +92,10 @@ export const messageRouter = router({
    * - `proposalId`     → look up / create the proposal thread (race-safe id);
    * - `subject` only   → start a general thread.
    * Then adds the message and fires the (never-fail) fan-out.
+   *
+   * `recipientSpeakerId` targets the subject speaker of an ORGANIZER-initiated
+   * general thread: it is FORBIDDEN for a non-organizer, and REQUIRED (and must
+   * resolve to a real speaker) when an organizer starts a general thread.
    */
   send: protectedProcedure
     .input(SendMessageSchema)
@@ -105,6 +110,15 @@ export const messageRouter = router({
       const conferenceId = conference._id
       const actorId = ctx.speaker._id
       const isOrganizer = ctx.speaker.isOrganizer === true
+
+      // `recipientSpeakerId` is an organizer-only capability: a non-organizer
+      // must never be able to name the subject speaker of a thread.
+      if (input.recipientSpeakerId !== undefined && !isOrganizer) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'recipientSpeakerId may only be set by an organizer',
+        })
+      }
 
       let conversation: ConversationWithContext
 
@@ -147,10 +161,30 @@ export const messageRouter = router({
         }
         conversation = created
       } else if (input.subject) {
+        // An organizer-initiated general thread MUST target a real speaker; a
+        // speaker-initiated one is about themselves and takes no recipient.
+        let subjectSpeakerId: string | undefined
+        if (isOrganizer) {
+          if (!input.recipientSpeakerId) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message:
+                'recipientSpeakerId is required when an organizer starts a general conversation',
+            })
+          }
+          if (!(await speakerExists(input.recipientSpeakerId))) {
+            throw new TRPCError({
+              code: 'NOT_FOUND',
+              message: 'recipientSpeakerId does not resolve to a speaker',
+            })
+          }
+          subjectSpeakerId = input.recipientSpeakerId
+        }
         const id = await createGeneralConversation({
           conferenceId,
           createdById: actorId,
           subject: input.subject,
+          subjectSpeakerId,
         })
         const created = await getConversationById(id)
         if (!created) {

--- a/src/server/routers/notification.ts
+++ b/src/server/routers/notification.ts
@@ -2,11 +2,13 @@ import { router, protectedProcedure, resolveConferenceId } from '@/server/trpc'
 import {
   ListNotificationsSchema,
   MarkReadSchema,
+  MarkReadByLinkSchema,
 } from '@/server/schemas/notification'
 import {
   getNotificationsForSpeaker,
   getUnreadCount,
   markNotificationsRead,
+  markNotificationsReadByLinks,
   markAllRead,
 } from '@/lib/notification/sanity'
 
@@ -41,6 +43,16 @@ export const notificationRouter = router({
       const count = await markNotificationsRead({
         speakerId: ctx.speaker._id,
         ids: input.ids,
+      })
+      return { count }
+    }),
+
+  markReadByLink: protectedProcedure
+    .input(MarkReadByLinkSchema)
+    .mutation(async ({ ctx, input }) => {
+      const count = await markNotificationsReadByLinks({
+        speakerId: ctx.speaker._id,
+        links: input.links,
       })
       return { count }
     }),

--- a/src/server/schemas/message.ts
+++ b/src/server/schemas/message.ts
@@ -25,16 +25,22 @@ export const ListMessagesSchema = z.object({
 })
 
 /**
- * Send a message. Exactly one of two entry points:
+ * Send a message. Exactly one of three entry points:
  * - an existing `conversationId`, OR
  * - a `proposalId` (auto-creates/looks up the proposal thread), OR
  * - a `subject` with no proposalId (starts a general thread).
  * The router enforces the precedence; the body cap mirrors the schema (≤5000).
+ *
+ * `recipientSpeakerId` is the speaker an ORGANIZER-initiated general thread is
+ * about/with. It is ONLY honored for an organizer (the router rejects it with
+ * FORBIDDEN when a non-organizer supplies it) and is REQUIRED when an organizer
+ * starts a general thread. Speaker-started threads must not supply it.
  */
 export const SendMessageSchema = z.object({
   conversationId: z.string().min(1).max(200).optional(),
   proposalId: z.string().min(1).max(200).optional(),
   subject: z.string().min(1).max(200).optional(),
+  recipientSpeakerId: z.string().min(1).max(200).optional(),
   body: z.string().min(1).max(5000),
 })
 

--- a/src/server/schemas/notification.ts
+++ b/src/server/schemas/notification.ts
@@ -23,3 +23,31 @@ export const ListNotificationsSchema = z.object({
 export const MarkReadSchema = z.object({
   ids: z.array(z.string()).min(1).max(100),
 })
+
+/**
+ * Input for `notification.markReadByLink`. Each link is an APP-RELATIVE deep
+ * link (the same `link` a notification carries): it must start with '/' and
+ * must not be an absolute/protocol-relative URL or a backslash path. Bounded to
+ * 8 links; the data layer additionally scopes patches to the caller's own docs.
+ */
+export const MarkReadByLinkSchema = z.object({
+  links: z
+    .array(
+      z
+        .string()
+        .min(1)
+        .max(300)
+        .refine(
+          (link) =>
+            link.startsWith('/') &&
+            !link.includes('://') &&
+            !link.includes('\\'),
+          {
+            message:
+              'Link must be an app-relative path (start with "/", no scheme or backslash)',
+          },
+        ),
+    )
+    .min(1)
+    .max(8),
+})


### PR DESCRIPTION
## M3a — messaging backend (no UI)

Builds on M1 (#527) and M2 (#528). Three backend features plus a one-line UI cleanup. No new UI surfaces in this phase.

### F1 — Organizer-initiated general threads (`subjectSpeaker`)

Organizers can now start a general thread *about/with* a specific speaker, not just receive speaker-started ones.

- **Schema** (`conversation`): new optional `subjectSpeaker` reference → `speaker`. Documented as "the speaker a general conversation is ABOUT/with, set when an organizer initiates; speaker-created threads leave it unset (creator IS the speaker)." Unused for proposal threads.
- **Type**: `ConversationWithContext` gains `subjectSpeakerId?`; the `CONVERSATION_PROJECTION` reads `subjectSpeaker._ref`.
- **Authz** (`canAccessConversation`): the general branch becomes `createdById === speaker._id || subjectSpeakerId === speaker._id`. Organizer short-circuit unchanged. Proposal branch unchanged.
- **Recipients** (`resolveParticipantIds` / `resolveRecipients`): a general thread resolves to `organizers ∪ {createdById, subjectSpeakerId}`, deduped, minus the actor. A missing `subjectSpeaker` is a no-op.
- **Inbox scope** (`listConversationsForSpeaker`): a non-organizer now also sees general threads where they are the `subjectSpeaker` (added `subjectSpeaker._ref == $speakerId` to the scope filter).
- **Router `send`**: new optional input `recipientSpeakerId`.
  - **FORBIDDEN** when a non-organizer supplies it (organizer-only capability, checked up-front regardless of path).
  - **REQUIRED** when an organizer starts a *new general* thread (subject path) — a `BAD_REQUEST` otherwise — and it must resolve to a real speaker doc (`speakerExists`, else `NOT_FOUND`).
  - Speaker-created general threads are unchanged (no recipient, subject is themselves).
- `createGeneralConversation` accepts an optional `subjectSpeakerId` and writes the `subjectSpeaker` ref only when present.

### F2 — Mark-read-by-link (notification side)

Lets a client clear a conversation's message notifications by the deep link it navigates to.

- **Lib** `markNotificationsReadByLinks({speakerId, links})`: ONE GROQ fetch of the caller's own ids where `recipient._ref == $speakerId && !defined(readAt) && link in $links`, then one patch transaction setting `readAt`. Mirrors `markNotificationsRead`: **the recipient filter IS the ownership guard** — a foreign link can clear nothing but the caller's own matching notifications. Links bounded to ≤8 defensively.
- **Router** `notification.markReadByLink` (`protectedProcedure`): input `{links: string[]}` — zod 1..8 items, each ≤300 chars, must start with `/`, rejects anything containing `://` or `\`. Returns `{count}`.

### F3 — Unread counts per conversation

- `listConversationsForSpeaker` now returns `unreadCount` per row. Rather than N subqueries, it runs ONE extra GROQ fetching the caller's unread `message_received` notification links for the conference, then counts in JS against each row's two audience link variants (`conversationLinkPath(row, true)` and `(row, false)` — the caller only ever received one variant, so matching both is correct and simplest). `ConversationListItem` gains `unreadCount: number`.

### Misc
- Removed a dead ternary (`isOwn ? 'max-w-[80%]' : 'max-w-[80%]'`) in `ConversationThread.tsx` — pure class-string cleanup, no behavior change.

### Router input contract for M3b
- `message.send`: optional `recipientSpeakerId` — organizer-only (FORBIDDEN for non-organizers), required when an organizer opens a new general thread, sets `subjectSpeaker`.
- `notification.markReadByLink`: `{links: string[]}` (1..8 app-relative paths) → `{count}`.
- `message.listConversations` rows now include `unreadCount`.

### Verification
- `tsc --noEmit`: 0 errors
- eslint (touched src dirs): clean
- prettier: clean
- knip: exit 0
- `vitest run __tests__/`: 186 files, 2813 passed / 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three backend messaging features (M3a) with no new UI surfaces: organizer-initiated general threads (`subjectSpeaker`), mark-read-by-link notifications, and per-conversation unread counts. The implementation is well-structured and follows existing patterns throughout.

- **F1 (subjectSpeaker)**: Schema field, type, authz, recipient resolution, inbox scope filter, and `send` router guard are all consistent; the `FORBIDDEN` check fires unconditionally before any branch, preventing non-organizers from ever naming a subject speaker.
- **F2 (markReadByLink)**: Mirrors `markNotificationsRead`; the recipient filter in GROQ is the ownership guard, links are bounded to 8 in both the schema and the data layer, and the router derives `speakerId` from `ctx` only.
- **F3 (unreadCount)**: One extra GROQ fetch per `listConversations` call instead of N per-row subqueries; JS-side counting against both audience link variants is safe because the two paths are always distinct strings.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the two findings are both defensive hardening items with no exploitable impact given how notification links are produced and consumed.

The organizer gate, subject-speaker authz, and mark-read-by-link ownership guard all correctly use server-derived identifiers. The protocol-relative URL gap in MarkReadByLinkSchema is a validation omission with zero practical impact (no notification will ever carry a //host/path link), and the unbounded unread-link fetch is an edge-case scalability concern only.

src/server/schemas/notification.ts (protocol-relative URL gap) and src/lib/messaging/sanity.ts (unbounded unread-links GROQ fetch).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/message.ts | Adds organizer-only recipientSpeakerId input to send; gate (FORBIDDEN for non-organizers) fires unconditionally at the top of the handler before any branch, and the BAD_REQUEST + speaker-existence checks are correctly confined to the subject (new general thread) branch only. |
| src/lib/messaging/sanity.ts | Core messaging data layer: resolveParticipantIds/resolveRecipients/canAccessConversation all gain subjectSpeakerId; listConversationsForSpeaker adds scope filter and unbounded unread-link query (P2). Logic is otherwise correct. |
| src/lib/notification/sanity.ts | New markNotificationsReadByLinks mirrors existing markNotificationsRead pattern: recipient filter is the ownership guard, links are bounded to 8, and patches are committed in a single transaction. |
| src/server/schemas/notification.ts | New MarkReadByLinkSchema validates 1-8 app-relative links but the :// check does not cover protocol-relative //host/path URLs (P2 gap). |
| src/server/routers/notification.ts | Adds markReadByLink protectedProcedure; delegates speakerId from ctx (never from client), passes links directly to markNotificationsReadByLinks. |
| src/lib/messaging/types.ts | Adds optional subjectSpeakerId to ConversationWithContext and required unreadCount to ConversationListItem; well-documented interface additions. |
| sanity/schemaTypes/conversation.ts | Adds optional subjectSpeaker reference field to the conversation schema with accurate documentation; no required-validation since speaker-created threads omit it. |
| src/server/schemas/message.ts | Adds optional recipientSpeakerId string field to SendMessageSchema; enforcement is handled in the router. |
| src/components/messaging/ConversationThread.tsx | Removes dead ternary isOwn ? 'max-w-[80%]' : 'max-w-[80%]' → 'max-w-[80%]'; no behavior change. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as message.send / notification.markReadByLink
    participant Auth as protectedProcedure (ctx.speaker)
    participant Sanity as Sanity data layer
    participant Notifier as notifyNewMessage

    Note over Client,Notifier: F1 — Organizer-initiated general thread
    Client->>Router: "send({ subject, recipientSpeakerId })"
    Router->>Auth: verify ctx.speaker.isOrganizer
    Auth-->>Router: "isOrganizer=true"
    Router->>Sanity: speakerExists(recipientSpeakerId)
    Sanity-->>Router: true
    Router->>Sanity: "createGeneralConversation({ subjectSpeakerId })"
    Sanity-->>Router: conversationId
    Router->>Sanity: addMessage(conversationId, body)
    Sanity-->>Router: message
    Router->>Notifier: notifyNewMessage(conversation, recipients)
    Notifier-->>Router: fire-and-forget
    Router-->>Client: "{ conversationId, message }"

    Note over Client,Sanity: F2 — Mark-read-by-link
    Client->>Router: "notification.markReadByLink({ links })"
    Router->>Auth: ctx.speaker._id
    Auth-->>Router: speakerId
    Router->>Sanity: "markNotificationsReadByLinks({ speakerId, links })"
    Sanity->>Sanity: "GROQ fetch (recipient==speakerId && !readAt && link in links)"
    Sanity->>Sanity: "transaction.patch(readAt=now) x count"
    Sanity-->>Router: count
    Router-->>Client: "{ count }"

    Note over Client,Sanity: F3 — Unread counts in inbox
    Client->>Router: "message.listConversations({ cursor })"
    Router->>Sanity: listConversationsForSpeaker(speakerId, isOrganizer)
    Sanity->>Sanity: GROQ fetch conversations (scoped)
    Sanity->>Sanity: GROQ fetch unread message_received links (ONE extra query)
    Sanity->>Sanity: JS count per row via conversationLinkPath(row, true/false)
    Sanity-->>Router: ConversationListItem[] with unreadCount
    Router-->>Client: rows
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as message.send / notification.markReadByLink
    participant Auth as protectedProcedure (ctx.speaker)
    participant Sanity as Sanity data layer
    participant Notifier as notifyNewMessage

    Note over Client,Notifier: F1 — Organizer-initiated general thread
    Client->>Router: "send({ subject, recipientSpeakerId })"
    Router->>Auth: verify ctx.speaker.isOrganizer
    Auth-->>Router: "isOrganizer=true"
    Router->>Sanity: speakerExists(recipientSpeakerId)
    Sanity-->>Router: true
    Router->>Sanity: "createGeneralConversation({ subjectSpeakerId })"
    Sanity-->>Router: conversationId
    Router->>Sanity: addMessage(conversationId, body)
    Sanity-->>Router: message
    Router->>Notifier: notifyNewMessage(conversation, recipients)
    Notifier-->>Router: fire-and-forget
    Router-->>Client: "{ conversationId, message }"

    Note over Client,Sanity: F2 — Mark-read-by-link
    Client->>Router: "notification.markReadByLink({ links })"
    Router->>Auth: ctx.speaker._id
    Auth-->>Router: speakerId
    Router->>Sanity: "markNotificationsReadByLinks({ speakerId, links })"
    Sanity->>Sanity: "GROQ fetch (recipient==speakerId && !readAt && link in links)"
    Sanity->>Sanity: "transaction.patch(readAt=now) x count"
    Sanity-->>Router: count
    Router-->>Client: "{ count }"

    Note over Client,Sanity: F3 — Unread counts in inbox
    Client->>Router: "message.listConversations({ cursor })"
    Router->>Sanity: listConversationsForSpeaker(speakerId, isOrganizer)
    Sanity->>Sanity: GROQ fetch conversations (scoped)
    Sanity->>Sanity: GROQ fetch unread message_received links (ONE extra query)
    Sanity->>Sanity: JS count per row via conversationLinkPath(row, true/false)
    Sanity-->>Router: ConversationListItem[] with unreadCount
    Router-->>Client: rows
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): organizer-initiated thr..."](https://github.com/cloudnativebergen/website/commit/9abd420015f2d11643e6c8b72e6fa6631e9accfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45407472)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->