### PR TITLE
fix(messaging): bound the unread-links fetch (review rider)

### DIFF
--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -267,10 +267,12 @@ export async function listConversationsForSpeaker({
   const rows = results ?? []
   if (rows.length === 0) return []
 
-  // ONE extra read: the caller's unread message_received notification links for
+  // ONE extra read (bounded [0...500] — plenty above any realistic unread count,
+  // and the 90-day retention caps the universe): the caller's unread
+  // message_received notification links for
   // this conference. Counted in JS per conversation below.
   const unreadLinks = await clientReadUncached.fetch<(string | null)[]>(
-    `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt)].link`,
+    `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt)][0...500].link`,
     { speakerId, conferenceId },
     { cache: 'no-store' },
   )


### PR DESCRIPTION
The accepted P2 rider from #529: the `unreadCount` helper fetched every unread `message_received` link with no slice. Capped at `[0...500]` — far above any realistic per-user unread count, with the 90-day notification retention bounding the universe regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `[0...500]` GROQ slice to the unbounded `unreadLinks` query in `listConversationsForSpeaker`, capping the fetch at 500 notification documents per user per conference. The query is already tightly scoped by `recipient._ref`, `conference._ref`, and `notificationType`, making overflow realistic only under pathological conditions.

- The slice is applied before the `.link` field projection — correct GROQ syntax.
- No explicit `order()` precedes the slice, so if a user somehow accumulates >500 unread notifications the 500 returned are arbitrary and `unreadCount` values would be silently under-counted; the PR description accepts this as an unlikely edge case given 90-day retention.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a one-line GROQ slice addition with a well-justified cap.

The fix is minimal and correct: it bounds a previously unbounded fetch to 500 documents. The only theoretical gap is that the sliced result has no preceding order() clause, so if the 500-item cap were ever hit the unreadCount values returned would be silently under-reported with no indication to the caller. Given the 90-day retention window and the tight per-user/per-conference filter this is an extremely unlikely edge case, but it is a silent failure rather than an explicit one.

src/lib/messaging/sanity.ts — specifically the unread-links GROQ query if notification volume assumptions ever change.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/messaging/sanity.ts | Added `[0...500]` slice to the unread-notification GROQ fetch; query is properly scoped and the cap is well above realistic per-user unread counts, though absent ordering means the 500 returned are non-deterministic if the limit is ever hit. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant F as listConversationsForSpeaker
    participant S as Sanity (clientReadUncached)

    C->>F: "{ speakerId, conferenceId, ... }"
    F->>S: fetch conversations (paginated, PAGE_SIZE)
    S-->>F: ConversationListItem[] (without unreadCount)
    F->>S: fetch unread notification links [0...500] bounded slice
    S-->>F: "(string | null)[] (max 500 links)"
    F->>F: build linkCounts Map
    F->>F: map rows add unreadCount per conversation
    F-->>C: ConversationListItem[] (with unreadCount)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant F as listConversationsForSpeaker
    participant S as Sanity (clientReadUncached)

    C->>F: "{ speakerId, conferenceId, ... }"
    F->>S: fetch conversations (paginated, PAGE_SIZE)
    S-->>F: ConversationListItem[] (without unreadCount)
    F->>S: fetch unread notification links [0...500] bounded slice
    S-->>F: "(string | null)[] (max 500 links)"
    F->>F: build linkCounts Map
    F->>F: map rows add unreadCount per conversation
    F-->>C: ConversationListItem[] (with unreadCount)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): bound the unread-links f..."](https://github.com/cloudnativebergen/website/commit/e2c66bd122a848f78708a7ca811171ed2b92971b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45410146)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->