### PR TITLE
fix(ui): modal shell — live backdrop, mobile sheet, standard header, dirty guard

### DIFF
--- a/__tests__/components/ModalShell.test.tsx
+++ b/__tests__/components/ModalShell.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+} from '@testing-library/react'
+import { ModalShell } from '@/components/ModalShell'
+
+afterEach(cleanup)
+
+describe('ModalShell — standard header', () => {
+  it('renders no injected header when `title` is omitted', () => {
+    render(
+      <ModalShell isOpen onClose={vi.fn()}>
+        <p>body content</p>
+      </ModalShell>,
+    )
+    expect(screen.getByText('body content')).toBeInTheDocument()
+    // No standard header ⇒ no injected close button.
+    expect(
+      screen.queryByRole('button', { name: 'Close dialog' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the house header (title, subtitle, icon, close button) and wires aria-labelledby', () => {
+    render(
+      <ModalShell
+        isOpen
+        onClose={vi.fn()}
+        title="Compose message"
+        subtitle="Proposal thread"
+        icon={<svg data-testid="header-icon" />}
+      >
+        <p>body</p>
+      </ModalShell>,
+    )
+
+    // Title is a HeadlessUI DialogTitle ⇒ the dialog is labelled by it.
+    const dialog = screen.getByRole('dialog')
+    const labelledBy = dialog.getAttribute('aria-labelledby')
+    expect(labelledBy).toBeTruthy()
+    const title = screen.getByText('Compose message')
+    expect(title.id).toBe(labelledBy)
+
+    expect(screen.getByText('Proposal thread')).toBeInTheDocument()
+    expect(screen.getByTestId('header-icon')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Close dialog' }),
+    ).toBeInTheDocument()
+  })
+
+  it('header close button calls onClose', () => {
+    const onClose = vi.fn()
+    render(
+      <ModalShell isOpen onClose={onClose} title="Title">
+        <p>body</p>
+      </ModalShell>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('ModalShell — presentation', () => {
+  it('sheet (default) applies the bottom-sheet panel classes', () => {
+    render(
+      <ModalShell isOpen onClose={vi.fn()} size="md">
+        <p>sheet body</p>
+      </ModalShell>,
+    )
+    const panel = screen.getByText('sheet body').closest('[class*="max-h-"]')!
+    // Full-width on mobile, max-width only at sm+, rounded top, capped height.
+    expect(panel.className).toContain('rounded-t-2xl')
+    expect(panel.className).toContain('sm:rounded-2xl')
+    expect(panel.className).toContain('sm:max-w-md')
+    expect(panel.className).toContain('max-h-[85dvh]')
+  })
+
+  it('centered forces the centered card at all sizes', () => {
+    render(
+      <ModalShell isOpen onClose={vi.fn()} size="md" presentation="centered">
+        <p>centered body</p>
+      </ModalShell>,
+    )
+    const panel = screen
+      .getByText('centered body')
+      .closest('[class*="rounded-2xl"]')!
+    expect(panel.className).toContain('rounded-2xl')
+    expect(panel.className).not.toContain('rounded-t-2xl')
+    // Centered applies its max-width at every size (no sm: prefix), never
+    // becomes a sheet.
+    expect(panel.className).toContain('max-w-md')
+    expect(panel.className).not.toContain('max-h-[85dvh]')
+  })
+})
+
+describe('ModalShell — dirty-close guard', () => {
+  const renderGuarded = (onClose: () => void) =>
+    render(
+      <ModalShell
+        isOpen
+        onClose={onClose}
+        title="Edit"
+        confirmOnDirtyClose
+        isDirty
+      >
+        <p>guarded body</p>
+      </ModalShell>,
+    )
+
+  it('Escape reveals the confirm instead of closing when dirty', () => {
+    const onClose = vi.fn()
+    renderGuarded(onClose)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('alertdialog', { name: 'Discard unsaved changes?' }),
+    ).toBeInTheDocument()
+  })
+
+  it('"Keep editing" dismisses the confirm without closing', () => {
+    const onClose = vi.fn()
+    renderGuarded(onClose)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    const confirm = screen.getByRole('alertdialog')
+    fireEvent.click(
+      within(confirm).getByRole('button', { name: 'Keep editing' }),
+    )
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('"Discard" closes the modal', () => {
+    const onClose = vi.fn()
+    renderGuarded(onClose)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    const confirm = screen.getByRole('alertdialog')
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Discard' }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes immediately on Escape when not dirty', () => {
+    const onClose = vi.fn()
+    render(
+      <ModalShell
+        isOpen
+        onClose={onClose}
+        title="Edit"
+        confirmOnDirtyClose
+        isDirty={false}
+      >
+        <p>body</p>
+      </ModalShell>,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument()
+  })
+
+  it('the confirm buttons meet the 44px minimum touch target', () => {
+    renderGuarded(vi.fn())
+    fireEvent.keyDown(document, { key: 'Escape' })
+    const confirm = screen.getByRole('alertdialog')
+    for (const name of ['Keep editing', 'Discard']) {
+      expect(within(confirm).getByRole('button', { name }).className).toContain(
+        'min-h-[44px]',
+      )
+    }
+  })
+})

--- a/src/components/ActionMenu.tsx
+++ b/src/components/ActionMenu.tsx
@@ -80,7 +80,7 @@ export function ActionMenu({
 
   const getDropdownClasses = () => {
     const baseClasses =
-      'absolute z-50 w-48 ring-opacity-5 rounded-lg bg-white shadow-lg ring-1 ring-black focus:outline-none dark:bg-gray-800 dark:ring-gray-700'
+      'absolute z-50 w-48 rounded-lg bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-gray-800 dark:ring-gray-700/5'
 
     const classes = shouldDropUp
       ? `${baseClasses} bottom-full mb-2 ${

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -184,7 +184,7 @@ export function Hero({
         <div className="mx-auto max-w-2xl lg:max-w-4xl lg:px-12">
           {conference.announcement &&
             !isPortableTextEmpty(conference.announcement) && (
-              <div className="bg-opacity-20 mb-8 rounded-lg border border-accent-yellow bg-brand-sunbeam-yellow p-6 shadow-sm dark:border-brand-sunbeam-yellow dark:bg-brand-sunbeam-yellow/20 dark:shadow-md">
+              <div className="mb-8 rounded-lg border border-accent-yellow bg-brand-sunbeam-yellow/20 p-6 shadow-sm dark:border-brand-sunbeam-yellow dark:bg-brand-sunbeam-yellow/20 dark:shadow-md">
                 <div className="flex items-center">
                   <div className="font-space-grotesk text-brand-slate-gray dark:text-white">
                     <PortableText

--- a/src/components/ModalShell.stories.tsx
+++ b/src/components/ModalShell.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+import { ThemeProvider } from 'next-themes'
+import { EnvelopeIcon } from '@heroicons/react/24/outline'
+import { fn, userEvent } from 'storybook/test'
 import { ModalShell } from './ModalShell'
-import { fn } from 'storybook/test'
 
 const meta: Meta<typeof ModalShell> = {
   title: 'Components/Feedback/ModalShell',
@@ -11,10 +14,24 @@ const meta: Meta<typeof ModalShell> = {
     docs: {
       description: {
         component:
-          'A shared modal wrapper providing consistent HeadlessUI Dialog + Transition boilerplate. Supply `isOpen`, `onClose`, `size`, and render children for your modal content.',
+          'The shared modal primitive. Wraps HeadlessUI Dialog + Transition and provides the house backdrop (`bg-black/50`), a mobile bottom-sheet presentation (`sm+` stays a centered card), an opt-in standard header (`title`/`subtitle`/`icon`), and an opt-in dirty-close guard. Supply `isOpen`, `onClose`, `size`, and render children.',
       },
     },
   },
+  decorators: [
+    // ModalShell reads `next-themes`; HeadlessUI portals the dialog to
+    // document.body, so the toolbar's decorator wrapper never reaches it.
+    // React context DOES cross portals, so forcing the theme here (synced to
+    // the Storybook theme global) is what actually renders the modal dark.
+    (Story, context) => (
+      <ThemeProvider
+        attribute="class"
+        forcedTheme={context.globals.theme === 'dark' ? 'dark' : 'light'}
+      >
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
   args: {
     isOpen: true,
     onClose: fn(),
@@ -141,5 +158,129 @@ export const Unpadded: Story = {
         </div>
       </div>
     ),
+  },
+}
+
+/**
+ * The default `presentation="sheet"` renders a bottom sheet below the `sm`
+ * breakpoint. Shoot this at 393px to see the sheet; at ≥640px it is the
+ * centered card. The tall body demonstrates the scrollable, safe-area-padded
+ * sheet body.
+ */
+export const SheetOnMobile: Story = {
+  args: {
+    size: 'lg',
+    children: (
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Bottom Sheet
+        </h3>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          On phones this pins to the bottom with a rounded top edge and scrolls
+          internally. On desktop it is the usual centered card.
+        </p>
+        <div className="mt-4 space-y-3">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-lg bg-gray-100 p-4 text-sm text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+            >
+              Row {i + 1}
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+}
+
+/**
+ * `presentation="centered"` forces the centered card at every size — the
+ * opt-out for edge cases that should never become a bottom sheet.
+ */
+export const CenteredAtAllSizes: Story = {
+  args: {
+    size: 'md',
+    presentation: 'centered',
+    children: (
+      <div className="text-center">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Always Centered
+        </h3>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          Stays a centered card even on a phone.
+        </p>
+      </div>
+    ),
+  },
+}
+
+/**
+ * Opt-in standard header via `title`/`subtitle`/`icon`: renders the house
+ * header (icon slot, `DialogTitle` wired to `aria-labelledby`, and a single
+ * 44×44 close button).
+ */
+export const WithStandardHeader: Story = {
+  args: {
+    size: 'lg',
+    padded: false,
+    title: 'Compose message',
+    subtitle: 'Proposal thread: Scaling Kubernetes at the edge',
+    icon: <EnvelopeIcon className="h-5 w-5" aria-hidden="true" />,
+    children: (
+      <div className="p-6">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          The header above is provided by ModalShell. Body content renders below
+          it.
+        </p>
+      </div>
+    ),
+  },
+}
+
+function DirtyGuardDemo() {
+  const [open, setOpen] = useState(true)
+  return (
+    <ModalShell
+      isOpen={open}
+      onClose={() => setOpen(false)}
+      size="md"
+      title="Edit profile"
+      confirmOnDirtyClose
+      isDirty
+    >
+      <div>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          There are unsaved changes. Press Escape or click the backdrop — the
+          modal asks you to confirm before discarding.
+        </p>
+        <input
+          type="text"
+          defaultValue="Unsaved value"
+          className="mt-4 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        />
+      </div>
+    </ModalShell>
+  )
+}
+
+/**
+ * With `confirmOnDirtyClose` + `isDirty`, a backdrop-click / Escape / header
+ * close first reveals an in-dialog "Discard unsaved changes?" confirm. Open the
+ * story and press Escape to see it.
+ */
+export const DirtyCloseGuard: Story = {
+  render: () => <DirtyGuardDemo />,
+}
+
+/**
+ * The same guard with the confirm already revealed (a play function presses
+ * Escape on mount) so the in-dialog "Discard unsaved changes?" state is
+ * captured in screenshots.
+ */
+export const DirtyCloseConfirmShown: Story = {
+  render: () => <DirtyGuardDemo />,
+  play: async () => {
+    await userEvent.keyboard('{Escape}')
   },
 }

--- a/src/components/ModalShell.tsx
+++ b/src/components/ModalShell.tsx
@@ -208,7 +208,7 @@ export function ModalShell({
                 <div
                   className={`${padded ? 'p-6' : ''} ${
                     isSheet
-                      ? `flex-1 overflow-y-auto overscroll-contain sm:overflow-visible${
+                      ? `flex-1 overflow-y-auto overscroll-contain sm:overflow-visible ${
                           padded
                             ? 'pb-[max(1.5rem,env(safe-area-inset-bottom))] sm:pb-6'
                             : ''

--- a/src/components/ModalShell.tsx
+++ b/src/components/ModalShell.tsx
@@ -1,11 +1,14 @@
 'use client'
 
+import { useState } from 'react'
 import {
   Dialog,
   DialogPanel,
+  DialogTitle,
   Transition,
   TransitionChild,
 } from '@headlessui/react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
 import { useTheme } from 'next-themes'
 
 type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl'
@@ -19,8 +22,36 @@ interface ModalShellProps {
   className?: string
   /** Whether to include default padding (p-6). Set to false for modals with custom section padding. */
   padded?: boolean
+  /**
+   * Optional standard "house" header title. When provided, ModalShell renders a
+   * shared header row (icon slot + title + subtitle + a single 44×44 close
+   * button) with the title wired to the dialog's `aria-labelledby` via
+   * HeadlessUI's `DialogTitle`. When omitted, no header is injected and
+   * consumers keep rendering their own — zero visual change for existing callers.
+   */
+  title?: React.ReactNode
+  /** Optional supporting line under the title (only rendered with `title`). */
+  subtitle?: React.ReactNode
+  /** Optional leading icon for the standard header (only rendered with `title`). */
+  icon?: React.ReactNode
+  /**
+   * Presentation mode. `'sheet'` (default) renders a bottom sheet below the `sm`
+   * breakpoint (rounded top, ≤85dvh, internally scrollable, safe-area padded)
+   * and the centered card on `sm+`. `'centered'` forces the centered card at all
+   * sizes (today's behaviour) — an opt-out for edge cases.
+   */
+  presentation?: 'sheet' | 'centered'
+  /**
+   * When both this and {@link ModalShellProps.isDirty} are true, a
+   * backdrop-click / Escape / header-close first shows an in-dialog
+   * "Discard unsaved changes?" confirm instead of closing immediately.
+   */
+  confirmOnDirtyClose?: boolean
+  /** Whether the modal currently holds unsaved changes (guards the close). */
+  isDirty?: boolean
 }
 
+// Centered card widths (apply at all sizes).
 const sizeClasses: Record<ModalSize, string> = {
   sm: 'max-w-sm',
   md: 'max-w-md',
@@ -32,6 +63,20 @@ const sizeClasses: Record<ModalSize, string> = {
   '5xl': 'max-w-5xl',
 }
 
+// Sheet widths: the max-width only kicks in at `sm+`, so the sheet spans the
+// full viewport width on mobile. Written as literal `sm:` classes so Tailwind's
+// scanner can see them (a computed `sm:${...}` would never be generated).
+const sheetSizeClasses: Record<ModalSize, string> = {
+  sm: 'sm:max-w-sm',
+  md: 'sm:max-w-md',
+  lg: 'sm:max-w-lg',
+  xl: 'sm:max-w-xl',
+  '2xl': 'sm:max-w-2xl',
+  '3xl': 'sm:max-w-3xl',
+  '4xl': 'sm:max-w-4xl',
+  '5xl': 'sm:max-w-5xl',
+}
+
 export function ModalShell({
   isOpen,
   onClose,
@@ -39,15 +84,53 @@ export function ModalShell({
   children,
   className = '',
   padded = true,
+  title,
+  subtitle,
+  icon,
+  presentation = 'sheet',
+  confirmOnDirtyClose = false,
+  isDirty = false,
 }: ModalShellProps) {
   const { theme } = useTheme()
+  const [confirmingClose, setConfirmingClose] = useState(false)
+
+  // Clear the dirty-close confirm once the modal is fully closed so it never
+  // flashes on the next open. Adjusting state during render (the React-blessed
+  // "reset on prop change" pattern) instead of an effect avoids a wasted commit.
+  const [wasOpen, setWasOpen] = useState(isOpen)
+  if (wasOpen !== isOpen) {
+    setWasOpen(isOpen)
+    if (!isOpen && confirmingClose) setConfirmingClose(false)
+  }
+
+  const guardActive = confirmOnDirtyClose && isDirty
+
+  // Routed through by the backdrop, Escape (HeadlessUI `onClose`) and the header
+  // close button. While the guard is armed the first attempt reveals the confirm
+  // and subsequent attempts are no-ops, so nothing is discarded without a choice.
+  const handleClose = () => {
+    if (guardActive) {
+      if (!confirmingClose) setConfirmingClose(true)
+      return
+    }
+    onClose()
+  }
+
+  const discardAndClose = () => {
+    setConfirmingClose(false)
+    onClose()
+  }
+
+  const isSheet = presentation === 'sheet'
+  const roundingClass = isSheet ? 'rounded-t-2xl sm:rounded-2xl' : 'rounded-2xl'
+  const widthClass = isSheet ? sheetSizeClasses[size] : sizeClasses[size]
 
   return (
     <Transition appear show={isOpen}>
       <Dialog
         as="div"
-        className={`relative z-10 ${theme === 'dark' ? 'dark' : ''}`}
-        onClose={onClose}
+        className={`relative z-50 ${theme === 'dark' ? 'dark' : ''}`}
+        onClose={handleClose}
       >
         <TransitionChild
           enter="ease-out duration-300"
@@ -57,23 +140,119 @@ export function ModalShell({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="bg-opacity-25 fixed inset-0 bg-black" />
+          <div className="fixed inset-0 bg-black/50" />
         </TransitionChild>
 
         <div className="fixed inset-0 overflow-y-auto">
-          <div className="flex min-h-full items-center justify-center p-4">
+          <div
+            className={`flex min-h-full justify-center ${
+              isSheet
+                ? 'items-end p-0 sm:items-center sm:p-4'
+                : 'items-center p-4'
+            }`}
+          >
             <TransitionChild
               enter="ease-out duration-300"
-              enterFrom="opacity-0 scale-95"
-              enterTo="opacity-100 scale-100"
+              enterFrom={
+                isSheet
+                  ? 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+                  : 'opacity-0 scale-95'
+              }
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
               leave="ease-in duration-200"
-              leaveFrom="opacity-100 scale-100"
-              leaveTo="opacity-0 scale-95"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo={
+                isSheet
+                  ? 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+                  : 'opacity-0 scale-95'
+              }
             >
               <DialogPanel
-                className={`w-full ${sizeClasses[size]} rounded-2xl bg-white ${padded ? 'p-6' : ''} shadow-2xl dark:bg-gray-900 ${className}`}
+                className={`relative flex w-full ${widthClass} flex-col bg-white shadow-2xl dark:bg-gray-900 ${roundingClass} ${
+                  isSheet ? 'max-h-[85dvh] sm:max-h-none' : ''
+                } ${className}`}
               >
-                {children}
+                {title ? (
+                  <div className="flex shrink-0 items-start justify-between gap-3 border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+                    <div className="flex min-w-0 items-start gap-2.5">
+                      {icon ? (
+                        <span
+                          className="mt-0.5 shrink-0 text-brand-cloud-blue dark:text-blue-400"
+                          aria-hidden="true"
+                        >
+                          {icon}
+                        </span>
+                      ) : null}
+                      <div className="min-w-0">
+                        <DialogTitle className="font-space-grotesk text-lg font-semibold text-gray-900 dark:text-white">
+                          {title}
+                        </DialogTitle>
+                        {subtitle ? (
+                          <p className="mt-0.5 truncate text-sm text-gray-500 dark:text-gray-400">
+                            {subtitle}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleClose}
+                      aria-label="Close dialog"
+                      className="-mr-2 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+                    >
+                      <XMarkIcon className="h-5 w-5" />
+                    </button>
+                  </div>
+                ) : null}
+
+                <div
+                  className={`${padded ? 'p-6' : ''} ${
+                    isSheet
+                      ? `flex-1 overflow-y-auto overscroll-contain sm:overflow-visible${
+                          padded
+                            ? 'pb-[max(1.5rem,env(safe-area-inset-bottom))] sm:pb-6'
+                            : ''
+                        }`
+                      : ''
+                  }`}
+                >
+                  {children}
+                </div>
+
+                {guardActive && confirmingClose ? (
+                  <div
+                    className={`absolute inset-0 z-10 flex items-end justify-center bg-gray-900/40 p-4 sm:items-center ${roundingClass}`}
+                  >
+                    <div
+                      role="alertdialog"
+                      aria-label="Discard unsaved changes?"
+                      className="w-full max-w-xs rounded-xl bg-white p-5 shadow-xl dark:bg-gray-800"
+                    >
+                      <p className="font-space-grotesk text-sm font-semibold text-gray-900 dark:text-white">
+                        Discard unsaved changes?
+                      </p>
+                      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                        Your changes haven&apos;t been saved yet.
+                      </p>
+                      <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingClose(false)}
+                          className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-200 dark:hover:bg-gray-700"
+                        >
+                          Keep editing
+                        </button>
+                        <button
+                          type="button"
+                          onClick={discardAndClose}
+                          className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-600"
+                        >
+                          Discard
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
               </DialogPanel>
             </TransitionChild>
           </div>

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -720,7 +720,7 @@ export function BadgeManagementClient({
                 leaveFrom="opacity-100"
                 leaveTo="opacity-0"
               >
-                <div className="bg-opacity-25 fixed inset-0 bg-black" />
+                <div className="fixed inset-0 bg-black/50" />
               </TransitionChild>
 
               <div className="fixed inset-0 overflow-y-auto">

--- a/src/components/admin/FilterDropdown.tsx
+++ b/src/components/admin/FilterDropdown.tsx
@@ -115,7 +115,7 @@ export function FilterDropdown({
   }
 
   const getDropdownClasses = () => {
-    const baseClasses = `absolute z-50 ${getWidthClass()} ring-opacity-5 rounded-md bg-white shadow-lg ring-1 ring-black focus:outline-none dark:bg-gray-800 dark:ring-gray-600`
+    const baseClasses = `absolute z-50 ${getWidthClass()} rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-gray-800 dark:ring-gray-600/5`
 
     const classes = shouldDropUp
       ? `${baseClasses} bottom-full mb-2 ${

--- a/src/components/admin/gallery/GalleryFilters.tsx
+++ b/src/components/admin/gallery/GalleryFilters.tsx
@@ -282,7 +282,7 @@ export function GalleryFilters({
                 <ChevronUpDownIcon className="h-4 w-4 text-gray-400" />
               </Combobox.Button>
               {searchResults && searchResults.length > 0 && (
-                <Combobox.Options className="ring-opacity-5 absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black focus:outline-none dark:bg-gray-800">
+                <Combobox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-gray-800">
                   {searchResults.map((speaker) => (
                     <Combobox.Option
                       key={speaker._id}

--- a/src/components/admin/gallery/ImageGrid.tsx
+++ b/src/components/admin/gallery/ImageGrid.tsx
@@ -175,7 +175,7 @@ export function ImageGrid({
                   e.stopPropagation()
                   handleSelectImage(image._id)
                 }}
-                className="bg-opacity-80 hover:bg-opacity-100 rounded bg-white p-1 shadow-sm dark:bg-gray-900"
+                className="rounded bg-white/80 p-1 shadow-sm hover:bg-white dark:bg-gray-900/80 dark:hover:bg-gray-900"
               >
                 <div
                   className={`h-4 w-4 rounded border ${

--- a/src/components/admin/gallery/ImageMetadataModal.tsx
+++ b/src/components/admin/gallery/ImageMetadataModal.tsx
@@ -448,7 +448,7 @@ export function ImageMetadataModal({
                     />
                   </ComboboxButton>
                   {filteredSpeakers.length > 0 && (
-                    <ComboboxOptions className="ring-opacity-5 absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black focus:outline-none sm:text-sm dark:bg-gray-800 dark:ring-gray-700">
+                    <ComboboxOptions className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm dark:bg-gray-800 dark:ring-gray-700/5">
                       {filteredSpeakers.map((speaker) => (
                         <ComboboxOption
                           key={speaker._id}

--- a/src/components/admin/gallery/ImageUploadZone.tsx
+++ b/src/components/admin/gallery/ImageUploadZone.tsx
@@ -677,20 +677,20 @@ export function ImageUploadZone({
                   className="h-32 w-full rounded-lg object-cover"
                 />
                 {file.status === 'error' && (
-                  <div className="bg-opacity-75 absolute inset-0 flex items-center justify-center rounded-lg bg-red-500">
+                  <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-red-500/75">
                     <p className="text-sm text-white">Failed</p>
                   </div>
                 )}
                 {file.status === 'completed' && (
-                  <div className="bg-opacity-75 absolute inset-0 flex items-center justify-center rounded-lg bg-green-700 dark:bg-green-800">
+                  <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-green-700/75 dark:bg-green-800/75">
                     <p className="text-sm text-white">Uploaded</p>
                   </div>
                 )}
                 {file.status === 'uploading' && (
-                  <div className="bg-opacity-75 absolute inset-0 flex flex-col items-center justify-center rounded-lg bg-blue-600 dark:bg-blue-800">
+                  <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg bg-blue-600/75 dark:bg-blue-800/75">
                     <p className="text-sm text-white">Uploading...</p>
                     <p className="text-xs text-white">{file.progress}%</p>
-                    <div className="bg-opacity-30 mt-2 h-1 w-3/4 rounded-full bg-white">
+                    <div className="mt-2 h-1 w-3/4 rounded-full bg-white/30">
                       <div
                         className="h-full rounded-full bg-white transition-all duration-300"
                         style={{ width: `${file.progress}%` }}

--- a/src/components/admin/schedule/track/ScheduledTalk.tsx
+++ b/src/components/admin/schedule/track/ScheduledTalk.tsx
@@ -60,7 +60,7 @@ export const ScheduledTalk = ({
       <div
         className={`relative h-full transition-all duration-200 ${
           isSwapTarget
-            ? 'ring-opacity-75 scale-105 transform shadow-lg ring-2 ring-amber-400'
+            ? 'scale-105 transform shadow-lg ring-2 ring-amber-400/75'
             : ''
         }`}
       >

--- a/src/components/admin/sponsor/SponsorAddModal.tsx
+++ b/src/components/admin/sponsor/SponsorAddModal.tsx
@@ -420,7 +420,7 @@ export function SponsorAddModal({
                     />
                   </ComboboxButton>
 
-                  <ComboboxOptions className="ring-opacity-5 absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black focus:outline-none sm:text-sm dark:bg-gray-800 dark:ring-gray-700">
+                  <ComboboxOptions className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm dark:bg-gray-800 dark:ring-gray-700/5">
                     {!isCreatingNew && (
                       <ComboboxOption
                         value={null}

--- a/src/components/admin/sponsor/SponsorTierEditor.tsx
+++ b/src/components/admin/sponsor/SponsorTierEditor.tsx
@@ -314,7 +314,7 @@ function SponsorTierModal({
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="bg-opacity-25 fixed inset-0 bg-black" />
+            <div className="fixed inset-0 bg-black/50" />
           </TransitionChild>
 
           <div className="fixed inset-0 overflow-y-auto">


### PR DESCRIPTION
## Why — the dead-class bug (Tailwind v4)

This repo is on **Tailwind v4** (`tailwindcss ^4.3.1`), which **removed the `*-opacity-*` utilities** (`bg-opacity-*`, `ring-opacity-*`, …). They are no longer generated, so every remaining occurrence is a **dead class** that renders nothing.

The most visible casualty was the shared `ModalShell` backdrop: `bg-opacity-25 fixed inset-0 bg-black`. In v3 that was a 25%-opaque scrim; in v4 the `bg-opacity-25` is dropped and the backdrop renders **fully opaque black**, blacking out the page behind every one of the ~18 modals built on `ModalShell`.

The fix everywhere is the slash-opacity syntax (`bg-black/50`, `ring-black/5`, …), preserving each site's original intended visual.

## `ModalShell` upgrade (crowning it the shared modal primitive)

- **A1 — live backdrop:** `bg-opacity-25 bg-black` → **`bg-black/50`** (house-bar opacity), transitions intact. Restores a translucent scrim instead of a solid black wall.
- **A3 — z-index:** shell `z-10` → **`z-50`** to match the `useModalA11y` overlay family.
- **A4 — standard header (opt-in):** new `title` / `subtitle` / `icon` props. When `title` is set, ModalShell renders the house header — icon slot, `DialogTitle` wired to the dialog's `aria-labelledby`, and a **single 44×44 `XMarkIcon` close button**. When absent, rendering is unchanged and consumers keep their own headers (zero visual change; migration happens in later batches).
- **A5 — mobile bottom sheet (new default):** `presentation="sheet"` (default) renders a bottom sheet `<sm` — `justify-end`, `rounded-t-2xl`, `max-h-[85dvh]`, internally-scrollable `overscroll-contain` body, safe-area bottom padding — and the **pixel-equivalent centered card at `sm+`**. `presentation="centered"` forces today's centered card at all sizes (opt-out for edge cases). Sheet widths use literal `sm:max-w-*` classes so the mobile sheet is full-width and Tailwind's scanner can see them. Desktop keeps `sm:overflow-visible` so in-modal comboboxes/popovers are never clipped.
- **A6 — dirty guard (opt-in):** `confirmOnDirtyClose` + `isDirty`. When both true, backdrop-click / Escape / header-close first reveals a tiny **in-dialog** "Discard unsaved changes?" confirm (Keep editing / Discard, both ≥44px) — no `window.confirm`. Repeat close attempts are no-ops until an explicit choice. No consumer opts in yet.
- **A7 — stories:** added `SheetOnMobile`, `CenteredAtAllSizes`, `WithStandardHeader`, `DirtyCloseGuard`, `DirtyCloseConfirmShown` (+ a `next-themes` `ThemeProvider` decorator so the portaled dialog actually renders dark, since HeadlessUI portals escape the toolbar wrapper — React context still crosses the portal).
- **A8 — tests:** `__tests__/components/ModalShell.test.tsx` — 10 tests covering header rendering + `aria-labelledby`, close button, sheet vs centered presentation classes, and the full dirty-guard flow (Escape → confirm → Keep editing / Discard, plus the not-dirty passthrough and 44px targets).

## A2 — full dead-class sweep (one-line edits only)

Every removed-utility occurrence in `src/`, converted to slash-opacity preserving the original visual:

| File:line | Before | After |
|---|---|---|
| `ModalShell.tsx:60` | `bg-opacity-25 bg-black` | `bg-black/50` |
| `Hero.tsx:187` | `bg-opacity-20 bg-brand-sunbeam-yellow` | `bg-brand-sunbeam-yellow/20` |
| `admin/BadgeManagementClient.tsx:723` | `bg-opacity-25 bg-black` | `bg-black/50` (modal backdrop → matches A1) |
| `admin/sponsor/SponsorTierEditor.tsx:317` | `bg-opacity-25 bg-black` | `bg-black/50` (modal backdrop → matches A1) |
| `admin/gallery/ImageUploadZone.tsx:680` | `bg-opacity-75 bg-red-500` | `bg-red-500/75` |
| `admin/gallery/ImageUploadZone.tsx:685` | `bg-opacity-75 bg-green-700 dark:bg-green-800` | `bg-green-700/75 dark:bg-green-800/75` |
| `admin/gallery/ImageUploadZone.tsx:690` | `bg-opacity-75 bg-blue-600 dark:bg-blue-800` | `bg-blue-600/75 dark:bg-blue-800/75` |
| `admin/gallery/ImageUploadZone.tsx:693` | `bg-opacity-30 bg-white` | `bg-white/30` |
| `admin/gallery/ImageGrid.tsx:178` | `bg-opacity-80 hover:bg-opacity-100 bg-white dark:bg-gray-900` | `bg-white/80 hover:bg-white dark:bg-gray-900/80 dark:hover:bg-gray-900` |
| `ActionMenu.tsx:83` | `ring-opacity-5 ring-black dark:ring-gray-700` | `ring-black/5 dark:ring-gray-700/5` |
| `admin/FilterDropdown.tsx:118` | `ring-opacity-5 ring-black dark:ring-gray-600` | `ring-black/5 dark:ring-gray-600/5` |
| `admin/gallery/ImageMetadataModal.tsx:451` | `ring-opacity-5 ring-black dark:ring-gray-700` | `ring-black/5 dark:ring-gray-700/5` |
| `admin/gallery/GalleryFilters.tsx:285` | `ring-opacity-5 ring-black` | `ring-black/5` |
| `admin/sponsor/SponsorAddModal.tsx:423` | `ring-opacity-5 ring-black dark:ring-gray-700` | `ring-black/5 dark:ring-gray-700/5` |
| `admin/schedule/track/ScheduledTalk.tsx:63` | `ring-opacity-75 ring-amber-400` | `ring-amber-400/75` |

A post-fix exhaustive grep for `(bg|text|border|ring|placeholder|divide)-opacity-*` across `src/` returns **zero** matches.

## Shoot findings (393 light+dark + 1280 desktop, Storybook)

- **Before/after backdrop:** confirmed the fix. With the dead `bg-opacity-25`, the backdrop was solid black; now `bg-black/50` renders as a translucent scrim (medium-gray over the light canvas) in every shot.
- **Mobile sheet (393):** `SheetOnMobile` and `WithStandardHeader` render a full-width bottom sheet — rounded top, pinned to bottom, internally scrollable — in both light and dark.
- **Standard header:** envelope icon + title + truncated subtitle + 44×44 close button, correct in light and dark.
- **Dirty guard:** the play-driven `DirtyCloseConfirmShown` capture shows the in-dialog "Discard unsaved changes?" confirm with Keep editing / Discard.
- **Desktop pixel-equivalence (1280):** `Medium` and the representative consumer `ConfirmationModal (danger)` render as the usual centered card — the consumer routes through the restructured shell with no regression.

## Checks

`tsc`, `eslint`, `prettier --check`, `knip` (exit 0) all clean. Full `vitest run`: **209 files, 3100 passed / 5 skipped**, including the 10 new ModalShell tests.

## Scope

Territory: `ModalShell.tsx` + its stories/tests, plus one-line dead-class edits in the sweep files. No behavioural/structural changes to other modal components (parallel batches own those); `src/lib` and the admin settings page untouched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Tailwind v4 dead-class regression that made every `ModalShell`-backed modal render a fully-opaque black backdrop, and uses the opportunity to promote `ModalShell` into a full shared modal primitive with mobile bottom-sheet, standard header, and dirty-close guard.

- **Dead-class sweep (A2):** All 15 `bg-opacity-*` / `ring-opacity-*` occurrences across `src/` are converted to slash-opacity syntax (`bg-black/50`, `ring-black/5`, etc.), fixing visually broken backdrops and ring borders under Tailwind v4.
- **`ModalShell` upgrade:** Adds `presentation=\"sheet\"` (default) for a full-width bottom sheet on mobile that becomes a centered card at `sm+`, an opt-in standard header via `title`/`subtitle`/`icon` props, and an opt-in dirty-close guard. Accompanied by 10 Vitest tests and 5 new Storybook stories.
- **One bug to fix:** A missing leading space in the sheet body class template literal silently merges `sm:overflow-visible` with the safe-area padding class — combobox content inside padded sheet modals will be clipped on desktop and home-indicator padding won't apply on iOS.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the missing space in the sheet body class template is fixed; all other changes are straightforward Tailwind v4 dead-class conversions with no logic impact.

The dead-class sweep across 13 files is mechanical and correct. The ModalShell rewrite is well-tested and the dirty-guard logic is sound. The one concrete defect is a missing space in a template literal that causes sm:overflow-visible and the safe-area padding class to concatenate into a single invalid token — both silently fail to apply on every padded sheet modal. This is already the default presentation for all future ModalShell consumers.

src/components/ModalShell.tsx lines 208-217 — the sheet body class template literal needs a leading space before the safe-area padding class.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/ModalShell.tsx | Core modal primitive rewrite — backdrop fix, mobile sheet, standard header, dirty guard; has a missing-space class concatenation bug that silently breaks sm:overflow-visible and safe-area padding on padded sheet modals |
| __tests__/components/ModalShell.test.tsx | New test suite: 10 tests covering header rendering, aria-labelledby, close button, presentation classes, and full dirty-guard flow |
| src/components/ModalShell.stories.tsx | Added SheetOnMobile, CenteredAtAllSizes, WithStandardHeader, DirtyCloseGuard, and DirtyCloseConfirmShown stories plus a next-themes ThemeProvider decorator for dark-mode portal rendering |
| src/components/Hero.tsx | Dead-class fix: bg-opacity-20 bg-brand-sunbeam-yellow → bg-brand-sunbeam-yellow/20 |
| src/components/ActionMenu.tsx | One-line dead-class fix: ring-opacity-5 → ring-black/5 and dark:ring-gray-700/5 |
| src/components/admin/gallery/ImageUploadZone.tsx | Dead-class sweep: four bg-opacity-* instances converted to slash-opacity on status overlay badges and progress bar track |
| src/components/admin/gallery/ImageGrid.tsx | Dead-class fix: bg-opacity-80 hover:bg-opacity-100 → bg-white/80 hover:bg-white dark:bg-gray-900/80 dark:hover:bg-gray-900 |
| src/components/admin/BadgeManagementClient.tsx | Dead-class fix: bg-opacity-25 bg-black → bg-black/50 on inline modal backdrop |
| src/components/admin/sponsor/SponsorTierEditor.tsx | Dead-class fix: bg-opacity-25 bg-black → bg-black/50 on inline modal backdrop |
| src/components/admin/FilterDropdown.tsx | Dead-class fix: ring-opacity-5 ring-black → ring-black/5 and dark:ring-gray-600/5 |
| src/components/admin/gallery/GalleryFilters.tsx | Dead-class fix: ring-opacity-5 ring-black → ring-black/5 on combobox options dropdown |
| src/components/admin/gallery/ImageMetadataModal.tsx | Dead-class fix: ring-opacity-5 ring-black → ring-black/5 and dark:ring-gray-700/5 on combobox dropdown |
| src/components/admin/schedule/track/ScheduledTalk.tsx | Dead-class fix: ring-opacity-75 ring-amber-400 → ring-amber-400/75 on swap-target highlight ring |
| src/components/admin/sponsor/SponsorAddModal.tsx | Dead-class fix: ring-opacity-5 ring-black → ring-black/5 and dark:ring-gray-700/5 on combobox dropdown |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User triggers close] --> B{confirmOnDirtyClose AND isDirty?}
    B -- No --> C[onClose called]
    B -- Yes --> D{confirmingClose already true?}
    D -- No --> E[setConfirmingClose true - Show alertdialog]
    D -- Yes --> F[no-op]
    E --> G{User chooses}
    G -- Keep editing --> H[setConfirmingClose false - Dialog stays open]
    G -- Discard --> I[setConfirmingClose false - onClose called]
    C --> J[Modal closed]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User triggers close] --> B{confirmOnDirtyClose AND isDirty?}
    B -- No --> C[onClose called]
    B -- Yes --> D{confirmingClose already true?}
    D -- No --> E[setConfirmingClose true - Show alertdialog]
    D -- Yes --> F[no-op]
    E --> G{User chooses}
    G -- Keep editing --> H[setConfirmingClose false - Dialog stays open]
    G -- Discard --> I[setConfirmingClose false - onClose called]
    C --> J[Modal closed]
    I --> J
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): missing space in sheet body cla..."](https://github.com/cloudnativebergen/website/commit/1e944e496c9353c0313411484defb146b3a6cde7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45429785)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->