### PR TITLE
fix(messaging): review follow-up batch F

### DIFF
--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -69,6 +69,7 @@ vi.mock('@/lib/messaging/sanity', async (importActual) => {
 import {
   getConversationById,
   listConversationsForSpeaker,
+  listMessages,
   ensureProposalConversation,
   createGeneralConversation,
   getProposalForConversation,
@@ -80,6 +81,7 @@ import { notifyNewMessage } from '@/lib/messaging/notify'
 type LooseMock = ReturnType<typeof vi.fn>
 const getById = getConversationById as unknown as LooseMock
 const listConvs = listConversationsForSpeaker as unknown as LooseMock
+const listMsgs = listMessages as unknown as LooseMock
 const ensureProposal = ensureProposalConversation as unknown as LooseMock
 const createGeneral = createGeneralConversation as unknown as LooseMock
 const getProposal = getProposalForConversation as unknown as LooseMock
@@ -206,6 +208,46 @@ describe('listConversations — scope by role', () => {
     const caller = createAdminCaller()
     await caller.message.listConversations({})
     expect(listConvs.mock.calls[0][0]).toMatchObject({ isOrganizer: true })
+  })
+})
+
+describe('keyset cursor threading (F3)', () => {
+  const iso = '2026-05-01T12:00:00.000Z'
+
+  it('splits a compound listMessages cursor into before + beforeId', async () => {
+    getById.mockResolvedValue(ownProposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    await caller.message.listMessages({
+      conversationId: 'conversation.proposal.prop-1',
+      cursor: `${iso}~message.42`,
+    })
+    expect(listMsgs.mock.calls[0][0]).toMatchObject({
+      conversationId: 'conversation.proposal.prop-1',
+      before: iso,
+      beforeId: 'message.42',
+    })
+  })
+
+  it('threads a legacy plain-datetime listMessages cursor as before only', async () => {
+    getById.mockResolvedValue(ownProposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    await caller.message.listMessages({
+      conversationId: 'conversation.proposal.prop-1',
+      cursor: iso,
+    })
+    expect(listMsgs.mock.calls[0][0]).toMatchObject({
+      before: iso,
+      beforeId: undefined,
+    })
+  })
+
+  it('splits a compound listConversations cursor into before + beforeId', async () => {
+    const caller = createAdminCaller()
+    await caller.message.listConversations({ cursor: `${iso}~conversation.9` })
+    expect(listConvs.mock.calls[0][0]).toMatchObject({
+      before: iso,
+      beforeId: 'conversation.9',
+    })
   })
 })
 

--- a/__tests__/components/email/MessageNotificationTemplate.test.tsx
+++ b/__tests__/components/email/MessageNotificationTemplate.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Audience-correct body copy for the new-message email (F4). The organizer and
+ * speaker variants share the CTA + "Manage notification preferences" link but
+ * differ in the "Prefer email?" sentence: an organizer reply reaches the speaker
+ * and fellow organizers; a speaker reply reaches the organizers.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MessageNotificationTemplate } from '@/components/email/MessageNotificationTemplate'
+
+const base = {
+  recipientName: 'Recipient',
+  authorName: 'Jane Speaker',
+  subject: 'About your talk',
+  excerpt: 'Could you shorten the abstract?',
+  replyUrl: 'https://cndn.no/cfp/proposal/p1#messages',
+  preferencesUrl: 'https://cndn.no/cfp/profile#notification-settings',
+  eventName: 'CNDN',
+  eventLocation: 'Bergen, Norway',
+  eventDate: '2026-09-01',
+  eventUrl: 'https://cndn.no',
+  socialLinks: [],
+}
+
+describe('MessageNotificationTemplate copy', () => {
+  it('uses speaker-phrased copy for a speaker recipient (default)', () => {
+    const html = renderToStaticMarkup(
+      <MessageNotificationTemplate {...base} isOrganizer={false} />,
+    )
+    expect(html).toContain('reaches the organizers by email')
+    expect(html).not.toContain('speaker and fellow organizers')
+    // Shared elements intact for both audiences.
+    expect(html).toContain('Reply in app')
+    expect(html).toContain('Manage notification preferences')
+  })
+
+  it('uses organizer-phrased copy for an organizer recipient', () => {
+    const html = renderToStaticMarkup(
+      <MessageNotificationTemplate {...base} isOrganizer />,
+    )
+    expect(html).toContain('reaches the speaker and fellow organizers by email')
+    // Shared elements still intact.
+    expect(html).toContain('Reply in app')
+    expect(html).toContain('Manage notification preferences')
+  })
+})

--- a/__tests__/components/messaging/ConversationThread.test.tsx
+++ b/__tests__/components/messaging/ConversationThread.test.tsx
@@ -157,6 +157,31 @@ describe('ConversationThreadView', () => {
       />,
     )
     expect(live).toHaveTextContent('New message from Program Committee')
+
+    // Back-to-back message from the SAME author yields an identical phrase; the
+    // live region must still re-announce it (a plain setState would no-op). The
+    // announced text stays the same but the raw content differs (nonce).
+    const afterFirst = live?.textContent
+    const withSecond: DisplayMessage[] = [
+      ...withNew,
+      {
+        id: 'm4',
+        authorName: 'Program Committee',
+        isOrganizer: true,
+        isOwn: false,
+        body: 'And another…',
+        createdAt: new Date().toISOString(),
+      },
+    ]
+    rerender(
+      <ConversationThreadView
+        messages={withSecond}
+        emptyText="Start the conversation with the organizers."
+        onSend={vi.fn()}
+      />,
+    )
+    expect(live).toHaveTextContent('New message from Program Committee')
+    expect(live?.textContent).not.toBe(afterFirst)
   })
 
   it('disables Send when the composer is empty or whitespace', () => {

--- a/__tests__/lib/messaging/email.test.ts
+++ b/__tests__/lib/messaging/email.test.ts
@@ -43,6 +43,7 @@ function recipients(n: number): MessageEmailRecipient[] {
     email: `r${i}@x.no`,
     name: `R${i}`,
     replyUrl: 'https://cndn.no/cfp/proposal/p1#messages',
+    isOrganizer: false,
   }))
 }
 

