### PR TITLE
feat(messaging): who/what/when inbox rows (M6)

### DIFF
--- a/__tests__/components/messaging/ConversationList.test.tsx
+++ b/__tests__/components/messaging/ConversationList.test.tsx
@@ -16,6 +16,12 @@ const items: ConversationListItem[] = [
     createdAt: new Date('2026-07-15T10:00:00Z').toISOString(),
     lastMessageAt: new Date('2026-07-18T10:00:00Z').toISOString(),
     unreadCount: 0,
+    lastMessage: {
+      authorId: 'speaker-me',
+      authorName: 'Kari Nordmann',
+      excerpt: 'I have updated the abstract.',
+    },
+    counterpart: { name: 'Kari Nordmann' },
   },
   {
     _id: 'conversation.abc123',
@@ -24,6 +30,12 @@ const items: ConversationListItem[] = [
     createdAt: new Date('2026-07-15T10:00:00Z').toISOString(),
     lastMessageAt: new Date('2026-07-18T09:00:00Z').toISOString(),
     unreadCount: 0,
+    lastMessage: {
+      authorId: 'organizer-1',
+      authorName: 'Ola Organizer',
+      excerpt: 'We cover flights booked before June.',
+    },
+    counterpart: { name: 'Ola Organizer' },
   },
 ]
 
@@ -93,5 +105,51 @@ describe('ConversationList', () => {
   it('keeps a read row subject at semibold (not bold)', () => {
     render(<ConversationList items={items} isOrganizer={false} />)
     expect(screen.getByText('Scaling Kubernetes')).toHaveClass('font-semibold')
+  })
+
+  // --- Who/What/When metadata (M6) ---
+
+  it('renders the counterpart name and the last-message snippet per row', () => {
+    render(<ConversationList items={items} isOrganizer={false} />)
+    expect(screen.getByText('Kari Nordmann')).toBeInTheDocument()
+    expect(screen.getByText('Ola Organizer')).toBeInTheDocument()
+    expect(screen.getByText(/updated the abstract/)).toBeInTheDocument()
+    expect(screen.getByText(/flights booked before June/)).toBeInTheDocument()
+  })
+
+  it('prefixes the snippet with "You:" only on rows whose last message the caller wrote', () => {
+    render(
+      <ConversationList
+        items={items}
+        isOrganizer={false}
+        callerId="speaker-me"
+      />,
+    )
+    // Row 1's last message is the caller's; row 2's is not.
+    const row1 = linkFor('Scaling Kubernetes')
+    const row2 = linkFor('Travel question')
+    expect(row1).toHaveTextContent('You:')
+    expect(row2?.textContent).not.toContain('You:')
+  })
+
+  it('shows no "You:" prefix at all without a callerId', () => {
+    render(<ConversationList items={items} isOrganizer={false} />)
+    expect(screen.queryByText('You:')).not.toBeInTheDocument()
+  })
+
+  it('marks proposal threads with a "Proposal" chip and leaves general threads unmarked', () => {
+    render(<ConversationList items={items} isOrganizer={false} />)
+    expect(screen.getAllByText('Proposal')).toHaveLength(1)
+    expect(linkFor('Scaling Kubernetes')).toHaveTextContent('Proposal')
+    expect(linkFor('Travel question')?.textContent).not.toContain('Proposal')
+  })
+
+  it('renders a row without a snippet line when the conversation has no messages', () => {
+    const empty: ConversationListItem[] = [
+      { ...items[1], lastMessage: null, counterpart: { name: 'Organizers' } },
+    ]
+    render(<ConversationList items={empty} isOrganizer={false} />)
+    expect(screen.getByText('Travel question')).toBeInTheDocument()
+    expect(screen.queryByText(/flights booked/)).not.toBeInTheDocument()
   })
 })

