### PR TITLE
fix(messaging): review batch B — data lifecycle

### DIFF
--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -42,8 +42,10 @@ import {
   setConversationPreference,
   getConversationPreferencesFor,
   listConversationsForSpeaker,
+  listMessages,
   speakerExists,
 } from '@/lib/messaging/sanity'
+import { truncateToGraphemeBoundary } from '@/lib/messaging/links'
 import type { ConversationWithContext } from '@/lib/messaging/types'
 
 type LooseMock = ReturnType<typeof vi.fn>
@@ -351,15 +353,49 @@ describe('listConversationsForSpeaker — unread counts per conversation', () =>
     ).toBe(0)
 
     // The unread query is scoped to the caller, the conference, message_received,
-    // unread only, and projects coalesce(count, 1) so a pre-collapse
-    // per-message document still counts as 1.
+    // unread only, and — crucially — to THIS page's conversations via
+    // `link in $pageLinks` (both audience variants per row). It projects
+    // coalesce(count, 1) so a pre-collapse per-message document still counts as 1.
     const [query, params] = readMock.fetch.mock.calls[1]
     expect(query).toContain('recipient._ref == $speakerId')
     expect(query).toContain('conference._ref == $conferenceId')
     expect(query).toContain('notificationType == "message_received"')
     expect(query).toContain('!defined(readAt)')
     expect(query).toContain('coalesce(count, 1)')
