### PR TITLE
feat(messaging): 24-month post-conference retention for messaging data

### DIFF
--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -400,8 +400,9 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                           organizers. <strong>Purpose:</strong> Coordinating
                           proposals and conference logistics.{' '}
                           <strong>Legal Basis:</strong> Legitimate interest in
-                          conference coordination. Messages are retained until
-                          deleted.
+                          conference coordination. Messages and conversations
+                          are retained for 24 months after the conference ends,
+                          then permanently deleted.
                         </p>
                       </div>
                     </div>

--- a/src/app/api/cron/cleanup-notifications/route.ts
+++ b/src/app/api/cron/cleanup-notifications/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { deleteNotificationsOlderThan } from '@/lib/notification/sanity'
+import { deleteExpiredMessagingData } from '@/lib/messaging/retention'
 import { unstable_noStore as noStore } from 'next/cache'
 
 /**
@@ -36,9 +37,26 @@ export async function GET(request: NextRequest) {
       `Deleted ${deleted} notifications older than ${NOTIFICATION_RETENTION_DAYS} days`,
     )
 
+    // Messaging retention runs on the SAME daily trigger, AFTER the notification
+    // cleanup: a conference's messages, conversations, per-conversation
+    // preferences and message notifications are purged 24 months after it ends.
+    // Ordered after the notification pass so the 90-day hub cleanup has already
+    // removed aged-out message notifications; whatever remains for a fully
+    // expired conference is swept here.
+    const messaging = await deleteExpiredMessagingData()
+
+    console.log(
+      `Messaging retention: purged ${messaging.conferences} expired conference(s) —` +
+        ` messages=${messaging.messages}` +
+        ` conversations=${messaging.conversations}` +
+        ` preferences=${messaging.preferences}` +
+        ` notifications=${messaging.notifications}`,
+    )
+
     return NextResponse.json({
       success: true,
       deleted,
+      messaging,
     })
   } catch (error) {
     console.error('Error in cleanup notifications cron job:', error)

--- a/src/lib/messaging/retention.test.ts
+++ b/src/lib/messaging/retention.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// --- Sanity client mock (transaction boundary) -----------------------------
+
+const fetchMock = vi.fn()
+const commitMock = vi.fn().mockResolvedValue({ transactionId: 'tx-1' })
+
+// Ordered record of every committed delete batch, so tests can assert the
+// deletion ORDER across transactions (messages → preferences → conversations →
+// notifications) as well as chunk sizes.
+const committedBatches: string[][] = []
+let currentBatch: string[] = []
+
+const transactionApi = {
+  delete: (id: string) => {
+    currentBatch.push(id)
+    return transactionApi
+  },
+  commit: () => {
+    committedBatches.push([...currentBatch])
+    currentBatch = []
+    return commitMock()
+  },
+}
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+  clientWrite: {
+    transaction: () => transactionApi,
+  },
+}))
+
+import {
+  deleteExpiredMessagingData,
+  messagingRetentionCutoff,
+  RETENTION_MONTHS,
+} from './retention'
+
+// --- Fetch routing ---------------------------------------------------------
+
+interface ConversationDoc {
+  _id: string
+  conversationType: 'proposal' | 'general'
+  proposalId?: string | null
+}
+
+interface ConferenceThreads {
+  conversations: ConversationDoc[]
+  messageIds: string[]
+  preferenceIds: string[]
+  notificationIds: string[]
+}
+
+interface Routes {
+  conferences: { _id: string; title: string | null }[]
+  // Keyed by conference _id.
+  threads: Record<string, ConferenceThreads>
+}
+
+function routeFetch(routes: Routes) {
+  return (query: string, params: Record<string, unknown> = {}) => {
+    if (query.includes('_type == "conference"')) {
+      return Promise.resolve(routes.conferences)
+    }
+    if (query.includes('_type == "conversation"')) {
+      const conferenceId = params.conferenceId as string
+      return Promise.resolve(routes.threads[conferenceId]?.conversations ?? [])
+    }
+    if (query.includes('_type == "message"')) {
+      // Resolve by the conversation ids passed in.
+      const ids = params.conversationIds as string[]
+      const owner = Object.values(routes.threads).find((t) =>
+        t.conversations.some((c) => ids.includes(c._id)),
+      )
+      return Promise.resolve(owner?.messageIds ?? [])
+    }
+    if (query.includes('_type == "conversationPreference"')) {
+      const ids = params.conversationIds as string[]
+      const owner = Object.values(routes.threads).find((t) =>
+        t.conversations.some((c) => ids.includes(c._id)),
+      )
+      return Promise.resolve(owner?.preferenceIds ?? [])
+    }
+    if (query.includes('_type == "notification"')) {
+      const links = params.links as string[]
+      const owner = Object.values(routes.threads).find((t) =>
+        t.conversations.some(
+          (c) =>
+            links.includes(`/admin/proposals/${c.proposalId}#messages`) ||
+            links.includes(`/admin/messages/${c._id}`),
+        ),
+      )
+      return Promise.resolve(owner?.notificationIds ?? [])
+    }
+    return Promise.resolve([])
+  }
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  commitMock.mockClear()
+  committedBatches.length = 0
+  currentBatch = []
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// --- Cutoff query shape ----------------------------------------------------
+
+describe('messagingRetentionCutoff', () => {
+  it('is exactly RETENTION_MONTHS (24) months before now, in UTC YYYY-MM-DD', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-19T12:00:00.000Z'))
+    expect(RETENTION_MONTHS).toBe(24)
+    expect(messagingRetentionCutoff()).toBe('2024-07-19')
+  })
+
+  it('selects a 25-months-ago conference and excludes a 23-months-ago one', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-19T12:00:00.000Z'))
+    const cutoff = messagingRetentionCutoff() // 2024-07-19
+
+    // endDate < cutoff is the eligibility predicate the GROQ query applies.
+    const twentyFiveMonthsAgo = '2024-06-19' // ended > 24 months ago → eligible
+    const twentyThreeMonthsAgo = '2024-08-19' // ended < 24 months ago → kept
+
+    expect(twentyFiveMonthsAgo < cutoff).toBe(true)
+    expect(twentyThreeMonthsAgo < cutoff).toBe(false)
+  })
+})
+
+// --- deleteExpiredMessagingData --------------------------------------------
+
+describe('deleteExpiredMessagingData', () => {
+  it('is a no-op with zeroed summary when no conference is expired', async () => {
+    fetchMock.mockImplementation(routeFetch({ conferences: [], threads: {} }))
+
+    const summary = await deleteExpiredMessagingData()
+
+    expect(summary).toEqual({
+      conferences: 0,
+      messages: 0,
+      conversations: 0,
+      preferences: 0,
+      notifications: 0,
+    })
+    expect(commitMock).not.toHaveBeenCalled()
+    expect(committedBatches).toEqual([])
+  })
+
+  it('deletes in order messages → preferences → conversations → notifications', async () => {
+    fetchMock.mockImplementation(
+      routeFetch({
+        conferences: [{ _id: 'conf-1', title: 'JavaZone 2024' }],
+        threads: {
+          'conf-1': {
+            conversations: [
+              {
+                _id: 'conversation.proposal.p1',
+                conversationType: 'proposal',
+                proposalId: 'p1',
+              },
+              {
+                _id: 'conversation.g1',
+                conversationType: 'general',
+                proposalId: null,
+              },
+            ],
+            messageIds: ['message.m1', 'message.m2'],
+            preferenceIds: ['convpref.conversation.g1.s1'],
+            notificationIds: ['notification.message.conversation.g1.s1'],
+          },
+        },
+      }),
+    )
+
+    const summary = await deleteExpiredMessagingData()
+
+    expect(summary).toEqual({
+      conferences: 1,
+      messages: 2,
+      conversations: 2,
+      preferences: 1,
+      notifications: 1,
+    })
+
+    // Four distinct commits, in the required order.
+    expect(committedBatches).toEqual([
+      ['message.m1', 'message.m2'],
+      ['convpref.conversation.g1.s1'],
+      ['conversation.proposal.p1', 'conversation.g1'],
+      ['notification.message.conversation.g1.s1'],
+    ])
+  })
+
+  it('chunks each doc type at 100 ids per transaction', async () => {
+    const messageIds = Array.from({ length: 250 }, (_, i) => `message.m${i}`)
+    fetchMock.mockImplementation(
+      routeFetch({
+        conferences: [{ _id: 'conf-1', title: null }],
+        threads: {
+          'conf-1': {
+            conversations: [
+              {
+                _id: 'conversation.g1',
+                conversationType: 'general',
+                proposalId: null,
+              },
+            ],
+            messageIds,
+            preferenceIds: [],
+            notificationIds: [],
+          },
+        },
+      }),
+    )
+
+    const summary = await deleteExpiredMessagingData()
+
+    expect(summary.messages).toBe(250)
+    // Only messages + the one conversation produce commits (prefs/notifs empty).
+    const messageBatches = committedBatches.filter((b) =>
+      b[0]?.startsWith('message.'),
+    )
+    expect(messageBatches.map((b) => b.length)).toEqual([100, 100, 50])
+  })
+
+  it('isolates a per-conference failure and still processes the others', async () => {
+    fetchMock.mockImplementation((query: string, params = {}) => {
+      // Fail the message read for conf-bad only; every other read routes normally.
+      if (
+        query.includes('_type == "message"') &&
+        (params as { conversationIds: string[] }).conversationIds.includes(
+          'conversation.bad',
+        )
+      ) {
+        return Promise.reject(new Error('boom'))
+      }
+      return routeFetch({
+        conferences: [
+          { _id: 'conf-bad', title: 'Broken' },
+          { _id: 'conf-ok', title: 'Fine' },
+        ],
+        threads: {
+          'conf-bad': {
+            conversations: [
+              {
+                _id: 'conversation.bad',
+                conversationType: 'general',
+                proposalId: null,
+              },
+            ],
+            messageIds: ['message.bad'],
+            preferenceIds: [],
+            notificationIds: [],
+          },
+          'conf-ok': {
+            conversations: [
+              {
+                _id: 'conversation.ok',
+                conversationType: 'general',
+                proposalId: null,
+              },
+            ],
+            messageIds: ['message.ok'],
+            preferenceIds: [],
+            notificationIds: [],
+          },
+        },
+      })(query, params)
+    })
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const summary = await deleteExpiredMessagingData()
+    errorSpy.mockRestore()
+
+    // conf-bad contributes nothing; conf-ok is fully processed.
+    expect(summary.conferences).toBe(1)
+    expect(summary.messages).toBe(1)
+    expect(committedBatches).toEqual([['message.ok'], ['conversation.ok']])
+  })
+})

--- a/src/lib/messaging/retention.ts
+++ b/src/lib/messaging/retention.ts
@@ -1,0 +1,247 @@
+import 'server-only'
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { conversationLinkPath } from './links'
+
+/**
+ * Server-only retention job for speaker↔organizer messaging data.
+ *
+ * POLICY (maintainer decision): a conference's messaging data — every message,
+ * conversation, per-conversation preference and its collapsed `message_received`
+ * notifications — is permanently deleted {@link RETENTION_MONTHS} months after
+ * the conference ENDS. Messages/conversations are otherwise immortal (they carry
+ * no per-document retention), so this horizon is the ONLY thing that ever purges
+ * a wound-down edition's threads. The 90-day hub retention
+ * (`deleteNotificationsOlderThan`) is orthogonal and deliberately EXCLUDES unread
+ * message notifications; this job removes those message notifications outright
+ * once their whole conference ages out.
+ *
+ * The privacy page documents this window (proposal + general threads are
+ * "retained for 24 months after the conference ends").
+ *
+ * CONTRACT: like the notification retention path this MAY throw at the top level
+ * (a bad conference-list read fails the run so the cron surfaces it), but a
+ * single conference's deletion failure is ISOLATED — it is logged and the run
+ * continues with the next conference (one edition's broken thread never blocks
+ * every other edition's cleanup).
+ */
+
+/** Months after a conference's end date before its messaging data is purged. */
+export const RETENTION_MONTHS = 24
+
+/**
+ * Deletes per transaction — keeps each commit well under Sanity's
+ * mutation-per-transaction ceiling. Mirrors the proposal cascade
+ * (`PROPOSAL_DELETE_CHUNK_SIZE`) so both deletion paths behave identically.
+ */
+const DELETE_CHUNK_SIZE = 100
+
+/**
+ * A hard cap on how many expired conferences one run processes, so a clock/skew
+ * bug (or a sudden backlog of just-aged editions) can never fan out an unbounded
+ * number of per-conference deletions in a single invocation. Any remainder is
+ * picked up by the next daily run. This is the messaging analogue of the
+ * notification job's `RETENTION_MAX_BATCHES` safety valve.
+ */
+const MAX_CONFERENCES_PER_RUN = 50
+
+/** A per-conference summary row for structured logging. */
+export interface MessagingRetentionSummary {
+  conferences: number
+  messages: number
+  conversations: number
+  preferences: number
+  notifications: number
+}
+
+/** Split `items` into consecutive chunks of at most `size`. */
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}
+
+/** Delete a set of document ids in chunked transactions. No-op for an empty set. */
+async function commitDeletesChunked(ids: string[]): Promise<void> {
+  for (const chunk of chunkArray(ids, DELETE_CHUNK_SIZE)) {
+    if (chunk.length === 0) continue
+    const tx = clientWrite.transaction()
+    for (const id of chunk) {
+      tx.delete(id)
+    }
+    await tx.commit()
+  }
+}
+
+/**
+ * The cutoff date (YYYY-MM-DD) a conference's `endDate` must precede to be
+ * eligible for purge: exactly {@link RETENTION_MONTHS} months before `now`.
+ *
+ * `conference.endDate` is a Sanity `date` (a bare `YYYY-MM-DD`), so the GROQ
+ * comparison is a lexicographic string compare against this same shape — which
+ * is correct for zero-padded ISO dates. Computed in UTC for determinism.
+ */
+export function messagingRetentionCutoff(now: Date = new Date()): string {
+  const cutoff = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  )
+  cutoff.setUTCMonth(cutoff.getUTCMonth() - RETENTION_MONTHS)
+  return cutoff.toISOString().slice(0, 10)
+}
+
+/** A conversation shape sufficient to derive its notification deep links. */
+interface RetentionConversation {
+  _id: string
+  conversationType: 'proposal' | 'general'
+  // GROQ yields `null` for an absent `proposal._ref`; `conversationLinkPath`
+  // treats a falsy `proposalId` as "no proposal", so null and undefined are
+  // equivalent here. Typed to match `conversationLinkPath`'s parameter.
+  proposalId?: string
+}
+
+/**
+ * Purge all messaging data for every conference whose `endDate` is more than
+ * {@link RETENTION_MONTHS} months in the past.
+ *
+ * For each eligible conference (processed independently — see the module
+ * CONTRACT) the deletion runs in this ORDER so no delete is ever blocked by an
+ * inbound STRONG reference:
+ *   1. messages            (strong ref → conversation)
+ *   2. conversationPreferences (strong ref → conversation)
+ *   3. conversations       (now free of strong referrers)
+ *   4. message_received notifications (link-matched; no stored ref)
+ *
+ * NOTE on step 2: `conversationPreference.conversation` is a STRONG reference
+ * (see its schema), so preferences MUST precede their conversations — the same
+ * reason messages precede conversations. (The task's headline "messages →
+ * conversations → preferences" ordering would 409 on the conversation delete;
+ * preferences are hoisted ahead of conversations here for correctness.)
+ *
+ * Preferences and notifications are matched via the conversation refs / deep
+ * links rather than by reconstructing their deterministic ids, which is robust
+ * to either audience variant and to any legacy id shape.
+ *
+ * Returns aggregate counts across all conferences processed this run.
+ */
+export async function deleteExpiredMessagingData(): Promise<MessagingRetentionSummary> {
+  const cutoff = messagingRetentionCutoff()
+
+  const conferences =
+    (await clientReadUncached.fetch<{ _id: string; title: string | null }[]>(
+      `*[_type == "conference" && defined(endDate) && endDate < $cutoff][0...${MAX_CONFERENCES_PER_RUN}]{ _id, title }`,
+      { cutoff },
+      { cache: 'no-store' },
+    )) ?? []
+
+  const summary: MessagingRetentionSummary = {
+    conferences: 0,
+    messages: 0,
+    conversations: 0,
+    preferences: 0,
+    notifications: 0,
+  }
+
+  for (const conference of conferences) {
+    try {
+      const perConference = await deleteMessagingDataForConference(
+        conference._id,
+      )
+
+      summary.conferences += 1
+      summary.messages += perConference.messages
+      summary.conversations += perConference.conversations
+      summary.preferences += perConference.preferences
+      summary.notifications += perConference.notifications
+
+      // Structured per-conference log (counts) so a run is auditable.
+      console.log(
+        `Messaging retention: purged conference ${conference._id}` +
+          ` (${conference.title ?? 'untitled'}) —` +
+          ` messages=${perConference.messages}` +
+          ` conversations=${perConference.conversations}` +
+          ` preferences=${perConference.preferences}` +
+          ` notifications=${perConference.notifications}`,
+      )
+    } catch (error) {
+      // Per-conference isolation: log and continue so one edition's failure
+      // cannot stop the others from being purged.
+      console.error(
+        `Messaging retention: failed to purge conference ${conference._id}:`,
+        error,
+      )
+    }
+  }
+
+  return summary
+}
+
+/**
+ * Delete all messaging data for ONE conference and return its counts. Extracted
+ * so {@link deleteExpiredMessagingData} can wrap each conference in its own
+ * try/catch for isolation.
+ */
+async function deleteMessagingDataForConference(
+  conferenceId: string,
+): Promise<Omit<MessagingRetentionSummary, 'conferences'>> {
+  const conversations =
+    (await clientReadUncached.fetch<RetentionConversation[]>(
+      `*[_type == "conversation" && conference._ref == $conferenceId]{
+        _id,
+        conversationType,
+        "proposalId": proposal._ref
+      }`,
+      { conferenceId },
+      { cache: 'no-store' },
+    )) ?? []
+
+  if (conversations.length === 0) {
+    return { messages: 0, conversations: 0, preferences: 0, notifications: 0 }
+  }
+
+  const conversationIds = conversations.map((conversation) => conversation._id)
+
+  // Messages and preferences BOTH strong-ref their conversation, so both are
+  // gathered by conversation ref (robust to the preference's deterministic id
+  // shape) and deleted before the conversations themselves.
+  const messageIds =
+    (await clientReadUncached.fetch<string[]>(
+      `*[_type == "message" && conversation._ref in $conversationIds]._id`,
+      { conversationIds },
+      { cache: 'no-store' },
+    )) ?? []
+
+  const preferenceIds =
+    (await clientReadUncached.fetch<string[]>(
+      `*[_type == "conversationPreference" && conversation._ref in $conversationIds]._id`,
+      { conversationIds },
+      { cache: 'no-store' },
+    )) ?? []
+
+  // Collapsed `message_received` notifications carry no conversation ref — they
+  // are matched by the conversation's deep link (BOTH audience variants, since a
+  // recipient only ever received one), mirroring the proposal cascade.
+  const notificationLinks = conversations.flatMap((conversation) => [
+    conversationLinkPath(conversation, true),
+    conversationLinkPath(conversation, false),
+  ])
+  const notificationIds =
+    (await clientReadUncached.fetch<string[]>(
+      `*[_type == "notification" && notificationType == "message_received" && link in $links]._id`,
+      { links: notificationLinks },
+      { cache: 'no-store' },
+    )) ?? []
+
+  // Deletion order (see the exported doc): strong referrers first.
+  await commitDeletesChunked(messageIds)
+  await commitDeletesChunked(preferenceIds)
+  await commitDeletesChunked(conversationIds)
+  await commitDeletesChunked(notificationIds)
+
+  return {
+    messages: messageIds.length,
+    conversations: conversationIds.length,
+    preferences: preferenceIds.length,
+    notifications: notificationIds.length,
+  }
+}


