### PR TITLE
fix(ui): banner semantics, shortcut suppression, story gaps (modal audit batch D)

### DIFF
--- a/__tests__/components/admin/schedule/ServiceEditSheet.test.tsx
+++ b/__tests__/components/admin/schedule/ServiceEditSheet.test.tsx
@@ -23,6 +23,65 @@ const trackWith = (
   ],
 })
 
+describe('ServiceEditSheet rename mode', () => {
+  const renameProps = {
+    trackIndex: 0,
+    talkIndex: 0,
+    track: trackWith('11:00', '11:30'),
+    mode: 'rename' as const,
+  }
+
+  it('disables Save while the title is empty and never dispatches an empty rename', () => {
+    const dispatch = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <ServiceEditSheet
+        {...renameProps}
+        talk={{ ...session, placeholder: '' }}
+        dispatch={dispatch}
+        onClose={onClose}
+      />,
+    )
+
+    const save = screen.getByRole('button', { name: 'Save' })
+    expect(save).toBeDisabled()
+
+    // Even a forced click must not commit an empty title or close the sheet.
+    fireEvent.click(save)
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('enables Save once the title has non-whitespace text and commits it trimmed', () => {
+    const dispatch = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <ServiceEditSheet
+        {...renameProps}
+        talk={{ ...session, placeholder: '' }}
+        dispatch={dispatch}
+        onClose={onClose}
+      />,
+    )
+
+    const input = screen.getByLabelText('Session title')
+    const save = screen.getByRole('button', { name: 'Save' })
+
+    // Whitespace-only keeps it disabled…
+    fireEvent.change(input, { target: { value: '   ' } })
+    expect(save).toBeDisabled()
+
+    // …real text enables it, and the committed title is trimmed.
+    fireEvent.change(input, { target: { value: '  Lunch  ' } })
+    expect(save).toBeEnabled()
+    fireEvent.click(save)
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'renameService', title: 'Lunch' }),
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+})
+
 describe('ServiceEditSheet duration mode', () => {
   it('filters options to the surrounding gap and keeps a non-standard current duration selectable', () => {
     render(

--- a/__tests__/components/common/DashboardLayout.test.tsx
+++ b/__tests__/components/common/DashboardLayout.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { DashboardLayout } from '@/components/common/DashboardLayout'
+import { HomeIcon } from '@heroicons/react/24/outline'
+
+// Stub the layout's data/child dependencies so the ⌘K shortcut can be tested
+// without tRPC/session/theme wiring.
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null }),
+}))
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/admin',
+}))
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'light' }),
+}))
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+vi.mock('@/components/ConferenceLogo', () => ({ ConferenceLogo: () => null }))
+vi.mock('@/components/ThemeToggle', () => ({ ThemeToggle: () => null }))
+vi.mock('@/components/UserMenu', () => ({ UserMenu: () => null }))
+vi.mock('@/components/notifications/NotificationBell', () => ({
+  NotificationBell: () => null,
+}))
+
+const navigation = [{ name: 'Home', href: '/admin', icon: HomeIcon }]
+const cmdK = () => fireEvent.keyDown(document, { key: 'k', metaKey: true })
+
+afterEach(() => cleanup())
+
+describe('DashboardLayout ⌘K search shortcut', () => {
+  it('opens the search modal on ⌘K when no dialog is open', () => {
+    const onSearch = vi.fn()
+    render(
+      <DashboardLayout
+        navigation={navigation}
+        mode="admin"
+        title="Admin"
+        onSearch={onSearch}
+      >
+        content
+      </DashboardLayout>,
+    )
+
+    cmdK()
+    expect(onSearch).toHaveBeenCalledTimes(1)
+  })
+
+  it('suppresses ⌘K while another dialog is already open (no stacked focus trap)', () => {
+    const onSearch = vi.fn()
+    render(
+      <DashboardLayout
+        navigation={navigation}
+        mode="admin"
+        title="Admin"
+        onSearch={onSearch}
+      >
+        content
+      </DashboardLayout>,
+    )
+
+    // Simulate any open dialog (Headless UI or useModalA11y both render this).
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    document.body.appendChild(dialog)
+
+    cmdK()
+    expect(onSearch).not.toHaveBeenCalled()
+
+    dialog.remove()
+  })
+})

