### PR TITLE
fix(storybook): deterministic dates in MessagesInbox stories

### DIFF
--- a/src/components/messaging/MessagesInbox.stories.tsx
+++ b/src/components/messaging/MessagesInbox.stories.tsx
@@ -74,15 +74,18 @@ const makeItems = (): ConversationListItem[] => [
 ]
 
 /** msw handler answering the inbox's `message.listConversations` infinite query
- * with a single page (fewer than PAGE_SIZE rows ⇒ no "show more"). */
-const conversationHandlers = (items: ConversationListItem[]) => [
+ * with a single page (fewer than PAGE_SIZE rows ⇒ no "show more"). Takes a
+ * BUILDER, invoked per request, so `minutesAgo` timestamps are computed after
+ * `mockDateBeforeEach` has pinned the clock — calling `makeItems()` at module
+ * load would freeze them against the real wall clock instead. */
+const conversationHandlers = (getItems: () => ConversationListItem[]) => [
   http.get('/api/trpc/:procs', ({ params }) =>
     HttpResponse.json(
       String(params.procs)
         .split(',')
         .map((proc) =>
           proc === 'message.listConversations'
-            ? { result: { data: items } }
+            ? { result: { data: getItems() } }
             : { result: { data: null } },
         ),
     ),
@@ -136,30 +139,30 @@ type Story = StoryObj<typeof meta>
 /** Speaker audience with no conversations yet — the empty state. */
 export const SpeakerEmpty: Story = {
   args: { audience: 'speaker' },
-  parameters: { msw: { handlers: conversationHandlers([]) } },
+  parameters: { msw: { handlers: conversationHandlers(() => []) } },
 }
 
 /** Organizer audience with no conversations yet — the empty state. */
 export const OrganizerEmpty: Story = {
   args: { audience: 'organizer' },
-  parameters: { msw: { handlers: conversationHandlers([]) } },
+  parameters: { msw: { handlers: conversationHandlers(() => []) } },
 }
 
 /** Speaker inbox with a representative Who/What/When mix (rows link to /cfp). */
 export const SpeakerPopulated: Story = {
   args: { audience: 'speaker' },
-  parameters: { msw: { handlers: conversationHandlers(makeItems()) } },
+  parameters: { msw: { handlers: conversationHandlers(makeItems) } },
 }
 
 export const SpeakerEmptyDark: Story = {
   args: { audience: 'speaker' },
-  parameters: { dark: true, msw: { handlers: conversationHandlers([]) } },
+  parameters: { dark: true, msw: { handlers: conversationHandlers(() => []) } },
 }
 
 export const SpeakerPopulatedDark: Story = {
   args: { audience: 'speaker' },
   parameters: {
     dark: true,
-    msw: { handlers: conversationHandlers(makeItems()) },
+    msw: { handlers: conversationHandlers(makeItems) },
   },
 }


### PR DESCRIPTION
Follow-up to #536's post-merge badge: `makeItems()` was invoked at module load inside `parameters`, so its `minutesAgo` timestamps froze against the real wall clock before `mockDateBeforeEach` pinned it — the exact drift class fixed in the M6 stories. The msw handler now takes a builder invoked per request, after the clock pin.

Visual output is the same fixture set already shoot-verified in #536 (labels now deterministically pinned rather than wall-clock relative).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes non-deterministic timestamps in `MessagesInbox` Storybook stories by changing `conversationHandlers` to accept a builder function (invoked per MSW request) instead of a pre-built array (evaluated at module load, before `mockDateBeforeEach` pins the clock).

- `conversationHandlers` signature changes from `(items: ConversationListItem[])` to `(getItems: () => ConversationListItem[])`, and `getItems()` is called inside the handler so `minutesAgo` timestamps are computed against the pinned clock.
- All five story call-sites are updated: populated stories pass `makeItems` directly as a function reference, empty-state stories pass `() => []` lambdas.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is scoped entirely to test/story fixtures with no effect on production code.

The diff is a one-file, narrowly scoped fix to Storybook stories. The builder-function pattern correctly defers makeItems() until after mockDateBeforeEach pins the clock, and all five story call-sites are consistently updated. No production code paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/messaging/MessagesInbox.stories.tsx | Refactors conversationHandlers to accept a builder function instead of a pre-built array, ensuring makeItems() is evaluated after mockDateBeforeEach pins the clock; all five story call-sites updated correctly. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SB as Storybook Runner
    participant BE as beforeEach (mockDateBeforeEach)
    participant MSW as MSW Handler
    participant GI as getItems() / makeItems()

    SB->>BE: pin Date.now() → 2026-07-18T12:00:00Z
    BE-->>SB: clock fixed
    SB->>MSW: story renders → HTTP GET /api/trpc/message.listConversations
    MSW->>GI: invoke getItems() (builder called per request)
    GI->>GI: minutesAgo() uses pinned Date.now()
    GI-->>MSW: deterministic ConversationListItem[]
    MSW-->>SB: HttpResponse.json with pinned timestamps
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SB as Storybook Runner
    participant BE as beforeEach (mockDateBeforeEach)
    participant MSW as MSW Handler
    participant GI as getItems() / makeItems()

    SB->>BE: pin Date.now() → 2026-07-18T12:00:00Z
    BE-->>SB: clock fixed
    SB->>MSW: story renders → HTTP GET /api/trpc/message.listConversations
    MSW->>GI: invoke getItems() (builder called per request)
    GI->>GI: minutesAgo() uses pinned Date.now()
    GI-->>MSW: deterministic ConversationListItem[]
    MSW-->>SB: HttpResponse.json with pinned timestamps
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(storybook): defer inbox story fixtur..."](https://github.com/cloudnativebergen/website/commit/1acf9524b6d02fd5b3092e7e2689ae5a43553652) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45418229)</sub>

<!-- /greptile_comment -->