### PR TITLE
feat(workshop): participant announcements broadcast rail

### DIFF
--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -27,6 +27,7 @@ import travelSupport from './schemaTypes/travelSupport'
 import travelExpense from './schemaTypes/travelExpense'
 import volunteer from './schemaTypes/volunteer'
 import workshopSignup from './schemaTypes/workshopSignup'
+import workshopAnnouncement from './schemaTypes/workshopAnnouncement'
 import staff from './schemaTypes/staff'
 
 export const schema: { types: SchemaTypeDefinition[] } = {
@@ -54,6 +55,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     topic,
     review,
     workshopSignup,
+    workshopAnnouncement,
 
     // Speakers
     speaker,

--- a/sanity/schemaTypes/workshopAnnouncement.ts
+++ b/sanity/schemaTypes/workshopAnnouncement.ts
@@ -1,0 +1,108 @@
+import { defineField, defineType } from 'sanity'
+
+/**
+ * A one-way broadcast from a workshop owner (a `talk` speaker) or an organizer
+ * to the workshop's CONFIRMED participants. Announcements are emailed on create
+ * (fan-out lives in the `workshop.announce` mutation) AND rendered on the
+ * workshop page. There are deliberately NO threads and NO participant replies:
+ * participants are WorkOS attendees (id strings), not speaker docs, so there is
+ * no authenticated identity to attribute a reply to. See the broadcast rail.
+ */
+export default defineType({
+  name: 'workshopAnnouncement',
+  title: 'Workshop Announcement',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'workshop',
+      title: 'Workshop',
+      type: 'reference',
+      to: [{ type: 'talk' }],
+      // Mirrors workshopSignup's workshop validation: the reference must resolve
+      // to a talk in a workshop format, so a broadcast can never target a normal
+      // session.
+      validation: (Rule) => [
+        Rule.required().error('Workshop reference is required'),
+        Rule.custom(async (value, context) => {
+          if (!value?._ref) return true
+          const client = context.getClient({ apiVersion: '2024-01-01' })
+          const workshop = await client.fetch(
+            `*[_type == "talk" && _id == $id][0]`,
+            { id: value._ref },
+          )
+          if (!workshop) return 'Workshop not found'
+          if (!['workshop_120', 'workshop_240'].includes(workshop.format)) {
+            return 'Referenced talk must be a workshop format'
+          }
+          return true
+        }),
+      ],
+    }),
+
+    defineField({
+      name: 'conference',
+      title: 'Conference',
+      type: 'reference',
+      to: [{ type: 'conference' }],
+      validation: (Rule) =>
+        Rule.required().error('Conference reference is required'),
+    }),
+
+    defineField({
+      name: 'author',
+      title: 'Author',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      // WEAK reference (GDPR house rule): if the authoring speaker is later
+      // erased, the announcement survives without a dangling strong ref — the
+      // page just shows a generic author name.
+      weak: true,
+      validation: (Rule) => Rule.required().error('Author is required'),
+    }),
+
+    defineField({
+      name: 'body',
+      title: 'Message',
+      type: 'text',
+      rows: 6,
+      validation: (Rule) => [
+        Rule.required().error('Announcement message is required'),
+        Rule.max(2000).error('Announcement must be 2000 characters or fewer'),
+      ],
+    }),
+
+    defineField({
+      name: 'createdAt',
+      title: 'Created At',
+      type: 'datetime',
+      initialValue: () => new Date().toISOString(),
+      readOnly: true,
+      validation: (Rule) =>
+        Rule.required().error('Created timestamp is required'),
+    }),
+  ],
+
+  orderings: [
+    {
+      title: 'Newest first',
+      name: 'createdAtDesc',
+      by: [{ field: 'createdAt', direction: 'desc' }],
+    },
+  ],
+
+  preview: {
+    select: {
+      workshopTitle: 'workshop.title',
+      createdAt: 'createdAt',
+      body: 'body',
+    },
+    prepare(selection) {
+      const { workshopTitle, createdAt, body } = selection
+      const date = createdAt ? new Date(createdAt).toLocaleDateString() : ''
+      return {
+        title: workshopTitle || 'Unknown Workshop',
+        subtitle: [date, body].filter(Boolean).join(' • '),
+      }
+    },
+  },
+})

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -321,6 +321,13 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                           confirmations, waitlist updates, and workshop-related
                           announcements
                         </li>
+                        <li>
+                          • <strong>Workshop Announcements:</strong> Broadcast
+                          messages from a workshop owner or organizer to
+                          confirmed participants — we store the message text,
+                          its author, and when it was sent, and display it on
+                          the workshop page
+                        </li>
                       </ul>
                     </div>
 

