### PR TITLE
fix(push): surface malformed VAPID configuration instead of 'internal error'

### DIFF
--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -1,5 +1,9 @@
 import 'server-only'
-import { getConfiguredWebPush, isPushConfigured } from './vapid'
+import {
+  getConfiguredWebPush,
+  getWebPushConfigError,
+  isPushConfigured,
+} from './vapid'
 import { getSpeakerPushState, prunePushSubscription } from './sanity'
 import { isValidPushEndpoint } from './validate'
 import type {
@@ -81,7 +85,17 @@ export async function sendPush(
 ): Promise<PushSendResult> {
   const client = getConfiguredWebPush()
   if (!client) {
-    return { ok: false, gone: false, errorMessage: 'VAPID keys not configured' }
+    // Distinguish "no keys" from "keys present but MALFORMED" (bad subject /
+    // wrong-length key) — the latter previously threw out of this function and
+    // surfaced as an unexplained 'internal error' on the test button.
+    const configError = getWebPushConfigError()
+    return {
+      ok: false,
+      gone: false,
+      errorMessage: configError
+        ? `VAPID configuration invalid: ${configError}`
+        : 'VAPID keys not configured',
+    }
   }
 
   try {

--- a/src/lib/push/vapid.ts
+++ b/src/lib/push/vapid.ts
@@ -40,23 +40,46 @@ export function isPushConfigured(): boolean {
 }
 
 let configured = false
+let configError: string | null = null
+
+/**
+ * The reason VAPID configuration FAILED (malformed subject/keys), or null when
+ * configuration succeeded or hasn't been attempted. `setVapidDetails` throws
+ * synchronously on e.g. a bare-email VAPID_SUBJECT (must be a URL or mailto:)
+ * or a wrong-length key — surfacing the message here lets the push test button
+ * and the admin self-check page explain the misconfiguration instead of a
+ * generic "internal error".
+ */
+export function getWebPushConfigError(): string | null {
+  return configError
+}
 
 /**
  * Lazily apply the VAPID details to the shared `web-push` client exactly once.
- * Returns the configured client, or `null` when keys are missing (so callers
- * can no-op instead of throwing in an unconfigured environment).
+ * Returns the configured client, or `null` when keys are missing OR when the
+ * configured values are MALFORMED (so callers can no-op instead of throwing) —
+ * in the malformed case {@link getWebPushConfigError} carries the reason.
  */
 export function getConfiguredWebPush(): typeof webpush | null {
   if (!isPushConfigured()) {
     return null
   }
+  if (configError) {
+    return null
+  }
   if (!configured) {
-    webpush.setVapidDetails(
-      getVapidSubject(),
-      getVapidPublicKey(),
-      getVapidPrivateKey(),
-    )
-    configured = true
+    try {
+      webpush.setVapidDetails(
+        getVapidSubject(),
+        getVapidPublicKey(),
+        getVapidPrivateKey(),
+      )
+      configured = true
+    } catch (error) {
+      configError = error instanceof Error ? error.message : String(error)
+      console.error('[push] VAPID configuration is invalid:', configError)
+      return null
+    }
   }
   return webpush
 }

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -3,7 +3,12 @@ import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { clientReadUncached } from '@/lib/sanity/client'
-import { isPushConfigured, getVapidPublicKey } from '@/lib/push/vapid'
+import {
+  isPushConfigured,
+  getVapidPublicKey,
+  getConfiguredWebPush,
+  getWebPushConfigError,
+} from '@/lib/push/vapid'
 import { checkinGraphQLClient } from '@/lib/tickets/graphql-client'
 import { providerMap } from '@/lib/auth'
 import type {
@@ -361,15 +366,23 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
 
   // ---- PUSH -----------------------------------------------------------------
   const pushOn = isPushConfigured()
+  // Exercise the REAL web-push configuration: keys can be present but
+  // MALFORMED (bare-email VAPID_SUBJECT, wrong-length key) — setVapidDetails
+  // rejects those synchronously, and until surfaced here that only appeared
+  // as an opaque failure on the push test button.
+  if (pushOn) getConfiguredWebPush()
+  const vapidError = getWebPushConfigError()
   checks.push({
     id: 'push.configured',
     group: 'push',
     label: 'VAPID key pair',
-    status: pushOn ? 'ok' : 'off',
-    value: pushOn ? 'configured' : 'not set',
-    detail: pushOn
-      ? undefined
-      : 'Both VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY must be set',
+    status: vapidError ? 'error' : pushOn ? 'ok' : 'off',
+    value: vapidError ? 'invalid' : pushOn ? 'configured' : 'not set',
+    detail: vapidError
+      ? `web-push rejected the configuration: ${vapidError}`
+      : pushOn
+        ? undefined
+        : 'Both VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY must be set',
   })
   const vapidPublic = getVapidPublicKey()
   checks.push(

--- a/src/server/routers/push.ts
+++ b/src/server/routers/push.ts
@@ -249,7 +249,14 @@ export const pushRouter = router({
           `[push] test send task rejected for speaker ${ctx.speaker._id}:`,
           r.reason,
         )
-        failures.push({ statusCode: undefined, message: 'internal error' })
+        // Carry the actual rejection reason to the client (truncated) — the
+        // opaque 'internal error' copy hid a real VAPID misconfiguration once.
+        const reason =
+          r.reason instanceof Error ? r.reason.message : String(r.reason)
+        failures.push({
+          statusCode: undefined,
+          message: reason.slice(0, 200) || 'internal error',
+        })
         continue
       }
       if (r.value.ok) {


### PR DESCRIPTION
Maintainer-reported: the push test button failed with 'Delivery failed (internal error). internal error' and no useful server logs.

Root cause: `webpush.setVapidDetails` throws SYNCHRONOUSLY on malformed configuration (e.g. a bare-email VAPID_SUBJECT without `mailto:`, or a wrong-length key) — and it ran in `getConfiguredWebPush()` BEFORE `sendPush`'s try block, so the throw escaped as a rejected promise, hitting the defensive branch we had labeled unreachable and mapping to the opaque 'internal error'.

Three layers fixed:
1. `getConfiguredWebPush` catches the config error, logs it, caches it, and exposes it via `getWebPushConfigError()`.
2. `sendPush` distinguishes 'no keys' from 'keys present but MALFORMED' — the test button now shows e.g. 'VAPID configuration invalid: Vapid subject is not a valid URL or mailto: address'.
3. The admin settings self-check now EXERCISES the real configuration: the VAPID check turns red with the exact rejection when keys are present but malformed. This page exists precisely to catch this class of issue.
Plus: the sendTest rejected-promise branch now carries the actual rejection reason instead of 'internal error', so any future escape self-explains.

Likely action for prod once deployed: check /admin/settings → the VAPID check will name the offending value (expect VAPID_SUBJECT missing its mailto: prefix).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes opaque "internal error" failures when VAPID configuration is malformed. The root cause was `webpush.setVapidDetails` throwing synchronously outside `sendPush`'s try block, escaping as a rejected promise and hitting a defensive fallback labeled "unreachable."

- **`vapid.ts`**: Wraps `setVapidDetails` in a try/catch; caches the error in a module-level `configError` variable and exposes it via `getWebPushConfigError()`, returning `null` from `getConfiguredWebPush()` in both the "no keys" and "malformed keys" cases.
- **`send.ts`**: `sendPush` now distinguishes the two `null`-client states and returns a human-readable `"VAPID configuration invalid: <reason>"` error message instead of the generic `"VAPID keys not configured"`.
- **`checks.ts`**: The admin settings page now actively exercises the VAPID configuration (calling `getConfiguredWebPush()`) to surface malformed-key errors as `status: 'error'` rather than silently showing `'ok'`.
- **`push.ts`**: The rejected-promise defensive branch in `sendTest` now propagates the actual rejection reason (truncated to 200 chars) instead of the hardcoded `"internal error"` string.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a targeted bug fix with no new failure modes introduced.

The fix is well-scoped and targeted. The module-level caching of configError is correct, the mutual exclusivity of `configured` and `configError` is properly enforced, and the admin check now genuinely exercises the real configuration path. The one gap is that `sendPushForNotifications` does not short-circuit on `getWebPushConfigError()`, causing unnecessary Sanity reads when VAPID keys are present but malformed, though this does not produce incorrect behaviour.

src/lib/push/send.ts — sendPushForNotifications should also check getWebPushConfigError() as an early exit to avoid unnecessary Sanity reads when VAPID keys are present but malformed.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/push/vapid.ts | Core fix: wraps setVapidDetails in try/catch, caches the error in module state, and exposes it via getWebPushConfigError(). Logic is correct; the mutual-exclusivity of `configured` and `configError` is well-enforced. |
| src/lib/push/send.ts | sendPush now correctly surfaces the config error message. sendPushForNotifications still uses only isPushConfigured() as its early-exit guard and does not check getWebPushConfigError(), causing unnecessary Sanity reads when VAPID is malformed. |
| src/lib/system-status/checks.ts | Admin check now actively exercises the VAPID configuration and surfaces malformed-key errors as status:'error' with the exact rejection message. Change is correct and minimal. |
| src/server/routers/push.ts | Rejected-promise fallback in sendTest now carries the actual reason (truncated to 200 chars) instead of the hardcoded "internal error". Change is safe; the 200-char limit is consistent with MAX_ERROR_MESSAGE in send.ts. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin Settings Page
    participant Checks as checks.ts
    participant Vapid as vapid.ts
    participant WebPush as web-push lib
    participant Send as send.ts
    participant Router as push.ts sendTest

    Note over Admin,WebPush: Admin self-check (new behaviour)
    Admin->>Checks: load /admin/settings
    Checks->>Vapid: isPushConfigured()
    Vapid-->>Checks: true
    Checks->>Vapid: getConfiguredWebPush()
    Vapid->>WebPush: setVapidDetails(subject, pub, priv)
    WebPush-->>Vapid: throws on malformed subject or key
    Vapid->>Vapid: store configError, console.error
    Vapid-->>Checks: null
    Checks->>Vapid: getWebPushConfigError()
    Vapid-->>Checks: Vapid subject is not a valid URL
    Checks-->>Admin: status error, detail web-push rejected

    Note over Router,Send: Test button (new behaviour)
    Router->>Send: sendPush(subscription, payload)
    Send->>Vapid: getConfiguredWebPush()
    Vapid-->>Send: null, configError set
    Send->>Vapid: getWebPushConfigError()
    Vapid-->>Send: Vapid subject is not a valid URL
    Send-->>Router: ok false, errorMessage VAPID configuration invalid
    Router-->>Router: failures push with real reason
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin Settings Page
    participant Checks as checks.ts
    participant Vapid as vapid.ts
    participant WebPush as web-push lib
    participant Send as send.ts
    participant Router as push.ts sendTest

    Note over Admin,WebPush: Admin self-check (new behaviour)
    Admin->>Checks: load /admin/settings
    Checks->>Vapid: isPushConfigured()
    Vapid-->>Checks: true
    Checks->>Vapid: getConfiguredWebPush()
    Vapid->>WebPush: setVapidDetails(subject, pub, priv)
    WebPush-->>Vapid: throws on malformed subject or key
    Vapid->>Vapid: store configError, console.error
    Vapid-->>Checks: null
    Checks->>Vapid: getWebPushConfigError()
    Vapid-->>Checks: Vapid subject is not a valid URL
    Checks-->>Admin: status error, detail web-push rejected

    Note over Router,Send: Test button (new behaviour)
    Router->>Send: sendPush(subscription, payload)
    Send->>Vapid: getConfiguredWebPush()
    Vapid-->>Send: null, configError set
    Send->>Vapid: getWebPushConfigError()
    Vapid-->>Send: Vapid subject is not a valid URL
    Send-->>Router: ok false, errorMessage VAPID configuration invalid
    Router-->>Router: failures push with real reason
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/push/send.ts`, line 212-215 ([link](https://github.com/cloudnativebergen/website/blob/1cfe9463facb48ee8009bf54744f60c13ce62723/src/lib/push/send.ts#L212-L215)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `sendPushForNotifications` uses only `isPushConfigured()` as its early-exit guard, which returns `true` when VAPID keys are present but malformed. In that case the function continues into Sanity reads and per-subscription `sendPush` calls that all silently return `ok: false` — the config-error log fires only once (inside `getConfiguredWebPush` on the first attempt) and is then invisible at the fan-out level. Adding a `getWebPushConfigError()` guard here matches the comment's intent ("skip entirely") and avoids the unnecessary I/O.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(push): surface malformed VAPID confi..."](https://github.com/cloudnativebergen/website/commit/1cfe9463facb48ee8009bf54744f60c13ce62723) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45478828)</sub>

<!-- /greptile_comment -->