### PR TITLE
fix(messaging): canonical organizer definition (conference.organizers membership)

### DIFF
--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -437,7 +437,9 @@ describe('send — organizer-initiated general threads (subjectSpeaker)', () => 
     // (speaker.admin.search) offers them, and a narrower server check regressed
     // into "Speaker not found" for autocompleted organizers in prod.
     const standingQuery = standingFetch.mock.calls[0][0] as string
-    expect(standingQuery).toContain('isOrganizer == true')
+    expect(standingQuery).toContain(
+      '_id in *[_type == "conference"].organizers[]._ref',
+    )
     expect(standingQuery).toContain('conference._ref == $conferenceId')
 
     expect(standingFetch).toHaveBeenCalledWith(

--- a/__tests__/components/messaging/NewConversationForm.test.tsx
+++ b/__tests__/components/messaging/NewConversationForm.test.tsx
@@ -115,7 +115,7 @@ describe('NewConversationForm — organizer flow', () => {
       error: { data: { code: 'NOT_FOUND' } },
     }
     render(<NewConversationForm basePath="/admin/messages" requireRecipient />)
-    expect(screen.getByText(/speaker not found/i)).toBeInTheDocument()
+    expect(screen.getByText(/can't receive messages/i)).toBeInTheDocument()
     expect(screen.getByTestId('picker-invalid')).toBeInTheDocument()
     // The generic failure copy is suppressed in favour of the specific message.
     expect(
@@ -143,7 +143,7 @@ describe('NewConversationForm — organizer flow', () => {
       error: { data: { code: 'NOT_FOUND' } },
     }
     render(<NewConversationForm basePath="/admin/messages" requireRecipient />)
-    expect(screen.getByText(/speaker not found/i)).toBeInTheDocument()
+    expect(screen.getByText(/can't receive messages/i)).toBeInTheDocument()
 
     // Picking a DIFFERENT speaker must clear the stale NOT_FOUND.
     fireEvent.click(screen.getByTestId('pick-speaker'))

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -923,7 +923,7 @@ describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () 
     // Cached: only one underlying read despite two calls.
     expect(readMock.fetch).toHaveBeenCalledTimes(1)
     const [query] = readMock.fetch.mock.calls[0]
-    expect(query).toContain('isOrganizer == true')
+    expect(query).toContain('_id in *[_type == "conference"].organizers[]._ref')
     expect(query).toContain('[0...200]')
   })
 

--- a/src/components/messaging/NewConversationForm.tsx
+++ b/src/components/messaging/NewConversationForm.tsx
@@ -152,7 +152,9 @@ export function NewConversationForm({
               role="alert"
               className="mt-1 text-xs text-red-600 dark:text-red-400"
             >
-              Speaker not found. Pick another speaker.
+              This person can&apos;t receive messages: they have no proposal in
+              this conference and aren&apos;t an organizer. If that looks wrong,
+              check the conference&apos;s organizer list in settings.
             </p>
           )}
         </div>

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -649,10 +649,17 @@ let organizerCache: { ids: string[]; expiresAt: number } | null = null
 
 /**
  * The `_id`s of every organizer speaker (bounded to
- * [0...{@link ORGANIZER_FETCH_LIMIT}]). `isOrganizer` is GLOBAL (an organizer of
- * one edition is an organizer everywhere); the conference scoping happens
- * implicitly because the created notification carries the conference ref. Cached
- * per instance for {@link ORGANIZER_CACHE_TTL_MS} (see the note above). The
+ * [0...{@link ORGANIZER_FETCH_LIMIT}]). THE CANONICAL ORGANIZER DEFINITION is
+ * membership in ANY conference's `organizers[]` array — the same rule the auth
+ * session and the admin speaker picker derive `isOrganizer` from
+ * (src/lib/speaker/sanity.ts). The speaker schema has NO stored `isOrganizer`
+ * field: an earlier version of this query tested `isOrganizer == true`, which
+ * matched NOTHING in production — silently emptying the messaging fan-out's
+ * organizer recipients, needs-reply, standing checks, and assignee validation
+ * while organizers could still browse /admin via the session's DERIVED flag.
+ * Organizer-of-one-edition = organizer everywhere (matches auth). Conference
+ * scoping happens implicitly because the created notification carries the
+ * conference ref. Cached per instance for {@link ORGANIZER_CACHE_TTL_MS}. The
  * returned array is treated as read-only by callers (they wrap it in a Set).
  */
 export async function getOrganizerSpeakerIds(): Promise<string[]> {
@@ -667,7 +674,7 @@ export async function getOrganizerSpeakerIds(): Promise<string[]> {
   // empty result (`null`/`[]` — a conference with no organizers yet) IS a
   // success and is cached normally.
   const ids = await clientReadUncached.fetch<string[]>(
-    `*[_type == "speaker" && isOrganizer == true][0...${ORGANIZER_FETCH_LIMIT}]._id`,
+    `*[_type == "speaker" && _id in *[_type == "conference"].organizers[]._ref][0...${ORGANIZER_FETCH_LIMIT}]._id`,
   )
   const resolved = ids || []
   organizerCache = { ids: resolved, expiresAt: now + ORGANIZER_CACHE_TTL_MS }

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -94,19 +94,23 @@ function claimSendSlot(speakerId: string): boolean {
 
 /**
  * Does `speakerId` have standing in `conferenceId` — a proposal (talk) in that
- * conference OR the organizer flag? This MUST match the population the admin
+ * conference OR organizer status? This MUST match the population the admin
  * speaker picker offers (`speaker.admin.search` = confirmed/accepted speakers ∪
  * organizers): a stricter server check rejects recipients the UI legitimately
- * suggests — the prod bug where an autocompleted organizer (no talk this
- * edition) failed with "Speaker not found". Cross-conference targeting stays
- * blocked: a talk-less non-organizer from another edition has no standing here.
+ * suggests. THE ORGANIZER CLAUSE USES THE CANONICAL DEFINITION — membership in
+ * a conference's `organizers[]` array, the same rule the session and the picker
+ * derive from. (The speaker schema has NO stored `isOrganizer` field: a prior
+ * version tested `isOrganizer == true`, which matches nothing in production and
+ * kept rejecting picker-offered organizers with "Speaker not found".)
+ * Cross-conference targeting stays blocked: a talk-less non-organizer from
+ * another edition has no standing here.
  */
 async function speakerHasStandingInConference(
   speakerId: string,
   conferenceId: string,
 ): Promise<boolean> {
   const id = await clientReadUncached.fetch<string | null>(
-    `*[_type == "speaker" && _id == $speakerId && (isOrganizer == true || count(*[_type == "talk" && conference._ref == $conferenceId && ^._id in speakers[]._ref]) > 0)][0]._id`,
+    `*[_type == "speaker" && _id == $speakerId && (_id in *[_type == "conference"].organizers[]._ref || count(*[_type == "talk" && conference._ref == $conferenceId && ^._id in speakers[]._ref]) > 0)][0]._id`,
     { speakerId, conferenceId },
     { cache: 'no-store' },
   )


### PR DESCRIPTION
Maintainer-reported (second occurrence): sending to an organizer without a talk still failed with 'Speaker not found'.

Root cause is systemic, not the picker: the repo has TWO organizer definitions. The auth session and the admin speaker picker DERIVE isOrganizer from membership in `conference.organizers[]` (src/lib/speaker/sanity.ts:19,752) — but messaging's `getOrganizerSpeakerIds` and the #550 standing check queried a stored `isOrganizer == true` field **that does not exist in the speaker schema**. That query matches nothing, so in production the messaging fan-out's organizer recipient set, needs-reply derivation, assignee validation, and recipient standing were all running on an EMPTY organizer set — masked because organizers still browse /admin via the session's derived flag, and self-authored tests are actor-excluded.

Fix: both GROQ sites now use the canonical membership predicate (`_id in *[_type == "conference"].organizers[]._ref`), matching auth exactly; organizer-of-any-edition = organizer everywhere (auth's existing semantics). Query-shape test assertions updated to pin the canonical form. Also: the recipient error copy now explains the actual condition instead of 'Speaker not found. Pick another speaker.'

Post-merge verification worth doing in prod: (1) send to a talk-less organizer — should now work; (2) have a speaker-authored message arrive as hub/push for an organizer who didn't author it — this path was silently dead.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a longstanding silent data bug where two GROQ queries in the messaging system checked `isOrganizer == true` against a field that does not exist in the speaker schema, causing the organizer recipient set, needs-reply derivation, standing validation, and assignee checks to always operate on an empty result. Both sites now use the canonical membership predicate (`_id in *[_type == "conference"].organizers[]._ref`), matching the auth session and admin speaker picker exactly.

- **`src/lib/notification/sanity.ts`** (`getOrganizerSpeakerIds`): fixes the fan-out organizer lookup that has been returning an empty set in production since the `isOrganizer` field was removed from the speaker schema.
- **`src/server/routers/message.ts`** (`speakerHasStandingInConference`): fixes the standing check so organizers without a talk in the current edition are no longer rejected as "Speaker not found."
- **`src/components/messaging/NewConversationForm.tsx`**: improves the error copy from the generic "Speaker not found. Pick another speaker." to a description that explains the actual condition and points admins toward the organizer list in settings.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both query sites now use the same membership predicate as the auth session, closing the silent empty-organizer-set bug that was masking delivery failures in production.

The two changed GROQ queries are a straightforward predicate swap from a non-existent stored field to the canonical join expression already used by the auth layer. The fix is self-consistent: both fan-out and standing-check now agree on what 'organizer' means, and the tests pin the exact query shape. The cross-conference semantics (organizer of any edition = organizer everywhere) are intentional, explicitly documented, and already reflected in the auth session — no new semantic surface is introduced. The error-copy change is additive and accurate.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/notification/sanity.ts | Fixes getOrganizerSpeakerIds GROQ query from the non-existent isOrganizer == true to the canonical conference membership predicate; comment is thorough and accurate. |
| src/server/routers/message.ts | Fixes speakerHasStandingInConference GROQ query to use canonical organizer membership predicate; cross-conference organizer semantics are intentional and match auth. |
| src/components/messaging/NewConversationForm.tsx | Error message copy updated to describe the actual condition (no proposal + not an organizer) instead of the generic 'Speaker not found.' |
| __tests__/api/trpc/message.test.ts | Standing query shape assertion updated to pin the canonical organizer membership predicate; test intent remains correct. |
| __tests__/lib/notification/sanity.test.ts | getOrganizerSpeakerIds query shape assertion updated to pin the canonical organizer membership predicate. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): canonical organizer defi..."](https://github.com/cloudnativebergen/website/commit/459b1683e06215a056f41b798a56c5a9a7efb9c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45456723)</sub>

<!-- /greptile_comment -->