--- a/src/components/admin/workshop/AnnounceModal.stories.tsx
+++ b/src/components/admin/workshop/AnnounceModal.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useEffect } from 'react'
+import type { Decorator } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { AnnounceModal } from './AnnounceModal'
+
+// Renders the REAL admin compose modal (ModalShell portal + AdminButton). The
+// modal portals onto document.body, so the theme must live on the document root
+// for the `dark:` classes to resolve — the decorator syncs it.
+
+function ThemedFrame({
+  dark,
+  children,
+}: {
+  dark: boolean
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark)
+    return () => document.documentElement.classList.remove('dark')
+  }, [dark])
+  return (
+    <div className={dark ? 'dark' : ''}>
+      <div className="min-h-screen bg-gray-100 dark:bg-gray-950">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+const withPortalTheme: Decorator = (Story, context) => (
+  <ThemedFrame dark={!!context.parameters.dark}>
+    <Story />
+  </ThemedFrame>
+)
+
+const meta = {
+  title: 'Systems/Workshops/Admin/AnnounceModal',
+  component: AnnounceModal,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Admin compose modal for broadcasting an announcement to a workshop’s confirmed participants. Shows the participant count up front, a 2000-char-limited message with a live counter, and a one-way-broadcast notice.',
+      },
+    },
+  },
+  decorators: [withPortalTheme],
+  args: {
+    isOpen: true,
+    workshopTitle: 'Getting Started with Kubernetes Operators',
+    confirmedCount: 24,
+    onClose: fn(),
+    onSubmit: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AnnounceModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Light: Story = {}
+
+export const Dark: Story = {
+  parameters: { dark: true },
+}
+
+export const Submitting: Story = {
+  args: { isSubmitting: true },
+}
+
+export const SingleParticipant: Story = {
+  args: { confirmedCount: 1 },
+}

--- a/src/components/admin/workshop/AnnounceModal.tsx
+++ b/src/components/admin/workshop/AnnounceModal.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState } from 'react'
+import { MegaphoneIcon } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+
+const MAX_BODY_LENGTH = 2000
+
+interface AnnounceModalProps {
+  isOpen: boolean
+  onClose: () => void
+  workshopTitle: string
+  /** Confirmed participant count shown to the author before they broadcast. */
+  confirmedCount: number
+  onSubmit: (body: string) => void
+  isSubmitting?: boolean
+}
+
+/**
+ * Compose + send a one-way broadcast announcement to a workshop's CONFIRMED
+ * participants. The author sees exactly how many people will be emailed before
+ * sending. Deliberately no recipient list / no reply UI — this is a broadcast.
+ */
+export function AnnounceModal({
+  isOpen,
+  onClose,
+  workshopTitle,
+  confirmedCount,
+  onSubmit,
+  isSubmitting = false,
+}: AnnounceModalProps) {
+  const [body, setBody] = useState('')
+
+  // Reset the textarea whenever the modal transitions open (React-blessed
+  // "reset on prop change" so a previous draft never lingers).
+  const [wasOpen, setWasOpen] = useState(isOpen)
+  if (wasOpen !== isOpen) {
+    setWasOpen(isOpen)
+    if (isOpen) setBody('')
+  }
+
+  const trimmed = body.trim()
+  const overLimit = body.length > MAX_BODY_LENGTH
+  const canSend = trimmed.length > 0 && !overLimit && !isSubmitting
+
+  const handleSubmit = () => {
+    if (!canSend) return
+    onSubmit(trimmed)
+  }
+
+  return (
+    <ModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      size="lg"
+      title="Announce to participants"
+      subtitle={workshopTitle}
+      icon={<MegaphoneIcon className="h-5 w-5" />}
+      confirmOnDirtyClose
+      isDirty={trimmed.length > 0 && !isSubmitting}
+    >
+      <div className="space-y-4">
+        <div className="rounded-lg bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
+          Will email{' '}
+          <strong>
+            {confirmedCount} confirmed participant
+            {confirmedCount === 1 ? '' : 's'}
+          </strong>{' '}
+          and post to the workshop page. This is a one-way broadcast —
+          participants cannot reply.
+        </div>
+
+        <div>
+          <label
+            htmlFor="workshop-announcement-body"
+            className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Message
+          </label>
+          <textarea
+            id="workshop-announcement-body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={6}
+            maxLength={MAX_BODY_LENGTH}
+            placeholder="Share prerequisites, room changes, or any update your participants need to know…"
+            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+          />
+          <div className="mt-1 flex justify-end">
+            <span
+              className={`text-xs ${
+                overLimit
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-gray-500 dark:text-gray-400'
+              }`}
+            >
+              {body.length}/{MAX_BODY_LENGTH}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+          <AdminButton
+            variant="secondary"
+            size="md"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="min-h-[44px]"
+          >
+            Cancel
+          </AdminButton>
+          <AdminButton
+            color="blue"
+            size="md"
+            onClick={handleSubmit}
+            disabled={!canSend}
+            className="min-h-[44px]"
+          >
+            {isSubmitting
+              ? 'Sending…'
+              : `Send to ${confirmedCount} participant${confirmedCount === 1 ? '' : 's'}`}
+          </AdminButton>
+        </div>
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/components/admin/workshop/WorkshopCard.tsx
+++ b/src/components/admin/workshop/WorkshopCard.tsx
@@ -4,6 +4,7 @@ import {
   UserGroupIcon,
   PlusCircleIcon,
   PencilIcon,
+  MegaphoneIcon,
 } from '@heroicons/react/24/outline'
 import { getWorkshopDuration } from '@/lib/workshop/utils'
 import { calculateWorkshopStats, getCapacityColorClass } from './utils'
@@ -18,6 +19,7 @@ interface WorkshopCardProps {
   onViewWaitlist: () => void
   onAddParticipant: () => void
   onEditCapacity: () => void
+  onAnnounce: () => void
 }
 
 export function WorkshopCard({
@@ -28,6 +30,7 @@ export function WorkshopCard({
   onViewWaitlist,
   onAddParticipant,
   onEditCapacity,
+  onAnnounce,
 }: WorkshopCardProps) {
   const { capacityPercentage } = calculateWorkshopStats(
     workshop,
@@ -85,18 +88,33 @@ export function WorkshopCard({
         </div>
       </div>
 
-      <div className="flex gap-2 border-t border-gray-200 p-3 dark:border-gray-700">
+      <div className="flex flex-col gap-2 border-t border-gray-200 p-3 dark:border-gray-700">
+        <div className="flex gap-2">
+          <AdminButton
+            variant="secondary"
+            onClick={onEditCapacity}
+            title="Edit capacity"
+          >
+            <PencilIcon className="h-4 w-4" />
+            Capacity
+          </AdminButton>
+          <AdminButton
+            color="blue"
+            onClick={onAddParticipant}
+            className="flex-1"
+          >
+            <PlusCircleIcon className="h-4 w-4" />
+            Add Participant
+          </AdminButton>
+        </div>
         <AdminButton
           variant="secondary"
-          onClick={onEditCapacity}
-          title="Edit capacity"
+          onClick={onAnnounce}
+          className="w-full"
+          title="Announce to confirmed participants"
         >
-          <PencilIcon className="h-4 w-4" />
-          Capacity
-        </AdminButton>
-        <AdminButton color="blue" onClick={onAddParticipant} className="flex-1">
-          <PlusCircleIcon className="h-4 w-4" />
-          Add Participant
+          <MegaphoneIcon className="h-4 w-4" />
+          Announce to participants
         </AdminButton>
       </div>
     </div>

--- a/src/components/admin/workshop/WorkshopsClientPage.tsx
+++ b/src/components/admin/workshop/WorkshopsClientPage.tsx
@@ -8,9 +8,11 @@ import {
   SignupDetailsModal,
   AddParticipantModal,
   EditCapacityModal,
+  AnnounceModal,
 } from '@/components/admin/workshop'
 import type { ParticipantFormData } from '@/components/admin/workshop'
 import { api } from '@/lib/trpc/client'
+import { useNotification } from '@/components/admin/NotificationProvider'
 import type {
   WorkshopSignupStatus,
   ProposalWithWorkshopData,
@@ -39,6 +41,13 @@ interface EditCapacityModalState {
   currentSignups: number
 }
 
+interface AnnounceModalState {
+  isOpen: boolean
+  workshopId: string
+  workshopTitle: string
+  confirmedCount: number
+}
+
 interface WorkshopsClientPageProps {
   conferenceId: string
   initialWorkshops: ProposalWithWorkshopData[]
@@ -49,6 +58,13 @@ export function WorkshopsClientPage({
   initialWorkshops,
 }: WorkshopsClientPageProps) {
   const queryClient = useQueryClient()
+  const { showNotification } = useNotification()
+  const [announceModal, setAnnounceModal] = useState<AnnounceModalState>({
+    isOpen: false,
+    workshopId: '',
+    workshopTitle: '',
+    confirmedCount: 0,
+  })
   const [signupModal, setSignupModal] = useState<SignupModalState>({
     isOpen: false,
     workshopId: '',
@@ -146,6 +162,27 @@ export function WorkshopsClientPage({
     },
   })
 
+  const announceMutation = api.workshop.announce.useMutation({
+    onSuccess: (result) => {
+      setAnnounceModal((prev) => ({ ...prev, isOpen: false }))
+      showNotification({
+        type: result.failed > 0 ? 'warning' : 'success',
+        title: 'Announcement sent',
+        message:
+          result.failed > 0
+            ? `${result.sent} sent, ${result.failed} failed of ${result.recipientCount} confirmed participants.`
+            : `Emailed ${result.sent} confirmed participant${result.sent === 1 ? '' : 's'}.`,
+      })
+    },
+    onError: (error) => {
+      showNotification({
+        type: 'error',
+        title: 'Could not send announcement',
+        message: error.message,
+      })
+    },
+  })
+
   const signups = useMemo(() => signupsData?.data || [], [signupsData?.data])
 
   const signupsByWorkshop = useMemo(() => {
@@ -202,6 +239,13 @@ export function WorkshopsClientPage({
     updateCapacityMutation.mutate({
       workshopId: editCapacityModal.workshopId,
       capacity,
+    })
+  }
+
+  const handleAnnounce = (body: string) => {
+    announceMutation.mutate({
+      workshopId: announceModal.workshopId,
+      body,
     })
   }
 
@@ -314,6 +358,14 @@ export function WorkshopsClientPage({
                     currentSignups: confirmedCount,
                   })
                 }}
+                onAnnounce={() =>
+                  setAnnounceModal({
+                    isOpen: true,
+                    workshopId: workshop._id,
+                    workshopTitle: workshop.title,
+                    confirmedCount,
+                  })
+                }
               />
             )
           })
@@ -352,6 +404,15 @@ export function WorkshopsClientPage({
         currentSignups={editCapacityModal.currentSignups}
         onSubmit={handleUpdateCapacity}
         isSubmitting={updateCapacityMutation.isPending}
+      />
+
+      <AnnounceModal
+        isOpen={announceModal.isOpen}
+        onClose={() => setAnnounceModal({ ...announceModal, isOpen: false })}
+        workshopTitle={announceModal.workshopTitle}
+        confirmedCount={announceModal.confirmedCount}
+        onSubmit={handleAnnounce}
+        isSubmitting={announceMutation.isPending}
       />
     </div>
   )

--- a/src/components/admin/workshop/index.ts
+++ b/src/components/admin/workshop/index.ts
@@ -2,6 +2,7 @@ export { WorkshopCard } from './WorkshopCard'
 export { SignupDetailsModal } from './SignupDetailsModal'
 export { AddParticipantModal } from './AddParticipantModal'
 export { EditCapacityModal } from './EditCapacityModal'
+export { AnnounceModal } from './AnnounceModal'
 export { WorkshopsClientPage } from './WorkshopsClientPage'
 
 export type { ParticipantFormData } from './AddParticipantModal'

--- a/src/components/workshop/WorkshopAnnouncements.stories.tsx
+++ b/src/components/workshop/WorkshopAnnouncements.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useEffect } from 'react'
+import type { Decorator } from '@storybook/nextjs-vite'
+import WorkshopAnnouncements from './WorkshopAnnouncements'
+import { mockDateBeforeEach } from '@/lib/storybook'
+import type { WorkshopAnnouncementView } from '@/lib/workshop/announcements'
+
+// Renders the REAL presentational announcements block participants see inside a
+// workshop card. Dates are pinned via mockDateBeforeEach so the relative-time
+// labels ("2 hours ago") are deterministic across visual captures.
+
+const NOW = new Date('2026-09-08T12:00:00Z')
+
+/**
+ * Force a theme onto both a wrapping div and the document root so captures are
+ * theme-accurate whether or not the story is a portal. Keyed off
+ * `parameters.dark` so a story just declares the theme it wants.
+ */
+function ThemedFrame({
+  dark,
+  children,
+}: {
+  dark: boolean
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark)
+    return () => document.documentElement.classList.remove('dark')
+  }, [dark])
+  return (
+    <div className={dark ? 'dark' : ''}>
+      <div className="min-h-screen bg-white p-4 dark:bg-gray-800">
+        <div className="mx-auto max-w-md rounded-xl bg-white p-6 shadow-sm dark:bg-gray-800">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const withTheme: Decorator = (Story, context) => (
+  <ThemedFrame dark={!!context.parameters.dark}>
+    <Story />
+  </ThemedFrame>
+)
+
+const announcements: WorkshopAnnouncementView[] = [
+  {
+    _id: 'a-3',
+    body: 'Room change! We have moved to Workshop Room B on the 2nd floor. Signs will be posted at the entrance.',
+    createdAt: '2026-09-08T10:00:00Z',
+    authorName: 'Grace Hopper',
+  },
+  {
+    _id: 'a-2',
+    body: 'Please install Docker and kubectl before the session.\n\nA setup guide was emailed to the address on your ticket — reply if you hit any issues.',
+    createdAt: '2026-09-07T09:00:00Z',
+    authorName: 'Grace Hopper',
+  },
+  {
+    _id: 'a-1',
+    body: 'Thanks for signing up! Bring a laptop with at least 8GB of RAM.',
+    createdAt: '2026-09-05T15:30:00Z',
+    authorName: null,
+  },
+]
+
+const meta = {
+  title: 'Systems/Workshops/WorkshopAnnouncements',
+  component: WorkshopAnnouncements,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'One-way broadcast announcements shown to workshop participants, newest first, with author and relative time. Plain text preserves the author’s line breaks. Renders nothing when there are no announcements.',
+      },
+    },
+  },
+  beforeEach: mockDateBeforeEach(NOW),
+  decorators: [withTheme],
+  args: { announcements },
+  tags: ['autodocs'],
+} satisfies Meta<typeof WorkshopAnnouncements>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Light: Story = {}
+
+export const Dark: Story = {
+  parameters: { dark: true },
+}
+
+export const Single: Story = {
+  args: { announcements: [announcements[0]] },
+}

--- a/src/components/workshop/WorkshopAnnouncements.tsx
+++ b/src/components/workshop/WorkshopAnnouncements.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { MegaphoneIcon } from '@heroicons/react/24/outline'
+import { formatRelativeTime } from '@/lib/time'
+import type { WorkshopAnnouncementView } from '@/lib/workshop/announcements'
+
+interface WorkshopAnnouncementsProps {
+  announcements: WorkshopAnnouncementView[]
+}
+
+/**
+ * Presentational 'Announcements' block shown to workshop participants inside the
+ * workshop card. One-way broadcasts from the owner/organizer, newest first, with
+ * author + relative time. Plain text is rendered with `whitespace-pre-wrap` so
+ * the author's line breaks survive. Renders nothing when there are no
+ * announcements (keeps the card clean for workshops that never broadcast).
+ */
+export default function WorkshopAnnouncements({
+  announcements,
+}: WorkshopAnnouncementsProps) {
+  if (announcements.length === 0) return null
+
+  return (
+    <div className="mt-4 border-t border-gray-200 pt-4 dark:border-gray-700">
+      <h4 className="font-space-grotesk mb-3 flex items-center gap-2 text-sm font-semibold text-brand-slate-gray dark:text-gray-200">
+        <MegaphoneIcon className="h-4 w-4 text-brand-cloud-blue dark:text-blue-400" />
+        Announcements
+      </h4>
+      <ul className="space-y-3">
+        {announcements.map((announcement) => (
+          <li
+            key={announcement._id}
+            className="rounded-lg bg-brand-sky-mist/60 p-3 dark:bg-gray-700/40"
+          >
+            <p className="text-sm whitespace-pre-wrap text-gray-700 dark:text-gray-200">
+              {announcement.body}
+            </p>
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              {announcement.authorName || 'Workshop organizer'}
+              {' · '}
+              {formatRelativeTime(announcement.createdAt)}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/workshop/WorkshopAnnouncementsSection.tsx
+++ b/src/components/workshop/WorkshopAnnouncementsSection.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { api } from '@/lib/trpc/client'
+import WorkshopAnnouncements from './WorkshopAnnouncements'
+
+interface WorkshopAnnouncementsSectionProps {
+  workshopId: string
+}
+
+/**
+ * Data wrapper that fetches a workshop's broadcast announcements and renders the
+ * presentational {@link WorkshopAnnouncements} block. Kept separate so the block
+ * itself stays trivially inspectable in Storybook without a network layer.
+ */
+export default function WorkshopAnnouncementsSection({
+  workshopId,
+}: WorkshopAnnouncementsSectionProps) {
+  const { data } = api.workshop.announcements.useQuery({ workshopId })
+  return <WorkshopAnnouncements announcements={data?.data ?? []} />
+}

--- a/src/components/workshop/WorkshopCard.tsx
+++ b/src/components/workshop/WorkshopCard.tsx
@@ -48,6 +48,12 @@ interface WorkshopCardProps {
   isLoading?: boolean
   hasTimeConflict?: boolean
   conflictingWorkshopTitle?: string
+  /**
+   * Optional 'Announcements' block rendered inside the card. Passed as a slot
+   * (rather than fetched here) so WorkshopCard stays decoupled from tRPC and
+   * trivially renderable in isolation; the data wrapper lives at the list level.
+   */
+  announcements?: React.ReactNode
 }
 
 export default function WorkshopCard({
@@ -60,6 +66,7 @@ export default function WorkshopCard({
   isLoading: externalLoading = false,
   hasTimeConflict = false,
   conflictingWorkshopTitle,
+  announcements,
 }: WorkshopCardProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -497,6 +504,8 @@ export default function WorkshopCard({
             {error}
           </div>
         )}
+
+        {announcements}
 
         {hasTimeConflict && !actuallySignedUp && (
           <div className="mb-4 rounded-lg bg-yellow-50 p-3 text-sm text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-200">

--- a/src/components/workshop/WorkshopList.tsx
+++ b/src/components/workshop/WorkshopList.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import WorkshopCard from './WorkshopCard'
+import WorkshopAnnouncementsSection from './WorkshopAnnouncementsSection'
 import type {
   ProposalWithWorkshopData,
   ExperienceLevel,
@@ -282,6 +283,9 @@ export default function WorkshopList({
                     userSignup ? () => handleCancel(userSignup._id) : undefined
                   }
                   isSignedUp={true}
+                  announcements={
+                    <WorkshopAnnouncementsSection workshopId={workshop._id} />
+                  }
                 />
               )
             })}
@@ -312,6 +316,9 @@ export default function WorkshopList({
                   isLoading={signupMutation.isPending}
                   hasTimeConflict={hasConflict}
                   conflictingWorkshopTitle={conflictingWorkshop?.title}
+                  announcements={
+                    <WorkshopAnnouncementsSection workshopId={workshop._id} />
+                  }
                 />
               )
             })}
@@ -341,6 +348,9 @@ export default function WorkshopList({
                   }
                   isFull={true}
                   isSignedUp={!!userSignup}
+                  announcements={
+                    <WorkshopAnnouncementsSection workshopId={workshop._id} />
+                  }
                 />
               )
             })}

--- a/src/lib/email/workshop.announcement.test.ts
+++ b/src/lib/email/workshop.announcement.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const sendMock = vi.fn()
+vi.mock('./config', () => ({
+  resend: { emails: { send: (...args: unknown[]) => sendMock(...args) } },
+  // Pass-through retry so the render path runs once, deterministically.
+  retryWithBackoff: (fn: () => Promise<unknown>) => fn(),
+  createEmailError: (message: string, status = 500) => ({
+    error: message,
+    status,
+  }),
+}))
+
+import { sendWorkshopAnnouncementEmail } from './workshop'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sendMock.mockResolvedValue({ data: { id: 'email-1' }, error: null })
+})
+
+describe('sendWorkshopAnnouncementEmail', () => {
+  it('renders the announcement into the email and returns the id', async () => {
+    const result = await sendWorkshopAnnouncementEmail({
+      userEmail: 'attendee@example.com',
+      userName: 'Ada',
+      conference: {
+        organizer: 'Cloud Native Bergen',
+        contactEmail: 'hello@cnb.no',
+        domains: ['cloudnativebergen.no'],
+      } as never,
+      workshopTitle: 'Kubernetes Operators',
+      authorName: 'Grace Hopper',
+      body: 'Bring a laptop.',
+    })
+
+    expect(result.data?.emailId).toBe('email-1')
+    const payload = sendMock.mock.calls[0][0]
+    expect(payload.to).toEqual(['attendee@example.com'])
+    expect(payload.from).toBe('Cloud Native Bergen <hello@cnb.no>')
+    expect(payload.subject).toBe('Workshop Update: Kubernetes Operators')
+    expect(payload.html).toContain('Bring a laptop.')
+    expect(payload.html).toContain('Grace Hopper')
+    expect(payload.html).toContain('Ada')
+  })
+
+  it('HTML-escapes the body and converts newlines to <br>', async () => {
+    await sendWorkshopAnnouncementEmail({
+      userEmail: 'attendee@example.com',
+      userName: 'Ada',
+      workshopTitle: 'W',
+      authorName: 'Owner',
+      body: 'Line 1\nBeware <script>alert("x")</script> & co',
+    })
+
+    const html = sendMock.mock.calls[0][0].html as string
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+    expect(html).toContain('&amp; co')
+    expect(html).toContain('Line 1<br>Beware')
+  })
+
+  it('returns an error result (never throws) when Resend fails', async () => {
+    sendMock.mockResolvedValue({ data: null, error: { message: 'boom' } })
+
+    const result = await sendWorkshopAnnouncementEmail({
+      userEmail: 'attendee@example.com',
+      userName: 'Ada',
+      workshopTitle: 'W',
+      authorName: 'Owner',
+      body: 'hi',
+    })
+
+    expect(result.error).toBeTruthy()
+    expect(result.data).toBeUndefined()
+  })
+})

--- a/src/lib/email/workshop.ts
+++ b/src/lib/email/workshop.ts
@@ -250,3 +250,125 @@ export async function sendWorkshopSignupInstructions({
     }
   }
 }
+
+export interface WorkshopAnnouncementEmailRequest {
+  userEmail: string
+  userName: string
+  conference?: Conference
+  workshopTitle: string
+  /** Display name of the owner/organizer who wrote the announcement. */
+  authorName: string
+  /** Raw announcement text (owner-authored). MUST be HTML-escaped before embed. */
+  body: string
+}
+
+/**
+ * Escape HTML-significant characters so an announcement's free-text body cannot
+ * inject markup into the email. Newlines are converted to <br> AFTER escaping so
+ * the participant sees the same line breaks the author typed.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Send ONE announcement email to ONE confirmed workshop participant. This is the
+ * attendee-facing counterpart to `sendBasicWorkshopConfirmation` (raw-HTML,
+ * Resend, retry-with-backoff) — deliberately NOT the speaker-audience messaging
+ * BaseEmailTemplate, since recipients are workshop attendees. Returns an
+ * `EmailResult` and never throws; the caller fans out with bounded concurrency
+ * and tolerates per-recipient failures.
+ */
+export async function sendWorkshopAnnouncementEmail({
+  userEmail,
+  userName,
+  conference,
+  workshopTitle,
+  authorName,
+  body,
+}: WorkshopAnnouncementEmailRequest): Promise<
+  EmailResult<{ emailId: string }>
+> {
+  try {
+    const fromEmail = conference?.contactEmail
+      ? `${conference.organizer} <${conference.contactEmail}>`
+      : conference?.domains?.[0]
+        ? `${conference.organizer} <contact@${conference.domains[0]}>`
+        : 'Cloud Native Days <contact@cloudnativedays.org>'
+
+    const contactEmail =
+      conference?.contactEmail || 'contact@cloudnativedays.org'
+
+    const subject = `Workshop Update: ${workshopTitle}`
+    const safeBody = escapeHtml(body).replace(/\r?\n/g, '<br>')
+
+    const html = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      </head>
+      <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #F9FAFB; color: #334155;">
+        <table width="100%" cellpadding="0" cellspacing="0" style="background-color: #F9FAFB; padding: 40px 20px;">
+          <tr>
+            <td align="center">
+              <table width="600" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; border-radius: 8px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);">
+                <tr>
+                  <td style="padding: 40px;">
+                    <h2 style="margin: 0 0 8px 0; font-size: 28px; font-weight: 700; color: #1D4ED8;">Workshop Update</h2>
+                    <p style="margin: 0 0 24px 0; font-size: 16px; line-height: 24px; color: #64748B;">${escapeHtml(workshopTitle)}</p>
+                    <p style="margin: 0 0 16px 0; font-size: 16px; line-height: 24px; color: #334155;">Hi ${escapeHtml(userName)},</p>
+                    <div style="background-color: #F1F5F9; border-left: 4px solid #1D4ED8; padding: 16px 20px; margin: 0 0 24px 0; border-radius: 4px;">
+                      <p style="margin: 0; font-size: 16px; line-height: 24px; color: #334155;">${safeBody}</p>
+                    </div>
+                    <p style="margin: 24px 0 0 0; font-size: 14px; line-height: 20px; color: #64748B;">— ${escapeHtml(authorName)}</p>
+                    <p style="margin: 24px 0 16px 0; font-size: 14px; line-height: 20px; color: #334155;">If you have any questions, please contact us at <a href="mailto:${contactEmail}" style="color: #1D4ED8; text-decoration: none;">${contactEmail}</a>.</p>
+                    <p style="margin: 16px 0 0 0; font-size: 16px; line-height: 24px; color: #334155;">Best regards,<br><strong>${escapeHtml(conference?.organizer || 'Cloud Native Days')}</strong></p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 24px 40px; background-color: #F9FAFB; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px;">
+                    <p style="margin: 0; font-size: 12px; line-height: 18px; color: #64748B; text-align: center;">© ${new Date().getFullYear()} ${escapeHtml(conference?.organizer || 'Cloud Native Days')}. You are receiving this because you are a confirmed participant of this workshop.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </body>
+      </html>
+    `
+
+    const emailResult = await retryWithBackoff(async () => {
+      const result = await resend.emails.send({
+        from: fromEmail,
+        to: [userEmail],
+        subject,
+        html,
+      })
+
+      if (result.error) {
+        throw new Error(`Failed to send email: ${result.error.message}`)
+      }
+
+      return result
+    })
+
+    return {
+      data: {
+        emailId: emailResult.data?.id || '',
+      },
+    }
+  } catch (error) {
+    console.error('Error sending workshop announcement email:', error)
+    return {
+      error: createEmailError('Failed to send announcement email', 500),
+    }
+  }
+}

--- a/src/lib/workshop/announcementRateLimit.test.ts
+++ b/src/lib/workshop/announcementRateLimit.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  consumeAnnouncementRateLimit,
+  resetAnnouncementRateLimits,
+  RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW_MS,
+} from './announcementRateLimit'
+
+beforeEach(() => {
+  resetAnnouncementRateLimits()
+})
+
+describe('consumeAnnouncementRateLimit', () => {
+  it('allows up to RATE_LIMIT_MAX announcements per workshop in-window', () => {
+    const t0 = 1_000_000
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      expect(consumeAnnouncementRateLimit('ws-1', t0 + i).allowed).toBe(true)
+    }
+  })
+
+  it('rejects the (MAX+1)th attempt with a positive retryAfterMs', () => {
+    const t0 = 1_000_000
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      consumeAnnouncementRateLimit('ws-1', t0 + i)
+    }
+    const blocked = consumeAnnouncementRateLimit('ws-1', t0 + RATE_LIMIT_MAX)
+    expect(blocked.allowed).toBe(false)
+    expect(blocked.retryAfterMs).toBeGreaterThan(0)
+  })
+
+  it('isolates the limit per workshop', () => {
+    const t0 = 1_000_000
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      consumeAnnouncementRateLimit('ws-1', t0 + i)
+    }
+    // A different workshop still has a full quota.
+    expect(consumeAnnouncementRateLimit('ws-2', t0).allowed).toBe(true)
+  })
+
+  it('frees a slot once the oldest attempt ages out of the window', () => {
+    const t0 = 1_000_000
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      consumeAnnouncementRateLimit('ws-1', t0 + i)
+    }
+    expect(consumeAnnouncementRateLimit('ws-1', t0 + 100).allowed).toBe(false)
+
+    // Just past the window relative to the first attempt → one slot reopens.
+    const later = t0 + RATE_LIMIT_WINDOW_MS + 1
+    expect(consumeAnnouncementRateLimit('ws-1', later).allowed).toBe(true)
+  })
+})

--- a/src/lib/workshop/announcementRateLimit.ts
+++ b/src/lib/workshop/announcementRateLimit.ts
@@ -1,0 +1,49 @@
+/**
+ * In-memory, per-workshop rate limit for the announcement broadcast rail: at
+ * most {@link RATE_LIMIT_MAX} announcements per workshop per
+ * {@link RATE_LIMIT_WINDOW_MS}. This is the classic module-Map pattern — best
+ * effort per serverless instance, which is an acceptable bound for a
+ * spam/misfire guard (an owner accidentally hammering "Send"). It is NOT a
+ * security control; authorization is enforced separately in the router.
+ */
+
+export const RATE_LIMIT_MAX = 3
+export const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000 // 1 hour
+
+/** workshopId -> ascending timestamps (ms) of accepted announcements in-window. */
+const buckets = new Map<string, number[]>()
+
+export interface RateLimitResult {
+  allowed: boolean
+  /** Milliseconds until the caller may try again (0 when allowed). */
+  retryAfterMs: number
+}
+
+/**
+ * Check the workshop's announcement quota and, when under the limit, RECORD this
+ * attempt. Prunes timestamps older than the window on every call so the map
+ * never grows unbounded for a given key. Pass `now` in tests for determinism.
+ */
+export function consumeAnnouncementRateLimit(
+  workshopId: string,
+  now: number = Date.now(),
+): RateLimitResult {
+  const windowStart = now - RATE_LIMIT_WINDOW_MS
+  const recent = (buckets.get(workshopId) ?? []).filter((t) => t > windowStart)
+
+  if (recent.length >= RATE_LIMIT_MAX) {
+    // Oldest in-window attempt frees a slot once it ages out of the window.
+    const retryAfterMs = recent[0] + RATE_LIMIT_WINDOW_MS - now
+    buckets.set(workshopId, recent)
+    return { allowed: false, retryAfterMs: Math.max(retryAfterMs, 0) }
+  }
+
+  recent.push(now)
+  buckets.set(workshopId, recent)
+  return { allowed: true, retryAfterMs: 0 }
+}
+
+/** Clear all rate-limit state. Exposed for tests. */
+export function resetAnnouncementRateLimits(): void {
+  buckets.clear()
+}

--- a/src/lib/workshop/announcements.test.ts
+++ b/src/lib/workshop/announcements.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Email sender mock -----------------------------------------------------
+const sendEmailMock = vi.fn()
+vi.mock('@/lib/email/workshop', () => ({
+  sendWorkshopAnnouncementEmail: (...args: unknown[]) => sendEmailMock(...args),
+}))
+
+// --- Sanity client mock ----------------------------------------------------
+const fetchMock = vi.fn()
+const createMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    fetch: (...args: unknown[]) => fetchMock(...args),
+    create: (...args: unknown[]) => createMock(...args),
+  },
+}))
+
+import {
+  sendAnnouncementToConfirmedParticipants,
+  getConfirmedAnnouncementRecipients,
+  getWorkshopForAnnouncement,
+  createWorkshopAnnouncement,
+  isWorkshopFormat,
+  type AnnouncementRecipient,
+} from './announcements'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function makeRecipients(n: number): AnnouncementRecipient[] {
+  return Array.from({ length: n }, (_, i) => ({
+    userEmail: `person${i}@example.com`,
+    userName: `Person ${i}`,
+  }))
+}
+
+describe('isWorkshopFormat', () => {
+  it('accepts workshop formats and rejects others', () => {
+    expect(isWorkshopFormat('workshop_120')).toBe(true)
+    expect(isWorkshopFormat('workshop_240')).toBe(true)
+    expect(isWorkshopFormat('presentation_25')).toBe(false)
+    expect(isWorkshopFormat(undefined)).toBe(false)
+  })
+})
+
+describe('getConfirmedAnnouncementRecipients', () => {
+  it('queries only confirmed signups', async () => {
+    fetchMock.mockResolvedValueOnce([
+      { userEmail: 'a@example.com', userName: 'A' },
+    ])
+
+    const recipients = await getConfirmedAnnouncementRecipients('ws-1')
+
+    expect(recipients).toHaveLength(1)
+    const query = fetchMock.mock.calls[0][0] as string
+    expect(query).toContain('status == "confirmed"')
+    expect(query).toContain('workshop._ref == $workshopId')
+  })
+
+  it('returns [] when the query yields null', async () => {
+    fetchMock.mockResolvedValueOnce(null)
+    expect(await getConfirmedAnnouncementRecipients('ws-1')).toEqual([])
+  })
+})
+
+describe('createWorkshopAnnouncement', () => {
+  it('writes a doc with a WEAK author ref and returns the view', async () => {
+    createMock.mockResolvedValueOnce({ _id: 'ann-1' })
+
+    const result = await createWorkshopAnnouncement({
+      workshopId: 'ws-1',
+      conferenceId: 'conf-1',
+      authorId: 'sp-1',
+      body: 'Hello everyone',
+    })
+
+    const doc = createMock.mock.calls[0][0]
+    expect(doc._type).toBe('workshopAnnouncement')
+    expect(doc.author).toEqual({
+      _type: 'reference',
+      _ref: 'sp-1',
+      _weak: true,
+    })
+    expect(doc.body).toBe('Hello everyone')
+    expect(result._id).toBe('ann-1')
+    expect(result.createdAt).toBeTruthy()
+  })
+})
+
+describe('getWorkshopForAnnouncement', () => {
+  it('normalizes missing speakers/conference to safe defaults', async () => {
+    fetchMock.mockResolvedValueOnce({
+      _id: 'ws-1',
+      title: 'K8s Ops',
+      format: 'workshop_120',
+      conferenceId: null,
+      speakerIds: null,
+    })
+
+    const workshop = await getWorkshopForAnnouncement('ws-1')
+    expect(workshop).toMatchObject({
+      _id: 'ws-1',
+      conferenceId: null,
+      speakerIds: [],
+    })
+  })
+
+  it('returns null when the talk does not exist', async () => {
+    fetchMock.mockResolvedValueOnce(null)
+    expect(await getWorkshopForAnnouncement('nope')).toBeNull()
+  })
+})
+
+describe('sendAnnouncementToConfirmedParticipants', () => {
+  it('sends exactly one email per recipient and counts successes', async () => {
+    sendEmailMock.mockResolvedValue({ data: { emailId: 'e' } })
+    const recipients = makeRecipients(5)
+
+    const result = await sendAnnouncementToConfirmedParticipants({
+      workshopTitle: 'W',
+      authorName: 'Owner',
+      body: 'hi',
+      recipients,
+    })
+
+    expect(sendEmailMock).toHaveBeenCalledTimes(5)
+    expect(result).toEqual({ sent: 5, failed: 0 })
+  })
+
+  it('never fails the batch: tolerates per-recipient errors AND throws', async () => {
+    const recipients = makeRecipients(4)
+    sendEmailMock
+      .mockResolvedValueOnce({ data: { emailId: 'e' } }) // ok
+      .mockResolvedValueOnce({ error: { error: 'bad address', status: 400 } }) // soft-fail
+      .mockRejectedValueOnce(new Error('network')) // hard-throw
+      .mockResolvedValueOnce({ data: { emailId: 'e' } }) // ok
+
+    const result = await sendAnnouncementToConfirmedParticipants({
+      workshopTitle: 'W',
+      authorName: 'Owner',
+      body: 'hi',
+      recipients,
+    })
+
+    // Every recipient is accounted for; nothing propagates out.
+    expect(result.sent + result.failed).toBe(4)
+    expect(result).toEqual({ sent: 2, failed: 2 })
+  })
+
+  it('bounds concurrency to 3 simultaneous sends', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    sendEmailMock.mockImplementation(async () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      inFlight -= 1
+      return { data: { emailId: 'e' } }
+    })
+
+    await sendAnnouncementToConfirmedParticipants({
+      workshopTitle: 'W',
+      authorName: 'Owner',
+      body: 'hi',
+      recipients: makeRecipients(9),
+    })
+
+    expect(maxInFlight).toBeLessThanOrEqual(3)
+    expect(sendEmailMock).toHaveBeenCalledTimes(9)
+  })
+
+  it('handles an empty recipient list without sending', async () => {
+    const result = await sendAnnouncementToConfirmedParticipants({
+      workshopTitle: 'W',
+      authorName: 'Owner',
+      body: 'hi',
+      recipients: [],
+    })
+    expect(sendEmailMock).not.toHaveBeenCalled()
+    expect(result).toEqual({ sent: 0, failed: 0 })
+  })
+})

--- a/src/lib/workshop/announcements.ts
+++ b/src/lib/workshop/announcements.ts
@@ -1,0 +1,184 @@
+import { groq } from 'next-sanity'
+import { clientWrite } from '@/lib/sanity/client'
+import type { Conference } from '@/lib/conference/types'
+import { sendWorkshopAnnouncementEmail } from '@/lib/email/workshop'
+
+/** Talk formats that qualify as a workshop (mirrors workshopSignup validation). */
+export const WORKSHOP_FORMATS = ['workshop_120', 'workshop_240'] as const
+
+export function isWorkshopFormat(format: string | undefined): boolean {
+  return !!format && (WORKSHOP_FORMATS as readonly string[]).includes(format)
+}
+
+/** Minimal projection of a workshop talk used to authorize + label a broadcast. */
+export interface WorkshopForAnnouncement {
+  _id: string
+  title: string
+  format: string
+  conferenceId: string | null
+  /** `_id`s of the talk's speakers — the workshop OWNERS. */
+  speakerIds: string[]
+}
+
+/** A confirmed participant's email target (the only fields the fan-out needs). */
+export interface AnnouncementRecipient {
+  userEmail: string
+  userName: string
+}
+
+/** Announcement as rendered to participants / returned by the public query. */
+export interface WorkshopAnnouncementView {
+  _id: string
+  body: string
+  createdAt: string
+  /** Author display name, or null if the author speaker was erased (GDPR). */
+  authorName: string | null
+}
+
+/**
+ * Fetch the workshop talk that a broadcast targets, projected down to what the
+ * `workshop.announce` mutation needs to authorize (speaker owners), validate
+ * (format + conference), and label (title) the announcement.
+ */
+export async function getWorkshopForAnnouncement(
+  workshopId: string,
+): Promise<WorkshopForAnnouncement | null> {
+  const query = groq`*[_type == "talk" && _id == $workshopId][0]{
+    _id,
+    title,
+    format,
+    "conferenceId": conference._ref,
+    "speakerIds": speakers[]._ref
+  }`
+
+  const result = await clientWrite.fetch<{
+    _id: string
+    title: string
+    format: string
+    conferenceId: string | null
+    speakerIds: string[] | null
+  } | null>(query, { workshopId })
+
+  if (!result) return null
+
+  return {
+    _id: result._id,
+    title: result.title,
+    format: result.format,
+    conferenceId: result.conferenceId ?? null,
+    speakerIds: result.speakerIds ?? [],
+  }
+}
+
+/** Emails + names of every CONFIRMED signup for a workshop (waitlist excluded). */
+export async function getConfirmedAnnouncementRecipients(
+  workshopId: string,
+): Promise<AnnouncementRecipient[]> {
+  const query = groq`*[_type == "workshopSignup" && workshop._ref == $workshopId && status == "confirmed"]{
+    userEmail,
+    userName
+  }`
+
+  const recipients = await clientWrite.fetch<AnnouncementRecipient[]>(query, {
+    workshopId,
+  })
+  return recipients ?? []
+}
+
+/** Persist an announcement document. Author is a WEAK speaker ref (GDPR). */
+export async function createWorkshopAnnouncement(input: {
+  workshopId: string
+  conferenceId: string
+  authorId: string
+  body: string
+}): Promise<WorkshopAnnouncementView & { conferenceId: string }> {
+  const createdAt = new Date().toISOString()
+  const doc = await clientWrite.create({
+    _type: 'workshopAnnouncement',
+    workshop: { _type: 'reference', _ref: input.workshopId },
+    conference: { _type: 'reference', _ref: input.conferenceId },
+    author: { _type: 'reference', _ref: input.authorId, _weak: true },
+    body: input.body,
+    createdAt,
+  })
+
+  return {
+    _id: doc._id,
+    body: input.body,
+    createdAt,
+    authorName: null,
+    conferenceId: input.conferenceId,
+  }
+}
+
+/** Read announcements for a workshop, newest first, bounded to `limit`. */
+export async function getWorkshopAnnouncements(
+  workshopId: string,
+  limit: number,
+): Promise<WorkshopAnnouncementView[]> {
+  const query = groq`*[_type == "workshopAnnouncement" && workshop._ref == $workshopId] | order(createdAt desc)[0...$limit]{
+    _id,
+    body,
+    createdAt,
+    "authorName": author->name
+  }`
+
+  const announcements = await clientWrite.fetch<WorkshopAnnouncementView[]>(
+    query,
+    { workshopId, limit },
+  )
+  return announcements ?? []
+}
+
+/** Upper bound on simultaneous announcement emails in flight. */
+const EMAIL_CONCURRENCY = 3
+
+export interface FanOutResult {
+  sent: number
+  failed: number
+}
+
+/**
+ * Fan out ONE announcement email per confirmed participant with bounded
+ * concurrency ({@link EMAIL_CONCURRENCY}). Never-fail per recipient: each send
+ * is wrapped so a single bad address or transient Resend error cannot abort the
+ * batch (Promise.allSettled + the sender's own try/catch). Returns delivery
+ * counts for the caller's response — it never throws.
+ */
+export async function sendAnnouncementToConfirmedParticipants(input: {
+  conference?: Conference
+  workshopTitle: string
+  authorName: string
+  body: string
+  recipients: AnnouncementRecipient[]
+}): Promise<FanOutResult> {
+  const { conference, workshopTitle, authorName, body, recipients } = input
+  let sent = 0
+  let failed = 0
+
+  for (let i = 0; i < recipients.length; i += EMAIL_CONCURRENCY) {
+    const chunk = recipients.slice(i, i + EMAIL_CONCURRENCY)
+    const results = await Promise.allSettled(
+      chunk.map((recipient) =>
+        sendWorkshopAnnouncementEmail({
+          userEmail: recipient.userEmail,
+          userName: recipient.userName,
+          conference,
+          workshopTitle,
+          authorName,
+          body,
+        }),
+      ),
+    )
+
+    for (const result of results) {
+      if (result.status === 'fulfilled' && !result.value.error) {
+        sent += 1
+      } else {
+        failed += 1
+      }
+    }
+  }
+
+  return { sent, failed }
+}

--- a/src/server/routers/workshop.announce.test.ts
+++ b/src/server/routers/workshop.announce.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+// --- next/cache -------------------------------------------------------------
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+// --- Conference resolution (drives resolveConferenceId) ---------------------
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+// --- Organizer set ----------------------------------------------------------
+const getOrganizerSpeakerIdsMock = vi.fn()
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
+}))
+
+// --- Announcements data layer (keep isWorkshopFormat real) ------------------
+const getWorkshopForAnnouncementMock = vi.fn()
+const getConfirmedRecipientsMock = vi.fn()
+const createAnnouncementMock = vi.fn()
+const getAnnouncementsMock = vi.fn()
+const fanOutMock = vi.fn()
+vi.mock('@/lib/workshop/announcements', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/workshop/announcements')>()
+  return {
+    ...actual,
+    getWorkshopForAnnouncement: (...a: unknown[]) =>
+      getWorkshopForAnnouncementMock(...a),
+    getConfirmedAnnouncementRecipients: (...a: unknown[]) =>
+      getConfirmedRecipientsMock(...a),
+    createWorkshopAnnouncement: (...a: unknown[]) =>
+      createAnnouncementMock(...a),
+    getWorkshopAnnouncements: (...a: unknown[]) => getAnnouncementsMock(...a),
+    sendAnnouncementToConfirmedParticipants: (...a: unknown[]) =>
+      fanOutMock(...a),
+  }
+})
+
+// --- Rate limit (allow by default; individual tests can block) --------------
+const consumeRateLimitMock = vi.fn()
+vi.mock('@/lib/workshop/announcementRateLimit', () => ({
+  consumeAnnouncementRateLimit: (...a: unknown[]) => consumeRateLimitMock(...a),
+}))
+
+import { workshopRouter } from './workshop'
+
+const CONFERENCE_ID = 'conf-1'
+const OWNER_ID = 'sp-owner'
+const ORGANIZER_ID = 'sp-org'
+const STRANGER_ID = 'sp-stranger'
+
+function makeCaller(speakerId: string | null) {
+  const speaker = speakerId
+    ? { _id: speakerId, name: 'Test Speaker', isOrganizer: false }
+    : undefined
+  const ctx = {
+    session: speaker ? { speaker, user: { name: 'Test Speaker' } } : null,
+    speaker,
+  } as unknown as Context
+  return workshopRouter.createCaller(ctx)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: CONFERENCE_ID, organizer: 'CNB' },
+    error: null,
+  })
+  getWorkshopForAnnouncementMock.mockResolvedValue({
+    _id: 'ws-1',
+    title: 'K8s Ops',
+    format: 'workshop_120',
+    conferenceId: CONFERENCE_ID,
+    speakerIds: [OWNER_ID],
+  })
+  getOrganizerSpeakerIdsMock.mockResolvedValue([ORGANIZER_ID])
+  getConfirmedRecipientsMock.mockResolvedValue([
+    { userEmail: 'a@example.com', userName: 'A' },
+  ])
+  createAnnouncementMock.mockResolvedValue({
+    _id: 'ann-1',
+    body: 'hi',
+    createdAt: '2026-09-08T12:00:00Z',
+    authorName: null,
+  })
+  fanOutMock.mockResolvedValue({ sent: 1, failed: 0 })
+  consumeRateLimitMock.mockReturnValue({ allowed: true, retryAfterMs: 0 })
+})
+
+describe('workshop.announce — authorization', () => {
+  it('allows the workshop OWNER', async () => {
+    const result = await makeCaller(OWNER_ID).announce({
+      workshopId: 'ws-1',
+      body: 'Bring a laptop',
+    })
+    expect(result.success).toBe(true)
+    expect(result.recipientCount).toBe(1)
+    expect(createAnnouncementMock).toHaveBeenCalledOnce()
+    expect(fanOutMock).toHaveBeenCalledOnce()
+    // An owner is authorized without needing the organizer lookup.
+    expect(getOrganizerSpeakerIdsMock).not.toHaveBeenCalled()
+  })
+
+  it('allows an ORGANIZER who is not a workshop speaker', async () => {
+    const result = await makeCaller(ORGANIZER_ID).announce({
+      workshopId: 'ws-1',
+      body: 'Room change',
+    })
+    expect(result.success).toBe(true)
+    expect(getOrganizerSpeakerIdsMock).toHaveBeenCalledOnce()
+    expect(createAnnouncementMock).toHaveBeenCalledOnce()
+  })
+
+  it('rejects an unrelated speaker (not owner, not organizer)', async () => {
+    await expect(
+      makeCaller(STRANGER_ID).announce({ workshopId: 'ws-1', body: 'hi' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(createAnnouncementMock).not.toHaveBeenCalled()
+    expect(fanOutMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unauthenticated caller', async () => {
+    await expect(
+      makeCaller(null).announce({ workshopId: 'ws-1', body: 'hi' }),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
+    expect(createAnnouncementMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('workshop.announce — guards', () => {
+  it('rejects a workshop in a different conference (multi-tenant isolation)', async () => {
+    getWorkshopForAnnouncementMock.mockResolvedValue({
+      _id: 'ws-1',
+      title: 'Other',
+      format: 'workshop_120',
+      conferenceId: 'conf-OTHER',
+      speakerIds: [OWNER_ID],
+    })
+    await expect(
+      makeCaller(OWNER_ID).announce({ workshopId: 'ws-1', body: 'hi' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(createAnnouncementMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-workshop talk', async () => {
+    getWorkshopForAnnouncementMock.mockResolvedValue({
+      _id: 'ws-1',
+      title: 'Talk',
+      format: 'presentation_25',
+      conferenceId: CONFERENCE_ID,
+      speakerIds: [OWNER_ID],
+    })
+    await expect(
+      makeCaller(OWNER_ID).announce({ workshopId: 'ws-1', body: 'hi' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+  })
+
+  it('enforces the rate limit', async () => {
+    consumeRateLimitMock.mockReturnValue({
+      allowed: false,
+      retryAfterMs: 30 * 60 * 1000,
+    })
+    await expect(
+      makeCaller(OWNER_ID).announce({ workshopId: 'ws-1', body: 'hi' }),
+    ).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' })
+    expect(createAnnouncementMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty body via input validation', async () => {
+    await expect(
+      makeCaller(OWNER_ID).announce({ workshopId: 'ws-1', body: '   ' }),
+    ).rejects.toBeTruthy()
+    expect(createAnnouncementMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('workshop.announcements — public query bounds', () => {
+  it('returns announcements with the default limit', async () => {
+    getAnnouncementsMock.mockResolvedValue([
+      { _id: 'a1', body: 'hi', createdAt: 'x', authorName: 'Owner' },
+    ])
+    const result = await makeCaller(null).announcements({ workshopId: 'ws-1' })
+    expect(result.count).toBe(1)
+    // Default limit (50) applied by the schema.
+    expect(getAnnouncementsMock).toHaveBeenCalledWith('ws-1', 50)
+  })
+
+  it('rejects a limit above 50', async () => {
+    await expect(
+      makeCaller(null).announcements({ workshopId: 'ws-1', limit: 51 }),
+    ).rejects.toBeTruthy()
+  })
+})

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import {
   router,
   publicProcedure,
+  protectedProcedure,
   adminProcedure,
   resolveConferenceId,
   type Context,
@@ -23,6 +24,8 @@ import {
   batchConfirmSignupsSchema,
   batchCancelSignupsSchema,
   WorkshopSignupIdSchema,
+  workshopAnnounceSchema,
+  workshopAnnouncementsQuerySchema,
 } from '@/server/schemas/workshop'
 import {
   checkWorkshopCapacity,
@@ -41,6 +44,16 @@ import { Status } from '@/lib/proposal/types'
 import { sendBasicWorkshopConfirmation } from '@/lib/email/workshop'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { WorkshopSignupStatus } from '@/lib/workshop/types'
+import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import {
+  getWorkshopForAnnouncement,
+  getConfirmedAnnouncementRecipients,
+  createWorkshopAnnouncement,
+  getWorkshopAnnouncements,
+  sendAnnouncementToConfirmedParticipants,
+  isWorkshopFormat,
+} from '@/lib/workshop/announcements'
+import { consumeAnnouncementRateLimit } from '@/lib/workshop/announcementRateLimit'
 
 /**
  * Return the authenticated WorkOS attendee for a self-service workshop action,
@@ -94,6 +107,131 @@ export const workshopRouter = router({
       })
     }
   }),
+
+  // Public read of a workshop's broadcast announcements, newest first. Bounded
+  // [0...50] by the schema. Author name is projected through a WEAK ref, so it
+  // may be null if the authoring speaker was erased (GDPR).
+  announcements: publicProcedure
+    .input(workshopAnnouncementsQuerySchema)
+    .query(async ({ input }) => {
+      try {
+        const announcements = await getWorkshopAnnouncements(
+          input.workshopId,
+          input.limit,
+        )
+        return {
+          success: true,
+          data: announcements,
+          count: announcements.length,
+        }
+      } catch (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to fetch workshop announcements',
+          cause: error,
+        })
+      }
+    }),
+
+  // Compose + broadcast an announcement to a workshop's CONFIRMED participants.
+  // One-way only (no threads/replies): recipients are WorkOS attendees, not
+  // speakers, so there is no identity to attribute a reply to.
+  announce: protectedProcedure
+    .input(workshopAnnounceSchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const conferenceId = await resolveConferenceId()
+        const workshop = await getWorkshopForAnnouncement(input.workshopId)
+
+        // Multi-tenant isolation: the workshop must live in the caller's
+        // resolved conference, and must actually be a workshop-format talk.
+        if (!workshop || workshop.conferenceId !== conferenceId) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Workshop not found for this conference',
+          })
+        }
+        if (!isWorkshopFormat(workshop.format)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Referenced talk is not a workshop',
+          })
+        }
+
+        // Authorization: the caller must OWN the workshop (be one of its
+        // speakers) OR be an organizer. Organizer = membership in any
+        // conference's organizers[] (the canonical getOrganizerSpeakerIds
+        // definition); there is NO stored isOrganizer field on speaker docs.
+        const speakerId = ctx.speaker._id
+        const isOwner = workshop.speakerIds.includes(speakerId)
+        const isOrganizer = isOwner
+          ? false
+          : (await getOrganizerSpeakerIds()).includes(speakerId)
+
+        if (!isOwner && !isOrganizer) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message:
+              'Only the workshop owner or an organizer can send announcements',
+          })
+        }
+
+        // Rate limit: 3 announcements per workshop per hour (best-effort,
+        // per-instance). Guards against an accidental double/triple send.
+        const rateLimit = consumeAnnouncementRateLimit(input.workshopId)
+        if (!rateLimit.allowed) {
+          const minutes = Math.max(1, Math.ceil(rateLimit.retryAfterMs / 60000))
+          throw new TRPCError({
+            code: 'TOO_MANY_REQUESTS',
+            message: `Announcement limit reached for this workshop. Try again in about ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+          })
+        }
+
+        const announcement = await createWorkshopAnnouncement({
+          workshopId: input.workshopId,
+          conferenceId,
+          authorId: speakerId,
+          body: input.body,
+        })
+
+        // Fan out one email per confirmed participant (bounded concurrency,
+        // never-fail per recipient). Failures are counted, not thrown: the
+        // announcement is already persisted and visible on the page.
+        const recipients = await getConfirmedAnnouncementRecipients(
+          input.workshopId,
+        )
+        const { conference } = await getConferenceForCurrentDomain({})
+        const { sent, failed } = await sendAnnouncementToConfirmedParticipants({
+          conference: conference || undefined,
+          workshopTitle: workshop.title,
+          authorName: ctx.speaker.name,
+          body: input.body,
+          recipients,
+        })
+
+        revalidateTag('content:workshops', 'default')
+
+        return {
+          success: true,
+          data: {
+            ...announcement,
+            authorName: ctx.speaker.name,
+          },
+          recipientCount: recipients.length,
+          sent,
+          failed,
+          message: `Announcement sent to ${sent} of ${recipients.length} confirmed participant${recipients.length === 1 ? '' : 's'}`,
+        }
+      } catch (error) {
+        if (error instanceof TRPCError) throw error
+
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to send workshop announcement',
+          cause: error,
+        })
+      }
+    }),
 
   getAvailability: publicProcedure
     .input(workshopAvailabilitySchema)

