### PR TITLE
fix(ui): form-modal fixes from modal audit (batch C)

### DIFF
--- a/__tests__/components/admin/gallery/ImageMetadataModal.test.tsx
+++ b/__tests__/components/admin/gallery/ImageMetadataModal.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { ImageMetadataModal } from '@/components/admin/gallery/ImageMetadataModal'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
+
+const { mutate } = vi.hoisted(() => ({ mutate: vi.fn() }))
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    speaker: {
+      admin: { search: { useQuery: () => ({ data: [] }) } },
+    },
+    gallery: {
+      admin: {
+        update: {
+          useMutation: () => ({ mutate, mutateAsync: vi.fn() }),
+        },
+      },
+    },
+  },
+}))
+
+const singleImage = {
+  _id: 'img-1',
+  photographer: 'Olav',
+  date: '2025-06-12T14:30:00Z',
+  location: 'Bergen',
+  imageAlt: 'Keynote',
+  featured: false,
+  speakers: [],
+} as unknown as GalleryImageWithSpeakers
+
+afterEach(() => {
+  cleanup()
+  mutate.mockReset()
+})
+
+describe('ImageMetadataModal ⌘S (C2)', () => {
+  it('submits THIS modal form, not the first form on the page', () => {
+    const decoySubmit = vi.fn((e: React.FormEvent) => e.preventDefault())
+
+    render(
+      <>
+        {/* A decoy form that appears FIRST in document order. The old
+            document.querySelector('form') would have submitted this one. */}
+        <form data-testid="decoy" onSubmit={decoySubmit}>
+          <button type="submit">decoy</button>
+        </form>
+        <NotificationProvider>
+          <ImageMetadataModal
+            image={singleImage}
+            isOpen
+            onClose={vi.fn()}
+            onUpdate={vi.fn()}
+          />
+        </NotificationProvider>
+      </>,
+    )
+
+    fireEvent.keyDown(window, { key: 's', metaKey: true })
+
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'img-1' }),
+    )
+    expect(decoySubmit).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/admin/sponsor/SponsorAddModal.test.tsx
+++ b/__tests__/components/admin/sponsor/SponsorAddModal.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { SponsorAddModal } from '@/components/admin/sponsor/SponsorAddModal'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import type {
+  ConferenceSponsor,
+  SponsorTierExisting,
+} from '@/lib/sponsor/types'
+
+const state = vi.hoisted(() => ({
+  crmUpdatePending: false,
+  // A STABLE empty array — returning a fresh `[]` per render would retrigger
+  // the component's list-sync effect on every render (infinite loop / OOM).
+  emptyList: [] as unknown[],
+}))
+
+vi.mock('@/lib/trpc/client', () => {
+  const idle = () => ({ mutateAsync: vi.fn(), isPending: false })
+  return {
+    api: {
+      sponsor: {
+        list: { useQuery: () => ({ data: state.emptyList }) },
+        create: { useMutation: idle },
+        update: { useMutation: idle },
+        crm: {
+          create: { useMutation: idle },
+          update: {
+            useMutation: () => ({
+              mutateAsync: vi.fn(),
+              isPending: state.crmUpdatePending,
+            }),
+          },
+        },
+      },
+      useUtils: () => ({ sponsor: { list: { invalidate: vi.fn() } } }),
+    },
+  }
+})
+
+vi.mock('@/components/admin/sponsor/SponsorLogoEditor', () => ({
+  SponsorLogoEditor: () => <div data-testid="logo-editor" />,
+}))
+
+const sponsorTiers = [
+  { _id: 't1', title: 'Gold', price: [] },
+] as unknown as SponsorTierExisting[]
+
+const editingSponsor = {
+  _sfcId: 'sfc-1',
+  sponsor: { _id: 's1', name: 'Acme', website: 'https://acme.test' },
+  tier: { _id: 't1', title: 'Gold', tagline: '' },
+} as unknown as ConferenceSponsor
+
+function renderModal() {
+  render(
+    <NotificationProvider>
+      <SponsorAddModal
+        isOpen
+        onClose={vi.fn()}
+        conferenceId="conf-1"
+        sponsorTiers={sponsorTiers}
+        editingSponsor={editingSponsor}
+      />
+    </NotificationProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  state.crmUpdatePending = false
+})
+
+describe('SponsorAddModal double-submit guard (C7)', () => {
+  it('disables submit while the CRM update mutation is pending', () => {
+    state.crmUpdatePending = true
+    renderModal()
+    expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled()
+  })
+
+  it('keeps submit enabled for a valid form when nothing is pending', () => {
+    state.crmUpdatePending = false
+    renderModal()
+    expect(screen.getByRole('button', { name: 'Update Sponsor' })).toBeEnabled()
+  })
+})

--- a/__tests__/components/admin/workshop/AddParticipantModal.test.tsx
+++ b/__tests__/components/admin/workshop/AddParticipantModal.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { AddParticipantModal } from '@/components/admin/workshop/AddParticipantModal'
+
+afterEach(() => cleanup())
+
+describe('AddParticipantModal (C1)', () => {
+  it('shows an inline validation error (not a native alert) when required fields are empty', () => {
+    const onSubmit = vi.fn()
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    render(
+      <AddParticipantModal
+        isOpen
+        onClose={vi.fn()}
+        workshopTitle="Kubernetes 101"
+        onSubmit={onSubmit}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Participant' }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(alertSpy).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Please fill in both name and email.'),
+    ).toBeInTheDocument()
+    alertSpy.mockRestore()
+  })
+
+  it('keeps the typed values after submit so a failed parent mutation loses nothing', () => {
+    const onSubmit = vi.fn()
+    render(
+      <AddParticipantModal
+        isOpen
+        onClose={vi.fn()}
+        workshopTitle="Kubernetes 101"
+        onSubmit={onSubmit}
+      />,
+    )
+
+    const name = screen.getByPlaceholderText('John Doe') as HTMLInputElement
+    const email = screen.getByPlaceholderText(
+      'john@example.com',
+    ) as HTMLInputElement
+    fireEvent.change(name, { target: { value: 'Ada Lovelace' } })
+    fireEvent.change(email, { target: { value: 'ada@example.com' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Participant' }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userName: 'Ada Lovelace',
+        userEmail: 'ada@example.com',
+      }),
+    )
+    // The modal stays open (parent controls close on success); inputs are NOT
+    // reset synchronously, so a rejected mutation preserves the entered data.
+    expect(name.value).toBe('Ada Lovelace')
+    expect(email.value).toBe('ada@example.com')
+  })
+
+  it('resets the form the next time it opens (success is signalled by a re-open)', () => {
+    const { rerender } = render(
+      <AddParticipantModal
+        isOpen
+        onClose={vi.fn()}
+        workshopTitle="Kubernetes 101"
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    const name = screen.getByPlaceholderText('John Doe') as HTMLInputElement
+    fireEvent.change(name, { target: { value: 'Ada Lovelace' } })
+    expect(name.value).toBe('Ada Lovelace')
+
+    // Close then reopen — the reset-on-open effect clears the previous entry.
+    rerender(
+      <AddParticipantModal
+        isOpen={false}
+        onClose={vi.fn()}
+        workshopTitle="Kubernetes 101"
+        onSubmit={vi.fn()}
+      />,
+    )
+    rerender(
+      <AddParticipantModal
+        isOpen
+        onClose={vi.fn()}
+        workshopTitle="Kubernetes 101"
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    expect(
+      (screen.getByPlaceholderText('John Doe') as HTMLInputElement).value,
+    ).toBe('')
+  })
+})

--- a/__tests__/components/admin/workshop/SignupDetailsModal.test.tsx
+++ b/__tests__/components/admin/workshop/SignupDetailsModal.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { SignupDetailsModal } from '@/components/admin/workshop/SignupDetailsModal'
+import {
+  WorkshopSignupStatus,
+  type WorkshopSignupExisting,
+} from '@/lib/workshop/types'
+
+const signups = [
+  {
+    _id: 'signup-1',
+    _type: 'workshopSignup',
+    userName: 'Ada Lovelace',
+    userEmail: 'ada@example.com',
+    status: WorkshopSignupStatus.CONFIRMED,
+    signedUpAt: '2025-01-10T08:00:00Z',
+    _createdAt: '2025-01-10T08:00:00Z',
+  },
+] as unknown as WorkshopSignupExisting[]
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof SignupDetailsModal>> = {},
+) {
+  const onDeleteSignup = vi.fn()
+  render(
+    <SignupDetailsModal
+      isOpen
+      onClose={vi.fn()}
+      workshopTitle="Kubernetes 101"
+      status={WorkshopSignupStatus.CONFIRMED}
+      signups={signups}
+      onConfirmSignup={vi.fn()}
+      onDeleteSignup={onDeleteSignup}
+      {...overrides}
+    />,
+  )
+  return { onDeleteSignup }
+}
+
+afterEach(() => cleanup())
+
+describe('SignupDetailsModal delete confirmation (C6)', () => {
+  it('does not delete immediately — it opens a confirmation naming the participant', () => {
+    const { onDeleteSignup } = renderModal()
+
+    fireEvent.click(screen.getAllByTitle('Delete participant')[0])
+
+    expect(onDeleteSignup).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(/permanently delete Ada Lovelace's signup/i),
+    ).toBeInTheDocument()
+  })
+
+  it('routes the delete through the confirmation modal', () => {
+    const { onDeleteSignup } = renderModal()
+
+    fireEvent.click(screen.getAllByTitle('Delete participant')[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(onDeleteSignup).toHaveBeenCalledWith('signup-1', 'Ada Lovelace')
+  })
+
+  it('cancelling the confirmation leaves the signup untouched', () => {
+    const { onDeleteSignup } = renderModal()
+
+    fireEvent.click(screen.getAllByTitle('Delete participant')[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onDeleteSignup).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/SpeakerProfilePreview.tsx
+++ b/src/components/SpeakerProfilePreview.tsx
@@ -46,7 +46,7 @@ export default function SpeakerProfilePreview({
       onClose={onClose}
       size="5xl"
       padded={false}
-      className="flex max-h-[90vh] transform flex-col overflow-hidden bg-brand-glacier-white text-left align-middle transition-all"
+      className="flex max-h-[90dvh] transform flex-col overflow-hidden bg-brand-glacier-white text-left align-middle transition-all"
     >
       <div className="flex items-center justify-between border-b border-gray-200 p-6 dark:border-gray-700">
         <DialogTitle

--- a/src/components/admin/ConfirmationModal.tsx
+++ b/src/components/admin/ConfirmationModal.tsx
@@ -92,11 +92,22 @@ export function ConfirmationModal({
         </div>
       </div>
       {children && <div className="mt-4 text-left">{children}</div>}
-      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:gap-4">
+      {/* Cancel first in DOM; flex-col-reverse stacks the destructive primary
+          on top on mobile, sm:flex-row + justify-end puts Cancel left / primary
+          right on desktop (mirrors SendMessageModal's footer). */}
+      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end sm:gap-4">
+        <Button
+          variant="outline"
+          onClick={onClose}
+          disabled={isLoading}
+          className="font-space-grotesk w-full justify-center rounded-xl border-brand-frosted-steel px-4 py-3 text-sm font-semibold text-brand-slate-gray transition-all duration-200 hover:bg-brand-sky-mist disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          {cancelButtonText}
+        </Button>
         <Button
           onClick={onConfirm}
           disabled={isLoading || confirmDisabled}
-          className={`font-space-grotesk w-full justify-center rounded-xl px-4 py-3 text-sm font-semibold text-white shadow-sm ${styles.confirmButton} disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:flex-1`}
+          className={`font-space-grotesk w-full justify-center rounded-xl px-4 py-3 text-sm font-semibold text-white shadow-sm ${styles.confirmButton} disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto`}
         >
           {isLoading ? (
             <div className="flex items-center justify-center gap-2">
@@ -106,14 +117,6 @@ export function ConfirmationModal({
           ) : (
             confirmButtonText
           )}
-        </Button>
-        <Button
-          variant="outline"
-          onClick={onClose}
-          disabled={isLoading}
-          className="font-space-grotesk w-full justify-center rounded-xl border-brand-frosted-steel px-4 py-3 text-sm font-semibold text-brand-slate-gray transition-all duration-200 hover:bg-brand-sky-mist disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:flex-1 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-        >
-          {cancelButtonText}
         </Button>
       </div>
     </ModalShell>

--- a/src/components/admin/EmailModal.stories.tsx
+++ b/src/components/admin/EmailModal.stories.tsx
@@ -95,6 +95,28 @@ export const WithTicketUrl: Story = {
   },
 }
 
+export const WithTemplateSelector: Story = {
+  args: {
+    title: 'Send Sponsor Email',
+    contextInfo: 'Sponsor: TechGiant Corp • Gold tier',
+    templateSelector: () => (
+      <select className="w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white">
+        <option>Choose a template…</option>
+        <option>Welcome sponsor</option>
+        <option>Contract follow-up</option>
+      </select>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With a template selector. The From/Template row stacks vertically below sm (flex-col sm:flex-row) so the dropdown stays usable at 393px.',
+      },
+    },
+  },
+}
+
 export const WithInitialValues: Story = {
   args: {
     title: 'Follow Up Email',

--- a/src/components/admin/EmailModal.tsx
+++ b/src/components/admin/EmailModal.tsx
@@ -324,7 +324,7 @@ export function EmailModal({
       onClose={handleClose}
       size="3xl"
       padded={false}
-      className="flex max-h-[90vh] flex-col"
+      className="flex max-h-[90dvh] flex-col"
     >
       <div className="flex items-center justify-between border-b border-gray-200 p-6 pb-4 dark:border-gray-700">
         <div className="flex-1">
@@ -413,11 +413,11 @@ export function EmailModal({
                 </div>
               </div>
 
-              <div className="flex items-center border-b border-gray-200/50 px-6 py-3 dark:border-gray-700/50">
+              <div className="flex flex-col border-b border-gray-200/50 px-6 py-3 sm:flex-row sm:items-center dark:border-gray-700/50">
                 <div
                   className={
                     templateSelector
-                      ? 'flex w-1/2 items-center'
+                      ? 'flex w-full items-center sm:w-1/2'
                       : 'flex flex-1 items-center'
                   }
                 >
@@ -431,7 +431,7 @@ export function EmailModal({
                   </div>
                 </div>
                 {templateSelector && (
-                  <div className="flex w-1/2 items-center border-l border-gray-200/50 pl-4 dark:border-gray-700/50">
+                  <div className="mt-2 flex w-full items-center border-gray-200/50 sm:mt-0 sm:w-1/2 sm:border-l sm:pl-4 dark:border-gray-700/50">
                     <label className="font-space-grotesk mr-2 text-sm font-medium text-gray-600 dark:text-gray-300">
                       Template:
                     </label>
@@ -507,7 +507,7 @@ export function EmailModal({
           </div>
         )}
       </div>
-      <div className="flex shrink-0 justify-between border-t border-gray-200 p-6 dark:border-gray-700">
+      <div className="flex shrink-0 justify-between border-t border-gray-200 p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] dark:border-gray-700">
         <div className="flex space-x-3">
           {previewComponent && (
             <button

--- a/src/components/admin/ProposalActionModal.tsx
+++ b/src/components/admin/ProposalActionModal.tsx
@@ -154,10 +154,10 @@ export function ProposalActionModal({
       padded={false}
       className="relative overflow-hidden px-6 py-5 sm:p-8"
     >
-      <div className="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
+      <div className="absolute top-0 right-0 pt-2 pr-2">
         <button
           type="button"
-          className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-400"
+          className="flex h-11 w-11 items-center justify-center rounded-md bg-white text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-400"
           onClick={() => close()}
         >
           <span className="sr-only">Close</span>

--- a/src/components/admin/SpeakerManagementModal.tsx
+++ b/src/components/admin/SpeakerManagementModal.tsx
@@ -170,7 +170,7 @@ export function SpeakerManagementModal({
       isOpen={isOpen}
       onClose={onClose}
       size="3xl"
-      className="max-h-[90vh] transform overflow-hidden border border-brand-frosted-steel bg-brand-glacier-white transition-all dark:border-gray-700"
+      className="max-h-[90dvh] transform overflow-hidden border border-brand-frosted-steel bg-brand-glacier-white transition-all dark:border-gray-700"
     >
       <div className="mb-6 flex items-start justify-between">
         <DialogTitle className="font-space-grotesk text-xl font-semibold text-brand-slate-gray dark:text-white">
@@ -187,7 +187,7 @@ export function SpeakerManagementModal({
       </div>
 
       <form onSubmit={handleSubmit}>
-        <div className="max-h-[calc(90vh-200px)] overflow-y-auto py-6">
+        <div className="max-h-[calc(90dvh-200px)] overflow-y-auto py-6">
           <div className="mb-6">
             <Input
               name="email"
@@ -232,7 +232,7 @@ export function SpeakerManagementModal({
           </div>
         )}
 
-        <div className="mt-6 flex justify-end gap-3">
+        <div className="mt-6 flex justify-end gap-3 pb-[env(safe-area-inset-bottom)]">
           <Button
             type="button"
             variant="outline"

--- a/src/components/admin/gallery/ImageMetadataModal.tsx
+++ b/src/components/admin/gallery/ImageMetadataModal.tsx
@@ -72,6 +72,7 @@ export function ImageMetadataModal({
     right: number
   } | null>(singleImage?.image?.crop || null)
   const speakerInputRef = useRef<HTMLInputElement>(null)
+  const formRef = useRef<HTMLFormElement>(null)
 
   const { data: searchResults } = api.speaker.admin.search.useQuery(
     { query: speakerQuery, includeFeatured: true },
@@ -140,8 +141,9 @@ export function ImageMetadataModal({
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
         e.preventDefault()
         if (!isSubmitting) {
-          const form = document.querySelector('form') as HTMLFormElement | null
-          form?.requestSubmit()
+          // Scope the submit to THIS modal's form via a ref — a document-wide
+          // querySelector('form') would submit the first form on the page.
+          formRef.current?.requestSubmit()
         }
       }
     }
@@ -252,7 +254,7 @@ export function ImageMetadataModal({
       isOpen={isOpen}
       onClose={onClose}
       size="2xl"
-      className="max-h-screen overflow-y-auto rounded-xl shadow-lg"
+      className="max-h-[90dvh] overflow-y-auto rounded-xl shadow-lg"
     >
       <div className="flex items-center justify-between">
         <h3 className="text-lg leading-6 font-semibold text-gray-900 dark:text-white">
@@ -306,7 +308,7 @@ export function ImageMetadataModal({
         </div>
       )}
 
-      <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+      <form ref={formRef} onSubmit={handleSubmit} className="mt-4 space-y-4">
         <div className="space-y-4">
           {!isBulkMode && singleImage?.image && (
             <ImageHotspotEditor

--- a/src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.tsx
+++ b/src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.tsx
@@ -109,7 +109,7 @@ export function ImportHistoricSponsorsButton({
             <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
           </TransitionChild>
 
-          <div className="fixed inset-0 flex items-center justify-center p-4">
+          <div className="fixed inset-0 flex items-center justify-center overflow-y-auto p-4">
             <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
@@ -119,14 +119,15 @@ export function ImportHistoricSponsorsButton({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <DialogPanel className="mx-auto w-full max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-gray-800">
+              <DialogPanel className="mx-auto max-h-[90dvh] w-full max-w-md overflow-y-auto rounded-xl bg-white p-6 shadow-xl dark:bg-gray-800">
                 <div className="flex items-start justify-between">
                   <DialogTitle className="text-lg font-semibold text-gray-900 dark:text-white">
                     Import Historic Sponsors
                   </DialogTitle>
                   <button
+                    type="button"
                     onClick={() => setIsOpen(false)}
-                    className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-500 dark:hover:bg-gray-700"
+                    className="flex h-11 w-11 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-500 dark:hover:bg-gray-700"
                   >
                     <XMarkIcon className="h-5 w-5" />
                   </button>

--- a/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
@@ -262,7 +262,7 @@ export function SponsorCRMForm({
                 leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                 leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
               >
-                <DialogPanel className="relative flex max-h-[85vh] w-full max-w-3xl transform flex-col overflow-hidden rounded-2xl border border-brand-frosted-steel bg-brand-glacier-white shadow-2xl transition-all dark:border-gray-700 dark:bg-gray-900">
+                <DialogPanel className="relative flex max-h-[85dvh] w-full max-w-3xl transform flex-col overflow-hidden rounded-2xl border border-brand-frosted-steel bg-brand-glacier-white shadow-2xl transition-all dark:border-gray-700 dark:bg-gray-900">
                   <div className="shrink-0 border-b border-gray-200 p-6 dark:border-gray-700">
                     <div className="flex items-start justify-between">
                       <div className="min-w-0 text-left">
@@ -319,8 +319,9 @@ export function SponsorCRMForm({
                           </span>
                         )}
                         <button
+                          type="button"
                           onClick={handleClose}
-                          className="cursor-pointer rounded-md text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none dark:text-gray-500 dark:hover:text-gray-400"
+                          className="flex h-11 w-11 cursor-pointer items-center justify-center rounded-md text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none dark:text-gray-500 dark:hover:text-gray-400"
                         >
                           <span className="sr-only">Close</span>
                           <XMarkIcon className="h-6 w-6" />
@@ -329,7 +330,7 @@ export function SponsorCRMForm({
                     </div>
                   </div>
 
-                  <div className="flex-1 overflow-y-auto p-6">
+                  <div className="flex-1 overflow-y-auto overscroll-contain p-6">
                     <div className="min-h-100 text-left">
                       {view === 'contacts' && sponsor ? (
                         <SponsorContactEditor

--- a/src/components/admin/sponsor-crm/SponsorDeleteModal.tsx
+++ b/src/components/admin/sponsor-crm/SponsorDeleteModal.tsx
@@ -132,7 +132,18 @@ export function SponsorDeleteModal({
         </div>
       )}
 
-      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:gap-4">
+      {/* Cancel first in DOM; flex-col-reverse stacks the destructive primary
+          on top on mobile, sm:flex-row + justify-end puts Cancel left / primary
+          right on desktop (mirrors SendMessageModal's footer). */}
+      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end sm:gap-4">
+        <Button
+          variant="outline"
+          onClick={onClose}
+          disabled={isLoading}
+          className="font-space-grotesk w-full justify-center rounded-xl border-brand-frosted-steel px-4 py-3 text-sm font-semibold text-brand-slate-gray transition-all duration-200 hover:bg-brand-sky-mist disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          Cancel
+        </Button>
         <Button
           onClick={() =>
             onConfirm({
@@ -143,7 +154,7 @@ export function SponsorDeleteModal({
             })
           }
           disabled={isLoading}
-          className="font-space-grotesk w-full justify-center rounded-xl bg-red-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-red-500 focus-visible:outline-red-600 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:flex-1 dark:bg-red-700 dark:hover:bg-red-600"
+          className="font-space-grotesk w-full justify-center rounded-xl bg-red-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-red-500 focus-visible:outline-red-600 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto dark:bg-red-700 dark:hover:bg-red-600"
         >
           {isLoading ? (
             <div className="flex items-center justify-center gap-2">
@@ -153,14 +164,6 @@ export function SponsorDeleteModal({
           ) : (
             `Delete ${isBulk ? `${count} sponsors` : 'sponsor'}`
           )}
-        </Button>
-        <Button
-          variant="outline"
-          onClick={onClose}
-          disabled={isLoading}
-          className="font-space-grotesk w-full justify-center rounded-xl border-brand-frosted-steel px-4 py-3 text-sm font-semibold text-brand-slate-gray transition-all duration-200 hover:bg-brand-sky-mist disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:flex-1 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-        >
-          Cancel
         </Button>
       </div>
     </ModalShell>

--- a/src/components/admin/sponsor/SponsorAddModal.tsx
+++ b/src/components/admin/sponsor/SponsorAddModal.tsx
@@ -25,6 +25,7 @@ import {
 import { api } from '@/lib/trpc/client'
 import { SponsorLogoEditor } from './SponsorLogoEditor'
 import { ModalShell } from '@/components/ModalShell'
+import { useNotification } from '@/components/admin/NotificationProvider'
 
 interface SponsorAddModalProps {
   isOpen: boolean
@@ -53,6 +54,7 @@ export function SponsorAddModal({
   onSponsorUpdated,
 }: SponsorAddModalProps) {
   const companyNameInputRef = useRef<HTMLInputElement>(null)
+  const { showNotification } = useNotification()
   const [formData, setFormData] = useState<SponsorFormData>({
     name: '',
     website: '',
@@ -281,7 +283,14 @@ export function SponsorAddModal({
       onClose()
     } catch (error) {
       console.error('Error submitting sponsor:', error)
-      alert('Error submitting sponsor. Please try again.')
+      showNotification({
+        type: 'error',
+        title: 'Failed to save sponsor',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred. Please try again.',
+      })
     }
   }
 
@@ -349,15 +358,16 @@ export function SponsorAddModal({
       isOpen={isOpen}
       onClose={onClose}
       size="4xl"
-      className="max-h-screen overflow-y-auto rounded-xl shadow-lg"
+      className="max-h-[90dvh] overflow-y-auto rounded-xl shadow-lg"
     >
       <div className="flex items-center justify-between">
         <h3 className="text-lg leading-6 font-semibold text-gray-900 dark:text-white">
           {editingSponsor ? 'Edit Sponsor' : 'Add Sponsor'}
         </h3>
         <button
+          type="button"
           onClick={onClose}
-          className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-indigo-600 dark:bg-white/10 dark:text-gray-300 dark:hover:text-gray-200 dark:focus:outline-indigo-500"
+          className="flex h-11 w-11 items-center justify-center rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-indigo-600 dark:bg-white/10 dark:text-gray-300 dark:hover:text-gray-200 dark:focus:outline-indigo-500"
         >
           <span className="sr-only">Close</span>
           <XMarkIcon className="h-6 w-6" aria-hidden="true" />
@@ -601,13 +611,15 @@ export function SponsorAddModal({
               !isFormValid() ||
               createMutation.isPending ||
               updateMutation.isPending ||
-              crmCreateMutation.isPending
+              crmCreateMutation.isPending ||
+              crmUpdateMutation.isPending
             }
             className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
           >
             {createMutation.isPending ||
             updateMutation.isPending ||
-            crmCreateMutation.isPending
+            crmCreateMutation.isPending ||
+            crmUpdateMutation.isPending
               ? 'Saving...'
               : editingSponsor
                 ? 'Update Sponsor'

--- a/src/components/admin/workshop/AddParticipantModal.tsx
+++ b/src/components/admin/workshop/AddParticipantModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { DialogTitle } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
@@ -41,19 +41,32 @@ export function AddParticipantModal({
 }: AddParticipantModalProps) {
   const [formData, setFormData] =
     useState<ParticipantFormData>(DEFAULT_PARTICIPANT)
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  // Reset the form each time the modal opens. Because a successful submit is
+  // signalled by the parent closing the modal (isOpen -> false), resetting on
+  // open — rather than synchronously after onSubmit — means a failed parent
+  // mutation keeps the modal open with everything the user typed intact.
+  useEffect(() => {
+    if (isOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Reset form on open
+      setFormData(DEFAULT_PARTICIPANT)
+      setValidationError(null)
+    }
+  }, [isOpen])
 
   const handleClose = () => {
-    setFormData(DEFAULT_PARTICIPANT)
+    setValidationError(null)
     onClose()
   }
 
   const handleSubmit = () => {
     if (!formData.userName || !formData.userEmail) {
-      alert('Please fill in all required fields')
+      setValidationError('Please fill in both name and email.')
       return
     }
+    setValidationError(null)
     onSubmit(formData)
-    setFormData(DEFAULT_PARTICIPANT)
   }
 
   return (
@@ -178,6 +191,12 @@ export function AddParticipantModal({
             />
           </div>
         </div>
+
+        {validationError && (
+          <p className="mt-4 text-sm text-red-600 dark:text-red-400">
+            {validationError}
+          </p>
+        )}
 
         <div className="mt-6 flex justify-end gap-3">
           <AdminButton

--- a/src/components/admin/workshop/EditCapacityModal.tsx
+++ b/src/components/admin/workshop/EditCapacityModal.tsx
@@ -33,8 +33,9 @@ export function EditCapacityModal({
   }, [currentCapacity, isOpen])
 
   const handleSubmit = () => {
+    // The inline error (isInvalid) and the disabled submit button already
+    // surface this; guard silently rather than firing a native alert().
     if (capacity < currentSignups) {
-      alert(`Capacity cannot be less than current signups (${currentSignups})`)
       return
     }
     onSubmit(capacity)

--- a/src/components/admin/workshop/SignupDetailsModal.tsx
+++ b/src/components/admin/workshop/SignupDetailsModal.tsx
@@ -1,10 +1,12 @@
 'use client'
 
+import { useState } from 'react'
 import { formatDateSafe } from '@/lib/time'
 
 import { DialogTitle } from '@headlessui/react'
 import { XMarkIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
+import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import { DataTable, type Column } from '@/components/DataTable'
 import type {
   WorkshopSignupExisting,
@@ -34,6 +36,11 @@ export function SignupDetailsModal({
   isConfirming = false,
   isDeleting = false,
 }: SignupDetailsModalProps) {
+  const [deleteTarget, setDeleteTarget] = useState<{
+    signupId: string
+    userName: string
+  } | null>(null)
+
   const statusLabel = status
     ? status.charAt(0).toUpperCase() + status.slice(1)
     : ''
@@ -82,9 +89,14 @@ export function SignupDetailsModal({
             </button>
           )}
           <button
-            onClick={() => onDeleteSignup(signup._id, signup.userName)}
+            onClick={() =>
+              setDeleteTarget({
+                signupId: signup._id,
+                userName: signup.userName,
+              })
+            }
             disabled={isConfirming || isDeleting}
-            className="text-gray-600 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-red-400"
+            className="flex h-11 w-11 items-center justify-center rounded-md text-gray-600 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:bg-red-900/20 dark:hover:text-red-400"
             title="Delete participant"
           >
             <TrashIcon className="h-4 w-4" />
@@ -133,6 +145,26 @@ export function SignupDetailsModal({
           </div>
         </div>
       </div>
+
+      <ConfirmationModal
+        isOpen={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => {
+          if (deleteTarget) {
+            onDeleteSignup(deleteTarget.signupId, deleteTarget.userName)
+          }
+          setDeleteTarget(null)
+        }}
+        title="Delete signup"
+        message={
+          deleteTarget
+            ? `Are you sure you want to permanently delete ${deleteTarget.userName}'s signup for ${workshopTitle}? This cannot be undone.`
+            : ''
+        }
+        confirmButtonText="Delete"
+        variant="danger"
+        isLoading={isDeleting}
+      />
     </ModalShell>
   )
 }

--- a/src/components/admin/workshop/WorkshopsClientPage.tsx
+++ b/src/components/admin/workshop/WorkshopsClientPage.tsx
@@ -16,7 +16,6 @@ import type {
   ProposalWithWorkshopData,
 } from '@/lib/workshop/types'
 import { useQueryClient } from '@tanstack/react-query'
-import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import { EmptyState } from '@/components/EmptyState'
 
 interface SignupModalState {
@@ -70,11 +69,6 @@ export function WorkshopsClientPage({
       currentCapacity: 0,
       currentSignups: 0,
     })
-  const [deleteSignupInfo, setDeleteSignupInfo] = useState<{
-    signupId: string
-    userName: string
-  } | null>(null)
-
   const { data: signupsData, refetch: refetchSignups } =
     api.workshop.admin.getAllSignups.useQuery(
       {
@@ -180,14 +174,10 @@ export function WorkshopsClientPage({
     )
   }
 
-  const handleDeleteSignup = (signupId: string, userName: string) => {
-    setDeleteSignupInfo({ signupId, userName })
-  }
-
-  const confirmDeleteSignup = () => {
-    if (!deleteSignupInfo) return
-    deleteMutation.mutate({ signupId: deleteSignupInfo.signupId })
-    setDeleteSignupInfo(null)
+  // Confirmation is handled inside SignupDetailsModal (its own ConfirmationModal
+  // gates this destructive action), so this runs only after the admin confirms.
+  const handleDeleteSignup = (signupId: string) => {
+    deleteMutation.mutate({ signupId })
   }
 
   const handleAddParticipant = (participant: ParticipantFormData) => {
@@ -362,16 +352,6 @@ export function WorkshopsClientPage({
         currentSignups={editCapacityModal.currentSignups}
         onSubmit={handleUpdateCapacity}
         isSubmitting={updateCapacityMutation.isPending}
-      />
-
-      <ConfirmationModal
-        isOpen={!!deleteSignupInfo}
-        onClose={() => setDeleteSignupInfo(null)}
-        onConfirm={confirmDeleteSignup}
-        title="Delete Signup"
-        message={`Are you sure you want to permanently delete ${deleteSignupInfo?.userName}&apos;s signup?`}
-        confirmButtonText="Delete"
-        variant="danger"
       />
     </div>
   )


### PR DESCRIPTION
Form-modal fixes from the modal audit (batch C). Each item below is a verified audit finding.

## Fixes

- **C1 — AddParticipantModal**: replaced the native `alert()` with inline validation error text, and stopped resetting the form synchronously after `onSubmit`. The form now resets on open (success is signalled by the parent closing the modal), so a failed parent mutation keeps everything typed. Parent (`WorkshopsClientPage`) unchanged for this path.
- **C2 — ImageMetadataModal**: `⌘S` now submits **this modal's** form via a `ref` instead of `document.querySelector('form')` (which submitted the first form on the page). `max-h-screen` → `max-h-[90dvh]`.
- **C3 — SpeakerManagementModal**: `90vh`/`calc(90vh-200px)` → `dvh` equivalents; added safe-area bottom padding to the footer so it clears iOS toolbars.
- **C4 — EmailModal**: `max-h-[90vh]` → `90dvh` + safe-area footer padding; the From/Template row now stacks (`flex-col sm:flex-row`) so the template dropdown is usable at 393px. Added a `WithTemplateSelector` story.
- **C5 — ProposalActionModal**: the close X is no longer `hidden sm:block` — always visible with a ≥44px hit area.
- **C6 — SignupDetailsModal**: the delete now has a ≥44px hit area and routes through `ConfirmationModal` (naming the participant) inside the component. The parent's duplicate confirmation modal was removed to avoid a double-confirm (this also fixes a pre-existing literal `&apos;` in the old message string).
- **C7 — SponsorAddModal**: added `crmUpdateMutation.isPending` to the double-submit guard; replaced `alert()` with the app's `useNotification` toast; `max-h-screen` → `90dvh`; close X ≥44px.
- **C8 — EditCapacityModal**: dropped the `alert()`; the existing inline error + disabled submit already cover the invalid case.
- **C9 — SponsorCRMForm**: `85vh` → `85dvh`; `overscroll-contain` on the scroll body; close X ≥44px.
- **C10 — ImportHistoricSponsorsButton**: wrapper `overflow-y-auto` + panel `max-h-[90dvh] overflow-y-auto` so Import/Cancel can't fall off-screen; close X ≥44px.
- **C11 — ConfirmationModal & SponsorDeleteModal**: reordered so Cancel is first in the DOM with `flex-col-reverse sm:flex-row sm:justify-end`, mirroring the house `SendMessageModal` footer (desktop: Cancel left / primary right; mobile: primary on top).
- **C12 — SpeakerProfilePreview**: `90vh` → `90dvh`.

## Tests

New component tests (jsdom): C1 reset-on-success + inline error, C2 ref-scoped `⌘S`, C6 confirm flow, C7 guard. Full suite green: **3099 passed, 5 skipped**. `tsc`, `eslint`, `knip`, `prettier` all clean.

## Visual QA

Shot every touched real-component modal at 393px in light + dark (`⌘S` template stacking, visible X, button reorder, delete hit area, dvh caps, off-screen guards) — all render correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Batch C of the modal audit fixes 12 distinct issues across 19 files: replacing `alert()` calls with inline errors and `useNotification` toasts, scoping `⌘S` keyboard submission to the correct form via `ref`, converting `vh` units to `dvh` equivalents, adding safe-area-inset padding to footers for iOS, widening close-button hit areas to ≥44 px, and reordering confirmation-dialog buttons (Cancel first in DOM / destructive primary on top for mobile).

- **C1/C6/C7**: `alert()` removed from three components; `AddParticipantModal` now resets on open rather than after submit (preserves typed data on mutation failure); `SignupDetailsModal` gates the delete through its own inline `ConfirmationModal`, removing the duplicate confirm flow from the parent `WorkshopsClientPage`.
- **C2**: `⌘S` in `ImageMetadataModal` now uses a `formRef` instead of `document.querySelector('form')`, preventing it from submitting an unrelated form earlier in the DOM.
- **C11**: `ConfirmationModal` and `SponsorDeleteModal` footers adopt `flex-col-reverse sm:flex-row sm:justify-end` so Cancel is first in tab order on all screen sizes.

<h3>Confidence Score: 4/5</h3>

Safe to merge. All changes are UI-layer only — no data-model, API, or auth-boundary modifications.

The refactoring is thorough and well-tested across all 12 audit items. The one notable subtlety is that isLoading={isDeleting} on the nested ConfirmationModal in SignupDetailsModal never fires the loading spinner, because setDeleteTarget(null) closes that dialog synchronously before the parent mutation state can propagate back.

src/components/admin/workshop/SignupDetailsModal.tsx — the inline ConfirmationModal's isLoading prop is dead code due to the synchronous close.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/workshop/SignupDetailsModal.tsx | C6 fix: delete now gates through an inline ConfirmationModal; isLoading={isDeleting} prop passed to the inner dialog is effectively dead since setDeleteTarget(null) closes it synchronously before the mutation's loading state can flip. |
| src/components/admin/workshop/AddParticipantModal.tsx | C1 fix: replaces alert() with inline validation error; resets form on open via useEffect instead of after submit. Logic is correct; one minor lint-comment concern. |
| src/components/admin/gallery/ImageMetadataModal.tsx | C2 fix: ⌘S now targets the modal's own form via formRef instead of document.querySelector('form'). Clean, well-tested fix. |
| src/components/admin/workshop/WorkshopsClientPage.tsx | C6 parent cleanup: removes duplicate ConfirmationModal and simplifies handleDeleteSignup to (signupId: string) — userName argument dropped because confirmation message now lives in the child. |
| src/components/admin/ConfirmationModal.tsx | C11 fix: Cancel button moved first in DOM with flex-col-reverse; sm:flex-row + justify-end restores Cancel-left/primary-right on desktop. |
| src/components/admin/sponsor/SponsorAddModal.tsx | C7 fix: crmUpdateMutation.isPending added to double-submit guard; alert() replaced with useNotification toast; close button gets type=button and ≥44px hit area. |
| src/components/admin/sponsor-crm/SponsorDeleteModal.tsx | C11 fix: button order mirrored to match ConfirmationModal change; sm:flex-1 dropped in favour of sm:justify-end. |
| src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.tsx | C10 fix: overflow-y-auto on wrapper + max-h-[90dvh] on panel; close button gains type=button and ≥44px hit area. |
| src/components/admin/EmailModal.tsx | C4 fix: 90vh to 90dvh; From/Template row stacks flex-col sm:flex-row; safe-area footer padding with max() fallback. |
| src/components/admin/ProposalActionModal.tsx | C5 fix: close X loses hidden sm:block, gains flex h-11 w-11 for ≥44px hit area. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant SDM as SignupDetailsModal
    participant CM as ConfirmationModal (inline)
    participant WCP as WorkshopsClientPage

    U->>SDM: click trash icon
    SDM->>SDM: "setDeleteTarget({signupId, userName})"
    SDM->>CM: "isOpen=true"
    U->>CM: click Delete
    CM->>SDM: onConfirm()
    SDM->>WCP: onDeleteSignup(signupId, userName)
    WCP->>WCP: "deleteMutation.mutate({signupId})"
    SDM->>SDM: setDeleteTarget(null)
    SDM->>CM: "isOpen=false (closes immediately)"
    Note over CM: isLoading=isDeleting never becomes true before close
    WCP-->>SDM: "isDeleting=true (too late for CM)"
    SDM->>SDM: trash buttons disabled (isDeleting)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant SDM as SignupDetailsModal
    participant CM as ConfirmationModal (inline)
    participant WCP as WorkshopsClientPage

    U->>SDM: click trash icon
    SDM->>SDM: "setDeleteTarget({signupId, userName})"
    SDM->>CM: "isOpen=true"
    U->>CM: click Delete
    CM->>SDM: onConfirm()
    SDM->>WCP: onDeleteSignup(signupId, userName)
    WCP->>WCP: "deleteMutation.mutate({signupId})"
    SDM->>SDM: setDeleteTarget(null)
    SDM->>CM: "isOpen=false (closes immediately)"
    Note over CM: isLoading=isDeleting never becomes true before close
    WCP-->>SDM: "isDeleting=true (too late for CM)"
    SDM->>SDM: trash buttons disabled (isDeleting)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): form-modal fixes from modal aud..."](https://github.com/cloudnativebergen/website/commit/e69395f2d0a0434bd39b5b587c3e3c6087146bb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45430293)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->