--- a/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
+++ b/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
@@ -96,7 +96,7 @@ describe('ServiceWorkerRegistrar', () => {
     worker.setState('installed')
 
     expect(
-      await screen.findByRole('dialog', { name: 'Update available' }),
+      await screen.findByRole('status', { name: 'Update available' }),
     ).toBeInTheDocument()
   })
 
@@ -111,7 +111,7 @@ describe('ServiceWorkerRegistrar', () => {
     worker.setState('installed')
 
     expect(
-      screen.queryByRole('dialog', { name: 'Update available' }),
+      screen.queryByRole('status', { name: 'Update available' }),
     ).not.toBeInTheDocument()
   })
 
@@ -124,7 +124,7 @@ describe('ServiceWorkerRegistrar', () => {
     registration.dispatch('updatefound')
     worker.setState('installed')
 
-    await screen.findByRole('dialog', { name: 'Update available' })
+    await screen.findByRole('status', { name: 'Update available' })
     fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
 
     expect(worker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
@@ -141,7 +141,7 @@ describe('ServiceWorkerRegistrar', () => {
     registration.installing = worker
     registration.dispatch('updatefound')
     worker.setState('installed')
-    await screen.findByRole('dialog', { name: 'Update available' })
+    await screen.findByRole('status', { name: 'Update available' })
     fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
 
     container.dispatch('controllerchange')
@@ -171,14 +171,14 @@ describe('ServiceWorkerRegistrar', () => {
     registration.dispatch('updatefound')
     worker.setState('installed')
 
-    await screen.findByRole('dialog', { name: 'Update available' })
+    await screen.findByRole('status', { name: 'Update available' })
     fireEvent.click(
       screen.getByRole('button', { name: 'Dismiss update prompt' }),
     )
 
     await waitFor(() =>
       expect(
-        screen.queryByRole('dialog', { name: 'Update available' }),
+        screen.queryByRole('status', { name: 'Update available' }),
       ).not.toBeInTheDocument(),
     )
     expect(reloadMock).not.toHaveBeenCalled()

--- a/src/components/admin/SpeakerMergeModal.stories.tsx
+++ b/src/components/admin/SpeakerMergeModal.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useEffect } from 'react'
+import { fn, userEvent, within } from 'storybook/test'
+import { http, HttpResponse } from 'msw'
+import { SpeakerMergeModal, type MergeCandidate } from './SpeakerMergeModal'
+import { NotificationProvider } from './NotificationProvider'
+
+// The REAL modal (not a mock shell): it is the house destructive-confirm modal
+// — pick a survivor + duplicate, preview the exact reference/identity changes,
+// then confirm through a second danger dialog. tRPC + NotificationProvider come
+// from the global Storybook decorators / the wrapper below; the dry-run
+// `speaker.admin.mergePreview` query is served by the msw handler.
+
+const speakers: MergeCandidate[] = [
+  { _id: 'spk-ada', name: 'Ada Lovelace', email: 'ada@example.com' },
+  { _id: 'spk-ada-dup', name: 'Ada Lovelace', email: 'ada.l@work.io' },
+  { _id: 'spk-grace', name: 'Grace Hopper', email: 'grace@example.com' },
+  { _id: 'spk-noemail', name: 'Katherine Johnson', email: null },
+]
+
+// Shape mirrors `MergePreview` from '@/lib/speaker/merge' — the exact fields the
+// modal renders (repoint counts by type, provider/email identity union, and the
+// fields filled in from the duplicate).
+const previewFixture = {
+  survivorId: 'spk-ada',
+  loserId: 'spk-ada-dup',
+  referencingDocCount: 3,
+  referenceRepointsByType: { talk: 2, review: 1 },
+  fieldChanges: {
+    providers: {
+      before: ['github:1'],
+      after: ['github:1', 'linkedin:2'],
+    },
+    knownEmails: {
+      before: ['ada@example.com'],
+      after: ['ada@example.com', 'ada.l@work.io'],
+    },
+    email: { before: 'ada@example.com', after: 'ada@example.com' },
+    filledFromLoser: ['title', 'bio'],
+  },
+  willDeleteLoserId: 'spk-ada-dup',
+}
+
+// The global TRPCDecorator uses a non-batching httpLink, so each query is its
+// own request answered with a single `{ result: { data } }` object (same shape
+// SendMessageModal.stories relies on).
+const handlers = [
+  http.get('/api/trpc/speaker.admin.mergePreview', () =>
+    HttpResponse.json({ result: { data: previewFixture } }),
+  ),
+]
+
+const meta = {
+  title: 'Systems/Speakers/Admin/SpeakerMergeModal',
+  component: SpeakerMergeModal,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'Admin modal to fold a duplicate speaker into a canonical one: all references are repointed to the survivor and the duplicate is deleted. A dry-run preview (`speaker.admin.mergePreview`) spells out exactly what will change before a second danger dialog confirms the irreversible merge.',
+      },
+    },
+  },
+  args: {
+    isOpen: true,
+    onClose: fn(),
+    onMerged: fn(),
+    speakers,
+  },
+  decorators: [
+    (Story, context) => {
+      // ModalShell renders through a Headless UI Dialog portal on `document.body`,
+      // which escapes Storybook's theme-wrapper `<div class="dark">`. Mirror the
+      // toolbar theme onto the document root so the portaled modal's `dark:`
+      // classes resolve (in the app, next-themes puts the class there).
+      const dark = context.globals.theme === 'dark'
+      useEffect(() => {
+        document.documentElement.classList.toggle('dark', dark)
+        return () => document.documentElement.classList.remove('dark')
+      }, [dark])
+      return (
+        <NotificationProvider>
+          <Story />
+        </NotificationProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof SpeakerMergeModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Initial state: pick a survivor and a duplicate to merge. */
+export const Default: Story = {}
+
+/** Same modal at phone width — the selects stack and the arrow hides. */
+export const Mobile: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+}
+
+/**
+ * Survivor + duplicate chosen and previewed: the change summary and the red
+ * "Merge and delete duplicate" action are shown. The modal portals to the body,
+ * so the play function queries the whole document.
+ */
+export const Previewed: Story = {
+  play: async () => {
+    const body = within(document.body)
+    await userEvent.selectOptions(
+      await body.findByRole('combobox', { name: /survivor/i }),
+      'spk-ada',
+    )
+    await userEvent.selectOptions(
+      await body.findByRole('combobox', { name: /duplicate/i }),
+      'spk-ada-dup',
+    )
+    await userEvent.click(
+      await body.findByRole('button', { name: /preview changes/i }),
+    )
+    await body.findByRole('button', { name: /merge and delete duplicate/i })
+  },
+}

--- a/src/components/admin/schedule/AddTrackModal.stories.tsx
+++ b/src/components/admin/schedule/AddTrackModal.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { AddTrackModal } from './AddTrackModal'
+
+// The REAL modal — it renders its own fixed overlay and manages its own form
+// state, so it stands alone with just the two callbacks. Footer order follows
+// the house convention: Cancel on the left, the primary action on the right.
+
+const meta = {
+  title: 'Systems/Program/Admin/AddTrackModal',
+  component: AddTrackModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Modal for adding a new track to the schedule editor: a title (required) and an optional description. Escape closes, focus is trapped and restored, and the title input is auto-focused on open.',
+      },
+    },
+  },
+  args: {
+    onAdd: fn(),
+    onCancel: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AddTrackModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Mobile: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+}

--- a/src/components/admin/schedule/AddTrackModal.tsx
+++ b/src/components/admin/schedule/AddTrackModal.tsx
@@ -99,19 +99,21 @@ export const AddTrackModal = ({
             />
           </div>
 
+          {/* Cancel LEFT, primary RIGHT — mirrors the SendMessageModal footer
+              (the house order); a primary-on-the-left footer read as a bug. */}
           <div className="flex gap-3 pt-4">
-            <button
-              type="submit"
-              className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:bg-blue-700 dark:hover:bg-blue-600"
-            >
-              Add Track
-            </button>
             <button
               type="button"
               onClick={onCancel}
               className={CANCEL_BUTTON_STYLE}
             >
               Cancel
+            </button>
+            <button
+              type="submit"
+              className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:bg-blue-700 dark:hover:bg-blue-600"
+            >
+              Add Track
             </button>
           </div>
         </form>

--- a/src/components/admin/schedule/mobile/sheets/ServiceEditSheet.stories.tsx
+++ b/src/components/admin/schedule/mobile/sheets/ServiceEditSheet.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import type React from 'react'
+import { fn } from 'storybook/test'
+import { ServiceEditSheet } from './ServiceEditSheet'
+import type { ScheduleTrack, TrackTalk } from '@/lib/conference/types'
+import type { ScheduleAction } from '@/lib/schedule/reducer'
+
+// The REAL mobile bottom sheet — it renders its own overlay and takes plain
+// props (the reducer's `dispatch` is passed in), so it stands alone with small
+// fixtures. Shown at phone width since it is a mobile-only surface.
+
+const talk: TrackTalk = {
+  placeholder: 'Coffee Break',
+  startTime: '10:00',
+  endTime: '10:15',
+}
+
+const track: ScheduleTrack = {
+  trackTitle: 'Main Stage',
+  trackDescription: '',
+  talks: [talk],
+}
+
+const noopDispatch = fn() as unknown as React.Dispatch<ScheduleAction>
+
+const meta = {
+  title: 'Systems/Program/Admin/ServiceEditSheet',
+  component: ServiceEditSheet,
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { defaultViewport: 'mobile1' },
+    docs: {
+      description: {
+        component:
+          'Mobile bottom sheet for editing a service session — rename it or change its duration. Only durations that still fit the surrounding gap are offered, and Save is disabled while the rename field is empty so an empty title can never be committed.',
+      },
+    },
+  },
+  args: {
+    talk,
+    trackIndex: 0,
+    talkIndex: 0,
+    track,
+    dispatch: noopDispatch,
+    onClose: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ServiceEditSheet>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Rename mode with the current title prefilled — Save is enabled. */
+export const Rename: Story = {
+  args: { mode: 'rename' },
+}
+
+/** Rename mode with an empty title — Save is disabled until text is entered. */
+export const RenameEmpty: Story = {
+  args: {
+    mode: 'rename',
+    talk: { ...talk, placeholder: '' },
+  },
+}
+
+/** Duration mode — pick a length that fits the surrounding gap. */
+export const Duration: Story = {
+  args: { mode: 'duration' },
+}

--- a/src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx
+++ b/src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx
@@ -127,6 +127,7 @@ export function ServiceEditSheet({
           <button
             type="button"
             onClick={saveRename}
+            disabled={!renameValue.trim()}
             className={`flex-1 ${PRIMARY_BUTTON}`}
           >
             Save

--- a/src/components/admin/schedule/track/ServiceSessionModal.stories.tsx
+++ b/src/components/admin/schedule/track/ServiceSessionModal.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { ServiceSessionModal } from './ServiceSessionModal'
+import type { ScheduleTrack } from '@/lib/conference/types'
+
+// The REAL modal — it renders its own fixed overlay and derives the fitting
+// duration options from the LIVE track passed in, so it stands alone with a
+// small track fixture. Footer order follows the house convention: Cancel left,
+// primary right.
+
+// A track with a talk at 10:00–10:30 leaves a 60-minute gap from the 09:00
+// start, so the standard 5/10/15/… duration options that fit are offered.
+const track: ScheduleTrack = {
+  trackTitle: 'Main Stage',
+  trackDescription: 'Keynotes and headline talks',
+  talks: [
+    {
+      placeholder: 'Opening remarks',
+      startTime: '10:00',
+      endTime: '10:30',
+    },
+  ],
+}
+
+const meta = {
+  title: 'Systems/Program/Admin/ServiceSessionModal',
+  component: ServiceSessionModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Modal for creating a service session (coffee break, lunch, networking, …) in a track. Only durations that fit the free gap until the next item are offered; the create action re-validates against the live track so a rejected add surfaces an inline error instead of silently closing.',
+      },
+    },
+  },
+  args: {
+    isOpen: true,
+    timeSlot: '09:00',
+    track,
+    onClose: fn(),
+    onSave: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ServiceSessionModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Mobile: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+}

--- a/src/components/admin/schedule/track/ServiceSessionModal.tsx
+++ b/src/components/admin/schedule/track/ServiceSessionModal.tsx
@@ -181,20 +181,22 @@ const ServiceSessionDialog = ({
             </p>
           )}
 
+          {/* Cancel LEFT, primary RIGHT — mirrors the SendMessageModal footer
+              (the house order); a primary-on-the-left footer read as a bug. */}
           <div className="flex gap-3 pt-4">
-            <button
-              type="submit"
-              disabled={nothingFits}
-              className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
-            >
-              Create Session
-            </button>
             <button
               type="button"
               onClick={onClose}
               className="flex-1 rounded-md bg-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-400 focus:ring-2 focus:ring-gray-500 focus:outline-none dark:bg-gray-600 dark:text-gray-300 dark:hover:bg-gray-500"
             >
               Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={nothingFits}
+              className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
+            >
+              Create Session
             </button>
           </div>
         </form>

--- a/src/components/admin/sponsor-crm/MobileFilterSheet.tsx
+++ b/src/components/admin/sponsor-crm/MobileFilterSheet.tsx
@@ -67,7 +67,7 @@ export function MobileFilterSheet({
           leaveFrom="translate-y-0"
           leaveTo="translate-y-full"
         >
-          <DialogPanel className="fixed inset-x-0 bottom-0 flex max-h-[90vh] flex-col rounded-t-2xl bg-white shadow-2xl dark:bg-gray-900">
+          <DialogPanel className="fixed inset-x-0 bottom-0 flex max-h-[90dvh] flex-col rounded-t-2xl bg-white shadow-2xl dark:bg-gray-900">
             {/* Handle bar */}
             <div className="shrink-0 bg-white pt-3 pb-2 dark:bg-gray-900">
               <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-gray-300 dark:bg-gray-600" />

--- a/src/components/common/DashboardLayout.tsx
+++ b/src/components/common/DashboardLayout.tsx
@@ -134,6 +134,12 @@ export function DashboardLayout({
     if (mode === 'admin' && onSearch) {
       const handleKeyDown = (e: KeyboardEvent) => {
         if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+          // Don't open the search modal on top of another open dialog — a
+          // second focus trap stacked over the first traps the user with no way
+          // out. A live `[role="dialog"]` query catches both Headless UI and
+          // useModalA11y dialogs (all render that role), including the search
+          // modal itself once open. Mirrors the AdminActionBar fix in #538.
+          if (document.querySelector('[role="dialog"]')) return
           e.preventDefault()
           onSearch()
         }

--- a/src/components/pwa/InstallBanner.stories.tsx
+++ b/src/components/pwa/InstallBanner.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Presentational, dismissible install affordance for the PWA. The `chromium` variant surfaces an actionable Install button driven by the `beforeinstallprompt` event; the `ios` variant shows an Add-to-Home-Screen hint since iOS Safari has no install prompt API. Event handling lives in the `InstallPrompt` container; this component is pure so it renders standalone.',
+          'Presentational, dismissible install affordance for the PWA. The `chromium` variant surfaces an actionable Install button driven by the `beforeinstallprompt` event; the `ios` variant shows an Add-to-Home-Screen hint since iOS Safari has no install prompt API. Event handling lives in the `InstallPrompt` container; this component is pure so it renders standalone. It is a polite `role="status"` live region (NOT a dialog — nothing traps focus), sits below open dialogs (`z-40`), pads for the safe-area inset, and gives its actions 44px touch targets.',
       },
     },
   },

--- a/src/components/pwa/InstallBanner.tsx
+++ b/src/components/pwa/InstallBanner.tsx
@@ -27,9 +27,14 @@ export function InstallBanner({
 }: InstallBannerProps) {
   return (
     <div
-      role="dialog"
+      // A banner is NOT a dialog: nothing traps or returns focus, so
+      // `role="dialog"` misleads screen readers into announcing a modal.
+      // `role="status"` (implicit polite live region) announces it without
+      // stealing focus. It also sits BELOW open dialogs (shell family is z-50).
+      role="status"
+      aria-live="polite"
       aria-label="Install app"
-      className="fixed inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-4"
+      className="fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-[max(1rem,env(safe-area-inset-bottom))]"
     >
       <div className="flex w-full max-w-md items-center gap-3 rounded-2xl bg-white p-3 shadow-lg ring-1 ring-gray-900/10 dark:bg-gray-800 dark:ring-white/10">
         <div className="flex size-10 flex-none items-center justify-center rounded-xl bg-brand-cloud-blue/10 text-brand-cloud-blue dark:bg-brand-cloud-blue/20">
@@ -51,7 +56,7 @@ export function InstallBanner({
           <button
             type="button"
             onClick={onInstall}
-            className="flex-none rounded-lg bg-brand-cloud-blue px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue"
+            className="flex min-h-11 flex-none items-center justify-center rounded-lg bg-brand-cloud-blue px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue"
           >
             Install app
           </button>
@@ -61,7 +66,7 @@ export function InstallBanner({
           type="button"
           onClick={onDismiss}
           aria-label="Dismiss install prompt"
-          className="flex-none rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          className="flex min-h-11 min-w-11 flex-none items-center justify-center rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:hover:bg-gray-700 dark:hover:text-gray-200"
         >
           <XMarkIcon className="size-5" />
         </button>

--- a/src/components/pwa/UpdateBanner.stories.tsx
+++ b/src/components/pwa/UpdateBanner.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Presentational "new version available" banner shown after the service worker installs an update. Clicking Reload posts `SKIP_WAITING` to the waiting worker (handled by the `ServiceWorkerRegistrar` container), which then reloads the page exactly once. This component is pure — all service-worker logic lives in the container — so it renders standalone. The entrance animation is suppressed under `prefers-reduced-motion`.',
+          'Presentational "new version available" banner shown after the service worker installs an update. Clicking Reload posts `SKIP_WAITING` to the waiting worker (handled by the `ServiceWorkerRegistrar` container), which then reloads the page exactly once. This component is pure — all service-worker logic lives in the container — so it renders standalone. The entrance animation is suppressed under `prefers-reduced-motion`. It is a polite `role="status"` live region (NOT a dialog — nothing traps focus), sits below open dialogs (`z-40`), pads for the safe-area inset, and gives its actions 44px touch targets.',
       },
     },
   },

--- a/src/components/pwa/UpdateBanner.tsx
+++ b/src/components/pwa/UpdateBanner.tsx
@@ -31,9 +31,14 @@ export function UpdateBanner({ onReload, onDismiss }: UpdateBannerProps) {
 
   return (
     <div
-      role="dialog"
+      // A banner is NOT a dialog: nothing traps or returns focus, so
+      // `role="dialog"` misleads screen readers into announcing a modal.
+      // `role="status"` (implicit polite live region) announces it without
+      // stealing focus. It also sits BELOW open dialogs (shell family is z-50).
+      role="status"
+      aria-live="polite"
       aria-label="Update available"
-      className="fixed inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-4"
+      className="fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-[max(1rem,env(safe-area-inset-bottom))]"
     >
       <div
         className={`flex w-full max-w-md items-center gap-3 rounded-2xl bg-white p-3 shadow-lg ring-1 ring-gray-900/10 transition duration-300 ease-out motion-reduce:transform-none motion-reduce:transition-none dark:bg-gray-800 dark:ring-white/10 ${
@@ -51,7 +56,7 @@ export function UpdateBanner({ onReload, onDismiss }: UpdateBannerProps) {
         <button
           type="button"
           onClick={onReload}
-          className="flex-none rounded-lg bg-brand-cloud-blue px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue"
+          className="flex min-h-11 flex-none items-center justify-center rounded-lg bg-brand-cloud-blue px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue"
         >
           Reload
         </button>
@@ -60,7 +65,7 @@ export function UpdateBanner({ onReload, onDismiss }: UpdateBannerProps) {
           type="button"
           onClick={onDismiss}
           aria-label="Dismiss update prompt"
-          className="flex-none rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          className="flex min-h-11 min-w-11 flex-none items-center justify-center rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:hover:bg-gray-700 dark:hover:text-gray-200"
         >
           <XMarkIcon className="size-5" />
         </button>


### PR DESCRIPTION
Modal-audit fix batch M-D (BANNERS, SHORTCUTS, STORIES, NITS).

## D1 — Banner semantics (PWA-critical)
`InstallBanner` / `UpdateBanner` were `role="dialog"` but nothing traps or returns focus, misleading screen readers. Switched to `role="status"` + `aria-live="polite"` (announced, not modal). Added safe-area bottom padding `pb-[max(1rem,env(safe-area-inset-bottom))]` and 44px (`min-h-11`) touch targets on the action and dismiss buttons. Visual weight otherwise unchanged. Stories' docs updated.

## D2 — ⌘K shortcut suppression
`DashboardLayout`'s global ⌘K opened the SearchModal even while another dialog was open, stacking two focus traps. Now suppressed via `document.querySelector('[role="dialog"]')` at keydown (covers both Headless UI and `useModalA11y` families, including the search modal itself). Mirrors the AdminActionBar fix in #538. New test.

## D3 — MobileFilterSheet
`max-h-[90vh]` → `max-h-[90dvh]`. Nothing else changed.

## D4 — Missing-story gaps
- New real-component story for **SpeakerMergeModal** (the model destructive-confirm modal): `NotificationProvider` + msw-mocked `speaker.admin.mergePreview` dry-run, with `Default`, `Mobile`, and a play-driven `Previewed` variant (shows the change summary + red confirm). A decorator syncs the toolbar theme onto the document root so the ModalShell/Headless UI portal renders dark.
- New stories for **AddTrackModal**, **ServiceSessionModal**, **ServiceEditSheet** (all render standalone with small fixtures — no full schedule-editor context needed).

## D5 — Schedule modal nits
- `AddTrackModal` + `ServiceSessionModal` footers reordered to **Cancel-left / primary-right**, mirroring the SendMessageModal footer (a primary-on-the-left footer read as a bug).
- `ServiceEditSheet` rename **Save is disabled while the title is empty**. New tests.

## D6 — Banner z-index
Banners were `z-50`, tying with the dialog family. Lowered to `z-40` so they sit **below** open dialogs.

## Verification
- tsc, eslint, prettier, knip clean; full `vitest run` green (3094 passed).
- Added tests: DashboardLayout ⌘K suppression (2), ServiceEditSheet rename disable (2); ServiceWorkerRegistrar role query updated dialog→status.
- `pnpm shoot` at 393 light+dark inspected for both banners, MobileFilterSheet, SpeakerMergeModal (Default/Mobile/Previewed), AddTrackModal, ServiceSessionModal, ServiceEditSheet — footer order, disabled Save, and dark all confirmed; no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a focused accessibility and UX audit batch: it corrects banner ARIA roles from `dialog` to `status`, suppresses the ⌘K search shortcut when another dialog is already open, fixes footer button order in two schedule modals, and fills several Storybook story gaps with real-component stories including MSW and play-function variants.

- **Banner semantics (D1/D6):** `InstallBanner` and `UpdateBanner` switch from the misleading `role="dialog"` to `role="status"`, drop to `z-40` so they sit below open dialogs (`z-50`), gain safe-area bottom padding, and receive 44 px touch targets on action buttons. Tests updated to query `role="status"`.
- **⌘K suppression (D2):** `DashboardLayout` now checks for a live `[role="dialog"]` element before handling Cmd/Ctrl+K, preventing a second focus trap from stacking over an already-open dialog. New unit tests cover both paths.
- **Footer order & empty-title guard (D5):** `AddTrackModal` and `ServiceSessionModal` footers are reordered to Cancel-left / primary-right. `ServiceEditSheet` gains a `disabled` guard on the Save button backed by a pre-existing `saveRename` callback guard, though the footer order in `ServiceEditSheet` itself was not updated.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are isolated UI/accessibility fixes with no data-path or auth implications.

The banner ARIA corrections, ⌘K guard, and footer reorders are all straightforward and well-tested. The only gap is that `ServiceEditSheet` was left with primary-left / cancel-right footers in both `rename` and `duration` modes, directly contrary to the convention this PR is establishing for its sibling modals. That inconsistency doesn't break anything at runtime but leaves the codebase in a partially-fixed state.

src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx — footer button order was not updated to match the Cancel-left / primary-right convention applied to AddTrackModal and ServiceSessionModal in this same PR.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/common/DashboardLayout.tsx | Adds a live DOM query guard to suppress ⌘K when a dialog is already open; prevents stacked focus traps. Guard is correct and tests cover both the open and suppressed paths. |
| src/components/pwa/InstallBanner.tsx | Corrects ARIA role from dialog to status + aria-live="polite" (redundant since role="status" implies polite live region but harmless), lowers z-index to z-40, adds safe-area padding, and 44px min-height touch targets on action buttons. |
| src/components/pwa/UpdateBanner.tsx | Same semantics fix as InstallBanner: role="status" + aria-live="polite", z-40, safe-area bottom padding, and 44px touch targets. Mirrors InstallBanner symmetrically. |
| src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx | Adds disabled={!renameValue.trim()} guard to the Save button; the saveRename callback already has the same guard internally. Footer order (Save-left, Cancel-right) is inconsistent with the Cancel-left/primary-right convention being established elsewhere in this PR. |
| src/components/admin/schedule/AddTrackModal.tsx | Footer reordered to Cancel-left / primary-right per house convention. Clean one-block swap with no logic changes. |
| src/components/admin/schedule/track/ServiceSessionModal.tsx | Footer reordered to Cancel-left / primary-right, matching AddTrackModal. Disabled state on the submit button preserved correctly after the swap. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Document
    participant DashboardLayout
    participant SearchModal
    participant AnyDialog

    User->>Document: keydown (⌘K)
    Document->>DashboardLayout: handleKeyDown
    DashboardLayout->>Document: "querySelector('[role="dialog"]')"
    alt No dialog open
        Document-->>DashboardLayout: null
        DashboardLayout->>DashboardLayout: e.preventDefault()
        DashboardLayout->>SearchModal: onSearch()
        SearchModal-->>User: Focus trapped in search
    else Dialog already open
        Document-->>DashboardLayout: AnyDialog element
        DashboardLayout-->>User: return (no-op, no stacked trap)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Document
    participant DashboardLayout
    participant SearchModal
    participant AnyDialog

    User->>Document: keydown (⌘K)
    Document->>DashboardLayout: handleKeyDown
    DashboardLayout->>Document: "querySelector('[role="dialog"]')"
    alt No dialog open
        Document-->>DashboardLayout: null
        DashboardLayout->>DashboardLayout: e.preventDefault()
        DashboardLayout->>SearchModal: onSearch()
        SearchModal-->>User: Focus trapped in search
    else Dialog already open
        Document-->>DashboardLayout: AnyDialog element
        DashboardLayout-->>User: return (no-op, no stacked trap)
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx`, line 126-142 ([link](https://github.com/cloudnativebergen/website/blob/938115495b8657ac064991a66a98acb562685417/src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx#L126-L142)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **ServiceEditSheet footer order mismatches the house convention**

   This PR explicitly reorders AddTrackModal and ServiceSessionModal to Cancel-left / primary-right, noting "a primary-on-the-left footer read as a bug." The same pattern exists in both `rename` and `duration` modes of `ServiceEditSheet` — Save is on the left and Cancel is on the right — but was not updated here. The new stories description also omits the footer-order note that the other two stories explicitly include.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx`, line 167-182 ([link](https://github.com/cloudnativebergen/website/blob/938115495b8657ac064991a66a98acb562685417/src/components/admin/schedule/mobile/sheets/ServiceEditSheet.tsx#L167-L182)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same Cancel-left / primary-right fix applies to the `duration` mode footer — the `duration` branch has the same Save-left, Cancel-right order that was treated as a bug in the other modals.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ui): banner semantics, shortcut supp..."](https://github.com/cloudnativebergen/website/commit/938115495b8657ac064991a66a98acb562685417) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45429884)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->