### PR TITLE
feat(messaging): ticketing UI — views, status, assignee, archive (T2)

### DIFF
--- a/__tests__/components/messaging/ConversationList.ticketing.test.tsx
+++ b/__tests__/components/messaging/ConversationList.ticketing.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Row-metadata tests for the T2b ConversationList additions:
+ * - ORGANIZER rows: needs-reply amber dot, Resolved chip, assignee avatar;
+ * - SPEAKER rows: ONLY the Resolved chip (no needs-reply, no assignee);
+ * - the Archived-view Unarchive button acts without navigating (T2d).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+} from '@testing-library/react'
+import { ConversationList } from '@/components/messaging'
+import type { ConversationListItem } from '@/lib/messaging/types'
+
+afterEach(cleanup)
+
+function item(
+  overrides: Partial<ConversationListItem> = {},
+): ConversationListItem {
+  return {
+    _id: 'conversation.gen-1',
+    conversationType: 'general',
+    subject: 'Travel question',
+    createdAt: '2026-01-01T00:00:00Z',
+    lastMessageAt: '2026-02-01T00:00:00Z',
+    unreadCount: 0,
+    lastMessage: { authorId: 'sp-1', authorName: 'Kari', excerpt: 'hello' },
+    counterpart: { name: 'Kari Nordmann' },
+    status: 'open',
+    needsReply: false,
+    assignedTo: null,
+    archived: false,
+    ...overrides,
+  }
+}
+
+describe('ConversationList — organizer row metadata (T2b)', () => {
+  it('shows the needs-reply dot, Resolved chip and assignee avatar for organizers', () => {
+    render(
+      <ConversationList
+        isOrganizer
+        items={[
+          item({
+            _id: 'c1',
+            needsReply: true,
+            assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+          }),
+          item({ _id: 'c2', status: 'resolved' }),
+        ]}
+      />,
+    )
+    expect(screen.getByLabelText('Needs reply')).toBeInTheDocument()
+    expect(screen.getByText('Resolved')).toBeInTheDocument()
+    // Assignee avatar carries an accessible label + the initial.
+    const assignee = screen.getByLabelText('Assigned to Ola Organizer')
+    expect(assignee).toHaveTextContent('O')
+  })
+})
+
+describe('ConversationList — speaker rows only get the Resolved chip', () => {
+  it('never renders needs-reply or the assignee for a speaker', () => {
+    render(
+      <ConversationList
+        isOrganizer={false}
+        items={[
+          item({
+            status: 'resolved',
+            needsReply: true, // must be IGNORED for a speaker
+            assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+          }),
+        ]}
+      />,
+    )
+    expect(screen.getByText('Resolved')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Needs reply')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/assigned to/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('ConversationList — Archived view Unarchive (T2d)', () => {
+  it('calls onUnarchive without navigating and only when provided', () => {
+    const onUnarchive = vi.fn()
+    const { rerender } = render(
+      <ConversationList
+        isOrganizer
+        items={[item({ archived: true })]}
+        onUnarchive={onUnarchive}
+      />,
+    )
+    const button = screen.getByRole('button', { name: /unarchive/i })
+    const clickEvent = fireEvent.click(button)
+    // The handler fired and the click was prevented (so the row Link never
+    // navigates out from under the action).
+    expect(onUnarchive).toHaveBeenCalledTimes(1)
+    expect(onUnarchive.mock.calls[0][0]._id).toBe('conversation.gen-1')
+    expect(clickEvent).toBe(false) // preventDefault() → dispatchEvent returns false
+
+    // Without onUnarchive the button is absent (non-archived views).
+    rerender(
+      <ConversationList isOrganizer items={[item({ archived: true })]} />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /unarchive/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders a row Link that would otherwise navigate', () => {
+    render(
+      <ConversationList
+        isOrganizer
+        items={[item({ archived: true })]}
+        onUnarchive={vi.fn()}
+      />,
+    )
+    // The row is still a link to the admin thread; the Unarchive button lives
+    // inside it but stops propagation.
+    const row = screen.getByRole('link')
+    expect(
+      within(row).getByRole('button', { name: /unarchive/i }),
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/messaging/ConversationThreadContainer.test.tsx
+++ b/__tests__/components/messaging/ConversationThreadContainer.test.tsx
@@ -54,6 +54,15 @@ vi.mock('@/lib/trpc/client', () => ({
       listMessages: { useInfiniteQuery: () => listMessagesResult },
       send: { useMutation: () => noopMutation },
       setPreference: { useMutation: () => noopMutation },
+      // T2 organizer ticketing mutations (unused by these mark-read tests).
+      setStatus: { useMutation: () => noopMutation },
+      setAssignee: { useMutation: () => noopMutation },
+      setArchived: { useMutation: () => noopMutation },
+    },
+    sponsor: {
+      crm: {
+        listOrganizers: { useQuery: () => ({ data: [] }) },
+      },
     },
     notification: {
       markReadByLink: {

--- a/__tests__/components/messaging/ConversationThreadContainer.ticketing.test.tsx
+++ b/__tests__/components/messaging/ConversationThreadContainer.ticketing.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Container wiring tests for the T2c/T2e organizer ticketing controls on
+ * ConversationThread:
+ * - an organizer container wires setStatus (and passes the current
+ *   status/assignee/global-archive through);
+ * - a speaker container NEVER renders the organizer controls or calls their
+ *   mutations.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+let mockSession: {
+  speaker?: { _id: string }
+  isImpersonating?: boolean
+} | null = { speaker: { _id: 'me' } }
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: mockSession }),
+}))
+
+Object.defineProperty(document, 'visibilityState', {
+  configurable: true,
+  get: () => 'visible',
+})
+
+const statusMutate = vi.fn()
+const assigneeMutate = vi.fn()
+const archivedMutate = vi.fn()
+const noop = { mutate: vi.fn(), isPending: false, isError: false }
+
+let getConversationResult: { data: unknown; error: unknown } = {
+  data: undefined,
+  error: null,
+}
+let organizersEnabled: boolean | undefined
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    useUtils: () => ({
+      message: {
+        listMessages: { invalidate: vi.fn() },
+        getConversation: { invalidate: vi.fn() },
+        listConversations: { invalidate: vi.fn() },
+      },
+      notification: {
+        unreadCount: { invalidate: vi.fn() },
+        list: { invalidate: vi.fn() },
+      },
+    }),
+    message: {
+      getConversation: { useQuery: () => getConversationResult },
+      listMessages: {
+        useInfiniteQuery: () => ({
+          data: {
+            pages: [
+              [
+                {
+                  _id: 'm1',
+                  authorId: 'org',
+                  body: 'hi',
+                  createdAt: '2026-01-01T00:00:00Z',
+                },
+              ],
+            ],
+          },
+          isLoading: false,
+          isError: false,
+          isSuccess: true,
+          hasNextPage: false,
+          isFetchingNextPage: false,
+          fetchNextPage: vi.fn(),
+        }),
+      },
+      send: { useMutation: () => noop },
+      setPreference: { useMutation: () => noop },
+      setStatus: { useMutation: () => ({ ...noop, mutate: statusMutate }) },
+      setAssignee: { useMutation: () => ({ ...noop, mutate: assigneeMutate }) },
+      setArchived: { useMutation: () => ({ ...noop, mutate: archivedMutate }) },
+    },
+    sponsor: {
+      crm: {
+        listOrganizers: {
+          useQuery: (_input: unknown, opts?: { enabled?: boolean }) => {
+            organizersEnabled = opts?.enabled
+            return {
+              data: [{ _id: 'org-2', name: 'Grace Hopper', email: 'g@x' }],
+            }
+          },
+        },
+      },
+    },
+    notification: {
+      markReadByLink: { useMutation: () => ({ mutate: vi.fn() }) },
+    },
+  },
+}))
+
+import { ConversationThread } from '@/components/messaging'
+
+function conversation(overrides = {}) {
+  return {
+    data: {
+      conversation: {
+        _id: 'conversation.abc',
+        conversationType: 'general',
+        subject: 'Travel',
+        status: 'open',
+        assignedTo: null,
+        archivedAt: null,
+        lastMessageAt: '2026-01-01T00:00:00Z',
+        ...overrides,
+      },
+      participants: [],
+      preference: { muted: false, emailOverride: 'default' },
+    },
+    error: null,
+  }
+}
+
+beforeEach(() => {
+  statusMutate.mockClear()
+  assigneeMutate.mockClear()
+  archivedMutate.mockClear()
+  organizersEnabled = undefined
+  mockSession = { speaker: { _id: 'me' } }
+})
+
+afterEach(cleanup)
+
+describe('ConversationThread — organizer ticketing wiring (T2e)', () => {
+  it('wires the Resolve button to setStatus with the conversation id', () => {
+    getConversationResult = conversation()
+    render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /resolve/i }))
+    expect(statusMutate).toHaveBeenCalledWith({
+      conversationId: 'conversation.abc',
+      status: 'resolved',
+    })
+    // The organizer picker query is enabled for an organizer on an existing thread.
+    expect(organizersEnabled).toBe(true)
+  })
+
+  it('wires the overflow global-archive action to setArchived', () => {
+    getConversationResult = conversation()
+    render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="organizer"
+      />,
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: /more conversation actions/i }),
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: /archive for everyone/i }),
+    )
+    expect(archivedMutate).toHaveBeenCalledWith({
+      conversationId: 'conversation.abc',
+      archived: true,
+    })
+  })
+})
+
+describe('ConversationThread — speaker never gets organizer controls', () => {
+  it('renders no Resolve/overflow and never enables the organizer picker query', () => {
+    getConversationResult = conversation()
+    render(
+      <ConversationThread
+        conversationId="conversation.abc"
+        audience="speaker"
+      />,
+    )
+    expect(
+      screen.queryByRole('button', { name: /resolve/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /more conversation actions/i }),
+    ).not.toBeInTheDocument()
+    // The picker query is present but disabled for a speaker.
+    expect(organizersEnabled).toBe(false)
+    expect(statusMutate).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/messaging/ConversationThreadView.ticketing.test.tsx
+++ b/__tests__/components/messaging/ConversationThreadView.ticketing.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Presentational tests for the T2 thread header controls on
+ * ConversationThreadView:
+ * - ORGANIZER: Resolve/Reopen toggle, the overflow "…" menu (Assign options,
+ *   per-user & global archive), and readOnly (impersonation) gating;
+ * - SPEAKER: the per-user Archive affordance joining the Mute/Emails bar.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ConversationThreadView } from '@/components/messaging'
+import type { DisplayMessage } from '@/components/messaging'
+
+afterEach(cleanup)
+
+const messages: DisplayMessage[] = [
+  {
+    id: 'm1',
+    authorName: 'Kari',
+    isOrganizer: false,
+    isOwn: false,
+    body: 'hi',
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+]
+
+const organizers = [
+  { _id: 'org-1', name: 'Ola Organizer' },
+  { _id: 'org-2', name: 'Grace Hopper' },
+]
+
+const preference = { muted: false, emailOverride: 'default' as const }
+
+function renderOrganizer(overrides = {}) {
+  const props = {
+    onSetStatus: vi.fn(),
+    onSetAssignee: vi.fn(),
+    onSetGlobalArchived: vi.fn(),
+    onArchiveForMe: vi.fn(),
+    onSetMuted: vi.fn(),
+    onSetEmailOverride: vi.fn(),
+    ...overrides,
+  }
+  render(
+    <ConversationThreadView
+      messages={messages}
+      emptyText=""
+      subject="Talk"
+      onSend={vi.fn()}
+      preference={preference}
+      status="open"
+      organizers={organizers}
+      assignedTo={null}
+      globallyArchived={false}
+      {...props}
+    />,
+  )
+  return props
+}
+
+describe('ConversationThreadView — organizer ticketing controls', () => {
+  it('Resolve calls onSetStatus("resolved")', () => {
+    const props = renderOrganizer({ status: 'open' })
+    fireEvent.click(screen.getByRole('button', { name: /resolve/i }))
+    expect(props.onSetStatus).toHaveBeenCalledWith('resolved')
+  })
+
+  it('Reopen calls onSetStatus("open") when already resolved', () => {
+    const props = renderOrganizer({ status: 'resolved' })
+    fireEvent.click(screen.getByRole('button', { name: /reopen/i }))
+    expect(props.onSetStatus).toHaveBeenCalledWith('open')
+  })
+
+  it('the overflow menu assigns an organizer and unassigns via null', () => {
+    const props = renderOrganizer({
+      assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+    })
+    fireEvent.click(
+      screen.getByRole('button', { name: /more conversation actions/i }),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Grace Hopper' }))
+    expect(props.onSetAssignee).toHaveBeenCalledWith('org-2')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unassigned' }))
+    expect(props.onSetAssignee).toHaveBeenCalledWith(null)
+  })
+
+  it('the overflow menu archives for me and toggles the global archive', () => {
+    const props = renderOrganizer({ globallyArchived: false })
+    fireEvent.click(
+      screen.getByRole('button', { name: /more conversation actions/i }),
+    )
+    fireEvent.click(screen.getByRole('button', { name: /archive for me/i }))
+    expect(props.onArchiveForMe).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /archive for everyone/i }),
+    )
+    expect(props.onSetGlobalArchived).toHaveBeenCalledWith(true)
+  })
+
+  it('shows "Unarchive for everyone" when globally archived', () => {
+    const props = renderOrganizer({ globallyArchived: true })
+    fireEvent.click(
+      screen.getByRole('button', { name: /more conversation actions/i }),
+    )
+    fireEvent.click(
+      screen.getByRole('button', { name: /unarchive for everyone/i }),
+    )
+    expect(props.onSetGlobalArchived).toHaveBeenCalledWith(false)
+  })
+
+  it('readOnly (impersonation) disables the Resolve control', () => {
+    const props = renderOrganizer({ readOnly: true })
+    const resolve = screen.getByRole('button', { name: /resolve/i })
+    expect(resolve).toBeDisabled()
+    fireEvent.click(resolve)
+    expect(props.onSetStatus).not.toHaveBeenCalled()
+  })
+})
+
+describe('ConversationThreadView — speaker archive affordance', () => {
+  it('renders Archive in the Mute/Emails bar and calls onArchiveForMe', () => {
+    const onArchiveForMe = vi.fn()
+    render(
+      <ConversationThreadView
+        messages={messages}
+        emptyText=""
+        subject="Talk"
+        onSend={vi.fn()}
+        preference={preference}
+        onSetMuted={vi.fn()}
+        onSetEmailOverride={vi.fn()}
+        onArchiveForMe={onArchiveForMe}
+      />,
+    )
+    // No organizer controls for a speaker.
+    expect(
+      screen.queryByRole('button', { name: /resolve/i }),
+    ).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /archive/i }))
+    expect(onArchiveForMe).toHaveBeenCalledTimes(1)
+  })
+
+  it('readOnly disables the speaker Archive action', () => {
+    const onArchiveForMe = vi.fn()
+    render(
+      <ConversationThreadView
+        messages={messages}
+        emptyText=""
+        subject="Talk"
+        onSend={vi.fn()}
+        preference={preference}
+        onSetMuted={vi.fn()}
+        onSetEmailOverride={vi.fn()}
+        onArchiveForMe={onArchiveForMe}
+        readOnly
+      />,
+    )
+    const archive = screen.getByRole('button', { name: /archive/i })
+    expect(archive).toBeDisabled()
+  })
+})