--- a/__tests__/components/messaging/NewConversationForm.test.tsx
+++ b/__tests__/components/messaging/NewConversationForm.test.tsx
@@ -196,11 +196,7 @@ describe('NewConversationForm — fixed recipient (organizer, known target)', ()
 describe('NewConversationForm — proposal thread mode', () => {
   it('hides picker and subject, sends { proposalId, body }', () => {
     render(
-      <NewConversationForm
-        basePath="/admin/messages"
-        proposalId="prop-1"
-        navigateOnCreate={false}
-      />,
+      <NewConversationForm basePath="/admin/messages" proposalId="prop-1" />,
     )
     expect(screen.queryByTestId('pick-speaker')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Subject')).not.toBeInTheDocument()
@@ -216,13 +212,12 @@ describe('NewConversationForm — proposal thread mode', () => {
     })
   })
 
-  it('does not navigate on success when navigateOnCreate is false, but invalidates the thread', () => {
+  it('does not navigate on success BY DEFAULT, but invalidates the thread', () => {
     const onCreated = vi.fn()
     render(
       <NewConversationForm
         basePath="/admin/messages"
         proposalId="prop-1"
-        navigateOnCreate={false}
         onCreated={onCreated}
       />,
     )
@@ -242,8 +237,16 @@ describe('NewConversationForm — proposal thread mode', () => {
     })
   })
 
-  it('still navigates by default in the general flow', () => {
+  // Navigation is explicit opt-in: an embedded mount (modal + proposalId) must
+  // never be one forgotten prop away from an unwanted route change.
+  it('does NOT navigate by default in the general flow either', () => {
     render(<NewConversationForm basePath="/cfp/messages" />)
+    mutationOptions?.onSuccess?.({ conversationId: 'conversation.abc' })
+    expect(routerPush).not.toHaveBeenCalled()
+  })
+
+  it('navigates to the created thread when navigateOnCreate is set', () => {
+    render(<NewConversationForm basePath="/cfp/messages" navigateOnCreate />)
     mutationOptions?.onSuccess?.({ conversationId: 'conversation.abc' })
     expect(routerPush).toHaveBeenCalledWith('/cfp/messages/conversation.abc')
   })

--- a/__tests__/components/notifications/NotificationList.test.tsx
+++ b/__tests__/components/notifications/NotificationList.test.tsx
@@ -166,4 +166,27 @@ describe('NotificationList', () => {
     fireEvent.click(screen.getByRole('link', { name: /view all messages/i }))
     expect(onMessagesClick).toHaveBeenCalledOnce()
   })
+
+  it('renders the header settings gear when settingsHref is provided', () => {
+    renderList({ settingsHref: '/cfp/profile#notification-settings' })
+    const gear = screen.getByRole('link', { name: 'Notification settings' })
+    expect(gear).toHaveAttribute('href', '/cfp/profile#notification-settings')
+  })
+
+  it('does NOT render the settings gear when settingsHref is absent', () => {
+    renderList()
+    expect(
+      screen.queryByRole('link', { name: 'Notification settings' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('fires onSettingsClick (popover close) when the gear is activated', () => {
+    const onSettingsClick = vi.fn()
+    renderList({
+      settingsHref: '/cfp/profile#notification-settings',
+      onSettingsClick,
+    })
+    fireEvent.click(screen.getByRole('link', { name: 'Notification settings' }))
+    expect(onSettingsClick).toHaveBeenCalledOnce()
+  })
 })

--- a/__tests__/components/notifications/NotificationPanel.test.tsx
+++ b/__tests__/components/notifications/NotificationPanel.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Container tests for NotificationPanel — specifically the session-hydration
+ * guard: `messagesHref`/`settingsHref` are audience-derived, so while the
+ * session is still resolving NEITHER may render (an organizer would otherwise
+ * briefly get, and could click, the speaker link).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NotificationPanel } from '@/components/notifications/NotificationPanel'
+
+// Mutable session state the tests set before rendering.
+let sessionState: { data: unknown; status: string } = {
+  data: undefined,
+  status: 'loading',
+}
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => sessionState,
+}))
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    useUtils: () => ({
+      notification: {
+        unreadCount: { invalidate: vi.fn() },
+        list: { invalidate: vi.fn() },
+      },
+    }),
+    notification: {
+      list: {
+        useInfiniteQuery: () => ({
+          data: { pages: [[]] },
+          isLoading: false,
+          isError: false,
+          fetchNextPage: vi.fn(),
+          hasNextPage: false,
+          isFetchingNextPage: false,
+        }),
+      },
+      markRead: { useMutation: () => ({ mutate: vi.fn() }) },
+      markAllRead: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+  },
+}))
+
+function renderPanel() {
+  return render(<NotificationPanel unreadCount={0} onClose={vi.fn()} />)
+}
+
+beforeEach(() => {
+  sessionState = { data: undefined, status: 'loading' }
+})
+
+describe('NotificationPanel — session-derived quick links', () => {
+  it('renders NEITHER the messages link nor the settings gear while the session is loading', () => {
+    renderPanel()
+    expect(
+      screen.queryByRole('link', { name: /view all messages/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Notification settings' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the speaker messages link and the settings gear once the session resolves', () => {
+    sessionState = {
+      data: { speaker: { _id: 'sp-1', isOrganizer: false } },
+      status: 'authenticated',
+    }
+    renderPanel()
+    expect(
+      screen.getByRole('link', { name: /view all messages/i }),
+    ).toHaveAttribute('href', '/cfp/messages')
+    expect(
+      screen.getByRole('link', { name: 'Notification settings' }),
+    ).toHaveAttribute('href', '/cfp/profile#notification-settings')
+  })
+
+  it('routes an organizer to the admin inbox (same profile settings anchor)', () => {
+    sessionState = {
+      data: { speaker: { _id: 'org-1', isOrganizer: true } },
+      status: 'authenticated',
+    }
+    renderPanel()
+    expect(
+      screen.getByRole('link', { name: /view all messages/i }),
+    ).toHaveAttribute('href', '/admin/messages')
+    expect(
+      screen.getByRole('link', { name: 'Notification settings' }),
+    ).toHaveAttribute('href', '/cfp/profile#notification-settings')
+  })
+})

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/lib/notification/sanity', () => ({
 vi.mock('nanoid', () => ({ nanoid: () => 'FIXED' }))
 
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
 import {
   proposalConversationId,
   conversationPreferenceId,
@@ -414,6 +415,137 @@ describe('listConversationsForSpeaker — unread counts per conversation', () =>
     })
     expect(result).toEqual([])
     expect(readMock.fetch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('listConversationsForSpeaker — Who/What metadata (M6)', () => {
+  const proposalRow = {
+    _id: 'conversation.proposal.prop-1',
+    conversationType: 'proposal' as const,
+    subject: 'My Talk',
+    proposalId: 'prop-1',
+    proposalTitle: 'My Talk',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastMessageAt: '2026-01-02T00:00:00.000Z',
+    lastMessage: {
+      authorId: 'sp-1',
+      authorName: 'Kari Speaker',
+      authorImage: 'https://img/kari.jpg',
+      body: 'Short update',
+    },
+    speakerSideName: 'Kari Speaker',
+    speakerSideImage: 'https://img/kari.jpg',
+  }
+  const generalRow = {
+    _id: 'conversation.gen-1',
+    conversationType: 'general' as const,
+    subject: 'Q',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastMessageAt: '2026-01-01T00:00:00.000Z',
+    lastMessage: {
+      authorId: 'org-1',
+      authorName: 'Ola Organizer',
+      authorImage: 'https://img/ola.jpg',
+      body: 'An answer',
+    },
+    speakerSideName: 'Sub Ject',
+    speakerSideImage: null,
+  }
+
+  it('ORGANIZER audience: the counterpart is the pre-resolved speaker side (no organizer-id fetch)', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce([proposalRow, generalRow])
+      .mockResolvedValueOnce([])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+    })
+
+    expect(result[0].counterpart).toEqual({
+      name: 'Kari Speaker',
+      image: 'https://img/kari.jpg',
+    })
+    // General thread: subject speaker (image absent → undefined).
+    expect(result[1].counterpart).toEqual({
+      name: 'Sub Ject',
+      image: undefined,
+    })
+    // The projection resolves the speaker side inside the ONE page query,
+    // using the house coalesce(image.asset->url, imageURL) speaker-image
+    // pattern on each dereferenced side.
+    const [query] = readMock.fetch.mock.calls[0]
+    expect(query).toContain(
+      'coalesce(author->image.asset->url, author->imageURL)',
+    )
+    expect(query).toContain('proposal->speakers[0]->name')
+    expect(query).toContain('subjectSpeaker->name')
+    // Organizer path never needs the organizer id set.
+    expect(getOrganizerSpeakerIds).not.toHaveBeenCalled()
+  })
+
+  it('SPEAKER audience: an organizer last-author becomes the counterpart; otherwise the Organizers label', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValueOnce(['org-1'])
+    readMock.fetch
+      .mockResolvedValueOnce([proposalRow, generalRow])
+      .mockResolvedValueOnce([])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'sp-1',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+    })
+
+    // Proposal row: last author sp-1 is NOT an organizer → collective label,
+    // deliberately without an image.
+    expect(result[0].counterpart).toEqual({ name: 'Organizers' })
+    // General row: last author org-1 IS an organizer → their name + image.
+    expect(result[1].counterpart).toEqual({
+      name: 'Ola Organizer',
+      image: 'https://img/ola.jpg',
+    })
+  })
+
+  it('maps lastMessage to an author + excerpt, ellipsizing bodies over 120 chars', async () => {
+    const longBody = 'A'.repeat(150)
+    readMock.fetch
+      .mockResolvedValueOnce([
+        {
+          ...proposalRow,
+          lastMessage: { ...proposalRow.lastMessage, body: longBody },
+        },
+        generalRow,
+      ])
+      .mockResolvedValueOnce([])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+    })
+
+    expect(result[0].lastMessage).toEqual({
+      authorId: 'sp-1',
+      authorName: 'Kari Speaker',
+      excerpt: `${'A'.repeat(120)}…`,
+    })
+    // Short bodies pass through untouched.
+    expect(result[1].lastMessage?.excerpt).toBe('An answer')
+  })
+
+  it('returns lastMessage null for a conversation with no messages yet', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce([{ ...generalRow, lastMessage: null }])
+      .mockResolvedValueOnce([])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+    })
+
+    expect(result[0].lastMessage).toBeNull()
   })
 })
 

