### PR TITLE
fix(messaging): organizer recipients pass the conference-standing check

### DIFF
--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -379,8 +379,8 @@ describe('send — organizer-initiated general threads (subjectSpeaker)', () => 
   })
 
   it('creates an organizer general thread when the recipient HAS standing (A5)', async () => {
-    // A proposal id comes back → the recipient belongs to this conference.
-    standingFetch.mockResolvedValue('talk-1')
+    // The speaker id comes back → proposal in this conference OR organizer.
+    standingFetch.mockResolvedValue('sp-target')
     getById.mockResolvedValue(organizerGeneralConv)
     const caller = createAdminCaller()
 
@@ -389,6 +389,13 @@ describe('send — organizer-initiated general threads (subjectSpeaker)', () => 
       recipientSpeakerId: 'sp-target',
       body: 'hi',
     })
+
+    // Standing MUST accept organizers without a talk this edition — the picker
+    // (speaker.admin.search) offers them, and a narrower server check regressed
+    // into "Speaker not found" for autocompleted organizers in prod.
+    const standingQuery = standingFetch.mock.calls[0][0] as string
+    expect(standingQuery).toContain('isOrganizer == true')
+    expect(standingQuery).toContain('conference._ref == $conferenceId')
 
     expect(standingFetch).toHaveBeenCalledWith(
       expect.any(String),

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -72,18 +72,20 @@ function claimSendSlot(speakerId: string): boolean {
 }
 
 /**
- * Does `speakerId` have standing in `conferenceId` — i.e. at least one proposal
- * (talk) in that conference? An organizer-initiated general thread must target a
- * speaker who belongs to the CURRENT conference, not merely one who exists in
- * some conference (batch A / A5). Cheapest correct check: a single existence
- * probe rather than loading proposals.
+ * Does `speakerId` have standing in `conferenceId` — a proposal (talk) in that
+ * conference OR the organizer flag? This MUST match the population the admin
+ * speaker picker offers (`speaker.admin.search` = confirmed/accepted speakers ∪
+ * organizers): a stricter server check rejects recipients the UI legitimately
+ * suggests — the prod bug where an autocompleted organizer (no talk this
+ * edition) failed with "Speaker not found". Cross-conference targeting stays
+ * blocked: a talk-less non-organizer from another edition has no standing here.
  */
 async function speakerHasStandingInConference(
   speakerId: string,
   conferenceId: string,
 ): Promise<boolean> {
   const id = await clientReadUncached.fetch<string | null>(
-    `*[_type == "talk" && conference._ref == $conferenceId && $speakerId in speakers[]._ref][0]._id`,
+    `*[_type == "speaker" && _id == $speakerId && (isOrganizer == true || count(*[_type == "talk" && conference._ref == $conferenceId && ^._id in speakers[]._ref]) > 0)][0]._id`,
     { speakerId, conferenceId },
     { cache: 'no-store' },
   )


### PR DESCRIPTION
Prod bug (maintainer screenshot): an autocompleted speaker in the admin New Conversation form failed with 'Speaker not found. Pick another speaker.'

Cause: review batch A's A5 hardening required the recipient to have a TALK in the current conference, but the picker's population (speaker.admin.search) is confirmed/accepted speakers ∪ ALL ORGANIZERS — so organizers without a talk this edition (and any picker-offered talk-less speaker) were rejected server-side after being legitimately suggested.

Fix: standing = talk in this conference OR isOrganizer, matching the picker exactly. Cross-conference protection intact — a talk-less non-organizer from another edition still has no standing. Test asserts the query covers the organizer clause so the check can't silently re-narrow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production bug where organizers autocompleted in the admin "New Conversation" picker were rejected server-side with "Speaker not found" because the standing check required a talk in the current conference, but organizers are offered by the picker regardless of whether they have a talk this edition.

- **`src/server/routers/message.ts`**: The GROQ query in `speakerHasStandingInConference` is changed from a talk-lookup to a speaker-lookup that accepts `isOrganizer == true` as an alternative to having a talk in the conference; cross-conference protection for non-organizers is preserved.
- **`__tests__/api/trpc/message.test.ts`**: The happy-path mock is updated (returns speaker `_id` instead of talk `_id`) and two new string-content assertions lock in the `isOrganizer` clause and conference filter so the query can't silently re-narrow.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only concern is a stale call-site comment that does not mention the organizer path.

The query change is logically correct and the test additions provide a solid regression guard. The only thing worth noting is a stale inline comment at the call site that still describes only the proposal-in-conference requirement, which a future developer could use to incorrectly justify narrowing the query back to proposals-only.

The inline comment at lines 253-254 of src/server/routers/message.ts needs updating to mention the organizer branch.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/routers/message.ts | GROQ query in speakerHasStandingInConference broadened from a talk-only check to talk-in-conference OR isOrganizer; the call-site comment is now stale. |
| __tests__/api/trpc/message.test.ts | Test updated to return a speaker _id instead of a talk _id, and two new assertions verify the organizer clause and conference filter are present in the standing query. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin UI
    participant Router as message.send (tRPC)
    participant Standing as speakerHasStandingInConference
    participant Sanity as Sanity (clientReadUncached)

    Admin->>Router: "send({ subject, recipientSpeakerId, body })"
    Router->>Router: "guard: isOrganizer == true"
    Router->>Standing: speakerHasStandingInConference(recipientId, confId)
    Standing->>Sanity: "GROQ speaker._id == speakerId and isOrganizer or count talks"
    Sanity-->>Standing: speaker._id or null
    Standing-->>Router: true or false
    alt false
        Router-->>Admin: NOT_FOUND
    else true
        Router->>Sanity: createGeneralConversation
        Router->>Sanity: addMessage
        Router-->>Admin: conversationId and message
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin UI
    participant Router as message.send (tRPC)
    participant Standing as speakerHasStandingInConference
    participant Sanity as Sanity (clientReadUncached)

    Admin->>Router: "send({ subject, recipientSpeakerId, body })"
    Router->>Router: "guard: isOrganizer == true"
    Router->>Standing: speakerHasStandingInConference(recipientId, confId)
    Standing->>Sanity: "GROQ speaker._id == speakerId and isOrganizer or count talks"
    Sanity-->>Standing: speaker._id or null
    Standing-->>Router: true or false
    alt false
        Router-->>Admin: NOT_FOUND
    else true
        Router->>Sanity: createGeneralConversation
        Router->>Sanity: addMessage
        Router-->>Admin: conversationId and message
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/server/routers/message.ts`, line 253-254 ([link](https://github.com/cloudnativebergen/website/blob/32c6840bf3f9e3d607a13ec862c75e498bd1bf1b/src/server/routers/message.ts#L253-L254)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The call-site comment still describes only the proposal-in-conference requirement and omits the organizer branch now accepted by `speakerHasStandingInConference`. A future developer reading just this call site could re-narrow the query back to proposals-only, re-introducing the prod bug.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): organizer recipients pas..."](https://github.com/cloudnativebergen/website/commit/32c6840bf3f9e3d607a13ec862c75e498bd1bf1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45435283)</sub>

<!-- /greptile_comment -->