--- a/__tests__/components/messaging/MessagesInbox.test.tsx
+++ b/__tests__/components/messaging/MessagesInbox.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Container tests for the T2a/T2e MessagesInbox additions:
+ * - the view tab bar drives the `listConversations` `view` input (organizer);
+ * - the speaker toggle exposes only Active / Archived;
+ * - the Archived view wires Unarchive to the un-archive mutations.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { speaker: { _id: 'me' } } }),
+}))
+
+// Capture every `view` the inbox query is called with, plus the mutation calls.
+const listInputs: Array<{ view: string }> = []
+const setArchivedMutate = vi.fn()
+const setPreferenceMutate = vi.fn()
+const listInvalidate = vi.fn()
+
+let infiniteResult: Record<string, unknown> = {}
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    useUtils: () => ({
+      message: { listConversations: { invalidate: listInvalidate } },
+    }),
+    message: {
+      listConversations: {
+        useInfiniteQuery: (input: { view: string }) => {
+          listInputs.push(input)
+          return infiniteResult
+        },
+      },
+      setArchived: {
+        useMutation: () => ({ mutate: setArchivedMutate, isPending: false }),
+      },
+      setPreference: {
+        useMutation: () => ({ mutate: setPreferenceMutate, isPending: false }),
+      },
+    },
+  },
+}))
+
+import { MessagesInbox } from '@/components/messaging'
+
+function pageOf(items: unknown[]) {
+  return {
+    data: { pages: [items] },
+    isLoading: false,
+    isError: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }
+}
+
+const archivedRow = {
+  _id: 'conversation.gen-1',
+  conversationType: 'general',
+  subject: 'Old thread',
+  createdAt: '2026-01-01T00:00:00Z',
+  lastMessageAt: '2026-02-01T00:00:00Z',
+  unreadCount: 0,
+  lastMessage: { authorId: 'sp-1', authorName: 'Kari', excerpt: 'hi' },
+  counterpart: { name: 'Kari' },
+  status: 'open',
+  needsReply: false,
+  assignedTo: null,
+  archived: true,
+}
+
+beforeEach(() => {
+  listInputs.length = 0
+  setArchivedMutate.mockClear()
+  setPreferenceMutate.mockClear()
+  listInvalidate.mockClear()
+  infiniteResult = pageOf([])
+})
+
+afterEach(cleanup)
+
+describe('MessagesInbox — view tabs (T2a)', () => {
+  it('defaults to the active view and switches the query input on tab click', () => {
+    render(<MessagesInbox audience="organizer" />)
+    // Initial render queried the default `active` view.
+    expect(listInputs[0]).toEqual({ view: 'active' })
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Needs reply' }))
+    expect(listInputs.at(-1)).toEqual({ view: 'needs-reply' })
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Mine' }))
+    expect(listInputs.at(-1)).toEqual({ view: 'mine' })
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Resolved' }))
+    expect(listInputs.at(-1)).toEqual({ view: 'resolved' })
+  })
+
+  it('organizers get the full tab bar; the "All" view is omitted from the UI', () => {
+    render(<MessagesInbox audience="organizer" />)
+    for (const label of [
+      'Active',
+      'Needs reply',
+      'Mine',
+      'Resolved',
+      'Archived',
+    ]) {
+      expect(screen.getByRole('tab', { name: label })).toBeInTheDocument()
+    }
+    expect(screen.queryByRole('tab', { name: 'All' })).not.toBeInTheDocument()
+  })
+
+  it('speakers get only Active / Archived', () => {
+    render(<MessagesInbox audience="speaker" />)
+    expect(screen.getByRole('tab', { name: 'Active' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Archived' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('tab', { name: 'Needs reply' }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'Mine' })).not.toBeInTheDocument()
+  })
+})
+
+describe('MessagesInbox — Archived view Unarchive wiring (T2e)', () => {
+  it('un-archives a row (global + per-user) only in the archived view', () => {
+    infiniteResult = pageOf([archivedRow])
+    render(<MessagesInbox audience="organizer" />)
+
+    // Active view: no Unarchive affordance.
+    expect(
+      screen.queryByRole('button', { name: /unarchive/i }),
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Archived' }))
+    fireEvent.click(screen.getByRole('button', { name: /unarchive/i }))
+
+    // Organizer unarchive lifts BOTH archives so the row leaves the view.
+    expect(setArchivedMutate).toHaveBeenCalledWith({
+      conversationId: 'conversation.gen-1',
+      archived: false,
+    })
+    expect(setPreferenceMutate).toHaveBeenCalledWith({
+      conversationId: 'conversation.gen-1',
+      archived: false,
+    })
+  })
+
+  it('a speaker unarchive lifts ONLY the per-user archive', () => {
+    infiniteResult = pageOf([archivedRow])
+    render(<MessagesInbox audience="speaker" />)
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Archived' }))
+    fireEvent.click(screen.getByRole('button', { name: /unarchive/i }))
+
+    expect(setArchivedMutate).not.toHaveBeenCalled()
+    expect(setPreferenceMutate).toHaveBeenCalledWith({
+      conversationId: 'conversation.gen-1',
+      archived: false,
+    })
+  })
+})

--- a/__tests__/lib/messaging/nudge.test.ts
+++ b/__tests__/lib/messaging/nudge.test.ts
@@ -31,6 +31,9 @@ import {
   staleConversationCutoff,
   STALE_AFTER_DAYS,
 } from '@/lib/messaging/nudge'
+// The nudge selection MUST use the SAME last-author projection as the inbox
+// needs-reply filter (single home — R1).
+import { LAST_AUTHOR_REF } from '@/lib/messaging/sanity'
 import type { NotificationInput } from '@/lib/notification/types'
 
 type LooseMock = ReturnType<typeof vi.fn>
@@ -105,6 +108,17 @@ describe('selection GROQ encodes the stale policy', () => {
     expect(query).toContain('in $organizerIds)')
     expect(params.organizerIds).toEqual(['org-1', 'org-2'])
     expect(typeof params.cutoff).toBe('string')
+  })
+
+  it('uses the SHARED LAST_AUTHOR_REF projection (single home, R1)', async () => {
+    readMock.fetch.mockResolvedValueOnce([])
+    await nudgeStaleConversations()
+    const [query] = readMock.fetch.mock.calls[0]
+    // The exact exported string appears (both in `defined(...)` and the
+    // `!(... in $organizerIds)` clauses), proving the nudge never re-declares a
+    // divergent copy.
+    expect(query).toContain(LAST_AUTHOR_REF)
+    expect(query.split(LAST_AUTHOR_REF).length - 1).toBe(2)
   })
 
   it('no-ops (no notifications, no writes) when nothing is stale', async () => {

--- a/__tests__/lib/messaging/ticketing.test.ts
+++ b/__tests__/lib/messaging/ticketing.test.ts
@@ -137,6 +137,10 @@ describe('inbox views — ORGANIZER GROQ predicates', () => {
     expect(query).toContain("coalesce(status, 'open') != 'resolved'")
     // The last-message author must not be in the organizer set.
     expect(query).toContain('in $organizerIds)')
+    // R2 guard: with an empty organizer set `x in []` is false, so the negation
+    // would vacuously match EVERY thread. The `count(...) > 0` gate prevents the
+    // needs-reply view flooding on a misconfigured/transiently-empty org set.
+    expect(query).toContain('count($organizerIds) > 0')
     expect(params.organizerIds).toEqual(['org-1', 'org-2'])
   })
 
@@ -298,6 +302,20 @@ describe('derived needsReply (ORGANIZER audience)', () => {
       view: 'all',
     })
     expect(noMsg.needsReply).toBe(false)
+  })
+
+  it('is FALSE for an ORGANIZER when the organizer set is empty (R2 guard)', async () => {
+    // A misconfigured conference (or a transient organizer-fetch that resolves
+    // empty) must NOT flag every thread as needing a reply — nobody can reply.
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValue([])
+    readMock.fetch.mockResolvedValueOnce([orgRow({})]).mockResolvedValueOnce([])
+    const [row] = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'all',
+    })
+    expect(row.needsReply).toBe(false)
   })
 
   it('is always false for a SPEAKER caller', async () => {

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -894,4 +894,18 @@ describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () 
     readMock.fetch.mockResolvedValue(null)
     expect(await getOrganizerSpeakerIds()).toEqual([])
   })
+
+  it('does NOT cache a FAILED fetch as [] — a later call re-reads (R2)', async () => {
+    // A transient read failure must throw and leave the cache EMPTY, so the very
+    // next call re-reads rather than serving a poisoned empty organizer set for a
+    // full TTL (which would vacuously empty the needs-reply view / misroute
+    // nudges).
+    readMock.fetch.mockRejectedValueOnce(new Error('sanity down'))
+    await expect(getOrganizerSpeakerIds()).rejects.toThrow('sanity down')
+
+    readMock.fetch.mockResolvedValueOnce(['org-1'])
+    expect(await getOrganizerSpeakerIds()).toEqual(['org-1'])
+    // Two real reads: the failed one was NOT cached.
+    expect(readMock.fetch).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/components/messaging/ConversationList.stories.tsx
+++ b/src/components/messaging/ConversationList.stories.tsx
@@ -111,6 +111,73 @@ const makeLongItems = (): ConversationListItem[] => [
   },
 ]
 
+/**
+ * ORGANIZER rows carrying the ticketing metadata (T2b): a needs-reply amber dot,
+ * a gray Resolved chip, and an assignee avatar+initial at the row's trailing
+ * edge. Row 1 needs a reply and is assigned; row 2 is resolved; row 3 is a plain
+ * assigned thread.
+ */
+const makeOrganizerItems = (): ConversationListItem[] => [
+  {
+    _id: 'conversation.proposal.talk-1',
+    conversationType: 'proposal',
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    proposalId: 'talk-1',
+    proposalTitle: 'Scaling Kubernetes to 10,000 nodes',
+    createdAt: minutesAgo(60 * 24 * 3),
+    lastMessageAt: minutesAgo(24),
+    unreadCount: 2,
+    lastMessage: {
+      authorId: 'speaker-1',
+      authorName: 'Kari Nordmann',
+      excerpt: 'Any update on the review? Happy to tweak the abstract.',
+    },
+    counterpart: { name: 'Kari Nordmann' },
+    status: 'open',
+    needsReply: true,
+    assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+    archived: false,
+  },
+  {
+    _id: 'conversation.abc123',
+    conversationType: 'general',
+    subject: 'Question about speaker travel',
+    createdAt: minutesAgo(60 * 24 * 2),
+    lastMessageAt: minutesAgo(60 * 5),
+    unreadCount: 0,
+    lastMessage: {
+      authorId: 'org-2',
+      authorName: 'Grace Hopper',
+      excerpt: 'Sorted — reimbursement is on its way. Closing this out.',
+    },
+    counterpart: { name: 'Grace Hopper' },
+    status: 'resolved',
+    needsReply: false,
+    assignedTo: null,
+    archived: false,
+  },
+  {
+    _id: 'conversation.proposal.talk-2',
+    conversationType: 'proposal',
+    subject: 'Designing for Failure',
+    proposalId: 'talk-2',
+    proposalTitle: 'Designing for Failure',
+    createdAt: minutesAgo(60 * 24 * 10),
+    lastMessageAt: minutesAgo(60 * 24 * 4),
+    unreadCount: 0,
+    lastMessage: {
+      authorId: 'org-1',
+      authorName: 'Ola Organizer',
+      excerpt: 'Thanks! Could you keep the demo under ten minutes?',
+    },
+    counterpart: { name: 'Åsa Berg' },
+    status: 'open',
+    needsReply: false,
+    assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+    archived: false,
+  },
+]
+
 const meta = {
   title: 'Components/Messaging/ConversationList',
   component: ConversationList,
@@ -203,4 +270,66 @@ export const LongContentDark: Story = {
   args: { items: [], isOrganizer: false, callerId: CALLER_ID },
   parameters: { dark: true },
   render: (args) => <ConversationList {...args} items={makeLongItems()} />,
+}
+
+/**
+ * Organizer rows with ticketing metadata (T2b): needs-reply amber dot + assignee
+ * avatar (row 1), Resolved chip (row 2), assigned but not needing a reply (row 3).
+ */
+export const OrganizerTicketing: Story = {
+  args: { items: [], isOrganizer: true },
+  render: (args) => <ConversationList {...args} items={makeOrganizerItems()} />,
+}
+
+export const OrganizerTicketingDark: Story = {
+  args: { items: [], isOrganizer: true },
+  parameters: { dark: true },
+  render: (args) => <ConversationList {...args} items={makeOrganizerItems()} />,
+}
+
+/**
+ * Speaker rows only ever surface the Resolved chip (their signal the matter is
+ * closed) — no needs-reply dot, no assignee.
+ */
+export const SpeakerResolvedChip: Story = {
+  args: { items: [], isOrganizer: false, callerId: CALLER_ID },
+  render: (args) => (
+    <ConversationList
+      {...args}
+      items={makeOrganizerItems().map((item) => ({ ...item }))}
+    />
+  ),
+}
+
+/**
+ * Archived view: every row shows a trailing Unarchive button (T2d). Shown for
+ * the organizer audience (rows also carry the assignee avatar).
+ */
+export const ArchivedWithUnarchive: Story = {
+  args: {
+    items: [],
+    isOrganizer: true,
+    onUnarchive: () => {},
+  },
+  render: (args) => (
+    <ConversationList
+      {...args}
+      items={makeOrganizerItems().map((item) => ({ ...item, archived: true }))}
+    />
+  ),
+}
+
+export const ArchivedWithUnarchiveDark: Story = {
+  args: {
+    items: [],
+    isOrganizer: true,
+    onUnarchive: () => {},
+  },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationList
+      {...args}
+      items={makeOrganizerItems().map((item) => ({ ...item, archived: true }))}
+    />
+  ),
 }

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import {
+  ArchiveBoxXMarkIcon,
   ChatBubbleLeftRightIcon,
   UserGroupIcon,
 } from '@heroicons/react/24/outline'
@@ -30,6 +31,31 @@ export interface ConversationListProps {
   hasMore?: boolean
   onShowMore?: () => void
   isLoadingMore?: boolean
+  /**
+   * Archived-view affordance (all audiences, T2d): when provided, each row shows
+   * a trailing "Unarchive" button that un-archives the conversation for the
+   * caller (organizer → global archive; speaker → their per-user archive) WITHOUT
+   * navigating into the thread. Omitted (the default) in every non-archived view.
+   */
+  onUnarchive?: (item: ConversationListItem) => void
+}
+
+/**
+ * The organizer follow-up owner, as a compact avatar+initial at the row's
+ * trailing edge (organizer audience only). `title` carries the full name for a
+ * hover tooltip; the accessible label spells out the assignment.
+ */
+function AssigneeBadge({ name }: { name: string }) {
+  const initial = name.trim().charAt(0).toUpperCase() || '?'
+  return (
+    <span
+      title={name}
+      aria-label={`Assigned to ${name}`}
+      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand-cloud-blue/10 text-[11px] font-semibold text-brand-cloud-blue dark:bg-blue-400/10 dark:text-blue-300"
+    >
+      {initial}
+    </span>
+  )
 }
 
 function SkeletonRow() {
@@ -94,6 +120,7 @@ export function ConversationList({
   hasMore = false,
   onShowMore,
   isLoadingMore = false,
+  onUnarchive,
 }: ConversationListProps) {
   return (
     <div
@@ -135,6 +162,11 @@ export function ConversationList({
             const isUnread = item.unreadCount > 0
             const isOwnLastMessage =
               !!callerId && item.lastMessage?.authorId === callerId
+            // Organizer-only signals; a speaker never sees needs-reply or the
+            // assignee (both are organizer-side concepts).
+            const showNeedsReply = isOrganizer && item.needsReply === true
+            const isResolved = item.status === 'resolved'
+            const assignee = isOrganizer ? item.assignedTo : null
             return (
               <Link
                 key={item._id}
@@ -164,8 +196,18 @@ export function ConversationList({
                     </span>
                   </span>
                   {/* WHAT: subject (the talk title for proposal threads — the
-                      chip marks the type instead of repeating it). */}
+                      chip marks the type instead of repeating it). A small amber
+                      dot leads the subject when the thread needs an organizer
+                      reply (least-noisy affordance, consistent with the unread
+                      pill); a gray 'Resolved' chip marks a closed thread. */}
                   <span className="mt-0.5 flex items-center gap-2">
+                    {showNeedsReply && (
+                      <span
+                        title="Needs reply"
+                        aria-label="Needs reply"
+                        className="h-2 w-2 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400"
+                      />
+                    )}
                     <span
                       className={`truncate text-sm text-gray-900 dark:text-white ${
                         isUnread ? 'font-bold' : 'font-semibold'
@@ -176,6 +218,11 @@ export function ConversationList({
                     {item.conversationType === 'proposal' && (
                       <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
                         Proposal
+                      </span>
+                    )}
+                    {isResolved && (
+                      <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                        Resolved
                       </span>
                     )}
                   </span>
@@ -192,6 +239,31 @@ export function ConversationList({
                     </span>
                   )}
                 </span>
+                {/* Trailing column: the follow-up owner's avatar (organizer
+                    audience) and, in the archived view, an Unarchive button that
+                    acts WITHOUT navigating into the thread. */}
+                {(assignee || onUnarchive) && (
+                  <span className="flex shrink-0 flex-col items-end justify-center gap-1.5">
+                    {assignee && <AssigneeBadge name={assignee.name} />}
+                    {onUnarchive && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          onUnarchive(item)
+                        }}
+                        className="inline-flex min-h-[44px] items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium text-brand-cloud-blue transition hover:bg-brand-cloud-blue/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-blue-300 dark:hover:bg-blue-400/10"
+                      >
+                        <ArchiveBoxXMarkIcon
+                          className="h-4 w-4"
+                          aria-hidden="true"
+                        />
+                        Unarchive
+                      </button>
+                    )}
+                  </span>
+                )}
               </Link>
             )
           })}

--- a/src/components/messaging/ConversationThread.stories.tsx
+++ b/src/components/messaging/ConversationThread.stories.tsx
@@ -61,6 +61,13 @@ const defaultPreference: ConversationPreference = {
   emailOverride: 'default',
 }
 
+/** Organizer picker options for the Assign menu. */
+const organizers = [
+  { _id: 'org-1', name: 'Ola Organizer' },
+  { _id: 'org-2', name: 'Grace Hopper' },
+  { _id: 'org-3', name: 'Linus Berg' },
+]
+
 const meta = {
   title: 'Components/Messaging/ConversationThread',
   component: ConversationThreadView,
@@ -75,6 +82,9 @@ const meta = {
     onSetEmailOverride: fn(),
     emptyText: 'Start the conversation with the organizers.',
   },
+  // NOTE: the organizer ticketing handlers (onSetStatus/onSetAssignee/…) are set
+  // PER-STORY, not on `meta`, so the existing speaker-facing stories keep their
+  // Mute/Emails bar unchanged.
   decorators: [
     // `.dark` is applied at the OUTERMOST node (via `parameters.dark`) so every
     // `dark:` variant inside the card activates for the dark capture.
@@ -232,6 +242,99 @@ export const ReadOnlyImpersonation: Story = {
     preference: defaultPreference,
     readOnly: true,
   },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/**
+ * ORGANIZER thread header (T2c): a visible green Resolve button + Mute, with the
+ * lower-frequency actions (Assign, Emails, per-user & global Archive) behind the
+ * overflow "…" menu so the header never crowds at 393px. Assigned to Ola.
+ */
+export const OrganizerControls: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+    status: 'open',
+    onSetStatus: fn(),
+    organizers,
+    assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+    onSetAssignee: fn(),
+    globallyArchived: false,
+    onSetGlobalArchived: fn(),
+    onArchiveForMe: fn(),
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+export const OrganizerControlsDark: Story = {
+  args: {
+    messages: [],
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    preference: defaultPreference,
+    status: 'open',
+    onSetStatus: fn(),
+    organizers,
+    assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+    onSetAssignee: fn(),
+    globallyArchived: false,
+    onSetGlobalArchived: fn(),
+    onArchiveForMe: fn(),
+  },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/** A RESOLVED organizer thread — the primary button flips to "Reopen". */
+export const OrganizerControlsResolved: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: defaultPreference,
+    status: 'resolved',
+    onSetStatus: fn(),
+    organizers,
+    assignedTo: null,
+    onSetAssignee: fn(),
+    globallyArchived: false,
+    onSetGlobalArchived: fn(),
+    onArchiveForMe: fn(),
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/**
+ * SPEAKER thread header with the per-user Archive affordance (T2d): Archive joins
+ * the existing Mute / Emails bar. No organizer ticketing controls.
+ */
+export const SpeakerArchiveAffordance: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: defaultPreference,
+    onArchiveForMe: fn(),
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+export const SpeakerArchiveAffordanceDark: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: defaultPreference,
+    onArchiveForMe: fn(),
+  },
+  parameters: { dark: true },
   render: (args) => (
     <ConversationThreadView {...args} messages={makeMessages()} />
   ),

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -10,8 +10,13 @@ import {
 } from 'react'
 import { useSession } from 'next-auth/react'
 import {
+  ArchiveBoxArrowDownIcon,
+  ArchiveBoxXMarkIcon,
+  ArrowUturnLeftIcon,
   BellIcon,
   BellSlashIcon,
+  CheckCircleIcon,
+  EllipsisHorizontalIcon,
   PaperAirplaneIcon,
 } from '@heroicons/react/24/outline'
 import { api } from '@/lib/trpc/client'
@@ -21,8 +26,11 @@ import {
 } from '@/lib/messaging/links'
 import { errorCode } from '@/lib/messaging/trpc'
 import { formatRelativeTime } from '@/lib/notification/format'
+import { ModalShell } from '@/components/ModalShell'
 import type {
+  ConversationAssignee,
   ConversationPreference,
+  ConversationStatus,
   EmailOverride,
 } from '@/lib/messaging/types'
 
@@ -98,6 +106,31 @@ export interface ConversationThreadViewProps {
   onSetMuted?: (muted: boolean) => void
   onSetEmailOverride?: (override: EmailOverride) => void
   isSavingPreference?: boolean
+  /**
+   * Per-user "Archive for me" (ALL participants, T2d). When provided the prefs
+   * bar / overflow gains an Archive action that hides the thread from the
+   * caller's inbox until a new message resurfaces it (un-archiving lives on the
+   * Archived-view rows). Gated by `readOnly` like the other preference controls.
+   */
+  onArchiveForMe?: () => void
+  // --- Organizer ticketing controls (T2c). Each is rendered only when its
+  // handler is provided, so the speaker view (which passes none) is unchanged.
+  /** Current ticketing status; drives the Resolve/Reopen toggle label. */
+  status?: ConversationStatus
+  /** Organizer-only: flip the thread between open and resolved. */
+  onSetStatus?: (status: ConversationStatus) => void
+  /** The organizer picker options for the Assign menu (`{ _id, name }`). */
+  organizers?: ConversationAssignee[]
+  /** The currently-assigned organizer (null when unassigned). */
+  assignedTo?: ConversationAssignee | null
+  /** Organizer-only: (re)assign or unassign (`null`) the follow-up owner. */
+  onSetAssignee?: (assigneeId: string | null) => void
+  /** Whether the thread is GLOBALLY archived (organizer archive state). */
+  globallyArchived?: boolean
+  /** Organizer-only: set/clear the GLOBAL archive. */
+  onSetGlobalArchived?: (archived: boolean) => void
+  /** True while any organizer ticketing mutation is in flight (disables them). */
+  isSavingTicket?: boolean
 }
 
 function MessageSkeleton() {
@@ -150,55 +183,298 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
   )
 }
 
+/** The shared icon-button styling used by the header preference/ticketing actions. */
+const HEADER_BUTTON_CLASS =
+  'inline-flex min-h-[44px] items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800'
+
+function MuteButton({
+  muted,
+  onSetMuted,
+  disabled,
+}: {
+  muted: boolean
+  onSetMuted: (muted: boolean) => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSetMuted(!muted)}
+      disabled={disabled}
+      aria-pressed={muted}
+      title={muted ? 'Muted — click to unmute' : 'Mute this conversation'}
+      className={HEADER_BUTTON_CLASS}
+    >
+      {muted ? (
+        <BellSlashIcon className="h-4 w-4" aria-hidden="true" />
+      ) : (
+        <BellIcon className="h-4 w-4" aria-hidden="true" />
+      )}
+      {muted ? 'Muted' : 'Mute'}
+    </button>
+  )
+}
+
+function EmailOverrideSelect({
+  emailOverride,
+  onSetEmailOverride,
+  disabled,
+}: {
+  emailOverride: EmailOverride
+  onSetEmailOverride?: (override: EmailOverride) => void
+  disabled?: boolean
+}) {
+  return (
+    <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+      <span>Emails</span>
+      <select
+        value={emailOverride}
+        disabled={disabled || !onSetEmailOverride}
+        onChange={(e) => onSetEmailOverride?.(e.target.value as EmailOverride)}
+        aria-label="Email notifications for this conversation"
+        className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 focus:border-brand-cloud-blue focus:outline-none disabled:opacity-50 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200"
+      >
+        <option value="default">Default</option>
+        <option value="on">Always</option>
+        <option value="off">Never</option>
+      </select>
+    </label>
+  )
+}
+
+/**
+ * SPEAKER preference bar: Mute + Emails, plus the per-user "Archive" action
+ * (T2d) when `onArchiveForMe` is provided. Every control is blocked under
+ * `readOnly` (impersonation).
+ */
 function PreferencesBar({
   preference,
   onSetMuted,
   onSetEmailOverride,
+  onArchiveForMe,
   isSavingPreference,
   readOnly = false,
 }: {
   preference: ConversationPreference
   onSetMuted: (muted: boolean) => void
   onSetEmailOverride?: (override: EmailOverride) => void
+  onArchiveForMe?: () => void
   isSavingPreference?: boolean
   /** Impersonation: render the controls but block every mutation. */
   readOnly?: boolean
 }) {
   const { muted, emailOverride } = preference
+  const disabled = isSavingPreference || readOnly
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center gap-2">
+      <MuteButton muted={muted} onSetMuted={onSetMuted} disabled={disabled} />
+      <EmailOverrideSelect
+        emailOverride={emailOverride}
+        onSetEmailOverride={onSetEmailOverride}
+        disabled={disabled}
+      />
+      {onArchiveForMe && (
+        // Icon-only so the three-control bar (Mute + Emails + Archive) stays
+        // compact enough at 393px to leave the thread subject room in the header.
+        <button
+          type="button"
+          onClick={onArchiveForMe}
+          disabled={disabled}
+          title="Archive this conversation"
+          aria-label="Archive this conversation"
+          className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          <ArchiveBoxArrowDownIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+/**
+ * ORGANIZER thread controls (T2c): a visible Resolve/Reopen toggle and Mute
+ * button, with the lower-frequency actions (Assign, Emails, per-user Archive,
+ * global Archive) tucked into an overflow "…" menu so the header never crowds or
+ * wraps at 393px. Every mutation is blocked under `readOnly` (impersonation).
+ */
+function OrganizerThreadControls({
+  status,
+  onSetStatus,
+  preference,
+  onSetMuted,
+  onSetEmailOverride,
+  onArchiveForMe,
+  organizers = [],
+  assignedTo,
+  onSetAssignee,
+  globallyArchived = false,
+  onSetGlobalArchived,
+  isSavingPreference = false,
+  isSavingTicket = false,
+  readOnly = false,
+}: {
+  status?: ConversationStatus
+  onSetStatus: (status: ConversationStatus) => void
+  preference?: ConversationPreference
+  onSetMuted?: (muted: boolean) => void
+  onSetEmailOverride?: (override: EmailOverride) => void
+  onArchiveForMe?: () => void
+  organizers?: ConversationAssignee[]
+  assignedTo?: ConversationAssignee | null
+  onSetAssignee?: (assigneeId: string | null) => void
+  globallyArchived?: boolean
+  onSetGlobalArchived?: (archived: boolean) => void
+  isSavingPreference?: boolean
+  isSavingTicket?: boolean
+  readOnly?: boolean
+}) {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const resolved = status === 'resolved'
+  const ticketDisabled = isSavingTicket || readOnly
+  const prefDisabled = isSavingPreference || readOnly
+  const currentAssigneeId = assignedTo?._id ?? null
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* Primary organizer action: Resolve / Reopen. */}
       <button
         type="button"
-        onClick={() => onSetMuted(!muted)}
-        disabled={isSavingPreference || readOnly}
-        aria-pressed={muted}
-        title={muted ? 'Muted — click to unmute' : 'Mute this conversation'}
-        className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800"
+        onClick={() => onSetStatus(resolved ? 'open' : 'resolved')}
+        disabled={ticketDisabled}
+        aria-pressed={resolved}
+        title={resolved ? 'Reopen this conversation' : 'Mark as resolved'}
+        className={`inline-flex min-h-[44px] items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 ${
+          resolved
+            ? 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
+            : 'bg-green-600 text-white hover:bg-green-500'
+        }`}
       >
-        {muted ? (
-          <BellSlashIcon className="h-4 w-4" aria-hidden="true" />
+        {resolved ? (
+          <ArrowUturnLeftIcon className="h-4 w-4" aria-hidden="true" />
         ) : (
-          <BellIcon className="h-4 w-4" aria-hidden="true" />
+          <CheckCircleIcon className="h-4 w-4" aria-hidden="true" />
         )}
-        {muted ? 'Muted' : 'Mute'}
+        {resolved ? 'Reopen' : 'Resolve'}
       </button>
 
-      <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
-        <span>Emails</span>
-        <select
-          value={emailOverride}
-          disabled={isSavingPreference || readOnly || !onSetEmailOverride}
-          onChange={(e) =>
-            onSetEmailOverride?.(e.target.value as EmailOverride)
-          }
-          aria-label="Email notifications for this conversation"
-          className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 focus:border-brand-cloud-blue focus:outline-none disabled:opacity-50 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200"
-        >
-          <option value="default">Default</option>
-          <option value="on">Always</option>
-          <option value="off">Never</option>
-        </select>
-      </label>
+      {onSetMuted && preference && (
+        <MuteButton
+          muted={preference.muted}
+          onSetMuted={onSetMuted}
+          disabled={prefDisabled}
+        />
+      )}
+
+      <button
+        type="button"
+        onClick={() => setMenuOpen(true)}
+        title="More actions"
+        aria-label="More conversation actions"
+        aria-haspopup="dialog"
+        className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-300 dark:hover:bg-gray-800"
+      >
+        <EllipsisHorizontalIcon className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      <ModalShell
+        isOpen={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        size="sm"
+        title="Conversation options"
+      >
+        <div className="space-y-5">
+          {/* Assign menu: Unassigned + every organizer. */}
+          {onSetAssignee && (
+            <div>
+              <p className="mb-1.5 text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                Assign to
+              </p>
+              <div className="-mx-1 flex flex-col">
+                {[{ _id: null, name: 'Unassigned' }, ...organizers].map(
+                  (option) => {
+                    const selected = currentAssigneeId === option._id
+                    return (
+                      <button
+                        key={option._id ?? 'unassigned'}
+                        type="button"
+                        onClick={() => onSetAssignee(option._id)}
+                        disabled={ticketDisabled}
+                        aria-pressed={selected}
+                        className={`flex min-h-[44px] items-center justify-between rounded-lg px-3 text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 ${
+                          selected
+                            ? 'bg-brand-cloud-blue/10 font-semibold text-brand-cloud-blue dark:bg-blue-400/10 dark:text-blue-300'
+                            : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800'
+                        }`}
+                      >
+                        <span className="truncate">{option.name}</span>
+                        {selected && (
+                          <CheckCircleIcon
+                            className="h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </button>
+                    )
+                  },
+                )}
+              </div>
+            </div>
+          )}
+
+          {onSetMuted && preference && onSetEmailOverride && (
+            <div>
+              <p className="mb-1.5 text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                Notifications
+              </p>
+              <EmailOverrideSelect
+                emailOverride={preference.emailOverride}
+                onSetEmailOverride={onSetEmailOverride}
+                disabled={prefDisabled}
+              />
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1 border-t border-gray-200 pt-4 dark:border-gray-700">
+            {onArchiveForMe && (
+              <button
+                type="button"
+                onClick={onArchiveForMe}
+                disabled={prefDisabled}
+                className="flex min-h-[44px] items-center gap-2 rounded-lg px-3 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-200 dark:hover:bg-gray-800"
+              >
+                <ArchiveBoxArrowDownIcon
+                  className="h-4 w-4 shrink-0"
+                  aria-hidden="true"
+                />
+                Archive for me
+              </button>
+            )}
+            {onSetGlobalArchived && (
+              <button
+                type="button"
+                onClick={() => onSetGlobalArchived(!globallyArchived)}
+                disabled={ticketDisabled}
+                className="flex min-h-[44px] items-center gap-2 rounded-lg px-3 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-200 dark:hover:bg-gray-800"
+              >
+                {globallyArchived ? (
+                  <ArchiveBoxXMarkIcon
+                    className="h-4 w-4 shrink-0"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <ArchiveBoxArrowDownIcon
+                    className="h-4 w-4 shrink-0"
+                    aria-hidden="true"
+                  />
+                )}
+                {globallyArchived
+                  ? 'Unarchive for everyone'
+                  : 'Archive for everyone'}
+              </button>
+            )}
+          </div>
+        </div>
+      </ModalShell>
     </div>
   )
 }
@@ -228,6 +504,15 @@ export function ConversationThreadView({
   onSetMuted,
   onSetEmailOverride,
   isSavingPreference = false,
+  onArchiveForMe,
+  status,
+  onSetStatus,
+  organizers,
+  assignedTo,
+  onSetAssignee,
+  globallyArchived = false,
+  onSetGlobalArchived,
+  isSavingTicket = false,
 }: ConversationThreadViewProps) {
   const [draft, setDraft] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -366,23 +651,46 @@ export function ConversationThreadView({
       // of a stretched card.
       className={fillHeight ? 'flex min-h-0 flex-col' : 'flex flex-col'}
     >
-      {(subject || onSetMuted) && (
+      {(subject || onSetMuted || onSetStatus) && (
         <div className="flex shrink-0 items-center justify-between gap-3 border-b border-gray-200 pb-3 dark:border-gray-700">
           {subject ? (
-            <h2 className="truncate text-sm font-semibold text-gray-900 dark:text-white">
+            <h2 className="min-w-0 truncate text-sm font-semibold text-gray-900 dark:text-white">
               {subject}
             </h2>
           ) : (
             <span />
           )}
-          {onSetMuted && preference && (
-            <PreferencesBar
+          {/* ORGANIZER (onSetStatus present) → the ticketing control cluster with
+              an overflow menu; SPEAKER → the lighter Mute/Emails/Archive bar. */}
+          {onSetStatus ? (
+            <OrganizerThreadControls
+              status={status}
+              onSetStatus={onSetStatus}
               preference={preference}
               onSetMuted={onSetMuted}
               onSetEmailOverride={onSetEmailOverride}
+              onArchiveForMe={onArchiveForMe}
+              organizers={organizers}
+              assignedTo={assignedTo}
+              onSetAssignee={onSetAssignee}
+              globallyArchived={globallyArchived}
+              onSetGlobalArchived={onSetGlobalArchived}
               isSavingPreference={isSavingPreference}
+              isSavingTicket={isSavingTicket}
               readOnly={readOnly}
             />
+          ) : (
+            onSetMuted &&
+            preference && (
+              <PreferencesBar
+                preference={preference}
+                onSetMuted={onSetMuted}
+                onSetEmailOverride={onSetEmailOverride}
+                onArchiveForMe={onArchiveForMe}
+                isSavingPreference={isSavingPreference}
+                readOnly={readOnly}
+              />
+            )
           )}
         </div>
       )}
@@ -733,6 +1041,44 @@ export function ConversationThread({
     onSuccess: invalidate,
   })
 
+  // ORGANIZER ticketing (T2c/T2e): status / assignee / global-archive. These are
+  // organizer-only capabilities, so the queries/mutations are gated on
+  // `isOrganizer` — a speaker container never fetches organizers or calls them.
+  const isOrganizer = audience === 'organizer'
+  const statusMutation = api.message.setStatus.useMutation({
+    onSuccess: invalidate,
+  })
+  const assigneeMutation = api.message.setAssignee.useMutation({
+    onSuccess: invalidate,
+  })
+  const archivedMutation = api.message.setArchived.useMutation({
+    onSuccess: invalidate,
+  })
+  // The organizer picker for the Assign menu — the cheapest existing organizer
+  // list the codebase offers (also used by the sponsor CRM assignee picker).
+  // Fetched only for an organizer viewing an EXISTING conversation.
+  const organizersQuery = api.sponsor.crm.listOrganizers.useQuery(undefined, {
+    enabled: isOrganizer && conversationExists,
+    staleTime: 5 * 60_000,
+  })
+  const organizers = useMemo(
+    () =>
+      (organizersQuery.data ?? []).map((o) => ({ _id: o._id, name: o.name })),
+    [organizersQuery.data],
+  )
+  const isSavingTicket =
+    statusMutation.isPending ||
+    assigneeMutation.isPending ||
+    archivedMutation.isPending
+
+  // Globally archived IFF archivedAt >= lastMessageAt (a newer message
+  // auto-resurfaces it — the same timestamp rule the data layer applies).
+  // `conversation` is resolved above (shared with the mark-read wiring).
+  const globallyArchived =
+    !!conversation?.archivedAt &&
+    !!conversation.lastMessageAt &&
+    conversation.archivedAt >= conversation.lastMessageAt
+
   const handleSend = (body: string) => {
     // A not-yet-created proposal thread must be opened via `proposalId`; once it
     // exists (or for a real conversation id) post directly to the conversation.
@@ -782,6 +1128,45 @@ export function ConversationThread({
           : undefined
       }
       isSavingPreference={preferenceMutation.isPending}
+      // Per-user "Archive for me" (ALL participants) — rides setPreference. Only
+      // offered once the conversation exists (nothing to archive before then).
+      onArchiveForMe={
+        conversationExists && convId
+          ? () =>
+              preferenceMutation.mutate({
+                conversationId: convId,
+                archived: true,
+              })
+          : undefined
+      }
+      // ORGANIZER ticketing controls — passed only for an organizer viewing an
+      // existing conversation, so a speaker container never wires them.
+      status={conversation?.status}
+      assignedTo={conversation?.assignedTo}
+      organizers={organizers}
+      globallyArchived={globallyArchived}
+      isSavingTicket={isSavingTicket}
+      onSetStatus={
+        isOrganizer && conversationExists && convId
+          ? (nextStatus) =>
+              statusMutation.mutate({
+                conversationId: convId,
+                status: nextStatus,
+              })
+          : undefined
+      }
+      onSetAssignee={
+        isOrganizer && conversationExists && convId
+          ? (assigneeId) =>
+              assigneeMutation.mutate({ conversationId: convId, assigneeId })
+          : undefined
+      }
+      onSetGlobalArchived={
+        isOrganizer && conversationExists && convId
+          ? (archived) =>
+              archivedMutation.mutate({ conversationId: convId, archived })
+          : undefined
+      }
     />
   )
 }

--- a/src/components/messaging/MessagesInbox.stories.tsx
+++ b/src/components/messaging/MessagesInbox.stories.tsx
@@ -92,6 +92,49 @@ const conversationHandlers = (getItems: () => ConversationListItem[]) => [
   ),
 ]
 
+/** Organizer inbox rows carrying ticketing metadata so the row affordances show
+ *  alongside the tab bar. */
+const makeOrganizerItems = (): ConversationListItem[] => [
+  {
+    _id: 'conversation.proposal.talk-1',
+    conversationType: 'proposal',
+    subject: 'Scaling Kubernetes to 10,000 nodes',
+    proposalId: 'talk-1',
+    proposalTitle: 'Scaling Kubernetes to 10,000 nodes',
+    createdAt: minutesAgo(60 * 24 * 3),
+    lastMessageAt: minutesAgo(24),
+    unreadCount: 2,
+    lastMessage: {
+      authorId: 'speaker-1',
+      authorName: 'Kari Nordmann',
+      excerpt: 'Any update on the review?',
+    },
+    counterpart: { name: 'Kari Nordmann' },
+    status: 'open',
+    needsReply: true,
+    assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+    archived: false,
+  },
+  {
+    _id: 'conversation.abc123',
+    conversationType: 'general',
+    subject: 'Question about speaker travel',
+    createdAt: minutesAgo(60 * 24 * 2),
+    lastMessageAt: minutesAgo(60 * 5),
+    unreadCount: 0,
+    lastMessage: {
+      authorId: 'org-2',
+      authorName: 'Grace Hopper',
+      excerpt: 'Sorted — closing this out.',
+    },
+    counterpart: { name: 'Grace Hopper' },
+    status: 'resolved',
+    needsReply: false,
+    assignedTo: null,
+    archived: false,
+  },
+]
+
 const speaker = {
   _id: CALLER_ID,
   name: 'Jane Doe',
@@ -152,6 +195,35 @@ export const OrganizerEmpty: Story = {
 export const SpeakerPopulated: Story = {
   args: { audience: 'speaker' },
   parameters: { msw: { handlers: conversationHandlers(makeItems) } },
+}
+
+/** Organizer inbox — the full view tab bar (Active / Needs reply / Mine /
+ *  Resolved / Archived) sits above rows with ticketing metadata. */
+export const OrganizerPopulated: Story = {
+  args: { audience: 'organizer' },
+  parameters: { msw: { handlers: conversationHandlers(makeOrganizerItems) } },
+}
+
+export const OrganizerPopulatedDark: Story = {
+  args: { audience: 'organizer' },
+  parameters: {
+    dark: true,
+    msw: { handlers: conversationHandlers(makeOrganizerItems) },
+  },
+}
+
+/** Speaker inbox — the subtle Active / Archived toggle (not a full tab bar). */
+export const SpeakerToggle: Story = {
+  args: { audience: 'speaker' },
+  parameters: { msw: { handlers: conversationHandlers(makeItems) } },
+}
+
+export const SpeakerToggleDark: Story = {
+  args: { audience: 'speaker' },
+  parameters: {
+    dark: true,
+    msw: { handlers: conversationHandlers(makeItems) },
+  },
 }
 
 export const SpeakerEmptyDark: Story = {

--- a/src/components/messaging/MessagesInbox.tsx
+++ b/src/components/messaging/MessagesInbox.tsx
@@ -4,11 +4,32 @@ import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { PlusIcon } from '@heroicons/react/24/outline'
 import { api } from '@/lib/trpc/client'
+import type {
+  ConversationListItem,
+  ConversationView,
+} from '@/lib/messaging/types'
 import { ConversationList } from './ConversationList'
 import { NewConversationForm } from './NewConversationForm'
 
 /** Page size for the inbox (mirrors the server keyset page). */
 const PAGE_SIZE = 20
+
+/** Organizer inbox tabs. `all` is deliberately omitted from the UI (kept as a
+ *  server capability); `active` is the default landing view. */
+const ORGANIZER_TABS: { view: ConversationView; label: string }[] = [
+  { view: 'active', label: 'Active' },
+  { view: 'needs-reply', label: 'Needs reply' },
+  { view: 'mine', label: 'Mine' },
+  { view: 'resolved', label: 'Resolved' },
+  { view: 'archived', label: 'Archived' },
+]
+
+/** Speakers get a subtle two-way toggle (Active / Archived), not a full tab bar
+ *  — the organizer-only views carry no speaker meaning. */
+const SPEAKER_TABS: { view: ConversationView; label: string }[] = [
+  { view: 'active', label: 'Active' },
+  { view: 'archived', label: 'Archived' },
+]
 
 export interface MessagesInboxProps {
   /** The viewer's audience — drives per-row links and the inbox base path. */
@@ -18,8 +39,93 @@ export interface MessagesInboxProps {
 }
 
 /**
+ * Organizer view tabs: a horizontally scrollable row (no wrap, scrollbar hidden)
+ * so the five tabs never crowd or reflow at 393px. Each tab is a 44px target and
+ * exposes its selected state via `aria-current`.
+ */
+function OrganizerViewTabs({
+  view,
+  onChange,
+}: {
+  view: ConversationView
+  onChange: (view: ConversationView) => void
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Filter conversations"
+      className="no-scrollbar -mx-1 flex gap-1 overflow-x-auto px-1"
+    >
+      {ORGANIZER_TABS.map((tab) => {
+        const active = tab.view === view
+        return (
+          <button
+            key={tab.view}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-current={active ? 'page' : undefined}
+            onClick={() => onChange(tab.view)}
+            className={`inline-flex min-h-[44px] shrink-0 items-center rounded-lg px-3 text-sm font-medium whitespace-nowrap transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue ${
+              active
+                ? 'bg-brand-cloud-blue text-white dark:bg-blue-600'
+                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
+            }`}
+          >
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * Speaker view toggle: a subtle segmented control (Active / Archived). Presented
+ * as a pill pair rather than a full tab bar to match the lighter speaker surface.
+ */
+function SpeakerViewToggle({
+  view,
+  onChange,
+}: {
+  view: ConversationView
+  onChange: (view: ConversationView) => void
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Filter conversations"
+      className="inline-flex rounded-lg bg-gray-100 p-0.5 dark:bg-gray-800"
+    >
+      {SPEAKER_TABS.map((tab) => {
+        const active = tab.view === view
+        return (
+          <button
+            key={tab.view}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-current={active ? 'page' : undefined}
+            onClick={() => onChange(tab.view)}
+            className={`inline-flex min-h-[44px] items-center rounded-md px-4 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue ${
+              active
+                ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+            }`}
+          >
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
  * Inbox container for both audiences: loads the caller's conversations and
- * renders {@link ConversationList}. When `allowNew` is set a
+ * renders {@link ConversationList}. A view tab bar (organizer) / toggle
+ * (speaker) drives the `listConversations` `view` input — switching views swaps
+ * the query key so each view fetches fresh. When `allowNew` is set a
  * {@link NewConversationForm} opens a general thread — speakers with the
  * organizers; organizers with a chosen recipient speaker.
  */
@@ -30,9 +136,11 @@ export function MessagesInbox({
   const isOrganizer = audience === 'organizer'
   const basePath = isOrganizer ? '/admin/messages' : '/cfp/messages'
   const [showNew, setShowNew] = useState(false)
+  const [view, setView] = useState<ConversationView>('active')
   // The viewer's own speaker id drives the rows' "You: " snippet prefix.
   const { data: session } = useSession()
   const callerId = session?.speaker?._id
+  const utils = api.useUtils()
 
   const {
     data,
@@ -42,7 +150,7 @@ export function MessagesInbox({
     hasNextPage,
     isFetchingNextPage,
   } = api.message.listConversations.useInfiniteQuery(
-    {},
+    { view },
     {
       staleTime: 10_000,
       getNextPageParam: (lastPage) => {
@@ -57,33 +165,60 @@ export function MessagesInbox({
   )
 
   const items = data?.pages.flat() ?? []
+  const isArchivedView = view === 'archived'
+
+  // Un-archive a row from the Archived view. Organizers see BOTH globally- and
+  // per-user-archived threads there, so lifting both guarantees the thread leaves
+  // the view regardless of which archive hid it; speakers only ever have their
+  // per-user archive. Both mutations invalidate the inbox list on success.
+  const setArchivedMutation = api.message.setArchived.useMutation({
+    onSuccess: () => utils.message.listConversations.invalidate(),
+  })
+  const setPreferenceMutation = api.message.setPreference.useMutation({
+    onSuccess: () => utils.message.listConversations.invalidate(),
+  })
+  const handleUnarchive = (item: ConversationListItem) => {
+    if (isOrganizer) {
+      setArchivedMutation.mutate({
+        conversationId: item._id,
+        archived: false,
+      })
+    }
+    setPreferenceMutation.mutate({
+      conversationId: item._id,
+      archived: false,
+    })
+  }
 
   return (
     <div className="space-y-4">
-      {allowNew && (
-        <div>
-          {showNew ? (
-            <NewConversationForm
-              basePath={basePath}
-              requireRecipient={isOrganizer}
-              // The standalone inbox owns no success flow of its own — opt in
-              // to navigating to the created thread (no longer the default).
-              navigateOnCreate
-              onCancel={() => setShowNew(false)}
-            />
-          ) : (
-            <div className="flex justify-end">
-              <button
-                type="button"
-                onClick={() => setShowNew(true)}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:bg-blue-600 dark:hover:bg-blue-500"
-              >
-                <PlusIcon className="h-4 w-4" aria-hidden="true" />
-                New conversation
-              </button>
-            </div>
-          )}
-        </div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        {isOrganizer ? (
+          <OrganizerViewTabs view={view} onChange={setView} />
+        ) : (
+          <SpeakerViewToggle view={view} onChange={setView} />
+        )}
+        {allowNew && !showNew && (
+          <button
+            type="button"
+            onClick={() => setShowNew(true)}
+            className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:bg-blue-600 dark:hover:bg-blue-500"
+          >
+            <PlusIcon className="h-4 w-4" aria-hidden="true" />
+            New conversation
+          </button>
+        )}
+      </div>
+
+      {allowNew && showNew && (
+        <NewConversationForm
+          basePath={basePath}
+          requireRecipient={isOrganizer}
+          // The standalone inbox owns no success flow of its own — opt in to
+          // navigating to the created thread (no longer the default).
+          navigateOnCreate
+          onCancel={() => setShowNew(false)}
+        />
       )}
 
       <ConversationList
@@ -95,6 +230,7 @@ export function MessagesInbox({
         hasMore={hasNextPage}
         onShowMore={() => fetchNextPage()}
         isLoadingMore={isFetchingNextPage}
+        onUnarchive={isArchivedView ? handleUnarchive : undefined}
       />
     </div>
   )

--- a/src/lib/messaging/nudge.ts
+++ b/src/lib/messaging/nudge.ts
@@ -6,6 +6,10 @@ import {
 } from '@/lib/notification/sanity'
 import type { NotificationInput } from '@/lib/notification/types'
 import { conversationLinkPath } from './links'
+// Single home for the last-author projection (R1): sharing the exact string with
+// the inbox `needs-reply` filter guarantees the nudge selection and the inbox can
+// never disagree on which thread's ball is in the organizers' court.
+import { LAST_AUTHOR_REF } from './sanity'
 
 /**
  * Server-only stale-thread nudge for speaker↔organizer messaging (ticketing).
@@ -69,11 +73,6 @@ interface StaleConversation {
   assignedToId?: string | null
   lastMessageAt: string
 }
-
-// The newest message's author (null for a message-less thread). Same shape used
-// by the inbox `needs-reply` filter.
-const LAST_AUTHOR_REF =
-  '*[_type == "message" && conversation._ref == ^._id] | order(createdAt desc, _id desc)[0].author._ref'
 
 /**
  * Emit stale-thread nudges. See the module CONTRACT — this never throws.

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -62,7 +62,10 @@ const CONVERSATION_PROJECTION = `{
   "subjectSpeakerId": subjectSpeaker._ref,
   subject,
   createdAt,
-  lastMessageAt
+  lastMessageAt,
+  "status": coalesce(status, 'open'),
+  "assignedTo": assignedTo->{ _id, name },
+  archivedAt
 }`
 
 // ---------------------------------------------------------------------------
@@ -97,11 +100,19 @@ const NOT_GLOBALLY_ARCHIVED =
   '(!defined(archivedAt) || archivedAt < lastMessageAt)'
 const GLOBALLY_ARCHIVED = '(defined(archivedAt) && archivedAt >= lastMessageAt)'
 // The newest message's author (null when the thread has no messages yet).
-const LAST_AUTHOR_REF =
+// EXPORTED as the single home for this correlated projection so the stale-nudge
+// job (nudge.ts) imports the SAME string — the last-author ordering can never
+// drift between the inbox needs-reply filter and the nudge selection (R1).
+export const LAST_AUTHOR_REF =
   '*[_type == "message" && conversation._ref == ^._id] | order(createdAt desc, _id desc)[0].author._ref'
-// Needs an organizer reply: not resolved AND a message exists whose author is
-// not an organizer. Uses $organizerIds — bound only for the `needs-reply` view.
-const NEEDS_REPLY = `${STATUS_NOT_RESOLVED} && defined(${LAST_AUTHOR_REF}) && !(${LAST_AUTHOR_REF} in $organizerIds)`
+// Needs an organizer reply: not resolved AND at least one organizer exists AND a
+// message exists whose author is not an organizer. Uses $organizerIds — bound
+// only for the `needs-reply` view. The `count($organizerIds) > 0` guard is
+// LOAD-BEARING: with an empty organizer set `x in []` is false, so the negation
+// would match EVERY thread vacuously (a misconfigured conference would flood the
+// needs-reply view). No organizers means nobody can reply → needs-reply is empty
+// (mirrors the JS derivation below and the nudge job's routing skip). (R2)
+const NEEDS_REPLY = `${STATUS_NOT_RESOLVED} && count($organizerIds) > 0 && defined(${LAST_AUTHOR_REF}) && !(${LAST_AUTHOR_REF} in $organizerIds)`
 
 /**
  * Build the GROQ predicate fragment (leading ` && ...`, or empty for `all`) for
@@ -520,9 +531,14 @@ export async function listConversationsForSpeaker({
       ? globallyArchived || userArchived
       : userArchived
     // needs-reply is an ORGANIZER concept: last message from a non-organizer and
-    // not resolved. Always false for a speaker caller.
+    // not resolved. Always false for a speaker caller. The `organizerSet.size > 0`
+    // guard mirrors the GROQ `count($organizerIds) > 0` guard: with NO organizers
+    // (misconfigured conference or a transient organizer-fetch failure)
+    // `!organizerSet.has(...)` is vacuously true, which would flag every thread —
+    // nobody can reply, so needs-reply must be FALSE. (R2)
     const needsReply =
       isOrganizer &&
+      organizerSet.size > 0 &&
       row.status !== 'resolved' &&
       row.lastMessage != null &&
       !organizerSet.has(row.lastMessage.authorId)

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -78,6 +78,17 @@ export interface ConversationWithContext {
   subject: string
   createdAt: string
   lastMessageAt: string
+  /**
+   * Ticketing state, projected so the organizer thread header can render its
+   * Resolve/Reopen, Assign and global-archive controls without a second
+   * round-trip. `status` is coalesced (absent ⇒ `'open'`); `assignedTo` is the
+   * dereffed organizer (null when unassigned); `archivedAt` is the GLOBAL archive
+   * timestamp (globally archived iff `archivedAt >= lastMessageAt`). All optional
+   * so the pre-ticketing shape still satisfies the type.
+   */
+  status?: ConversationStatus
+  assignedTo?: ConversationAssignee | null
+  archivedAt?: string | null
 }
 
 /** The newest message of a conversation, summarized for an inbox row (M6). */

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -642,6 +642,12 @@ export async function getOrganizerSpeakerIds(): Promise<string[]> {
   if (organizerCache && organizerCache.expiresAt > now) {
     return organizerCache.ids
   }
+  // ONLY successes are cached (R2): the `await` throws on a failed read BEFORE
+  // the cache assignment below, so a transient Sanity failure is never poisoned
+  // into the cache as an empty organizer set (which would, e.g., vacuously empty
+  // the needs-reply view or misroute stale nudges for a full TTL). A genuinely
+  // empty result (`null`/`[]` — a conference with no organizers yet) IS a
+  // success and is cached normally.
   const ids = await clientReadUncached.fetch<string[]>(
     `*[_type == "speaker" && isOrganizer == true][0...${ORGANIZER_FETCH_LIMIT}]._id`,
   )


### PR DESCRIPTION
Ticketing UI (T2) for the speaker↔organizer messaging system, consuming the merged T1 backend (#552): inbox views, thread status/assignee, and dual (global + per-user) archive. Built entirely in the worktree; T1 row/conversation projections tightened as consumed.

## Tasks

**T2a — Inbox views (organizer + speaker).** `MessagesInbox` gains a view control that drives `listConversations`'s `view` input (switching the view swaps the query key → fresh fetch). Organizers get a horizontally scrollable tab bar (Active / Needs reply / Mine / Resolved / Archived — `all` omitted from the UI; `active` default; `no-scrollbar` + `overflow-x-auto`, no wrap, 44px targets). Speakers get a subtle Active/Archived segmented toggle (not a full tab bar).

**T2b — Row metadata (`ConversationList`).** Organizer rows: a small amber needs-reply dot leading the subject (least-noisy affordance, consistent with the unread pill), a gray `Resolved` chip (matching the Proposal chip), and an assignee avatar+initial (`title=name`) in a trailing column. Speaker rows: only the `Resolved` chip. Three-line anatomy preserved.

**T2c — Thread controls (organizer header).** Visible green Resolve/Reopen toggle + Mute; the lower-frequency actions (Assign menu, Emails, per-user Archive, global Archive/Unarchive) live in an overflow "…" menu rendered via `ModalShell` (bottom sheet on mobile). Assign menu lists Unassigned + every organizer (fetched via the existing `sponsor.crm.listOrganizers` picker query). All gated by impersonation `readOnly`.

**T2d — Per-user archive (all participants).** Speaker header: Archive joins the Mute/Emails bar (icon-only so the subject keeps room at 393px). Organizer: "Archive for me" in the overflow menu. Both ride `setPreference {archived}`. Archived-view rows carry a trailing Unarchive button that acts without navigating the row Link.

**T2e — Container wiring.** `MessagesInbox` passes `view` and wires archived-row Unarchive (organizer → lifts BOTH global `setArchived` and per-user `setPreference`; speaker → per-user only) with inbox-list invalidation. `ConversationThread` wires `setStatus`/`setAssignee`/`setArchived` + per-user archive, invalidating the thread + inbox list; organizer mutations/queries are gated on `audience==='organizer'` (a speaker container never calls them) and on `conversationExists`.

**T2f — Riders.**
- **R1:** `LAST_AUTHOR_REF` is now exported from `src/lib/messaging/sanity.ts` and imported by `nudge.ts` (removed the duplicate) — the last-author ordering can never drift between the inbox needs-reply filter and the stale-nudge selection.
- **R2:** needs-reply no longer computes vacuously true on an empty organizer set — guarded in BOTH the GROQ (`count($organizerIds) > 0`) and the JS derivation (`organizerSet.size > 0`), so a misconfigured/transiently-empty org set yields FALSE. Documented that `getOrganizerSpeakerIds` only caches successes (a thrown fetch never poisons the cache as `[]`); added a test locking it.

**T2g — Stories + tests.** Real-component stories for the tab bar / speaker toggle, rows with needs-reply/resolved/assignee, archived rows with Unarchive, and the organizer/speaker thread headers (light+dark). Component tests: tab switching → `view` input, Unarchive mutation wiring (organizer vs speaker), organizer control wiring + `readOnly` gating, row-metadata rendering, and the R1/R2 riders.

## Shoot findings (393×852, DPR 3, light+dark)

- **Overflow decision (SHOOT DECIDES):** with Resolve + Mute inline, the organizer header stays on ONE row at 393px only because Assign/Emails/Archive are in the "…" overflow. Confirmed the overflow `ModalShell` sheet renders Assign (Unassigned + 3 organizers, selected highlighted) / Emails / Archive-for-me / Archive-for-everyone cleanly. → overflow menu is the right call.
- Organizer tab bar scrolls horizontally at 393px (Resolved clipped, Archived off-screen — no wrap), as intended.
- Speaker header initially squeezed the subject to nothing once Archive was added; fixed by making the speaker Archive icon-only, restoring the truncated subject. Re-shot to confirm.
- All shot stories pass the per-card viewport-overflow check (no cut-offs); dark variants verified.

## Checks
tsc / eslint / prettier / knip clean. Full `vitest run`: 225 files, 3224 passed, 5 skipped.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the T2 ticketing UI layer on top of the T1 backend from #552: inbox view switching (organizer tab bar / speaker toggle), per-row metadata (needs-reply dot, Resolved chip, assignee avatar), organizer thread controls (Resolve/Reopen, Assign, overflow menu for archive), and per-user archive for all participants. Two data-layer riders are also included: exporting `LAST_AUTHOR_REF` as a single source of truth (R1) and guarding `needs-reply` against a vacuously-true result on an empty organizer set in both GROQ and JS (R2).

- **Inbox views (T2a/b):** `MessagesInbox` gains view state driving `listConversations`'s query key; `ConversationList` rows gain needs-reply dot, Resolved chip, assignee badge, and an archived-view Unarchive button \u2014 currently rendered as a `<button>` nested inside the row `<Link>`, which is invalid HTML and has mild accessibility implications.
- **Thread controls (T2c/e):** `OrganizerThreadControls` surfaces Resolve/Reopen + Mute inline, with Assign/Emails/Archive in a `ModalShell` overflow; all mutations are gated on `isOrganizer && conversationExists`; the overflow menu does not auto-close after one-shot archive actions.
- **ARIA / accessibility:** Both tab bar components use `role=\"tablist\"` / `role=\"tab\"` without associated `role=\"tabpanel\"` elements or `aria-controls` wiring, leaving the WAI-ARIA tabs pattern incomplete for screen-reader users.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the data layer, mutation wiring, and gating logic are correct and well-tested. The open issues are presentation-layer accessibility concerns that do not affect data integrity or correctness.

The business logic, GROQ predicates, R1/R2 riders, and mutation invalidation chains are all sound and backed by thorough tests (3224 passing). The only concerns are three UI-layer issues: a button nested inside a Next.js Link (invalid HTML with screen-reader implications), incomplete WAI-ARIA tab panel wiring, and the overflow menu not self-closing after archive actions. None of these affect data correctness or runtime behavior for sighted users.

src/components/messaging/ConversationList.tsx for the button-inside-anchor pattern; src/components/messaging/MessagesInbox.tsx for the incomplete ARIA tab wiring; src/components/messaging/ConversationThread.tsx for the overflow menu close behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/messaging/ConversationList.tsx | Adds needs-reply dot, Resolved chip, assignee badge, and archived-view Unarchive button; the Unarchive button is nested inside a Next.js Link (a element), which is invalid HTML per spec and can cause accessibility issues. |
| src/components/messaging/MessagesInbox.tsx | Adds view tabs (organizer) / toggle (speaker) with per-view query keys, plus handleUnarchive that intentionally fires both global and per-user archive mutations for organizers. Tab bar uses role=tablist/role=tab without associated tabpanel elements. |
| src/components/messaging/ConversationThread.tsx | Adds organizer ticketing mutations (status, assignee, global archive) and per-user archive for all audiences, all gated on audience and conversationExists. Overflow menu actions do not close the modal on success, leaving it open after archiving. |
| src/lib/messaging/sanity.ts | Exports LAST_AUTHOR_REF for R1 de-duplication, adds count($organizerIds) > 0 GROQ guard (R2), extends listConversationsForSpeaker with view predicates, and adds setConversationStatus/Assignee/Archived mutations. Logic is sound and well-tested. |
| src/lib/messaging/nudge.ts | Removes the duplicate LAST_AUTHOR_REF constant and imports from sanity.ts (R1). The rest of the stale-nudge logic is unchanged and correct. |
| src/lib/messaging/types.ts | Adds ConversationView union, SPEAKER_ALLOWED_VIEWS constant, and ConversationAssignee type. Types are well-documented with audience-specific semantics. |
| __tests__/lib/messaging/ticketing.test.ts | Comprehensive GROQ predicate tests for all view variants plus mutation tests for status/assignee/archive and setPreference archived flag. R2 guard is locked by a dedicated test. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant MessagesInbox
    participant ConversationList
    participant ConversationThread
    participant tRPC as tRPC router

    User->>MessagesInbox: change view tab
    MessagesInbox->>tRPC: listConversations fresh query
    tRPC-->>MessagesInbox: ConversationListItem[]
    MessagesInbox->>ConversationList: render rows

    alt Archived view
        User->>ConversationList: click Unarchive
        ConversationList->>MessagesInbox: onUnarchive(item)
        MessagesInbox->>tRPC: setArchived(false) organizer only
        MessagesInbox->>tRPC: setPreference archived false
        tRPC-->>MessagesInbox: invalidate list
    end

    User->>ConversationThread: open thread organizer
    ConversationThread->>tRPC: getConversation + listOrganizers
    tRPC-->>ConversationThread: conversation + organizers

    User->>ConversationThread: click Resolve
    ConversationThread->>tRPC: setStatus resolved
    tRPC-->>ConversationThread: invalidate thread + inbox

    User->>ConversationThread: overflow Archive for everyone
    ConversationThread->>tRPC: setArchived true
    tRPC-->>ConversationThread: invalidate thread + inbox
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant MessagesInbox
    participant ConversationList
    participant ConversationThread
    participant tRPC as tRPC router

    User->>MessagesInbox: change view tab
    MessagesInbox->>tRPC: listConversations fresh query
    tRPC-->>MessagesInbox: ConversationListItem[]
    MessagesInbox->>ConversationList: render rows

    alt Archived view
        User->>ConversationList: click Unarchive
        ConversationList->>MessagesInbox: onUnarchive(item)
        MessagesInbox->>tRPC: setArchived(false) organizer only
        MessagesInbox->>tRPC: setPreference archived false
        tRPC-->>MessagesInbox: invalidate list
    end

    User->>ConversationThread: open thread organizer
    ConversationThread->>tRPC: getConversation + listOrganizers
    tRPC-->>ConversationThread: conversation + organizers

    User->>ConversationThread: click Resolve
    ConversationThread->>tRPC: setStatus resolved
    tRPC-->>ConversationThread: invalidate thread + inbox

    User->>ConversationThread: overflow Archive for everyone
    ConversationThread->>tRPC: setArchived true
    tRPC-->>ConversationThread: invalidate thread + inbox
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): ticketing UI — views, s..."](https://github.com/cloudnativebergen/website/commit/13ae53a79097c20c6a0024b3776410c08a24cc95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45440092)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->