-    expect(params).toEqual({ speakerId: 'sp-1', conferenceId: 'conf-1' })
+    expect(query).toContain('link in $pageLinks')
+    // No fixed [0...N] cap — the fetch is bounded by the page's link set.
+    expect(query).not.toContain('[0...500]')
+    expect(params).toEqual({
+      speakerId: 'sp-1',
+      conferenceId: 'conf-1',
+      pageLinks: [
+        '/admin/proposals/prop-1#messages',
+        '/cfp/proposal/prop-1#messages',
+        '/admin/messages/conversation.gen-1',
+        '/cfp/messages/conversation.gen-1',
+      ],
+    })
+  })
+
+  it('counts unread beyond any fixed cap now the fetch is page-scoped (B4)', async () => {
+    // A caller with far more than the old 500-doc cap of conference-wide unread
+    // notifications still gets correct per-row counts: the fetch returns only
+    // this page's links, so nothing is truncated away.
+    readMock.fetch
+      .mockResolvedValueOnce(rows)
+      .mockResolvedValueOnce([
+        { link: '/cfp/proposal/prop-1#messages', count: 999 },
+      ])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'sp-1',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+    })
+
+    expect(
+      result.find((r) => r._id === 'conversation.proposal.prop-1')!.unreadCount,
+    ).toBe(999)
   })
 
   it('sums MIXED collapsed and legacy per-message docs for the same conversation', async () => {
@@ -606,5 +642,161 @@ describe('getConversationPreferencesFor — batched, normalized', () => {
     ])
     expect(map.get('sp-1')).toEqual({ muted: true, emailOverride: 'on' })
     expect(map.get('sp-2')).toEqual({ muted: false, emailOverride: 'default' })
+  })
+})
+
+describe('listMessages — compound keyset cursor (B5)', () => {
+  it('omits the cursor clause and orders by (createdAt desc, _id desc) with no cursor', async () => {
+    readMock.fetch.mockResolvedValue([])
+    await listMessages({ conversationId: 'conversation.gen-1' })
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('order(createdAt desc, _id desc)')
+    expect(query).not.toContain('createdAt < $before')
+    expect(params).toEqual({ conversationId: 'conversation.gen-1' })
+  })
+
+  it('uses the simple strict-less-than predicate when only `before` is given', async () => {
+    readMock.fetch.mockResolvedValue([])
+    await listMessages({
+      conversationId: 'conversation.gen-1',
+      before: '2026-01-02T00:00:00.000Z',
+    })
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('createdAt < $before')
+    expect(query).not.toContain('$beforeId')
+    expect(params).toEqual({
+      conversationId: 'conversation.gen-1',
+      before: '2026-01-02T00:00:00.000Z',
+    })
+  })
+
+  it('uses the compound (createdAt, _id) predicate so equal-timestamp rows are not skipped', async () => {
+    readMock.fetch.mockResolvedValue([])
+    await listMessages({
+      conversationId: 'conversation.gen-1',
+      before: '2026-01-02T00:00:00.000Z',
+      beforeId: 'message.abc',
+    })
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain(
+      '(createdAt < $before || (createdAt == $before && _id < $beforeId))',
+    )
+    expect(params).toEqual({
+      conversationId: 'conversation.gen-1',
+      before: '2026-01-02T00:00:00.000Z',
+      beforeId: 'message.abc',
+    })
+  })
+})
+
+describe('listConversationsForSpeaker — compound keyset cursor (B5)', () => {
+  it('uses the compound (lastMessageAt, _id) predicate when `beforeId` is given', async () => {
+    readMock.fetch.mockResolvedValueOnce([]) // empty page → no unread fetch
+    await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      before: '2026-01-02T00:00:00.000Z',
+      beforeId: 'conversation.gen-1',
+    })
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('order(lastMessageAt desc, _id desc)')
+    expect(query).toContain(
+      '(lastMessageAt < $before || (lastMessageAt == $before && _id < $beforeId))',
+    )
+    expect(params).toEqual({
+      conferenceId: 'conf-1',
+      before: '2026-01-02T00:00:00.000Z',
+      beforeId: 'conversation.gen-1',
+    })
+  })
+})
+
+describe('listConversationsForSpeaker — empty-excerpt lastMessage (B8)', () => {
+  it('returns lastMessage null when the body trims to an empty excerpt', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce([
+        {
+          _id: 'conversation.gen-1',
+          conversationType: 'general' as const,
+          subject: 'Q',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          lastMessageAt: '2026-01-01T00:00:00.000Z',
+          lastMessage: {
+            authorId: 'org-1',
+            authorName: 'Ola',
+            authorImage: null,
+            body: '   \n  ', // whitespace only → empty excerpt
+          },
+          speakerSideName: 'Sub',
+          speakerSideImage: null,
+        },
+      ])
+      .mockResolvedValueOnce([])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+    })
+
+    expect(result[0].lastMessage).toBeNull()
+  })
+})
+
+describe('listConversationsForSpeaker — grapheme-safe excerpt (B6)', () => {
+  it('does not split an emoji straddling the 120-char cap into a lone surrogate', async () => {
+    // 119 ASCII chars then a 2-code-unit emoji: a naive slice(0,120) would keep
+    // only the emoji's high surrogate → �. The grapheme-safe cut drops the whole
+    // emoji instead.
+    const body = `${'a'.repeat(119)}😀 tail`
+    readMock.fetch
+      .mockResolvedValueOnce([
+        {
+          _id: 'conversation.gen-1',
+          conversationType: 'general' as const,
+          subject: 'Q',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          lastMessageAt: '2026-01-01T00:00:00.000Z',
+          lastMessage: {
+            authorId: 'org-1',
+            authorName: 'Ola',
+            authorImage: null,
+            body,
+          },
+          speakerSideName: 'Sub',
+          speakerSideImage: null,
+        },
+      ])
+      .mockResolvedValueOnce([])
+
+    const result = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+    })
+
+    const excerpt = result[0].lastMessage!.excerpt
+    expect(excerpt).not.toContain('�')
+    // No lone surrogate at the boundary.
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(excerpt)).toBe(false)
+    expect(excerpt.endsWith('…')).toBe(true)
+  })
+})
+
+describe('truncateToGraphemeBoundary (B6)', () => {
+  it('returns the input unchanged when it already fits', () => {
+    expect(truncateToGraphemeBoundary('hello', 10)).toBe('hello')
+  })
+
+  it('never emits a lone surrogate when an emoji straddles the cap', () => {
+    const out = truncateToGraphemeBoundary('ab😀cd', 3) // cap lands inside 😀
+    expect(out).toBe('ab')
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false)
+  })
+
+  it('keeps a whole emoji when the cap lands exactly after it', () => {
+    // 'a' + 😀 (2 code units) = length 3; cap 3 keeps both.
+    expect(truncateToGraphemeBoundary('a😀bc', 3)).toBe('a😀')
   })
 })

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -47,6 +47,9 @@ import {
   markNotificationsReadByLinks,
   markAllRead,
   deleteNotificationsOlderThan,
+  deleteMessageNotificationsFor,
+  getOrganizerSpeakerIds,
+  clearOrganizerSpeakerIdsCache,
 } from '@/lib/notification/sanity'
 import type {
   MessageNotificationInput,
@@ -86,6 +89,9 @@ const input = (
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // The organizer id set is cached in module scope; clear it so cache-sensitive
+  // tests (and the fresh-fetch assumptions of others) don't leak across tests.
+  clearOrganizerSpeakerIdsCache()
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
 
@@ -342,6 +348,55 @@ describe('upsertMessageNotifications — per-conversation collapse (M5)', () => 
     expect(pushItems[0].notificationType).toBe('message_received')
     expect(pushItems[0].title).toBe('2 new messages — A question')
     expect(pushItems[0].recipientId).toBe('sp-1')
+    // B10: a stable per-conversation tag so successive pushes REPLACE on-device.
+    expect(pushItems[0].tag).toBe('msg:conversation.gen-1')
+  })
+
+  it('gives a grapheme-safe title when an emoji straddles the 200-char cap (B6)', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+    // Long subject whose emoji lands on the title cap; a naive slice(0,200)
+    // would keep the emoji's high surrogate alone (�).
+    const subject = `${'x'.repeat(178)}😀tail`
+    await upsertMessageNotifications([msgInput({ authorName: 'A', subject })])
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown> },
+    ]
+    const title = ops.set.title as string
+    expect(title.length).toBeLessThanOrEqual(200)
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(title)).toBe(false)
+  })
+
+  it('isolates a failing chunk: other recipients still commit and get pushed (B11)', async () => {
+    // 15 recipients → two chunks (10 + 5). Make the FIRST chunk's commit reject;
+    // the second must still commit, and push fires only for its recipients.
+    readMock.fetch.mockResolvedValue([]) // all brand-new
+    const tx = installTransaction()
+    tx.commit.mockReset()
+    tx.commit
+      .mockRejectedValueOnce(new Error('bad recipient ref'))
+      .mockResolvedValue({})
+
+    const items = Array.from({ length: 15 }, (_, i) =>
+      msgInput({ recipientId: `sp-${i}` }),
+    )
+    await upsertMessageNotifications(items)
+
+    // Two transactions attempted (two chunks).
+    expect(writeMock.transaction).toHaveBeenCalledTimes(2)
+    expect(tx.commit).toHaveBeenCalledTimes(2)
+    // The failed chunk is logged.
+    expect(console.error).toHaveBeenCalled()
+
+    // Push fired ONCE, only for the committed chunk's 5 recipients.
+    expect(pushMock).toHaveBeenCalledTimes(1)
+    const [pushItems] = pushMock.mock.calls[0] as [NotificationInput[]]
+    expect(pushItems).toHaveLength(5)
+    const pushedIds = pushItems.map((p) => p.recipientId).sort()
+    expect(pushedIds).toEqual(
+      ['sp-10', 'sp-11', 'sp-12', 'sp-13', 'sp-14'].sort(),
+    )
   })
 
   it('is a no-op (no read, no transaction) for an empty list', async () => {
@@ -670,6 +725,17 @@ describe('deleteNotificationsOlderThan — batched retention cleanup', () => {
     expect(cutoff).toBeLessThanOrEqual(after)
   })
 
+  it('EXCLUDES unread message notifications from the purge (B2)', async () => {
+    readMock.fetch.mockResolvedValueOnce([])
+    await deleteNotificationsOlderThan(90)
+    const [query] = readMock.fetch.mock.calls[0]
+    // An unread collapsed message notification is the only store of message
+    // unread state, so it must outlive the retention horizon.
+    expect(query).toContain(
+      '!(notificationType == "message_received" && !defined(readAt))',
+    )
+  })
+
   it('is a no-op (no transaction) when nothing is expired', async () => {
     readMock.fetch.mockResolvedValueOnce([])
     const tx = installTransaction()
@@ -727,5 +793,105 @@ describe('deleteNotificationsOlderThan — batched retention cleanup', () => {
     await expect(deleteNotificationsOlderThan(90)).rejects.toThrow(
       'sanity down',
     )
+  })
+})
+
+describe('deleteMessageNotificationsFor — access-loss cleanup (B3)', () => {
+  it('deletes a speaker message notifications matched by proposal-thread links', async () => {
+    readMock.fetch.mockResolvedValue(['notif-msg-1'])
+    const tx = installTransaction()
+
+    const count = await deleteMessageNotificationsFor({
+      proposalIds: ['prop-1'],
+      speakerId: 'sp-7',
+    })
+
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('recipient._ref == $speakerId')
+    expect(query).toContain('notificationType == "message_received"')
+    expect(query).toContain('link in $links')
+    expect(params).toEqual({
+      speakerId: 'sp-7',
+      links: [
+        '/admin/proposals/prop-1#messages',
+        '/cfp/proposal/prop-1#messages',
+      ],
+    })
+    expect(tx.delete).toHaveBeenCalledWith('notif-msg-1')
+    expect(tx.commit).toHaveBeenCalledTimes(1)
+    expect(count).toBe(1)
+  })
+
+  it('builds general-thread links from conversationIds', async () => {
+    readMock.fetch.mockResolvedValue([])
+    await deleteMessageNotificationsFor({
+      conversationIds: ['conversation.gen-1'],
+      speakerId: 'sp-7',
+    })
+    const [, params] = readMock.fetch.mock.calls[0]
+    expect((params as { links: string[] }).links).toEqual([
+      '/admin/messages/conversation.gen-1',
+      '/cfp/messages/conversation.gen-1',
+    ])
+  })
+
+  it('is a no-op (no fetch, no write) when no threads are given', async () => {
+    const tx = installTransaction()
+    const count = await deleteMessageNotificationsFor({ speakerId: 'sp-7' })
+    expect(count).toBe(0)
+    expect(readMock.fetch).not.toHaveBeenCalled()
+    expect(tx.commit).not.toHaveBeenCalled()
+  })
+
+  it('returns 0 and writes nothing when nothing matches', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+    const count = await deleteMessageNotificationsFor({
+      proposalIds: ['prop-1'],
+      speakerId: 'sp-7',
+    })
+    expect(count).toBe(0)
+    expect(writeMock.transaction).not.toHaveBeenCalled()
+    expect(tx.delete).not.toHaveBeenCalled()
+  })
+
+  it('NEVER throws when the fetch fails — swallows, logs, returns 0', async () => {
+    readMock.fetch.mockRejectedValue(new Error('sanity down'))
+    const count = await deleteMessageNotificationsFor({
+      proposalIds: ['prop-1'],
+      speakerId: 'sp-7',
+    })
+    expect(count).toBe(0)
+    expect(console.error).toHaveBeenCalled()
+  })
+})
+
+describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () => {
+  it('bounds the fetch to [0...200] and caches within the TTL (ONE read for two calls)', async () => {
+    readMock.fetch.mockResolvedValue(['org-1', 'org-2'])
+
+    const first = await getOrganizerSpeakerIds()
+    const second = await getOrganizerSpeakerIds()
+
+    expect(first).toEqual(['org-1', 'org-2'])
+    expect(second).toEqual(['org-1', 'org-2'])
+    // Cached: only one underlying read despite two calls.
+    expect(readMock.fetch).toHaveBeenCalledTimes(1)
+    const [query] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('isOrganizer == true')
+    expect(query).toContain('[0...200]')
+  })
+
+  it('re-fetches after the cache is cleared', async () => {
+    readMock.fetch.mockResolvedValue(['org-1'])
+    await getOrganizerSpeakerIds()
+    clearOrganizerSpeakerIdsCache()
+    await getOrganizerSpeakerIds()
+    expect(readMock.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces a null fetch to an empty array', async () => {
+    readMock.fetch.mockResolvedValue(null)
+    expect(await getOrganizerSpeakerIds()).toEqual([])
   })
 })

--- a/__tests__/lib/proposal/data/sanity.test.ts
+++ b/__tests__/lib/proposal/data/sanity.test.ts
@@ -73,11 +73,17 @@ describe('deleteProposal', () => {
   })
 
   it('deletes co-speaker invitations and reviews together with the talk in a single transaction', async () => {
-    mockFetch.mockResolvedValue([
-      { _id: 'invitation-1', _type: 'coSpeakerInvitation' },
-      { _id: 'invitation-2', _type: 'coSpeakerInvitation' },
-      { _id: 'review-1', _type: 'review' },
-    ])
+    mockFetch
+      // referencing docs (cascade-safe only, no thread)
+      .mockResolvedValueOnce([
+        { _id: 'invitation-1', _type: 'coSpeakerInvitation' },
+        { _id: 'invitation-2', _type: 'coSpeakerInvitation' },
+        { _id: 'review-1', _type: 'review' },
+      ])
+      // conversationIds (no thread)
+      .mockResolvedValueOnce([])
+      // messageNotificationIds (no message notifications for the thread)
+      .mockResolvedValueOnce([])
 
     const { err } = await deleteProposal('proposal-1')
 
@@ -86,6 +92,8 @@ describe('deleteProposal', () => {
       expect.stringContaining('references($proposalId)'),
       { proposalId: 'proposal-1' },
     )
+    // With no thread, everything collapses into the single final transaction:
+    // the cascade dependents + the proposal itself.
     expect(mockTransaction).toHaveBeenCalledTimes(1)
     expect(mockTxDelete.mock.calls.map((call) => call[0])).toEqual([
       'invitation-1',
@@ -96,8 +104,79 @@ describe('deleteProposal', () => {
     expect(mockTxCommit).toHaveBeenCalledTimes(1)
   })
 
+  it('cascade-deletes the proposal thread — messages, conversation, and message notifications — keeping other notifications', async () => {
+    mockFetch
+      // referencing docs: a conversation (weak), a message notification (weak),
+      // a non-message notification (weak), and a review (cascade). NONE block.
+      .mockResolvedValueOnce([
+        { _id: 'conversation.proposal.proposal-1', _type: 'conversation' },
+        { _id: 'notif-msg-1', _type: 'notification' },
+        { _id: 'notif-status-1', _type: 'notification' },
+        { _id: 'review-1', _type: 'review' },
+      ])
+      // conversationIds for the proposal
+      .mockResolvedValueOnce(['conversation.proposal.proposal-1'])
+      // messageIds in those conversations
+      .mockResolvedValueOnce(['msg-1', 'msg-2'])
+      // message notification ids (matched by proposal-thread link)
+      .mockResolvedValueOnce(['notif-msg-1'])
+
+    const { err } = await deleteProposal('proposal-1')
+
+    expect(err).toBeNull()
+
+    // The message-notification lookup filters on message_received + link in the
+    // two proposal-thread audience variants.
+    const notifCall = mockFetch.mock.calls[3]
+    expect(notifCall[0]).toContain('notificationType == "message_received"')
+    expect(notifCall[0]).toContain('link in $messageLinks')
+    expect(notifCall[1]).toEqual({
+      messageLinks: [
+        '/admin/proposals/proposal-1#messages',
+        '/cfp/proposal/proposal-1#messages',
+      ],
+    })
+
+    // Four transactions: messages, conversation, message-notification, then the
+    // cascade dependents + proposal.
+    expect(mockTransaction).toHaveBeenCalledTimes(4)
+    const deleted = mockTxDelete.mock.calls.map((call) => call[0])
+    expect(deleted).toEqual([
+      'msg-1',
+      'msg-2',
+      'conversation.proposal.proposal-1',
+      'notif-msg-1',
+      'review-1',
+      'proposal-1',
+    ])
+    // The non-message notification is neither blocking nor deleted (its weak
+    // ref simply dangles).
+    expect(deleted).not.toContain('notif-status-1')
+  })
+
+  it('keeps a non-message notification referencing the proposal without blocking or deleting it', async () => {
+    mockFetch
+      // Only a (weak) notification references the proposal — must NOT block.
+      .mockResolvedValueOnce([{ _id: 'notif-1', _type: 'notification' }])
+      // no conversations
+      .mockResolvedValueOnce([])
+      // no message notifications
+      .mockResolvedValueOnce([])
+
+    const { err } = await deleteProposal('proposal-1')
+
+    expect(err).toBeNull()
+    // Only the proposal itself is deleted; the notification is kept.
+    expect(mockTxDelete.mock.calls.map((call) => call[0])).toEqual([
+      'proposal-1',
+    ])
+  })
+
   it('deletes a talk without referencing documents', async () => {
-    mockFetch.mockResolvedValue([])
+    mockFetch
+      .mockResolvedValueOnce([]) // referencing docs
+      .mockResolvedValueOnce([]) // conversationIds
+      .mockResolvedValueOnce([]) // messageNotificationIds
 
     const { err } = await deleteProposal('proposal-1')
 
@@ -108,7 +187,7 @@ describe('deleteProposal', () => {
   })
 
   it('returns a descriptive error when the talk is placed in a schedule', async () => {
-    mockFetch.mockResolvedValue([{ _id: 'schedule-1', _type: 'schedule' }])
+    mockFetch.mockResolvedValueOnce([{ _id: 'schedule-1', _type: 'schedule' }])
 
     const { err } = await deleteProposal('proposal-1')
 
@@ -120,8 +199,23 @@ describe('deleteProposal', () => {
     expect(mockTxCommit).not.toHaveBeenCalled()
   })
 
+  it('still blocks on a schedule even when a message thread also references the proposal', async () => {
+    mockFetch.mockResolvedValueOnce([
+      { _id: 'conversation.proposal.proposal-1', _type: 'conversation' },
+      { _id: 'schedule-1', _type: 'schedule' },
+    ])
+
+    const { err } = await deleteProposal('proposal-1')
+
+    expect(err).toBeInstanceOf(ProposalDeletionBlockedError)
+    expect(err?.message).toContain('a published schedule')
+    // Blocked before any cascade fetch or delete.
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockTransaction).not.toHaveBeenCalled()
+  })
+
   it('does not delete invitations or reviews when a blocking reference exists', async () => {
-    mockFetch.mockResolvedValue([
+    mockFetch.mockResolvedValueOnce([
       { _id: 'invitation-1', _type: 'coSpeakerInvitation' },
       { _id: 'review-1', _type: 'review' },
       { _id: 'conference-1', _type: 'conference' },
@@ -136,7 +230,7 @@ describe('deleteProposal', () => {
   })
 
   it('lists every blocking reference type once in the error message', async () => {
-    mockFetch.mockResolvedValue([
+    mockFetch.mockResolvedValueOnce([
       { _id: 'schedule-1', _type: 'schedule' },
       { _id: 'schedule-2', _type: 'schedule' },
       { _id: 'signup-1', _type: 'workshopSignup' },
@@ -150,7 +244,7 @@ describe('deleteProposal', () => {
   })
 
   it('falls back to the raw document type for unknown blocking references', async () => {
-    mockFetch.mockResolvedValue([{ _id: 'other-1', _type: 'someNewType' }])
+    mockFetch.mockResolvedValueOnce([{ _id: 'other-1', _type: 'someNewType' }])
 
     const { err } = await deleteProposal('proposal-1')
 
@@ -169,7 +263,10 @@ describe('deleteProposal', () => {
   })
 
   it('returns the error when the transaction commit fails', async () => {
-    mockFetch.mockResolvedValue([])
+    mockFetch
+      .mockResolvedValueOnce([]) // referencing docs
+      .mockResolvedValueOnce([]) // conversationIds
+      .mockResolvedValueOnce([]) // messageNotificationIds
     const failure = new Error('commit failed')
     mockTxCommit.mockRejectedValue(failure)
 

--- a/__tests__/lib/push/send-bridge.test.ts
+++ b/__tests__/lib/push/send-bridge.test.ts
@@ -145,6 +145,22 @@ describe('sendPushForNotifications', () => {
     })
   })
 
+  it('threads a stable tag into the payload so repeat pushes replace on-device (B10)', async () => {
+    mockGetState.mockResolvedValue(state())
+    await sendPushForNotifications([
+      item({ notificationType: 'message_received', tag: 'msg:conv-1' }),
+    ])
+    const [, body] = sendNotification.mock.calls[0]
+    expect(JSON.parse(body as string).tag).toBe('msg:conv-1')
+  })
+
+  it('omits tag entirely for items without one (one-shot types keep stacking)', async () => {
+    mockGetState.mockResolvedValue(state())
+    await sendPushForNotifications([item()])
+    const [, body] = sendNotification.mock.calls[0]
+    expect('tag' in JSON.parse(body as string)).toBe(false)
+  })
+
   it('falls back to an empty body and root url when message/link are absent', async () => {
     mockGetState.mockResolvedValue(state())
     await sendPushForNotifications([

--- a/migrations/041-weak-messaging-refs/README.md
+++ b/migrations/041-weak-messaging-refs/README.md
@@ -1,0 +1,82 @@
+# Migration 041: Weaken messaging / notification speaker references
+
+## ⚠️ NOT RUN — maintainer decision required
+
+This migration is committed but **has not been run against any dataset**. Running
+it is a deliberate maintainer action via the
+[`Run Sanity Migration`](../../.github/workflows/run-migration.yml) workflow
+after review.
+
+## Overview
+
+The messaging and notification systems held **strong** references to speakers:
+
+- `message.author`
+- `conversation.createdBy`
+- `conversation.subjectSpeaker`
+- `notification.recipient`
+- `notification.actor`
+
+Sanity refuses to delete a document that has inbound **strong** references, so a
+speaker who had ever sent a message, created (or was the subject of) a
+conversation, or received/triggered a notification could **never be deleted** —
+a GDPR erasure trap.
+
+The schema now declares these fields `weak: true` (see the `weak: true` edits in
+`sanity/schemaTypes/{message,conversation,notification}.ts`). That fixes new
+writes, but **reference strength is stored per ref object** (`_weak`), not on the
+schema, so **existing documents keep their strong refs** until rewritten. This
+migration rewrites them.
+
+## What it does
+
+Streams every `message`, `conversation`, and `notification` document and, for
+each of the fields above that is present and **not already weak**, sets
+`_weak: true` on the reference object (preserving `_ref` and any other keys).
+
+It never changes a `_ref` target, never deletes anything, and skips drafts (the
+published document owns the fields).
+
+## Idempotency
+
+Safe to run repeatedly: a ref that already carries `_weak: true` is skipped, so a
+re-run only touches refs that are still strong. Counts of patched documents and
+weakened references are logged.
+
+## Running the migration
+
+Via the **`Run Sanity Migration`** GitHub Actions workflow (`workflow_dispatch`):
+
+- **migration**: `041-weak-messaging-refs`
+- **dataset**: `production` (or the target dataset)
+
+The workflow exports a dataset backup artifact, performs a **dry run**, and only
+then applies. Review the dry-run log before the apply step.
+
+Equivalent local invocation:
+
+```bash
+pnpm sanity migration run 041-weak-messaging-refs \
+  --project "$SANITY_STUDIO_PROJECT_ID" --dataset production   # dry run
+pnpm sanity migration run 041-weak-messaging-refs \
+  --project "$SANITY_STUDIO_PROJECT_ID" --dataset production --no-dry-run --no-confirm
+```
+
+## Verification
+
+After running, confirm no strong messaging refs remain:
+
+```bash
+# Should return 0 once the migration has applied.
+npx sanity documents query 'count(*[
+  (_type == "message" && defined(author._ref) && author._weak != true) ||
+  (_type == "conversation" && ((defined(createdBy._ref) && createdBy._weak != true) || (defined(subjectSpeaker._ref) && subjectSpeaker._weak != true))) ||
+  (_type == "notification" && ((defined(recipient._ref) && recipient._weak != true) || (defined(actor._ref) && actor._weak != true)))
+])'
+```
+
+## Rollback
+
+Weak refs are backward compatible (a weak ref resolves exactly like a strong one
+for reads), so there is normally nothing to roll back. If required, restore from
+the backup artifact produced by the workflow.

--- a/migrations/041-weak-messaging-refs/index.ts
+++ b/migrations/041-weak-messaging-refs/index.ts
@@ -1,0 +1,112 @@
+import { defineMigration, at, patch, set } from 'sanity/migrate'
+import type { SanityDocument } from '@sanity/types'
+
+/**
+ * ⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED. ⚠️
+ *
+ * Backfill `_weak: true` onto the speaker references that the messaging system
+ * newly declares `weak` in the schema (see the matching `weak: true` edits in
+ * `sanity/schemaTypes/{message,conversation,notification}.ts`):
+ *
+ *   - `message.author`
+ *   - `conversation.createdBy`
+ *   - `conversation.subjectSpeaker`
+ *   - `notification.recipient`
+ *   - `notification.actor`
+ *
+ * WHY: these were STRONG references, so Sanity refused to delete any speaker who
+ * had ever sent a message, created/was the subject of a conversation, or
+ * received/triggered a notification — a GDPR erasure trap. Marking the fields
+ * `weak` in the schema fixes it going FORWARD, but reference strength lives on
+ * each stored ref object (`_weak`), not the schema, so EXISTING documents keep
+ * their strong refs until rewritten. This migration rewrites them.
+ *
+ * SAFETY / IDEMPOTENCY: read-only-ish — it only adds `_weak: true` to ref
+ * objects that already point at a speaker and don't already carry it. Re-running
+ * is a no-op (already-weak refs are skipped). It never changes `_ref` targets,
+ * never deletes anything, and preserves any extra keys on the ref object.
+ *
+ * NOT RUN: run intentionally, after review, via the "Run Sanity Migration"
+ * workflow (`.github/workflows/run-migration.yml`) with migration id
+ * `041-weak-messaging-refs`. The workflow exports a dataset backup and performs
+ * a dry run first.
+ */
+
+interface RefObject {
+  _type?: string
+  _ref?: string
+  _weak?: boolean
+  [key: string]: unknown
+}
+
+interface MessagingDoc extends SanityDocument {
+  author?: RefObject | null
+  createdBy?: RefObject | null
+  subjectSpeaker?: RefObject | null
+  recipient?: RefObject | null
+  actor?: RefObject | null
+}
+
+/** The ref fields to weaken, per document type. */
+const WEAK_FIELDS: Record<string, readonly string[]> = {
+  message: ['author'],
+  conversation: ['createdBy', 'subjectSpeaker'],
+  notification: ['recipient', 'actor'],
+}
+
+const isDraft = (id: string): boolean => id.startsWith('drafts.')
+
+/** True when `value` is a reference object that is not yet weak. */
+function isStrongRef(value: unknown): value is RefObject {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as RefObject)._ref === 'string' &&
+    (value as RefObject)._weak !== true
+  )
+}
+
+export default defineMigration({
+  title: 'Weaken messaging/notification speaker references (GDPR erasure)',
+  description:
+    'Adds _weak:true to message.author, conversation.createdBy/subjectSpeaker, ' +
+    'and notification.recipient/actor on existing documents so a speaker who ' +
+    'ever messaged can be erased. Idempotent; NOT RUN by default — run via the ' +
+    'Run Sanity Migration workflow after maintainer review.',
+  documentTypes: ['message', 'conversation', 'notification'],
+
+  async *migrate(documents) {
+    let patched = 0
+    let refsWeakened = 0
+
+    for await (const rawDoc of documents()) {
+      const doc = rawDoc as MessagingDoc
+      // The published document is the source of truth; a draft inherits on
+      // publish. (Weakening a draft's refs is harmless but unnecessary.)
+      if (isDraft(doc._id)) continue
+
+      const fields = WEAK_FIELDS[doc._type] ?? []
+      const mutations = []
+      for (const field of fields) {
+        const value = doc[field as keyof MessagingDoc]
+        if (isStrongRef(value)) {
+          mutations.push(at(field, set({ ...value, _weak: true })))
+          refsWeakened++
+        }
+      }
+
+      if (mutations.length > 0) {
+        patched++
+        console.log(
+          `  ✓ ${doc._type} ${doc._id}: weakening ${mutations.length} ref(s)`,
+        )
+        yield patch(doc._id, mutations)
+      }
+    }
+
+    console.log('\n=== Weaken-refs summary ===')
+    console.log(
+      `  ${patched} document(s) patched, ${refsWeakened} reference(s) weakened.`,
+    )
+  },
+})

--- a/sanity/schemaTypes/conversation.ts
+++ b/sanity/schemaTypes/conversation.ts
@@ -64,6 +64,9 @@ export default defineType({
       title: 'Created By',
       type: 'reference',
       to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion; a
+      // dangling creator ref is tolerated.
+      weak: true,
       description: 'The speaker who started this conversation.',
       validation: (Rule) => Rule.required(),
     }),
@@ -72,6 +75,8 @@ export default defineType({
       title: 'Subject Speaker',
       type: 'reference',
       to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion.
+      weak: true,
       description:
         'The speaker a general conversation is ABOUT/with. Set when an ORGANIZER initiates a general thread targeting a speaker; speaker-created threads leave this unset (the creator IS the speaker). Unused for proposal threads.',
     }),

--- a/sanity/schemaTypes/message.ts
+++ b/sanity/schemaTypes/message.ts
@@ -23,6 +23,10 @@ export default defineType({
       title: 'Author',
       type: 'reference',
       to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion;
+      // messages are immortal, so a dangling author ref is tolerated (it simply
+      // no longer resolves to a speaker).
+      weak: true,
       description: 'The speaker (or organizer) who wrote this message.',
       validation: (Rule) => Rule.required(),
     }),

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -26,6 +26,10 @@ export default defineType({
       title: 'Recipient',
       type: 'reference',
       to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion;
+      // retention prunes notifications anyway, so a dangling recipient ref on a
+      // not-yet-purged doc is tolerated.
+      weak: true,
       description: 'The speaker who receives this notification.',
       validation: (Rule) => Rule.required(),
     }),
@@ -87,6 +91,8 @@ export default defineType({
       title: 'Actor',
       type: 'reference',
       to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion.
+      weak: true,
       description:
         'The speaker whose action triggered this notification. Omitted for system-generated notifications.',
     }),

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -5,7 +5,7 @@ import {
   ChatBubbleLeftRightIcon,
   UserGroupIcon,
 } from '@heroicons/react/24/outline'
-import { conversationLinkPath } from '@/lib/messaging/links'
+import { conversationLinkPath, ORGANIZERS_LABEL } from '@/lib/messaging/links'
 import { formatRelativeTime } from '@/lib/notification/format'
 import { MissingAvatar } from '@/components/common/MissingAvatar'
 import { SpeakerAvatarImage } from '@/components/common/SpeakerAvatarImage'
@@ -67,7 +67,7 @@ function RowAvatar({ item }: { item: ConversationListItem }) {
     >
       {image ? (
         <SpeakerAvatarImage src={image} name={name} size={40} />
-      ) : name === 'Organizers' ? (
+      ) : name === ORGANIZERS_LABEL ? (
         <span className="flex h-full w-full items-center justify-center bg-gray-100 dark:bg-gray-700">
           <UserGroupIcon className="h-5 w-5 text-gray-400 dark:text-gray-500" />
         </span>

--- a/src/lib/messaging/links.ts
+++ b/src/lib/messaging/links.ts
@@ -10,9 +10,54 @@
 
 import type { ConversationWithContext } from './types'
 
+/**
+ * The collective label shown as the message counterpart when the "other side"
+ * of a thread is the whole organizer team rather than one identifiable person
+ * (a speaker looking at a thread whose last author is not an organizer). Shared
+ * so the data layer ({@link resolveCounterpart} in `./sanity`) and the inbox
+ * avatar branch (`ConversationList.tsx`) agree on ONE string.
+ */
+export const ORGANIZERS_LABEL = 'Organizers'
+
 /** Deterministic id for the single conversation attached to a proposal. */
 export function proposalConversationId(proposalId: string): string {
   return `conversation.proposal.${proposalId}`
+}
+
+/**
+ * The longest prefix of `text` that is at most `max` UTF-16 code units long AND
+ * ends on a grapheme-cluster boundary, so truncation never splits a multi-code-
+ * unit cluster (emoji, flags, combined sequences) into a lone surrogate — which
+ * renders as the replacement character (�).
+ *
+ * Uses `Intl.Segmenter` where available (every runtime this ships on has it);
+ * falls back to a surrogate-pair-aware trim otherwise. Returns `text` unchanged
+ * when it already fits. Callers append their own ellipsis, so this only ever
+ * removes — never adds — characters.
+ */
+export function truncateToGraphemeBoundary(text: string, max: number): string {
+  if (max <= 0) return ''
+  if (text.length <= max) return text
+
+  const SegmenterCtor = (
+    Intl as unknown as { Segmenter?: typeof Intl.Segmenter }
+  ).Segmenter
+  if (SegmenterCtor) {
+    const segmenter = new SegmenterCtor(undefined, { granularity: 'grapheme' })
+    let out = ''
+    for (const { segment } of segmenter.segment(text)) {
+      if (out.length + segment.length > max) break
+      out += segment
+    }
+    return out
+  }
+
+  // Fallback: cut at `max`, but if that split a surrogate pair (the last kept
+  // code unit is a high surrogate whose low half was excluded), drop it.
+  let end = max
+  const code = text.charCodeAt(end - 1)
+  if (code >= 0xd800 && code <= 0xdbff) end -= 1
+  return text.slice(0, end)
 }
 
 /**

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -12,6 +12,7 @@ import {
   getConversationPreferencesFor,
   conversationLinkPath,
 } from './sanity'
+import { truncateToGraphemeBoundary } from './links'
 import { sendMessageEmails, type MessageEmailRecipient } from './email'
 import type { ConversationWithContext, Message } from './types'
 
@@ -21,7 +22,11 @@ const EXCERPT_LENGTH = 140
 /** A single-line excerpt of a message body, capped and ellipsised. */
 export function messageExcerpt(body: string, max = EXCERPT_LENGTH): string {
   const flat = body.replace(/\s+/g, ' ').trim()
-  return flat.length > max ? `${flat.slice(0, max).trimEnd()}…` : flat
+  // Grapheme-safe cut so an emoji straddling the cap can't leave a lone
+  // surrogate (�) at the boundary of the notification/email excerpt.
+  return flat.length > max
+    ? `${truncateToGraphemeBoundary(flat, max).trimEnd()}…`
+    : flat
 }
 
 function absoluteLink(

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -13,7 +13,12 @@ import type {
   Message,
 } from './types'
 import { DEFAULT_CONVERSATION_PREFERENCE } from './types'
-import { proposalConversationId, conversationLinkPath } from './links'
+import {
+  proposalConversationId,
+  conversationLinkPath,
+  truncateToGraphemeBoundary,
+  ORGANIZERS_LABEL,
+} from './links'
 
 // Re-export the client-safe pure helpers so existing server importers keep
 // their `./sanity` import surface (the definitions live in `./links`).
@@ -222,9 +227,13 @@ export async function getConversationParticipants(
  *
  * Each row carries the caller's `unreadCount`: their unread `message_received`
  * notifications for that conversation. Rather than N per-row subqueries we run
- * ONE extra fetch of the caller's unread message links for the conference and
- * count them in JS against each row's two audience link variants (the caller
- * only ever received one variant, so matching both is simplest and correct).
+ * ONE extra fetch of the caller's unread message links and count them in JS
+ * against each row's two audience link variants (the caller only ever received
+ * one variant, so matching both is simplest and correct). That fetch is SCOPED
+ * to the current page's conversations (`link in $pageLinks`, ≤ 2×PAGE_SIZE
+ * links) rather than the whole conference — an unscoped fetch with a fixed cap
+ * silently zeroed page rows for a caller (e.g. an organizer) whose conference-
+ * wide unread count exceeded the cap.
  *
  * Each row also carries Who/What metadata (M6):
  * - `lastMessage`: the newest message's author + a ~120-char excerpt (null for
@@ -241,17 +250,30 @@ export async function listConversationsForSpeaker({
   isOrganizer,
   conferenceId,
   before,
+  beforeId,
 }: {
   speakerId: string
   isOrganizer: boolean
   conferenceId: string
   before?: string
+  beforeId?: string
 }): Promise<ConversationListItem[]> {
   const params: Record<string, unknown> = { conferenceId }
   let cursor = ''
   if (before) {
-    cursor = ' && lastMessageAt < $before'
-    params.before = before
+    // Compound keyset cursor: order by (lastMessageAt desc, _id desc) so rows
+    // that share an exact `lastMessageAt` are totally ordered and none is
+    // skipped at a page boundary. Callers that only pass `before` (no
+    // `beforeId`) keep the original strict-less-than behaviour.
+    if (beforeId) {
+      cursor =
+        ' && (lastMessageAt < $before || (lastMessageAt == $before && _id < $beforeId))'
+      params.before = before
+      params.beforeId = beforeId
+    } else {
+      cursor = ' && lastMessageAt < $before'
+      params.before = before
+    }
   }
 
   let scope = ''
@@ -265,7 +287,7 @@ export async function listConversationsForSpeaker({
   // the whole page stays ONE fetch; `speakerSide*` pre-resolves the speaker-side
   // counterpart (organizer audience) via the house
   // `coalesce(image.asset->url, imageURL)` speaker-image pattern.
-  const query = `*[_type == "conversation" && conference._ref == $conferenceId${scope}${cursor}] | order(lastMessageAt desc) [0...${PAGE_SIZE}] {
+  const query = `*[_type == "conversation" && conference._ref == $conferenceId${scope}${cursor}] | order(lastMessageAt desc, _id desc) [0...${PAGE_SIZE}] {
     "_id": _id,
     conversationType,
     subject,
@@ -299,21 +321,27 @@ export async function listConversationsForSpeaker({
   const rows = results ?? []
   if (rows.length === 0) return []
 
-  // ONE extra read (bounded [0...500] — plenty above any realistic unread count,
-  // and the 90-day retention caps the universe): the caller's unread
-  // message_received notifications for this conference. Since M5 a collapsed
-  // notification represents `count` unread messages (absent = 1, which also
-  // covers pre-collapse per-message documents), so we SUM `coalesce(count, 1)`
-  // per link in JS rather than counting documents.
+  // ONE extra read, SCOPED to THIS page's conversations via `link in $pageLinks`
+  // (both audience variants per row → ≤ 2×PAGE_SIZE links). This replaces an
+  // unscoped conference-wide fetch with a fixed [0...500] cap that silently
+  // zeroed page rows once a caller's total unread count crossed the cap
+  // (organizers see EVERY conversation). Since M5 a collapsed notification
+  // represents `count` unread messages (absent = 1, which also covers
+  // pre-collapse per-message documents), so we SUM `coalesce(count, 1)` per link
+  // in JS rather than counting documents.
   //
   // A SPEAKER caller additionally needs the organizer id set to decide whether
   // the last message's author is "an organizer" (their counterpart); organizers
   // don't (their counterpart is the pre-resolved speaker side), so their path
   // stays at two fetches.
+  const pageLinks = rows.flatMap((row) => [
+    conversationLinkPath(row, true),
+    conversationLinkPath(row, false),
+  ])
   const [unreadRows, organizerIds] = await Promise.all([
     clientReadUncached.fetch<{ link: string | null; count: number }[]>(
-      `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt)][0...500]{ link, "count": coalesce(count, 1) }`,
-      { speakerId, conferenceId },
+      `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt) && link in $pageLinks]{ link, "count": coalesce(count, 1) }`,
+      { speakerId, conferenceId, pageLinks },
       { cache: 'no-store' },
     ),
     isOrganizer ? Promise.resolve<string[]>([]) : getOrganizerSpeakerIds(),
@@ -331,6 +359,10 @@ export async function listConversationsForSpeaker({
     const unreadCount =
       (linkCounts.get(conversationLinkPath(row, true)) ?? 0) +
       (linkCounts.get(conversationLinkPath(row, false)) ?? 0)
+    // A body that trims to nothing (only whitespace) produces an empty excerpt:
+    // return no lastMessage at all so the row renders without a blank snippet
+    // line, rather than an object carrying an empty string.
+    const excerpt = row.lastMessage ? excerptOf(row.lastMessage.body ?? '') : ''
     return {
       _id: row._id,
       conversationType: row.conversationType,
@@ -340,13 +372,14 @@ export async function listConversationsForSpeaker({
       createdAt: row.createdAt,
       lastMessageAt: row.lastMessageAt,
       unreadCount,
-      lastMessage: row.lastMessage
-        ? {
-            authorId: row.lastMessage.authorId,
-            authorName: row.lastMessage.authorName ?? 'Unknown',
-            excerpt: excerptOf(row.lastMessage.body ?? ''),
-          }
-        : null,
+      lastMessage:
+        row.lastMessage && excerpt
+          ? {
+              authorId: row.lastMessage.authorId,
+              authorName: row.lastMessage.authorName ?? 'Unknown',
+              excerpt,
+            }
+          : null,
       counterpart: resolveCounterpart(row, isOrganizer, organizerSet),
     }
   })
@@ -372,9 +405,10 @@ const EXCERPT_LENGTH = 120
 
 function excerptOf(body: string): string {
   const trimmed = body.trim()
-  return trimmed.length > EXCERPT_LENGTH
-    ? `${trimmed.slice(0, EXCERPT_LENGTH).trimEnd()}…`
-    : trimmed
+  if (trimmed.length <= EXCERPT_LENGTH) return trimmed
+  // Grapheme-safe cut so an emoji straddling the cap can't become a lone
+  // surrogate (�) at the boundary.
+  return `${truncateToGraphemeBoundary(trimmed, EXCERPT_LENGTH).trimEnd()}…`
 }
 
 /**
@@ -396,7 +430,7 @@ function resolveCounterpart(
   if (author && organizerSet.has(author.authorId) && author.authorName) {
     return { name: author.authorName, image: author.authorImage ?? undefined }
   }
-  return { name: 'Organizers' }
+  return { name: ORGANIZERS_LABEL }
 }
 
 /**
@@ -406,18 +440,31 @@ function resolveCounterpart(
 export async function listMessages({
   conversationId,
   before,
+  beforeId,
 }: {
   conversationId: string
   before?: string
+  beforeId?: string
 }): Promise<Message[]> {
   const params: Record<string, unknown> = { conversationId }
   let cursor = ''
   if (before) {
-    cursor = ' && createdAt < $before'
-    params.before = before
+    // Compound keyset cursor: order by (createdAt desc, _id desc) so messages
+    // that share an exact `createdAt` (bulk / same-instant writes) are totally
+    // ordered and none is skipped at a page boundary. Callers that only pass
+    // `before` (no `beforeId`) keep the original strict-less-than behaviour.
+    if (beforeId) {
+      cursor =
+        ' && (createdAt < $before || (createdAt == $before && _id < $beforeId))'
+      params.before = before
+      params.beforeId = beforeId
+    } else {
+      cursor = ' && createdAt < $before'
+      params.before = before
+    }
   }
 
-  const query = `*[_type == "message" && conversation._ref == $conversationId${cursor}] | order(createdAt desc) [0...${PAGE_SIZE}] {
+  const query = `*[_type == "message" && conversation._ref == $conversationId${cursor}] | order(createdAt desc, _id desc) [0...${PAGE_SIZE}] {
     "_id": _id,
     "conversationId": conversation._ref,
     "authorId": author._ref,

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -16,6 +16,10 @@
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import { createReference } from '@/lib/sanity/helpers'
 import { sendPushForNotifications } from '@/lib/push/send'
+import {
+  truncateToGraphemeBoundary,
+  conversationLinkPath,
+} from '@/lib/messaging/links'
 import type {
   MessageNotificationInput,
   NotificationInput,
@@ -119,7 +123,9 @@ function messageNotificationTitle(
     count > 1
       ? `${count} new messages — ${subject}`
       : `New message from ${authorName} — ${subject}`
-  return title.slice(0, NOTIFICATION_TITLE_MAX)
+  // Grapheme-safe cut (an emoji in the author name or subject can straddle the
+  // 200-char cap) so the stored title never ends in a lone surrogate (�).
+  return truncateToGraphemeBoundary(title, NOTIFICATION_TITLE_MAX)
 }
 
 /**
@@ -168,80 +174,118 @@ export async function upsertMessageNotifications(
     )
 
     const now = new Date().toISOString()
-    const tx = clientWrite.transaction()
-    const pushItems: NotificationInput[] = []
 
-    for (const item of items) {
+    // Precompute the count-aware title + deterministic id per recipient ONCE so
+    // the transaction write and the push payload share the exact same title.
+    const prepared = items.map((item) => {
       const id = messageNotificationId(item.conversationId, item.recipientId)
       const existing = existingById.get(id)
       // Unread accumulates; a read (or brand-new) document resets to 1.
       const count =
         (existing && !existing.readAt ? (existing.count ?? 1) : 0) + 1
-      const title = messageNotificationTitle(
+      return {
+        item,
+        id,
         count,
-        item.authorName,
-        item.subject,
-      )
+        title: messageNotificationTitle(count, item.authorName, item.subject),
+      }
+    })
 
-      const set: Record<string, unknown> = {
-        // Bubbles the collapsed item back to the top of the inbox.
-        createdAt: now,
-        title,
-        count,
-      }
-      if (item.message) {
-        set.message = item.message
-      }
-      if (item.link) {
-        set.link = item.link
-      }
-      if (item.actorId) {
-        set.actor = createReference(item.actorId)
-      }
-      if (item.relatedProposalId) {
-        // Weak reference so a later proposal deletion doesn't orphan-block.
-        set.relatedProposal = {
-          ...createReference(item.relatedProposalId),
-          _weak: true,
-        }
-      }
-
-      tx.createIfNotExists({
-        _id: id,
-        _type: 'notification',
-        recipient: createReference(item.recipientId),
-        conference: createReference(item.conferenceId),
-        notificationType: 'message_received',
-        title,
-        count: 1,
-        createdAt: now,
-      }).patch(id, { set, unset: ['readAt'] })
-
-      pushItems.push({
-        recipientId: item.recipientId,
-        conferenceId: item.conferenceId,
-        notificationType: 'message_received',
-        title,
-        ...(item.message ? { message: item.message } : {}),
-        ...(item.link ? { link: item.link } : {}),
-        ...(item.actorId ? { actorId: item.actorId } : {}),
-        ...(item.relatedProposalId
-          ? { relatedProposalId: item.relatedProposalId }
-          : {}),
-      })
+    // Chunk the per-recipient upserts so ONE malformed recipient ref can't fail
+    // the whole fan-out (per-recipient failure isolation): each chunk commits in
+    // its own transaction via `Promise.allSettled`, and the push bridge fires
+    // only for the recipients whose chunk actually committed.
+    const CHUNK_SIZE = 10
+    const chunks: (typeof prepared)[] = []
+    for (let i = 0; i < prepared.length; i += CHUNK_SIZE) {
+      chunks.push(prepared.slice(i, i + CHUNK_SIZE))
     }
 
-    await tx.commit()
+    const commitResults = await Promise.allSettled(
+      chunks.map((chunk) => {
+        const tx = clientWrite.transaction()
+        for (const { item, id, title, count } of chunk) {
+          const set: Record<string, unknown> = {
+            // Bubbles the collapsed item back to the top of the inbox.
+            createdAt: now,
+            title,
+            count,
+          }
+          if (item.message) {
+            set.message = item.message
+          }
+          if (item.link) {
+            set.link = item.link
+          }
+          if (item.actorId) {
+            set.actor = createReference(item.actorId)
+          }
+          if (item.relatedProposalId) {
+            // Weak reference so a later proposal deletion doesn't orphan-block.
+            set.relatedProposal = {
+              ...createReference(item.relatedProposalId),
+              _weak: true,
+            }
+          }
+
+          tx.createIfNotExists({
+            _id: id,
+            _type: 'notification',
+            recipient: createReference(item.recipientId),
+            conference: createReference(item.conferenceId),
+            notificationType: 'message_received',
+            title,
+            count: 1,
+            createdAt: now,
+          }).patch(id, { set, unset: ['readAt'] })
+        }
+        return tx.commit()
+      }),
+    )
+
+    // Build push items ONLY for the chunks that committed; a rejected chunk is
+    // logged and its recipients simply get no hub/push for this message.
+    const pushItems: NotificationInput[] = []
+    commitResults.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        console.error(
+          'Failed to commit a message-notification chunk:',
+          result.reason,
+        )
+        return
+      }
+      for (const { item, title } of chunks[index]) {
+        pushItems.push({
+          recipientId: item.recipientId,
+          conferenceId: item.conferenceId,
+          notificationType: 'message_received',
+          title,
+          // Stable per-conversation tag: successive pushes for the same thread
+          // REPLACE each other on the device instead of stacking N lock-screen
+          // notifications while the hub shows one collapsed item (M5).
+          tag: `msg:${item.conversationId}`,
+          ...(item.message ? { message: item.message } : {}),
+          ...(item.link ? { link: item.link } : {}),
+          ...(item.actorId ? { actorId: item.actorId } : {}),
+          ...(item.relatedProposalId
+            ? { relatedProposalId: item.relatedProposalId }
+            : {}),
+        })
+      }
+    })
 
     // Same isolated push bridge as `createNotifications`: a push failure can
     // neither fail the (already committed) upsert nor the business mutation.
-    try {
-      await sendPushForNotifications(pushItems)
-    } catch (pushError) {
-      console.error(
-        'Failed to send web push for message notifications:',
-        pushError,
-      )
+    // Skip entirely when no chunk committed (nothing to deliver).
+    if (pushItems.length > 0) {
+      try {
+        await sendPushForNotifications(pushItems)
+      } catch (pushError) {
+        console.error(
+          'Failed to send web push for message notifications:',
+          pushError,
+        )
+      }
     }
   } catch (error) {
     // Never propagate — see the contract above.
@@ -398,6 +442,77 @@ export async function markNotificationsReadByLinks({
   return ids.length
 }
 
+/**
+ * Delete a speaker's collapsed `message_received` notifications for the given
+ * proposal threads and/or general conversations. Called when a participant
+ * LOSES access to a thread (e.g. a co-speaker removed from a proposal): their
+ * message notifications would otherwise linger as PERMANENT phantom unread — the
+ * bell keeps counting them, the deep link 403/404s once access is gone, and
+ * mark-read can never fire because they can no longer open the thread to clear
+ * it. Deletes both read and unread (a thread they can't reach shouldn't show up
+ * at all).
+ *
+ * Matching is by the recipient + the audience deep links of each thread (both
+ * variants), so it's robust to whichever audience the speaker actually received.
+ *
+ * NEVER-FAIL: wrapped so a cleanup failure can't fail the access-change mutation
+ * that triggered it; returns how many were deleted (0 on error / no match).
+ */
+export async function deleteMessageNotificationsFor({
+  proposalIds = [],
+  conversationIds = [],
+  speakerId,
+}: {
+  proposalIds?: string[]
+  conversationIds?: string[]
+  speakerId: string
+}): Promise<number> {
+  const links: string[] = []
+  for (const proposalId of proposalIds) {
+    const conv = { _id: '', conversationType: 'proposal' as const, proposalId }
+    links.push(
+      conversationLinkPath(conv, true),
+      conversationLinkPath(conv, false),
+    )
+  }
+  for (const conversationId of conversationIds) {
+    const conv = {
+      _id: conversationId,
+      conversationType: 'general' as const,
+      proposalId: undefined,
+    }
+    links.push(
+      conversationLinkPath(conv, true),
+      conversationLinkPath(conv, false),
+    )
+  }
+  if (links.length === 0) {
+    return 0
+  }
+
+  try {
+    const ids = await clientReadUncached.fetch<string[]>(
+      `*[_type == "notification" && recipient._ref == $speakerId && notificationType == "message_received" && link in $links]._id`,
+      { speakerId, links },
+    )
+    if (!ids || ids.length === 0) {
+      return 0
+    }
+    const tx = clientWrite.transaction()
+    for (const id of ids) {
+      tx.delete(id)
+    }
+    await tx.commit()
+    return ids.length
+  } catch (error) {
+    console.error(
+      'Failed to delete message notifications for access loss:',
+      error,
+    )
+    return 0
+  }
+}
+
 /** The maximum number of notifications marked read in one `markAllRead` call. */
 const MARK_ALL_READ_LIMIT = 500
 
@@ -449,6 +564,14 @@ const RETENTION_MAX_BATCHES = 20
  * or the {@link RETENTION_MAX_BATCHES} safety cap is reached. Returns the total
  * number of documents deleted.
  *
+ * UNREAD MESSAGE EXCEPTION: an unread collapsed `message_received` notification
+ * is the ONLY store of a conversation's per-recipient unread state (the messages
+ * themselves are immortal — they have no retention policy). Purging it at the
+ * horizon would silently drop that unread signal, so we EXCLUDE unread message
+ * notifications from the cutoff. Once read (`readAt` set) they age out normally;
+ * every OTHER type ages out at the cutoff even when unread (the hub is not an
+ * archive).
+ *
  * CONTRACT: unlike the fan-out write paths, this function MAY throw. It backs a
  * retention cron route that reports (and should surface) failures rather than
  * silently swallowing them, so the caller is expected to handle errors.
@@ -461,7 +584,7 @@ export async function deleteNotificationsOlderThan(
   let deleted = 0
   for (let batch = 0; batch < RETENTION_MAX_BATCHES; batch++) {
     const ids = await clientReadUncached.fetch<string[]>(
-      `*[_type == "notification" && createdAt < $cutoff][0...${RETENTION_DELETE_BATCH_SIZE}]._id`,
+      `*[_type == "notification" && createdAt < $cutoff && !(notificationType == "message_received" && !defined(readAt))][0...${RETENTION_DELETE_BATCH_SIZE}]._id`,
       { cutoff },
     )
 
@@ -487,13 +610,51 @@ export async function deleteNotificationsOlderThan(
 }
 
 /**
- * The `_id`s of every organizer speaker. `isOrganizer` is GLOBAL (an organizer
- * of one edition is an organizer everywhere); the conference scoping happens
- * implicitly because the created notification carries the conference ref.
+ * Per-instance cache TTL for the organizer id set. Organizer membership changes
+ * are RARE (promoting/removing an organizer is an infrequent admin action), so a
+ * short TTL is an ample freshness bound while collapsing the many per-request
+ * reads (EVERY notification fan-out and messaging list resolves organizers) into
+ * ~one read per instance per minute.
+ *
+ * SERVERLESS NOTE: this cache lives in module scope, so it is PER WARM INSTANCE,
+ * not global — each lambda/instance refreshes independently and a cold start
+ * always reads fresh. The worst-case staleness any caller can observe is
+ * {@link ORGANIZER_CACHE_TTL_MS} on whichever instance served them, which is an
+ * acceptable bound for organizer membership.
+ */
+const ORGANIZER_CACHE_TTL_MS = 60_000
+
+/** Upper bound on the organizer fetch; the organizer set is tiny in practice. */
+const ORGANIZER_FETCH_LIMIT = 200
+
+let organizerCache: { ids: string[]; expiresAt: number } | null = null
+
+/**
+ * The `_id`s of every organizer speaker (bounded to
+ * [0...{@link ORGANIZER_FETCH_LIMIT}]). `isOrganizer` is GLOBAL (an organizer of
+ * one edition is an organizer everywhere); the conference scoping happens
+ * implicitly because the created notification carries the conference ref. Cached
+ * per instance for {@link ORGANIZER_CACHE_TTL_MS} (see the note above). The
+ * returned array is treated as read-only by callers (they wrap it in a Set).
  */
 export async function getOrganizerSpeakerIds(): Promise<string[]> {
+  const now = Date.now()
+  if (organizerCache && organizerCache.expiresAt > now) {
+    return organizerCache.ids
+  }
   const ids = await clientReadUncached.fetch<string[]>(
-    `*[_type == "speaker" && isOrganizer == true]._id`,
+    `*[_type == "speaker" && isOrganizer == true][0...${ORGANIZER_FETCH_LIMIT}]._id`,
   )
-  return ids || []
+  const resolved = ids || []
+  organizerCache = { ids: resolved, expiresAt: now + ORGANIZER_CACHE_TTL_MS }
+  return resolved
+}
+
+/**
+ * Clear the per-instance organizer cache. Exposed for tests (which assert fresh
+ * reads) and as a hook if a future admin flow wants to invalidate eagerly after
+ * changing organizer membership.
+ */
+export function clearOrganizerSpeakerIdsCache(): void {
+  organizerCache = null
 }

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -37,6 +37,15 @@ export interface NotificationInput {
   actorId?: string
   /** Weakly referenced proposal (talk) id, if the notification relates to one. */
   relatedProposalId?: string
+  /**
+   * Optional stable push `tag`. When set, successive web pushes carrying the
+   * same tag REPLACE each other on the device (the SW passes it to
+   * `showNotification`) instead of stacking. Used by the collapsed
+   * `message_received` upsert to keep one lock-screen notification per thread,
+   * mirroring the single collapsed hub item. Absent for one-shot event types
+   * (they intentionally stack).
+   */
+  tag?: string
 }
 
 /**

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -8,6 +8,7 @@ import { Reference } from 'sanity'
 import { v4 as randomUUID } from 'uuid'
 import { convertStringToPortableTextBlocks } from '../utils/validation'
 import { Review } from '@/lib/review/types'
+import { conversationLinkPath } from '@/lib/messaging/links'
 import {
   prepareReferenceArray,
   createReference,
@@ -301,6 +302,43 @@ export async function updateProposal(
 const CASCADE_DELETE_TYPES = ['coSpeakerInvitation', 'review']
 
 /**
+ * Types that reference a proposal only WEAKLY and must neither block deletion
+ * nor generally be deleted with it:
+ * - `notification` — a hub notification's `relatedProposal` is weak and is NEVER
+ *   dereferenced by any list projection, so a dangling ref renders harmlessly.
+ *   (The proposal thread's `message_received` notifications ARE cleaned up
+ *   separately below, since they'd otherwise 404 on their deep link.)
+ * - `conversation` — the proposal thread; CASCADE-deleted below along with its
+ *   messages.
+ * Both are excluded from the blocking check so a proposal with an active message
+ * thread and notifications stays deletable.
+ */
+const NON_BLOCKING_TYPES = ['notification', 'conversation']
+
+/** Deletes per transaction when cascading a proposal's thread — keeps each
+ * commit well under Sanity's mutation-per-transaction ceiling. */
+const PROPOSAL_DELETE_CHUNK_SIZE = 100
+
+/** Split `items` into consecutive chunks of at most `size`. */
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}
+
+/** Delete a set of document ids in ONE transaction. No-op for an empty set. */
+async function commitDeletes(ids: string[]): Promise<void> {
+  if (ids.length === 0) return
+  const transaction = clientWrite.transaction()
+  for (const id of ids) {
+    transaction.delete(id)
+  }
+  await transaction.commit()
+}
+
+/**
  * Human readable descriptions for document types that block deletion of a
  * proposal. Any other unexpected referencing type falls back to its raw
  * `_type` name.
@@ -335,8 +373,15 @@ export async function deleteProposal(
 
     const docs = referencingDocs ?? []
 
+    // A GROQ `references()` match includes WEAK refs, so notifications
+    // (weak `relatedProposal`) and the proposal conversation (weak `proposal`)
+    // show up here too. Only STRONG-ref holders that aren't cascade-safe (a
+    // published schedule, a featured-talk conference ref, workshop signups, …)
+    // genuinely block deletion.
     const blocking = docs.filter(
-      (doc) => !CASCADE_DELETE_TYPES.includes(doc._type),
+      (doc) =>
+        !CASCADE_DELETE_TYPES.includes(doc._type) &&
+        !NON_BLOCKING_TYPES.includes(doc._type),
     )
 
     if (blocking.length > 0) {
@@ -354,14 +399,75 @@ export async function deleteProposal(
       }
     }
 
-    // Delete dependent documents (co-speaker invitations and reviews) and
-    // the proposal itself in a single atomic transaction.
-    const transaction = clientWrite.transaction()
-    for (const doc of docs) {
-      transaction.delete(doc._id)
+    // Cascade-safe dependents that reference the proposal (co-speaker
+    // invitations + reviews). Notifications are intentionally KEPT (their weak
+    // ref dangles harmlessly); the message thread is handled just below.
+    const cascadeIds = docs
+      .filter((doc) => CASCADE_DELETE_TYPES.includes(doc._type))
+      .map((doc) => doc._id)
+
+    // Cascade the proposal's message thread: the conversation(s), their
+    // messages, and every participant's collapsed message notification. Fetched
+    // fresh (not filtered from `docs`) because message documents don't reference
+    // the proposal, and message notifications are matched by the proposal-thread
+    // deep link (both audience variants) rather than a stored proposal ref.
+    const conversationIds =
+      (await clientRead.fetch<string[]>(
+        groq`*[_type == "conversation" && proposal._ref == $proposalId]._id`,
+        { proposalId },
+      )) ?? []
+
+    let messageIds: string[] = []
+    if (conversationIds.length > 0) {
+      messageIds =
+        (await clientRead.fetch<string[]>(
+          groq`*[_type == "message" && conversation._ref in $conversationIds]._id`,
+          { conversationIds },
+        )) ?? []
     }
-    transaction.delete(proposalId)
-    await transaction.commit()
+
+    const threadLinkConv = {
+      _id: '',
+      conversationType: 'proposal' as const,
+      proposalId,
+    }
+    const messageLinks = [
+      conversationLinkPath(threadLinkConv, true),
+      conversationLinkPath(threadLinkConv, false),
+    ]
+    const messageNotificationIds =
+      (await clientRead.fetch<string[]>(
+        groq`*[_type == "notification" && notificationType == "message_received" && link in $messageLinks]._id`,
+        { messageLinks },
+      )) ?? []
+
+    // Deletion ORDER matters for strong references: a message strongly refs its
+    // conversation, so messages must go before conversations; the proposal is
+    // deleted LAST, together with the co-speaker invitations / reviews that
+    // strongly ref it (Sanity resolves intra-transaction constraints, so those
+    // may share the final transaction). Everything else is weak-ref or
+    // unreferenced and can be chunked freely. Chunking trades the previous
+    // single-transaction atomicity for staying under the mutation ceiling on a
+    // large thread — a mid-way failure surfaces an error and leaves a partially
+    // cascaded thread, which a retry finishes.
+    for (const chunk of chunkArray(messageIds, PROPOSAL_DELETE_CHUNK_SIZE)) {
+      await commitDeletes(chunk)
+    }
+    for (const chunk of chunkArray(
+      conversationIds,
+      PROPOSAL_DELETE_CHUNK_SIZE,
+    )) {
+      await commitDeletes(chunk)
+    }
+    for (const chunk of chunkArray(
+      messageNotificationIds,
+      PROPOSAL_DELETE_CHUNK_SIZE,
+    )) {
+      await commitDeletes(chunk)
+    }
+    // Final transaction: the cascade dependents (strong refs to the proposal)
+    // and the proposal itself, atomically.
+    await commitDeletes([...cascadeIds, proposalId])
   } catch (error) {
     console.error('Error deleting proposal:', error)
     err = error as Error

--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -272,6 +272,10 @@ async function deliverPushToRecipient(
       // The SW re-sanitises this to a same-origin path; hub links are already
       // app-relative (e.g. /cfp/proposal/<id>). Fall back to the app root.
       url: item.link ?? '/',
+      // Stable per-thread tag (message notifications) → the SW passes it to
+      // showNotification so repeat pushes for the same thread REPLACE the prior
+      // one instead of stacking. Undefined for one-shot types (they stack).
+      ...(item.tag ? { tag: item.tag } : {}),
     }
 
     const results = await Promise.allSettled(

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -51,6 +51,7 @@ import { createReference, createReferenceWithKey } from '@/lib/sanity/helpers'
 import {
   createNotifications,
   getOrganizerSpeakerIds,
+  deleteMessageNotificationsFor,
 } from '@/lib/notification/sanity'
 import type { NotificationInput } from '@/lib/notification/types'
 import type { ProposalInput, ProposalExisting } from '@/lib/proposal/types'
@@ -582,6 +583,16 @@ export const proposalRouter = router({
         }
 
         await transaction.commit()
+
+        // The removed speaker loses access to the proposal's message thread;
+        // delete their collapsed message notifications so they don't linger as
+        // permanent phantom unread (the bell counts them, but their deep link
+        // now 403/404s and they can never open the thread to clear it).
+        // Never-fail: cleanup must not fail the (committed) removal.
+        await deleteMessageNotificationsFor({
+          proposalIds: [input.proposalId],
+          speakerId: input.speakerId,
+        })
 
         return { success: true }
       } catch (error) {


### PR DESCRIPTION
Data-lifecycle fix batch (batch B) from the adversarial review of the speaker↔organizer messaging system. Each item cites its review finding.

## Fixes

**B1 (P1) — undeletable proposals.** `deleteProposal` blocked on ANY referencing `_type` outside the cascade list, and GROQ `references()` matches WEAK refs, so `notification.relatedProposal` (weak, written on every proposal event) and `conversation.proposal` (weak) made effectively every active proposal undeletable. Now: `notification` and `conversation` are treated as non-blocking; the proposal's conversation(s), their messages, and the per-recipient collapsed **message** notifications (matched by the proposal-thread deep link, both audience variants) are CASCADE-deleted (messages before conversations for the strong ref; proposal + cascade dependents atomic in the final tx; chunked at 100/tx for large threads). Non-message notifications are KEPT with a harmless dangling weak ref — verified no projection dereferences `relatedProposal` (`getNotificationsForSpeaker` only derefs `actor->`). Genuinely-blocking strong-ref types (schedule/conference/workshopSignup) still block. `src/lib/proposal/data/sanity.ts`.

**B2 (P2) — retention purged unread message state.** `deleteNotificationsOlderThan` deleted by `createdAt` with no read guard, silently dropping an unread collapsed message notification (the ONLY store of message unread state) at 90d. The purge query now excludes `notificationType == "message_received" && !defined(readAt)`; JSDoc documents why (unread message signal must outlive the horizon; messages are immortal). `src/lib/notification/sanity.ts`.

**B3 (P2) — access-loss orphan notifications.** Added `deleteMessageNotificationsFor({ proposalIds?, conversationIds?, speakerId })` (link-matched, never-fail) and call it from `removeCoSpeaker` after the removal commits, so a removed co-speaker's message notifications don't linger as permanent phantom unread (bell counts them, deep link 403/404s, mark-read can never fire). `src/lib/notification/sanity.ts` + one additive call in `src/server/routers/proposal.ts` (see Cross-territory below).

**B4 (P2) — unread cap undercount.** `listConversationsForSpeaker` fetched unread notifications conference-wide with a fixed `[0...500]` cap, so a caller (e.g. an organizer) with >500 unread docs got silent zeros on page rows. The fetch is now SCOPED to the current page's conversations via `link in $pageLinks` (both audience variants per row → ≤ 2×PAGE_SIZE, no fixed cap). `coalesce(count,1)` summing preserved. `src/lib/messaging/sanity.ts`.

**B5 (P3) — keyset ties.** `listMessages` (`createdAt < $before`) and `listConversationsForSpeaker` (`lastMessageAt < $before`) skip equal-timestamp boundary rows forever. Both now order by `(ts desc, _id desc)` and accept an optional `beforeId` for a compound predicate `ts < $before || (ts == $before && _id < $beforeId)`. **Backward-compatible & currently dormant:** the data layer supports it, but the tRPC layer isn't wired yet — see Follow-ups.

**B6 (P3) — surrogate slicing.** `excerptOf`, `messageNotificationTitle`, and `messageExcerpt` sliced at UTF-16 offsets, so an emoji at the boundary produced a lone surrogate (�). Added one shared grapheme-safe `truncateToGraphemeBoundary` (Intl.Segmenter + surrogate-pair fallback) in `src/lib/messaging/links.ts`; used in all three. (`messageExcerpt` is in `notify.ts` — see Cross-territory.)

**B7 (P2) — GDPR erasure trap.** `message.author`, `conversation.createdBy`, `conversation.subjectSpeaker`, `notification.recipient`, `notification.actor` were STRONG refs, so any speaker who ever messaged could never be deleted. Set `weak: true` on all five schemas. Migration `041-weak-messaging-refs` rewrites existing refs weak (`_weak: true`), idempotent.

> ⚠️ **MIGRATION NOT RUN — maintainer decision required.** `migrations/041-weak-messaging-refs` is committed but has not run against any dataset. Run intentionally via the `Run Sanity Migration` workflow (backup + dry run first) after review. Details in its README.

**B8 (P3) — 'Organizers' constant + empty snippet.** Exported `ORGANIZERS_LABEL` from `links.ts` (client-safe); used in `resolveCounterpart` and the `ConversationList.tsx` avatar branch (the one sanctioned component line). A `lastMessage` whose body trims to an empty excerpt now returns `lastMessage: null` (no blank snippet line).

**B9 (P3) — unbounded organizer fetch.** `getOrganizerSpeakerIds` now bounds to `[0...200]` and caches per-instance with a 60s TTL (organizer membership changes are rare; serverless per-instance staleness documented). Exported `clearOrganizerSpeakerIdsCache()` for tests/eager invalidation. `src/lib/notification/sanity.ts`.

**B10 (P2) — push notifications stack on the lock screen.** M5 collapses message notifications to one hub doc per (recipient, conversation), but the push bridge sent `{title, body, url}` with no `tag`, so N messages = N stacked OS pushes. Added a stable per-conversation `tag` (`msg:<conversationId>`) on `NotificationInput`, threaded through `deliverPushToRecipient` into the payload. The SW push handler already forwards `data.tag` to `showNotification`, so successive pushes for a thread now REPLACE on-device. Non-message types keep no tag (intentional stacking). `src/lib/notification/{sanity,types}.ts`, `src/lib/push/send.ts`.

**B11 (P3) — hub channel all-or-nothing.** `upsertMessageNotifications` committed ALL recipients in ONE transaction, so one malformed recipient ref dropped the hub notification + push for everyone. Now chunked (10/tx) with `Promise.allSettled`; a failed chunk is logged and its recipients skipped, the push bridge fires only for committed recipients. The single batched read and never-throw contract are unchanged.

## Cross-territory touches (flagged for coordination)
Two edits fall outside the stated file territory but are explicitly sanctioned by their task notes; both are narrow and additive:
- `src/lib/messaging/notify.ts` — `messageExcerpt` body swapped to the shared B6 helper (B6 names this function explicitly).
- `src/server/routers/proposal.ts` — one additive `deleteMessageNotificationsFor(...)` call after the `removeCoSpeaker` commit (B3 conditionally authorizes the call site since it is proposal-remove-cospeaker-specific).

## Follow-ups (owned by other batches)
- **B5 wiring:** to activate the compound cursor end-to-end, the message router (`src/server/routers/message.ts`) + schema (`src/server/schemas/message.ts`) must pass an optional `beforeId` (and the client must send the last row's `_id`). Kept optional/backward-compatible so nothing breaks until then.

## Tests
Full `pnpm vitest run` green: **3045 passed / 5 skipped** (203 files). New coverage for B1 cascade + non-blocking notifications + schedule-still-blocks, B2 unread exclusion, B3 delete/never-fail/no-op, B4 page-scoped + beyond-cap, B5 tie predicates (both lists), B6 grapheme helper + emoji straddle, B9 bound/cache/clear, B10 tag payload, B11 chunk isolation. tsc / eslint / prettier / knip all clean. B8's UI line is non-visual (constant swap) → no shoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses eleven data-lifecycle defects in the speaker↔organizer messaging system, covering proposal cascade-delete correctness, retention safety, access-loss cleanup, unread-count accuracy, keyset pagination, surrogate-safe truncation, GDPR erasure, push notification deduplication, and transaction fault isolation.

- **B1** rewrites `deleteProposal` to cascade-delete the message thread (messages → conversations → message notifications) before the proposal itself, bypassing weak-ref holders that previously made every active proposal undeletable; chunked at 100/tx.
- **B7** marks five speaker reference fields `weak: true` across `message`, `conversation`, and `notification` schemas (migration committed but intentionally unrun) so any speaker who ever messaged can be erased under GDPR.
- **B2/B3/B4/B9/B10/B11** close a cluster of correctness gaps: unread message state excluded from 90-day retention, co-speaker removal cleans up phantom notifications, page-scoped unread counts replace a fixed-cap fetch, organizer IDs bounded and cached, push notifications replace rather than stack per thread, and fan-out chunks per recipient for failure isolation.

<h3>Confidence Score: 4/5</h3>

Safe to merge after updating AGENTS.md and considering switching the cascade-fetch queries to the uncached client; the core logic is correct and well-tested.

The cascade ordering is correct and the test suite is thorough (3045 passing). AGENTS.md documents two contracts this PR deliberately overrides without updating the guide, which will mislead future work. The cascade-fetch queries in deleteProposal use the CDN-cached client where the dedicated cleanup helper uses the uncached one — a notification created shortly before proposal deletion could escape the cascade.

src/lib/proposal/data/sanity.ts (cascade fetch client consistency) and AGENTS.md (two stale contract statements)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/proposal/data/sanity.ts | B1 cascade-delete refactor: correctly orders deletions (messages → conversations → message notifications → proposal), filters non-blocking types, chunks large deletes. Cascade-fetch queries use clientRead (cached) instead of clientReadUncached, which could miss recently-written notifications. |
| src/lib/notification/sanity.ts | B2 (unread retention guard), B3 (deleteMessageNotificationsFor — never-fail, clientReadUncached), B9 (bounded organizer fetch with 60s TTL cache), B11 (chunked upsert with Promise.allSettled, push scoped to committed chunks). All changes correct and well-tested. |
| src/lib/messaging/sanity.ts | B4 page-scoped unread count, B5 compound keyset cursor (backward-compatible), B6 grapheme-safe excerptOf, B8 null lastMessage for empty excerpts, resolveCounterpart uses ORGANIZERS_LABEL. All correct. |
| src/lib/messaging/links.ts | Adds ORGANIZERS_LABEL constant and truncateToGraphemeBoundary with Intl.Segmenter + surrogate-pair fallback. Correctly handles the high-surrogate edge case. |
| migrations/041-weak-messaging-refs/index.ts | Idempotent migration weakening five speaker ref fields; skips drafts and already-weak refs. Correctly unrun by default. |
| src/server/routers/proposal.ts | B3: additive deleteMessageNotificationsFor call after removeCoSpeaker commit. Correctly scoped to removed speaker and never-fail. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deleteProposal called] --> B[Fetch referencing docs]
    B --> C{Blocking strong-ref holders?}
    C -->|Yes| D[Return ProposalDeletionBlockedError]
    C -->|No| E[Identify cascade IDs]
    E --> F[Fetch conversationIds]
    F --> G[Fetch messageIds]
    G --> H[Fetch messageNotificationIds by thread link]
    H --> I[Delete messages chunked 100/tx]
    I --> J[Delete conversations chunked 100/tx]
    J --> K[Delete message notifications chunked 100/tx]
    K --> L[Final tx: cascadeIds + proposalId]
    L --> M[Done]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[deleteProposal called] --> B[Fetch referencing docs]
    B --> C{Blocking strong-ref holders?}
    C -->|Yes| D[Return ProposalDeletionBlockedError]
    C -->|No| E[Identify cascade IDs]
    E --> F[Fetch conversationIds]
    F --> G[Fetch messageIds]
    G --> H[Fetch messageNotificationIds by thread link]
    H --> I[Delete messages chunked 100/tx]
    I --> J[Delete conversations chunked 100/tx]
    J --> K[Delete message notifications chunked 100/tx]
    K --> L[Final tx: cascadeIds + proposalId]
    L --> M[Done]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): data lifecycle from adve..."](https://github.com/cloudnativebergen/website/commit/986162f6d91b3c3891e45005824d9a01e802587f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45418302)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->