### PR TITLE
feat(admin): settings page with system status + self-check probes

### DIFF
--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,11 +1,16 @@
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { formatDate } from '@/lib/time'
 import { formats, Format } from '@/lib/proposal/types'
+import { buildSystemChecks } from '@/lib/system-status/checks'
 import {
   ErrorDisplay,
   WorkshopRegistrationSettings,
   AdminPageHeader,
 } from '@/components/admin'
+import {
+  SystemStatusSection,
+  SelfCheckPanel,
+} from '@/components/admin/system-status'
 import { StatusBadge } from '@/components/StatusBadge'
 import {
   CalendarIcon,
@@ -21,6 +26,9 @@ import {
   LinkIcon,
   EnvelopeIcon,
   Cog6ToothIcon,
+  PencilSquareIcon,
+  ServerStackIcon,
+  BeakerIcon,
 } from '@heroicons/react/24/outline'
 
 interface NamedItem {
@@ -34,22 +42,48 @@ function isValidFormat(key: string): key is Format {
   return Object.values(Format).includes(key as Format)
 }
 
+/**
+ * Sanity Studio deep-link (v3 intent URL) for the conference document. Returns
+ * null when NEXT_PUBLIC_STUDIO_URL is unset so the "Edit in Studio" affordance
+ * simply isn't rendered.
+ */
+function studioEditUrl(conferenceId: string | undefined): string | null {
+  const base = process.env.NEXT_PUBLIC_STUDIO_URL
+  if (!base || !conferenceId) return null
+  return `${base.replace(/\/$/, '')}/intent/edit/id=${conferenceId};type=conference`
+}
+
 function InfoCard({
   title,
   children,
   icon: Icon,
+  editUrl,
 }: {
   title: string
   children: React.ReactNode
   icon: React.ComponentType<{ className?: string }>
+  editUrl?: string | null
 }) {
   return (
     <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
-      <div className="mb-4 flex items-center">
-        <Icon className="mr-2 h-5 w-5 text-gray-400 dark:text-gray-500" />
-        <h3 className="text-lg font-medium text-gray-900 dark:text-white">
-          {title}
-        </h3>
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center">
+          <Icon className="mr-2 h-5 w-5 text-gray-400 dark:text-gray-500" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+            {title}
+          </h3>
+        </div>
+        {editUrl && (
+          <a
+            href={editUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+          >
+            <PencilSquareIcon className="h-4 w-4" />
+            Edit in Studio
+          </a>
+        )}
       </div>
       <div className="space-y-3">{children}</div>
     </div>
@@ -234,6 +268,56 @@ function FieldRow({
   )
 }
 
+function SectionNav() {
+  const items = [
+    { href: '#configuration', label: 'Configuration' },
+    { href: '#system-status', label: 'System status' },
+    { href: '#self-check', label: 'Self-check' },
+  ]
+  return (
+    <nav className="sticky top-0 z-10 -mx-4 mb-2 border-b border-gray-200 bg-gray-50/90 px-4 py-2 backdrop-blur sm:mx-0 sm:rounded-lg sm:border sm:px-4 dark:border-gray-700 dark:bg-gray-900/90">
+      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+        {items.map((item) => (
+          <li key={item.href}>
+            <a
+              href={item.href}
+              className="font-medium text-gray-600 hover:text-indigo-600 dark:text-gray-300 dark:hover:text-indigo-400"
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+function SectionHeading({
+  id,
+  icon: Icon,
+  title,
+  description,
+}: {
+  id: string
+  icon: React.ComponentType<{ className?: string }>
+  title: string
+  description: string
+}) {
+  return (
+    <div id={id} className="scroll-mt-16">
+      <div className="flex items-center gap-2">
+        <Icon className="h-6 w-6 text-gray-400 dark:text-gray-500" />
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          {title}
+        </h2>
+      </div>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {description}
+      </p>
+    </div>
+  )
+}
+
 export default async function AdminSettings() {
   const { conference, error } = await getConferenceForCurrentDomain({
     organizers: true,
@@ -258,6 +342,9 @@ export default async function AdminSettings() {
     )
   }
 
+  const editUrl = studioEditUrl(conference._id)
+  const systemChecks = await buildSystemChecks(conference)
+
   return (
     <div className="space-y-6">
       <AdminPageHeader
@@ -271,173 +358,251 @@ export default async function AdminSettings() {
         }
       />
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <InfoCard title="Basic Information" icon={InformationCircleIcon}>
-          <FieldRow label="Title" value={conference.title} />
-          <FieldRow label="Organizer" value={conference.organizer} />
-          <FieldRow label="City" value={conference.city} />
-          <FieldRow label="Country" value={conference.country} />
-          <FieldRow label="Tagline" value={conference.tagline} />
-          <FieldRow label="Description" value={conference.description} />
-        </InfoCard>
+      <SectionNav />
 
-        <InfoCard title="Venue Information" icon={MapPinIcon}>
-          <FieldRow label="Venue Name" value={conference.venueName} />
-          <FieldRow label="Venue Address" value={conference.venueAddress} />
-        </InfoCard>
-
-        <InfoCard title="Dates & Timeline" icon={CalendarIcon}>
-          <FieldRow
-            label="Start Date"
-            value={conference.startDate}
-            type="date"
-          />
-          <FieldRow label="End Date" value={conference.endDate} type="date" />
-          <FieldRow
-            label="CFP Start Date"
-            value={conference.cfpStartDate}
-            type="date"
-          />
-          <FieldRow
-            label="CFP End Date"
-            value={conference.cfpEndDate}
-            type="date"
-          />
-          <FieldRow
-            label="CFP Notify Date"
-            value={conference.cfpNotifyDate}
-            type="date"
-          />
-          <FieldRow
-            label="Program Release Date"
-            value={conference.programDate}
-            type="date"
-          />
-        </InfoCard>
-
-        <InfoCard title="Configuration" icon={DocumentTextIcon}>
-          <FieldRow
-            label="Registration Enabled"
-            value={conference.registrationEnabled}
-            type="boolean"
-          />
-          <FieldRow
-            label="Registration Link"
-            value={conference.registrationLink}
-            type="url"
-          />
-          <FieldRow
-            label="Contact Email"
-            value={conference.contactEmail}
-            type="email"
-          />
-        </InfoCard>
-
-        <WorkshopRegistrationSettings
-          workshopRegistrationStart={conference.workshopRegistrationStart}
-          workshopRegistrationEnd={conference.workshopRegistrationEnd}
+      {/* ---- TIER 1: Conference configuration ---- */}
+      <section className="space-y-4">
+        <SectionHeading
+          id="configuration"
+          icon={DocumentTextIcon}
+          title="Conference configuration"
+          description="Content managed in Sanity for this conference."
         />
 
-        <InfoCard title="Domain Configuration" icon={GlobeAltIcon}>
-          <FieldRow label="Domains" value={conference.domains} type="array" />
-          <FieldRow
-            label="Social Links"
-            value={conference.socialLinks}
-            type="links"
-          />
-        </InfoCard>
-
-        <InfoCard title="External Integrations" icon={LinkIcon}>
-          <FieldRow
-            label="Checkin Customer ID"
-            value={conference.checkinCustomerId}
-          />
-          <FieldRow
-            label="Checkin Event ID"
-            value={conference.checkinEventId}
-          />
-        </InfoCard>
-
-        <InfoCard title="Content Configuration" icon={TagIcon}>
-          <FieldRow
-            label="Available Formats"
-            value={conference.formats}
-            type="formats"
-          />
-          <FieldRow
-            label="Available Topics"
-            value={conference.topics}
-            type="array"
-          />
-          <FieldRow label="Features" value={conference.features} type="array" />
-        </InfoCard>
-
-        <InfoCard title="Team" icon={UserGroupIcon}>
-          <FieldRow
-            label="Organizers"
-            value={conference.organizers?.map((org) => org.name)}
-            type="team"
-          />
-        </InfoCard>
-
-        {conference.sponsorTiers && conference.sponsorTiers.length > 0 && (
-          <InfoCard title="Sponsorship Tiers" icon={CurrencyDollarIcon}>
-            {conference.sponsorTiers.map((tier, idx) => (
-              <div
-                key={idx}
-                className="border-b border-gray-200 pb-3 last:border-b-0 last:pb-0 dark:border-gray-700"
-              >
-                <div className="mb-2 flex items-center justify-between">
-                  <span className="font-medium text-gray-900 dark:text-white">
-                    {tier.title}
-                  </span>
-                  <div className="flex items-center space-x-2">
-                    {tier.soldOut && (
-                      <StatusBadge label="Sold Out" color="red" />
-                    )}
-                    {tier.mostPopular && (
-                      <StatusBadge label="Popular" color="green" />
-                    )}
-                  </div>
-                </div>
-                <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
-                  {tier.tagline}
-                </p>
-                {tier.price && tier.price.length > 0 && (
-                  <div className="text-sm text-gray-500 dark:text-gray-400">
-                    {tier.price.map((price, pidx) => (
-                      <span key={pidx}>
-                        {price.amount} {price.currency}
-                        {pidx < tier.price!.length - 1 && ', '}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <InfoCard
+            title="Basic Information"
+            icon={InformationCircleIcon}
+            editUrl={editUrl}
+          >
+            <FieldRow label="Title" value={conference.title} />
+            <FieldRow label="Organizer" value={conference.organizer} />
+            <FieldRow label="City" value={conference.city} />
+            <FieldRow label="Country" value={conference.country} />
+            <FieldRow label="Tagline" value={conference.tagline} />
+            <FieldRow label="Description" value={conference.description} />
           </InfoCard>
-        )}
 
-        {conference.sponsors && conference.sponsors.length > 0 && (
-          <InfoCard title="Current Sponsors" icon={CurrencyDollarIcon}>
+          <InfoCard
+            title="Venue Information"
+            icon={MapPinIcon}
+            editUrl={editUrl}
+          >
+            <FieldRow label="Venue Name" value={conference.venueName} />
+            <FieldRow label="Venue Address" value={conference.venueAddress} />
+          </InfoCard>
+
+          <InfoCard
+            title="Dates & Timeline"
+            icon={CalendarIcon}
+            editUrl={editUrl}
+          >
             <FieldRow
-              label="Sponsors"
-              value={conference.sponsors.map(
-                (s) => `${s.sponsor.name} (${s.tier?.title ?? 'No Tier'})`,
-              )}
+              label="Start Date"
+              value={conference.startDate}
+              type="date"
+            />
+            <FieldRow label="End Date" value={conference.endDate} type="date" />
+            <FieldRow
+              label="CFP Start Date"
+              value={conference.cfpStartDate}
+              type="date"
+            />
+            <FieldRow
+              label="CFP End Date"
+              value={conference.cfpEndDate}
+              type="date"
+            />
+            <FieldRow
+              label="CFP Notify Date"
+              value={conference.cfpNotifyDate}
+              type="date"
+            />
+            <FieldRow
+              label="Program Release Date"
+              value={conference.programDate}
+              type="date"
+            />
+          </InfoCard>
+
+          <InfoCard
+            title="Configuration"
+            icon={DocumentTextIcon}
+            editUrl={editUrl}
+          >
+            <FieldRow
+              label="Registration Enabled"
+              value={conference.registrationEnabled}
+              type="boolean"
+            />
+            <FieldRow
+              label="Registration Link"
+              value={conference.registrationLink}
+              type="url"
+            />
+            <FieldRow
+              label="Contact Email"
+              value={conference.contactEmail}
+              type="email"
+            />
+          </InfoCard>
+
+          <WorkshopRegistrationSettings
+            workshopRegistrationStart={conference.workshopRegistrationStart}
+            workshopRegistrationEnd={conference.workshopRegistrationEnd}
+          />
+
+          <InfoCard
+            title="Domain Configuration"
+            icon={GlobeAltIcon}
+            editUrl={editUrl}
+          >
+            <FieldRow label="Domains" value={conference.domains} type="array" />
+            <FieldRow
+              label="Social Links"
+              value={conference.socialLinks}
+              type="links"
+            />
+          </InfoCard>
+
+          <InfoCard
+            title="External Integrations"
+            icon={LinkIcon}
+            editUrl={editUrl}
+          >
+            <FieldRow
+              label="Checkin Customer ID"
+              value={conference.checkinCustomerId}
+            />
+            <FieldRow
+              label="Checkin Event ID"
+              value={conference.checkinEventId}
+            />
+          </InfoCard>
+
+          <InfoCard
+            title="Content Configuration"
+            icon={TagIcon}
+            editUrl={editUrl}
+          >
+            <FieldRow
+              label="Available Formats"
+              value={conference.formats}
+              type="formats"
+            />
+            <FieldRow
+              label="Available Topics"
+              value={conference.topics}
+              type="array"
+            />
+            <FieldRow
+              label="Features"
+              value={conference.features}
               type="array"
             />
           </InfoCard>
-        )}
 
-        {conference.vanityMetrics && conference.vanityMetrics.length > 0 && (
-          <InfoCard title="Vanity Metrics" icon={ChartPieIcon}>
-            {conference.vanityMetrics.map((metric, idx) => (
-              <FieldRow key={idx} label={metric.label} value={metric.value} />
-            ))}
+          <InfoCard title="Team" icon={UserGroupIcon} editUrl={editUrl}>
+            <FieldRow
+              label="Organizers"
+              value={conference.organizers?.map((org) => org.name)}
+              type="team"
+            />
           </InfoCard>
-        )}
-      </div>
+
+          {conference.sponsorTiers && conference.sponsorTiers.length > 0 && (
+            <InfoCard
+              title="Sponsorship Tiers"
+              icon={CurrencyDollarIcon}
+              editUrl={editUrl}
+            >
+              {conference.sponsorTiers.map((tier, idx) => (
+                <div
+                  key={idx}
+                  className="border-b border-gray-200 pb-3 last:border-b-0 last:pb-0 dark:border-gray-700"
+                >
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      {tier.title}
+                    </span>
+                    <div className="flex items-center space-x-2">
+                      {tier.soldOut && (
+                        <StatusBadge label="Sold Out" color="red" />
+                      )}
+                      {tier.mostPopular && (
+                        <StatusBadge label="Popular" color="green" />
+                      )}
+                    </div>
+                  </div>
+                  <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
+                    {tier.tagline}
+                  </p>
+                  {tier.price && tier.price.length > 0 && (
+                    <div className="text-sm text-gray-500 dark:text-gray-400">
+                      {tier.price.map((price, pidx) => (
+                        <span key={pidx}>
+                          {price.amount} {price.currency}
+                          {pidx < tier.price!.length - 1 && ', '}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </InfoCard>
+          )}
+
+          {conference.sponsors && conference.sponsors.length > 0 && (
+            <InfoCard
+              title="Current Sponsors"
+              icon={CurrencyDollarIcon}
+              editUrl={editUrl}
+            >
+              <FieldRow
+                label="Sponsors"
+                value={conference.sponsors.map(
+                  (s) => `${s.sponsor.name} (${s.tier?.title ?? 'No Tier'})`,
+                )}
+                type="array"
+              />
+            </InfoCard>
+          )}
+
+          {conference.vanityMetrics && conference.vanityMetrics.length > 0 && (
+            <InfoCard
+              title="Vanity Metrics"
+              icon={ChartPieIcon}
+              editUrl={editUrl}
+            >
+              {conference.vanityMetrics.map((metric, idx) => (
+                <FieldRow key={idx} label={metric.label} value={metric.value} />
+              ))}
+            </InfoCard>
+          )}
+        </div>
+      </section>
+
+      {/* ---- TIER 2: System status ---- */}
+      <section className="space-y-4">
+        <SectionHeading
+          id="system-status"
+          icon={ServerStackIcon}
+          title="System status"
+          description="Environment configuration and live integration health. Secrets are shown only as a sha256 fingerprint and length — never their value."
+        />
+        <SystemStatusSection checks={systemChecks} />
+      </section>
+
+      {/* ---- Self-check probes ---- */}
+      <section className="space-y-4">
+        <SectionHeading
+          id="self-check"
+          icon={BeakerIcon}
+          title="Self-check"
+          description="Actively exercise an integration end to end. These deliver real messages, so they are rate-limited."
+        />
+        <SelfCheckPanel />
+      </section>
     </div>
   )
 }

--- a/src/components/admin/system-status/ProbeCard.stories.tsx
+++ b/src/components/admin/system-status/ProbeCard.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import {
+  ChatBubbleLeftRightIcon,
+  EnvelopeIcon,
+  CircleStackIcon,
+} from '@heroicons/react/24/outline'
+import { ProbeCard } from './ProbeCard'
+
+const meta = {
+  title: 'Systems/Admin/SystemStatus/ProbeCard',
+  component: ProbeCard,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    onRun: fn(),
+    icon: ChatBubbleLeftRightIcon,
+    title: 'Slack',
+    description: 'Post a test message to the weekly-update channel.',
+    actionLabel: 'Send Slack test',
+    pending: false,
+    state: null,
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ProbeCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Grid({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {children}
+    </div>
+  )
+}
+
+export const ResultStates: Story = {
+  render: (args) => (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <Grid>
+        <ProbeCard
+          {...args}
+          icon={ChatBubbleLeftRightIcon}
+          title="Slack"
+          description="Post a test message to the weekly-update channel."
+          actionLabel="Send Slack test"
+          pending={false}
+          state={{ tone: 'success', text: 'Posted to #cndn-updates' }}
+        />
+        <ProbeCard
+          {...args}
+          icon={EnvelopeIcon}
+          title="Email"
+          description="Send a test email to your own address via Resend."
+          actionLabel="Send test email"
+          pending={true}
+          state={null}
+        />
+        <ProbeCard
+          {...args}
+          icon={CircleStackIcon}
+          title="Sanity write"
+          description="Create and delete a scratch document through the write client."
+          actionLabel="Run write probe"
+          pending={false}
+          state={{
+            tone: 'warn',
+            text: 'Please wait 30 seconds before running this probe again.',
+            detail: '12 ms',
+          }}
+        />
+      </Grid>
+    </div>
+  ),
+}
+
+export const Dark: Story = {
+  render: (args) => (
+    <div className="dark min-h-screen bg-gray-950 p-4">
+      <Grid>
+        <ProbeCard
+          {...args}
+          icon={ChatBubbleLeftRightIcon}
+          title="Slack"
+          description="Post a test message to the weekly-update channel."
+          actionLabel="Send Slack test"
+          pending={false}
+          state={{ tone: 'success', text: 'Posted to #cndn-updates' }}
+        />
+        <ProbeCard
+          {...args}
+          icon={EnvelopeIcon}
+          title="Email"
+          description="Send a test email to your own address via Resend."
+          actionLabel="Send test email"
+          pending={false}
+          state={{
+            tone: 'success',
+            text: 'Test email sent to your address',
+            detail: 'Resend id: 9f1c-4a2e-bd77',
+          }}
+        />
+        <ProbeCard
+          {...args}
+          icon={CircleStackIcon}
+          title="Sanity write"
+          description="Create and delete a scratch document through the write client."
+          actionLabel="Run write probe"
+          pending={false}
+          state={{
+            tone: 'warn',
+            text: 'Sanity write probe failed',
+            detail: '204 ms',
+          }}
+        />
+      </Grid>
+    </div>
+  ),
+}

--- a/src/components/admin/system-status/ProbeCard.tsx
+++ b/src/components/admin/system-status/ProbeCard.tsx
@@ -1,0 +1,70 @@
+export type ProbeTone = 'success' | 'warn' | 'muted'
+
+export interface ProbeState {
+  tone: ProbeTone
+  text: string
+  detail?: string
+}
+
+const TONE_CLASS: Record<ProbeTone, string> = {
+  success: 'text-green-700 dark:text-green-400',
+  warn: 'text-amber-700 dark:text-amber-400',
+  muted: 'text-gray-500 dark:text-gray-400',
+}
+
+/**
+ * Presentational self-check probe tile. Pure props (no tRPC), so it can be
+ * rendered in isolation in Storybook to exercise every result tone.
+ */
+export function ProbeCard({
+  icon: Icon,
+  title,
+  description,
+  actionLabel,
+  pending,
+  state,
+  onRun,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  title: string
+  description: string
+  actionLabel: string
+  pending: boolean
+  state: ProbeState | null
+  onRun: () => void
+}) {
+  return (
+    <div className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className="h-5 w-5 text-gray-400 dark:text-gray-500" />
+        <h4 className="text-sm font-semibold text-gray-900 dark:text-white">
+          {title}
+        </h4>
+      </div>
+      <p className="mb-4 text-xs leading-snug text-gray-500 dark:text-gray-400">
+        {description}
+      </p>
+      <button
+        type="button"
+        onClick={onRun}
+        disabled={pending}
+        className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+      >
+        {pending ? 'Running…' : actionLabel}
+      </button>
+      {state && (
+        <div role="status" className="mt-3 space-y-1">
+          <p className={`text-sm ${TONE_CLASS[state.tone]}`}>{state.text}</p>
+          {state.detail && (
+            <p
+              className="truncate font-mono text-xs text-gray-400 dark:text-gray-500"
+              title={state.detail}
+            >
+              {state.detail}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/system-status/SelfCheckPanel.tsx
+++ b/src/components/admin/system-status/SelfCheckPanel.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { api } from '@/lib/trpc/client'
+import {
+  ChatBubbleLeftRightIcon,
+  EnvelopeIcon,
+  CircleStackIcon,
+  BellAlertIcon,
+} from '@heroicons/react/24/outline'
+import { ProbeCard, type ProbeState } from './ProbeCard'
+
+export function SelfCheckPanel() {
+  const [slackState, setSlackState] = useState<ProbeState | null>(null)
+  const [emailState, setEmailState] = useState<ProbeState | null>(null)
+  const [sanityState, setSanityState] = useState<ProbeState | null>(null)
+
+  const slack = api.status.admin.probeSlack.useMutation()
+  const email = api.status.admin.probeEmail.useMutation()
+  const sanityWrite = api.status.admin.probeSanityWrite.useMutation()
+
+  const runSlack = async () => {
+    setSlackState(null)
+    try {
+      const res = await slack.mutateAsync()
+      setSlackState(
+        res.ok
+          ? { tone: 'success', text: `Posted to ${res.channel}` }
+          : { tone: 'warn', text: res.error ?? 'Slack probe failed' },
+      )
+    } catch (err) {
+      setSlackState({ tone: 'warn', text: messageFromError(err) })
+    }
+  }
+
+  const runEmail = async () => {
+    setEmailState(null)
+    try {
+      const res = await email.mutateAsync()
+      setEmailState(
+        res.ok
+          ? {
+              tone: 'success',
+              text: 'Test email sent to your address',
+              detail: res.id ? `Resend id: ${res.id}` : undefined,
+            }
+          : { tone: 'warn', text: res.error ?? 'Email probe failed' },
+      )
+    } catch (err) {
+      setEmailState({ tone: 'warn', text: messageFromError(err) })
+    }
+  }
+
+  const runSanity = async () => {
+    setSanityState(null)
+    try {
+      const res = await sanityWrite.mutateAsync()
+      setSanityState(
+        res.ok
+          ? {
+              tone: 'success',
+              text: `Write round-trip OK (${res.latencyMs} ms)`,
+            }
+          : {
+              tone: 'warn',
+              text: res.error ?? 'Sanity write probe failed',
+              detail: `${res.latencyMs} ms`,
+            },
+      )
+    } catch (err) {
+      setSanityState({ tone: 'warn', text: messageFromError(err) })
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Active probes actually deliver — each is rate-limited to once every 30
+        seconds per organizer.
+      </p>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <ProbeCard
+          icon={ChatBubbleLeftRightIcon}
+          title="Slack"
+          description="Post a test message to the weekly-update channel."
+          actionLabel="Send Slack test"
+          pending={slack.isPending}
+          state={slackState}
+          onRun={runSlack}
+        />
+        <ProbeCard
+          icon={EnvelopeIcon}
+          title="Email"
+          description="Send a test email to your own address via Resend."
+          actionLabel="Send test email"
+          pending={email.isPending}
+          state={emailState}
+          onRun={runEmail}
+        />
+        <ProbeCard
+          icon={CircleStackIcon}
+          title="Sanity write"
+          description="Create and delete a scratch document through the write client."
+          actionLabel="Run write probe"
+          pending={sanityWrite.isPending}
+          state={sanityState}
+          onRun={runSanity}
+        />
+      </div>
+      <div className="rounded-lg bg-gray-50 p-4 ring-1 ring-gray-200 dark:bg-gray-800/50 dark:ring-gray-700">
+        <div className="flex items-start gap-2">
+          <BellAlertIcon className="mt-0.5 h-5 w-5 shrink-0 text-gray-400 dark:text-gray-500" />
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Web push is tested per-device.{' '}
+            <Link
+              href="/cfp/profile#notification-settings"
+              className="font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+            >
+              Open your notification settings
+            </Link>{' '}
+            and use the &ldquo;Send test notification&rdquo; button there.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function messageFromError(err: unknown): string {
+  return err instanceof Error ? err.message : 'Probe failed'
+}

--- a/src/components/admin/system-status/StatusDot.tsx
+++ b/src/components/admin/system-status/StatusDot.tsx
@@ -1,0 +1,32 @@
+import type { CheckStatus } from '@/lib/system-status/types'
+
+const DOT_CLASSES: Record<CheckStatus, string> = {
+  ok: 'bg-green-500 dark:bg-green-400',
+  warn: 'bg-amber-500 dark:bg-amber-400',
+  error: 'bg-red-500 dark:bg-red-400',
+  off: 'bg-gray-400 dark:bg-gray-500',
+}
+
+const STATUS_LABEL: Record<CheckStatus, string> = {
+  ok: 'OK',
+  warn: 'Warning',
+  error: 'Error',
+  off: 'Not configured',
+}
+
+export function StatusDot({
+  status,
+  className = '',
+}: {
+  status: CheckStatus
+  className?: string
+}) {
+  return (
+    <span
+      role="img"
+      aria-label={STATUS_LABEL[status]}
+      title={STATUS_LABEL[status]}
+      className={`inline-block size-2.5 shrink-0 rounded-full ring-2 ring-white dark:ring-gray-900 ${DOT_CLASSES[status]} ${className}`}
+    />
+  )
+}

--- a/src/components/admin/system-status/SystemCheckRow.tsx
+++ b/src/components/admin/system-status/SystemCheckRow.tsx
@@ -1,0 +1,47 @@
+import type { SystemCheck } from '@/lib/system-status/types'
+import { StatusDot } from './StatusDot'
+
+function isHttpUrl(value: string): boolean {
+  return value.startsWith('http://') || value.startsWith('https://')
+}
+
+export function SystemCheckRow({ check }: { check: SystemCheck }) {
+  const { label, value, detail, status } = check
+  return (
+    <div className="flex items-start justify-between gap-3 border-b border-gray-100 py-2 last:border-b-0 dark:border-gray-800">
+      <div className="flex min-w-0 items-start gap-2">
+        <span className="mt-1.5">
+          <StatusDot status={status} />
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-medium break-words text-gray-900 dark:text-white">
+            {label}
+          </p>
+          {detail && (
+            <p className="mt-0.5 text-xs leading-snug text-gray-500 dark:text-gray-400">
+              {detail}
+            </p>
+          )}
+        </div>
+      </div>
+      {value !== undefined && (
+        <div className="max-w-[45%] shrink-0 text-right">
+          {isHttpUrl(value) ? (
+            <a
+              href={value}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-xs break-all text-indigo-600 hover:underline dark:text-indigo-400"
+            >
+              {value}
+            </a>
+          ) : (
+            <span className="font-mono text-xs break-all text-gray-700 dark:text-gray-300">
+              {value}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/system-status/SystemStatusCard.tsx
+++ b/src/components/admin/system-status/SystemStatusCard.tsx
@@ -1,0 +1,23 @@
+import type { SystemCheckGroup } from '@/lib/system-status/types'
+import { worstStatus } from '@/lib/system-status/types'
+import { StatusDot } from './StatusDot'
+import { SystemCheckRow } from './SystemCheckRow'
+
+export function SystemStatusCard({ group }: { group: SystemCheckGroup }) {
+  const rollup = worstStatus(group.checks)
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+      <div className="mb-3 flex items-center gap-2">
+        <StatusDot status={rollup} />
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+          {group.label}
+        </h3>
+      </div>
+      <div>
+        {group.checks.map((check) => (
+          <SystemCheckRow key={check.id} check={check} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/system-status/SystemStatusSection.stories.tsx
+++ b/src/components/admin/system-status/SystemStatusSection.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SystemStatusSection } from './SystemStatusSection'
+import { fixtureChecks } from './fixtures'
+
+const meta = {
+  title: 'Systems/Admin/SystemStatus/SystemStatusSection',
+  component: SystemStatusSection,
+  parameters: { layout: 'fullscreen' },
+  args: { checks: fixtureChecks },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SystemStatusSection>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllStatuses: Story = {
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-gray-50 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const Dark: Story = {
+  decorators: [
+    (Story) => (
+      <div className="dark min-h-screen bg-gray-950 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/components/admin/system-status/SystemStatusSection.tsx
+++ b/src/components/admin/system-status/SystemStatusSection.tsx
@@ -1,0 +1,46 @@
+import type { CheckStatus, SystemCheck } from '@/lib/system-status/types'
+import { groupSystemChecks } from '@/lib/system-status/types'
+import { StatusDot } from './StatusDot'
+import { SystemStatusCard } from './SystemStatusCard'
+
+const LEGEND: { status: CheckStatus; label: string }[] = [
+  { status: 'ok', label: 'OK' },
+  { status: 'warn', label: 'Degraded / fallback' },
+  { status: 'error', label: 'Broken' },
+  { status: 'off', label: 'Not configured' },
+]
+
+function StatusTally({ checks }: { checks: SystemCheck[] }) {
+  const counts = checks.reduce<Record<CheckStatus, number>>(
+    (acc, c) => {
+      acc[c.status] += 1
+      return acc
+    },
+    { ok: 0, warn: 0, error: 0, off: 0 },
+  )
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600 dark:text-gray-300">
+      {LEGEND.map(({ status, label }) => (
+        <span key={status} className="inline-flex items-center gap-1.5">
+          <StatusDot status={status} />
+          <span className="font-medium">{counts[status]}</span>
+          <span className="text-gray-500 dark:text-gray-400">{label}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function SystemStatusSection({ checks }: { checks: SystemCheck[] }) {
+  const groups = groupSystemChecks(checks)
+  return (
+    <div className="space-y-4">
+      <StatusTally checks={checks} />
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {groups.map((group) => (
+          <SystemStatusCard key={group.group} group={group} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/system-status/fixtures.ts
+++ b/src/components/admin/system-status/fixtures.ts
@@ -1,0 +1,205 @@
+import type { SystemCheck } from '@/lib/system-status/types'
+
+/**
+ * Deterministic fixture registry for Storybook. Covers every status
+ * (ok / warn / error / off), secret fingerprints, plain values, and a URL value
+ * so the section renders realistically without a server round-trip.
+ */
+export const fixtureChecks: SystemCheck[] = [
+  // build
+  {
+    id: 'build.commit',
+    group: 'build',
+    label: 'Git commit',
+    status: 'ok',
+    value: '9799258',
+  },
+  {
+    id: 'build.cacheVersion',
+    group: 'build',
+    label: 'Service worker CACHE_VERSION',
+    status: 'ok',
+    value: 'cndn-9799258',
+    detail: 'Stamped with the deploy SHA at build; drives PWA updates',
+  },
+  {
+    id: 'build.appVersion',
+    group: 'build',
+    label: 'App version',
+    status: 'ok',
+    value: '2025.10.30',
+  },
+  {
+    id: 'build.baseUrl',
+    group: 'build',
+    label: 'NEXT_PUBLIC_BASE_URL',
+    status: 'warn',
+    value: 'not set',
+    detail: 'Absolute links fall back to http://localhost:3000',
+  },
+  {
+    id: 'build.nodeEnv',
+    group: 'build',
+    label: 'NODE_ENV',
+    status: 'ok',
+    value: 'production',
+  },
+
+  // sanity
+  {
+    id: 'sanity.projectId',
+    group: 'sanity',
+    label: 'Project ID',
+    status: 'ok',
+    value: 'abc123xy',
+  },
+  {
+    id: 'sanity.dataset',
+    group: 'sanity',
+    label: 'Dataset',
+    status: 'ok',
+    value: 'production',
+  },
+  {
+    id: 'sanity.readToken',
+    group: 'sanity',
+    label: 'Read token (SANITY_API_TOKEN_READ)',
+    status: 'ok',
+    value: 'a1b2c3d4 (172 chars)',
+  },
+  {
+    id: 'sanity.writeToken',
+    group: 'sanity',
+    label: 'Write token (SANITY_API_TOKEN_WRITE)',
+    status: 'error',
+    value: 'not set',
+    detail: "Client falls back to the literal 'invalid' — writes will fail",
+  },
+  {
+    id: 'sanity.readProbe',
+    group: 'sanity',
+    label: 'Live read probe',
+    status: 'ok',
+    value: '84 ms',
+    detail: 'Read conference conf-2026',
+  },
+
+  // auth
+  {
+    id: 'auth.providers',
+    group: 'auth',
+    label: 'Enabled providers',
+    status: 'ok',
+    value: 'GitHub, LinkedIn',
+  },
+  {
+    id: 'auth.github',
+    group: 'auth',
+    label: 'GitHub OAuth',
+    status: 'ok',
+    value: 'deadbeef (40 chars)',
+    detail: 'Client id + secret set',
+  },
+  {
+    id: 'auth.linkedin',
+    group: 'auth',
+    label: 'LinkedIn OAuth',
+    status: 'warn',
+    value: 'partial',
+    detail: 'Only AUTH_LINKEDIN_ID is set — this provider is misconfigured',
+  },
+  {
+    id: 'auth.secret',
+    group: 'auth',
+    label: 'AUTH_SECRET',
+    status: 'ok',
+    value: 'feedface (44 chars)',
+  },
+
+  // slack
+  {
+    id: 'slack.botToken',
+    group: 'slack',
+    label: 'SLACK_BOT_TOKEN',
+    status: 'off',
+    value: 'not set',
+    detail:
+      'Unset → messages are logged to the console in dev, skipped otherwise',
+  },
+  {
+    id: 'slack.weeklyChannel',
+    group: 'slack',
+    label: 'Weekly-update channel',
+    status: 'ok',
+    value: '#cndn-updates',
+    detail: 'conference.salesNotificationChannel',
+  },
+
+  // push
+  {
+    id: 'push.configured',
+    group: 'push',
+    label: 'VAPID key pair',
+    status: 'ok',
+    value: 'configured',
+  },
+  {
+    id: 'push.vapidPublic',
+    group: 'push',
+    label: 'VAPID public key',
+    status: 'ok',
+    value: 'c0ffee12 (87 chars)',
+  },
+  {
+    id: 'push.subscriptions',
+    group: 'push',
+    label: 'Active subscriptions',
+    status: 'ok',
+    value: '312',
+    detail: 'Registered devices across all speakers',
+  },
+
+  // ops
+  {
+    id: 'ops.cronSecret',
+    group: 'ops',
+    label: 'CRON_SECRET',
+    status: 'error',
+    value: 'not set',
+    detail: 'Cron endpoints reject Vercel invocations — scheduled jobs fail',
+  },
+  {
+    id: 'ops.cron.weekly',
+    group: 'ops',
+    label: 'cron: weekly-update',
+    status: 'ok',
+    value: '0 9 * * 1',
+  },
+  {
+    id: 'ops.migrationWorkflow',
+    group: 'ops',
+    label: 'Run-migration workflow',
+    status: 'ok',
+    value:
+      'https://github.com/CloudNativeBergen/website/actions/workflows/run-migration.yml',
+    detail: 'Trigger data migrations from GitHub Actions',
+  },
+
+  // misc
+  {
+    id: 'misc.exchangeRate',
+    group: 'misc',
+    label: 'NEXT_PUBLIC_EXCHANGE_RATE_API_KEY',
+    status: 'warn',
+    value: 'not set',
+    detail: 'Free-tier fallback in effect (limited exchange-rate lookups)',
+  },
+  {
+    id: 'misc.workos',
+    group: 'misc',
+    label: 'WORKOS_CLIENT_ID',
+    status: 'off',
+    value: 'not set',
+    detail: 'Workshop (WorkOS) login unavailable',
+  },
+]

--- a/src/components/admin/system-status/index.ts
+++ b/src/components/admin/system-status/index.ts
@@ -1,0 +1,6 @@
+export { StatusDot } from './StatusDot'
+export { ProbeCard } from './ProbeCard'
+export { SystemCheckRow } from './SystemCheckRow'
+export { SystemStatusCard } from './SystemStatusCard'
+export { SystemStatusSection } from './SystemStatusSection'
+export { SelfCheckPanel } from './SelfCheckPanel'

--- a/src/lib/system-status/checks.test.ts
+++ b/src/lib/system-status/checks.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { createHash } from 'node:crypto'
+import type { SystemCheck } from './types'
+import { groupSystemChecks, worstStatus } from './types'
+
+// clientReadUncached is used by the live probes in buildSystemChecks. Mock it so
+// the async probe paths are deterministic and never hit the network.
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+}))
+
+import { collectStaticChecks, buildSystemChecks } from './checks'
+
+const CONFERENCE = {
+  _id: 'conf-1',
+  organizer: 'Test Org',
+  cfpEmail: 'cfp@example.com',
+  salesNotificationChannel: '#updates',
+  cfpNotificationChannel: '#cfp',
+  checkinCustomerId: 42,
+  checkinEventId: 7,
+}
+
+function byId(checks: SystemCheck[], id: string): SystemCheck {
+  const found = checks.find((c) => c.id === id)
+  if (!found) throw new Error(`check ${id} not found`)
+  return found
+}
+
+const FINGERPRINT_RE = /^[0-9a-f]{8} \(\d+ chars\)$/
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+})
+
+describe('collectStaticChecks — secrets are never echoed', () => {
+  it('renders a secret as a sha256 fingerprint + length, never the value', () => {
+    const secret = 'super-secret-resend-key-value'
+    vi.stubEnv('RESEND_API_KEY', secret)
+    const check = byId(collectStaticChecks(CONFERENCE), 'email.resendKey')
+
+    expect(check.status).toBe('ok')
+    expect(check.value).toMatch(FINGERPRINT_RE)
+    expect(check.value).not.toContain(secret)
+
+    const expected = createHash('sha256')
+      .update(secret)
+      .digest('hex')
+      .slice(0, 8)
+    expect(check.value).toBe(`${expected} (${secret.length} chars)`)
+  })
+
+  it('reports error status when a required secret is missing', () => {
+    vi.stubEnv('RESEND_API_KEY', '')
+    const check = byId(collectStaticChecks(CONFERENCE), 'email.resendKey')
+    expect(check.status).toBe('error')
+    expect(check.value).toBe('not set')
+  })
+})
+
+describe('collectStaticChecks — status semantics', () => {
+  it('marks a deliberately-optional integration as off when unset', () => {
+    vi.stubEnv('SLACK_BOT_TOKEN', '')
+    const check = byId(collectStaticChecks(CONFERENCE), 'slack.botToken')
+    expect(check.status).toBe('off')
+  })
+
+  it('warns (not errors) for the free-tier exchange-rate fallback', () => {
+    vi.stubEnv('NEXT_PUBLIC_EXCHANGE_RATE_API_KEY', '')
+    const check = byId(collectStaticChecks(CONFERENCE), 'misc.exchangeRate')
+    expect(check.status).toBe('warn')
+  })
+
+  it('errors when CRON_SECRET is missing', () => {
+    vi.stubEnv('CRON_SECRET', '')
+    const check = byId(collectStaticChecks(CONFERENCE), 'ops.cronSecret')
+    expect(check.status).toBe('error')
+  })
+
+  it('shows plain (non-secret) values verbatim', () => {
+    vi.stubEnv('NEXT_PUBLIC_SANITY_DATASET', 'production')
+    const check = byId(collectStaticChecks(CONFERENCE), 'sanity.dataset')
+    expect(check.status).toBe('ok')
+    expect(check.value).toBe('production')
+  })
+
+  it('surfaces conference-derived non-secrets plainly', () => {
+    const checks = collectStaticChecks(CONFERENCE)
+    expect(byId(checks, 'email.from').value).toBe('cfp@example.com')
+    expect(byId(checks, 'slack.weeklyChannel').value).toBe('#updates')
+    expect(byId(checks, 'tickets.customerId').value).toBe('42')
+  })
+})
+
+describe('collectStaticChecks — paired OAuth provider', () => {
+  it('is ok with both id and secret, warns on a partial pair, off when neither', () => {
+    vi.stubEnv('AUTH_GITHUB_ID', 'id')
+    vi.stubEnv('AUTH_GITHUB_SECRET', 'shhh')
+    expect(byId(collectStaticChecks(CONFERENCE), 'auth.github').status).toBe(
+      'ok',
+    )
+
+    vi.stubEnv('AUTH_GITHUB_SECRET', '')
+    const partial = byId(collectStaticChecks(CONFERENCE), 'auth.github')
+    expect(partial.status).toBe('warn')
+    expect(partial.value).toBe('partial')
+
+    vi.stubEnv('AUTH_GITHUB_ID', '')
+    expect(byId(collectStaticChecks(CONFERENCE), 'auth.github').status).toBe(
+      'off',
+    )
+  })
+})
+
+describe('collectStaticChecks — contract provider conditional', () => {
+  it('omits Adobe checks unless the provider is adobe-sign', () => {
+    vi.stubEnv('CONTRACT_SIGNING_PROVIDER', 'self-hosted')
+    const selfHosted = collectStaticChecks(CONFERENCE)
+    expect(byId(selfHosted, 'contracts.provider').value).toBe('self-hosted')
+    expect(
+      selfHosted.find((c) => c.id === 'contracts.adobeAppId'),
+    ).toBeUndefined()
+
+    vi.stubEnv('CONTRACT_SIGNING_PROVIDER', 'adobe-sign')
+    vi.stubEnv('ADOBE_SIGN_APPLICATION_ID', '')
+    const adobe = collectStaticChecks(CONFERENCE)
+    expect(byId(adobe, 'contracts.adobeAppId').status).toBe('error')
+  })
+})
+
+describe('buildSystemChecks — live probes', () => {
+  beforeEach(() => {
+    vi.stubEnv('RESEND_API_KEY', 'x')
+  })
+
+  it('reports an ok Sanity read probe with latency', async () => {
+    fetchMock.mockImplementation((query: string) => {
+      if (query.includes('count(')) return Promise.resolve(5)
+      return Promise.resolve('conf-1')
+    })
+    const checks = await buildSystemChecks(CONFERENCE)
+    const probe = byId(checks, 'sanity.readProbe')
+    expect(probe.status).toBe('ok')
+    expect(probe.value).toMatch(/\d+ ms/)
+    expect(byId(checks, 'push.subscriptions').value).toBe('5')
+  })
+
+  it('reports an error Sanity read probe when the fetch throws', async () => {
+    fetchMock.mockImplementation((query: string) => {
+      if (query.includes('count(')) return Promise.resolve(0)
+      return Promise.reject(new Error('network down'))
+    })
+    const checks = await buildSystemChecks(CONFERENCE)
+    const probe = byId(checks, 'sanity.readProbe')
+    expect(probe.status).toBe('error')
+    expect(probe.detail).toBe('network down')
+  })
+})
+
+describe('types helpers', () => {
+  const sample: SystemCheck[] = [
+    { id: 'a', group: 'sanity', label: 'A', status: 'ok' },
+    { id: 'b', group: 'sanity', label: 'B', status: 'error' },
+    { id: 'c', group: 'push', label: 'C', status: 'warn' },
+  ]
+
+  it('groups checks into ordered, non-empty cards', () => {
+    const groups = groupSystemChecks(sample)
+    expect(groups.map((g) => g.group)).toEqual(['sanity', 'push'])
+    expect(groups[0].checks).toHaveLength(2)
+  })
+
+  it('rolls a group up to its worst status', () => {
+    expect(worstStatus(sample)).toBe('error')
+    expect(
+      worstStatus([{ id: 'x', group: 'push', label: 'X', status: 'off' }]),
+    ).toBe('off')
+  })
+})

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -1,0 +1,699 @@
+import 'server-only'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { clientReadUncached } from '@/lib/sanity/client'
+import { isPushConfigured, getVapidPublicKey } from '@/lib/push/vapid'
+import { checkinGraphQLClient } from '@/lib/tickets/graphql-client'
+import { providerMap } from '@/lib/auth'
+import type {
+  CheckGroup,
+  CheckStatus,
+  ConferenceForSystemChecks,
+  SystemCheck,
+} from './types'
+
+/**
+ * Server-only registry of passive system checks for /admin/settings.
+ *
+ * DESIGN CONTRACT (do not break):
+ *  - Read `process.env.X` DIRECTLY. Never import a module that asserts/throws at
+ *    load when unconfigured (email/config asserts RESEND_API_KEY;
+ *    cospeaker/server throws on INVITATION_TOKEN_SECRET; badge/config and
+ *    adobe-sign/auth getters throw on missing keys). We only import modules that
+ *    are provably import-safe: sanity/client (falls back to 'invalid'),
+ *    push/vapid (returns '' when unset), tickets/graphql-client (warns, never
+ *    throws at import), and auth (providers just get undefined ids).
+ *  - SECRETS ARE NEVER ECHOED. A secret is surfaced only as a sha256 fingerprint
+ *    plus its length, e.g. `a1b2c3d4 (32 chars)` — never the value itself.
+ *    Non-secrets (dataset, project id, from-address, provider names, schedules,
+ *    channels) are shown plain.
+ *  - Status semantics: 'error' only when the absence breaks a LIVE feature;
+ *    'warn' for degraded/fallback; 'off' for a deliberately-optional integration
+ *    left unconfigured; 'ok' otherwise.
+ */
+
+const REPO_URL = 'https://github.com/CloudNativeBergen/website'
+
+const VERCEL_CRONS: ReadonlyArray<{ path: string; schedule: string }> = [
+  { path: '/api/cron/weekly-update', schedule: '0 9 * * 1' },
+  { path: '/api/cron/cleanup-orphaned-blobs', schedule: '0 3 * * *' },
+  { path: '/api/cron/contract-reminders', schedule: '0 9 * * *' },
+  { path: '/api/cron/cleanup-notifications', schedule: '0 4 * * *' },
+]
+
+/** sha256 fingerprint (first 8 hex) + length. NEVER returns the raw value. */
+function fingerprint(value: string): string {
+  const hash = createHash('sha256').update(value).digest('hex').slice(0, 8)
+  return `${hash} (${value.length} chars)`
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : 'Unknown error'
+}
+
+interface CheckMeta {
+  id: string
+  group: CheckGroup
+  label: string
+}
+
+/** Presence + fingerprint of a SECRET env var. Absent → `missingStatus`. */
+function secretCheck(
+  meta: CheckMeta,
+  env: string,
+  missingStatus: CheckStatus,
+  detail?: { present?: string; missing?: string },
+): SystemCheck {
+  const value = process.env[env]
+  if (value && value.length > 0) {
+    return {
+      ...meta,
+      status: 'ok',
+      value: fingerprint(value),
+      detail: detail?.present,
+    }
+  }
+  return {
+    ...meta,
+    status: missingStatus,
+    value: 'not set',
+    detail: detail?.missing,
+  }
+}
+
+/** Presence-only of an env var (no fingerprint — e.g. large keys). */
+function presenceCheck(
+  meta: CheckMeta,
+  env: string,
+  missingStatus: CheckStatus,
+  detail?: { present?: string; missing?: string },
+): SystemCheck {
+  const set = Boolean(process.env[env])
+  return set
+    ? { ...meta, status: 'ok', value: 'set', detail: detail?.present }
+    : {
+        ...meta,
+        status: missingStatus,
+        value: 'not set',
+        detail: detail?.missing,
+      }
+}
+
+/** Plain (non-secret) env value. Absent → `missingStatus`. */
+function plainCheck(
+  meta: CheckMeta,
+  raw: string | number | undefined | null,
+  missingStatus: CheckStatus,
+  detail?: { present?: string; missing?: string },
+): SystemCheck {
+  const value =
+    raw === undefined || raw === null || raw === '' ? undefined : String(raw)
+  return value !== undefined
+    ? { ...meta, status: 'ok', value, detail: detail?.present }
+    : {
+        ...meta,
+        status: missingStatus,
+        value: 'not set',
+        detail: detail?.missing,
+      }
+}
+
+function readFileSafe(relative: string): string | null {
+  try {
+    return readFileSync(path.join(process.cwd(), relative), 'utf8')
+  } catch {
+    return null
+  }
+}
+
+function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
+  const checks: SystemCheck[] = []
+
+  // ---- BUILD & RUNTIME ------------------------------------------------------
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA
+  checks.push(
+    sha
+      ? {
+          id: 'build.commit',
+          group: 'build',
+          label: 'Git commit',
+          status: 'ok',
+          value: sha.slice(0, 7),
+        }
+      : {
+          id: 'build.commit',
+          group: 'build',
+          label: 'Git commit',
+          status: 'off',
+          value: 'not set',
+          detail: 'Only injected on the Vercel build runtime',
+        },
+  )
+
+  const swSrc = readFileSafe('public/sw.js')
+  const cacheMatch = swSrc?.match(
+    /const\s+CACHE_VERSION\s*=\s*['"]([^'"]*)['"]/,
+  )
+  checks.push(
+    cacheMatch
+      ? {
+          id: 'build.cacheVersion',
+          group: 'build',
+          label: 'Service worker CACHE_VERSION',
+          status: 'ok',
+          value: cacheMatch[1],
+          detail: 'Stamped with the deploy SHA at build; drives PWA updates',
+        }
+      : {
+          id: 'build.cacheVersion',
+          group: 'build',
+          label: 'Service worker CACHE_VERSION',
+          status: 'warn',
+          value: 'unavailable',
+          detail: 'Could not read CACHE_VERSION from public/sw.js',
+        },
+  )
+
+  const pkgSrc = readFileSafe('package.json')
+  let pkgVersion: string | undefined
+  try {
+    pkgVersion = pkgSrc ? (JSON.parse(pkgSrc).version as string) : undefined
+  } catch {
+    pkgVersion = undefined
+  }
+  checks.push(
+    plainCheck(
+      { id: 'build.appVersion', group: 'build', label: 'App version' },
+      pkgVersion,
+      'warn',
+      { missing: 'Could not read version from package.json' },
+    ),
+  )
+
+  checks.push(
+    plainCheck(
+      { id: 'build.baseUrl', group: 'build', label: 'NEXT_PUBLIC_BASE_URL' },
+      process.env.NEXT_PUBLIC_BASE_URL,
+      'warn',
+      { missing: 'Absolute links fall back to http://localhost:3000' },
+    ),
+  )
+
+  checks.push(
+    plainCheck(
+      { id: 'build.nodeEnv', group: 'build', label: 'NODE_ENV' },
+      process.env.NODE_ENV,
+      'warn',
+    ),
+  )
+
+  // ---- SANITY ---------------------------------------------------------------
+  checks.push(
+    plainCheck(
+      { id: 'sanity.projectId', group: 'sanity', label: 'Project ID' },
+      process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+      'error',
+      { missing: 'Sanity cannot be reached without a project id' },
+    ),
+    plainCheck(
+      { id: 'sanity.dataset', group: 'sanity', label: 'Dataset' },
+      process.env.NEXT_PUBLIC_SANITY_DATASET,
+      'error',
+      { missing: 'No dataset configured' },
+    ),
+    plainCheck(
+      { id: 'sanity.apiVersion', group: 'sanity', label: 'API version' },
+      process.env.NEXT_PUBLIC_SANITY_API_VERSION ?? '2023-05-03',
+      'warn',
+    ),
+    secretCheck(
+      {
+        id: 'sanity.readToken',
+        group: 'sanity',
+        label: 'Read token (SANITY_API_TOKEN_READ)',
+      },
+      'SANITY_API_TOKEN_READ',
+      'error',
+      {
+        missing: "Client falls back to the literal 'invalid' — reads will fail",
+      },
+    ),
+    secretCheck(
+      {
+        id: 'sanity.writeToken',
+        group: 'sanity',
+        label: 'Write token (SANITY_API_TOKEN_WRITE)',
+      },
+      'SANITY_API_TOKEN_WRITE',
+      'error',
+      {
+        missing:
+          "Client falls back to the literal 'invalid' — writes will fail",
+      },
+    ),
+  )
+
+  // ---- AUTH -----------------------------------------------------------------
+  const providerNames = providerMap.map((p) => p.name).join(', ')
+  checks.push(
+    providerMap.length > 0
+      ? {
+          id: 'auth.providers',
+          group: 'auth',
+          label: 'Enabled providers',
+          status: 'ok',
+          value: providerNames,
+        }
+      : {
+          id: 'auth.providers',
+          group: 'auth',
+          label: 'Enabled providers',
+          status: 'error',
+          value: 'none',
+          detail: 'No OAuth providers registered — sign-in is impossible',
+        },
+  )
+  checks.push(
+    pairedProvider(
+      'github',
+      'GitHub OAuth',
+      'AUTH_GITHUB_ID',
+      'AUTH_GITHUB_SECRET',
+    ),
+  )
+  checks.push(
+    pairedProvider(
+      'linkedin',
+      'LinkedIn OAuth',
+      'AUTH_LINKEDIN_ID',
+      'AUTH_LINKEDIN_SECRET',
+    ),
+  )
+  checks.push(
+    secretCheck(
+      { id: 'auth.secret', group: 'auth', label: 'AUTH_SECRET' },
+      'AUTH_SECRET',
+      'error',
+      { missing: 'JWT signing/verification breaks — no one can sign in' },
+    ),
+  )
+  // NOTE: AUTH_COOKIE_DOMAIN (the prod subdomain-cookie fix) is NOT read as an
+  // env var anywhere in the codebase today, so there is nothing to surface.
+  // If it is later wired as a `process.env.AUTH_COOKIE_DOMAIN` read, add a plain
+  // check here that warns when unset.
+
+  // ---- EMAIL ----------------------------------------------------------------
+  checks.push(
+    secretCheck(
+      { id: 'email.resendKey', group: 'email', label: 'RESEND_API_KEY' },
+      'RESEND_API_KEY',
+      'error',
+      { missing: 'All outbound email (CFP, badges, broadcasts) fails' },
+    ),
+    plainCheck(
+      { id: 'email.from', group: 'email', label: 'CFP from-address' },
+      conference.cfpEmail,
+      'warn',
+      {
+        present: 'Used as the From address for speaker email',
+        missing: 'conference.cfpEmail is unset',
+      },
+    ),
+  )
+
+  // ---- SLACK ----------------------------------------------------------------
+  checks.push(
+    secretCheck(
+      { id: 'slack.botToken', group: 'slack', label: 'SLACK_BOT_TOKEN' },
+      'SLACK_BOT_TOKEN',
+      'off',
+      {
+        present: 'Messages are posted to Slack',
+        missing:
+          'Unset → messages are logged to the console in dev, skipped otherwise',
+      },
+    ),
+    plainCheck(
+      {
+        id: 'slack.weeklyChannel',
+        group: 'slack',
+        label: 'Weekly-update channel',
+      },
+      conference.salesNotificationChannel,
+      'off',
+      {
+        present: 'conference.salesNotificationChannel',
+        missing: 'Weekly update has nowhere to post',
+      },
+    ),
+    plainCheck(
+      {
+        id: 'slack.cfpChannel',
+        group: 'slack',
+        label: 'CFP notification channel',
+      },
+      conference.cfpNotificationChannel,
+      'off',
+      { present: 'conference.cfpNotificationChannel' },
+    ),
+  )
+
+  // ---- PUSH -----------------------------------------------------------------
+  const pushOn = isPushConfigured()
+  checks.push({
+    id: 'push.configured',
+    group: 'push',
+    label: 'VAPID key pair',
+    status: pushOn ? 'ok' : 'off',
+    value: pushOn ? 'configured' : 'not set',
+    detail: pushOn
+      ? undefined
+      : 'Both VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY must be set',
+  })
+  const vapidPublic = getVapidPublicKey()
+  checks.push(
+    vapidPublic
+      ? {
+          id: 'push.vapidPublic',
+          group: 'push',
+          label: 'VAPID public key',
+          status: 'ok',
+          value: fingerprint(vapidPublic),
+        }
+      : {
+          id: 'push.vapidPublic',
+          group: 'push',
+          label: 'VAPID public key',
+          status: 'off',
+          value: 'not set',
+        },
+  )
+  checks.push(
+    plainCheck(
+      { id: 'push.vapidSubject', group: 'push', label: 'VAPID_SUBJECT' },
+      process.env.VAPID_SUBJECT ?? 'mailto:hei@cloudnativedays.no',
+      'warn',
+    ),
+  )
+
+  // ---- TICKETS --------------------------------------------------------------
+  const checkinOn = checkinGraphQLClient.isConfigured()
+  checks.push({
+    id: 'tickets.apiCreds',
+    group: 'tickets',
+    label: 'Checkin.no API credentials',
+    status: checkinOn ? 'ok' : 'off',
+    value: checkinOn ? 'configured' : 'not set',
+    detail: checkinOn
+      ? undefined
+      : 'CHECKIN_API_KEY and CHECKIN_API_SECRET are required for ticket sync',
+  })
+  checks.push(
+    plainCheck(
+      {
+        id: 'tickets.customerId',
+        group: 'tickets',
+        label: 'Checkin customer ID',
+      },
+      conference.checkinCustomerId,
+      'off',
+      { present: 'conference.checkinCustomerId' },
+    ),
+    plainCheck(
+      { id: 'tickets.eventId', group: 'tickets', label: 'Checkin event ID' },
+      conference.checkinEventId,
+      'off',
+      { present: 'conference.checkinEventId' },
+    ),
+    secretCheck(
+      {
+        id: 'tickets.webhookSecret',
+        group: 'tickets',
+        label: 'CHECKIN_WEBHOOK_SECRET',
+      },
+      'CHECKIN_WEBHOOK_SECRET',
+      'off',
+      { missing: 'Inbound ticket-sold webhooks cannot be verified' },
+    ),
+  )
+
+  // ---- CONTRACTS ------------------------------------------------------------
+  const provider = process.env.CONTRACT_SIGNING_PROVIDER ?? 'self-hosted'
+  checks.push({
+    id: 'contracts.provider',
+    group: 'contracts',
+    label: 'Signing provider',
+    status: 'ok',
+    value: provider,
+  })
+  if (provider === 'adobe-sign') {
+    checks.push(
+      presenceCheck(
+        {
+          id: 'contracts.adobeAppId',
+          group: 'contracts',
+          label: 'ADOBE_SIGN_APPLICATION_ID',
+        },
+        'ADOBE_SIGN_APPLICATION_ID',
+        'error',
+        { missing: 'Adobe Sign is selected but the application id is unset' },
+      ),
+      secretCheck(
+        {
+          id: 'contracts.adobeAppSecret',
+          group: 'contracts',
+          label: 'ADOBE_SIGN_APPLICATION_SECRET',
+        },
+        'ADOBE_SIGN_APPLICATION_SECRET',
+        'error',
+        {
+          missing: 'Adobe Sign is selected but the application secret is unset',
+        },
+      ),
+      plainCheck(
+        {
+          id: 'contracts.adobeShard',
+          group: 'contracts',
+          label: 'ADOBE_SIGN_SHARD',
+        },
+        process.env.ADOBE_SIGN_SHARD ?? 'eu2',
+        'warn',
+      ),
+    )
+  }
+
+  // ---- BADGES (presence only — large keys) ----------------------------------
+  checks.push(
+    presenceCheck(
+      {
+        id: 'badges.rsaPrivate',
+        group: 'badges',
+        label: 'BADGE_ISSUER_RSA_PRIVATE_KEY',
+      },
+      'BADGE_ISSUER_RSA_PRIVATE_KEY',
+      'off',
+      { missing: 'RSA badge signing unavailable' },
+    ),
+    presenceCheck(
+      {
+        id: 'badges.rsaPublic',
+        group: 'badges',
+        label: 'BADGE_ISSUER_RSA_PUBLIC_KEY',
+      },
+      'BADGE_ISSUER_RSA_PUBLIC_KEY',
+      'off',
+    ),
+    presenceCheck(
+      {
+        id: 'badges.ed25519Seed',
+        group: 'badges',
+        label: 'BADGE_ISSUER_ED25519_SEED',
+      },
+      'BADGE_ISSUER_ED25519_SEED',
+      'off',
+      { missing: 'Ed25519 badge signing unavailable' },
+    ),
+  )
+
+  // ---- INVITES --------------------------------------------------------------
+  checks.push(
+    presenceCheck(
+      {
+        id: 'invites.tokenSecret',
+        group: 'invites',
+        label: 'INVITATION_TOKEN_SECRET',
+      },
+      'INVITATION_TOKEN_SECRET',
+      'off',
+      { missing: 'Co-speaker invitation tokens cannot be signed or verified' },
+    ),
+  )
+
+  // ---- CRON / OPS -----------------------------------------------------------
+  checks.push(
+    secretCheck(
+      { id: 'ops.cronSecret', group: 'ops', label: 'CRON_SECRET' },
+      'CRON_SECRET',
+      'error',
+      {
+        missing:
+          'Cron endpoints reject Vercel invocations — scheduled jobs fail',
+      },
+    ),
+  )
+  for (const cron of VERCEL_CRONS) {
+    checks.push({
+      id: `ops.cron.${cron.path}`,
+      group: 'ops',
+      label: cron.path.replace('/api/cron/', 'cron: '),
+      status: 'ok',
+      value: cron.schedule,
+    })
+  }
+  checks.push(
+    secretCheck(
+      { id: 'ops.blobToken', group: 'ops', label: 'BLOB_READ_WRITE_TOKEN' },
+      'BLOB_READ_WRITE_TOKEN',
+      'warn',
+      { missing: 'Vercel Blob storage (uploads, badge assets) unavailable' },
+    ),
+  )
+  checks.push({
+    id: 'ops.migrationWorkflow',
+    group: 'ops',
+    label: 'Run-migration workflow',
+    status: 'ok',
+    value: `${REPO_URL}/actions/workflows/run-migration.yml`,
+    detail: 'Trigger data migrations from GitHub Actions',
+  })
+
+  // ---- MISC -----------------------------------------------------------------
+  checks.push(
+    secretCheck(
+      {
+        id: 'misc.exchangeRate',
+        group: 'misc',
+        label: 'NEXT_PUBLIC_EXCHANGE_RATE_API_KEY',
+      },
+      'NEXT_PUBLIC_EXCHANGE_RATE_API_KEY',
+      'warn',
+      {
+        missing: 'Free-tier fallback in effect (limited exchange-rate lookups)',
+      },
+    ),
+    presenceCheck(
+      { id: 'misc.workos', group: 'misc', label: 'WORKOS_CLIENT_ID' },
+      'WORKOS_CLIENT_ID',
+      'off',
+      { missing: 'Workshop (WorkOS) login unavailable' },
+    ),
+  )
+
+  return checks
+}
+
+function pairedProvider(
+  key: string,
+  label: string,
+  idEnv: string,
+  secretEnv: string,
+): SystemCheck {
+  const id = process.env[idEnv]
+  const secret = process.env[secretEnv]
+  const meta = { id: `auth.${key}`, group: 'auth' as const, label }
+  if (id && secret) {
+    return {
+      ...meta,
+      status: 'ok',
+      value: fingerprint(secret),
+      detail: 'Client id + secret set',
+    }
+  }
+  if (id || secret) {
+    return {
+      ...meta,
+      status: 'warn',
+      value: 'partial',
+      detail: `Only ${id ? idEnv : secretEnv} is set — this provider is misconfigured`,
+    }
+  }
+  return {
+    ...meta,
+    status: 'off',
+    value: 'not set',
+    detail: 'Provider disabled',
+  }
+}
+
+/** Live uncached Sanity read probe with latency. */
+async function sanityReadProbe(): Promise<SystemCheck> {
+  const meta = {
+    id: 'sanity.readProbe',
+    group: 'sanity' as const,
+    label: 'Live read probe',
+  }
+  const start = Date.now()
+  try {
+    const id = await clientReadUncached.fetch<string | null>(
+      `*[_type == "conference"][0]._id`,
+    )
+    const ms = Date.now() - start
+    return {
+      ...meta,
+      status: 'ok',
+      value: `${ms} ms`,
+      detail: id
+        ? `Read conference ${id}`
+        : 'Connected, but no conference document found',
+    }
+  } catch (err) {
+    return {
+      ...meta,
+      status: 'error',
+      value: `${Date.now() - start} ms`,
+      detail: errMsg(err),
+    }
+  }
+}
+
+/** Total active web-push subscriptions across all speakers (count only). */
+async function pushSubscriptionCount(): Promise<SystemCheck> {
+  const meta = {
+    id: 'push.subscriptions',
+    group: 'push' as const,
+    label: 'Active subscriptions',
+  }
+  try {
+    const count = await clientReadUncached.fetch<number>(
+      `count(*[_type == "speaker"].pushSubscriptions[])`,
+    )
+    return {
+      ...meta,
+      status: 'ok',
+      value: String(count ?? 0),
+      detail: 'Registered devices across all speakers',
+    }
+  } catch (err) {
+    return { ...meta, status: 'warn', value: 'unknown', detail: errMsg(err) }
+  }
+}
+
+/**
+ * Full registry: synchronous env/file/conference checks PLUS the live Sanity
+ * read probe and the push-subscription count. The live probes are appended into
+ * their groups so the UI renders them alongside the static rows.
+ */
+export async function buildSystemChecks(
+  conference: ConferenceForSystemChecks,
+): Promise<SystemCheck[]> {
+  const staticChecks = buildChecks(conference)
+  const [readProbe, pushCount] = await Promise.all([
+    sanityReadProbe(),
+    pushSubscriptionCount(),
+  ])
+  return [...staticChecks, readProbe, pushCount]
+}
+
+/** Exposed for unit tests: the synchronous, side-effect-light checks only. */
+export { buildChecks as collectStaticChecks }

--- a/src/lib/system-status/types.ts
+++ b/src/lib/system-status/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Types for the admin system-status / self-check registry.
+ *
+ * This file is intentionally free of `server-only` and of any import that reads
+ * secrets or throws at load, so it can be imported by presentational components
+ * and Storybook stories. The actual checks live in `./checks` (server-only).
+ */
+
+export type CheckStatus = 'ok' | 'warn' | 'error' | 'off'
+
+export type CheckGroup =
+  | 'sanity'
+  | 'email'
+  | 'slack'
+  | 'push'
+  | 'auth'
+  | 'tickets'
+  | 'contracts'
+  | 'badges'
+  | 'invites'
+  | 'ops'
+  | 'build'
+  | 'misc'
+
+/** A single passive system check. Never carries a raw secret — see `checks.ts`. */
+export interface SystemCheck {
+  id: string
+  group: CheckGroup
+  label: string
+  status: CheckStatus
+  /** Plain non-secret value, or a secret fingerprint like `a1b2c3d4 (32 chars)`. */
+  value?: string
+  /** Human-readable elaboration (what breaks, or the fallback in effect). */
+  detail?: string
+}
+
+/** Ordered, human-readable labels for each group card. */
+export const CHECK_GROUP_LABELS: Record<CheckGroup, string> = {
+  sanity: 'Sanity CMS',
+  email: 'Email (Resend)',
+  slack: 'Slack',
+  push: 'Web Push',
+  auth: 'Authentication',
+  tickets: 'Ticketing (Checkin.no)',
+  contracts: 'Contract Signing',
+  badges: 'Badges',
+  invites: 'Co-speaker Invites',
+  ops: 'Cron & Ops',
+  build: 'Build & Runtime',
+  misc: 'Miscellaneous',
+}
+
+/** Card render order. */
+export const CHECK_GROUP_ORDER: CheckGroup[] = [
+  'build',
+  'sanity',
+  'auth',
+  'email',
+  'slack',
+  'push',
+  'tickets',
+  'contracts',
+  'badges',
+  'invites',
+  'ops',
+  'misc',
+]
+
+/** A group of checks, ready to render as one status card. */
+export interface SystemCheckGroup {
+  group: CheckGroup
+  label: string
+  checks: SystemCheck[]
+}
+
+/**
+ * Narrow slice of the conference document the checks need. Deliberately a
+ * structural subset of `Conference` so the page can pass the full doc and tests
+ * can pass a small fixture.
+ */
+export interface ConferenceForSystemChecks {
+  _id?: string
+  organizer?: string
+  cfpEmail?: string
+  salesNotificationChannel?: string
+  cfpNotificationChannel?: string
+  checkinCustomerId?: number
+  checkinEventId?: number
+}
+
+/** Group a flat registry into ordered, labelled cards (drops empty groups). */
+export function groupSystemChecks(checks: SystemCheck[]): SystemCheckGroup[] {
+  return CHECK_GROUP_ORDER.map((group) => ({
+    group,
+    label: CHECK_GROUP_LABELS[group],
+    checks: checks.filter((c) => c.group === group),
+  })).filter((g) => g.checks.length > 0)
+}
+
+/** Roll a set of checks up to the worst status, for a group/section badge. */
+export function worstStatus(checks: SystemCheck[]): CheckStatus {
+  const rank: Record<CheckStatus, number> = { error: 3, warn: 2, off: 1, ok: 0 }
+  return checks.reduce<CheckStatus>((worst, c) => {
+    return rank[c.status] > rank[worst] ? c.status : worst
+  }, 'ok')
+}

--- a/src/server/routers/status.probes.test.ts
+++ b/src/server/routers/status.probes.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+const postSlackMessageMock = vi.fn()
+vi.mock('@/lib/slack/client', () => ({
+  postSlackMessage: (...args: unknown[]) => postSlackMessageMock(...args),
+}))
+
+const createOrReplaceMock = vi.fn()
+const deleteMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    createOrReplace: (...args: unknown[]) => createOrReplaceMock(...args),
+    delete: (...args: unknown[]) => deleteMock(...args),
+  },
+  clientReadUncached: { fetch: vi.fn() },
+}))
+
+const sendMock = vi.fn()
+vi.mock('@/lib/email/config', () => ({
+  resend: { emails: { send: (...args: unknown[]) => sendMock(...args) } },
+}))
+
+import { statusRouter } from './status'
+
+function makeCaller(opts: { isOrganizer?: boolean; speakerId?: string } = {}) {
+  const speaker = {
+    _id: opts.speakerId ?? 'admin-1',
+    name: 'Admin',
+    email: 'admin@example.com',
+    isOrganizer: opts.isOrganizer ?? true,
+  }
+  const ctx = {
+    session: { speaker, user: { name: 'Admin' } },
+    speaker,
+  } as unknown as Context
+  return statusRouter.createCaller(ctx)
+}
+
+const CONFERENCE = {
+  _id: 'conf-1',
+  organizer: 'Test Org',
+  cfpEmail: 'cfp@example.com',
+  salesNotificationChannel: '#updates',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getConferenceMock.mockResolvedValue({ conference: CONFERENCE, error: null })
+})
+
+describe('status.admin probes — auth gate', () => {
+  it('rejects a non-organizer', async () => {
+    const caller = makeCaller({ isOrganizer: false, speakerId: 'nonorg' })
+    await expect(caller.admin.probeSlack()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+    expect(postSlackMessageMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('status.admin.probeSlack', () => {
+  it('posts to the weekly-update channel and returns ok', async () => {
+    postSlackMessageMock.mockResolvedValue(undefined)
+    const res = await makeCaller({ speakerId: 'slack-ok' }).admin.probeSlack()
+    expect(res).toEqual({ ok: true, channel: '#updates' })
+    expect(postSlackMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('Admin') }),
+      expect.objectContaining({ channel: '#updates', forceSlack: true }),
+    )
+  })
+
+  it('returns an error when no channel is configured', async () => {
+    getConferenceMock.mockResolvedValue({
+      conference: { ...CONFERENCE, salesNotificationChannel: undefined },
+      error: null,
+    })
+    const res = await makeCaller({
+      speakerId: 'slack-nochan',
+    }).admin.probeSlack()
+    expect(res.ok).toBe(false)
+    expect(postSlackMessageMock).not.toHaveBeenCalled()
+  })
+
+  it('captures a transport failure without throwing', async () => {
+    postSlackMessageMock.mockRejectedValue(new Error('slack 500'))
+    const res = await makeCaller({ speakerId: 'slack-err' }).admin.probeSlack()
+    expect(res).toEqual({ ok: false, error: 'slack 500' })
+  })
+
+  it('enforces a per-organizer cooldown', async () => {
+    postSlackMessageMock.mockResolvedValue(undefined)
+    const caller = makeCaller({ speakerId: 'slack-cooldown' })
+    await caller.admin.probeSlack()
+    await expect(caller.admin.probeSlack()).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    })
+  })
+})
+
+describe('status.admin.probeEmail', () => {
+  it('sends to the caller and returns the resend id', async () => {
+    sendMock.mockResolvedValue({ data: { id: 'email-1' }, error: null })
+    const res = await makeCaller({ speakerId: 'email-ok' }).admin.probeEmail()
+    expect(res).toEqual({ ok: true, id: 'email-1' })
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'admin@example.com' }),
+    )
+  })
+
+  it('returns the resend error message on failure', async () => {
+    sendMock.mockResolvedValue({ data: null, error: { message: 'bad key' } })
+    const res = await makeCaller({ speakerId: 'email-err' }).admin.probeEmail()
+    expect(res).toEqual({ ok: false, error: 'bad key' })
+  })
+})
+
+describe('status.admin.probeSanityWrite', () => {
+  it('round-trips a scratch doc and reports latency', async () => {
+    createOrReplaceMock.mockResolvedValue({})
+    deleteMock.mockResolvedValue({})
+    const res = await makeCaller({
+      speakerId: 'sanity-ok',
+    }).admin.probeSanityWrite()
+    expect(res.ok).toBe(true)
+    expect(typeof res.latencyMs).toBe('number')
+    expect(createOrReplaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: 'system.probe', _type: 'systemProbe' }),
+    )
+    expect(deleteMock).toHaveBeenCalledWith('system.probe')
+  })
+
+  it('captures a write failure without throwing', async () => {
+    createOrReplaceMock.mockRejectedValue(new Error('write forbidden'))
+    const res = await makeCaller({
+      speakerId: 'sanity-err',
+    }).admin.probeSanityWrite()
+    expect(res.ok).toBe(false)
+    expect(res.error).toBe('write forbidden')
+  })
+})

--- a/src/server/routers/status.probes.test.ts
+++ b/src/server/routers/status.probes.test.ts
@@ -10,6 +10,8 @@ vi.mock('@/lib/conference/sanity', () => ({
 const postSlackMessageMock = vi.fn()
 vi.mock('@/lib/slack/client', () => ({
   postSlackMessage: (...args: unknown[]) => postSlackMessageMock(...args),
+  escapeMrkdwn: (text: string) =>
+    text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
 }))
 
 const createOrReplaceMock = vi.fn()

--- a/src/server/routers/status.ts
+++ b/src/server/routers/status.ts
@@ -2,7 +2,11 @@ import { router, adminProcedure } from '../trpc'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { buildConferenceStatusSummary } from '@/lib/status/summary'
 import { buildSystemChecks } from '@/lib/system-status/checks'
-import { postSlackMessage, type SlackMessage } from '@/lib/slack/client'
+import {
+  postSlackMessage,
+  escapeMrkdwn,
+  type SlackMessage,
+} from '@/lib/slack/client'
 import { clientWrite } from '@/lib/sanity/client'
 import { TRPCError } from '@trpc/server'
 
@@ -92,7 +96,7 @@ export const statusRouter = router({
             'No weekly-update Slack channel is configured for this conference.',
         }
       }
-      const body = `Test message from the admin status page (sent by ${ctx.speaker.name})`
+      const body = `Test message from the admin status page (sent by ${escapeMrkdwn(ctx.speaker.name)})`
       const message: SlackMessage = {
         text: body,
         blocks: [{ type: 'section', text: { type: 'mrkdwn', text: body } }],
@@ -124,7 +128,7 @@ export const statusRouter = router({
           from,
           to,
           subject: 'Admin status page — test email',
-          html: `<p>This is a test email triggered from the admin status page by ${ctx.speaker.name}.</p>`,
+          text: `This is a test email triggered from the admin status page by ${ctx.speaker.name}.`,
         })
         if (error) {
           return { ok: false as const, error: error.message }

--- a/src/server/routers/status.ts
+++ b/src/server/routers/status.ts
@@ -1,7 +1,60 @@
 import { router, adminProcedure } from '../trpc'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { buildConferenceStatusSummary } from '@/lib/status/summary'
+import { buildSystemChecks } from '@/lib/system-status/checks'
+import { postSlackMessage, type SlackMessage } from '@/lib/slack/client'
+import { clientWrite } from '@/lib/sanity/client'
 import { TRPCError } from '@trpc/server'
+
+/**
+ * Per-organizer, per-probe cooldown so a self-check button can't be hammered
+ * (each probe actually sends a Slack message / email / Sanity write). Same
+ * size-capped, insertion-ordered `Map` eviction as `push.claimTestCooldown`.
+ */
+const PROBE_COOLDOWN_MS = 30_000
+const MAX_COOLDOWN_ENTRIES = 10_000
+const lastProbeAt = new Map<string, number>()
+
+function claimProbeCooldown(speakerId: string, probe: string): boolean {
+  const key = `${speakerId}:${probe}`
+  const now = Date.now()
+  const previous = lastProbeAt.get(key)
+  if (previous !== undefined && now - previous < PROBE_COOLDOWN_MS) {
+    return false
+  }
+  lastProbeAt.delete(key)
+  if (lastProbeAt.size >= MAX_COOLDOWN_ENTRIES) {
+    const oldest = lastProbeAt.keys().next().value
+    if (oldest !== undefined) lastProbeAt.delete(oldest)
+  }
+  lastProbeAt.set(key, now)
+  return true
+}
+
+function requireCooldown(speakerId: string, probe: string): void {
+  if (!claimProbeCooldown(speakerId, probe)) {
+    throw new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: 'Please wait 30 seconds before running this probe again.',
+    })
+  }
+}
+
+/** Errors from Slack/Resend/Sanity do not echo credentials, but keep messages short. */
+function probeError(err: unknown): string {
+  return err instanceof Error ? err.message : 'Unknown error'
+}
+
+async function requireConference() {
+  const { conference, error } = await getConferenceForCurrentDomain()
+  if (error || !conference?._id) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Could not resolve conference from domain',
+    })
+  }
+  return conference
+}
 
 export const statusRouter = router({
   admin: router({
@@ -19,6 +72,88 @@ export const statusRouter = router({
       }
 
       return buildConferenceStatusSummary(conference)
+    }),
+
+    // Passive registry, including the live Sanity read probe + subscription count.
+    systemChecks: adminProcedure.query(async () => {
+      const conference = await requireConference()
+      return buildSystemChecks(conference)
+    }),
+
+    // Post a test message to the same Slack channel the weekly update uses.
+    probeSlack: adminProcedure.mutation(async ({ ctx }) => {
+      requireCooldown(ctx.speaker._id, 'slack')
+      const conference = await requireConference()
+      const channel = conference.salesNotificationChannel
+      if (!channel) {
+        return {
+          ok: false as const,
+          error:
+            'No weekly-update Slack channel is configured for this conference.',
+        }
+      }
+      const body = `Test message from the admin status page (sent by ${ctx.speaker.name})`
+      const message: SlackMessage = {
+        text: body,
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text: body } }],
+      }
+      try {
+        await postSlackMessage(message, { channel, forceSlack: true })
+        return { ok: true as const, channel }
+      } catch (err) {
+        return { ok: false as const, error: probeError(err) }
+      }
+    }),
+
+    // Send a minimal test email to the acting organizer's own address.
+    probeEmail: adminProcedure.mutation(async ({ ctx }) => {
+      requireCooldown(ctx.speaker._id, 'email')
+      const conference = await requireConference()
+      const from = `${conference.organizer || 'Cloud Native Days'} <${conference.cfpEmail}>`
+      const to = ctx.speaker.email
+      if (!to) {
+        return {
+          ok: false as const,
+          error: 'Your account has no email address on file.',
+        }
+      }
+      try {
+        // Lazy import: `@/lib/email/config` asserts RESEND_API_KEY at module load.
+        const { resend } = await import('@/lib/email/config')
+        const { data, error } = await resend.emails.send({
+          from,
+          to,
+          subject: 'Admin status page — test email',
+          html: `<p>This is a test email triggered from the admin status page by ${ctx.speaker.name}.</p>`,
+        })
+        if (error) {
+          return { ok: false as const, error: error.message }
+        }
+        return { ok: true as const, id: data?.id }
+      } catch (err) {
+        return { ok: false as const, error: probeError(err) }
+      }
+    }),
+
+    // Round-trip a scratch document through the write client, then remove it.
+    probeSanityWrite: adminProcedure.mutation(async ({ ctx }) => {
+      requireCooldown(ctx.speaker._id, 'sanityWrite')
+      const start = Date.now()
+      try {
+        await clientWrite.createOrReplace({
+          _id: 'system.probe',
+          _type: 'systemProbe',
+          at: new Date().toISOString(),
+        })
+        await clientWrite.delete('system.probe')
+        return { ok: true as const, latencyMs: Date.now() - start }
+      } catch (err) {
+        return {
+          ok: false as const,
+          latencyMs: Date.now() - start,
+          error: probeError(err),
+        }
+      }
     }),
   }),
 })


### PR DESCRIPTION
## Redesigned `/admin/settings` — configuration + system status/self-check

Rebuilds the admin settings page into two tiers and adds a server-side system-status registry plus active self-check probes.

### Tier 1 — Conference configuration
All existing InfoCard/FieldRow content is preserved and now grouped under a "Conference configuration" section. Each card gains an optional **Edit in Studio** deep-link.

- Introduces **`NEXT_PUBLIC_STUDIO_URL`** (new env var). When set, cards link to the Sanity v3 intent URL `"${NEXT_PUBLIC_STUDIO_URL}/intent/edit/id=<conference._id>;type=conference"`. When unset, no link renders (zero behavioural change until configured). There is no `.env.example` in the repo, so it is documented here only.

### Tier 2 — System status (passive registry)
New server-only `src/lib/system-status/checks.ts` builds a typed `SystemCheck { id, group, label, status: 'ok'|'warn'|'error'|'off', value?, detail? }` registry, rendered as grouped status cards (server component — no tRPC round-trip). A status tally + legend sits on top.

**Design contract — read `process.env` directly, never import a module that throws at load.** `email/config` asserts `RESEND_API_KEY`, `cospeaker/server` throws on `INVITATION_TOKEN_SECRET`, and `badge/config` / `adobe-sign/auth` getters throw on missing keys — so those are probed via `process.env` reads. Only provably import-safe modules are imported (`sanity/client`, `push/vapid`, `tickets/graphql-client`, `auth`'s `providerMap`).

**Never echo secrets.** A secret is surfaced only as `sha256(value).slice(0,8) + length`, e.g. `a1b2c3d4 (32 chars)` — unit-tested to never contain the raw value. Non-secrets (dataset, project id, from-address, channels, schedules, provider names) show plain.

Check groups: BUILD (commit SHA, `CACHE_VERSION` parsed from `public/sw.js`, package version, base URL, NODE_ENV), SANITY (project/dataset/version plain; read+write token fingerprints; **live uncached read probe with latency**), AUTH (`providerMap`; GitHub/LinkedIn paired id+secret; `AUTH_SECRET`), EMAIL (`RESEND_API_KEY`; conference `cfpEmail` from-address), SLACK (`SLACK_BOT_TOKEN`; weekly-update + CFP channels), PUSH (`isPushConfigured()`; VAPID public fingerprint + subject; **total active subscription count** via GROQ), TICKETS (`checkinGraphQLClient.isConfigured()`; customer/event ids; webhook secret), CONTRACTS (`CONTRACT_SIGNING_PROVIDER`; Adobe id/secret/shard only when `adobe-sign`), BADGES (RSA + Ed25519 presence), INVITES (`INVITATION_TOKEN_SECRET`), CRON/OPS (`CRON_SECRET`; the 4 `vercel.json` crons + schedules; `BLOB_READ_WRITE_TOKEN`; run-migration workflow link), MISC (exchange-rate key → warn/free-tier fallback; `WORKOS_CLIENT_ID`).

Status semantics: `error` only when the absence breaks a live feature; `warn` for degraded/fallback; `off` for a deliberately-optional integration left unconfigured; `ok` otherwise.

### Self-check probes (active)
New `adminProcedure` mutations on `status.admin`, each with a **per-organizer, per-probe 30s cooldown** (size-capped, insertion-ordered `Map` eviction, mirroring `push.claimTestCooldown`). Errors are caught and returned as `{ ok:false, error }` (short messages; the Slack/Resend/Sanity SDKs don't echo credentials).

- `probeSlack` — posts a test message to the weekly-update channel (`conference.salesNotificationChannel`, `forceSlack: true`).
- `probeEmail` — sends a minimal test email to the acting organizer's own address (lazy `import('@/lib/email/config')` to avoid the load-time assert).
- `probeSanityWrite` — `createOrReplace` a `system.probe` scratch doc then `delete` it, returning `latencyMs`.
- Also `systemChecks` query (returns the registry incl. the live probe).

A client island (`SelfCheckPanel`) renders the three buttons with pending/result/cooldown feedback (reusing the success/warn/muted tone pattern from `PushNotificationSettings`), plus a link to `/cfp/profile#notification-settings` for the per-device push test.

**`systemProbe` Sanity schema:** intentionally NOT added — Sanity writes unregistered types fine, so no schema is needed (verified).

### Judgment calls / deviations
- **`AUTH_COOKIE_DOMAIN`**: grep found it is *not* read as an env var anywhere in the codebase today, so there is nothing to surface. Left a code comment noting where to add a plain check if it is later wired up.
- Cooldown is **30s per the task spec** (not the 10s in `push.ts`), keyed `speakerId:probe`.
- Presentational `ProbeCard` was extracted into its own file so it can be storied without a tRPC provider.

### Components & stories
Presentational components live in `src/components/admin/system-status/` with a barrel. Real-component stories: `SystemStatusSection` (fixture registry covering all four statuses, light + dark) and `ProbeCard` (success/pending/warn result states, light + dark). No dates render, so no date mocking needed.

### Shoot findings (393px, light + dark)
Captured all four stories at 393px. Status dots are legible in both themes (dark uses the brighter `*-400` variants; `off` gray stays visible). No horizontal overflow. One fix made after inspection: long single-token env-name labels (e.g. `NEXT_PUBLIC_EXCHANGE_RATE_API_KEY`) collided with their right-aligned value — added `break-words` so labels wrap cleanly with values aligned right. Re-shot to confirm.

### Checks
tsc, eslint, prettier, knip all green. Full `vitest run`: **210 files, 3112 passed / 5 skipped**. 24 new tests (checks registry via `vi.stubEnv` incl. the never-echo-secrets assertion; probe cooldown + error paths with mocked transports; grouping helpers).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rebuilds the `/admin/settings` page into two tiers: a reorganised conference-configuration section with optional Sanity Studio deep-links, and a new system-status section that renders a server-side registry of environment/integration health checks plus three active self-check probes (Slack, Email, Sanity write) behind a 30-second per-organizer cooldown.

- **System status registry (`checks.ts`):** Flat list of `SystemCheck` items built from `process.env` reads, file reads, and two live Sanity network probes (`sanityReadProbe`, `pushSubscriptionCount`), grouped into labelled cards rendered as a server component. Secrets are fingerprinted; non-secrets shown plain.
- **Self-check probes (`status.ts`):** Three new `adminProcedure` mutations with a size-capped insertion-ordered `Map` cooldown; errors are caught and returned as `{ ok: false, error }` so the tRPC boundary never leaks exception details.
- **Presentational layer:** `SelfCheckPanel` (client island), `ProbeCard`, `SystemStatusCard`, `StatusDot`, `SystemCheckRow`, `SystemStatusSection` — all with Storybook stories and 24 new Vitest tests.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the main flows; the email probe will return a confusing third-party error message rather than a helpful one when cfpEmail is unset, but it does not crash or leak data.

The admin settings page and status registry are purely read-oriented and well-tested. The three self-check probes are write-side but limited to organisers with a cooldown gate. One probe (email) skips a config guard that the other two apply, so a missing cfpEmail surfaces as an opaque Resend error rather than a clear local message. The NEXT_PUBLIC_ key and VAPID public key being fingerprinted are display-quality issues on an admin-only page, not functional regressions.

src/server/routers/status.ts — the probeEmail mutation is missing a pre-flight check for conference.cfpEmail, and probeSanityWrite should use a transaction to keep the scratch-document round-trip atomic.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/routers/status.ts | Adds three adminProcedure mutations (probeSlack, probeEmail, probeSanityWrite) with a per-organizer 30s cooldown. probeEmail doesn't guard against an unset cfpEmail, producing a confusing Resend error when it's missing. probeSanityWrite uses two independent Sanity calls rather than a transaction, so a delete failure leaves a stale scratch document. |
| src/lib/system-status/checks.ts | Server-only registry of passive system checks. Well-structured with good secret-fingerprinting discipline, but NEXT_PUBLIC_EXCHANGE_RATE_API_KEY (a public value) is incorrectly fingerprinted via secretCheck, and the VAPID public key is also fingerprinted when it should be shown in full for operational verification. |
| src/lib/system-status/types.ts | Clean type definitions for SystemCheck, CheckGroup, CHECK_GROUP_ORDER, and helpers groupSystemChecks/worstStatus. No issues. |
| src/components/admin/system-status/SelfCheckPanel.tsx | Client island wiring the three probe mutations to ProbeCard tiles; error handling and pending state management look correct. |
| src/app/(admin)/admin/settings/page.tsx | Reorganises admin settings into two tiers; adds SectionNav, SectionHeading, and studioEditUrl helper. No issues. |
| src/lib/system-status/checks.test.ts | Comprehensive unit tests covering secret fingerprinting, status semantics, paired OAuth providers, conditional Adobe checks, and live probe paths via vi.stubEnv and mocked Sanity client. |
| src/server/routers/status.probes.test.ts | Tests auth gating, cooldown enforcement, transport-error capturing, and happy paths for all three probes. Coverage is solid. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant AdminPage as AdminSettings (Server)
    participant Checks as buildSystemChecks
    participant Sanity
    participant SelfCheck as SelfCheckPanel (Client)
    participant tRPC as status.admin.*

    Browser->>AdminPage: GET /admin/settings
    AdminPage->>Checks: buildSystemChecks(conference)
    Checks->>Sanity: clientReadUncached.fetch (read probe + push count)
    Sanity-->>Checks: _id, push subscription count
    Checks-->>AdminPage: SystemCheck[]
    AdminPage-->>Browser: HTML (SystemStatusSection + SelfCheckPanel)

    Browser->>SelfCheck: click "Send Slack test"
    SelfCheck->>tRPC: probeSlack.mutate()
    tRPC->>tRPC: requireCooldown (30s gate)
    tRPC->>Sanity: getConferenceForCurrentDomain()
    tRPC->>Slack: postSlackMessage(channel, forceSlack:true)
    Slack-->>tRPC: ok
    tRPC-->>SelfCheck: "{ ok: true, channel }"

    Browser->>SelfCheck: click "Send test email"
    SelfCheck->>tRPC: probeEmail.mutate()
    tRPC->>tRPC: requireCooldown (30s gate)
    tRPC->>tRPC: lazy import email/config
    tRPC->>Resend: resend.emails.send(from, to)
    Resend-->>tRPC: "{ data, error }"
    tRPC-->>SelfCheck: "{ ok, id }"

    Browser->>SelfCheck: click "Run write probe"
    SelfCheck->>tRPC: probeSanityWrite.mutate()
    tRPC->>tRPC: requireCooldown (30s gate)
    tRPC->>Sanity: clientWrite.createOrReplace(system.probe)
    tRPC->>Sanity: clientWrite.delete(system.probe)
    Sanity-->>tRPC: ok
    tRPC-->>SelfCheck: "{ ok: true, latencyMs }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant AdminPage as AdminSettings (Server)
    participant Checks as buildSystemChecks
    participant Sanity
    participant SelfCheck as SelfCheckPanel (Client)
    participant tRPC as status.admin.*

    Browser->>AdminPage: GET /admin/settings
    AdminPage->>Checks: buildSystemChecks(conference)
    Checks->>Sanity: clientReadUncached.fetch (read probe + push count)
    Sanity-->>Checks: _id, push subscription count
    Checks-->>AdminPage: SystemCheck[]
    AdminPage-->>Browser: HTML (SystemStatusSection + SelfCheckPanel)

    Browser->>SelfCheck: click "Send Slack test"
    SelfCheck->>tRPC: probeSlack.mutate()
    tRPC->>tRPC: requireCooldown (30s gate)
    tRPC->>Sanity: getConferenceForCurrentDomain()
    tRPC->>Slack: postSlackMessage(channel, forceSlack:true)
    Slack-->>tRPC: ok
    tRPC-->>SelfCheck: "{ ok: true, channel }"

    Browser->>SelfCheck: click "Send test email"
    SelfCheck->>tRPC: probeEmail.mutate()
    tRPC->>tRPC: requireCooldown (30s gate)
    tRPC->>tRPC: lazy import email/config
    tRPC->>Resend: resend.emails.send(from, to)
    Resend-->>tRPC: "{ data, error }"
    tRPC-->>SelfCheck: "{ ok, id }"

    Browser->>SelfCheck: click "Run write probe"
    SelfCheck->>tRPC: probeSanityWrite.mutate()
    tRPC->>tRPC: requireCooldown (30s gate)
    tRPC->>Sanity: clientWrite.createOrReplace(system.probe)
    tRPC->>Sanity: clientWrite.delete(system.probe)
    Sanity-->>tRPC: ok
    tRPC-->>SelfCheck: "{ ok: true, latencyMs }"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/server/routers/status.ts`, line 2592-2616 ([link](https://github.com/cloudnativebergen/website/blob/248a8b9f3f69bcdebde4378f80f9ae20cc78f5f1/src/server/routers/status.ts#L2592-L2616)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`probeEmail` builds an invalid `from` address when `cfpEmail` is unset**

   `conference.cfpEmail` is typed as optional (`cfpEmail?: string` in `ConferenceForSystemChecks`), so when it is absent the constructed `from` string becomes `"<conference organizer> <undefined>"`. Resend will reject the malformed address and return a cryptic API error (`"Invalid 'from' address"`) rather than the clear, actionable message the organizer needs. `probeSlack` correctly guards with an early return when the channel is missing — `probeEmail` should apply the same pattern before invoking the transport.


2. `src/server/routers/status.ts`, line 2622-2641 ([link](https://github.com/cloudnativebergen/website/blob/248a8b9f3f69bcdebde4378f80f9ae20cc78f5f1/src/server/routers/status.ts#L2622-L2641)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`probeSanityWrite` leaves an orphaned scratch document when `delete` fails**

   `createOrReplace` and `delete` are issued as two independent Sanity mutations. If `createOrReplace` succeeds but `delete` throws (a transient network error, a permission issue, etc.), the `system.probe` document is left in the dataset. It has no registered schema and does not affect live behaviour, but repeated probe failures will accumulate stale documents until a manual cleanup. Wrapping both operations in a single Sanity transaction (`clientWrite.transaction().createOrReplace(…).delete(…).commit()`) would make the round-trip atomic and avoid this state.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(admin): settings page with system s..."](https://github.com/cloudnativebergen/website/commit/248a8b9f3f69bcdebde4378f80f9ae20cc78f5f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45429831)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->