### PR TITLE
fix(ui): converge bare overlays onto ModalShell + story/nit riders (batch B)

### DIFF
--- a/__tests__/components/ModalShell.test.tsx
+++ b/__tests__/components/ModalShell.test.tsx
@@ -27,6 +27,34 @@ describe('ModalShell — standard header', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('applies `ariaLabel` to the panel as the dialog name when `title` is omitted', () => {
+    render(
+      <ModalShell isOpen onClose={vi.fn()} ariaLabel="Receipt: hotel.jpg">
+        <p>viewer body</p>
+      </ModalShell>,
+    )
+    // No standard title header, so the dialog takes its name from aria-label.
+    expect(
+      screen.getByRole('dialog', { name: 'Receipt: hotel.jpg' }),
+    ).toBeInTheDocument()
+  })
+
+  it('ignores `ariaLabel` when `title` is set (title wins via aria-labelledby)', () => {
+    render(
+      <ModalShell
+        isOpen
+        onClose={vi.fn()}
+        title="Real title"
+        ariaLabel="ignored label"
+      >
+        <p>body</p>
+      </ModalShell>,
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAccessibleName('Real title')
+    expect(dialog).not.toHaveAttribute('aria-label')
+  })
+
   it('renders the house header (title, subtitle, icon, close button) and wires aria-labelledby', () => {
     render(
       <ModalShell

--- a/__tests__/components/modal-conversions.a11y.test.tsx
+++ b/__tests__/components/modal-conversions.a11y.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * a11y-basics for the three bare-overlay → ModalShell conversions (batch B):
+ * WidgetPicker (B1), ReceiptViewer (B2) and the WorkshopCard signup modal (B3).
+ * Each previously used a hand-rolled `fixed inset-0` div with no dialog
+ * semantics. These jsdom tests assert the ModalShell essentials: a `role=dialog`
+ * with an accessible name, Escape closing, and focus returning to the trigger.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { useState } from 'react'
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from '@testing-library/react'
+import { WidgetPicker } from '@/components/admin/dashboard/WidgetPicker'
+import { ReceiptViewer } from '@/components/travel-support/ReceiptViewer'
+import WorkshopCard from '@/components/workshop/WorkshopCard'
+import type { ExpenseReceipt } from '@/lib/travel-support/types'
+import type { ProposalWithWorkshopData } from '@/lib/workshop/types'
+
+afterEach(cleanup)
+
+describe('WidgetPicker (B1) — ModalShell a11y', () => {
+  it('exposes a role=dialog named "Add widget"', () => {
+    render(<WidgetPicker onSelect={vi.fn()} onClose={vi.fn()} />)
+    expect(
+      screen.getByRole('dialog', { name: /add widget/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<WidgetPicker onSelect={vi.fn()} onClose={onClose} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns focus to the trigger after closing', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button data-testid="trigger" onClick={() => setOpen(true)}>
+            open
+          </button>
+          {open && (
+            <WidgetPicker onSelect={vi.fn()} onClose={() => setOpen(false)} />
+          )}
+        </>
+      )
+    }
+    render(<Harness />)
+    const trigger = screen.getByTestId('trigger')
+    trigger.focus()
+    fireEvent.click(trigger)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+})
+
+const imageReceipt: ExpenseReceipt = {
+  file: { _type: 'file', asset: { _ref: 'file-1', _type: 'reference' } },
+  filename: 'hotel-receipt.jpg',
+  uploadedAt: '2026-01-15T10:30:00Z',
+  url: 'https://example.com/hotel-receipt.jpg',
+} as unknown as ExpenseReceipt
+
+describe('ReceiptViewer (B2) — ModalShell a11y', () => {
+  it('exposes a role=dialog named from the receipt filename', () => {
+    render(
+      <ReceiptViewer
+        receipt={imageReceipt}
+        receiptIndex={0}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(
+      screen.getByRole('dialog', { name: /receipt: hotel-receipt\.jpg/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(
+      <ReceiptViewer
+        receipt={imageReceipt}
+        receiptIndex={0}
+        onClose={onClose}
+      />,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns focus to the trigger after closing', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button data-testid="trigger" onClick={() => setOpen(true)}>
+            open
+          </button>
+          {open && (
+            <ReceiptViewer
+              receipt={imageReceipt}
+              receiptIndex={0}
+              onClose={() => setOpen(false)}
+            />
+          )}
+        </>
+      )
+    }
+    render(<Harness />)
+    const trigger = screen.getByTestId('trigger')
+    trigger.focus()
+    fireEvent.click(trigger)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+})
+
+const workshop = {
+  _id: 'ws-1',
+  title: 'Getting Started with Kubernetes Operators',
+  format: 'workshop_120',
+  capacity: 30,
+  signups: 12,
+  available: 18,
+  waitlistCount: 0,
+  date: '2026-09-10',
+  startTime: '2026-09-10T09:00:00Z',
+  endTime: '2026-09-10T11:00:00Z',
+  room: 'Room A',
+  description: 'A hands-on introduction to Kubernetes Operators.',
+  speakers: [],
+  topics: [],
+} as unknown as ProposalWithWorkshopData
+
+describe('WorkshopCard signup modal (B3) — ModalShell a11y', () => {
+  const openModal = () => {
+    fireEvent.click(
+      screen.getByRole('button', { name: /register for workshop/i }),
+    )
+  }
+
+  it('the signup modal is a role=dialog named after the workshop', () => {
+    render(
+      <WorkshopCard
+        workshop={workshop}
+        userSignups={[]}
+        onSignup={vi.fn(async () => ({ success: true }))}
+      />,
+    )
+    openModal()
+    expect(
+      screen.getByRole('dialog', { name: new RegExp(workshop.title, 'i') }),
+    ).toBeInTheDocument()
+  })
+
+  it('closes the signup modal on Escape', async () => {
+    render(
+      <WorkshopCard
+        workshop={workshop}
+        userSignups={[]}
+        onSignup={vi.fn(async () => ({ success: true }))}
+      />,
+    )
+    openModal()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('returns focus to the register button after closing', async () => {
+    render(
+      <WorkshopCard
+        workshop={workshop}
+        userSignups={[]}
+        onSignup={vi.fn(async () => ({ success: true }))}
+      />,
+    )
+    const register = screen.getByRole('button', {
+      name: /register for workshop/i,
+    })
+    register.focus()
+    fireEvent.click(register)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(register).toHaveFocus())
+  })
+})

--- a/src/components/ModalShell.tsx
+++ b/src/components/ModalShell.tsx
@@ -32,6 +32,13 @@ interface ModalShellProps {
   title?: React.ReactNode
   /** Optional supporting line under the title (only rendered with `title`). */
   subtitle?: React.ReactNode
+  /**
+   * Accessible name for the dialog when no standard `title` header is used
+   * (e.g. a viewer with a custom toolbar). Applied as `aria-label` on the
+   * DialogPanel so the dialog always has a name. Ignored when `title` is set —
+   * `title` already wires `aria-labelledby` via `DialogTitle`.
+   */
+  ariaLabel?: string
   /** Optional leading icon for the standard header (only rendered with `title`). */
   icon?: React.ReactNode
   /**
@@ -87,6 +94,7 @@ export function ModalShell({
   title,
   subtitle,
   icon,
+  ariaLabel,
   presentation = 'sheet',
   confirmOnDirtyClose = false,
   isDirty = false,
@@ -129,6 +137,7 @@ export function ModalShell({
     <Transition appear show={isOpen}>
       <Dialog
         as="div"
+        aria-label={title ? undefined : ariaLabel}
         className={`relative z-50 ${theme === 'dark' ? 'dark' : ''}`}
         onClose={handleClose}
       >

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -3,14 +3,6 @@
 import { formatDateSafe } from '@/lib/time'
 
 import { useState, useEffect } from 'react'
-import {
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-  Transition,
-  TransitionChild,
-} from '@headlessui/react'
-import { useTheme } from 'next-themes'
 import { api } from '@/lib/trpc/client'
 import { isLocalhostClient } from '@/lib/environment/localhost'
 import type { BadgeType } from '@/lib/badge/types'
@@ -25,7 +17,9 @@ import {
   TrashIcon,
   ClipboardDocumentIcon,
   ArrowDownTrayIcon,
+  IdentificationIcon,
 } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
 import { BadgePreviewModal } from '@/components/admin/BadgePreviewModal'
 import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import BadgeValidator from '@/components/admin/BadgeValidator'
@@ -64,7 +58,6 @@ export function BadgeManagementClient({
   initialBadges,
 }: BadgeManagementClientProps) {
   const { showNotification } = useNotification()
-  const { theme } = useTheme()
   const [activeTab, setActiveTab] = useState<TabView>('issue')
   const [badgeType, setBadgeType] = useState<BadgeType>('speaker')
   const [searchQuery, setSearchQuery] = useState('')
@@ -706,111 +699,70 @@ export function BadgeManagementClient({
           />
 
           {/* Badge Preview Modal */}
-          <Transition appear show={showPreview}>
-            <Dialog
-              as="div"
-              className={`relative z-10 ${theme === 'dark' ? 'dark' : ''}`}
-              onClose={() => setShowPreview(false)}
-            >
-              <TransitionChild
-                enter="ease-out duration-300"
-                enterFrom="opacity-0"
-                enterTo="opacity-100"
-                leave="ease-in duration-200"
-                leaveFrom="opacity-100"
-                leaveTo="opacity-0"
-              >
-                <div className="fixed inset-0 bg-black/50" />
-              </TransitionChild>
+          <ModalShell
+            isOpen={showPreview}
+            onClose={() => setShowPreview(false)}
+            size="2xl"
+            title={`Badge Preview - ${badgeType === 'speaker' ? 'Speaker' : 'Organizer'}`}
+            icon={<IdentificationIcon className="h-5 w-5" />}
+          >
+            <div className="max-h-[calc(85dvh-200px)] overflow-y-auto sm:max-h-[calc(90vh-200px)]">
+              <div className="bg-brand-mist/50 mb-6 rounded-lg p-4 dark:bg-gray-800/50">
+                <p className="text-sm text-brand-slate-gray dark:text-gray-400">
+                  This preview shows how the badge will look. You can use this
+                  to adjust the design in{' '}
+                  <code className="bg-brand-mist rounded px-2 py-1 font-mono text-xs dark:bg-gray-700">
+                    /src/lib/badge/svg.ts
+                  </code>{' '}
+                  before issuing badges.
+                </p>
+              </div>
 
-              <div className="fixed inset-0 overflow-y-auto">
-                <div className="flex min-h-full items-center justify-center p-4">
-                  <TransitionChild
-                    enter="ease-out duration-300"
-                    enterFrom="opacity-0 scale-95"
-                    enterTo="opacity-100 scale-100"
-                    leave="ease-in duration-200"
-                    leaveFrom="opacity-100 scale-100"
-                    leaveTo="opacity-0 scale-95"
-                  >
-                    <DialogPanel className="max-h-[90vh] w-full max-w-2xl transform overflow-hidden rounded-2xl border border-brand-frosted-steel bg-brand-glacier-white p-6 shadow-2xl transition-all dark:border-gray-700 dark:bg-gray-900">
-                      <div className="mb-6 flex items-start justify-between">
-                        <DialogTitle className="font-space-grotesk text-xl font-semibold text-brand-slate-gray dark:text-white">
-                          Badge Preview -{' '}
-                          {badgeType === 'speaker' ? 'Speaker' : 'Organizer'}
-                        </DialogTitle>
-                        <button
-                          type="button"
-                          className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
-                          onClick={() => setShowPreview(false)}
-                          aria-label="Close"
-                        >
-                          <XMarkIcon className="h-6 w-6" />
-                        </button>
-                      </div>
-
-                      <div className="max-h-[calc(90vh-200px)] overflow-y-auto">
-                        <div className="bg-brand-mist/50 mb-6 rounded-lg p-4 dark:bg-gray-800/50">
-                          <p className="text-sm text-brand-slate-gray dark:text-gray-400">
-                            This preview shows how the badge will look. You can
-                            use this to adjust the design in{' '}
-                            <code className="bg-brand-mist rounded px-2 py-1 font-mono text-xs dark:bg-gray-700">
-                              /src/lib/badge/svg.ts
-                            </code>{' '}
-                            before issuing badges.
-                          </p>
-                        </div>
-
-                        <div className="flex justify-center">
-                          <div
-                            className="inline-block rounded-xl border border-brand-frosted-steel bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800"
-                            style={{ width: '100%', maxWidth: '400px' }}
-                          >
-                            <div
-                              style={{
-                                width: '100%',
-                                height: 'auto',
-                                aspectRatio: '1/1',
-                              }}
-                              dangerouslySetInnerHTML={{
-                                __html: previewSvg || '',
-                              }}
-                            />
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="mt-6 flex justify-end gap-3 border-t border-brand-frosted-steel pt-4 dark:border-gray-700">
-                        <button
-                          onClick={() => {
-                            if (!previewSvg) return
-                            const blob = new Blob([previewSvg], {
-                              type: 'image/svg+xml',
-                            })
-                            const url = URL.createObjectURL(blob)
-                            const a = document.createElement('a')
-                            a.href = url
-                            a.download = `badge-preview-${badgeType}.svg`
-                            a.click()
-                            URL.revokeObjectURL(url)
-                          }}
-                          className="bg-brand-mist rounded-lg px-4 py-2 text-sm font-medium text-brand-slate-gray transition-colors hover:bg-brand-frosted-steel dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-                        >
-                          Download Preview
-                        </button>
-                        <button
-                          onClick={() => setShowPreview(false)}
-                          className="bg-brand-aqua dark:hover:bg-brand-aqua rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-cloud-blue dark:bg-brand-cloud-blue"
-                        >
-                          Close
-                        </button>
-                      </div>
-                    </DialogPanel>
-                  </TransitionChild>
+              <div className="flex justify-center">
+                <div
+                  className="inline-block rounded-xl border border-brand-frosted-steel bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+                  style={{ width: '100%', maxWidth: '400px' }}
+                >
+                  <div
+                    style={{
+                      width: '100%',
+                      height: 'auto',
+                      aspectRatio: '1/1',
+                    }}
+                    dangerouslySetInnerHTML={{
+                      __html: previewSvg || '',
+                    }}
+                  />
                 </div>
               </div>
-            </Dialog>
-          </Transition>
+            </div>
+
+            <div className="mt-6 flex justify-end gap-3 border-t border-brand-frosted-steel pt-4 dark:border-gray-700">
+              <button
+                onClick={() => {
+                  if (!previewSvg) return
+                  const blob = new Blob([previewSvg], {
+                    type: 'image/svg+xml',
+                  })
+                  const url = URL.createObjectURL(blob)
+                  const a = document.createElement('a')
+                  a.href = url
+                  a.download = `badge-preview-${badgeType}.svg`
+                  a.click()
+                  URL.revokeObjectURL(url)
+                }}
+                className="bg-brand-mist rounded-lg px-4 py-2 text-sm font-medium text-brand-slate-gray transition-colors hover:bg-brand-frosted-steel dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+              >
+                Download Preview
+              </button>
+              <button
+                onClick={() => setShowPreview(false)}
+                className="bg-brand-aqua dark:hover:bg-brand-aqua rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-cloud-blue dark:bg-brand-cloud-blue"
+              >
+                Close
+              </button>
+            </div>
+          </ModalShell>
 
           {/* Badge Preview Modal */}
           {selectedBadge && (

--- a/src/components/admin/SpeakerMergeModal.tsx
+++ b/src/components/admin/SpeakerMergeModal.tsx
@@ -264,7 +264,7 @@ export function SpeakerMergeModal({
                   <Button
                     variant="primary"
                     onClick={() => setIsConfirmOpen(true)}
-                    className="bg-red-600 hover:bg-red-500 dark:bg-red-700 dark:hover:bg-red-600"
+                    className="!bg-red-600 hover:!bg-red-500 focus-visible:!outline-red-600 dark:!bg-red-700 dark:hover:!bg-red-600"
                   >
                     Merge and delete duplicate
                   </Button>

--- a/src/components/admin/dashboard/WidgetPicker.stories.tsx
+++ b/src/components/admin/dashboard/WidgetPicker.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { WidgetPicker } from './WidgetPicker'
+import { withPortalTheme } from '@/lib/storybook'
+
+// Renders the REAL WidgetPicker (not a mock shell). It was converted from a
+// hand-rolled `fixed inset-0` overlay with no dialog a11y to the shared
+// ModalShell (focus trap, Escape, scroll-lock, backdrop-close), and the
+// category chip row now wraps instead of overflowing at phone width.
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/WidgetPicker',
+  component: WidgetPicker,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Admin dashboard widget picker: search + category filters over the widget registry, grouped by category. Converted onto ModalShell for full dialog a11y; the category chip row wraps at narrow widths. Also inspect at 393px (mobile bottom-sheet) and in dark mode via the toolbar.',
+      },
+    },
+  },
+  args: {
+    onSelect: fn(),
+    onClose: fn(),
+  },
+  decorators: [withPortalTheme],
+  tags: ['autodocs'],
+} satisfies Meta<typeof WidgetPicker>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** The picker with all widgets shown; the "Add widget" ModalShell header. */
+export const Default: Story = {}
+
+/**
+ * Phone width — ModalShell presents the picker as a bottom sheet and the
+ * category chip row wraps onto multiple lines instead of overflowing.
+ */
+export const Mobile: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+}

--- a/src/components/admin/dashboard/WidgetPicker.tsx
+++ b/src/components/admin/dashboard/WidgetPicker.tsx
@@ -3,8 +3,12 @@
 import { useState, useMemo } from 'react'
 import { WIDGET_REGISTRY } from '@/lib/dashboard/widget-registry'
 import type { WidgetMetadata } from '@/lib/dashboard/widget-metadata'
-import { XMarkIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import {
+  MagnifyingGlassIcon,
+  Squares2X2Icon,
+} from '@heroicons/react/24/outline'
 import * as HeroIcons from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
 
 interface WidgetPickerProps {
   onSelect: (widgetType: string) => void
@@ -106,29 +110,18 @@ export function WidgetPicker({ onSelect, onClose }: WidgetPickerProps) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="animate-in fade-in zoom-in-95 w-full max-w-4xl rounded-xl bg-white shadow-2xl duration-200 dark:bg-gray-800">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-gray-200 bg-linear-to-r from-gray-50 to-white px-6 py-5 dark:border-gray-700 dark:from-gray-800 dark:to-gray-800">
-          <div>
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-              ✨ Add a Widget
-            </h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-              Choose from {widgets.length} powerful widgets to customize your
-              dashboard
-            </p>
-          </div>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
-        </div>
-
+    <ModalShell
+      isOpen
+      onClose={onClose}
+      size="4xl"
+      padded={false}
+      title="Add widget"
+      subtitle={`Choose from ${widgets.length} widgets to customize your dashboard`}
+      icon={<Squares2X2Icon className="h-5 w-5" />}
+    >
+      <div className="flex min-h-0 flex-col">
         {/* Search and Filters */}
-        <div className="border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+        <div className="shrink-0 border-b border-gray-200 px-6 py-4 dark:border-gray-700">
           <div className="mb-3 flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-gray-900">
             <MagnifyingGlassIcon className="h-4 w-4 text-gray-400" />
             <input
@@ -140,7 +133,7 @@ export function WidgetPicker({ onSelect, onClose }: WidgetPickerProps) {
             />
           </div>
 
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <button
               onClick={() => setSelectedCategory(null)}
               className={`rounded-lg px-3 py-1 text-xs font-medium transition-colors ${
@@ -173,7 +166,7 @@ export function WidgetPicker({ onSelect, onClose }: WidgetPickerProps) {
         </div>
 
         {/* Widget Grid */}
-        <div className="max-h-[60vh] overflow-y-auto px-6 py-5">
+        <div className="max-h-[60vh] min-h-0 overflow-y-auto px-6 py-5">
           {CATEGORY_ORDER.map((category) => {
             const categoryWidgets = groupedWidgets[category]
             if (!categoryWidgets || categoryWidgets.length === 0) return null
@@ -244,6 +237,6 @@ export function WidgetPicker({ onSelect, onClose }: WidgetPickerProps) {
           )}
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/src/components/admin/gallery/ImageMetadataModal.stories.tsx
+++ b/src/components/admin/gallery/ImageMetadataModal.stories.tsx
@@ -1,226 +1,124 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { XMarkIcon, ChevronUpDownIcon } from '@heroicons/react/24/outline'
+import { fn } from 'storybook/test'
+import { http, HttpResponse } from 'msw'
+import { ImageMetadataModal } from './ImageMetadataModal'
+import { NotificationProvider } from '../NotificationProvider'
+import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
+import { withPortalTheme } from '@/lib/storybook'
+
+// Renders the REAL ImageMetadataModal (not the previous static mock shell that
+// shipped two prod bugs). It sits on the shared ModalShell (C-batch: <sm
+// bottom-sheet with 85dvh + safe-area padding, ref-scoped ⌘S submit). The
+// speaker search (`speaker.admin.search`) and save (`gallery.admin.update`) are
+// served by the msw handlers below; the global TRPCDecorator provides the
+// client.
+
+const speakerResults = [
+  {
+    _id: 'sp-1',
+    name: 'Jane Doe',
+    slug: 'jane-doe',
+    title: 'Staff Engineer',
+    image: null,
+    isOrganizer: false,
+  },
+  {
+    _id: 'sp-2',
+    name: 'John Smith',
+    slug: 'john-smith',
+    title: 'SRE Lead',
+    image: null,
+    isOrganizer: true,
+  },
+]
+
+// The global TRPCDecorator uses a non-batching httpLink, so each procedure is
+// its own request answered with a single `{ result: { data } }` object.
+const handlers = [
+  http.get('/api/trpc/speaker.admin.search', () =>
+    HttpResponse.json({ result: { data: speakerResults } }),
+  ),
+  http.post('/api/trpc/gallery.admin.update', () =>
+    HttpResponse.json({ result: { data: { _id: 'img-1' } } }),
+  ),
+]
+
+const singleImage: GalleryImageWithSpeakers = {
+  _id: 'img-1',
+  _rev: 'rev-1',
+  _createdAt: '2026-06-12T14:30:00Z',
+  _updatedAt: '2026-06-12T14:30:00Z',
+  photographer: 'Olav Nordmann',
+  date: '2026-06-12T14:30:00Z',
+  location: 'Grieghallen, Bergen',
+  featured: false,
+  image: {
+    _type: 'image',
+    asset: {
+      _ref: 'image-Tb9Ew8CXIwaY6R1kjMvI0uRR-2000x3000-jpg',
+      _type: 'reference',
+    },
+    alt: 'Keynote presentation at Cloud Native Days',
+  },
+  imageAlt: 'Keynote presentation at Cloud Native Days',
+  speakers: [{ _id: 'sp-1', name: 'Jane Doe', slug: 'jane-doe' }],
+}
+
+const bulkImages: GalleryImageWithSpeakers[] = [
+  singleImage,
+  { ...singleImage, _id: 'img-2' },
+  { ...singleImage, _id: 'img-3' },
+  { ...singleImage, _id: 'img-4' },
+  { ...singleImage, _id: 'img-5' },
+]
 
 const meta = {
   title: 'Systems/Proposals/Admin/Gallery/ImageMetadataModal',
+  component: ImageMetadataModal,
   parameters: {
-    layout: 'centered',
-    options: { showPanel: false },
+    layout: 'fullscreen',
+    msw: { handlers },
     docs: {
       description: {
         component:
-          'Modal for editing image metadata including photographer, date, time, location, alt text, speaker tags, hotspot/crop editing, and featured toggle. Supports both single-image and bulk-edit modes. Uses `api.speaker.admin.search` for speaker search and `api.gallery.admin.update` for saving. Includes speaker notification checkbox and ⌘S keyboard shortcut.',
+          'Modal for editing gallery image metadata (photographer, date/time, location, alt text, speaker tags, hotspot/crop, featured) in single or bulk mode. Uses `speaker.admin.search` and `gallery.admin.update`; ⌘S submits. Built on the shared ModalShell (mobile bottom-sheet). Inspect at 393px and in dark mode.',
       },
     },
   },
-} satisfies Meta
+  args: {
+    isOpen: true,
+    onClose: fn(),
+    onUpdate: fn(),
+  },
+  decorators: [
+    withPortalTheme,
+    (Story) => (
+      <NotificationProvider>
+        <Story />
+      </NotificationProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof ImageMetadataModal>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-const taggedSpeakers = [
-  { _id: 'sp-1', name: 'Jane Doe', slug: 'jane-doe' },
-  { _id: 'sp-2', name: 'John Smith', slug: 'john-smith' },
-]
-
-function MockImageMetadataModal({ mode }: { mode: 'single' | 'bulk' }) {
-  return (
-    <div className="w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl dark:bg-gray-800">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-          {mode === 'bulk' ? 'Bulk Update 5 Images' : 'Edit Image Metadata'}
-        </h3>
-        <button className="rounded-md text-gray-400 hover:text-gray-500 dark:text-gray-300">
-          <XMarkIcon className="h-6 w-6" />
-        </button>
-      </div>
-
-      <div className="mt-4 space-y-4">
-        {/* Image hotspot preview (single mode only) */}
-        {mode === 'single' && (
-          <div className="relative overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-700">
-            <div className="flex h-48 items-center justify-center text-gray-400">
-              Image with hotspot editor
-            </div>
-          </div>
-        )}
-
-        {/* Form fields */}
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div>
-            <label className="block text-sm font-medium text-gray-900 dark:text-white">
-              Photographer{mode === 'bulk' ? ' (optional)' : ''}
-            </label>
-            <input
-              type="text"
-              defaultValue={mode === 'single' ? 'Olav Nordmann' : ''}
-              placeholder={
-                mode === 'bulk' ? 'Leave empty to keep existing' : ''
-              }
-              className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-              readOnly
-            />
-          </div>
-
-          {mode === 'single' && (
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-900 dark:text-white">
-                  Date
-                </label>
-                <input
-                  type="date"
-                  defaultValue="2025-06-12"
-                  className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                  readOnly
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-900 dark:text-white">
-                  Time
-                </label>
-                <input
-                  type="time"
-                  defaultValue="14:30"
-                  className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                  readOnly
-                />
-              </div>
-            </div>
-          )}
-
-          <div>
-            <label className="block text-sm font-medium text-gray-900 dark:text-white">
-              Location{mode === 'bulk' ? ' (optional)' : ''}
-            </label>
-            <input
-              type="text"
-              defaultValue={mode === 'single' ? 'Grieghallen, Bergen' : ''}
-              placeholder={
-                mode === 'bulk' ? 'Leave empty to keep existing' : ''
-              }
-              className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-              readOnly
-            />
-          </div>
-
-          {mode === 'single' && (
-            <div>
-              <label className="block text-sm font-medium text-gray-900 dark:text-white">
-                Alt Text
-              </label>
-              <input
-                type="text"
-                defaultValue="Keynote presentation at Cloud Native Days"
-                placeholder="Description for accessibility"
-                className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                readOnly
-              />
-            </div>
-          )}
-        </div>
-
-        {/* Speaker search */}
-        <div>
-          <label className="block text-sm font-medium text-gray-900 dark:text-white">
-            {mode === 'bulk' ? 'Add Speakers' : 'Tag Speakers'}
-          </label>
-          <div className="relative mt-2">
-            <input
-              type="text"
-              placeholder="Search for speakers..."
-              className="w-full rounded-md border border-gray-300 py-1.5 pr-10 pl-3 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-              readOnly
-            />
-            <div className="absolute inset-y-0 right-0 flex items-center pr-2">
-              <ChevronUpDownIcon className="h-5 w-5 text-gray-400" />
-            </div>
-          </div>
-
-          {/* Tagged speakers */}
-          <div className="mt-3 flex flex-wrap gap-2">
-            {taggedSpeakers.map((speaker) => (
-              <span
-                key={speaker._id}
-                className="inline-flex items-center gap-x-2 rounded-full bg-indigo-100 py-1 pr-2 pl-1 text-xs font-medium text-indigo-700 dark:bg-indigo-500/10 dark:text-indigo-400"
-              >
-                <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-200 dark:bg-indigo-500/20">
-                  <span className="text-[10px] font-medium">
-                    {speaker.name.charAt(0)}
-                  </span>
-                </div>
-                <span>{speaker.name}</span>
-                <button className="inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-indigo-200">
-                  <XMarkIcon className="h-3 w-3" />
-                </button>
-              </span>
-            ))}
-          </div>
-
-          {/* Notify checkbox */}
-          <div className="mt-3">
-            <label className="flex cursor-pointer items-center">
-              <input
-                type="checkbox"
-                defaultChecked
-                className="h-4 w-4 rounded border-gray-300 text-indigo-600"
-              />
-              <span className="ml-2 text-sm text-gray-700 dark:text-gray-300">
-                Send email notification to{' '}
-                {mode === 'bulk' ? 'tagged' : 'newly tagged'} speakers
-              </span>
-            </label>
-          </div>
-        </div>
-
-        {/* Featured toggle (single mode only) */}
-        {mode === 'single' && (
-          <label className="flex cursor-pointer items-center">
-            <input
-              type="checkbox"
-              className="h-4 w-4 rounded border-gray-300 text-indigo-600"
-            />
-            <span className="ml-2 text-sm text-gray-700 dark:text-gray-300">
-              Featured image
-            </span>
-          </label>
-        )}
-      </div>
-
-      {/* Footer */}
-      <div className="flex justify-end gap-3 pt-6">
-        <button className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300">
-          Cancel
-        </button>
-        <button className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500">
-          {mode === 'bulk' ? 'Update Images' : 'Save Changes'}
-        </button>
-      </div>
-    </div>
-  )
-}
-
+/** Single-image edit: hotspot editor, date/time, alt text, featured toggle. */
 export const SingleImage: Story = {
-  render: () => <MockImageMetadataModal mode="single" />,
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Single image editing mode with all fields including hotspot editor, date/time, alt text, and featured toggle.',
-      },
-    },
-  },
+  args: { image: singleImage },
 }
 
+/**
+ * Bulk edit across 5 images — only photographer, location and added speakers
+ * apply. No hotspot editor.
+ */
 export const BulkEdit: Story = {
-  render: () => <MockImageMetadataModal mode="bulk" />,
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Bulk edit mode for multiple images. Only photographer, location, and speaker tags are available. Fields are optional — empty values preserve existing data.',
-      },
-    },
-  },
+  args: { images: bulkImages },
+}
+
+/** Bulk edit at phone width — ModalShell presents it as a bottom sheet. */
+export const Mobile: Story = {
+  args: { images: bulkImages },
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
 }

--- a/src/components/admin/sponsor/SponsorAddModal.stories.tsx
+++ b/src/components/admin/sponsor/SponsorAddModal.stories.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from 'msw'
 import { SponsorAddModal } from './SponsorAddModal'
 import type { SponsorTierExisting } from '@/lib/sponsor/types'
 import { withPortalTheme } from '@/lib/storybook'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
 
 // Renders the REAL SponsorAddModal (not the previous static mock shell that
 // duplicated the markup and drifted from production). It sits on the shared
@@ -95,7 +96,16 @@ const meta = {
     onSponsorAdded: fn(),
     onSponsorUpdated: fn(),
   },
-  decorators: [withPortalTheme],
+  decorators: [
+    withPortalTheme,
+    // The real component surfaces submit errors via useNotification (batch C),
+    // so the story must provide the NotificationProvider context.
+    (Story) => (
+      <NotificationProvider>
+        <Story />
+      </NotificationProvider>
+    ),
+  ],
   tags: ['autodocs'],
 } satisfies Meta<typeof SponsorAddModal>
 

--- a/src/components/admin/sponsor/SponsorAddModal.stories.tsx
+++ b/src/components/admin/sponsor/SponsorAddModal.stories.tsx
@@ -1,216 +1,116 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { http, HttpResponse } from 'msw'
 import { SponsorAddModal } from './SponsorAddModal'
-import { XMarkIcon, PhotoIcon, PlusIcon } from '@heroicons/react/24/outline'
-import { useState } from 'react'
+import type { SponsorTierExisting } from '@/lib/sponsor/types'
+import { withPortalTheme } from '@/lib/storybook'
+
+// Renders the REAL SponsorAddModal (not the previous static mock shell that
+// duplicated the markup and drifted from production). It sits on the shared
+// ModalShell. The existing-sponsor combobox reads `sponsor.list`; create/update
+// flows use `sponsor.create|update` and `sponsor.crm.create|update`. The global
+// TRPCDecorator provides the client; msw serves the sponsor list below.
+
+const existingSponsors = [
+  {
+    _id: 'sponsor-1',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    name: 'TechGiant Corp',
+    website: 'https://techgiant.example',
+    logo: null,
+    logoBright: null,
+  },
+  {
+    _id: 'sponsor-2',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    name: 'CloudPro Inc',
+    website: 'https://cloudpro.example',
+    logo: null,
+    logoBright: null,
+  },
+]
+
+const handlers = [
+  http.get('/api/trpc/sponsor.list', () =>
+    HttpResponse.json({ result: { data: existingSponsors } }),
+  ),
+]
+
+const tiers: SponsorTierExisting[] = [
+  {
+    _id: 'tier-1',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    title: 'Platinum',
+    tagline: 'Top-level partnership',
+    tierType: 'standard',
+    price: [{ _key: 'p1', amount: 100000, currency: 'NOK' }],
+    soldOut: false,
+    mostPopular: true,
+  },
+  {
+    _id: 'tier-2',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    title: 'Gold',
+    tagline: 'Premium partnership',
+    tierType: 'standard',
+    price: [{ _key: 'p2', amount: 50000, currency: 'NOK' }],
+    soldOut: false,
+    mostPopular: false,
+  },
+  {
+    _id: 'tier-3',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    title: 'Silver',
+    tagline: 'Supporting partnership',
+    tierType: 'standard',
+    price: [{ _key: 'p3', amount: 25000, currency: 'NOK' }],
+    soldOut: false,
+    mostPopular: false,
+  },
+]
 
 const meta = {
   title: 'Systems/Sponsors/Admin/Pipeline/SponsorAddModal',
   component: SponsorAddModal,
-  tags: ['autodocs'],
   parameters: {
-    layout: 'centered',
-    options: { showPanel: false },
+    layout: 'fullscreen',
+    msw: { handlers },
     docs: {
       description: {
         component:
-          'Modal dialog for adding a sponsor to a conference. Supports two modes: selecting an existing sponsor from the database or creating a new sponsor inline with logo upload. Tier selection with pricing display and form validation.',
+          'Modal for adding a sponsor to a conference: pick a tier, then select an existing sponsor from the database or create a new one inline (name, website, org number, logo). Built on the shared ModalShell. Inspect at 393px and in dark mode.',
       },
     },
   },
-} as Meta
+  args: {
+    isOpen: true,
+    conferenceId: 'conf-1',
+    sponsorTiers: tiers,
+    onClose: fn(),
+    onSponsorAdded: fn(),
+    onSponsorUpdated: fn(),
+  },
+  decorators: [withPortalTheme],
+  tags: ['autodocs'],
+} satisfies Meta<typeof SponsorAddModal>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-const mockTiers = [
-  { _id: 'tier-1', title: 'Platinum', value: 100000 },
-  { _id: 'tier-2', title: 'Gold', value: 50000 },
-  { _id: 'tier-3', title: 'Silver', value: 25000 },
-  { _id: 'tier-4', title: 'Bronze', value: 10000 },
-]
+/** Default add flow: tier select + existing-sponsor combobox. */
+export const Default: Story = {}
 
-const mockExistingSponsors = [
-  { _id: 'sponsor-1', name: 'TechGiant Corp' },
-  { _id: 'sponsor-2', name: 'CloudPro Inc' },
-  { _id: 'sponsor-3', name: 'DataSys' },
-]
-
-function formatCurrency(value: number) {
-  return new Intl.NumberFormat('nb-NO', {
-    style: 'currency',
-    currency: 'NOK',
-    maximumFractionDigits: 0,
-  }).format(value)
-}
-
-function AddSponsorModal({ preselectedTier }: { preselectedTier?: string }) {
-  const [mode, setMode] = useState<'select' | 'create'>('select')
-  const [selectedTier, setSelectedTier] = useState(preselectedTier || '')
-  const [selectedSponsor, setSelectedSponsor] = useState('')
-  const [newSponsorName, setNewSponsorName] = useState('')
-  const [newSponsorWebsite, setNewSponsorWebsite] = useState('')
-
-  return (
-    <div className="w-full max-w-lg rounded-xl bg-white shadow-xl dark:bg-gray-800">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4 dark:border-gray-700">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-          Add Sponsor to Conference
-        </h2>
-        <button className="rounded-full p-1 hover:bg-gray-100 dark:hover:bg-gray-700">
-          <XMarkIcon className="h-5 w-5 text-gray-500" />
-        </button>
-      </div>
-
-      <div className="space-y-6 p-6">
-        {/* Mode toggle */}
-        <div className="flex rounded-lg bg-gray-100 p-1 dark:bg-gray-700">
-          <button
-            onClick={() => setMode('select')}
-            className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-              mode === 'select'
-                ? 'bg-white text-gray-900 shadow dark:bg-gray-600 dark:text-white'
-                : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
-            }`}
-          >
-            Select Existing
-          </button>
-          <button
-            onClick={() => setMode('create')}
-            className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-              mode === 'create'
-                ? 'bg-white text-gray-900 shadow dark:bg-gray-600 dark:text-white'
-                : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
-            }`}
-          >
-            Create New
-          </button>
-        </div>
-
-        {/* Tier selection */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-            Sponsor Tier
-          </label>
-          <select
-            value={selectedTier}
-            onChange={(e) => setSelectedTier(e.target.value)}
-            className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          >
-            <option value="">Select a tier...</option>
-            {mockTiers.map((tier) => (
-              <option key={tier._id} value={tier._id}>
-                {tier.title} ({formatCurrency(tier.value)})
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {mode === 'select' ? (
-          /* Select existing sponsor */
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-              Select Sponsor
-            </label>
-            <select
-              value={selectedSponsor}
-              onChange={(e) => setSelectedSponsor(e.target.value)}
-              className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-            >
-              <option value="">Select a sponsor...</option>
-              {mockExistingSponsors.map((sponsor) => (
-                <option key={sponsor._id} value={sponsor._id}>
-                  {sponsor.name}
-                </option>
-              ))}
-            </select>
-            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-              Sponsors already added to this conference are not shown
-            </p>
-          </div>
-        ) : (
-          /* Create new sponsor form */
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Sponsor Name
-              </label>
-              <input
-                type="text"
-                value={newSponsorName}
-                onChange={(e) => setNewSponsorName(e.target.value)}
-                placeholder="e.g. Acme Corporation"
-                className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 placeholder:text-gray-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Website
-              </label>
-              <input
-                type="url"
-                value={newSponsorWebsite}
-                onChange={(e) => setNewSponsorWebsite(e.target.value)}
-                placeholder="https://example.com"
-                className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 placeholder:text-gray-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Logo
-              </label>
-              <div className="mt-1 flex items-center justify-center rounded-lg border-2 border-dashed border-gray-300 px-6 py-8 dark:border-gray-600">
-                <div className="text-center">
-                  <PhotoIcon className="mx-auto h-10 w-10 text-gray-400" />
-                  <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                    Drop logo here or click to upload
-                  </p>
-                  <p className="mt-1 text-xs text-gray-500">
-                    SVG or PNG recommended
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Footer */}
-      <div className="flex justify-end gap-3 border-t border-gray-200 px-6 py-4 dark:border-gray-700">
-        <button className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700">
-          Cancel
-        </button>
-        <button
-          disabled={
-            !selectedTier ||
-            (mode === 'select' ? !selectedSponsor : !newSponsorName)
-          }
-          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <span className="flex items-center gap-1.5">
-            <PlusIcon className="h-4 w-4" />
-            {mode === 'select' ? 'Add Sponsor' : 'Create & Add'}
-          </span>
-        </button>
-      </div>
-    </div>
-  )
-}
-
-export const Default: Story = {
-  render: () => (
-    <div className="p-6">
-      <AddSponsorModal />
-    </div>
-  ),
-}
-
+/** A tier is preselected (e.g. opened from a specific tier row). */
 export const WithPreselectedTier: Story = {
-  render: () => (
-    <div className="p-6">
-      <AddSponsorModal preselectedTier="tier-2" />
-    </div>
-  ),
+  args: { preselectedTierId: 'tier-2' },
+}
+
+/** Phone width — ModalShell presents the form as a bottom sheet. */
+export const Mobile: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
 }

--- a/src/components/admin/sponsor/SponsorTierEditor.tsx
+++ b/src/components/admin/sponsor/SponsorTierEditor.tsx
@@ -1,22 +1,15 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
-import {
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-  Transition,
-  TransitionChild,
-} from '@headlessui/react'
 import { useTheme } from 'next-themes'
 import {
   PlusIcon,
   PencilIcon,
   TrashIcon,
-  XMarkIcon,
   TagIcon,
   ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
 import { StarIcon } from '@heroicons/react/20/solid'
 import { CheckIcon } from '@heroicons/react/16/solid'
 import { Dropdown } from '@/components/Form'
@@ -51,7 +44,6 @@ function SponsorTierModal({
   onSave,
   onDelete,
 }: SponsorTierModalProps) {
-  const { theme } = useTheme()
   const { showNotification } = useNotification()
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [formData, setFormData] = useState<SponsorTierInput>({
@@ -300,411 +292,356 @@ function SponsorTierModal({
 
   return (
     <>
-      <Transition appear show={isOpen}>
-        <Dialog
-          as="div"
-          className={`relative z-10 ${theme === 'dark' ? 'dark' : ''}`}
-          onClose={onClose}
-        >
-          <TransitionChild
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-black/50" />
-          </TransitionChild>
-
-          <div className="fixed inset-0 overflow-y-auto">
-            <div className="flex min-h-full items-center justify-center p-4 text-center">
-              <TransitionChild
-                enter="ease-out duration-300"
-                enterFrom="opacity-0 scale-95"
-                enterTo="opacity-100 scale-100"
-                leave="ease-in duration-200"
-                leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
+      <ModalShell
+        isOpen={isOpen}
+        onClose={onClose}
+        size="4xl"
+        title={tier ? 'Edit Sponsor Tier' : 'Create Sponsor Tier'}
+        icon={<TagIcon className="h-5 w-5" />}
+      >
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+            <div>
+              <label
+                htmlFor="title"
+                className="block text-sm/6 font-medium text-gray-900 dark:text-white"
               >
-                <DialogPanel className="w-full max-w-4xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-gray-900">
-                  <div className="flex items-center justify-between">
-                    <DialogTitle
-                      as="h3"
-                      className="text-lg leading-6 font-medium text-gray-900 dark:text-white"
-                    >
-                      {tier ? 'Edit Sponsor Tier' : 'Create Sponsor Tier'}
-                    </DialogTitle>
-                    <button
-                      onClick={onClose}
-                      disabled={isLoading}
-                      className="cursor-pointer rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-indigo-600 disabled:opacity-50 dark:bg-white/10 dark:text-gray-300 dark:hover:text-gray-200 dark:focus:outline-indigo-500"
-                    >
-                      <span className="sr-only">Close</span>
-                      <XMarkIcon className="h-6 w-6" />
-                    </button>
-                  </div>
+                Title *
+              </label>
+              <div className="mt-2">
+                <input
+                  type="text"
+                  id="title"
+                  value={formData.title}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      title: e.target.value,
+                    }))
+                  }
+                  required
+                  disabled={isLoading}
+                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
+                  placeholder="e.g., Gold, Silver, Bronze"
+                />
+              </div>
+            </div>
 
-                  <form onSubmit={handleSubmit} className="mt-4 space-y-4">
-                    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-                      <div>
-                        <label
-                          htmlFor="title"
-                          className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                        >
-                          Title *
-                        </label>
-                        <div className="mt-2">
-                          <input
-                            type="text"
-                            id="title"
-                            value={formData.title}
-                            onChange={(e) =>
-                              setFormData((prev) => ({
-                                ...prev,
-                                title: e.target.value,
-                              }))
-                            }
-                            required
-                            disabled={isLoading}
-                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
-                            placeholder="e.g., Gold, Silver, Bronze"
-                          />
-                        </div>
-                      </div>
-
-                      <div>
-                        <label
-                          htmlFor="tagline"
-                          className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                        >
-                          Tagline *
-                        </label>
-                        <div className="mt-2">
-                          <input
-                            type="text"
-                            id="tagline"
-                            value={formData.tagline}
-                            onChange={(e) =>
-                              setFormData((prev) => ({
-                                ...prev,
-                                tagline: e.target.value,
-                              }))
-                            }
-                            required
-                            disabled={isLoading}
-                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
-                            placeholder="e.g., Premium partnership opportunity"
-                          />
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-                      <div>
-                        <Dropdown
-                          name="tierType"
-                          label="Tier Type"
-                          options={
-                            new Map([
-                              ['standard', 'Standard'],
-                              ['special', 'Special'],
-                              ['addon', 'Add-on'],
-                            ])
-                          }
-                          value={formData.tierType}
-                          setValue={(val) =>
-                            setFormData((prev) => ({
-                              ...prev,
-                              tierType: val as 'standard' | 'special' | 'addon',
-                            }))
-                          }
-                          disabled={isLoading}
-                        />
-                      </div>
-
-                      <div>
-                        <label
-                          htmlFor="max_quantity"
-                          className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                        >
-                          Capacity
-                        </label>
-                        <div className="mt-2">
-                          <input
-                            type="number"
-                            id="max_quantity"
-                            value={formData.maxQuantity ?? ''}
-                            onChange={(e) =>
-                              setFormData((prev) => ({
-                                ...prev,
-                                maxQuantity: e.target.value
-                                  ? parseInt(e.target.value)
-                                  : undefined,
-                              }))
-                            }
-                            min="1"
-                            disabled={isLoading}
-                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
-                            placeholder="Unlimited"
-                          />
-                        </div>
-                      </div>
-
-                      <div className="flex items-end">
-                        <div className="flex gap-3">
-                          <div className="flex h-6 shrink-0 items-center">
-                            <div className="group grid size-4 grid-cols-1">
-                              <input
-                                id="sold_out"
-                                type="checkbox"
-                                checked={formData.soldOut}
-                                onChange={(e) =>
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    soldOut: e.target.checked,
-                                  }))
-                                }
-                                disabled={isLoading}
-                                className="col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:indeterminate:border-indigo-500 dark:indeterminate:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/5 dark:disabled:bg-white/10 dark:disabled:checked:bg-white/10 forced-colors:appearance-auto"
-                              />
-                              <svg
-                                fill="none"
-                                viewBox="0 0 14 14"
-                                className="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25 dark:group-has-disabled:stroke-white/25"
-                              >
-                                <path
-                                  d="M3 8L6 11L11 3.5"
-                                  strokeWidth={2}
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  className="opacity-0 group-has-checked:opacity-100"
-                                />
-                              </svg>
-                            </div>
-                          </div>
-                          <div className="text-sm/6">
-                            <label
-                              htmlFor="sold_out"
-                              className="font-medium whitespace-nowrap text-gray-900 dark:text-white"
-                            >
-                              Sold Out
-                            </label>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="flex items-end">
-                        <div className="flex gap-3">
-                          <div className="flex h-6 shrink-0 items-center">
-                            <div className="group grid size-4 grid-cols-1">
-                              <input
-                                id="most_popular"
-                                type="checkbox"
-                                checked={formData.mostPopular}
-                                onChange={(e) =>
-                                  setFormData((prev) => ({
-                                    ...prev,
-                                    mostPopular: e.target.checked,
-                                  }))
-                                }
-                                disabled={isLoading}
-                                className="col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:indeterminate:border-indigo-500 dark:indeterminate:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/5 dark:disabled:bg-white/10 dark:disabled:checked:bg-white/10 forced-colors:appearance-auto"
-                              />
-                              <CheckIcon className="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white opacity-0 group-has-checked:opacity-100 group-has-disabled:stroke-gray-950/25 dark:group-has-disabled:stroke-white/25" />
-                            </div>
-                          </div>
-                          <div className="text-sm/6">
-                            <label
-                              htmlFor="most_popular"
-                              className="font-medium whitespace-nowrap text-gray-900 dark:text-white"
-                            >
-                              Most Popular
-                              <StarIcon className="ml-1 inline h-4 w-4 text-yellow-400" />
-                            </label>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div>
-                      <div className="flex items-center justify-between">
-                        <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
-                          Pricing
-                        </label>
-                        <button
-                          type="button"
-                          onClick={addPrice}
-                          disabled={isLoading}
-                          className="inline-flex cursor-pointer items-center rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 dark:bg-indigo-500 dark:shadow-none dark:focus-visible:outline-indigo-500"
-                        >
-                          <PlusIcon className="mr-1.5 h-3 w-3" />
-                          Add Price
-                        </button>
-                      </div>
-                      <div className="mt-2 space-y-2">
-                        {formData.price?.map((price, index) => (
-                          <div
-                            key={index}
-                            className="flex items-center space-x-3"
-                          >
-                            <div className="w-40">
-                              <input
-                                type="number"
-                                value={price.amount}
-                                onChange={(e) =>
-                                  updatePrice(
-                                    index,
-                                    'amount',
-                                    parseFloat(e.target.value) || 0,
-                                  )
-                                }
-                                min="0"
-                                step="0.01"
-                                disabled={isLoading}
-                                className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
-                                placeholder="Amount"
-                              />
-                            </div>
-                            <div className="w-24">
-                              <CurrencySelect
-                                value={price.currency}
-                                setValue={(val) =>
-                                  updatePrice(index, 'currency', val)
-                                }
-                                disabled={isLoading}
-                                name={`currency-${index}`}
-                              />
-                            </div>
-                            {formData.price && formData.price.length > 1 && (
-                              <button
-                                type="button"
-                                onClick={() => removePrice(index)}
-                                disabled={isLoading}
-                                className="cursor-pointer rounded-md bg-red-50 p-1.5 text-red-600 hover:bg-red-100 disabled:opacity-50"
-                              >
-                                <TrashIcon className="h-4 w-4" />
-                              </button>
-                            )}
-                          </div>
-                        )) || []}
-                      </div>
-                    </div>
-
-                    <div>
-                      <div className="flex items-center justify-between">
-                        <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
-                          Perks & Benefits
-                        </label>
-                        <button
-                          type="button"
-                          onClick={addPerk}
-                          disabled={isLoading}
-                          className="inline-flex cursor-pointer items-center rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 dark:bg-indigo-500 dark:shadow-none dark:focus-visible:outline-indigo-500"
-                        >
-                          <PlusIcon className="mr-1.5 h-3 w-3" />
-                          Add Perk
-                        </button>
-                      </div>
-                      <div className="mt-2 space-y-2">
-                        {formData.perks?.map((perk, index) => (
-                          <div
-                            key={index}
-                            className="grid grid-cols-1 gap-3 sm:grid-cols-3"
-                          >
-                            <div>
-                              <input
-                                type="text"
-                                value={perk.label}
-                                onChange={(e) =>
-                                  updatePerk(index, 'label', e.target.value)
-                                }
-                                onPaste={(e) => handlePerkPaste(e, index)}
-                                disabled={isLoading}
-                                className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
-                                placeholder="Perk title (paste multi-line to bulk add)"
-                              />
-                            </div>
-                            <div className="sm:col-span-2">
-                              <div className="flex space-x-2">
-                                <input
-                                  type="text"
-                                  value={perk.description}
-                                  onChange={(e) =>
-                                    updatePerk(
-                                      index,
-                                      'description',
-                                      e.target.value,
-                                    )
-                                  }
-                                  onPaste={(e) => handlePerkPaste(e, index)}
-                                  disabled={isLoading}
-                                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
-                                  placeholder="Perk description"
-                                />
-                                {formData.perks &&
-                                  formData.perks.length > 1 && (
-                                    <button
-                                      type="button"
-                                      onClick={() => removePerk(index)}
-                                      disabled={isLoading}
-                                      className="cursor-pointer rounded-md bg-red-50 p-1.5 text-red-600 hover:bg-red-100 disabled:opacity-50"
-                                    >
-                                      <TrashIcon className="h-4 w-4" />
-                                    </button>
-                                  )}
-                              </div>
-                            </div>
-                          </div>
-                        )) || []}
-                      </div>
-                    </div>
-
-                    <div className="flex justify-between pt-4">
-                      <div>
-                        {tier && onDelete && (
-                          <button
-                            type="button"
-                            onClick={handleDelete}
-                            disabled={isLoading}
-                            className="inline-flex cursor-pointer items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold whitespace-nowrap text-white shadow-xs hover:bg-red-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 disabled:opacity-50 dark:bg-red-500 dark:shadow-none dark:focus-visible:outline-red-500"
-                          >
-                            <ExclamationTriangleIcon className="mr-1.5 h-4 w-4" />
-                            {deleteMutation.isPending
-                              ? 'Deleting...'
-                              : 'Delete Tier'}
-                          </button>
-                        )}
-                      </div>
-                      <div className="flex space-x-3">
-                        <button
-                          type="button"
-                          onClick={onClose}
-                          disabled={isLoading}
-                          className="cursor-pointer text-sm/6 font-semibold whitespace-nowrap text-gray-900 disabled:opacity-50 dark:text-white"
-                        >
-                          Cancel
-                        </button>
-                        <button
-                          type="submit"
-                          disabled={isLoading}
-                          className="inline-flex cursor-pointer items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 dark:bg-indigo-500 dark:shadow-none dark:focus-visible:outline-indigo-500"
-                        >
-                          {createMutation.isPending || updateMutation.isPending
-                            ? 'Saving...'
-                            : tier
-                              ? 'Update Tier'
-                              : 'Create Tier'}
-                        </button>
-                      </div>
-                    </div>
-                  </form>
-                </DialogPanel>
-              </TransitionChild>
+            <div>
+              <label
+                htmlFor="tagline"
+                className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+              >
+                Tagline *
+              </label>
+              <div className="mt-2">
+                <input
+                  type="text"
+                  id="tagline"
+                  value={formData.tagline}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      tagline: e.target.value,
+                    }))
+                  }
+                  required
+                  disabled={isLoading}
+                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
+                  placeholder="e.g., Premium partnership opportunity"
+                />
+              </div>
             </div>
           </div>
-        </Dialog>
-      </Transition>
+
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div>
+              <Dropdown
+                name="tierType"
+                label="Tier Type"
+                options={
+                  new Map([
+                    ['standard', 'Standard'],
+                    ['special', 'Special'],
+                    ['addon', 'Add-on'],
+                  ])
+                }
+                value={formData.tierType}
+                setValue={(val) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    tierType: val as 'standard' | 'special' | 'addon',
+                  }))
+                }
+                disabled={isLoading}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="max_quantity"
+                className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+              >
+                Capacity
+              </label>
+              <div className="mt-2">
+                <input
+                  type="number"
+                  id="max_quantity"
+                  value={formData.maxQuantity ?? ''}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      maxQuantity: e.target.value
+                        ? parseInt(e.target.value)
+                        : undefined,
+                    }))
+                  }
+                  min="1"
+                  disabled={isLoading}
+                  className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
+                  placeholder="Unlimited"
+                />
+              </div>
+            </div>
+
+            <div className="flex items-end">
+              <div className="flex gap-3">
+                <div className="flex h-6 shrink-0 items-center">
+                  <div className="group grid size-4 grid-cols-1">
+                    <input
+                      id="sold_out"
+                      type="checkbox"
+                      checked={formData.soldOut}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          soldOut: e.target.checked,
+                        }))
+                      }
+                      disabled={isLoading}
+                      className="col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:indeterminate:border-indigo-500 dark:indeterminate:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/5 dark:disabled:bg-white/10 dark:disabled:checked:bg-white/10 forced-colors:appearance-auto"
+                    />
+                    <svg
+                      fill="none"
+                      viewBox="0 0 14 14"
+                      className="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-disabled:stroke-gray-950/25 dark:group-has-disabled:stroke-white/25"
+                    >
+                      <path
+                        d="M3 8L6 11L11 3.5"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="opacity-0 group-has-checked:opacity-100"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div className="text-sm/6">
+                  <label
+                    htmlFor="sold_out"
+                    className="font-medium whitespace-nowrap text-gray-900 dark:text-white"
+                  >
+                    Sold Out
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-end">
+              <div className="flex gap-3">
+                <div className="flex h-6 shrink-0 items-center">
+                  <div className="group grid size-4 grid-cols-1">
+                    <input
+                      id="most_popular"
+                      type="checkbox"
+                      checked={formData.mostPopular}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          mostPopular: e.target.checked,
+                        }))
+                      }
+                      disabled={isLoading}
+                      className="col-start-1 row-start-1 appearance-none rounded-sm border border-gray-300 bg-white checked:border-indigo-600 checked:bg-indigo-600 indeterminate:border-indigo-600 indeterminate:bg-indigo-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:checked:border-indigo-500 dark:checked:bg-indigo-500 dark:indeterminate:border-indigo-500 dark:indeterminate:bg-indigo-500 dark:focus-visible:outline-indigo-500 dark:disabled:border-white/5 dark:disabled:bg-white/10 dark:disabled:checked:bg-white/10 forced-colors:appearance-auto"
+                    />
+                    <CheckIcon className="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white opacity-0 group-has-checked:opacity-100 group-has-disabled:stroke-gray-950/25 dark:group-has-disabled:stroke-white/25" />
+                  </div>
+                </div>
+                <div className="text-sm/6">
+                  <label
+                    htmlFor="most_popular"
+                    className="font-medium whitespace-nowrap text-gray-900 dark:text-white"
+                  >
+                    Most Popular
+                    <StarIcon className="ml-1 inline h-4 w-4 text-yellow-400" />
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between">
+              <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                Pricing
+              </label>
+              <button
+                type="button"
+                onClick={addPrice}
+                disabled={isLoading}
+                className="inline-flex cursor-pointer items-center rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 dark:bg-indigo-500 dark:shadow-none dark:focus-visible:outline-indigo-500"
+              >
+                <PlusIcon className="mr-1.5 h-3 w-3" />
+                Add Price
+              </button>
+            </div>
+            <div className="mt-2 space-y-2">
+              {formData.price?.map((price, index) => (
+                <div key={index} className="flex items-center space-x-3">
+                  <div className="w-40">
+                    <input
+                      type="number"
+                      value={price.amount}
+                      onChange={(e) =>
+                        updatePrice(
+                          index,
+                          'amount',
+                          parseFloat(e.target.value) || 0,
+                        )
+                      }
+                      min="0"
+                      step="0.01"
+                      disabled={isLoading}
+                      className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
+                      placeholder="Amount"
+                    />
+                  </div>
+                  <div className="w-24">
+                    <CurrencySelect
+                      value={price.currency}
+                      setValue={(val) => updatePrice(index, 'currency', val)}
+                      disabled={isLoading}
+                      name={`currency-${index}`}
+                    />
+                  </div>
+                  {formData.price && formData.price.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removePrice(index)}
+                      disabled={isLoading}
+                      className="cursor-pointer rounded-md bg-red-50 p-1.5 text-red-600 hover:bg-red-100 disabled:opacity-50"
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+              )) || []}
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between">
+              <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                Perks & Benefits
+              </label>
+              <button
+                type="button"
+                onClick={addPerk}
+                disabled={isLoading}
+                className="inline-flex cursor-pointer items-center rounded-md bg-indigo-600 px-3 py-2 text-xs font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 dark:bg-indigo-500 dark:shadow-none dark:focus-visible:outline-indigo-500"
+              >
+                <PlusIcon className="mr-1.5 h-3 w-3" />
+                Add Perk
+              </button>
+            </div>
+            <div className="mt-2 space-y-2">
+              {formData.perks?.map((perk, index) => (
+                <div
+                  key={index}
+                  className="grid grid-cols-1 gap-3 sm:grid-cols-3"
+                >
+                  <div>
+                    <input
+                      type="text"
+                      value={perk.label}
+                      onChange={(e) =>
+                        updatePerk(index, 'label', e.target.value)
+                      }
+                      onPaste={(e) => handlePerkPaste(e, index)}
+                      disabled={isLoading}
+                      className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
+                      placeholder="Perk title (paste multi-line to bulk add)"
+                    />
+                  </div>
+                  <div className="sm:col-span-2">
+                    <div className="flex space-x-2">
+                      <input
+                        type="text"
+                        value={perk.description}
+                        onChange={(e) =>
+                          updatePerk(index, 'description', e.target.value)
+                        }
+                        onPaste={(e) => handlePerkPaste(e, index)}
+                        disabled={isLoading}
+                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500 dark:disabled:bg-white/5 dark:disabled:text-gray-400"
+                        placeholder="Perk description"
+                      />
+                      {formData.perks && formData.perks.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => removePerk(index)}
+                          disabled={isLoading}
+                          className="cursor-pointer rounded-md bg-red-50 p-1.5 text-red-600 hover:bg-red-100 disabled:opacity-50"
+                        >
+                          <TrashIcon className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )) || []}
+            </div>
+          </div>
+
+          <div className="flex justify-between pt-4">
+            <div>
+              {tier && onDelete && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={isLoading}
+                  className="inline-flex cursor-pointer items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold whitespace-nowrap text-white shadow-xs hover:bg-red-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 disabled:opacity-50 dark:bg-red-500 dark:shadow-none dark:focus-visible:outline-red-500"
+                >
+                  <ExclamationTriangleIcon className="mr-1.5 h-4 w-4" />
+                  {deleteMutation.isPending ? 'Deleting...' : 'Delete Tier'}
+                </button>
+              )}
+            </div>
+            <div className="flex space-x-3">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isLoading}
+                className="cursor-pointer text-sm/6 font-semibold whitespace-nowrap text-gray-900 disabled:opacity-50 dark:text-white"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="inline-flex cursor-pointer items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 dark:bg-indigo-500 dark:shadow-none dark:focus-visible:outline-indigo-500"
+              >
+                {createMutation.isPending || updateMutation.isPending
+                  ? 'Saving...'
+                  : tier
+                    ? 'Update Tier'
+                    : 'Create Tier'}
+              </button>
+            </div>
+          </div>
+        </form>
+      </ModalShell>
 
       <ConfirmationModal
         isOpen={showDeleteConfirm}

--- a/src/components/admin/workshop/AddParticipantModal.stories.tsx
+++ b/src/components/admin/workshop/AddParticipantModal.stories.tsx
@@ -1,17 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { fn } from 'storybook/test'
 import { AddParticipantModal } from './AddParticipantModal'
+import { withPortalTheme } from '@/lib/storybook'
 
 const meta = {
   title: 'Systems/Proposals/Admin/Workshop/AddParticipantModal',
   component: AddParticipantModal,
   tags: ['autodocs'],
+  decorators: [withPortalTheme],
   parameters: {
-    layout: 'centered',
+    layout: 'fullscreen',
     docs: {
       description: {
         component:
-          'Form modal for manually adding a participant to a workshop. Includes fields for name, email, WorkOS ID, experience level, and operating system.',
+          'Form modal for manually adding a participant to a workshop. Includes fields for name, email, WorkOS ID, experience level, and operating system. Built on the shared ModalShell — the workshop title uses the standard header (truncating cleanly), replacing the old bespoke absolute close button.',
       },
     },
   },
@@ -36,5 +38,18 @@ export const Submitting: Story = {
     isOpen: true,
     workshopTitle: 'Advanced Terraform Workshop',
     isSubmitting: true,
+  },
+}
+
+/**
+ * A very long workshop title. It now flows into ModalShell's standard header,
+ * which truncates the subtitle and keeps the close button clear — the old
+ * bespoke absolutely-positioned close X used to overlap the title text.
+ */
+export const LongTitle: Story = {
+  args: {
+    isOpen: true,
+    workshopTitle:
+      'Building Production-Grade Multi-Cluster Kubernetes Platforms with GitOps, Service Mesh, and Progressive Delivery',
   },
 }

--- a/src/components/admin/workshop/AddParticipantModal.tsx
+++ b/src/components/admin/workshop/AddParticipantModal.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { DialogTitle } from '@headlessui/react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
+import { UserPlusIcon } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
 import { Dropdown } from '@/components/Form'
 import { AdminButton } from '@/components/admin/AdminButton'
@@ -74,28 +73,11 @@ export function AddParticipantModal({
       isOpen={isOpen}
       onClose={handleClose}
       size="lg"
-      padded={false}
-      className="relative overflow-hidden px-4 pt-5 pb-4 sm:p-6"
+      title={`Add Participant to ${workshopTitle}`}
+      icon={<UserPlusIcon className="h-5 w-5" />}
     >
-      <div className="absolute top-0 right-0 pt-4 pr-4">
-        <button
-          type="button"
-          className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none dark:bg-gray-800 dark:text-gray-500 dark:hover:text-gray-400"
-          onClick={handleClose}
-        >
-          <span className="sr-only">Close</span>
-          <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
-      </div>
       <div>
-        <DialogTitle
-          as="h3"
-          className="mb-4 text-lg leading-6 font-semibold text-gray-900 dark:text-white"
-        >
-          Add Participant to {workshopTitle}
-        </DialogTitle>
-
-        <div className="mt-4 space-y-4">
+        <div className="space-y-4">
           <div>
             <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
               Name *

--- a/src/components/travel-support/ReceiptViewer.stories.tsx
+++ b/src/components/travel-support/ReceiptViewer.stories.tsx
@@ -2,17 +2,27 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { fn } from 'storybook/test'
 import { ReceiptViewer } from './ReceiptViewer'
 import type { ExpenseReceipt } from '@/lib/travel-support/types'
+import { withPortalTheme } from '@/lib/storybook'
+
+// Renders the REAL ReceiptViewer (not a mock shell). It was converted from a
+// bare `fixed inset-0` overlay to the shared ModalShell with a custom 5-control
+// toolbar. Presentation is `centered` (opting out of the mobile bottom sheet):
+// a document/image viewer wants the same full-height centered card at every
+// width so the receipt is never cropped and zoom/scroll behave consistently.
+// The dialog takes its accessible name from ModalShell's `ariaLabel` since the
+// toolbar has too many actions for the standard single-close header.
 
 const meta = {
   title: 'Systems/Speakers/TravelSupport/ReceiptViewer',
   component: ReceiptViewer,
   tags: ['autodocs'],
+  decorators: [withPortalTheme],
   parameters: {
     layout: 'fullscreen',
     docs: {
       description: {
         component:
-          'Full-screen receipt viewer overlay with zoom controls for images, download button, and close action. Renders images inline with zoom and falls back to an iframe for PDFs and other file types.',
+          'Receipt viewer built on the shared ModalShell (centered full-height presentation) with a custom toolbar: zoom controls for images, download, and close. Renders images inline with zoom and falls back to an iframe for PDFs and other file types.',
       },
     },
   },

--- a/src/components/travel-support/ReceiptViewer.tsx
+++ b/src/components/travel-support/ReceiptViewer.tsx
@@ -8,6 +8,7 @@ import {
   MagnifyingGlassPlusIcon,
 } from '@heroicons/react/24/outline'
 import { ExpenseReceipt } from '@/lib/travel-support/types'
+import { formatDate } from '@/lib/time'
 import { ModalShell } from '@/components/ModalShell'
 
 // Shared classes for the toolbar controls — 44×44 minimum tap target.
@@ -140,7 +141,7 @@ export function ReceiptViewer({
         {/* Footer */}
         <div className="shrink-0 border-t border-gray-200 px-4 py-3 dark:border-gray-700">
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            Uploaded on {new Date(receipt.uploadedAt).toLocaleDateString()}
+            Uploaded on {formatDate(receipt.uploadedAt)}
           </p>
         </div>
       </div>

--- a/src/components/travel-support/ReceiptViewer.tsx
+++ b/src/components/travel-support/ReceiptViewer.tsx
@@ -8,6 +8,11 @@ import {
   MagnifyingGlassPlusIcon,
 } from '@heroicons/react/24/outline'
 import { ExpenseReceipt } from '@/lib/travel-support/types'
+import { ModalShell } from '@/components/ModalShell'
+
+// Shared classes for the toolbar controls — 44×44 minimum tap target.
+const controlButton =
+  'inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-600 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800'
 
 interface ReceiptViewerProps {
   receipt: ExpenseReceipt
@@ -43,21 +48,37 @@ export function ReceiptViewer({
     document.body.removeChild(link)
   }
 
+  const label = receipt.filename || `Receipt ${receiptIndex + 1}`
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
-      <div className="relative flex h-full max-h-[90vh] w-full max-w-4xl flex-col rounded-lg bg-white shadow-2xl dark:bg-gray-900">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-            {receipt.filename || `Receipt ${receiptIndex + 1}`}
+    <ModalShell
+      isOpen
+      onClose={onClose}
+      size="4xl"
+      // A document/image viewer wants the same full-height centered card at every
+      // width — a bottom-sheet would crop the receipt and fight the zoom/scroll —
+      // so it opts out of the default mobile sheet presentation.
+      presentation="centered"
+      padded={false}
+      ariaLabel={`Receipt: ${label}`}
+      className="overflow-hidden"
+    >
+      <div className="flex h-[85vh] flex-col">
+        {/* Custom 5-control toolbar (title + zoom out/in + download + close) — too
+          many actions for the shell's standard single-close header, so the
+          dialog takes its accessible name from `ariaLabel` above instead. */}
+        <div className="flex shrink-0 items-center justify-between gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+          <h3 className="min-w-0 truncate text-lg font-semibold text-gray-900 dark:text-white">
+            {label}
           </h3>
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-1">
             {isImage && (
               <>
                 <button
                   onClick={handleZoomOut}
                   disabled={zoom <= 50}
-                  className="rounded-md p-2 text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                  className={controlButton}
+                  aria-label="Zoom out"
                   title="Zoom out"
                 >
                   <MagnifyingGlassMinusIcon className="h-5 w-5" />
@@ -68,24 +89,27 @@ export function ReceiptViewer({
                 <button
                   onClick={handleZoomIn}
                   disabled={zoom >= 200}
-                  className="rounded-md p-2 text-gray-600 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                  className={controlButton}
+                  aria-label="Zoom in"
                   title="Zoom in"
                 >
                   <MagnifyingGlassPlusIcon className="h-5 w-5" />
                 </button>
-                <div className="mx-2 h-6 w-px bg-gray-300 dark:bg-gray-600" />
+                <div className="mx-1 h-6 w-px bg-gray-300 dark:bg-gray-600" />
               </>
             )}
             <button
               onClick={handleDownload}
-              className="rounded-md p-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+              className={controlButton}
+              aria-label="Download receipt"
               title="Download receipt"
             >
               <ArrowDownTrayIcon className="h-5 w-5" />
             </button>
             <button
               onClick={onClose}
-              className="rounded-md p-2 text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+              className={controlButton}
+              aria-label="Close"
               title="Close"
             >
               <XMarkIcon className="h-5 w-5" />
@@ -99,7 +123,7 @@ export function ReceiptViewer({
             <div className="flex min-h-full items-center justify-center">
               <img
                 src={fileUrl}
-                alt={receipt.filename || `Receipt ${receiptIndex + 1}`}
+                alt={label}
                 className="max-h-full max-w-full rounded-lg shadow-lg transition-transform duration-200"
                 style={{ transform: `scale(${zoom / 100})` }}
               />
@@ -107,19 +131,19 @@ export function ReceiptViewer({
           ) : (
             <iframe
               src={fileUrl}
-              title={receipt.filename || `Receipt ${receiptIndex + 1}`}
+              title={label}
               className="h-full w-full rounded-lg shadow-lg"
             />
           )}
         </div>
 
         {/* Footer */}
-        <div className="border-t border-gray-200 px-4 py-3 dark:border-gray-700">
+        <div className="shrink-0 border-t border-gray-200 px-4 py-3 dark:border-gray-700">
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Uploaded on {new Date(receipt.uploadedAt).toLocaleDateString()}
           </p>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/src/components/workshop/WorkshopCard.stories.tsx
+++ b/src/components/workshop/WorkshopCard.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn, userEvent, within } from 'storybook/test'
+import WorkshopCard from './WorkshopCard'
+import type { ProposalWithWorkshopData } from '@/lib/workshop/types'
+import { withPortalTheme } from '@/lib/storybook'
+
+// Renders the REAL public WorkshopCard (not a mock shell). The "Register for
+// Workshop" action opens the signup modal, which was converted from a
+// hand-rolled portal overlay to the shared ModalShell (Headless UI a11y +
+// bottom-sheet on mobile). The Signup* stories open that modal via a play
+// function so the capture shows the real converted modal.
+
+const workshop = {
+  _id: 'ws-1',
+  title: 'Getting Started with Kubernetes Operators',
+  format: 'workshop_120',
+  capacity: 30,
+  signups: 12,
+  available: 18,
+  waitlistCount: 0,
+  date: '2026-09-10',
+  startTime: '2026-09-10T09:00:00Z',
+  endTime: '2026-09-10T11:00:00Z',
+  room: 'Workshop Room A',
+  description:
+    'A hands-on introduction to building Kubernetes Operators with the ' +
+    'Operator SDK. Bring a laptop with kubectl and Docker installed.',
+  speakers: [
+    {
+      _id: 'sp-1',
+      name: 'Grace Hopper',
+      slug: 'grace-hopper',
+      title: 'Principal Engineer, CloudCorp',
+      image: 'https://placehold.co/80x80/3b82f6/ffffff?text=GH',
+    },
+  ],
+  topics: [{ _id: 't-1', title: 'Kubernetes', color: '#3b82f6' }],
+} as unknown as ProposalWithWorkshopData
+
+const meta = {
+  title: 'Systems/Workshops/WorkshopCard',
+  component: WorkshopCard,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Public workshop card with capacity/time badges and a signup flow. The "Register for Workshop" button opens the registration modal (experience level + operating system), now built on the shared ModalShell.',
+      },
+    },
+  },
+  args: {
+    workshop,
+    userSignups: [],
+    onSignup: fn(async () => ({ success: true })),
+    onCancel: fn(async () => ({ success: true })),
+  },
+  decorators: [withPortalTheme],
+  tags: ['autodocs'],
+} satisfies Meta<typeof WorkshopCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** The card in its default, not-yet-registered state. */
+export const Default: Story = {}
+
+/**
+ * Signup modal opened via the register button. On the default desktop viewport
+ * the modal is a centered card; the play function queries `document.body`
+ * because ModalShell portals there.
+ */
+export const SignupModal: Story = {
+  play: async () => {
+    const body = within(document.body)
+    await userEvent.click(
+      await body.findByRole('button', { name: /register for workshop/i }),
+    )
+    await body.findByText(/complete your registration/i)
+  },
+}
+
+/**
+ * Same signup modal at phone width — ModalShell presents it as a bottom sheet
+ * (rounded top, safe-area padding, internally scrollable).
+ */
+export const SignupModalMobile: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+  play: SignupModal.play,
+}

--- a/src/components/workshop/WorkshopCard.tsx
+++ b/src/components/workshop/WorkshopCard.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { createPortal } from 'react-dom'
+import { useState } from 'react'
 import Link from 'next/link'
 import { PortableText } from '@portabletext/react'
 import { portableTextComponents } from '@/lib/portabletext/components'
 import { Button } from '@/components/Button'
+import { ModalShell } from '@/components/ModalShell'
 import type {
   ProposalWithWorkshopData,
   WorkshopSignupExisting,
@@ -31,7 +31,6 @@ import {
   UserIcon,
   MapPinIcon,
   ExclamationTriangleIcon,
-  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { CheckCircleIcon as CheckCircleIconSolid } from '@heroicons/react/24/solid'
 
@@ -70,13 +69,6 @@ export default function WorkshopCard({
   )
   const [operatingSystem, setOperatingSystem] =
     useState<OperatingSystem>('macos')
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMounted(true)
-    return () => setMounted(false)
-  }, [])
 
   const actuallySignedUp =
     isSignedUp || hasConfirmedSignup(workshop._id, userSignups)
@@ -135,28 +127,16 @@ export default function WorkshopCard({
     }
   }
 
-  const modalContent = showSignupModal && (
-    <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center p-4"
-      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
-      onClick={() => setShowSignupModal(false)}
+  const modalContent = (
+    <ModalShell
+      isOpen={showSignupModal}
+      onClose={() => setShowSignupModal(false)}
+      size="md"
+      title={workshop.title}
+      subtitle="Complete your registration"
+      icon={<AcademicCapIcon className="h-5 w-5" />}
     >
-      <div
-        className="relative w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-gray-800"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <button
-          onClick={() => setShowSignupModal(false)}
-          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-          aria-label="Close"
-        >
-          <XMarkIcon className="h-6 w-6" />
-        </button>
-
-        <h3 className="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
-          Complete Your Registration
-        </h3>
-
+      <div>
         <div className="space-y-4">
           <div>
             <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -271,15 +251,12 @@ export default function WorkshopCard({
           </div>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 
   return (
     <>
-      {mounted &&
-        showSignupModal &&
-        typeof window !== 'undefined' &&
-        createPortal(modalContent, document.body)}
+      {modalContent}
 
       <div className="rounded-xl bg-white p-6 shadow-sm transition-all hover:shadow-md dark:bg-gray-800 dark:hover:shadow-lg">
         <div className="mb-4 flex flex-wrap items-start justify-between gap-4">

--- a/src/components/workshop/WorkshopCard.tsx
+++ b/src/components/workshop/WorkshopCard.tsx
@@ -84,6 +84,11 @@ export default function WorkshopCard({
   } = getWorkshopDateTime(workshop)
 
   const handleSignupClick = () => {
+    // Reset the selections on every open so a previously cancelled signup's
+    // choices don't silently carry over into a fresh attempt.
+    setExperienceLevel('intermediate' as ExperienceLevel)
+    setOperatingSystem('macos')
+    setError(null)
     setShowSignupModal(true)
   }
 

--- a/src/lib/storybook/index.ts
+++ b/src/lib/storybook/index.ts
@@ -1,2 +1,3 @@
 // Barrel for Storybook-only helpers (AGENTS.md subdirectory-barrel convention).
 export * from './mockDate'
+export * from './portalTheme'

--- a/src/lib/storybook/portalTheme.tsx
+++ b/src/lib/storybook/portalTheme.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react'
+import type { Decorator } from '@storybook/nextjs-vite'
+
+/**
+ * ModalShell (and any Headless UI Dialog) renders through a portal on
+ * `document.body`, which escapes Storybook's theme-wrapper `<div class="dark">`.
+ * This component mirrors the toolbar theme onto the document root so the
+ * portaled modal's `dark:` classes resolve — in the app, next-themes puts the
+ * class there.
+ */
+function PortalThemeSync({
+  dark,
+  children,
+}: {
+  dark: boolean
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark)
+    return () => document.documentElement.classList.remove('dark')
+  }, [dark])
+  return <>{children}</>
+}
+
+/** Storybook decorator that syncs the toolbar theme onto `<html>` for portaled modals. */
+export const withPortalTheme: Decorator = (Story, context) => (
+  <PortalThemeSync dark={context.globals.theme === 'dark'}>
+    <Story />
+  </PortalThemeSync>
+)


### PR DESCRIPTION
Modal-audit fix batch **B** — converges hand-rolled `fixed inset-0` overlays onto the house `ModalShell` primitive (#544) and clears several story/nit riders. Every touched surface has a real-component Storybook story and was visually inspected at 393px in light + dark (plus a desktop capture for the ReceiptViewer presentation call).

### B1 — WidgetPicker
`src/components/admin/dashboard/WidgetPicker.tsx`: replaced the bare `fixed inset-0` div (no dialog role, no focus trap/Escape/scroll-lock, backdrop didn't close) with `ModalShell` (title "Add widget", `Squares2X2Icon`, `size="4xl"`). Added `flex-wrap` to the category chip row so it no longer overflows at 393px (Operations/Engagement now wrap to a second line). New real-component story (Default + Mobile).

### B2 — ReceiptViewer
`src/components/travel-support/ReceiptViewer.tsx`: converted the full-screen overlay (zero a11y, 36px controls) to `ModalShell`. Kept a **custom 5-control toolbar inside the shell body** (zoom out / % / zoom in / download / close) since that's too many actions for the shell's single-close standard header; controls are now ≥44×44. **Presentation judgment: `presentation="centered"`** (opting out of the default mobile bottom-sheet) — a document/image viewer wants the same full-height centered card at every width so the receipt is never cropped and zoom/scroll behave consistently; verified with a desktop capture. Because it forgoes the `title` prop, the dialog takes its accessible name from a new **`ariaLabel` escape-hatch prop added to `ModalShell`** (applied to the `Dialog` root that carries `role="dialog"`; ignored when `title` is set). Story updated to real-component + portal-theme decorator.

### B3 — WorkshopCard signup modal (public-facing)
`src/components/workshop/WorkshopCard.tsx`: replaced the hand-rolled `createPortal` overlay (no a11y, 24px close) with `ModalShell` (title = workshop title, `AcademicCapIcon`, sheet default — right for mobile signups). Dropped the now-redundant `mounted`/`createPortal` plumbing (ModalShell portals itself). New real-component story incl. mobile (opens the modal via a play function).

### B4 — inline Headless dialogs → ModalShell
- `src/components/admin/BadgeManagementClient.tsx` (~723): the inline `Transition`/`Dialog` badge-preview modal → `ModalShell` (title "Badge Preview - …", `IdentificationIcon`, `size="2xl"`), preserving the scrollable preview + Download/Close footer. Dropped now-unused Headless UI + `useTheme` imports.
- `src/components/admin/sponsor/SponsorTierEditor.tsx` (~317): the inline `SponsorTierModal` dialog → `ModalShell` (title "Edit/Create Sponsor Tier", `TagIcon`, `size="4xl"`). Dropped now-unused Headless UI + `XMarkIcon` imports.

### B5 — replace static mock-shell stories with real-component stories (house-rule violation)
Both story files rendered lookalike markup, not the real components (the exact pattern that shipped two prod bugs before it was banned).
- `ImageMetadataModal.stories.tsx`: now renders the real component with msw handlers for `speaker.admin.search` + `gallery.admin.update`, a `NotificationProvider` decorator, and single-image / bulk / mobile fixtures. The C-batch ModalShell behaviours (mobile bottom-sheet 85dvh, ⌘S submit) are now in the real captures.
- `SponsorAddModal.stories.tsx`: now renders the real component with an msw `sponsor.list` handler + tier fixtures (Default / WithPreselectedTier / Mobile).

### B6 — SpeakerMergeModal destructive button renders red (M-D)
`src/components/admin/SpeakerMergeModal.tsx`: the merge-confirm button's `bg-red-600` was defeated by the shared `Button` primary variant's own background (Tailwind source order). The `Button` component has no danger variant, so the override now uses `!important` modifiers (`!bg-red-600 hover:!bg-red-500 focus-visible:!outline-red-600 …`). Confirmed **red** in the `Previewed` story shoot.

### B7 — AddParticipantModal long-title header (M-C)
`src/components/admin/workshop/AddParticipantModal.tsx`: already on ModalShell but used a bespoke absolutely-positioned close X that a long workshop title ran under. Adopted the shell's standard `title` header (which truncates/wraps properly and keeps the close button clear) and dropped the absolute close. Added a `LongTitle` story variant + portal-theme decorator; verified no overlap at 393px.

### Shared
- `src/lib/storybook/portalTheme.tsx`: new `withPortalTheme` decorator (mirrors the toolbar theme onto `<html>` so portaled modals' `dark:` classes resolve), exported from the storybook barrel and reused across the new/updated stories.

### Checks
- `tsc --noEmit`, `eslint .` (0 errors), `prettier --check`, `knip` — all clean.
- Full `vitest run`: **213 files, 3137 passed / 5 skipped**. Includes new `__tests__/components/modal-conversions.a11y.test.tsx` (role=dialog + accessible name, Escape closes, focus returns to trigger for all three conversions) and two new `ModalShell.test.tsx` cases covering the `ariaLabel` prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is modal-audit batch B: it converges five hand-rolled `fixed inset-0` overlays (WidgetPicker, ReceiptViewer, WorkshopCard signup, BadgeManagementClient, SponsorTierEditor) onto the shared `ModalShell` primitive, fixing the missing `role=dialog`, focus-trap, Escape handling, and scroll-lock. It also adds an `ariaLabel` escape-hatch to `ModalShell` for viewer-style dialogs with custom toolbars, replaces static mock-shell Storybook stories with real-component stories, fixes the destructive button colour in `SpeakerMergeModal`, and introduces a `withPortalTheme` Storybook decorator so portaled modals render with the correct dark-mode classes.

- **B1–B3 conversions** (WidgetPicker, ReceiptViewer, WorkshopCard): bare `fixed inset-0` divs replaced with `ModalShell`; new a11y integration tests confirm `role=dialog`, Escape-close, and focus-return for all three.
- **B4 conversions** (BadgeManagementClient, SponsorTierEditor): inline Headless UI `Transition`/`Dialog` blocks folded into `ModalShell`; now-unused HeadlessUI + icon imports dropped.
- **B5–B7** (story rewrites, `SpeakerMergeModal` red button, `AddParticipantModal` long-title header): quality/correctness riders on top of the structural changes.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the raw date display in ReceiptViewer and optionally the stale form-state in WorkshopCard.

The overlay-to-ModalShell conversions are clean and well-tested, but ReceiptViewer introduces a direct `new Date().toLocaleDateString()` call for display — the project explicitly bans this in favour of the shared time utilities. The WorkshopCard conversion changes the modal lifecycle from unmount-on-close to always-mounted, leaving `experienceLevel` and `operatingSystem` stale across re-opens. Everything else in the batch is solid.

src/components/travel-support/ReceiptViewer.tsx (date display) and src/components/workshop/WorkshopCard.tsx (form state reset on close)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/ModalShell.tsx | Adds `ariaLabel` escape-hatch prop for dialogs with a custom toolbar (applied as `aria-label` on Dialog root only when `title` is absent); no behaviour changes for existing callers. |
| src/components/travel-support/ReceiptViewer.tsx | Converted bare overlay to ModalShell with `ariaLabel`; uses raw `new Date().toLocaleDateString()` for the upload date footer, violating the project's time-utility rule. |
| src/components/workshop/WorkshopCard.tsx | Replaced createPortal overlay with ModalShell; `experienceLevel`/`operatingSystem` form state is no longer reset on cancel because ModalShell keeps the panel mounted. |
| src/components/admin/dashboard/WidgetPicker.tsx | Replaced bare fixed overlay with ModalShell (`size="4xl"`, standard title header); adds `flex-wrap` to category chip row for 393px wrapping — clean conversion. |
| src/components/admin/SpeakerMergeModal.tsx | B6 fix: overrides the primary `Button` variant's background with Tailwind `!important` modifiers (`!bg-red-600`) to surface the destructive red colour that was previously defeated by source-order. |
| src/components/admin/workshop/AddParticipantModal.tsx | B7: drops the absolute-positioned close button that could be obscured by long titles; adopts the shell's standard `title` header which truncates/wraps correctly. |
| src/lib/storybook/portalTheme.tsx | New `withPortalTheme` Storybook decorator that mirrors toolbar theme to `document.documentElement` so portaled modals resolve `dark:` classes; correctly cleans up on unmount. |
| __tests__/components/modal-conversions.a11y.test.tsx | New a11y integration tests for all three bare-overlay conversions (B1–B3); covers role=dialog accessible name, Escape-close, and focus return. |
| __tests__/components/ModalShell.test.tsx | Adds two new test cases for `ariaLabel`: applied when `title` is absent, ignored when `title` is set. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (hand-rolled overlays)"]
        B1["fixed inset-0 div\n(no role, no focus-trap)"]
        B2["createPortal + div\n(no a11y)"]
        B3["Headless UI Transition+Dialog\n(inline, per-component)"]
    end

    subgraph After["After (ModalShell)"]
        MS["ModalShell\n(role=dialog, focus-trap,\nEscape, scroll-lock,\nbottom-sheet / centered)"]
        MS --> WP["WidgetPicker\ntitle prop → aria-labelledby"]
        MS --> RV["ReceiptViewer\nariaLabel prop → aria-label"]
        MS --> WC["WorkshopCard signup\ntitle prop → aria-labelledby"]
        MS --> BM["BadgeManagementClient\ntitle prop → aria-labelledby"]
        MS --> ST["SponsorTierEditor\ntitle prop → aria-labelledby"]
    end

    B1 -->|"B1 converted"| WP
    B2 -->|"B2 converted"| RV
    B2 -->|"B3 converted"| WC
    B3 -->|"B4 converted"| BM
    B3 -->|"B4 converted"| ST
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["Before (hand-rolled overlays)"]
        B1["fixed inset-0 div\n(no role, no focus-trap)"]
        B2["createPortal + div\n(no a11y)"]
        B3["Headless UI Transition+Dialog\n(inline, per-component)"]
    end

    subgraph After["After (ModalShell)"]
        MS["ModalShell\n(role=dialog, focus-trap,\nEscape, scroll-lock,\nbottom-sheet / centered)"]
        MS --> WP["WidgetPicker\ntitle prop → aria-labelledby"]
        MS --> RV["ReceiptViewer\nariaLabel prop → aria-label"]
        MS --> WC["WorkshopCard signup\ntitle prop → aria-labelledby"]
        MS --> BM["BadgeManagementClient\ntitle prop → aria-labelledby"]
        MS --> ST["SponsorTierEditor\ntitle prop → aria-labelledby"]
    end

    B1 -->|"B1 converted"| WP
    B2 -->|"B2 converted"| RV
    B2 -->|"B3 converted"| WC
    B3 -->|"B4 converted"| BM
    B3 -->|"B4 converted"| ST
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): converge bare overlays onto Mod..."](https://github.com/cloudnativebergen/website/commit/a5afc2ea7e90798647acc3ad247eca420bff1365) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45432570)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->