### PR TITLE
fix(messaging): review batch A — server hardening

### DIFF
--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -10,7 +10,7 @@
  * The data layer is mocked (IO functions only); the pure authz helper runs for
  * real so the FORBIDDEN paths exercise the true rule.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   createAuthenticatedCaller,
   createAdminCaller,
@@ -28,6 +28,11 @@ vi.mock('@/lib/conference/sanity', () => ({
 
 vi.mock('@/lib/messaging/notify', () => ({
   notifyNewMessage: vi.fn(async () => {}),
+}))
+
+// The organizer-standing check (A5) probes the sanity read client directly.
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: vi.fn(async () => null) },
 }))
 
 vi.mock('@/lib/messaging/sanity', async (importActual) => {
@@ -53,7 +58,6 @@ vi.mock('@/lib/messaging/sanity', async (importActual) => {
       async () => 'conversation.proposal.prop-1',
     ),
     createGeneralConversation: vi.fn(async () => 'conversation.gen-1'),
-    speakerExists: vi.fn(async () => true),
     getProposalForConversation: vi.fn(),
     setConversationPreference: vi.fn(async () => ({
       muted: true,
@@ -68,9 +72,9 @@ import {
   ensureProposalConversation,
   createGeneralConversation,
   getProposalForConversation,
-  speakerExists,
   addMessage,
 } from '@/lib/messaging/sanity'
+import { clientReadUncached } from '@/lib/sanity/client'
 import { notifyNewMessage } from '@/lib/messaging/notify'
 
 type LooseMock = ReturnType<typeof vi.fn>
@@ -79,7 +83,8 @@ const listConvs = listConversationsForSpeaker as unknown as LooseMock
 const ensureProposal = ensureProposalConversation as unknown as LooseMock
 const createGeneral = createGeneralConversation as unknown as LooseMock
 const getProposal = getProposalForConversation as unknown as LooseMock
-const speakerExistsMock = speakerExists as unknown as LooseMock
+const standingFetch = (clientReadUncached as unknown as { fetch: LooseMock })
+  .fetch
 const addMsg = addMessage as unknown as LooseMock
 const notifyMock = notifyNewMessage as unknown as LooseMock
 
@@ -110,25 +115,28 @@ beforeEach(() => {
 })
 
 describe('authorization', () => {
-  it('blocks a non-participant speaker from getConversation (FORBIDDEN)', async () => {
+  // A3: a non-participant is denied with NOT_FOUND (not FORBIDDEN) so the
+  // deterministic proposal-thread id can't be used as an existence oracle. The
+  // denial itself is still asserted — addMessage never runs on the send path.
+  it('denies a non-participant speaker on getConversation with NOT_FOUND (A3)', async () => {
     getById.mockResolvedValue(strangerProposalConv)
     const caller = createAuthenticatedCaller(speaker1)
     await expect(
       caller.message.getConversation({ id: 'conversation.proposal.prop-1' }),
-    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+    ).rejects.toThrow(/NOT_FOUND|not found/)
   })
 
-  it('blocks a non-participant speaker from listMessages (FORBIDDEN)', async () => {
+  it('denies a non-participant speaker on listMessages with NOT_FOUND (A3)', async () => {
     getById.mockResolvedValue(strangerProposalConv)
     const caller = createAuthenticatedCaller(speaker1)
     await expect(
       caller.message.listMessages({
         conversationId: 'conversation.proposal.prop-1',
       }),
-    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+    ).rejects.toThrow(/NOT_FOUND|not found/)
   })
 
-  it('blocks a non-participant speaker from sending to an existing thread', async () => {
+  it('denies a non-participant sending to an existing thread with NOT_FOUND (A3)', async () => {
     getById.mockResolvedValue(strangerProposalConv)
     const caller = createAuthenticatedCaller(speaker1)
     await expect(
@@ -136,7 +144,24 @@ describe('authorization', () => {
         conversationId: 'conversation.proposal.prop-1',
         body: 'hi',
       }),
-    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+    ).rejects.toThrow(/NOT_FOUND|not found/)
+    expect(addMsg).not.toHaveBeenCalled()
+  })
+
+  it('denies a cross-conference conversation with NOT_FOUND on a mismatched domain (A4)', async () => {
+    // Organizer would otherwise pass the access check, so the conference guard
+    // is what rejects: the conversation belongs to conf-2, the domain is conf-1.
+    getById.mockResolvedValue({
+      ...strangerProposalConv,
+      conferenceId: 'conf-2',
+    })
+    const caller = createAdminCaller()
+    await expect(
+      caller.message.send({
+        conversationId: 'conversation.proposal.prop-1',
+        body: 'hi',
+      }),
+    ).rejects.toThrow(/NOT_FOUND|not found/)
     expect(addMsg).not.toHaveBeenCalled()
   })
 
@@ -297,8 +322,9 @@ describe('send — organizer-initiated general threads (subjectSpeaker)', () => 
     expect(createGeneral).not.toHaveBeenCalled()
   })
 
-  it('404s when the organizer recipientSpeakerId does not resolve to a speaker', async () => {
-    speakerExistsMock.mockResolvedValue(false)
+  it('404s when the organizer recipient has NO standing in this conference (A5)', async () => {
+    // Speaker exists somewhere but has no proposal in the current conference.
+    standingFetch.mockResolvedValue(null)
     const caller = createAdminCaller()
     await expect(
       caller.message.send({
@@ -306,12 +332,13 @@ describe('send — organizer-initiated general threads (subjectSpeaker)', () => 
         recipientSpeakerId: 'ghost',
         body: 'hi',
       }),
-    ).rejects.toThrow(/NOT_FOUND|does not resolve/)
+    ).rejects.toThrow(/NOT_FOUND|in this conference/)
     expect(createGeneral).not.toHaveBeenCalled()
   })
 
-  it('creates an organizer general thread that persists the subjectSpeaker', async () => {
-    speakerExistsMock.mockResolvedValue(true)
+  it('creates an organizer general thread when the recipient HAS standing (A5)', async () => {
+    // A proposal id comes back → the recipient belongs to this conference.
+    standingFetch.mockResolvedValue('talk-1')
     getById.mockResolvedValue(organizerGeneralConv)
     const caller = createAdminCaller()
 
@@ -321,12 +348,61 @@ describe('send — organizer-initiated general threads (subjectSpeaker)', () => 
       body: 'hi',
     })
 
-    expect(speakerExistsMock).toHaveBeenCalledWith('sp-target')
+    expect(standingFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      { speakerId: 'sp-target', conferenceId: 'conf-1' },
+      expect.anything(),
+    )
     expect(createGeneral).toHaveBeenCalledWith(
       expect.objectContaining({ subjectSpeakerId: 'sp-target' }),
     )
     expect(result.conversationId).toBe('conversation.gen-1')
     expect(addMsg).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('send — per-speaker rate limit (A2)', () => {
+  // A dedicated speaker (Alice) so the module-level sliding window is not
+  // polluted by — and does not pollute — the other send tests.
+  const aliceId = 'c3a7f9e0-9e8d-4e4b-9e8f-2a4b6d8f9e8d'
+  const aliceConv: ConversationWithContext = {
+    _id: 'conversation.gen-alice',
+    conferenceId: 'conf-1',
+    conversationType: 'general',
+    proposalSpeakerIds: [],
+    createdById: aliceId,
+    subject: 'Q',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastMessageAt: '2026-01-01T00:00:00.000Z',
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T00:00:00.000Z'))
+    createGeneral.mockResolvedValue('conversation.gen-alice')
+    getById.mockResolvedValue(aliceConv)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('allows a burst of 10, rejects the 11th, then allows again after the window', async () => {
+    const caller = createAuthenticatedCaller(aliceId)
+    const send = () => caller.message.send({ subject: 'Q', body: 'hi' })
+
+    for (let i = 0; i < 10; i++) {
+      await expect(send()).resolves.toMatchObject({
+        conversationId: 'conversation.gen-alice',
+      })
+    }
+    await expect(send()).rejects.toThrow(/TOO_MANY_REQUESTS|too quickly/)
+
+    // Advance past the 60s window → the burst budget refills.
+    vi.setSystemTime(new Date('2026-05-01T00:01:01.000Z'))
+    await expect(send()).resolves.toMatchObject({
+      conversationId: 'conversation.gen-alice',
+    })
   })
 })
 
@@ -341,7 +417,7 @@ describe('setPreference', () => {
     expect(result).toEqual({ muted: true, emailOverride: 'default' })
   })
 
-  it('blocks a non-participant from setting a preference', async () => {
+  it('denies a non-participant setting a preference with NOT_FOUND (A3)', async () => {
     getById.mockResolvedValue(strangerProposalConv)
     const caller = createAuthenticatedCaller(speaker1)
     await expect(
@@ -349,6 +425,6 @@ describe('setPreference', () => {
         conversationId: 'conversation.proposal.prop-1',
         muted: true,
       }),
-    ).rejects.toThrow(/FORBIDDEN|Access denied/)
+    ).rejects.toThrow(/NOT_FOUND|not found/)
   })
 })

--- a/__tests__/lib/events/persistNotification.test.ts
+++ b/__tests__/lib/events/persistNotification.test.ts
@@ -133,6 +133,38 @@ describe('status change — speakers minus actor, gated by shouldNotify', () => 
     expect(lastItems()[0].message).toBe('Not a fit this year')
   })
 
+  it('links to the #messages anchor when a decision comment is present (A7)', async () => {
+    // A commented decision is ALSO relayed into the proposal thread, so the
+    // status notification points at the same #messages anchor as the message
+    // notification (they must not lead to two seemingly different places).
+    await handlePersistNotification(
+      makeEvent(
+        {
+          action: Action.accept,
+          newStatus: Status.accepted,
+          speakers: [
+            { _id: 'sp-1' },
+          ] as unknown as ProposalStatusChangeEvent['speakers'],
+        },
+        { comment: 'See you in Bergen!' },
+      ),
+    )
+    expect(lastItems()[0].link).toBe('/cfp/proposal/prop-1#messages')
+  })
+
+  it('links to the bare proposal when there is no comment (A7)', async () => {
+    await handlePersistNotification(
+      makeEvent({
+        action: Action.accept,
+        newStatus: Status.accepted,
+        speakers: [
+          { _id: 'sp-1' },
+        ] as unknown as ProposalStatusChangeEvent['speakers'],
+      }),
+    )
+    expect(lastItems()[0].link).toBe('/cfp/proposal/prop-1')
+  })
+
   it('does NOT notify when shouldNotify is false', async () => {
     await handlePersistNotification(
       makeEvent(

--- a/__tests__/lib/messaging/email.test.ts
+++ b/__tests__/lib/messaging/email.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the messaging email fan-out (src/lib/messaging/email.ts):
+ * - bounded concurrency (A8): never more than 3 sends in flight at once, so a
+ *   large recipient set no longer serializes behind a per-recipient delay;
+ * - never-fail: a per-recipient failure is logged and excluded from the count,
+ *   but never throws and never abandons the other recipients.
+ *
+ * Only the Resend transport boundary is mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const sendMock = vi.fn()
+
+vi.mock('@/lib/email/config', () => ({
+  resend: { emails: { send: (...args: unknown[]) => sendMock(...args) } },
+  // Pass-through: exercise sendOne's own success/failure handling directly.
+  retryWithBackoff: async (fn: () => Promise<unknown>) => fn(),
+}))
+
+import {
+  sendMessageEmails,
+  type MessageEmailRecipient,
+} from '@/lib/messaging/email'
+import type { Conference } from '@/lib/conference/types'
+
+const conference = {
+  organizer: 'CNDN',
+  cfpEmail: 'cfp@cndn.no',
+  title: 'CNDN',
+  city: 'Bergen',
+  country: 'Norway',
+  startDate: '2026-09-01',
+  domains: ['cndn.no'],
+  socialLinks: [],
+} as unknown as Conference
+
+const context = { authorName: 'A', subject: 'S', excerpt: 'E', conference }
+
+function recipients(n: number): MessageEmailRecipient[] {
+  return Array.from({ length: n }, (_, i) => ({
+    email: `r${i}@x.no`,
+    name: `R${i}`,
+    replyUrl: 'https://cndn.no/cfp/proposal/p1#messages',
+  }))
+}
+
+beforeEach(() => {
+  sendMock.mockReset()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('sendMessageEmails — bounded concurrency (A8)', () => {
+  it('delivers to every recipient and returns the delivered count', async () => {
+    sendMock.mockResolvedValue({ error: null })
+    const sent = await sendMessageEmails(recipients(5), context)
+    expect(sent).toBe(5)
+    expect(sendMock).toHaveBeenCalledTimes(5)
+  })
+
+  it('never runs more than 3 sends concurrently', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    sendMock.mockImplementation(async () => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise((r) => setTimeout(r, 5))
+      inFlight--
+      return { error: null }
+    })
+
+    await sendMessageEmails(recipients(9), context)
+
+    expect(maxInFlight).toBeLessThanOrEqual(3)
+    // ...and it IS concurrent (not a serial loop).
+    expect(maxInFlight).toBeGreaterThan(1)
+  })
+
+  it('never throws; counts only successes and logs per-recipient failures', async () => {
+    sendMock
+      .mockResolvedValueOnce({ error: null }) // ok
+      .mockRejectedValueOnce(new Error('boom')) // transport reject
+      .mockResolvedValueOnce({ error: { message: 'bad' } }) // API error result
+      .mockResolvedValue({ error: null }) // ok
+
+    const sent = await sendMessageEmails(recipients(4), context)
+
+    expect(sent).toBe(2)
+    expect(console.error).toHaveBeenCalled()
+  })
+})

--- a/__tests__/lib/slack/client.test.ts
+++ b/__tests__/lib/slack/client.test.ts
@@ -51,6 +51,20 @@ describe('Slack client', () => {
     blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Hello' } }],
   }
 
+  describe('escapeMrkdwn (A1)', () => {
+    it('escapes &, < and > and neutralizes link/mention injection', async () => {
+      const { escapeMrkdwn } = await import('@/lib/slack/client')
+      expect(escapeMrkdwn('a & b')).toBe('a &amp; b')
+      expect(escapeMrkdwn('<!channel>')).toBe('&lt;!channel&gt;')
+      expect(escapeMrkdwn('<https://evil|Label>')).toBe(
+        '&lt;https://evil|Label&gt;',
+      )
+      // `&` is escaped first, so introduced entities are not double-escaped.
+      expect(escapeMrkdwn('<a>')).toBe('&lt;a&gt;')
+      expect(escapeMrkdwn('plain text')).toBe('plain text')
+    })
+  })
+
   describe('development mode', () => {
     it('should log to console instead of sending', async () => {
       setEnv({ nodeEnv: 'development' })

--- a/__tests__/lib/slack/notify.test.ts
+++ b/__tests__/lib/slack/notify.test.ts
@@ -10,11 +10,15 @@ const mockPostSlackMessage = vi.fn() as MockedFunction<
   typeof import('@/lib/slack/client').postSlackMessage
 >
 
-vi.mock('@/lib/slack/client', () => ({
-  postSlackMessage: (
-    ...args: Parameters<typeof import('@/lib/slack/client').postSlackMessage>
-  ) => mockPostSlackMessage(...args),
-}))
+vi.mock('@/lib/slack/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/slack/client')>()
+  return {
+    ...actual, // keep the real escapeMrkdwn (A1)
+    postSlackMessage: (
+      ...args: Parameters<typeof import('@/lib/slack/client').postSlackMessage>
+    ) => mockPostSlackMessage(...args),
+  }
+})
 
 vi.mock('@/lib/speaker/sanity', () => ({
   getSpeaker: vi
@@ -179,6 +183,33 @@ describe('Slack notifications', () => {
 
       const [, options] = mockPostSlackMessage.mock.calls[0]
       expect(options).toEqual({ channel: undefined })
+    })
+  })
+
+  describe('notifyNewSpeakerMessage — mrkdwn injection escaping (A1)', () => {
+    it('escapes &, < and > in speaker-controlled fields', async () => {
+      const { notifyNewSpeakerMessage } = await import('@/lib/slack/notify')
+
+      await notifyNewSpeakerMessage(
+        {
+          authorName: '<!channel> Mallory & co',
+          subject: '<https://evil.example|CNCF Payroll>',
+          excerpt: 'wire money to <https://evil.example|here> & now',
+          adminPath: '/admin/proposals/p1#messages',
+        },
+        createMockConference(),
+      )
+
+      const [message] = mockPostSlackMessage.mock.calls[0]
+      const rendered = JSON.stringify(message.blocks)
+
+      // No raw control sequences survive: no link syntax, no broadcast mention.
+      expect(rendered).not.toContain('<!channel>')
+      expect(rendered).not.toContain('<https://evil.example|')
+      // The dangerous characters are entity-escaped instead.
+      expect(rendered).toContain('&lt;!channel&gt;')
+      expect(rendered).toContain('Mallory &amp; co')
+      expect(rendered).toContain('&lt;https://evil.example|CNCF Payroll&gt;')
     })
   })
 

--- a/__tests__/server/schemas/message.test.ts
+++ b/__tests__/server/schemas/message.test.ts
@@ -24,6 +24,20 @@ describe('SendMessageSchema', () => {
     ).toBe(false)
   })
 
+  it('rejects a whitespace-only body after trimming (A6)', () => {
+    expect(SendMessageSchema.safeParse({ body: ' ' }).success).toBe(false)
+    expect(SendMessageSchema.safeParse({ body: '\n\n' }).success).toBe(false)
+    expect(SendMessageSchema.safeParse({ body: '  \t \n ' }).success).toBe(
+      false,
+    )
+  })
+
+  it('trims surrounding whitespace but preserves interior whitespace (A6)', () => {
+    const parsed = SendMessageSchema.safeParse({ body: '  a  b  ' })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.body).toBe('a  b')
+  })
+
   it('caps the subject at 200 chars', () => {
     expect(
       SendMessageSchema.safeParse({ subject: 'x'.repeat(200), body: 'hi' })

--- a/src/lib/events/handlers/persistNotification.ts
+++ b/src/lib/events/handlers/persistNotification.ts
@@ -107,7 +107,13 @@ export async function handlePersistNotification(
         message: event.metadata.comment || undefined,
         actorId,
         relatedProposalId: proposalId,
-        link: `/cfp/proposal/${proposalId}`,
+        // When the decision carries a comment it is ALSO relayed into the
+        // proposal's message thread; point the status notification at the same
+        // #messages anchor as the message notification so the two bell rows lead
+        // to the same place instead of diverging (batch A / A7).
+        link: event.metadata.comment
+          ? `/cfp/proposal/${proposalId}#messages`
+          : `/cfp/proposal/${proposalId}`,
       })
     }
     await createNotifications(items)

--- a/src/lib/messaging/email.ts
+++ b/src/lib/messaging/email.ts
@@ -1,11 +1,6 @@
 import 'server-only'
 import React from 'react'
-import {
-  resend,
-  retryWithBackoff,
-  delay,
-  EMAIL_CONFIG,
-} from '@/lib/email/config'
+import { resend, retryWithBackoff } from '@/lib/email/config'
 import { MessageNotificationTemplate } from '@/components/email/MessageNotificationTemplate'
 import type { Conference } from '@/lib/conference/types'
 import { formatDate } from '@/lib/time'
@@ -48,9 +43,10 @@ async function sendOne(
           subject,
           excerpt,
           replyUrl: recipient.replyUrl,
-          // Same domain source as the deep link; profile hosts the settings.
+          // Settings live on the cfp profile for BOTH audiences; anchor at the
+          // notification section so the link matches the in-app gear (A9).
           preferencesUrl: conference.domains?.[0]
-            ? `https://${conference.domains[0]}/cfp/profile`
+            ? `https://${conference.domains[0]}/cfp/profile#notification-settings`
             : undefined,
           eventName: conference.title,
           eventLocation: `${conference.city}, ${conference.country}`,
@@ -75,10 +71,17 @@ async function sendOne(
   }
 }
 
+/** How many recipient emails to have in flight at once (A8). */
+const EMAIL_CONCURRENCY = 3
+
 /**
- * Send new-message emails to several recipients, sequentially with the shared
- * rate-limit delay between sends (mirrors the other email senders). Never
- * throws; returns how many were delivered.
+ * Send new-message emails to several recipients with BOUNDED CONCURRENCY (A8):
+ * a fixed pool of at most {@link EMAIL_CONCURRENCY} in-flight sends instead of a
+ * serial loop with a per-recipient delay, so a large recipient set no longer
+ * turns into a multi-second Send-button hang. `sendOne` never throws and
+ * `retryWithBackoff` absorbs Resend rate-limits (429), so no artificial spacing
+ * is needed. Per-recipient failures are logged inside `sendOne`; this function
+ * never throws and returns how many were delivered.
  */
 export async function sendMessageEmails(
   recipients: MessageEmailRecipient[],
@@ -90,10 +93,22 @@ export async function sendMessageEmails(
   },
 ): Promise<number> {
   let sent = 0
-  for (let i = 0; i < recipients.length; i++) {
-    if (i > 0) await delay(EMAIL_CONFIG.RATE_LIMIT_DELAY)
-    const ok = await sendOne(recipients[i], context)
-    if (ok) sent++
+  let cursor = 0
+
+  async function worker(): Promise<void> {
+    while (cursor < recipients.length) {
+      const index = cursor++
+      const ok = await sendOne(recipients[index], context)
+      if (ok) sent++
+    }
   }
+
+  const workers = Array.from(
+    { length: Math.min(EMAIL_CONCURRENCY, recipients.length) },
+    () => worker(),
+  )
+  // `sendOne` is never-fail, but allSettled guarantees one worker's rejection
+  // can never abandon the others (never-fail contract).
+  await Promise.allSettled(workers)
   return sent
 }

--- a/src/lib/slack/client.ts
+++ b/src/lib/slack/client.ts
@@ -1,3 +1,17 @@
+/**
+ * Escape the three characters Slack treats as control characters inside a
+ * `mrkdwn` text field — `&`, `<`, `>` — per Slack's formatting guidance
+ * (https://api.slack.com/reference/surfaces/formatting#escaping). MUST be
+ * applied to EVERY user-controlled string interpolated into an `mrkdwn` field,
+ * otherwise a value like `<https://evil|CNCF Payroll>` renders as a phishing
+ * link and `<!channel>` broadcasts to the whole workspace (batch A / A1).
+ *
+ * `&` is replaced first so the entities we introduce are not double-escaped.
+ */
+export function escapeMrkdwn(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
 export type SlackBlock = {
   type: string
   text?: {

--- a/src/lib/slack/notify.ts
+++ b/src/lib/slack/notify.ts
@@ -6,6 +6,7 @@ import { Conference } from '@/lib/conference/types'
 import { Volunteer } from '@/lib/volunteer/types'
 import {
   postSlackMessage,
+  escapeMrkdwn,
   type SlackBlock,
   type SlackMessage,
 } from '@/lib/slack/client'
@@ -117,11 +118,11 @@ function createProposalInfoBlocks(
       fields: [
         {
           type: 'mrkdwn',
-          text: `*Title:*\n${proposal.title}`,
+          text: `*Title:*\n${escapeMrkdwn(proposal.title)}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Speaker:*\n${speakerNames}`,
+          text: `*Speaker:*\n${escapeMrkdwn(speakerNames)}`,
         },
       ],
     },
@@ -177,7 +178,7 @@ export async function notifyProposalStatusChange(
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*Reason:*\n${reason.trim()}`,
+        text: `*Reason:*\n${escapeMrkdwn(reason.trim())}`,
       },
     })
   }
@@ -258,11 +259,11 @@ export async function notifyNewSpeakerMessage(
       fields: [
         {
           type: 'mrkdwn',
-          text: `*From:*\n${authorName}`,
+          text: `*From:*\n${escapeMrkdwn(authorName)}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Subject:*\n${subject}`,
+          text: `*Subject:*\n${escapeMrkdwn(subject)}`,
         },
       ],
     },
@@ -270,7 +271,7 @@ export async function notifyNewSpeakerMessage(
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*Message:*\n${excerpt}`,
+        text: `*Message:*\n${escapeMrkdwn(excerpt)}`,
       },
     },
   ]
@@ -304,7 +305,7 @@ export async function notifyNewVolunteer(
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*Conference:* ${conference.title}`,
+        text: `*Conference:* ${escapeMrkdwn(conference.title)}`,
       },
     },
     {
@@ -312,11 +313,11 @@ export async function notifyNewVolunteer(
       fields: [
         {
           type: 'mrkdwn',
-          text: `*Name:*\n${volunteer.name}`,
+          text: `*Name:*\n${escapeMrkdwn(volunteer.name)}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Email:*\n${volunteer.email}`,
+          text: `*Email:*\n${escapeMrkdwn(volunteer.email)}`,
         },
       ],
     },
@@ -325,11 +326,11 @@ export async function notifyNewVolunteer(
       fields: [
         {
           type: 'mrkdwn',
-          text: `*Phone:*\n${volunteer.phone}`,
+          text: `*Phone:*\n${escapeMrkdwn(volunteer.phone)}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Occupation:*\n${volunteer.occupation.charAt(0).toUpperCase() + volunteer.occupation.slice(1)}`,
+          text: `*Occupation:*\n${escapeMrkdwn(volunteer.occupation.charAt(0).toUpperCase() + volunteer.occupation.slice(1))}`,
         },
       ],
     },
@@ -341,28 +342,28 @@ export async function notifyNewVolunteer(
   if (volunteer.availability) {
     detailFields.push({
       type: 'mrkdwn',
-      text: `*Availability:*\n${volunteer.availability}`,
+      text: `*Availability:*\n${escapeMrkdwn(volunteer.availability)}`,
     })
   }
 
   if (volunteer.preferredTasks && volunteer.preferredTasks.length > 0) {
     detailFields.push({
       type: 'mrkdwn',
-      text: `*Preferred Tasks:*\n${volunteer.preferredTasks.join(', ')}`,
+      text: `*Preferred Tasks:*\n${escapeMrkdwn(volunteer.preferredTasks.join(', '))}`,
     })
   }
 
   if (volunteer.tshirtSize) {
     detailFields.push({
       type: 'mrkdwn',
-      text: `*T-Shirt Size:*\n${volunteer.tshirtSize}`,
+      text: `*T-Shirt Size:*\n${escapeMrkdwn(volunteer.tshirtSize)}`,
     })
   }
 
   if (volunteer.dietaryRestrictions) {
     detailFields.push({
       type: 'mrkdwn',
-      text: `*Dietary Restrictions:*\n${volunteer.dietaryRestrictions}`,
+      text: `*Dietary Restrictions:*\n${escapeMrkdwn(volunteer.dietaryRestrictions)}`,
     })
   }
 
@@ -379,7 +380,7 @@ export async function notifyNewVolunteer(
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*Other Information:*\n${volunteer.otherInfo}`,
+        text: `*Other Information:*\n${escapeMrkdwn(volunteer.otherInfo)}`,
       },
     })
   }
@@ -428,11 +429,11 @@ export async function notifySponsorRegistrationComplete(
       fields: [
         {
           type: 'mrkdwn',
-          text: `*Sponsor:*\n${sponsorName}`,
+          text: `*Sponsor:*\n${escapeMrkdwn(sponsorName)}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Tier:*\n${tierTitle || 'Not set'}`,
+          text: `*Tier:*\n${tierTitle ? escapeMrkdwn(tierTitle) : 'Not set'}`,
         },
       ],
     },
@@ -494,11 +495,11 @@ export async function notifySponsorContractSigned(
       fields: [
         {
           type: 'mrkdwn',
-          text: `*Sponsor:*\n${sponsorName}`,
+          text: `*Sponsor:*\n${escapeMrkdwn(sponsorName)}`,
         },
         {
           type: 'mrkdwn',
-          text: `*Tier:*\n${tierTitle || 'Not set'}`,
+          text: `*Tier:*\n${tierTitle ? escapeMrkdwn(tierTitle) : 'Not set'}`,
         },
       ],
     },
@@ -507,7 +508,10 @@ export async function notifySponsorContractSigned(
   if (signerName || valueStr) {
     const fields: Array<{ type: string; text: string }> = []
     if (signerName) {
-      fields.push({ type: 'mrkdwn', text: `*Signed by:*\n${signerName}` })
+      fields.push({
+        type: 'mrkdwn',
+        text: `*Signed by:*\n${escapeMrkdwn(signerName)}`,
+      })
     }
     if (valueStr) {
       fields.push({

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -1,6 +1,8 @@
 import { TRPCError } from '@trpc/server'
 import { router, protectedProcedure, resolveConferenceId } from '@/server/trpc'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { clientReadUncached } from '@/lib/sanity/client'
+import { runAfterResponse } from '@/server/runAfterResponse'
 import {
   ListConversationsSchema,
   GetConversationSchema,
@@ -20,10 +22,72 @@ import {
   getProposalForConversation,
   setConversationPreference,
   canAccessConversation,
-  speakerExists,
 } from '@/lib/messaging/sanity'
 import { notifyNewMessage } from '@/lib/messaging/notify'
 import type { ConversationWithContext } from '@/lib/messaging/types'
+
+/**
+ * Per-speaker sliding-window throttle for `message.send` (batch A / A2). Sending
+ * fans out to Slack (one post) and to N organizer emails, so an unthrottled
+ * loop amplifies. Allow a burst of {@link SEND_MAX_IN_WINDOW} sends per
+ * {@link SEND_WINDOW_MS}, then reject with TOO_MANY_REQUESTS.
+ *
+ * Lives in module memory, so on serverless it is PER-INSTANCE only — a burst
+ * spread across instances sees a higher effective ceiling. That's acceptable:
+ * this caps accidental/abusive hammering on a single instance while the email
+ * and Slack providers rate-limit further downstream (same caveat as push.ts's
+ * claimTestCooldown). The map is size-capped so it can never grow without bound.
+ */
+const SEND_WINDOW_MS = 60_000
+const SEND_MAX_IN_WINDOW = 10
+const MAX_RATE_ENTRIES = 10_000
+const recentSendsBySpeaker = new Map<string, number[]>()
+
+/**
+ * Record a send for `speakerId` and report whether it is allowed right now.
+ * Returns false when the speaker already made {@link SEND_MAX_IN_WINDOW} sends
+ * within the trailing {@link SEND_WINDOW_MS}; otherwise stamps now and allows.
+ */
+function claimSendSlot(speakerId: string): boolean {
+  const now = Date.now()
+  const cutoff = now - SEND_WINDOW_MS
+  const recent = (recentSendsBySpeaker.get(speakerId) ?? []).filter(
+    (t) => t > cutoff,
+  )
+  // Re-insert at the tail so the just-active speaker is the most-recent entry
+  // (eviction below always targets the genuinely oldest key).
+  recentSendsBySpeaker.delete(speakerId)
+  if (recent.length >= SEND_MAX_IN_WINDOW) {
+    recentSendsBySpeaker.set(speakerId, recent)
+    return false
+  }
+  recent.push(now)
+  if (recentSendsBySpeaker.size >= MAX_RATE_ENTRIES) {
+    const oldest = recentSendsBySpeaker.keys().next().value
+    if (oldest !== undefined) recentSendsBySpeaker.delete(oldest)
+  }
+  recentSendsBySpeaker.set(speakerId, recent)
+  return true
+}
+
+/**
+ * Does `speakerId` have standing in `conferenceId` — i.e. at least one proposal
+ * (talk) in that conference? An organizer-initiated general thread must target a
+ * speaker who belongs to the CURRENT conference, not merely one who exists in
+ * some conference (batch A / A5). Cheapest correct check: a single existence
+ * probe rather than loading proposals.
+ */
+async function speakerHasStandingInConference(
+  speakerId: string,
+  conferenceId: string,
+): Promise<boolean> {
+  const id = await clientReadUncached.fetch<string | null>(
+    `*[_type == "talk" && conference._ref == $conferenceId && $speakerId in speakers[]._ref][0]._id`,
+    { speakerId, conferenceId },
+    { cache: 'no-store' },
+  )
+  return Boolean(id)
+}
 
 /**
  * Speaker↔organizer messaging (M1). Every procedure derives the actor from
@@ -50,14 +114,14 @@ export const messageRouter = router({
     .input(GetConversationSchema)
     .query(async ({ ctx, input }) => {
       const conversation = await getConversationById(input.id)
-      if (!conversation) {
+      // Return NOT_FOUND for both "absent" and "access denied" so that, with
+      // deterministic proposal-thread ids, the response never reveals whether a
+      // thread the caller can't see exists (batch A / A3).
+      if (!conversation || !canAccessConversation(conversation, ctx.speaker)) {
         throw new TRPCError({
           code: 'NOT_FOUND',
           message: 'Conversation not found',
         })
-      }
-      if (!canAccessConversation(conversation, ctx.speaker)) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
       }
       const [participants, preference] = await Promise.all([
         getConversationParticipants(conversation),
@@ -71,14 +135,12 @@ export const messageRouter = router({
     .input(ListMessagesSchema)
     .query(async ({ ctx, input }) => {
       const conversation = await getConversationById(input.conversationId)
-      if (!conversation) {
+      // NOT_FOUND for absent OR inaccessible — no existence oracle (A3).
+      if (!conversation || !canAccessConversation(conversation, ctx.speaker)) {
         throw new TRPCError({
           code: 'NOT_FOUND',
           message: 'Conversation not found',
         })
-      }
-      if (!canAccessConversation(conversation, ctx.speaker)) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
       }
       return listMessages({
         conversationId: conversation._id,
@@ -124,14 +186,19 @@ export const messageRouter = router({
 
       if (input.conversationId) {
         const existing = await getConversationById(input.conversationId)
-        if (!existing) {
+        // Collapse absent / wrong-conference / inaccessible into a single
+        // NOT_FOUND: no existence oracle (A3), and a conversation from another
+        // conference must never be posted to on this domain — that would stamp
+        // the message with wrong-domain email/Slack links (batch A / A4).
+        if (
+          !existing ||
+          existing.conferenceId !== conferenceId ||
+          !canAccessConversation(existing, ctx.speaker)
+        ) {
           throw new TRPCError({
             code: 'NOT_FOUND',
             message: 'Conversation not found',
           })
-        }
-        if (!canAccessConversation(existing, ctx.speaker)) {
-          throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
         }
         conversation = existing
       } else if (input.proposalId) {
@@ -172,10 +239,18 @@ export const messageRouter = router({
                 'recipientSpeakerId is required when an organizer starts a general conversation',
             })
           }
-          if (!(await speakerExists(input.recipientSpeakerId))) {
+          // The recipient must have standing in THIS conference (a proposal in
+          // it), not merely exist in some conference (batch A / A5).
+          if (
+            !(await speakerHasStandingInConference(
+              input.recipientSpeakerId,
+              conferenceId,
+            ))
+          ) {
             throw new TRPCError({
               code: 'NOT_FOUND',
-              message: 'recipientSpeakerId does not resolve to a speaker',
+              message:
+                'recipientSpeakerId does not resolve to a speaker in this conference',
             })
           }
           subjectSpeakerId = input.recipientSpeakerId
@@ -202,20 +277,35 @@ export const messageRouter = router({
         })
       }
 
+      // Throttle only genuine sends (after authz/validation), since only a
+      // committed message triggers the Slack + N-email amplification (A2).
+      if (!claimSendSlot(actorId)) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message:
+            'You are sending messages too quickly. Please wait a moment and try again.',
+        })
+      }
+
       const message = await addMessage({
         conversationId: conversation._id,
         authorId: actorId,
         body: input.body,
       })
 
-      // Fan-out is fire-and-forget within the request: it never throws, and a
-      // failure must not fail the (committed) message write.
-      await notifyNewMessage({
-        conversation,
-        message,
-        authorId: actorId,
-        conference,
-      })
+      // Detach the fan-out from the response path (A8): the message is already
+      // committed and returned below; the (never-fail) Slack/email/hub fan-out
+      // runs AFTER the response so a large recipient set can't hang the Send
+      // button. `runAfterResponse` uses Next's `after()` in a request scope and
+      // falls back to a self-catching detachment elsewhere.
+      runAfterResponse(() =>
+        notifyNewMessage({
+          conversation,
+          message,
+          authorId: actorId,
+          conference,
+        }),
+      )
 
       return { conversationId: conversation._id, message }
     }),
@@ -225,14 +315,12 @@ export const messageRouter = router({
     .input(SetPreferenceSchema)
     .mutation(async ({ ctx, input }) => {
       const conversation = await getConversationById(input.conversationId)
-      if (!conversation) {
+      // NOT_FOUND for absent OR inaccessible — no existence oracle (A3).
+      if (!conversation || !canAccessConversation(conversation, ctx.speaker)) {
         throw new TRPCError({
           code: 'NOT_FOUND',
           message: 'Conversation not found',
         })
-      }
-      if (!canAccessConversation(conversation, ctx.speaker)) {
-        throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
       }
       return setConversationPreference({
         conversationId: conversation._id,

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -79,6 +79,7 @@ import {
   addMessage,
 } from '@/lib/messaging/sanity'
 import { notifyNewMessage } from '@/lib/messaging/notify'
+import { runAfterResponse } from '@/server/runAfterResponse'
 import '@/lib/events/registry'
 
 /**
@@ -786,13 +787,17 @@ export const proposalRouter = router({
                 body: trimmedComment,
               })
               // Never throws; fans out hub/email (no proposal actions, so no
-              // feedback loop with this procedure).
-              await notifyNewMessage({
-                conversation,
-                message,
-                authorId: ctx.speaker._id,
-                conference,
-              })
+              // feedback loop with this procedure). Detached from the response
+              // path (A8) so the fan-out can't hang the decision action; the
+              // message is already committed above.
+              runAfterResponse(() =>
+                notifyNewMessage({
+                  conversation,
+                  message,
+                  authorId: ctx.speaker._id,
+                  conference,
+                }),
+              )
             }
           } catch (error) {
             console.error(

--- a/src/server/runAfterResponse.ts
+++ b/src/server/runAfterResponse.ts
@@ -1,0 +1,23 @@
+import { after } from 'next/server'
+
+/**
+ * Run a never-fail side-effect (e.g. a message fan-out) AFTER the response has
+ * been sent, so a slow multi-recipient email/Slack fan-out can't block the
+ * mutation's response (batch A / A8).
+ *
+ * Prefers Next's `after()`, which defers the task until the App Router request
+ * has responded. Outside a request scope — unit tests, or any runtime where
+ * `after` has no work store — `after` throws synchronously; we fall back to a
+ * detached, self-catching invocation. The passed task is never-fail by
+ * contract, but we still guard so a detachment can never surface an unhandled
+ * rejection.
+ */
+export function runAfterResponse(task: () => Promise<void>): void {
+  try {
+    after(task)
+  } catch {
+    void task().catch((error) => {
+      console.error('Detached after-response task failed:', error)
+    })
+  }
+}

--- a/src/server/schemas/message.ts
+++ b/src/server/schemas/message.ts
@@ -41,7 +41,10 @@ export const SendMessageSchema = z.object({
   proposalId: z.string().min(1).max(200).optional(),
   subject: z.string().min(1).max(200).optional(),
   recipientSpeakerId: z.string().min(1).max(200).optional(),
-  body: z.string().min(1).max(5000),
+  // Trim BEFORE the non-empty check so a whitespace-only body (' ', '\n\n')
+  // can never fan out empty content; interior whitespace is preserved and the
+  // 5000-char cap still applies (batch A / A6).
+  body: z.string().trim().min(1).max(5000),
 })
 
 export const SetPreferenceSchema = z


### PR DESCRIPTION
Server-hardening fixes from the adversarial messaging review. File territory: `src/server/routers/message.ts` + `proposal.ts`, `src/server/schemas/message.ts`, `src/lib/slack/*`, `src/lib/messaging/{email,notify}.ts` (+ tests). One helper added: `src/server/runAfterResponse.ts`.

- **A1 (P2, Slack injection):** speaker-controlled `authorName`/`subject`/`excerpt` (and every other user string across the slack lib — proposal title/speakers/reason, volunteer fields, sponsor name/tier/signer) were interpolated into `mrkdwn` unescaped, so `<https://evil|CNCF Payroll>` rendered as a phishing link and `<!channel>` pinged the workspace. Added a shared `escapeMrkdwn` (`&`,`<`,`>`) in `slack/client.ts` and applied it to all user-controlled mrkdwn interpolations.
- **A2 (P2, no rate limit):** `message.send` had no throttle while it amplifies to Slack + N emails. Added a per-speaker sliding window (10 sends / 60s, size-capped module Map, per-instance serverless caveat noted like `push.ts`) that rejects the 11th with `TOO_MANY_REQUESTS`; only genuine post-validation sends consume a slot.
- **A3 (P3, existence oracle):** `getConversation`/`listMessages`/`send`(existing-thread)/`setPreference` returned `FORBIDDEN` when a conversation existed but access failed, leaking thread existence under deterministic ids. All now return `NOT_FOUND` ("Conversation not found") for both absent and inaccessible.
- **A4 (P2, conference guard):** the `conversationId` branch of `send` never checked the conversation's `conferenceId` against the domain-resolved conference, so a cross-conference post stamped wrong-domain email/Slack links. Now `NOT_FOUND` when `existing.conferenceId !== conferenceId`.
- **A5 (P3, recipient scoping):** organizer general-thread creation validated `recipientSpeakerId` only via `speakerExists` (any conference). Now requires the speaker to have standing in the CURRENT conference (a proposal in it) via a cheap existence probe, else `NOT_FOUND`.
- **A6 (P3, whitespace body):** `SendMessageSchema.body` was `min(1)`, so `' '` fanned out empty content. Changed to `z.string().trim().min(1).max(5000)` — whitespace-only rejected, interior whitespace preserved, 5000 cap kept.
- **A7 (P3, decision link divergence):** the status notification linked to `/cfp/proposal/<id>` while the relayed decision-comment message linked to `…#messages`. When a comment is present the status notification now targets `…#messages` too (smallest change: in `persistNotification.ts` where the link is built).
- **A8 (P2, blocking fan-out):** `send` and the proposal decision path `await`ed `notifyNewMessage`, whose email loop ran serial with `await delay(500)` per recipient → multi-second Send hangs. (1) `email.ts` now uses a bounded-concurrency pool (3, `Promise.allSettled`, never-fail preserved) instead of the serial delay loop; (2) the fan-out is detached from the response via `runAfterResponse` (Next's `after()`, with a self-catching fallback outside a request scope). The message is committed and returned before fan-out runs.
- **A9 (P3, email prefs link):** the prefs CTA now anchors at `/cfp/profile#notification-settings` for everyone, matching the in-app gear. NOTE: the audience-appropriate body copy ("replying reaches the organizers") lives in `src/components/email/MessageNotificationTemplate.tsx`, which is outside batch A's file territory — the copy change is deferred to the client/UI batch that owns `src/components/`.

Checks: `tsc --noEmit`, eslint (only a pre-existing unrelated warning), prettier, knip — all clean; full `vitest run` = 3030 passed / 5 skipped (204 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies nine server-hardening fixes (batch A) to the speaker↔organizer messaging subsystem, covering mrkdwn injection escaping, rate limiting, existence-oracle leakage, cross-conference guard, recipient scoping, whitespace body validation, notification link consistency, async fan-out decoupling, and email preferences URL.

- **A1 (Slack injection):** `escapeMrkdwn` is applied to every user-controlled string in `slack/notify.ts` — proposal/speaker/reason, volunteer fields, sponsor name/tier/signer — except `valueStr` (which includes `contractCurrency`) in `notifySponsorRegistrationComplete` and `notifySponsorContractSigned`; those two mrkdwn interpolations remain unescaped.
- **A2/A8 (rate limit + async fan-out):** a per-speaker sliding-window rate limiter guards the amplifying Slack+email fan-out, and the fan-out is detached from the response via `runAfterResponse` (Next `after()` with a self-catching fallback), so the Send button no longer hangs on large recipient sets.
- **A3–A7:** existence oracle, conference guard, recipient scoping, whitespace body, and decision-link divergence all fixed cleanly with targeted changes and full test coverage.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one targeted fix: the `contractCurrency` string is injected unescaped into two mrkdwn blocks in the sponsor notification functions.

The nine hardening fixes are well-implemented and thoroughly tested. The one gap is in `notifySponsorRegistrationComplete` and `notifySponsorContractSigned` where `valueStr` (containing `contractCurrency`) is interpolated into mrkdwn without `escapeMrkdwn`, while every other field in those same functions was escaped in this PR. All other changes — rate limiting, NOT_FOUND flattening, conference guard, speaker standing check, async fan-out, whitespace validation, and escape coverage elsewhere — are correct.

`src/lib/slack/notify.ts` — the `*Contract Value:*` mrkdwn block in both sponsor functions.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/slack/notify.ts | A1 mrkdwn-escape applied to all user-controlled fields except `valueStr` (contractCurrency) in both sponsor notification functions — two unescaped interpolations remain. |
| src/lib/slack/client.ts | Adds `escapeMrkdwn` helper — correct order (`&` first), exported cleanly, well-documented. |
| src/server/routers/message.ts | A2 rate-limit, A3 NOT_FOUND flattening, A4 conference-guard, A5 speaker-standing check all correctly implemented; fan-out detached via `runAfterResponse`. |
| src/server/runAfterResponse.ts | Thin, correct wrapper: tries `next/server after()`, falls back to a detached self-catching promise; no regressions. |
| src/lib/messaging/email.ts | Serial delay loop replaced with a 3-worker bounded-concurrency pool using JS single-threaded `cursor++` (race-safe); preference URL anchored; `delay` import removed cleanly. |
| src/server/schemas/message.ts | A6: body field now uses `z.string().trim().min(1).max(5000)` — whitespace-only bodies correctly rejected, interior whitespace preserved. |
| src/server/routers/proposal.ts | Decision notification fan-out detached from response path via `runAfterResponse`; minimal, correct change. |
| src/lib/events/handlers/persistNotification.ts | A7: status-notification link now points to `#messages` when a decision comment is present, matching the relayed message notification anchor. |
| __tests__/api/trpc/message.test.ts | Updated tests for A3 (NOT_FOUND), A4 (conference guard), A5 (speaker standing), A2 (rate limit) — new rate-limit test uses fake timers correctly. |
| __tests__/lib/messaging/email.test.ts | New test file verifying bounded concurrency (≤3 in-flight), never-throws contract, and correct delivered count; good coverage. |
| __tests__/lib/slack/client.test.ts | Adds unit tests for `escapeMrkdwn` covering `&`, `<`, `>`, double-escape safety, and plain text pass-through. |
| __tests__/lib/slack/notify.test.ts | Real `escapeMrkdwn` kept in mock (not stubbed out); injection test verifies no raw control sequences survive in rendered blocks. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant message.send as message.send (tRPC)
    participant claimSendSlot as claimSendSlot (A2)
    participant addMessage as addMessage (Sanity)
    participant runAfterResponse as runAfterResponse (A8)
    participant notifyNewMessage as notifyNewMessage (fan-out)
    participant Slack as Slack (escapeMrkdwn A1)
    participant Email as Email (pool A8)

    Client->>message.send: "send({ body, conversationId? })"
    message.send->>message.send: authz / conference guard (A3/A4/A5)
    message.send->>claimSendSlot: claimSendSlot(actorId)
    alt rate limit hit (A2)
        claimSendSlot-->>message.send: false
        message.send-->>Client: TOO_MANY_REQUESTS
    else allowed
        claimSendSlot-->>message.send: true
        message.send->>addMessage: persist message
        addMessage-->>message.send: message
        message.send->>runAfterResponse: schedule fan-out
        message.send-->>Client: "{ conversationId, message }"
        runAfterResponse->>notifyNewMessage: (after response)
        notifyNewMessage->>Slack: escapeMrkdwn(fields)
        notifyNewMessage->>Email: bounded pool (≤3 concurrent)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant message.send as message.send (tRPC)
    participant claimSendSlot as claimSendSlot (A2)
    participant addMessage as addMessage (Sanity)
    participant runAfterResponse as runAfterResponse (A8)
    participant notifyNewMessage as notifyNewMessage (fan-out)
    participant Slack as Slack (escapeMrkdwn A1)
    participant Email as Email (pool A8)

    Client->>message.send: "send({ body, conversationId? })"
    message.send->>message.send: authz / conference guard (A3/A4/A5)
    message.send->>claimSendSlot: claimSendSlot(actorId)
    alt rate limit hit (A2)
        claimSendSlot-->>message.send: false
        message.send-->>Client: TOO_MANY_REQUESTS
    else allowed
        claimSendSlot-->>message.send: true
        message.send->>addMessage: persist message
        addMessage-->>message.send: message
        message.send->>runAfterResponse: schedule fan-out
        message.send-->>Client: "{ conversationId, message }"
        runAfterResponse->>notifyNewMessage: (after response)
        notifyNewMessage->>Slack: escapeMrkdwn(fields)
        notifyNewMessage->>Email: bounded pool (≤3 concurrent)
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/slack/notify.ts`, line 447-452 ([link](https://github.com/cloudnativebergen/website/blob/93877bfad781cb4dd154182ad326540b727dfd2c/src/lib/slack/notify.ts#L447-L452)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`valueStr` missed by A1 escaping in two sponsor functions**

   `valueStr` is built as `` `${formatNumber(contractValue)} ${contractCurrency}` `` — `contractCurrency` is a Sanity CMS string field and can contain any character. Both `notifySponsorRegistrationComplete` (line 448) and `notifySponsorContractSigned` (line 519) interpolate it into an `mrkdwn` block without calling `escapeMrkdwn`, leaving a `<`, `>`, or `&` in a currency field able to render as a Slack link or special sequence. Every other sponsor field (`sponsorName`, `tierTitle`, `signerName`) was patched in this PR, but `valueStr` was not.


2. `src/lib/slack/notify.ts`, line 442-463 ([link](https://github.com/cloudnativebergen/website/blob/93877bfad781cb4dd154182ad326540b727dfd2c/src/lib/slack/notify.ts#L442-L463)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `valueStr` includes `contractCurrency`, a CMS string that can contain `<`, `>`, or `&`. Both `notifySponsorRegistrationComplete` and `notifySponsorContractSigned` have this same unescaped interpolation — apply `escapeMrkdwn` here the same way the other sponsor fields were treated in this PR.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): server hardening from ad..."](https://github.com/cloudnativebergen/website/commit/93877bfad781cb4dd154182ad326540b727dfd2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45417741)</sub>

<!-- /greptile_comment -->