### PR TITLE
fix(push): surface push-service errors in test-notification feedback

### DIFF
--- a/__tests__/api/trpc/push.test.ts
+++ b/__tests__/api/trpc/push.test.ts
@@ -192,7 +192,13 @@ describe('push router', () => {
       const caller = createAuthenticatedCaller(speakerA)
       const result = await caller.push.sendTest()
 
-      expect(result).toEqual({ sent: 2, gone: 0, total: 2, configured: true })
+      expect(result).toEqual({
+        sent: 2,
+        gone: 0,
+        total: 2,
+        configured: true,
+        failures: [],
+      })
       expect(mockGetState).toHaveBeenCalledWith(speakerA)
       expect(mockSendPush).toHaveBeenCalledTimes(2)
       // Uses the production payload shape: deep link + collapse tag, bypassing
@@ -233,8 +239,85 @@ describe('push router', () => {
       const caller = createAuthenticatedCaller(speakerA)
       const result = await caller.push.sendTest()
 
-      expect(result).toEqual({ sent: 0, gone: 1, total: 1, configured: true })
+      expect(result).toEqual({
+        sent: 0,
+        gone: 1,
+        total: 1,
+        configured: true,
+        failures: [],
+      })
       expect(mockPrune).toHaveBeenCalledWith(speakerA, SUB.endpoint)
+    })
+
+    it('surfaces a rejected (non-gone) subscription as a diagnostic failure', async () => {
+      // A live subscription the push service rejected with a 403 — the VAPID
+      // key-mismatch case that used to vanish into a bare count.
+      mockSendPush.mockResolvedValue({
+        ok: false,
+        statusCode: 403,
+        gone: false,
+        errorMessage: 'HTTP 403 — VapidPkHashMismatch',
+      })
+      const caller = createAuthenticatedCaller(speakerA)
+      const result = await caller.push.sendTest()
+
+      expect(result).toMatchObject({ sent: 0, gone: 0, total: 1 })
+      expect(result.failures).toEqual([
+        { statusCode: 403, message: 'HTTP 403 — VapidPkHashMismatch' },
+      ])
+      // A 403 is NOT gone — it must not be pruned (a server-side key misconfig
+      // would otherwise mass-destroy valid subscriptions).
+      expect(mockPrune).not.toHaveBeenCalled()
+    })
+
+    it('dedupes identical (statusCode, message) failures across devices', async () => {
+      mockGetState.mockResolvedValue({
+        subscriptions: [
+          SUB,
+          { ...SUB, endpoint: 'https://fcm.googleapis.com/fcm/send/device-2' },
+          { ...SUB, endpoint: 'https://fcm.googleapis.com/fcm/send/device-3' },
+        ],
+        preferences: DEFAULT_PUSH_PREFERENCES,
+      })
+      mockSendPush.mockResolvedValue({
+        ok: false,
+        statusCode: 403,
+        gone: false,
+        errorMessage: 'HTTP 403 — VapidPkHashMismatch',
+      })
+      const caller = createAuthenticatedCaller(speakerA)
+      const result = await caller.push.sendTest()
+
+      expect(result).toMatchObject({ sent: 0, total: 3 })
+      // Three devices failed identically → one deduped entry.
+      expect(result.failures).toEqual([
+        { statusCode: 403, message: 'HTTP 403 — VapidPkHashMismatch' },
+      ])
+    })
+
+    it('caps the failures list at 5 distinct entries', async () => {
+      mockGetState.mockResolvedValue({
+        subscriptions: Array.from({ length: 8 }, (_, i) => ({
+          ...SUB,
+          endpoint: `https://fcm.googleapis.com/fcm/send/device-${i}`,
+        })),
+        preferences: DEFAULT_PUSH_PREFERENCES,
+      })
+      let call = 0
+      mockSendPush.mockImplementation(async () => {
+        const statusCode = 500 + call
+        call += 1
+        return {
+          ok: false,
+          statusCode,
+          gone: false,
+          errorMessage: `HTTP ${statusCode} — boom`,
+        }
+      })
+      const caller = createAuthenticatedCaller(speakerA)
+      const result = await caller.push.sendTest()
+
+      expect(result.failures).toHaveLength(5)
     })
 
     it('refuses a second test within the cooldown window', async () => {

--- a/__tests__/components/pwa/PushNotificationSettings.test.tsx
+++ b/__tests__/components/pwa/PushNotificationSettings.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Behavioural tests for the test-notification feedback mapping in
+ * `PushNotificationSettingsView` (src/components/pwa/PushNotificationSettings.tsx).
+ * The `testFeedback` helper is exercised through the rendered view so we assert
+ * on what a speaker actually sees: the actionable copy driven by the dominant
+ * push-service rejection, plus the muted technical detail line.
+ */
+import { render, screen, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  PushNotificationSettingsView,
+  type PushTestResult,
+} from '@/components/pwa/PushNotificationSettings'
+import { DEFAULT_PUSH_PREFERENCES } from '@/lib/push/types'
+
+afterEach(cleanup)
+
+function renderWithResult(result: PushTestResult) {
+  render(
+    <PushNotificationSettingsView
+      status="enabled"
+      preferences={DEFAULT_PUSH_PREFERENCES}
+      onToggleMaster={vi.fn()}
+      onToggleCategory={vi.fn()}
+      onSendTest={vi.fn()}
+      sendTestResult={result}
+    />,
+  )
+}
+
+describe('PushNotificationSettingsView test-send feedback', () => {
+  it('403 (all failed): shows the re-subscribe hint and the detail line', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 0,
+      total: 2,
+      configured: true,
+      failures: [
+        { statusCode: 403, message: 'HTTP 403 — VapidPkHashMismatch' },
+      ],
+    })
+    expect(screen.getByText(/HTTP 403/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/turn notifications off and on again/i),
+    ).toBeInTheDocument()
+    // Muted technical detail line, with the HTTP prefix stripped.
+    expect(screen.getByText('403 — VapidPkHashMismatch')).toBeInTheDocument()
+  })
+
+  it('400 is treated like 403 (older-key re-subscribe advice)', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 0,
+      total: 1,
+      configured: true,
+      failures: [{ statusCode: 400, message: 'HTTP 400 — bad key' }],
+    })
+    expect(screen.getByText(/HTTP 400/)).toBeInTheDocument()
+    expect(screen.getByText(/re-subscribe/i)).toBeInTheDocument()
+  })
+
+  it('401: blames the server VAPID configuration, not the device', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 0,
+      total: 1,
+      configured: true,
+      failures: [{ statusCode: 401, message: 'HTTP 401 — Unauthorized' }],
+    })
+    expect(screen.getByText(/HTTP 401/)).toBeInTheDocument()
+    expect(screen.getByText(/VAPID configuration/i)).toBeInTheDocument()
+  })
+
+  it('429: advises retrying in a minute', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 0,
+      total: 1,
+      configured: true,
+      failures: [{ statusCode: 429, message: 'HTTP 429 — slow down' }],
+    })
+    expect(screen.getByText(/HTTP 429/)).toBeInTheDocument()
+    expect(screen.getByText(/try again in a minute/i)).toBeInTheDocument()
+  })
+
+  it('undefined status: falls back to the composed message', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 0,
+      total: 1,
+      configured: true,
+      failures: [{ statusCode: undefined, message: 'internal error' }],
+    })
+    expect(
+      screen.getByText(/Delivery failed \(internal error\)/i),
+    ).toBeInTheDocument()
+  })
+
+  it('failure with no message at all: says network error', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 0,
+      total: 1,
+      configured: true,
+      failures: [{}],
+    })
+    expect(
+      screen.getByText(/Delivery failed \(network error\)/i),
+    ).toBeInTheDocument()
+  })
+
+  it('partial success: success count PLUS a secondary re-subscribe line', () => {
+    renderWithResult({
+      sent: 1,
+      gone: 0,
+      total: 2,
+      configured: true,
+      failures: [
+        { statusCode: 403, message: 'HTTP 403 — VapidPkHashMismatch' },
+      ],
+    })
+    expect(screen.getByText(/Sent to 1 device/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/turn notifications off and on again/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText('403 — VapidPkHashMismatch')).toBeInTheDocument()
+  })
+
+  it('every device failed with NO diagnostics: generic retry hint, no detail line', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 0,
+      total: 2,
+      configured: true,
+      failures: [],
+    })
+    expect(
+      screen.getByText(/Could not deliver to your devices/i),
+    ).toBeInTheDocument()
+  })
+
+  it('all devices were expired and pruned: reports the pruning, not a rejection', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 2,
+      total: 2,
+      configured: true,
+      failures: [],
+    })
+    expect(
+      screen.getByText(/Removed 2 expired subscriptions/i),
+    ).toBeInTheDocument()
+  })
+
+  it('full success: green confirmation, no failure copy', () => {
+    renderWithResult({
+      sent: 2,
+      gone: 0,
+      total: 2,
+      configured: true,
+      failures: [],
+    })
+    expect(screen.getByText(/Sent to 2 devices/i)).toBeInTheDocument()
+    expect(screen.queryByText(/re-subscribe/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/pwa/PushNotificationSettings.stories.tsx
+++ b/src/components/pwa/PushNotificationSettings.stories.tsx
@@ -80,11 +80,75 @@ export const EnabledTestNoDevices: Story = {
   },
 }
 
-/** Devices exist but every send failed — distinct from having no devices. */
+/**
+ * Devices exist but every send failed with NO diagnostics (e.g. a network
+ * error the push service reported nothing useful for) — the generic retry hint.
+ */
 export const EnabledTestDeliveryFailed: Story = {
   args: {
     ...EnabledTestNoDevices.args,
     sendTestResult: { sent: 0, gone: 0, total: 2, configured: true },
+  },
+}
+
+/**
+ * All devices rejected with HTTP 403 (VAPID key mismatch): both of the two
+ * subscriptions failed identically, so the failure list deduped to one entry.
+ * Shows the actionable re-subscribe hint plus the muted technical detail line.
+ */
+export const EnabledTestAllFailed403: Story = {
+  args: {
+    status: 'enabled',
+    sendTestResult: {
+      sent: 0,
+      gone: 0,
+      total: 2,
+      configured: true,
+      failures: [
+        { statusCode: 403, message: 'HTTP 403 — VapidPkHashMismatch' },
+      ],
+    },
+  },
+}
+
+/**
+ * Partial failure: one of two devices got the test, the other was rejected with
+ * a 403. Success count plus a secondary re-subscribe line and the detail line.
+ */
+export const EnabledTestPartialFailure: Story = {
+  args: {
+    status: 'enabled',
+    sendTestResult: {
+      sent: 1,
+      gone: 0,
+      total: 2,
+      configured: true,
+      failures: [
+        { statusCode: 403, message: 'HTTP 403 — VapidPkHashMismatch' },
+      ],
+    },
+  },
+}
+
+/**
+ * All devices rejected with HTTP 401 — the server's own VAPID credentials are
+ * wrong (a server-side misconfiguration, not something the user can fix).
+ */
+export const EnabledTestAllFailed401: Story = {
+  args: {
+    status: 'enabled',
+    sendTestResult: {
+      sent: 0,
+      gone: 0,
+      total: 1,
+      configured: true,
+      failures: [
+        {
+          statusCode: 401,
+          message: 'HTTP 401 — Unauthorized WebPush Registration',
+        },
+      ],
+    },
   },
 }
 

--- a/src/components/pwa/PushNotificationSettings.tsx
+++ b/src/components/pwa/PushNotificationSettings.tsx
@@ -114,6 +114,13 @@ export interface PushTestResult {
   configured: boolean
   /** Total subscriptions on the account when the test ran. */
   total: number
+  /**
+   * Deduped, capped diagnostics for LIVE subscriptions the push service
+   * rejected (non-gone). Drives the actionable failure copy below. Each
+   * `message` is server-composed from the push-service response and never
+   * contains the endpoint.
+   */
+  failures?: Array<{ statusCode?: number; message?: string }>
 }
 
 export interface PushNotificationSettingsViewProps {
@@ -136,11 +143,79 @@ export interface PushNotificationSettingsViewProps {
   sendTestError?: boolean
 }
 
+type PushFailure = { statusCode?: number; message?: string }
+
+/** One-line technical detail cap so the muted line never wraps/overflows. */
+const MAX_DETAIL_LINE = 120
+
+/**
+ * The most actionable of the deduped failures: prefer one with a known HTTP
+ * status (it maps to specific advice) over a bare transport error.
+ */
+function dominantFailure(failures: PushFailure[]): PushFailure | undefined {
+  if (failures.length === 0) return undefined
+  return failures.find((f) => typeof f.statusCode === 'number') ?? failures[0]
+}
+
+/**
+ * Actionable, human copy for the dominant push-service rejection. A 403/400 is
+ * almost always a VAPID key mismatch (the subscription was created under an
+ * older/different applicationServerKey) — permanently unfixable server-side, so
+ * the ONLY remedy is for the user to re-subscribe on the affected device.
+ */
+function failureCopy(dominant: PushFailure | undefined): string {
+  const code = dominant?.statusCode
+  if (code === 403 || code === 400) {
+    return `The push service rejected the send (HTTP ${code}). This usually means this device was subscribed under an older server key — turn notifications off and on again on the affected device to re-subscribe.`
+  }
+  if (code === 401) {
+    return `The push service rejected the server’s credentials (HTTP 401). The server’s VAPID configuration may be wrong.`
+  }
+  if (code === 413) {
+    return 'The notification was too large to deliver (HTTP 413).'
+  }
+  if (code === 429) {
+    return 'The push service is rate-limiting sends (HTTP 429). Try again in a minute.'
+  }
+  const detail = dominant?.message?.trim() || 'network error'
+  return `Delivery failed (${detail}).`
+}
+
+/**
+ * Render one deduped failure as `<code> — <detail>` for the muted debug line.
+ * The server-composed `message` already carries an `HTTP <code> — ` prefix, so
+ * strip it to avoid repeating the status.
+ */
+function formatFailureDetail(failure: PushFailure): string {
+  const stripped = (failure.message ?? '')
+    .trim()
+    .replace(/^HTTP\s+\d+\s*(?:—|-)?\s*/i, '')
+  if (failure.statusCode !== undefined) {
+    return stripped
+      ? `${failure.statusCode} — ${stripped}`
+      : `${failure.statusCode}`
+  }
+  return stripped || 'unknown error'
+}
+
+/** Build the single muted technical line from the deduped failures. */
+function failureDetailLine(failures: PushFailure[]): string | undefined {
+  if (failures.length === 0) return undefined
+  const line = failures.map(formatFailureDetail).join(' · ')
+  return line.length > MAX_DETAIL_LINE
+    ? `${line.slice(0, MAX_DETAIL_LINE)}…`
+    : line
+}
+
 /** Human-readable feedback for the last test-notification send. */
 function testFeedback(
   result: PushTestResult | null | undefined,
   error: boolean | undefined,
-): { text: string; tone: 'success' | 'muted' | 'warn' } | null {
+): {
+  text: string
+  tone: 'success' | 'muted' | 'warn'
+  detail?: string
+} | null {
   if (error) {
     return {
       text: 'Could not send a test notification. Please try again.',
@@ -160,28 +235,60 @@ function testFeedback(
       tone: 'muted',
     }
   }
-  if (result.sent === 0 && result.gone === 0) {
-    // Devices exist but every send failed (non-gone transport errors) — a
-    // different situation from having no devices at all.
+
+  const failures = result.failures ?? []
+  const detail = failureDetailLine(failures)
+
+  if (result.sent === 0) {
+    if (failures.length > 0) {
+      // Live devices exist but the push service REJECTED the send — the
+      // diagnosable case (usually a 403 VAPID mismatch). Give the actionable fix
+      // plus the technical detail line for a maintainer reading a screenshot.
+      return {
+        text: failureCopy(dominantFailure(failures)),
+        tone: 'warn',
+        detail,
+      }
+    }
+    if (result.gone > 0) {
+      // Every device was a dead/expired subscription that got pruned — not a
+      // rejection we can advise on.
+      return {
+        text: `No active devices received the test. Removed ${result.gone} expired subscription${
+          result.gone === 1 ? '' : 's'
+        }.`,
+        tone: 'warn',
+      }
+    }
+    // Devices exist but the send failed with no diagnostics at all.
     return {
       text: 'Could not deliver to your devices right now. Please try again shortly.',
       tone: 'warn',
     }
   }
+
   const devices = `${result.sent} device${result.sent === 1 ? '' : 's'}`
-  const base =
-    result.sent > 0
-      ? `Sent to ${devices} — check for the notification.`
-      : 'No active devices received the test.'
+  const base = `Sent to ${devices} — check for the notification.`
   const expired =
     result.gone > 0
       ? ` Removed ${result.gone} expired subscription${
           result.gone === 1 ? '' : 's'
         }.`
       : ''
+
+  if (failures.length > 0) {
+    // Partial: some devices got it, others were rejected. Deliver the success
+    // count AND a secondary actionable line for the failing devices.
+    return {
+      text: `${base}${expired} ${failureCopy(dominantFailure(failures))}`,
+      tone: 'warn',
+      detail,
+    }
+  }
+
   return {
     text: base + expired,
-    tone: result.sent > 0 ? 'success' : 'warn',
+    tone: 'success',
   }
 }
 
@@ -360,18 +467,27 @@ export function PushNotificationSettingsView({
                   {sendTestPending ? 'Sending test…' : 'Send test notification'}
                 </button>
                 {feedback && (
-                  <p
-                    role="status"
-                    className={`font-inter text-sm ${
-                      feedback.tone === 'success'
-                        ? 'text-green-700 dark:text-green-400'
-                        : feedback.tone === 'warn'
-                          ? 'text-amber-700 dark:text-amber-400'
-                          : 'text-gray-500 dark:text-gray-400'
-                    }`}
-                  >
-                    {feedback.text}
-                  </p>
+                  <div role="status" className="space-y-1">
+                    <p
+                      className={`font-inter text-sm ${
+                        feedback.tone === 'success'
+                          ? 'text-green-700 dark:text-green-400'
+                          : feedback.tone === 'warn'
+                            ? 'text-amber-700 dark:text-amber-400'
+                            : 'text-gray-500 dark:text-gray-400'
+                      }`}
+                    >
+                      {feedback.text}
+                    </p>
+                    {feedback.detail && (
+                      <p
+                        className="truncate font-mono text-xs text-gray-400 dark:text-gray-500"
+                        title={feedback.detail}
+                      >
+                        {feedback.detail}
+                      </p>
+                    )}
+                  </div>
                 )}
               </div>
             )}

--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -23,11 +23,47 @@ export interface PushSendResult {
    * pruned from the speaker document.
    */
   gone: boolean
+  /**
+   * A short, human-readable failure summary composed from the push service's
+   * response (HTTP status + response body/message), truncated. Present only on
+   * failure. NEVER contains the subscription endpoint (a secret capability URL);
+   * it is safe to surface to the authenticated owner of the subscription.
+   */
+  errorMessage?: string
 }
 
 /** A push service returns 404/410 when a subscription is permanently dead. */
 function isGoneStatus(statusCode: number | undefined): boolean {
   return statusCode === 404 || statusCode === 410
+}
+
+/** Cap the push-service response body we log (it can be an arbitrary page). */
+const MAX_LOGGED_BODY = 300
+/** Cap the composed error summary we hand back to callers/clients. */
+const MAX_ERROR_MESSAGE = 200
+
+/** Truncate with an ellipsis so long push-service responses stay bounded. */
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value
+}
+
+/**
+ * Compose a short, greppable failure summary from a web-push error. The push
+ * service response `body` (e.g. FCM's `VapidPkHashMismatch`) is the most useful
+ * signal, so it wins over the library's generic `message`. Returns `undefined`
+ * only when there is genuinely nothing to report. NEVER includes the endpoint.
+ */
+function composeErrorMessage(
+  statusCode: number | undefined,
+  message: string | undefined,
+  body: string | undefined,
+): string | undefined {
+  const detail = body?.trim() || message?.trim() || undefined
+  if (statusCode === undefined && !detail) return undefined
+  const parts: string[] = []
+  if (statusCode !== undefined) parts.push(`HTTP ${statusCode}`)
+  if (detail) parts.push(detail)
+  return truncate(parts.join(' — '), MAX_ERROR_MESSAGE)
 }
 
 /**
@@ -45,7 +81,7 @@ export async function sendPush(
 ): Promise<PushSendResult> {
   const client = getConfiguredWebPush()
   if (!client) {
-    return { ok: false, gone: false }
+    return { ok: false, gone: false, errorMessage: 'VAPID keys not configured' }
   }
 
   try {
@@ -61,11 +97,41 @@ export async function sendPush(
     )
     return { ok: true, statusCode: response.statusCode, gone: false }
   } catch (error) {
-    const statusCode = (error as { statusCode?: number })?.statusCode
+    // web-push throws a `WebPushError` carrying the push service's HTTP status,
+    // response body, and a generic message. Capture all three: the status alone
+    // (the old behaviour) can't distinguish a transient 500 from a permanent
+    // 403 VapidPkHashMismatch (subscription made under a different/older
+    // applicationServerKey), which is only diagnosable from the body.
+    const err = error as {
+      statusCode?: number
+      message?: unknown
+      body?: unknown
+    }
+    const statusCode =
+      typeof err?.statusCode === 'number' ? err.statusCode : undefined
+    const message = typeof err?.message === 'string' ? err.message : undefined
+    const body = typeof err?.body === 'string' ? err.body : undefined
+
+    // Log the ORIGIN only — the full endpoint is a secret capability URL and is
+    // never logged anywhere in this module (matches deliverPushToRecipient).
+    let endpointOrigin: string
+    try {
+      endpointOrigin = new URL(subscription.endpoint).origin
+    } catch {
+      endpointOrigin = 'unknown'
+    }
+    console.error('[push] delivery failed', {
+      endpointOrigin,
+      statusCode,
+      message,
+      body: body === undefined ? undefined : truncate(body, MAX_LOGGED_BODY),
+    })
+
     return {
       ok: false,
       statusCode,
       gone: isGoneStatus(statusCode),
+      errorMessage: composeErrorMessage(statusCode, message, body),
     }
   }
 }

--- a/src/server/routers/push.ts
+++ b/src/server/routers/push.ts
@@ -145,10 +145,16 @@ export const pushRouter = router({
    * write another speaker's subscriptions, so it needs no extra authz beyond
    * `protectedProcedure`.
    *
-   * Returns `{ sent, gone, configured }`:
+   * Returns `{ sent, gone, total, configured, failures }`:
    *   - `configured`: whether the server has VAPID keys at all;
    *   - `sent`: how many of the caller's devices the push service accepted;
-   *   - `gone`: how many dead/invalid subscriptions were pruned in the process.
+   *   - `gone`: how many dead/invalid subscriptions were pruned in the process;
+   *   - `total`: how many subscriptions existed when the test ran;
+   *   - `failures`: deduped, capped diagnostics for LIVE subscriptions the push
+   *     service rejected (e.g. a 403 VapidPkHashMismatch), so the client can
+   *     advise the fix (turn notifications off/on to re-subscribe). A 403 is
+   *     NOT auto-pruned — a server-side key misconfig would otherwise mass-purge
+   *     valid subscriptions — it is surfaced as a hint only.
    */
   sendTest: protectedProcedure.mutation(async ({ ctx }) => {
     // No VAPID keys → push can never work; report it rather than pretending.
@@ -229,14 +235,58 @@ export const pushRouter = router({
       }),
     )
 
+    // Diagnostic failures for LIVE (non-gone) subscriptions the push service
+    // rejected. `sendPush` composes each `message` from the push-service
+    // response and never includes the endpoint, so it is safe to return to the
+    // authenticated OWNER of these subscriptions (their own device's result).
+    const failures: Array<{ statusCode?: number; message?: string }> = []
     for (const r of results) {
-      if (r.status !== 'fulfilled') continue
-      if (r.value.ok) sent += 1
-      if (r.value.gone) gone += 1
+      if (r.status !== 'fulfilled') {
+        // `sendPush` never throws and the prune helpers catch their own
+        // rejections, so this is unreachable in practice — but map it
+        // defensively rather than let a rejection vanish silently.
+        console.error(
+          `[push] test send task rejected for speaker ${ctx.speaker._id}:`,
+          r.reason,
+        )
+        failures.push({ statusCode: undefined, message: 'internal error' })
+        continue
+      }
+      if (r.value.ok) {
+        sent += 1
+        continue
+      }
+      if (r.value.gone) {
+        gone += 1
+        continue
+      }
+      failures.push({
+        statusCode: r.value.statusCode,
+        message: r.value.errorMessage,
+      })
+    }
+
+    // Dedupe identical (statusCode, message) pairs — every device behind the
+    // same push service typically fails identically — then cap the list so the
+    // response stays small.
+    const seen = new Set<string>()
+    const dedupedFailures: Array<{ statusCode?: number; message?: string }> = []
+    for (const failure of failures) {
+      const key = `${failure.statusCode ?? ''}::${failure.message ?? ''}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      dedupedFailures.push(failure)
     }
 
     // `total` lets the client distinguish "no devices subscribed" (total 0)
-    // from "devices exist but every send failed" (total > 0, sent 0).
-    return { sent, gone, total: state.subscriptions.length, configured: true }
+    // from "devices exist but every send failed" (total > 0, sent 0); `failures`
+    // lets it explain WHY (e.g. a 403 → re-subscribe hint).
+    return {
+      sent,
+      gone,
+      total: state.subscriptions.length,
+      configured: true,
+      failures: dedupedFailures.slice(0, 5),
+    }
   }),
 })


### PR DESCRIPTION
## Problem

Pressing **Send test notification** on `/cfp/profile` showed «Could not deliver to your devices right now. Please try again shortly.» with **nothing in the server logs** — impossible to diagnose from production.

**Root cause (silent catch):** `sendPush` in `src/lib/push/send.ts` caught the `web-push` error but extracted only `statusCode`, discarding the error name/message and the push-service response `body`, and never called `console.error` on the failure path. `sendTest` in `src/server/routers/push.ts` then flattened everything to counts `{ sent, gone, total, configured }`, so the client could only render a generic string. The most likely production cause — a **VAPID key mismatch** (a subscription created under a different/older `applicationServerKey`, so the push service returns **403** with an FCM body of `VapidPkHashMismatch`) — is permanently unfixable server-side; the only remedy is for the user to re-subscribe. That fix hint never reached the UI.

## The three layers

**T1 — `src/lib/push/send.ts` (shared transport, fixes observability for BOTH the test path and the production fan-out):**
- `sendPush`'s catch now extracts `statusCode`, `message`, and `body` from the `WebPushError` and **always** logs a structured, greppable line: `console.error('[push] delivery failed', { endpointOrigin, statusCode, message, body })`. It logs `new URL(subscription.endpoint).origin` only — **never the full endpoint** (a secret capability URL), matching the existing rule in `deliverPushToRecipient`. `body` is truncated to ~300 chars. Never-throw contract preserved; `gone` (404/410) logic untouched.
- `PushSendResult` gains optional `errorMessage?: string` composed as `HTTP <code> — <body|message>` (truncated ~200 chars). The push-service `body` wins over the generic library `message`.
- The null-client branch (unconfigured VAPID) now returns `errorMessage: 'VAPID keys not configured'` for consistency.

**T2 — `src/server/routers/push.ts` `sendTest`:**
- Collects `{ statusCode, message }` (message = `errorMessage`) for each fulfilled-but-not-ok, **non-gone** result. Rejected settled promises (shouldn't happen — `sendPush` never throws) are defensively mapped to `{ message: 'internal error' }` and `console.error`'d.
- Returns the existing shape **plus** `failures: Array<{ statusCode?; message? }>`, deduped by `statusCode+message` and capped at 5. Endpoints never appear in it (guaranteed by T1). Cooldown, SSRF guard, and prune logic unchanged.

**T3 — `src/components/pwa/PushNotificationSettings.tsx` (+ its container):**
- `PushTestResult` gains `failures?`. `testFeedback` maps the dominant failure to actionable copy:
  - **403 / 400** → «…subscribed under an older server key — turn notifications off and on again on the affected device to re-subscribe.»
  - **401** → server VAPID credentials may be wrong.
  - **413** → payload too large. **429** → rate-limited, try again in a minute.
  - other/undefined → «Delivery failed (<message | network error>).»
  - Applies to both the all-failed (`sent === 0`) and the partial (`sent > 0` with failures) case, always appending a one-line muted monospace detail line (e.g. `403 — VapidPkHashMismatch`) for screenshot debugging.
- Container passes `failures` through unchanged (it already forwards the whole result).

## Judgment call: 403 does NOT auto-prune

A 403 is deliberately surfaced as a **hint only** and never auto-prunes the subscription. Only 404/410 (`gone`) prune, exactly as before. A 403 is frequently caused by a **server-side** VAPID misconfiguration that would return 403 for *every* device at once — auto-pruning on 403 would mass-destroy otherwise-valid subscriptions on a transient/config error. The user-driven "turn off and on again" re-subscribe is the safe remedy.

## Tests

- `__tests__/api/trpc/push.test.ts` (extended the existing PR #524/#525 suite): failures array shape, gone-excluded-from-failures, dedupe, cap-at-5; existing happy-path/gone assertions updated for the new `failures: []` field.
- `__tests__/components/pwa/PushNotificationSettings.test.tsx` (new): `testFeedback` mapping for 403/400/401/429, undefined-code fallback, no-message → "network error", partial success, expired-only pruning, full success.
- Full suite green: **202 files, 2986 passed, 5 skipped**. tsc / eslint / knip / prettier all clean.

## Visual QA (`pnpm shoot`, 393×852)

Captured `EnabledTestAllFailed403` and `EnabledTestPartialFailure` in **light and dark**. The amber warning copy wraps cleanly and the muted `403 — VapidPkHashMismatch` detail line sits on one line, legible in both themes, **0 cards exceeding the 393px viewport**. Added Storybook stories: `EnabledTestAllFailed403`, `EnabledTestPartialFailure`, `EnabledTestAllFailed401` (fixtures kept internally consistent — device totals match sent+failure counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent failure in the push notification test flow where `web-push` errors were swallowed with no logging and the client received only an opaque retry hint. The fix is delivered across three layers: the shared transport (`sendPush`) now logs structured, endpoint-safe error info and returns an `errorMessage`; the `sendTest` router collects, dedupes, and caps these diagnostics into a `failures` array; and the settings UI maps each known HTTP status code to actionable copy (with a muted technical detail line for screenshot debugging).

- **`src/lib/push/send.ts`**: `sendPush` now extracts `statusCode`, `message`, and `body` from `WebPushError`, logs them against the endpoint *origin only* (never the full capability URL), and composes a truncated `errorMessage` on the returned `PushSendResult`.
- **`src/server/routers/push.ts`**: `sendTest` aggregates non-gone failures into a deduped, 5-capped `failures: Array<{ statusCode?, message? }>` included in the response.
- **`src/components/pwa/PushNotificationSettings.tsx`**: New helper functions (`dominantFailure`, `failureCopy`, `formatFailureDetail`, `failureDetailLine`) drive actionable copy for 400/403 (re-subscribe), 401 (VAPID config), 413 (payload size), 429 (rate limit), and a generic fallback — plus a muted monospace detail line for maintainer diagnostics.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the observability and UX improvements are well-scoped, the never-throw contract on `sendPush` is preserved, and endpoint privacy is maintained throughout.

The three-layer fix is coherent and the test suite is thorough. The only rough edges are in the `testFeedback` UX logic: when a user has both rejected and expired subscriptions simultaneously, the expired count is silently omitted; and `dominantFailure` surfaces the first numerically-coded failure by list order rather than actionability, so a generic 500 ahead of a 403 hides the re-subscribe hint. Both cases are rare in practice.

The two minor UX gaps are both in the `testFeedback` helper in `src/components/pwa/PushNotificationSettings.tsx` — specifically the `sent === 0` branch ordering and `dominantFailure`'s selection logic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/push/send.ts | Adds structured error capture and logging to `sendPush`; introduces `errorMessage` on `PushSendResult`. Well-guarded: endpoint origin only in logs, body truncated, never-throw contract preserved. |
| src/server/routers/push.ts | Extends `sendTest` to collect, dedupe, and cap failure diagnostics. Rejected-promise defensive path is correctly handled; gone vs failure distinction is accurate; early returns for unconfigured/no-subscriptions paths omit `failures` but the client handles `failures?: ...` correctly. |
| src/components/pwa/PushNotificationSettings.tsx | Adds `failures` to `PushTestResult`, helper functions for dominant-failure selection and detail-line formatting, and the `testFeedback` expansion. Minor UX gap: when `sent === 0` with concurrent failures+gone, the gone count is silently dropped; `dominantFailure` picks by list order rather than actionability. |
| __tests__/api/trpc/push.test.ts | New tests for 403 rejection surface, dedup, and cap-at-5; existing happy-path/gone assertions updated for the new `failures: []` field. Coverage is thorough. |
| __tests__/components/pwa/PushNotificationSettings.test.tsx | New unit tests for `testFeedback` across all status-code branches, partial success, expired-only, and full-success paths. Good coverage of the new UI logic. |
| src/components/pwa/PushNotificationSettings.stories.tsx | Three new Storybook stories (403 all-failed, partial failure, 401 all-failed) with internally consistent fixtures. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as PushNotificationSettings (client)
    participant Router as sendTest (tRPC router)
    participant Send as sendPush (send.ts)
    participant Push as Push Service (FCM/VAPID)

    UI->>Router: push.sendTest()
    Router->>Send: sendPush(subscription, payload) x N
    Send->>Push: POST /push-endpoint
    Push-->>Send: HTTP 403 VapidPkHashMismatch
    Send->>Send: "console.error('[push] delivery failed', {endpointOrigin, statusCode, body})"
    Send-->>Router: "{ ok: false, gone: false, errorMessage: 'HTTP 403 - VapidPkHashMismatch' }"
    Router->>Router: collect failures[], dedupe by statusCode+message, cap at 5
    Router-->>UI: "{ sent, gone, total, configured, failures: [{statusCode:403, message:'HTTP 403 - VapidPkHashMismatch'}] }"
    UI->>UI: "dominantFailure(failures) -> failureCopy(403) -> 'turn off and on again' hint"
    UI->>UI: "failureDetailLine(failures) -> '403 - VapidPkHashMismatch'"
    UI-->>UI: render amber warning + muted detail line
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as PushNotificationSettings (client)
    participant Router as sendTest (tRPC router)
    participant Send as sendPush (send.ts)
    participant Push as Push Service (FCM/VAPID)

    UI->>Router: push.sendTest()
    Router->>Send: sendPush(subscription, payload) x N
    Send->>Push: POST /push-endpoint
    Push-->>Send: HTTP 403 VapidPkHashMismatch
    Send->>Send: "console.error('[push] delivery failed', {endpointOrigin, statusCode, body})"
    Send-->>Router: "{ ok: false, gone: false, errorMessage: 'HTTP 403 - VapidPkHashMismatch' }"
    Router->>Router: collect failures[], dedupe by statusCode+message, cap at 5
    Router-->>UI: "{ sent, gone, total, configured, failures: [{statusCode:403, message:'HTTP 403 - VapidPkHashMismatch'}] }"
    UI->>UI: "dominantFailure(failures) -> failureCopy(403) -> 'turn off and on again' hint"
    UI->>UI: "failureDetailLine(failures) -> '403 - VapidPkHashMismatch'"
    UI-->>UI: render amber warning + muted detail line
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(push): surface push-service errors i..."](https://github.com/cloudnativebergen/website/commit/55d2a427baed7001b9291209e6d3c078fad4874b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45414877)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->