### PR TITLE
fix(messaging): proposal-cascade preference deletion + follow-up nits

### DIFF
--- a/__tests__/components/messaging/ConversationThread.test.tsx
+++ b/__tests__/components/messaging/ConversationThread.test.tsx
@@ -158,9 +158,10 @@ describe('ConversationThreadView', () => {
     )
     expect(live).toHaveTextContent('New message from Program Committee')
 
-    // Back-to-back message from the SAME author yields an identical phrase; the
-    // live region must still re-announce it (a plain setState would no-op). The
-    // announced text stays the same but the raw content differs (nonce).
+    // Back-to-back message from the SAME author would yield an identical
+    // phrase; the live region must still re-announce it (a plain setState
+    // would no-op). The phrasing alternates so consecutive announcements
+    // differ as real spoken text.
     const afterFirst = live?.textContent
     const withSecond: DisplayMessage[] = [
       ...withNew,
@@ -180,7 +181,7 @@ describe('ConversationThreadView', () => {
         onSend={vi.fn()}
       />,
     )
-    expect(live).toHaveTextContent('New message from Program Committee')
+    expect(live).toHaveTextContent('Another message from Program Committee')
     expect(live?.textContent).not.toBe(afterFirst)
   })
 

--- a/__tests__/lib/proposal/data/sanity.test.ts
+++ b/__tests__/lib/proposal/data/sanity.test.ts
@@ -122,6 +122,9 @@ describe('deleteProposal', () => {
       .mockResolvedValueOnce(['msg-1', 'msg-2'])
       // message notification ids (matched by proposal-thread link)
       .mockResolvedValueOnce(['notif-msg-1'])
+      // conversationPreference ids (strong conversation refs — must precede
+      // the conversation deletes)
+      .mockResolvedValueOnce(['pref-1'])
 
     const { err } = await deleteProposal('proposal-1')
 
@@ -139,13 +142,20 @@ describe('deleteProposal', () => {
       ],
     })
 
-    // Four transactions: messages, conversation, message-notification, then the
-    // cascade dependents + proposal.
-    expect(mockTransaction).toHaveBeenCalledTimes(4)
+    // The preference lookup targets the thread's conversations.
+    const prefCall = mockFetch.mock.calls[4]
+    expect(prefCall[0]).toContain('_type == "conversationPreference"')
+    expect(prefCall[0]).toContain('conversation._ref in $conversationIds')
+
+    // Five transactions: messages, preferences, conversation,
+    // message-notification, then the cascade dependents + proposal. Preferences
+    // strongly ref their conversation, so they must be deleted BEFORE it.
+    expect(mockTransaction).toHaveBeenCalledTimes(5)
     const deleted = mockTxDelete.mock.calls.map((call) => call[0])
     expect(deleted).toEqual([
       'msg-1',
       'msg-2',
+      'pref-1',
       'conversation.proposal.proposal-1',
       'notif-msg-1',
       'review-1',

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -91,7 +91,18 @@ const ADMIN_LINKS: MenuLink[] = [
  */
 function speakerLinksFor(isOrganizer: boolean): MenuLink[] {
   if (isOrganizer) return SPEAKER_LINKS
-  return [SPEAKER_LINKS[0], SPEAKER_MESSAGES_LINK, ...SPEAKER_LINKS.slice(1)]
+  // Anchor the insertion to the dashboard entry by href (not a positional
+  // splice) so a future reorder of SPEAKER_LINKS can't silently move Messages
+  // after the wrong item.
+  const dashboardIndex = SPEAKER_LINKS.findIndex(
+    (link) => link.href === '/cfp/list',
+  )
+  const insertAt = dashboardIndex === -1 ? 0 : dashboardIndex + 1
+  return [
+    ...SPEAKER_LINKS.slice(0, insertAt),
+    SPEAKER_MESSAGES_LINK,
+    ...SPEAKER_LINKS.slice(insertAt),
+  ]
 }
 
 /** Maps a NextAuth provider id to its display name and brand icon. */

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -342,12 +342,15 @@ export function ConversationThreadView({
       if (!last.isOwn) {
         // Two messages in a row from the SAME author produce an identical
         // phrase; a plain setState would be a no-op and the second would never
-        // be announced. Append a per-event count of zero-width spaces (U+200B —
-        // invisible and silent to assistive tech) so the live region's text
-        // genuinely changes and re-fires each time.
+        // be announced. Alternate between two meaningful phrasings so
+        // consecutive announcements always differ as REAL spoken text — no
+        // invisible codepoints, whose handling varies across screen readers.
         liveNonceRef.current += 1
-        const nonce = '\u200B'.repeat((liveNonceRef.current % 2) + 1)
-        setLiveMessage(`New message from ${last.authorName}${nonce}`)
+        setLiveMessage(
+          liveNonceRef.current % 2 === 0
+            ? `Another message from ${last.authorName}`
+            : `New message from ${last.authorName}`,
+        )
       }
     }
     lastIdRef.current = last.id

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -454,8 +454,23 @@ export async function deleteProposal(
         { cache: 'no-store' },
       )) ?? []
 
-    // Deletion ORDER matters for strong references: a message strongly refs its
-    // conversation, so messages must go before conversations; the proposal is
+    // Per-conversation preference docs STRONGLY reference their conversation
+    // (like messages do), so they must also be deleted before the conversations
+    // or the conversation delete 409s for any thread a participant ever muted.
+    // (Found by the messaging retention job, which orders the same way.)
+    let preferenceIds: string[] = []
+    if (conversationIds.length > 0) {
+      preferenceIds =
+        (await clientRead.fetch<string[]>(
+          groq`*[_type == "conversationPreference" && conversation._ref in $conversationIds]._id`,
+          { conversationIds },
+          { cache: 'no-store' },
+        )) ?? []
+    }
+
+    // Deletion ORDER matters for strong references: messages AND preference
+    // docs strongly ref their conversation, so both go before conversations;
+    // the proposal is
     // deleted LAST, together with the co-speaker invitations / reviews that
     // strongly ref it (Sanity resolves intra-transaction constraints, so those
     // may share the final transaction). Everything else is weak-ref or
@@ -464,6 +479,9 @@ export async function deleteProposal(
     // large thread — a mid-way failure surfaces an error and leaves a partially
     // cascaded thread, which a retry finishes.
     for (const chunk of chunkArray(messageIds, PROPOSAL_DELETE_CHUNK_SIZE)) {
+      await commitDeletes(chunk)
+    }
+    for (const chunk of chunkArray(preferenceIds, PROPOSAL_DELETE_CHUNK_SIZE)) {
       await commitDeletes(chunk)
     }
     for (const chunk of chunkArray(


### PR DESCRIPTION
Three small fixes surfaced during the retention build and #541's post-merge badges:

1. **deleteProposal 409 (latent P2)**: `conversationPreference.conversation` is a STRONG ref, but the #540 cascade deleted conversations without their preference docs — deleting any proposal whose thread a participant had muted would 409. Preferences are now fetched (no-store) and chunk-deleted between messages and conversations, mirroring the retention job's ordering (which found this).
2. **UserMenu insertion** anchored to the dashboard entry's href instead of a positional splice (#541 badge).
3. **Live region** alternates between two real phrasings ('New/Another message from X') instead of cycling zero-width spaces, whose screen-reader handling is inconsistent (#541 badge). Tests updated accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships three targeted fixes: a latent 409 regression in `deleteProposal` (conversation-preference docs hold a STRONG ref to their conversation and were being left in place when conversations were cascade-deleted), a href-anchored insertion for the Messages link in `UserMenu`, and a screen-reader–friendlier live-region strategy in `ConversationThread` that alternates between two real phrasings instead of cycling invisible zero-width spaces.

- **`deleteProposal` cascade fix**: fetches `conversationPreference` IDs (no-store) after message-notifications and deletes them in chunks between messages and conversations, matching the retention job's ordering that surfaced the bug.
- **`UserMenu` insertion**: locates the dashboard entry by `href === '/cfp/list'` rather than a positional splice, so future reorders of `SPEAKER_LINKS` can't silently mis-place the Messages item.
- **Live region alternation**: replaces U+200B padding with alternating `"New message from …"` / `"Another message from …"` phrasings, whose screen-reader handling is well-defined across AT implementations.

<h3>Confidence Score: 5/5</h3>

All three fixes are narrow and correct; the deletion cascade is properly ordered and the tests validate the new fetch call, transaction count, and deletion sequence.

The cascade fix correctly inserts the preference fetch and delete between messages and conversations, matching the retention job's proven ordering. The UserMenu change is a well-guarded refactor of a static constant, and the live-region alternation always produces a changed DOM text node. Tests are updated to cover the new behavior in both changed areas.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/proposal/data/sanity.ts | Adds `conversationPreference` fetch and chunk-delete between messages and conversations to fix 409s from strong-ref violations; deletion order is correct and mirrors the retention job. |
| src/components/UserMenu.tsx | Replaces positional splice with href-anchored `findIndex` for the Messages link insertion; fallback to index 0 is safe given `SPEAKER_LINKS` is a static constant. |
| src/components/messaging/ConversationThread.tsx | Replaces zero-width-space nonce with alternating "New/Another message from X" phrasings; the modulo-2 logic guarantees the live region text always changes on consecutive announcements. |
| __tests__/lib/proposal/data/sanity.test.ts | Adds the `pref-1` mock and validates fetch query shape, transaction count (4→5), and deletion order for the preference cascade fix. |
| __tests__/components/messaging/ConversationThread.test.tsx | Updates expected text for second-consecutive-message assertion from "New message" to "Another message", consistent with the alternating phrasing. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deleteProposal called] --> B[Fetch referencing docs]
    B --> C{Blocking strong refs?}
    C -- Yes --> D[Return ProposalDeletionBlockedError]
    C -- No --> E[Fetch conversationIds]
    E --> F{Any conversations?}
    F -- Yes --> G[Fetch messageIds]
    F -- No --> K
    G --> H[Fetch messageNotificationIds]
    H --> I[Fetch preferenceIds]
    I --> J[Delete messages in chunks]
    J --> K[Delete preferences in chunks]
    K --> L[Delete conversations in chunks]
    L --> M[Delete message-notifications in chunks]
    M --> N[Final tx: cascadeIds + proposalId]
    N --> O[Done]

    style K fill:#d4edda,stroke:#28a745
    style I fill:#d4edda,stroke:#28a745
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[deleteProposal called] --> B[Fetch referencing docs]
    B --> C{Blocking strong refs?}
    C -- Yes --> D[Return ProposalDeletionBlockedError]
    C -- No --> E[Fetch conversationIds]
    E --> F{Any conversations?}
    F -- Yes --> G[Fetch messageIds]
    F -- No --> K
    G --> H[Fetch messageNotificationIds]
    H --> I[Fetch preferenceIds]
    I --> J[Delete messages in chunks]
    J --> K[Delete preferences in chunks]
    K --> L[Delete conversations in chunks]
    L --> M[Delete message-notifications in chunks]
    M --> N[Final tx: cascadeIds + proposalId]
    N --> O[Done]

    style K fill:#d4edda,stroke:#28a745
    style I fill:#d4edda,stroke:#28a745
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): delete conversation pref..."](https://github.com/cloudnativebergen/website/commit/78b29c6497005c9f69c99c0de51cb12a602260d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45420700)</sub>

<!-- /greptile_comment -->