### PR TITLE
feat(messaging): organizer-initiated threads UI, auto-read, unread badges (M3b)

### DIFF
--- a/__tests__/components/messaging/ConversationList.test.tsx
+++ b/__tests__/components/messaging/ConversationList.test.tsx
@@ -69,4 +69,29 @@ describe('ConversationList', () => {
       screen.getByRole('region', { name: 'Conversations' }),
     ).toBeInTheDocument()
   })
+
+  it('hides the unread pill when a conversation has no unread messages', () => {
+    render(<ConversationList items={items} isOrganizer={false} />)
+    expect(screen.queryByLabelText(/unread/i)).not.toBeInTheDocument()
+  })
+
+  it('renders a blue unread pill and bolds the subject when unread', () => {
+    const unread: ConversationListItem[] = [{ ...items[0], unreadCount: 3 }]
+    render(<ConversationList items={unread} isOrganizer={false} />)
+    const pill = screen.getByLabelText('3 unread')
+    expect(pill).toHaveTextContent('3')
+    // Subject is bolded for an unread row.
+    expect(screen.getByText('Scaling Kubernetes')).toHaveClass('font-bold')
+  })
+
+  it('caps the unread pill at 9+', () => {
+    const unread: ConversationListItem[] = [{ ...items[0], unreadCount: 25 }]
+    render(<ConversationList items={unread} isOrganizer={false} />)
+    expect(screen.getByLabelText('25 unread')).toHaveTextContent('9+')
+  })
+
+  it('keeps a read row subject at semibold (not bold)', () => {
+    render(<ConversationList items={items} isOrganizer={false} />)
+    expect(screen.getByText('Scaling Kubernetes')).toHaveClass('font-semibold')
+  })
 })

