### PR TITLE
fix(messaging): thread page sizes to content instead of stretching to viewport

### DIFF
--- a/src/app/(admin)/admin/messages/[id]/page.tsx
+++ b/src/app/(admin)/admin/messages/[id]/page.tsx
@@ -34,7 +34,7 @@ export default async function AdminConversationPage({
         <BackLink fallbackUrl="/admin/messages">Back to Messages</BackLink>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
         <ConversationThread
           conversationId={id}
           audience="organizer"

--- a/src/app/(cfp)/cfp/messages/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/messages/[id]/page.tsx
@@ -33,7 +33,7 @@ export default async function CfpConversationPage({
         <BackLink fallbackUrl="/cfp/messages">Back to Messages</BackLink>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
         <ConversationThread conversationId={id} audience="speaker" fillHeight />
       </div>
     </div>

--- a/src/components/messaging/ConversationThread.stories.tsx
+++ b/src/components/messaging/ConversationThread.stories.tsx
@@ -236,3 +236,49 @@ export const ReadOnlyImpersonation: Story = {
     <ConversationThreadView {...args} messages={makeMessages()} />
   ),
 }
+
+/**
+ * The standalone thread page layout (fillHeight) with a SHORT thread: the card
+ * must size to its content — composer directly under the last message — and
+ * NOT stretch to fill the viewport-height container (the maintainer-reported
+ * "unnecessarily high" regression). The wrapper mimics the message pages'
+ * h-[100dvh] column at a fixed capture height.
+ */
+export const FillHeightShortThread: Story = {
+  args: {
+    messages: [],
+    subject: 'Test',
+    preference: defaultPreference,
+    fillHeight: true,
+  },
+  render: (args) => (
+    <div className="flex h-[760px] flex-col">
+      <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <ConversationThreadView
+          {...args}
+          messages={makeMessages().slice(0, 2)}
+        />
+      </div>
+    </div>
+  ),
+}
+
+/**
+ * fillHeight with a LONG thread: the card shrinks to the container, the list
+ * scrolls (opens pinned to newest) and the composer stays pinned at the bottom.
+ */
+export const FillHeightLongThread: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+    fillHeight: true,
+  },
+  render: (args) => (
+    <div className="flex h-[760px] flex-col">
+      <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <ConversationThreadView {...args} messages={makeLongHistory()} />
+      </div>
+    </div>
+  ),
+}

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -360,10 +360,14 @@ export function ConversationThreadView({
     <div
       role="region"
       aria-label={subject ? `Conversation: ${subject}` : 'Conversation'}
-      className={fillHeight ? 'flex min-h-0 flex-1 flex-col' : 'flex flex-col'}
+      // fillHeight sizes to CONTENT and only SHRINKS (list scrolls) when the
+      // thread exceeds the viewport — never grows, so a short thread keeps the
+      // composer right under the last message instead of pinned to the bottom
+      // of a stretched card.
+      className={fillHeight ? 'flex min-h-0 flex-col' : 'flex flex-col'}
     >
       {(subject || onSetMuted) && (
-        <div className="flex items-center justify-between gap-3 border-b border-gray-200 pb-3 dark:border-gray-700">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-gray-200 pb-3 dark:border-gray-700">
           {subject ? (
             <h2 className="truncate text-sm font-semibold text-gray-900 dark:text-white">
               {subject}
@@ -387,7 +391,7 @@ export function ConversationThreadView({
         ref={scrollRef}
         onScroll={handleScroll}
         className={`space-y-3 overflow-y-auto overscroll-contain py-4 ${
-          fillHeight ? 'min-h-0 flex-1' : 'max-h-[60vh] min-h-[8rem]'
+          fillHeight ? 'min-h-[8rem] shrink' : 'max-h-[60vh] min-h-[8rem]'
         }`}
       >
         {isLoading ? (


### PR DESCRIPTION
Maintainer-reported (screenshot): a short thread on /cfp/messages/<id> stretched the card to full viewport height, pinning the composer to the bottom with a huge void above it.

Cause: both the page card and the inner list used flex-1 — the layout GROWS to fill 100dvh instead of only CAPPING at it.

Fix: the card and list now size to content and only shrink (list scrolls) when the thread exceeds the viewport — grow never. Header/composer are shrink-0 so the list is the sole shrinker; embed (#messages) mode unchanged.

Two new stories cover both regimes (FillHeightShortThread / FillHeightLongThread); shoot-verified at 393px: short thread = composer directly under last message; long thread = capped card, newest-pinned scroll, pinned composer.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a layout regression where a short message thread on the `/cfp/messages/<id>` and `/admin/messages/<id>` pages stretched the card to full viewport height, pushing the composer to the bottom with a large empty void. The root cause was `flex-1` on both the page card wrapper and the inner message list, causing them to grow to fill the `h-[100dvh]` column rather than capping at it.

- Removes `flex-1` from the card wrapper div in both page files so the card sizes to its content instead of filling the viewport.
- In `ConversationThread.tsx`, removes `flex-1` from the outer region container and the message list in `fillHeight` mode; replaces the list's `min-h-0 flex-1` with `min-h-[8rem] shrink` so the list only shrinks (scrolls) when it overflows the bounded card, never grows; adds `shrink-0` to the header to ensure only the list absorbs flex-shrink pressure.
- Adds two Storybook stories (`FillHeightShortThread` / `FillHeightLongThread`) with a correctly constrained wrapper that covers both content-fit and scroll regimes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused CSS class removal with no logic, data, or API surface affected.

The flex layout reasoning is sound: removing flex-1 from the card and replacing flex-1 with shrink on the list correctly produces content-fit sizing for short threads and viewport-capped scrolling for long ones. Both page files receive the same treatment, the header gets the missing shrink-0, and the two new Storybook stories exercise both regimes. No logic branches, data paths, or auth flows are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/messaging/ConversationThread.tsx | Removes flex-1 from the fillHeight outer container and replaces the list's flex-1 with shrink + min-h-[8rem]; adds shrink-0 to the header. The sizing logic is correct for both short and long threads. |
| src/app/(cfp)/cfp/messages/[id]/page.tsx | Removes flex-1 from the card wrapper div so it no longer grows to fill the h-[100dvh] parent when the thread is short. |
| src/app/(admin)/admin/messages/[id]/page.tsx | Same flex-1 removal as the CFP page; admin and speaker surfaces are now consistent. |
| src/components/messaging/ConversationThread.stories.tsx | Adds FillHeightShortThread and FillHeightLongThread stories with a h-[760px] wrapper that correctly mirrors the page layout; covers both the fixed regression and the scroll regime. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["h-[100dvh] flex flex-col\n(page wrapper)"] --> B["BackLink\nshrink-0"]
    A --> C["Card: flex min-h-0 flex-col overflow-hidden\n(was: flex-1 removed)"]

    C --> D["Header\nflex shrink-0\n(was: no shrink-0)"]
    C --> E["Message List\nmin-h-[8rem] shrink overflow-y-auto\n(was: min-h-0 flex-1)"]
    C --> F["Composer / ReadOnly notice\nshrink-0"]

    E -- "short thread" --> G["List = natural content height\nCard sizes to content\nComposer directly below last message"]
    E -- "long thread" --> H["Card bounded by viewport\nList shrinks and scrolls\nComposer pinned at bottom"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["h-[100dvh] flex flex-col\n(page wrapper)"] --> B["BackLink\nshrink-0"]
    A --> C["Card: flex min-h-0 flex-col overflow-hidden\n(was: flex-1 removed)"]

    C --> D["Header\nflex shrink-0\n(was: no shrink-0)"]
    C --> E["Message List\nmin-h-[8rem] shrink overflow-y-auto\n(was: min-h-0 flex-1)"]
    C --> F["Composer / ReadOnly notice\nshrink-0"]

    E -- "short thread" --> G["List = natural content height\nCard sizes to content\nComposer directly below last message"]
    E -- "long thread" --> H["Card bounded by viewport\nList shrinks and scrolls\nComposer pinned at bottom"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): thread page sizes to con..."](https://github.com/cloudnativebergen/website/commit/0bd6de56398d49e42f9a4839a0c2ddbc56c51b1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45430068)</sub>

<!-- /greptile_comment -->