### PR TITLE
feat(messaging): party data model foundation (G1)

### DIFF
--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -720,6 +720,9 @@ describe('proposal router', () => {
         proposalId: 'proposal-1',
         proposalTitle: 'My Talk',
         createdById: adminSpeaker._id,
+        // Party model (G1): the decision-comment mirror now also seeds the
+        // dual-written participants[] from the proposal's current speakers.
+        proposalSpeakerIds: [regularSpeaker._id],
       })
       expect(addMessage).toHaveBeenCalledWith({
         conversationId,

--- a/__tests__/lib/messaging/party-model.test.ts
+++ b/__tests__/lib/messaging/party-model.test.ts
@@ -1,0 +1,405 @@
+/**
+ * @vitest-environment node
+ *
+ * Party data model (messaging G1) — representation-only foundation.
+ *
+ * Three concerns, all proving G1's core guarantee: the NEW `participants[]` /
+ * `authorParty` representation is BIT-IDENTICAL to what the legacy fields express.
+ *
+ * 1. RESOLVER EQUIVALENCE MATRIX — `resolveParticipants` yields the SAME party
+ *    list whether it derives from the legacy fields (participants absent) or reads
+ *    a dual-written `participants[]`, for every thread shape. The "dual-written"
+ *    arrays are hand-authored per the locked design (NOT produced by the derive
+ *    path), so the test genuinely proves derive-logic and stored-format agree.
+ * 2. DUAL-WRITE COVERAGE — both conversation creators and `addMessage` write the
+ *    exact party shapes ALONGSIDE the unchanged legacy fields.
+ * 3. SCHEMA VALIDATION — the pure `validateConversationParticipant` congruence
+ *    rule (partyType ↔ identity field) the `conversationParticipant` object uses.
+ *
+ * The Sanity clients are mocked so writes are asserted exactly; nanoid is fixed so
+ * `_key`s and ids are deterministic.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/sanity/helpers', () => ({
+  createReference: (id: string) => ({ _type: 'reference', _ref: id }),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { transaction: vi.fn(), create: vi.fn() },
+  clientReadUncached: { fetch: vi.fn() },
+}))
+
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn(async () => [] as string[]),
+}))
+
+// Fixed so message ids, general-conversation ids and every array `_key` are
+// deterministic ('FIXED').
+vi.mock('nanoid', () => ({ nanoid: () => 'FIXED' }))
+
+import { clientWrite } from '@/lib/sanity/client'
+import {
+  resolveParticipants,
+  ensureProposalConversation,
+  createGeneralConversation,
+  addMessage,
+} from '@/lib/messaging/sanity'
+import {
+  validateConversationParticipant,
+  type ConversationParty,
+  type ConversationWithContext,
+} from '@/lib/messaging/types'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const writeMock = clientWrite as unknown as {
+  transaction: LooseMock
+  create: LooseMock
+}
+
+function installTransaction() {
+  const tx = {
+    create: vi.fn((_doc?: unknown) => tx),
+    createIfNotExists: vi.fn((_doc?: unknown) => tx),
+    patch: vi.fn((_id?: string, _ops?: unknown) => tx),
+    commit: vi.fn(async () => ({})),
+  }
+  writeMock.transaction.mockReturnValue(tx)
+  return tx
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// Serialized (stored) party shapes, as the dual-write emits them: array items
+// carry a `_key`; speaker refs are WEAK.
+const storedSpeaker = (ref: string) => ({
+  _key: 'FIXED',
+  partyType: 'speaker',
+  speaker: { _type: 'reference', _ref: ref, _weak: true },
+})
+const storedOrganizersGroup = {
+  _key: 'FIXED',
+  partyType: 'group',
+  group: 'organizers',
+}
+
+// ---------------------------------------------------------------------------
+// 1. Resolver equivalence matrix
+// ---------------------------------------------------------------------------
+
+/** A thread-shape case: its legacy fields and the hand-authored dual-written array. */
+interface Shape {
+  name: string
+  legacy: Pick<
+    ConversationWithContext,
+    | 'conversationType'
+    | 'proposalSpeakerIds'
+    | 'createdById'
+    | 'subjectSpeakerId'
+  >
+  /** The parties the design specifies for this shape (authored INDEPENDENTLY). */
+  expected: ConversationParty[]
+}
+
+const ORG: ConversationParty = { partyType: 'group', group: 'organizers' }
+
+const SHAPES: Shape[] = [
+  {
+    name: 'proposal thread — two speakers',
+    legacy: {
+      conversationType: 'proposal',
+      proposalSpeakerIds: ['sp-1', 'sp-2'],
+      createdById: 'sp-1',
+    },
+    expected: [
+      { partyType: 'speaker', speakerId: 'sp-1' },
+      { partyType: 'speaker', speakerId: 'sp-2' },
+      ORG,
+    ],
+  },
+  {
+    name: 'proposal thread — single speaker',
+    legacy: {
+      conversationType: 'proposal',
+      proposalSpeakerIds: ['sp-1'],
+      createdById: 'sp-1',
+    },
+    expected: [{ partyType: 'speaker', speakerId: 'sp-1' }, ORG],
+  },
+  {
+    name: 'proposal thread — no speakers (organizers only)',
+    legacy: {
+      conversationType: 'proposal',
+      proposalSpeakerIds: [],
+      createdById: 'sp-1',
+    },
+    expected: [ORG],
+  },
+  {
+    name: 'general thread — speaker-created (no subject)',
+    legacy: {
+      conversationType: 'general',
+      proposalSpeakerIds: [],
+      createdById: 'sp-9',
+    },
+    expected: [{ partyType: 'speaker', speakerId: 'sp-9' }, ORG],
+  },
+  {
+    name: 'general thread — organizer-initiated (creator + subject)',
+    legacy: {
+      conversationType: 'general',
+      proposalSpeakerIds: [],
+      createdById: 'org-1',
+      subjectSpeakerId: 'sp-7',
+    },
+    expected: [
+      { partyType: 'speaker', speakerId: 'org-1' },
+      { partyType: 'speaker', speakerId: 'sp-7' },
+      ORG,
+    ],
+  },
+]
+
+describe('resolveParticipants — legacy-derived === dual-written, every shape', () => {
+  for (const shape of SHAPES) {
+    describe(shape.name, () => {
+      it('DERIVES the design-specified parties from the legacy fields', () => {
+        // participants absent → derive branch.
+        expect(resolveParticipants(shape.legacy)).toEqual(shape.expected)
+      })
+
+      it('PREFERS the dual-written participants[] (returns them verbatim)', () => {
+        const dualWritten = { ...shape.legacy, participants: shape.expected }
+        expect(resolveParticipants(dualWritten)).toEqual(shape.expected)
+      })
+
+      it('resolver(legacy) === resolver(dual-written) — the G1 equivalence guarantee', () => {
+        const dualWritten = { ...shape.legacy, participants: shape.expected }
+        expect(resolveParticipants(shape.legacy)).toEqual(
+          resolveParticipants(dualWritten),
+        )
+      })
+    })
+  }
+
+  it('an EMPTY participants[] is not a real party set → falls back to derive', () => {
+    const conv = {
+      conversationType: 'general' as const,
+      proposalSpeakerIds: [],
+      createdById: 'sp-9',
+      participants: [] as ConversationParty[],
+    }
+    expect(resolveParticipants(conv)).toEqual([
+      { partyType: 'speaker', speakerId: 'sp-9' },
+      ORG,
+    ])
+  })
+
+  it('PREFERS a stored array even when it diverges from the legacy derivation', () => {
+    // A backfilled/dual-written array that intentionally differs (a sponsor
+    // party the legacy fields could never derive): the resolver returns it
+    // verbatim, proving it truly prefers participants[] over re-deriving.
+    const stored: ConversationParty[] = [
+      { partyType: 'sponsor', sponsorForConferenceId: 'sfc-1' },
+      ORG,
+    ]
+    const conv = {
+      conversationType: 'general' as const,
+      proposalSpeakerIds: [],
+      createdById: 'sp-9',
+      participants: stored,
+    }
+    expect(resolveParticipants(conv)).toBe(stored)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. Dual-write coverage
+// ---------------------------------------------------------------------------
+
+describe('dual-write — ensureProposalConversation writes participants[] alongside legacy fields', () => {
+  it('one speaker party per proposal speaker, then the organizers group', async () => {
+    const tx = installTransaction()
+
+    await ensureProposalConversation({
+      conferenceId: 'conf-1',
+      proposalId: 'prop-1',
+      proposalTitle: 'My Talk',
+      createdById: 'sp-1',
+      proposalSpeakerIds: ['sp-1', 'sp-2'],
+    })
+
+    const doc = tx.createIfNotExists.mock.calls[0][0] as Record<string, unknown>
+    // Legacy write-source fields are UNCHANGED (still present).
+    expect(doc.createdBy).toEqual({ _type: 'reference', _ref: 'sp-1' })
+    expect(doc.proposal).toEqual({
+      _type: 'reference',
+      _ref: 'prop-1',
+      _weak: true,
+    })
+    // New dual-written representation.
+    expect(doc.participants).toEqual([
+      storedSpeaker('sp-1'),
+      storedSpeaker('sp-2'),
+      storedOrganizersGroup,
+    ])
+  })
+
+  it('a proposal with no speakers writes just the organizers group', async () => {
+    const tx = installTransaction()
+    await ensureProposalConversation({
+      conferenceId: 'conf-1',
+      proposalId: 'prop-2',
+      proposalTitle: 'Orphan',
+      createdById: 'sp-1',
+      proposalSpeakerIds: [],
+    })
+    const doc = tx.createIfNotExists.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.participants).toEqual([storedOrganizersGroup])
+  })
+})
+
+describe('dual-write — createGeneralConversation', () => {
+  it('speaker-created thread → creator speaker party + organizers group', async () => {
+    await createGeneralConversation({
+      conferenceId: 'conf-1',
+      createdById: 'sp-9',
+      subject: 'A question',
+    })
+    const doc = writeMock.create.mock.calls[0][0] as Record<string, unknown>
+    // Legacy fields unchanged: creator ref present, no subjectSpeaker.
+    expect(doc.createdBy).toEqual({ _type: 'reference', _ref: 'sp-9' })
+    expect('subjectSpeaker' in doc).toBe(false)
+    expect(doc.participants).toEqual([
+      storedSpeaker('sp-9'),
+      storedOrganizersGroup,
+    ])
+  })
+
+  it('organizer-initiated thread → creator + subject speaker parties + organizers group', async () => {
+    await createGeneralConversation({
+      conferenceId: 'conf-1',
+      createdById: 'org-1',
+      subject: 'About your talk',
+      subjectSpeakerId: 'sp-7',
+    })
+    const doc = writeMock.create.mock.calls[0][0] as Record<string, unknown>
+    expect(doc.subjectSpeaker).toEqual({ _type: 'reference', _ref: 'sp-7' })
+    expect(doc.participants).toEqual([
+      storedSpeaker('org-1'),
+      storedSpeaker('sp-7'),
+      storedOrganizersGroup,
+    ])
+  })
+})
+
+describe('dual-write — addMessage writes authorParty alongside the author ref', () => {
+  it('a single speaker party (weak ref, NO _key — it is an object field, not an array item)', async () => {
+    const tx = installTransaction()
+
+    await addMessage({
+      conversationId: 'conversation.gen-1',
+      authorId: 'sp-9',
+      body: 'hello',
+    })
+
+    const doc = tx.create.mock.calls[0][0] as Record<string, unknown>
+    // Legacy author ref unchanged.
+    expect(doc.author).toEqual({ _type: 'reference', _ref: 'sp-9' })
+    // Dual-written party form of the author.
+    expect(doc.authorParty).toEqual({
+      partyType: 'speaker',
+      speaker: { _type: 'reference', _ref: 'sp-9', _weak: true },
+    })
+    // A single-object field carries NO _key (only array items do).
+    expect('_key' in (doc.authorParty as object)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. Schema validation — partyType ↔ identity-field congruence
+// ---------------------------------------------------------------------------
+
+describe('validateConversationParticipant — discriminator congruence', () => {
+  it('accepts a well-formed speaker / sponsor / group party', () => {
+    expect(
+      validateConversationParticipant({
+        partyType: 'speaker',
+        speaker: { _ref: 'sp-1' },
+      }),
+    ).toBe(true)
+    expect(
+      validateConversationParticipant({
+        partyType: 'sponsor',
+        sponsorForConference: { _ref: 'sfc-1' },
+      }),
+    ).toBe(true)
+    expect(
+      validateConversationParticipant({
+        partyType: 'group',
+        group: 'organizers',
+      }),
+    ).toBe(true)
+  })
+
+  it('accepts an absent partyType (its own required rule reports that)', () => {
+    expect(validateConversationParticipant({})).toBe(true)
+    expect(validateConversationParticipant(undefined)).toBe(true)
+  })
+
+  it('rejects a party with NO identity field (zero present) via the exactly-one rule', () => {
+    // Zero identity fields trips the exactly-one check before the per-type
+    // messages; an empty/keyless group and an empty ref object both count as zero.
+    expect(validateConversationParticipant({ partyType: 'speaker' })).toMatch(
+      /exactly one identity field/,
+    )
+    expect(
+      validateConversationParticipant({ partyType: 'speaker', speaker: {} }),
+    ).toMatch(/exactly one identity field/)
+    expect(validateConversationParticipant({ partyType: 'sponsor' })).toMatch(
+      /exactly one identity field/,
+    )
+    expect(validateConversationParticipant({ partyType: 'group' })).toMatch(
+      /exactly one identity field/,
+    )
+    expect(
+      validateConversationParticipant({ partyType: 'group', group: '' }),
+    ).toMatch(/exactly one identity field/)
+  })
+
+  it('rejects a party carrying exactly one but WRONG identity field for its type', () => {
+    // Exactly one field present, but it does not match the discriminator → the
+    // per-type congruence message fires.
+    expect(
+      validateConversationParticipant({
+        partyType: 'speaker',
+        group: 'organizers',
+      }),
+    ).toMatch(/speaker party requires a speaker reference/)
+    expect(
+      validateConversationParticipant({
+        partyType: 'sponsor',
+        speaker: { _ref: 'sp-1' },
+      }),
+    ).toMatch(/sponsor party requires a sponsorForConference reference/)
+    expect(
+      validateConversationParticipant({
+        partyType: 'group',
+        speaker: { _ref: 'sp-1' },
+      }),
+    ).toMatch(/group party requires a non-empty group key/)
+  })
+
+  it('rejects MORE THAN ONE identity field (must be exactly one)', () => {
+    expect(
+      validateConversationParticipant({
+        partyType: 'speaker',
+        speaker: { _ref: 'sp-1' },
+        group: 'organizers',
+      }),
+    ).toMatch(/exactly one identity field/)
+  })
+})

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -254,6 +254,9 @@ describe('ensureProposalConversation — race-safe createIfNotExists', () => {
       proposalId: 'prop-1',
       proposalTitle: 'My Talk',
       createdById: 'sp-1',
+      // Party model (G1): `proposalSpeakerIds` is now a required arg (the
+      // proposal's current speakers seed the dual-written participants[]).
+      proposalSpeakerIds: ['sp-1', 'sp-2'],
     })
 
     expect(id).toBe('conversation.proposal.prop-1')
@@ -267,6 +270,22 @@ describe('ensureProposalConversation — race-safe createIfNotExists', () => {
       _ref: 'prop-1',
       _weak: true,
     })
+    // Party model (G1) dual-write ADDITION: participants[] carries a speaker
+    // party per proposal speaker (weak ref) then the organizers group, each with
+    // a _key. The legacy fields above are unchanged.
+    expect(doc.participants).toEqual([
+      {
+        _key: 'FIXED',
+        partyType: 'speaker',
+        speaker: { _type: 'reference', _ref: 'sp-1', _weak: true },
+      },
+      {
+        _key: 'FIXED',
+        partyType: 'speaker',
+        speaker: { _type: 'reference', _ref: 'sp-2', _weak: true },
+      },
+      { _key: 'FIXED', partyType: 'group', group: 'organizers' },
+    ])
   })
 })
 

--- a/migrations/043-backfill-conversation-participants/README.md
+++ b/migrations/043-backfill-conversation-participants/README.md
@@ -1,0 +1,96 @@
+# Migration 043: Backfill conversation participants + message authorParty (party model G1)
+
+## ⚠️ NOT RUN — maintainer decision required (run BEFORE the G2 read-path flip)
+
+Running this is a deliberate maintainer action via the
+[`Run Sanity Migration`](../../.github/workflows/run-migration.yml) workflow
+after review. It should be run once the G1 dual-write has shipped and **before**
+G2 flips the read path onto `participants[]`.
+
+## Overview
+
+The messaging **party data model** (G1) introduces a general representation of
+"who is on a thread":
+
+- `conversation.participants[]` — a list of `conversationParticipant` parties
+  (`speaker` / `sponsor` / `group`);
+- `message.authorParty` — the party form of a message's author.
+
+G1 **dual-writes** this representation going forward (`ensureProposalConversation`,
+`createGeneralConversation`, `addMessage` in `src/lib/messaging/sanity.ts`), but
+documents created **before** the dual-write landed carry only the legacy fields
+(`createdBy` / `subjectSpeaker` / `proposal` on a conversation, `author` on a
+message). This migration reconstructs the party representation for those
+documents from the **same legacy fields the read resolver derives from**, so that
+when G2 flips the read path to **prefer** `participants[]`, every historical
+thread already carries the bit-identical representation.
+
+## What it does
+
+- **Conversations** (explicit fetch — the proposal-thread derivation needs the
+  `proposal->speakers[]` join): for each non-draft conversation **without** a
+  non-empty `participants[]`, writes:
+  - proposal thread → one `speaker` party per proposal speaker, then the
+    `organizers` group;
+  - general thread → the creator, then the `subjectSpeaker` (when set), then the
+    `organizers` group.
+- **Messages** (streamed iterator — `author` is on the document): for each
+  non-draft message **without** an `authorParty` and **with** an author ref,
+  writes a `speaker` `authorParty`.
+
+Human-pointing references (`speaker`) are written **weak** (`_weak: true`, per
+migration 041) so a later GDPR erase never orphan-blocks. The derivation mirrors
+`deriveParties` / `partiesToStored` in `src/lib/messaging/sanity.ts` **verbatim**
+— the written arrays are exactly what a legacy-only document resolves to, and
+exactly what the live dual-write would have produced. Array-item `_key`s are
+**deterministic** (`speaker-<ref>`, `group-organizers`) so a dry run and the
+apply agree; the live dual-write uses random nanoid keys instead, which is
+harmless (keys are array identity only and carry no meaning).
+
+It never touches the legacy fields, never changes a `_ref` target, and never
+deletes anything.
+
+## Idempotency
+
+Safe to run repeatedly. A conversation that already carries a non-empty
+`participants[]` (a live dual-write, or a previous run) and a message that
+already carries an `authorParty` are **skipped**, so a re-run only patches
+documents still missing the representation. Drafts are skipped (the published
+document owns the fields). Counts of patched/skipped documents are logged.
+
+## Running the migration
+
+Via the **`Run Sanity Migration`** GitHub Actions workflow (`workflow_dispatch`):
+
+- **migration**: `043-backfill-conversation-participants`
+- **dataset**: `production` (or the target dataset)
+
+The workflow exports a dataset backup artifact, performs a **dry run**, and only
+then applies. Review the dry-run log before the apply step.
+
+Equivalent local invocation:
+
+```bash
+pnpm sanity migration run 043-backfill-conversation-participants \
+  --project "$SANITY_STUDIO_PROJECT_ID" --dataset production   # dry run
+pnpm sanity migration run 043-backfill-conversation-participants \
+  --project "$SANITY_STUDIO_PROJECT_ID" --dataset production --no-dry-run --no-confirm
+```
+
+## Verification
+
+After running, confirm no non-draft conversation lacks participants and no
+non-draft message with an author lacks an `authorParty`:
+
+```bash
+# Both should return 0 once the migration has applied.
+npx sanity documents query 'count(*[_type == "conversation" && !(_id in path("drafts.**")) && count(participants) == 0])'
+npx sanity documents query 'count(*[_type == "message" && !(_id in path("drafts.**")) && defined(author._ref) && !defined(authorParty)])'
+```
+
+## Rollback
+
+The backfill is additive and never read in G1 (the read path still derives from
+the legacy fields), so there is normally nothing to roll back — the fields sit
+inert until G2. If required, restore from the backup artifact produced by the
+workflow.

--- a/migrations/043-backfill-conversation-participants/index.ts
+++ b/migrations/043-backfill-conversation-participants/index.ts
@@ -1,0 +1,200 @@
+import { defineMigration, at, patch, set } from 'sanity/migrate'
+import type { SanityDocument } from '@sanity/types'
+
+/**
+ * ⚠️ MIGRATION NOT RUN — MAINTAINER DECISION REQUIRED. ⚠️
+ *
+ * Backfill the PARTY DATA MODEL (messaging G1) onto existing documents:
+ *
+ *   - `conversation.participants[]` — the GENERAL party representation derived
+ *     from the legacy fields: proposal threads → one speaker party per proposal
+ *     speaker + the organizers group; general threads → the creator + optional
+ *     subjectSpeaker + the organizers group.
+ *   - `message.authorParty` — the party form of the message author (a speaker
+ *     party; G1 authors are always speaker docs).
+ *
+ * WHY: G1 introduces the party representation and DUAL-WRITES it going forward
+ * (ensureProposalConversation / createGeneralConversation / addMessage), but
+ * documents created BEFORE the dual-write landed carry only the legacy fields.
+ * This migration reconstructs the party representation for them from the SAME
+ * legacy fields the read resolver derives from, so that once G2 flips the read
+ * path to prefer `participants[]`, every historical thread already carries the
+ * bit-identical representation. It must be run by the maintainer BEFORE the G2
+ * read-path flip.
+ *
+ * The derivation MIRRORS `deriveParties` / `partiesToStored` in
+ * src/lib/messaging/sanity.ts VERBATIM (migrations do not resolve the `@/` alias
+ * / `server-only` guard, so the pure bits are duplicated here — keep in sync with
+ * that source). The written arrays are exactly what a legacy-only document
+ * resolves to, and exactly what the live dual-write would have produced.
+ *
+ * SAFETY / IDEMPOTENCY: additive only — it never touches the legacy fields,
+ * never changes a `_ref` target, never deletes anything, and skips DRAFTS. A
+ * conversation that ALREADY carries a non-empty `participants[]`, and a message
+ * that already carries an `authorParty`, are SKIPPED — so a re-run only patches
+ * documents still missing the representation (e.g. a live dual-write that landed
+ * between runs is left untouched). Human-pointing refs are written WEAK (per
+ * 041) so a later GDPR erase never orphan-blocks.
+ *
+ * NOT RUN: run intentionally, after review, via the "Run Sanity Migration"
+ * workflow (.github/workflows/run-migration.yml) with migration id
+ * `043-backfill-conversation-participants`. The workflow exports a dataset
+ * backup and performs a dry run first.
+ */
+
+/** The universal organizer group key. Mirrors ORGANIZERS_GROUP in types.ts. */
+const ORGANIZERS_GROUP = 'organizers'
+
+const isDraft = (id: string): boolean => id.startsWith('drafts.')
+
+interface StoredRef {
+  _type: 'reference'
+  _ref: string
+  _weak: true
+}
+
+function weakRef(ref: string): StoredRef {
+  return { _type: 'reference', _ref: ref, _weak: true }
+}
+
+/**
+ * A stored `conversationParticipant` speaker party for a `participants[]` array
+ * item. `_key` is DETERMINISTIC (derived from the speaker ref) so a dry run and
+ * the apply agree, and so the array stays stable on any re-derivation. The live
+ * dual-write uses a random nanoid key instead; keys are array identity only and
+ * carry no meaning, so the two coexist harmlessly.
+ */
+function speakerArrayParty(ref: string): Record<string, unknown> {
+  return { _key: `speaker-${ref}`, partyType: 'speaker', speaker: weakRef(ref) }
+}
+
+/** The stored organizers-group party for a `participants[]` array item. */
+function organizersGroupArrayParty(): Record<string, unknown> {
+  return {
+    _key: `group-${ORGANIZERS_GROUP}`,
+    partyType: 'group',
+    group: ORGANIZERS_GROUP,
+  }
+}
+
+/** The stored `authorParty` speaker object (single field → NO `_key`). */
+function authorPartyObject(ref: string): Record<string, unknown> {
+  return { partyType: 'speaker', speaker: weakRef(ref) }
+}
+
+interface ConversationRow {
+  _id: string
+  conversationType?: string
+  createdById?: string | null
+  subjectSpeakerId?: string | null
+  proposalSpeakerIds?: Array<string | null>
+  hasParticipants?: boolean
+}
+
+/**
+ * Derive the stored `participants[]` from a conversation's legacy fields —
+ * mirrors `deriveParties` + `partiesToStored` in src/lib/messaging/sanity.ts.
+ */
+function deriveStoredParticipants(
+  conv: ConversationRow,
+): Record<string, unknown>[] {
+  const parties: Record<string, unknown>[] = []
+  if (conv.conversationType === 'proposal') {
+    for (const ref of conv.proposalSpeakerIds ?? []) {
+      if (ref) parties.push(speakerArrayParty(ref))
+    }
+  } else {
+    // A weak creator/subject ref may be dangling after a GDPR erase; skip nulls.
+    if (conv.createdById) parties.push(speakerArrayParty(conv.createdById))
+    if (conv.subjectSpeakerId)
+      parties.push(speakerArrayParty(conv.subjectSpeakerId))
+  }
+  parties.push(organizersGroupArrayParty())
+  return parties
+}
+
+interface MessageDoc extends SanityDocument {
+  author?: { _ref?: string } | null
+  authorParty?: unknown
+}
+
+export default defineMigration({
+  title:
+    'Backfill conversation participants + message authorParty (party model G1)',
+  description:
+    'Reconstructs conversation.participants[] and message.authorParty from the ' +
+    'legacy fields for documents predating the G1 dual-write, so the G2 read-path ' +
+    'flip finds every historical thread already carrying the party representation. ' +
+    'Additive, idempotent (skips docs already carrying the representation, skips ' +
+    'drafts); mirrors deriveParties/partiesToStored verbatim. NOT RUN by default — ' +
+    'run via the Run Sanity Migration workflow after maintainer review, before G2.',
+  // The message pass drives off the streamed iterator (author is on the doc);
+  // the conversation pass needs the proposal->speakers JOIN, so it uses an
+  // explicit fetch. Both types are declared so the workflow streams messages.
+  documentTypes: ['conversation', 'message'],
+
+  async *migrate(documents, context) {
+    // --- Conversations: explicit fetch (needs the proposal-speaker join) -----
+    const conversations = await context.client.fetch<ConversationRow[]>(
+      `*[_type == "conversation" && !(_id in path("drafts.**"))]{
+        _id,
+        conversationType,
+        "createdById": createdBy._ref,
+        "subjectSpeakerId": subjectSpeaker._ref,
+        "proposalSpeakerIds": coalesce(proposal->speakers[]._ref, []),
+        "hasParticipants": count(participants) > 0
+      }`,
+    )
+
+    let convPatched = 0
+    let convSkipped = 0
+    for (const conv of conversations ?? []) {
+      // Idempotency: a doc already carrying a non-empty participants[] (a live
+      // dual-write, or a previous run) is left untouched.
+      if (conv.hasParticipants) {
+        convSkipped++
+        continue
+      }
+      const participants = deriveStoredParticipants(conv)
+      console.log(
+        `  ✓ conversation ${conv._id}: writing ${participants.length} participant(s)`,
+      )
+      yield patch(conv._id, [at('participants', set(participants))])
+      convPatched++
+    }
+
+    // --- Messages: streamed iterator (author is on the doc, no join needed) ---
+    let msgPatched = 0
+    let msgSkipped = 0
+    let msgNoAuthor = 0
+    for await (const rawDoc of documents()) {
+      if (rawDoc._type !== 'message') continue
+      const doc = rawDoc as MessageDoc
+      if (isDraft(doc._id)) continue
+      // Idempotency: already carries the party form of its author.
+      if (doc.authorParty) {
+        msgSkipped++
+        continue
+      }
+      const authorRef = doc.author?._ref
+      if (!authorRef) {
+        // A dangling (erased) author leaves nothing to build a party from; the
+        // legacy `author` ref is likewise dangling, so this is faithful.
+        msgNoAuthor++
+        continue
+      }
+      yield patch(doc._id, [
+        at('authorParty', set(authorPartyObject(authorRef))),
+      ])
+      msgPatched++
+    }
+
+    console.log('\n=== Party-model backfill summary ===')
+    console.log(
+      `  conversations: ${convPatched} patched, ${convSkipped} skipped (already had participants)`,
+    )
+    console.log(
+      `  messages:      ${msgPatched} patched, ${msgSkipped} skipped (already had authorParty), ${msgNoAuthor} skipped (no author ref)`,
+    )
+  },
+})

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -5,6 +5,7 @@ import blockContent from './schemaTypes/blockContent'
 import conference from './schemaTypes/conference'
 import contractTemplate from './schemaTypes/contractTemplate'
 import conversation from './schemaTypes/conversation'
+import conversationParticipant from './schemaTypes/conversationParticipant'
 import conversationPreference from './schemaTypes/conversationPreference'
 import coSpeakerInvitation from './schemaTypes/coSpeakerInvitation'
 import dashboardConfig from './schemaTypes/dashboardConfig'
@@ -47,6 +48,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     staff,
     notification,
     conversation,
+    conversationParticipant,
     message,
     conversationPreference,
 

--- a/sanity/schemaTypes/conversation.ts
+++ b/sanity/schemaTypes/conversation.ts
@@ -164,6 +164,15 @@ export default defineType({
       readOnly: true,
       hidden: true,
     }),
+    defineField({
+      name: 'participants',
+      title: 'Participants',
+      type: 'array',
+      of: [{ type: 'conversationParticipant' }],
+      description:
+        'The GENERAL party representation of this thread (messaging party model, G1). Written ALONGSIDE the legacy createdBy/subjectSpeaker/proposal fields (dual-write): proposal threads → each proposal speaker + the organizers group; general threads → the creator + optional subject speaker + the organizers group. NOT yet the read source in G1 — the legacy fields still drive access, recipients and Studio previews; the read path flips to this array in G2 (after migration 043 backfills it). Written by the server, not edited in Studio.',
+      readOnly: true,
+    }),
   ],
   preview: {
     select: {

--- a/sanity/schemaTypes/conversationParticipant.ts
+++ b/sanity/schemaTypes/conversationParticipant.ts
@@ -1,0 +1,115 @@
+import { defineField, defineType } from 'sanity'
+import {
+  ORGANIZERS_GROUP,
+  validateConversationParticipant,
+} from '../../src/lib/messaging/types'
+
+/**
+ * A single PARTY in a conversation (messaging party model, G1).
+ *
+ * This is the GENERAL representation of "who is on a thread", introduced so the
+ * messaging system can later address non-speaker parties (sponsors, conference
+ * teams) without a parallel data model. In G1 it is written ALONGSIDE the legacy
+ * `createdBy`/`subjectSpeaker`/`proposal` fields (dual-write) and is NOT yet the
+ * read source — the read path still derives participants from those legacy fields
+ * (see `resolveParticipants` in `src/lib/messaging/sanity.ts`). Only `speaker`
+ * and `group` parties are produced in G1; `sponsor` parties arrive in G2.
+ *
+ * A party has a `partyType` discriminator and EXACTLY ONE matching identity
+ * field:
+ * - `speaker` → a WEAK ref to the speaker (weak so a GDPR erase never
+ *   orphan-blocks, consistent with every other human-pointing messaging ref);
+ * - `sponsor` → a ref to the `sponsorForConference` edition membership (G2);
+ * - `group`   → a group KEY string (e.g. `'organizers'`, the universal organizer
+ *   group; per-conference teams come in G3).
+ *
+ * The object-level validation enforces the discriminator↔field congruence so a
+ * malformed party (wrong field for its type, or more than one identity field)
+ * can never be written.
+ */
+
+interface ParticipantValue {
+  partyType?: string
+}
+
+export default defineType({
+  name: 'conversationParticipant',
+  title: 'Participant',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'partyType',
+      title: 'Party Type',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Speaker', value: 'speaker' },
+          { title: 'Sponsor', value: 'sponsor' },
+          { title: 'Group', value: 'group' },
+        ],
+        layout: 'radio',
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'speaker',
+      title: 'Speaker',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion —
+      // consistent with conversation.createdBy / message.author.
+      weak: true,
+      description: 'The speaker party (when partyType is "speaker").',
+      hidden: ({ parent }) =>
+        (parent as ParticipantValue)?.partyType !== 'speaker',
+    }),
+    defineField({
+      name: 'sponsorForConference',
+      title: 'Sponsor (for conference)',
+      type: 'reference',
+      to: [{ type: 'sponsorForConference' }],
+      // Weak for symmetry with the other party refs; G2 begins using it.
+      weak: true,
+      description:
+        'The sponsor edition-membership party (when partyType is "sponsor"). Unused in G1 — sponsor messaging lands in G2.',
+      hidden: ({ parent }) =>
+        (parent as ParticipantValue)?.partyType !== 'sponsor',
+    }),
+    defineField({
+      name: 'group',
+      title: 'Group',
+      type: 'string',
+      description:
+        'A group KEY (when partyType is "group"), e.g. "organizers" — the universal organizer group. Per-conference teams come in G3.',
+      options: {
+        list: [{ title: 'Organizers', value: ORGANIZERS_GROUP }],
+      },
+      hidden: ({ parent }) =>
+        (parent as ParticipantValue)?.partyType !== 'group',
+    }),
+  ],
+  // EXACTLY ONE identity field must be present AND it must match `partyType`.
+  // This keeps the discriminated union honest on write: no speaker party without
+  // a speaker ref, no group party carrying a sponsor ref, etc. The rule is a pure
+  // function shared with the unit tests (see validateConversationParticipant).
+  validation: (Rule) =>
+    Rule.custom((value) => validateConversationParticipant(value)),
+  preview: {
+    select: {
+      partyType: 'partyType',
+      speakerName: 'speaker.name',
+      group: 'group',
+    },
+    prepare({ partyType, speakerName, group }) {
+      const who =
+        partyType === 'speaker'
+          ? (speakerName ?? 'Speaker')
+          : partyType === 'group'
+            ? `Group: ${group ?? '—'}`
+            : partyType === 'sponsor'
+              ? 'Sponsor'
+              : 'Participant'
+      return { title: who, subtitle: partyType }
+    },
+  },
+})

--- a/sanity/schemaTypes/message.ts
+++ b/sanity/schemaTypes/message.ts
@@ -44,6 +44,14 @@ export default defineType({
       validation: (Rule) => Rule.required(),
       initialValue: () => new Date().toISOString(),
     }),
+    defineField({
+      name: 'authorParty',
+      title: 'Author (party)',
+      type: 'conversationParticipant',
+      description:
+        'The GENERAL party representation of the author (messaging party model, G1). Dual-written next to the legacy `author` ref; only speaker parties are produced in G1. NOT yet the read source — `author` still drives fan-out and previews; the read path flips in G2. Written by the server, not edited in Studio.',
+      readOnly: true,
+    }),
   ],
   preview: {
     select: {

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -7,6 +7,7 @@ import type {
   AccessSpeaker,
   ConversationListItem,
   ConversationParticipant,
+  ConversationParty,
   ConversationPreference,
   ConversationStatus,
   ConversationView,
@@ -15,7 +16,7 @@ import type {
   EmailOverride,
   Message,
 } from './types'
-import { DEFAULT_CONVERSATION_PREFERENCE } from './types'
+import { DEFAULT_CONVERSATION_PREFERENCE, ORGANIZERS_GROUP } from './types'
 import {
   proposalConversationId,
   conversationLinkPath,
@@ -67,7 +68,13 @@ const CONVERSATION_PROJECTION = `{
   "status": coalesce(status, 'open'),
   "assignedTo": assignedTo->{ _id, name },
   archivedAt,
-  "archivedBy": archivedBy->{ _id, name }
+  "archivedBy": archivedBy->{ _id, name },
+  "participants": participants[]{
+    partyType,
+    "speakerId": speaker._ref,
+    "sponsorForConferenceId": sponsorForConference._ref,
+    group
+  }
 }`
 
 // ---------------------------------------------------------------------------
@@ -235,6 +242,157 @@ export function resolveParticipantIds(
   return Array.from(ids)
 }
 
+// ---------------------------------------------------------------------------
+// Party model (G1): the GENERAL participant representation.
+//
+// A conversation's participants are expressed as a list of PARTIES (speaker /
+// sponsor / group). G1 introduces this representation and DUAL-WRITES it (below)
+// alongside the legacy createdBy/subjectSpeaker/proposal fields; the read path
+// is UNCHANGED (canAccessConversation / resolveRecipients / the GROQ scope
+// predicates all keep their legacy logic). The read path flips to prefer
+// participants[] in G2 (with the sponsor branch), after migration 043 backfills
+// existing documents.
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the party list from the LEGACY fields — the pre-party participant set,
+ * in party form and in a STABLE order:
+ * - proposal thread → one `speaker` party per proposal speaker, then the
+ *   `organizers` group;
+ * - general thread  → the creator, then the `subjectSpeaker` (when set), then
+ *   the `organizers` group.
+ *
+ * The organizer team is ONE `group` party — NOT the expanded organizer id list.
+ * Organizers are resolved from conference membership at read time, so a thread
+ * records only THAT the organizer group is a party, never who is in it (mirrors
+ * how `resolveParticipantIds` seeds the set with the live organizer ids rather
+ * than storing them). This is the exact set `resolveParticipantIds` expresses,
+ * with organizers collapsed to their group.
+ */
+function deriveParties(
+  conversation: Pick<
+    ConversationWithContext,
+    | 'conversationType'
+    | 'proposalSpeakerIds'
+    | 'createdById'
+    | 'subjectSpeakerId'
+  >,
+): ConversationParty[] {
+  const parties: ConversationParty[] = []
+  if (conversation.conversationType === 'proposal') {
+    for (const id of conversation.proposalSpeakerIds) {
+      parties.push({ partyType: 'speaker', speakerId: id })
+    }
+  } else {
+    parties.push({ partyType: 'speaker', speakerId: conversation.createdById })
+    if (conversation.subjectSpeakerId) {
+      parties.push({
+        partyType: 'speaker',
+        speakerId: conversation.subjectSpeakerId,
+      })
+    }
+  }
+  parties.push({ partyType: 'group', group: ORGANIZERS_GROUP })
+  return parties
+}
+
+/**
+ * The G1 party RESOLVER: PREFERS the dual-written `participants[]` when present
+ * and non-empty, otherwise DERIVES the identical set from the legacy fields
+ * ({@link deriveParties}).
+ *
+ * This is the seam the read path flips onto in G2. In G1 no legacy read consumer
+ * calls it — they keep their current logic — but the dual-write below constructs
+ * the stored `participants[]` THROUGH this resolver (on a participants-less
+ * context, so it takes the derive branch), which GUARANTEES the written array is
+ * exactly what a legacy-only document resolves to. Tests prove the equivalence
+ * `resolveParticipants(legacy) === resolveParticipants(dual-written)` for every
+ * thread shape.
+ */
+export function resolveParticipants(
+  conversation: Pick<
+    ConversationWithContext,
+    | 'conversationType'
+    | 'proposalSpeakerIds'
+    | 'createdById'
+    | 'subjectSpeakerId'
+    | 'participants'
+  >,
+): ConversationParty[] {
+  if (conversation.participants && conversation.participants.length > 0) {
+    return conversation.participants
+  }
+  return deriveParties(conversation)
+}
+
+/** A `participants[]` row as PROJECTED by GROQ (before {@link normalizeParties}). */
+interface RawParty {
+  partyType?: string | null
+  speakerId?: string | null
+  sponsorForConferenceId?: string | null
+  group?: string | null
+}
+
+/**
+ * Normalize the GROQ-projected `participants[]` into the {@link ConversationParty}
+ * union, dropping any malformed / dangling row (e.g. a `speaker` party whose weak
+ * ref was erased leaves `speakerId` null). Returns `undefined` for an
+ * absent/empty array so {@link resolveParticipants} falls back to the legacy
+ * derivation rather than treating "no parties" as a real empty set.
+ */
+function normalizeParties(
+  raw: RawParty[] | null | undefined,
+): ConversationParty[] | undefined {
+  if (!raw || raw.length === 0) return undefined
+  const parties: ConversationParty[] = []
+  for (const p of raw) {
+    if (p.partyType === 'speaker' && p.speakerId) {
+      parties.push({ partyType: 'speaker', speakerId: p.speakerId })
+    } else if (p.partyType === 'sponsor' && p.sponsorForConferenceId) {
+      parties.push({
+        partyType: 'sponsor',
+        sponsorForConferenceId: p.sponsorForConferenceId,
+      })
+    } else if (p.partyType === 'group' && p.group) {
+      parties.push({ partyType: 'group', group: p.group })
+    }
+  }
+  return parties.length > 0 ? parties : undefined
+}
+
+/**
+ * Serialize a {@link ConversationParty} to its stored `conversationParticipant`
+ * object shape. Human-pointing refs (`speaker`, `sponsorForConference`) are WEAK
+ * so a later GDPR erase never orphan-blocks — consistent with every other
+ * messaging ref. Used for the single-object `message.authorParty`; array items
+ * add a `_key` (see {@link partiesToStored}).
+ */
+function partyToStored(party: ConversationParty): Record<string, unknown> {
+  if (party.partyType === 'speaker') {
+    return {
+      partyType: 'speaker',
+      speaker: { ...createReference(party.speakerId), _weak: true },
+    }
+  }
+  if (party.partyType === 'sponsor') {
+    return {
+      partyType: 'sponsor',
+      sponsorForConference: {
+        ...createReference(party.sponsorForConferenceId),
+        _weak: true,
+      },
+    }
+  }
+  return { partyType: 'group', group: party.group }
+}
+
+/** Serialize parties for a `participants[]` array (each item needs a `_key`). */
+function partiesToStored(
+  parties: ConversationParty[],
+): Record<string, unknown>[] {
+  return parties.map((party) => ({ _key: nanoid(), ...partyToStored(party) }))
+}
+
 /**
  * The recipients of a new message: all participants EXCEPT the actor (an actor
  * is never notified about their own message — mirrors the hub's actor-exclusion
@@ -314,17 +472,34 @@ export async function getProposalForConversation(proposalId: string): Promise<{
   }
 }
 
+/**
+ * The raw shape of {@link CONVERSATION_PROJECTION}: identical to
+ * {@link ConversationWithContext} except `participants` arrives in the projected
+ * {@link RawParty} shape (normalized below).
+ */
+type RawConversationWithContext = Omit<
+  ConversationWithContext,
+  'participants'
+> & { participants?: RawParty[] | null }
+
 /** A single conversation with its authorization/recipient context. */
 export async function getConversationById(
   id: string,
 ): Promise<ConversationWithContext | null> {
-  const result = await clientReadUncached.fetch<ConversationWithContext | null>(
-    `*[_type == "conversation" && _id == $id][0]${CONVERSATION_PROJECTION}`,
-    { id },
-    { cache: 'no-store' },
-  )
+  const result =
+    await clientReadUncached.fetch<RawConversationWithContext | null>(
+      `*[_type == "conversation" && _id == $id][0]${CONVERSATION_PROJECTION}`,
+      { id },
+      { cache: 'no-store' },
+    )
   if (!result) return null
-  return { ...result, proposalSpeakerIds: result.proposalSpeakerIds ?? [] }
+  return {
+    ...result,
+    proposalSpeakerIds: result.proposalSpeakerIds ?? [],
+    // Party model (G1): projected alongside the legacy fields. No legacy read
+    // consumer uses it yet; it powers the G2 read-path flip.
+    participants: normalizeParties(result.participants),
+  }
 }
 
 /**
@@ -834,14 +1009,32 @@ export async function ensureProposalConversation({
   proposalId,
   proposalTitle,
   createdById,
+  proposalSpeakerIds,
 }: {
   conferenceId: string
   proposalId: string
   proposalTitle: string
   createdById: string
+  /**
+   * The proposal's current speaker ids (party model, G1). Passed by the router
+   * from the proposal it already fetched, so the dual-written `participants[]`
+   * snapshots the proposal's speakers at thread creation — exactly what the
+   * legacy read path derives from `proposal->speakers[]._ref` for a fresh thread.
+   */
+  proposalSpeakerIds: string[]
 }): Promise<string> {
   const id = proposalConversationId(proposalId)
   const now = new Date().toISOString()
+  // Party model (G1): dual-write `participants[]` alongside the legacy fields,
+  // constructed THROUGH the read resolver (participants-less context → derive
+  // branch) so the stored array is exactly what a legacy-only doc resolves to.
+  const participants = partiesToStored(
+    resolveParticipants({
+      conversationType: 'proposal',
+      proposalSpeakerIds,
+      createdById,
+    }),
+  )
   await clientWrite
     .transaction()
     .createIfNotExists({
@@ -854,6 +1047,7 @@ export async function ensureProposalConversation({
       subject: (proposalTitle || 'Proposal').slice(0, 200),
       createdAt: now,
       lastMessageAt: now,
+      participants,
     })
     .commit()
   return id
@@ -879,6 +1073,17 @@ export async function createGeneralConversation({
 }): Promise<string> {
   const id = `conversation.${nanoid()}`
   const now = new Date().toISOString()
+  // Party model (G1): dual-write `participants[]` (creator + optional subject
+  // speaker + organizers group), constructed THROUGH the read resolver so it
+  // matches the legacy derivation exactly.
+  const participants = partiesToStored(
+    resolveParticipants({
+      conversationType: 'general',
+      proposalSpeakerIds: [],
+      createdById,
+      subjectSpeakerId,
+    }),
+  )
   await clientWrite.create({
     _id: id,
     _type: 'conversation',
@@ -891,6 +1096,7 @@ export async function createGeneralConversation({
     subject: subject.slice(0, 200),
     createdAt: now,
     lastMessageAt: now,
+    participants,
   })
   return id
 }
@@ -940,6 +1146,11 @@ export async function addMessage({
       author: createReference(authorId),
       body,
       createdAt: now,
+      // Party model (G1): dual-write `authorParty` next to the legacy `author`
+      // ref. Only speaker parties are produced in G1 (the author is always a
+      // speaker/organizer speaker doc). Not yet read — `author` still drives
+      // fan-out; the read path flips in G2.
+      authorParty: partyToStored({ partyType: 'speaker', speakerId: authorId }),
     })
     .patch(conversationId, (patch) =>
       patch.set(

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -56,6 +56,74 @@ export const SPEAKER_ALLOWED_VIEWS: ConversationView[] = [
 /** Per-conversation email delivery override. */
 export type EmailOverride = 'default' | 'on' | 'off'
 
+/** The universal organizer group key (the only group value produced in G1). */
+export const ORGANIZERS_GROUP = 'organizers'
+
+/**
+ * A single PARTY of a conversation — the GENERAL representation of "who is on a
+ * thread" (mirrors the `conversationParticipant` Sanity object). A discriminated
+ * union on `partyType`, each member carrying EXACTLY ONE identity (`'speaker'`
+ * and `'group'` are produced in G1; `'sponsor'` is reserved for G2):
+ * - `speaker` → a speaker id (the dereferenced `speaker._ref`);
+ * - `sponsor` → a `sponsorForConference` id (unused in G1; G2 begins using it);
+ * - `group`   → a group KEY (e.g. `'organizers'`).
+ *
+ * In G1 this is dual-written alongside the legacy `createdBy`/`subjectSpeaker`/
+ * `proposal` fields and is NOT yet the read source. See `resolveParticipants` in
+ * `./sanity` for the derive-or-prefer resolver.
+ */
+export type ConversationParty =
+  | { partyType: 'speaker'; speakerId: string }
+  | { partyType: 'sponsor'; sponsorForConferenceId: string }
+  | { partyType: 'group'; group: string }
+
+/**
+ * The loose value shape the `conversationParticipant` Sanity object validation
+ * receives (a partially-filled party object from Studio or a write).
+ */
+export interface ConversationParticipantInput {
+  partyType?: string
+  speaker?: { _ref?: string } | null
+  sponsorForConference?: { _ref?: string } | null
+  group?: string | null
+}
+
+/**
+ * Validate the discriminator↔identity congruence of a `conversationParticipant`:
+ * EXACTLY ONE identity field must be present AND it must match `partyType`. Pure
+ * (no Sanity imports) so the schema's `Rule.custom` and unit tests share ONE
+ * implementation — the same extract-and-test idiom the sponsor CRM validations
+ * use. Returns `true` when valid, otherwise a human-readable error string.
+ *
+ * An ABSENT `partyType` returns `true` here: the field carries its own
+ * `Rule.required()`, so this validator never double-reports the missing
+ * discriminator.
+ */
+export function validateConversationParticipant(
+  value: ConversationParticipantInput | undefined,
+): true | string {
+  const v = value ?? {}
+  const { partyType } = v
+  if (!partyType) return true
+  const hasSpeaker = Boolean(v.speaker?._ref)
+  const hasSponsor = Boolean(v.sponsorForConference?._ref)
+  const hasGroup = typeof v.group === 'string' && v.group.length > 0
+  const present = [hasSpeaker, hasSponsor, hasGroup].filter(Boolean).length
+  if (present !== 1) {
+    return 'A participant must carry exactly one identity field (speaker, sponsorForConference, or group).'
+  }
+  if (partyType === 'speaker' && !hasSpeaker) {
+    return 'A speaker party requires a speaker reference.'
+  }
+  if (partyType === 'sponsor' && !hasSponsor) {
+    return 'A sponsor party requires a sponsorForConference reference.'
+  }
+  if (partyType === 'group' && !hasGroup) {
+    return 'A group party requires a non-empty group key.'
+  }
+  return true
+}
+
 /** A speaker as needed for authorization decisions (server-derived). */
 export interface AccessSpeaker {
   _id: string
@@ -103,6 +171,15 @@ export interface ConversationWithContext {
    * archiver speaker was erased). Only meaningful when `archivedAt` is set.
    */
   archivedBy?: ConversationArchiver | null
+  /**
+   * The GENERAL party representation (messaging party model, G1), projected from
+   * the conversation's dual-written `participants[]` when present. OPTIONAL in
+   * G1: the read path still DERIVES participants from the legacy fields (see
+   * `resolveParticipants` in `./sanity`), so this is populated only for
+   * conversations created (or backfilled by migration 043) since the dual-write
+   * landed, and no consumer reads it yet. The read path flips to prefer it in G2.
+   */
+  participants?: ConversationParty[]
 }
 
 /** The organizer who globally archived a thread (deref of `archivedBy`). */

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -325,6 +325,9 @@ export const messageRouter = router({
           proposalId: input.proposalId,
           proposalTitle: proposal.title ?? 'Proposal',
           createdById: actorId,
+          // Party model (G1): the proposal's current speakers seed the
+          // dual-written `participants[]` (see ensureProposalConversation).
+          proposalSpeakerIds: proposal.speakerIds,
         })
         const created = await getConversationById(id)
         if (!created) {

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -789,6 +789,9 @@ export const proposalRouter = router({
               proposalId: id,
               proposalTitle: proposal.title ?? 'Proposal',
               createdById: ctx.speaker._id,
+              // Party model (G1): the proposal's current speakers seed the
+              // dual-written participants[] (see ensureProposalConversation).
+              proposalSpeakerIds: extractSpeakerIds(proposal.speakers),
             })
             await addMessage({
               conversationId,


### PR DESCRIPTION
## SPONSOR-MESSAGING G1 — Party Data Model foundation

Maintainer-locked architecture: **generalize** the speaker messaging system into a party model (not a parallel lightweight model), **no special-casing**. This phase (G1) changes **representation only** — behaviour is **bit-identical**. Sponsor features come in G2.

### What G1 introduces
- **New Sanity object type `conversationParticipant`**: `{ partyType: 'speaker' | 'sponsor' | 'group', speaker? (weak), sponsorForConference? (weak), group? }` with object-level validation that **exactly one identity field matches `partyType`** (extracted to a pure, unit-tested `validateConversationParticipant`).
- **`conversation.participants: conversationParticipant[]`** and **`message.authorParty: conversationParticipant`** — the general representation, both `readOnly` (server-written).
- **Types**: `ConversationParty` union + optional `participants` on `ConversationWithContext`.
- **Pure read resolver `resolveParticipants(conversation)`** in the data layer: **prefers** `participants[]` when present & non-empty, else **derives** the identical set from the legacy fields (proposal → speaker party per proposal speaker + `organizers` group; general → creator + optional `subjectSpeaker` + `organizers` group).
- **Migration `043-backfill-conversation-participants`** (write, **NOT RUN**): backfills `participants[]`/`authorParty` from the legacy fields; additive, idempotent (skips docs already carrying the representation, skips drafts), README + candidate logging, mirrors the derive/serialize logic verbatim.

### Dual-write transition plan
```
G1 (this PR):  write BOTH  — legacy fields stay the read-source; participants[]/authorParty
                            written ALONGSIDE by ensureProposalConversation /
                            createGeneralConversation / addMessage.
   ↓  maintainer runs migration 043 (backfills historical docs)
G2:            read NEW    — flip consumers/GROQ onto resolveParticipants, add the sponsor branch.
```
The dual-write constructs the stored `participants[]` **through the same `resolveParticipants` resolver** the read path will use in G2 (on a participants-less context → derive branch), so the written array is **exactly** what a legacy-only document resolves to, by construction.

### No-behaviour-change guarantee (and how tests prove it)
Every existing read consumer keeps its **current** logic in G1 — `canAccessConversation`, `resolveRecipients`, `resolveParticipantIds`, counterpart resolution and the **GROQ scope predicates are untouched**. The new representation is written and projected but **no consumer reads it yet**. Proof:
- **Resolver equivalence matrix**: for every thread shape (proposal ×{2,1,0 speakers}, general ×{with/without subjectSpeaker}), `resolveParticipants(legacy-derived)` **deep-equals** `resolveParticipants(dual-written)`; the "dual-written" arrays are hand-authored per the locked design (not produced by the derive path), so the test genuinely proves derive-logic and stored-format agree. Plus: empty `participants[]` falls back to derive; a stored array that diverges (a sponsor party) is returned verbatim (proving true preference).
- **Dual-write coverage**: both conversation creators and `addMessage` write the exact party shapes **alongside the unchanged legacy fields**.
- **Schema validation**: `partyType`↔identity-field congruence (exactly-one, wrong-field, missing-field, absent-discriminator).
- **Full suite green**: 232 files / 3325 passed / 5 skipped (was 231 / 3298); +1 new test file, +27 tests. `tsc`, `eslint`, `prettier`, `knip` all clean.

### Existing tests touched (flagged — NOT silent adaptation)
Making the dual-write correct for proposal threads required threading the proposal's current speakers into `ensureProposalConversation` (new **required** `proposalSpeakerIds` arg), wired at both production call sites (`message.ts`, `proposal.ts`). This is a **signature change, not a behaviour change** — no assertion about what messaging *does* changed. Three existing-test call sites were updated to pass/expect the new argument:
- `__tests__/lib/messaging/sanity.test.ts` — pass the new arg (+ additive assertion on the dual-written `participants[]`).
- `__tests__/api/trpc/proposal.test.ts` — the decision-comment-mirror `toHaveBeenCalledWith` gains `proposalSpeakerIds`.

No existing test's expectations were altered to mask a regression.

### Not merging
This PR is for review. Migration 043 is **NOT RUN** — the maintainer runs it (backup → dry-run → apply) before the G2 read-path flip.

### Note for G2 (transition consideration, out of scope here)
Proposal-thread `participants[]` snapshots the proposal's speakers at thread creation, whereas the legacy read derives `proposal->speakers[]` **live**. In G1 this is irrelevant (legacy fields remain the read-source); before G2 flips the read path, migration 043 re-derives from current state, and co-speaker add/remove currency for the party read is a G2 concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lays the foundational party data model for the messaging system (G1), generalizing speaker threads toward a model that can address sponsors and groups. Behaviour is intentionally unchanged \u2014 all legacy read consumers (`canAccessConversation`, `resolveRecipients`, GROQ predicates) are untouched; the new representation is only written and projected.

- **New `conversationParticipant` Sanity object type** with a validated `partyType` discriminator and weak speaker/sponsor refs; object-level validation (`validateConversationParticipant`) is a pure function shared between the schema and unit tests.
- **Dual-write in `ensureProposalConversation`, `createGeneralConversation`, and `addMessage`**: `participants[]` / `authorParty` stored alongside unchanged legacy fields; the stored array is constructed through `resolveParticipants` on a participants-less context so it equals what the legacy derivation produces.
- **Migration 043** (not yet run) backfills historical documents before G2 flips the read path, using deterministic `_key` values and idempotent skipping logic.

<h3>Confidence Score: 4/5</h3>

Safe to merge as a representation-only foundation — no existing read consumer is touched and all legacy paths remain bit-identical.

The three findings are all forward-looking: normalizeParties lacks direct tests and will be the silent failure point when G2 flips the read path; co-speaker staleness is a documented G2 concern; and the migration’s in-memory conversation fetch is a one-time operational risk. None affect G1 behaviour since no consumer reads the new fields in this PR.

src/lib/messaging/sanity.ts (normalizeParties coverage and co-speaker snapshot semantics) and migrations/043-backfill-conversation-participants/index.ts (in-memory fetch size assessment before running in production).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/messaging/types.ts | Adds ConversationParty union type, validateConversationParticipant validator, ORGANIZERS_GROUP constant, and optional participants on ConversationWithContext. Pure/testable validator correctly shared with the schema. |
| src/lib/messaging/sanity.ts | Adds resolveParticipants, deriveParties, normalizeParties, partyToStored, partiesToStored, and CONVERSATION_PROJECTION participants[] projection. normalizeParties is the only untested normalization boundary between raw GROQ output and typed ConversationParty[]. |
| sanity/schemaTypes/conversationParticipant.ts | New Sanity object schema with discriminator/identity-field validation. Correctly reuses validateConversationParticipant from types.ts, weak refs for GDPR safety, radio-layout partyType picker. |
| migrations/043-backfill-conversation-participants/index.ts | Backfill migration: fetches all conversations via explicit GROQ for the proposal→speakers join, then streams messages. Additive, idempotent, deterministic _key values. Full in-memory fetch is a noted tradeoff. |
| __tests__/lib/messaging/party-model.test.ts | New test file covering resolver equivalence across all thread shapes, dual-write assertions, and schema validation. Does not cover the normalizeParties normalization path (raw GROQ → typed parties). |
| src/server/routers/message.ts | Threads proposalSpeakerIds from the already-fetched proposal into ensureProposalConversation. Minimal change, correct wiring. |
| src/server/routers/proposal.ts | Passes extractSpeakerIds(proposal.speakers) as proposalSpeakerIds at the decision-comment call site. Correct. |
| __tests__/lib/messaging/sanity.test.ts | Existing test updated to pass required proposalSpeakerIds with additive assertion on the dual-written participants[]. No existing assertions altered. |
| __tests__/api/trpc/proposal.test.ts | Adds proposalSpeakerIds to the decision-comment mirror call expectation. Additive, no existing assertion changed. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Router as message.ts / proposal.ts router
    participant Sanity as src/lib/messaging/sanity.ts
    participant DB as Sanity CMS

    Note over Router,DB: G1 Dual-Write - conversation creation
    Router->>Sanity: ensureProposalConversation with proposalSpeakerIds
    Sanity->>Sanity: resolveParticipants calls deriveParties (no participants yet)
    Sanity->>Sanity: partiesToStored with nanoid _keys
    Sanity->>DB: createIfNotExists with legacy fields + participants[]

    Note over Router,DB: G1 Dual-Write - message creation
    Router->>Sanity: addMessage with authorId
    Sanity->>Sanity: partyToStored speaker party
    Sanity->>DB: tx.create with legacy author ref + authorParty

    Note over Router,DB: G1 Read - getConversationById
    Router->>Sanity: getConversationById(id)
    Sanity->>DB: GROQ fetch with CONVERSATION_PROJECTION
    DB-->>Sanity: RawConversationWithContext with RawParty[]
    Sanity->>Sanity: normalizeParties drops dangling refs
    Sanity-->>Router: ConversationWithContext with optional participants

    Note over Sanity: resolveParticipants logic
    alt participants[] present and non-empty
        Sanity-->>Sanity: return participants verbatim
    else absent or empty
        Sanity->>Sanity: deriveParties from legacy fields
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Router as message.ts / proposal.ts router
    participant Sanity as src/lib/messaging/sanity.ts
    participant DB as Sanity CMS

    Note over Router,DB: G1 Dual-Write - conversation creation
    Router->>Sanity: ensureProposalConversation with proposalSpeakerIds
    Sanity->>Sanity: resolveParticipants calls deriveParties (no participants yet)
    Sanity->>Sanity: partiesToStored with nanoid _keys
    Sanity->>DB: createIfNotExists with legacy fields + participants[]

    Note over Router,DB: G1 Dual-Write - message creation
    Router->>Sanity: addMessage with authorId
    Sanity->>Sanity: partyToStored speaker party
    Sanity->>DB: tx.create with legacy author ref + authorParty

    Note over Router,DB: G1 Read - getConversationById
    Router->>Sanity: getConversationById(id)
    Sanity->>DB: GROQ fetch with CONVERSATION_PROJECTION
    DB-->>Sanity: RawConversationWithContext with RawParty[]
    Sanity->>Sanity: normalizeParties drops dangling refs
    Sanity-->>Router: ConversationWithContext with optional participants

    Note over Sanity: resolveParticipants logic
    alt participants[] present and non-empty
        Sanity-->>Sanity: return participants verbatim
    else absent or empty
        Sanity->>Sanity: deriveParties from legacy fields
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/messaging/sanity.ts`, line 1089-1107 ([link](https://github.com/cloudnativebergen/website/blob/9b9847e52b6ccff8d87bd3b6e4c34dd0fd418465/src/lib/messaging/sanity.ts#L1089-L1107)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`normalizeParties` has no direct test coverage**

   `normalizeParties` is the sole normalization boundary between raw GROQ output and typed `ConversationParty[]` — it silently drops dangling-ref rows, handles null `partyType`, and decides whether the stored array is non-empty enough to pass to `resolveParticipants`. In G1 no consumer calls the derive-or-prefer path via a real DB round-trip, so the gap is invisible now. In G2, when the read path flips to `resolveParticipants`, a bug here would silently fall back to the legacy derivation for every document — indistinguishable from correct behavior without a targeted test.

   Consider adding integration-style tests for `getConversationById` with a mocked `clientReadUncached.fetch` returning raw GROQ shapes (null `speakerId`, missing `partyType`, mixed valid/dangling rows).


2. `migrations/043-backfill-conversation-participants/index.ts`, line 706-735 ([link](https://github.com/cloudnativebergen/website/blob/9b9847e52b6ccff8d87bd3b6e4c34dd0fd418465/migrations/043-backfill-conversation-participants/index.ts#L706-L735)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **All conversations fetched into memory in a single GROQ call**

   The migration loads every non-draft conversation document into memory before yielding any patches. The tradeoff is acknowledged as necessary for the `proposal->speakers[]` JOIN, but it's worth adding a log of the conversation count at the start of the fetch so the maintainer can gauge memory risk before applying in production.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): party data model founda..."](https://github.com/cloudnativebergen/website/commit/9b9847e52b6ccff8d87bd3b6e4c34dd0fd418465) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45478619)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->