### PR TITLE
fix(messaging): no dead scroll on standalone thread pages

### DIFF
--- a/src/app/(admin)/admin/messages/[id]/page.tsx
+++ b/src/app/(admin)/admin/messages/[id]/page.tsx
@@ -27,9 +27,12 @@ export default async function AdminConversationPage({
   }
 
   return (
-    // dvh-bounded column so the composer stays pinned above the iOS PWA
-    // keyboard: the message list flexes and scrolls, the composer does not.
-    <div className="mx-auto flex h-[100dvh] max-w-3xl flex-col p-4">
+    // Content-sized column: the card hugs its content and the LIST caps its own
+    // height (max-h in ConversationThread's standalone mode), so long threads
+    // scroll internally WITHOUT the page claiming a full viewport inside the
+    // dashboard shell — an h-[100dvh] wrapper here stacked on the shell's chrome
+    // and produced ~200px of dead scroll below the card.
+    <div className="mx-auto max-w-3xl p-4">
       <div className="mb-4 shrink-0">
         <BackLink fallbackUrl="/admin/messages">Back to Messages</BackLink>
       </div>

--- a/src/app/(cfp)/cfp/messages/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/messages/[id]/page.tsx
@@ -26,9 +26,12 @@ export default async function CfpConversationPage({
   }
 
   return (
-    // dvh-bounded column so the composer stays pinned above the iOS PWA
-    // keyboard: the message list flexes and scrolls, the composer does not.
-    <div className="mx-auto flex h-[100dvh] max-w-3xl flex-col">
+    // Content-sized column: the card hugs its content and the LIST caps its own
+    // height (max-h in ConversationThread's standalone mode), so long threads
+    // scroll internally WITHOUT the page claiming a full viewport inside the
+    // dashboard shell — an h-[100dvh] wrapper here stacked on the shell's chrome
+    // and produced ~200px of dead scroll below the card.
+    <div className="mx-auto max-w-3xl">
       <div className="mb-4 shrink-0">
         <BackLink fallbackUrl="/cfp/messages">Back to Messages</BackLink>
       </div>

--- a/src/components/messaging/ConversationThread.stories.tsx
+++ b/src/components/messaging/ConversationThread.stories.tsx
@@ -342,10 +342,9 @@ export const SpeakerArchiveAffordanceDark: Story = {
 
 /**
  * The standalone thread page layout (fillHeight) with a SHORT thread: the card
- * must size to its content — composer directly under the last message — and
- * NOT stretch to fill the viewport-height container (the maintainer-reported
- * "unnecessarily high" regression). The wrapper mimics the message pages'
- * h-[100dvh] column at a fixed capture height.
+ * sizes to content: composer directly under the last message, no stretched
+ * card and no dead scroll below it (the standalone pages no longer claim
+ * viewport height inside the shell).
  */
 export const FillHeightShortThread: Story = {
   args: {
@@ -355,7 +354,7 @@ export const FillHeightShortThread: Story = {
     fillHeight: true,
   },
   render: (args) => (
-    <div className="flex h-[760px] flex-col">
+    <div>
       <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
         <ConversationThreadView
           {...args}
@@ -378,7 +377,7 @@ export const FillHeightLongThread: Story = {
     fillHeight: true,
   },
   render: (args) => (
-    <div className="flex h-[760px] flex-col">
+    <div>
       <div className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
         <ConversationThreadView {...args} messages={makeLongHistory()} />
       </div>

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -688,11 +688,12 @@ export function ConversationThreadView({
     <div
       role="region"
       aria-label={subject ? `Conversation: ${subject}` : 'Conversation'}
-      // fillHeight sizes to CONTENT and only SHRINKS (list scrolls) when the
-      // thread exceeds the viewport — never grows, so a short thread keeps the
-      // composer right under the last message instead of pinned to the bottom
-      // of a stretched card.
-      className={fillHeight ? 'flex min-h-0 flex-col' : 'flex flex-col'}
+      // Standalone (fillHeight) sizes to CONTENT with the LIST capping its own
+      // height (max-h below) — a short thread keeps the composer right under the
+      // last message, a long thread scrolls the list internally, and the page
+      // never claims viewport height inside the shell (which stacked on the
+      // shell's chrome and produced dead scroll below the card).
+      className="flex flex-col"
     >
       {(subject || onSetMuted || onSetStatus) && (
         <div className="flex shrink-0 items-center justify-between gap-3 border-b border-gray-200 pb-3 dark:border-gray-700">
@@ -793,7 +794,13 @@ export function ConversationThreadView({
         ref={scrollRef}
         onScroll={handleScroll}
         className={`space-y-3 overflow-y-auto overscroll-contain py-4 ${
-          fillHeight ? 'min-h-[8rem] shrink' : 'max-h-[60vh] min-h-[8rem]'
+          // Standalone gets a taller cap than the proposal embed: the page is
+          // dedicated to the thread, but the cap (not a viewport-filling flex
+          // chain) is what keeps composer + header on screen with no dead
+          // scroll under the dashboard shell's chrome.
+          fillHeight
+            ? 'max-h-[65dvh] min-h-[8rem]'
+            : 'max-h-[60vh] min-h-[8rem]'
         }`}
       >
         {isLoading ? (


### PR DESCRIPTION
Maintainer-reported (screenshot): the thread page scrolled ~200px into emptiness below the card.

Cause: the standalone pages wrapped the thread in an h-[100dvh] column INSIDE the dashboard shell — full viewport height stacked on the shell's top bar and padding, so document height exceeded the viewport by exactly the chrome height.

Fix: the page no longer claims viewport height at all. The card stays content-sized (#547) and the LIST caps itself (max-h-[65dvh] in standalone mode vs 60vh in the proposal embed) — long threads scroll internally with the composer always visible, short threads end where their content ends, and there is nothing below the card to scroll to. Stories updated to mirror the new structure; shoot-verified both regimes at 393px.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes dead scroll on standalone thread pages caused by wrapping `ConversationThread` in an `h-[100dvh]` column *inside* the dashboard shell — the shell's own chrome height pushed total document height past the viewport, producing ~200 px of empty scrollable space below the card.

- The `h-[100dvh] flex flex-col` wrapper is removed from both standalone page routes; the card becomes content-sized and the message list manages its own scroll cap (`max-h-[65dvh]` in standalone, `max-h-[60vh]` in embed).
- `ConversationThread`'s outer `div` class is simplified from a `fillHeight`-conditional to an unconditional `flex flex-col`; the `fillHeight` prop now only influences the list's `max-h` value.
- Storybook stories for `FillHeightShortThread` and `FillHeightLongThread` drop their fixed-height wrapper to mirror the new page structure.

<h3>Confidence Score: 4/5</h3>

The fix correctly removes the viewport-height wrapper that was causing dead scroll inside the dashboard shell. The only residual issue is a handful of orphaned Tailwind flex utilities left on elements that are no longer flex children.

The layout change is well-reasoned and the root cause clearly identified. Residual `min-h-0` and `shrink-0` utilities in both page files are harmless no-ops in their new block context but add noise to the class lists.

Both page files (admin/messages/[id]/page.tsx and cfp/messages/[id]/page.tsx) carry orphaned flex utilities worth cleaning up.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/(admin)/admin/messages/[id]/page.tsx | Removes h-[100dvh] flex wrapper; outer div is now a plain block. Child div retains min-h-0 and shrink-0 which are no-ops outside a flex parent. |
| src/app/(cfp)/cfp/messages/[id]/page.tsx | Same h-[100dvh] removal as the admin page; residual min-h-0 / shrink-0 on children are also now orphaned flex utilities. |
| src/components/messaging/ConversationThread.tsx | Root div class simplified to unconditional flex flex-col; list scrolling now uses max-h-[65dvh] in standalone vs max-h-[60vh] in embed — clean and correct. |
| src/components/messaging/ConversationThread.stories.tsx | Fixed-height Storybook wrappers removed to match the new content-sized page structure; stories now accurately reflect the shell-free layout. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Dashboard Shell\n(top bar + padding)"] --> B["Page wrapper\n(before: h-[100dvh] flex flex-col\nafter: plain block)"]
    B --> C["BackLink"]
    B --> D["Card div\n(flex flex-col overflow-hidden)"]
    D --> E["ConversationThread\n(flex flex-col)"]
    E --> F["Header / controls\n(shrink-0)"]
    E --> G["Message list\nstandalone: max-h-[65dvh]\nembed: max-h-[60vh]"]
    E --> H["Composer\n(shrink-0)"]

    style A fill:#f3f4f6,stroke:#9ca3af
    style B fill:#fef9c3,stroke:#ca8a04
    style G fill:#dcfce7,stroke:#16a34a
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Dashboard Shell\n(top bar + padding)"] --> B["Page wrapper\n(before: h-[100dvh] flex flex-col\nafter: plain block)"]
    B --> C["BackLink"]
    B --> D["Card div\n(flex flex-col overflow-hidden)"]
    D --> E["ConversationThread\n(flex flex-col)"]
    E --> F["Header / controls\n(shrink-0)"]
    E --> G["Message list\nstandalone: max-h-[65dvh]\nembed: max-h-[60vh]"]
    E --> H["Composer\n(shrink-0)"]

    style A fill:#f3f4f6,stroke:#9ca3af
    style B fill:#fef9c3,stroke:#ca8a04
    style G fill:#dcfce7,stroke:#16a34a
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/app/(admin)/admin/messages/[id]/page.tsx`, line 35-40 ([link](https://github.com/cloudnativebergen/website/blob/2a41d65d2e32674455b7d1493702c4eb023ac1d5/src/app/(admin)/admin/messages/[id]/page.tsx#L35-L40)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> With the outer `flex h-[100dvh] flex-col` wrapper removed, the card `div` is now a plain block child rather than a flex item. `min-h-0` and `shrink-0` on its direct children only take effect inside a flex container, so they are now no-ops. The same pattern appears in the CFP page.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `src/app/(cfp)/cfp/messages/[id]/page.tsx`, line 34-39 ([link](https://github.com/cloudnativebergen/website/blob/2a41d65d2e32674455b7d1493702c4eb023ac1d5/src/app/(cfp)/cfp/messages/[id]/page.tsx#L34-L39)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same as the admin page: with the outer flex container gone, `min-h-0` on the card and `shrink-0` on the BackLink wrapper are orphaned flex utilities that have no effect in a block context.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): no dead scroll on standa..."](https://github.com/cloudnativebergen/website/commit/2a41d65d2e32674455b7d1493702c4eb023ac1d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45465899)</sub>

<!-- /greptile_comment -->