### PR TITLE
feat(messaging): thread status, assignee, dual archive, stale nudge (ticketing T1)

### DIFF
--- a/__tests__/api/cron/cleanup-notifications.test.ts
+++ b/__tests__/api/cron/cleanup-notifications.test.ts
@@ -5,10 +5,21 @@ import { NextRequest } from 'next/server'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockDeleteOlderThan = vi.fn<(...args: any[]) => any>()
+const mockDeleteMessaging = vi.fn<(...args: any[]) => any>()
+const mockNudgeStale = vi.fn<(...args: any[]) => any>()
 
 vi.mock('@/lib/notification/sanity', () => ({
   deleteNotificationsOlderThan: (...args: unknown[]) =>
     mockDeleteOlderThan(...args),
+}))
+
+vi.mock('@/lib/messaging/retention', () => ({
+  deleteExpiredMessagingData: (...args: unknown[]) =>
+    mockDeleteMessaging(...args),
+}))
+
+vi.mock('@/lib/messaging/nudge', () => ({
+  nudgeStaleConversations: (...args: unknown[]) => mockNudgeStale(...args),
 }))
 
 vi.mock('next/cache', () => ({
@@ -28,6 +39,19 @@ describe('api/cron/cleanup-notifications', () => {
     vi.clearAllMocks()
     process.env.CRON_SECRET = 'test-cron-secret'
     mockDeleteOlderThan.mockResolvedValue({ deleted: 0 })
+    mockDeleteMessaging.mockResolvedValue({
+      conferences: 0,
+      messages: 0,
+      conversations: 0,
+      preferences: 0,
+      notifications: 0,
+    })
+    mockNudgeStale.mockResolvedValue({
+      scanned: 0,
+      nudged: 0,
+      notifications: 0,
+      failed: 0,
+    })
   })
 
   afterEach(() => {
@@ -79,6 +103,35 @@ describe('api/cron/cleanup-notifications', () => {
       expect(data.success).toBe(true)
       expect(data.deleted).toBe(7)
       expect(mockDeleteOlderThan).toHaveBeenCalledWith(90)
+    })
+
+    it('runs the stale-thread nudge AFTER retention and returns its summary', async () => {
+      mockNudgeStale.mockResolvedValueOnce({
+        scanned: 5,
+        nudged: 3,
+        notifications: 4,
+        failed: 1,
+      })
+      const { GET } = await import('@/app/api/cron/cleanup-notifications/route')
+
+      const response = await GET(cronRequest('Bearer test-cron-secret'))
+      expect(response.status).toBe(200)
+
+      const data = await response.json()
+      expect(data.staleNudge).toEqual({
+        scanned: 5,
+        nudged: 3,
+        notifications: 4,
+        failed: 1,
+      })
+      // Ordered: notification cleanup → messaging retention → stale nudge.
+      const nudgeOrder = mockNudgeStale.mock.invocationCallOrder[0]
+      expect(nudgeOrder).toBeGreaterThan(
+        mockDeleteMessaging.mock.invocationCallOrder[0],
+      )
+      expect(mockDeleteMessaging.mock.invocationCallOrder[0]).toBeGreaterThan(
+        mockDeleteOlderThan.mock.invocationCallOrder[0],
+      )
     })
 
     it('returns 500 and surfaces the error when cleanup throws (errors are not swallowed)', async () => {

--- a/__tests__/api/trpc/message-ticketing.test.ts
+++ b/__tests__/api/trpc/message-ticketing.test.ts
@@ -1,0 +1,240 @@
+/**
+ * @vitest-environment node
+ *
+ * Router-level tests for the ticketing procedures on `message.*`:
+ * - `listConversations` rejects the organizer-only views for a non-organizer and
+ *   passes `view` through for both audiences;
+ * - `setStatus` / `setAssignee` / `setArchived` are organizer-only (NOT_FOUND
+ *   for a non-organizer, per A3) and authz-checked;
+ * - `setAssignee` validates the assignee is an organizer (null unassigns);
+ * - `setPreference` forwards the per-user `archived` flag.
+ *
+ * The data layer is mocked (IO functions only); the pure authz helper runs for
+ * real so the denial paths exercise the true rule.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  createAuthenticatedCaller,
+  createAdminCaller,
+  speakers,
+} from '../../helpers/trpc'
+import type { ConversationWithContext } from '@/lib/messaging/types'
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: vi.fn(async () => ({
+    conference: { _id: 'conf-1', domains: ['cndn.no'] },
+    domain: 'cndn.no',
+    error: null,
+  })),
+}))
+
+vi.mock('@/lib/messaging/notify', () => ({
+  notifyNewMessage: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: vi.fn(async () => null) },
+}))
+
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn(async () => [] as string[]),
+}))
+
+vi.mock('@/lib/messaging/sanity', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/messaging/sanity')>()
+  return {
+    ...actual, // keep the real canAccessConversation
+    getConversationById: vi.fn(),
+    getConversationParticipants: vi.fn(async () => []),
+    getConversationPreference: vi.fn(async () => ({
+      muted: false,
+      emailOverride: 'default',
+    })),
+    listConversationsForSpeaker: vi.fn(async () => []),
+    setConversationPreference: vi.fn(async () => ({
+      muted: false,
+      emailOverride: 'default',
+    })),
+    setConversationStatus: vi.fn(async () => {}),
+    setConversationAssignee: vi.fn(async () => {}),
+    setConversationArchived: vi.fn(async () => {}),
+  }
+})
+
+import {
+  getConversationById,
+  listConversationsForSpeaker,
+  setConversationStatus,
+  setConversationAssignee,
+  setConversationArchived,
+  setConversationPreference,
+} from '@/lib/messaging/sanity'
+import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const getById = getConversationById as unknown as LooseMock
+const listConvs = listConversationsForSpeaker as unknown as LooseMock
+const setStatus = setConversationStatus as unknown as LooseMock
+const setAssignee = setConversationAssignee as unknown as LooseMock
+const setArchived = setConversationArchived as unknown as LooseMock
+const setPref = setConversationPreference as unknown as LooseMock
+const orgIds = getOrganizerSpeakerIds as unknown as LooseMock
+
+const speaker1 = speakers[0]._id // not an organizer
+const organizerId = speakers.find((s) => s.isOrganizer)!._id
+
+const proposalConv: ConversationWithContext = {
+  _id: 'conversation.proposal.prop-1',
+  conferenceId: 'conf-1',
+  conversationType: 'proposal',
+  proposalId: 'prop-1',
+  proposalTitle: 'T',
+  proposalSpeakerIds: [speaker1],
+  createdById: speaker1,
+  subject: 'T',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastMessageAt: '2026-01-01T00:00:00.000Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('listConversations — view restriction', () => {
+  it('rejects an organizer-only view for a non-organizer (BAD_REQUEST)', async () => {
+    const caller = createAuthenticatedCaller(speaker1)
+    for (const view of ['needs-reply', 'mine', 'resolved'] as const) {
+      await expect(caller.message.listConversations({ view })).rejects.toThrow(
+        /BAD_REQUEST|not available/,
+      )
+    }
+    expect(listConvs).not.toHaveBeenCalled()
+  })
+
+  it('allows the speaker-appropriate views for a non-organizer', async () => {
+    const caller = createAuthenticatedCaller(speaker1)
+    await caller.message.listConversations({ view: 'archived' })
+    expect(listConvs).toHaveBeenCalledWith(
+      expect.objectContaining({ isOrganizer: false, view: 'archived' }),
+    )
+  })
+
+  it('passes an organizer-only view through for an organizer', async () => {
+    const caller = createAdminCaller()
+    await caller.message.listConversations({ view: 'needs-reply' })
+    expect(listConvs).toHaveBeenCalledWith(
+      expect.objectContaining({ isOrganizer: true, view: 'needs-reply' }),
+    )
+  })
+})
+
+describe('setStatus — organizer only', () => {
+  it('lets an organizer resolve a thread', async () => {
+    getById.mockResolvedValue(proposalConv)
+    const caller = createAdminCaller()
+    const result = await caller.message.setStatus({
+      conversationId: proposalConv._id,
+      status: 'resolved',
+    })
+    expect(setStatus).toHaveBeenCalledWith(proposalConv._id, 'resolved')
+    expect(result).toEqual({
+      conversationId: proposalConv._id,
+      status: 'resolved',
+    })
+  })
+
+  it('denies a non-organizer participant with NOT_FOUND (no capability oracle)', async () => {
+    getById.mockResolvedValue(proposalConv) // speaker1 IS a participant
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.setStatus({
+        conversationId: proposalConv._id,
+        status: 'resolved',
+      }),
+    ).rejects.toThrow(/NOT_FOUND|not found/)
+    expect(setStatus).not.toHaveBeenCalled()
+  })
+
+  it('returns NOT_FOUND for an absent conversation', async () => {
+    getById.mockResolvedValue(null)
+    const caller = createAdminCaller()
+    await expect(
+      caller.message.setStatus({ conversationId: 'nope', status: 'open' }),
+    ).rejects.toThrow(/NOT_FOUND|not found/)
+  })
+})
+
+describe('setAssignee — organizer validation', () => {
+  it('assigns when the target is an organizer', async () => {
+    getById.mockResolvedValue(proposalConv)
+    orgIds.mockResolvedValue([organizerId, 'org-2'])
+    const caller = createAdminCaller()
+    await caller.message.setAssignee({
+      conversationId: proposalConv._id,
+      assigneeId: 'org-2',
+    })
+    expect(setAssignee).toHaveBeenCalledWith(proposalConv._id, 'org-2')
+  })
+
+  it('rejects a non-organizer assignee with BAD_REQUEST', async () => {
+    getById.mockResolvedValue(proposalConv)
+    orgIds.mockResolvedValue([organizerId])
+    const caller = createAdminCaller()
+    await expect(
+      caller.message.setAssignee({
+        conversationId: proposalConv._id,
+        assigneeId: speaker1, // not an organizer
+      }),
+    ).rejects.toThrow(/BAD_REQUEST|organizer/)
+    expect(setAssignee).not.toHaveBeenCalled()
+  })
+
+  it('allows unassigning (null) without an organizer check', async () => {
+    getById.mockResolvedValue(proposalConv)
+    const caller = createAdminCaller()
+    await caller.message.setAssignee({
+      conversationId: proposalConv._id,
+      assigneeId: null,
+    })
+    expect(orgIds).not.toHaveBeenCalled()
+    expect(setAssignee).toHaveBeenCalledWith(proposalConv._id, null)
+  })
+})
+
+describe('setArchived — organizer only (global archive)', () => {
+  it('lets an organizer archive globally', async () => {
+    getById.mockResolvedValue(proposalConv)
+    const caller = createAdminCaller()
+    await caller.message.setArchived({
+      conversationId: proposalConv._id,
+      archived: true,
+    })
+    expect(setArchived).toHaveBeenCalledWith(proposalConv._id, true)
+  })
+
+  it('denies a non-organizer with NOT_FOUND', async () => {
+    getById.mockResolvedValue(proposalConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    await expect(
+      caller.message.setArchived({
+        conversationId: proposalConv._id,
+        archived: true,
+      }),
+    ).rejects.toThrow(/NOT_FOUND|not found/)
+    expect(setArchived).not.toHaveBeenCalled()
+  })
+})
+
+describe('setPreference — per-user archive passthrough', () => {
+  it('forwards the archived flag for a participant (speaker)', async () => {
+    getById.mockResolvedValue(proposalConv) // speaker1 is a participant
+    const caller = createAuthenticatedCaller(speaker1)
+    await caller.message.setPreference({
+      conversationId: proposalConv._id,
+      archived: true,
+    })
+    expect(setPref).toHaveBeenCalledWith(
+      expect.objectContaining({ speakerId: speaker1, archived: true }),
+    )
+  })
+})

--- a/__tests__/lib/messaging/nudge.test.ts
+++ b/__tests__/lib/messaging/nudge.test.ts
@@ -1,0 +1,212 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the stale-thread nudge (src/lib/messaging/nudge.ts):
+ * - the selection GROQ encodes the stale policy (open, quiet 3+ days, not
+ *   globally archived, not already nudged for this trailing message, last author
+ *   a non-organizer);
+ * - routing: the assignee when set, otherwise every organizer;
+ * - `lastStaleNudgeAt` is stamped after a successful nudge;
+ * - never-fail envelope + per-conversation isolation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn(async () => ['org-1', 'org-2']),
+  createNotifications: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: vi.fn() },
+  clientWrite: { patch: vi.fn() },
+}))
+
+import { clientReadUncached, clientWrite } from '@/lib/sanity/client'
+import {
+  getOrganizerSpeakerIds,
+  createNotifications,
+} from '@/lib/notification/sanity'
+import {
+  nudgeStaleConversations,
+  staleConversationCutoff,
+  STALE_AFTER_DAYS,
+} from '@/lib/messaging/nudge'
+import type { NotificationInput } from '@/lib/notification/types'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const readMock = clientReadUncached as unknown as { fetch: LooseMock }
+const patchMock = (clientWrite as unknown as { patch: LooseMock }).patch
+const createNotificationsMock = createNotifications as unknown as LooseMock
+
+/** Chainable patch mock; records committed ids and returns a set/commit chain. */
+function installPatch(commit: () => Promise<unknown> = async () => ({})) {
+  const committed: string[] = []
+  patchMock.mockImplementation((id: string) => {
+    const chain = {
+      set: vi.fn(() => chain),
+      commit: vi.fn(async () => {
+        committed.push(id)
+        return commit()
+      }),
+    }
+    return chain
+  })
+  return committed
+}
+
+const assignedConv = {
+  _id: 'conversation.gen-1',
+  conversationType: 'general' as const,
+  subject: 'Need info',
+  conferenceId: 'conf-1',
+  proposalId: null,
+  assignedToId: 'org-2',
+  lastMessageAt: '2026-01-01T00:00:00.000Z',
+}
+
+const unassignedProposalConv = {
+  _id: 'conversation.proposal.prop-1',
+  conversationType: 'proposal' as const,
+  subject: 'My Talk',
+  conferenceId: 'conf-1',
+  proposalId: 'prop-1',
+  assignedToId: null,
+  lastMessageAt: '2026-01-01T00:00:00.000Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.mocked(getOrganizerSpeakerIds).mockResolvedValue(['org-1', 'org-2'])
+})
+
+describe('staleConversationCutoff', () => {
+  it('is exactly STALE_AFTER_DAYS before now', () => {
+    const now = new Date('2026-01-10T00:00:00.000Z')
+    expect(staleConversationCutoff(now)).toBe('2026-01-07T00:00:00.000Z')
+    expect(STALE_AFTER_DAYS).toBe(3)
+  })
+})
+
+describe('selection GROQ encodes the stale policy', () => {
+  it('filters on status, cutoff, global archive, prior nudge, and non-organizer last author', async () => {
+    readMock.fetch.mockResolvedValueOnce([])
+    await nudgeStaleConversations()
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain("coalesce(status, 'open') == 'open'")
+    expect(query).toContain('lastMessageAt < $cutoff')
+    expect(query).toContain(
+      '(!defined(archivedAt) || archivedAt < lastMessageAt)',
+    )
+    expect(query).toContain(
+      '(!defined(lastStaleNudgeAt) || lastStaleNudgeAt < lastMessageAt)',
+    )
+    expect(query).toContain('in $organizerIds)')
+    expect(params.organizerIds).toEqual(['org-1', 'org-2'])
+    expect(typeof params.cutoff).toBe('string')
+  })
+
+  it('no-ops (no notifications, no writes) when nothing is stale', async () => {
+    readMock.fetch.mockResolvedValueOnce([])
+    const summary = await nudgeStaleConversations()
+    expect(summary).toEqual({
+      scanned: 0,
+      nudged: 0,
+      notifications: 0,
+      failed: 0,
+    })
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+    expect(patchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('routing + stamping', () => {
+  it('notifies ONLY the assignee when set, and stamps lastStaleNudgeAt', async () => {
+    const committed = installPatch()
+    readMock.fetch.mockResolvedValueOnce([assignedConv])
+
+    const summary = await nudgeStaleConversations()
+
+    expect(summary.scanned).toBe(1)
+    expect(summary.nudged).toBe(1)
+    expect(summary.notifications).toBe(1)
+    const inputs = createNotificationsMock.mock
+      .calls[0][0] as NotificationInput[]
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0].recipientId).toBe('org-2')
+    expect(inputs[0].notificationType).toBe('message_stale')
+    // General thread → admin messages deep link, no relatedProposal.
+    expect(inputs[0].link).toBe('/admin/messages/conversation.gen-1')
+    expect(inputs[0].relatedProposalId).toBeUndefined()
+    // Stamped after notifying.
+    expect(committed).toEqual(['conversation.gen-1'])
+  })
+
+  it('notifies EVERY organizer when unassigned, links to the admin proposal thread', async () => {
+    installPatch()
+    readMock.fetch.mockResolvedValueOnce([unassignedProposalConv])
+
+    const summary = await nudgeStaleConversations()
+
+    expect(summary.notifications).toBe(2)
+    const inputs = createNotificationsMock.mock
+      .calls[0][0] as NotificationInput[]
+    expect(inputs.map((i) => i.recipientId).sort()).toEqual(['org-1', 'org-2'])
+    // Proposal thread → admin proposal deep link + weak relatedProposal.
+    expect(inputs[0].link).toBe('/admin/proposals/prop-1#messages')
+    expect(inputs[0].relatedProposalId).toBe('prop-1')
+  })
+
+  it('skips (does not stamp) an unassigned thread when there are no organizers', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValue([])
+    installPatch()
+    readMock.fetch.mockResolvedValueOnce([{ ...unassignedProposalConv }])
+
+    const summary = await nudgeStaleConversations()
+
+    expect(summary.scanned).toBe(1)
+    expect(summary.nudged).toBe(0)
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+    expect(patchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('resilience', () => {
+  it('never throws: a read failure returns a zeroed summary', async () => {
+    readMock.fetch.mockRejectedValueOnce(new Error('sanity down'))
+    const summary = await nudgeStaleConversations()
+    expect(summary).toEqual({
+      scanned: 0,
+      nudged: 0,
+      notifications: 0,
+      failed: 0,
+    })
+  })
+
+  it('isolates a per-conversation failure and continues with the rest', async () => {
+    // First conversation's stamp throws; the second still gets nudged.
+    let call = 0
+    patchMock.mockImplementation(() => {
+      const chain = {
+        set: vi.fn(() => chain),
+        commit: vi.fn(async () => {
+          call += 1
+          if (call === 1) throw new Error('write conflict')
+          return {}
+        }),
+      }
+      return chain
+    })
+    readMock.fetch.mockResolvedValueOnce([
+      assignedConv,
+      { ...assignedConv, _id: 'conversation.gen-2', assignedToId: 'org-1' },
+    ])
+
+    const summary = await nudgeStaleConversations()
+
+    expect(summary.scanned).toBe(2)
+    expect(summary.failed).toBe(1)
+    expect(summary.nudged).toBe(1)
+  })
+})

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -517,8 +517,10 @@ describe('listConversationsForSpeaker — Who/What metadata (M6)', () => {
     )
     expect(query).toContain('proposal->speakers[0]->name')
     expect(query).toContain('subjectSpeaker->name')
-    // Organizer path never needs the organizer id set.
-    expect(getOrganizerSpeakerIds).not.toHaveBeenCalled()
+    // Ticketing: the organizer path now resolves the organizer id set up front
+    // to derive each row's `needsReply` (last author not an organizer). It is
+    // cached, so the second batch reuses it — called exactly once here.
+    expect(getOrganizerSpeakerIds).toHaveBeenCalledTimes(1)
   })
 
   it('SPEAKER audience: an organizer last-author becomes the counterpart; otherwise the Organizers label', async () => {
@@ -704,8 +706,11 @@ describe('listConversationsForSpeaker — compound keyset cursor (B5)', () => {
     expect(query).toContain(
       '(lastMessageAt < $before || (lastMessageAt == $before && _id < $beforeId))',
     )
+    // `speakerId` is now ALWAYS bound (the default 'active' view's correlated
+    // per-user-archive probe and the `mine` view both key off it).
     expect(params).toEqual({
       conferenceId: 'conf-1',
+      speakerId: 'org-1',
       before: '2026-01-02T00:00:00.000Z',
       beforeId: 'conversation.gen-1',
     })

--- a/__tests__/lib/messaging/ticketing.test.ts
+++ b/__tests__/lib/messaging/ticketing.test.ts
@@ -1,0 +1,494 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the ticketing additions to the messaging data layer
+ * (src/lib/messaging/sanity.ts):
+ * - the inbox VIEW filters compile to the right GROQ predicate BEFORE pagination
+ *   (organizer + speaker variants), including the correlated per-user-archive
+ *   exclusion;
+ * - derived per-row `needsReply` / `archived` (audience-appropriate);
+ * - per-user vs global archive independence and resurface-on-new-message
+ *   (timestamp comparison);
+ * - the status / assignee / archive mutations and setPreference's `archived`.
+ *
+ * Both Sanity clients are mocked so we assert exactly what is written / queried.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/sanity/helpers', () => ({
+  createReference: (id: string) => ({ _type: 'reference', _ref: id }),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { transaction: vi.fn(), create: vi.fn(), patch: vi.fn() },
+  clientReadUncached: { fetch: vi.fn() },
+}))
+
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn(async () => [] as string[]),
+}))
+
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import {
+  listConversationsForSpeaker,
+  setConversationStatus,
+  setConversationAssignee,
+  setConversationArchived,
+  setConversationPreference,
+} from '@/lib/messaging/sanity'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const writeMock = clientWrite as unknown as {
+  transaction: LooseMock
+  create: LooseMock
+  patch: LooseMock
+}
+const readMock = clientReadUncached as unknown as { fetch: LooseMock }
+
+/** Chainable patch mock for `clientWrite.patch(id).set().unset().commit()`. */
+function installPatch() {
+  const patch = {
+    set: vi.fn((_v?: Record<string, unknown>) => patch),
+    unset: vi.fn((_v?: string[]) => patch),
+    commit: vi.fn(async () => ({})),
+  }
+  writeMock.patch.mockReturnValue(patch)
+  return patch
+}
+
+/** Transaction mock that INVOKES the `patch(id, fn)` callback so we can assert
+ *  the set/unset ops the preference upsert builds. */
+function installTransaction() {
+  const patchBuilder = {
+    set: vi.fn((_v?: Record<string, unknown>) => patchBuilder),
+    unset: vi.fn((_v?: string[]) => patchBuilder),
+  }
+  const tx = {
+    create: vi.fn(() => tx),
+    createIfNotExists: vi.fn(() => tx),
+    patch: vi.fn((_id: string, fn?: (p: typeof patchBuilder) => unknown) => {
+      if (typeof fn === 'function') fn(patchBuilder)
+      return tx
+    }),
+    commit: vi.fn(async () => ({})),
+  }
+  writeMock.transaction.mockReturnValue(tx)
+  return { tx, patchBuilder }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// ---------------------------------------------------------------------------
+// View → GROQ predicate (applied BEFORE pagination)
+// ---------------------------------------------------------------------------
+
+/** Run the list query for a view and return the main query string + params. */
+async function queryForView({
+  isOrganizer,
+  view,
+  speakerId = 'org-1',
+}: {
+  isOrganizer: boolean
+  view?: Parameters<typeof listConversationsForSpeaker>[0]['view']
+  speakerId?: string
+}): Promise<{ query: string; params: Record<string, unknown> }> {
+  // Empty page → the function returns after the single main fetch.
+  readMock.fetch.mockResolvedValueOnce([])
+  await listConversationsForSpeaker({
+    speakerId,
+    isOrganizer,
+    conferenceId: 'conf-1',
+    view,
+  })
+  const [query, params] = readMock.fetch.mock.calls[0]
+  return { query, params }
+}
+
+// The exact correlated per-user-archive exclusion (documented in the PR). The
+// deterministic preference id keeps it a cheap point lookup.
+const PREF_ARCHIVE_FILTER =
+  "*[_id == 'convpref.' + ^._id + '.' + $speakerId && defined(archivedAt) && archivedAt >= ^.lastMessageAt]"
+
+describe('inbox views — ORGANIZER GROQ predicates', () => {
+  it('active (default): open AND not globally archived AND not per-user archived', async () => {
+    const { query, params } = await queryForView({ isOrganizer: true })
+    expect(query).toContain("coalesce(status, 'open') == 'open'")
+    expect(query).toContain(
+      '(!defined(archivedAt) || archivedAt < lastMessageAt)',
+    )
+    expect(query).toContain(`count(${PREF_ARCHIVE_FILTER}) == 0`)
+    // No organizer-id param unless the needs-reply view needs it.
+    expect(params.organizerIds).toBeUndefined()
+    expect(params.speakerId).toBe('org-1')
+  })
+
+  it('needs-reply: active AND last author not an organizer (binds $organizerIds)', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValueOnce(['org-1', 'org-2'])
+    const { query, params } = await queryForView({
+      isOrganizer: true,
+      view: 'needs-reply',
+    })
+    expect(query).toContain("coalesce(status, 'open') == 'open'")
+    expect(query).toContain(`count(${PREF_ARCHIVE_FILTER}) == 0`)
+    expect(query).toContain("coalesce(status, 'open') != 'resolved'")
+    // The last-message author must not be in the organizer set.
+    expect(query).toContain('in $organizerIds)')
+    expect(params.organizerIds).toEqual(['org-1', 'org-2'])
+  })
+
+  it('mine: active AND assigned to the caller', async () => {
+    const { query } = await queryForView({ isOrganizer: true, view: 'mine' })
+    expect(query).toContain('assignedTo._ref == $speakerId')
+    expect(query).toContain(`count(${PREF_ARCHIVE_FILTER}) == 0`)
+  })
+
+  it('resolved: status resolved AND not archived (neither global nor per-user)', async () => {
+    const { query } = await queryForView({
+      isOrganizer: true,
+      view: 'resolved',
+    })
+    expect(query).toContain("coalesce(status, 'open') == 'resolved'")
+    expect(query).toContain(
+      '(!defined(archivedAt) || archivedAt < lastMessageAt)',
+    )
+    expect(query).toContain(`count(${PREF_ARCHIVE_FILTER}) == 0`)
+  })
+
+  it('archived: globally OR per-user archived', async () => {
+    const { query } = await queryForView({
+      isOrganizer: true,
+      view: 'archived',
+    })
+    expect(query).toContain(
+      '(defined(archivedAt) && archivedAt >= lastMessageAt)',
+    )
+    expect(query).toContain(`count(${PREF_ARCHIVE_FILTER}) > 0`)
+  })
+
+  it('all: no status/archive predicate', async () => {
+    const { query } = await queryForView({ isOrganizer: true, view: 'all' })
+    expect(query).not.toContain("count(*[_id == 'convpref")
+    expect(query).not.toContain("== 'resolved'")
+    expect(query).not.toContain('assignedTo._ref == $speakerId')
+  })
+})
+
+describe('inbox views — SPEAKER GROQ predicates (per-user archive only)', () => {
+  it('active: excludes ONLY the caller per-user archive, ignores global/status', async () => {
+    const { query } = await queryForView({
+      isOrganizer: false,
+      speakerId: 'sp-1',
+    })
+    expect(query).toContain(`count(${PREF_ARCHIVE_FILTER}) == 0`)
+    // Speakers never filter on global archive or status.
+    expect(query).not.toContain("== 'open'")
+    expect(query).not.toContain('archivedAt < lastMessageAt')
+    // Access scope is still applied.
+    expect(query).toContain('createdBy._ref == $speakerId')
+  })
+
+  it('archived: the caller per-user archive only', async () => {
+    const { query } = await queryForView({
+      isOrganizer: false,
+      speakerId: 'sp-1',
+      view: 'archived',
+    })
+    expect(query).toContain(`count(${PREF_ARCHIVE_FILTER}) > 0`)
+    expect(query).not.toContain(
+      '(defined(archivedAt) && archivedAt >= lastMessageAt)',
+    )
+  })
+
+  it('all: no archive predicate', async () => {
+    const { query } = await queryForView({
+      isOrganizer: false,
+      speakerId: 'sp-1',
+      view: 'all',
+    })
+    expect(query).not.toContain("count(*[_id == 'convpref")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Derived per-row needsReply / archived (timestamp semantics)
+// ---------------------------------------------------------------------------
+
+function orgRow(overrides: Record<string, unknown>) {
+  return {
+    _id: 'conversation.gen-1',
+    conversationType: 'general' as const,
+    subject: 'Q',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastMessageAt: '2026-02-01T00:00:00.000Z',
+    status: 'open' as const,
+    assignedTo: null,
+    archivedAt: null,
+    lastMessage: {
+      authorId: 'sp-9',
+      authorName: 'Kari',
+      authorImage: null,
+      body: 'hi',
+    },
+    speakerSideName: 'Kari',
+    speakerSideImage: null,
+    ...overrides,
+  }
+}
+
+describe('derived needsReply (ORGANIZER audience)', () => {
+  it('true when the last author is a non-organizer and status is open', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValueOnce(['org-1'])
+    readMock.fetch.mockResolvedValueOnce([orgRow({})]).mockResolvedValueOnce([])
+    const [row] = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(row.needsReply).toBe(true)
+  })
+
+  it('false when the last author IS an organizer', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValueOnce(['org-1'])
+    readMock.fetch
+      .mockResolvedValueOnce([
+        orgRow({
+          lastMessage: {
+            authorId: 'org-1',
+            authorName: 'O',
+            authorImage: null,
+            body: 'x',
+          },
+        }),
+      ])
+      .mockResolvedValueOnce([])
+    const [row] = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(row.needsReply).toBe(false)
+  })
+
+  it('false when resolved, and false when there is no message yet', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValue(['org-1'])
+    readMock.fetch
+      .mockResolvedValueOnce([orgRow({ status: 'resolved' })])
+      .mockResolvedValueOnce([])
+    const [resolved] = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(resolved.needsReply).toBe(false)
+
+    readMock.fetch
+      .mockResolvedValueOnce([orgRow({ lastMessage: null })])
+      .mockResolvedValueOnce([])
+    const [noMsg] = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(noMsg.needsReply).toBe(false)
+  })
+
+  it('is always false for a SPEAKER caller', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValueOnce([])
+    readMock.fetch.mockResolvedValueOnce([orgRow({})]).mockResolvedValueOnce([])
+    const [row] = await listConversationsForSpeaker({
+      speakerId: 'sp-9',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(row.needsReply).toBe(false)
+  })
+})
+
+describe('derived archived — global vs per-user, resurface-on-new-message', () => {
+  it('globally archived when archivedAt >= lastMessageAt (organizer)', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce([
+        orgRow({
+          lastMessageAt: '2026-02-01T00:00:00.000Z',
+          archivedAt: '2026-02-01T00:00:00.000Z', // equal → archived
+        }),
+      ])
+      .mockResolvedValueOnce([]) // unread
+      .mockResolvedValueOnce([]) // pref
+    const [row] = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(row.archived).toBe(true)
+  })
+
+  it('AUTO-RESURFACES when a newer message pushes lastMessageAt past archivedAt', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce([
+        orgRow({
+          lastMessageAt: '2026-03-01T00:00:00.000Z', // newer than archive
+          archivedAt: '2026-02-01T00:00:00.000Z',
+        }),
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+    const [row] = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(row.archived).toBe(false)
+  })
+
+  it('per-user and global archive are INDEPENDENT: a speaker ignores global archive', async () => {
+    // Globally archived, but the speaker has NO per-user archive → not archived
+    // for the speaker (global archive is an organizer-side hide).
+    readMock.fetch
+      .mockResolvedValueOnce([
+        orgRow({
+          lastMessageAt: '2026-02-01T00:00:00.000Z',
+          archivedAt: '2026-02-01T00:00:00.000Z',
+        }),
+      ])
+      .mockResolvedValueOnce([]) // unread
+      .mockResolvedValueOnce([]) // pref: none
+    const [speakerRow] = await listConversationsForSpeaker({
+      speakerId: 'sp-9',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(speakerRow.archived).toBe(false)
+
+    // Same conversation, this time the speaker DID per-user archive it (pref
+    // archivedAt >= lastMessageAt) → archived for the speaker.
+    readMock.fetch
+      .mockResolvedValueOnce([
+        orgRow({ lastMessageAt: '2026-02-01T00:00:00.000Z', archivedAt: null }),
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          conversationId: 'conversation.gen-1',
+          archivedAt: '2026-02-02T00:00:00.000Z',
+        },
+      ])
+    const [archivedForSpeaker] = await listConversationsForSpeaker({
+      speakerId: 'sp-9',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(archivedForSpeaker.archived).toBe(true)
+  })
+
+  it('projects status (coalesced) and assignedTo deref', async () => {
+    readMock.fetch
+      .mockResolvedValueOnce([
+        orgRow({
+          status: 'resolved',
+          assignedTo: { _id: 'org-2', name: 'Ola' },
+        }),
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+    const [row] = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(row.status).toBe('resolved')
+    expect(row.assignedTo).toEqual({ _id: 'org-2', name: 'Ola' })
+    // The projection coalesces an absent status to 'open'.
+    const [query] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('"status": coalesce(status, \'open\')')
+    expect(query).toContain('"assignedTo": assignedTo->{ _id, name }')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+describe('setConversationStatus', () => {
+  it('patches the status field', async () => {
+    const patch = installPatch()
+    await setConversationStatus('conversation.gen-1', 'resolved')
+    expect(writeMock.patch).toHaveBeenCalledWith('conversation.gen-1')
+    expect(patch.set).toHaveBeenCalledWith({ status: 'resolved' })
+    expect(patch.commit).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('setConversationAssignee', () => {
+  it('sets a WEAK assignee reference', async () => {
+    const patch = installPatch()
+    await setConversationAssignee('conversation.gen-1', 'org-2')
+    expect(patch.set).toHaveBeenCalledWith({
+      assignedTo: { _type: 'reference', _ref: 'org-2', _weak: true },
+    })
+  })
+
+  it('unsets the assignee when passed null', async () => {
+    const patch = installPatch()
+    await setConversationAssignee('conversation.gen-1', null)
+    expect(patch.unset).toHaveBeenCalledWith(['assignedTo'])
+    expect(patch.set).not.toHaveBeenCalled()
+  })
+})
+
+describe('setConversationArchived — global archive timestamp semantics', () => {
+  it('stamps archivedAt = now when archiving', async () => {
+    const patch = installPatch()
+    await setConversationArchived('conversation.gen-1', true)
+    const arg = patch.set.mock.calls[0][0] as { archivedAt: string }
+    expect(typeof arg.archivedAt).toBe('string')
+    expect(patch.unset).not.toHaveBeenCalled()
+  })
+
+  it('unsets archivedAt when un-archiving', async () => {
+    const patch = installPatch()
+    await setConversationArchived('conversation.gen-1', false)
+    expect(patch.unset).toHaveBeenCalledWith(['archivedAt'])
+    expect(patch.set).not.toHaveBeenCalled()
+  })
+})
+
+describe('setConversationPreference — per-user archive', () => {
+  it('stamps the preference archivedAt when archived=true', async () => {
+    const { patchBuilder } = installTransaction()
+    readMock.fetch.mockResolvedValue(null)
+    await setConversationPreference({
+      conversationId: 'conversation.gen-1',
+      speakerId: 'sp-3',
+      archived: true,
+    })
+    const arg = patchBuilder.set.mock.calls[0][0] as { archivedAt: string }
+    expect(typeof arg.archivedAt).toBe('string')
+    expect(patchBuilder.unset).not.toHaveBeenCalled()
+  })
+
+  it('unsets the preference archivedAt when archived=false', async () => {
+    const { patchBuilder } = installTransaction()
+    readMock.fetch.mockResolvedValue(null)
+    await setConversationPreference({
+      conversationId: 'conversation.gen-1',
+      speakerId: 'sp-3',
+      archived: false,
+    })
+    expect(patchBuilder.unset).toHaveBeenCalledWith(['archivedAt'])
+  })
+})

--- a/sanity/schemaTypes/conversation.ts
+++ b/sanity/schemaTypes/conversation.ts
@@ -104,6 +104,53 @@ export default defineType({
       validation: (Rule) => Rule.required(),
       initialValue: () => new Date().toISOString(),
     }),
+    defineField({
+      name: 'status',
+      title: 'Status',
+      type: 'string',
+      description:
+        'Ticketing state for the ORGANIZER audience. ABSENT MEANS OPEN — pre-ticketing threads carry no status and every read coalesces undefined to "open", so existing documents need no migration.',
+      options: {
+        list: [
+          { title: 'Open', value: 'open' },
+          { title: 'Resolved', value: 'resolved' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'open',
+    }),
+    defineField({
+      name: 'assignedTo',
+      title: 'Assigned To',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion; a
+      // dangling assignee ref is tolerated (mirrors createdBy/subjectSpeaker).
+      weak: true,
+      description: 'Organizer responsible for following up.',
+      // Restrict the Studio picker to organizers. `isOrganizer` is global, so
+      // (unlike sponsorForConference.assignedTo) this deliberately skips the
+      // per-conference filtering — the router validates the assignee instead.
+      options: {
+        filter: '_id in *[_type == "conference"].organizers[]._ref',
+      },
+    }),
+    defineField({
+      name: 'archivedAt',
+      title: 'Archived At',
+      type: 'datetime',
+      description:
+        'GLOBAL organizer archive. TIMESTAMP SEMANTICS: a conversation is globally archived IFF archivedAt >= lastMessageAt. A new message bumps lastMessageAt past archivedAt, so the thread AUTO-RESURFACES with zero fan-out writes. Speakers ignore this field (global archive is an organizer-side hide); a speaker archives via their own conversationPreference.archivedAt.',
+    }),
+    defineField({
+      name: 'lastStaleNudgeAt',
+      title: 'Last Stale Nudge At',
+      type: 'datetime',
+      description:
+        'Bookkeeping for the stale-thread cron: when a stale-nudge notification was last emitted for this thread. A nudge fires again only once a NEWER message arrives (lastStaleNudgeAt < lastMessageAt), so a thread is never nudged twice for the same trailing message.',
+      readOnly: true,
+      hidden: true,
+    }),
   ],
   preview: {
     select: {

--- a/sanity/schemaTypes/conversationPreference.ts
+++ b/sanity/schemaTypes/conversationPreference.ts
@@ -53,6 +53,13 @@ export default defineType({
       },
       initialValue: 'default',
     }),
+    defineField({
+      name: 'archivedAt',
+      title: 'Archived At',
+      type: 'datetime',
+      description:
+        'PER-USER archive for this participant. Same TIMESTAMP SEMANTICS as conversation.archivedAt: archived IFF archivedAt >= the conversation lastMessageAt, so a new message auto-resurfaces the thread for this participant with no extra write. This is the ONLY archive that hides a thread from a SPEAKER; organizers additionally honor the global conversation.archivedAt.',
+    }),
   ],
   preview: {
     select: {

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -55,6 +55,7 @@ export default defineType({
           // Reserved for future use — no emitter yet.
           { title: 'Proposal Comment', value: 'proposal_comment' },
           { title: 'Message Received', value: 'message_received' },
+          { title: 'Stale Conversation', value: 'message_stale' },
           { title: 'Co-Speaker Response', value: 'cospeaker_response' },
           { title: 'Travel Support Update', value: 'travel_support_update' },
           { title: 'Sponsor Activity', value: 'sponsor_activity' },

--- a/src/app/api/cron/cleanup-notifications/route.ts
+++ b/src/app/api/cron/cleanup-notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { deleteNotificationsOlderThan } from '@/lib/notification/sanity'
 import { deleteExpiredMessagingData } from '@/lib/messaging/retention'
+import { nudgeStaleConversations } from '@/lib/messaging/nudge'
 import { unstable_noStore as noStore } from 'next/cache'
 
 /**
@@ -53,10 +54,24 @@ export async function GET(request: NextRequest) {
         ` notifications=${messaging.notifications}`,
     )
 
+    // Stale-thread nudge runs LAST on the same daily trigger: open threads whose
+    // last message is from a non-organizer and which have gone quiet for 3+ days
+    // get one hub notification (to the assignee, else all organizers). This
+    // never throws — a failure only zeroes its summary and is logged.
+    const staleNudge = await nudgeStaleConversations()
+
+    console.log(
+      `Stale nudge: scanned=${staleNudge.scanned}` +
+        ` nudged=${staleNudge.nudged}` +
+        ` notifications=${staleNudge.notifications}` +
+        ` failed=${staleNudge.failed}`,
+    )
+
     return NextResponse.json({
       success: true,
       deleted,
       messaging,
+      staleNudge,
     })
   } catch (error) {
     console.error('Error in cleanup notifications cron job:', error)

--- a/src/lib/messaging/nudge.ts
+++ b/src/lib/messaging/nudge.ts
@@ -1,0 +1,181 @@
+import 'server-only'
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import {
+  createNotifications,
+  getOrganizerSpeakerIds,
+} from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
+import { conversationLinkPath } from './links'
+
+/**
+ * Server-only stale-thread nudge for speaker↔organizer messaging (ticketing).
+ *
+ * POLICY: a conversation that is still OPEN, whose LAST message is from a
+ * non-organizer (so the ball is in the organizers' court), and which has seen no
+ * new activity for {@link STALE_AFTER_DAYS} days gets ONE hub notification —
+ * routed to the assigned organizer when set, otherwise to every organizer — with
+ * a deep link to the admin thread. The conversation's `lastStaleNudgeAt` is then
+ * stamped so it is not nudged again until a NEWER message arrives
+ * (`lastStaleNudgeAt < lastMessageAt` re-arms it); a globally-archived thread is
+ * never nudged.
+ *
+ * CONTRACT: NEVER throws. Like the notification/messaging retention jobs this is
+ * cron-invoked, but it wraps its whole run so a read failure only zeroes the
+ * summary; each conversation is additionally isolated so one bad thread cannot
+ * stop the rest. Returns aggregate counts for structured cron logging.
+ */
+
+/** Days without an organizer reply before an open thread is nudged. */
+export const STALE_AFTER_DAYS = 3
+
+/**
+ * A hard cap on conversations nudged per run, so a backlog (or a clock/skew bug)
+ * can never fan out an unbounded number of notifications in one invocation. Any
+ * remainder is picked up by the next daily run. Mirrors the messaging retention
+ * job's `MAX_CONFERENCES_PER_RUN` safety valve.
+ */
+const MAX_CONVERSATIONS_PER_RUN = 200
+
+/** Aggregate counts for one nudge run. */
+export interface StaleNudgeSummary {
+  /** Stale conversations selected by the query (before per-thread work). */
+  scanned: number
+  /** Conversations for which a notification was emitted AND stamped. */
+  nudged: number
+  /** Total hub notifications created (assignee → 1; unassigned → N organizers). */
+  notifications: number
+  /** Conversations whose nudge failed and were isolated (logged, skipped). */
+  failed: number
+}
+
+/**
+ * The cutoff a conversation's `lastMessageAt` must PRECEDE to be considered
+ * stale: exactly {@link STALE_AFTER_DAYS} days before `now`. `lastMessageAt` is
+ * a full ISO datetime, so the GROQ comparison is against this same shape.
+ */
+export function staleConversationCutoff(now: Date = new Date()): string {
+  return new Date(
+    now.getTime() - STALE_AFTER_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString()
+}
+
+/** A stale conversation row, projected with what a nudge needs. */
+interface StaleConversation {
+  _id: string
+  conversationType: 'proposal' | 'general'
+  subject: string | null
+  conferenceId: string | null
+  proposalId?: string | null
+  assignedToId?: string | null
+  lastMessageAt: string
+}
+
+// The newest message's author (null for a message-less thread). Same shape used
+// by the inbox `needs-reply` filter.
+const LAST_AUTHOR_REF =
+  '*[_type == "message" && conversation._ref == ^._id] | order(createdAt desc, _id desc)[0].author._ref'
+
+/**
+ * Emit stale-thread nudges. See the module CONTRACT — this never throws.
+ */
+export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
+  const summary: StaleNudgeSummary = {
+    scanned: 0,
+    nudged: 0,
+    notifications: 0,
+    failed: 0,
+  }
+
+  try {
+    const organizerIds = await getOrganizerSpeakerIds()
+    const cutoff = staleConversationCutoff()
+
+    // Selection: open (or absent status) AND no activity since the cutoff AND
+    // NOT globally archived (archivedAt >= lastMessageAt) AND not already nudged
+    // for this trailing message (lastStaleNudgeAt < lastMessageAt) AND a last
+    // message exists whose author is NOT an organizer.
+    const conversations =
+      (await clientReadUncached.fetch<StaleConversation[]>(
+        `*[_type == "conversation"
+          && coalesce(status, 'open') == 'open'
+          && lastMessageAt < $cutoff
+          && (!defined(archivedAt) || archivedAt < lastMessageAt)
+          && (!defined(lastStaleNudgeAt) || lastStaleNudgeAt < lastMessageAt)
+          && defined(${LAST_AUTHOR_REF})
+          && !(${LAST_AUTHOR_REF} in $organizerIds)
+        ] | order(lastMessageAt asc) [0...${MAX_CONVERSATIONS_PER_RUN}] {
+          "_id": _id,
+          conversationType,
+          subject,
+          "conferenceId": conference._ref,
+          "proposalId": proposal._ref,
+          "assignedToId": assignedTo._ref,
+          lastMessageAt
+        }`,
+        { cutoff, organizerIds },
+        { cache: 'no-store' },
+      )) ?? []
+
+    summary.scanned = conversations.length
+
+    for (const conversation of conversations) {
+      try {
+        // A thread with no resolvable conference can't be notified about (the
+        // notification requires a conference ref); skip without stamping.
+        if (!conversation.conferenceId) continue
+
+        // Route to the assignee when set, else to every organizer. If nobody can
+        // be notified (no assignee AND no organizers), skip without stamping so
+        // the thread is retried once organizers exist.
+        const recipientIds = conversation.assignedToId
+          ? [conversation.assignedToId]
+          : organizerIds
+        if (recipientIds.length === 0) continue
+
+        const link = conversationLinkPath(
+          {
+            _id: conversation._id,
+            conversationType: conversation.conversationType,
+            proposalId: conversation.proposalId ?? undefined,
+          },
+          true,
+        )
+        const subject = conversation.subject ?? 'Conversation'
+        const inputs: NotificationInput[] = recipientIds.map((recipientId) => ({
+          recipientId,
+          conferenceId: conversation.conferenceId as string,
+          notificationType: 'message_stale',
+          title: `Awaiting reply: ${subject}`.slice(0, 200),
+          message: `No organizer reply in over ${STALE_AFTER_DAYS} days.`,
+          link,
+          ...(conversation.proposalId
+            ? { relatedProposalId: conversation.proposalId }
+            : {}),
+        }))
+
+        // createNotifications never throws; the stamp write can, so it is inside
+        // the per-conversation try/catch and runs only after the notifications.
+        await createNotifications(inputs)
+        await clientWrite
+          .patch(conversation._id)
+          .set({ lastStaleNudgeAt: new Date().toISOString() })
+          .commit()
+
+        summary.nudged += 1
+        summary.notifications += inputs.length
+      } catch (error) {
+        summary.failed += 1
+        console.error(
+          `Stale nudge: failed for conversation ${conversation._id}:`,
+          error,
+        )
+      }
+    }
+  } catch (error) {
+    // Never-fail envelope: a read failure zeroes the run rather than throwing
+    // into the cron (whose other steps must still complete).
+    console.error('Stale nudge: run failed:', error)
+  }
+
+  return summary
+}

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -8,6 +8,8 @@ import type {
   ConversationListItem,
   ConversationParticipant,
   ConversationPreference,
+  ConversationStatus,
+  ConversationView,
   ConversationWithContext,
   EmailOverride,
   Message,
@@ -62,6 +64,99 @@ const CONVERSATION_PROJECTION = `{
   createdAt,
   lastMessageAt
 }`
+
+// ---------------------------------------------------------------------------
+// Inbox view filtering (GROQ predicates applied BEFORE pagination)
+// ---------------------------------------------------------------------------
+//
+// Every view filter is folded into the base `*[...]` predicate, ANDed in BEFORE
+// the `| order(...) [0...PAGE_SIZE]` slice. This is deliberate: per-user archive
+// lives in a SEPARATE preference document, so excluding archived rows only after
+// the slice would silently shrink pages. The correlated preference subquery
+// below keeps the exclusion in the predicate where it belongs.
+
+/**
+ * Correlated per-user-archive probe. The deterministic preference doc
+ * `convpref.<conversationId>.<callerId>` archives this thread FOR THE CALLER iff
+ * its `archivedAt >= the conversation's lastMessageAt` — the same timestamp rule
+ * as the global archive, so a newer message auto-resurfaces it with no extra
+ * write. `^._id` / `^.lastMessageAt` reach out to the conversation being
+ * filtered; `$speakerId` is the caller. `count()` is 0 or 1 (the id is unique).
+ */
+const PREF_ARCHIVED_SUBQUERY =
+  "*[_id == 'convpref.' + ^._id + '.' + $speakerId && defined(archivedAt) && archivedAt >= ^.lastMessageAt]"
+const NOT_USER_ARCHIVED = `count(${PREF_ARCHIVED_SUBQUERY}) == 0`
+const USER_ARCHIVED = `count(${PREF_ARCHIVED_SUBQUERY}) > 0`
+
+const STATUS_OPEN = "coalesce(status, 'open') == 'open'"
+const STATUS_RESOLVED = "coalesce(status, 'open') == 'resolved'"
+const STATUS_NOT_RESOLVED = "coalesce(status, 'open') != 'resolved'"
+// Global archive: archived iff archivedAt >= lastMessageAt; a newer message
+// pushes lastMessageAt past archivedAt → no longer archived (auto-resurface).
+const NOT_GLOBALLY_ARCHIVED =
+  '(!defined(archivedAt) || archivedAt < lastMessageAt)'
+const GLOBALLY_ARCHIVED = '(defined(archivedAt) && archivedAt >= lastMessageAt)'
+// The newest message's author (null when the thread has no messages yet).
+const LAST_AUTHOR_REF =
+  '*[_type == "message" && conversation._ref == ^._id] | order(createdAt desc, _id desc)[0].author._ref'
+// Needs an organizer reply: not resolved AND a message exists whose author is
+// not an organizer. Uses $organizerIds — bound only for the `needs-reply` view.
+const NEEDS_REPLY = `${STATUS_NOT_RESOLVED} && defined(${LAST_AUTHOR_REF}) && !(${LAST_AUTHOR_REF} in $organizerIds)`
+
+/**
+ * Build the GROQ predicate fragment (leading ` && ...`, or empty for `all`) for
+ * an inbox `view`, plus whether it references `$organizerIds` (only
+ * `needs-reply` does). See {@link ConversationView} for the full semantics; the
+ * ORGANIZER `active` set — status open AND not globally archived AND not
+ * per-user archived — is the shared base of the organizer-only views.
+ */
+function buildViewPredicate(
+  view: ConversationView,
+  isOrganizer: boolean,
+): { predicate: string; needsOrganizerIds: boolean } {
+  if (!isOrganizer) {
+    // Speakers: only their OWN preference archive hides a thread. Global archive
+    // and status are organizer-side concepts a speaker never filters on.
+    switch (view) {
+      case 'archived':
+        return { predicate: ` && ${USER_ARCHIVED}`, needsOrganizerIds: false }
+      case 'all':
+        return { predicate: '', needsOrganizerIds: false }
+      default: // 'active'
+        return {
+          predicate: ` && ${NOT_USER_ARCHIVED}`,
+          needsOrganizerIds: false,
+        }
+    }
+  }
+  const active = `${STATUS_OPEN} && ${NOT_GLOBALLY_ARCHIVED} && ${NOT_USER_ARCHIVED}`
+  switch (view) {
+    case 'needs-reply':
+      return {
+        predicate: ` && ${active} && ${NEEDS_REPLY}`,
+        needsOrganizerIds: true,
+      }
+    case 'mine':
+      return {
+        predicate: ` && ${active} && assignedTo._ref == $speakerId`,
+        needsOrganizerIds: false,
+      }
+    case 'resolved':
+      return {
+        predicate: ` && ${STATUS_RESOLVED} && ${NOT_GLOBALLY_ARCHIVED} && ${NOT_USER_ARCHIVED}`,
+        needsOrganizerIds: false,
+      }
+    case 'archived':
+      return {
+        predicate: ` && (${GLOBALLY_ARCHIVED} || ${USER_ARCHIVED})`,
+        needsOrganizerIds: false,
+      }
+    case 'all':
+      return { predicate: '', needsOrganizerIds: false }
+    default: // 'active'
+      return { predicate: ` && ${active}`, needsOrganizerIds: false }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Pure helpers (authz + recipient resolution). Server-derived ids only.
@@ -251,14 +346,19 @@ export async function listConversationsForSpeaker({
   conferenceId,
   before,
   beforeId,
+  view = 'active',
 }: {
   speakerId: string
   isOrganizer: boolean
   conferenceId: string
   before?: string
   beforeId?: string
+  view?: ConversationView
 }): Promise<ConversationListItem[]> {
-  const params: Record<string, unknown> = { conferenceId }
+  // `$speakerId` is ALWAYS bound now: besides the non-organizer access scope, it
+  // keys the correlated per-user-archive probe (organizers archive per-user too)
+  // and the `mine` view. An unused binding (e.g. the `all` view) is harmless.
+  const params: Record<string, unknown> = { conferenceId, speakerId }
   let cursor = ''
   if (before) {
     // Compound keyset cursor: order by (lastMessageAt desc, _id desc) so rows
@@ -280,14 +380,30 @@ export async function listConversationsForSpeaker({
   if (!isOrganizer) {
     scope =
       ' && (createdBy._ref == $speakerId || subjectSpeaker._ref == $speakerId || $speakerId in proposal->speakers[]._ref)'
-    params.speakerId = speakerId
+  }
+
+  // Resolve the organizer id set UP FRONT for organizers: the `needs-reply`
+  // view's GROQ filter needs it as a param, and every organizer row derives
+  // `needsReply` in JS from it. It is cached (getOrganizerSpeakerIds), so the
+  // second-batch reuse below costs nothing. Speakers resolve it in the second
+  // batch (their counterpart rendering needs it) and never filter on needsReply.
+  const organizerIdsUpFront = isOrganizer
+    ? await getOrganizerSpeakerIds()
+    : null
+
+  const { predicate: viewPredicate, needsOrganizerIds } = buildViewPredicate(
+    view,
+    isOrganizer,
+  )
+  if (needsOrganizerIds) {
+    params.organizerIds = organizerIdsUpFront ?? []
   }
 
   // `lastMessage` is a correlated subquery (newest message per conversation) so
   // the whole page stays ONE fetch; `speakerSide*` pre-resolves the speaker-side
   // counterpart (organizer audience) via the house
   // `coalesce(image.asset->url, imageURL)` speaker-image pattern.
-  const query = `*[_type == "conversation" && conference._ref == $conferenceId${scope}${cursor}] | order(lastMessageAt desc, _id desc) [0...${PAGE_SIZE}] {
+  const query = `*[_type == "conversation" && conference._ref == $conferenceId${scope}${cursor}${viewPredicate}] | order(lastMessageAt desc, _id desc) [0...${PAGE_SIZE}] {
     "_id": _id,
     conversationType,
     subject,
@@ -295,6 +411,9 @@ export async function listConversationsForSpeaker({
     "proposalTitle": proposal->title,
     createdAt,
     lastMessageAt,
+    "status": coalesce(status, 'open'),
+    "assignedTo": assignedTo->{ _id, name },
+    archivedAt,
     "lastMessage": *[_type == "message" && conversation._ref == ^._id] | order(createdAt desc) [0] {
       "authorId": author._ref,
       "authorName": author->name,
@@ -338,19 +457,44 @@ export async function listConversationsForSpeaker({
     conversationLinkPath(row, true),
     conversationLinkPath(row, false),
   ])
-  const [unreadRows, organizerIds] = await Promise.all([
+  // The caller's OWN preference docs for exactly this page's conversations,
+  // fetched by their deterministic ids (`convpref.<convId>.<callerId>`). Used to
+  // derive the DISPLAY `archived` boolean per row (the correlated subquery above
+  // does the pre-pagination FILTERING; this cheap page-scoped read supplies the
+  // per-user archive timestamp for the returned rows). Runs in the SAME parallel
+  // batch as the unread fetch.
+  const prefIds = rows.map((row) =>
+    conversationPreferenceId(row._id, speakerId),
+  )
+  const [unreadRows, prefRows, organizerIds] = await Promise.all([
     clientReadUncached.fetch<{ link: string | null; count: number }[]>(
       `*[_type == "notification" && recipient._ref == $speakerId && conference._ref == $conferenceId && notificationType == "message_received" && !defined(readAt) && link in $pageLinks]{ link, "count": coalesce(count, 1) }`,
       { speakerId, conferenceId, pageLinks },
       { cache: 'no-store' },
     ),
-    isOrganizer ? Promise.resolve<string[]>([]) : getOrganizerSpeakerIds(),
+    clientReadUncached.fetch<
+      { conversationId: string | null; archivedAt: string | null }[]
+    >(
+      `*[_type == "conversationPreference" && _id in $prefIds]{ "conversationId": conversation._ref, archivedAt }`,
+      { prefIds },
+      { cache: 'no-store' },
+    ),
+    isOrganizer
+      ? Promise.resolve<string[]>(organizerIdsUpFront ?? [])
+      : getOrganizerSpeakerIds(),
   ])
   const organizerSet = new Set(organizerIds)
   const linkCounts = new Map<string, number>()
   for (const row of unreadRows ?? []) {
     if (row.link) {
       linkCounts.set(row.link, (linkCounts.get(row.link) ?? 0) + row.count)
+    }
+  }
+  // Per-user archive timestamp keyed by conversation id (null archivedAt ignored).
+  const prefArchivedAt = new Map<string, string>()
+  for (const pref of prefRows ?? []) {
+    if (pref.conversationId && pref.archivedAt) {
+      prefArchivedAt.set(pref.conversationId, pref.archivedAt)
     }
   }
 
@@ -363,6 +507,25 @@ export async function listConversationsForSpeaker({
     // return no lastMessage at all so the row renders without a blank snippet
     // line, rather than an object carrying an empty string.
     const excerpt = row.lastMessage ? excerptOf(row.lastMessage.body ?? '') : ''
+    // Timestamp archive semantics (both audiences): archived iff the archive
+    // stamp is at least as recent as the last message; a newer message
+    // auto-resurfaces the thread. A speaker sees ONLY their per-user archive; an
+    // organizer sees the global archive OR their own per-user archive.
+    const userArchiveStamp = prefArchivedAt.get(row._id)
+    const userArchived =
+      userArchiveStamp != null && userArchiveStamp >= row.lastMessageAt
+    const globallyArchived =
+      row.archivedAt != null && row.archivedAt >= row.lastMessageAt
+    const archived = isOrganizer
+      ? globallyArchived || userArchived
+      : userArchived
+    // needs-reply is an ORGANIZER concept: last message from a non-organizer and
+    // not resolved. Always false for a speaker caller.
+    const needsReply =
+      isOrganizer &&
+      row.status !== 'resolved' &&
+      row.lastMessage != null &&
+      !organizerSet.has(row.lastMessage.authorId)
     return {
       _id: row._id,
       conversationType: row.conversationType,
@@ -381,6 +544,12 @@ export async function listConversationsForSpeaker({
             }
           : null,
       counterpart: resolveCounterpart(row, isOrganizer, organizerSet),
+      status: row.status,
+      assignedTo: row.assignedTo
+        ? { _id: row.assignedTo._id, name: row.assignedTo.name }
+        : null,
+      needsReply,
+      archived,
     }
   })
 }
@@ -388,7 +557,12 @@ export async function listConversationsForSpeaker({
 /** A raw inbox row as projected by GROQ, before counterpart/excerpt mapping. */
 type RawConversationRow = Omit<
   ConversationListItem,
-  'unreadCount' | 'lastMessage' | 'counterpart'
+  | 'unreadCount'
+  | 'lastMessage'
+  | 'counterpart'
+  | 'assignedTo'
+  | 'needsReply'
+  | 'archived'
 > & {
   lastMessage: {
     authorId: string
@@ -398,6 +572,11 @@ type RawConversationRow = Omit<
   } | null
   speakerSideName: string | null
   speakerSideImage: string | null
+  // GROQ coalesces `status` to 'open'; `assignedTo`/`archivedAt` are null when
+  // unset (or, for a weak assignee ref, when the speaker was erased).
+  status: ConversationStatus
+  assignedTo: { _id: string; name: string } | null
+  archivedAt: string | null
 }
 
 /** Inbox snippet length — roughly two lines of a mobile row. */
@@ -596,6 +775,58 @@ export async function addMessage({
 }
 
 // ---------------------------------------------------------------------------
+// Ticketing mutations (organizer-side thread state). Authz is enforced by the
+// router BEFORE any of these run; they are pure writes.
+// ---------------------------------------------------------------------------
+
+/** Set a conversation's ticketing status ('open' | 'resolved'). */
+export async function setConversationStatus(
+  conversationId: string,
+  status: ConversationStatus,
+): Promise<void> {
+  await clientWrite.patch(conversationId).set({ status }).commit()
+}
+
+/**
+ * Assign (or, with `assigneeId === null`, unassign) the organizer responsible
+ * for a conversation. The assignee ref is WEAK so erasing a speaker (GDPR)
+ * doesn't orphan-block their deletion — consistent with the schema.
+ */
+export async function setConversationAssignee(
+  conversationId: string,
+  assigneeId: string | null,
+): Promise<void> {
+  if (assigneeId === null) {
+    await clientWrite.patch(conversationId).unset(['assignedTo']).commit()
+    return
+  }
+  await clientWrite
+    .patch(conversationId)
+    .set({ assignedTo: { ...createReference(assigneeId), _weak: true } })
+    .commit()
+}
+
+/**
+ * Set/clear the GLOBAL organizer archive. Archiving stamps `archivedAt = now`;
+ * because a thread is globally archived IFF `archivedAt >= lastMessageAt`, a
+ * later message auto-resurfaces it with no further write. Unarchiving simply
+ * unsets the field.
+ */
+export async function setConversationArchived(
+  conversationId: string,
+  archived: boolean,
+): Promise<void> {
+  if (archived) {
+    await clientWrite
+      .patch(conversationId)
+      .set({ archivedAt: new Date().toISOString() })
+      .commit()
+    return
+  }
+  await clientWrite.patch(conversationId).unset(['archivedAt']).commit()
+}
+
+// ---------------------------------------------------------------------------
 // Preferences (doc-per-pair; no array RMW)
 // ---------------------------------------------------------------------------
 
@@ -667,16 +898,26 @@ export async function setConversationPreference({
   speakerId,
   muted,
   emailOverride,
+  archived,
 }: {
   conversationId: string
   speakerId: string
   muted?: boolean
   emailOverride?: EmailOverride
+  archived?: boolean
 }): Promise<ConversationPreference> {
   const id = conversationPreferenceId(conversationId, speakerId)
   const set: Record<string, unknown> = {}
+  const unset: string[] = []
   if (muted !== undefined) set.muted = muted
   if (emailOverride !== undefined) set.emailOverride = emailOverride
+  // PER-USER archive: same timestamp semantics as the global archive — stamp
+  // `archivedAt = now` to archive (a later message auto-resurfaces it), unset to
+  // un-archive.
+  if (archived !== undefined) {
+    if (archived) set.archivedAt = new Date().toISOString()
+    else unset.push('archivedAt')
+  }
 
   const tx = clientWrite.transaction().createIfNotExists({
     _id: id,
@@ -686,8 +927,13 @@ export async function setConversationPreference({
     muted: false,
     emailOverride: 'default',
   })
-  if (Object.keys(set).length > 0) {
-    tx.patch(id, (patch) => patch.set(set))
+  if (Object.keys(set).length > 0 || unset.length > 0) {
+    tx.patch(id, (patch) => {
+      let next = patch
+      if (Object.keys(set).length > 0) next = next.set(set)
+      if (unset.length > 0) next = next.unset(unset)
+      return next
+    })
   }
   await tx.commit()
 

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -9,6 +9,43 @@
 
 export type ConversationType = 'proposal' | 'general'
 
+/**
+ * Ticketing status of a thread for the ORGANIZER audience. `'open'` is the
+ * default AND the meaning of an ABSENT `status` field — every read coalesces
+ * undefined to `'open'`, so pre-ticketing threads need no migration.
+ */
+export type ConversationStatus = 'open' | 'resolved'
+
+/**
+ * The inbox views a caller can request. ORGANIZERS may use all of them;
+ * SPEAKERS are restricted to `'active' | 'archived' | 'all'` (the router rejects
+ * the organizer-only views for a non-organizer).
+ *
+ * ORGANIZER semantics:
+ * - `active`      — status open (or absent) AND NOT globally archived AND NOT
+ *                   per-user archived;
+ * - `needs-reply` — active AND the last message's author is not an organizer;
+ * - `mine`        — active AND assigned to the caller;
+ * - `resolved`    — status resolved AND not archived (neither global nor per-user);
+ * - `archived`    — globally OR per-user archived;
+ * - `all`         — every conversation, no status/archive filter.
+ *
+ * SPEAKER semantics (global archive is an organizer-side hide, so speakers keep
+ * seeing globally-archived threads and only their OWN preference archive hides):
+ * - `active`   — NOT per-user archived;
+ * - `archived` — per-user archived;
+ * - `all`      — everything.
+ */
+export type ConversationView =
+  'active' | 'needs-reply' | 'mine' | 'resolved' | 'archived' | 'all'
+
+/** The views a non-organizer (speaker) is allowed to request. */
+export const SPEAKER_ALLOWED_VIEWS: ConversationView[] = [
+  'active',
+  'archived',
+  'all',
+]
+
 /** Per-conversation email delivery override. */
 export type EmailOverride = 'default' | 'on' | 'off'
 
@@ -64,6 +101,12 @@ export interface ConversationCounterpart {
   image?: string
 }
 
+/** The organizer assigned to follow up a thread (deref of `assignedTo`). */
+export interface ConversationAssignee {
+  _id: string
+  name: string
+}
+
 /** A conversation as listed in an inbox. */
 export interface ConversationListItem {
   _id: string
@@ -83,6 +126,25 @@ export interface ConversationListItem {
   lastMessage: ConversationLastMessage | null
   /** Audience-aware "who" for the row (see {@link ConversationCounterpart}). */
   counterpart: ConversationCounterpart
+  // NOTE: the ticketing fields below are ALWAYS populated by the data layer
+  // (`listConversationsForSpeaker`). They are declared optional ONLY so that
+  // pre-ticketing fixtures/stories (owned by the T2 UI work) still satisfy the
+  // type; runtime rows always carry them.
+  /** Ticketing status, coalesced so an absent field reads as `'open'`. */
+  status?: ConversationStatus
+  /** The organizer responsible for follow-up; null when unassigned. */
+  assignedTo?: ConversationAssignee | null
+  /**
+   * Whether this thread needs an organizer reply (ORGANIZER audience only): its
+   * last message is from a non-organizer AND status is not resolved. Always
+   * false for a speaker caller (needs-reply is an organizer-side concept).
+   */
+  needsReply?: boolean
+  /**
+   * Whether this thread is archived FOR THE CALLER's audience: for an organizer,
+   * globally OR per-user archived; for a speaker, per-user archived only.
+   */
+  archived?: boolean
 }
 
 /** A single message in a thread. */

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -12,6 +12,9 @@ export type NotificationType =
   | 'proposal_comment'
   // Speaker↔organizer conversation message (messaging M1).
   | 'message_received'
+  // A stale, unanswered speaker↔organizer thread (ticketing stale-nudge cron).
+  // Rendered generically by the hub (title/message/actor); no dedicated icon.
+  | 'message_stale'
   | 'cospeaker_response'
   | 'travel_support_update'
   | 'sponsor_activity'

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -9,6 +9,9 @@ import {
   ListMessagesSchema,
   SendMessageSchema,
   SetPreferenceSchema,
+  SetStatusSchema,
+  SetAssigneeSchema,
+  SetArchivedSchema,
   parseMessageCursor,
 } from '@/server/schemas/message'
 import {
@@ -22,10 +25,18 @@ import {
   createGeneralConversation,
   getProposalForConversation,
   setConversationPreference,
+  setConversationStatus,
+  setConversationAssignee,
+  setConversationArchived,
   canAccessConversation,
 } from '@/lib/messaging/sanity'
+import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
 import { notifyNewMessage } from '@/lib/messaging/notify'
-import type { ConversationWithContext } from '@/lib/messaging/types'
+import { SPEAKER_ALLOWED_VIEWS } from '@/lib/messaging/types'
+import type {
+  AccessSpeaker,
+  ConversationWithContext,
+} from '@/lib/messaging/types'
 
 /**
  * Per-speaker sliding-window throttle for `message.send` (batch A / A2). Sending
@@ -93,6 +104,31 @@ async function speakerHasStandingInConference(
 }
 
 /**
+ * Load a conversation for an ORGANIZER-ONLY management mutation (status /
+ * assignee / archive). Collapses absent, non-organizer, and inaccessible into a
+ * single NOT_FOUND — no existence oracle, and the ticketing capability itself is
+ * not revealed to a non-organizer participant (A3 semantics). `isOrganizer`
+ * already implies `canAccessConversation`, but both are asserted per the design.
+ */
+async function loadManageableConversation(
+  conversationId: string,
+  speaker: AccessSpeaker,
+): Promise<ConversationWithContext> {
+  const conversation = await getConversationById(conversationId)
+  if (
+    !conversation ||
+    speaker.isOrganizer !== true ||
+    !canAccessConversation(conversation, speaker)
+  ) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Conversation not found',
+    })
+  }
+  return conversation
+}
+
+/**
  * Speaker↔organizer messaging (M1). Every procedure derives the actor from
  * `ctx.speaker` and the conference from the domain; a client can never target
  * another user or another conference. Read/write access to a conversation is
@@ -104,15 +140,27 @@ export const messageRouter = router({
     .input(ListConversationsSchema)
     .query(async ({ ctx, input }) => {
       const conferenceId = await resolveConferenceId()
+      const isOrganizer = ctx.speaker.isOrganizer === true
+      const view = input.view ?? 'active'
+      // A non-organizer may only use the speaker-appropriate views; the
+      // organizer-only views (needs-reply / mine / resolved) carry organizer
+      // semantics, so reject them for a speaker rather than silently coercing.
+      if (!isOrganizer && !SPEAKER_ALLOWED_VIEWS.includes(view)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `View '${view}' is not available`,
+        })
+      }
       // The cursor is EITHER a plain ISO datetime (legacy) or `<iso>~<_id>`
       // (compound keyset); split it so exact-timestamp ties page correctly.
       const { before, beforeId } = parseMessageCursor(input.cursor)
       return listConversationsForSpeaker({
         speakerId: ctx.speaker._id,
-        isOrganizer: ctx.speaker.isOrganizer === true,
+        isOrganizer,
         conferenceId,
         before,
         beforeId,
+        view,
       })
     }),
 
@@ -338,6 +386,66 @@ export const messageRouter = router({
         speakerId: ctx.speaker._id,
         muted: input.muted,
         emailOverride: input.emailOverride,
+        // Per-user archive (all participants, speakers included) rides this
+        // existing procedure.
+        archived: input.archived,
       })
+    }),
+
+  /**
+   * Organizer-only: set a conversation's ticketing status ('open' | 'resolved').
+   * A resolved thread drops out of the organizer `active`/`needs-reply` views.
+   */
+  setStatus: protectedProcedure
+    .input(SetStatusSchema)
+    .mutation(async ({ ctx, input }) => {
+      const conversation = await loadManageableConversation(
+        input.conversationId,
+        ctx.speaker,
+      )
+      await setConversationStatus(conversation._id, input.status)
+      return { conversationId: conversation._id, status: input.status }
+    }),
+
+  /**
+   * Organizer-only: (re)assign or unassign the responsible organizer. A non-null
+   * assignee MUST be an organizer (validated against the organizer id set);
+   * `null` unassigns.
+   */
+  setAssignee: protectedProcedure
+    .input(SetAssigneeSchema)
+    .mutation(async ({ ctx, input }) => {
+      const conversation = await loadManageableConversation(
+        input.conversationId,
+        ctx.speaker,
+      )
+      if (input.assigneeId !== null) {
+        const organizerIds = await getOrganizerSpeakerIds()
+        if (!organizerIds.includes(input.assigneeId)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Assignee must be an organizer',
+          })
+        }
+      }
+      await setConversationAssignee(conversation._id, input.assigneeId)
+      return { conversationId: conversation._id, assigneeId: input.assigneeId }
+    }),
+
+  /**
+   * Organizer-only: set/unset the GLOBAL organizer archive. Archiving hides the
+   * thread from organizer views until a NEW message auto-resurfaces it (timestamp
+   * semantics); speakers keep seeing it (their archive is per-user via
+   * setPreference).
+   */
+  setArchived: protectedProcedure
+    .input(SetArchivedSchema)
+    .mutation(async ({ ctx, input }) => {
+      const conversation = await loadManageableConversation(
+        input.conversationId,
+        ctx.speaker,
+      )
+      await setConversationArchived(conversation._id, input.archived)
+      return { conversationId: conversation._id, archived: input.archived }
     }),
 })

--- a/src/server/schemas/message.ts
+++ b/src/server/schemas/message.ts
@@ -49,6 +49,12 @@ const cursor = z
 
 export const ListConversationsSchema = z.object({
   cursor,
+  // Inbox view. ORGANIZERS may use any; the router rejects the organizer-only
+  // views (`needs-reply` | `mine` | `resolved`) for a non-organizer. Defaults to
+  // `active` in the data layer when omitted.
+  view: z
+    .enum(['active', 'needs-reply', 'mine', 'resolved', 'archived', 'all'])
+    .optional(),
 })
 
 export const GetConversationSchema = z.object({
@@ -88,7 +94,38 @@ export const SetPreferenceSchema = z
     conversationId: z.string().min(1).max(200),
     muted: z.boolean().optional(),
     emailOverride: z.enum(['default', 'on', 'off']).optional(),
+    // Per-user archive for this participant (the speaker/all-participant archive
+    // rides this existing procedure). true archives, false un-archives.
+    archived: z.boolean().optional(),
   })
-  .refine((v) => v.muted !== undefined || v.emailOverride !== undefined, {
-    message: 'Provide at least one of muted or emailOverride',
-  })
+  .refine(
+    (v) =>
+      v.muted !== undefined ||
+      v.emailOverride !== undefined ||
+      v.archived !== undefined,
+    {
+      message: 'Provide at least one of muted, emailOverride, or archived',
+    },
+  )
+
+/** Organizer-only: set a conversation's ticketing status. */
+export const SetStatusSchema = z.object({
+  conversationId: z.string().min(1).max(200),
+  status: z.enum(['open', 'resolved']),
+})
+
+/**
+ * Organizer-only: (re)assign or unassign the responsible organizer. `null`
+ * unassigns; a non-null id must resolve to an organizer (validated in the
+ * router against the organizer id set).
+ */
+export const SetAssigneeSchema = z.object({
+  conversationId: z.string().min(1).max(200),
+  assigneeId: z.string().min(1).max(200).nullable(),
+})
+
+/** Organizer-only: set/unset the GLOBAL organizer archive for a conversation. */
+export const SetArchivedSchema = z.object({
+  conversationId: z.string().min(1).max(200),
+  archived: z.boolean(),
+})


### PR DESCRIPTION
## Ticketing T1 (backend) — messaging thread state

Lightweight thread-state on top of messaging M1: a per-thread ticketing
**status**, an **assignee**, **both archive models** (global organizer archive +
per-user archive), derived **needs-reply**, inbox **views**, and a daily
**stale-thread nudge**. Backend only — the UI (T2) follows. No changes to
`workshop.ts`.

### The timestamp-archive trick (core design)

Both archives are a single `archivedAt` datetime with the SAME rule:

> a thread is archived **iff `archivedAt >= lastMessageAt`**.

A new message bumps `lastMessageAt` past `archivedAt`, so the thread
**auto-resurfaces with zero fan-out writes** — no per-thread "unarchive" sweep.
`conversation.archivedAt` is the GLOBAL organizer archive;
`conversationPreference.archivedAt` is the PER-USER archive (one preference doc
per participant). The two are independent.

### Absent-means-open

`status` is `'open' | 'resolved'` with `initialValue 'open'`, but **absent means
open**: every read does `coalesce(status, 'open')`. Pre-ticketing threads need
**no migration**.

### View semantics

`listConversations` gains `view` (default `active`). Filters are applied in GROQ
**before pagination** (a post-slice filter would shrink pages).

| view | ORGANIZER | SPEAKER |
|---|---|---|
| `active` | open ∧ ¬global-archived ∧ ¬user-archived | ¬user-archived |
| `needs-reply` | active ∧ last author ∉ organizers | — (rejected) |
| `mine` | active ∧ `assignedTo == caller` | — (rejected) |
| `resolved` | resolved ∧ ¬archived | — (rejected) |
| `archived` | global **OR** per-user archived | per-user archived |
| `all` | everything | everything |

Global archive is an **organizer-side hide**: speakers keep seeing their thread
and only their own preference archive hides it. A non-organizer requesting an
organizer-only view gets `BAD_REQUEST`. `needs-reply` is derived (no stored
state) from the last message's author vs the cached organizer id set.

### Per-user-archive exclusion — exact GROQ

The default `active`/`resolved`/`mine` views exclude the caller's per-user
archive with a correlated point-lookup on the deterministic preference id
(`convpref.<conversationId>.<callerId>`), inside the base predicate:

```
count(*[_id == 'convpref.' + ^._id + '.' + $speakerId && defined(archivedAt) && archivedAt >= ^.lastMessageAt]) == 0
```

(`> 0` for the `archived` view.) `count()` is 0/1 because the id is unique; the
display `archived` boolean is derived from a separate page-scoped preference
fetch batched with the unread-count read.

### Stale-thread nudge (cron)

`nudgeStaleConversations()` (never-fail, summary counts) selects threads that are
open, whose last message is from a **non-organizer**, quiet for **3+ days**, NOT
globally archived, and not already nudged for this trailing message
(`lastStaleNudgeAt < lastMessageAt`). Each gets ONE hub notification
(`message_stale`) routed to the **assignee if set, else all organizers**, links
to the admin thread, then stamps `lastStaleNudgeAt`. Wired into the daily
`cleanup-notifications` cron **after** the retention steps.

### Notes / judgment calls

- Added a `message_stale` NotificationType (+ Studio list). Verified the hub
  renders types generically (title/message/actor; push maps unknown → default
  `otherUpdates`), so this is graceful and needs no UI change.
- `ConversationListItem`'s new fields (`status`/`assignedTo`/`needsReply`/
  `archived`) are declared **optional** so pre-ticketing fixtures/stories (owned
  by the T2 UI work) still typecheck; the data layer always populates them at
  runtime. T2 can tighten to required when it consumes them.
- `assignedTo` is a WEAK reference (GDPR erasure rule); the Studio picker filters
  to organizers, validation happens in the router.

### Checks

`tsc`, `eslint`, `prettier`, `knip` clean; full `vitest run` green (3191 passed).
No UI → no shoot.

**Do not merge** — held for review.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds lightweight thread ticketing state to the existing messaging layer (M1): per-thread `status` (`open`/`resolved`), an organizer `assignedTo` field, dual timestamp-based archive (global organizer + per-user), six inbox views (`active`, `needs-reply`, `mine`, `resolved`, `archived`, `all`), and a daily stale-thread nudge cron. No schema migration is needed thanks to an "absent-means-open" coalesce convention.

- **GROQ filtering** is applied inside the base `*[...]` predicate before `| order(...)[0...PAGE_SIZE]`, correctly avoiding the page-shrink trap of post-slice filtering; the deterministic preference-doc id (`convpref.<convId>.<speakerId>`) keeps the correlated per-user-archive exclusion cheap.
- **Three new organizer-only tRPC mutations** (`setStatus`, `setAssignee`, `setArchived`) follow the established `loadManageableConversation` pattern with correct `NOT_FOUND` collapse for non-organizers and assignee-organizer validation in the router.
- **`nudgeStaleConversations`** has a never-fail envelope and per-conversation isolation, but a stamp-write failure after a successful `createNotifications` call leaves the conversation un-stamped, causing duplicate nudges on subsequent daily runs.

<h3>Confidence Score: 3/5</h3>

The data-layer and router changes are solid, but the stale-nudge cron has a write-ordering gap that can send organizers repeated notifications for the same thread.

The notification-before-stamp ordering in nudgeStaleConversations means a transient Sanity write failure would leave a thread perpetually re-selected and re-notified on every daily cron run. This affects real organizer inboxes and the failure mode is silent (just a log line and a summary counter). Everything else — GROQ filtering, authz, schema design, and the test suite — is well-reasoned and thorough.

src/lib/messaging/nudge.ts — the notification/stamp ordering and the shared LAST_AUTHOR_REF; src/lib/messaging/sanity.ts — needs-reply with an empty organizer list.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/messaging/nudge.ts | New stale-thread nudge cron helper; never-fail contract is solid but a stamp-write failure after notification delivery causes duplicate nudges on subsequent daily runs. |
| src/lib/messaging/sanity.ts | Adds inbox view predicates and ticketing mutations; GROQ pre-pagination filter design is correct, but `needs-reply` vacuously matches everything when the organizer list is empty, and `LAST_AUTHOR_REF` is duplicated in nudge.ts. |
| src/server/routers/message.ts | New organizer-only procedures (setStatus, setAssignee, setArchived) using shared loadManageableConversation; authz and assignee-organizer validation are correct. |
| src/server/schemas/message.ts | Clean Zod schemas for new ticketing endpoints; SetPreferenceSchema correctly extended with archived field and updated refine guard. |
| src/lib/messaging/types.ts | New ConversationStatus, ConversationView, SPEAKER_ALLOWED_VIEWS, and ConversationAssignee types added cleanly; ticketing fields on ConversationListItem correctly declared optional for pre-T2 compatibility. |
| sanity/schemaTypes/conversation.ts | Adds status, assignedTo (weak ref), archivedAt, and lastStaleNudgeAt fields with clear descriptions and correct settings (readOnly/hidden for lastStaleNudgeAt). |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Cron as Daily Cron
    participant Route as cleanup-notifications/route
    participant Nudge as nudgeStaleConversations
    participant Sanity as Sanity (Read)
    participant Notif as createNotifications
    participant Write as Sanity (Write)

    Cron->>Route: GET (Bearer secret)
    Route->>Route: deleteNotificationsOlderThan(90)
    Route->>Route: deleteExpiredMessagingData()
    Route->>Nudge: nudgeStaleConversations()
    Nudge->>Sanity: fetch stale conversations
    Sanity-->>Nudge: StaleConversation[]
    loop per conversation
        Nudge->>Nudge: route to assignee or all organizers
        Nudge->>Notif: createNotifications(inputs) never throws
        Notif-->>Nudge: ok
        Nudge->>Write: patch lastStaleNudgeAt - can throw
        alt write succeeds
            Write-->>Nudge: ok
            Nudge->>Nudge: "nudged++ / notifications+=N"
        else write fails
            Write-->>Nudge: error caught
            Nudge->>Nudge: failed++ notification already sent
        end
    end
    Nudge-->>Route: StaleNudgeSummary
    Route-->>Cron: 200 success
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Cron as Daily Cron
    participant Route as cleanup-notifications/route
    participant Nudge as nudgeStaleConversations
    participant Sanity as Sanity (Read)
    participant Notif as createNotifications
    participant Write as Sanity (Write)

    Cron->>Route: GET (Bearer secret)
    Route->>Route: deleteNotificationsOlderThan(90)
    Route->>Route: deleteExpiredMessagingData()
    Route->>Nudge: nudgeStaleConversations()
    Nudge->>Sanity: fetch stale conversations
    Sanity-->>Nudge: StaleConversation[]
    loop per conversation
        Nudge->>Nudge: route to assignee or all organizers
        Nudge->>Notif: createNotifications(inputs) never throws
        Notif-->>Nudge: ok
        Nudge->>Write: patch lastStaleNudgeAt - can throw
        alt write succeeds
            Write-->>Nudge: ok
            Nudge->>Nudge: "nudged++ / notifications+=N"
        else write fails
            Write-->>Nudge: error caught
            Nudge->>Nudge: failed++ notification already sent
        end
    end
    Nudge-->>Route: StaleNudgeSummary
    Route-->>Cron: 200 success
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/messaging/nudge.ts`, line 1364-1380 ([link](https://github.com/cloudnativebergen/website/blob/30b561c84f7d2594d34c7ce60d4bb31eb6491330/src/lib/messaging/nudge.ts#L1364-L1380)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Notifications sent but stamp not written on commit failure**

   `createNotifications` is called first and never throws, so the hub notification is delivered. If the subsequent `patch.commit()` throws, the catch block increments `summary.failed` but the notification has already been sent to the organizer. Because `lastStaleNudgeAt` was never written, the GROQ filter `!defined(lastStaleNudgeAt) || lastStaleNudgeAt < lastMessageAt` re-selects this conversation on every following daily run, sending duplicate "awaiting reply" nudges until a new message re-arms it differently.

   A transient Sanity write conflict or network blip is enough to trigger this: the organizer receives the notification, the run logs a failure, and tomorrow they receive it again.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): thread status, assignee..."](https://github.com/cloudnativebergen/website/commit/30b561c84f7d2594d34c7ce60d4bb31eb6491330) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45437617)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->