--- a/__tests__/components/messaging/ConversationThreadContainer.test.tsx
+++ b/__tests__/components/messaging/ConversationThreadContainer.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { ConversationThread } from '@/components/messaging'
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { speaker: { _id: 'me' } } }),
+}))
+
+// --- tRPC surface, driven by mutable state the tests set before rendering ---
+const markReadMutate = vi.fn()
+let markReadOnSuccess: (() => void) | undefined
+const noopMutation = { mutate: vi.fn(), isPending: false }
+
+const unreadCountInvalidate = vi.fn()
+const notificationListInvalidate = vi.fn()
+
+let getConversationResult: { data: unknown; error: unknown } = {
+  data: undefined,
+  error: null,
+}
+let listMessagesResult: Record<string, unknown> = {}
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    useUtils: () => ({
+      message: {
+        listMessages: { invalidate: vi.fn() },
+        getConversation: { invalidate: vi.fn() },
+        listConversations: { invalidate: vi.fn() },
+      },
+      notification: {
+        unreadCount: { invalidate: unreadCountInvalidate },
+        list: { invalidate: notificationListInvalidate },
+      },
+    }),
+    message: {
+      getConversation: { useQuery: () => getConversationResult },
+      listMessages: { useInfiniteQuery: () => listMessagesResult },
+      send: { useMutation: () => noopMutation },
+      setPreference: { useMutation: () => noopMutation },
+    },
+    notification: {
+      markReadByLink: {
+        useMutation: (opts?: { onSuccess?: () => void }) => {
+          markReadOnSuccess = opts?.onSuccess
+          return { mutate: markReadMutate }
+        },
+      },
+    },
+  },
+}))
+
+function loadedMessages() {
+  return {
+    data: { pages: [[]] },
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }
+}
+
+function generalConversation(id: string) {
+  return {
+    data: {
+      conversation: {
+        _id: id,
+        conversationType: 'general',
+        subject: 'Travel',
+      },
+      participants: [],
+      preference: { muted: false, emailOverride: 'default' },
+    },
+    error: null,
+  }
+}
+
+beforeEach(() => {
+  markReadMutate.mockClear()
+  unreadCountInvalidate.mockClear()
+  notificationListInvalidate.mockClear()
+  markReadOnSuccess = undefined
+})
+
+describe('ConversationThread — auto-mark-read', () => {
+  it('marks BOTH audience link variants read once messages have loaded', () => {
+    getConversationResult = generalConversation('conversation.abc')
+    listMessagesResult = loadedMessages()
+
+    render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+
+    expect(markReadMutate).toHaveBeenCalledTimes(1)
+    expect(markReadMutate).toHaveBeenCalledWith({
+      links: [
+        '/admin/messages/conversation.abc',
+        '/cfp/messages/conversation.abc',
+      ],
+    })
+  })
+
+  it('invalidates the bell count and list on success', () => {
+    getConversationResult = generalConversation('conversation.abc')
+    listMessagesResult = loadedMessages()
+
+    render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+
+    expect(markReadOnSuccess).toBeTypeOf('function')
+    markReadOnSuccess?.()
+    expect(unreadCountInvalidate).toHaveBeenCalledTimes(1)
+    expect(notificationListInvalidate).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mark read while messages are still loading', () => {
+    getConversationResult = generalConversation('conversation.abc')
+    listMessagesResult = {
+      ...loadedMessages(),
+      isLoading: true,
+      isSuccess: false,
+    }
+
+    render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+    expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  it('does not mark read before the conversation resolves', () => {
+    getConversationResult = { data: undefined, error: null }
+    listMessagesResult = loadedMessages()
+
+    render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+    expect(markReadMutate).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/messaging/NewConversationForm.test.tsx
+++ b/__tests__/components/messaging/NewConversationForm.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { NewConversationForm } from '@/components/messaging'
+
+// The picker owns its own tRPC search query; stub it to a deterministic button
+// so this test focuses on how the form WIRES a selected recipient into send.
+vi.mock('@/components/messaging/SpeakerCombobox', () => ({
+  SpeakerCombobox: ({
+    value,
+    onChange,
+    invalid,
+  }: {
+    value: { _id: string; name: string } | null
+    onChange: (s: { _id: string; name: string } | null) => void
+    invalid?: boolean
+  }) => (
+    <div>
+      <button
+        type="button"
+        data-testid="pick-speaker"
+        onClick={() => onChange({ _id: 'speaker-9', name: 'Picked Speaker' })}
+      >
+        {value ? value.name : 'pick a speaker'}
+      </button>
+      {invalid && <span data-testid="picker-invalid" />}
+    </div>
+  ),
+}))
+
+const routerPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPush }),
+}))
+
+const sendMutate = vi.fn()
+const listConversationsInvalidate = vi.fn()
+let sendState: {
+  isPending: boolean
+  isError: boolean
+  error: unknown
+} = { isPending: false, isError: false, error: null }
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    useUtils: () => ({
+      message: {
+        listConversations: { invalidate: listConversationsInvalidate },
+      },
+    }),
+    message: {
+      send: {
+        useMutation: () => ({ mutate: sendMutate, ...sendState }),
+      },
+    },
+  },
+}))
+
+beforeEach(() => {
+  sendMutate.mockClear()
+  listConversationsInvalidate.mockClear()
+  routerPush.mockClear()
+  sendState = { isPending: false, isError: false, error: null }
+})
+
+function fill(subject: string, body: string) {
+  fireEvent.change(screen.getByLabelText('Subject'), {
+    target: { value: subject },
+  })
+  fireEvent.change(screen.getByLabelText('Message'), {
+    target: { value: body },
+  })
+}
+
+describe('NewConversationForm — organizer flow', () => {
+  it('passes recipientSpeakerId once a speaker is picked', () => {
+    render(<NewConversationForm basePath="/admin/messages" requireRecipient />)
+    // Submit is blocked until a recipient is chosen.
+    const submit = screen.getByRole('button', { name: /start conversation/i })
+    fill('Travel plans', 'Can you confirm your dates?')
+    expect(submit).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId('pick-speaker'))
+    expect(submit).toBeEnabled()
+    fireEvent.click(submit)
+
+    expect(sendMutate).toHaveBeenCalledWith({
+      subject: 'Travel plans',
+      body: 'Can you confirm your dates?',
+      recipientSpeakerId: 'speaker-9',
+    })
+  })
+
+  it('renders an inline "speaker not found" error on NOT_FOUND', () => {
+    sendState = {
+      isPending: false,
+      isError: true,
+      error: { data: { code: 'NOT_FOUND' } },
+    }
+    render(<NewConversationForm basePath="/admin/messages" requireRecipient />)
+    expect(screen.getByText(/speaker not found/i)).toBeInTheDocument()
+    expect(screen.getByTestId('picker-invalid')).toBeInTheDocument()
+    // The generic failure copy is suppressed in favour of the specific message.
+    expect(
+      screen.queryByText(/couldn.t start the conversation/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the generic error for a non-NOT_FOUND failure', () => {
+    sendState = {
+      isPending: false,
+      isError: true,
+      error: { data: { code: 'INTERNAL_SERVER_ERROR' } },
+    }
+    render(<NewConversationForm basePath="/admin/messages" requireRecipient />)
+    expect(
+      screen.getByText(/couldn.t start the conversation/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId('picker-invalid')).not.toBeInTheDocument()
+  })
+})
+
+describe('NewConversationForm — speaker flow', () => {
+  it('has no recipient picker and sends without recipientSpeakerId', () => {
+    render(<NewConversationForm basePath="/cfp/messages" />)
+    expect(screen.queryByTestId('pick-speaker')).not.toBeInTheDocument()
+
+    fill('Hello', 'A question for the organizers')
+    fireEvent.click(screen.getByRole('button', { name: /start conversation/i }))
+    expect(sendMutate).toHaveBeenCalledWith({
+      subject: 'Hello',
+      body: 'A question for the organizers',
+    })
+  })
+})

--- a/src/app/(admin)/admin/messages/page.tsx
+++ b/src/app/(admin)/admin/messages/page.tsx
@@ -18,7 +18,7 @@ export default function AdminMessagesPage() {
         </p>
       </div>
 
-      <MessagesInbox audience="organizer" />
+      <MessagesInbox audience="organizer" allowNew />
     </div>
   )
 }

--- a/src/components/messaging/ConversationList.stories.tsx
+++ b/src/components/messaging/ConversationList.stories.tsx
@@ -6,7 +6,9 @@ import type { ConversationListItem } from '@/lib/messaging/types'
 const minutesAgo = (m: number) =>
   new Date(Date.now() - m * 60_000).toISOString()
 
-const makeItems = (): ConversationListItem[] => [
+const makeItems = (
+  unread: [number, number, number] = [0, 0, 0],
+): ConversationListItem[] => [
   {
     _id: 'conversation.proposal.talk-1',
     conversationType: 'proposal',
@@ -15,7 +17,7 @@ const makeItems = (): ConversationListItem[] => [
     proposalTitle: 'Scaling Kubernetes to 10,000 nodes',
     createdAt: minutesAgo(60 * 24 * 3),
     lastMessageAt: minutesAgo(24),
-    unreadCount: 0,
+    unreadCount: unread[0],
   },
   {
     _id: 'conversation.abc123',
@@ -23,7 +25,7 @@ const makeItems = (): ConversationListItem[] => [
     subject: 'Question about speaker travel',
     createdAt: minutesAgo(60 * 24 * 2),
     lastMessageAt: minutesAgo(60 * 5),
-    unreadCount: 0,
+    unreadCount: unread[1],
   },
   {
     _id: 'conversation.proposal.talk-2',
@@ -33,7 +35,7 @@ const makeItems = (): ConversationListItem[] => [
     proposalTitle: 'Designing for Failure',
     createdAt: minutesAgo(60 * 24 * 10),
     lastMessageAt: minutesAgo(60 * 24 * 4),
-    unreadCount: 0,
+    unreadCount: unread[2],
   },
 ]
 
@@ -86,4 +88,23 @@ export const SpeakerInboxDark: Story = {
   args: { items: [], isOrganizer: false },
   parameters: { dark: true },
   render: (args) => <ConversationList {...args} items={makeItems()} />,
+}
+
+/**
+ * Mixed read/unread — unread rows carry a blue count pill and a bolded subject;
+ * read rows are unadorned. The last count exceeds 9 to show the `9+` cap.
+ */
+export const UnreadMixed: Story = {
+  args: { items: [], isOrganizer: true },
+  render: (args) => (
+    <ConversationList {...args} items={makeItems([3, 0, 12])} />
+  ),
+}
+
+export const UnreadMixedDark: Story = {
+  args: { items: [], isOrganizer: true },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationList {...args} items={makeItems([3, 0, 12])} />
+  ),
 }

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -88,28 +88,45 @@ export function ConversationList({
         </div>
       ) : (
         <>
-          {items.map((item) => (
-            <Link
-              key={item._id}
-              href={conversationLinkPath(item, isOrganizer)}
-              prefetch={false}
-              className="flex items-baseline justify-between gap-3 px-4 py-3 transition hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60"
-            >
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-semibold text-gray-900 dark:text-white">
-                  {conversationTitle(item)}
-                </span>
-                {item.conversationType === 'proposal' && (
-                  <span className="mt-0.5 block text-xs text-gray-400 dark:text-gray-500">
-                    Proposal thread
+          {items.map((item) => {
+            const isUnread = item.unreadCount > 0
+            return (
+              <Link
+                key={item._id}
+                href={conversationLinkPath(item, isOrganizer)}
+                prefetch={false}
+                className="flex items-baseline justify-between gap-3 px-4 py-3 transition hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60"
+              >
+                <span className="min-w-0 flex-1">
+                  <span
+                    className={`block truncate text-sm text-gray-900 dark:text-white ${
+                      isUnread ? 'font-bold' : 'font-semibold'
+                    }`}
+                  >
+                    {conversationTitle(item)}
                   </span>
-                )}
-              </span>
-              <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
-                {formatRelativeTime(item.lastMessageAt)}
-              </span>
-            </Link>
-          ))}
+                  {item.conversationType === 'proposal' && (
+                    <span className="mt-0.5 block text-xs text-gray-400 dark:text-gray-500">
+                      Proposal thread
+                    </span>
+                  )}
+                </span>
+                <span className="flex shrink-0 items-baseline gap-2">
+                  {isUnread && (
+                    <span
+                      aria-label={`${item.unreadCount} unread`}
+                      className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-cloud-blue px-1.5 text-[11px] leading-none font-semibold text-white dark:bg-blue-600"
+                    >
+                      {item.unreadCount > 9 ? '9+' : item.unreadCount}
+                    </span>
+                  )}
+                  <span className="text-xs text-gray-400 dark:text-gray-500">
+                    {formatRelativeTime(item.lastMessageAt)}
+                  </span>
+                </span>
+              </Link>
+            )
+          })}
           {hasMore && (
             <div className="p-2">
               <button

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSession } from 'next-auth/react'
 import {
   BellIcon,
@@ -8,7 +8,10 @@ import {
   PaperAirplaneIcon,
 } from '@heroicons/react/24/outline'
 import { api } from '@/lib/trpc/client'
-import { proposalConversationId } from '@/lib/messaging/links'
+import {
+  conversationLinkPath,
+  proposalConversationId,
+} from '@/lib/messaging/links'
 import { formatRelativeTime } from '@/lib/notification/format'
 import type {
   ConversationPreference,
@@ -411,6 +414,60 @@ export function ConversationThread({
       }
     })
   }, [pages, participantById, meId])
+
+  // AUTO-MARK-READ: opening a thread clears its `message_received` notifications
+  // for the bell. We mark BOTH audience link variants (a recipient only ever
+  // received one) and only once the messages have actually loaded — never on an
+  // error/empty state. It fires once per mount and again on regained focus.
+  const markReadMutation = api.notification.markReadByLink.useMutation({
+    onSuccess: () => {
+      utils.notification.unreadCount.invalidate()
+      utils.notification.list.invalidate()
+    },
+  })
+  const markReadMutate = markReadMutation.mutate
+  const conversation = conversationQuery.data?.conversation
+  const messagesLoaded = messagesQuery.isSuccess
+  const markReadLinks = useMemo(
+    () =>
+      conversation
+        ? [
+            conversationLinkPath(conversation, true),
+            conversationLinkPath(conversation, false),
+          ]
+        : null,
+    [conversation],
+  )
+
+  // Guarded so a re-render can't re-fire within the same mount/focus; the focus
+  // listener resets the guard so a regained tab re-marks any newly-read items.
+  const markedKeyRef = useRef<string | null>(null)
+  const markRead = useCallback(() => {
+    if (!markReadLinks || !messagesLoaded) return
+    const key = markReadLinks.join('|')
+    if (markedKeyRef.current === key) return
+    markedKeyRef.current = key
+    markReadMutate({ links: markReadLinks })
+  }, [markReadLinks, messagesLoaded, markReadMutate])
+
+  useEffect(() => {
+    markRead()
+  }, [markRead])
+
+  useEffect(() => {
+    const onFocus = () => {
+      if (document.visibilityState === 'visible') {
+        markedKeyRef.current = null
+        markRead()
+      }
+    }
+    window.addEventListener('focus', onFocus)
+    document.addEventListener('visibilitychange', onFocus)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onFocus)
+    }
+  }, [markRead])
 
   const invalidate = () => {
     if (convId) {

--- a/src/components/messaging/MessagesInbox.tsx
+++ b/src/components/messaging/MessagesInbox.tsx
@@ -18,8 +18,9 @@ export interface MessagesInboxProps {
 
 /**
  * Inbox container for both audiences: loads the caller's conversations and
- * renders {@link ConversationList}. Speakers additionally get a
- * {@link NewConversationForm} to open a general thread with the organizers.
+ * renders {@link ConversationList}. When `allowNew` is set a
+ * {@link NewConversationForm} opens a general thread — speakers with the
+ * organizers; organizers with a chosen recipient speaker.
  */
 export function MessagesInbox({
   audience,
@@ -57,6 +58,7 @@ export function MessagesInbox({
           {showNew ? (
             <NewConversationForm
               basePath={basePath}
+              requireRecipient={isOrganizer}
               onCancel={() => setShowNew(false)}
             />
           ) : (

--- a/src/components/messaging/NewConversationForm.stories.tsx
+++ b/src/components/messaging/NewConversationForm.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { userEvent, within } from 'storybook/test'
+import { http, HttpResponse } from 'msw'
+import { NewConversationForm } from '@/components/messaging'
+
+const speakers = [
+  {
+    _id: 'speaker-1',
+    name: 'Åsa Berg',
+    title: 'Principal Engineer, CloudScale',
+    isOrganizer: false,
+    proposals: [],
+  },
+  {
+    _id: 'speaker-2',
+    name: 'Anders Nilsson',
+    title: 'SRE Lead, Nordic Cloud',
+    isOrganizer: false,
+    proposals: [],
+  },
+]
+
+const handlers = [
+  http.get('/api/trpc/speaker.admin.search', () =>
+    HttpResponse.json({ result: { data: speakers } }),
+  ),
+  http.post('/api/trpc/message.send', () =>
+    HttpResponse.json({
+      result: {
+        data: { conversationId: 'conversation.new', message: {} },
+      },
+    }),
+  ),
+]
+
+const meta = {
+  title: 'Components/Messaging/NewConversationForm',
+  component: NewConversationForm,
+  parameters: { layout: 'padded', msw: { handlers } },
+  decorators: [
+    (Story, ctx) => (
+      <div className={ctx.parameters.dark ? 'dark bg-gray-950 p-4' : ''}>
+        <div className="mx-auto w-full max-w-xl">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof NewConversationForm>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Speaker flow — no recipient picker (the thread is implicitly about them). */
+export const SpeakerForm: Story = {
+  args: { basePath: '/cfp/messages' },
+}
+
+/** Organizer flow — a searchable recipient speaker picker is required. */
+export const OrganizerForm: Story = {
+  args: { basePath: '/admin/messages', requireRecipient: true },
+}
+
+/** Organizer flow with the recipient picker opened on a query. */
+export const OrganizerPickerOpen: Story = {
+  args: { basePath: '/admin/messages', requireRecipient: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByPlaceholderText(/search speakers/i)
+    await userEvent.click(input)
+    await userEvent.type(input, 'a')
+  },
+}
+
+export const OrganizerFormDark: Story = {
+  args: { basePath: '/admin/messages', requireRecipient: true },
+  parameters: { dark: true },
+}

--- a/src/components/messaging/NewConversationForm.tsx
+++ b/src/components/messaging/NewConversationForm.tsx
@@ -3,9 +3,14 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { api } from '@/lib/trpc/client'
+import { SpeakerCombobox, type SpeakerOption } from './SpeakerCombobox'
 
 const MAX_SUBJECT = 200
 const MAX_BODY = 5000
+
+function errorCode(error: unknown): string | undefined {
+  return (error as { data?: { code?: string } } | null)?.data?.code
+}
 
 export interface NewConversationFormProps {
   /**
@@ -13,6 +18,12 @@ export interface NewConversationFormProps {
    * (e.g. `/cfp/messages`). The created conversation id is appended.
    */
   basePath: string
+  /**
+   * When true (organizer flow), a speaker picker is shown and a recipient is
+   * required — the created thread's subject speaker. Speakers omit this: their
+   * general threads are implicitly about themselves.
+   */
+  requireRecipient?: boolean
   /** Optional callback after a thread is created (before navigation). */
   onCreated?: (conversationId: string) => void
   /** Optional cancel handler (e.g. to collapse the form). */
@@ -21,15 +32,18 @@ export interface NewConversationFormProps {
 
 /**
  * Starts a general (non-proposal) conversation: a subject plus a first message.
- * On success it navigates to the newly created thread.
+ * Organizers additionally pick the recipient speaker the thread is about
+ * (`recipientSpeakerId`). On success it navigates to the newly created thread.
  */
 export function NewConversationForm({
   basePath,
+  requireRecipient = false,
   onCreated,
   onCancel,
 }: NewConversationFormProps) {
   const router = useRouter()
   const utils = api.useUtils()
+  const [recipient, setRecipient] = useState<SpeakerOption | null>(null)
   const [subject, setSubject] = useState('')
   const [body, setBody] = useState('')
 
@@ -41,15 +55,26 @@ export function NewConversationForm({
     },
   })
 
+  // The recipient is only ever unresolvable when the organizer picked one; the
+  // server returns NOT_FOUND, which we surface inline against the picker.
+  const recipientNotFound = errorCode(sendMutation.error) === 'NOT_FOUND'
+
   const canSubmit =
     subject.trim().length > 0 &&
     body.trim().length > 0 &&
+    (!requireRecipient || recipient !== null) &&
     !sendMutation.isPending
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!canSubmit) return
-    sendMutation.mutate({ subject: subject.trim(), body: body.trim() })
+    sendMutation.mutate({
+      subject: subject.trim(),
+      body: body.trim(),
+      ...(requireRecipient && recipient
+        ? { recipientSpeakerId: recipient._id }
+        : {}),
+    })
   }
 
   return (
@@ -57,6 +82,31 @@ export function NewConversationForm({
       onSubmit={handleSubmit}
       className="space-y-3 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
     >
+      {requireRecipient && (
+        <div>
+          <label
+            htmlFor="new-conversation-recipient"
+            className="block text-sm font-medium text-gray-900 dark:text-white"
+          >
+            Speaker
+          </label>
+          <SpeakerCombobox
+            id="new-conversation-recipient"
+            value={recipient}
+            onChange={setRecipient}
+            invalid={recipientNotFound}
+          />
+          {recipientNotFound && (
+            <p
+              role="alert"
+              className="mt-1 text-xs text-red-600 dark:text-red-400"
+            >
+              Speaker not found. Pick another speaker.
+            </p>
+          )}
+        </div>
+      )}
+
       <div>
         <label
           htmlFor="new-conversation-subject"
@@ -93,7 +143,7 @@ export function NewConversationForm({
         />
       </div>
 
-      {sendMutation.isError && (
+      {sendMutation.isError && !recipientNotFound && (
         <p role="alert" className="text-sm text-red-600 dark:text-red-400">
           Couldn&apos;t start the conversation. Please try again.
         </p>

--- a/src/components/messaging/SpeakerCombobox.tsx
+++ b/src/components/messaging/SpeakerCombobox.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxButton,
+  ComboboxOptions,
+  ComboboxOption,
+} from '@headlessui/react'
+import { ChevronUpDownIcon, CheckIcon } from '@heroicons/react/20/solid'
+import { api } from '@/lib/trpc/client'
+
+/** The minimal shape a recipient speaker is picked and submitted as. */
+export interface SpeakerOption {
+  _id: string
+  name: string
+  title?: string
+}
+
+export interface SpeakerComboboxProps {
+  /** The chosen speaker, or `null` when none is selected yet. */
+  value: SpeakerOption | null
+  onChange: (speaker: SpeakerOption | null) => void
+  /** Marks the control invalid (e.g. the recipient could not be resolved). */
+  invalid?: boolean
+  disabled?: boolean
+  /** Ties the input to an external `<label>` for accessibility. */
+  id?: string
+}
+
+/**
+ * Organizer-only searchable speaker picker. Reuses the existing
+ * `speaker.admin.search` procedure (confirmed/accepted speakers + organizers),
+ * so no new server surface is introduced — the query is issued only once the
+ * organizer has typed something.
+ */
+export function SpeakerCombobox({
+  value,
+  onChange,
+  invalid = false,
+  disabled = false,
+  id,
+}: SpeakerComboboxProps) {
+  const [query, setQuery] = useState('')
+  const trimmed = query.trim()
+
+  const { data, isFetching } = api.speaker.admin.search.useQuery(
+    { query: trimmed },
+    { enabled: trimmed.length > 0, staleTime: 5_000 },
+  )
+
+  const options: SpeakerOption[] = (data ?? []).map((s) => ({
+    _id: s._id,
+    name: s.name,
+    title: s.title ?? undefined,
+  }))
+
+  return (
+    <Combobox
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      by="_id"
+      immediate
+    >
+      <div className="relative mt-1">
+        <ComboboxInput
+          id={id}
+          aria-invalid={invalid}
+          className={`block w-full rounded-lg border bg-white py-2 pr-10 pl-3 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus-visible:ring-1 dark:bg-gray-900 dark:text-white dark:placeholder-gray-500 ${
+            invalid
+              ? 'border-red-400 focus:border-red-500 focus-visible:ring-red-500 dark:border-red-500'
+              : 'border-gray-300 focus:border-brand-cloud-blue focus-visible:ring-brand-cloud-blue dark:border-gray-600'
+          }`}
+          displayValue={(s: SpeakerOption | null) => s?.name ?? ''}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search speakers by name…"
+        />
+        <ComboboxButton className="absolute inset-y-0 right-0 flex items-center pr-2">
+          <ChevronUpDownIcon
+            className="h-5 w-5 text-gray-400"
+            aria-hidden="true"
+          />
+        </ComboboxButton>
+
+        <ComboboxOptions className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-lg bg-white py-1 text-sm shadow-lg ring-1 ring-gray-200 focus:outline-none dark:bg-gray-800 dark:ring-white/10">
+          {trimmed.length === 0 ? (
+            <div className="px-3 py-2 text-gray-500 dark:text-gray-400">
+              Start typing to find a speaker
+            </div>
+          ) : isFetching && options.length === 0 ? (
+            <div className="px-3 py-2 text-gray-500 dark:text-gray-400">
+              Searching…
+            </div>
+          ) : options.length === 0 ? (
+            <div className="px-3 py-2 text-gray-500 dark:text-gray-400">
+              No speakers found
+            </div>
+          ) : (
+            options.map((speaker) => (
+              <ComboboxOption
+                key={speaker._id}
+                value={speaker}
+                className="group relative cursor-default px-3 py-2 pr-9 text-gray-900 select-none data-focus:bg-brand-cloud-blue data-focus:text-white dark:text-white"
+              >
+                <span className="block truncate font-normal group-data-selected:font-semibold">
+                  {speaker.name}
+                </span>
+                {speaker.title && (
+                  <span className="block truncate text-xs text-gray-500 group-data-focus:text-blue-100 dark:text-gray-400">
+                    {speaker.title}
+                  </span>
+                )}
+                <span className="absolute inset-y-0 right-0 hidden items-center pr-3 text-brand-cloud-blue group-data-focus:text-white group-data-selected:flex">
+                  <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                </span>
+              </ComboboxOption>
+            ))
+          )}
+        </ComboboxOptions>
+      </div>
+    </Combobox>
+  )
+}

--- a/src/components/messaging/index.ts
+++ b/src/components/messaging/index.ts
@@ -13,6 +13,11 @@ export {
   NewConversationForm,
   type NewConversationFormProps,
 } from './NewConversationForm'
+export {
+  SpeakerCombobox,
+  type SpeakerComboboxProps,
+  type SpeakerOption,
+} from './SpeakerCombobox'
 export { MessagesInbox, type MessagesInboxProps } from './MessagesInbox'
 export {
   ProposalMessagesSection,


### PR DESCRIPTION
## Messaging M3b (UI)

Builds the organizer-facing UI on top of the M3a backend (#529): organizer-initiated general threads, auto-mark-read on thread open, and unread badges in the inbox.

### F1 — Admin "New conversation" with speaker picker
- `/admin/messages` inbox now offers **New conversation** (`allowNew`), matching the speaker inbox.
- `NewConversationForm` gains `requireRecipient` (organizer flow): a searchable **speaker picker** (new `SpeakerCombobox`, Headless UI Combobox) is shown and required; the selection is submitted as `recipientSpeakerId` on `message.send`. The speaker-side form is unchanged (no picker, no recipient).
- Speaker search **reuses the existing `speaker.admin.search` procedure** (organizer-only, confirmed/accepted speakers + organizers) — no new server surface added. The query only fires once the organizer types.
- Error handling: a `NOT_FOUND` from send renders an inline "Speaker not found" message and marks the picker invalid; other failures keep the generic retry copy.

### F2 — Auto-mark-read on thread open
- `ConversationThread` container calls `notification.markReadByLink` with **both audience link variants** from `conversationLinkPath` (a recipient only ever received one), then invalidates `notification.unreadCount` + `notification.list` so the bell clears immediately.
- Guarded: fires only once the messages have actually loaded (never on error/empty/loading), throttled to once per mount and once per regained focus/visibility. Fire-and-forget.

### F3 — Unread badges
- `ConversationList` rows show a blue count pill (hidden at 0, capped at `9+`, reusing the bell-badge shape scaled to the row) and bold the subject when unread, driven by `unreadCount`.
- Stories updated with read/unread mixes (light + dark).

### Tests
- `NewConversationForm`: picker submit passes `recipientSpeakerId`; NOT_FOUND vs generic error rendering; speaker flow sends without a recipient.
- `ConversationThread` container: `markReadByLink` called once with both link variants after load; invalidations on success; suppressed while loading and before the conversation resolves.
- `ConversationList`: pill render/hide, `9+` cap, bold vs semibold subject.
- Full suite: 188 files, 2825 passed / 5 skipped. tsc 0, eslint clean, prettier clean, knip exit 0.

### Visual QA (`pnpm shoot`, 393px, light + dark)
- Inbox unread badges (light + dark): blue pill on unread rows, none on read rows, `9+` cap — correct.
- Organizer New Conversation form (light + dark) and picker-open (search returns speakers with name + title, brand-blue active option, focus ring) — correct.
- Thread with messages (light + dark): visually unchanged — F2 only touched the container, regression clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the M3b organizer-facing UI layer on top of the M3a backend: a searchable speaker picker for organizer-initiated threads, auto-mark-read when a thread is opened (with dual link-variant coverage), and unread count badges in the inbox. The implementation is well-structured with a clean presenter/container split, good test coverage across all three features, and no new server surfaces.

- `NewConversationForm` gains `requireRecipient` mode that renders `SpeakerCombobox` (Headless UI Combobox over `speaker.admin.search`) and passes `recipientSpeakerId` on send; NOT_FOUND surfaces as an inline picker error while other failures show generic copy.
- `ConversationThread` fires `notification.markReadByLink` with both audience link variants once messages load, guarded by a ref-key to prevent re-firing within the same mount/focus cycle, with listeners on both `window focus` and `document visibilitychange` to re-fire on regained attention.
- `ConversationList` rows now show a blue count pill (capped at `9+`) and bold the subject when `unreadCount > 0`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the two findings are UX edge cases that don't affect data integrity or auth.

The organizer-flow picker keeps the NOT_FOUND invalid state visible even after the organizer picks a fresh speaker, because sendMutation.error is not cleared on recipient change. Separately, window focus and document visibilitychange can both fire when switching back to the browser, each resetting the mark-read guard before the other fires, resulting in two markReadByLink mutations instead of one; the mutation is idempotent so no data is affected, but it is a duplicate network call. Neither issue blocks correctness of the messaging feature.

src/components/messaging/NewConversationForm.tsx (stale error state on picker) and src/components/messaging/ConversationThread.tsx (double mutation guard).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/messaging/NewConversationForm.tsx | Adds speaker picker (requireRecipient) and NOT_FOUND inline error; stale error state persists on the picker after a new speaker is selected, and errorCode is duplicated from ConversationThread.tsx. |
| src/components/messaging/SpeakerCombobox.tsx | New Headless UI Combobox wrapping speaker.admin.search; clean implementation with correct enabled/staleTime guards and accessible aria-invalid wiring. |
| src/components/messaging/ConversationThread.tsx | Adds auto-mark-read on mount and regained focus/visibility; potential double mutation when both window focus and visibilitychange fire together on tab-switch-plus-refocus. |
| src/components/messaging/ConversationList.tsx | Adds unread badge pill (capped at 9+) and bold subject for unread rows; clean presentational change. |
| src/components/messaging/MessagesInbox.tsx | Passes requireRecipient to NewConversationForm; trivial wiring change. |
| src/app/(admin)/admin/messages/page.tsx | Adds allowNew to MessagesInbox for organizers; minimal single-prop change. |
| __tests__/components/messaging/ConversationThreadContainer.test.tsx | New test file covering auto-mark-read: both links sent after load, invalidations on success, suppressed while loading or before conversation resolves. |
| __tests__/components/messaging/NewConversationForm.test.tsx | New test file covering organizer picker submit, NOT_FOUND vs generic error rendering, and speaker flow without recipient. |
| __tests__/components/messaging/ConversationList.test.tsx | Adds tests for pill visibility, 9+ cap, bold/semibold subject toggling; good coverage of the new unread badge behavior. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant O as Organizer
    participant NCF as NewConversationForm
    participant SC as SpeakerCombobox
    participant tRPC as tRPC
    participant CT as ConversationThread
    participant MR as markReadByLink
    participant Cache as tRPC Cache

    O->>NCF: Opens New conversation
    NCF->>SC: "renders requireRecipient=true"
    O->>SC: types speaker name
    SC->>tRPC: speaker.admin.search
    tRPC-->>SC: speaker results
    O->>SC: selects speaker
    SC-->>NCF: onChange(speakerOption)
    O->>NCF: fills subject + body, submits
    NCF->>tRPC: message.send with recipientSpeakerId
    alt success
        tRPC-->>NCF: conversationId
        NCF->>Cache: listConversations.invalidate
        NCF->>O: router.push to thread
        O->>CT: opens ConversationThread
        CT->>tRPC: getConversation + listMessages
        tRPC-->>CT: data isSuccess
        CT->>MR: markReadByLink adminLink + cfpLink
        MR-->>CT: onSuccess
        CT->>Cache: unreadCount.invalidate + list.invalidate
    else NOT_FOUND
        tRPC-->>NCF: NOT_FOUND error
        NCF->>O: Speaker not found + invalid picker
    else other error
        tRPC-->>NCF: error
        NCF->>O: generic error message
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant O as Organizer
    participant NCF as NewConversationForm
    participant SC as SpeakerCombobox
    participant tRPC as tRPC
    participant CT as ConversationThread
    participant MR as markReadByLink
    participant Cache as tRPC Cache

    O->>NCF: Opens New conversation
    NCF->>SC: "renders requireRecipient=true"
    O->>SC: types speaker name
    SC->>tRPC: speaker.admin.search
    tRPC-->>SC: speaker results
    O->>SC: selects speaker
    SC-->>NCF: onChange(speakerOption)
    O->>NCF: fills subject + body, submits
    NCF->>tRPC: message.send with recipientSpeakerId
    alt success
        tRPC-->>NCF: conversationId
        NCF->>Cache: listConversations.invalidate
        NCF->>O: router.push to thread
        O->>CT: opens ConversationThread
        CT->>tRPC: getConversation + listMessages
        tRPC-->>CT: data isSuccess
        CT->>MR: markReadByLink adminLink + cfpLink
        MR-->>CT: onSuccess
        CT->>Cache: unreadCount.invalidate + list.invalidate
    else NOT_FOUND
        tRPC-->>NCF: NOT_FOUND error
        NCF->>O: Speaker not found + invalid picker
    else other error
        tRPC-->>NCF: error
        NCF->>O: generic error message
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/messaging/ConversationThread.tsx`, line 556-569 ([link](https://github.com/cloudnativebergen/website/blob/60bc6bbb96729a2d8a194989d45d4deca06de3ec/src/components/messaging/ConversationThread.tsx#L556-L569)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Double `markReadByLink` mutation when Alt-Tabbing back to the browser while on a different tab — in that scenario, `document visibilitychange` (state → `visible`) AND `window focus` can both fire in the same event-loop turn. Each handler calls `markedKeyRef.current = null` then `markRead()`. Since the first handler's `markRead` sets the key and the second handler resets it to `null` before its own `markRead` checks it, `markReadMutate` is called twice. The mutation is idempotent so no data is corrupted, but it results in an extra network request on every such tab-switch-plus-window-refocus event. A `setTimeout(0)` debounce on the reset-and-fire path, or checking `markedKeyRef.current` before resetting, would prevent the extra call.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): organizer-initiated thr..."](https://github.com/cloudnativebergen/website/commit/60bc6bbb96729a2d8a194989d45d4deca06de3ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45409230)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->