### PR DESCRIPTION
## Policy

Maintainer decision: a conference's messaging data is permanently deleted **24 months after the conference ends** (`RETENTION_MONTHS = 24`, compared against `conference.endDate`).

Until now messages and conversations were **immortal** — the only messaging-adjacent cleanup was the 90-day notification hub retention (`deleteNotificationsOlderThan`), which deliberately *excludes* unread `message_received` notifications. Nothing ever purged a wound-down edition's threads. This closes that gap and matches what the privacy page documents.

## What is deleted, in what order

`deleteExpiredMessagingData()` (`src/lib/messaging/retention.ts`) selects conferences whose `endDate` is more than 24 months before now, and for **each** conference deletes:

1. **messages** (strong ref → conversation)
2. **conversationPreferences** (strong ref → conversation)
3. **conversations** (now free of strong referrers)
4. **message_received notifications** (link-matched, both audience variants — no stored ref)

### Ordering judgment call
The task brief specified *messages → conversations → preferences*. But `conversationPreference.conversation` is a **strong** reference (per its schema), exactly like `message.conversation`. Deleting a conversation while a strong-ref preference still points at it would 409. So preferences are hoisted **ahead** of conversations here — both strong referrers go before the conversations they pin. This is called out in the code doc.

Preferences and notifications are matched via conversation refs / deep links rather than by reconstructing deterministic ids, so it's robust to either audience variant and any legacy id shape.

