### PR TITLE
feat(teams): organizer teams foundation — schema, lib, settings display

### DIFF
--- a/docs/MESSAGING_UX.md
+++ b/docs/MESSAGING_UX.md
@@ -151,3 +151,5 @@ layered on the notification hub rather than an extension of `conversation`.
   link contracts, lifecycle, security.
 - **`ADMIN_NOTIFICATION_SYSTEM.md`** — the ephemeral toast system (not the hub).
 - **`AGENTS.md` → "In-app notifications"** — the hub rules messaging inherits.
+- **`ORGANIZER_TEAMS.md`** — the organizer-teams soft lens (routing / defaults /
+  filters, never access control) that the messaging fan-out will route through.

--- a/docs/ORGANIZER_TEAMS.md
+++ b/docs/ORGANIZER_TEAMS.md
@@ -1,0 +1,85 @@
+# Organizer Teams
+
+Organizer teams are an **optional soft lens over the existing organizer set**.
+They exist to make notifications and outbound mail land on the _right_
+organizers by default and to scope Studio pickers — nothing more. This document
+records the maintainer-locked design so later phases build on the same
+foundation.
+
+## The one principle: soft lens, never access control
+
+A team **changes who a message is aimed at by default**. It never gates what an
+organizer can see or do. Every organizer remains a full organizer everywhere —
+they can open any conversation, any admin surface, any sponsor. Teams only feed:
+
+- **routing** — which organizers are the default recipients of a given message,
+- **defaults** — which Slack channel / email identity a team's outbound
+  communication uses,
+- **filters** — the Studio reference picker for a team's members is scoped to
+  the conference's organizers.
+
+If you ever find yourself reaching for a team to _deny_ access, that is out of
+scope by design. Access control is derived from organizer membership as it is
+today; teams sit strictly on top.
+
+## Unified model
+
+Historically the routing knobs were split across proto-team fields
+(`cfpNotificationChannel`, `salesNotificationChannel`, the per-kind email
+identities, ad-hoc assignee references). `conference.teams[]` unifies those into
+one first-class list. Each team is:
+
+| field           | meaning                                                                                              |
+| --------------- | ---------------------------------------------------------------------------------------------------- |
+| `key`           | stable lowercase kebab-case id, unique within the array (e.g. `cfp`, `sponsors`)                     |
+| `title`         | human label                                                                                          |
+| `members`       | references to speakers, filtered in Studio to this conference's organizers (min 1)                   |
+| `slackChannel`  | optional; overrides the conference channel for this team's notifications                             |
+| `emailIdentity` | optional; which conference email identity (`contactEmail` / `cfpEmail` / `sponsorEmail`) it sends as |
+
+The library (`src/lib/teams`) exposes the read + resolve surface:
+`getConferenceTeams` (bounded, per-instance 60s TTL cache, only-cache-successes,
+mirroring `getOrganizerSpeakerIds`), `resolveTeamRecipients`,
+`resolveTeamSlackChannel`, `resolveTeamEmailIdentity`, and the
+`WELL_KNOWN_TEAM_KEYS` constant.
+
+## Absent means today
+
+A conference with **no teams behaves exactly as it does today**: all organizers
+receive everything. This is the load-bearing invariant. The lib never invents a
+recipient set — `resolveTeamRecipients` returns `[]` for an absent team, and the
+**fallback contract lives with the caller**: an empty result means "no
+team-specific routing, fall back to all organizers." Keeping that decision at the
+call site makes absent-means-today a single, auditable choice rather than a
+hidden default buried in the resolver.
+
+## Adopted routing map (implemented in TEAMS-2)
+
+The consumption layer (a separate change) wires message kinds to well-known team
+keys, each with the all-organizers fallback:
+
+- **proposal** → `cfp`
+- **sponsor** → `sponsors`
+- **volunteers** → `volunteers`
+- **nudge / assignee** → the assignee's team → all organizers
+
+Arbitrary additional keys beyond the well-known four are allowed; the constant is
+the routing map's anchor, not an allow-list.
+
+## Greenlit lenses (TEAMS-3)
+
+Four further lenses are greenlit on this foundation, all still soft: a team
+inbox/triage view, per-team dashboards, per-team digest scheduling, and
+team-scoped assignment suggestions. None of them introduce access boundaries.
+
+## Foundation scope (TEAMS-1)
+
+Schema (`conference.teams[]`), the `src/lib/teams` module, the admin settings
+Teams sub-display, and a `conference.teams` system-status check. The settings
+display is server-rendered and there is no story infra for that tier, so it has
+the same visual-QA gap as the rest of the settings page.
+
+## Related documents
+
+- **`MESSAGING_UX.md`** — the messaging surface these teams will route.
+- **`MESSAGING_SYSTEM.md`** — data model, channel contract, recipient resolution.

--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -1,4 +1,5 @@
 import { formats } from '../../src/lib/proposal/types'
+import { isValidTeamKey, countTeamKey } from '../../src/lib/teams/validation'
 import { defineField, defineType } from 'sanity'
 import { HEROICON_OPTIONS } from './constants'
 
