### PR TITLE
fix(messaging): UX review server batch — email routing, decision rail, reopen, assign notify

### DIFF
--- a/__tests__/api/trpc/message-ticketing.test.ts
+++ b/__tests__/api/trpc/message-ticketing.test.ts
@@ -38,6 +38,7 @@ vi.mock('@/lib/sanity/client', () => ({
 
 vi.mock('@/lib/notification/sanity', () => ({
   getOrganizerSpeakerIds: vi.fn(async () => [] as string[]),
+  createNotifications: vi.fn(async () => {}),
 }))
 
 vi.mock('@/lib/messaging/sanity', async (importActual) => {
@@ -51,6 +52,7 @@ vi.mock('@/lib/messaging/sanity', async (importActual) => {
       emailOverride: 'default',
     })),
     listConversationsForSpeaker: vi.fn(async () => []),
+    getConversationViewCounts: vi.fn(async () => ({ active: 0, archived: 0 })),
     setConversationPreference: vi.fn(async () => ({
       muted: false,
       emailOverride: 'default',
@@ -64,21 +66,27 @@ vi.mock('@/lib/messaging/sanity', async (importActual) => {
 import {
   getConversationById,
   listConversationsForSpeaker,
+  getConversationViewCounts,
   setConversationStatus,
   setConversationAssignee,
   setConversationArchived,
   setConversationPreference,
 } from '@/lib/messaging/sanity'
-import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import {
+  getOrganizerSpeakerIds,
+  createNotifications,
+} from '@/lib/notification/sanity'
 
 type LooseMock = ReturnType<typeof vi.fn>
 const getById = getConversationById as unknown as LooseMock
 const listConvs = listConversationsForSpeaker as unknown as LooseMock
+const viewCounts = getConversationViewCounts as unknown as LooseMock
 const setStatus = setConversationStatus as unknown as LooseMock
 const setAssignee = setConversationAssignee as unknown as LooseMock
 const setArchived = setConversationArchived as unknown as LooseMock
 const setPref = setConversationPreference as unknown as LooseMock
 const orgIds = getOrganizerSpeakerIds as unknown as LooseMock
+const createNotifs = createNotifications as unknown as LooseMock
 
 const speaker1 = speakers[0]._id // not an organizer
 const organizerId = speakers.find((s) => s.isOrganizer)!._id
@@ -164,8 +172,8 @@ describe('setStatus — organizer only', () => {
   })
 })
 
-describe('setAssignee — organizer validation', () => {
-  it('assigns when the target is an organizer', async () => {
+describe('setAssignee — organizer validation + assign notify (S4)', () => {
+  it('assigns to a DIFFERENT organizer and notifies them (S4)', async () => {
     getById.mockResolvedValue(proposalConv)
     orgIds.mockResolvedValue([organizerId, 'org-2'])
     const caller = createAdminCaller()
@@ -174,6 +182,31 @@ describe('setAssignee — organizer validation', () => {
       assigneeId: 'org-2',
     })
     expect(setAssignee).toHaveBeenCalledWith(proposalConv._id, 'org-2')
+    // One hub notification to the NEW assignee.
+    expect(createNotifs).toHaveBeenCalledTimes(1)
+    const [items] = createNotifs.mock.calls[0]
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      recipientId: 'org-2',
+      conferenceId: 'conf-1',
+      notificationType: 'conversation_assigned',
+      title: 'Assigned to you: T',
+      link: '/admin/proposals/prop-1#messages',
+      actorId: organizerId,
+      relatedProposalId: 'prop-1',
+    })
+  })
+
+  it('does NOT notify on self-assign (S4)', async () => {
+    getById.mockResolvedValue(proposalConv)
+    orgIds.mockResolvedValue([organizerId])
+    const caller = createAdminCaller()
+    await caller.message.setAssignee({
+      conversationId: proposalConv._id,
+      assigneeId: organizerId, // the caller assigns to themselves
+    })
+    expect(setAssignee).toHaveBeenCalledWith(proposalConv._id, organizerId)
+    expect(createNotifs).not.toHaveBeenCalled()
   })
 
   it('rejects a non-organizer assignee with BAD_REQUEST', async () => {
@@ -187,9 +220,10 @@ describe('setAssignee — organizer validation', () => {
       }),
     ).rejects.toThrow(/BAD_REQUEST|organizer/)
     expect(setAssignee).not.toHaveBeenCalled()
+    expect(createNotifs).not.toHaveBeenCalled()
   })
 
-  it('allows unassigning (null) without an organizer check', async () => {
+  it('allows unassigning (null) without an organizer check and does NOT notify', async () => {
     getById.mockResolvedValue(proposalConv)
     const caller = createAdminCaller()
     await caller.message.setAssignee({
@@ -198,18 +232,24 @@ describe('setAssignee — organizer validation', () => {
     })
     expect(orgIds).not.toHaveBeenCalled()
     expect(setAssignee).toHaveBeenCalledWith(proposalConv._id, null)
+    expect(createNotifs).not.toHaveBeenCalled()
   })
 })
 
 describe('setArchived — organizer only (global archive)', () => {
-  it('lets an organizer archive globally', async () => {
+  it('lets an organizer archive globally, recording the archiver (S6)', async () => {
     getById.mockResolvedValue(proposalConv)
     const caller = createAdminCaller()
     await caller.message.setArchived({
       conversationId: proposalConv._id,
       archived: true,
     })
-    expect(setArchived).toHaveBeenCalledWith(proposalConv._id, true)
+    // S6: the caller's id is passed so the data layer records archivedBy.
+    expect(setArchived).toHaveBeenCalledWith(
+      proposalConv._id,
+      true,
+      organizerId,
+    )
   })
 
   it('denies a non-organizer with NOT_FOUND', async () => {
@@ -222,6 +262,40 @@ describe('setArchived — organizer only (global archive)', () => {
       }),
     ).rejects.toThrow(/NOT_FOUND|not found/)
     expect(setArchived).not.toHaveBeenCalled()
+  })
+})
+
+describe('viewCounts — audience-scoped tab counts (S7)', () => {
+  it('returns organizer counts for an organizer caller', async () => {
+    viewCounts.mockResolvedValue({
+      active: 3,
+      needsReply: 2,
+      mine: 1,
+      resolved: 4,
+      archived: 5,
+    })
+    const caller = createAdminCaller()
+    const result = await caller.message.viewCounts()
+    expect(result).toEqual({
+      active: 3,
+      needsReply: 2,
+      mine: 1,
+      resolved: 4,
+      archived: 5,
+    })
+    expect(viewCounts).toHaveBeenCalledWith(
+      expect.objectContaining({ isOrganizer: true, conferenceId: 'conf-1' }),
+    )
+  })
+
+  it('passes isOrganizer=false for a speaker caller', async () => {
+    viewCounts.mockResolvedValue({ active: 2, archived: 1 })
+    const caller = createAuthenticatedCaller(speaker1)
+    const result = await caller.message.viewCounts()
+    expect(result).toEqual({ active: 2, archived: 1 })
+    expect(viewCounts).toHaveBeenCalledWith(
+      expect.objectContaining({ isOrganizer: false, speakerId: speaker1 }),
+    )
   })
 })
 

--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -251,6 +251,49 @@ describe('keyset cursor threading (F3)', () => {
   })
 })
 
+describe('send — reopen-on-reply (S3)', () => {
+  const resolvedOwnConv: ConversationWithContext = {
+    ...ownProposalConv,
+    status: 'resolved',
+  }
+
+  it('a NON-organizer replying to a resolved thread reopens it (reopen=true)', async () => {
+    getById.mockResolvedValue(resolvedOwnConv)
+    const caller = createAuthenticatedCaller(speaker1)
+    await caller.message.send({
+      conversationId: resolvedOwnConv._id,
+      body: 'follow up',
+    })
+    expect(addMsg).toHaveBeenCalledWith(
+      expect.objectContaining({ reopen: true }),
+    )
+  })
+
+  it('an ORGANIZER replying to a resolved thread does NOT reopen it (reopen=false)', async () => {
+    getById.mockResolvedValue(resolvedOwnConv)
+    const caller = createAdminCaller()
+    await caller.message.send({
+      conversationId: resolvedOwnConv._id,
+      body: 'answer',
+    })
+    expect(addMsg).toHaveBeenCalledWith(
+      expect.objectContaining({ reopen: false }),
+    )
+  })
+
+  it('a NON-organizer replying to an OPEN thread does not reopen (reopen=false)', async () => {
+    getById.mockResolvedValue(ownProposalConv) // status undefined → open
+    const caller = createAuthenticatedCaller(speaker1)
+    await caller.message.send({
+      conversationId: ownProposalConv._id,
+      body: 'hi again',
+    })
+    expect(addMsg).toHaveBeenCalledWith(
+      expect.objectContaining({ reopen: false }),
+    )
+  })
+})
+
 describe('send — conversation creation', () => {
   it('auto-creates the proposal thread (deterministic id) and is idempotent', async () => {
     getProposal.mockResolvedValue({

--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -47,13 +47,12 @@ vi.mock('@/lib/conference/state', () => ({
   isWithdrawalCutoffActive: vi.fn(),
 }))
 
-// Messaging M4: the action procedure mirrors organizer decision comments into
-// the proposal thread. Mock the messaging boundary; only the three functions
-// the proposal router uses need real stubs (the message router's other imports
-// from this module are never invoked in these tests).
+// Messaging M4/S2: the action procedure mirrors organizer decision comments into
+// the proposal thread (addMessage only — the decision status rail is the single
+// delivery, so notifyNewMessage is deliberately NOT called). Mock the messaging
+// boundary.
 vi.mock('@/lib/messaging/sanity', () => ({
   ensureProposalConversation: vi.fn(),
-  getConversationById: vi.fn(),
   addMessage: vi.fn(),
 }))
 
@@ -79,11 +78,7 @@ import {
 } from '@/lib/proposal/data/sanity'
 import { getProposalSanity, updateProposalStatus } from '@/lib/proposal/server'
 import { isCfpOpen, isWithdrawalCutoffActive } from '@/lib/conference/state'
-import {
-  ensureProposalConversation,
-  getConversationById,
-  addMessage,
-} from '@/lib/messaging/sanity'
+import { ensureProposalConversation, addMessage } from '@/lib/messaging/sanity'
 import { notifyNewMessage } from '@/lib/messaging/notify'
 import {
   Status,
@@ -682,24 +677,11 @@ describe('proposal router', () => {
   describe('action — decision comment mirrored to proposal thread (M4)', () => {
     beforeEach(() => {
       vi.mocked(ensureProposalConversation).mockClear()
-      vi.mocked(getConversationById).mockClear()
       vi.mocked(addMessage).mockClear()
       vi.mocked(notifyNewMessage).mockClear()
     })
 
     const conversationId = 'conversation.proposal.proposal-1'
-    const conversation = {
-      _id: conversationId,
-      conferenceId: 'conf-1',
-      conversationType: 'proposal',
-      proposalId: 'proposal-1',
-      proposalTitle: 'My Talk',
-      proposalSpeakerIds: [regularSpeaker._id],
-      createdById: adminSpeaker._id,
-      subject: 'My Talk',
-      createdAt: '2026-01-01T00:00:00.000Z',
-      lastMessageAt: '2026-01-01T00:00:00.000Z',
-    }
     const createdMessage = {
       _id: 'message.1',
       conversationId,
@@ -718,12 +700,11 @@ describe('proposal router', () => {
         err: null,
       })
       vi.mocked(ensureProposalConversation).mockResolvedValue(conversationId)
-      vi.mocked(getConversationById).mockResolvedValue(conversation as any)
       vi.mocked(addMessage).mockResolvedValue(createdMessage as any)
       vi.mocked(notifyNewMessage).mockResolvedValue(undefined)
     }
 
-    it('posts an organizer accept comment as a message and fans out', async () => {
+    it('posts an organizer accept comment as a message but does NOT fan out (S2 decision rail)', async () => {
       mockAcceptFlow()
 
       const caller = createAdminCaller()
@@ -745,13 +726,11 @@ describe('proposal router', () => {
         authorId: adminSpeaker._id,
         body: 'Congrats — see you in Bergen!',
       })
-      expect(notifyNewMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          conversation,
-          message: createdMessage,
-          authorId: adminSpeaker._id,
-        }),
-      )
+      // S2: the decision status rail (proposal_status_changed notification +
+      // decision email, both carrying this comment) is the single delivery — the
+      // message-thread fan-out must NOT fire, or the speaker would be
+      // double-notified for one organizer action.
+      expect(notifyNewMessage).not.toHaveBeenCalled()
     })
 
     it('never fails the action when the messaging write throws', async () => {

--- a/__tests__/components/email/MessageNotificationTemplate.test.tsx
+++ b/__tests__/components/email/MessageNotificationTemplate.test.tsx
@@ -1,8 +1,11 @@
 /**
- * Audience-correct body copy for the new-message email (F4). The organizer and
+ * Audience-correct body copy for the new-message email (S9). The organizer and
  * speaker variants share the CTA + "Manage notification preferences" link but
- * differ in the "Prefer email?" sentence: an organizer reply reaches the speaker
- * and fellow organizers; a speaker reply reaches the organizers.
+ * differ in the TRUTHFUL reply-fallback sentence (S9a): there is no inbound/
+ * Reply-To, so a reply never reaches the conversation — an organizer's lands in
+ * the CFP inbox; a speaker's reaches the organizers' shared inbox. The
+ * preferences line (S9b) describes the GLOBAL profile setting, not a
+ * per-conversation one. A speaker's FIRST contact (S9c) gets a warmer variant.
  */
 import { describe, it, expect } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -13,7 +16,7 @@ const base = {
   authorName: 'Jane Speaker',
   subject: 'About your talk',
   excerpt: 'Could you shorten the abstract?',
-  replyUrl: 'https://cndn.no/cfp/proposal/p1#messages',
+  replyUrl: 'https://cndn.no/cfp/messages/conv-1',
   preferencesUrl: 'https://cndn.no/cfp/profile#notification-settings',
   eventName: 'CNDN',
   eventLocation: 'Bergen, Norway',
@@ -23,24 +26,48 @@ const base = {
 }
 
 describe('MessageNotificationTemplate copy', () => {
-  it('uses speaker-phrased copy for a speaker recipient (default)', () => {
+  it('uses truthful speaker-phrased reply copy for a speaker recipient (S9a)', () => {
     const html = renderToStaticMarkup(
       <MessageNotificationTemplate {...base} isOrganizer={false} />,
     )
-    expect(html).toContain('reaches the organizers by email')
+    expect(html).toContain('shared inbox')
+    // The false "reaches the speaker and fellow organizers" claim is gone.
     expect(html).not.toContain('speaker and fellow organizers')
     // Shared elements intact for both audiences.
     expect(html).toContain('Reply in app')
     expect(html).toContain('Manage notification preferences')
   })
 
-  it('uses organizer-phrased copy for an organizer recipient', () => {
+  it('uses truthful organizer-phrased reply copy for an organizer recipient (S9a)', () => {
     const html = renderToStaticMarkup(
       <MessageNotificationTemplate {...base} isOrganizer />,
     )
-    expect(html).toContain('reaches the speaker and fellow organizers by email')
-    // Shared elements still intact.
+    expect(html).toContain('land in the CFP inbox, not the conversation')
+    expect(html).not.toContain('reaches the speaker and fellow organizers')
     expect(html).toContain('Reply in app')
     expect(html).toContain('Manage notification preferences')
+  })
+
+  it('preferences line describes the GLOBAL profile setting, not a per-conversation one (S9b)', () => {
+    const html = renderToStaticMarkup(
+      <MessageNotificationTemplate {...base} isOrganizer={false} />,
+    )
+    expect(html).toContain('global message-email setting on your profile')
+    // No per-conversation promise.
+    expect(html).not.toContain('for this conversation')
+  })
+
+  it('renders a warmer first-contact heading + intro for a speaker (S9c)', () => {
+    const html = renderToStaticMarkup(
+      <MessageNotificationTemplate
+        {...base}
+        isOrganizer={false}
+        firstContact
+      />,
+    )
+    expect(html).toContain('The CNDN organizers reached out')
+    expect(html).toContain('have started a conversation with you')
+    // The standard "<author> sent you a new message" intro is replaced.
+    expect(html).not.toContain('sent you a new message')
   })
 })

--- a/__tests__/lib/messaging/email.test.ts
+++ b/__tests__/lib/messaging/email.test.ts
@@ -78,6 +78,33 @@ describe('sendMessageEmails — bounded concurrency (A8)', () => {
     expect(maxInFlight).toBeGreaterThan(1)
   })
 
+  it('uses a warmer FIRST-CONTACT subject for a first-contact recipient (S9c)', async () => {
+    sendMock.mockResolvedValue({ error: null })
+    await sendMessageEmails(
+      [
+        {
+          email: 'bob@x.no',
+          name: 'Bob',
+          replyUrl: 'https://cndn.no/cfp/messages/c1',
+          isOrganizer: false,
+          firstContact: true,
+        },
+      ],
+      context,
+    )
+    const [payload] = sendMock.mock.calls[0]
+    expect(payload.subject).toBe(
+      'The CNDN organizers started a conversation with you — "S"',
+    )
+  })
+
+  it('uses the standard subject when firstContact is not set', async () => {
+    sendMock.mockResolvedValue({ error: null })
+    await sendMessageEmails(recipients(1), context)
+    const [payload] = sendMock.mock.calls[0]
+    expect(payload.subject).toBe('New message about "S"')
+  })
+
   it('never throws; counts only successes and logs per-recipient failures', async () => {
     sendMock
       .mockResolvedValueOnce({ error: null }) // ok

--- a/__tests__/lib/messaging/notify.test.ts
+++ b/__tests__/lib/messaging/notify.test.ts
@@ -155,6 +155,27 @@ describe('HUB fan-out — per-recipient collapse-upsert inputs, actor excluded',
       expect(item.message).toContain('Hello there')
     }
   })
+
+  it('threads the conversation subjectSpeakerId into hub items (S10c direct title)', async () => {
+    const orgInitiated: ConversationWithContext = {
+      ...proposalConv,
+      _id: 'conversation.gen-1',
+      conversationType: 'general',
+      proposalId: undefined,
+      proposalSpeakerIds: [],
+      createdById: 'org-1',
+      subjectSpeakerId: 'sp-2',
+    }
+    await notifyNewMessage({
+      conversation: orgInitiated,
+      message: { ...message, authorId: 'org-1' },
+      authorId: 'org-1',
+      conference,
+    })
+    const items = lastItems()
+    const bob = items.find((i) => i.recipientId === 'sp-2')
+    expect(bob?.subjectSpeakerId).toBe('sp-2')
+  })
 })
 
 describe('muting — excluded from every channel', () => {
@@ -175,9 +196,34 @@ describe('muting — excluded from every channel', () => {
   })
 })
 
-describe('EMAIL — on by default, explicit opt-out wins', () => {
-  it('emails only recipients whose effective pref is ON', async () => {
-    // sp-2 has messagingEmailDefault true; org-1 is EXPLICITLY false (opt-out).
+// The org-contact copy (name === 'Organizers') and the individual-recipients
+// call are two SEPARATE sendMessageEmails calls for a speaker-authored message.
+type EmailRecip = {
+  email: string
+  name: string
+  isOrganizer: boolean
+  replyUrl: string
+  firstContact?: boolean
+}
+const isOrgContactCall = (c: [EmailRecip[], unknown]) =>
+  c[0].length === 1 && c[0][0].name === 'Organizers'
+const individualRecipients = (): EmailRecip[] => {
+  const call = emailMock.mock.calls.find(
+    (c) => !isOrgContactCall(c as [EmailRecip[], unknown]),
+  )
+  return (call?.[0] ?? []) as EmailRecip[]
+}
+const orgContactRecipient = (): EmailRecip | undefined => {
+  const call = emailMock.mock.calls.find((c) =>
+    isOrgContactCall(c as [EmailRecip[], unknown]),
+  )
+  return call?.[0]?.[0] as EmailRecip | undefined
+}
+
+describe('EMAIL — audience-dependent default (S1b), thread-page links (S8)', () => {
+  it('speaker recipient on by default; organizer recipient OFF by default', async () => {
+    // sp-2 (speaker) messagingEmailDefault true → on; org-1 (organizer) false →
+    // off (and would be off even if absent — organizers must opt IN).
     await notifyNewMessage({
       conversation: proposalConv,
       message,
@@ -185,18 +231,65 @@ describe('EMAIL — on by default, explicit opt-out wins', () => {
       conference,
     })
 
-    expect(emailMock).toHaveBeenCalledTimes(1)
-    const [recipients] = emailMock.mock.calls[0]
-    expect(recipients.map((r: { email: string }) => r.email)).toEqual([
-      'bob@x.no',
-    ])
-    // Speaker recipient → absolute cfp link.
-    expect(recipients[0].replyUrl).toBe(
-      'https://cndn.no/cfp/proposal/prop-1#messages',
+    const emails = individualRecipients().map((r) => r.email)
+    expect(emails).toEqual(['bob@x.no'])
+    // S8: email links point at the dedicated thread page, not the proposal
+    // `#messages` fragment.
+    expect(individualRecipients()[0].replyUrl).toBe(
+      'https://cndn.no/cfp/messages/conversation.proposal.prop-1',
     )
   })
 
-  it("respects a per-conversation 'on' override even when the speaker default is off", async () => {
+  it('an organizer recipient stays OFF even when messagingEmailDefault is absent (S1b opt-in)', async () => {
+    fetchMock.mockResolvedValue([
+      { _id: 'sp-1', name: 'Alice', email: 'alice@x.no' },
+      { _id: 'sp-2', name: 'Bob', email: 'bob@x.no' }, // speaker absent → on
+      { _id: 'org-1', name: 'Olga', email: 'olga@x.no' }, // organizer absent → OFF
+    ])
+
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference,
+    })
+
+    expect(individualRecipients().map((r) => r.email)).toEqual(['bob@x.no'])
+  })
+
+  it('an organizer recipient opts IN with messagingEmailDefault === true', async () => {
+    fetchMock.mockResolvedValue([
+      { _id: 'sp-1', name: 'Alice', email: 'alice@x.no' },
+      {
+        _id: 'sp-2',
+        name: 'Bob',
+        email: 'bob@x.no',
+        messagingEmailDefault: false,
+      },
+      {
+        _id: 'org-1',
+        name: 'Olga',
+        email: 'olga@x.no',
+        messagingEmailDefault: true, // organizer opted in
+      },
+    ])
+
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference,
+    })
+
+    // org opted in; sp-2 opted out. Organizer email links go to /admin thread page.
+    const recips = individualRecipients()
+    expect(recips.map((r) => r.email)).toEqual(['olga@x.no'])
+    expect(recips[0].replyUrl).toBe(
+      'https://cndn.no/admin/messages/conversation.proposal.prop-1',
+    )
+  })
+
+  it("a per-conversation 'on' override pierces the organizer opt-out default", async () => {
     prefsMock.mockResolvedValue(
       new Map([['org-1', { muted: false, emailOverride: 'on' }]]),
     )
@@ -208,42 +301,15 @@ describe('EMAIL — on by default, explicit opt-out wins', () => {
       conference,
     })
 
-    const [recipients] = emailMock.mock.calls[0]
-    // org-1 forced on, plus sp-2 default-on.
-    expect(recipients.map((r: { email: string }) => r.email).sort()).toEqual([
-      'bob@x.no',
-      'olga@x.no',
-    ])
+    // org-1 forced on despite its default-off; sp-2 default-on.
+    expect(
+      individualRecipients()
+        .map((r) => r.email)
+        .sort(),
+    ).toEqual(['bob@x.no', 'olga@x.no'])
   })
 
-  it('emails a recipient whose speaker doc has NO messagingEmailDefault field (absent = enabled)', async () => {
-    fetchMock.mockResolvedValue([
-      { _id: 'sp-1', name: 'Alice', email: 'alice@x.no' },
-      // No messagingEmailDefault on sp-2: M4 absent-means-enabled.
-      { _id: 'sp-2', name: 'Bob', email: 'bob@x.no' },
-      {
-        _id: 'org-1',
-        name: 'Olga',
-        email: 'olga@x.no',
-        messagingEmailDefault: false,
-      },
-    ])
-
-    await notifyNewMessage({
-      conversation: proposalConv,
-      message,
-      authorId: 'sp-1',
-      conference,
-    })
-
-    expect(emailMock).toHaveBeenCalledTimes(1)
-    const [recipients] = emailMock.mock.calls[0]
-    expect(recipients.map((r: { email: string }) => r.email)).toEqual([
-      'bob@x.no',
-    ])
-  })
-
-  it("respects a per-conversation 'off' override even when the speaker default is on", async () => {
+  it("a per-conversation 'off' override still beats a speaker's default-on", async () => {
     prefsMock.mockResolvedValue(
       new Map([['sp-2', { muted: false, emailOverride: 'off' }]]),
     )
@@ -255,40 +321,158 @@ describe('EMAIL — on by default, explicit opt-out wins', () => {
       conference,
     })
 
-    // sp-2 default-on is overridden off; org-1 remains explicitly opted out.
-    expect(emailMock).not.toHaveBeenCalled()
+    // sp-2 off; org-1 default-off. No INDIVIDUAL recipients (org-contact still fires).
+    expect(individualRecipients()).toEqual([])
+  })
+})
+
+describe('EMAIL — org-contact shared copy (S1a)', () => {
+  it('sends ONE organizer-variant copy to the org contact for a speaker-authored message', async () => {
+    // Prefer contactEmail over cfpEmail.
+    const withContact = {
+      ...conference,
+      contactEmail: 'hei@cndn.no',
+    } as unknown as Conference
+
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference: withContact,
+    })
+
+    const org = orgContactRecipient()
+    expect(org).toBeDefined()
+    expect(org!.email).toBe('hei@cndn.no')
+    expect(org!.isOrganizer).toBe(true)
+    expect(org!.firstContact).toBe(false)
+    // Admin thread-page reply link (S8).
+    expect(org!.replyUrl).toBe(
+      'https://cndn.no/admin/messages/conversation.proposal.prop-1',
+    )
   })
 
-  it('sends no email when every recipient has explicitly opted out', async () => {
-    fetchMock.mockResolvedValue([
-      {
-        _id: 'sp-1',
-        name: 'Alice',
-        email: 'alice@x.no',
-        messagingEmailDefault: false,
-      },
-      {
-        _id: 'sp-2',
-        name: 'Bob',
-        email: 'bob@x.no',
-        messagingEmailDefault: false,
-      },
-      {
-        _id: 'org-1',
-        name: 'Olga',
-        email: 'olga@x.no',
-        messagingEmailDefault: false,
-      },
-    ])
+  it('falls back to cfpEmail when contactEmail is unset', async () => {
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference, // only cfpEmail
+    })
+    expect(orgContactRecipient()?.email).toBe('cfp@cndn.no')
+  })
 
+  it('is MUTE-INDEPENDENT: still sent when every individual recipient is muted', async () => {
+    prefsMock.mockResolvedValue(
+      new Map([
+        ['org-1', { muted: true, emailOverride: 'default' }],
+        ['sp-2', { muted: true, emailOverride: 'default' }],
+      ]),
+    )
     await notifyNewMessage({
       conversation: proposalConv,
       message,
       authorId: 'sp-1',
       conference,
     })
+    expect(individualRecipients()).toEqual([])
+    expect(orgContactRecipient()?.email).toBe('cfp@cndn.no')
+  })
 
-    expect(emailMock).not.toHaveBeenCalled()
+  it('is NOT sent for an organizer-authored message', async () => {
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message: { ...message, authorId: 'org-1' },
+      authorId: 'org-1',
+      conference,
+    })
+    expect(orgContactRecipient()).toBeUndefined()
+  })
+
+  it('is skipped when neither contactEmail nor cfpEmail is set', async () => {
+    const noEmails = {
+      ...conference,
+      cfpEmail: undefined,
+      contactEmail: undefined,
+    } as unknown as Conference
+    await notifyNewMessage({
+      conversation: proposalConv,
+      message,
+      authorId: 'sp-1',
+      conference: noEmails,
+    })
+    expect(orgContactRecipient()).toBeUndefined()
+  })
+})
+
+describe('EMAIL — first-contact warmer variant (S9c)', () => {
+  const orgInitiatedConv: ConversationWithContext = {
+    _id: 'conversation.gen-1',
+    conferenceId: 'conf-1',
+    conversationType: 'general',
+    proposalSpeakerIds: [],
+    createdById: 'org-1',
+    subjectSpeakerId: 'sp-2',
+    subject: 'Quick question',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastMessageAt: '2026-01-01T00:00:00.000Z',
+  }
+
+  it('flags firstContact for a SPEAKER recipient on an organizer-authored first message', async () => {
+    // speaker rows + the message-count fetch (=== 1 → first message).
+    fetchMock
+      .mockResolvedValueOnce([
+        {
+          _id: 'org-1',
+          name: 'Olga',
+          email: 'olga@x.no',
+          messagingEmailDefault: true,
+        },
+        { _id: 'sp-2', name: 'Bob', email: 'bob@x.no' },
+      ])
+      .mockResolvedValueOnce(1) // count() === 1
+
+    await notifyNewMessage({
+      conversation: orgInitiatedConv,
+      message: {
+        ...message,
+        authorId: 'org-1',
+        conversationId: 'conversation.gen-1',
+      },
+      authorId: 'org-1',
+      conference,
+    })
+
+    const bob = individualRecipients().find((r) => r.email === 'bob@x.no')
+    expect(bob?.firstContact).toBe(true)
+  })
+
+  it('does NOT flag firstContact once the thread already has messages', async () => {
+    fetchMock
+      .mockResolvedValueOnce([
+        {
+          _id: 'org-1',
+          name: 'Olga',
+          email: 'olga@x.no',
+          messagingEmailDefault: true,
+        },
+        { _id: 'sp-2', name: 'Bob', email: 'bob@x.no' },
+      ])
+      .mockResolvedValueOnce(3) // count() > 1 → not first
+
+    await notifyNewMessage({
+      conversation: orgInitiatedConv,
+      message: {
+        ...message,
+        authorId: 'org-1',
+        conversationId: 'conversation.gen-1',
+      },
+      authorId: 'org-1',
+      conference,
+    })
+
+    const bob = individualRecipients().find((r) => r.email === 'bob@x.no')
+    expect(bob?.firstContact).toBe(false)
   })
 })
 

--- a/__tests__/lib/messaging/ticketing.test.ts
+++ b/__tests__/lib/messaging/ticketing.test.ts
@@ -36,6 +36,9 @@ import {
   setConversationAssignee,
   setConversationArchived,
   setConversationPreference,
+  getConversationViewCounts,
+  getConversationById,
+  addMessage,
 } from '@/lib/messaging/sanity'
 
 type LooseMock = ReturnType<typeof vi.fn>
@@ -469,19 +472,138 @@ describe('setConversationAssignee', () => {
 })
 
 describe('setConversationArchived — global archive timestamp semantics', () => {
-  it('stamps archivedAt = now when archiving', async () => {
+  it('stamps archivedAt = now AND records archivedBy when archiving (S6)', async () => {
     const patch = installPatch()
-    await setConversationArchived('conversation.gen-1', true)
-    const arg = patch.set.mock.calls[0][0] as { archivedAt: string }
+    await setConversationArchived('conversation.gen-1', true, 'org-7')
+    const arg = patch.set.mock.calls[0][0] as {
+      archivedAt: string
+      archivedBy: { _ref: string; _weak: boolean }
+    }
     expect(typeof arg.archivedAt).toBe('string')
+    // Weak archiver ref for the audit trail (GDPR-safe like the other refs).
+    expect(arg.archivedBy).toEqual({
+      _type: 'reference',
+      _ref: 'org-7',
+      _weak: true,
+    })
     expect(patch.unset).not.toHaveBeenCalled()
   })
 
-  it('unsets archivedAt when un-archiving', async () => {
+  it('unsets archivedAt AND archivedBy together when un-archiving (S6)', async () => {
     const patch = installPatch()
-    await setConversationArchived('conversation.gen-1', false)
-    expect(patch.unset).toHaveBeenCalledWith(['archivedAt'])
+    await setConversationArchived('conversation.gen-1', false, 'org-7')
+    expect(patch.unset).toHaveBeenCalledWith(['archivedAt', 'archivedBy'])
     expect(patch.set).not.toHaveBeenCalled()
+  })
+})
+
+describe('addMessage — reopen-on-reply (S3)', () => {
+  it('folds status:open into the conversation patch when reopen=true', async () => {
+    const { patchBuilder } = installTransaction()
+    await addMessage({
+      conversationId: 'conversation.gen-1',
+      authorId: 'sp-1',
+      body: 'follow up',
+      reopen: true,
+    })
+    const arg = patchBuilder.set.mock.calls[0][0] as {
+      lastMessageAt: string
+      status?: string
+    }
+    expect(typeof arg.lastMessageAt).toBe('string')
+    expect(arg.status).toBe('open')
+  })
+
+  it('only bumps lastMessageAt when reopen is not set', async () => {
+    const { patchBuilder } = installTransaction()
+    await addMessage({
+      conversationId: 'conversation.gen-1',
+      authorId: 'org-1',
+      body: 'reply',
+    })
+    const arg = patchBuilder.set.mock.calls[0][0] as {
+      lastMessageAt: string
+      status?: string
+    }
+    expect(typeof arg.lastMessageAt).toBe('string')
+    expect(arg.status).toBeUndefined()
+  })
+})
+
+describe('getConversationById — archivedBy projection (S6)', () => {
+  it('projects archivedBy (id + name) for the audit line', async () => {
+    readMock.fetch.mockResolvedValueOnce({
+      _id: 'conversation.gen-1',
+      conferenceId: 'conf-1',
+      conversationType: 'general',
+      proposalSpeakerIds: [],
+      createdById: 'sp-1',
+      subject: 'Q',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      lastMessageAt: '2026-02-01T00:00:00.000Z',
+      status: 'open',
+      assignedTo: null,
+      archivedAt: '2026-02-02T00:00:00.000Z',
+      archivedBy: { _id: 'org-2', name: 'Ola' },
+    })
+    const conv = await getConversationById('conversation.gen-1')
+    expect(conv?.archivedBy).toEqual({ _id: 'org-2', name: 'Ola' })
+    const [query] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('"archivedBy": archivedBy->{ _id, name }')
+  })
+})
+
+describe('getConversationViewCounts — one GROQ round trip (S7)', () => {
+  it('organizer: counts every tab, reusing the view predicates, binding organizerIds', async () => {
+    vi.mocked(getOrganizerSpeakerIds).mockResolvedValueOnce(['org-1', 'org-2'])
+    readMock.fetch.mockResolvedValueOnce({
+      active: 3,
+      needsReply: 2,
+      mine: 1,
+      resolved: 4,
+      archived: 5,
+    })
+    const counts = await getConversationViewCounts({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+    })
+    expect(counts).toEqual({
+      active: 3,
+      needsReply: 2,
+      mine: 1,
+      resolved: 4,
+      archived: 5,
+    })
+    const [query, params] = readMock.fetch.mock.calls[0]
+    // ONE object projection with a count() per view.
+    expect(query).toContain('"active": count(')
+    expect(query).toContain('"needsReply": count(')
+    expect(query).toContain('"mine": count(')
+    expect(query).toContain('"resolved": count(')
+    expect(query).toContain('"archived": count(')
+    // Reuses the shared predicates (needs-reply binds organizerIds).
+    expect(query).toContain('assignedTo._ref == $speakerId')
+    expect(query).toContain('in $organizerIds)')
+    expect(params.organizerIds).toEqual(['org-1', 'org-2'])
+  })
+
+  it('speaker: only active + archived, scoped, no organizer-only tabs', async () => {
+    readMock.fetch.mockResolvedValueOnce({ active: 2, archived: 1 })
+    const counts = await getConversationViewCounts({
+      speakerId: 'sp-1',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+    })
+    expect(counts).toEqual({ active: 2, archived: 1 })
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('"active": count(')
+    expect(query).toContain('"archived": count(')
+    expect(query).not.toContain('"needsReply": count(')
+    expect(query).not.toContain('"mine": count(')
+    // Access scope applied; needs-reply org binding never introduced.
+    expect(query).toContain('createdBy._ref == $speakerId')
+    expect(params.organizerIds).toBeUndefined()
   })
 })
 

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -235,6 +235,51 @@ describe('upsertMessageNotifications — per-conversation collapse (M5)', () => 
     expect(tx.commit).toHaveBeenCalledTimes(1)
   })
 
+  it('DIRECT title (S10c): recipient IS the subject speaker → "Direct message from ..."', async () => {
+    readMock.fetch.mockResolvedValue([]) // new doc
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([
+      msgInput({ recipientId: 'sp-1', subjectSpeakerId: 'sp-1' }),
+    ])
+
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown> },
+    ]
+    expect(ops.set.title).toBe('Direct message from Alice — A question')
+  })
+
+  it('NON-direct title: subjectSpeaker is a DIFFERENT recipient → standard title', async () => {
+    readMock.fetch.mockResolvedValue([])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([
+      msgInput({ recipientId: 'sp-1', subjectSpeakerId: 'sp-2' }),
+    ])
+
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown> },
+    ]
+    expect(ops.set.title).toBe('New message from Alice — A question')
+  })
+
+  it('DIRECT collapse form is unchanged: N>1 keeps the count title (S10c)', async () => {
+    readMock.fetch.mockResolvedValue([{ _id: MSG_ID, readAt: null, count: 2 }])
+    const tx = installTransaction()
+
+    await upsertMessageNotifications([
+      msgInput({ recipientId: 'sp-1', subjectSpeakerId: 'sp-1' }),
+    ])
+
+    const [, ops] = tx.patch.mock.calls[0] as [
+      string,
+      { set: Record<string, unknown> },
+    ]
+    expect(ops.set.title).toBe('3 new messages — A question')
+  })
+
   it('UNREAD existing: increments count and switches to the N-messages title', async () => {
     readMock.fetch.mockResolvedValue([{ _id: MSG_ID, readAt: null, count: 2 }])
     const tx = installTransaction()

--- a/__tests__/lib/push/send-bridge.test.ts
+++ b/__tests__/lib/push/send-bridge.test.ts
@@ -94,6 +94,16 @@ describe('pushCategoryForNotificationType', () => {
     expect(pushCategoryForNotificationType('message_received')).toBe('messages')
   })
 
+  it('maps message_stale → messages (S5)', () => {
+    expect(pushCategoryForNotificationType('message_stale')).toBe('messages')
+  })
+
+  it('maps conversation_assigned → messages (S4)', () => {
+    expect(pushCategoryForNotificationType('conversation_assigned')).toBe(
+      'messages',
+    )
+  })
+
   it.each([
     'proposal_submitted',
     'travel_support_update',

--- a/sanity/schemaTypes/conversation.ts
+++ b/sanity/schemaTypes/conversation.ts
@@ -143,6 +143,19 @@ export default defineType({
         'GLOBAL organizer archive. TIMESTAMP SEMANTICS: a conversation is globally archived IFF archivedAt >= lastMessageAt. A new message bumps lastMessageAt past archivedAt, so the thread AUTO-RESURFACES with zero fan-out writes. Speakers ignore this field (global archive is an organizer-side hide); a speaker archives via their own conversationPreference.archivedAt.',
     }),
     defineField({
+      name: 'archivedBy',
+      title: 'Archived By',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion; a
+      // dangling archiver ref is tolerated (mirrors assignedTo/createdBy).
+      weak: true,
+      description:
+        'The organizer who set the GLOBAL archive (audit trail). Set alongside archivedAt and unset together with it; meaningful only while archivedAt is set. Written by the server, not editable in Studio.',
+      readOnly: true,
+      hidden: true,
+    }),
+    defineField({
       name: 'lastStaleNudgeAt',
       title: 'Last Stale Nudge At',
       type: 'datetime',

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -56,6 +56,7 @@ export default defineType({
           { title: 'Proposal Comment', value: 'proposal_comment' },
           { title: 'Message Received', value: 'message_received' },
           { title: 'Stale Conversation', value: 'message_stale' },
+          { title: 'Conversation Assigned', value: 'conversation_assigned' },
           { title: 'Co-Speaker Response', value: 'cospeaker_response' },
           { title: 'Travel Support Update', value: 'travel_support_update' },
           { title: 'Sponsor Activity', value: 'sponsor_activity' },

--- a/src/components/email/MessageNotificationTemplate.tsx
+++ b/src/components/email/MessageNotificationTemplate.tsx
@@ -15,10 +15,17 @@ export interface MessageNotificationTemplateProps {
   replyUrl: string
   /**
    * Whether the recipient is an organizer. Organizers get organizer-phrased copy
-   * (replying reaches the speaker + fellow organizers) and a `/admin` replyUrl;
-   * speakers get speaker-phrased copy (replying reaches the organizers).
+   * (replies land in the CFP inbox, not the conversation) and a `/admin`
+   * replyUrl; speakers get speaker-phrased copy (replies reach the organizers'
+   * shared inbox).
    */
   isOrganizer?: boolean
+  /**
+   * Whether this is a speaker's FIRST contact in a thread (S9c) — an organizer
+   * opening a conversation. Renders a warmer heading + intro. Only ever set for
+   * a speaker recipient.
+   */
+  firstContact?: boolean
   /** Absolute link to the recipient's notification preferences (cfp profile). */
   preferencesUrl?: string
   eventName: string
@@ -39,6 +46,7 @@ export function MessageNotificationTemplate({
   excerpt,
   replyUrl,
   isOrganizer = false,
+  firstContact = false,
   preferencesUrl,
   eventName,
   eventLocation,
@@ -47,13 +55,25 @@ export function MessageNotificationTemplate({
   socialLinks = [],
 }: MessageNotificationTemplateProps) {
   const customContent = {
-    heading: 'New message',
+    heading: firstContact
+      ? `The ${eventName} organizers reached out`
+      : 'New message',
     body: (
       <>
         <div style={{ marginBottom: '24px' }}>
           <EmailText>
-            <strong>{authorName}</strong> sent you a new message about{' '}
-            <strong>&quot;{subject}&quot;</strong>.
+            {firstContact ? (
+              <>
+                The <strong>{eventName}</strong> organizers have started a
+                conversation with you about{' '}
+                <strong>&quot;{subject}&quot;</strong>.
+              </>
+            ) : (
+              <>
+                <strong>{authorName}</strong> sent you a new message about{' '}
+                <strong>&quot;{subject}&quot;</strong>.
+              </>
+            )}
           </EmailText>
         </div>
 
@@ -74,16 +94,19 @@ export function MessageNotificationTemplate({
           <EmailButton href={replyUrl}>Reply in app</EmailButton>
         </div>
 
+        {/* S9a: truthful reply-fallback copy. There is no Reply-To / inbound
+            handler, so a reply never reaches the conversation — it lands in the
+            CFP inbox that organizers read. */}
         <EmailText size="14px" color="#64748B">
-          Prefer email?{' '}
           {isOrganizer
-            ? 'Replying to this email reaches the speaker and fellow organizers by email, while replying in the app keeps the whole conversation in one place.'
-            : 'Replying to this email reaches the organizers by email, while replying in the app keeps the whole conversation in one place.'}
+            ? 'Replies to this email land in the CFP inbox, not the conversation. Reply in the app to post to the thread.'
+            : "Replying to this email reaches the organizers' shared inbox — for the full conversation, reply in the app."}
         </EmailText>
 
+        {/* S9b: describe what the link actually opens — the GLOBAL message-email
+            setting on your profile — with no per-conversation promise. */}
         <EmailText size="14px" color="#64748B">
-          You can manage message emails for this conversation from its
-          notification settings.{' '}
+          The link below opens the global message-email setting on your profile.{' '}
           {preferencesUrl && (
             <a
               href={preferencesUrl}

--- a/src/lib/messaging/email.ts
+++ b/src/lib/messaging/email.ts
@@ -13,10 +13,18 @@ export interface MessageEmailRecipient {
   replyUrl: string
   /**
    * Whether THIS recipient is an organizer. Drives the audience-correct body
-   * copy (organizers reach the speaker + fellow organizers; speakers reach the
-   * organizers) so the wording matches the per-recipient `replyUrl` surface.
+   * copy (S9a: an organizer's replies land in the CFP inbox; a speaker's replies
+   * reach the organizers' shared inbox) so the wording matches the per-recipient
+   * `replyUrl` surface.
    */
   isOrganizer: boolean
+  /**
+   * Whether this is a SPEAKER being reached out to for the FIRST time in a
+   * thread (S9c). Only ever true for a speaker recipient on a thread's first
+   * message; drives a warmer subject + body. Organizer recipients and the
+   * org-contact copy keep the standard form.
+   */
+  firstContact?: boolean
 }
 
 /**
@@ -39,10 +47,15 @@ async function sendOne(
 ): Promise<boolean> {
   try {
     await retryWithBackoff(async () => {
+      // FIRST-CONTACT (S9c): a warmer subject when the organizers open a thread
+      // with a speaker; every other email keeps the standard subject.
+      const emailSubject = recipient.firstContact
+        ? `The ${conference.title} organizers started a conversation with you — "${subject}"`
+        : `New message about "${subject}"`
       const result = await resend.emails.send({
         from: `${conference.organizer} <${conference.cfpEmail}>`,
         to: [recipient.email],
-        subject: `New message about "${subject}"`,
+        subject: emailSubject,
         react: React.createElement(MessageNotificationTemplate, {
           recipientName: recipient.name,
           authorName,
@@ -51,6 +64,7 @@ async function sendOne(
           replyUrl: recipient.replyUrl,
           // Audience-correct copy for THIS recipient (matches their replyUrl).
           isOrganizer: recipient.isOrganizer,
+          firstContact: recipient.firstContact ?? false,
           // Settings live on the cfp profile for BOTH audiences; anchor at the
           // notification section so the link matches the in-app gear (A9).
           preferencesUrl: conference.domains?.[0]

--- a/src/lib/messaging/links.ts
+++ b/src/lib/messaging/links.ts
@@ -85,3 +85,28 @@ export function conversationLinkPath(
     ? `/admin/messages/${conversation._id}`
     : `/cfp/messages/${conversation._id}`
 }
+
+/**
+ * The app-relative deep link used in NEW-MESSAGE EMAILS (S8). Unlike
+ * {@link conversationLinkPath} (the HUB/PUSH contract, which deep-links proposal
+ * threads to the proposal page `#messages` fragment), email links ALWAYS point at
+ * the dedicated thread pages:
+ *
+ * - organizer → `/admin/messages/<conversationId>`
+ * - speaker   → `/cfp/messages/<conversationId>`
+ *
+ * WHY email differs: a message email is frequently opened while logged out, and
+ * the auth redirect drops the URL fragment — so a proposal-thread email pointing
+ * at `/cfp/proposal/<id>#messages` landed the speaker atop the proposal EDIT
+ * form with the `#messages` anchor gone. The thread pages render proposal threads
+ * fine by `conversationId`, and the C9 audience redirects cover a wrong-audience
+ * link, so both audiences get a stable, fragment-free destination.
+ */
+export function conversationEmailLinkPath(
+  conversation: Pick<ConversationWithContext, '_id'>,
+  isOrganizer: boolean,
+): string {
+  return isOrganizer
+    ? `/admin/messages/${conversation._id}`
+    : `/cfp/messages/${conversation._id}`
+}

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -12,7 +12,11 @@ import {
   getConversationPreferencesFor,
   conversationLinkPath,
 } from './sanity'
-import { truncateToGraphemeBoundary } from './links'
+import {
+  truncateToGraphemeBoundary,
+  conversationEmailLinkPath,
+  ORGANIZERS_LABEL,
+} from './links'
 import { sendMessageEmails, type MessageEmailRecipient } from './email'
 import type { ConversationWithContext, Message } from './types'
 
@@ -29,12 +33,20 @@ export function messageExcerpt(body: string, max = EXCERPT_LENGTH): string {
     : flat
 }
 
-function absoluteLink(
+/**
+ * Absolute deep link for an EMAIL reply button (S8). Uses
+ * {@link conversationEmailLinkPath} — the dedicated thread pages
+ * (/admin/messages/<id>, /cfp/messages/<id>) rather than the HUB/PUSH proposal
+ * `#messages` fragment, because a message email is often opened logged-out and
+ * the auth redirect drops URL fragments. HUB/PUSH links keep using
+ * `conversationLinkPath` (unchanged).
+ */
+function absoluteEmailLink(
   conversation: ConversationWithContext,
   isOrganizer: boolean,
   conference: Conference,
 ): string {
-  const path = conversationLinkPath(conversation, isOrganizer)
+  const path = conversationEmailLinkPath(conversation, isOrganizer)
   const domain = conference.domains?.[0]
   return domain ? `https://${domain}${path}` : path
 }
@@ -57,9 +69,20 @@ interface SpeakerRow {
  *   `upsertMessageNotifications` (M5) with a PER-RECIPIENT link (organizers →
  *   /admin, speakers → /cfp). Web push rides along inside the upsert
  *   (category `messages`).
- * - EMAIL: to non-muted recipients whose effective email pref is ON: override
- *   'on', or 'default' + speaker-level default. The speaker-level default is
- *   ENABLED unless `messagingEmailDefault` is explicitly false (M4).
+ * - EMAIL (individual recipients): to non-muted recipients whose EFFECTIVE email
+ *   pref is ON. A per-conversation override 'on' always wins (explicit opt-in);
+ *   otherwise the AUDIENCE-DEPENDENT default applies (S1):
+ *     - SPEAKER recipient  → ON unless `messagingEmailDefault` is explicitly
+ *       false (absent-means-on, unchanged);
+ *     - ORGANIZER recipient → OFF unless `messagingEmailDefault` is explicitly
+ *       true (organizers must OPT IN — no more per-message firehose to every
+ *       organizer). Mute still dominates (filtered out above). Email reply links
+ *       point at the dedicated thread pages (S8).
+ * - EMAIL (org-contact copy): for SPEAKER-authored messages ONLY, ONE shared
+ *   copy to the conference's `contactEmail` (fallback `cfpEmail`; skipped if
+ *   neither) addressed to the org team, organizer-variant copy, admin reply
+ *   link. MUTE-INDEPENDENT (like Slack — it's the shared org record), and
+ *   independent of any individual organizer's opt-in.
  * - SLACK: only when the author is NOT an organizer (speaker-authored).
  */
 export async function notifyNewMessage({
@@ -92,6 +115,22 @@ export async function notifyNewMessage({
     )
     const authorName = speakers.get(authorId)?.name ?? 'Someone'
 
+    // FIRST-CONTACT detection (S9c): a SPEAKER recipient gets a warmer subject +
+    // body ONLY when this is the thread's FIRST message AND an organizer authored
+    // it (an organizer reaching out). Cheap count() — one message ⇒ the one we
+    // just added ⇒ first. Only needed when an organizer authored (otherwise no
+    // speaker recipient qualifies for the warmer variant, and the org-contact
+    // copy keeps the standard form regardless).
+    let isFirstContact = false
+    if (authorIsOrganizer) {
+      const messageCount = await clientReadUncached.fetch<number>(
+        `count(*[_type == "message" && conversation._ref == $conversationId])`,
+        { conversationId: conversation._id },
+        { cache: 'no-store' },
+      )
+      isFirstContact = messageCount === 1
+    }
+
     if (recipientIds.length > 0) {
       const prefs = await getConversationPreferencesFor(
         conversation._id,
@@ -115,30 +154,43 @@ export async function notifyNewMessage({
         ...(conversation.proposalId
           ? { relatedProposalId: conversation.proposalId }
           : {}),
+        // DIRECT title variant (S10c): the collapse writer compares this to the
+        // recipient id to pick "Direct message from ..." for the addressee.
+        ...(conversation.subjectSpeakerId
+          ? { subjectSpeakerId: conversation.subjectSpeakerId }
+          : {}),
       }))
       await upsertMessageNotifications(items)
 
-      // EMAIL: on unless the recipient opted out (speaker default or override).
+      // EMAIL (individual recipients): effective default is AUDIENCE-DEPENDENT
+      // (S1b). A per-conversation 'on' override always wins (explicit opt-in);
+      // otherwise a SPEAKER is on unless `messagingEmailDefault === false`
+      // (absent-means-on) while an ORGANIZER is OFF unless
+      // `messagingEmailDefault === true` (must opt in). Mute already excluded
+      // above.
       const emailRecipients: MessageEmailRecipient[] = []
       for (const id of active) {
         const sp = speakers.get(id)
         if (!sp?.email) continue
+        const recipientIsOrganizer = organizerSet.has(id)
         const override = prefs.get(id)?.emailOverride ?? 'default'
-        // ABSENT-MEANS-ENABLED (M4): only an explicit `false` on the speaker
-        // doc disables the default-path email; 'off'/mute still win above.
+        const defaultOn = recipientIsOrganizer
+          ? sp.messagingEmailDefault === true
+          : sp.messagingEmailDefault !== false
         const wantsEmail =
-          override === 'on' ||
-          (override === 'default' && sp.messagingEmailDefault !== false)
+          override === 'on' || (override === 'default' && defaultOn)
         if (!wantsEmail) continue
         emailRecipients.push({
           email: sp.email,
           name: sp.name ?? 'there',
-          isOrganizer: organizerSet.has(id),
-          replyUrl: absoluteLink(
+          isOrganizer: recipientIsOrganizer,
+          replyUrl: absoluteEmailLink(
             conversation,
-            organizerSet.has(id),
+            recipientIsOrganizer,
             conference,
           ),
+          // Warmer first-contact copy for a speaker being reached out to (S9c).
+          firstContact: isFirstContact && !recipientIsOrganizer,
         })
       }
       if (emailRecipients.length > 0) {
@@ -151,8 +203,31 @@ export async function notifyNewMessage({
       }
     }
 
-    // SLACK: speaker-authored messages only.
+    // ORG-CONTACT COPY (S1a) + SLACK: SPEAKER-authored messages only. Both are
+    // MUTE-INDEPENDENT shared-org records, so they live OUTSIDE the recipient
+    // loop above and are not gated by any individual's prefs.
     if (!authorIsOrganizer) {
+      // ONE shared copy of the message to the org's contact inbox (prefer
+      // `contactEmail`, fall back to `cfpEmail`; skip if neither is set),
+      // organizer-variant copy with an admin reply link — the shared org record
+      // replacing the old per-organizer firehose.
+      const orgContactEmail = conference.contactEmail || conference.cfpEmail
+      if (orgContactEmail) {
+        await sendMessageEmails(
+          [
+            {
+              email: orgContactEmail,
+              name: ORGANIZERS_LABEL,
+              isOrganizer: true,
+              replyUrl: absoluteEmailLink(conversation, true, conference),
+              // The org-contact copy keeps the STANDARD form (S9c).
+              firstContact: false,
+            },
+          ],
+          { authorName, subject: conversation.subject, excerpt, conference },
+        )
+      }
+
       await notifyNewSpeakerMessage(
         {
           authorName,

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -10,6 +10,7 @@ import type {
   ConversationPreference,
   ConversationStatus,
   ConversationView,
+  ConversationViewCounts,
   ConversationWithContext,
   EmailOverride,
   Message,
@@ -65,7 +66,8 @@ const CONVERSATION_PROJECTION = `{
   lastMessageAt,
   "status": coalesce(status, 'open'),
   "assignedTo": assignedTo->{ _id, name },
-  archivedAt
+  archivedAt,
+  "archivedBy": archivedBy->{ _id, name }
 }`
 
 // ---------------------------------------------------------------------------
@@ -115,13 +117,27 @@ export const LAST_AUTHOR_REF =
 const NEEDS_REPLY = `${STATUS_NOT_RESOLVED} && count($organizerIds) > 0 && defined(${LAST_AUTHOR_REF}) && !(${LAST_AUTHOR_REF} in $organizerIds)`
 
 /**
- * Build the GROQ predicate fragment (leading ` && ...`, or empty for `all`) for
- * an inbox `view`, plus whether it references `$organizerIds` (only
- * `needs-reply` does). See {@link ConversationView} for the full semantics; the
- * ORGANIZER `active` set — status open AND not globally archived AND not
- * per-user archived — is the shared base of the organizer-only views.
+ * The non-organizer access scope: a speaker sees only conversations they
+ * created, are the subject speaker of, or are a proposal-speaker on. Exported as
+ * ONE string so the inbox list and the view-count projection (S7) apply the
+ * IDENTICAL scope — the tab badges can never count threads the list wouldn't
+ * show. Binds `$speakerId`.
  */
-function buildViewPredicate(
+export const SPEAKER_SCOPE_PREDICATE =
+  '(createdBy._ref == $speakerId || subjectSpeaker._ref == $speakerId || $speakerId in proposal->speakers[]._ref)'
+
+/**
+ * The RAW GROQ predicate for an inbox `view` (no leading ` && `, empty for
+ * `all`), plus whether it references `$organizerIds` (only `needs-reply` does).
+ * This is the single home for every view's filter so the inbox list
+ * ({@link buildViewPredicate}) and the count-per-view projection
+ * ({@link getConversationViewCounts}, S7) share EXACTLY the same predicates —
+ * a badge count can never disagree with the list it labels. See
+ * {@link ConversationView} for the full semantics; the ORGANIZER `active` set —
+ * status open AND not globally archived AND not per-user archived — is the
+ * shared base of the organizer-only views.
+ */
+export function rawViewPredicate(
   view: ConversationView,
   isOrganizer: boolean,
 ): { predicate: string; needsOrganizerIds: boolean } {
@@ -130,42 +146,55 @@ function buildViewPredicate(
     // and status are organizer-side concepts a speaker never filters on.
     switch (view) {
       case 'archived':
-        return { predicate: ` && ${USER_ARCHIVED}`, needsOrganizerIds: false }
+        return { predicate: USER_ARCHIVED, needsOrganizerIds: false }
       case 'all':
         return { predicate: '', needsOrganizerIds: false }
       default: // 'active'
-        return {
-          predicate: ` && ${NOT_USER_ARCHIVED}`,
-          needsOrganizerIds: false,
-        }
+        return { predicate: NOT_USER_ARCHIVED, needsOrganizerIds: false }
     }
   }
   const active = `${STATUS_OPEN} && ${NOT_GLOBALLY_ARCHIVED} && ${NOT_USER_ARCHIVED}`
   switch (view) {
     case 'needs-reply':
       return {
-        predicate: ` && ${active} && ${NEEDS_REPLY}`,
+        predicate: `${active} && ${NEEDS_REPLY}`,
         needsOrganizerIds: true,
       }
     case 'mine':
       return {
-        predicate: ` && ${active} && assignedTo._ref == $speakerId`,
+        predicate: `${active} && assignedTo._ref == $speakerId`,
         needsOrganizerIds: false,
       }
     case 'resolved':
       return {
-        predicate: ` && ${STATUS_RESOLVED} && ${NOT_GLOBALLY_ARCHIVED} && ${NOT_USER_ARCHIVED}`,
+        predicate: `${STATUS_RESOLVED} && ${NOT_GLOBALLY_ARCHIVED} && ${NOT_USER_ARCHIVED}`,
         needsOrganizerIds: false,
       }
     case 'archived':
       return {
-        predicate: ` && (${GLOBALLY_ARCHIVED} || ${USER_ARCHIVED})`,
+        predicate: `(${GLOBALLY_ARCHIVED} || ${USER_ARCHIVED})`,
         needsOrganizerIds: false,
       }
     case 'all':
       return { predicate: '', needsOrganizerIds: false }
     default: // 'active'
-      return { predicate: ` && ${active}`, needsOrganizerIds: false }
+      return { predicate: active, needsOrganizerIds: false }
+  }
+}
+
+/**
+ * Build the GROQ predicate FRAGMENT (leading ` && ...`, or empty for `all`) for
+ * an inbox `view` — the inline form the list query ANDs into its base filter.
+ * Thin wrapper over {@link rawViewPredicate}.
+ */
+function buildViewPredicate(
+  view: ConversationView,
+  isOrganizer: boolean,
+): { predicate: string; needsOrganizerIds: boolean } {
+  const { predicate, needsOrganizerIds } = rawViewPredicate(view, isOrganizer)
+  return {
+    predicate: predicate ? ` && ${predicate}` : '',
+    needsOrganizerIds,
   }
 }
 
@@ -389,8 +418,7 @@ export async function listConversationsForSpeaker({
 
   let scope = ''
   if (!isOrganizer) {
-    scope =
-      ' && (createdBy._ref == $speakerId || subjectSpeaker._ref == $speakerId || $speakerId in proposal->speakers[]._ref)'
+    scope = ` && ${SPEAKER_SCOPE_PREDICATE}`
   }
 
   // Resolve the organizer id set UP FRONT for organizers: the `needs-reply`
@@ -420,6 +448,7 @@ export async function listConversationsForSpeaker({
     subject,
     "proposalId": proposal._ref,
     "proposalTitle": proposal->title,
+    "subjectSpeakerId": subjectSpeaker._ref,
     createdAt,
     lastMessageAt,
     "status": coalesce(status, 'open'),
@@ -509,7 +538,7 @@ export async function listConversationsForSpeaker({
     }
   }
 
-  return rows.map((row) => {
+  const items = rows.map((row) => {
     // Match EITHER audience variant; the caller received only one of them.
     const unreadCount =
       (linkCounts.get(conversationLinkPath(row, true)) ?? 0) +
@@ -542,12 +571,19 @@ export async function listConversationsForSpeaker({
       row.status !== 'resolved' &&
       row.lastMessage != null &&
       !organizerSet.has(row.lastMessage.authorId)
+    // DIRECT-THREAD IDENTITY (S10), viewer-relative: the caller is personally
+    // addressed — they ARE the subject speaker (organizer-initiated thread
+    // about/to them) OR they are the assignee.
+    const subjectSpeakerId = row.subjectSpeakerId ?? undefined
+    const direct =
+      subjectSpeakerId === speakerId || row.assignedTo?._id === speakerId
     return {
       _id: row._id,
       conversationType: row.conversationType,
       subject: row.subject,
       proposalId: row.proposalId,
       proposalTitle: row.proposalTitle,
+      subjectSpeakerId,
       createdAt: row.createdAt,
       lastMessageAt: row.lastMessageAt,
       unreadCount,
@@ -566,8 +602,24 @@ export async function listConversationsForSpeaker({
         : null,
       needsReply,
       archived,
+      direct,
     }
   })
+
+  // ACTIVE-VIEW DIRECT GROUPING (S10b, organizer audience only): float direct
+  // threads above non-direct ones. A STABLE partition WITHIN the fetched page —
+  // the base fetch already orders by (lastMessageAt desc, _id desc), so recency
+  // is preserved inside each group. TRADEOFF: because keyset pagination pages by
+  // lastMessageAt, this groups direct-first only within each page, not globally
+  // across page boundaries; a fully global grouping would need a second sort key
+  // in the cursor. Accepted (maintainer): the first page — where it matters most
+  // — is correctly grouped, and within-page recency is intact.
+  if (isOrganizer && view === 'active') {
+    const directRows = items.filter((item) => item.direct)
+    const rest = items.filter((item) => !item.direct)
+    return [...directRows, ...rest]
+  }
+  return items
 }
 
 /** A raw inbox row as projected by GROQ, before counterpart/excerpt mapping. */
@@ -579,7 +631,11 @@ type RawConversationRow = Omit<
   | 'assignedTo'
   | 'needsReply'
   | 'archived'
+  | 'subjectSpeakerId'
+  | 'direct'
 > & {
+  // `subjectSpeaker._ref` — null for proposal / speaker-created threads.
+  subjectSpeakerId: string | null
   lastMessage: {
     authorId: string
     authorName: string | null
@@ -626,6 +682,75 @@ function resolveCounterpart(
     return { name: author.authorName, image: author.authorImage ?? undefined }
   }
   return { name: ORGANIZERS_LABEL }
+}
+
+/**
+ * Conversation COUNTS per inbox view for the tab badges (S7). ORGANIZERS get
+ * `{ active, needsReply, mine, resolved, archived }`; SPEAKERS get
+ * `{ active, archived }` (the organizer-only tabs are omitted).
+ *
+ * ONE GROQ round trip: a single object projection whose fields are each a
+ * `count(*[<base> && <viewPredicate>])`, reusing the EXACT predicate strings the
+ * inbox list applies ({@link rawViewPredicate} + {@link SPEAKER_SCOPE_PREDICATE})
+ * so a badge can never disagree with the list it labels. The correlated
+ * per-user-archive / last-author subqueries inside those predicates use `^`,
+ * which resolves to the conversation being counted (one nesting level, exactly
+ * as in the list query).
+ *
+ * COST: bounded and cheap — the counts scan only this conference's conversation
+ * set (`conference._ref == $conferenceId`, plus the speaker scope for a
+ * non-organizer), no pagination, no document bodies fetched; the per-view
+ * `count()`s are evaluated server-side in the one request. It is meant to be
+ * called alongside the first inbox page, not polled hot.
+ */
+export async function getConversationViewCounts({
+  speakerId,
+  isOrganizer,
+  conferenceId,
+}: {
+  speakerId: string
+  isOrganizer: boolean
+  conferenceId: string
+}): Promise<ConversationViewCounts> {
+  const params: Record<string, unknown> = { conferenceId, speakerId }
+  const base = `_type == "conversation" && conference._ref == $conferenceId`
+  const scope = isOrganizer ? '' : ` && ${SPEAKER_SCOPE_PREDICATE}`
+
+  // Build one `count()` field per relevant view from the shared predicates.
+  const views: ConversationView[] = isOrganizer
+    ? ['active', 'needs-reply', 'mine', 'resolved', 'archived']
+    : ['active', 'archived']
+  // Stable field keys (the enum's hyphenated names aren't valid identifiers).
+  const KEY: Record<string, keyof ConversationViewCounts> = {
+    active: 'active',
+    'needs-reply': 'needsReply',
+    mine: 'mine',
+    resolved: 'resolved',
+    archived: 'archived',
+  }
+
+  const fields: string[] = []
+  for (const view of views) {
+    const { predicate, needsOrganizerIds } = rawViewPredicate(view, isOrganizer)
+    if (needsOrganizerIds) params.organizerIds = await getOrganizerSpeakerIds()
+    const filter = predicate ? ` && ${predicate}` : ''
+    fields.push(`"${KEY[view]}": count(*[${base}${scope}${filter}])`)
+  }
+
+  const result = await clientReadUncached.fetch<Partial<
+    Record<keyof ConversationViewCounts, number>
+  > | null>(`{ ${fields.join(', ')} }`, params, { cache: 'no-store' })
+
+  const counts: ConversationViewCounts = {
+    active: result?.active ?? 0,
+    archived: result?.archived ?? 0,
+  }
+  if (isOrganizer) {
+    counts.needsReply = result?.needsReply ?? 0
+    counts.mine = result?.mine ?? 0
+    counts.resolved = result?.resolved ?? 0
+  }
+  return counts
 }
 
 /**
@@ -761,15 +886,25 @@ export async function speakerExists(speakerId: string): Promise<boolean> {
 /**
  * Append a message AND bump the parent conversation's `lastMessageAt` in ONE
  * transaction (the two must never drift apart). Returns the created message.
+ *
+ * REOPEN-ON-REPLY (S3): pass `reopen: true` to ALSO set the conversation's
+ * `status` back to `'open'` in the SAME transaction. The router sets this when a
+ * NON-organizer replies to a `resolved` thread, so the speaker's follow-up
+ * re-enters the organizer needs-reply queue atomically with the message write (no
+ * window where the message exists but the thread is still resolved). Organizer
+ * replies never pass it (an organizer answering a resolved thread keeps it
+ * resolved).
  */
 export async function addMessage({
   conversationId,
   authorId,
   body,
+  reopen = false,
 }: {
   conversationId: string
   authorId: string
   body: string
+  reopen?: boolean
 }): Promise<Message> {
   const now = new Date().toISOString()
   const messageId = `message.${nanoid()}`
@@ -784,7 +919,13 @@ export async function addMessage({
       body,
       createdAt: now,
     })
-    .patch(conversationId, (patch) => patch.set({ lastMessageAt: now }))
+    .patch(conversationId, (patch) =>
+      patch.set(
+        reopen
+          ? { lastMessageAt: now, status: 'open' }
+          : { lastMessageAt: now },
+      ),
+    )
     .commit()
 
   return { _id: messageId, conversationId, authorId, body, createdAt: now }
@@ -823,23 +964,33 @@ export async function setConversationAssignee(
 }
 
 /**
- * Set/clear the GLOBAL organizer archive. Archiving stamps `archivedAt = now`;
- * because a thread is globally archived IFF `archivedAt >= lastMessageAt`, a
- * later message auto-resurfaces it with no further write. Unarchiving simply
- * unsets the field.
+ * Set/clear the GLOBAL organizer archive. Archiving stamps `archivedAt = now`
+ * AND records `archivedBy` (the organizer who archived it) for the audit trail
+ * (S6); because a thread is globally archived IFF `archivedAt >= lastMessageAt`,
+ * a later message auto-resurfaces it with no further write. Unarchiving unsets
+ * BOTH fields together (a cleared archive has no archiver). The `archiverId` ref
+ * is WEAK so erasing a speaker (GDPR) doesn't orphan-block their deletion —
+ * consistent with the other speaker refs on this doc.
  */
 export async function setConversationArchived(
   conversationId: string,
   archived: boolean,
+  archiverId: string,
 ): Promise<void> {
   if (archived) {
     await clientWrite
       .patch(conversationId)
-      .set({ archivedAt: new Date().toISOString() })
+      .set({
+        archivedAt: new Date().toISOString(),
+        archivedBy: { ...createReference(archiverId), _weak: true },
+      })
       .commit()
     return
   }
-  await clientWrite.patch(conversationId).unset(['archivedAt']).commit()
+  await clientWrite
+    .patch(conversationId)
+    .unset(['archivedAt', 'archivedBy'])
+    .commit()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -89,6 +89,19 @@ export interface ConversationWithContext {
   status?: ConversationStatus
   assignedTo?: ConversationAssignee | null
   archivedAt?: string | null
+  /**
+   * WHO globally archived the thread (deref of the weak `archivedBy` ref), so
+   * the thread header can render "Archived by X" (S6). Set alongside
+   * `archivedAt` and unset with it; null when the thread is not archived (or the
+   * archiver speaker was erased). Only meaningful when `archivedAt` is set.
+   */
+  archivedBy?: ConversationArchiver | null
+}
+
+/** The organizer who globally archived a thread (deref of `archivedBy`). */
+export interface ConversationArchiver {
+  _id: string
+  name: string
 }
 
 /** The newest message of a conversation, summarized for an inbox row (M6). */
@@ -137,6 +150,20 @@ export interface ConversationListItem {
   lastMessage: ConversationLastMessage | null
   /** Audience-aware "who" for the row (see {@link ConversationCounterpart}). */
   counterpart: ConversationCounterpart
+  /**
+   * The speaker an organizer-initiated general thread is ABOUT/with (the
+   * conversation's `subjectSpeaker`); undefined for proposal or speaker-created
+   * threads. Projected so the client can derive direct-thread identity (S10).
+   */
+  subjectSpeakerId?: string
+  /**
+   * DIRECT-THREAD IDENTITY (S10), VIEWER-RELATIVE: this thread personally
+   * addresses the caller — the caller IS the conversation's `subjectSpeaker`
+   * (an organizer-initiated thread about/to them) OR the caller is its
+   * `assignedTo`. Computed server-side so the client stays dumb; drives the
+   * distinct direct-vs-org-broadcast chip/accent and the Active-view grouping.
+   */
+  direct?: boolean
   // NOTE: the ticketing fields below are ALWAYS populated by the data layer
   // (`listConversationsForSpeaker`). They are declared optional ONLY so that
   // pre-ticketing fixtures/stories (owned by the T2 UI work) still satisfy the
@@ -156,6 +183,19 @@ export interface ConversationListItem {
    * globally OR per-user archived; for a speaker, per-user archived only.
    */
   archived?: boolean
+}
+
+/**
+ * Per-view unread-independent CONVERSATION COUNTS for the inbox tab badges (S7).
+ * ORGANIZERS get every tab; SPEAKERS only `active` + `archived` (the
+ * organizer-only tabs are omitted — undefined — for a speaker caller).
+ */
+export interface ConversationViewCounts {
+  active: number
+  archived: number
+  needsReply?: number
+  mine?: number
+  resolved?: number
 }
 
 /** A single message in a thread. */

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -113,16 +113,25 @@ const NOTIFICATION_TITLE_MAX = 200
  * Title copy for a collapsed message notification: a single unread message
  * names its author; an accumulated pile leads with the count (the latest
  * author still appears via the excerpt/actor line).
+ *
+ * DIRECT variant (S10c): when the recipient IS the conversation's subject
+ * speaker (an organizer-initiated thread addressed to them), the single-message
+ * title reads "Direct message from <author> — <subject>" to visually distinguish
+ * a personal outreach from an org-broadcast thread. The collapsed count form is
+ * unchanged (the count already conveys the pile).
  */
 function messageNotificationTitle(
   count: number,
   authorName: string,
   subject: string,
+  isDirect: boolean,
 ): string {
   const title =
     count > 1
       ? `${count} new messages — ${subject}`
-      : `New message from ${authorName} — ${subject}`
+      : isDirect
+        ? `Direct message from ${authorName} — ${subject}`
+        : `New message from ${authorName} — ${subject}`
   // Grapheme-safe cut (an emoji in the author name or subject can straddle the
   // 200-char cap) so the stored title never ends in a lone surrogate (�).
   return truncateToGraphemeBoundary(title, NOTIFICATION_TITLE_MAX)
@@ -183,11 +192,20 @@ export async function upsertMessageNotifications(
       // Unread accumulates; a read (or brand-new) document resets to 1.
       const count =
         (existing && !existing.readAt ? (existing.count ?? 1) : 0) + 1
+      // DIRECT when THIS recipient is the thread's subject speaker (S10c).
+      const isDirect =
+        item.subjectSpeakerId != null &&
+        item.subjectSpeakerId === item.recipientId
       return {
         item,
         id,
         count,
-        title: messageNotificationTitle(count, item.authorName, item.subject),
+        title: messageNotificationTitle(
+          count,
+          item.authorName,
+          item.subject,
+          isDirect,
+        ),
       }
     })
 

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -15,6 +15,9 @@ export type NotificationType =
   // A stale, unanswered speaker↔organizer thread (ticketing stale-nudge cron).
   // Rendered generically by the hub (title/message/actor); no dedicated icon.
   | 'message_stale'
+  // A conversation was assigned to this organizer for follow-up (S4). Rendered
+  // generically by the hub (title/message/actor); no dedicated icon.
+  | 'conversation_assigned'
   | 'cospeaker_response'
   | 'travel_support_update'
   | 'sponsor_activity'
@@ -77,6 +80,13 @@ export interface MessageNotificationInput {
   actorId?: string
   /** Weakly referenced proposal (talk) id, for proposal threads. */
   relatedProposalId?: string
+  /**
+   * The conversation's `subjectSpeaker` id (organizer-initiated thread about/to a
+   * speaker), if any. When it EQUALS this item's `recipientId`, the collapsed
+   * notification's single-message title becomes the DIRECT variant (S10) —
+   * "Direct message from <author> — <subject>".
+   */
+  subjectSpeakerId?: string
 }
 
 /** The actor sub-object projected for the client. */

--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -146,6 +146,10 @@ export async function sendPush(
  *        notifications both carry this type)
  *   - `cospeaker_response`       → `coSpeakerInvites`
  *   - `message_received`         → `messages`
+ *   - `message_stale`            → `messages` (S5 — a stale-thread nudge is a
+ *        messaging event; it previously fell through to `otherUpdates`)
+ *   - `conversation_assigned`    → `messages` (S4 — a follow-up assignment is a
+ *        messaging event)
  *   - everything else            → `otherUpdates`
  *       (`proposal_submitted`, `travel_support_update`, `sponsor_activity`,
  *        `gallery_tagged`, `schedule_update`, `proposal_comment`, `system`)
@@ -163,6 +167,8 @@ export function pushCategoryForNotificationType(
     case 'cospeaker_response':
       return 'coSpeakerInvites'
     case 'message_received':
+    case 'message_stale':
+    case 'conversation_assigned':
       return 'messages'
     default:
       return 'otherUpdates'

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -28,9 +28,17 @@ import {
   setConversationStatus,
   setConversationAssignee,
   setConversationArchived,
+  getConversationViewCounts,
   canAccessConversation,
 } from '@/lib/messaging/sanity'
-import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import {
+  getOrganizerSpeakerIds,
+  createNotifications,
+} from '@/lib/notification/sanity'
+import {
+  conversationLinkPath,
+  truncateToGraphemeBoundary,
+} from '@/lib/messaging/links'
 import { notifyNewMessage } from '@/lib/messaging/notify'
 import { SPEAKER_ALLOWED_VIEWS } from '@/lib/messaging/types'
 import type {
@@ -163,6 +171,22 @@ export const messageRouter = router({
         view,
       })
     }),
+
+  /**
+   * Conversation COUNTS per inbox tab for the caller's audience (S7). Organizers
+   * get every tab ({ active, needsReply, mine, resolved, archived }); speakers
+   * get { active, archived }. ONE bounded GROQ round trip over this conference's
+   * conversation set, reusing the same predicates the list views apply — meant to
+   * accompany the first inbox page, not to be polled hot.
+   */
+  viewCounts: protectedProcedure.query(async ({ ctx }) => {
+    const conferenceId = await resolveConferenceId()
+    return getConversationViewCounts({
+      speakerId: ctx.speaker._id,
+      isOrganizer: ctx.speaker.isOrganizer === true,
+      conferenceId,
+    })
+  }),
 
   /** A single conversation + participants + the caller's own preference. */
   getConversation: protectedProcedure
@@ -346,10 +370,18 @@ export const messageRouter = router({
         })
       }
 
+      // REOPEN-ON-REPLY (S3): a NON-organizer replying to a resolved thread
+      // reopens it, atomically with the message write, so the follow-up
+      // re-enters the organizer needs-reply queue. `conversation.status` is
+      // coalesced ('open' when absent) by `getConversationById`. An organizer
+      // reply to a resolved thread does NOT reopen it.
+      const reopen = !isOrganizer && conversation.status === 'resolved'
+
       const message = await addMessage({
         conversationId: conversation._id,
         authorId: actorId,
         body: input.body,
+        reopen,
       })
 
       // Detach the fan-out from the response path (A8): the message is already
@@ -429,6 +461,31 @@ export const messageRouter = router({
         }
       }
       await setConversationAssignee(conversation._id, input.assigneeId)
+
+      // ASSIGN NOTIFY (S4): tell the NEW assignee they own this thread — but not
+      // when unassigning (null) or self-assigning (an organizer picking up their
+      // own thread doesn't need a notification about their own action).
+      // `createNotifications` is never-fail, so a failed notify can't fail the
+      // (already committed) assignment. The link is the ADMIN thread (assignees
+      // are always organizers). The push category maps to `messages` (S4).
+      if (input.assigneeId !== null && input.assigneeId !== ctx.speaker._id) {
+        await createNotifications([
+          {
+            recipientId: input.assigneeId,
+            conferenceId: conversation.conferenceId,
+            notificationType: 'conversation_assigned',
+            title: truncateToGraphemeBoundary(
+              `Assigned to you: ${conversation.subject}`,
+              200,
+            ),
+            link: conversationLinkPath(conversation, true),
+            actorId: ctx.speaker._id,
+            ...(conversation.proposalId
+              ? { relatedProposalId: conversation.proposalId }
+              : {}),
+          },
+        ])
+      }
       return { conversationId: conversation._id, assigneeId: input.assigneeId }
     }),
 
@@ -445,7 +502,12 @@ export const messageRouter = router({
         input.conversationId,
         ctx.speaker,
       )
-      await setConversationArchived(conversation._id, input.archived)
+      // Record WHO archived (S6) for the "Archived by X" audit line.
+      await setConversationArchived(
+        conversation._id,
+        input.archived,
+        ctx.speaker._id,
+      )
       return { conversationId: conversation._id, archived: input.archived }
     }),
 })

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -74,13 +74,7 @@ import {
 } from '@/lib/proposal/server'
 import { createReview, updateReview } from '@/lib/review/sanity'
 import { getFeaturedTalks } from '@/lib/featured/sanity'
-import {
-  ensureProposalConversation,
-  getConversationById,
-  addMessage,
-} from '@/lib/messaging/sanity'
-import { notifyNewMessage } from '@/lib/messaging/notify'
-import { runAfterResponse } from '@/server/runAfterResponse'
+import { ensureProposalConversation, addMessage } from '@/lib/messaging/sanity'
 import '@/lib/events/registry'
 
 /**
@@ -771,12 +765,18 @@ export const proposalRouter = router({
           console.error('Failed to publish status change event:', error)
         })
 
-        // Messaging M4: an organizer decision comment also lands in the
+        // Messaging M4/S2: an organizer decision comment also lands in the
         // proposal's message thread, so the speaker keeps it with the rest of
-        // the conversation. Guarded never-fail: the status change above is
-        // already committed, so a messaging failure must not fail the action.
-        // NOTE: the speaker intentionally receives BOTH the status notification
-        // and a new-message notification (accepted by the maintainer).
+        // the conversation. We add the message (thread content + lastMessageAt
+        // bump) but DELIBERATELY SKIP the message fan-out (notifyNewMessage) —
+        // the DECISION STATUS RAIL is the single delivery for a decision: the
+        // `proposal_status_changed` hub notification and the decision email
+        // (published on `eventBus` above) ALREADY carry this same comment. Firing
+        // notifyNewMessage too would double-notify the speaker (a second hub
+        // item + a second email) for one organizer action. The message still
+        // appears in the thread on next open; it just doesn't generate its own
+        // notification. Guarded never-fail: the status change is already
+        // committed, so a messaging failure must not fail the action.
         const trimmedComment = comment?.trim()
         if (
           ctx.speaker.isOrganizer &&
@@ -790,26 +790,11 @@ export const proposalRouter = router({
               proposalTitle: proposal.title ?? 'Proposal',
               createdById: ctx.speaker._id,
             })
-            const conversation = await getConversationById(conversationId)
-            if (conversation) {
-              const message = await addMessage({
-                conversationId,
-                authorId: ctx.speaker._id,
-                body: trimmedComment,
-              })
-              // Never throws; fans out hub/email (no proposal actions, so no
-              // feedback loop with this procedure). Detached from the response
-              // path (A8) so the fan-out can't hang the decision action; the
-              // message is already committed above.
-              runAfterResponse(() =>
-                notifyNewMessage({
-                  conversation,
-                  message,
-                  authorId: ctx.speaker._id,
-                  conference,
-                }),
-              )
-            }
+            await addMessage({
+              conversationId,
+              authorId: ctx.speaker._id,
+              body: trimmedComment,
+            })
           } catch (error) {
             console.error(
               'Failed to mirror decision comment into the proposal thread:',


### PR DESCRIPTION
Server half of the messaging UX-review fix batch. Maintainer-decided changes; each task cites its S#. Territory limited to `src/lib/messaging/*`, `src/lib/notification/*`, `src/lib/push/send.ts`, `message.ts` + `proposal.ts` + schemas, `sanity/schemaTypes/conversation.ts`, and the message-notification email template/lib. No other `src/components` touched (a UI batch follows).

## What & why

| S# | Maintainer decision | Implementation |
|----|--------------------|----------------|
| **S1** | Stop the per-organizer email firehose for speaker messages | (a) Speaker-authored messages send ONE shared copy to the conference `contactEmail` (fallback `cfpEmail`, skip if neither), organizer-variant copy, admin reply link, **mute-independent** (lives beside Slack). (b) Individual **organizer** recipients now default **OFF** (`messagingEmailDefault === true` to opt in); **speakers** unchanged (absent = on). Per-conversation `'on'` override still pierces; mute still dominates. Channel-matrix JSDoc in `notify.ts` updated. |
| **S2** | Decision comment = status rail only | `proposal.action` still `addMessage`s the decision comment into the thread (content + `lastMessageAt` bump) but **skips `notifyNewMessage`** — the `proposal_status_changed` notification + decision email already carry the comment; firing the message fan-out too would double-notify. Documented at the call site; unused imports removed. |
| **S3** | Speaker reply reopens a resolved thread | `message.send` sets `status:'open'` **atomically inside the `addMessage` transaction** (new `reopen` flag) when a non-organizer replies to a `resolved` thread. Organizer replies do not reopen. |
| **S4** | Notify the new assignee | `setAssignee` emits a never-fail hub notification (`createNotifications`) to the assignee when assigning to **someone other than the caller** (no notify on unassign/self-assign). New `conversation_assigned` NotificationType (hub renders it generically; Studio list updated); push category maps to `messages`. Title `Assigned to you: <subject>` (200-cap, grapheme-safe); link = admin thread; actor = caller. |
| **S5** | `message_stale` is a messaging event | `pushCategoryForNotificationType` maps `message_stale` to `messages` (was `otherUpdates`). |
| **S6** | Global-archive audit trail | New weak `conversation.archivedBy` (hidden/readOnly in Studio), set with `archivedAt` and unset together, in `setConversationArchived(id, archived, archiverId)`. Projected (`{_id, name}`) in `getConversationById` for the UI's "Archived by X". |
| **S7** | Inbox tab counts | New `message.viewCounts` query: organizer `{active, needsReply, mine, resolved, archived}`, speaker `{active, archived}`, in **ONE GROQ round trip** (object projection of `count()` per view). Refactored `buildViewPredicate` into exported `rawViewPredicate` + `SPEAKER_SCOPE_PREDICATE` so the counts reuse the exact predicates the list views apply. Cost documented (bounded, no bodies fetched; meant to accompany the first page, not polled hot). |
| **S8** | Email links survive the logged-out redirect | Email `replyUrl` (both audiences) now points at the dedicated thread pages `/cfp/messages/<id>` and `/admin/messages/<id>` (new `conversationEmailLinkPath`) instead of `/…/proposal/<id>#messages` (the fragment died through the auth redirect, landing speakers atop the edit form). **HUB/PUSH links unchanged.** |
| **S9** | Truthful + warmer email copy | (a) Reply-fallback reworded truthfully per audience (no Reply-To exists): speaker to "reaches the organizers' shared inbox — for the full conversation, reply in the app"; organizer to "Replies to this email land in the CFP inbox, not the conversation." (b) Preferences line now describes the **global** message-email setting on your profile (no per-conversation promise). (c) **First contact**: a speaker receiving a thread's first message (organizer-authored, cheap `count()` detect) gets a warmer subject `The <conference> organizers started a conversation with you — "<subject>"` + intro; organizer recipients and the org-contact copy keep the standard form. |
| **S10** | Direct-thread identity (addendum) | (a) `ConversationListItem` gains `subjectSpeakerId` + a server-computed viewer-relative `direct` (caller IS the `subjectSpeaker` OR the `assignedTo`). (b) Organizer **Active** view floats direct threads above non-direct via a stable within-page partition (keyset ordering preserved; grouping is per-page — documented tradeoff). (c) `upsertMessageNotifications` renders `Direct message from <author> — <subject>` when the recipient is the thread's subject speaker (collapsed N-message form unchanged); `subjectSpeakerId` threaded through the notify items. |

## S1 effective email default (as implemented)

For each non-muted recipient of a message: `wantsEmail = override === 'on' || (override === 'default' && defaultOn)`, where
`defaultOn = isOrganizer ? (messagingEmailDefault === true) : (messagingEmailDefault !== false)`.
Mute excludes a recipient from every channel first. The org-contact shared copy (speaker-authored only) is independent of all of this.

## Checks

`tsc`, `eslint`, `prettier`, `knip`, and the full `vitest` suite (**3252 passed, 5 skipped, 225 files**) all green. No UI components changed, so no `shoot` (email render tests cover the template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is the server half of the messaging UX-review batch, touching `src/lib/messaging/*`, `src/lib/notification/*`, `src/lib/push/send.ts`, and the two routers. Ten independently scoped tasks (S1–S10) land together because they share data-layer types and the test suite must stay green as a unit.

- **S1–S3, S8–S9**: Email routing now sends one shared copy to the conference contact address for speaker-authored messages, switches organizers from opt-out to opt-in (`messagingEmailDefault === true`), and updates email links to the fragment-safe `/cfp/messages/<id>` / `/admin/messages/<id>` paths. Decision comments (S2) skip `notifyNewMessage` to avoid double-notification, and a non-organizer reply to a resolved thread atomically reopens it (S3).
- **S4–S7, S10**: `setAssignee` emits a hub `conversation_assigned` notification to the new assignee (skipping self-assign and unassign). `message_stale` is remapped to the `messages` push category (S5). Global archive gains a weak `archivedBy` reference for audit (S6). A single GROQ round-trip produces per-view tab counts (S7) reusing the exact same predicates the list queries apply. `ConversationListItem` gains `subjectSpeakerId` + a server-computed `direct` flag, with within-page direct-first grouping for the organizer Active view (S10).

<h3>Confidence Score: 4/5</h3>

Safe to merge — all ten tasks are well-scoped, the changes are limited to the messaging and notification layers, and the full test suite covers the new behaviours in detail.

The implementation is thorough and the tests directly validate every S# decision. The only notes are minor: the first-contact message-count query in notify.ts fires for all organizer messages even when there are no non-organizer recipients to use the result, and setConversationArchived silently ignores its archiverId parameter on the unarchive path despite requiring it in the signature. Neither affects correctness.

src/lib/messaging/notify.ts (first-contact count query) and src/lib/messaging/sanity.ts (setConversationArchived signature) are worth a quick look, but neither has a correctness problem.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/messaging/notify.ts | Implements S1 org-contact copy and audience-dependent email default, S2 skip, S8 email links, S9a/b/c copy changes, and S10c subjectSpeakerId threading. Minor: first-contact count query fires even when no non-organizer recipients exist. |
| src/lib/messaging/sanity.ts | Adds rawViewPredicate and SPEAKER_SCOPE_PREDICATE export (S7), getConversationViewCounts (S7), reopen flag in addMessage (S3), setConversationArchived with archiverId (S6), archivedBy projection, and S10a/b direct-thread identity. |
| src/server/routers/message.ts | Adds viewCounts procedure (S7), reopen-on-reply logic (S3), setAssignee notify via createNotifications (S4), and passes archiverId to setConversationArchived (S6). All server-derived IDs; authz unchanged and correct. |
| src/server/routers/proposal.ts | S2: removes the notifyNewMessage call after addMessage for decision comments and documents why the fan-out is skipped. Removes now-unused getConversationById import. |
| src/lib/messaging/links.ts | Adds conversationEmailLinkPath (S8): always uses the direct thread page path, avoiding the auth-redirect fragment-drop bug for proposal threads. |
| src/lib/notification/sanity.ts | Adds S10c isDirect logic in upsertMessageNotifications: subjectSpeakerId compared to recipientId to render Direct message from author title. Never-throw contract maintained. |
| src/components/email/MessageNotificationTemplate.tsx | S9a/b/c email copy rewrite: truthful reply-fallback per audience, global-profile prefs description, and warmer firstContact heading and intro. |
| src/lib/messaging/email.ts | Adds firstContact field to MessageEmailRecipient and uses it to select the warmer S9c subject line. Concurrency pool unchanged. |
| src/lib/push/send.ts | S5: maps message_stale to messages push category (was otherUpdates). S4: maps conversation_assigned to messages. |
| sanity/schemaTypes/conversation.ts | S6: adds archivedBy field (weak reference, hidden and readOnly in Studio) set alongside archivedAt and unset with it for the global-archive audit trail. |
| sanity/schemaTypes/notification.ts | Adds conversation_assigned to the Studio notification type dropdown. Clean additive change. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as message.ts / proposal.ts
    participant Sanity as messaging/sanity.ts
    participant Notify as messaging/notify.ts
    participant Hub as notification/sanity.ts
    participant Push as push/send.ts

    Client->>Router: message.send (speaker)
    Router->>Sanity: "addMessage reopen=true if resolved+non-org S3"
    Router-->>Client: conversationId and message
    Note over Router,Notify: runAfterResponse
    Router->>Notify: notifyNewMessage
    Notify->>Hub: upsertMessageNotifications subjectSpeakerId S10c
    Hub->>Push: sendPushForNotifications messages category
    Notify->>Router: sendMessageEmails individual S1b thread-page S8
    Notify->>Router: sendMessageEmails org-contact copy S1a mute-independent

    Client->>Router: message.setAssignee assigneeId org-2
    Router->>Sanity: setConversationAssignee
    Router->>Hub: createNotifications conversation_assigned S4
    Hub->>Push: sendPushForNotifications messages S4 S5
    Router-->>Client: conversationId and assigneeId

    Client->>Router: proposal.action accept or reject
    Router->>Sanity: addMessage decision comment S2
    Note over Router: notifyNewMessage NOT called decision rail is sole delivery S2
    Router-->>Client: proposal updated
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as message.ts / proposal.ts
    participant Sanity as messaging/sanity.ts
    participant Notify as messaging/notify.ts
    participant Hub as notification/sanity.ts
    participant Push as push/send.ts

    Client->>Router: message.send (speaker)
    Router->>Sanity: "addMessage reopen=true if resolved+non-org S3"
    Router-->>Client: conversationId and message
    Note over Router,Notify: runAfterResponse
    Router->>Notify: notifyNewMessage
    Notify->>Hub: upsertMessageNotifications subjectSpeakerId S10c
    Hub->>Push: sendPushForNotifications messages category
    Notify->>Router: sendMessageEmails individual S1b thread-page S8
    Notify->>Router: sendMessageEmails org-contact copy S1a mute-independent

    Client->>Router: message.setAssignee assigneeId org-2
    Router->>Sanity: setConversationAssignee
    Router->>Hub: createNotifications conversation_assigned S4
    Hub->>Push: sendPushForNotifications messages S4 S5
    Router-->>Client: conversationId and assigneeId

    Client->>Router: proposal.action accept or reject
    Router->>Sanity: addMessage decision comment S2
    Note over Router: notifyNewMessage NOT called decision rail is sole delivery S2
    Router-->>Client: proposal updated
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): UX review server batch —..."](https://github.com/cloudnativebergen/website/commit/f36502c91d15231f8ef8be4326596850e8c842ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45444832)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->