--- a/src/components/admin/SendMessageModal.tsx
+++ b/src/components/admin/SendMessageModal.tsx
@@ -139,7 +139,6 @@ export function SendMessageModal({
               <NewConversationForm
                 basePath="/admin/messages"
                 proposalId={proposalId}
-                navigateOnCreate={false}
                 autoFocusFirstField
                 onCreated={handleCreated}
                 onCancel={onClose}

--- a/src/components/cfp/CFPProfilePage.tsx
+++ b/src/components/cfp/CFPProfilePage.tsx
@@ -289,58 +289,65 @@ export function CFPProfilePage({
             className="space-y-6"
           />
 
-          <section
-            aria-labelledby="messaging-emails-heading"
-            className="border-t border-gray-200 pt-6 dark:border-gray-600"
-          >
-            <h2
-              id="messaging-emails-heading"
-              className="font-space-grotesk text-lg font-semibold text-gray-900 dark:text-white"
+          {/* Anchor target for the notification panel's settings gear
+              (#notification-settings): the message-email default and the push
+              settings card below are THE notification settings. `space-y-8`
+              mirrors the parent so wrapping them changes no spacing. */}
+          <div id="notification-settings" className="scroll-mt-20 space-y-8">
+            <section
+              aria-labelledby="messaging-emails-heading"
+              className="border-t border-gray-200 pt-6 dark:border-gray-600"
             >
-              Message emails
-            </h2>
-            <div className="mt-3 flex items-start justify-between gap-4">
-              <label
-                htmlFor="messaging-email-default"
-                className="font-inter flex-1 text-sm text-gray-600 dark:text-gray-400"
+              <h2
+                id="messaging-emails-heading"
+                className="font-space-grotesk text-lg font-semibold text-gray-900 dark:text-white"
               >
-                Message emails are on by default: we email you when an organizer
-                writes in one of your conversations. Turn this off to rely on
-                in-app notifications only — you can still override it per
-                conversation.
-              </label>
-              {/* ABSENT-MEANS-ENABLED (M4): only an explicit false is off. */}
-              <button
-                type="button"
-                role="switch"
-                id="messaging-email-default"
-                aria-checked={speakerData.messagingEmailDefault !== false}
-                aria-label="Email me about new messages"
-                onClick={() =>
-                  setSpeakerData((prev) => ({
-                    ...prev,
-                    messagingEmailDefault: prev.messagingEmailDefault === false,
-                  }))
-                }
-                className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue ${
-                  speakerData.messagingEmailDefault !== false
-                    ? 'bg-brand-cloud-blue dark:bg-blue-600'
-                    : 'bg-gray-200 dark:bg-gray-600'
-                }`}
-              >
-                <span
-                  aria-hidden="true"
-                  className={`pointer-events-none inline-block h-5 w-5 translate-y-0.5 rounded-full bg-white shadow-sm transition-transform ${
+                Message emails
+              </h2>
+              <div className="mt-3 flex items-start justify-between gap-4">
+                <label
+                  htmlFor="messaging-email-default"
+                  className="font-inter flex-1 text-sm text-gray-600 dark:text-gray-400"
+                >
+                  Message emails are on by default: we email you when an
+                  organizer writes in one of your conversations. Turn this off
+                  to rely on in-app notifications only — you can still override
+                  it per conversation.
+                </label>
+                {/* ABSENT-MEANS-ENABLED (M4): only an explicit false is off. */}
+                <button
+                  type="button"
+                  role="switch"
+                  id="messaging-email-default"
+                  aria-checked={speakerData.messagingEmailDefault !== false}
+                  aria-label="Email me about new messages"
+                  onClick={() =>
+                    setSpeakerData((prev) => ({
+                      ...prev,
+                      messagingEmailDefault:
+                        prev.messagingEmailDefault === false,
+                    }))
+                  }
+                  className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors focus:outline-2 focus:outline-offset-2 focus:outline-brand-cloud-blue ${
                     speakerData.messagingEmailDefault !== false
-                      ? 'translate-x-5'
-                      : 'translate-x-0.5'
+                      ? 'bg-brand-cloud-blue dark:bg-blue-600'
+                      : 'bg-gray-200 dark:bg-gray-600'
                   }`}
-                />
-              </button>
-            </div>
-          </section>
+                >
+                  <span
+                    aria-hidden="true"
+                    className={`pointer-events-none inline-block h-5 w-5 translate-y-0.5 rounded-full bg-white shadow-sm transition-transform ${
+                      speakerData.messagingEmailDefault !== false
+                        ? 'translate-x-5'
+                        : 'translate-x-0.5'
+                    }`}
+                  />
+                </button>
+              </div>
+            </section>
 
-          <PushNotificationSettings />
+            <PushNotificationSettings />
+          </div>
 
           <div className="flex justify-end border-t border-gray-200 pt-6 dark:border-gray-600">
             <button

--- a/src/components/messaging/ConversationList.stories.tsx
+++ b/src/components/messaging/ConversationList.stories.tsx
@@ -6,6 +6,15 @@ import type { ConversationListItem } from '@/lib/messaging/types'
 const minutesAgo = (m: number) =>
   new Date(Date.now() - m * 60_000).toISOString()
 
+/** The viewer in the "You: " stories (last message on row 1 is theirs). */
+const CALLER_ID = 'speaker-me'
+
+/**
+ * A representative Who/What/When mix: a proposal thread whose last message is
+ * the viewer's own ("You: "), a general thread answered by a named organizer
+ * (avatar via image), and a proposal thread from the collective 'Organizers'
+ * counterpart (group glyph, no single person).
+ */
 const makeItems = (
   unread: [number, number, number] = [0, 0, 0],
 ): ConversationListItem[] => [
@@ -18,6 +27,12 @@ const makeItems = (
     createdAt: minutesAgo(60 * 24 * 3),
     lastMessageAt: minutesAgo(24),
     unreadCount: unread[0],
+    lastMessage: {
+      authorId: CALLER_ID,
+      authorName: 'Kari Nordmann',
+      excerpt: 'Thanks — I have updated the abstract with the new numbers.',
+    },
+    counterpart: { name: 'Kari Nordmann' },
   },
   {
     _id: 'conversation.abc123',
@@ -26,6 +41,16 @@ const makeItems = (
     createdAt: minutesAgo(60 * 24 * 2),
     lastMessageAt: minutesAgo(60 * 5),
     unreadCount: unread[1],
+    lastMessage: {
+      authorId: 'organizer-1',
+      authorName: 'Ola Organizer',
+      excerpt:
+        'We cover flights booked before June — send us the receipt and we will sort it out.',
+    },
+    counterpart: {
+      name: 'Ola Organizer',
+      image: '/images/default-avatar.png',
+    },
   },
   {
     _id: 'conversation.proposal.talk-2',
@@ -36,6 +61,53 @@ const makeItems = (
     createdAt: minutesAgo(60 * 24 * 10),
     lastMessageAt: minutesAgo(60 * 24 * 4),
     unreadCount: unread[2],
+    lastMessage: {
+      authorId: 'organizer-2',
+      authorName: 'Grace Hopper',
+      excerpt: 'Could you keep the demo under ten minutes?',
+    },
+    counterpart: { name: 'Organizers' },
+  },
+]
+
+/** Overflow guards: an unbroken subject and a long snippet must both truncate.
+ * A FUNCTION (like `makeItems`) so the relative times are computed against the
+ * mocked story clock, keeping the labels deterministic. */
+const makeLongItems = (): ConversationListItem[] => [
+  {
+    _id: 'conversation.long-1',
+    conversationType: 'general',
+    subject:
+      'A very long subject about accommodation, travel reimbursement, workshop equipment and the speaker dinner on Thursday evening',
+    createdAt: minutesAgo(60 * 24),
+    lastMessageAt: minutesAgo(30),
+    unreadCount: 2,
+    lastMessage: {
+      authorId: 'organizer-1',
+      authorName: 'Ola Organizer',
+      excerpt:
+        'This is a deliberately long snippet that goes on and on about the details of the venue, the AV setup, the rehearsal s…',
+    },
+    counterpart: { name: 'Ola Organizer' },
+  },
+  {
+    _id: 'conversation.proposal.long-2',
+    conversationType: 'proposal',
+    subject:
+      'Observability-Driven-Development-Without-Tears-A-Practitioners-Guide-To-Instrumenting-Everything',
+    proposalId: 'talk-9',
+    proposalTitle:
+      'Observability-Driven-Development-Without-Tears-A-Practitioners-Guide-To-Instrumenting-Everything',
+    createdAt: minutesAgo(60 * 48),
+    lastMessageAt: minutesAgo(60 * 2),
+    unreadCount: 0,
+    lastMessage: {
+      authorId: CALLER_ID,
+      authorName: 'Kari Nordmann',
+      excerpt:
+        'Supercalifragilisticexpialidocious-unbroken-snippet-string-that-must-truncate-not-wrap-or-overflow-the-row-container',
+    },
+    counterpart: { name: 'Kari Nordmann' },
   },
 ]
 
@@ -59,10 +131,17 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-/** Speaker inbox — rows link to `/cfp/...`. */
+/**
+ * Speaker inbox — rows link to `/cfp/...`. A full Who/What/When mix: row 1 is
+ * read with the viewer's own last message ("You: "), row 2 unread (count pill +
+ * organizer avatar), row 3 unread past the 9+ cap (proposal chip + the
+ * collective Organizers glyph).
+ */
 export const SpeakerInbox: Story = {
-  args: { items: [], isOrganizer: false },
-  render: (args) => <ConversationList {...args} items={makeItems()} />,
+  args: { items: [], isOrganizer: false, callerId: CALLER_ID },
+  render: (args) => (
+    <ConversationList {...args} items={makeItems([0, 2, 12])} />
+  ),
 }
 
 /** Organizer inbox — same data, rows link to `/admin/...`. */
@@ -85,9 +164,11 @@ export const HasMore: Story = {
 }
 
 export const SpeakerInboxDark: Story = {
-  args: { items: [], isOrganizer: false },
+  args: { items: [], isOrganizer: false, callerId: CALLER_ID },
   parameters: { dark: true },
-  render: (args) => <ConversationList {...args} items={makeItems()} />,
+  render: (args) => (
+    <ConversationList {...args} items={makeItems([0, 2, 12])} />
+  ),
 }
 
 /**
@@ -107,4 +188,19 @@ export const UnreadMixedDark: Story = {
   render: (args) => (
     <ConversationList {...args} items={makeItems([3, 0, 12])} />
   ),
+}
+
+/**
+ * Truncation guard: a long unbroken subject and a long snippet must both stay
+ * on one line (ellipsized) without stretching the row or the container.
+ */
+export const LongContent: Story = {
+  args: { items: [], isOrganizer: false, callerId: CALLER_ID },
+  render: (args) => <ConversationList {...args} items={makeLongItems()} />,
+}
+
+export const LongContentDark: Story = {
+  args: { items: [], isOrganizer: false, callerId: CALLER_ID },
+  parameters: { dark: true },
+  render: (args) => <ConversationList {...args} items={makeLongItems()} />,
 }

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -1,9 +1,14 @@
 'use client'
 
 import Link from 'next/link'
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline'
+import {
+  ChatBubbleLeftRightIcon,
+  UserGroupIcon,
+} from '@heroicons/react/24/outline'
 import { conversationLinkPath } from '@/lib/messaging/links'
 import { formatRelativeTime } from '@/lib/notification/format'
+import { MissingAvatar } from '@/components/common/MissingAvatar'
+import { SpeakerAvatarImage } from '@/components/common/SpeakerAvatarImage'
 import type { ConversationListItem } from '@/lib/messaging/types'
 
 export interface ConversationListProps {
@@ -14,6 +19,12 @@ export interface ConversationListProps {
    * speakers → /cfp) via the shared {@link conversationLinkPath} contract.
    */
   isOrganizer: boolean
+  /**
+   * The viewer's own speaker id — rows whose last message they authored get a
+   * "You: " snippet prefix. Optional so the list renders before the session
+   * resolves (no prefix until it does).
+   */
+  callerId?: string
   isLoading?: boolean
   isError?: boolean
   hasMore?: boolean
@@ -23,9 +34,12 @@ export interface ConversationListProps {
 
 function SkeletonRow() {
   return (
-    <div className="flex flex-col gap-2 px-4 py-3">
-      <div className="h-4 w-2/3 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
-      <div className="h-3 w-1/4 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+    <div className="flex gap-3 px-4 py-3">
+      <div className="h-10 w-10 shrink-0 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+      <div className="flex-1 space-y-2">
+        <div className="h-4 w-2/3 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+        <div className="h-3 w-1/4 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+      </div>
     </div>
   )
 }
@@ -39,13 +53,42 @@ function conversationTitle(item: ConversationListItem): string {
 }
 
 /**
+ * WHO: the row avatar. A counterpart with an image gets the photo (initials
+ * fallback on load failure); a named counterpart without one gets initials; the
+ * collective 'Organizers' counterpart (speaker audience, no single person) gets
+ * a neutral group glyph — initials would wrongly suggest a person.
+ */
+function RowAvatar({ item }: { item: ConversationListItem }) {
+  const { name, image } = item.counterpart
+  return (
+    <span
+      aria-hidden="true"
+      className="mt-0.5 h-10 w-10 shrink-0 overflow-hidden rounded-full"
+    >
+      {image ? (
+        <SpeakerAvatarImage src={image} name={name} size={40} />
+      ) : name === 'Organizers' ? (
+        <span className="flex h-full w-full items-center justify-center bg-gray-100 dark:bg-gray-700">
+          <UserGroupIcon className="h-5 w-5 text-gray-400 dark:text-gray-500" />
+        </span>
+      ) : (
+        <MissingAvatar name={name} size={40} />
+      )}
+    </span>
+  )
+}
+
+/**
  * Presentational inbox: one row per conversation linking to its thread for the
- * given audience. Pure — the container supplies data and pagination handlers so
- * this renders without tRPC in Storybook and tests.
+ * given audience. Each row reads Who (counterpart avatar + name) / What
+ * (subject, snippet) / When (relative time) at a glance. Pure — the container
+ * supplies data and pagination handlers so this renders without tRPC in
+ * Storybook and tests.
  */
 export function ConversationList({
   items,
   isOrganizer,
+  callerId,
   isLoading = false,
   isError = false,
   hasMore = false,
@@ -90,39 +133,64 @@ export function ConversationList({
         <>
           {items.map((item) => {
             const isUnread = item.unreadCount > 0
+            const isOwnLastMessage =
+              !!callerId && item.lastMessage?.authorId === callerId
             return (
               <Link
                 key={item._id}
                 href={conversationLinkPath(item, isOrganizer)}
                 prefetch={false}
-                className="flex items-baseline justify-between gap-3 px-4 py-3 transition hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60"
+                className="flex gap-3 px-4 py-3 transition hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60"
               >
+                <RowAvatar item={item} />
                 <span className="min-w-0 flex-1">
-                  <span
-                    className={`block truncate text-sm text-gray-900 dark:text-white ${
-                      isUnread ? 'font-bold' : 'font-semibold'
-                    }`}
-                  >
-                    {conversationTitle(item)}
-                  </span>
-                  {item.conversationType === 'proposal' && (
-                    <span className="mt-0.5 block text-xs text-gray-400 dark:text-gray-500">
-                      Proposal thread
+                  {/* WHO + WHEN: counterpart name, unread pill, relative time. */}
+                  <span className="flex items-baseline justify-between gap-2">
+                    <span className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                      {item.counterpart.name}
                     </span>
-                  )}
-                </span>
-                <span className="flex shrink-0 items-baseline gap-2">
-                  {isUnread && (
+                    <span className="flex shrink-0 items-baseline gap-2">
+                      {isUnread && (
+                        <span
+                          aria-label={`${item.unreadCount} unread`}
+                          className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-cloud-blue px-1.5 text-[11px] leading-none font-semibold text-white dark:bg-blue-600"
+                        >
+                          {item.unreadCount > 9 ? '9+' : item.unreadCount}
+                        </span>
+                      )}
+                      <span className="text-xs text-gray-400 dark:text-gray-500">
+                        {formatRelativeTime(item.lastMessageAt)}
+                      </span>
+                    </span>
+                  </span>
+                  {/* WHAT: subject (the talk title for proposal threads — the
+                      chip marks the type instead of repeating it). */}
+                  <span className="mt-0.5 flex items-center gap-2">
                     <span
-                      aria-label={`${item.unreadCount} unread`}
-                      className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-cloud-blue px-1.5 text-[11px] leading-none font-semibold text-white dark:bg-blue-600"
+                      className={`truncate text-sm text-gray-900 dark:text-white ${
+                        isUnread ? 'font-bold' : 'font-semibold'
+                      }`}
                     >
-                      {item.unreadCount > 9 ? '9+' : item.unreadCount}
+                      {conversationTitle(item)}
+                    </span>
+                    {item.conversationType === 'proposal' && (
+                      <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                        Proposal
+                      </span>
+                    )}
+                  </span>
+                  {/* Snippet: one truncated line; "You: " when the viewer wrote
+                      the last message. */}
+                  {item.lastMessage && (
+                    <span className="mt-0.5 block truncate text-sm text-gray-500 dark:text-gray-400">
+                      {isOwnLastMessage && (
+                        <span className="font-medium text-gray-600 dark:text-gray-300">
+                          You:{' '}
+                        </span>
+                      )}
+                      {item.lastMessage.excerpt}
                     </span>
                   )}
-                  <span className="text-xs text-gray-400 dark:text-gray-500">
-                    {formatRelativeTime(item.lastMessageAt)}
-                  </span>
                 </span>
               </Link>
             )

--- a/src/components/messaging/MessagesInbox.tsx
+++ b/src/components/messaging/MessagesInbox.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useSession } from 'next-auth/react'
 import { PlusIcon } from '@heroicons/react/24/outline'
 import { api } from '@/lib/trpc/client'
 import { ConversationList } from './ConversationList'
@@ -29,6 +30,9 @@ export function MessagesInbox({
   const isOrganizer = audience === 'organizer'
   const basePath = isOrganizer ? '/admin/messages' : '/cfp/messages'
   const [showNew, setShowNew] = useState(false)
+  // The viewer's own speaker id drives the rows' "You: " snippet prefix.
+  const { data: session } = useSession()
+  const callerId = session?.speaker?._id
 
   const {
     data,
@@ -59,6 +63,9 @@ export function MessagesInbox({
             <NewConversationForm
               basePath={basePath}
               requireRecipient={isOrganizer}
+              // The standalone inbox owns no success flow of its own — opt in
+              // to navigating to the created thread (no longer the default).
+              navigateOnCreate
               onCancel={() => setShowNew(false)}
             />
           ) : (
@@ -79,6 +86,7 @@ export function MessagesInbox({
       <ConversationList
         items={items}
         isOrganizer={isOrganizer}
+        callerId={callerId}
         isLoading={isLoading}
         isError={isError}
         hasMore={hasNextPage}

--- a/src/components/messaging/NewConversationForm.stories.tsx
+++ b/src/components/messaging/NewConversationForm.stories.tsx
@@ -97,6 +97,5 @@ export const ProposalThread: Story = {
   args: {
     basePath: '/admin/messages',
     proposalId: 'proposal-1',
-    navigateOnCreate: false,
   },
 }

--- a/src/components/messaging/NewConversationForm.tsx
+++ b/src/components/messaging/NewConversationForm.tsx
@@ -34,8 +34,10 @@ export interface NewConversationFormProps {
    */
   proposalId?: string
   /**
-   * Navigate to the created thread on success (default). Callers embedding the
-   * form in their own success flow (modal + toast) pass `false`.
+   * Navigate to the created thread on success. OFF by default: embedded mounts
+   * (modals, proposal pages) own their success flow, and an implicit navigation
+   * combined with `proposalId` is a footgun. The standalone inbox pages opt in
+   * explicitly.
    */
   navigateOnCreate?: boolean
   /**
@@ -54,14 +56,14 @@ export interface NewConversationFormProps {
  * pick the recipient speaker the thread is about (`requireRecipient`) or have
  * one preset (`fixedRecipient`); with a `proposalId` the message goes to the
  * proposal's own thread instead. On success it navigates to the new thread
- * unless `navigateOnCreate` is false.
+ * only when `navigateOnCreate` is set.
  */
 export function NewConversationForm({
   basePath,
   requireRecipient = false,
   fixedRecipient,
   proposalId,
-  navigateOnCreate = true,
+  navigateOnCreate = false,
   autoFocusFirstField = false,
   onCreated,
   onCancel,

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -93,8 +93,9 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-// Also carries the audience-aware "View all messages" footer quick link
-// (present when `messagesHref` is provided; the Empty story shows it absent).
+// Also carries the audience-aware "View all messages" footer quick link and
+// the header settings gear (both present only when their href prop is
+// provided; the Empty story shows them absent).
 export const UnreadAndRead: Story = {
   args: {
     // Placeholder for typing; the render below rebuilds items at render time so
@@ -103,6 +104,8 @@ export const UnreadAndRead: Story = {
     unreadCount: 3,
     messagesHref: '/cfp/messages',
     onMessagesClick: fn(),
+    settingsHref: '/cfp/profile#notification-settings',
+    onSettingsClick: fn(),
   },
   render: (args) => <NotificationList {...args} items={makeItems()} />,
 }

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
-import { CheckCircleIcon } from '@heroicons/react/24/outline'
+import { CheckCircleIcon, Cog6ToothIcon } from '@heroicons/react/24/outline'
 import { formatRelativeTime } from '@/lib/notification/format'
 import type { NotificationItem } from '@/lib/notification/types'
 
@@ -49,6 +49,18 @@ export interface NotificationListProps {
    * popover (same flow as item clicks); navigation is handled by the `<Link>`.
    */
   onMessagesClick?: () => void
+  /**
+   * Href of the notification/messaging settings page. When provided, a gear
+   * shortcut is rendered in the header (left of "Mark all read"); omitted → no
+   * gear. A prop for the same reason as `messagesHref`: this component stays
+   * presentational.
+   */
+  settingsHref?: string
+  /**
+   * Fired when the settings gear is activated — the container closes the
+   * popover (same flow as item clicks); navigation is handled by the `<Link>`.
+   */
+  onSettingsClick?: () => void
 }
 
 function SkeletonRow() {
@@ -205,6 +217,8 @@ export function NotificationList({
   readOnly = false,
   messagesHref,
   onMessagesClick,
+  settingsHref,
+  onSettingsClick,
 }: NotificationListProps) {
   return (
     // `role="region"` makes the aria-label an actual named landmark — on a
@@ -214,23 +228,37 @@ export function NotificationList({
         <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
           Notifications
         </h2>
-        {readOnly ? (
-          <span
-            title="Viewing as speaker — read state is left untouched"
-            className="ml-2 shrink-0 text-xs font-medium whitespace-nowrap text-gray-400 dark:text-gray-500"
-          >
-            Speaker view · read-only
-          </span>
-        ) : (
-          <button
-            type="button"
-            onClick={onMarkAllRead}
-            disabled={unreadCount === 0 || isMarkingAll}
-            className="rounded text-xs font-medium text-brand-cloud-blue transition hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:text-gray-300 dark:disabled:text-gray-600"
-          >
-            Mark all read
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {settingsHref && (
+            <Link
+              href={settingsHref}
+              prefetch={false}
+              onClick={onSettingsClick}
+              aria-label="Notification settings"
+              // 44px tap target; negative margin keeps the header compact.
+              className="-my-2.5 flex h-11 w-11 items-center justify-center rounded-lg text-gray-400 transition hover:bg-gray-50 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-500 dark:hover:bg-gray-800/60 dark:hover:text-gray-300"
+            >
+              <Cog6ToothIcon aria-hidden="true" className="h-5 w-5" />
+            </Link>
+          )}
+          {readOnly ? (
+            <span
+              title="Viewing as speaker — read state is left untouched"
+              className="ml-2 shrink-0 text-xs font-medium whitespace-nowrap text-gray-400 dark:text-gray-500"
+            >
+              Speaker view · read-only
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={onMarkAllRead}
+              disabled={unreadCount === 0 || isMarkingAll}
+              className="rounded text-xs font-medium text-brand-cloud-blue transition hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:text-gray-300 dark:disabled:text-gray-600"
+            >
+              Mark all read
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="max-h-[70vh] divide-y divide-gray-100 overflow-y-auto dark:divide-gray-800/70">

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -36,14 +36,28 @@ export function NotificationPanel({
   onClose,
 }: NotificationPanelProps) {
   const utils = api.useUtils()
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
   const isImpersonating = session?.isImpersonating === true
 
   // Audience-aware Messages inbox quick link (T-QUICKLINK): organizers land in
   // the admin inbox, speakers in the CFP inbox. Passed down as a plain href so
   // NotificationList stays presentational.
-  const messagesHref =
-    session?.speaker?.isOrganizer === true ? '/admin/messages' : '/cfp/messages'
+  //
+  // Until the session resolves the audience is UNKNOWN — an organizer would
+  // briefly get (and could click) the speaker link. Both hrefs are therefore
+  // withheld while loading; the presentational props already handle absence, so
+  // the quick link and settings gear simply don't render until then.
+  const sessionReady = status !== 'loading' && !!session
+  const messagesHref = sessionReady
+    ? session.speaker?.isOrganizer === true
+      ? '/admin/messages'
+      : '/cfp/messages'
+    : undefined
+  // Organizers are speakers too — everyone's notification/messaging settings
+  // live on the CFP profile page, anchored at #notification-settings.
+  const settingsHref = sessionReady
+    ? '/cfp/profile#notification-settings'
+    : undefined
 
   const {
     data,
@@ -105,6 +119,8 @@ export function NotificationPanel({
       readOnly={isImpersonating}
       messagesHref={messagesHref}
       onMessagesClick={onClose}
+      settingsHref={settingsHref}
+      onSettingsClick={onClose}
     />
   )
 }

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -225,6 +225,16 @@ export async function getConversationParticipants(
  * ONE extra fetch of the caller's unread message links for the conference and
  * count them in JS against each row's two audience link variants (the caller
  * only ever received one variant, so matching both is simplest and correct).
+ *
+ * Each row also carries Who/What metadata (M6):
+ * - `lastMessage`: the newest message's author + a ~120-char excerpt (null for
+ *   a conversation with no messages yet);
+ * - `counterpart`: who the row is "with" for the caller's audience —
+ *   ORGANIZERS see the speaker side (proposal → first proposal speaker;
+ *   general → subject speaker, else the creator); SPEAKERS see the last
+ *   message's author when that author is an organizer, else the collective
+ *   'Organizers' label with no image (the organizer side has no single
+ *   counterpart, so a label is the honest rendering).
  */
 export async function listConversationsForSpeaker({
   speakerId,
@@ -251,6 +261,10 @@ export async function listConversationsForSpeaker({
     params.speakerId = speakerId
   }
 
+  // `lastMessage` is a correlated subquery (newest message per conversation) so
+  // the whole page stays ONE fetch; `speakerSide*` pre-resolves the speaker-side
+  // counterpart (organizer audience) via the house
+  // `coalesce(image.asset->url, imageURL)` speaker-image pattern.
   const query = `*[_type == "conversation" && conference._ref == $conferenceId${scope}${cursor}] | order(lastMessageAt desc) [0...${PAGE_SIZE}] {
     "_id": _id,
     conversationType,
@@ -258,12 +272,30 @@ export async function listConversationsForSpeaker({
     "proposalId": proposal._ref,
     "proposalTitle": proposal->title,
     createdAt,
-    lastMessageAt
+    lastMessageAt,
+    "lastMessage": *[_type == "message" && conversation._ref == ^._id] | order(createdAt desc) [0] {
+      "authorId": author._ref,
+      "authorName": author->name,
+      "authorImage": coalesce(author->image.asset->url, author->imageURL),
+      body
+    },
+    "speakerSideName": select(
+      conversationType == "proposal" => proposal->speakers[0]->name,
+      defined(subjectSpeaker) => subjectSpeaker->name,
+      createdBy->name
+    ),
+    "speakerSideImage": select(
+      conversationType == "proposal" => coalesce(proposal->speakers[0]->image.asset->url, proposal->speakers[0]->imageURL),
+      defined(subjectSpeaker) => coalesce(subjectSpeaker->image.asset->url, subjectSpeaker->imageURL),
+      coalesce(createdBy->image.asset->url, createdBy->imageURL)
+    )
   }`
 
-  const results = await clientReadUncached.fetch<
-    Omit<ConversationListItem, 'unreadCount'>[]
-  >(query, params, { cache: 'no-store' })
+  const results = await clientReadUncached.fetch<RawConversationRow[]>(
+    query,
+    params,
+    { cache: 'no-store' },
+  )
   const rows = results ?? []
   if (rows.length === 0) return []
 
@@ -273,13 +305,20 @@ export async function listConversationsForSpeaker({
   // notification represents `count` unread messages (absent = 1, which also
   // covers pre-collapse per-message documents), so we SUM `coalesce(count, 1)`
   // per link in JS rather than counting documents.
-  const unreadRows = await clientReadUncached.fetch<
-    { link: string | null; count: number }[]
-  >(
-    `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt)][0...500]{ link, "count": coalesce(count, 1) }`,
-    { speakerId, conferenceId },
-    { cache: 'no-store' },
-  )
+  //
+  // A SPEAKER caller additionally needs the organizer id set to decide whether
+  // the last message's author is "an organizer" (their counterpart); organizers
+  // don't (their counterpart is the pre-resolved speaker side), so their path
+  // stays at two fetches.
+  const [unreadRows, organizerIds] = await Promise.all([
+    clientReadUncached.fetch<{ link: string | null; count: number }[]>(
+      `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt)][0...500]{ link, "count": coalesce(count, 1) }`,
+      { speakerId, conferenceId },
+      { cache: 'no-store' },
+    ),
+    isOrganizer ? Promise.resolve<string[]>([]) : getOrganizerSpeakerIds(),
+  ])
+  const organizerSet = new Set(organizerIds)
   const linkCounts = new Map<string, number>()
   for (const row of unreadRows ?? []) {
     if (row.link) {
@@ -292,8 +331,72 @@ export async function listConversationsForSpeaker({
     const unreadCount =
       (linkCounts.get(conversationLinkPath(row, true)) ?? 0) +
       (linkCounts.get(conversationLinkPath(row, false)) ?? 0)
-    return { ...row, unreadCount }
+    return {
+      _id: row._id,
+      conversationType: row.conversationType,
+      subject: row.subject,
+      proposalId: row.proposalId,
+      proposalTitle: row.proposalTitle,
+      createdAt: row.createdAt,
+      lastMessageAt: row.lastMessageAt,
+      unreadCount,
+      lastMessage: row.lastMessage
+        ? {
+            authorId: row.lastMessage.authorId,
+            authorName: row.lastMessage.authorName ?? 'Unknown',
+            excerpt: excerptOf(row.lastMessage.body ?? ''),
+          }
+        : null,
+      counterpart: resolveCounterpart(row, isOrganizer, organizerSet),
+    }
   })
+}
+
+/** A raw inbox row as projected by GROQ, before counterpart/excerpt mapping. */
+type RawConversationRow = Omit<
+  ConversationListItem,
+  'unreadCount' | 'lastMessage' | 'counterpart'
+> & {
+  lastMessage: {
+    authorId: string
+    authorName: string | null
+    authorImage: string | null
+    body: string | null
+  } | null
+  speakerSideName: string | null
+  speakerSideImage: string | null
+}
+
+/** Inbox snippet length — roughly two lines of a mobile row. */
+const EXCERPT_LENGTH = 120
+
+function excerptOf(body: string): string {
+  const trimmed = body.trim()
+  return trimmed.length > EXCERPT_LENGTH
+    ? `${trimmed.slice(0, EXCERPT_LENGTH).trimEnd()}…`
+    : trimmed
+}
+
+/**
+ * The audience-aware counterpart of an inbox row (see the
+ * {@link listConversationsForSpeaker} doc for the full rules).
+ */
+function resolveCounterpart(
+  row: RawConversationRow,
+  isOrganizer: boolean,
+  organizerSet: Set<string>,
+): { name: string; image?: string } {
+  if (isOrganizer) {
+    return {
+      name: row.speakerSideName ?? 'Speaker',
+      image: row.speakerSideImage ?? undefined,
+    }
+  }
+  const author = row.lastMessage
+  if (author && organizerSet.has(author.authorId) && author.authorName) {
+    return { name: author.authorName, image: author.authorImage ?? undefined }
+  }
+  return { name: 'Organizers' }
 }
 
 /**

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -43,6 +43,27 @@ export interface ConversationWithContext {
   lastMessageAt: string
 }
 
+/** The newest message of a conversation, summarized for an inbox row (M6). */
+export interface ConversationLastMessage {
+  authorId: string
+  authorName: string
+  /** First ~120 chars of the message body (ellipsized when longer). */
+  excerpt: string
+}
+
+/**
+ * Who the conversation is "with" from the viewer's perspective (M6):
+ * - ORGANIZER audience → the speaker side (proposal → first proposal speaker;
+ *   general → subject speaker, else the creator);
+ * - SPEAKER audience → the last message's author when that author is an
+ *   organizer; otherwise the collective `'Organizers'` label with no image
+ *   (no single counterpart exists on the organizer side).
+ */
+export interface ConversationCounterpart {
+  name: string
+  image?: string
+}
+
 /** A conversation as listed in an inbox. */
 export interface ConversationListItem {
   _id: string
@@ -58,6 +79,10 @@ export interface ConversationListItem {
    * received one).
    */
   unreadCount: number
+  /** Newest message summary; null for a conversation with no messages yet. */
+  lastMessage: ConversationLastMessage | null
+  /** Audience-aware "who" for the row (see {@link ConversationCounterpart}). */
+  counterpart: ConversationCounterpart
 }
 
 /** A single message in a thread. */


### PR DESCRIPTION
Makes the conversation inbox rows real messaging-app rows: **Who / What / When at a glance** (M6 of the messaging plan).

## Row anatomy

Each row is now: **avatar** (40px, rounded-full) + three lines:

1. **Who + When** — counterpart name (truncated) with the unread count pill and relative time right-aligned.
2. **What** — subject, bold when unread (semibold when read), plus a small muted **`Proposal` chip** for proposal threads. The subject *is* the talk title for proposal threads, so the chip replaces the old "Proposal thread" sub-line — no duplication.
3. **Snippet** — the last message's ~120-char excerpt on one truncated line, prefixed **`You: `** when the viewer authored it (caller id passed down from the session by the container; omitted while the session resolves).

Avatars reuse the house components: `SpeakerAvatarImage` (photo, initials fallback on load failure) / `MissingAvatar` (initials). The collective **Organizers** counterpart gets a neutral group glyph instead of initials — initials would wrongly suggest a single person. Rows stay ≥44px, keyboard-focusable, dark-mode styled.

## Audience counterpart rules (backend)

`listConversationsForSpeaker` now projects, still in **one** page query (correlated `lastMessage` subquery + `select()`-resolved speaker side, house `coalesce(image.asset->url, imageURL)` image pattern):

- **Organizer audience** → the speaker side: proposal thread → first proposal speaker; general thread → subject speaker, else the creator.
- **Speaker audience** → the last message's author *when that author is an organizer* (name + image); otherwise the **`Organizers`** label with no image — the organizer side has no single counterpart, so a label is the honest rendering. The organizer-id set is fetched only on this path (in parallel with the unread query); the organizer path stays at two fetches.
- `lastMessage` → `{ authorId, authorName, excerpt }` (body ellipsized at 120 chars in JS, matching the codebase's JS-side normalization style); `null` when the thread has no messages.

M5's collapsed-notification unread summing (`coalesce(count, 1)`) is untouched.

## Riders

- **Rider 1 — `navigateOnCreate` default flip (Greptile P2, #532):** `NewConversationForm` no longer navigates on success by default; navigation is explicit opt-in. The standalone inbox (`MessagesInbox`) now passes `navigateOnCreate`; `SendMessageModal`'s redundant `navigateOnCreate={false}` is dropped. Tests updated: default-no-navigation asserted for both proposal and general flows, plus an explicit opt-in case.
- **Rider 2 — notification settings shortcut (maintainer):** `NotificationList` header gains a gear (`Cog6ToothIcon`) left of "Mark all read" — 44px tap target, `aria-label="Notification settings"`, presentational `settingsHref`/`onSettingsClick` props following the M5 `messagesHref` pattern (rendered only when provided; closes the popover via the same flow). `NotificationPanel` passes `/cfp/profile#notification-settings` for **all** audiences (organizers are speakers; same profile page). The CFP profile's Message-emails toggle + Push-notification card are wrapped in an anchored `#notification-settings` container (`scroll-mt-20`, `space-y-8` mirroring the parent so spacing is unchanged).
- **Rider 3 — session-hydration guard (#533 post-merge review):** `NotificationPanel` withholds `messagesHref` *and* `settingsHref` while `useSession()` is loading/undefined, so an organizer can never see (or click) the momentary speaker link; the presentational props already handle absence. Covered by a new `NotificationPanel` container test (loading → neither renders; resolved → speaker/organizer links correct).

## Shoot findings (393×852, DPR 3)

Captured `SpeakerInbox` (mixed: read + `You:`, unread w/ count pill + photo avatar, unread `9+` + Proposal chip + Organizers glyph), `LongContent` (unbroken long subject + long snippet), each light **and** dark, plus the notification header with the gear:

- all rows render the avatar / three-line anatomy correctly in both themes; pills, chips and `You:` prefix all visible;
- long subject and snippet truncate to one line with ellipsis — **no horizontal overflow** (shoot's hard viewport check passed on every capture);
- gear renders in the header left of "Mark all read", visibly but subtly gray.

One fix out of the shoot: the long-content story fixtures were built at module load with the real clock (labels rendered "just now" under the mocked story date) — converted to a render-time builder so the relative times are deterministic.

## Verification

- `tsc --noEmit` 0 errors; eslint clean on touched dirs; prettier clean; knip exit 0 (one pre-existing config hint, untouched by this PR)
- `vitest run __tests__/`: **189 files, 2870 passed, 0 failed** (5 pre-existing skips) — includes 4 new backend metadata tests, 5 new row-metadata component tests, 3 gear tests, 3 panel session-guard tests, and the rewritten navigation-default tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds "Who / What / When" anatomy to inbox conversation rows (M6): each row now shows a counterpart avatar, three lines of metadata (name + unread pill + relative time, subject + proposal chip, last-message excerpt with optional "You:" prefix), and a session-derived `callerId` for ownership detection. Backend `listConversationsForSpeaker` is extended with a correlated `lastMessage` GROQ subquery and an audience-aware `resolveCounterpart` helper; the organizer-id set is fetched in parallel only on the speaker path. Three riders ship alongside: the `navigateOnCreate` default is flipped to `false`, a gear shortcut appears in the notification header, and `NotificationPanel` withholds audience-dependent hrefs until the session resolves.

- **M6 row anatomy**: `ConversationList` gains `RowAvatar` (photo / initials / group-glyph), a WHO+WHEN line, a WHAT line with an optional "Proposal" chip, and a snippet line — all wired from a new `counterpart` + `lastMessage` projection added to the GROQ page query.
- **Rider 1 / `navigateOnCreate`**: default flips from `true` to `false`; the standalone inbox opts in explicitly, `SendMessageModal` drops its now-redundant `navigateOnCreate={false}`, and tests are rewritten to assert the new default.
- **Riders 2 & 3**: a gear icon in the `NotificationList` header links to `#notification-settings` on the CFP profile page; `NotificationPanel` gates both `messagesHref` and `settingsHref` on `status !== 'loading'` to prevent organizers from briefly receiving the speaker link.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The two findings are minor defensive-coding gaps that don't affect current behavior in any realistic data scenario.

The M6 row anatomy, session-hydration guard, navigateOnCreate flip, and notification-settings gear are all well-implemented and covered by 2870 passing tests. The magic-string coupling between RowAvatar and resolveCounterpart is a future-maintenance hazard with no present defect, and the empty-excerpt phantom row requires a message with a non-null document but a null body — an edge case not currently produced by any write path in the codebase.

src/components/messaging/ConversationList.tsx and src/lib/messaging/sanity.ts share the literal string 'Organizers' with no shared constant; worth a second look if the label is ever expected to change.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/messaging/sanity.ts | Extends listConversationsForSpeaker with a correlated GROQ lastMessage subquery, speakerSide projection, parallel organizer-id fetch, and audience-aware resolveCounterpart/excerptOf helpers. Logic is well-structured; one P2 noted (magic string coupling). |
| src/components/messaging/ConversationList.tsx | New RowAvatar + three-line row anatomy. Hardcodes the string 'Organizers' to branch between group-glyph and MissingAvatar; this string must stay in sync with resolveCounterpart in sanity.ts (P2). |
| src/components/messaging/MessagesInbox.tsx | Adds useSession to derive callerId for the "You:" prefix and adds explicit navigateOnCreate to the NewConversationForm mount. Clean container wiring. |
| src/components/notifications/NotificationPanel.tsx | Session-hydration guard: derives messagesHref and settingsHref only after status !== 'loading' && session is defined, preventing organizers from briefly seeing the speaker link. Well-covered by new tests. |
| src/lib/messaging/types.ts | Adds ConversationLastMessage and ConversationCounterpart interfaces; extends ConversationListItem with lastMessage and counterpart fields. Types are clean and well-documented. |
| src/components/messaging/NewConversationForm.tsx | navigateOnCreate default flipped from true to false; JSDoc updated. Behavioral change is intentional, well-documented, and confirmed by updated tests. |
| src/components/cfp/CFPProfilePage.tsx | Wraps the message-email toggle and PushNotificationSettings in a div with id="notification-settings" and scroll-mt-20 as the anchor target for the gear link. Pure structural change with no functional impact. |
| __tests__/lib/messaging/sanity.test.ts | Adds 4 new tests for the Who/What metadata: organizer/speaker counterpart resolution, excerpt ellipsization, and null lastMessage. Well-structured and covers the core paths. |
| __tests__/components/notifications/NotificationPanel.test.tsx | New test file covering the session-hydration guard: loading → neither link renders; authenticated speaker → /cfp/messages + settings gear; organizer → /admin/messages + settings gear. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant MessagesInbox
    participant tRPC
    participant listConversationsForSpeaker
    participant Sanity

    Browser->>MessagesInbox: render (useSession → callerId)
    MessagesInbox->>tRPC: conversation.list.useInfiniteQuery()
    tRPC->>listConversationsForSpeaker: "{ speakerId, isOrganizer, conferenceId }"

    listConversationsForSpeaker->>Sanity: "GROQ page query (conversations + correlated lastMessage + speakerSide* projections)"
    Sanity-->>listConversationsForSpeaker: RawConversationRow[]

    par Parallel fetches
        listConversationsForSpeaker->>Sanity: unread notification links [0...500]
        Sanity-->>listConversationsForSpeaker: "{ link, count }[]"
    and Speaker path only
        listConversationsForSpeaker->>Sanity: getOrganizerSpeakerIds()
        Sanity-->>listConversationsForSpeaker: string[]
    end

    Note over listConversationsForSpeaker: resolveCounterpart() per row, excerptOf(body) per lastMessage
    listConversationsForSpeaker-->>tRPC: ConversationListItem[]
    tRPC-->>MessagesInbox: paginated items

    MessagesInbox->>Browser: ConversationList(items, callerId) → RowAvatar + WHO/WHAT/WHEN rows
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant MessagesInbox
    participant tRPC
    participant listConversationsForSpeaker
    participant Sanity

    Browser->>MessagesInbox: render (useSession → callerId)
    MessagesInbox->>tRPC: conversation.list.useInfiniteQuery()
    tRPC->>listConversationsForSpeaker: "{ speakerId, isOrganizer, conferenceId }"

    listConversationsForSpeaker->>Sanity: "GROQ page query (conversations + correlated lastMessage + speakerSide* projections)"
    Sanity-->>listConversationsForSpeaker: RawConversationRow[]

    par Parallel fetches
        listConversationsForSpeaker->>Sanity: unread notification links [0...500]
        Sanity-->>listConversationsForSpeaker: "{ link, count }[]"
    and Speaker path only
        listConversationsForSpeaker->>Sanity: getOrganizerSpeakerIds()
        Sanity-->>listConversationsForSpeaker: string[]
    end

    Note over listConversationsForSpeaker: resolveCounterpart() per row, excerptOf(body) per lastMessage
    listConversationsForSpeaker-->>tRPC: ConversationListItem[]
    tRPC-->>MessagesInbox: paginated items

    MessagesInbox->>Browser: ConversationList(items, callerId) → RowAvatar + WHO/WHAT/WHEN rows
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): who/what/when inbox row..."](https://github.com/cloudnativebergen/website/commit/7ff0c45f3302aa87607b6cc8d730387b67c8e4d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45415258)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->