### PR TITLE
chore(messaging): final review nits from #556/#557 badges

### DIFF
--- a/src/components/cfp/NotSeeingTalksPrompt.tsx
+++ b/src/components/cfp/NotSeeingTalksPrompt.tsx
@@ -93,7 +93,7 @@ function Guidance({
         </h4>
         <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Contact the organizers and we&apos;ll merge your accounts for you
-          &mdash; by email or{' '}
+          &mdash; {contactEmail ? 'by email or ' : ''}
           <Link
             href="/cfp/messages"
             className="font-medium text-brand-cloud-blue hover:underline dark:text-blue-400"

--- a/src/components/email/BaseEmailTemplate.tsx
+++ b/src/components/email/BaseEmailTemplate.tsx
@@ -34,8 +34,17 @@ interface BaseEmailTemplateProps {
  * with a trailing slash). Normalise all three to `https://<domain>/cfp/messages`.
  */
 function messagesUrlFromEventUrl(eventUrl: string): string {
-  const domain = eventUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '')
-  return `https://${domain}/cfp/messages`
+  // Parse rather than regex-strip: an eventUrl carrying a path (or lacking a
+  // scheme) must still resolve to the bare origin's /cfp/messages.
+  try {
+    const url = new URL(
+      /^https?:\/\//.test(eventUrl) ? eventUrl : `https://${eventUrl}`,
+    )
+    return `${url.origin}/cfp/messages`
+  } catch {
+    const domain = eventUrl.replace(/^https?:\/\//, '').replace(/\/.*$/, '')
+    return `https://${domain}/cfp/messages`
+  }
 }
 
 export function BaseEmailTemplate({

--- a/src/components/messaging/MessagesInbox.tsx
+++ b/src/components/messaging/MessagesInbox.tsx
@@ -243,6 +243,9 @@ export function MessagesInbox({
   // fetched alongside the first inbox page, not polled hot).
   const { data: viewCounts } = api.message.viewCounts.useQuery(undefined, {
     staleTime: 30_000,
+    // Only the organizer tab bar renders count badges — don't spend the query
+    // on speakers, whose Active/Archived toggle shows none.
+    enabled: audience === 'organizer',
   })
 
   const {

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -1005,15 +1005,18 @@ export async function setConversationArchived(
   archiverId?: string,
 ): Promise<void> {
   if (archived) {
+    // The audit line ("Archived for everyone by X") depends on attribution —
+    // an anonymous archive must be a programming error, not a silent row.
+    if (!archiverId) {
+      throw new Error('setConversationArchived: archiverId required to archive')
+    }
     await clientWrite
       .patch(conversationId)
       .set({
         archivedAt: new Date().toISOString(),
-        // Attribute the archive when we know who did it; the ref is WEAK so a
-        // later GDPR erase of that organizer never orphan-blocks this doc.
-        ...(archiverId
-          ? { archivedBy: { ...createReference(archiverId), _weak: true } }
-          : {}),
+        // The ref is WEAK so a later GDPR erase of that organizer never
+        // orphan-blocks this doc.
+        archivedBy: { ...createReference(archiverId), _weak: true },
       })
       .commit()
     return


### PR DESCRIPTION
Four one-liners closing the last review badges of the messaging program:

1. NotSeeingTalksPrompt: 'by email or' only renders when a contactEmail exists.
2. BaseEmailTemplate: messages URL derived via URL parse (origin) instead of regex-stripping — an eventUrl with a path can no longer produce a malformed link.
3. MessagesInbox: viewCounts query gated to the organizer audience (speakers rendered no badges but paid the query).
4. setConversationArchived: archiving without an archiverId now throws — the 'Archived by X' audit line depends on attribution; anonymous archives were a silent programming-error path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Four targeted nits closing review badges from the messaging program — each change is narrow and self-contained with no new behaviour introduced.

- **NotSeeingTalksPrompt**: "by email or" text is now gated behind `contactEmail` so it no longer renders when no email is configured.
- **BaseEmailTemplate**: `messagesUrlFromEventUrl` switches from a regex strip to `new URL().origin`, correctly handling event URLs that carry a path segment; the fallback regex is also tightened to strip full paths rather than trailing slashes only.
- **MessagesInbox**: `viewCounts` query is disabled for the speaker audience, avoiding a round trip that produced no visible output.
- **setConversationArchived**: archiving without an `archiverId` now throws explicitly instead of silently writing a row with no attribution.

<h3>Confidence Score: 4/5</h3>

All four changes are small, well-scoped fixes with no regressions on the changed paths.

The archiving guard in sanity.ts now throws at runtime when archiverId is absent, but the TypeScript signature still types it as optional — call sites that forget to pass it will compile cleanly and fail only at runtime. The other three changes are clean and correct.

src/lib/messaging/sanity.ts — worth a second look to decide whether to add TypeScript overloads or leave the runtime guard as the sole protection.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/cfp/NotSeeingTalksPrompt.tsx | Guards 'by email or' text behind a contactEmail truthiness check — straightforward conditional rendering fix. |
| src/components/email/BaseEmailTemplate.tsx | Replaces brittle regex URL stripping with new URL() origin extraction; fallback regex also corrected to strip full paths rather than trailing slashes only. |
| src/components/messaging/MessagesInbox.tsx | Gates the viewCounts query behind audience === 'organizer'; should use the already-computed isOrganizer local for consistency. |
| src/lib/messaging/sanity.ts | Adds a runtime throw when archiving without an archiverId, removing the silent no-op path; archiverId remains typed as optional so the constraint is not enforced by TypeScript. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/messaging/sanity.ts`, line 1002-1011 ([link](https://github.com/cloudnativebergen/website/blob/70d4f2101630097134e10b08387ca39412ae7a73/src/lib/messaging/sanity.ts#L1002-L1011)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Runtime guard without compile-time enforcement**

   `archiverId` remains typed as `string | undefined`, so TypeScript will not flag a call like `setConversationArchived(id, true)` (no archiver), and the error surfaces only at runtime. Overloading the signature would catch this at the call site — the runtime throw is a solid safety net, but making the type conditional eliminates the entire class of mistake.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore(messaging): final review nits — co..."](https://github.com/cloudnativebergen/website/commit/70d4f2101630097134e10b08387ca39412ae7a73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45449776)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->