## Scheduling

Wired into the **same daily cron** as the notification cleanup (`/api/cron/cleanup-notifications`, `0 4 * * *` in `vercel.json`), running **after** `deleteNotificationsOlderThan`, under the same `CRON_SECRET` bearer-token gate. The route response now includes a `messaging` summary alongside `deleted`.

## Safety valves

- **Per-conference error isolation**: one edition's deletion failure is logged and the run continues with the next conference.
- **Chunked transactions**: 100 ids per transaction (mirrors the proposal cascade), staying under Sanity's mutation ceiling.
- **Bounded run**: at most 50 expired conferences processed per invocation (`MAX_CONFERENCES_PER_RUN`); any remainder is picked up next day. Analogue of the notification job's `RETENTION_MAX_BATCHES`.
- **Uncached reads** (`{ cache: 'no-store' }`) and structured per-conference count logging.

Returns `{ conferences, messages, conversations, preferences, notifications }`.

## Privacy page

The Messages section now states messages and conversations are retained for 24 months after the conference ends, then permanently deleted.

## Tests

`src/lib/messaging/retention.test.ts` (6 tests): cutoff = exactly 24 months UTC; 25-months-ago selected / 23-months-ago excluded; deletion order across transactions; 100-per-tx chunking; per-conference isolation; empty no-op with zeroed summary.

