### PR TITLE
fix(workshop): bind signup identity to the WorkOS session

### DIFF
--- a/__tests__/api/trpc/schedule.test.ts
+++ b/__tests__/api/trpc/schedule.test.ts
@@ -47,6 +47,7 @@ function baseCtx(): Context {
     session: null,
     speaker: undefined,
     user: undefined,
+    workosUser: null,
     ipAddress: '',
   }
 }

--- a/__tests__/api/trpc/workshop.test.ts
+++ b/__tests__/api/trpc/workshop.test.ts
@@ -1,0 +1,236 @@
+/**
+ * @vitest-environment node
+ *
+ * Router-level tests for the PUBLIC workshop procedures (src/server/routers/
+ * workshop.ts) that were the subject of the signup-authorization fix:
+ * - `signup` binds the created doc to the WorkOS session identity and IGNORES
+ *   any identity a client tries to smuggle in;
+ * - `signup`/`cancelSignup` reject with UNAUTHORIZED when there is no WorkOS
+ *   session;
+ * - `cancelSignup` may only cancel the caller's OWN signup (ownership check);
+ * - `getMySignups` is scoped to the session identity, never client input;
+ * - admin procedures remain gated by the NextAuth organizer session and are not
+ *   reachable via a WorkOS attendee session.
+ *
+ * The workshop data layer is mocked (IO only); the router's authz logic runs for
+ * real. Callers are built with the WorkOS-attendee / anonymous / admin helpers.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  createWorkshopCaller,
+  createAnonymousCaller,
+  createAdminCaller,
+} from '../../helpers/trpc'
+
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: vi.fn(async () => ({
+    conference: {
+      _id: 'conf-1',
+      title: 'CNDN',
+      workshopRegistrationStart: null,
+      workshopRegistrationEnd: null,
+    },
+    domain: 'cndn.no',
+    error: null,
+  })),
+}))
+
+vi.mock('@/lib/email/workshop', () => ({
+  sendBasicWorkshopConfirmation: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/workshop/sanity', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/workshop/sanity')>()
+  return {
+    ...actual,
+    getWorkshopSignups: vi.fn(async () => []),
+    checkWorkshopCapacity: vi.fn(async () => ({
+      available: 10,
+      capacity: 10,
+      signups: 0,
+    })),
+    verifyWorkshopBelongsToConference: vi.fn(async () => true),
+    createWorkshopSignup: vi.fn(async (data) => ({
+      _id: 'signup-1',
+      _type: 'workshopSignup',
+      status: data.status ?? 'confirmed',
+      userEmail: data.userEmail,
+      userName: data.userName,
+      userWorkOSId: data.userWorkOSId,
+      workshop: { _ref: data.workshop._ref, title: 'Kubernetes 101' },
+      conference: { _ref: data.conference._ref },
+    })),
+    getAllWorkshopSignups: vi.fn(async () => []),
+    cancelWorkshopSignup: vi.fn(async () => {}),
+    getWorkshopStatistics: vi.fn(async () => ({
+      workshops: [],
+      totals: {
+        totalWorkshops: 0,
+        totalCapacity: 0,
+        totalSignups: 0,
+        uniqueParticipants: 0,
+        totalConfirmed: 0,
+        totalPending: 0,
+        totalWaitlist: 0,
+        totalCancelled: 0,
+        averageUtilization: 0,
+      },
+    })),
+  }
+})
+
+import {
+  getWorkshopSignups,
+  createWorkshopSignup,
+  getAllWorkshopSignups,
+  cancelWorkshopSignup,
+} from '@/lib/workshop/sanity'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const getSignupsMock = getWorkshopSignups as unknown as LooseMock
+const createSignupMock = createWorkshopSignup as unknown as LooseMock
+const getAllMock = getAllWorkshopSignups as unknown as LooseMock
+const cancelMock = cancelWorkshopSignup as unknown as LooseMock
+
+const workshopRef = { _type: 'reference' as const, _ref: 'workshop-1' }
+const conferenceRef = { _type: 'reference' as const, _ref: 'conf-1' }
+
+const baseSignupInput = {
+  experienceLevel: 'beginner' as const,
+  operatingSystem: 'linux' as const,
+  workshop: workshopRef,
+  conference: conferenceRef,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('workshop.signup identity binding', () => {
+  it('binds the signup to the WorkOS session id, not to client-sent identity', async () => {
+    const caller = createWorkshopCaller({
+      id: 'workos-real',
+      email: 'real@example.com',
+      firstName: 'Real',
+      lastName: 'User',
+    })
+
+    // A malicious client tries to smuggle another person's identity in. The
+    // input schema no longer declares these fields, so they are stripped; the
+    // server binds to the session regardless.
+    await caller.workshop.signup({
+      ...baseSignupInput,
+      userWorkOSId: 'victim-id',
+      userEmail: 'victim@example.com',
+      userName: 'Victim',
+    } as unknown as typeof baseSignupInput)
+
+    expect(createSignupMock).toHaveBeenCalledTimes(1)
+    const written = createSignupMock.mock.calls[0][0]
+    expect(written.userWorkOSId).toBe('workos-real')
+    expect(written.userEmail).toBe('real@example.com')
+    expect(written.userName).toBe('Real User')
+    // The duplicate-check read is also scoped to the session id.
+    expect(getSignupsMock).toHaveBeenCalledWith(
+      'workos-real',
+      'conf-1',
+      undefined,
+    )
+  })
+
+  it('rejects signup with UNAUTHORIZED when there is no WorkOS session', async () => {
+    const caller = createAnonymousCaller()
+    await expect(caller.workshop.signup(baseSignupInput)).rejects.toThrow(
+      /UNAUTHORIZED|signed in/,
+    )
+    expect(createSignupMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('workshop.cancelSignup ownership', () => {
+  it('rejects cancel with UNAUTHORIZED when there is no WorkOS session', async () => {
+    const caller = createAnonymousCaller()
+    await expect(
+      caller.workshop.cancelSignup({ signupId: 'signup-1' }),
+    ).rejects.toThrow(/UNAUTHORIZED|signed in/)
+    expect(cancelMock).not.toHaveBeenCalled()
+  })
+
+  it('returns NOT_FOUND when the signup does not exist', async () => {
+    getAllMock.mockResolvedValueOnce([])
+    const caller = createWorkshopCaller({ id: 'workos-real' })
+    await expect(
+      caller.workshop.cancelSignup({ signupId: 'missing' }),
+    ).rejects.toThrow(/NOT_FOUND|not found/)
+    expect(cancelMock).not.toHaveBeenCalled()
+  })
+
+  it('forbids cancelling another attendee’s signup', async () => {
+    getAllMock.mockResolvedValueOnce([
+      { _id: 'signup-1', userWorkOSId: 'someone-else' },
+    ])
+    const caller = createWorkshopCaller({ id: 'workos-real' })
+    await expect(
+      caller.workshop.cancelSignup({ signupId: 'signup-1' }),
+    ).rejects.toThrow(/FORBIDDEN|your own/)
+    expect(cancelMock).not.toHaveBeenCalled()
+  })
+
+  it('cancels the caller’s own signup', async () => {
+    getAllMock.mockResolvedValueOnce([
+      { _id: 'signup-1', userWorkOSId: 'workos-real' },
+    ])
+    const caller = createWorkshopCaller({ id: 'workos-real' })
+    const result = await caller.workshop.cancelSignup({ signupId: 'signup-1' })
+    expect(result.success).toBe(true)
+    expect(cancelMock).toHaveBeenCalledWith('signup-1')
+  })
+})
+
+describe('workshop.getMySignups scoping', () => {
+  it('scopes the query to the session id', async () => {
+    getSignupsMock.mockResolvedValueOnce([{ _id: 's1' }])
+    const caller = createWorkshopCaller({ id: 'workos-real' })
+    const result = await caller.workshop.getMySignups()
+    expect(result.count).toBe(1)
+    expect(getSignupsMock).toHaveBeenCalledWith(
+      'workos-real',
+      'conf-1',
+      undefined,
+    )
+  })
+
+  it('returns an empty list when there is no WorkOS session', async () => {
+    const caller = createAnonymousCaller()
+    const result = await caller.workshop.getMySignups()
+    expect(result.data).toEqual([])
+    expect(getSignupsMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('workshop admin procedures remain NextAuth-gated', () => {
+  it('rejects a WorkOS attendee from admin.manualSignup', async () => {
+    // A WorkOS attendee session must NOT grant admin access — admin procedures
+    // key on the NextAuth organizer session, which the attendee does not have.
+    const caller = createWorkshopCaller({ id: 'workos-real' })
+    await expect(
+      caller.workshop.admin.manualSignup({
+        ...baseSignupInput,
+        userWorkOSId: 'workos-real',
+        userEmail: 'real@example.com',
+        userName: 'Real User',
+      }),
+    ).rejects.toThrow(/UNAUTHORIZED|FORBIDDEN|Authentication required/)
+  })
+
+  it('allows an organizer (NextAuth) through the admin auth gate', async () => {
+    // The admin caller passes the auth/admin middleware unchanged by this fix.
+    const caller = createAdminCaller()
+    const result = await caller.workshop.admin.getSummary()
+    expect(result.success).toBe(true)
+  })
+})

--- a/__tests__/helpers/trpc.ts
+++ b/__tests__/helpers/trpc.ts
@@ -19,7 +19,31 @@ export function createAnonymousCaller() {
     session: null,
     speaker: undefined,
     user: undefined,
+    workosUser: null,
     ipAddress: '',
+  })
+}
+
+/**
+ * A caller authenticated as a WorkOS AuthKit workshop attendee (NOT a NextAuth
+ * speaker). Mirrors what `createTRPCContext` derives from the sealed
+ * `wos-session` cookie, so workshop-router authz can be exercised directly.
+ */
+export function createWorkshopCaller(
+  workosUser?: Partial<import('@/server/trpc').WorkshopUserIdentity>,
+) {
+  return createCaller({
+    req: mockReq(),
+    session: null,
+    speaker: undefined,
+    user: undefined,
+    workosUser: {
+      id: workosUser?.id ?? 'workos-user-1',
+      email: workosUser?.email ?? 'attendee@example.com',
+      firstName: workosUser?.firstName ?? 'Test',
+      lastName: workosUser?.lastName ?? 'Attendee',
+    },
+    ipAddress: '127.0.0.1',
   })
 }
 