--- a/__tests__/lib/proposal/data/sanity.test.ts
+++ b/__tests__/lib/proposal/data/sanity.test.ts
@@ -91,6 +91,8 @@ describe('deleteProposal', () => {
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('references($proposalId)'),
       { proposalId: 'proposal-1' },
+      // Mutation-path reads bypass the Next data cache (no-store).
+      { cache: 'no-store' },
     )
     // With no thread, everything collapses into the single final transaction:
     // the cascade dependents + the proposal itself.

--- a/__tests__/server/schemas/message.test.ts
+++ b/__tests__/server/schemas/message.test.ts
@@ -7,6 +7,9 @@ import {
   SendMessageSchema,
   SetPreferenceSchema,
   GetConversationSchema,
+  ListMessagesSchema,
+  ListConversationsSchema,
+  parseMessageCursor,
 } from '@/server/schemas/message'
 
 describe('SendMessageSchema', () => {
@@ -81,5 +84,65 @@ describe('GetConversationSchema', () => {
   it('requires a non-empty id', () => {
     expect(GetConversationSchema.safeParse({ id: '' }).success).toBe(false)
     expect(GetConversationSchema.safeParse({ id: 'conv-1' }).success).toBe(true)
+  })
+})
+
+describe('keyset cursor (F3)', () => {
+  const iso = '2026-05-01T12:00:00.000Z'
+  const compound = `${iso}~message.abc-123`
+
+  it('accepts an omitted cursor (first page)', () => {
+    expect(ListMessagesSchema.safeParse({ conversationId: 'c' }).success).toBe(
+      true,
+    )
+    expect(ListConversationsSchema.safeParse({}).success).toBe(true)
+  })
+
+  it('accepts a plain ISO datetime cursor (legacy inflight clients)', () => {
+    expect(
+      ListMessagesSchema.safeParse({ conversationId: 'c', cursor: iso })
+        .success,
+    ).toBe(true)
+    expect(ListConversationsSchema.safeParse({ cursor: iso }).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts a compound `<iso>~<_id>` cursor', () => {
+    expect(
+      ListMessagesSchema.safeParse({ conversationId: 'c', cursor: compound })
+        .success,
+    ).toBe(true)
+    expect(
+      ListConversationsSchema.safeParse({ cursor: compound }).success,
+    ).toBe(true)
+  })
+
+  it('rejects garbage: non-datetime, empty id half, or over-long', () => {
+    expect(ListConversationsSchema.safeParse({ cursor: 'nope' }).success).toBe(
+      false,
+    )
+    // A compound cursor whose datetime half is invalid.
+    expect(
+      ListConversationsSchema.safeParse({ cursor: `not-a-date~id` }).success,
+    ).toBe(false)
+    // A trailing `~` with an empty id half.
+    expect(
+      ListConversationsSchema.safeParse({ cursor: `${iso}~` }).success,
+    ).toBe(false)
+    // Over the length cap.
+    expect(
+      ListConversationsSchema.safeParse({ cursor: `${iso}~${'x'.repeat(300)}` })
+        .success,
+    ).toBe(false)
+  })
+
+  it('parseMessageCursor splits both forms', () => {
+    expect(parseMessageCursor(undefined)).toEqual({})
+    expect(parseMessageCursor(iso)).toEqual({ before: iso })
+    expect(parseMessageCursor(compound)).toEqual({
+      before: iso,
+      beforeId: 'message.abc-123',
+    })
   })
 })

--- a/src/components/UserMenu.stories.tsx
+++ b/src/components/UserMenu.stories.tsx
@@ -79,6 +79,16 @@ export const SignedInSpeaker: Story = {
   play: async ({ canvasElement }) => {
     await openMenu(canvasElement)
     await expect(screen.getByText('My Dashboard')).toBeVisible()
+    // The new-proposal form is labelled clearly (not "My Proposals").
+    await expect(screen.getByText('Submit New Proposal')).toBeVisible()
+    await expect(screen.queryByText('My Proposals')).not.toBeInTheDocument()
+    // Exactly one Messages entry, pointing at the speaker inbox.
+    const messages = screen.getAllByText('Messages')
+    await expect(messages).toHaveLength(1)
+    await expect(messages[0].closest('a')).toHaveAttribute(
+      'href',
+      '/cfp/messages',
+    )
     await expect(screen.getByText('View public profile')).toBeVisible()
     await expect(screen.getByText('Signed in with GitHub')).toBeVisible()
     await expect(screen.getByText('Sign Out')).toBeVisible()
@@ -107,6 +117,14 @@ export const Organizer: Story = {
     await expect(screen.getByText('Admin')).toBeVisible()
     await expect(screen.getByText('Admin Dashboard')).toBeVisible()
     await expect(screen.getByText('Speakers')).toBeVisible()
+    // Organizers see exactly ONE Messages entry — in the Admin section, linking
+    // to the admin inbox (isOrganizer wins; it is dropped from speaker links).
+    const messages = screen.getAllByText('Messages')
+    await expect(messages).toHaveLength(1)
+    await expect(messages[0].closest('a')).toHaveAttribute(
+      'href',
+      '/admin/messages',
+    )
     await expect(screen.getByText('Signed in with LinkedIn')).toBeVisible()
   },
 }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -12,6 +12,8 @@ import {
   BanknotesIcon,
   BuildingOfficeIcon,
   CalendarDaysIcon,
+  ChatBubbleLeftRightIcon,
+  DocumentPlusIcon,
   DocumentTextIcon,
   HomeIcon,
   PencilSquareIcon,
@@ -34,10 +36,36 @@ interface MenuLink {
   external?: boolean
 }
 
-/** Speaker-facing links available to every signed-in speaker. */
+/**
+ * The audience-aware Messages entry. Exactly ONE renders for any user: an
+ * organizer sees it in the Admin section (linking to the admin inbox), everyone
+ * else sees it inline with the speaker links (the speaker inbox). The audience
+ * rule everywhere is "isOrganizer wins", so it is omitted from the speaker links
+ * for organizers and added to the Admin links instead (see `speakerLinksFor`).
+ */
+const SPEAKER_MESSAGES_LINK: MenuLink = {
+  href: '/cfp/messages',
+  label: 'Messages',
+  icon: ChatBubbleLeftRightIcon,
+}
+const ADMIN_MESSAGES_LINK: MenuLink = {
+  href: '/admin/messages',
+  label: 'Messages',
+  icon: ChatBubbleLeftRightIcon,
+}
+
+/**
+ * Speaker-facing links available to every signed-in speaker. `/cfp/proposal` is
+ * the NEW-proposal form (the list lives at `/cfp/list` = "My Dashboard"), so it
+ * is labelled "Submit New Proposal" to avoid confusion with the dashboard.
+ */
 const SPEAKER_LINKS: MenuLink[] = [
   { href: '/cfp/list', label: 'My Dashboard', icon: Squares2X2Icon },
-  { href: '/cfp/proposal', label: 'My Proposals', icon: DocumentTextIcon },
+  {
+    href: '/cfp/proposal',
+    label: 'Submit New Proposal',
+    icon: DocumentPlusIcon,
+  },
   { href: '/cfp/profile', label: 'Edit Profile', icon: PencilSquareIcon },
   { href: '/cfp/expense', label: 'Travel & Expenses', icon: BanknotesIcon },
 ]
@@ -49,11 +77,22 @@ const SPEAKER_LINKS: MenuLink[] = [
 const ADMIN_LINKS: MenuLink[] = [
   { href: '/admin', label: 'Admin Dashboard', icon: HomeIcon },
   { href: '/admin/proposals', label: 'Proposals', icon: DocumentTextIcon },
+  ADMIN_MESSAGES_LINK,
   { href: '/admin/speakers', label: 'Speakers', icon: UsersIcon },
   { href: '/admin/sponsors', label: 'Sponsors', icon: BuildingOfficeIcon },
   { href: '/admin/schedule', label: 'Schedule', icon: CalendarDaysIcon },
   { href: '/admin/tickets', label: 'Tickets', icon: TicketIcon },
 ]
+
+/**
+ * The speaker links to render, given the viewer's audience. A non-organizer
+ * gets the Messages entry inline; an organizer gets it in the Admin section
+ * instead, so Messages never appears twice.
+ */
+function speakerLinksFor(isOrganizer: boolean): MenuLink[] {
+  if (isOrganizer) return SPEAKER_LINKS
+  return [SPEAKER_LINKS[0], SPEAKER_MESSAGES_LINK, ...SPEAKER_LINKS.slice(1)]
+}
 
 /** Maps a NextAuth provider id to its display name and brand icon. */
 const PROVIDER_META: Record<string, { name: string; Icon: IconType }> = {
@@ -139,7 +178,7 @@ export function UserMenu({ name, picture, speaker, account }: UserMenuProps) {
           </div>
         )}
 
-        {SPEAKER_LINKS.map((link) => (
+        {speakerLinksFor(isOrganizer).map((link) => (
           <LinkItem key={link.href} {...link} />
         ))}
         {slug && (

--- a/src/components/email/MessageNotificationTemplate.tsx
+++ b/src/components/email/MessageNotificationTemplate.tsx
@@ -13,6 +13,12 @@ export interface MessageNotificationTemplateProps {
   subject: string
   excerpt: string
   replyUrl: string
+  /**
+   * Whether the recipient is an organizer. Organizers get organizer-phrased copy
+   * (replying reaches the speaker + fellow organizers) and a `/admin` replyUrl;
+   * speakers get speaker-phrased copy (replying reaches the organizers).
+   */
+  isOrganizer?: boolean
   /** Absolute link to the recipient's notification preferences (cfp profile). */
   preferencesUrl?: string
   eventName: string
@@ -32,6 +38,7 @@ export function MessageNotificationTemplate({
   subject,
   excerpt,
   replyUrl,
+  isOrganizer = false,
   preferencesUrl,
   eventName,
   eventLocation,
@@ -68,8 +75,10 @@ export function MessageNotificationTemplate({
         </div>
 
         <EmailText size="14px" color="#64748B">
-          Prefer email? Replying to this email reaches the organizers by email,
-          while replying in the app keeps the whole conversation in one place.
+          Prefer email?{' '}
+          {isOrganizer
+            ? 'Replying to this email reaches the speaker and fellow organizers by email, while replying in the app keeps the whole conversation in one place.'
+            : 'Replying to this email reaches the organizers by email, while replying in the app keeps the whole conversation in one place.'}
         </EmailText>
 
         <EmailText size="14px" color="#64748B">

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useSession } from 'next-auth/react'
 import {
   BellIcon,
@@ -271,6 +278,8 @@ export function ConversationThreadView({
   const lastIdRef = useRef<string | null>(null)
   const hadMessagesRef = useRef(false)
   const [liveMessage, setLiveMessage] = useState('')
+  // Monotonic counter that re-announces back-to-back messages (see below).
+  const liveNonceRef = useRef(0)
 
   const handleScroll = () => {
     const el = scrollRef.current
@@ -280,8 +289,22 @@ export function ConversationThreadView({
       el.scrollHeight - el.scrollTop - el.clientHeight < 80
   }
 
-  useEffect(() => {
+  // INITIAL positioning runs in a LAYOUT effect (before paint) so a long thread
+  // never flashes its top for a frame before jumping to the newest message.
+  // This is a client component ('use client') so useLayoutEffect never executes
+  // on the server — no SSR hydration warning path is reachable.
+  useLayoutEffect(() => {
+    if (hadMessagesRef.current || messages.length === 0) return
     const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+    hadMessagesRef.current = true
+    lastIdRef.current = messages[messages.length - 1].id
+  }, [messages])
+
+  // Subsequent follow-scrolls + a polite announcement for genuinely NEW
+  // messages. The initial jump is handled by the layout effect above; this
+  // passive effect only reacts to later arrivals (and resets on an empty list).
+  useEffect(() => {
     if (messages.length === 0) {
       hadMessagesRef.current = false
       lastIdRef.current = null
@@ -289,14 +312,18 @@ export function ConversationThreadView({
     }
     const last = messages[messages.length - 1]
     const prevLastId = lastIdRef.current
-    const prefersReduced =
-      typeof window !== 'undefined' &&
-      !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-
+    // First population is fully owned by the layout effect (it recorded the id);
+    // nothing to follow or announce yet.
     if (!hadMessagesRef.current) {
-      // Initial load: jump straight to the newest message (no animation).
-      if (el) el.scrollTop = el.scrollHeight
-    } else if (last.id !== prevLastId) {
+      hadMessagesRef.current = true
+      lastIdRef.current = last.id
+      return
+    }
+    if (last.id !== prevLastId) {
+      const el = scrollRef.current
+      const prefersReduced =
+        typeof window !== 'undefined' &&
+        !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
       // A genuinely new message arrived. Only follow it if the reader is
       // already near the bottom — don't yank them up mid-history-read.
       if (el && nearBottomRef.current) {
@@ -313,11 +340,16 @@ export function ConversationThreadView({
       // derives an assistive-tech announcement from an incoming-message event —
       // a legitimate effect→state sync, not render-derived state.
       if (!last.isOwn) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setLiveMessage(`New message from ${last.authorName}`)
+        // Two messages in a row from the SAME author produce an identical
+        // phrase; a plain setState would be a no-op and the second would never
+        // be announced. Append a per-event count of zero-width spaces (U+200B —
+        // invisible and silent to assistive tech) so the live region's text
+        // genuinely changes and re-fires each time.
+        liveNonceRef.current += 1
+        const nonce = '\u200B'.repeat((liveNonceRef.current % 2) + 1)
+        setLiveMessage(`New message from ${last.authorName}${nonce}`)
       }
     }
-    hadMessagesRef.current = true
     lastIdRef.current = last.id
   }, [messages])
 
@@ -544,10 +576,13 @@ export function ConversationThread({
       // Pause polling while the composer is focused so a refetch can't yank
       // scroll/state out from under someone mid-message.
       refetchInterval: isComposing ? false : 20_000,
-      getNextPageParam: (lastPage) =>
-        lastPage.length === PAGE_SIZE
-          ? lastPage[lastPage.length - 1]?.createdAt
-          : undefined,
+      getNextPageParam: (lastPage) => {
+        if (lastPage.length !== PAGE_SIZE) return undefined
+        const last = lastPage[lastPage.length - 1]
+        // Compound keyset cursor `<createdAt>~<_id>` so messages sharing an
+        // exact `createdAt` page without skips (server splits it).
+        return last ? `${last.createdAt}~${last._id}` : undefined
+      },
       initialCursor: undefined,
     },
   )

--- a/src/components/messaging/MessagesInbox.tsx
+++ b/src/components/messaging/MessagesInbox.tsx
@@ -45,10 +45,13 @@ export function MessagesInbox({
     {},
     {
       staleTime: 10_000,
-      getNextPageParam: (lastPage) =>
-        lastPage.length === PAGE_SIZE
-          ? lastPage[lastPage.length - 1]?.lastMessageAt
-          : undefined,
+      getNextPageParam: (lastPage) => {
+        if (lastPage.length !== PAGE_SIZE) return undefined
+        const last = lastPage[lastPage.length - 1]
+        // Compound keyset cursor `<lastMessageAt>~<_id>` so conversations
+        // sharing an exact `lastMessageAt` page without skips (server splits it).
+        return last ? `${last.lastMessageAt}~${last._id}` : undefined
+      },
       initialCursor: undefined,
     },
   )

--- a/src/lib/messaging/email.ts
+++ b/src/lib/messaging/email.ts
@@ -11,6 +11,12 @@ export interface MessageEmailRecipient {
   name: string
   /** Absolute deep link into the thread for THIS recipient's surface. */
   replyUrl: string
+  /**
+   * Whether THIS recipient is an organizer. Drives the audience-correct body
+   * copy (organizers reach the speaker + fellow organizers; speakers reach the
+   * organizers) so the wording matches the per-recipient `replyUrl` surface.
+   */
+  isOrganizer: boolean
 }
 
 /**
@@ -43,6 +49,8 @@ async function sendOne(
           subject,
           excerpt,
           replyUrl: recipient.replyUrl,
+          // Audience-correct copy for THIS recipient (matches their replyUrl).
+          isOrganizer: recipient.isOrganizer,
           // Settings live on the cfp profile for BOTH audiences; anchor at the
           // notification section so the link matches the in-app gear (A9).
           preferencesUrl: conference.domains?.[0]

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -133,6 +133,7 @@ export async function notifyNewMessage({
         emailRecipients.push({
           email: sp.email,
           name: sp.name ?? 'there',
+          isOrganizer: organizerSet.has(id),
           replyUrl: absoluteLink(
             conversation,
             organizerSet.has(id),

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -367,9 +367,14 @@ export async function deleteProposal(
     // them up front instead of surfacing a raw 409 to the user.
     const referencingDocs = await clientRead.fetch<
       Array<{ _id: string; _type: string }>
-    >(groq`*[references($proposalId) && _id != $proposalId]{ _id, _type }`, {
-      proposalId,
-    })
+    >(
+      groq`*[references($proposalId) && _id != $proposalId]{ _id, _type }`,
+      { proposalId },
+      // Mutation-path read: bypass the Next data cache so a stale entry can't
+      // hide a document that references the proposal (mirrors every other
+      // read in this file, which all pass `cache: 'no-store'`).
+      { cache: 'no-store' },
+    )
 
     const docs = referencingDocs ?? []
 
@@ -415,6 +420,9 @@ export async function deleteProposal(
       (await clientRead.fetch<string[]>(
         groq`*[_type == "conversation" && proposal._ref == $proposalId]._id`,
         { proposalId },
+        // A just-created conversation must not be missed by a stale cache read,
+        // or its messages/notifications would orphan on delete.
+        { cache: 'no-store' },
       )) ?? []
 
     let messageIds: string[] = []
@@ -423,6 +431,8 @@ export async function deleteProposal(
         (await clientRead.fetch<string[]>(
           groq`*[_type == "message" && conversation._ref in $conversationIds]._id`,
           { conversationIds },
+          // A just-sent message must not be missed by a stale cache read.
+          { cache: 'no-store' },
         )) ?? []
     }
 
@@ -439,6 +449,9 @@ export async function deleteProposal(
       (await clientRead.fetch<string[]>(
         groq`*[_type == "notification" && notificationType == "message_received" && link in $messageLinks]._id`,
         { messageLinks },
+        // A just-fanned-out message notification must not be missed by a stale
+        // cache read.
+        { cache: 'no-store' },
       )) ?? []
 
     // Deletion ORDER matters for strong references: a message strongly refs its

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -9,6 +9,7 @@ import {
   ListMessagesSchema,
   SendMessageSchema,
   SetPreferenceSchema,
+  parseMessageCursor,
 } from '@/server/schemas/message'
 import {
   listConversationsForSpeaker,
@@ -101,11 +102,15 @@ export const messageRouter = router({
     .input(ListConversationsSchema)
     .query(async ({ ctx, input }) => {
       const conferenceId = await resolveConferenceId()
+      // The cursor is EITHER a plain ISO datetime (legacy) or `<iso>~<_id>`
+      // (compound keyset); split it so exact-timestamp ties page correctly.
+      const { before, beforeId } = parseMessageCursor(input.cursor)
       return listConversationsForSpeaker({
         speakerId: ctx.speaker._id,
         isOrganizer: ctx.speaker.isOrganizer === true,
         conferenceId,
-        before: input.cursor,
+        before,
+        beforeId,
       })
     }),
 
@@ -142,9 +147,13 @@ export const messageRouter = router({
           message: 'Conversation not found',
         })
       }
+      // Plain ISO (legacy) or `<iso>~<_id>` (compound keyset) — split so
+      // messages sharing an exact `createdAt` page without skips/dupes.
+      const { before, beforeId } = parseMessageCursor(input.cursor)
       return listMessages({
         conversationId: conversation._id,
-        before: input.cursor,
+        before,
+        beforeId,
       })
     }),
 

--- a/src/server/schemas/message.ts
+++ b/src/server/schemas/message.ts
@@ -8,8 +8,44 @@ import { z } from 'zod'
  * client input (multi-tenant isolation rule).
  */
 
-/** Cursor pages use the `lastMessageAt` / `createdAt` of the last item seen. */
-const cursor = z.string().datetime().optional()
+/**
+ * Keyset cursor. Historically a bare ISO datetime (the `lastMessageAt` /
+ * `createdAt` of the last item seen). To totally-order rows that share an exact
+ * timestamp it now ALSO accepts the compound form `<iso>~<_id>` — the datetime
+ * plus the last row's document id. Both forms are accepted so an old inflight
+ * client sending a plain datetime keeps working. Anything else is rejected.
+ *
+ * A Sanity `_id` never contains `~`, and an ISO datetime never does either, so
+ * the FIRST `~` unambiguously splits the two parts.
+ */
+const CURSOR_MAX = 260
+
+export function parseMessageCursor(cursor: string | undefined): {
+  before?: string
+  beforeId?: string
+} {
+  if (!cursor) return {}
+  const idx = cursor.indexOf('~')
+  if (idx === -1) return { before: cursor }
+  return { before: cursor.slice(0, idx), beforeId: cursor.slice(idx + 1) }
+}
+
+const isoDateTime = z.string().datetime()
+
+const cursor = z
+  .string()
+  .max(CURSOR_MAX)
+  .refine((v) => {
+    const idx = v.indexOf('~')
+    const iso = idx === -1 ? v : v.slice(0, idx)
+    const id = idx === -1 ? undefined : v.slice(idx + 1)
+    // The datetime part must always be a valid ISO datetime; when a compound
+    // cursor carries an id, that id must be non-empty.
+    if (!isoDateTime.safeParse(iso).success) return false
+    if (id !== undefined && id.length === 0) return false
+    return true
+  }, 'Invalid cursor')
+  .optional()
 
 export const ListConversationsSchema = z.object({
   cursor,


### PR DESCRIPTION
Final cleanup PR of the messaging adversarial-review cycle (follow-up batch F). Each item is a post-merge badge or maintainer-reported polish from #536–#540.

## F1 — deleteProposal cascade reads bypass the Next data cache
`src/lib/proposal/data/sanity.ts`. The file already imports `clientReadUncached as clientRead` (so the Sanity CDN is already bypassed), but the four `deleteProposal` reads — `referencingDocs` + the three cascade fetches (`conversationIds`, `messageIds`, `messageNotificationIds`) — were missing the `{ cache: 'no-store' }` Next data-cache option that every other mutation-path read in the file passes. A stale data-cache entry during deletion could miss a just-sent message/notification and orphan it. Added `no-store` to all four and aligned the `referencingDocs` read consistently. Test updated to assert the third arg.

## F2 — UserMenu: relabel + audience-aware Messages
`src/components/UserMenu.tsx` (+ stories).
- (a) `/cfp/proposal` (the NEW-proposal form) relabelled **"My Proposals" → "Submit New Proposal"** with `DocumentPlusIcon` (the list lives at `/cfp/list` = "My Dashboard").
- (b) Added an audience-aware **Messages** entry (`ChatBubbleLeftRightIcon`): non-organizers get `/cfp/messages` inline with the speaker links; organizers get `/admin/messages` in the Admin section instead. Exactly ONE Messages entry renders for any user (isOrganizer wins) via a small `speakerLinksFor(isOrganizer)` helper.
- (c) Extended both existing stories to assert the relabel + single-Messages rule and the correct href per audience. Shoot: `SHOOT_OUT=/tmp/f-shoot` at 393, both stories, light+dark — verified single Messages entry in each audience, correct icons, no overflow/truncation.

## F3 — activate B5's dormant compound keyset cursor end-to-end
`src/server/schemas/message.ts` + `src/server/routers/message.ts` + `ConversationThread.tsx` + `MessagesInbox.tsx`. #540 gave the data layer an optional `beforeId` + compound predicate, but the tRPC layer only sent the datetime. The `cursor` string now accepts EITHER a plain ISO datetime (legacy) OR `<iso>~<_id>` (compound), validated by a `refine` and split by a shared `parseMessageCursor` helper in the router. `getNextPageParam` emits the compound form from the last row (`createdAt+_id` for messages, `lastMessageAt+_id` for conversations). Old inflight clients sending a plain datetime keep working. Rows sharing an exact timestamp now page without skips/dupes.

## F4 — audience-correct new-message email copy
`src/components/email/MessageNotificationTemplate.tsx` + `src/lib/messaging/email.ts` (+ `notify.ts`). The body copy was speaker-phrased for everyone ("replying reaches the organizers") while organizer recipients get organizer links. `email.ts`/`notify.ts` already resolve per-recipient audience for `replyUrl`; now they thread an `isOrganizer` flag into `MessageEmailRecipient` → the template. Organizer variant reads "…reaches the **speaker and fellow organizers** by email…". The "reply to this email or in the app" line and the "Manage notification preferences" link are intact for both. New template render test covers both variants.

## F5 — ConversationThread polish (two #538 badges)
`src/components/messaging/ConversationThread.tsx`.
- (a) Moved the INITIAL jump-to-bottom into `useLayoutEffect` (pre-paint) so a long thread never flashes its top for a frame; subsequent follow-scrolls stay in the passive effect. Client component — no SSR path executes it.
- (b) The live region was a state no-op when the same author sent twice in a row (identical string), so the second message was never announced. Appends a per-event count of zero-width spaces (U+200B — invisible + silent to AT) so the region's text genuinely changes and re-fires. Live-region test extended with the back-to-back case.

## Checks
tsc ✅ · eslint ✅ · prettier ✅ · knip ✅ (only a pre-existing unrelated hint) · full `vitest run` ✅ **207 files, 3084 passed / 5 skipped** · F2 shoot 393 light+dark inspected ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is the final cleanup PR for the messaging adversarial-review cycle, addressing five distinct polish items across the messaging stack with no new features. All changes are defensive fixes or UX refinements to work introduced in #536–#540.

- **F1**: Adds `{ cache: 'no-store' }` to four mutation-path reads in `deleteProposal`, preventing a stale Next data-cache entry from silently skipping a just-sent message or notification during a cascade delete.
- **F2**: Introduces `speakerLinksFor(isOrganizer)` in `UserMenu.tsx` to guarantee exactly one \"Messages\" entry per audience, and relabels `/cfp/proposal` to \"Submit New Proposal\".
- **F3**: Extends the tRPC cursor to a compound `<iso>~<_id>` form split by `parseMessageCursor`, fixing pages that could skip or duplicate rows sharing an exact timestamp; legacy plain-datetime cursors continue to work.
- **F4**: Threads a per-recipient `isOrganizer` flag through `notify.ts → MessageEmailRecipient → email.ts → MessageNotificationTemplate` so organizer recipients receive correctly-phrased body copy.
- **F5**: Moves the initial scroll-to-bottom into `useLayoutEffect` to eliminate a one-frame flash, and uses a cycling zero-width-space nonce so back-to-back messages from the same author reliably re-fire the aria-live region.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all five areas are well-tested and the logic is sound, with only minor style/robustness observations.

The cascade-delete cache fix and compound keyset cursor are implemented correctly and backed by focused tests. The two observations (positional index slicing in speakerLinksFor, and the zero-width-space nonce for the aria-live region) are non-blocking style points rather than defects in current behaviour.

src/components/UserMenu.tsx (index-based splice in speakerLinksFor) and src/components/messaging/ConversationThread.tsx (ZWS nonce for live-region re-announcement).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/proposal/data/sanity.ts | Adds `{ cache: 'no-store' }` to all four mutation-path reads in `deleteProposal` — consistent with every other read in the file and prevents stale cache entries from silently orphaning messages/notifications during cascade deletes. |
| src/components/UserMenu.tsx | Introduces `speakerLinksFor(isOrganizer)` to guarantee exactly one Messages entry per audience; relabels the new-proposal route. The helper uses positional index slicing on SPEAKER_LINKS — correct today but brittle if the array is reordered without also updating the function. |
| src/server/schemas/message.ts | New cursor schema accepts both the legacy plain-ISO form and the compound `<iso>~<_id>` form, with a refine that validates the datetime half and requires a non-empty id half. parseMessageCursor is cleanly exported as a shared helper. |
| src/server/routers/message.ts | Both listConversations and listMessages now call parseMessageCursor to thread before + beforeId to the data layer. Backwards-compatible: plain datetime cursors still work. |
| src/components/messaging/ConversationThread.tsx | Initial scroll-to-bottom moved to useLayoutEffect (correct in a client-only component); live-region nonce uses (count % 2) + 1 zero-width spaces to force re-announce on identical back-to-back messages. getNextPageParam now emits compound cursors. |
| src/components/messaging/MessagesInbox.tsx | getNextPageParam now emits compound `<lastMessageAt>~<_id>` cursors for conversations, mirroring the message side. |
| src/lib/messaging/email.ts | Adds required isOrganizer: boolean to MessageEmailRecipient and threads it into MessageNotificationTemplate; audience-correct copy is now driven by per-recipient data. |
| src/lib/messaging/notify.ts | Sets isOrganizer: organizerSet.has(id) on each emailRecipient, correctly deriving the flag from the same organizerSet used for the replyUrl — consistent and correct. |
| src/components/email/MessageNotificationTemplate.tsx | Adds optional isOrganizer prop with a clean ternary for the Prefer email? copy; default is false for backwards compatibility. Shared elements (CTA, preferences link) are preserved for both variants. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant R as tRPC Router
    participant S as parseMessageCursor
    participant DB as Sanity

    Note over C: Compound cursor from getNextPageParam
    C->>R: "listMessages cursor=iso~message.42"
    R->>S: parseMessageCursor(cursor)
    S-->>R: before + beforeId
    R->>DB: listMessages(before, beforeId)
    DB-->>R: stable page, no skips
    R-->>C: messages[]

    Note over C: Legacy plain-ISO cursor
    C->>R: "listMessages cursor=iso"
    R->>S: parseMessageCursor(cursor)
    S-->>R: before only
    R->>DB: listMessages(before, undefined)
    DB-->>R: messages[]
    R-->>C: messages[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant R as tRPC Router
    participant S as parseMessageCursor
    participant DB as Sanity

    Note over C: Compound cursor from getNextPageParam
    C->>R: "listMessages cursor=iso~message.42"
    R->>S: parseMessageCursor(cursor)
    S-->>R: before + beforeId
    R->>DB: listMessages(before, beforeId)
    DB-->>R: stable page, no skips
    R-->>C: messages[]

    Note over C: Legacy plain-ISO cursor
    C->>R: "listMessages cursor=iso"
    R->>S: parseMessageCursor(cursor)
    S-->>R: before only
    R->>DB: listMessages(before, undefined)
    DB-->>R: messages[]
    R-->>C: messages[]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): review follow-ups — curs..."](https://github.com/cloudnativebergen/website/commit/57d4c471773fffc8d1321f9a8d8fea00df902870) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45419920)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->