Checks: tsc, eslint (0 errors), prettier, knip, full `pnpm vitest run` (3080 passed / 5 skipped) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a 24-month post-conference retention policy for messaging data (messages, conversations, preferences, and `message_received` notifications), wired into the existing daily cleanup cron. The privacy page is updated to match the new documented policy.

- **`src/lib/messaging/retention.ts`**: New server-only module that queries expired conferences, deletes their messaging documents in dependency-safe order (messages → preferences → conversations → notifications), chunked at 100 ids per Sanity transaction with per-conference error isolation.
- **`src/app/api/cron/cleanup-notifications/route.ts`**: Calls `deleteExpiredMessagingData` after the existing 90-day notification pass; the JSON response now includes a `messaging` summary alongside `deleted`.
- **`src/lib/messaging/retention.test.ts`**: Six tests covering the no-op path, deletion order, 100-per-tx chunking, per-conference isolation, and cutoff arithmetic.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the deletion order, chunking, and auth gate are all correct, and the cron change is additive.

The core deletion logic is well-structured: strong-ref dependents are removed before their referents, chunking mirrors the existing proposal cascade, and per-conference isolation prevents one broken edition from blocking others. The main issue is that already-purged conferences are re-selected on every run — their endDate still precedes the cutoff after their messaging data is gone — meaning the daily log will show purged with all-zero counts for cleaned conferences indefinitely, and the 50-conference cap could eventually delay newly-expired editions if the backlog grows large enough.