--- a/src/server/schemas/workshop.ts
+++ b/src/server/schemas/workshop.ts
@@ -113,6 +113,22 @@ export const updateWorkshopCapacitySchema = z.object({
     .max(500, 'Capacity too large'),
 })
 
+/** Owner/organizer composing a broadcast announcement to confirmed participants. */
+export const workshopAnnounceSchema = z.object({
+  workshopId: z.string().min(1, 'Workshop ID is required'),
+  body: z
+    .string()
+    .trim()
+    .min(1, 'Announcement message is required')
+    .max(2000, 'Announcement must be 2000 characters or fewer'),
+})
+
+/** Public read of a workshop's announcements, bounded to [0...50], newest first. */
+export const workshopAnnouncementsQuerySchema = z.object({
+  workshopId: z.string().min(1, 'Workshop ID is required'),
+  limit: z.number().int().min(0).max(50).optional().default(50),
+})
+
 export type WorkshopSignupInput = z.infer<typeof workshopSignupInputSchema>
 
 export const WorkshopSignupIdSchema = z.object({


### PR DESCRIPTION
## Scope (maintainer-locked)

A **one-way broadcast rail** for workshops: a workshop owner or an organizer composes an announcement, it is **emailed to every CONFIRMED participant** and **shown on the workshop page**. Deliberately **no threads, no participant replies** — participants are WorkOS attendee id-strings, not speaker docs, so there is no authenticated identity to attribute a reply to (this defers the WorkOS identity problem). No coupling to `src/lib/messaging/*`.

## Authorization model

`workshop.announce` is a `protectedProcedure` (NextAuth speaker session). A caller may broadcast iff:
- they **own** the workshop — their `speaker._id` is in the workshop `talk.speakers[]`, **or**
- they are an **organizer** — membership in any conference's `organizers[]`, resolved via the canonical `getOrganizerSpeakerIds()` (there is no stored `isOrganizer` field on speaker docs). The organizer lookup is skipped when the caller is already an owner.

Also guarded: multi-tenant isolation (workshop must live in the caller's resolved conference), workshop-format check, and empty-body validation. Unauthenticated → `UNAUTHORIZED`; unrelated speaker → `FORBIDDEN`.

## Fan-out mechanics

1. Create the `workshopAnnouncement` doc (workshop + conference refs, **WEAK** author ref per the GDPR house rule, body ≤ 2000, `createdAt`).
2. Fetch **confirmed** signups only and send **one email per recipient** using the attendee-style raw-HTML sender (`sendWorkshopAnnouncementEmail`, sibling of `sendBasicWorkshopConfirmation`), **bounded concurrency 3**, `Promise.allSettled`, **never-fail per recipient** (the announcement is already persisted/visible; failures are counted, not thrown). Body is HTML-escaped.
3. **Rate limit: 3 announcements per workshop per hour** (module-Map pattern), returns `TOO_MANY_REQUESTS` when exceeded.

`workshop.announcements` is a `publicProcedure` returning a workshop's announcements newest-first, bounded `[0...50]`, with author name (null when the author was erased).

## Where compose lives

- **Admin** (`/admin/workshops`): each workshop card gets an **"Announce to participants"** button opening a `ModalShell` compose dialog — textarea (max 2000 + live counter), a **"Will email N confirmed participants"** notice, 44px targets, house `AdminButton`s, toast on success/partial-failure via the admin `NotificationProvider`.
- **CFP owner surface**: none exists today — there is no `getWorkshopsBySpeaker` usage / speaker-facing workshop management page. Compose is therefore **admin-only**; workshop owners who are speakers can ask an organizer (no new page invented). The router authz still allows an owner-speaker to call `announce` directly.
- **Participant view** (`/workshop`): an **Announcements** block inside each `WorkshopCard` (passed as a decoupled slot from `WorkshopList`, which holds the tRPC provider), newest-first, author + relative time, `whitespace-pre-wrap`.

## Tests

- Router authz: owner ✓ / organizer ✓ / unrelated speaker ✗ / unauthenticated ✗, plus wrong-conference, non-workshop, rate-limit, empty-body, and query-bound cases.
- Fan-out: confirmed-only query, never-fail (tolerates soft errors AND thrown rejections), bounded concurrency ≤ 3, empty list.
- Rate limit: quota, per-workshop isolation, window reset.
- Email render: body/subject/escaping/newline→`<br>`, error path.

Stories + light/dark shoots for the announcements block and compose modal (visually verified). Privacy page updated to document stored announcement content (author + message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a one-way announcement broadcast rail for workshops: an admin compose modal sends a message to all confirmed participants via email and persists it as a `workshopAnnouncement` Sanity document shown on the workshop page. Authorization is correctly layered (owner or organizer, multi-tenant isolated, rate-limited at 3/hour per workshop), and the email fan-out uses bounded concurrency with `Promise.allSettled` so per-recipient failures never abort the batch.

- **New tRPC procedures**: `workshop.announce` (protected mutation) persists the announcement, fans out emails with bounded concurrency, and returns per-recipient delivery counts; `workshop.announcements` (public query) returns newest-first, bounded to 50.
- **Email sender** (`sendWorkshopAnnouncementEmail`): raw-HTML template with correct `escapeHtml` + `\n→<br>` conversion, retry-with-backoff, and a never-throw contract.
- **UI**: admin `AnnounceModal` compose dialog with live character counter and confirmed-count notice; participant-facing `WorkshopAnnouncements` presentational block rendered as a slot inside `WorkshopCard` from `WorkshopList`.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the announcement-before-recipients ordering; the rest of the implementation is solid

The mutation writes the Sanity announcement document before fetching the confirmed recipient list and conference branding. A transient Sanity error during the recipient fetch would leave an announcement already visible on the workshop page while returning an error to the client, causing confused retries and potential duplicate announcements. Moving both fetches before the `create` call (they can even run in parallel) eliminates the window. All other aspects — auth layering, HTML escaping, bounded-concurrency fan-out, rate limiting, GDPR weak-ref pattern, schema validation — are well implemented.

src/server/routers/workshop.ts — the ordering of createWorkshopAnnouncement vs getConfirmedAnnouncementRecipients in the announce mutation

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/workshop.ts | Adds `announcements` (public query) and `announce` (protected mutation) procedures; the mutation persists the announcement doc before fetching the recipient list, so a transient fetch error after creation leaves a phantom announcement with no emails sent and returns an error to the client |
| src/lib/workshop/announcements.ts | Well-structured fan-out helpers; bounded concurrency (3), Promise.allSettled, never-fail per recipient, and correct GROQ range operator — all look correct |
| src/lib/workshop/announcementRateLimit.ts | Sliding-window in-memory rate limiter using a module-Map pattern; correctly prunes on every call and returns retryAfterMs; per-instance limitation is documented and intentional |
| src/lib/email/workshop.ts | New sendWorkshopAnnouncementEmail function with correct HTML escaping and newline→br conversion; never-throw contract upheld via try/catch; template uses trusted conference data for unescaped href |
| sanity/schemaTypes/workshopAnnouncement.ts | New Sanity schema with correct GDPR-conscious weak author reference, workshop-format validation, and body length constraint matching the router schema |
| src/components/admin/workshop/WorkshopsClientPage.tsx | Adds AnnounceModal state management and announce mutation with success/partial-failure toast handling; correctly closes modal on success and shows error on failure |
| src/components/admin/workshop/AnnounceModal.tsx | Compose modal with 2000-char live counter, participant count notice, and body-reset-on-open via derived state — correct implementation |
| src/components/workshop/WorkshopList.tsx | Passes WorkshopAnnouncementsSection as a slot to all three workshop card groups (signed-up, available, full); announcements visible to all visitors since the query is a publicProcedure |
| src/server/schemas/workshop.ts | New Zod schemas for announce and announcements query; body trimming, length constraints, and limit bounds all correct |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin UI
    participant Router as workshop.announce
    participant Sanity as Sanity (clientWrite)
    participant Email as sendWorkshopAnnouncementEmail

    Admin->>Router: "announce({ workshopId, body })"
    Router->>Router: resolveConferenceId()
    Router->>Sanity: getWorkshopForAnnouncement()
    Router->>Router: isOwner / isOrganizer check
    Router->>Router: consumeAnnouncementRateLimit()
    Router->>Sanity: createWorkshopAnnouncement() ← doc persisted here
    Router->>Sanity: getConfirmedAnnouncementRecipients()
    Router->>Router: getConferenceForCurrentDomain()
    loop per chunk of 3
        Router->>Email: sendWorkshopAnnouncementEmail()
        Email-->>Router: "{ data } | { error }"
    end
    Router->>Router: revalidateTag('content:workshops')
    Router-->>Admin: "{ success, sent, failed, recipientCount }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin UI
    participant Router as workshop.announce
    participant Sanity as Sanity (clientWrite)
    participant Email as sendWorkshopAnnouncementEmail

    Admin->>Router: "announce({ workshopId, body })"
    Router->>Router: resolveConferenceId()
    Router->>Sanity: getWorkshopForAnnouncement()
    Router->>Router: isOwner / isOrganizer check
    Router->>Router: consumeAnnouncementRateLimit()
    Router->>Sanity: createWorkshopAnnouncement() ← doc persisted here
    Router->>Sanity: getConfirmedAnnouncementRecipients()
    Router->>Router: getConferenceForCurrentDomain()
    loop per chunk of 3
        Router->>Email: sendWorkshopAnnouncementEmail()
        Email-->>Router: "{ data } | { error }"
    end
    Router->>Router: revalidateTag('content:workshops')
    Router-->>Admin: "{ success, sent, failed, recipientCount }"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(workshop): participant announcement..."](https://github.com/cloudnativebergen/website/commit/e3f6a86f6cb71d385080fec46ba86a18c7784765) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45470342)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->