@@ -561,6 +562,129 @@ export default defineType({
       type: 'array',
       fieldset: 'communication',
       of: [{ type: 'string' }],
+    }),
+    defineField({
+      name: 'teams',
+      title: 'Organizer Teams',
+      type: 'array',
+      fieldset: 'communication',
+      description:
+        'Optional sub-teams of organizers used as a SOFT LENS for routing notifications and outbound mail — never an access-control boundary. When no teams are defined, all organizers receive everything (today’s behaviour). Well-known keys: cfp, sponsors, volunteers, workshops (additional keys are allowed).',
+      of: [
+        {
+          type: 'object',
+          name: 'organizerTeam',
+          fields: [
+            defineField({
+              name: 'key',
+              title: 'Key',
+              type: 'string',
+              description:
+                'Stable lowercase kebab-case identifier (e.g. "cfp", "sponsors"). Used by notification routing; must be unique within this list.',
+              validation: (Rule) =>
+                Rule.required().custom((value, context) => {
+                  if (typeof value !== 'string' || value.length === 0) {
+                    return 'Key is required'
+                  }
+                  if (!isValidTeamKey(value)) {
+                    return 'Key must be lowercase kebab-case (letters, numbers and single hyphens)'
+                  }
+                  // Uniqueness within the array. Cross-field validation is done
+                  // by counting siblings on the parent document; Sanity has no
+                  // built-in per-field array-unique rule.
+                  const teams = (
+                    context?.document as { teams?: Array<{ key?: string }> }
+                  )?.teams
+                  if (countTeamKey(teams, value) > 1) {
+                    return `Duplicate team key "${value}" — keys must be unique`
+                  }
+                  return true
+                }),
+            }),
+            defineField({
+              name: 'title',
+              title: 'Title',
+              type: 'string',
+              validation: (Rule) => Rule.required(),
+            }),
+            defineField({
+              name: 'members',
+              title: 'Members',
+              type: 'array',
+              description:
+                'Organizers on this team. Filtered to this conference’s organizers; membership is documented as a subset of organizers but not enforced cross-field.',
+              of: [
+                {
+                  type: 'reference',
+                  to: [{ type: 'speaker' }],
+                  options: {
+                    // Mirror sponsorForConference.assignedTo’s conference-scoped
+                    // organizer filter, but scope to THIS conference document’s
+                    // own _id (strip the drafts. prefix so it matches the
+                    // published organizers[] refs).
+                    filter: ({ document }: { document: { _id?: string } }) => {
+                      const id = document?._id?.replace(/^drafts\./, '')
+                      if (!id) {
+                        return {
+                          filter:
+                            '_id in *[_type == "conference"].organizers[]._ref',
+                        }
+                      }
+                      return {
+                        filter:
+                          '_id in *[_type == "conference" && _id == $conferenceId][0].organizers[]._ref',
+                        params: { conferenceId: id },
+                      }
+                    },
+                  },
+                },
+              ],
+              validation: (Rule) => Rule.required().min(1).unique(),
+            }),
+            defineField({
+              name: 'slackChannel',
+              title: 'Slack Channel',
+              type: 'string',
+              description:
+                'Overrides the conference-level channel for this team’s notifications; falls back to cfpNotificationChannel / salesNotificationChannel per event kind.',
+            }),
+            defineField({
+              name: 'emailIdentity',
+              title: 'Email Identity',
+              type: 'array',
+              of: [{ type: 'string' }],
+              options: {
+                list: [
+                  { title: 'Contact Email', value: 'contactEmail' },
+                  { title: 'CFP Email', value: 'cfpEmail' },
+                  { title: 'Sponsor Email', value: 'sponsorEmail' },
+                ],
+              },
+              description:
+                'Which conference email identity this team’s outbound mail uses. Falls back to the conference default when unset.',
+            }),
+          ],
+          preview: {
+            select: {
+              title: 'title',
+              key: 'key',
+              members: 'members',
+            },
+            prepare(selection) {
+              const { title, key, members } = selection as {
+                title?: string
+                key?: string
+                members?: unknown[]
+              }
+              const count = Array.isArray(members) ? members.length : 0
+              return {
+                title: title || key || 'Team',
+                subtitle: `${key ? `${key} · ` : ''}${count} member${count === 1 ? '' : 's'}`,
+              }
+            },
+          },
+        },
+      ],
     }),
 
     // === Content & Announcements ===

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -2,6 +2,7 @@ import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { formatDate } from '@/lib/time'
 import { formats, Format } from '@/lib/proposal/types'
 import { buildSystemChecks } from '@/lib/system-status/checks'
