### PR TITLE
fix(admin): settings page horizontal scroll from unbreakable link URLs

### DIFF
--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -233,10 +233,12 @@ function FieldRow({
           href={value as string}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          className="flex min-w-0 items-start text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
         >
-          {value as string}
-          <LinkIcon className="ml-1 h-3 w-3" />
+          {/* Same overflow class as the 'links' case: an unbreakable URL must
+              break rather than widen the row past the viewport. */}
+          <span className="min-w-0 break-all">{value as string}</span>
+          <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
         </a>
       ) : (
         'Not set'

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -169,10 +169,13 @@ function FieldRow({
                   href={link as string}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center text-sm text-indigo-600 hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300"
+                  className="inline-flex max-w-full min-w-0 items-start text-sm text-indigo-600 hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300"
                 >
-                  <span className="max-w-sm truncate">{link as string}</span>
-                  <LinkIcon className="ml-1 h-3 w-3 shrink-0" />
+                  {/* break-all, not truncate: a URL is an unbreakable token, and
+                      an unconstrained nowrap span dictated the row's intrinsic
+                      width — the whole page scrolled horizontally on mobile. */}
+                  <span className="min-w-0 break-all">{link as string}</span>
+                  <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
                 </a>
               </div>
             ))}
@@ -257,11 +260,14 @@ function FieldRow({
   }
 
   return (
-    <div className="flex justify-between border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
-      <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+    <div className="flex justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
+      <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
         {label}
       </dt>
-      <dd className="max-w-xs text-right text-sm text-gray-900 dark:text-white">
+      {/* min-w-0 lets the value column actually shrink inside the flex row —
+          without it, wide unbreakable content (URLs) forces the row past the
+          viewport and the page pans horizontally. */}
+      <dd className="max-w-xs min-w-0 text-right text-sm text-gray-900 dark:text-white">
         {displayValue}
       </dd>
     </div>


### PR DESCRIPTION
Maintainer-reported (screenshot): the Domain Configuration card's social links forced horizontal page scroll on mobile — labels cut off, whole page panned.

Cause: the link span used truncate inside an inline-flex chain without min-w-0, so the nowrap URL dictated the row's intrinsic width past the viewport; the FieldRow's dd also lacked min-w-0 so the flex row couldn't shrink it.

Fix: value column gets min-w-0 (rows can shrink), labels shrink-0 (never squashed), and URLs break-all instead of truncating — full URLs stay readable across lines with no overflow at any width.

Honest QA note: this page is a server component with no story for the config tier (only the status-section components are storied), so no shoot capture exists — verified by CSS reasoning; a config-tier story is a candidate for the teams/settings follow-up work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes horizontal page scroll on the admin settings page by correcting the CSS flex layout in the `FieldRow` component so long, unbreakable URL tokens no longer push past the card boundary on mobile. The `links` case is correctly updated with `break-all` + `min-w-0`, and the outer `dd` gains `min-w-0` while the `dt` gets `shrink-0`.

- The `links` type (Social Links card) gets the full fix: `min-w-0 break-all` on the URL span, `items-start` on the anchor, and `mt-1` on the icon for correct multi-line alignment.
- The `dd`/`dt` structural fix (gap, shrink-0, min-w-0) benefits all field types in the row.
- The `url` type — used by `registrationLink` — was not updated and still renders its URL as bare inline text inside a `flex` anchor with no character-break constraint, so long registration URLs can reproduce the same scroll issue.

<h3>Confidence Score: 3/5</h3>

The fix resolves the reported mobile scroll for social links but leaves the same problem in the url type, which is actively used for the registration link field.

The structural dd/dt change is solid and the links fix is complete and correct. The url branch — used by conference.registrationLink — was not updated and still renders bare URL text in a flex anchor with no break-all, so a long registration URL will still pan the page horizontally on mobile.

src/app/(admin)/admin/settings/page.tsx — the url type case (around line 230) needs the same overflow fix applied to the links type.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/(admin)/admin/settings/page.tsx | CSS overflow fix for `links` type is correct and well-reasoned, but the parallel `url` type (used by `registrationLink`) has the same unbreakable-URL overflow problem and was not updated. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/app/(admin)/admin/settings/page.tsx`, line 230-243 ([link](https://github.com/cloudnativebergen/website/blob/c42941ec9cc176ae91020b45da9af69289ed806a/src/app/(admin)/admin/settings/page.tsx#L230-L243)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`url` type still missing overflow fix**

   The `links` case received `break-all` + `min-w-0` on the span, but the `url` case renders its URL text as bare inline text inside a `flex items-center` anchor with no break-word constraint. The `dd` container now has `min-w-0` (a necessary condition), but that only lets the flex item *shrink* — a URL token that can't break still overflows the `dd` boundary and pushes past the card edge. `conference.registrationLink` (line 447) uses this type, so a long registration URL (e.g., a Tito or Eventbrite link) will reproduce the same horizontal scroll that prompted this PR.


2. `src/app/(admin)/admin/settings/page.tsx`, line 230-243 ([link](https://github.com/cloudnativebergen/website/blob/c42941ec9cc176ae91020b45da9af69289ed806a/src/app/(admin)/admin/settings/page.tsx#L230-L243)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Apply the same `break-all` + `min-w-0` treatment here so long URLs (e.g., registration links) can't overflow the card on narrow screens.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(admin): break-all on url field rows ..."](https://github.com/cloudnativebergen/website/commit/c42941ec9cc176ae91020b45da9af69289ed806a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45478451)</sub>

<!-- /greptile_comment -->