### PR TITLE
fix(messaging): UX polish — direct identity, toolbar, counts, state visibility (V1)

### DIFF
--- a/__tests__/components/messaging/ConversationList.ticketing.test.tsx
+++ b/__tests__/components/messaging/ConversationList.ticketing.test.tsx
@@ -62,7 +62,7 @@ describe('ConversationList — organizer row metadata (T2b)', () => {
   })
 })
 
-describe('ConversationList — speaker rows only get the Resolved chip', () => {
+describe('ConversationList — speaker rows only get the closed chip', () => {
   it('never renders needs-reply or the assignee for a speaker', () => {
     render(
       <ConversationList
@@ -76,13 +76,15 @@ describe('ConversationList — speaker rows only get the Resolved chip', () => {
         ]}
       />,
     )
-    expect(screen.getByText('Resolved')).toBeInTheDocument()
+    // Speaker copy for a resolved thread reads "Closed by organizers" (V1h).
+    expect(screen.getByText('Closed by organizers')).toBeInTheDocument()
+    expect(screen.queryByText('Resolved')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Needs reply')).not.toBeInTheDocument()
     expect(screen.queryByLabelText(/assigned to/i)).not.toBeInTheDocument()
   })
 })
 
-describe('ConversationList — Archived view Unarchive (T2d)', () => {
+describe('ConversationList — Archived view Unarchive (T2d / V1-r1)', () => {
   it('calls onUnarchive without navigating and only when provided', () => {
     const onUnarchive = vi.fn()
     const { rerender } = render(
@@ -93,12 +95,11 @@ describe('ConversationList — Archived view Unarchive (T2d)', () => {
       />,
     )
     const button = screen.getByRole('button', { name: /unarchive/i })
-    const clickEvent = fireEvent.click(button)
-    // The handler fired and the click was prevented (so the row Link never
-    // navigates out from under the action).
+    fireEvent.click(button)
+    // The handler fired; the button is a SIBLING of the row link (V1-r1), so a
+    // click never reaches the link — no preventDefault gymnastics required.
     expect(onUnarchive).toHaveBeenCalledTimes(1)
     expect(onUnarchive.mock.calls[0][0]._id).toBe('conversation.gen-1')
-    expect(clickEvent).toBe(false) // preventDefault() → dispatchEvent returns false
 
     // Without onUnarchive the button is absent (non-archived views).
     rerender(
@@ -109,7 +110,7 @@ describe('ConversationList — Archived view Unarchive (T2d)', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('renders a row Link that would otherwise navigate', () => {
+  it('renders the Unarchive action OUTSIDE the row Link (valid HTML, V1-r1)', () => {
     render(
       <ConversationList
         isOrganizer
@@ -117,11 +118,37 @@ describe('ConversationList — Archived view Unarchive (T2d)', () => {
         onUnarchive={vi.fn()}
       />,
     )
-    // The row is still a link to the admin thread; the Unarchive button lives
-    // inside it but stops propagation.
+    // The row is still a link to the admin thread, but the Unarchive button is a
+    // sibling overlay — a <button> nested inside an <a> is invalid HTML.
     const row = screen.getByRole('link')
     expect(
-      within(row).getByRole('button', { name: /unarchive/i }),
+      within(row).queryByRole('button', { name: /unarchive/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /unarchive/i }),
     ).toBeInTheDocument()
+  })
+
+  it('keeps a sane keyboard focus order after the row restructure (V1-r2)', () => {
+    const { container } = render(
+      <ConversationList
+        isOrganizer
+        items={[
+          item({ _id: 'c1', archived: true }),
+          item({ _id: 'c2', archived: true }),
+        ]}
+        onUnarchive={vi.fn()}
+      />,
+    )
+    // Tab order follows DOM order: each row's link, then its Unarchive action,
+    // then the next row's link — the action is a later sibling of its own link,
+    // never interleaved with another row's controls.
+    const focusables = Array.from(
+      container.querySelectorAll('a, button'),
+    ) as HTMLElement[]
+    const kinds = focusables.map((el) =>
+      el.tagName === 'A' ? 'link' : 'unarchive',
+    )
+    expect(kinds).toEqual(['link', 'unarchive', 'link', 'unarchive'])
   })
 })

--- a/__tests__/components/messaging/ConversationThreadContainer.test.tsx
+++ b/__tests__/components/messaging/ConversationThreadContainer.test.tsx
@@ -284,7 +284,7 @@ describe('ConversationThread — auto-mark-read', () => {
 })
 
 describe('ConversationThread — not-found scoping (C5)', () => {
-  it('shows the error state (no composer) for a not-found conversationId', () => {
+  it('shows the honest not-found state (no composer) for a not-found conversationId', () => {
     getConversationResult = { data: undefined, error: NOT_FOUND }
     listMessagesResult = notFoundMessages()
 
@@ -295,7 +295,14 @@ describe('ConversationThread — not-found scoping (C5)', () => {
       />,
     )
 
-    expect(screen.getByRole('alert')).toHaveTextContent(/couldn.t load/i)
+    // V1e: a bare-conversationId NOT_FOUND is a permanent no-access state with a
+    // Back-to-Messages CTA, distinct from the transient "couldn't load" retry.
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /doesn.t exist or you don.t have access/i,
+    )
+    expect(
+      screen.getByRole('link', { name: /back to messages/i }),
+    ).toHaveAttribute('href', '/cfp/messages')
     expect(screen.queryByLabelText(/write a message/i)).not.toBeInTheDocument()
   })
 

--- a/__tests__/components/messaging/MessagesInbox.test.tsx
+++ b/__tests__/components/messaging/MessagesInbox.test.tsx
@@ -13,6 +13,15 @@ vi.mock('next-auth/react', () => ({
   useSession: () => ({ data: { speaker: { _id: 'me' } } }),
 }))
 
+// The inbox persists the view in `?view=` (V1i). Local state still drives the
+// immediate switch, so a static searchParams + a no-op router are enough here.
+const routerReplace = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: routerReplace }),
+  usePathname: () => '/admin/messages',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
 // Capture every `view` the inbox query is called with, plus the mutation calls.
 const listInputs: Array<{ view: string }> = []
 const setArchivedMutate = vi.fn()
@@ -27,6 +36,9 @@ vi.mock('@/lib/trpc/client', () => ({
       message: { listConversations: { invalidate: listInvalidate } },
     }),
     message: {
+      viewCounts: {
+        useQuery: () => ({ data: undefined }),
+      },
       listConversations: {
         useInfiniteQuery: (input: { view: string }) => {
           listInputs.push(input)
@@ -76,6 +88,7 @@ beforeEach(() => {
   setArchivedMutate.mockClear()
   setPreferenceMutate.mockClear()
   listInvalidate.mockClear()
+  routerReplace.mockClear()
   infiniteResult = pageOf([])
 })
 
@@ -90,6 +103,9 @@ describe('MessagesInbox — view tabs (T2a)', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Needs reply' }))
     expect(listInputs.at(-1)).toEqual({ view: 'needs-reply' })
 
+    fireEvent.click(screen.getByRole('tab', { name: 'Unassigned' }))
+    expect(listInputs.at(-1)).toEqual({ view: 'unassigned' })
+
     fireEvent.click(screen.getByRole('tab', { name: 'Mine' }))
     expect(listInputs.at(-1)).toEqual({ view: 'mine' })
 
@@ -97,11 +113,27 @@ describe('MessagesInbox — view tabs (T2a)', () => {
     expect(listInputs.at(-1)).toEqual({ view: 'resolved' })
   })
 
+  it('persists the selected view in the URL query string (V1i)', () => {
+    render(<MessagesInbox audience="organizer" />)
+    fireEvent.click(screen.getByRole('tab', { name: 'Needs reply' }))
+    expect(routerReplace).toHaveBeenLastCalledWith(
+      '/admin/messages?view=needs-reply',
+      expect.objectContaining({ scroll: false }),
+    )
+    // Returning to the default view drops the param entirely.
+    fireEvent.click(screen.getByRole('tab', { name: 'Active' }))
+    expect(routerReplace).toHaveBeenLastCalledWith(
+      '/admin/messages',
+      expect.objectContaining({ scroll: false }),
+    )
+  })
+
   it('organizers get the full tab bar; the "All" view is omitted from the UI', () => {
     render(<MessagesInbox audience="organizer" />)
     for (const label of [
       'Active',
       'Needs reply',
+      'Unassigned',
       'Mine',
       'Resolved',
       'Archived',

--- a/__tests__/components/notifications/NotificationBell.test.tsx
+++ b/__tests__/components/notifications/NotificationBell.test.tsx
@@ -17,6 +17,8 @@ let unreadState: { data: number | undefined; isSuccess: boolean } = {
   data: 0,
   isSuccess: true,
 }
+// The `notification.list` (limit 1) query the bell reads for the toast title.
+let listState: { data: { title: string }[] | undefined } = { data: undefined }
 let sessionState: { data: { isImpersonating?: boolean } | null } = {
   data: { isImpersonating: false },
 }
@@ -39,12 +41,16 @@ vi.mock('@/lib/trpc/client', () => ({
       unreadCount: {
         useQuery: () => unreadState,
       },
+      list: {
+        useQuery: () => listState,
+      },
     },
   },
 }))
 
 beforeEach(() => {
   unreadState = { data: 0, isSuccess: true }
+  listState = { data: undefined }
   sessionState = { data: { isImpersonating: false } }
   showNotification.mockClear()
 })
@@ -104,5 +110,30 @@ describe('NotificationBell — toast bridge', () => {
     unreadState = { data: 7, isSuccess: true }
     rerender(<NotificationBell />)
     expect(showNotification).not.toHaveBeenCalled()
+  })
+
+  it('carries the newest notification title when one is available (V1l)', () => {
+    listState = { data: [{ title: 'Direct message from Ola Organizer' }] }
+    unreadState = { data: 0, isSuccess: true }
+    const { rerender } = render(<NotificationBell />)
+    unreadState = { data: 1, isSuccess: true }
+    rerender(<NotificationBell />)
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Direct message from Ola Organizer',
+        message: 'You have 1 new notification.',
+      }),
+    )
+  })
+
+  it('falls back to the generic title when no newest title is available', () => {
+    listState = { data: [] }
+    unreadState = { data: 1, isSuccess: true }
+    const { rerender } = render(<NotificationBell />)
+    unreadState = { data: 3, isSuccess: true }
+    rerender(<NotificationBell />)
+    expect(showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'You have new notifications' }),
+    )
   })
 })

--- a/__tests__/lib/messaging/ticketing.test.ts
+++ b/__tests__/lib/messaging/ticketing.test.ts
@@ -436,7 +436,9 @@ describe('derived archived — global vs per-user, resurface-on-new-message', ()
     // The projection coalesces an absent status to 'open'.
     const [query] = readMock.fetch.mock.calls[0]
     expect(query).toContain('"status": coalesce(status, \'open\')')
-    expect(query).toContain('"assignedTo": assignedTo->{ _id, name }')
+    expect(query).toContain(
+      '"assignedTo": assignedTo->{ _id, name, "image": coalesce(image.asset->url, imageURL) }',
+    )
   })
 })
 
@@ -559,6 +561,7 @@ describe('getConversationViewCounts — one GROQ round trip (S7)', () => {
     readMock.fetch.mockResolvedValueOnce({
       active: 3,
       needsReply: 2,
+      unassigned: 6,
       mine: 1,
       resolved: 4,
       archived: 5,
@@ -571,6 +574,7 @@ describe('getConversationViewCounts — one GROQ round trip (S7)', () => {
     expect(counts).toEqual({
       active: 3,
       needsReply: 2,
+      unassigned: 6,
       mine: 1,
       resolved: 4,
       archived: 5,
@@ -579,11 +583,14 @@ describe('getConversationViewCounts — one GROQ round trip (S7)', () => {
     // ONE object projection with a count() per view.
     expect(query).toContain('"active": count(')
     expect(query).toContain('"needsReply": count(')
+    expect(query).toContain('"unassigned": count(')
     expect(query).toContain('"mine": count(')
     expect(query).toContain('"resolved": count(')
     expect(query).toContain('"archived": count(')
-    // Reuses the shared predicates (needs-reply binds organizerIds).
+    // Reuses the shared predicates (needs-reply binds organizerIds; unassigned
+    // filters on an absent assignee).
     expect(query).toContain('assignedTo._ref == $speakerId')
+    expect(query).toContain('!defined(assignedTo)')
     expect(query).toContain('in $organizerIds)')
     expect(params.organizerIds).toEqual(['org-1', 'org-2'])
   })

--- a/src/app/(admin)/admin/messages/page.tsx
+++ b/src/app/(admin)/admin/messages/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import { MessagesInbox } from '@/components/messaging'
 
 export const metadata: Metadata = {
@@ -18,7 +19,11 @@ export default function AdminMessagesPage() {
         </p>
       </div>
 
-      <MessagesInbox audience="organizer" allowNew />
+      {/* MessagesInbox reads `?view=` via useSearchParams — needs a Suspense
+          boundary so this page can still statically render its shell. */}
+      <Suspense>
+        <MessagesInbox audience="organizer" allowNew />
+      </Suspense>
     </div>
   )
 }

--- a/src/app/(cfp)/cfp/messages/page.tsx
+++ b/src/app/(cfp)/cfp/messages/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Suspense } from 'react'
 import { MessagesInbox } from '@/components/messaging'
 
 export const metadata: Metadata = {
@@ -18,7 +19,11 @@ export default function CfpMessagesPage() {
         </p>
       </div>
 
-      <MessagesInbox audience="speaker" allowNew />
+      {/* MessagesInbox reads `?view=` via useSearchParams — needs a Suspense
+          boundary so this page can still statically render its shell. */}
+      <Suspense>
+        <MessagesInbox audience="speaker" allowNew />
+      </Suspense>
     </div>
   )
 }

--- a/src/components/messaging/ConversationList.stories.tsx
+++ b/src/components/messaging/ConversationList.stories.tsx
@@ -333,3 +333,116 @@ export const ArchivedWithUnarchiveDark: Story = {
     />
   ),
 }
+
+/**
+ * DIRECT-THREAD IDENTITY (V1a): rows the viewer is personally addressed on
+ * (`direct: true`) carry a brand-blue left edge and a "Direct" chip so they read
+ * distinctly from the organizer-broadcast threads (rows 2 & 3 here).
+ */
+const makeDirectItems = (): ConversationListItem[] =>
+  makeOrganizerItems().map((item, i) =>
+    i === 0
+      ? {
+          ...item,
+          direct: true,
+          assignedTo: {
+            _id: 'org-1',
+            name: 'Ola Organizer',
+            image: '/images/default-avatar.png',
+          },
+        }
+      : item,
+  )
+
+export const DirectVsBroadcast: Story = {
+  args: { items: [], isOrganizer: true, view: 'active' },
+  render: (args) => <ConversationList {...args} items={makeDirectItems()} />,
+}
+
+export const DirectVsBroadcastDark: Story = {
+  args: { items: [], isOrganizer: true, view: 'active' },
+  parameters: { dark: true },
+  render: (args) => <ConversationList {...args} items={makeDirectItems()} />,
+}
+
+/**
+ * STATE VISIBILITY (V1g): a muted row shows a small bell-slash glyph beside the
+ * time; the assignee avatar (V1k) uses the organizer's photo when available.
+ */
+export const MutedAndAssigneePhoto: Story = {
+  args: { items: [], isOrganizer: true, view: 'active' },
+  render: (args) => (
+    <ConversationList
+      {...args}
+      items={makeOrganizerItems().map((item, i) =>
+        i === 0
+          ? {
+              ...item,
+              muted: true,
+              assignedTo: {
+                _id: 'org-1',
+                name: 'Ola Organizer',
+                image: '/images/default-avatar.png',
+              },
+            }
+          : item,
+      )}
+    />
+  ),
+}
+
+export const MutedAndAssigneePhotoDark: Story = {
+  args: { items: [], isOrganizer: true, view: 'active' },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationList
+      {...args}
+      items={makeOrganizerItems().map((item, i) =>
+        i === 0
+          ? {
+              ...item,
+              muted: true,
+              assignedTo: {
+                _id: 'org-1',
+                name: 'Ola Organizer',
+                image: '/images/default-avatar.png',
+              },
+            }
+          : item,
+      )}
+    />
+  ),
+}
+
+/** PER-VIEW EMPTY STATE (V1d): the organizer needs-reply view's tailored copy. */
+export const EmptyNeedsReply: Story = {
+  args: { items: [], isOrganizer: true, view: 'needs-reply' },
+}
+
+/** PER-VIEW EMPTY STATE (V1d): the organizer unassigned view. */
+export const EmptyUnassigned: Story = {
+  args: { items: [], isOrganizer: true, view: 'unassigned' },
+}
+
+/**
+ * SPEAKER ADOPTION PITCH (V1d rider): the speaker Active-view empty state is a
+ * marketing surface — a headline, a pitch line, and the New conversation CTA.
+ */
+export const SpeakerEmptyPitch: Story = {
+  args: {
+    items: [],
+    isOrganizer: false,
+    view: 'active',
+    onNewConversation: () => {},
+  },
+}
+
+export const SpeakerEmptyPitchDark: Story = {
+  args: {
+    items: [],
+    isOrganizer: false,
+    view: 'active',
+    onNewConversation: () => {},
+  },
+  parameters: { dark: true },
+}

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -3,14 +3,19 @@
 import Link from 'next/link'
 import {
   ArchiveBoxXMarkIcon,
+  BellSlashIcon,
   ChatBubbleLeftRightIcon,
+  PlusIcon,
   UserGroupIcon,
 } from '@heroicons/react/24/outline'
 import { conversationLinkPath, ORGANIZERS_LABEL } from '@/lib/messaging/links'
 import { formatRelativeTime } from '@/lib/notification/format'
 import { MissingAvatar } from '@/components/common/MissingAvatar'
 import { SpeakerAvatarImage } from '@/components/common/SpeakerAvatarImage'
-import type { ConversationListItem } from '@/lib/messaging/types'
+import type {
+  ConversationListItem,
+  ConversationView,
+} from '@/lib/messaging/types'
 
 export interface ConversationListProps {
   /** Conversations, newest activity first. Ignored while `isLoading`. */
@@ -38,22 +43,86 @@ export interface ConversationListProps {
    * navigating into the thread. Omitted (the default) in every non-archived view.
    */
   onUnarchive?: (item: ConversationListItem) => void
+  /**
+   * The active inbox view — drives the view-aware empty copy (V1d), the amber
+   * needs-reply dot suppression in the needs-reply view (V1j), and hiding the
+   * assignee badge in the Mine view (V1k). Defaults to `active`.
+   */
+  view?: ConversationView
+  /**
+   * When set (speaker inbox, Active view empty state), the adoption-pitch empty
+   * state renders a "New conversation" CTA that invokes this (V1d rider).
+   */
+  onNewConversation?: () => void
+  /**
+   * Tab wiring (V1-r1): the id given to the list container so the inbox tabs can
+   * point their `aria-controls` at it; when provided the container becomes a
+   * `role="tabpanel"` labelled by {@link labelledById}.
+   */
+  panelId?: string
+  /** The id of the currently-selected tab, for the tabpanel's `aria-labelledby`. */
+  labelledById?: string
 }
 
 /**
- * The organizer follow-up owner, as a compact avatar+initial at the row's
- * trailing edge (organizer audience only). `title` carries the full name for a
- * hover tooltip; the accessible label spells out the assignment.
+ * View-aware empty-state copy (V1d). Organizer views each get a purpose-specific
+ * line; the speaker Active view is an adoption pitch (a maintainer-picked
+ * marketing surface). Returns a headline plus, optionally, a pitch body and a
+ * flag to render the "New conversation" CTA beside it.
  */
-function AssigneeBadge({ name }: { name: string }) {
+function emptyStateFor(
+  view: ConversationView,
+  isOrganizer: boolean,
+): { headline: string; body?: string; pitch?: boolean } {
+  if (isOrganizer) {
+    switch (view) {
+      case 'needs-reply':
+        return { headline: 'Nothing needs a reply 🎉' }
+      case 'unassigned':
+        return { headline: 'No unassigned conversations' }
+      case 'mine':
+        return { headline: 'Nothing assigned to you' }
+      case 'resolved':
+        return { headline: 'No resolved conversations' }
+      case 'archived':
+        return { headline: 'No archived conversations' }
+      default:
+        return { headline: 'No conversations yet' }
+    }
+  }
+  // Speaker audience.
+  if (view === 'archived') return { headline: 'No archived conversations' }
+  return {
+    headline: 'No conversations yet',
+    body: 'Questions about your proposal or the conference? Message the organizers directly — replies arrive here, by email, and as push notifications.',
+    pitch: true,
+  }
+}
+
+/**
+ * The organizer follow-up owner, as a compact avatar at the row's trailing edge
+ * (organizer audience only). Uses the organizer's photo when available (V1k),
+ * falling back to initials. `title` carries the full name for a hover tooltip;
+ * the accessible label spells out the assignment.
+ */
+function AssigneeBadge({ name, image }: { name: string; image?: string }) {
   const initial = name.trim().charAt(0).toUpperCase() || '?'
   return (
     <span
       title={name}
       aria-label={`Assigned to ${name}`}
-      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand-cloud-blue/10 text-[11px] font-semibold text-brand-cloud-blue dark:bg-blue-400/10 dark:text-blue-300"
+      className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full bg-brand-cloud-blue/10 text-[11px] font-semibold text-brand-cloud-blue dark:bg-blue-400/10 dark:text-blue-300"
     >
-      {initial}
+      {image ? (
+        <SpeakerAvatarImage
+          src={image}
+          name={name}
+          size={24}
+          textSizeClass="text-[11px]"
+        />
+      ) : (
+        initial
+      )}
     </span>
   )
 }
@@ -121,12 +190,19 @@ export function ConversationList({
   onShowMore,
   isLoadingMore = false,
   onUnarchive,
+  view = 'active',
+  onNewConversation,
+  panelId,
+  labelledById,
 }: ConversationListProps) {
   return (
     <div
-      role="region"
-      aria-label="Conversations"
-      className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200 bg-white dark:divide-gray-800/70 dark:border-gray-700 dark:bg-gray-800"
+      id={panelId}
+      role={panelId ? 'tabpanel' : 'region'}
+      tabIndex={panelId ? 0 : undefined}
+      aria-label={panelId ? undefined : 'Conversations'}
+      aria-labelledby={panelId ? labelledById : undefined}
+      className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200 bg-white focus:outline-none dark:divide-gray-800/70 dark:border-gray-700 dark:bg-gray-800"
     >
       {isLoading ? (
         <>
@@ -147,15 +223,35 @@ export function ConversationList({
           </p>
         </div>
       ) : items.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
-          <ChatBubbleLeftRightIcon
-            aria-hidden="true"
-            className="h-10 w-10 text-gray-300 dark:text-gray-600"
-          />
-          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
-            No conversations yet
-          </p>
-        </div>
+        (() => {
+          const empty = emptyStateFor(view, isOrganizer)
+          return (
+            <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
+              <ChatBubbleLeftRightIcon
+                aria-hidden="true"
+                className="h-10 w-10 text-gray-300 dark:text-gray-600"
+              />
+              <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                {empty.headline}
+              </p>
+              {empty.body && (
+                <p className="max-w-sm text-sm text-gray-500 dark:text-gray-400">
+                  {empty.body}
+                </p>
+              )}
+              {empty.pitch && onNewConversation && (
+                <button
+                  type="button"
+                  onClick={onNewConversation}
+                  className="mt-2 inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:bg-blue-600 dark:hover:bg-blue-500"
+                >
+                  <PlusIcon className="h-4 w-4" aria-hidden="true" />
+                  New conversation
+                </button>
+              )}
+            </div>
+          )
+        })()
       ) : (
         <>
           {items.map((item) => {
@@ -163,96 +259,136 @@ export function ConversationList({
             const isOwnLastMessage =
               !!callerId && item.lastMessage?.authorId === callerId
             // Organizer-only signals; a speaker never sees needs-reply or the
-            // assignee (both are organizer-side concepts).
-            const showNeedsReply = isOrganizer && item.needsReply === true
+            // assignee (both are organizer-side concepts). The needs-reply dot
+            // is suppressed WITHIN the needs-reply view — every row there needs a
+            // reply, so the marker is redundant (V1j).
+            const showNeedsReply =
+              isOrganizer && item.needsReply === true && view !== 'needs-reply'
             const isResolved = item.status === 'resolved'
-            const assignee = isOrganizer ? item.assignedTo : null
+            // Hide the assignee badge in the Mine view — every row is the
+            // caller's own, so the badge carries no information there (V1k).
+            const assignee =
+              isOrganizer && view !== 'mine' ? item.assignedTo : null
+            // DIRECT-THREAD IDENTITY (V1a): a thread that personally addresses
+            // the viewer gets a brand-blue left edge and a "Direct" chip so it
+            // reads distinctly from the organizer broadcast threads.
+            const isDirect = item.direct === true
             return (
-              <Link
+              // A `relative` row wrapper so the Unarchive ACTION can be a sibling
+              // overlay of the row link rather than a <button> nested inside an
+              // <a> (invalid HTML) — V1-r1. The left accent edge lives here so it
+              // spans the full row height.
+              <div
                 key={item._id}
-                href={conversationLinkPath(item, isOrganizer)}
-                prefetch={false}
-                className="flex gap-3 px-4 py-3 transition hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60"
+                className={`relative border-l-2 ${
+                  isDirect
+                    ? 'border-brand-cloud-blue dark:border-blue-500'
+                    : 'border-transparent'
+                }`}
               >
-                <RowAvatar item={item} />
-                <span className="min-w-0 flex-1">
-                  {/* WHO + WHEN: counterpart name, unread pill, relative time. */}
-                  <span className="flex items-baseline justify-between gap-2">
-                    <span className="truncate text-sm font-medium text-gray-900 dark:text-white">
-                      {item.counterpart.name}
-                    </span>
-                    <span className="flex shrink-0 items-baseline gap-2">
-                      {isUnread && (
-                        <span
-                          aria-label={`${item.unreadCount} unread`}
-                          className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-cloud-blue px-1.5 text-[11px] leading-none font-semibold text-white dark:bg-blue-600"
-                        >
-                          {item.unreadCount > 9 ? '9+' : item.unreadCount}
+                <Link
+                  href={conversationLinkPath(item, isOrganizer)}
+                  prefetch={false}
+                  className={`flex gap-3 py-3 pl-4 transition hover:bg-gray-50 focus:outline-none focus-visible:bg-gray-50 focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60 ${
+                    assignee || onUnarchive ? 'pr-20' : 'pr-4'
+                  }`}
+                >
+                  <RowAvatar item={item} />
+                  <span className="min-w-0 flex-1">
+                    {/* WHO + WHEN: counterpart name, mute glyph, unread pill,
+                        relative time. */}
+                    <span className="flex items-baseline justify-between gap-2">
+                      <span className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                        {item.counterpart.name}
+                      </span>
+                      <span className="flex shrink-0 items-center gap-2">
+                        {item.muted && (
+                          <BellSlashIcon
+                            title="Muted"
+                            aria-label="Muted"
+                            className="h-3.5 w-3.5 text-gray-400 dark:text-gray-500"
+                          />
+                        )}
+                        {isUnread && (
+                          <span
+                            aria-label={`${item.unreadCount} unread`}
+                            className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-cloud-blue px-1.5 text-[11px] leading-none font-semibold text-white dark:bg-blue-600"
+                          >
+                            {item.unreadCount > 9 ? '9+' : item.unreadCount}
+                          </span>
+                        )}
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
+                          {formatRelativeTime(item.lastMessageAt)}
                         </span>
-                      )}
-                      <span className="text-xs text-gray-400 dark:text-gray-500">
-                        {formatRelativeTime(item.lastMessageAt)}
                       </span>
                     </span>
-                  </span>
-                  {/* WHAT: subject (the talk title for proposal threads — the
-                      chip marks the type instead of repeating it). A small amber
-                      dot leads the subject when the thread needs an organizer
-                      reply (least-noisy affordance, consistent with the unread
-                      pill); a gray 'Resolved' chip marks a closed thread. */}
-                  <span className="mt-0.5 flex items-center gap-2">
-                    {showNeedsReply && (
+                    {/* WHAT: subject (the talk title for proposal threads — the
+                        chip marks the type instead of repeating it). A brand-blue
+                        'Direct' chip leads a direct thread; a small amber dot
+                        leads the subject when the thread needs an organizer reply
+                        (least-noisy affordance, consistent with the unread pill);
+                        a gray status chip marks a closed thread. */}
+                    <span className="mt-0.5 flex items-center gap-2">
+                      {isDirect && (
+                        <span className="shrink-0 rounded-full bg-brand-cloud-blue/10 px-2 py-0.5 text-[10px] font-semibold text-brand-cloud-blue dark:bg-blue-400/10 dark:text-blue-300">
+                          Direct
+                        </span>
+                      )}
+                      {showNeedsReply && (
+                        <span
+                          title="Needs reply"
+                          aria-label="Needs reply"
+                          className="h-2 w-2 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400"
+                        />
+                      )}
                       <span
-                        title="Needs reply"
-                        aria-label="Needs reply"
-                        className="h-2 w-2 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400"
+                        className={`truncate text-sm text-gray-900 dark:text-white ${
+                          isUnread ? 'font-bold' : 'font-semibold'
+                        }`}
+                      >
+                        {conversationTitle(item)}
+                      </span>
+                      {item.conversationType === 'proposal' && (
+                        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                          Proposal
+                        </span>
+                      )}
+                      {isResolved && (
+                        <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                          {isOrganizer ? 'Resolved' : 'Closed by organizers'}
+                        </span>
+                      )}
+                    </span>
+                    {/* Snippet: one truncated line; "You: " when the viewer wrote
+                        the last message. */}
+                    {item.lastMessage && (
+                      <span className="mt-0.5 block truncate text-sm text-gray-500 dark:text-gray-400">
+                        {isOwnLastMessage && (
+                          <span className="font-medium text-gray-600 dark:text-gray-300">
+                            You:{' '}
+                          </span>
+                        )}
+                        {item.lastMessage.excerpt}
+                      </span>
+                    )}
+                  </span>
+                </Link>
+                {/* Trailing action column, a SIBLING of the row link (not nested
+                    inside the <a>): the follow-up owner's avatar (organizer
+                    audience) and, in the archived view, an Unarchive button that
+                    acts WITHOUT navigating into the thread (V1-r1). */}
+                {(assignee || onUnarchive) && (
+                  <span className="absolute inset-y-0 right-2 flex flex-col items-end justify-center gap-1.5">
+                    {assignee && (
+                      <AssigneeBadge
+                        name={assignee.name}
+                        image={assignee.image}
                       />
                     )}
-                    <span
-                      className={`truncate text-sm text-gray-900 dark:text-white ${
-                        isUnread ? 'font-bold' : 'font-semibold'
-                      }`}
-                    >
-                      {conversationTitle(item)}
-                    </span>
-                    {item.conversationType === 'proposal' && (
-                      <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
-                        Proposal
-                      </span>
-                    )}
-                    {isResolved && (
-                      <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
-                        Resolved
-                      </span>
-                    )}
-                  </span>
-                  {/* Snippet: one truncated line; "You: " when the viewer wrote
-                      the last message. */}
-                  {item.lastMessage && (
-                    <span className="mt-0.5 block truncate text-sm text-gray-500 dark:text-gray-400">
-                      {isOwnLastMessage && (
-                        <span className="font-medium text-gray-600 dark:text-gray-300">
-                          You:{' '}
-                        </span>
-                      )}
-                      {item.lastMessage.excerpt}
-                    </span>
-                  )}
-                </span>
-                {/* Trailing column: the follow-up owner's avatar (organizer
-                    audience) and, in the archived view, an Unarchive button that
-                    acts WITHOUT navigating into the thread. */}
-                {(assignee || onUnarchive) && (
-                  <span className="flex shrink-0 flex-col items-end justify-center gap-1.5">
-                    {assignee && <AssigneeBadge name={assignee.name} />}
                     {onUnarchive && (
                       <button
                         type="button"
-                        onClick={(e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-                          onUnarchive(item)
-                        }}
+                        onClick={() => onUnarchive(item)}
                         className="inline-flex min-h-[44px] items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium text-brand-cloud-blue transition hover:bg-brand-cloud-blue/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-blue-300 dark:hover:bg-blue-400/10"
                       >
                         <ArchiveBoxXMarkIcon
@@ -264,7 +400,7 @@ export function ConversationList({
                     )}
                   </span>
                 )}
-              </Link>
+              </div>
             )
           })}
           {hasMore && (

--- a/src/components/messaging/ConversationThread.stories.tsx
+++ b/src/components/messaging/ConversationThread.stories.tsx
@@ -385,3 +385,116 @@ export const FillHeightLongThread: Story = {
     </div>
   ),
 }
+
+/**
+ * HONEST NOT_FOUND (V1e): a bare-conversationId thread the viewer can't see (or
+ * that doesn't exist) shows a permanent no-access message with a Back-to-Messages
+ * CTA — never the transient "couldn't load / retry" copy, and no composer.
+ */
+export const NotFound: Story = {
+  args: {
+    messages: [],
+    isNotFound: true,
+    backHref: '/cfp/messages',
+  },
+}
+
+export const NotFoundDark: Story = {
+  args: {
+    messages: [],
+    isNotFound: true,
+    backHref: '/cfp/messages',
+  },
+  parameters: { dark: true },
+}
+
+/**
+ * ARCHIVED-FOR-EVERYONE banner (V1f): an organizer thread that is globally
+ * archived shows a subtle "Archived for everyone by X" audit line with an
+ * adjacent Unarchive affordance.
+ */
+export const ArchivedForEveryoneBanner: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: defaultPreference,
+    status: 'open',
+    onSetStatus: fn(),
+    organizers,
+    assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+    onSetAssignee: fn(),
+    globallyArchived: true,
+    archivedByName: 'Grace Hopper',
+    onSetGlobalArchived: fn(),
+    onArchiveForMe: fn(),
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+export const ArchivedForEveryoneBannerDark: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: defaultPreference,
+    status: 'open',
+    onSetStatus: fn(),
+    organizers,
+    assignedTo: { _id: 'org-1', name: 'Ola Organizer' },
+    onSetAssignee: fn(),
+    globallyArchived: true,
+    archivedByName: 'Grace Hopper',
+    onSetGlobalArchived: fn(),
+    onArchiveForMe: fn(),
+  },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/**
+ * SPEAKER RESOLVED NOTE (V1h): a closed thread shows a one-line note explaining
+ * that replying reopens it (speaker audience — no organizer ticketing controls).
+ */
+export const SpeakerResolvedNote: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: defaultPreference,
+    status: 'resolved',
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+export const SpeakerResolvedNoteDark: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: defaultPreference,
+    status: 'resolved',
+  },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}
+
+/**
+ * MUTED STATE (V1g): while muted, mute dominates every channel — the Emails
+ * select is disabled (tooltip: "Muted — no notifications of any kind") and the
+ * Default option reads "Default (see profile)".
+ */
+export const MutedEmailsDisabled: Story = {
+  args: {
+    messages: [],
+    subject: 'Travel reimbursement question',
+    preference: { muted: true, emailOverride: 'default' },
+  },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeMessages()} />
+  ),
+}

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import Link from 'next/link'
 import { useSession } from 'next-auth/react'
 import {
   ArchiveBoxArrowDownIcon,
@@ -61,6 +62,15 @@ export interface ConversationThreadViewProps {
   messages: DisplayMessage[]
   isLoading?: boolean
   isError?: boolean
+  /**
+   * The conversation genuinely doesn't exist or the viewer can't access it
+   * (server NOT_FOUND, not a transport failure). Distinguished from `isError` so
+   * the empty/error state can be HONEST (V1e): a permanent "no access" message
+   * with a Back-to-Messages CTA, rather than the retry copy a flaky network gets.
+   */
+  isNotFound?: boolean
+  /** Audience-aware href of the Messages inbox, for the NOT_FOUND Back CTA (V1e). */
+  backHref?: string
   /** A full previous page implies older messages remain. */
   hasMore?: boolean
   onShowMore?: () => void
@@ -129,6 +139,13 @@ export interface ConversationThreadViewProps {
   globallyArchived?: boolean
   /** Organizer-only: set/clear the GLOBAL archive. */
   onSetGlobalArchived?: (archived: boolean) => void
+  /**
+   * Name of the organizer who globally archived the thread (deref of
+   * `archivedBy`). When present alongside `globallyArchived`, the organizer
+   * header shows an "Archived for everyone by X" banner with an adjacent
+   * Unarchive affordance (V1f).
+   */
+  archivedByName?: string
   /** True while any organizer ticketing mutation is in flight (disables them). */
   isSavingTicket?: boolean
 }
@@ -219,22 +236,34 @@ function EmailOverrideSelect({
   emailOverride,
   onSetEmailOverride,
   disabled,
+  muted = false,
 }: {
   emailOverride: EmailOverride
   onSetEmailOverride?: (override: EmailOverride) => void
   disabled?: boolean
+  /**
+   * When the conversation is muted, mute dominates every channel — email
+   * included — so the select is disabled with an explaining tooltip (V1g).
+   */
+  muted?: boolean
 }) {
   return (
-    <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+    <label
+      className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
+      title={muted ? 'Muted — no notifications of any kind' : undefined}
+    >
       <span>Emails</span>
       <select
         value={emailOverride}
-        disabled={disabled || !onSetEmailOverride}
+        disabled={disabled || muted || !onSetEmailOverride}
         onChange={(e) => onSetEmailOverride?.(e.target.value as EmailOverride)}
         aria-label="Email notifications for this conversation"
         className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 focus:border-brand-cloud-blue focus:outline-none disabled:opacity-50 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-200"
       >
-        <option value="default">Default</option>
+        {/* The effective global default (audience-dependent, and a per-user
+            toggle) isn't cheaply reachable client-side, so the label points at
+            the profile rather than asserting on/off here (V1g). */}
+        <option value="default">Default (see profile)</option>
         <option value="on">Always</option>
         <option value="off">Never</option>
       </select>
@@ -272,6 +301,7 @@ function PreferencesBar({
         emailOverride={emailOverride}
         onSetEmailOverride={onSetEmailOverride}
         disabled={disabled}
+        muted={muted}
       />
       {onArchiveForMe && (
         // Icon-only so the three-control bar (Mute + Emails + Archive) stays
@@ -430,6 +460,7 @@ function OrganizerThreadControls({
                 emailOverride={preference.emailOverride}
                 onSetEmailOverride={onSetEmailOverride}
                 disabled={prefDisabled}
+                muted={preference.muted}
               />
             </div>
           )}
@@ -438,7 +469,12 @@ function OrganizerThreadControls({
             {onArchiveForMe && (
               <button
                 type="button"
-                onClick={onArchiveForMe}
+                // Close the overflow sheet after the archive action (V1-r1); the
+                // Assign section deliberately stays open for multi-select.
+                onClick={() => {
+                  onArchiveForMe()
+                  setMenuOpen(false)
+                }}
                 disabled={prefDisabled}
                 className="flex min-h-[44px] items-center gap-2 rounded-lg px-3 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-200 dark:hover:bg-gray-800"
               >
@@ -452,7 +488,11 @@ function OrganizerThreadControls({
             {onSetGlobalArchived && (
               <button
                 type="button"
-                onClick={() => onSetGlobalArchived(!globallyArchived)}
+                // Close the sheet after toggling the global archive (V1-r1).
+                onClick={() => {
+                  onSetGlobalArchived(!globallyArchived)
+                  setMenuOpen(false)
+                }}
                 disabled={ticketDisabled}
                 className="flex min-h-[44px] items-center gap-2 rounded-lg px-3 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-200 dark:hover:bg-gray-800"
               >
@@ -488,6 +528,8 @@ export function ConversationThreadView({
   messages,
   isLoading = false,
   isError = false,
+  isNotFound = false,
+  backHref,
   hasMore = false,
   onShowMore,
   isLoadingMore = false,
@@ -512,6 +554,7 @@ export function ConversationThreadView({
   onSetAssignee,
   globallyArchived = false,
   onSetGlobalArchived,
+  archivedByName,
   isSavingTicket = false,
 }: ConversationThreadViewProps) {
   const [draft, setDraft] = useState('')
@@ -695,6 +738,57 @@ export function ConversationThreadView({
         </div>
       )}
 
+      {/* ARCHIVED-FOR-EVERYONE banner (V1f, organizer): a subtle audit line with
+          an adjacent Unarchive affordance when the thread is globally archived. */}
+      {onSetStatus && globallyArchived && (
+        <div className="mt-3 flex shrink-0 items-center justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-300">
+          <span className="flex min-w-0 items-center gap-1.5">
+            <ArchiveBoxArrowDownIcon
+              className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
+              aria-hidden="true"
+            />
+            <span
+              className="truncate"
+              title={
+                archivedByName
+                  ? `Archived for everyone by ${archivedByName}`
+                  : undefined
+              }
+            >
+              {archivedByName
+                ? `Archived for everyone by ${archivedByName}`
+                : 'Archived for everyone'}
+            </span>
+          </span>
+          {onSetGlobalArchived && (
+            <button
+              type="button"
+              onClick={() => onSetGlobalArchived(false)}
+              disabled={isSavingTicket || readOnly}
+              className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 font-semibold text-brand-cloud-blue transition hover:bg-brand-cloud-blue/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:text-blue-300 dark:hover:bg-blue-400/10"
+            >
+              <ArchiveBoxXMarkIcon className="h-4 w-4" aria-hidden="true" />
+              Unarchive
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* SPEAKER resolved note (V1h): a closed thread reopens on reply. Shown for
+          the speaker audience only (no organizer ticketing controls). */}
+      {!onSetStatus && status === 'resolved' && (
+        <div className="mt-3 flex shrink-0 items-center gap-1.5 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-300">
+          <CheckCircleIcon
+            className="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+          <span>
+            The organizers marked this conversation closed — replying reopens
+            it.
+          </span>
+        </div>
+      )}
+
       <div
         ref={scrollRef}
         onScroll={handleScroll}
@@ -704,6 +798,28 @@ export function ConversationThreadView({
       >
         {isLoading ? (
           <MessageSkeleton />
+        ) : isNotFound ? (
+          // HONEST NOT_FOUND (V1e): a permanent no-access state, not a transient
+          // load failure — offer a way back to the inbox instead of a retry.
+          <div
+            role="alert"
+            className="flex flex-col items-center justify-center gap-2 py-10 text-center"
+          >
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              This conversation doesn&apos;t exist or you don&apos;t have
+              access.
+            </p>
+            {backHref && (
+              <Link
+                href={backHref}
+                prefetch={false}
+                className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold text-brand-cloud-blue transition hover:bg-brand-cloud-blue/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-blue-300 dark:hover:bg-blue-400/10"
+              >
+                <ArrowUturnLeftIcon className="h-4 w-4" aria-hidden="true" />
+                Back to Messages
+              </Link>
+            )}
+          </div>
         ) : isError ? (
           <div
             role="alert"
@@ -757,7 +873,8 @@ export function ConversationThreadView({
           </p>
         </div>
       ) : (
-        !isError && (
+        !isError &&
+        !isNotFound && (
           <div
             className={`border-t border-gray-200 pt-3 dark:border-gray-700 ${
               fillHeight
@@ -910,6 +1027,10 @@ export function ConversationThread({
   // than a working composer whose sends would fail.
   const messagesNotFound = errorCode(messagesQuery.error) === 'NOT_FOUND'
   const notFoundIsEmpty = messagesNotFound && !!proposalId
+  // A bare-conversationId NOT_FOUND (no proposal to auto-create) is a genuine
+  // "doesn't exist / no access" — surface it honestly (V1e), distinct from a
+  // transport failure which keeps the retry copy.
+  const isConversationNotFound = messagesNotFound && !notFoundIsEmpty
 
   const participants = conversationQuery.data?.participants
   const participantById = useMemo(() => {
@@ -1098,7 +1219,12 @@ export function ConversationThread({
     <ConversationThreadView
       messages={messages}
       isLoading={messagesQuery.isLoading && !notFoundIsEmpty}
-      isError={messagesQuery.isError && !notFoundIsEmpty}
+      // Transport error only — a NOT_FOUND routes to the honest not-found state.
+      isError={
+        messagesQuery.isError && !notFoundIsEmpty && !isConversationNotFound
+      }
+      isNotFound={isConversationNotFound}
+      backHref={isOrganizer ? '/admin/messages' : '/cfp/messages'}
       hasMore={messagesQuery.hasNextPage}
       onShowMore={() => messagesQuery.fetchNextPage()}
       isLoadingMore={messagesQuery.isFetchingNextPage}
@@ -1145,6 +1271,7 @@ export function ConversationThread({
       assignedTo={conversation?.assignedTo}
       organizers={organizers}
       globallyArchived={globallyArchived}
+      archivedByName={conversation?.archivedBy?.name}
       isSavingTicket={isSavingTicket}
       onSetStatus={
         isOrganizer && conversationExists && convId

--- a/src/components/messaging/MessagesInbox.stories.tsx
+++ b/src/components/messaging/MessagesInbox.stories.tsx
@@ -5,7 +5,10 @@ import type { Session } from 'next-auth'
 import { mockDateBeforeEach } from '@/lib/storybook'
 import { TRPCProvider } from '@/components/providers/TRPCProvider'
 import { MessagesInbox } from '@/components/messaging'
-import type { ConversationListItem } from '@/lib/messaging/types'
+import type {
+  ConversationListItem,
+  ConversationViewCounts,
+} from '@/lib/messaging/types'
 import type { Speaker } from '@/lib/speaker/types'
 
 // Renders the REAL MessagesInbox container (not just its presentational
@@ -78,7 +81,10 @@ const makeItems = (): ConversationListItem[] => [
  * BUILDER, invoked per request, so `minutesAgo` timestamps are computed after
  * `mockDateBeforeEach` has pinned the clock — calling `makeItems()` at module
  * load would freeze them against the real wall clock instead. */
-const conversationHandlers = (getItems: () => ConversationListItem[]) => [
+const conversationHandlers = (
+  getItems: () => ConversationListItem[],
+  counts?: ConversationViewCounts,
+) => [
   http.get('/api/trpc/:procs', ({ params }) =>
     HttpResponse.json(
       String(params.procs)
@@ -86,11 +92,23 @@ const conversationHandlers = (getItems: () => ConversationListItem[]) => [
         .map((proc) =>
           proc === 'message.listConversations'
             ? { result: { data: getItems() } }
-            : { result: { data: null } },
+            : proc === 'message.viewCounts'
+              ? { result: { data: counts ?? null } }
+              : { result: { data: null } },
         ),
     ),
   ),
 ]
+
+/** Representative organizer tab counts for the badge story. */
+const ORGANIZER_COUNTS: ConversationViewCounts = {
+  active: 8,
+  needsReply: 3,
+  unassigned: 2,
+  mine: 1,
+  resolved: 12,
+  archived: 5,
+}
 
 /** Organizer inbox rows carrying ticketing metadata so the row affordances show
  *  alongside the tab bar. */
@@ -197,19 +215,38 @@ export const SpeakerPopulated: Story = {
   parameters: { msw: { handlers: conversationHandlers(makeItems) } },
 }
 
-/** Organizer inbox — the full view tab bar (Active / Needs reply / Mine /
- *  Resolved / Archived) sits above rows with ticketing metadata. */
+/** Organizer inbox — the single-row toolbar (V1b): the full view tab bar
+ *  (Active / Needs reply / Unassigned / Mine / Resolved / Archived) with per-tab
+ *  count badges (V1c) scrolls beside the pinned compact New button. */
 export const OrganizerPopulated: Story = {
-  args: { audience: 'organizer' },
-  parameters: { msw: { handlers: conversationHandlers(makeOrganizerItems) } },
+  args: { audience: 'organizer', allowNew: true },
+  parameters: {
+    msw: {
+      handlers: conversationHandlers(makeOrganizerItems, ORGANIZER_COUNTS),
+    },
+  },
 }
 
 export const OrganizerPopulatedDark: Story = {
-  args: { audience: 'organizer' },
+  args: { audience: 'organizer', allowNew: true },
   parameters: {
     dark: true,
-    msw: { handlers: conversationHandlers(makeOrganizerItems) },
+    msw: {
+      handlers: conversationHandlers(makeOrganizerItems, ORGANIZER_COUNTS),
+    },
   },
+}
+
+/** Speaker Active-view empty state — the adoption pitch + New conversation CTA
+ *  (V1d rider); a marketing surface that must look good at 393px. */
+export const SpeakerEmptyPitch: Story = {
+  args: { audience: 'speaker', allowNew: true },
+  parameters: { msw: { handlers: conversationHandlers(() => []) } },
+}
+
+export const SpeakerEmptyPitchDark: Story = {
+  args: { audience: 'speaker', allowNew: true },
+  parameters: { dark: true, msw: { handlers: conversationHandlers(() => []) } },
 }
 
 /** Speaker inbox — the subtle Active / Archived toggle (not a full tab bar). */

--- a/src/components/messaging/MessagesInbox.tsx
+++ b/src/components/messaging/MessagesInbox.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { PlusIcon } from '@heroicons/react/24/outline'
 import { api } from '@/lib/trpc/client'
 import type {
   ConversationListItem,
   ConversationView,
+  ConversationViewCounts,
 } from '@/lib/messaging/types'
 import { ConversationList } from './ConversationList'
 import { NewConversationForm } from './NewConversationForm'
@@ -14,11 +16,17 @@ import { NewConversationForm } from './NewConversationForm'
 /** Page size for the inbox (mirrors the server keyset page). */
 const PAGE_SIZE = 20
 
+/** The id of the list container, targeted by every tab's `aria-controls`. */
+const PANEL_ID = 'messages-conversation-panel'
+/** Deterministic per-tab id so the tabpanel can be `aria-labelledby` the tab. */
+const tabId = (view: ConversationView) => `messages-tab-${view}`
+
 /** Organizer inbox tabs. `all` is deliberately omitted from the UI (kept as a
  *  server capability); `active` is the default landing view. */
 const ORGANIZER_TABS: { view: ConversationView; label: string }[] = [
   { view: 'active', label: 'Active' },
   { view: 'needs-reply', label: 'Needs reply' },
+  { view: 'unassigned', label: 'Unassigned' },
   { view: 'mine', label: 'Mine' },
   { view: 'resolved', label: 'Resolved' },
   { view: 'archived', label: 'Archived' },
@@ -31,6 +39,30 @@ const SPEAKER_TABS: { view: ConversationView; label: string }[] = [
   { view: 'archived', label: 'Archived' },
 ]
 
+/** The count-badge value for a tab (undefined ⇒ no badge; zero is omitted). */
+function countForView(
+  view: ConversationView,
+  counts: ConversationViewCounts | undefined,
+): number | undefined {
+  if (!counts) return undefined
+  switch (view) {
+    case 'active':
+      return counts.active
+    case 'needs-reply':
+      return counts.needsReply
+    case 'unassigned':
+      return counts.unassigned
+    case 'mine':
+      return counts.mine
+    case 'resolved':
+      return counts.resolved
+    case 'archived':
+      return counts.archived
+    default:
+      return undefined
+  }
+}
+
 export interface MessagesInboxProps {
   /** The viewer's audience — drives per-row links and the inbox base path. */
   audience: 'speaker' | 'organizer'
@@ -38,41 +70,63 @@ export interface MessagesInboxProps {
   allowNew?: boolean
 }
 
+/** A small count badge shown after a tab label; omitted when the count is 0. */
+function TabCount({ count, active }: { count?: number; active: boolean }) {
+  if (!count || count <= 0) return null
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-semibold ${
+        active
+          ? 'bg-white/25 text-white'
+          : 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+      }`}
+    >
+      {count > 99 ? '99+' : count}
+    </span>
+  )
+}
+
 /**
  * Organizer view tabs: a horizontally scrollable row (no wrap, scrollbar hidden)
- * so the five tabs never crowd or reflow at 393px. Each tab is a 44px target and
- * exposes its selected state via `aria-current`.
+ * so the tabs never crowd or reflow at 393px. Each tab is a 44px target, exposes
+ * its selected state via `aria-selected`, and carries a per-view count badge.
  */
 function OrganizerViewTabs({
   view,
+  counts,
   onChange,
 }: {
   view: ConversationView
+  counts: ConversationViewCounts | undefined
   onChange: (view: ConversationView) => void
 }) {
   return (
     <div
       role="tablist"
       aria-label="Filter conversations"
-      className="no-scrollbar -mx-1 flex gap-1 overflow-x-auto px-1"
+      className="no-scrollbar flex flex-1 gap-1 overflow-x-auto"
     >
       {ORGANIZER_TABS.map((tab) => {
         const active = tab.view === view
+        const count = countForView(tab.view, counts)
         return (
           <button
             key={tab.view}
+            id={tabId(tab.view)}
             type="button"
             role="tab"
             aria-selected={active}
-            aria-current={active ? 'page' : undefined}
+            aria-controls={PANEL_ID}
             onClick={() => onChange(tab.view)}
-            className={`inline-flex min-h-[44px] shrink-0 items-center rounded-lg px-3 text-sm font-medium whitespace-nowrap transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue ${
+            className={`inline-flex min-h-[44px] shrink-0 items-center gap-1.5 rounded-lg px-3 text-sm font-medium whitespace-nowrap transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue ${
               active
                 ? 'bg-brand-cloud-blue text-white dark:bg-blue-600'
                 : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
             }`}
           >
             {tab.label}
+            <TabCount count={count} active={active} />
           </button>
         )
       })}
@@ -102,10 +156,11 @@ function SpeakerViewToggle({
         return (
           <button
             key={tab.view}
+            id={tabId(tab.view)}
             type="button"
             role="tab"
             aria-selected={active}
-            aria-current={active ? 'page' : undefined}
+            aria-controls={PANEL_ID}
             onClick={() => onChange(tab.view)}
             className={`inline-flex min-h-[44px] items-center rounded-md px-4 text-sm font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue ${
               active
@@ -125,9 +180,11 @@ function SpeakerViewToggle({
  * Inbox container for both audiences: loads the caller's conversations and
  * renders {@link ConversationList}. A view tab bar (organizer) / toggle
  * (speaker) drives the `listConversations` `view` input — switching views swaps
- * the query key so each view fetches fresh. When `allowNew` is set a
- * {@link NewConversationForm} opens a general thread — speakers with the
- * organizers; organizers with a chosen recipient speaker.
+ * the query key so each view fetches fresh. The selected view is persisted in
+ * the `?view=` query string (V1i) so back-navigation restores it; the default
+ * `active` omits the param. When `allowNew` is set a {@link NewConversationForm}
+ * opens a general thread — speakers with the organizers; organizers with a
+ * chosen recipient speaker.
  */
 export function MessagesInbox({
   audience,
@@ -136,11 +193,57 @@ export function MessagesInbox({
   const isOrganizer = audience === 'organizer'
   const basePath = isOrganizer ? '/admin/messages' : '/cfp/messages'
   const [showNew, setShowNew] = useState(false)
-  const [view, setView] = useState<ConversationView>('active')
+
+  // The selected view is persisted in the URL (`?view=`) so it survives
+  // back/forward navigation. Local state drives the immediate switch; the URL is
+  // written alongside, and an effect syncs the state back when the URL changes
+  // out from under us (browser back/forward). Any value not valid for this
+  // audience falls back to `active`.
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const tabs = isOrganizer ? ORGANIZER_TABS : SPEAKER_TABS
+  const paramView = searchParams.get('view')
+  const urlView: ConversationView =
+    paramView && tabs.some((t) => t.view === paramView)
+      ? (paramView as ConversationView)
+      : 'active'
+  const [view, setLocalView] = useState<ConversationView>(urlView)
+
+  // Restore the view from the URL when it changes independently of a tab click
+  // (browser back/forward). Adjusting state DURING render — React's endorsed
+  // "you might not need an effect" pattern — keeps the switch in sync without an
+  // effect's extra commit; a tab click sets both local state and the URL, so the
+  // two agree and this branch is a no-op.
+  const [prevUrlView, setPrevUrlView] = useState<ConversationView>(urlView)
+  if (urlView !== prevUrlView) {
+    setPrevUrlView(urlView)
+    setLocalView(urlView)
+  }
+
+  const setView = useCallback(
+    (next: ConversationView) => {
+      setLocalView(next)
+      const params = new URLSearchParams(searchParams.toString())
+      // Default `active` is the canonical no-param state.
+      if (next === 'active') params.delete('view')
+      else params.set('view', next)
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [router, pathname, searchParams],
+  )
+
   // The viewer's own speaker id drives the rows' "You: " snippet prefix.
   const { data: session } = useSession()
   const callerId = session?.speaker?._id
   const utils = api.useUtils()
+
+  // Per-view conversation counts for the tab badges (one bounded round trip,
+  // fetched alongside the first inbox page, not polled hot).
+  const { data: viewCounts } = api.message.viewCounts.useQuery(undefined, {
+    staleTime: 30_000,
+  })
 
   const {
     data,
@@ -192,20 +295,29 @@ export function MessagesInbox({
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      {/* SINGLE-ROW toolbar (V1b): the view tabs flex and scroll; the compact
+          "New" button is pinned to the right and never wraps below them. */}
+      <div className="flex items-center gap-2">
         {isOrganizer ? (
-          <OrganizerViewTabs view={view} onChange={setView} />
+          <OrganizerViewTabs
+            view={view}
+            counts={viewCounts}
+            onChange={setView}
+          />
         ) : (
-          <SpeakerViewToggle view={view} onChange={setView} />
+          <div className="min-w-0 flex-1">
+            <SpeakerViewToggle view={view} onChange={setView} />
+          </div>
         )}
         {allowNew && !showNew && (
           <button
             type="button"
             onClick={() => setShowNew(true)}
-            className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:bg-blue-600 dark:hover:bg-blue-500"
+            className="inline-flex min-h-[44px] shrink-0 items-center gap-1.5 rounded-lg bg-brand-cloud-blue px-3 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:bg-blue-600 dark:hover:bg-blue-500"
           >
             <PlusIcon className="h-4 w-4" aria-hidden="true" />
-            New conversation
+            <span className="hidden sm:inline">New conversation</span>
+            <span className="sm:hidden">New</span>
           </button>
         )}
       </div>
@@ -225,12 +337,16 @@ export function MessagesInbox({
         items={items}
         isOrganizer={isOrganizer}
         callerId={callerId}
+        view={view}
         isLoading={isLoading}
         isError={isError}
         hasMore={hasNextPage}
         onShowMore={() => fetchNextPage()}
         isLoadingMore={isFetchingNextPage}
         onUnarchive={isArchivedView ? handleUnarchive : undefined}
+        onNewConversation={allowNew ? () => setShowNew(true) : undefined}
+        panelId={PANEL_ID}
+        labelledById={tabId(view)}
       />
     </div>
   )

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -26,6 +26,21 @@ export function NotificationBell() {
   })
   const unreadCount = data ?? 0
 
+  // The newest notification's title, for the rising-count toast (V1l). A small
+  // dedicated query (one row) polled on the SAME cadence as the count — the
+  // cheapest correct source; the panel's own list query is a separate key that
+  // only exists while the panel is open, so we don't rely on it. When no title
+  // is available the toast falls back to the generic copy below.
+  const { data: latest } = api.notification.list.useQuery(
+    { limit: 1 },
+    {
+      refetchInterval: 30_000,
+      refetchOnWindowFocus: true,
+      staleTime: 10_000,
+    },
+  )
+  const newestTitle = latest?.[0]?.title
+
   // Bridge a rising unread count to the ephemeral toast system so a live
   // notification surfaces even when the bell is closed. `useNotificationSafe`
   // returns `undefined` (rather than throwing) if the toast provider isn't
@@ -53,14 +68,16 @@ export function NotificationBell() {
       const delta = unreadCount - prev
       notify?.showNotification({
         type: 'info',
-        title: 'You have new notifications',
+        // Carry the newest notification's own title when we have it (V1l), so the
+        // toast previews the actual event; fall back to the generic headline.
+        title: newestTitle || 'You have new notifications',
         message:
           delta === 1
             ? 'You have 1 new notification.'
             : `You have ${delta} new notifications.`,
       })
     }
-  }, [isSuccess, unreadCount, isImpersonating, notify])
+  }, [isSuccess, unreadCount, isImpersonating, notify, newestTitle])
 
   const hasUnread = unreadCount > 0
   const badgeLabel = unreadCount > 9 ? '9+' : String(unreadCount)

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -25,6 +25,20 @@ const makeItems = (): NotificationItem[] => [
     actor: { _id: 'a3', name: 'Maria Jensen' },
   },
   {
+    // DIRECT-THREAD IDENTITY on the hub (V1a): a collapsed message notification
+    // for an organizer-initiated thread that personally addresses the recipient
+    // — the "Direct message" title carries the distinction, so the panel needs
+    // no extra styling; this row verifies it renders and reads well.
+    id: 'notification.message.conversation.gen-42.sp-1',
+    type: 'message_received',
+    title: 'Direct message from Ola Organizer',
+    message: 'Quick question about your travel dates before we book.',
+    link: '/cfp/messages/conversation.gen-42',
+    readAt: null,
+    createdAt: minutesAgo(2),
+    actor: { _id: 'a4', name: 'Ola Organizer' },
+  },
+  {
     id: '1',
     type: 'proposal_status_changed',
     title: 'Your proposal was accepted',

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -118,11 +118,13 @@ export async function notifyNewMessage({
     // FIRST-CONTACT detection (S9c): a SPEAKER recipient gets a warmer subject +
     // body ONLY when this is the thread's FIRST message AND an organizer authored
     // it (an organizer reaching out). Cheap count() — one message ⇒ the one we
-    // just added ⇒ first. Only needed when an organizer authored (otherwise no
-    // speaker recipient qualifies for the warmer variant, and the org-contact
-    // copy keeps the standard form regardless).
+    // just added ⇒ first. Only the warmer SPEAKER-recipient variant consumes it,
+    // so skip the read entirely unless an organizer authored AND at least one
+    // recipient is a non-organizer (speaker) — on an organizer→organizer-only
+    // fan-out nothing could ever read `isFirstContact` (V1-r3a).
     let isFirstContact = false
-    if (authorIsOrganizer) {
+    const hasSpeakerRecipient = recipientIds.some((id) => !organizerSet.has(id))
+    if (authorIsOrganizer && hasSpeakerRecipient) {
       const messageCount = await clientReadUncached.fetch<number>(
         `count(*[_type == "message" && conversation._ref == $conversationId])`,
         { conversationId: conversation._id },

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -160,6 +160,11 @@ export function rawViewPredicate(
         predicate: `${active} && ${NEEDS_REPLY}`,
         needsOrganizerIds: true,
       }
+    case 'unassigned':
+      return {
+        predicate: `${active} && !defined(assignedTo)`,
+        needsOrganizerIds: false,
+      }
     case 'mine':
       return {
         predicate: `${active} && assignedTo._ref == $speakerId`,
@@ -452,7 +457,7 @@ export async function listConversationsForSpeaker({
     createdAt,
     lastMessageAt,
     "status": coalesce(status, 'open'),
-    "assignedTo": assignedTo->{ _id, name },
+    "assignedTo": assignedTo->{ _id, name, "image": coalesce(image.asset->url, imageURL) },
     archivedAt,
     "lastMessage": *[_type == "message" && conversation._ref == ^._id] | order(createdAt desc) [0] {
       "authorId": author._ref,
@@ -513,9 +518,13 @@ export async function listConversationsForSpeaker({
       { cache: 'no-store' },
     ),
     clientReadUncached.fetch<
-      { conversationId: string | null; archivedAt: string | null }[]
+      {
+        conversationId: string | null
+        archivedAt: string | null
+        muted: boolean | null
+      }[]
     >(
-      `*[_type == "conversationPreference" && _id in $prefIds]{ "conversationId": conversation._ref, archivedAt }`,
+      `*[_type == "conversationPreference" && _id in $prefIds]{ "conversationId": conversation._ref, archivedAt, muted }`,
       { prefIds },
       { cache: 'no-store' },
     ),
@@ -532,9 +541,14 @@ export async function listConversationsForSpeaker({
   }
   // Per-user archive timestamp keyed by conversation id (null archivedAt ignored).
   const prefArchivedAt = new Map<string, string>()
+  // The caller's mute preference keyed by conversation id (V1g row mute glyph).
+  const prefMuted = new Map<string, boolean>()
   for (const pref of prefRows ?? []) {
     if (pref.conversationId && pref.archivedAt) {
       prefArchivedAt.set(pref.conversationId, pref.archivedAt)
+    }
+    if (pref.conversationId && pref.muted) {
+      prefMuted.set(pref.conversationId, true)
     }
   }
 
@@ -598,10 +612,15 @@ export async function listConversationsForSpeaker({
       counterpart: resolveCounterpart(row, isOrganizer, organizerSet),
       status: row.status,
       assignedTo: row.assignedTo
-        ? { _id: row.assignedTo._id, name: row.assignedTo.name }
+        ? {
+            _id: row.assignedTo._id,
+            name: row.assignedTo.name,
+            image: row.assignedTo.image ?? undefined,
+          }
         : null,
       needsReply,
       archived,
+      muted: prefMuted.get(row._id) ?? false,
       direct,
     }
   })
@@ -631,6 +650,7 @@ type RawConversationRow = Omit<
   | 'assignedTo'
   | 'needsReply'
   | 'archived'
+  | 'muted'
   | 'subjectSpeakerId'
   | 'direct'
 > & {
@@ -647,7 +667,7 @@ type RawConversationRow = Omit<
   // GROQ coalesces `status` to 'open'; `assignedTo`/`archivedAt` are null when
   // unset (or, for a weak assignee ref, when the speaker was erased).
   status: ConversationStatus
-  assignedTo: { _id: string; name: string } | null
+  assignedTo: { _id: string; name: string; image: string | null } | null
   archivedAt: string | null
 }
 
@@ -718,12 +738,13 @@ export async function getConversationViewCounts({
 
   // Build one `count()` field per relevant view from the shared predicates.
   const views: ConversationView[] = isOrganizer
-    ? ['active', 'needs-reply', 'mine', 'resolved', 'archived']
+    ? ['active', 'needs-reply', 'unassigned', 'mine', 'resolved', 'archived']
     : ['active', 'archived']
   // Stable field keys (the enum's hyphenated names aren't valid identifiers).
   const KEY: Record<string, keyof ConversationViewCounts> = {
     active: 'active',
     'needs-reply': 'needsReply',
+    unassigned: 'unassigned',
     mine: 'mine',
     resolved: 'resolved',
     archived: 'archived',
@@ -747,6 +768,7 @@ export async function getConversationViewCounts({
   }
   if (isOrganizer) {
     counts.needsReply = result?.needsReply ?? 0
+    counts.unassigned = result?.unassigned ?? 0
     counts.mine = result?.mine ?? 0
     counts.resolved = result?.resolved ?? 0
   }
@@ -971,18 +993,27 @@ export async function setConversationAssignee(
  * BOTH fields together (a cleared archive has no archiver). The `archiverId` ref
  * is WEAK so erasing a speaker (GDPR) doesn't orphan-block their deletion —
  * consistent with the other speaker refs on this doc.
+ *
+ * `archiverId` is required only when ARCHIVING (it records `archivedBy` for the
+ * "Archived for everyone by X" audit line, V1f); it is IGNORED — and may be
+ * omitted — when unarchiving, which clears both fields (V1-r3b). A cleared
+ * archive has no archiver, so there is nothing to attribute.
  */
 export async function setConversationArchived(
   conversationId: string,
   archived: boolean,
-  archiverId: string,
+  archiverId?: string,
 ): Promise<void> {
   if (archived) {
     await clientWrite
       .patch(conversationId)
       .set({
         archivedAt: new Date().toISOString(),
-        archivedBy: { ...createReference(archiverId), _weak: true },
+        // Attribute the archive when we know who did it; the ref is WEAK so a
+        // later GDPR erase of that organizer never orphan-blocks this doc.
+        ...(archiverId
+          ? { archivedBy: { ...createReference(archiverId), _weak: true } }
+          : {}),
       })
       .commit()
     return

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -25,6 +25,7 @@ export type ConversationStatus = 'open' | 'resolved'
  * - `active`      — status open (or absent) AND NOT globally archived AND NOT
  *                   per-user archived;
  * - `needs-reply` — active AND the last message's author is not an organizer;
+ * - `unassigned`  — active AND no organizer is assigned to follow up;
  * - `mine`        — active AND assigned to the caller;
  * - `resolved`    — status resolved AND not archived (neither global nor per-user);
  * - `archived`    — globally OR per-user archived;
@@ -37,7 +38,13 @@ export type ConversationStatus = 'open' | 'resolved'
  * - `all`      — everything.
  */
 export type ConversationView =
-  'active' | 'needs-reply' | 'mine' | 'resolved' | 'archived' | 'all'
+  | 'active'
+  | 'needs-reply'
+  | 'unassigned'
+  | 'mine'
+  | 'resolved'
+  | 'archived'
+  | 'all'
 
 /** The views a non-organizer (speaker) is allowed to request. */
 export const SPEAKER_ALLOWED_VIEWS: ConversationView[] = [
@@ -129,6 +136,12 @@ export interface ConversationCounterpart {
 export interface ConversationAssignee {
   _id: string
   name: string
+  /**
+   * The organizer's avatar URL when available (house
+   * `coalesce(image.asset->url, imageURL)` pattern); undefined falls back to
+   * initials in the assignee badge (S12 / V1k).
+   */
+  image?: string
 }
 
 /** A conversation as listed in an inbox. */
@@ -183,6 +196,13 @@ export interface ConversationListItem {
    * globally OR per-user archived; for a speaker, per-user archived only.
    */
   archived?: boolean
+  /**
+   * Whether the CALLER has muted this conversation (their per-user preference).
+   * Projected so the inbox row can surface a mute glyph (V1g) — a muted thread
+   * still appears in the list, it just receives no notifications on any channel.
+   * Absent/false when unmuted.
+   */
+  muted?: boolean
 }
 
 /**
@@ -194,6 +214,7 @@ export interface ConversationViewCounts {
   active: number
   archived: number
   needsReply?: number
+  unassigned?: number
   mine?: number
   resolved?: number
 }

--- a/src/server/schemas/message.ts
+++ b/src/server/schemas/message.ts
@@ -50,10 +50,18 @@ const cursor = z
 export const ListConversationsSchema = z.object({
   cursor,
   // Inbox view. ORGANIZERS may use any; the router rejects the organizer-only
-  // views (`needs-reply` | `mine` | `resolved`) for a non-organizer. Defaults to
-  // `active` in the data layer when omitted.
+  // views (`needs-reply` | `unassigned` | `mine` | `resolved`) for a
+  // non-organizer. Defaults to `active` in the data layer when omitted.
   view: z
-    .enum(['active', 'needs-reply', 'mine', 'resolved', 'archived', 'all'])
+    .enum([
+      'active',
+      'needs-reply',
+      'unassigned',
+      'mine',
+      'resolved',
+      'archived',
+      'all',
+    ])
     .optional(),
 })
 


### PR DESCRIPTION
## Messaging UX polish — batch V1

Follow-up UI polish on the merged messaging system (server prerequisites landed in #555). Territory: `src/components/messaging/*`, `src/components/notifications/*`, plus two sanctioned one-line server fixes. No touches to CFP profile, proposal pages, email templates, or docs.

### Tasks

- **V1a — Direct-thread identity.** Rows with server `direct: true` get a brand-blue left edge + a small "Direct" chip before the subject. Hub side verified: `NotificationList` renders "Direct message from …" titles (added a story row).
- **V1b — Single-row toolbar.** `MessagesInbox` merges the view tabs and the New button into one row: tabs `flex-1` scroll (scrollbar hidden), a compact `+ New` pinned right ("New conversation" ≥sm, "New" below). Speaker toggle gets the same treatment.
- **V1c — Tab counts + Unassigned.** `message.viewCounts` wired into the organizer tabs (badge per tab, zero omitted). Added an **Unassigned** view (`active && !defined(assignedTo)`) — narrow server touch: view union + predicate + counts + schema enum. Order: Active, Needs reply, Unassigned, Mine, Resolved, Archived.
- **V1d — Per-view empty states.** `ConversationList` gains view-aware empty copy. **Rider:** the speaker Active-view empty is an adoption pitch (headline + pitch line + New conversation CTA); speaker Archived stays "No archived conversations".
- **V1e — Honest NOT_FOUND.** The thread distinguishes NOT_FOUND ("This conversation doesn't exist or you don't have access." + audience-aware Back to Messages CTA, no composer) from transport errors (retry copy).
- **V1f — Archived-by banner.** Organizer thread header shows "Archived for everyone by <name>" with an adjacent Unarchive affordance when globally archived.
- **V1g — State visibility.** Mute glyph on muted inbox rows (narrow server touch: project the caller's `muted`); the Emails select is disabled while muted (title "Muted — no notifications of any kind"); the Default option reads "Default (see profile)" (global default not cheaply reachable client-side — see notes).
- **V1h — Speaker resolved copy.** Speaker Resolved chip reads "Closed by organizers"; a one-line thread note: "The organizers marked this conversation closed — replying reopens it."
- **V1i — View in URL.** The inbox view persists in `?view=` (restored on back-nav; default `active` omits the param). Pages wrapped in `<Suspense>` for `useSearchParams`.
- **V1j — Amber dot suppression.** The needs-reply dot is hidden when the current view is needs-reply.
- **V1k — Assignee avatar.** Uses the organizer's photo when available (narrow server touch: `image` in the `assignedTo` projection); the badge is hidden entirely in the Mine view.
- **V1l — Toast title.** The bell's rising-count toast carries the newest notification's title (cheapest correct source: a dedicated `list` limit-1 query), falling back to the generic copy. Toast-logic tests updated.

### Riders

- **V1-r1** — Unarchive button moved OUT of the row `<a>` (valid HTML: sibling overlay in a `relative` row container); tab/tabpanel aria wiring (`aria-controls` + `role=tabpanel`/`id`); overflow sheet closes after either archive action (Assign stays open).
- **V1-r2** — Keyboard focus-order test after the row restructure.
- **V1-r3** — Sanctioned server one-liners: (a) `notify.ts` first-contact `count()` only runs when an organizer authored AND a speaker recipient exists; (b) `setConversationArchived` `archiverId` is now optional/omitted on unarchive.

### Notes / deviations

- **V1g Default label:** the effective global email default (`messagingEmailDefault`) is not on the session token and adding it wasn't sanctioned, so the per-conversation Default option is labelled "Default (see profile)" rather than "(currently on/off)" — the documented fallback.
- **Narrow server touches taken** (all in sanctioned scope): `unassigned` view (V1c), row `muted` projection (V1g), `assignedTo.image` projection (V1k), plus the two V1-r3 one-liners.

### Verification

tsc, eslint, prettier, knip all clean. Full `vitest run` green (3256 passed, 5 skipped). Stories added/updated for every visual change and shot at 393px light+dark (direct identity, toolbar+counts, per-view/adoption empties, NOT_FOUND, archived banner, resolved note, muted glyph/emails) — all inspected, no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a large UX polish batch on the messaging system, touching the inbox, conversation list, conversation thread, and notification bell. No new data models are introduced — the changes wire existing server capabilities (direct flag, muted preference, assignedTo image) into visible UI and add a narrow set of new server predicates (unassigned view, view-count query, first-contact optimisation).

- **V1a–V1k inbox and thread polish:** direct-thread blue edge + chip, single-row toolbar with scrollable tabs, Unassigned view + count badges, per-view empty states (with adoption pitch for speaker Active), honest NOT_FOUND vs. transport-error distinction, archived-by banner with inline Unarchive, mute glyph + disabled email select, speaker "Closed by organizers" copy, URL-persisted `?view=` with Suspense boundary, needs-reply dot suppression, and assignee photo.
- **V1l — toast title:** a dedicated `notification.list` limit-1 query supplies the newest notification's title to the rising-count toast, falling back to generic copy; `newestTitle` added to the effect dependency array (safe — delta guard prevents spurious toasts).
- **V1-r1–V1-r3 riders:** Unarchive button moved to a sibling div (fixing button-in-anchor invalid HTML), ARIA tabpanel/aria-controls wiring, overflow sheet auto-closes after archive actions, and two server micro-fixes (first-contact count skipped without a speaker recipient; archiverId optional on unarchive).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the two findings are minor — an unused TRPC query for speakers and a relaxed function signature that could silently skip the archivedBy attribution if called incorrectly.

The change is wide (12 features, 19 files) but well-tested — 3256 tests green, stories added for every visual change. The structural fixes (button-outside-anchor, ARIA wiring) are solid and the URL-state pattern is idiomatic React. Two observations worth addressing before follow-up PRs add callers: the viewCounts query fires unnecessarily for speakers (wasted network call, trivially fixed), and making archiverId optional on setConversationArchived means the type system no longer enforces attribution when archiving — a silent audit-trail gap if any future caller omits it when archived === true.

src/components/messaging/MessagesInbox.tsx (unused viewCounts query for speakers) and src/lib/messaging/sanity.ts (optional archiverId guard).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/messaging/MessagesInbox.tsx | URL-persisted view state (V1i), single-row toolbar (V1b), tab counts with Unassigned (V1c); viewCounts query fires unconditionally for both audiences but is only wired to OrganizerViewTabs, so speaker sessions make an unused network call |
| src/components/messaging/ConversationList.tsx | Row restructured to div+Link sibling pattern (V1-r1) fixing button-in-anchor invalid HTML; direct identity, mute glyph, speaker closed copy, per-view empty states, and needs-reply dot suppression all look correct |
| src/components/messaging/ConversationThread.tsx | Honest NOT_FOUND state (V1e), archived-by banner (V1f), speaker resolved note (V1h), muted email-select disable (V1g), and overflow sheet auto-close (V1-r1) all appear correct |
| src/components/notifications/NotificationBell.tsx | Added a dedicated limit-1 notification.list query for the toast title (V1l); newestTitle in the effect dependency array is safe (delta guard prevents spurious toasts), but the two independent query timers mean the title shown may lag behind the count that triggered the toast |
| src/lib/messaging/sanity.ts | Unassigned view predicate added, assignedTo image projection and muted preference projection correct; setConversationArchived archiverId now optional per V1-r3b |
| src/lib/messaging/types.ts | unassigned added to ConversationView union, muted field added to ConversationListItem, image added to ConversationAssignee, unassigned added as optional to ConversationViewCounts — all consistent with the rest of the diff |
| src/lib/messaging/notify.ts | First-contact count() now skipped when no speaker recipient is in the fan-out set (V1-r3a) — correct optimisation |
| src/server/schemas/message.ts | unassigned added to the Zod view enum; schema comment updated to reflect the new organizer-only view list |
| src/app/(admin)/admin/messages/page.tsx | Suspense boundary added correctly around MessagesInbox to support useSearchParams without breaking static shell rendering |
| src/app/(cfp)/cfp/messages/page.tsx | Suspense boundary added to match the admin page pattern for useSearchParams support |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant MessagesInbox
    participant URL as URL (?view=)
    participant TRPC_list as TRPC listConversations
    participant TRPC_counts as TRPC viewCounts
    participant NotificationBell
    participant TRPC_unread as TRPC unreadCount
    participant TRPC_title as TRPC notification.list (limit 1)
    participant Toast

    User->>MessagesInbox: Land on /messages
    MessagesInbox->>URL: "Read ?view= param (default: active)"
    MessagesInbox->>TRPC_list: listConversations(view)
    MessagesInbox->>TRPC_counts: viewCounts() [organizer only]
    TRPC_list-->>MessagesInbox: ConversationListItems
    TRPC_counts-->>MessagesInbox: "{active, needsReply, unassigned, mine, resolved, archived}"
    MessagesInbox-->>User: Render tab bar with count badges + ConversationList

    User->>MessagesInbox: Click tab (Unassigned)
    MessagesInbox->>URL: "router.replace(?view=unassigned)"
    MessagesInbox->>TRPC_list: "listConversations(view=unassigned)"
    TRPC_list-->>MessagesInbox: filtered items
    MessagesInbox-->>User: Re-render ConversationList

    User->>User: Navigate away and back
    URL-->>MessagesInbox: "?view=unassigned restored"
    MessagesInbox->>TRPC_list: "listConversations(view=unassigned)"

    Note over NotificationBell,Toast: V1l Toast title
    NotificationBell->>TRPC_unread: poll unreadCount
    NotificationBell->>TRPC_title: "poll notification.list limit=1"
    TRPC_unread-->>NotificationBell: count increases
    TRPC_title-->>NotificationBell: newestTitle
    NotificationBell->>Toast: "showNotification(title=newestTitle)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant MessagesInbox
    participant URL as URL (?view=)
    participant TRPC_list as TRPC listConversations
    participant TRPC_counts as TRPC viewCounts
    participant NotificationBell
    participant TRPC_unread as TRPC unreadCount
    participant TRPC_title as TRPC notification.list (limit 1)
    participant Toast

    User->>MessagesInbox: Land on /messages
    MessagesInbox->>URL: "Read ?view= param (default: active)"
    MessagesInbox->>TRPC_list: listConversations(view)
    MessagesInbox->>TRPC_counts: viewCounts() [organizer only]
    TRPC_list-->>MessagesInbox: ConversationListItems
    TRPC_counts-->>MessagesInbox: "{active, needsReply, unassigned, mine, resolved, archived}"
    MessagesInbox-->>User: Render tab bar with count badges + ConversationList

    User->>MessagesInbox: Click tab (Unassigned)
    MessagesInbox->>URL: "router.replace(?view=unassigned)"
    MessagesInbox->>TRPC_list: "listConversations(view=unassigned)"
    TRPC_list-->>MessagesInbox: filtered items
    MessagesInbox-->>User: Re-render ConversationList

    User->>User: Navigate away and back
    URL-->>MessagesInbox: "?view=unassigned restored"
    MessagesInbox->>TRPC_list: "listConversations(view=unassigned)"

    Note over NotificationBell,Toast: V1l Toast title
    NotificationBell->>TRPC_unread: poll unreadCount
    NotificationBell->>TRPC_title: "poll notification.list limit=1"
    TRPC_unread-->>NotificationBell: count increases
    TRPC_title-->>NotificationBell: newestTitle
    NotificationBell->>Toast: "showNotification(title=newestTitle)"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): UX polish — direct ident..."](https://github.com/cloudnativebergen/website/commit/578276d44ea076a180da03d98be46ce90501344e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45448032)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->