+import { formatTeamSummary } from '@/lib/teams'
 import {
   ErrorDisplay,
   WorkshopRegistrationSettings,
@@ -508,6 +509,23 @@ export default async function AdminSettings() {
               value={conference.organizers?.map((org) => org.name)}
               type="team"
             />
+            {conference.teams && conference.teams.length > 0 && (
+              <div className="border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
+                <dt className="mb-2 text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Teams
+                </dt>
+                <dd className="space-y-1">
+                  {conference.teams.map((team) => (
+                    <div
+                      key={team._key ?? team.key}
+                      className="min-w-0 text-sm break-words text-gray-900 dark:text-white"
+                    >
+                      {formatTeamSummary(team)}
+                    </div>
+                  ))}
+                </dd>
+              </div>
+            )}
           </InfoCard>
 
           {conference.sponsorTiers && conference.sponsorTiers.length > 0 && (

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -111,6 +111,14 @@ export async function getConferenceForDomain(
   try {
     const query = `*[ _type == "conference" && ($domain in domains || $wildcardSubdomain in domains)][0]{
       ...,
+      teams[]{
+        _key,
+        key,
+        title,
+        slackChannel,
+        emailIdentity,
+        "members": members[]._ref
+      },
       ${
         organizers
           ? `organizers[]->{

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -5,6 +5,7 @@ import { Topic } from '@/lib/topic/types'
 import { SponsorTier, ConferenceSponsor } from '@/lib/sponsor/types'
 import type { SalesTargetConfig } from '@/lib/tickets/types'
 import { GalleryImageWithSpeakers } from '@/lib/gallery/types'
+import type { OrganizerTeam } from '@/lib/teams/types'
 
 export interface CrmActivityThreshold {
   _key?: string
@@ -140,6 +141,13 @@ export interface Conference {
   salesNotificationChannel?: string
   cfpNotificationChannel?: string
   socialLinks?: string[]
+  /**
+   * Optional organizer sub-teams — a SOFT routing lens, never access control.
+   * Absent = today’s behaviour (all organizers receive everything). `members`
+   * are speaker `_id`s when fetched via the normalized conference projection or
+   * {@link import('@/lib/teams').getConferenceTeams}. See docs/ORGANIZER_TEAMS.md.
+   */
+  teams?: OrganizerTeam[]
   organizers: Speaker[]
   featuredSpeakers?: SpeakerWithTalks[]
   featuredTalks?: ProposalExisting[]

--- a/src/lib/system-status/checks.test.ts
+++ b/src/lib/system-status/checks.test.ts
@@ -94,6 +94,35 @@ describe('collectStaticChecks — status semantics', () => {
   })
 })
 
+describe('collectStaticChecks — organizer teams', () => {
+  it('is off with a helpful detail when no teams are configured', () => {
+    const check = byId(collectStaticChecks(CONFERENCE), 'conference.teams')
+    expect(check.group).toBe('conference')
+    expect(check.status).toBe('off')
+    expect(check.value).toBe('no teams')
+  })
+
+  it('is ok and counts the teams when configured', () => {
+    const check = byId(
+      collectStaticChecks({
+        ...CONFERENCE,
+        teams: [{ key: 'cfp' }, { key: 'sponsors' }],
+      }),
+      'conference.teams',
+    )
+    expect(check.status).toBe('ok')
+    expect(check.value).toBe('2 teams configured')
+  })
+
+  it('singularizes a single team', () => {
+    const check = byId(
+      collectStaticChecks({ ...CONFERENCE, teams: [{ key: 'cfp' }] }),
+      'conference.teams',
+    )
+    expect(check.value).toBe('1 team configured')
+  })
+})
+
 describe('collectStaticChecks — paired OAuth provider', () => {
   it('is ok with both id and secret, warns on a partial pair, off when neither', () => {
     vi.stubEnv('AUTH_GITHUB_ID', 'id')

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -254,6 +254,31 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
     ),
   )
 
+  // ---- CONFERENCE -----------------------------------------------------------
+  const teamCount = Array.isArray(conference.teams)
+    ? conference.teams.length
+    : 0
+  checks.push(
+    teamCount > 0
+      ? {
+          id: 'conference.teams',
+          group: 'conference',
+          label: 'Organizer teams',
+          status: 'ok',
+          value: `${teamCount} team${teamCount === 1 ? '' : 's'} configured`,
+          detail:
+            'Notifications and outbound mail can be routed per team; a soft lens, never access control',
+        }
+      : {
+          id: 'conference.teams',
+          group: 'conference',
+          label: 'Organizer teams',
+          status: 'off',
+          value: 'no teams',
+          detail: 'All organizers receive everything (today’s behaviour)',
+        },
+  )
+
   // ---- AUTH -----------------------------------------------------------------
   const providerNames = providerMap.map((p) => p.name).join(', ')
   checks.push(

--- a/src/lib/system-status/types.ts
+++ b/src/lib/system-status/types.ts
@@ -10,6 +10,7 @@ export type CheckStatus = 'ok' | 'warn' | 'error' | 'off'
 
 export type CheckGroup =
   | 'sanity'
+  | 'conference'
   | 'email'
   | 'slack'
   | 'push'
@@ -37,6 +38,7 @@ export interface SystemCheck {
 /** Ordered, human-readable labels for each group card. */
 export const CHECK_GROUP_LABELS: Record<CheckGroup, string> = {
   sanity: 'Sanity CMS',
+  conference: 'Conference',
   email: 'Email (Resend)',
   slack: 'Slack',
   push: 'Web Push',
@@ -54,6 +56,7 @@ export const CHECK_GROUP_LABELS: Record<CheckGroup, string> = {
 export const CHECK_GROUP_ORDER: CheckGroup[] = [
   'build',
   'sanity',
+  'conference',
   'auth',
   'email',
   'slack',
@@ -86,6 +89,7 @@ export interface ConferenceForSystemChecks {
   cfpNotificationChannel?: string
   checkinCustomerId?: number
   checkinEventId?: number
+  teams?: Array<{ key?: string }>
 }
 
 /** Group a flat registry into ordered, labelled cards (drops empty groups). */

--- a/src/lib/teams/format.test.ts
+++ b/src/lib/teams/format.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { formatTeamSummary } from './format'
+import type { OrganizerTeam } from './types'
+
+describe('formatTeamSummary', () => {
+  it('renders title, key, member count, channel and identity', () => {
+    const team: OrganizerTeam = {
+      key: 'cfp',
+      title: 'Program Committee',
+      members: ['a', 'b', 'c'],
+      slackChannel: '#cfp',
+      emailIdentity: ['cfpEmail'],
+    }
+    expect(formatTeamSummary(team)).toBe(
+      'Program Committee (cfp) — 3 members · #cfp · cfpEmail',
+    )
+  })
+
+  it('singularizes a single member and omits optional segments', () => {
+    const team: OrganizerTeam = {
+      key: 'volunteers',
+      title: 'Volunteers',
+      members: ['a'],
+    }
+    expect(formatTeamSummary(team)).toBe('Volunteers (volunteers) — 1 member')
+  })
+
+  it('prefixes a missing # on the channel', () => {
+    const team: OrganizerTeam = {
+      key: 'sponsors',
+      title: 'Sponsors',
+      members: [],
+      slackChannel: 'sponsor-chat',
+    }
+    expect(formatTeamSummary(team)).toBe(
+      'Sponsors (sponsors) — 0 members · #sponsor-chat',
+    )
+  })
+})

--- a/src/lib/teams/format.ts
+++ b/src/lib/teams/format.ts
@@ -1,0 +1,23 @@
+import type { OrganizerTeam } from './types'
+
+/**
+ * Pure, render-agnostic summary of a team for the admin settings display:
+ * `title (key) — N members · #channel? · identity?`. Extracted so the settings
+ * page (a server component with no story infra) can be unit-tested without
+ * React. Optional segments (channel, email identity) are omitted when unset.
+ */
+export function formatTeamSummary(team: OrganizerTeam): string {
+  const count = team.members.length
+  const parts: string[] = [`${count} member${count === 1 ? '' : 's'}`]
+  if (team.slackChannel) {
+    parts.push(
+      team.slackChannel.startsWith('#')
+        ? team.slackChannel
+        : `#${team.slackChannel}`,
+    )
+  }
+  if (team.emailIdentity && team.emailIdentity.length > 0) {
+    parts.push(team.emailIdentity.join(', '))
+  }
+  return `${team.title} (${team.key}) — ${parts.join(' · ')}`
+}

--- a/src/lib/teams/index.ts
+++ b/src/lib/teams/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Organizer teams — a SOFT LENS (routing / defaults / Studio filters) over the
+ * existing organizer set, NEVER an access-control boundary. See {@link OrganizerTeam}
+ * and docs/ORGANIZER_TEAMS.md for the locked design.
+ */
+export {
+  WELL_KNOWN_TEAM_KEYS,
+  type OrganizerTeam,
+  type ConferenceTeamsConfig,
+  type TeamKey,
+  type TeamEmailIdentity,
+  type TeamSlackKind,
+} from './types'
+export { getConferenceTeams, clearConferenceTeamsCache } from './sanity'
+export {
+  resolveTeamRecipients,
+  resolveTeamSlackChannel,
+  resolveTeamEmailIdentity,
+} from './resolve'
+export { formatTeamSummary } from './format'
+export { TEAM_KEY_PATTERN, isValidTeamKey, countTeamKey } from './validation'

--- a/src/lib/teams/resolve.test.ts
+++ b/src/lib/teams/resolve.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { OrganizerTeam, ConferenceTeamsConfig } from './types'
+
+const getConferenceTeamsMock = vi.fn<(id: string) => Promise<OrganizerTeam[]>>()
+vi.mock('./sanity', () => ({
+  getConferenceTeams: (id: string) => getConferenceTeamsMock(id),
+}))
+
+import {
+  resolveTeamRecipients,
+  resolveTeamSlackChannel,
+  resolveTeamEmailIdentity,
+} from './resolve'
+
+beforeEach(() => {
+  getConferenceTeamsMock.mockReset()
+})
+
+const CFP_TEAM: OrganizerTeam = {
+  key: 'cfp',
+  title: 'CFP',
+  members: ['spk-1', 'spk-2'],
+  slackChannel: '#cfp-team',
+  emailIdentity: ['cfpEmail'],
+}
+
+describe('resolveTeamRecipients', () => {
+  it('returns the member ids of the named team', async () => {
+    getConferenceTeamsMock.mockResolvedValue([CFP_TEAM])
+    expect(
+      await resolveTeamRecipients({ conferenceId: 'c1', teamKey: 'cfp' }),
+    ).toEqual(['spk-1', 'spk-2'])
+  })
+
+  it('returns [] when the team is absent (caller falls back to all organizers)', async () => {
+    getConferenceTeamsMock.mockResolvedValue([CFP_TEAM])
+    expect(
+      await resolveTeamRecipients({ conferenceId: 'c1', teamKey: 'sponsors' }),
+    ).toEqual([])
+  })
+
+  it('returns [] when the conference has no teams at all', async () => {
+    getConferenceTeamsMock.mockResolvedValue([])
+    expect(
+      await resolveTeamRecipients({ conferenceId: 'c1', teamKey: 'cfp' }),
+    ).toEqual([])
+  })
+})
+
+const CONFERENCE: ConferenceTeamsConfig = {
+  teams: [CFP_TEAM, { key: 'sponsors', title: 'Sponsors' }],
+  salesNotificationChannel: '#sales',
+  cfpNotificationChannel: '#cfp',
+  contactEmail: 'hei@example.com',
+  cfpEmail: 'cfp@example.com',
+  sponsorEmail: 'sponsor@example.com',
+}
+
+describe('resolveTeamSlackChannel', () => {
+  it('prefers the team channel over the conference channel', () => {
+    expect(
+      resolveTeamSlackChannel({
+        conference: CONFERENCE,
+        teamKey: 'cfp',
+        kind: 'cfp',
+      }),
+    ).toBe('#cfp-team')
+  })
+
+  it('falls back to the cfp channel for a team without its own channel', () => {
+    expect(
+      resolveTeamSlackChannel({
+        conference: CONFERENCE,
+        teamKey: 'sponsors',
+        kind: 'cfp',
+      }),
+    ).toBe('#cfp')
+  })
+
+  it('falls back to the sales channel for kind=sales', () => {
+    expect(
+      resolveTeamSlackChannel({
+        conference: CONFERENCE,
+        teamKey: 'sponsors',
+        kind: 'sales',
+      }),
+    ).toBe('#sales')
+  })
+
+  it('falls back to the conference channel when the team is absent', () => {
+    expect(
+      resolveTeamSlackChannel({
+        conference: CONFERENCE,
+        teamKey: 'nope',
+        kind: 'sales',
+      }),
+    ).toBe('#sales')
+  })
+})
+
+describe('resolveTeamEmailIdentity', () => {
+  it('resolves the address the team’s identity points at', () => {
+    expect(resolveTeamEmailIdentity(CONFERENCE, 'cfp')).toBe('cfp@example.com')
+  })
+
+  it('falls back to contactEmail for a team with no identity', () => {
+    expect(resolveTeamEmailIdentity(CONFERENCE, 'sponsors')).toBe(
+      'hei@example.com',
+    )
+  })
+
+  it('falls back to contactEmail when the team is absent', () => {
+    expect(resolveTeamEmailIdentity(CONFERENCE, 'nope')).toBe('hei@example.com')
+  })
+
+  it('uses the first identity when several are listed', () => {
+    const conf: ConferenceTeamsConfig = {
+      ...CONFERENCE,
+      teams: [
+        {
+          key: 'multi',
+          title: 'Multi',
+          emailIdentity: ['sponsorEmail', 'cfpEmail'],
+        },
+      ],
+    }
+    expect(resolveTeamEmailIdentity(conf, 'multi')).toBe('sponsor@example.com')
+  })
+})

--- a/src/lib/teams/resolve.ts
+++ b/src/lib/teams/resolve.ts
@@ -1,0 +1,74 @@
+import { getConferenceTeams } from './sanity'
+import type {
+  ConferenceTeamsConfig,
+  TeamEmailIdentity,
+  TeamKey,
+  TeamSlackKind,
+} from './types'
+
+/**
+ * The member speaker `_id`s of a conference’s team, or `[]` when the team is
+ * absent (or the conference has no teams at all).
+ *
+ * FALLBACK CONTRACT (lives with the CALLER, not here): an empty result means
+ * "no team-specific routing" and the caller MUST fall back to its today’s
+ * behaviour — i.e. all organizers receive the message. This function never
+ * substitutes the organizer set itself, so that ABSENT-MEANS-TODAY stays a
+ * single, explicit decision at the call site.
+ */
+export async function resolveTeamRecipients({
+  conferenceId,
+  teamKey,
+}: {
+  conferenceId: string
+  teamKey: TeamKey
+}): Promise<string[]> {
+  const teams = await getConferenceTeams(conferenceId)
+  const team = teams.find((t) => t.key === teamKey)
+  return team ? [...team.members] : []
+}
+
+/**
+ * The Slack channel a team’s notifications of a given `kind` post to:
+ * `team.slackChannel` when set, otherwise the conference-level channel for that
+ * kind (`sales` → salesNotificationChannel, otherwise cfpNotificationChannel).
+ *
+ * Returns `undefined` when neither the team nor the conference has a channel —
+ * the caller decides whether that means "skip Slack" (today’s behaviour when a
+ * conference channel is unset).
+ */
+export function resolveTeamSlackChannel({
+  conference,
+  teamKey,
+  kind,
+}: {
+  conference: ConferenceTeamsConfig
+  teamKey: TeamKey
+  kind: TeamSlackKind
+}): string | undefined {
+  const team = conference.teams?.find((t) => t.key === teamKey)
+  const conferenceChannel =
+    kind === 'sales'
+      ? conference.salesNotificationChannel
+      : conference.cfpNotificationChannel
+  return team?.slackChannel ?? conferenceChannel
+}
+
+/**
+ * The conference email identity a team’s outbound mail is sent as: the address
+ * the team’s `emailIdentity` points at (first entry wins — the field is a list
+ * for forward-compat, but a team sends AS one identity), falling back to the
+ * conference’s general `contactEmail`.
+ *
+ * Returns `undefined` only when the conference itself has no matching email
+ * configured (in practice contactEmail is required, so this is defensive).
+ */
+export function resolveTeamEmailIdentity(
+  conference: ConferenceTeamsConfig,
+  teamKey: TeamKey,
+): string | undefined {
+  const team = conference.teams?.find((t) => t.key === teamKey)
+  const identity: TeamEmailIdentity | undefined = team?.emailIdentity?.[0]
+  const pointed = identity ? conference[identity] : undefined
+  return pointed ?? conference.contactEmail
+}

--- a/src/lib/teams/sanity.test.ts
+++ b/src/lib/teams/sanity.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+}))
+
+import { getConferenceTeams, clearConferenceTeamsCache } from './sanity'
+
+beforeEach(() => {
+  clearConferenceTeamsCache()
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const TEAM_ROWS = [
+  {
+    _key: 'a',
+    key: 'cfp',
+    title: 'CFP',
+    slackChannel: '#cfp',
+    emailIdentity: ['cfpEmail'],
+    members: ['spk-1', 'spk-2'],
+  },
+]
+
+describe('getConferenceTeams', () => {
+  it('returns the resolved teams with members as speaker ids', async () => {
+    fetchMock.mockResolvedValueOnce(TEAM_ROWS)
+    const teams = await getConferenceTeams('conf-1')
+    expect(teams).toHaveLength(1)
+    expect(teams[0].members).toEqual(['spk-1', 'spk-2'])
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // conference id is passed as a bound param, never interpolated
+    expect(fetchMock.mock.calls[0][1]).toEqual({ conferenceId: 'conf-1' })
+  })
+
+  it('returns [] when the conference has no teams (absent = today)', async () => {
+    fetchMock.mockResolvedValueOnce(null)
+    expect(await getConferenceTeams('conf-x')).toEqual([])
+  })
+
+  it('normalizes a missing members array to []', async () => {
+    fetchMock.mockResolvedValueOnce([
+      { _key: 'b', key: 'volunteers', title: 'Volunteers' },
+    ])
+    const teams = await getConferenceTeams('conf-2')
+    expect(teams[0].members).toEqual([])
+  })
+
+  it('caches successes per conference within the TTL (one read per instance)', async () => {
+    fetchMock.mockResolvedValue(TEAM_ROWS)
+    await getConferenceTeams('conf-1')
+    await getConferenceTeams('conf-1')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches per conference id independently', async () => {
+    fetchMock.mockResolvedValue(TEAM_ROWS)
+    await getConferenceTeams('conf-1')
+    await getConferenceTeams('conf-2')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-reads after the TTL expires', async () => {
+    vi.useFakeTimers()
+    fetchMock.mockResolvedValue(TEAM_ROWS)
+    await getConferenceTeams('conf-1')
+    vi.advanceTimersByTime(60_001)
+    await getConferenceTeams('conf-1')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT cache failures — a transient error is retried, not poisoned', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('sanity down'))
+    await expect(getConferenceTeams('conf-1')).rejects.toThrow('sanity down')
+    fetchMock.mockResolvedValueOnce(TEAM_ROWS)
+    const teams = await getConferenceTeams('conf-1')
+    expect(teams).toHaveLength(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/teams/sanity.ts
+++ b/src/lib/teams/sanity.ts
@@ -1,0 +1,79 @@
+import { clientReadUncached } from '@/lib/sanity/client'
+import type { OrganizerTeam } from './types'
+
+/**
+ * Per-instance cache TTL for a conference’s teams, mirroring
+ * {@link import('@/lib/notification/sanity').getOrganizerSpeakerIds}. Team
+ * membership changes are RARE (an admin edits the conference), so a short TTL is
+ * an ample freshness bound while collapsing the many per-request reads (every
+ * routed notification resolves teams) into ~one read per conference per minute.
+ *
+ * SERVERLESS NOTE: this cache lives in module scope, so it is PER WARM INSTANCE,
+ * not global — each lambda/instance refreshes independently and a cold start
+ * always reads fresh. The worst-case staleness any caller can observe is
+ * {@link TEAMS_CACHE_TTL_MS} on whichever instance served them.
+ */
+const TEAMS_CACHE_TTL_MS = 60_000
+
+/** Upper bound on the teams fetch; the team set is tiny in practice. */
+const TEAMS_FETCH_LIMIT = 100
+
+const teamsCache = new Map<
+  string,
+  { teams: OrganizerTeam[]; expiresAt: number }
+>()
+
+/**
+ * The organizer teams configured on a conference, with each team’s `members`
+ * resolved to speaker `_id` strings. Bounded to
+ * [0...{@link TEAMS_FETCH_LIMIT}] and cached per instance per conference id for
+ * {@link TEAMS_CACHE_TTL_MS}.
+ *
+ * Returns `[]` when the conference has no teams (or does not exist) — that
+ * empty result IS a success and is cached normally, because ABSENT-MEANS-TODAY:
+ * an empty team list is the steady state, not an error.
+ *
+ * ONLY successes are cached: the `await` throws on a failed read BEFORE the
+ * cache assignment below, so a transient Sanity failure is never poisoned into
+ * the cache as an empty team set for a full TTL.
+ *
+ * The returned arrays are treated as read-only by callers.
+ */
+export async function getConferenceTeams(
+  conferenceId: string,
+): Promise<OrganizerTeam[]> {
+  const now = Date.now()
+  const cached = teamsCache.get(conferenceId)
+  if (cached && cached.expiresAt > now) {
+    return cached.teams
+  }
+  const teams = await clientReadUncached.fetch<OrganizerTeam[] | null>(
+    `*[_type == "conference" && _id == $conferenceId][0].teams[0...${TEAMS_FETCH_LIMIT}]{
+      _key,
+      key,
+      title,
+      slackChannel,
+      emailIdentity,
+      "members": members[]._ref
+    }`,
+    { conferenceId },
+  )
+  const resolved = (teams || []).map((team) => ({
+    ...team,
+    members: Array.isArray(team.members) ? team.members : [],
+  }))
+  teamsCache.set(conferenceId, {
+    teams: resolved,
+    expiresAt: now + TEAMS_CACHE_TTL_MS,
+  })
+  return resolved
+}
+
+/**
+ * Clear the per-instance teams cache. Exposed for tests (which assert fresh
+ * reads) and as a hook if a future admin flow wants to invalidate eagerly after
+ * editing a conference’s teams.
+ */
+export function clearConferenceTeamsCache(): void {
+  teamsCache.clear()
+}

--- a/src/lib/teams/types.ts
+++ b/src/lib/teams/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Organizer teams — SHARED TYPES.
+ *
+ * Organizer teams are a SOFT LENS over the existing organizer set: they route
+ * notifications and outbound mail and drive Studio filters, but they are NEVER
+ * an access-control boundary. Every organizer can still see and do everything;
+ * teams only change WHO a given message is aimed at by default.
+ *
+ * ABSENT-MEANS-TODAY: a conference with no `teams` behaves exactly as it does
+ * today — all organizers receive everything. The fallback CONTRACT lives with
+ * callers (see {@link resolveTeamRecipients}); this module never invents a
+ * recipient set of its own.
+ *
+ * This file is free of `server-only` and of any import that reads secrets or
+ * throws at load, so presentational components and tests can import it.
+ */
+
+/** The conference email identity a team’s outbound mail is sent as. */
+export type TeamEmailIdentity = 'contactEmail' | 'cfpEmail' | 'sponsorEmail'
+
+/**
+ * Slack routing kind. `sales` maps to the weekly-update / sponsor channel,
+ * everything else (`cfp`) to the CFP channel — mirroring the two conference
+ * channel fields.
+ */
+export type TeamSlackKind = 'sales' | 'cfp'
+
+/** A team key. Free-form string; {@link WELL_KNOWN_TEAM_KEYS} are the greenlit ones. */
+export type TeamKey = string
+
+/**
+ * A resolved organizer team. `members` are speaker `_id`s (resolved from the
+ * stored references by {@link getConferenceTeams}) — NOT reference objects.
+ */
+export interface OrganizerTeam {
+  _key?: string
+  key: string
+  title: string
+  /** Speaker `_id`s of the team members. */
+  members: string[]
+  slackChannel?: string
+  emailIdentity?: TeamEmailIdentity[]
+}
+
+/**
+ * The structural slice of a conference the channel/email resolvers need. A full
+ * {@link import('@/lib/conference/types').Conference} satisfies this, and so
+ * does a small test fixture. Note the resolvers read only `key`, `slackChannel`
+ * and `emailIdentity` off each team — never `members` — so the members shape is
+ * irrelevant here.
+ */
+export interface ConferenceTeamsConfig {
+  teams?: Array<
+    Pick<OrganizerTeam, 'key' | 'slackChannel' | 'emailIdentity'> & {
+      title?: string
+    }
+  >
+  salesNotificationChannel?: string
+  cfpNotificationChannel?: string
+  contactEmail?: string
+  cfpEmail?: string
+  sponsorEmail?: string
+}
+
+/**
+ * The greenlit, well-known team keys the TEAMS-2 routing map consumes:
+ *  - `cfp`        ← proposal threads / CFP notifications
+ *  - `sponsors`   ← sponsor threads / sales notifications
+ *  - `volunteers` ← volunteer coordination
+ *  - `workshops`  ← workshop coordination
+ *
+ * Arbitrary ADDITIONAL keys are allowed; this constant is the routing map’s
+ * anchor, not an allow-list.
+ *
+ * @public consumed by the TEAMS-2 routing map (not yet wired in this change).
+ */
+export const WELL_KNOWN_TEAM_KEYS = [
+  'cfp',
+  'sponsors',
+  'volunteers',
+  'workshops',
+] as const

--- a/src/lib/teams/validation.test.ts
+++ b/src/lib/teams/validation.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { isValidTeamKey, countTeamKey } from './validation'
+
+describe('isValidTeamKey', () => {
+  it.each(['cfp', 'sponsors', 'a', 'team-1', 'cloud-native-bergen'])(
+    'accepts kebab-case %s',
+    (key) => {
+      expect(isValidTeamKey(key)).toBe(true)
+    },
+  )
+
+  it.each(['CFP', 'has space', 'trailing-', '-leading', 'double--hyphen', ''])(
+    'rejects invalid %s',
+    (key) => {
+      expect(isValidTeamKey(key)).toBe(false)
+    },
+  )
+
+  it('rejects non-strings', () => {
+    expect(isValidTeamKey(undefined)).toBe(false)
+    expect(isValidTeamKey(42)).toBe(false)
+  })
+})
+
+describe('countTeamKey', () => {
+  it('counts occurrences of a key across the team list', () => {
+    const teams = [{ key: 'cfp' }, { key: 'sponsors' }, { key: 'cfp' }]
+    expect(countTeamKey(teams, 'cfp')).toBe(2)
+    expect(countTeamKey(teams, 'sponsors')).toBe(1)
+    expect(countTeamKey(teams, 'nope')).toBe(0)
+  })
+
+  it('returns 0 for an undefined list', () => {
+    expect(countTeamKey(undefined, 'cfp')).toBe(0)
+  })
+})

--- a/src/lib/teams/validation.ts
+++ b/src/lib/teams/validation.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure validation helpers for organizer team keys, shared between the Sanity
+ * schema custom rule (Studio-side) and unit tests. Kept free of any Sanity or
+ * server import so both sides can use them.
+ */
+
+/** Lowercase kebab-case: letters/numbers in segments joined by single hyphens. */
+export const TEAM_KEY_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+/** True when `value` is a non-empty lowercase kebab-case string. */
+export function isValidTeamKey(value: unknown): value is string {
+  return typeof value === 'string' && TEAM_KEY_PATTERN.test(value)
+}
+
+/**
+ * How many entries in `teams` carry `key`. Used to enforce key-uniqueness
+ * within a conference’s teams array (a value counted more than once is a
+ * duplicate). Cross-field uniqueness has no built-in Sanity rule, so this is
+ * evaluated against the sibling list in the custom validator.
+ */
+export function countTeamKey(
+  teams: Array<{ key?: string }> | undefined,
+  key: string,
+): number {
+  if (!Array.isArray(teams)) return 0
+  return teams.filter((team) => team?.key === key).length
+}


### PR DESCRIPTION
## TEAMS-1: organizer-teams FOUNDATION

Maintainer-locked design: `conference.teams[]` is a **soft lens** over the existing organizer set — routing, defaults and Studio filters, **never** access control. **Absent teams = today's behaviour exactly** (all organizers receive everything).

### What's in this PR (foundation only)
- **Schema** (`sanity/schemaTypes/conference.ts`): new `teams` array of `organizerTeam` in the Communication fieldset — `key` (required, lowercase-kebab, **unique within the array** via a custom rule), `title` (required), `members` (references → speaker, min 1, Studio-filtered to *this conference's* organizers, mirroring `sponsorForConference.assignedTo`), `slackChannel` (optional override), `emailIdentity` (optional `contactEmail`/`cfpEmail`/`sponsorEmail` list).
- **Lib** `src/lib/teams/` (server-safe, no throw-at-import): `OrganizerTeam`/`TeamKey`/`TeamSlackKind` types, `getConferenceTeams(conferenceId)` (bounded fetch, 60s per-instance TTL cache, only-cache-successes — mirrors `getOrganizerSpeakerIds`), `resolveTeamRecipients` (member ids, `[]` when absent), `resolveTeamSlackChannel`, `resolveTeamEmailIdentity`, `WELL_KNOWN_TEAM_KEYS` = `['cfp','sponsors','volunteers','workshops']`.
- **Settings** (`/admin/settings` Team card): Teams sub-display when configured (`title (key) — N members · #channel? · identity?`); unchanged when no teams. Server-rendered.
- **System check**: new `conference` group with a `teams` row — `ok, N teams configured` / `off — no teams (all organizers receive everything)`.
- **Docs**: `docs/ORGANIZER_TEAMS.md` records the locked design; cross-linked from `MESSAGING_UX.md`.

### Fallback contracts (documented, live with CALLERS)
- `resolveTeamRecipients` returns `[]` for an absent team — the caller falls back to **all organizers**. The lib never invents a recipient set, keeping absent-means-today a single auditable decision at the call site.
- `resolveTeamSlackChannel` → `team.slackChannel ?? (kind==='sales' ? salesNotificationChannel : cfpNotificationChannel)`.
- `resolveTeamEmailIdentity` → the pointed identity's address ?? `contactEmail`.

### What TEAMS-2 / TEAMS-3 will consume
- **TEAMS-2** (routing, separate track — this PR does NOT touch `src/lib/messaging/*` or `message.ts`): the routing map proposal→`cfp`, sponsor→`sponsors`, volunteers→`volunteers`, nudge assignee→team→all, built on `resolveTeam*` + `WELL_KNOWN_TEAM_KEYS`.
- **TEAMS-3**: the four greenlit soft lenses (team inbox, per-team dashboards, digests, assignment suggestions).

### Checks
tsc, eslint (0 errors), prettier, knip, and full `pnpm vitest run` (235 files / 3336 passed) all green. New tests: teams lib (cache/TTL/only-cache-successes, resolvers incl. absent-team `[]`, format, key-uniqueness/kebab validation) + system-check rows.

### Known gap
The settings Teams sub-display is server-rendered and there is no Storybook tier for it (same visual-QA gap as the rest of the settings page) — noted in the docs.

DO NOT MERGE — foundation held for review.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lays the foundation for organizer teams on conference objects — a soft routing lens over the existing organizer set. It adds the `organizerTeam` Sanity schema, a `src/lib/teams` module (fetch with per-instance TTL cache, resolvers for recipients/Slack channel/email identity, formatting, validation), a teams sub-display in the admin settings page, and a new `conference` system-check group.

- **Schema & types**: `conference.teams[]` stores team key, title, members (references→speaker, Studio-filtered), optional `slackChannel`, and optional `emailIdentity`; the TypeScript types cleanly separate the full `OrganizerTeam` from the narrower `ConferenceTeamsConfig` slice used by resolvers.
- **Library**: `getConferenceTeams` correctly mirrors the `getOrganizerSpeakerIds` caching pattern (only-cache-successes, 60 s TTL, per-conference-id key); resolver fallback contracts are explicitly placed at call sites.
- **Settings page**: teams are rendered only when at least one team exists; format is delegated to the pure `formatTeamSummary` function, which is separately unit-tested.

<h3>Confidence Score: 3/5</h3>

The settings page can throw a TypeError and 500 if any team's members array is null at runtime — a condition the notification-path normalization avoids but the conference projection does not. The emailIdentity multi-select issue is a silent misconfiguration trap for Studio editors. Both issues should be fixed before merging.

Two concrete defects on live paths: `formatTeamSummary` does an unguarded `.length` on `team.members` that comes from a GROQ projection which can return `null` when references are absent, crashing the settings page; and the `emailIdentity` Sanity field accepts multiple selections while the resolver silently discards all but the first. The library core (cache, resolvers, validation) is solid and well-tested.

`src/lib/teams/format.ts` (null guard on members) and `sanity/schemaTypes/conference.ts` (max(1) on emailIdentity).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/teams/format.ts | formatTeamSummary reads team.members.length without a null guard — GROQ returns null for members[]._ref when references are absent, which crashes the settings page. |
| sanity/schemaTypes/conference.ts | New organizerTeam schema added. emailIdentity is defined as a multi-select array but the resolver only uses the first entry; no max(1) validation or Studio description warning prevents silent multi-selection. |
| src/lib/teams/sanity.ts | Well-structured per-instance TTL cache mirroring getOrganizerSpeakerIds; correctly normalizes null members and only caches successes. |
| src/lib/teams/resolve.ts | Resolver functions are clean, well-documented, and correctly handle absent-team cases; fallback contract clearly placed at call site. |
| src/app/(admin)/admin/settings/page.tsx | Teams sub-display added; delegates formatting to formatTeamSummary which can crash if team.members is null at runtime. |
| src/lib/conference/sanity.ts | Added teams[] projection to conference query; members[]._ref can return null when references are absent, which is not normalized here (unlike getConferenceTeams). |
| src/lib/teams/types.ts | Type definitions are well-structured with ConferenceTeamsConfig correctly avoiding the members field in the channel/email resolver slice. |
| src/lib/teams/validation.ts | Clean pure-function validation helpers; TEAM_KEY_PATTERN is correct and countTeamKey handles undefined cleanly. |
| src/lib/system-status/checks.ts | New conference.teams check correctly uses Array.isArray guard, pluralizes properly, and uses off status for unconfigured state. |
| src/lib/conference/types.ts | OrganizerTeam[] added to Conference interface with good JSDoc cross-referencing the design doc. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Page as Settings Page
    participant Conf as getConferenceForDomain
    participant TeamsLib as getConferenceTeams
    participant Cache as teamsCache (Map)
    participant Sanity as Sanity GROQ

    Page->>Conf: getConferenceForCurrentDomain()
    Conf->>Sanity: "GROQ teams[]{_key,key,title,...,members[]._ref}"
    Sanity-->>Conf: Conference (teams[].members may be null)
    Conf-->>Page: conference.teams (no null normalization)
    Page->>Page: formatTeamSummary(team) — team.members.length null risk

    Note over TeamsLib,Cache: Notification routing path (separate)
    TeamsLib->>Cache: teamsCache.get(conferenceId)
    alt cache hit and not expired
        Cache-->>TeamsLib: OrganizerTeam[]
    else cache miss or expired
        TeamsLib->>Sanity: "GROQ teams[0...100]{...,members[]._ref}"
        Sanity-->>TeamsLib: raw rows (members may be null)
        TeamsLib->>TeamsLib: normalize members Array.isArray check
        TeamsLib->>Cache: teamsCache.set(conferenceId, teams+expiresAt)
        Cache-->>TeamsLib: OrganizerTeam[] normalized
    end
    TeamsLib-->>TeamsLib: resolveTeamRecipients / resolveTeamSlackChannel / resolveTeamEmailIdentity
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Page as Settings Page
    participant Conf as getConferenceForDomain
    participant TeamsLib as getConferenceTeams
    participant Cache as teamsCache (Map)
    participant Sanity as Sanity GROQ

    Page->>Conf: getConferenceForCurrentDomain()
    Conf->>Sanity: "GROQ teams[]{_key,key,title,...,members[]._ref}"
    Sanity-->>Conf: Conference (teams[].members may be null)
    Conf-->>Page: conference.teams (no null normalization)
    Page->>Page: formatTeamSummary(team) — team.members.length null risk

    Note over TeamsLib,Cache: Notification routing path (separate)
    TeamsLib->>Cache: teamsCache.get(conferenceId)
    alt cache hit and not expired
        Cache-->>TeamsLib: OrganizerTeam[]
    else cache miss or expired
        TeamsLib->>Sanity: "GROQ teams[0...100]{...,members[]._ref}"
        Sanity-->>TeamsLib: raw rows (members may be null)
        TeamsLib->>TeamsLib: normalize members Array.isArray check
        TeamsLib->>Cache: teamsCache.set(conferenceId, teams+expiresAt)
        Cache-->>TeamsLib: OrganizerTeam[] normalized
    end
    TeamsLib-->>TeamsLib: resolveTeamRecipients / resolveTeamSlackChannel / resolveTeamEmailIdentity
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sanity/schemaTypes/conference.ts`, line 201-215 ([link](https://github.com/cloudnativebergen/website/blob/12d5e45ace21982a5aff6980d914e5f8716eed30/sanity/schemaTypes/conference.ts#L201-L215)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Silent multi-select on emailIdentity** — the field is an array with no `max(1)` validation. An editor can select all three identities in Studio without any error, but `resolveTeamEmailIdentity` silently uses only `team?.emailIdentity?.[0]`, discarding anything else. Adding `validation: (Rule) => Rule.max(1)` (and updating the description to say "select one") surfaces this constraint in Studio before data is saved, preventing silent misconfiguration.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(teams): organizer teams foundation ..."](https://github.com/cloudnativebergen/website/commit/12d5e45ace21982a5aff6980d914e5f8716eed30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45480369)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->