### PR TITLE
chore(messaging): review batch D — stories, privacy, copy

### DIFF
--- a/__tests__/components/notifications/NotificationBell.test.tsx
+++ b/__tests__/components/notifications/NotificationBell.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Logic tests for the NotificationBell toast bridge. The bell mirrors a rising
+ * unread count to the ephemeral toast system, but only for a GENUINE increase:
+ * the first resolved value establishes a baseline (no toast on login/first
+ * load), a decrease (mark-read) is silent, and while impersonating a speaker
+ * the toast is suppressed entirely. These are asserted through the real
+ * component with tRPC / session / toast provider mocked at their seams.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { NotificationBell } from '@/components/notifications/NotificationBell'
+
+// Mutable seams the tests drive before each (re)render.
+let unreadState: { data: number | undefined; isSuccess: boolean } = {
+  data: 0,
+  isSuccess: true,
+}
+let sessionState: { data: { isImpersonating?: boolean } | null } = {
+  data: { isImpersonating: false },
+}
+const showNotification = vi.fn()
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => sessionState,
+}))
+
+vi.mock('@/components/admin/NotificationProvider', () => ({
+  useNotificationSafe: () => ({
+    showNotification,
+    removeNotification: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    notification: {
+      unreadCount: {
+        useQuery: () => unreadState,
+      },
+    },
+  },
+}))
+
+beforeEach(() => {
+  unreadState = { data: 0, isSuccess: true }
+  sessionState = { data: { isImpersonating: false } }
+  showNotification.mockClear()
+})
+
+describe('NotificationBell — toast bridge', () => {
+  it('does NOT toast on first load, even with unread notifications', () => {
+    unreadState = { data: 5, isSuccess: true }
+    render(<NotificationBell />)
+    expect(showNotification).not.toHaveBeenCalled()
+  })
+
+  it('does NOT toast until the first value has resolved (isSuccess false)', () => {
+    unreadState = { data: undefined, isSuccess: false }
+    const { rerender } = render(<NotificationBell />)
+    // First RESOLVED value only establishes the baseline — still no toast.
+    unreadState = { data: 3, isSuccess: true }
+    rerender(<NotificationBell />)
+    expect(showNotification).not.toHaveBeenCalled()
+  })
+
+  it('toasts on a genuine increase, with a pluralized delta message', () => {
+    unreadState = { data: 3, isSuccess: true }
+    const { rerender } = render(<NotificationBell />)
+    unreadState = { data: 5, isSuccess: true }
+    rerender(<NotificationBell />)
+    expect(showNotification).toHaveBeenCalledTimes(1)
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        message: 'You have 2 new notifications.',
+      }),
+    )
+  })
+
+  it('uses the singular message for a delta of one', () => {
+    unreadState = { data: 0, isSuccess: true }
+    const { rerender } = render(<NotificationBell />)
+    unreadState = { data: 1, isSuccess: true }
+    rerender(<NotificationBell />)
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'You have 1 new notification.' }),
+    )
+  })
+
+  it('does NOT toast on a decrease (e.g. marking notifications read)', () => {
+    unreadState = { data: 5, isSuccess: true }
+    const { rerender } = render(<NotificationBell />)
+    unreadState = { data: 2, isSuccess: true }
+    rerender(<NotificationBell />)
+    expect(showNotification).not.toHaveBeenCalled()
+  })
+
+  it('suppresses the toast entirely while impersonating a speaker', () => {
+    sessionState = { data: { isImpersonating: true } }
+    unreadState = { data: 3, isSuccess: true }
+    const { rerender } = render(<NotificationBell />)
+    unreadState = { data: 7, isSuccess: true }
+    rerender(<NotificationBell />)
+    expect(showNotification).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/pwa/PushNotificationSettings.test.tsx
+++ b/__tests__/components/pwa/PushNotificationSettings.test.tsx
@@ -128,6 +128,46 @@ describe('PushNotificationSettingsView test-send feedback', () => {
     expect(screen.getByText('403 — VapidPkHashMismatch')).toBeInTheDocument()
   })
 
+  it('all failed AND some pruned: the rejection copy KEEPS the expired-subscriptions note', () => {
+    renderWithResult({
+      sent: 0,
+      gone: 1,
+      total: 3,
+      configured: true,
+      failures: [
+        { statusCode: 403, message: 'HTTP 403 — VapidPkHashMismatch' },
+      ],
+    })
+    // The actionable rejection copy is still shown …
+    expect(
+      screen.getByText(/turn notifications off and on again/i),
+    ).toBeInTheDocument()
+    // … and the pruning note is no longer dropped (regression #534).
+    expect(
+      screen.getByText(/Removed 1 expired subscription\b/i),
+    ).toBeInTheDocument()
+    expect(screen.getByText('403 — VapidPkHashMismatch')).toBeInTheDocument()
+  })
+
+  it('partial success AND some pruned: success count, pruning note, and rejection copy', () => {
+    renderWithResult({
+      sent: 1,
+      gone: 2,
+      total: 4,
+      configured: true,
+      failures: [
+        { statusCode: 403, message: 'HTTP 403 — VapidPkHashMismatch' },
+      ],
+    })
+    expect(screen.getByText(/Sent to 1 device/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/Removed 2 expired subscriptions/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/turn notifications off and on again/i),
+    ).toBeInTheDocument()
+  })
+
   it('every device failed with NO diagnostics: generic retry hint, no detail line', () => {
     renderWithResult({
       sent: 0,

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -206,6 +206,12 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                               in to push notifications and removed when you turn
                               them off
                             </li>
+                            <li>
+                              • Per-category push notification preferences
+                              (whether you receive proposal decisions, talk
+                              confirmations, co-speaker invites, messages, and
+                              other updates), stored on your speaker profile
+                            </li>
                           </ul>
                         </div>
                       </div>
@@ -378,6 +384,11 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                         <li>
                           • <strong>Conversation preferences:</strong> Your
                           per-conversation mute and email delivery settings
+                        </li>
+                        <li>
+                          • <strong>Message email default:</strong> Your
+                          account-level default for whether new message
+                          conversations also email you
                         </li>
                       </ul>
                       <div className="mt-3 rounded-lg bg-sky-100 p-2 dark:bg-sky-800/30">

--- a/src/components/messaging/MessagesInbox.stories.tsx
+++ b/src/components/messaging/MessagesInbox.stories.tsx
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { SessionProvider } from 'next-auth/react'
+import type { Session } from 'next-auth'
+import { mockDateBeforeEach } from '@/lib/storybook'
+import { TRPCProvider } from '@/components/providers/TRPCProvider'
+import { MessagesInbox } from '@/components/messaging'
+import type { ConversationListItem } from '@/lib/messaging/types'
+import type { Speaker } from '@/lib/speaker/types'
+
+// Renders the REAL MessagesInbox container (not just its presentational
+// ConversationList): the inbox owns the `message.listConversations` infinite
+// query and the "You: " snippet prefix derived from the session. The rows'
+// fixture shapes mirror ConversationList.stories; here they arrive through
+// msw so the container's own data wiring is exercised, not bypassed.
+
+const minutesAgo = (m: number) =>
+  new Date(Date.now() - m * 60_000).toISOString()
+
+/** The signed-in viewer — row 1's last message is theirs, so it renders "You: ". */
+const CALLER_ID = 'speaker-me'
+
+const makeItems = (): ConversationListItem[] => [
+  {
+    _id: 'conversation.proposal.talk-1',
+    conversationType: 'proposal',
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    proposalId: 'talk-1',
+    proposalTitle: 'Scaling Kubernetes to 10,000 nodes',
+    createdAt: minutesAgo(60 * 24 * 3),
+    lastMessageAt: minutesAgo(24),
+    unreadCount: 0,
+    lastMessage: {
+      authorId: CALLER_ID,
+      authorName: 'Kari Nordmann',
+      excerpt: 'Thanks — I have updated the abstract with the new numbers.',
+    },
+    counterpart: { name: 'Kari Nordmann' },
+  },
+  {
+    _id: 'conversation.abc123',
+    conversationType: 'general',
+    subject: 'Question about speaker travel',
+    createdAt: minutesAgo(60 * 24 * 2),
+    lastMessageAt: minutesAgo(60 * 5),
+    unreadCount: 2,
+    lastMessage: {
+      authorId: 'organizer-1',
+      authorName: 'Ola Organizer',
+      excerpt:
+        'We cover flights booked before June — send us the receipt and we will sort it out.',
+    },
+    counterpart: {
+      name: 'Ola Organizer',
+      image: '/images/default-avatar.png',
+    },
+  },
+  {
+    _id: 'conversation.proposal.talk-2',
+    conversationType: 'proposal',
+    subject: 'Designing for Failure',
+    proposalId: 'talk-2',
+    proposalTitle: 'Designing for Failure',
+    createdAt: minutesAgo(60 * 24 * 10),
+    lastMessageAt: minutesAgo(60 * 24 * 4),
+    unreadCount: 12,
+    lastMessage: {
+      authorId: 'organizer-2',
+      authorName: 'Grace Hopper',
+      excerpt: 'Could you keep the demo under ten minutes?',
+    },
+    counterpart: { name: 'Organizers' },
+  },
+]
+
+/** msw handler answering the inbox's `message.listConversations` infinite query
+ * with a single page (fewer than PAGE_SIZE rows ⇒ no "show more"). */
+const conversationHandlers = (items: ConversationListItem[]) => [
+  http.get('/api/trpc/:procs', ({ params }) =>
+    HttpResponse.json(
+      String(params.procs)
+        .split(',')
+        .map((proc) =>
+          proc === 'message.listConversations'
+            ? { result: { data: items } }
+            : { result: { data: null } },
+        ),
+    ),
+  ),
+]
+
+const speaker = {
+  _id: CALLER_ID,
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  slug: 'jane-doe',
+} as unknown as Speaker
+
+const session: Session = {
+  user: { name: 'Jane Doe', email: 'jane@example.com' },
+  speaker,
+  expires: '2027-01-01T00:00:00.000Z',
+} as unknown as Session
+
+const meta = {
+  title: 'Components/Messaging/MessagesInbox',
+  component: MessagesInbox,
+  beforeEach: mockDateBeforeEach(new Date('2026-07-18T12:00:00Z')),
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The inbox container mounted on both `/cfp/messages` (speaker) and `/admin/messages` (organizer). Loads the caller’s conversations via `message.listConversations` and renders `ConversationList`; the row links are audience-derived. Data is msw-mocked per story.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => (
+      <SessionProvider session={session} refetchOnWindowFocus={false}>
+        <TRPCProvider>
+          <div className={ctx.parameters.dark ? 'dark bg-gray-950 p-4' : 'p-4'}>
+            <div className="mx-auto w-full max-w-2xl">
+              <Story />
+            </div>
+          </div>
+        </TRPCProvider>
+      </SessionProvider>
+    ),
+  ],
+} satisfies Meta<typeof MessagesInbox>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Speaker audience with no conversations yet — the empty state. */
+export const SpeakerEmpty: Story = {
+  args: { audience: 'speaker' },
+  parameters: { msw: { handlers: conversationHandlers([]) } },
+}
+
+/** Organizer audience with no conversations yet — the empty state. */
+export const OrganizerEmpty: Story = {
+  args: { audience: 'organizer' },
+  parameters: { msw: { handlers: conversationHandlers([]) } },
+}
+
+/** Speaker inbox with a representative Who/What/When mix (rows link to /cfp). */
+export const SpeakerPopulated: Story = {
+  args: { audience: 'speaker' },
+  parameters: { msw: { handlers: conversationHandlers(makeItems()) } },
+}
+
+export const SpeakerEmptyDark: Story = {
+  args: { audience: 'speaker' },
+  parameters: { dark: true, msw: { handlers: conversationHandlers([]) } },
+}
+
+export const SpeakerPopulatedDark: Story = {
+  args: { audience: 'speaker' },
+  parameters: {
+    dark: true,
+    msw: { handlers: conversationHandlers(makeItems()) },
+  },
+}

--- a/src/components/messaging/ProposalMessagesSection.stories.tsx
+++ b/src/components/messaging/ProposalMessagesSection.stories.tsx
@@ -1,0 +1,169 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { SessionProvider } from 'next-auth/react'
+import type { Session } from 'next-auth'
+import { mockDateBeforeEach } from '@/lib/storybook'
+import { TRPCProvider } from '@/components/providers/TRPCProvider'
+import { ProposalMessagesSection } from '@/components/messaging'
+import type { Speaker } from '@/lib/speaker/types'
+
+// The REAL #messages card mounted on both proposal detail pages. It renders the
+// container ConversationThread, so these stories exercise the actual data
+// wiring (getConversation / listMessages) through msw — including the
+// not-yet-created "empty thread" case where the composer still shows.
+
+const minutesAgo = (m: number) =>
+  new Date(Date.now() - m * 60_000).toISOString()
+
+const CALLER_ID = 'speaker-me'
+const PROPOSAL_ID = 'talk-1'
+
+/** Empty thread: the proposal conversation does not exist yet. getConversation
+ * resolves to null (no prefs bar) and listMessages to an empty page, so the
+ * audience-specific "start the conversation …" empty state renders with the
+ * composer beneath it. */
+const emptyThreadHandlers = [
+  http.get('/api/trpc/:procs', ({ params }) =>
+    HttpResponse.json(
+      String(params.procs)
+        .split(',')
+        .map((proc) =>
+          proc === 'message.listMessages'
+            ? { result: { data: [] } }
+            : { result: { data: null } },
+        ),
+    ),
+  ),
+]
+
+/** A populated thread: getConversation returns the participants + the viewer's
+ * preference; listMessages returns a page (newest-first, the container reverses
+ * it to chat order). */
+const populatedThreadHandlers = [
+  http.get('/api/trpc/:procs', ({ params }) =>
+    HttpResponse.json(
+      String(params.procs)
+        .split(',')
+        .map((proc) => {
+          if (proc === 'message.getConversation') {
+            return {
+              result: {
+                data: {
+                  conversation: {
+                    _id: 'conversation.proposal.talk-1',
+                    subject: 'Scaling Kubernetes to 10,000 nodes',
+                  },
+                  participants: [
+                    {
+                      _id: CALLER_ID,
+                      name: 'Kari Nordmann',
+                      isOrganizer: false,
+                    },
+                    {
+                      _id: 'organizer-1',
+                      name: 'Ola Organizer',
+                      isOrganizer: true,
+                    },
+                  ],
+                  preference: { muted: false, emailOverride: 'default' },
+                },
+              },
+            }
+          }
+          if (proc === 'message.listMessages') {
+            return {
+              result: {
+                data: [
+                  {
+                    _id: 'm2',
+                    authorId: CALLER_ID,
+                    body: 'Thanks — I have updated the abstract with the new numbers.',
+                    createdAt: minutesAgo(20),
+                  },
+                  {
+                    _id: 'm1',
+                    authorId: 'organizer-1',
+                    body: 'Could you tighten the abstract to focus on the scaling story?',
+                    createdAt: minutesAgo(90),
+                  },
+                ],
+              },
+            }
+          }
+          return { result: { data: null } }
+        }),
+    ),
+  ),
+]
+
+const speaker = {
+  _id: CALLER_ID,
+  name: 'Kari Nordmann',
+  email: 'kari@example.com',
+  slug: 'kari-nordmann',
+} as unknown as Speaker
+
+const session: Session = {
+  user: { name: 'Kari Nordmann', email: 'kari@example.com' },
+  speaker,
+  expires: '2027-01-01T00:00:00.000Z',
+} as unknown as Session
+
+const meta = {
+  title: 'Components/Messaging/ProposalMessagesSection',
+  component: ProposalMessagesSection,
+  beforeEach: mockDateBeforeEach(new Date('2026-07-18T12:00:00Z')),
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The "Messages" card anchored `#messages` on both proposal detail pages (speaker and organizer). Renders the real ConversationThread for the proposal’s deterministic thread; the composer shows even before the thread exists. Data is msw-mocked per story.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => (
+      <SessionProvider session={session} refetchOnWindowFocus={false}>
+        <TRPCProvider>
+          <div className={ctx.parameters.dark ? 'dark bg-gray-950 p-4' : 'p-4'}>
+            <div className="mx-auto w-full max-w-2xl">
+              <Story />
+            </div>
+          </div>
+        </TRPCProvider>
+      </SessionProvider>
+    ),
+  ],
+} satisfies Meta<typeof ProposalMessagesSection>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Speaker audience, empty thread — "Start the conversation with the organizers." */
+export const SpeakerEmpty: Story = {
+  args: { proposalId: PROPOSAL_ID, audience: 'speaker' },
+  parameters: { msw: { handlers: emptyThreadHandlers } },
+}
+
+/** Organizer audience, empty thread — "Start the conversation with the speakers." */
+export const OrganizerEmpty: Story = {
+  args: { proposalId: PROPOSAL_ID, audience: 'organizer' },
+  parameters: { msw: { handlers: emptyThreadHandlers } },
+}
+
+/** A live thread with messages from both sides (speaker view). */
+export const SpeakerPopulated: Story = {
+  args: { proposalId: PROPOSAL_ID, audience: 'speaker' },
+  parameters: { msw: { handlers: populatedThreadHandlers } },
+}
+
+export const SpeakerEmptyDark: Story = {
+  args: { proposalId: PROPOSAL_ID, audience: 'speaker' },
+  parameters: { dark: true, msw: { handlers: emptyThreadHandlers } },
+}
+
+export const SpeakerPopulatedDark: Story = {
+  args: { proposalId: PROPOSAL_ID, audience: 'speaker' },
+  parameters: { dark: true, msw: { handlers: populatedThreadHandlers } },
+}

--- a/src/components/notifications/NotificationBell.stories.tsx
+++ b/src/components/notifications/NotificationBell.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { SessionProvider } from 'next-auth/react'
+import type { Session } from 'next-auth'
+import { mockDateBeforeEach } from '@/lib/storybook'
+import { TRPCProvider } from '@/components/providers/TRPCProvider'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import { NotificationBell } from '@/components/notifications/NotificationBell'
+import type { Speaker } from '@/lib/speaker/types'
+
+// These stories render the REAL NotificationBell (not a mock shell): a prior
+// replica of the DashboardLayout bell drifted from production, so the badge cap
+// ('9+') and the unread states are verified against the actual component here.
+// Session comes from next-auth's SessionProvider; the bell's `unreadCount`
+// tRPC query is served by the msw handlers below (same comma-batch-splitting
+// pattern as Header.stories / DashboardLayout.stories).
+
+const notificationItems = () => [
+  {
+    id: 'n1',
+    type: 'proposal_status_changed',
+    title: 'Your proposal was accepted',
+    message: 'Congratulations! "Scaling Kubernetes" was accepted.',
+    link: '/cfp/proposal/1',
+    readAt: null,
+    createdAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+    actor: { _id: 'a1', name: 'Program Committee' },
+  },
+  {
+    id: 'n2',
+    type: 'message_received',
+    title: 'New message from the organizers',
+    readAt: null,
+    createdAt: new Date(Date.now() - 90 * 60_000).toISOString(),
+    actor: null,
+  },
+]
+
+/** msw handlers answering the bell's `unreadCount` (and the panel's `list`)
+ * for a given unread total — the badge reads only `unreadCount`. */
+const makeHandlers = (unread: number) => [
+  http.get('/api/trpc/:procs', ({ params }) =>
+    HttpResponse.json(
+      String(params.procs)
+        .split(',')
+        .map((proc) =>
+          proc === 'notification.unreadCount'
+            ? { result: { data: unread } }
+            : proc === 'notification.list'
+              ? { result: { data: notificationItems() } }
+              : { result: { data: null } },
+        ),
+    ),
+  ),
+]
+
+const speaker = {
+  _id: 'speaker-1',
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  slug: 'jane-doe',
+} as unknown as Speaker
+
+const session: Session = {
+  user: {
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+  },
+  speaker,
+  expires: '2027-01-01T00:00:00.000Z',
+} as unknown as Session
+
+const meta = {
+  title: 'Components/Notifications/NotificationBell',
+  component: NotificationBell,
+  beforeEach: mockDateBeforeEach(new Date('2026-07-18T12:00:00Z')),
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The notification hub entry point (the REAL component): a bell with an unread badge that opens the inbox panel. The badge caps at `9+`; it is absent at zero unread. Session is injected via `SessionProvider`; the `unreadCount` tRPC query is msw-mocked per story.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => (
+      <SessionProvider session={session} refetchOnWindowFocus={false}>
+        <TRPCProvider>
+          <NotificationProvider>
+            <div
+              className={
+                ctx.parameters.dark
+                  ? 'dark flex justify-center bg-gray-950 p-10'
+                  : 'flex justify-center bg-white p-10'
+              }
+            >
+              <Story />
+            </div>
+          </NotificationProvider>
+        </TRPCProvider>
+      </SessionProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof NotificationBell>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Zero unread — no badge, just the bell. */
+export const Unread0: Story = {
+  parameters: { msw: { handlers: makeHandlers(0) } },
+}
+
+/** A low count renders the exact number in the badge. */
+export const Unread3: Story = {
+  parameters: { msw: { handlers: makeHandlers(3) } },
+}
+
+/** Past the cap: any count over nine collapses to '9+'. */
+export const Unread12: Story = {
+  parameters: { msw: { handlers: makeHandlers(12) } },
+}
+
+export const Unread0Dark: Story = {
+  parameters: { dark: true, msw: { handlers: makeHandlers(0) } },
+}
+
+export const Unread3Dark: Story = {
+  parameters: { dark: true, msw: { handlers: makeHandlers(3) } },
+}
+
+export const Unread12Dark: Story = {
+  parameters: { dark: true, msw: { handlers: makeHandlers(12) } },
+}

--- a/src/components/pwa/PushNotificationSettings.tsx
+++ b/src/components/pwa/PushNotificationSettings.tsx
@@ -238,14 +238,23 @@ function testFeedback(
 
   const failures = result.failures ?? []
   const detail = failureDetailLine(failures)
+  // The pruned-subscriptions note, reused by every branch where devices went
+  // away (leading space so it appends cleanly after the preceding sentence).
+  const expiredNote =
+    result.gone > 0
+      ? ` Removed ${result.gone} expired subscription${
+          result.gone === 1 ? '' : 's'
+        }.`
+      : ''
 
   if (result.sent === 0) {
     if (failures.length > 0) {
       // Live devices exist but the push service REJECTED the send — the
       // diagnosable case (usually a 403 VAPID mismatch). Give the actionable fix
       // plus the technical detail line for a maintainer reading a screenshot.
+      // Any devices pruned alongside the rejection are still reported.
       return {
-        text: failureCopy(dominantFailure(failures)),
+        text: `${failureCopy(dominantFailure(failures))}${expiredNote}`,
         tone: 'warn',
         detail,
       }
@@ -269,25 +278,19 @@ function testFeedback(
 
   const devices = `${result.sent} device${result.sent === 1 ? '' : 's'}`
   const base = `Sent to ${devices} — check for the notification.`
-  const expired =
-    result.gone > 0
-      ? ` Removed ${result.gone} expired subscription${
-          result.gone === 1 ? '' : 's'
-        }.`
-      : ''
 
   if (failures.length > 0) {
     // Partial: some devices got it, others were rejected. Deliver the success
     // count AND a secondary actionable line for the failing devices.
     return {
-      text: `${base}${expired} ${failureCopy(dominantFailure(failures))}`,
+      text: `${base}${expiredNote} ${failureCopy(dominantFailure(failures))}`,
       tone: 'warn',
       detail,
     }
   }
 
   return {
-    text: base + expired,
+    text: base + expiredNote,
     tone: 'success',
   }
 }


### PR DESCRIPTION
Batch D (STORIES & DOCS) from the adversarial messaging review. Story/documentation/copy gaps only — no product-logic changes beyond one queued copy fix. All new stories render the REAL components (no mock-shell replicas), wrapped in `SessionProvider` + `TRPCProvider`, with deterministic dates via `mockDateBeforeEach` and msw handlers using the comma-batch `:procs` split pattern.

## D1 — NotificationBell story + toast-logic test
- New `NotificationBell.stories.tsx`: real-component stories for unread 0 / 3 / 12 (verifies the `9+` badge cap), light + dark. Badge legibility and the zero-state (no badge) are now visually covered.
- New `NotificationBell.test.tsx`: drives the toast bridge through the real component (tRPC/session/toast mocked at their seams) — asserts no toast on first load / before the first resolved value (null baseline), a toast only on a genuine increase (singular vs. plural delta), silence on a decrease, and full suppression under impersonation.

## D2 — MessagesInbox stories
- New `MessagesInbox.stories.tsx`: renders the real inbox container (owns `message.listConversations`), speaker + organizer empty states and a populated speaker state (fixture shapes reused from `ConversationList.stories`, delivered via msw so the container's own wiring — including the "You: " prefix from the session — is exercised).

## D3 — ProposalMessagesSection story
- New `ProposalMessagesSection.stories.tsx`: the real `#messages` card, both audience variants (speaker/organizer) as msw-backed empty threads (composer still shows), plus a populated thread with both-sides bubbles.

## D4 — queued #534 copy fix
- `PushNotificationSettings.tsx`: when the test send has `sent === 0` AND rejections AND `gone > 0`, the "Removed N expired subscriptions" note was dropped because the failures branch returned early. The pruning note is now appended to the failure-branch copy (extracted a shared `expiredNote` reused by every branch). Extended the `testFeedback` tests with the all-failed+pruned and partial-success+pruned mixed states.

## D5 — privacy page
- `privacy/page.tsx`: documented the five per-category push preferences (`pushPreferences`: proposal decisions / talk confirmations / co-speaker invites / messages / other updates) under Speaker Information, and the speaker-level `messagingEmailDefault` under the Messages section — concise line items matching the surrounding copy style.

## Checks
- tsc, eslint, prettier, knip: clean
- Full `vitest run`: 3027 passed / 5 skipped (204 files)
- `pnpm shoot` at 393px light + dark for every new story; PNGs inspected — badge legible with `9+` cap, empty-state copy correct per audience, own/other bubble alignment and truncation correct, no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is the "Batch D" messaging review: new Storybook stories for `NotificationBell`, `MessagesInbox`, and `ProposalMessagesSection` (all real-component, msw-backed), new unit tests for the `NotificationBell` toast bridge, a targeted bug fix in `PushNotificationSettings.tsx` that prevented the expired-subscriptions note from appearing when all sends were rejected, and two new privacy-page list items.

- **D4 bug fix** (`PushNotificationSettings.tsx`): the `expiredNote` string is extracted before the branch tree so every branch (all-rejected, partial-success, full-success) now appends it correctly; regression tests cover both the all-failed+pruned and partial-success+pruned states.
- **Story files**: three new story files use real components wrapped in `SessionProvider` + `TRPCProvider` with msw handlers following the comma-batch `:procs` split pattern; `NotificationBell.stories.tsx` and `ProposalMessagesSection.stories.tsx` correctly call date helpers inside the msw response callback (after `beforeEach` mocks the date), but `MessagesInbox.stories.tsx` calls `makeItems()` at story-definition time, before the mock runs, which can cause non-deterministic relative timestamps.
- **Privacy page**: two new list items under Speaker Information and Messages sections, consistent in style with the surrounding `•` bullet pattern.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the logic fix is mechanically correct and tested, and the only concern is a story quality issue in MessagesInbox where fixture dates may not align with the mocked baseline.

The PushNotificationSettings.tsx refactor is correct and well-tested. The one issue is MessagesInbox.stories.tsx calling makeItems() at module init rather than inside the msw response callback, meaning fixture timestamps are computed before the date mock is applied — the other two story files handle this correctly by computing dates at request time.

src/components/messaging/MessagesInbox.stories.tsx — the makeItems() call should move inside the msw response callback so timestamps are computed after beforeEach mocks the date.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| __tests__/components/notifications/NotificationBell.test.tsx | New test file covering the toast-bridge logic with well-structured mocks at tRPC/session/toast seams; all five cases (no-toast on first load, baseline on first resolve, increase delta, decrease silence, impersonation suppression) are covered. |
| __tests__/components/pwa/PushNotificationSettings.test.tsx | Two new regression tests added for the D4 fix: all-failed+pruned and partial-success+pruned; both cases assert the expired-subscriptions note survives alongside rejection copy. |
| src/app/(main)/privacy/page.tsx | Adds two list items under Speaker Information (push preferences) and Messages (email default); copy style and bullet character are consistent with surrounding items. |
| src/components/pwa/PushNotificationSettings.tsx | Extracts expiredNote into a shared variable so the all-failures branch no longer drops the pruning note; refactoring is mechanically correct and all three branches now compose the same expiredNote string. |
| src/components/notifications/NotificationBell.stories.tsx | New Storybook stories for 0/3/12 unread counts in light and dark; notificationItems() is called inside the msw response callback so dates are evaluated after beforeEach mocks globalThis.Date — deterministic pattern is correct. |
| src/components/messaging/MessagesInbox.stories.tsx | New inbox stories using real container + msw; makeItems() is called at story-definition time (module init), before beforeEach mocks globalThis.Date, so the minutesAgo timestamps are frozen against real wall-clock time rather than the 2026-07-18 baseline. |
| src/components/messaging/ProposalMessagesSection.stories.tsx | New stories for both audience variants with empty and populated threads; minutesAgo() is correctly called inside the msw handler callback (at request time, after beforeEach), so relative timestamps are deterministic. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[testFeedback called] --> B{result null / error?}
    B -- error --> C[return error copy]
    B -- null --> D[return null]
    B -- ok --> E{configured?}
    E -- no --> F[return not-available copy]
    E -- yes --> G{total === 0?}
    G -- yes --> H[return no-devices copy]
    G -- no --> I[compute failures, detail]
    I --> J[compute expiredNote shared by all branches]
    J --> K{sent === 0?}
    K -- yes, failures > 0 --> L[failureCopy + expiredNote tone: warn + detail]
    K -- yes, gone > 0 --> M[no-active-devices + inline gone count tone: warn]
    K -- yes, no diagnostics --> N[generic retry copy tone: warn]
    K -- no, sent > 0 --> O{failures > 0?}
    O -- yes partial --> P[base + expiredNote + failureCopy tone: warn + detail]
    O -- no --> Q[base + expiredNote tone: success]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[testFeedback called] --> B{result null / error?}
    B -- error --> C[return error copy]
    B -- null --> D[return null]
    B -- ok --> E{configured?}
    E -- no --> F[return not-available copy]
    E -- yes --> G{total === 0?}
    G -- yes --> H[return no-devices copy]
    G -- no --> I[compute failures, detail]
    I --> J[compute expiredNote shared by all branches]
    J --> K{sent === 0?}
    K -- yes, failures > 0 --> L[failureCopy + expiredNote tone: warn + detail]
    K -- yes, gone > 0 --> M[no-active-devices + inline gone count tone: warn]
    K -- yes, no diagnostics --> N[generic retry copy tone: warn]
    K -- no, sent > 0 --> O{failures > 0?}
    O -- yes partial --> P[base + expiredNote + failureCopy tone: warn + detail]
    O -- no --> Q[base + expiredNote tone: success]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(messaging): story/docs gaps from a..."](https://github.com/cloudnativebergen/website/commit/e8ae080da4001ef90b84ed211df3147669964faf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45417530)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->