### PR TITLE
feat(notifications): collapse message notifications per conversation (M5)

### DIFF
--- a/__tests__/components/notifications/NotificationList.test.tsx
+++ b/__tests__/components/notifications/NotificationList.test.tsx
@@ -146,4 +146,24 @@ describe('NotificationList', () => {
     ).not.toBeInTheDocument()
     expect(screen.getByText(/read-only/i)).toBeInTheDocument()
   })
+
+  it('renders the "View all messages" footer link when messagesHref is provided', () => {
+    renderList({ messagesHref: '/cfp/messages' })
+    const link = screen.getByRole('link', { name: /view all messages/i })
+    expect(link).toHaveAttribute('href', '/cfp/messages')
+  })
+
+  it('does NOT render the messages footer link when messagesHref is absent', () => {
+    renderList()
+    expect(
+      screen.queryByRole('link', { name: /view all messages/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('fires onMessagesClick (popover close) when the footer link is activated', () => {
+    const onMessagesClick = vi.fn()
+    renderList({ messagesHref: '/admin/messages', onMessagesClick })
+    fireEvent.click(screen.getByRole('link', { name: /view all messages/i }))
+    expect(onMessagesClick).toHaveBeenCalledOnce()
+  })
 })

--- a/__tests__/lib/messaging/notify.test.ts
+++ b/__tests__/lib/messaging/notify.test.ts
@@ -2,7 +2,9 @@
  * @vitest-environment node
  *
  * Unit tests for the messaging fan-out (src/lib/messaging/notify.ts):
- * - HUB items are per-recipient (organizer → /admin link, speaker → /cfp link);
+ * - HUB items are per-recipient COLLAPSE-UPSERT inputs (M5): one per
+ *   (recipient, conversation) with an audience link (organizer → /admin,
+ *   speaker → /cfp) and the raw title ingredients (authorName + subject);
  * - muted recipients are excluded from every channel;
  * - EMAIL fires for recipients whose effective email pref is ON (M4: the
  *   speaker-level default is ENABLED unless explicitly false);
@@ -15,7 +17,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('@/lib/notification/sanity', () => ({
-  createNotifications: vi.fn(async () => {}),
+  upsertMessageNotifications: vi.fn(async () => {}),
   getOrganizerSpeakerIds: vi.fn(async () => ['org-1']),
 }))
 
@@ -41,7 +43,7 @@ vi.mock('@/lib/messaging/sanity', async (importActual) => {
 })
 
 import {
-  createNotifications,
+  upsertMessageNotifications,
   getOrganizerSpeakerIds,
 } from '@/lib/notification/sanity'
 import { clientReadUncached } from '@/lib/sanity/client'
@@ -49,12 +51,12 @@ import { getConversationPreferencesFor } from '@/lib/messaging/sanity'
 import { sendMessageEmails } from '@/lib/messaging/email'
 import { notifyNewSpeakerMessage } from '@/lib/slack/notify'
 import { notifyNewMessage } from '@/lib/messaging/notify'
-import type { NotificationInput } from '@/lib/notification/types'
+import type { MessageNotificationInput } from '@/lib/notification/types'
 import type { ConversationWithContext, Message } from '@/lib/messaging/types'
 import type { Conference } from '@/lib/conference/types'
 
 type LooseMock = ReturnType<typeof vi.fn>
-const createMock = createNotifications as unknown as LooseMock
+const upsertMock = upsertMessageNotifications as unknown as LooseMock
 const organizersMock = getOrganizerSpeakerIds as unknown as LooseMock
 const fetchMock = (clientReadUncached as unknown as { fetch: LooseMock }).fetch
 const prefsMock = getConversationPreferencesFor as unknown as LooseMock
@@ -110,10 +112,10 @@ const speakerRows = [
   },
 ]
 
-const lastItems = (): NotificationInput[] =>
-  createMock.mock.calls[
-    createMock.mock.calls.length - 1
-  ][0] as NotificationInput[]
+const lastItems = (): MessageNotificationInput[] =>
+  upsertMock.mock.calls[
+    upsertMock.mock.calls.length - 1
+  ][0] as MessageNotificationInput[]
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -124,8 +126,8 @@ beforeEach(() => {
   emailMock.mockResolvedValue(1)
 })
 
-describe('HUB fan-out — per-recipient links, actor excluded', () => {
-  it('emits message_received to each recipient with an audience-specific link', async () => {
+describe('HUB fan-out — per-recipient collapse-upsert inputs, actor excluded', () => {
+  it('upserts one collapsed item per recipient with an audience-specific link', async () => {
     await notifyNewMessage({
       conversation: proposalConv,
       message,
@@ -133,7 +135,7 @@ describe('HUB fan-out — per-recipient links, actor excluded', () => {
       conference,
     })
 
-    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(upsertMock).toHaveBeenCalledTimes(1)
     const items = lastItems()
     // Author (sp-1) excluded; recipients are org-1 and sp-2.
     expect(items.map((i) => i.recipientId).sort()).toEqual(['org-1', 'sp-2'])
@@ -143,8 +145,11 @@ describe('HUB fan-out — per-recipient links, actor excluded', () => {
     expect(byId['sp-2'].link).toBe('/cfp/proposal/prop-1#messages')
 
     for (const item of items) {
-      expect(item.notificationType).toBe('message_received')
-      expect(item.title).toBe('New message from Alice')
+      // The collapse writer derives the title from the accumulated count, so
+      // the fan-out passes the raw ingredients + the conversation identity.
+      expect(item.conversationId).toBe('conversation.proposal.prop-1')
+      expect(item.authorName).toBe('Alice')
+      expect(item.subject).toBe('My Talk')
       expect(item.actorId).toBe('sp-1')
       expect(item.relatedProposalId).toBe('prop-1')
       expect(item.message).toContain('Hello there')
@@ -325,7 +330,7 @@ describe('never-fail contract', () => {
       }),
     ).resolves.toBeUndefined()
 
-    expect(createMock).not.toHaveBeenCalled()
+    expect(upsertMock).not.toHaveBeenCalled()
     expect(console.error).toHaveBeenCalled()
   })
 })

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -328,13 +328,13 @@ describe('listConversationsForSpeaker — unread counts per conversation', () =>
     },
   ]
 
-  it('counts a speaker unread message_received notifications matching the /cfp link variant', async () => {
+  it('SUMS a speaker unread message counts matching the /cfp link variant (collapsed doc)', async () => {
     readMock.fetch
       .mockResolvedValueOnce(rows) // conversations page
+      // ONE collapsed notification representing 2 unread messages (M5).
       .mockResolvedValueOnce([
-        '/cfp/proposal/prop-1#messages',
-        '/cfp/proposal/prop-1#messages',
-      ]) // caller's unread message links
+        { link: '/cfp/proposal/prop-1#messages', count: 2 },
+      ])
 
     const result = await listConversationsForSpeaker({
       speakerId: 'sp-1',
@@ -350,19 +350,45 @@ describe('listConversationsForSpeaker — unread counts per conversation', () =>
     ).toBe(0)
 
     // The unread query is scoped to the caller, the conference, message_received,
-    // and unread only (read notifications are never fetched, so never counted).
+    // unread only, and projects coalesce(count, 1) so a pre-collapse
+    // per-message document still counts as 1.
     const [query, params] = readMock.fetch.mock.calls[1]
     expect(query).toContain('recipient._ref == $speakerId')
     expect(query).toContain('conference._ref == $conferenceId')
     expect(query).toContain('notificationType == "message_received"')
     expect(query).toContain('!defined(readAt)')
+    expect(query).toContain('coalesce(count, 1)')
     expect(params).toEqual({ speakerId: 'sp-1', conferenceId: 'conf-1' })
   })
 
-  it('counts an organizer unread notifications matching the /admin link variant', async () => {
+  it('sums MIXED collapsed and legacy per-message docs for the same conversation', async () => {
     readMock.fetch
       .mockResolvedValueOnce(rows)
-      .mockResolvedValueOnce(['/admin/messages/conversation.gen-1'])
+      // A collapsed doc (count 3) plus two legacy per-message docs (GROQ
+      // coalesce projects their absent count as 1 each) → 5 total.
+      .mockResolvedValueOnce([
+        { link: '/cfp/proposal/prop-1#messages', count: 3 },
+        { link: '/cfp/proposal/prop-1#messages', count: 1 },
+        { link: '/cfp/proposal/prop-1#messages', count: 1 },
+      ])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'sp-1',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+    })
+
+    expect(
+      result.find((r) => r._id === 'conversation.proposal.prop-1')!.unreadCount,
+    ).toBe(5)
+  })
+
+  it('sums an organizer unread counts matching the /admin link variant', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce(rows)
+      .mockResolvedValueOnce([
+        { link: '/admin/messages/conversation.gen-1', count: 1 },
+      ])
 
     const result = await listConversationsForSpeaker({
       speakerId: 'org-1',

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -29,9 +29,18 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }))
 
+// The push bridge is mocked so the collapse-upsert tests can assert it fires
+// with the computed (count-aware) titles without touching VAPID config.
+vi.mock('@/lib/push/send', () => ({
+  sendPushForNotifications: vi.fn(async () => {}),
+}))
+
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { sendPushForNotifications } from '@/lib/push/send'
 import {
   createNotifications,
+  upsertMessageNotifications,
+  messageNotificationId,
   getNotificationsForSpeaker,
   getUnreadCount,
   markNotificationsRead,
@@ -39,19 +48,24 @@ import {
   markAllRead,
   deleteNotificationsOlderThan,
 } from '@/lib/notification/sanity'
-import type { NotificationInput } from '@/lib/notification/types'
+import type {
+  MessageNotificationInput,
+  NotificationInput,
+} from '@/lib/notification/types'
 
 type LooseMock = ReturnType<typeof vi.fn>
 const writeMock = clientWrite as unknown as { transaction: LooseMock }
 const readMock = clientReadUncached as unknown as { fetch: LooseMock }
+const pushMock = sendPushForNotifications as unknown as LooseMock
 
 /**
- * A chainable Sanity transaction mock. `create` and `patch` return the same
- * object; `commit` is configurable per test.
+ * A chainable Sanity transaction mock. `create`, `createIfNotExists` and
+ * `patch` return the same object; `commit` is configurable per test.
  */
 function installTransaction(commit: () => Promise<unknown> = async () => ({})) {
   const tx = {
     create: vi.fn((_doc?: unknown) => tx),
+    createIfNotExists: vi.fn((_doc?: unknown) => tx),
     patch: vi.fn((_id?: string, _ops?: unknown) => tx),
     delete: vi.fn((_id?: string) => tx),
     commit: vi.fn(commit),
@@ -150,6 +164,231 @@ describe('createNotifications — single-transaction fan-out', () => {
   })
 })
 
+const msgInput = (
+  overrides: Partial<MessageNotificationInput> = {},
+): MessageNotificationInput => ({
+  recipientId: 'sp-1',
+  conversationId: 'conversation.gen-1',
+  conferenceId: 'conf-1',
+  authorName: 'Alice',
+  subject: 'A question',
+  message: 'hey there',
+  link: '/cfp/messages/conversation.gen-1',
+  actorId: 'actor-1',
+  ...overrides,
+})
+
+const MSG_ID = 'notification.message.conversation.gen-1.sp-1'
+
+describe('upsertMessageNotifications — per-conversation collapse (M5)', () => {
+  it('derives the deterministic per-(conversation, recipient) id', () => {
+    expect(messageNotificationId('conversation.gen-1', 'sp-1')).toBe(MSG_ID)
+  })
+
+  it('NEW: seeds count 1 via createIfNotExists and patches the same values', async () => {
+    readMock.fetch.mockResolvedValue([]) // no existing docs
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([msgInput()])
+
+    // ONE batched read of the collapse state for all target ids.
+    expect(readMock.fetch).toHaveBeenCalledTimes(1)
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('_id in $ids')
+    expect(query).toContain('readAt')
+    expect(query).toContain('count')
+    expect(params).toEqual({ ids: [MSG_ID] })
+
+    // ONE transaction: createIfNotExists + patch on the deterministic id.
+    expect(writeMock.transaction).toHaveBeenCalledTimes(1)
+    expect(tx.createIfNotExists).toHaveBeenCalledTimes(1)
+    const base = tx.createIfNotExists.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >
+    expect(base._id).toBe(MSG_ID)
+    expect(base._type).toBe('notification')
+    expect(base.notificationType).toBe('message_received')
+    expect(base.count).toBe(1)
+    expect(base.recipient).toEqual({ _type: 'reference', _ref: 'sp-1' })
+    expect(base.conference).toEqual({ _type: 'reference', _ref: 'conf-1' })
+
+    expect(tx.patch).toHaveBeenCalledTimes(1)
+    const [patchId, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown>; unset: string[] },
+    ]
+    expect(patchId).toBe(MSG_ID)
+    expect(ops.unset).toEqual(['readAt'])
+    expect(ops.set.count).toBe(1)
+    expect(ops.set.title).toBe('New message from Alice — A question')
+    expect(ops.set.message).toBe('hey there')
+    expect(ops.set.link).toBe('/cfp/messages/conversation.gen-1')
+    expect(ops.set.actor).toEqual({ _type: 'reference', _ref: 'actor-1' })
+    expect(typeof ops.set.createdAt).toBe('string')
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('UNREAD existing: increments count and switches to the N-messages title', async () => {
+    readMock.fetch.mockResolvedValue([{ _id: MSG_ID, readAt: null, count: 2 }])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([msgInput()])
+
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown>; unset: string[] },
+    ]
+    expect(ops.set.count).toBe(3)
+    expect(ops.set.title).toBe('3 new messages — A question')
+    // Re-surfaced: readAt is unset and createdAt bumped even when incrementing.
+    expect(ops.unset).toEqual(['readAt'])
+    expect(typeof ops.set.createdAt).toBe('string')
+  })
+
+  it('UNREAD existing WITHOUT a count field: treats it as 1 and increments to 2', async () => {
+    readMock.fetch.mockResolvedValue([{ _id: MSG_ID, readAt: null }])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([msgInput()])
+
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown> },
+    ]
+    expect(ops.set.count).toBe(2)
+    expect(ops.set.title).toBe('2 new messages — A question')
+  })
+
+  it('READ existing: resets to count 1, re-unreads, and bumps createdAt', async () => {
+    readMock.fetch.mockResolvedValue([
+      { _id: MSG_ID, readAt: '2026-07-01T00:00:00.000Z', count: 5 },
+    ])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([msgInput()])
+
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown>; unset: string[] },
+    ]
+    expect(ops.set.count).toBe(1)
+    expect(ops.set.title).toBe('New message from Alice — A question')
+    expect(ops.unset).toEqual(['readAt'])
+    expect(typeof ops.set.createdAt).toBe('string')
+  })
+
+  it('BATCH: many recipients → ONE read (all ids) and ONE transaction (pair per recipient)', async () => {
+    const otherId = 'notification.message.conversation.gen-1.sp-2'
+    readMock.fetch.mockResolvedValue([{ _id: otherId, readAt: null, count: 4 }])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([
+      msgInput({ recipientId: 'sp-1' }),
+      msgInput({
+        recipientId: 'sp-2',
+        link: '/admin/messages/conversation.gen-1',
+      }),
+    ])
+
+    expect(readMock.fetch).toHaveBeenCalledTimes(1)
+    expect(readMock.fetch.mock.calls[0][1]).toEqual({
+      ids: [MSG_ID, otherId],
+    })
+    expect(writeMock.transaction).toHaveBeenCalledTimes(1)
+    expect(tx.createIfNotExists).toHaveBeenCalledTimes(2)
+    expect(tx.patch).toHaveBeenCalledTimes(2)
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+
+    // Per-recipient state: sp-1 is new (count 1), sp-2 accumulates (count 5).
+    const bySetId = new Map(
+      (tx.patch.mock.calls as [string, { set: Record<string, unknown> }][]).map(
+        ([id, ops]) => [id, ops.set],
+      ),
+    )
+    expect(bySetId.get(MSG_ID)?.count).toBe(1)
+    expect(bySetId.get(otherId)?.count).toBe(5)
+    expect(bySetId.get(otherId)?.title).toBe('5 new messages — A question')
+  })
+
+  it('sets a WEAK relatedProposal reference only when provided', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([
+      msgInput({ relatedProposalId: 'prop-1' }),
+    ])
+
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown> },
+    ]
+    expect(ops.set.relatedProposal).toEqual({
+      _type: 'reference',
+      _ref: 'prop-1',
+      _weak: true,
+    })
+  })
+
+  it('bridges to web push with the computed (count-aware) title', async () => {
+    readMock.fetch.mockResolvedValue([{ _id: MSG_ID, readAt: null, count: 1 }])
+    installTransaction()
+
+    await upsertMessageNotifications([msgInput()])
+
+    expect(pushMock).toHaveBeenCalledTimes(1)
+    const [pushItems] = pushMock.mock.calls[0] as [NotificationInput[]]
+    expect(pushItems).toHaveLength(1)
+    expect(pushItems[0].notificationType).toBe('message_received')
+    expect(pushItems[0].title).toBe('2 new messages — A question')
+    expect(pushItems[0].recipientId).toBe('sp-1')
+  })
+
+  it('is a no-op (no read, no transaction) for an empty list', async () => {
+    const tx = installTransaction()
+    await upsertMessageNotifications([])
+    expect(readMock.fetch).not.toHaveBeenCalled()
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+    expect(tx.commit).not.toHaveBeenCalled()
+  })
+
+  it('NEVER throws when the commit fails — swallows, logs, and skips push', async () => {
+    readMock.fetch.mockResolvedValue([])
+    installTransaction(async () => {
+      throw new Error('sanity down')
+    })
+
+    await expect(
+      upsertMessageNotifications([msgInput()]),
+    ).resolves.toBeUndefined()
+    expect(console.error).toHaveBeenCalled()
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+
+  it('NEVER throws when the batched read fails', async () => {
+    readMock.fetch.mockRejectedValue(new Error('sanity down'))
+    const tx = installTransaction()
+
+    await expect(
+      upsertMessageNotifications([msgInput()]),
+    ).resolves.toBeUndefined()
+    expect(tx.commit).not.toHaveBeenCalled()
+    expect(console.error).toHaveBeenCalled()
+  })
+
+  it('NEVER throws when the push bridge rejects (already committed)', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+    pushMock.mockRejectedValue(new Error('push down'))
+
+    await expect(
+      upsertMessageNotifications([msgInput()]),
+    ).resolves.toBeUndefined()
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+    expect(console.error).toHaveBeenCalled()
+  })
+})
+
 describe('markNotificationsRead — recipient security guard', () => {
   it('patches ONLY recipient-owned ids (drops a foreign id) and returns the owned count', async () => {
     // The client asked to mark two ids read; the ownership fetch confirms only
@@ -225,6 +464,24 @@ describe('markNotificationsReadByLinks — link-matched read (recipient guard)',
     })
     expect(tx.commit).toHaveBeenCalledTimes(1)
     expect(count).toBe(2)
+  })
+
+  it('clears a COLLAPSED message notification too — matching is by link, id-agnostic (M5)', async () => {
+    // A collapsed doc carries the same audience deep link as the per-message
+    // docs did, so opening the thread auto-clears it through the same query.
+    const collapsedId = 'notification.message.conversation.gen-1.sp-1'
+    readMock.fetch.mockResolvedValue([collapsedId])
+    const tx = installTransaction()
+
+    const count = await markNotificationsReadByLinks({
+      speakerId: 'sp-1',
+      links: ['/cfp/messages/conversation.gen-1'],
+    })
+
+    expect(tx.patch).toHaveBeenCalledWith(collapsedId, {
+      set: { readAt: expect.any(String) },
+    })
+    expect(count).toBe(1)
   })
 
   it('returns 0 and writes nothing when no unread notification matches a link', async () => {

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -7,6 +7,14 @@ import { defineField, defineType } from 'sanity'
  *
  * NOTE: distinct from the ephemeral toast system (`NotificationProvider` /
  * `NotificationToast`). This is the durable notification hub.
+ *
+ * COLLAPSE MODEL (message_received, M5): instead of one document per message,
+ * the hub keeps ONE persistent document per (recipient, conversation) with a
+ * deterministic id (`notification.message.<conversationId>.<recipientId>`).
+ * Every new message re-surfaces that document: `createdAt` is bumped, `readAt`
+ * is unset, and `count` tracks how many unread messages it represents (unread
+ * accumulates; a read document resets to 1). Other notification types remain
+ * one-document-per-event.
  */
 export default defineType({
   name: 'notification',
@@ -90,6 +98,14 @@ export default defineType({
       // Weak so deleting the proposal does not orphan-block or fail the delete;
       // the notification simply ends up with a dangling reference.
       weak: true,
+    }),
+    defineField({
+      name: 'count',
+      title: 'Count',
+      type: 'number',
+      description:
+        'How many unread messages this collapsed notification represents; absent = 1. Only used by the message_received collapse model.',
+      validation: (Rule) => Rule.min(1).integer(),
     }),
     defineField({
       name: 'readAt',

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -13,6 +13,18 @@ const minutesAgo = (m: number) =>
 
 const makeItems = (): NotificationItem[] => [
   {
+    // A COLLAPSED message notification (M5): one persistent item per
+    // conversation whose title carries the accumulated unread count.
+    id: 'notification.message.conversation.proposal.p1.sp-1',
+    type: 'message_received',
+    title: '3 new messages — Scaling Kubernetes to 10,000 nodes',
+    message: 'Sounds great — let’s lock in the demo cluster size today.',
+    link: '/cfp/proposal/p1#messages',
+    readAt: null,
+    createdAt: minutesAgo(1),
+    actor: { _id: 'a3', name: 'Maria Jensen' },
+  },
+  {
     id: '1',
     type: 'proposal_status_changed',
     title: 'Your proposal was accepted',
@@ -81,12 +93,16 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+// Also carries the audience-aware "View all messages" footer quick link
+// (present when `messagesHref` is provided; the Empty story shows it absent).
 export const UnreadAndRead: Story = {
   args: {
     // Placeholder for typing; the render below rebuilds items at render time so
     // the relative-time labels are stable.
     items: [],
-    unreadCount: 2,
+    unreadCount: 3,
+    messagesHref: '/cfp/messages',
+    onMessagesClick: fn(),
   },
   render: (args) => <NotificationList {...args} items={makeItems()} />,
 }

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -37,6 +37,18 @@ export interface NotificationListProps {
    * still navigates; the container is responsible for not marking read.
    */
   readOnly?: boolean
+  /**
+   * Audience-aware href of the Messages inbox (/admin/messages or
+   * /cfp/messages). When provided, a "View all messages" quick link is rendered
+   * as a footer; omitted → no footer. Kept as a prop so this component stays
+   * presentational (the container derives the audience from the session).
+   */
+  messagesHref?: string
+  /**
+   * Fired when the messages quick link is activated — the container closes the
+   * popover (same flow as item clicks); navigation is handled by the `<Link>`.
+   */
+  onMessagesClick?: () => void
 }
 
 function SkeletonRow() {
@@ -191,6 +203,8 @@ export function NotificationList({
   hasMore = false,
   isLoadingMore = false,
   readOnly = false,
+  messagesHref,
+  onMessagesClick,
 }: NotificationListProps) {
   return (
     // `role="region"` makes the aria-label an actual named landmark — on a
@@ -250,6 +264,20 @@ export function NotificationList({
           </>
         )}
       </div>
+
+      {messagesHref && (
+        <div className="border-t border-gray-200 dark:border-gray-800">
+          <Link
+            href={messagesHref}
+            prefetch={false}
+            onClick={onMessagesClick}
+            // min-h-11 keeps the tap target ≥44px.
+            className="flex min-h-11 items-center justify-center px-4 py-3 text-xs font-medium text-brand-cloud-blue transition hover:bg-gray-50 hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60"
+          >
+            View all messages &rarr;
+          </Link>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -39,6 +39,12 @@ export function NotificationPanel({
   const { data: session } = useSession()
   const isImpersonating = session?.isImpersonating === true
 
+  // Audience-aware Messages inbox quick link (T-QUICKLINK): organizers land in
+  // the admin inbox, speakers in the CFP inbox. Passed down as a plain href so
+  // NotificationList stays presentational.
+  const messagesHref =
+    session?.speaker?.isOrganizer === true ? '/admin/messages' : '/cfp/messages'
+
   const {
     data,
     isLoading,
@@ -97,6 +103,8 @@ export function NotificationPanel({
       hasMore={hasNextPage}
       isLoadingMore={isFetchingNextPage}
       readOnly={isImpersonating}
+      messagesHref={messagesHref}
+      onMessagesClick={onClose}
     />
   )
 }

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -1,11 +1,11 @@
 import 'server-only'
 import {
-  createNotifications,
+  upsertMessageNotifications,
   getOrganizerSpeakerIds,
 } from '@/lib/notification/sanity'
 import { clientReadUncached } from '@/lib/sanity/client'
 import { notifyNewSpeakerMessage } from '@/lib/slack/notify'
-import type { NotificationInput } from '@/lib/notification/types'
+import type { MessageNotificationInput } from '@/lib/notification/types'
 import type { Conference } from '@/lib/conference/types'
 import {
   resolveRecipients,
@@ -47,9 +47,11 @@ interface SpeakerRow {
  * caught and logged — it must never fail the (already committed) message write.
  *
  * Channels:
- * - HUB: one `message_received` notification per non-muted recipient, with a
- *   PER-RECIPIENT link (organizers → /admin, speakers → /cfp). Web push rides
- *   along inside `createNotifications` (category `messages`).
+ * - HUB: ONE collapsed `message_received` notification per (non-muted
+ *   recipient, conversation) — every new message re-surfaces it via
+ *   `upsertMessageNotifications` (M5) with a PER-RECIPIENT link (organizers →
+ *   /admin, speakers → /cfp). Web push rides along inside the upsert
+ *   (category `messages`).
  * - EMAIL: to non-muted recipients whose effective email pref is ON: override
  *   'on', or 'default' + speaker-level default. The speaker-level default is
  *   ENABLED unless `messagingEmailDefault` is explicitly false (M4).
@@ -93,12 +95,15 @@ export async function notifyNewMessage({
       // Muted participants get NO notifications on any channel.
       const active = recipientIds.filter((id) => !prefs.get(id)?.muted)
 
-      // HUB (+ push): per-recipient link by audience.
-      const items: NotificationInput[] = active.map((id) => ({
+      // HUB (+ push): the per-conversation collapse upsert derives the title
+      // from the accumulated unread count; we pass the raw ingredients and the
+      // per-recipient audience link.
+      const items: MessageNotificationInput[] = active.map((id) => ({
         recipientId: id,
+        conversationId: conversation._id,
         conferenceId: conversation.conferenceId,
-        notificationType: 'message_received',
-        title: `New message from ${authorName}`,
+        authorName,
+        subject: conversation.subject,
         message: excerpt,
         link: conversationLinkPath(conversation, organizerSet.has(id)),
         actorId: authorId,
@@ -106,7 +111,7 @@ export async function notifyNewMessage({
           ? { relatedProposalId: conversation.proposalId }
           : {}),
       }))
-      await createNotifications(items)
+      await upsertMessageNotifications(items)
 
       // EMAIL: on unless the recipient opted out (speaker default or override).
       const emailRecipients: MessageEmailRecipient[] = []

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -269,16 +269,22 @@ export async function listConversationsForSpeaker({
 
   // ONE extra read (bounded [0...500] — plenty above any realistic unread count,
   // and the 90-day retention caps the universe): the caller's unread
-  // message_received notification links for
-  // this conference. Counted in JS per conversation below.
-  const unreadLinks = await clientReadUncached.fetch<(string | null)[]>(
-    `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt)][0...500].link`,
+  // message_received notifications for this conference. Since M5 a collapsed
+  // notification represents `count` unread messages (absent = 1, which also
+  // covers pre-collapse per-message documents), so we SUM `coalesce(count, 1)`
+  // per link in JS rather than counting documents.
+  const unreadRows = await clientReadUncached.fetch<
+    { link: string | null; count: number }[]
+  >(
+    `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt)][0...500]{ link, "count": coalesce(count, 1) }`,
     { speakerId, conferenceId },
     { cache: 'no-store' },
   )
   const linkCounts = new Map<string, number>()
-  for (const link of unreadLinks ?? []) {
-    if (link) linkCounts.set(link, (linkCounts.get(link) ?? 0) + 1)
+  for (const row of unreadRows ?? []) {
+    if (row.link) {
+      linkCounts.set(row.link, (linkCounts.get(row.link) ?? 0) + row.count)
+    }
   }
 
   return rows.map((row) => {

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -4,6 +4,8 @@
  * Design:
  * - Notifications are fanned out PER RECIPIENT (one document each), so read
  *   state is per-user and reads are a simple recipient filter.
+ * - EXCEPTION (M5): `message_received` collapses to ONE persistent document per
+ *   (recipient, conversation) — see `upsertMessageNotifications`.
  * - A fan-out writes all recipients in ONE transaction.
  * - `createNotifications` NEVER throws into the caller: a failed notification
  *   must not fail the business mutation that produced it (see its doc).
@@ -14,7 +16,11 @@
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import { createReference } from '@/lib/sanity/helpers'
 import { sendPushForNotifications } from '@/lib/push/send'
-import type { NotificationInput, NotificationItem } from './types'
+import type {
+  MessageNotificationInput,
+  NotificationInput,
+  NotificationItem,
+} from './types'
 
 /**
  * Persist one `notification` document per input, all in a SINGLE
@@ -82,6 +88,164 @@ export async function createNotifications(
   } catch (error) {
     // Never propagate — see the contract above.
     console.error('Failed to create notifications:', error)
+  }
+}
+
+/**
+ * Deterministic id for the SINGLE collapsed message notification a recipient
+ * holds per conversation (M5 collapse model — see `sanity/schemaTypes/notification.ts`).
+ */
+export function messageNotificationId(
+  conversationId: string,
+  recipientId: string,
+): string {
+  return `notification.message.${conversationId}.${recipientId}`
+}
+
+/** Schema cap on `notification.title` (Rule.max(200)). */
+const NOTIFICATION_TITLE_MAX = 200
+
+/**
+ * Title copy for a collapsed message notification: a single unread message
+ * names its author; an accumulated pile leads with the count (the latest
+ * author still appears via the excerpt/actor line).
+ */
+function messageNotificationTitle(
+  count: number,
+  authorName: string,
+  subject: string,
+): string {
+  const title =
+    count > 1
+      ? `${count} new messages — ${subject}`
+      : `New message from ${authorName} — ${subject}`
+  return title.slice(0, NOTIFICATION_TITLE_MAX)
+}
+
+/**
+ * Collapse-aware writer for `message_received` (M5): each recipient keeps ONE
+ * persistent notification per conversation (deterministic id via
+ * {@link messageNotificationId}) which every new message re-surfaces instead of
+ * stacking a new document.
+ *
+ * Mechanics — ONE batched read, then ONE transaction:
+ * - the current `{readAt, count}` of every target id is fetched in a single
+ *   GROQ query;
+ * - per recipient the transaction chains `createIfNotExists` (base doc,
+ *   count 1) and a `patch` that bumps `createdAt` to now (bubbling the item to
+ *   the top of the createdAt-desc inbox), UNSETS `readAt` (re-unread), refreshes
+ *   title/message/link/actor to the latest message, and sets
+ *   `count = (existing && unread ? existing.count || 1 : 0) + 1` — unread
+ *   accumulates, read-or-new resets to 1.
+ *
+ * Web push rides along exactly as in {@link createNotifications} (category
+ * `messages`), one push per recipient per message.
+ *
+ * CONTRACT: NEVER throws into the caller's flow — identical envelope to
+ * {@link createNotifications}. Non-message notification types are unaffected
+ * and keep using `createNotifications`.
+ */
+export async function upsertMessageNotifications(
+  items: MessageNotificationInput[],
+): Promise<void> {
+  if (items.length === 0) {
+    return
+  }
+
+  try {
+    const ids = items.map((item) =>
+      messageNotificationId(item.conversationId, item.recipientId),
+    )
+
+    // ONE batched read: the collapse state of every target document.
+    const existingRows = await clientReadUncached.fetch<
+      { _id: string; readAt?: string | null; count?: number | null }[]
+    >(`*[_type == "notification" && _id in $ids]{ _id, readAt, count }`, {
+      ids,
+    })
+    const existingById = new Map(
+      (existingRows ?? []).map((row) => [row._id, row]),
+    )
+
+    const now = new Date().toISOString()
+    const tx = clientWrite.transaction()
+    const pushItems: NotificationInput[] = []
+
+    for (const item of items) {
+      const id = messageNotificationId(item.conversationId, item.recipientId)
+      const existing = existingById.get(id)
+      // Unread accumulates; a read (or brand-new) document resets to 1.
+      const count =
+        (existing && !existing.readAt ? (existing.count ?? 1) : 0) + 1
+      const title = messageNotificationTitle(
+        count,
+        item.authorName,
+        item.subject,
+      )
+
+      const set: Record<string, unknown> = {
+        // Bubbles the collapsed item back to the top of the inbox.
+        createdAt: now,
+        title,
+        count,
+      }
+      if (item.message) {
+        set.message = item.message
+      }
+      if (item.link) {
+        set.link = item.link
+      }
+      if (item.actorId) {
+        set.actor = createReference(item.actorId)
+      }
+      if (item.relatedProposalId) {
+        // Weak reference so a later proposal deletion doesn't orphan-block.
+        set.relatedProposal = {
+          ...createReference(item.relatedProposalId),
+          _weak: true,
+        }
+      }
+
+      tx.createIfNotExists({
+        _id: id,
+        _type: 'notification',
+        recipient: createReference(item.recipientId),
+        conference: createReference(item.conferenceId),
+        notificationType: 'message_received',
+        title,
+        count: 1,
+        createdAt: now,
+      }).patch(id, { set, unset: ['readAt'] })
+
+      pushItems.push({
+        recipientId: item.recipientId,
+        conferenceId: item.conferenceId,
+        notificationType: 'message_received',
+        title,
+        ...(item.message ? { message: item.message } : {}),
+        ...(item.link ? { link: item.link } : {}),
+        ...(item.actorId ? { actorId: item.actorId } : {}),
+        ...(item.relatedProposalId
+          ? { relatedProposalId: item.relatedProposalId }
+          : {}),
+      })
+    }
+
+    await tx.commit()
+
+    // Same isolated push bridge as `createNotifications`: a push failure can
+    // neither fail the (already committed) upsert nor the business mutation.
+    try {
+      await sendPushForNotifications(pushItems)
+    } catch (pushError) {
+      console.error(
+        'Failed to send web push for message notifications:',
+        pushError,
+      )
+    }
+  } catch (error) {
+    // Never propagate — see the contract above.
+    console.error('Failed to upsert message notifications:', error)
   }
 }
 

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -39,6 +39,34 @@ export interface NotificationInput {
   relatedProposalId?: string
 }
 
+/**
+ * The write-side shape for the COLLAPSED message notification upsert (M5).
+ * One of these is produced per recipient of a new message;
+ * `upsertMessageNotifications` folds each into the recipient's single
+ * per-conversation `notification` document (deterministic id
+ * `notification.message.<conversationId>.<recipientId>`) instead of creating a
+ * new document per message. The title is derived from the accumulated unread
+ * count, so callers pass the raw ingredients (author name + subject) rather
+ * than a pre-built title.
+ */
+export interface MessageNotificationInput {
+  recipientId: string
+  conversationId: string
+  conferenceId: string
+  /** Display name of the latest message's author. */
+  authorName: string
+  /** Conversation subject (proposal threads default this to the talk title). */
+  subject: string
+  /** Excerpt of the latest message body. */
+  message?: string
+  /** App-relative deep link to the conversation for THIS recipient's audience. */
+  link?: string
+  /** Speaker whose message triggered this. */
+  actorId?: string
+  /** Weakly referenced proposal (talk) id, for proposal threads. */
+  relatedProposalId?: string
+}
+
 /** The actor sub-object projected for the client. */
 export interface NotificationActor {
   _id: string


### PR DESCRIPTION
## M5 — collapse message notifications per conversation

Replaces the one-document-per-message hub fan-out for `message_received` with ONE persistent notification per (recipient, conversation), re-surfaced on every new message. Non-message notification types are untouched.

### Upsert semantics (`upsertMessageNotifications`)

Deterministic id: `notification.message.<conversationId>.<recipientId>`. ONE batched GROQ read of `{_id, readAt, count}` for all targets, then ONE transaction chaining `createIfNotExists` + `patch` per recipient.

| Existing doc state | Resulting `count` | `readAt` | `createdAt` | Title |
| --- | --- | --- | --- | --- |
| none (new) | 1 | unset | now | `New message from <author> — <subject>` |
| unread (`count` = N) | N + 1 | unset (stays unread) | bumped to now (bubbles to top) | `<N+1> new messages — <subject>` |
| unread, no `count` field | 2 (absent = 1) | unset | bumped | `2 new messages — <subject>` |
| read | reset to 1 | UNSET (re-unread) | bumped | `New message from <author> — <subject>` |

`message`/`link`/`actor`/`relatedProposal` are refreshed to the latest message each time. Web push rides along per message with the computed count-aware title, and the never-throw envelope of `createNotifications` is preserved (read failure, commit failure and push failure are all swallowed and logged).

### Count / read-reset rules

- Unread accumulates: `count = (existing && !existing.readAt ? existing.count || 1 : 0) + 1`.
- Reading (any path: item click, mark-all, link-based auto-clear on thread open) sets `readAt`; the NEXT message resets the pile to 1.
- Inbox per-conversation unread badges now SUM `coalesce(count, 1)` per matching link (still bounded `[0...500]`) instead of counting documents.

### Migration note

Existing per-message notifications are left as-is (history). They keep counting as 1 each via `coalesce(count, 1)` and still auto-clear on thread open — `markNotificationsReadByLinks` matches by `link`, which collapsed items carry under the exact same contract (`conversationLinkPath` per audience), so the auto-clear flow is id-agnostic.

### Bell / toast

The generic increase-toast is kept: the bell only holds the polled numeric unread count and the list query is not mounted while the popover is closed, so detecting "the increase was a message" would need an extra query. Deliberately not over-engineered.

### View all messages quick link (T-QUICKLINK)

Maintainer self-test context: senders are (by design) never notified of their own messages — actor exclusion is intact. To reach conversations from the bell regardless, the notification panel now renders a footer quick link "View all messages →", audience-aware (organizer → `/admin/messages`, speaker → `/cfp/messages`). The target is derived from the session in the container (`NotificationPanel`) and passed down as a plain `messagesHref` prop so `NotificationList` stays presentational; activating it closes the popover through the same flow as item clicks. ≥44px tap target; footer renders only when the prop is provided.

### Verification

- `tsc` 0 errors; eslint touched dirs clean; prettier clean; knip exit 0 (one pre-existing config hint on main)
- `vitest run __tests__/`: 188 files, 2854 passed, 5 skipped, 0 failures
- `pnpm shoot` of the NotificationList unread-mix story at 393px with a count-bearing collapsed fixture: renders like any other row, footer link present, no viewport overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the one-document-per-message hub fan-out for `message_received` with a single persistent collapsed notification per `(recipient, conversation)`, re-surfaced on every new message via an upsert (`createIfNotExists` + `patch`). Unread counts in the conversation list are updated to sum `coalesce(count, 1)` instead of counting documents, keeping backward compatibility with legacy per-message docs. A "View all messages" footer quick link is added to the notification panel, audience-routed by session.

- **`upsertMessageNotifications`** (new): deterministic `notification.message.<conversationId>.<recipientId>` ID, one batched GROQ read of all target states, single transaction chaining create-if-not-exists + patch per recipient with count accumulation and `readAt` reset logic; never-throw contract preserved.
- **Conversation unread badges**: GROQ query now projects `{ link, \"count\": coalesce(count,1) }` and JS sums per link, so collapsed docs and legacy per-message docs both count correctly without migration.
- **Footer quick link**: `messagesHref` prop added to `NotificationList` (presentational); `NotificationPanel` derives it from session audience and passes `onClose` as the click handler.

<h3>Confidence Score: 4/5</h3>

The change is well-structured and covered by a thorough test suite; the two concerns are minor edge cases unlikely to affect normal usage.

The upsert's read-modify-write is non-atomic, so two messages arriving simultaneously for the same conversation could leave the count one short — harmless but observable. The messagesHref in NotificationPanel defaults to /cfp/messages before the NextAuth session resolves, meaning an organizer who opens the bell in the brief hydration window gets the wrong inbox link. Neither concern affects data integrity or security; both have contained impact and straightforward fixes.

src/lib/notification/sanity.ts (race window in upsert count logic) and src/components/notifications/NotificationPanel.tsx (messagesHref computed before session is ready)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/notification/sanity.ts | Core upsert logic added: deterministic ID, batched read, single transaction with createIfNotExists+patch per recipient; count accumulation and read-reset are correct; non-atomic read-modify-write is the one acknowledged limitation. |
| src/lib/messaging/notify.ts | Switches from createNotifications to upsertMessageNotifications; passes conversationId, authorName, subject instead of a pre-built title; actor exclusion and link routing unchanged. |
| src/lib/messaging/sanity.ts | Unread count query upgraded to fetch {link, count} rows and sum coalesce(count,1) in JS — correctly handles both collapsed and legacy per-message documents. |
| src/components/notifications/NotificationPanel.tsx | Derives messagesHref from session.speaker.isOrganizer and passes it unconditionally; during NextAuth session hydration the value defaults to /cfp/messages even for organizers. |
| __tests__/lib/notification/sanity.test.ts | Comprehensive upsert test suite covering new/unread/read/batch/push/error paths; collapsed auto-clear and never-throw contract also covered. |
| src/lib/notification/types.ts | Adds MessageNotificationInput with raw title ingredients (authorName + subject) instead of a pre-built title; clean separation from NotificationInput. |
| sanity/schemaTypes/notification.ts | Adds optional count field (integer ≥ 1) with schema doc explaining the M5 collapse model; backward-compatible since absent = 1 via coalesce. |
| src/components/notifications/NotificationList.tsx | Adds optional messagesHref footer rendered only when the prop is truthy; 44px tap target, focus-visible ring, popover close wired correctly. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant MsgRoute as Message Route
    participant Notify as notifyNewMessage
    participant UpsertFn as upsertMessageNotifications
    participant SanityRead as Sanity (read)
    participant SanityWrite as Sanity (write tx)
    participant Push as sendPushForNotifications

    MsgRoute->>Notify: "notifyNewMessage({conversation, message, …})"
    Notify->>SanityRead: fetch recipients, prefs, organizer ids
    Notify->>UpsertFn: upsertMessageNotifications(items[])
    UpsertFn->>SanityRead: "fetch {_id, readAt, count} for all target ids (ONE query)"
    SanityRead-->>UpsertFn: existingRows[]
    loop per recipient
        UpsertFn->>UpsertFn: "compute count = (unread ? existing.count??1 : 0) + 1"
        UpsertFn->>UpsertFn: build createIfNotExists + patch ops
    end
    UpsertFn->>SanityWrite: tx.commit() — ONE transaction, all recipients
    SanityWrite-->>UpsertFn: committed
    UpsertFn->>Push: sendPushForNotifications(pushItems[])
    Push-->>UpsertFn: done (errors swallowed)
    UpsertFn-->>Notify: void (never throws)
    Notify->>Notify: send emails, Slack (parallel)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant MsgRoute as Message Route
    participant Notify as notifyNewMessage
    participant UpsertFn as upsertMessageNotifications
    participant SanityRead as Sanity (read)
    participant SanityWrite as Sanity (write tx)
    participant Push as sendPushForNotifications

    MsgRoute->>Notify: "notifyNewMessage({conversation, message, …})"
    Notify->>SanityRead: fetch recipients, prefs, organizer ids
    Notify->>UpsertFn: upsertMessageNotifications(items[])
    UpsertFn->>SanityRead: "fetch {_id, readAt, count} for all target ids (ONE query)"
    SanityRead-->>UpsertFn: existingRows[]
    loop per recipient
        UpsertFn->>UpsertFn: "compute count = (unread ? existing.count??1 : 0) + 1"
        UpsertFn->>UpsertFn: build createIfNotExists + patch ops
    end
    UpsertFn->>SanityWrite: tx.commit() — ONE transaction, all recipients
    SanityWrite-->>UpsertFn: committed
    UpsertFn->>Push: sendPushForNotifications(pushItems[])
    Push-->>UpsertFn: done (errors swallowed)
    UpsertFn-->>Notify: void (never throws)
    Notify->>Notify: send emails, Slack (parallel)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): collapse message no..."](https://github.com/cloudnativebergen/website/commit/4bcc661365535bb59ad752913198f965aeb49603) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45413430)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->