### PR TITLE
fix(messaging): review batch C — thread UX

### DIFF
--- a/__tests__/components/admin/AdminActionBar.test.tsx
+++ b/__tests__/components/admin/AdminActionBar.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { AdminActionBar } from '@/components/admin/AdminActionBar'
+import {
+  ProposalExisting,
+  Format,
+  Language,
+  Level,
+  Audience,
+  Status,
+} from '@/lib/proposal/types'
+import type { Conference } from '@/lib/conference/types'
+
+// Lightweight stand-ins so the shortcut behaviour can be tested without the
+// modals' tRPC/query dependencies.
+vi.mock('@/components/admin/SendMessageModal', () => ({
+  SendMessageModal: () => <div data-testid="message-modal" />,
+}))
+vi.mock('@/components/admin/ProposalManagementModal', () => ({
+  ProposalManagementModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="edit-modal" /> : null,
+}))
+vi.mock('@/components/SpeakerProfilePreview', () => ({
+  default: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="preview-modal" /> : null,
+}))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}))
+
+const proposal = {
+  _id: 'prop-1',
+  _rev: '1',
+  _type: 'talk',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+  title: 'Scaling Kubernetes',
+  description: [],
+  language: Language.english,
+  format: Format.presentation_45,
+  level: Level.intermediate,
+  audiences: [Audience.developer],
+  status: Status.submitted,
+  outline: '',
+  topics: [],
+  tos: true,
+  speakers: [
+    {
+      _id: 'spk-1',
+      _rev: '1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      slug: 'jane-doe',
+    },
+  ],
+  conference: { _type: 'reference', _ref: 'conf-1' },
+  attachments: [],
+} as unknown as ProposalExisting
+
+const conference = { _id: 'conf-1' } as unknown as Conference
+
+const cmd = (key: string) => fireEvent.keyDown(window, { key, metaKey: true })
+
+afterEach(() => cleanup())
+
+describe('AdminActionBar keyboard shortcuts (C8)', () => {
+  it('opens the edit modal on ⌘E when no modal is open', () => {
+    render(<AdminActionBar proposal={proposal} conference={conference} />)
+    cmd('e')
+    expect(screen.getByTestId('edit-modal')).toBeInTheDocument()
+  })
+
+  it('suppresses global shortcuts while a modal is already open', () => {
+    render(<AdminActionBar proposal={proposal} conference={conference} />)
+
+    // Open the message modal via ⌘M.
+    cmd('m')
+    expect(screen.getByTestId('message-modal')).toBeInTheDocument()
+
+    // ⌘E must NOT stack a second focus-trapped modal on top.
+    cmd('e')
+    expect(screen.queryByTestId('edit-modal')).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/components/messaging/ConversationThread.test.tsx
+++ b/__tests__/components/messaging/ConversationThread.test.tsx
@@ -61,14 +61,102 @@ describe('ConversationThreadView', () => {
     ).toBeInTheDocument()
   })
 
-  it('calls onSend with the trimmed body and clears the composer', () => {
+  it('calls onSend with the trimmed body but keeps the draft until success', () => {
+    // The composer must NOT clear optimistically — a failed send would then
+    // silently discard the text. It clears only when sendResetKey advances.
     const onSend = vi.fn()
-    renderView({ onSend })
+    const { rerender } = renderView({ onSend, sendResetKey: 0 })
     const textarea = screen.getByLabelText(/write a message/i)
     fireEvent.change(textarea, { target: { value: '  Hello there  ' } })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
     expect(onSend).toHaveBeenCalledWith('Hello there')
+    // Draft preserved (success not yet signalled).
+    expect((textarea as HTMLTextAreaElement).value).toBe('  Hello there  ')
+
+    // Container signals success by advancing sendResetKey → composer clears.
+    rerender(
+      <ConversationThreadView
+        messages={messages}
+        emptyText="Start the conversation with the organizers."
+        onSend={onSend}
+        sendResetKey={1}
+      />,
+    )
     expect((textarea as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('surfaces a send error with a Retry that keeps the failed draft (C2)', () => {
+    const onSend = vi.fn()
+    renderView({ onSend, sendError: true })
+    const textarea = screen.getByLabelText(/write a message/i)
+    fireEvent.change(textarea, { target: { value: 'important reply' } })
+
+    // The inline error is announced and the draft is preserved.
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn.t send/i)
+    expect((textarea as HTMLTextAreaElement).value).toBe('important reply')
+
+    // Retry re-submits the same preserved text.
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(onSend).toHaveBeenCalledWith('important reply')
+    expect((textarea as HTMLTextAreaElement).value).toBe('important reply')
+  })
+
+  it('fires onSend only once for a rapid double-activation (C6)', () => {
+    const onSend = vi.fn()
+    renderView({ onSend })
+    const textarea = screen.getByLabelText(/write a message/i)
+    fireEvent.change(textarea, { target: { value: 'no dupes' } })
+    const sendButton = screen.getByRole('button', { name: 'Send' })
+    fireEvent.click(sendButton)
+    fireEvent.click(sendButton)
+    expect(onSend).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders read-only notice and disables prefs while impersonating (C1)', () => {
+    const onSend = vi.fn()
+    const onSetMuted = vi.fn()
+    renderView({ onSend, onSetMuted, preference, readOnly: true })
+
+    // Composer is replaced by a subtle notice — no textarea to post as them.
+    expect(screen.queryByLabelText(/write a message/i)).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/read-only while impersonating/i),
+    ).toBeInTheDocument()
+
+    // The preferences bar is present but its mutations are disabled.
+    const muteButton = screen.getByRole('button', { name: /mute/i })
+    expect(muteButton).toBeDisabled()
+    fireEvent.click(muteButton)
+    expect(onSetMuted).not.toHaveBeenCalled()
+  })
+
+  it('exposes a polite live region for newly appended messages (C7)', () => {
+    const { container, rerender } = renderView()
+    const live = container.querySelector('[aria-live="polite"]')
+    expect(live).toBeInTheDocument()
+    // Nothing announced on the initial render (no spam).
+    expect(live).toHaveTextContent('')
+
+    // A new message from someone else is announced politely.
+    const withNew: DisplayMessage[] = [
+      ...messages,
+      {
+        id: 'm3',
+        authorName: 'Program Committee',
+        isOrganizer: true,
+        isOwn: false,
+        body: 'One more thing…',
+        createdAt: new Date().toISOString(),
+      },
+    ]
+    rerender(
+      <ConversationThreadView
+        messages={withNew}
+        emptyText="Start the conversation with the organizers."
+        onSend={vi.fn()}
+      />,
+    )
+    expect(live).toHaveTextContent('New message from Program Committee')
   })
 
   it('disables Send when the composer is empty or whitespace', () => {

--- a/__tests__/components/messaging/ConversationThreadContainer.test.tsx
+++ b/__tests__/components/messaging/ConversationThreadContainer.test.tsx
@@ -2,12 +2,25 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { ConversationThread } from '@/components/messaging'
 
+// Mutable session the mocked `useSession()` returns; each test may override it
+// (e.g. to exercise the impersonation read-only mode).
+let mockSession: {
+  speaker?: { _id: string }
+  isImpersonating?: boolean
+} | null = { speaker: { _id: 'me' } }
 vi.mock('next-auth/react', () => ({
-  useSession: () => ({ data: { speaker: { _id: 'me' } } }),
+  useSession: () => ({ data: mockSession }),
 }))
+
+// jsdom leaves visibilityState unset; the C4 "re-mark while visible" path needs
+// it to read as visible.
+Object.defineProperty(document, 'visibilityState', {
+  configurable: true,
+  get: () => 'visible',
+})
 
 // --- tRPC surface, driven by mutable state the tests set before rendering ---
 const markReadMutate = vi.fn()
@@ -65,6 +78,39 @@ function loadedMessages() {
   }
 }
 
+function messagesPage(
+  items: Array<{
+    _id: string
+    authorId: string
+    body: string
+    createdAt: string
+  }>,
+) {
+  return {
+    data: { pages: [items] },
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }
+}
+
+const NOT_FOUND = { data: { code: 'NOT_FOUND' } }
+function notFoundMessages() {
+  return {
+    data: undefined,
+    isLoading: false,
+    isError: true,
+    isSuccess: false,
+    error: NOT_FOUND,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }
+}
+
 function generalConversation(id: string) {
   return {
     data: {
@@ -85,6 +131,7 @@ beforeEach(() => {
   unreadCountInvalidate.mockClear()
   notificationListInvalidate.mockClear()
   markReadOnSuccess = undefined
+  mockSession = { speaker: { _id: 'me' } }
 })
 
 describe('ConversationThread — auto-mark-read', () => {
@@ -153,5 +200,103 @@ describe('ConversationThread — auto-mark-read', () => {
       />,
     )
     expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  it('never marks read while impersonating a speaker (C1)', () => {
+    mockSession = { speaker: { _id: 'me' }, isImpersonating: true }
+    getConversationResult = generalConversation('conversation.abc')
+    listMessagesResult = messagesPage([
+      {
+        _id: 'm1',
+        authorId: 'org',
+        body: 'hi',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ])
+
+    render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+
+    expect(markReadMutate).not.toHaveBeenCalled()
+    // Composer is replaced by the read-only notice.
+    expect(
+      screen.getByText(/read-only while impersonating/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText(/write a message/i)).not.toBeInTheDocument()
+  })
+
+  it('re-marks read when a newer message arrives while visible (C4)', () => {
+    getConversationResult = generalConversation('conversation.abc')
+    listMessagesResult = messagesPage([
+      {
+        _id: 'm1',
+        authorId: 'org',
+        body: 'hi',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ])
+
+    const { rerender } = render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+    expect(markReadMutate).toHaveBeenCalledTimes(1)
+
+    // A newer message lands via the poll (server newest-first, so it's the new
+    // head of the page) — the newest id advances while the tab is visible.
+    listMessagesResult = messagesPage([
+      {
+        _id: 'm2',
+        authorId: 'org',
+        body: 'new',
+        createdAt: '2026-01-01T00:05:00Z',
+      },
+      {
+        _id: 'm1',
+        authorId: 'org',
+        body: 'hi',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ])
+    rerender(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+    expect(markReadMutate).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('ConversationThread — not-found scoping (C5)', () => {
+  it('shows the error state (no composer) for a not-found conversationId', () => {
+    getConversationResult = { data: undefined, error: NOT_FOUND }
+    listMessagesResult = notFoundMessages()
+
+    render(
+      <ConversationThread
+        conversationId="conversation.zzz"
+        audience="speaker"
+      />,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn.t load/i)
+    expect(screen.queryByLabelText(/write a message/i)).not.toBeInTheDocument()
+  })
+
+  it('shows an empty startable thread (with composer) for a not-found proposalId', () => {
+    getConversationResult = { data: undefined, error: NOT_FOUND }
+    listMessagesResult = notFoundMessages()
+
+    render(<ConversationThread proposalId="prop-1" audience="speaker" />)
+
+    expect(screen.getByText(/start the conversation/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/write a message/i)).toBeInTheDocument()
   })
 })

--- a/src/app/(admin)/admin/messages/[id]/page.tsx
+++ b/src/app/(admin)/admin/messages/[id]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
 import { BackLink } from '@/components/BackButton'
 import { ConversationThread } from '@/components/messaging'
+import { getAuthSession } from '@/lib/auth'
 
 export const metadata: Metadata = {
   title: 'Conversation',
@@ -16,14 +18,28 @@ export default async function AdminConversationPage({
 }: AdminConversationPageProps) {
   const { id } = await params
 
+  // The admin layout already denies non-organizers, but redirect any speaker
+  // who reaches this route to their own labelled surface rather than the bare
+  // "Access Denied" wall (audience-correct deep link, admin mirror of /cfp).
+  const session = await getAuthSession()
+  if (session?.speaker && !session.speaker.isOrganizer) {
+    redirect(`/cfp/messages/${id}`)
+  }
+
   return (
-    <div className="mx-auto max-w-3xl p-4">
-      <div className="mb-4">
+    // dvh-bounded column so the composer stays pinned above the iOS PWA
+    // keyboard: the message list flexes and scrolls, the composer does not.
+    <div className="mx-auto flex h-[100dvh] max-w-3xl flex-col p-4">
+      <div className="mb-4 shrink-0">
         <BackLink fallbackUrl="/admin/messages">Back to Messages</BackLink>
       </div>
 
-      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-        <ConversationThread conversationId={id} audience="organizer" />
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <ConversationThread
+          conversationId={id}
+          audience="organizer"
+          fillHeight
+        />
       </div>
     </div>
   )

--- a/src/app/(cfp)/cfp/messages/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/messages/[id]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
 import { BackLink } from '@/components/BackButton'
 import { ConversationThread } from '@/components/messaging'
+import { getAuthSession } from '@/lib/auth'
 
 export const metadata: Metadata = {
   title: 'Conversation',
@@ -16,14 +18,23 @@ export default async function CfpConversationPage({
 }: CfpConversationPageProps) {
   const { id } = await params
 
+  // Audience-correct deep link: an organizer following a handed /cfp link would
+  // otherwise land on a speaker-labelled surface. Send them to the admin thread.
+  const session = await getAuthSession()
+  if (session?.speaker?.isOrganizer && !session.isImpersonating) {
+    redirect(`/admin/messages/${id}`)
+  }
+
   return (
-    <div className="mx-auto max-w-3xl">
-      <div className="mb-4">
+    // dvh-bounded column so the composer stays pinned above the iOS PWA
+    // keyboard: the message list flexes and scrolls, the composer does not.
+    <div className="mx-auto flex h-[100dvh] max-w-3xl flex-col">
+      <div className="mb-4 shrink-0">
         <BackLink fallbackUrl="/cfp/messages">Back to Messages</BackLink>
       </div>
 
-      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-        <ConversationThread conversationId={id} audience="speaker" />
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <ConversationThread conversationId={id} audience="speaker" fillHeight />
       </div>
     </div>
   )

--- a/src/components/admin/AdminActionBar.tsx
+++ b/src/components/admin/AdminActionBar.tsx
@@ -110,7 +110,12 @@ export function AdminActionBar({ proposal, conference }: AdminActionBarProps) {
     proposal.status === 'accepted' || proposal.status === 'confirmed'
 
   // Keyboard shortcuts
+  const anyModalOpen = showMessageModal || showEditModal || showPreviewModal
   useEffect(() => {
+    // Suppress the bar's global shortcuts while any of its modals is open, so
+    // ⌘E/⌘P/⌘M can't stack a second focus-trapped modal on top of the first.
+    if (anyModalOpen) return
+
     const handleKeyDown = (event: KeyboardEvent) => {
       // Check if Cmd (Mac) or Ctrl (Windows/Linux) is pressed
       const isCmdOrCtrl = event.metaKey || event.ctrlKey
@@ -142,7 +147,7 @@ export function AdminActionBar({ proposal, conference }: AdminActionBarProps) {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [speakers, handleMessageSpeakers, handlePreviewSpeaker])
+  }, [speakers, handleMessageSpeakers, handlePreviewSpeaker, anyModalOpen])
   const {
     isSeasonedSpeaker,
     isNewSpeaker,

--- a/src/components/admin/NotificationProvider.tsx
+++ b/src/components/admin/NotificationProvider.tsx
@@ -98,7 +98,11 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     >
       {children}
 
-      <div className="pointer-events-none fixed inset-0 z-[60] flex flex-col items-end justify-end space-y-6 p-6 pr-8 pb-8">
+      <div
+        role="status"
+        aria-live="polite"
+        className="pointer-events-none fixed inset-0 z-[60] flex flex-col items-end justify-end space-y-6 p-6 pr-8 pb-8"
+      >
         {notifications.map((notification) => (
           <NotificationToast
             key={notification.id}

--- a/src/components/messaging/ConversationThread.stories.tsx
+++ b/src/components/messaging/ConversationThread.stories.tsx
@@ -39,6 +39,23 @@ const makeMessages = (): DisplayMessage[] => [
   },
 ]
 
+// A long back-and-forth history, oldest-first, for verifying that the thread
+// opens scrolled to the NEWEST message rather than the top.
+const makeLongHistory = (): DisplayMessage[] =>
+  Array.from({ length: 24 }, (_, i) => {
+    const organizer = i % 2 === 0
+    return {
+      id: `h${i}`,
+      authorName: organizer ? 'Program Committee' : 'Åsa Berg',
+      isOrganizer: organizer,
+      isOwn: !organizer,
+      body: organizer
+        ? `Follow-up point ${i + 1}: could you clarify the section on autoscaling and node pools?`
+        : `Reply ${i + 1}: sure — I have updated the abstract and outline accordingly.`,
+      createdAt: minutesAgo((24 - i) * 15),
+    }
+  })
+
 const defaultPreference: ConversationPreference = {
   muted: false,
   emailOverride: 'default',
@@ -143,4 +160,79 @@ export const EmptyDark: Story = {
     onSetMuted: undefined,
   },
   parameters: { dark: true },
+}
+
+/**
+ * The last send failed: an inline error sits above the composer, the drafted
+ * text is preserved in the textarea, and a Retry affordance re-submits it.
+ */
+export const SendError: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+    sendError: true,
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/** Dark theme, send-error state. */
+export const SendErrorDark: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+    sendError: true,
+  },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/**
+ * A long history: the scroll container should open pinned to the NEWEST message
+ * (bottom), not the oldest (top).
+ */
+export const LongHistory: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeLongHistory()} />
+  ),
+}
+
+/** Dark theme, long history (scroll-to-newest verification). */
+export const LongHistoryDark: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+  },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeLongHistory()} />
+  ),
+}
+
+/**
+ * Impersonation read-only mode: the composer is replaced by a subtle notice and
+ * the preferences bar is disabled — an admin viewing as a speaker cannot post
+ * or mutate preferences as them.
+ */
+export const ReadOnlyImpersonation: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: defaultPreference,
+    readOnly: true,
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
 }

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -57,6 +57,29 @@ export interface ConversationThreadViewProps {
   /** Send a (trimmed, non-empty) message body. */
   onSend: (body: string) => void
   isSending?: boolean
+  /**
+   * True when the most recent send FAILED. The composer keeps the failed draft,
+   * an inline error is shown above it, and a Retry affordance re-submits.
+   */
+  sendError?: boolean
+  /**
+   * Advances (via the container) on every SUCCESSFUL send. The composer clears
+   * its draft only when this changes — never optimistically — so a failed send
+   * can't silently discard the text.
+   */
+  sendResetKey?: number
+  /**
+   * Fill the parent's height (standalone thread page): the message list flexes
+   * and the composer is pinned to the bottom. Default `false` keeps the normal
+   * flow used by the proposal `#messages` embed.
+   */
+  fillHeight?: boolean
+  /**
+   * Impersonation read-only mode: the composer is replaced by a subtle notice
+   * and the preferences bar is disabled, so an admin viewing as a speaker can't
+   * post or mutate preferences as them.
+   */
+  readOnly?: boolean
   /** Reports composer focus so the container can pause polling while typing. */
   onComposingChange?: (composing: boolean) => void
   /**
@@ -125,11 +148,14 @@ function PreferencesBar({
   onSetMuted,
   onSetEmailOverride,
   isSavingPreference,
+  readOnly = false,
 }: {
   preference: ConversationPreference
   onSetMuted: (muted: boolean) => void
   onSetEmailOverride?: (override: EmailOverride) => void
   isSavingPreference?: boolean
+  /** Impersonation: render the controls but block every mutation. */
+  readOnly?: boolean
 }) {
   const { muted, emailOverride } = preference
   return (
@@ -137,7 +163,7 @@ function PreferencesBar({
       <button
         type="button"
         onClick={() => onSetMuted(!muted)}
-        disabled={isSavingPreference}
+        disabled={isSavingPreference || readOnly}
         aria-pressed={muted}
         title={muted ? 'Muted — click to unmute' : 'Mute this conversation'}
         className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
@@ -154,7 +180,7 @@ function PreferencesBar({
         <span>Emails</span>
         <select
           value={emailOverride}
-          disabled={isSavingPreference || !onSetEmailOverride}
+          disabled={isSavingPreference || readOnly || !onSetEmailOverride}
           onChange={(e) =>
             onSetEmailOverride?.(e.target.value as EmailOverride)
           }
@@ -186,6 +212,10 @@ export function ConversationThreadView({
   subject,
   onSend,
   isSending = false,
+  sendError = false,
+  sendResetKey,
+  fillHeight = false,
+  readOnly = false,
   onComposingChange,
   preference,
   onSetMuted,
@@ -195,12 +225,36 @@ export function ConversationThreadView({
   const [draft, setDraft] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
+  // Synchronous in-flight guard: `isSending` reflects the PREVIOUS render, so a
+  // fast double-activation would slip through before it flips. This ref blocks
+  // the second fire immediately and is released when the send settles (a
+  // `sendResetKey` advance on success, or `sendError` flipping true on failure).
+  const sendingRef = useRef(false)
+
   const submit = () => {
     const body = draft.trim()
-    if (!body || isSending) return
+    if (!body || isSending || sendingRef.current) return
+    sendingRef.current = true
     onSend(body)
-    setDraft('')
   }
+
+  // Clear the composer ONLY after a send succeeds (the container advances
+  // `sendResetKey`); skipped on the initial mount so an in-progress draft is
+  // never wiped on first render.
+  const didMountRef = useRef(false)
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true
+      return
+    }
+    setDraft('')
+    sendingRef.current = false
+  }, [sendResetKey])
+
+  // A failed send releases the guard so the preserved draft can be retried.
+  useEffect(() => {
+    if (sendError) sendingRef.current = false
+  }, [sendError])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
@@ -209,11 +263,69 @@ export function ConversationThreadView({
     }
   }
 
+  // Scroll management + a polite live region for newly appended messages.
+  // Newest-at-bottom means an incoming message changes the LAST id; a
+  // "Show earlier messages" load prepends and leaves the last id untouched.
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const nearBottomRef = useRef(true)
+  const lastIdRef = useRef<string | null>(null)
+  const hadMessagesRef = useRef(false)
+  const [liveMessage, setLiveMessage] = useState('')
+
+  const handleScroll = () => {
+    const el = scrollRef.current
+    if (!el) return
+    // Within ~80px of the bottom counts as "following the conversation".
+    nearBottomRef.current =
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80
+  }
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (messages.length === 0) {
+      hadMessagesRef.current = false
+      lastIdRef.current = null
+      return
+    }
+    const last = messages[messages.length - 1]
+    const prevLastId = lastIdRef.current
+    const prefersReduced =
+      typeof window !== 'undefined' &&
+      !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+
+    if (!hadMessagesRef.current) {
+      // Initial load: jump straight to the newest message (no animation).
+      if (el) el.scrollTop = el.scrollHeight
+    } else if (last.id !== prevLastId) {
+      // A genuinely new message arrived. Only follow it if the reader is
+      // already near the bottom — don't yank them up mid-history-read.
+      if (el && nearBottomRef.current) {
+        if (typeof el.scrollTo === 'function') {
+          el.scrollTo({
+            top: el.scrollHeight,
+            behavior: prefersReduced ? 'auto' : 'smooth',
+          })
+        } else {
+          el.scrollTop = el.scrollHeight
+        }
+      }
+      // Announce it politely (skip the viewer's own outgoing messages). This
+      // derives an assistive-tech announcement from an incoming-message event —
+      // a legitimate effect→state sync, not render-derived state.
+      if (!last.isOwn) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setLiveMessage(`New message from ${last.authorName}`)
+      }
+    }
+    hadMessagesRef.current = true
+    lastIdRef.current = last.id
+  }, [messages])
+
   return (
     <div
       role="region"
       aria-label={subject ? `Conversation: ${subject}` : 'Conversation'}
-      className="flex flex-col"
+      className={fillHeight ? 'flex min-h-0 flex-1 flex-col' : 'flex flex-col'}
     >
       {(subject || onSetMuted) && (
         <div className="flex items-center justify-between gap-3 border-b border-gray-200 pb-3 dark:border-gray-700">
@@ -230,12 +342,19 @@ export function ConversationThreadView({
               onSetMuted={onSetMuted}
               onSetEmailOverride={onSetEmailOverride}
               isSavingPreference={isSavingPreference}
+              readOnly={readOnly}
             />
           )}
         </div>
       )}
 
-      <div className="max-h-[60vh] min-h-[8rem] space-y-3 overflow-y-auto py-4">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className={`space-y-3 overflow-y-auto overscroll-contain py-4 ${
+          fillHeight ? 'min-h-0 flex-1' : 'max-h-[60vh] min-h-[8rem]'
+        }`}
+      >
         {isLoading ? (
           <MessageSkeleton />
         ) : isError ? (
@@ -277,38 +396,78 @@ export function ConversationThreadView({
         )}
       </div>
 
-      <div className="border-t border-gray-200 pt-3 dark:border-gray-700">
-        <label htmlFor="message-composer" className="sr-only">
-          Write a message
-        </label>
-        <textarea
-          id="message-composer"
-          ref={textareaRef}
-          value={draft}
-          maxLength={MAX_BODY}
-          rows={3}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onFocus={() => onComposingChange?.(true)}
-          onBlur={() => onComposingChange?.(false)}
-          placeholder="Write a message…"
-          className="block w-full resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-brand-cloud-blue focus:outline-none focus-visible:ring-1 focus-visible:ring-brand-cloud-blue dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder-gray-500"
-        />
-        <div className="mt-2 flex items-center justify-between">
-          <span className="text-xs text-gray-400 dark:text-gray-500">
-            {draft.length}/{MAX_BODY} · ⌘/Ctrl+Enter to send
-          </span>
-          <button
-            type="button"
-            onClick={submit}
-            disabled={draft.trim().length === 0 || isSending}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-500"
-          >
-            <PaperAirplaneIcon className="h-4 w-4" aria-hidden="true" />
-            {isSending ? 'Sending…' : 'Send'}
-          </button>
-        </div>
+      {/* Polite live region: announces newly appended messages to screen
+          readers without stealing focus. Empty on initial load (no spam). */}
+      <div aria-live="polite" className="sr-only">
+        {liveMessage}
       </div>
+
+      {readOnly ? (
+        <div className="border-t border-gray-200 pt-3 dark:border-gray-700">
+          <p className="rounded-lg bg-gray-50 px-3 py-2.5 text-center text-xs text-gray-500 dark:bg-gray-800/60 dark:text-gray-400">
+            You&apos;re viewing this conversation as the speaker. Messaging is
+            read-only while impersonating.
+          </p>
+        </div>
+      ) : (
+        !isError && (
+          <div
+            className={`border-t border-gray-200 pt-3 dark:border-gray-700 ${
+              fillHeight
+                ? 'shrink-0 pb-[max(0.25rem,env(safe-area-inset-bottom))]'
+                : ''
+            }`}
+          >
+            {sendError && (
+              <div
+                role="alert"
+                className="mb-2 flex items-center justify-between gap-3 rounded-lg border border-red-300/60 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-400/30 dark:bg-red-900/20 dark:text-red-300"
+              >
+                <span>
+                  Couldn&apos;t send your message. Your text is saved.
+                </span>
+                <button
+                  type="button"
+                  onClick={submit}
+                  className="shrink-0 rounded-md px-2 py-1 font-semibold text-red-700 underline-offset-2 transition hover:bg-red-100 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 dark:text-red-300 dark:hover:bg-red-900/40"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+            <label htmlFor="message-composer" className="sr-only">
+              Write a message
+            </label>
+            <textarea
+              id="message-composer"
+              ref={textareaRef}
+              value={draft}
+              maxLength={MAX_BODY}
+              rows={3}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onFocus={() => onComposingChange?.(true)}
+              onBlur={() => onComposingChange?.(false)}
+              placeholder="Write a message…"
+              className="block w-full resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-brand-cloud-blue focus:outline-none focus-visible:ring-1 focus-visible:ring-brand-cloud-blue dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:placeholder-gray-500"
+            />
+            <div className="mt-2 flex items-center justify-between">
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {draft.length}/{MAX_BODY} · ⌘/Ctrl+Enter to send
+              </span>
+              <button
+                type="button"
+                onClick={submit}
+                disabled={draft.trim().length === 0 || isSending}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-500"
+              >
+                <PaperAirplaneIcon className="h-4 w-4" aria-hidden="true" />
+                {isSending ? 'Sending…' : 'Send'}
+              </button>
+            </div>
+          </div>
+        )
+      )}
     </div>
   )
 }
@@ -327,6 +486,11 @@ export interface ConversationThreadProps {
   proposalId?: string
   /** The viewer's audience — only affects the empty-state wording. */
   audience: 'speaker' | 'organizer'
+  /**
+   * Fill the parent's height (standalone thread pages) so the composer pins to
+   * the bottom above the mobile keyboard. Left `false` for the proposal embed.
+   */
+  fillHeight?: boolean
 }
 
 /**
@@ -343,9 +507,15 @@ export function ConversationThread({
   conversationId,
   proposalId,
   audience,
+  fillHeight = false,
 }: ConversationThreadProps) {
   const { data: session } = useSession()
   const meId = session?.speaker?._id
+  // IMPERSONATION: while an admin views as a speaker, every query/mutation is
+  // scoped to the SPEAKER. Marking their notifications read or posting/mutating
+  // preferences as them would corrupt their real state, so the thread goes
+  // read-only (mirrors NotificationPanel).
+  const isImpersonating = session?.isImpersonating === true
   const utils = api.useUtils()
   const [isComposing, setIsComposing] = useState(false)
 
@@ -381,7 +551,15 @@ export function ConversationThread({
       initialCursor: undefined,
     },
   )
+  // NOT_FOUND means "no such conversation OR you can't access it" (the server
+  // no longer distinguishes non-participants). Treat it as a startable empty
+  // thread ONLY in the proposal auto-create context — the first send with a
+  // `proposalId` materialises the conversation. For a bare `conversationId`
+  // there is nothing to create, so a not-found there is a real error (e.g. a
+  // non-participant following a handed link) and must surface as such rather
+  // than a working composer whose sends would fail.
   const messagesNotFound = errorCode(messagesQuery.error) === 'NOT_FOUND'
+  const notFoundIsEmpty = messagesNotFound && !!proposalId
 
   const participants = conversationQuery.data?.participants
   const participantById = useMemo(() => {
@@ -440,16 +618,41 @@ export function ConversationThread({
   // listener resets the guard so a regained tab re-marks any newly-read items.
   const markedKeyRef = useRef<string | null>(null)
   const markRead = useCallback(() => {
-    if (!markReadLinks || !messagesLoaded) return
+    // Never mark read while impersonating — it would destroy the speaker's
+    // real unread state (their inbox is what these queries are scoped to).
+    if (!markReadLinks || !messagesLoaded || isImpersonating) return
     const key = markReadLinks.join('|')
     if (markedKeyRef.current === key) return
     markedKeyRef.current = key
     markReadMutate({ links: markReadLinks })
-  }, [markReadLinks, messagesLoaded, markReadMutate])
+  }, [markReadLinks, messagesLoaded, markReadMutate, isImpersonating])
 
   useEffect(() => {
     markRead()
   }, [markRead])
+
+  // A message arriving via the 20s poll while the thread is open + visible is
+  // rendered on screen but its bell notification would stay unread until the
+  // tab blurs/refocuses (markRead fires once per key). Re-mark when the newest
+  // message id advances while the document is visible so the bell stays honest.
+  const newestMessageId = messages[messages.length - 1]?.id
+  const prevNewestIdRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    const prev = prevNewestIdRef.current
+    prevNewestIdRef.current = newestMessageId
+    // Only on a genuine advance (not the initial load, which the effect above
+    // already handles) and only when the reader can actually see it.
+    if (!newestMessageId || prev === undefined || prev === newestMessageId) {
+      return
+    }
+    if (
+      typeof document === 'undefined' ||
+      document.visibilityState === 'visible'
+    ) {
+      markedKeyRef.current = null
+      markRead()
+    }
+  }, [newestMessageId, markRead])
 
   useEffect(() => {
     const onFocus = () => {
@@ -474,7 +677,16 @@ export function ConversationThread({
     utils.message.listConversations.invalidate()
   }
 
-  const sendMutation = api.message.send.useMutation({ onSuccess: invalidate })
+  // Advances on every successful send; the presentational view watches this to
+  // clear the composer ONLY on success (never optimistically), so a failed send
+  // keeps the drafted text instead of silently discarding it.
+  const [sendSuccessKey, setSendSuccessKey] = useState(0)
+  const sendMutation = api.message.send.useMutation({
+    onSuccess: () => {
+      setSendSuccessKey((k) => k + 1)
+      invalidate()
+    },
+  })
   const preferenceMutation = api.message.setPreference.useMutation({
     onSuccess: invalidate,
   })
@@ -497,8 +709,8 @@ export function ConversationThread({
   return (
     <ConversationThreadView
       messages={messages}
-      isLoading={messagesQuery.isLoading && !messagesNotFound}
-      isError={messagesQuery.isError && !messagesNotFound}
+      isLoading={messagesQuery.isLoading && !notFoundIsEmpty}
+      isError={messagesQuery.isError && !notFoundIsEmpty}
       hasMore={messagesQuery.hasNextPage}
       onShowMore={() => messagesQuery.fetchNextPage()}
       isLoadingMore={messagesQuery.isFetchingNextPage}
@@ -506,6 +718,10 @@ export function ConversationThread({
       subject={conversationQuery.data?.conversation.subject}
       onSend={handleSend}
       isSending={sendMutation.isPending}
+      sendError={sendMutation.isError}
+      sendResetKey={sendSuccessKey}
+      fillHeight={fillHeight}
+      readOnly={isImpersonating}
       onComposingChange={setIsComposing}
       preference={conversationQuery.data?.preference}
       onSetMuted={


### PR DESCRIPTION
Batch C (THREAD UX) from the adversarial messaging review. All changes are scoped to the ConversationThread surface, the standalone thread pages, AdminActionBar, and the notification toast provider.

Note: a parallel server batch changes non-participant access errors from FORBIDDEN to NOT_FOUND; this batch treats any inaccessible thread uniformly (does not distinguish them).

## Fixes

- **C1 (P1, impersonation):** ConversationThread now mirrors NotificationPanel's `isImpersonating` guard. While an admin views as a speaker: the auto-mark-read effect is skipped (no destroying the speaker's real unread), the composer is replaced by a subtle read-only notice, and the preferences bar is disabled (no mutations).
- **C2 (P1, silent send failure + draft loss):** the composer no longer clears optimistically — it clears only on send **success** (container advances `sendResetKey`). A failed send (`sendMutation.isError`) surfaces an inline error above the composer, keeps the failed text in the textarea, and offers a Retry. New `SendError` story.
- **C3 (P1, no scroll-to-latest):** the message list now opens scrolled to the newest message and follows new messages only when the reader is already near the bottom (never yanks them up mid-history-read). Respects `prefers-reduced-motion` (instant vs smooth). New `LongHistory` story for verification.
- **C4 (P2, stale bell while viewing):** mark-read re-runs when the newest message id advances while `document.visibilityState === 'visible'`, so a message arriving via the 20s poll clears its bell notification without needing a blur/refocus.
- **C5 (P2, NOT_FOUND-as-empty too broad):** a not-found result is treated as a startable empty thread **only** when a `proposalId` is provided (the auto-create context). A bare `conversationId` that is not found now renders the error state with no composer, instead of a working composer whose sends would fail.
- **C6 (P2, double-send):** a synchronous ref guard inside `submit()` blocks a fast double-activation from double-firing `onSend`; released when the send settles.
- **C7 (P3, live regions):** the toast stack is wrapped in `role="status" aria-live="polite"`; the thread has a polite visually-hidden live region announcing newly appended messages (no announcement spam on initial load).
- **C8 (P3, shortcut stacking):** AdminActionBar's global ⌘E/⌘P/⌘M shortcuts are suppressed while any of its modals is open, so a second focus-trapped modal can't stack on the first.
- **C9 (P3, wrong-audience deep link):** `/cfp/messages/[id]` redirects organizers to `/admin/messages/<id>`; `/admin/messages/[id]` redirects speakers to `/cfp/messages/<id>` (the admin layout already denies non-organizers; this replaces the bare "Access Denied" wall).
- **C10 (P3, iOS keyboard):** the standalone thread pages are now dvh-bounded flex columns (list flexes/scrolls, composer pinned) with safe-area padding, so the iOS PWA keyboard can't cover the composer. The proposal-page `#messages` embed keeps normal flow (`fillHeight` opt-in).

## Verification

- tsc, eslint (only a pre-existing unrelated warning), prettier, knip all clean.
- Full `pnpm vitest run`: 204 files, 3029 passed / 5 skipped. Added tests for C1, C2, C4, C5, C6, C7, C8.
- Visual QA (`pnpm shoot` @ 393 light+dark) on ConversationThread stories incl. new SendError, LongHistory, ReadOnlyImpersonation. LongHistory confirms the thread opens pinned to the newest message; SendError banner + Retry render correctly in both themes; read-only notice replaces the composer with a disabled prefs bar. No horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This batch applies ten UX fixes to the ConversationThread surface, AdminActionBar, and the toast provider, covering impersonation safety (C1), draft-preserving send failure (C2), scroll-to-latest (C3), stale-bell correction on poll (C4), NOT_FOUND scoping (C5), double-send guard (C6), ARIA live regions (C7), shortcut stacking (C8), wrong-audience redirects (C9), and iOS dvh keyboard layout (C10). The component logic, tests, and stories for C1–C8 are well-implemented and thoroughly verified.

- **C1–C8 (component layer):** The impersonation guard, non-optimistic draft clearing, `sendingRef` double-send protection, NOT_FOUND scoping, scroll management, and ARIA improvements are all correct; new tests tightly cover each path.
- **C9 (redirects):** The `isImpersonating` guard on the CFP→admin redirect is correctly placed, preventing an admin-impersonating-speaker from being bounced back to the admin surface.
- **C10 (dvh layout):** Both page files use `h-[100dvh]` on the content div, but that div sits inside `DashboardLayout`'s sticky header (~56–64 px) and padded `<main>` (16–40 px); the page therefore overflows the viewport by ~88–144 px and the composer is not visible on initial load without scrolling.

<h3>Confidence Score: 3/5</h3>

The component-layer fixes (C1–C8) are safe and well-tested, but both standalone thread pages introduce a layout that doesn't account for the surrounding DashboardLayout chrome, leaving the composer below the fold on both desktop and mobile.

C1–C8 are carefully implemented with matching unit tests covering the most security-sensitive path (impersonation). C9 redirects are correct. C10 breaks down: both page files set h-[100dvh] inside a layout with a sticky header and padded main, pushing the composer below the visible fold on initial load — the opposite of the intended behaviour. The visual QA ran against isolated Storybook stories, not the full-page layout, so the overflow wasn't caught.

src/app/(admin)/admin/messages/[id]/page.tsx and src/app/(cfp)/cfp/messages/[id]/page.tsx — both use h-[100dvh] inside DashboardLayout without accounting for the sticky header and main padding.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/messaging/ConversationThread.tsx | Major rework: impersonation guard (C1), non-optimistic draft clearing (C2), scroll-to-latest with near-bottom follow (C3), re-mark-read on poll arrival (C4), NOT_FOUND scoping (C5), double-send ref guard (C6), and ARIA live region (C7). Two issues: initial scroll uses useEffect (post-paint flash) and live region skipped for back-to-back same-author messages. |
| src/app/(admin)/admin/messages/[id]/page.tsx | Adds speaker-to-organizer redirect (C9) and dvh flex layout (C10), but h-[100dvh] inside DashboardLayout's sticky header and padded main causes ~88–144 px overflow; composer not visible on load without scrolling. |
| src/app/(cfp)/cfp/messages/[id]/page.tsx | Adds organizer-to-speaker redirect (C9, correctly guarded by !isImpersonating) and same dvh layout; carries the same h-[100dvh] overflow issue, worsened when ImpersonationBanner is present. |
| src/components/admin/AdminActionBar.tsx | C8: correctly suppresses global keyboard shortcuts while any modal is open by returning early from useEffect; cleanup and dependency array are sound. |
| src/components/admin/NotificationProvider.tsx | C7: adds role=status aria-live=polite to the toast container; the explicit aria-live is redundant with role=status but harmless. |
| __tests__/components/messaging/ConversationThread.test.tsx | New tests cover C1, C2, C6, and C7 correctly. |
| __tests__/components/messaging/ConversationThreadContainer.test.tsx | New container tests cover C1, C4, and C5 with correct stubs. |
| __tests__/components/admin/AdminActionBar.test.tsx | New C8 test correctly verifies shortcut suppression while a modal is open. |
| src/components/messaging/ConversationThread.stories.tsx | Adds SendError, LongHistory, and ReadOnlyImpersonation stories; all correctly wired. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/(admin)/admin/messages/[id]/page.tsx`, line 421 ([link](https://github.com/cloudnativebergen/website/blob/e51e5846f22bdd21b1a88e4e7ba7ee33b5648c3e/src/app/(admin)/admin/messages/[id]/page.tsx#L421)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`h-[100dvh]` overflows the viewport inside DashboardLayout**

   The page's outer div is `h-[100dvh]`, but it sits inside `DashboardLayout`'s sticky top header (`h-16` = 64 px on desktop, ~56 px on mobile) and the `<main className="py-4 lg:py-10 ...">` wrapper (16–40 px of top padding). The document height therefore becomes `100dvh + ~80–104 px`, which creates a page-level scrollbar and pushes the composer below the visible fold. The user must scroll before seeing or tapping the composer — exactly the scenario C10 was meant to eliminate.

   The same problem exists in `src/app/(cfp)/cfp/messages/[id]/page.tsx` (additionally, an `ImpersonationBanner` can be rendered above the layout on that route, adding more height). The visual QA captured Storybook stories (`ConversationThreadView` in isolation), not the actual pages inside `DashboardLayout`, so this wouldn't have been caught by `pnpm shoot`.

   A correct fix must subtract the layout overhead — either via `calc(100dvh - var(--header-height))` with a CSS custom property set by the layout, by opting these pages out of the padded `<main>` wrapper, or by switching to a flex-1 / min-h-0 column on the layout's main element.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): thread UX from adversari..."](https://github.com/cloudnativebergen/website/commit/e51e5846f22bdd21b1a88e4e7ba7ee33b5648c3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45417770)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->