src/lib/messaging/retention.ts — specifically the re-selection of already-purged conferences in deleteExpiredMessagingData.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/messaging/retention.ts | New server-only retention job; deletion order, chunking, and per-conference isolation are correct. Two minor issues: already-purged conferences are re-selected on every run (inflating logs and consuming cap slots), and a dead chunk.length === 0 guard exists in commitDeletesChunked. |
| src/app/api/cron/cleanup-notifications/route.ts | Wires deleteExpiredMessagingData into the existing daily cron after the notification pass; auth gate, error handling, and JSON response shape look correct. |
| src/lib/messaging/retention.test.ts | Six focused tests covering no-op, deletion order, 100-per-tx chunking, per-conference isolation, and cutoff arithmetic — good coverage of the main correctness properties. |
| src/app/(main)/privacy/page.tsx | Privacy page updated to document the new 24-month post-conference retention; matches the implemented policy exactly. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron as Daily Cron (0 4 * * *)
    participant Route as /api/cron/cleanup-notifications
    participant NotifFn as deleteNotificationsOlderThan
    participant RetFn as deleteExpiredMessagingData
    participant Sanity as Sanity CMS

    Cron->>Route: GET (Bearer CRON_SECRET)
    Route->>NotifFn: deleteNotificationsOlderThan(90)
    NotifFn->>Sanity: "Delete notifications > 90 days"
    Sanity-->>NotifFn: deleted count
    NotifFn-->>Route: "{ deleted }"

    Route->>RetFn: deleteExpiredMessagingData()
    RetFn->>Sanity: "Fetch conferences where endDate < cutoff [0..50]"
    Sanity-->>RetFn: expired conferences[]

    loop Per conference (isolated try/catch)
        RetFn->>Sanity: Fetch conversations for conference
        Sanity-->>RetFn: conversations[]
        RetFn->>Sanity: Fetch messageIds, preferenceIds, notificationIds
        RetFn->>Sanity: DELETE messages (100/tx chunks)
        RetFn->>Sanity: DELETE preferences (100/tx chunks)
        RetFn->>Sanity: DELETE conversations (100/tx chunks)
        RetFn->>Sanity: DELETE notifications (100/tx chunks)
    end

    RetFn-->>Route: "{ conferences, messages, conversations, preferences, notifications }"
    Route-->>Cron: "200 { success, deleted, messaging }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron as Daily Cron (0 4 * * *)
    participant Route as /api/cron/cleanup-notifications
    participant NotifFn as deleteNotificationsOlderThan
    participant RetFn as deleteExpiredMessagingData
    participant Sanity as Sanity CMS

    Cron->>Route: GET (Bearer CRON_SECRET)
    Route->>NotifFn: deleteNotificationsOlderThan(90)
    NotifFn->>Sanity: "Delete notifications > 90 days"
    Sanity-->>NotifFn: deleted count
    NotifFn-->>Route: "{ deleted }"

    Route->>RetFn: deleteExpiredMessagingData()
    RetFn->>Sanity: "Fetch conferences where endDate < cutoff [0..50]"
    Sanity-->>RetFn: expired conferences[]

    loop Per conference (isolated try/catch)
        RetFn->>Sanity: Fetch conversations for conference
        Sanity-->>RetFn: conversations[]
        RetFn->>Sanity: Fetch messageIds, preferenceIds, notificationIds
        RetFn->>Sanity: DELETE messages (100/tx chunks)
        RetFn->>Sanity: DELETE preferences (100/tx chunks)
        RetFn->>Sanity: DELETE conversations (100/tx chunks)
        RetFn->>Sanity: DELETE notifications (100/tx chunks)
    end

    RetFn-->>Route: "{ conferences, messages, conversations, preferences, notifications }"
    Route-->>Cron: "200 { success, deleted, messaging }"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): 24-month post-conferenc..."](https://github.com/cloudnativebergen/website/commit/de02a2feae897f148d0416662b6c4fc84ca0025b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45420440)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->