### PR TITLE
feat(migrations): backfill organizer notifications (messages + events rail)

### DIFF
--- a/migrations/042-backfill-organizer-notifications/README.md
+++ b/migrations/042-backfill-organizer-notifications/README.md
@@ -1,0 +1,216 @@
+# Migration 042: Backfill Organizer Notifications (messages + events rail)
+
+## Overview
+
+A one-shot backfill that reconstructs the **organizer side** of the in-app
+notification hub, which was **silently never populated** until #559.
+
+### The #559 root cause
+
+From the hub launch until #559, every code path that fanned notifications out to
+organizers resolved the organizer set with a query that tested
+`isOrganizer == true` — **a field that does not exist on the speaker schema**. It
+matched **nothing** in production, so **every organizer-recipient notification
+was silently never created**. The maintainer's hub is therefore empty of
+organizer history.
+
+#559 fixed the pipe going **forward** (organizers are now resolved by membership
+in a conference's `organizers[]` array — the canonical rule the auth session
+already uses). This migration reconstructs the missing **history** from the
+current dataset state.
+
+Two families of organizer notification were lost, and this migration restores
+both:
+
+## PART A — collapsed `message_received` notifications
+
+The live writer `upsertMessageNotifications`
+(`src/lib/notification/sanity.ts`) keeps **one collapsed notification per
+(recipient, conversation)**: every new message re-surfaces the same document
+instead of stacking a new one. Its recipient set includes **every organizer**
+(`resolveParticipantIds` always seeds the participant set with the full
+organizer list), so each organizer should hold one collapsed message
+notification per conversation they participate in — but got none.
+
+For **every conversation** in the target conference that has **at least one
+message**, for **every organizer**, this migration creates the collapsed doc
+with fields mirroring the live single-message shape exactly:
+
+- `recipient` → the organizer (**weak** ref, per 041)
+- `conference` → the conference
+- `notificationType` → `message_received`
+- `title` → the live single-message form
+  `New message from <lastAuthorName> — <subject>`, or the **DIRECT** variant
+  `Direct message from <lastAuthorName> — <subject>` when the organizer **is**
+  the conversation's `subjectSpeaker` (mirrors the live `isDirect` comparison);
+  grapheme-safe, capped at 200
+- `message` → the last message body excerpt (~140 chars, grapheme-safe)
+- `link` → the **organizer-audience** `conversationLinkPath`
+  (`/admin/proposals/<id>#messages` for proposal threads, else
+  `/admin/messages/<conversationId>`)
+- `actor` → the last message's author (**weak** ref)
+- `count` → 1
+- `createdAt` → `conversation.lastMessageAt`
+- `readAt` → `conversation.lastMessageAt` (**arrives read** — see Read-state)
+
+### The live-id collapse trick (critical)
+
+The document `_id` is the **LIVE deterministic id**
+`notification.message.<conversationId>.<organizerId>` — the exact id
+`messageNotificationId` computes. The live upsert **patches this same id** on
+every subsequent message, so a future message **collapses into the backfilled
+document** instead of creating a second one. **No duplicates, ever.** And because
+the write is `createIfNotExists`, if a post-#559 message already re-created the
+live doc, this migration **no-ops** on it and never clobbers the fresher
+(possibly unread) live state.
+
+### Actor-exclusion limitation (honest current-state note)
+
+The backfilled doc mirrors the conversation's **last** message. An organizer who
+**authored** that last message is skipped (the live upsert excludes the actor;
+otherwise they'd get a nonsensical "New message from _themselves_"). This means a
+notification such an organizer may have earned from an **earlier** message in the
+same thread is **not** reconstructed — an accepted limitation of reconstructing
+from current state only (the same spirit as 040 reconstructing from current
+proposal status).
+
+## PART B — events-rail organizer notifications
+
+The events handler `handlePersistNotification`
+(`src/lib/events/handlers/persistNotification.ts`) emits **three**
+organizer-facing notifications, all targeting `getOrganizerSpeakerIds()` and all
+lost to the `isOrganizer` bug. This migration reconstructs each from current
+talk state, mirroring the live titles / types / links verbatim:
+
+| Source (current talk state) | `notificationType`        | Title                           | `link`                      | Timestamp used        |
+| --------------------------- | ------------------------- | ------------------------------- | --------------------------- | --------------------- |
+| status left `draft`\*       | `proposal_submitted`      | `New proposal: "<title>"`       | `/admin/proposals/<talkId>` | talk `_createdAt`     |
+| status == `confirmed`       | `proposal_status_changed` | `Speaker confirmed: "<title>"`  | `/admin/proposals/<talkId>` | talk `_updatedAt`\*\* |
+| status == `withdrawn`       | `proposal_status_changed` | `Proposal withdrawn: "<title>"` | `/admin/proposals/<talkId>` | talk `_updatedAt`\*\* |
+
+\* "left `draft`" = current `status` ∈ {`submitted`, `accepted`, `waitlisted`,
+`confirmed`, `rejected`, `withdrawn`} — any such talk was submitted at least once
+(the live `Action.submit` handler would have fired). `draft` and `deleted` are
+excluded.
+
+\*\* The talk schema has **no dedicated status-change timestamp**, so `_updatedAt`
+is used as the honest best proxy for when the confirm/withdraw happened. For a
+withdrawn talk, the `withdrawnReason` becomes the notification `message` (mirrors
+the live handler relaying `event.metadata.reason`).
+
+Each doc carries: `recipient` (organizer, **weak**), `conference`,
+`notificationType`, `title`, `link`, `relatedProposal` (**weak**, per 040),
+`actor` (the talk's first speaker, **weak**), `createdAt` (the source timestamp),
+and `readAt == createdAt`. The **actor** is excluded from the organizer
+recipients (an organizer who is also that speaker is skipped, mirroring the live
+`id !== actorId`).
+
+The `_id` is deterministic:
+`notification.backfill-042.<notificationType>.<talkId>.<organizerId>`. A talk is
+only ever one of confirmed/withdrawn in current state, so the two
+`proposal_status_changed` variants never collide on an id.
+
+## Read-state rule
+
+**Every** backfilled notification (both parts) arrives **already read**
+(`readAt == createdAt`). Reconstructed history should populate the panel
+chronologically **without lighting up the unread badge** — a flood of historical
+unread items would be noise, not signal. (Contrast 040, which deliberately left
+`accepted` proposals **unread** because they are still-actionable speaker
+call-to-actions; nothing backfilled here is a fresh call-to-action for an
+organizer.)
+
+## Target conference
+
+Identical to 040. The app resolves the conference by request domain
+(`getConferenceForCurrentDomain`), unavailable inside a migration, so this
+migration queries all conferences, picks the one with the **latest `startDate`**,
+and **logs every candidate** (the production dataset contains test/dummy
+conference docs with far-future `startDate`s that break the naive heuristic). To
+pin a specific edition, set `BACKFILL_CONFERENCE_ID=<conferenceId>` in the run
+environment — **the maintainer intends to pin it** for the production run.
+
+## Idempotency
+
+Safe to run multiple times. `createIfNotExists` **only** — no patches, no
+deletes to any existing document.
+
+1. **Deterministic `_id`s**:
+   - PART A → `notification.message.<conversationId>.<organizerId>` (the **live**
+     id — see the collapse trick above)
+   - PART B → `notification.backfill-042.<type>.<talkId>.<organizerId>`
+
+   A re-run recreates the same ids, so `createIfNotExists` no-ops.
+
+2. **PART B dedup set** (belt-and-braces, like 040) — a pre-pass loads existing
+   `notification` documents for the conference of type `proposal_submitted` /
+   `proposal_status_changed` and builds a set keyed
+   `(recipient, notificationType, relatedProposal)`. A candidate is skipped when
+   its key already exists. This catches a **live emitter that already fired**
+   post-#559 for the same (organizer, talk, kind) with a **random** `_id` — which
+   the deterministic-id check alone would miss — so no duplicate is created.
+
+PART A needs no separate dedup set: the live deterministic id **is** the dedup,
+and `createIfNotExists` guarantees the live doc (if any) wins.
+
+Drafts are skipped (the published document owns the fields). Skipped counts are
+logged.
+
+## Dry-run friendliness
+
+The migration logs, before writing:
+
+- every **conference candidate** and the chosen target;
+- the resolved **organizer count**;
+- **PART A** candidate count (`conversations with ≥1 message × organizers`);
+- **PART B** source breakdown (talks: submitted / confirmed / withdrawn ×
+  organizers) and the existing-key skip count;
+- a final summary of created / skipped for each part.
+
+## Running the migration
+
+Run via the **`Run Sanity Migration`** GitHub Actions workflow
+(`.github/workflows/run-migration.yml`, `workflow_dispatch`):
+
+- **migration**: `042-backfill-organizer-notifications`
+- **dataset**: `production` (or the target dataset)
+- pin **`BACKFILL_CONFERENCE_ID`** to the current edition
+
+The workflow exports a dataset backup artifact, performs a **dry run** (logging
+every intended creation without writing), and only then applies. Review the
+dry-run log before the apply step — it is the validation gate, since the
+migration cannot be exercised against the real dataset from a PR.
+
+Equivalent local invocation:
+
+```bash
+BACKFILL_CONFERENCE_ID=<conferenceId> pnpm sanity migration run 042-backfill-organizer-notifications \
+  --project "$SANITY_STUDIO_PROJECT_ID" --dataset production   # dry run
+BACKFILL_CONFERENCE_ID=<conferenceId> pnpm sanity migration run 042-backfill-organizer-notifications \
+  --project "$SANITY_STUDIO_PROJECT_ID" --dataset production --no-dry-run --no-confirm
+```
+
+## Verification
+
+After running, spot-check counts and a sample:
+
+```bash
+# PART B backfilled docs (deterministic prefix)
+npx sanity documents query '*[_type == "notification" && _id in path("notification.backfill-042.**")] | count'
+
+# PART A collapsed message docs for organizers (live id shape) — all should be read
+npx sanity documents query '*[_type == "notification" && notificationType == "message_received" && _id in path("notification.message.**")]{title, readAt, count}[0...10]'
+```
+
+## Rollback
+
+```bash
+# PART B only (deterministic prefix — safe, these ids are unique to this migration)
+npx sanity documents query 'delete *[_type == "notification" && _id in path("notification.backfill-042.**")]'
+```
+
+> ⚠ **PART A cannot be blanket-deleted by id prefix**: it shares the LIVE
+> `notification.message.*` id space, so a live message may since have collapsed
+> into (and updated) a backfilled doc. Deleting by that prefix would destroy live
+> notifications too. If PART A must be undone, restore from the backup artifact
+> produced by the workflow.

--- a/migrations/042-backfill-organizer-notifications/index.ts
+++ b/migrations/042-backfill-organizer-notifications/index.ts
@@ -1,0 +1,559 @@
+import { defineMigration, createIfNotExists } from 'sanity/migrate'
+
+/**
+ * One-shot backfill of the ORGANIZER side of the notification hub.
+ *
+ * WHY (the #559 root cause): from the hub launch until #559, every code path
+ * that fanned notifications out to organizers resolved the organizer set with a
+ * query that tested `isOrganizer == true` — a field that DOES NOT EXIST on the
+ * speaker schema. It matched NOTHING, so EVERY organizer-recipient notification
+ * was silently never created. Two families of organizer notification were lost:
+ *
+ *   PART A — collapsed `message_received` notifications: when a speaker sent a
+ *   message, `upsertMessageNotifications` (src/lib/notification/sanity.ts) was
+ *   supposed to keep ONE collapsed notification per (organizer, conversation).
+ *   The organizer set was empty, so organizers got nothing.
+ *
+ *   PART B — the events-rail organizer notifications emitted by
+ *   `handlePersistNotification` (src/lib/events/handlers/persistNotification.ts):
+ *     - `proposal_submitted`     "New proposal: \"<title>\""        (Action.submit)
+ *     - `proposal_status_changed` "Speaker confirmed: \"<title>\""  (Action.confirm)
+ *     - `proposal_status_changed` "Proposal withdrawn: \"<title>\"" (Action.withdraw)
+ *   all targeting `getOrganizerSpeakerIds()`, all lost for the same reason.
+ *
+ * #559 fixed the pipe going FORWARD (organizers are now resolved by conference
+ * `organizers[]` membership). This migration reconstructs the missing HISTORY
+ * from the CURRENT dataset state so the maintainer's hub is not empty.
+ *
+ * READ-STATE RULE: every backfilled notification arrives ALREADY READ
+ * (`readAt == createdAt`). Reconstructed history should populate the panel
+ * chronologically WITHOUT lighting up the unread badge — a flood of historical
+ * unread items would be noise, not signal. (Contrast 040, which left `accepted`
+ * proposals unread because they are still-actionable speaker call-to-actions;
+ * nothing backfilled here is a fresh call-to-action.)
+ *
+ * PART A COLLAPSE TRICK: the message notifications are written with the LIVE
+ * deterministic id `notification.message.<conversationId>.<organizerId>` (the
+ * exact id `messageNotificationId` computes). The live upsert PATCHES this same
+ * id on every new message, so a future message collapses INTO the backfilled
+ * doc instead of creating a second one — no duplicates, ever. `createIfNotExists`
+ * also means that if a post-#559 message already re-created the live doc, this
+ * migration no-ops on it and never clobbers the fresher (possibly unread) state.
+ *
+ * IDEMPOTENCY: every write is `createIfNotExists` with a deterministic id (no
+ * patches, no deletes). PART B additionally runs a pre-pass that builds a dedup
+ * set keyed like 040 — (recipient, notificationType, relatedProposal) — from the
+ * existing `notification` docs, so a live-emitted post-#559 organizer notification
+ * (which carries a RANDOM id) is never duplicated by the backfill.
+ */
+
+/** Optional operator override to pin the target conference explicitly. */
+const CONFERENCE_OVERRIDE = process.env.BACKFILL_CONFERENCE_ID
+
+/** Deterministic id prefix for PART B (events-rail) notifications. */
+const PART_B_ID_PREFIX = 'notification.backfill-042'
+
+// ---------------------------------------------------------------------------
+// Pure helpers — MIRRORED VERBATIM from the live source so the backfilled docs
+// are byte-for-byte the shape the live emitters produce. Migrations do not
+// resolve the `@/` path alias / `server-only` guards, so the pure bits are
+// duplicated here rather than imported. Keep in sync with the cited sources.
+// ---------------------------------------------------------------------------
+
+/**
+ * Live deterministic id for the single collapsed message notification a
+ * recipient holds per conversation. Mirrors `messageNotificationId` in
+ * src/lib/notification/sanity.ts EXACTLY — this is what makes the live upsert
+ * collapse future messages into the backfilled doc (see PART A COLLAPSE TRICK).
+ */
+function messageNotificationId(
+  conversationId: string,
+  recipientId: string,
+): string {
+  return `notification.message.${conversationId}.${recipientId}`
+}
+
+/** Schema cap on `notification.title` (Rule.max(200)). Mirrors the live const. */
+const NOTIFICATION_TITLE_MAX = 200
+
+/** How many characters of the message body ride into the notification. */
+const EXCERPT_LENGTH = 140
+
+/**
+ * The longest prefix of `text` that is at most `max` UTF-16 code units long AND
+ * ends on a grapheme-cluster boundary. Mirrors `truncateToGraphemeBoundary` in
+ * src/lib/messaging/links.ts VERBATIM so a truncated emoji never leaves a lone
+ * surrogate (�).
+ */
+function truncateToGraphemeBoundary(text: string, max: number): string {
+  if (max <= 0) return ''
+  if (text.length <= max) return text
+
+  const SegmenterCtor = (
+    Intl as unknown as { Segmenter?: typeof Intl.Segmenter }
+  ).Segmenter
+  if (SegmenterCtor) {
+    const segmenter = new SegmenterCtor(undefined, { granularity: 'grapheme' })
+    let out = ''
+    for (const { segment } of segmenter.segment(text)) {
+      if (out.length + segment.length > max) break
+      out += segment
+    }
+    return out
+  }
+
+  let end = max
+  const code = text.charCodeAt(end - 1)
+  if (code >= 0xd800 && code <= 0xdbff) end -= 1
+  return text.slice(0, end)
+}
+
+/**
+ * A single-line excerpt of a message body, capped and ellipsised. Mirrors
+ * `messageExcerpt` in src/lib/messaging/notify.ts VERBATIM.
+ */
+function messageExcerpt(body: string, max = EXCERPT_LENGTH): string {
+  const flat = body.replace(/\s+/g, ' ').trim()
+  return flat.length > max
+    ? `${truncateToGraphemeBoundary(flat, max).trimEnd()}…`
+    : flat
+}
+
+/**
+ * Title copy for the SINGLE-message form of a collapsed message notification
+ * (backfilled docs always start at count 1). Mirrors the `count === 1` branches
+ * of `messageNotificationTitle` in src/lib/notification/sanity.ts: the DIRECT
+ * variant when the recipient IS the conversation's subject speaker (S10c), the
+ * standard variant otherwise, both grapheme-capped at 200.
+ */
+function singleMessageTitle(
+  authorName: string,
+  subject: string,
+  isDirect: boolean,
+): string {
+  const title = isDirect
+    ? `Direct message from ${authorName} — ${subject}`
+    : `New message from ${authorName} — ${subject}`
+  return truncateToGraphemeBoundary(title, NOTIFICATION_TITLE_MAX)
+}
+
+/**
+ * The ORGANIZER-audience deep link to a conversation. Mirrors
+ * `conversationLinkPath(conversation, true)` in src/lib/messaging/links.ts —
+ * organizers always get the /admin variant.
+ */
+function organizerConversationLink(conv: {
+  _id: string
+  conversationType?: string
+  proposalId?: string | null
+}): string {
+  if (conv.conversationType === 'proposal' && conv.proposalId) {
+    return `/admin/proposals/${conv.proposalId}#messages`
+  }
+  return `/admin/messages/${conv._id}`
+}
+
+// ---------------------------------------------------------------------------
+// PART B — events-rail organizer notification catalogue.
+// Mirrors the three organizer-facing emits in
+// src/lib/events/handlers/persistNotification.ts (titles / types / links).
+// ---------------------------------------------------------------------------
+
+const PROPOSAL_ADMIN_LINK = (talkId: string): string =>
+  `/admin/proposals/${talkId}`
+
+/**
+ * A talk's `status` (src/lib/proposal/types.ts `Status`) is post-submit for
+ * every value except `draft` and `deleted`. Any such talk was submitted at
+ * least once, so the live `Action.submit` handler would have emitted one
+ * `proposal_submitted` per organizer. Reconstruct from that current-state fact.
+ */
+const SUBMITTED_STATUSES = new Set([
+  'submitted',
+  'accepted',
+  'waitlisted',
+  'confirmed',
+  'rejected',
+  'withdrawn',
+])
+
+interface ConferenceRow {
+  _id: string
+  title?: string
+  startDate?: string
+}
+
+interface ExistingEventsNotificationRow {
+  recipientRef?: string
+  notificationType?: string
+  relatedProposalRef?: string
+}
+
+interface ConversationRow {
+  _id: string
+  conversationType?: string
+  subject?: string
+  proposalId?: string | null
+  subjectSpeakerId?: string | null
+  lastMessageAt?: string
+  lastMessage?: {
+    authorId?: string | null
+    authorName?: string | null
+    body?: string | null
+    createdAt?: string | null
+  } | null
+}
+
+interface TalkRow {
+  _id: string
+  title?: string
+  status?: string
+  withdrawnReason?: string | null
+  _createdAt?: string
+  _updatedAt?: string
+  speakerIds?: Array<string | null>
+}
+
+/** Dedup key mirroring 040's shape: (recipient, notificationType, relatedProposal). */
+function eventsKey(
+  recipientRef: string,
+  notificationType: string,
+  relatedProposalRef: string,
+): string {
+  return `${recipientRef}::${notificationType}::${relatedProposalRef}`
+}
+
+export default defineMigration({
+  title: 'Backfill organizer notifications (messages + events rail)',
+  description:
+    'Reconstructs the organizer-side notification history that was silently ' +
+    'never created before #559 (the organizer set was resolved via a ' +
+    'non-existent isOrganizer field). PART A: collapsed message_received ' +
+    'notifications (LIVE deterministic id so future messages collapse in). ' +
+    'PART B: proposal_submitted / speaker-confirmed / proposal-withdrawn ' +
+    'events-rail notifications. All arrive READ. Idempotent via deterministic ' +
+    'ids + a 040-style dedup set; createIfNotExists only, no patches/deletes.',
+  // These are the source document types; the migration drives off explicit
+  // GROQ fetches (it needs joins the streamed docs can't provide), so the
+  // streamed `documents()` iterator is intentionally not consumed.
+  documentTypes: ['conversation', 'talk'],
+
+  async *migrate(_documents, context) {
+    // --- Pre-pass 1: resolve the target conference (copied from 040) ---------
+    // The app scopes the conference by request domain
+    // (getConferenceForCurrentDomain), which is unavailable in a migration. So
+    // we pick the latest edition by startDate — the current conference —
+    // logging every candidate (the production dataset contains test/dummy
+    // conference docs with far-future startDates that break the heuristic). An
+    // operator pins a specific edition via BACKFILL_CONFERENCE_ID.
+    const conferences = await context.client.fetch<ConferenceRow[]>(
+      `*[_type == "conference" && !(_id in path("drafts.**"))]{ _id, title, startDate } | order(startDate desc)`,
+    )
+
+    if (!conferences || conferences.length === 0) {
+      console.warn('  ⚠ No conference documents found — nothing to backfill.')
+      return
+    }
+
+    console.log('  Conference candidates:')
+    for (const c of conferences) {
+      console.log(
+        `    - ${c._id}  startDate=${c.startDate ?? '—'}  ${c.title ?? '—'}`,
+      )
+    }
+
+    let conference: ConferenceRow | undefined
+    if (CONFERENCE_OVERRIDE) {
+      conference = conferences.find((c) => c._id === CONFERENCE_OVERRIDE)
+      if (!conference) {
+        console.warn(
+          `  ⚠ BACKFILL_CONFERENCE_ID=${CONFERENCE_OVERRIDE} not found — aborting.`,
+        )
+        return
+      }
+      console.log(
+        `  → Target conference (pinned): ${conference.title ?? '—'} (${conference._id}, startDate ${conference.startDate ?? '—'})`,
+      )
+    } else {
+      conference = conferences[0]
+      console.log(
+        `  → Target conference (latest startDate): ${conference.title ?? '—'} (${conference._id}, startDate ${conference.startDate ?? '—'})`,
+      )
+      if (conferences.length > 1) {
+        console.log(
+          `    (${conferences.length} conferences total; chose the one with the latest startDate. Set BACKFILL_CONFERENCE_ID to override.)`,
+        )
+      }
+    }
+    const conferenceId = conference._id
+
+    // --- Pre-pass 2: the CANONICAL organizer set -----------------------------
+    // Membership in ANY conference's organizers[] array — the SAME rule #559
+    // now uses (getOrganizerSpeakerIds). NEVER a stored `isOrganizer` field
+    // (which does not exist — that was the whole bug).
+    const organizerIds = await context.client.fetch<string[]>(
+      `*[_type == "speaker" && _id in *[_type == "conference"].organizers[]._ref][0...200]._id`,
+    )
+    const organizers = (organizerIds ?? []).filter(Boolean)
+    console.log(`  → ${organizers.length} organizer(s) resolved.`)
+    if (organizers.length === 0) {
+      console.warn('  ⚠ No organizers found — nothing to backfill.')
+      return
+    }
+
+    // =====================================================================
+    // PART A — collapsed message_received notifications
+    // =====================================================================
+    // Every conversation in the conference that HAS at least one message, with
+    // its LAST message (author + body) joined in. Every organizer is a
+    // participant of every conversation (resolveParticipantIds always seeds the
+    // set with the full organizer list), so each organizer should hold one
+    // collapsed notification per such conversation.
+    const conversations = await context.client.fetch<ConversationRow[]>(
+      `*[_type == "conversation" && conference._ref == $conferenceId
+          && !(_id in path("drafts.**"))
+          && count(*[_type == "message" && conversation._ref == ^._id]) > 0]{
+        _id,
+        conversationType,
+        subject,
+        "proposalId": proposal._ref,
+        "subjectSpeakerId": subjectSpeaker._ref,
+        lastMessageAt,
+        "lastMessage": *[_type == "message" && conversation._ref == ^._id]
+          | order(createdAt desc)[0]{
+            "authorId": author._ref,
+            "authorName": author->name,
+            body,
+            createdAt
+          }
+      }`,
+      { conferenceId },
+    )
+
+    const convCount = conversations?.length ?? 0
+    console.log(
+      `\n  PART A — ${convCount} conversation(s) with ≥1 message × ${organizers.length} organizer(s) = ${convCount * organizers.length} candidate(s) (before actor-exclusion).`,
+    )
+
+    let messageCreated = 0
+    let messageSelfSkipped = 0
+
+    for (const conv of conversations ?? []) {
+      // The collapsed doc mirrors the LAST message. Fall back to the
+      // conversation's own lastMessageAt for createdAt/readAt (they should
+      // agree; the conversation field is authoritative for inbox ordering).
+      const createdAt = conv.lastMessageAt ?? conv.lastMessage?.createdAt
+      if (!createdAt) {
+        console.warn(
+          `  ⚠ conversation ${conv._id} has no lastMessageAt — skipping.`,
+        )
+        continue
+      }
+      const authorName = conv.lastMessage?.authorName || 'Someone'
+      const lastAuthorId = conv.lastMessage?.authorId ?? undefined
+      const body = conv.lastMessage?.body ?? ''
+      const excerpt = body ? messageExcerpt(body) : ''
+      const link = organizerConversationLink(conv)
+      const subject = conv.subject ?? ''
+
+      for (const organizerId of organizers) {
+        // ACTOR EXCLUSION: an author is never notified about their OWN message
+        // (mirrors the live upsert, which excludes the actor). Because the
+        // backfilled doc reflects the LAST message, an organizer who authored
+        // it would otherwise get a nonsensical "New message from <themselves>";
+        // skip them. (We cannot faithfully reconstruct a notification they may
+        // have earned from an EARLIER message — this is an honest current-state
+        // limitation, documented in the README.)
+        if (lastAuthorId && organizerId === lastAuthorId) {
+          messageSelfSkipped++
+          continue
+        }
+
+        // DIRECT variant when this organizer IS the thread's subject speaker
+        // (mirrors the live isDirect comparison exactly).
+        const isDirect =
+          conv.subjectSpeakerId != null && conv.subjectSpeakerId === organizerId
+
+        const _id = messageNotificationId(conv._id, organizerId)
+        const doc: { _type: string; [key: string]: unknown } = {
+          _id,
+          _type: 'notification',
+          // Weak refs (per 041 — a later GDPR erasure must not orphan-block).
+          recipient: { _type: 'reference', _ref: organizerId, _weak: true },
+          conference: { _type: 'reference', _ref: conferenceId },
+          notificationType: 'message_received',
+          title: singleMessageTitle(authorName, subject, isDirect),
+          link,
+          count: 1,
+          createdAt,
+          // Backfilled history arrives READ — no badge flood.
+          readAt: createdAt,
+        }
+        if (excerpt) doc.message = excerpt
+        if (lastAuthorId) {
+          doc.actor = { _type: 'reference', _ref: lastAuthorId, _weak: true }
+        }
+
+        yield [createIfNotExists(doc)]
+        messageCreated++
+      }
+    }
+
+    // =====================================================================
+    // PART B — events-rail organizer notifications
+    // =====================================================================
+    // Dedup pre-pass (belt-and-braces, like 040): existing organizer-facing
+    // events-rail notifications for the conference, keyed
+    // (recipient, notificationType, relatedProposal) — so a live-emitted
+    // post-#559 doc (random id) is never duplicated.
+    const existingRows = await context.client.fetch<
+      ExistingEventsNotificationRow[]
+    >(
+      `*[_type == "notification" && conference._ref == $conferenceId
+          && notificationType in ["proposal_submitted", "proposal_status_changed"]]{
+        "recipientRef": recipient._ref,
+        notificationType,
+        "relatedProposalRef": relatedProposal._ref
+      }`,
+      { conferenceId },
+    )
+    const existingKeys = new Set<string>()
+    for (const row of existingRows ?? []) {
+      if (!row.recipientRef || !row.notificationType || !row.relatedProposalRef)
+        continue
+      existingKeys.add(
+        eventsKey(
+          row.recipientRef,
+          row.notificationType,
+          row.relatedProposalRef,
+        ),
+      )
+    }
+    console.log(
+      `  → ${existingKeys.size} existing events-rail organizer key(s) will be skipped if re-encountered.`,
+    )
+
+    const talks = await context.client.fetch<TalkRow[]>(
+      `*[_type == "talk" && conference._ref == $conferenceId && !(_id in path("drafts.**"))]{
+        _id, title, status, withdrawnReason, _createdAt, _updatedAt,
+        "speakerIds": speakers[]._ref
+      }`,
+      { conferenceId },
+    )
+
+    // Count PART B source docs by kind for a dry-run-friendly summary.
+    let submittedTalks = 0
+    let confirmedTalks = 0
+    let withdrawnTalks = 0
+    for (const t of talks ?? []) {
+      if (t.status && SUBMITTED_STATUSES.has(t.status)) submittedTalks++
+      if (t.status === 'confirmed') confirmedTalks++
+      if (t.status === 'withdrawn') withdrawnTalks++
+    }
+    console.log(
+      `\n  PART B — ${talks?.length ?? 0} talk(s): ${submittedTalks} submitted, ${confirmedTalks} confirmed, ${withdrawnTalks} withdrawn × ${organizers.length} organizer(s).`,
+    )
+
+    let eventsCreated = 0
+    let eventsSkipped = 0
+
+    // Emit one events-rail notification (createIfNotExists) per organizer for a
+    // given (source talk, kind). `actorId` is the talk's first speaker (the live
+    // handler excludes the actor from organizer recipients — an organizer who is
+    // also that speaker is skipped, mirroring `id !== actorId`).
+    function* emitForTalk(
+      talk: TalkRow,
+      notificationType: 'proposal_submitted' | 'proposal_status_changed',
+      title: string,
+      createdAt: string,
+      message?: string,
+    ) {
+      const actorId =
+        (talk.speakerIds ?? []).find((id): id is string => Boolean(id)) ??
+        undefined
+      const emissions: ReturnType<typeof createIfNotExists>[][] = []
+      for (const organizerId of organizers) {
+        if (actorId && organizerId === actorId) continue // actor exclusion
+        const key = eventsKey(organizerId, notificationType, talk._id)
+        if (existingKeys.has(key)) {
+          eventsSkipped++
+          continue
+        }
+        existingKeys.add(key)
+
+        const _id = `${PART_B_ID_PREFIX}.${notificationType}.${talk._id}.${organizerId}`
+        const doc: { _type: string; [key: string]: unknown } = {
+          _id,
+          _type: 'notification',
+          recipient: { _type: 'reference', _ref: organizerId, _weak: true },
+          conference: { _type: 'reference', _ref: conferenceId },
+          notificationType,
+          title,
+          link: PROPOSAL_ADMIN_LINK(talk._id),
+          // Weak (per 040) — a later proposal deletion must not orphan-block.
+          relatedProposal: { _type: 'reference', _ref: talk._id, _weak: true },
+          createdAt,
+          // Events-rail history arrives READ.
+          readAt: createdAt,
+        }
+        if (message) doc.message = message
+        if (actorId) {
+          doc.actor = { _type: 'reference', _ref: actorId, _weak: true }
+        }
+        emissions.push([createIfNotExists(doc)])
+        eventsCreated++
+      }
+      yield* emissions
+    }
+
+    for (const talk of talks ?? []) {
+      const talkTitle = talk.title ?? 'Untitled proposal'
+
+      // proposal_submitted — for every talk that has left draft (was submitted).
+      // Timestamp: the talk's _createdAt (submission time).
+      if (talk.status && SUBMITTED_STATUSES.has(talk.status)) {
+        const createdAt = talk._createdAt
+        if (createdAt) {
+          yield* emitForTalk(
+            talk,
+            'proposal_submitted',
+            `New proposal: "${talkTitle}"`,
+            createdAt,
+          )
+        }
+      }
+
+      // Speaker confirmed — current status == confirmed. No dedicated status
+      // timestamp exists on the talk, so _updatedAt is the honest best proxy
+      // for when the confirm happened (documented in the README).
+      if (talk.status === 'confirmed' && talk._updatedAt) {
+        yield* emitForTalk(
+          talk,
+          'proposal_status_changed',
+          `Speaker confirmed: "${talkTitle}"`,
+          talk._updatedAt,
+        )
+      }
+
+      // Proposal withdrawn — current status == withdrawn. Mirror the live
+      // handler: the withdrawal reason becomes the message when present.
+      if (talk.status === 'withdrawn' && talk._updatedAt) {
+        yield* emitForTalk(
+          talk,
+          'proposal_status_changed',
+          `Proposal withdrawn: "${talkTitle}"`,
+          talk._updatedAt,
+          talk.withdrawnReason || undefined,
+        )
+      }
+    }
+
+    console.log('\n=== Backfill summary ===')
+    console.log(
+      `  PART A (messages):    ${messageCreated} created, ${messageSelfSkipped} skipped (organizer authored the last message)`,
+    )
+    console.log(
+      `  PART B (events rail): ${eventsCreated} created, ${eventsSkipped} skipped (already present)`,
+    )
+  },
+})


### PR DESCRIPTION
## Why (the #559 root cause)

Until #559, every code path that fanned notifications out to **organizers**
resolved the organizer set with a query testing `isOrganizer == true` — **a field
that does not exist on the speaker schema**. It matched **nothing** in
production, so **every organizer-recipient notification was silently never
created** since the hub launched. #559 fixed the pipe going **forward**
(organizers are now resolved by `organizers[]` membership — the canonical rule);
this migration reconstructs the missing **history** from current dataset state.
The maintainer's hub is currently empty of organizer history.

Migration `042-backfill-organizer-notifications` (createIfNotExists only — no
patches, no deletes).

## PART A — collapsed `message_received` notifications

For every conversation in the target conference with ≥1 message, for every
organizer, create the collapsed notification mirroring the live single-message
shape (title `New message from <author> — <subject>`, or the `Direct message
from …` variant when the organizer is the thread's `subjectSpeaker`; excerpt,
organizer-audience link, weak recipient/actor refs, `count: 1`, `createdAt =
lastMessageAt`).

**Live-id collapse trick:** the doc is written with the **live** deterministic id
`notification.message.<conversationId>.<organizerId>` — the exact id the live
`upsertMessageNotifications` patches on every new message. So a future message
**collapses into the backfilled doc** instead of duplicating it, and
`createIfNotExists` means a post-#559 live doc is never clobbered.

## PART B — events-rail organizer notifications

Reconstructs the three organizer-facing emits from
`handlePersistNotification`, from current talk state:

| Source (current talk state) | type | title | timestamp |
| --- | --- | --- | --- |
| status left `draft` | `proposal_submitted` | `New proposal: "<title>"` | `_createdAt` |
| status == `confirmed` | `proposal_status_changed` | `Speaker confirmed: "<title>"` | `_updatedAt`\* |
| status == `withdrawn` | `proposal_status_changed` | `Proposal withdrawn: "<title>"` (message = `withdrawnReason`) | `_updatedAt`\* |

\* the talk schema has no dedicated status-change timestamp; `_updatedAt` is the
honest best proxy (documented). Deterministic id
`notification.backfill-042.<type>.<talkId>.<organizerId>`.

## Read-state

**Every** backfilled notification (both parts) arrives **already read**
(`readAt == createdAt`) — reconstructed history populates the panel
chronologically without flooding the unread badge.

## Idempotency

- Deterministic ids + `createIfNotExists` (no patches, no deletes).
- PART B additionally runs a **040-style dedup pre-pass** keyed
  `(recipient, notificationType, relatedProposal)` against existing docs, so a
  live-emitted post-#559 organizer notification (random id) is never duplicated.
- PART A needs no dedup set — the live id **is** the dedup.

## Targeting & running

`BACKFILL_CONFERENCE_ID` env override, else 040's latest-startDate heuristic with
full candidate logging. Dry-run friendly: logs conference candidates, organizer
count, per-part candidate counts, and created/skipped summaries.

**The maintainer intends to RUN this right after merge**, with
`BACKFILL_CONFERENCE_ID` pinned to the current edition (dry run → review → apply
via the `Run Sanity Migration` workflow). Not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds migration `042-backfill-organizer-notifications` to reconstruct the organizer-side notification history that was silently never created before #559, where an `isOrganizer == true` GROQ predicate matched nothing (the field doesn't exist on the speaker schema). The migration is idempotent via `createIfNotExists` + deterministic IDs, and every backfilled notification arrives already-read to avoid flooding the unread badge.

- **PART A** backfills one collapsed `message_received` notification per (organizer, conversation) using the **live deterministic ID** (`notification.message.<conversationId>.<organizerId>`), so future messages collapse into the backfilled doc and no live doc is ever clobbered.
- **PART B** backfills three organizer-facing events-rail notification types (`proposal_submitted`, `proposal_status_changed` for confirmed, `proposal_status_changed` for withdrawn) with a 040-style dedup pre-pass keyed on `(recipient, notificationType, relatedProposal)` to prevent duplicating any live post-#559 emission that has a random ID.

<h3>Confidence Score: 4/5</h3>

Safe to merge — every write is `createIfNotExists` with deterministic IDs, so the migration is non-destructive and idempotent; the two edge cases noted are cosmetic or extremely narrow in scope.

The migration is well-designed and carefully documented. The PART A summary counter labels no-op `createIfNotExists` calls as 'created', which could mildly mislead during dry-run review; and the PART B dedup key doesn't distinguish the 'confirmed' vs 'withdrawn' variants of `proposal_status_changed`, meaning a rare sequence (post-#559 live confirm notification + subsequent withdrawal before the migration runs) could cause the withdrawn backfill to be silently skipped for affected organizers. Neither issue corrupts existing data or produces duplicates.

The `index.ts` migration file deserves a second look around the PART B dedup key and the PART A summary counter before the production apply run.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| migrations/042-backfill-organizer-notifications/index.ts | Core migration logic: PART A (message_received) and PART B (events-rail) organizer notification backfill. Logic is well-structured and idempotent; two minor counter/dedup edge cases noted. |
| migrations/042-backfill-organizer-notifications/README.md | Comprehensive documentation covering root cause, both migration parts, idempotency, rollback, and dry-run guidance. Accurate and well cross-referenced to live source files. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Start migrate]) --> B[Pre-pass 1: resolve target conference\nBACKFILL_CONFERENCE_ID or latest startDate]
    B --> C[Pre-pass 2: resolve all organizers\n*speaker in any conference.organizers 0..200]
    C --> D{Any organizers?}
    D -- No --> Z([Exit — nothing to backfill])
    D -- Yes --> E

    subgraph PARTA [PART A — message_received]
        E[Fetch conversations with ≥1 message\njoined with last message author+body]
        E --> F{For each conversation × organizer}
        F -- organizer IS last author --> G[Skip — actor exclusion\nmessageSelfSkipped++]
        F -- organizer is NOT last author --> H[Build doc with LIVE id\nnotification.message.convId.orgId\ncreatedAt=lastMessageAt, readAt=createdAt, count=1]
        H --> I[yield createIfNotExists doc\nmessageCreated++]
    end

    I --> J

    subgraph PARTB [PART B — events-rail]
        J[Pre-pass: build existingKeys set\nproposal_submitted + proposal_status_changed\nfor conference, keyed recipient::type::relatedProposal]
        J --> K[Fetch talks for conference\nexcluding drafts]
        K --> L{For each talk × status}
        L -- status in SUBMITTED_STATUSES --> M[emitForTalk proposal_submitted\ncreatedAt=_createdAt]
        L -- status == confirmed --> N[emitForTalk proposal_status_changed confirmed\ncreatedAt=_updatedAt]
        L -- status == withdrawn --> O[emitForTalk proposal_status_changed withdrawn\ncreatedAt=_updatedAt, message=withdrawnReason]
        M & N & O --> P{key in existingKeys?}
        P -- Yes --> Q[Skip — eventsSkipped++]
        P -- No --> R[yield createIfNotExists doc\ndeterministic id: backfill-042.type.talkId.orgId\neventsCreated++]
    end

    R --> S([Log summary and exit])
    Q --> S
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([Start migrate]) --> B[Pre-pass 1: resolve target conference\nBACKFILL_CONFERENCE_ID or latest startDate]
    B --> C[Pre-pass 2: resolve all organizers\n*speaker in any conference.organizers 0..200]
    C --> D{Any organizers?}
    D -- No --> Z([Exit — nothing to backfill])
    D -- Yes --> E

    subgraph PARTA [PART A — message_received]
        E[Fetch conversations with ≥1 message\njoined with last message author+body]
        E --> F{For each conversation × organizer}
        F -- organizer IS last author --> G[Skip — actor exclusion\nmessageSelfSkipped++]
        F -- organizer is NOT last author --> H[Build doc with LIVE id\nnotification.message.convId.orgId\ncreatedAt=lastMessageAt, readAt=createdAt, count=1]
        H --> I[yield createIfNotExists doc\nmessageCreated++]
    end

    I --> J

    subgraph PARTB [PART B — events-rail]
        J[Pre-pass: build existingKeys set\nproposal_submitted + proposal_status_changed\nfor conference, keyed recipient::type::relatedProposal]
        J --> K[Fetch talks for conference\nexcluding drafts]
        K --> L{For each talk × status}
        L -- status in SUBMITTED_STATUSES --> M[emitForTalk proposal_submitted\ncreatedAt=_createdAt]
        L -- status == confirmed --> N[emitForTalk proposal_status_changed confirmed\ncreatedAt=_updatedAt]
        L -- status == withdrawn --> O[emitForTalk proposal_status_changed withdrawn\ncreatedAt=_updatedAt, message=withdrawnReason]
        M & N & O --> P{key in existingKeys?}
        P -- Yes --> Q[Skip — eventsSkipped++]
        P -- No --> R[yield createIfNotExists doc\ndeterministic id: backfill-042.type.talkId.orgId\neventsCreated++]
    end

    R --> S([Log summary and exit])
    Q --> S
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `migrations/042-backfill-organizer-notifications/index.ts`, line 566 ([link](https://github.com/cloudnativebergen/website/blob/e0405b64ede4a3435a39e53df06f2369548f42fa/migrations/042-backfill-organizer-notifications/index.ts#L566)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **PART A summary counter overcounts "created"**

   `messageCreated` increments for every candidate that clears actor-exclusion, but `createIfNotExists` silently no-ops when a post-#559 live doc already occupies that deterministic ID. The final log will read "N created" when some of those N were actually skipped by the framework. This is inherent to using the live ID without a pre-pass, and the README documents the behaviour; consider labelling the counter `messageAttempted` (or adding a parenthetical to the log line) so the dry-run review isn't ambiguous about how many documents were genuinely net-new.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(migrations): backfill organizer not..."](https://github.com/cloudnativebergen/website/commit/e0405b64ede4a3435a39e53df06f2369548f42fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45475569)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->