@@ -48,6 +72,7 @@ export function createAuthenticatedCaller(speakerId?: string) {
       name: speaker.name!,
       picture: 'https://example.com/avatar.jpg',
     },
+    workosUser: null,
     ipAddress: '127.0.0.1',
   })
 }

--- a/src/components/workshop/WorkshopList.tsx
+++ b/src/components/workshop/WorkshopList.tsx
@@ -44,14 +44,12 @@ export default function WorkshopList({
   })
 
   const { data: signupsData, refetch: refetchSignups } =
-    api.workshop.getMySignups.useQuery(
-      {
-        userWorkOSId: userWorkOSId || '',
-      },
-      {
-        enabled: !!userWorkOSId,
-      },
-    )
+    api.workshop.getMySignups.useQuery(undefined, {
+      // Identity is resolved server-side from the WorkOS session; this gate is
+      // purely a client-side UX guard so the query doesn't fire before the page
+      // has established the signed-in user.
+      enabled: !!userWorkOSId,
+    })
 
   const signupMutation = api.workshop.signup.useMutation({
     onSuccess: (data) => {
@@ -121,10 +119,9 @@ export default function WorkshopList({
     }
 
     try {
+      // Identity (userWorkOSId/userEmail/userName) is intentionally NOT sent:
+      // the server binds the signup to the authenticated WorkOS session.
       await signupMutation.mutateAsync({
-        userEmail,
-        userName,
-        userWorkOSId,
         experienceLevel,
         operatingSystem,
         workshop: { _type: 'reference', _ref: workshopId },

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -4,6 +4,8 @@ import {
   publicProcedure,
   adminProcedure,
   resolveConferenceId,
+  type Context,
+  type WorkshopUserIdentity,
 } from '@/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { revalidateTag } from 'next/cache'
@@ -12,7 +14,7 @@ import {
   workshopListInputSchema,
   workshopAvailabilitySchema,
   workshopSignupInputSchema,
-  workshopSignupsByUserSchema,
+  workshopSignupClientInputSchema,
   workshopSignupsByWorkshopSchema,
   cancelWorkshopSignupSchema,
   confirmWorkshopSignupSchema,
@@ -39,6 +41,31 @@ import { Status } from '@/lib/proposal/types'
 import { sendBasicWorkshopConfirmation } from '@/lib/email/workshop'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { WorkshopSignupStatus } from '@/lib/workshop/types'
+
+/**
+ * Return the authenticated WorkOS attendee for a self-service workshop action,
+ * or throw UNAUTHORIZED. The identity comes exclusively from the sealed WorkOS
+ * session cookie (see `resolveWorkshopUser` in trpc.ts) — it is NEVER taken from
+ * client input, which is what an attacker previously spoofed.
+ */
+function requireWorkshopUser(ctx: Context): WorkshopUserIdentity {
+  const user = ctx.workosUser
+  if (!user?.id) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'You must be signed in to manage workshop signups',
+    })
+  }
+  return user
+}
+
+/** Display name for a signup doc, mirroring the workshop page's fallback order. */
+function workshopUserName(user: WorkshopUserIdentity): string {
+  if (user.firstName && user.lastName) {
+    return `${user.firstName} ${user.lastName}`
+  }
+  return user.firstName || user.lastName || user.email
+}
 
 export const workshopRouter = router({
   list: publicProcedure.input(workshopListInputSchema).query(async () => {
@@ -108,59 +135,57 @@ export const workshopRouter = router({
       }
     }),
 
-  getMySignups: publicProcedure
-    .input(workshopSignupsByUserSchema)
-    .query(async ({ input, ctx }) => {
-      try {
-        const sessionUser = ctx.session?.user as
-          { id?: string; sub?: string } | undefined
-        const userWorkOSId =
-          input.userWorkOSId || sessionUser?.id || sessionUser?.sub
+  getMySignups: publicProcedure.query(async ({ ctx }) => {
+    try {
+      // Identity is taken ONLY from the WorkOS session — never from client
+      // input — so a caller cannot read another attendee's signups. No session
+      // → no signups (rather than an error, since the workshop page renders
+      // this list optimistically).
+      const userWorkOSId = ctx.workosUser?.id
 
-        const conferenceId = await resolveConferenceId()
-
-        if (!userWorkOSId) {
-          return {
-            success: true,
-            data: [],
-            count: 0,
-          }
-        }
-
-        const signups = await getWorkshopSignups(
-          userWorkOSId,
-          conferenceId,
-          'status' in input && typeof input.status === 'string'
-            ? input.status
-            : undefined,
-        )
-
+      if (!userWorkOSId) {
         return {
           success: true,
-          data: signups,
-          count: signups.length,
+          data: [],
+          count: 0,
         }
-      } catch (error) {
-        if (error instanceof TRPCError) throw error
-
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to fetch user signups',
-          cause: error,
-        })
       }
-    }),
+
+      const conferenceId = await resolveConferenceId()
+
+      const signups = await getWorkshopSignups(
+        userWorkOSId,
+        conferenceId,
+        undefined,
+      )
+
+      return {
+        success: true,
+        data: signups,
+        count: signups.length,
+      }
+    } catch (error) {
+      if (error instanceof TRPCError) throw error
+
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to fetch user signups',
+        cause: error,
+      })
+    }
+  }),
 
   signup: publicProcedure
-    .input(workshopSignupInputSchema)
-    .mutation(async ({ input }) => {
+    .input(workshopSignupClientInputSchema)
+    .mutation(async ({ input, ctx }) => {
       try {
-        if (!input.userWorkOSId || !input.userEmail || !input.userName) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: 'User information is required',
-          })
-        }
+        // Bind the signup to the authenticated WorkOS session. The id/email come
+        // from the sealed session cookie (authoritative); the client no longer
+        // sends — and cannot spoof — any identity.
+        const actor = requireWorkshopUser(ctx)
+        const userWorkOSId = actor.id
+        const userEmail = actor.email
+        const userName = workshopUserName(actor)
 
         const { conference } = await getConferenceForCurrentDomain({})
 
@@ -205,7 +230,7 @@ export const workshopRouter = router({
         }
 
         const existingSignups = await getWorkshopSignups(
-          input.userWorkOSId,
+          userWorkOSId,
           input.conference._ref,
           undefined,
         )
@@ -225,7 +250,14 @@ export const workshopRouter = router({
         const isWaitlist = !capacity || capacity.available <= 0
 
         const signup = await createWorkshopSignup({
-          ...input,
+          userWorkOSId,
+          userEmail,
+          userName,
+          experienceLevel: input.experienceLevel,
+          operatingSystem: input.operatingSystem,
+          workshop: input.workshop,
+          conference: input.conference,
+          notes: input.notes,
           status: isWaitlist
             ? WorkshopSignupStatus.WAITLIST
             : WorkshopSignupStatus.CONFIRMED,
@@ -264,8 +296,10 @@ export const workshopRouter = router({
 
   cancelSignup: publicProcedure
     .input(cancelWorkshopSignupSchema)
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       try {
+        const actor = requireWorkshopUser(ctx)
+
         const signups = await getAllWorkshopSignups({
           signupIds: [input.signupId],
         })
@@ -274,6 +308,16 @@ export const workshopRouter = router({
           throw new TRPCError({
             code: 'NOT_FOUND',
             message: 'Signup not found',
+          })
+        }
+
+        // Ownership check: a caller may only cancel their OWN signup. Previously
+        // any authenticated caller could cancel ANY signup id, evicting other
+        // attendees' seats.
+        if (signups[0].userWorkOSId !== actor.id) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'You can only cancel your own workshop signup',
           })
         }
 

--- a/src/server/schemas/workshop.ts
+++ b/src/server/schemas/workshop.ts
@@ -1,6 +1,15 @@
 import { z } from 'zod'
 import { WorkshopSignupStatus } from '@/lib/workshop/types'
 
+/**
+ * Full signup payload INCLUDING the user identity fields. This is only safe for
+ * admin (`adminProcedure`) callers such as `admin.manualSignup`, where an
+ * organizer intentionally registers a named participant. It MUST NOT back a
+ * public procedure — a public caller supplying `userWorkOSId`/`userEmail` could
+ * sign up (or impersonate) any other person. Public self-service signups use
+ * `workshopSignupClientInputSchema` below, which omits identity entirely; the
+ * server derives it from the WorkOS session.
+ */
 export const workshopSignupInputSchema = z.object({
   userEmail: z.string().email('Invalid email address'),
   userName: z
@@ -25,6 +34,27 @@ export const workshopSignupInputSchema = z.object({
   notes: z.string().optional(),
 })
 
+/**
+ * Public self-service signup payload. Deliberately carries NO identity
+ * (`userWorkOSId`/`userEmail`/`userName`) and NO `status`: the acting identity
+ * is bound server-side to the authenticated WorkOS session, and confirmed-vs-
+ * waitlist is decided by live capacity on the server. Removing these fields from
+ * the client contract is what closes the identity-spoofing hole.
+ */
+export const workshopSignupClientInputSchema = z.object({
+  experienceLevel: z.enum(['beginner', 'intermediate', 'advanced']),
+  operatingSystem: z.enum(['windows', 'macos', 'linux']),
+  workshop: z.object({
+    _type: z.literal('reference'),
+    _ref: z.string().min(1, 'Workshop reference is required'),
+  }),
+  conference: z.object({
+    _type: z.literal('reference'),
+    _ref: z.string().min(1, 'Conference reference is required'),
+  }),
+  notes: z.string().optional(),
+})
+
 export const workshopListInputSchema = z.object({
   includeCapacity: z.boolean().optional().default(false),
 })
@@ -32,15 +62,6 @@ export const workshopListInputSchema = z.object({
 export const workshopAvailabilitySchema = z.object({
   workshopId: z.string().min(1, 'Workshop ID is required'),
 })
-
-export const workshopSignupsByUserSchema = z
-  .object({
-    userEmail: z.string().email('Invalid email address').optional(),
-    userWorkOSId: z.string().optional(),
-  })
-  .refine((data) => data.userEmail || data.userWorkOSId, {
-    message: 'Either userEmail or userWorkOSId is required',
-  })
 
 export const workshopSignupsByWorkshopSchema = z.object({
   workshopId: z.string().min(1, 'Workshop ID is required'),

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -2,13 +2,70 @@ import { initTRPC, TRPCError } from '@trpc/server'
 import { NextRequest } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { AppEnvironment } from '@/lib/environment/config'
 import { structuredErrorData, type StructuredErrorData } from './errors'
+
+/**
+ * Identity of an authenticated WorkOS AuthKit user, projected from the sealed
+ * `wos-session` cookie. This is a SEPARATE auth system from the NextAuth
+ * (GitHub/LinkedIn) `session` above: NextAuth backs speakers/organizers on
+ * `/cfp` and `/admin`, whereas WorkOS backs workshop attendees on `/workshop`.
+ * Workshop signup authorization keys on this, never on client-supplied input.
+ */
+export interface WorkshopUserIdentity {
+  id: string
+  email: string
+  firstName?: string | null
+  lastName?: string | null
+}
+
+/**
+ * Resolve the WorkOS attendee identity for a tRPC request from the sealed
+ * `wos-session` cookie.
+ *
+ * Why not `withAuth()`: `withAuth()` reads the session out of a request header
+ * that the AuthKit MIDDLEWARE injects, and the middleware matcher only covers
+ * `/workshop*` — it does NOT run for `/api/trpc`, so `withAuth()` throws there.
+ * Instead we call `authkit(req)`, a public AuthKit helper that reads and unseals
+ * the `wos-session` cookie directly (via `getSessionFromCookie`). That cookie is
+ * encrypted+signed server-side with `WORKOS_COOKIE_PASSWORD`, so a client cannot
+ * forge it — it is a trustworthy, cookie-based server session, exactly the
+ * source authorization should bind to.
+ *
+ * We first cheaply check the cookie is present so the vast majority of tRPC
+ * calls (NextAuth admin/cfp/sponsor/message traffic, which carries no WorkOS
+ * cookie) skip AuthKit entirely. Any failure resolves to `null` (never throws),
+ * so a procedure's own guard decides (UNAUTHORIZED for workshop signup/cancel).
+ */
+async function resolveWorkshopUser(
+  req: NextRequest,
+): Promise<WorkshopUserIdentity | null> {
+  if (AppEnvironment.isTestMode) return null
+  const cookieName = process.env.WORKOS_COOKIE_NAME || 'wos-session'
+  if (!req.cookies.get(cookieName)) return null
+  try {
+    const { authkit } = await import('@workos-inc/authkit-nextjs')
+    const { session } = await authkit(req)
+    const user = session.user
+    if (!user?.id) return null
+    return {
+      id: user.id,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+    }
+  } catch {
+    return null
+  }
+}
 
 export async function createTRPCContext(opts: { req: NextRequest }) {
   const session = await getAuthSession({
     url: opts.req.url,
     headers: opts.req.headers,
   })
+
+  const workosUser = await resolveWorkshopUser(opts.req)
 
   // Extract IP address from headers
   const forwardedFor = opts.req.headers.get('x-forwarded-for')
@@ -26,6 +83,7 @@ export async function createTRPCContext(opts: { req: NextRequest }) {
     session,
     speaker: session?.speaker,
     user: session?.user,
+    workosUser,
     ipAddress,
   }
 }


### PR DESCRIPTION
## Security fix: workshop signup identity spoofing

### The hole
The public workshop procedures in `src/server/routers/workshop.ts` trusted a **client-supplied `userWorkOSId`**:

- `signup` (a `publicProcedure`) wrote the signup document using `input.userWorkOSId` / `input.userEmail` / `input.userName`. Any caller could register a signup **as any WorkOS user id**, filling workshops under arbitrary/fake identities.
- `cancelSignup` (a `publicProcedure`) cancelled **any** signup by id with **no ownership check at all** — an attacker could evict other participants' confirmed seats.
- `getMySignups` preferred `input.userWorkOSId` over the session, so any caller could **read another attendee's signups**.

### Root cause / why the session wasn't used
The workshop area authenticates with **WorkOS AuthKit** (`/workshop` uses `withAuth()`), which is a *separate* auth system from the NextAuth (GitHub/LinkedIn) session that backs `ctx.session` for `/cfp` and `/admin`. The WorkOS identity was **not present in the tRPC context at all** — `getMySignups`' `ctx.session?.user?.id ?? .sub` read the NextAuth session, which is null for workshop attendees, so it silently fell back to client input.

`withAuth()` cannot be used on `/api/trpc` because it reads a header injected by the AuthKit middleware, and the middleware matcher only covers `/workshop*` (it throws elsewhere). So the fix makes the WorkOS identity available in the tRPC context by reading the **sealed `wos-session` cookie** directly.

### The fix
1. **`src/server/trpc.ts`** — resolve the WorkOS attendee from the sealed cookie via the public `authkit(req)` helper (which unseals `wos-session`; the cookie is encrypted+signed server-side with `WORKOS_COOKIE_PASSWORD`, so a client cannot forge it). Exposed as `ctx.workosUser: WorkshopUserIdentity | null`. Gated on cookie presence so non-workshop tRPC traffic skips AuthKit entirely; never throws (falls back to `null`).
2. **`signup`** — bind the doc identity to `ctx.workosUser` (`UNAUTHORIZED` if absent). Identity is derived server-side: `userWorkOSId`/`userEmail` come from the session; `userName` from the session's first/last name (mirroring the page's fallback), falling back to email.
3. **`cancelSignup`** — require a WorkOS session and verify `signup.userWorkOSId === ctx.workosUser.id` before cancelling (`FORBIDDEN` otherwise).
4. **`getMySignups`** — scope strictly to `ctx.workosUser.id`; ignore client input.
5. **Input-schema break (internal-only client)** — `signup` now uses a new `workshopSignupClientInputSchema` that carries **no** identity and no `status`. `getMySignups` takes no identity input. The only caller is our own `WorkshopList` component, updated to stop sending identity. The full `workshopSignupInputSchema` (with identity) is retained **only** for `admin.manualSignup` (`adminProcedure`), where an organizer intentionally registers a named participant.

`admin.*` procedures were already `adminProcedure` (NextAuth organizer) and are unchanged; a WorkOS attendee session does not grant admin access.

### What the WorkOS session actually carries
The sealed `wos-session` cookie unseals to `{ accessToken, refreshToken, user, ... }` where `user` is the WorkOS `User`: `id`, `email`, `firstName`, `lastName`, etc. Authorization keys on `user.id` (email/name are used only for the signup doc's display fields).

### Tests
New `__tests__/api/trpc/workshop.test.ts` (10 tests): signup binds to the session id and ignores smuggled identity; no-session signup/cancel → `UNAUTHORIZED`; cancel of another attendee's signup → `FORBIDDEN`; cancel of own signup succeeds; `getMySignups` scoped to session / empty without session; WorkOS attendee rejected from `admin.manualSignup`; organizer passes the admin gate. Full suite: **3145 passed, 5 skipped, 217 files**. tsc / eslint / prettier / knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a significant identity-spoofing hole in the workshop signup flow by binding all self-service procedures (`signup`, `cancelSignup`, `getMySignups`) to the server-side WorkOS session cookie instead of trusting client-supplied identity fields. The fix is well-structured, properly isolated from the existing NextAuth flow, and ships with a comprehensive test suite.

- **`src/server/trpc.ts`**: Introduces `resolveWorkshopUser`, which unseals the sealed `wos-session` cookie via `authkit(req)` and exposes the verified `workosUser` identity on every tRPC context. The early-exit on a missing cookie keeps non-workshop traffic unaffected.
- **`src/server/routers/workshop.ts`**: `signup` and `cancelSignup` now require a valid WorkOS session via `requireWorkshopUser(ctx)` and include an ownership check before cancellation; `getMySignups` is strictly scoped to `ctx.workosUser.id`.
- **`src/server/schemas/workshop.ts`**: The original `workshopSignupInputSchema` (with identity fields) is retained for the admin-only `manualSignup` path; a new `workshopSignupClientInputSchema` without identity fields backs the public procedure, making spoofing structurally impossible.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the auth fix is correct and well-tested; minor observability gaps in the catch block are the only concerns.

The core fix — binding workshop procedures to the sealed WorkOS cookie rather than client input — is sound and closes a real spoofing hole. All three affected procedures are updated consistently, the schema split cleanly prevents identity fields from reaching public callers, and the 10 new tests exercise the key authorization paths including the forbidden cross-user cancel. The small gaps are: errors in resolveWorkshopUser are silently dropped with no log (makes production auth failures invisible), session.user is accessed without optional chaining (relies on catch for a predictable null case), and when a WorkOS access token expires the lack of a response object means authkit(req) may re-trigger a token refresh on every tRPC call until the cookie is renewed.

src/server/trpc.ts — the resolveWorkshopUser catch block and session?.user access pattern

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/trpc.ts | Adds WorkshopUserIdentity type and resolveWorkshopUser helper that unseals the wos-session cookie via authkit(req); errors are silently caught returning null with no logging |
| src/server/routers/workshop.ts | Correctly binds signup identity to ctx.workosUser; adds ownership check in cancelSignup and scopes getMySignups to session; logic is sound |
| src/server/schemas/workshop.ts | Splits schema into admin-only workshopSignupInputSchema (with identity) and public workshopSignupClientInputSchema (no identity/status); clean separation |
| __tests__/api/trpc/workshop.test.ts | New test file with 10 tests covering identity binding, UNAUTHORIZED/FORBIDDEN paths, ownership check, getMySignups scoping, and admin gate; comprehensive coverage of the fix |
| __tests__/helpers/trpc.ts | Adds createWorkshopCaller helper with workosUser context; all existing callers updated with workosUser: null to match the new Context type |
| src/components/workshop/WorkshopList.tsx | Removes identity fields from signup mutation call and passes undefined to getMySignups; UX guard (enabled: !!userWorkOSId) preserved |
| __tests__/api/trpc/schedule.test.ts | Minimal update: adds workosUser: null to baseCtx to satisfy the updated Context type |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workshop): bind signup identity to t..."](https://github.com/cloudnativebergen/website/commit/2dcb959e16726eed9415c42a8258fbdcfde12e89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45436224)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->