### PR TITLE
feat(messaging): party read path + co-speaker participant sync (G2a)

### DIFF
--- a/__tests__/lib/messaging/party-model.test.ts
+++ b/__tests__/lib/messaging/party-model.test.ts
@@ -26,7 +26,7 @@ vi.mock('@/lib/sanity/helpers', () => ({
 }))
 
 vi.mock('@/lib/sanity/client', () => ({
-  clientWrite: { transaction: vi.fn(), create: vi.fn() },
+  clientWrite: { transaction: vi.fn(), create: vi.fn(), patch: vi.fn() },
   clientReadUncached: { fetch: vi.fn() },
 }))
 
@@ -38,12 +38,16 @@ vi.mock('@/lib/notification/sanity', () => ({
 // deterministic ('FIXED').
 vi.mock('nanoid', () => ({ nanoid: () => 'FIXED' }))
 
-import { clientWrite } from '@/lib/sanity/client'
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import {
   resolveParticipants,
+  resolveParticipantIds,
+  resolveRecipients,
+  canAccessConversation,
   ensureProposalConversation,
   createGeneralConversation,
   addMessage,
+  syncProposalConversationParticipants,
 } from '@/lib/messaging/sanity'
 import {
   validateConversationParticipant,
@@ -55,6 +59,7 @@ type LooseMock = ReturnType<typeof vi.fn>
 const writeMock = clientWrite as unknown as {
   transaction: LooseMock
   create: LooseMock
+  patch: LooseMock
 }
 
 function installTransaction() {
@@ -213,6 +218,163 @@ describe('resolveParticipants — legacy-derived === dual-written, every shape',
       participants: stored,
     }
     expect(resolveParticipants(conv)).toBe(stored)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 1b. READ FLIP (G2a) — the flipped authz/recipient reads over participants[]
+//     are equivalent to the legacy derive, for every thread shape.
+// ---------------------------------------------------------------------------
+
+describe('READ FLIP (G2a): resolveParticipantIds / resolveRecipients / canAccessConversation', () => {
+  const ORGS = ['org-1', 'org-2']
+
+  const speakerPartyIds = (parties: ConversationParty[]): string[] =>
+    parties.flatMap((p) => (p.partyType === 'speaker' ? [p.speakerId] : []))
+
+  for (const shape of SHAPES) {
+    describe(shape.name, () => {
+      const dualWritten = { ...shape.legacy, participants: shape.expected }
+
+      it('resolveParticipantIds: dual-written === legacy-derived, organizers expanded to the live ids', () => {
+        const fromStored = resolveParticipantIds(dualWritten, ORGS).sort()
+        const fromLegacy = resolveParticipantIds(shape.legacy, ORGS).sort()
+        expect(fromStored).toEqual(fromLegacy)
+        // The `organizers` group party expands to the caller-supplied id set.
+        expect(fromStored).toEqual(expect.arrayContaining(ORGS))
+      })
+
+      it('resolveRecipients: dual-written === legacy-derived (actor excluded)', () => {
+        const actor = ORGS[0]
+        expect(resolveRecipients(dualWritten, actor, ORGS).sort()).toEqual(
+          resolveRecipients(shape.legacy, actor, ORGS).sort(),
+        )
+        expect(resolveRecipients(dualWritten, actor, ORGS)).not.toContain(actor)
+      })
+
+      it('canAccessConversation: identical verdict for every member speaker and a stranger', () => {
+        for (const id of [...speakerPartyIds(shape.expected), 'stranger-xyz']) {
+          const speaker = { _id: id }
+          expect(canAccessConversation(dualWritten, speaker)).toBe(
+            canAccessConversation(shape.legacy, speaker),
+          )
+        }
+        // An organizer always has access (short-circuits before party membership).
+        expect(
+          canAccessConversation(dualWritten, { _id: 'o-x', isOrganizer: true }),
+        ).toBe(true)
+      })
+    })
+  }
+
+  it('resolveParticipantIds SKIPS a sponsor party (G2b) — it carries no speaker id', () => {
+    const conv = {
+      conversationType: 'general' as const,
+      proposalSpeakerIds: [],
+      createdById: 'sp-9',
+      participants: [
+        { partyType: 'speaker', speakerId: 'sp-9' },
+        { partyType: 'sponsor', sponsorForConferenceId: 'sfc-1' },
+        ORG,
+      ] as ConversationParty[],
+    }
+    expect(resolveParticipantIds(conv, ['org-1']).sort()).toEqual([
+      'org-1',
+      'sp-9',
+    ])
+  })
+
+  it('PREFERS a stored participants[] over STALE legacy proposal fields (the snapshot-sync motivation)', () => {
+    // A proposal thread whose stored participants[] (sp-1, sp-3) has diverged
+    // from the legacy proposalSpeakerIds snapshot (sp-1, sp-2): the flipped read
+    // follows participants[], which is exactly why co-speaker changes MUST resync
+    // participants[] (Task 3). sp-3 is granted; sp-2 (only in the stale legacy
+    // field) is denied.
+    const conv = {
+      conversationType: 'proposal' as const,
+      proposalSpeakerIds: ['sp-1', 'sp-2'],
+      createdById: 'sp-1',
+      participants: [
+        { partyType: 'speaker', speakerId: 'sp-1' },
+        { partyType: 'speaker', speakerId: 'sp-3' },
+        ORG,
+      ] as ConversationParty[],
+    }
+    expect(canAccessConversation(conv, { _id: 'sp-3' })).toBe(true)
+    expect(canAccessConversation(conv, { _id: 'sp-2' })).toBe(false)
+    expect(resolveParticipantIds(conv, ['org-1']).sort()).toEqual([
+      'org-1',
+      'sp-1',
+      'sp-3',
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 1c. SNAPSHOT SYNC (G2a) — co-speaker add/remove resyncs the thread's
+//     participants[]; no-op without a thread; never-fail.
+// ---------------------------------------------------------------------------
+
+describe('syncProposalConversationParticipants — co-speaker add/remove resync', () => {
+  const readMock = clientReadUncached as unknown as { fetch: LooseMock }
+
+  function installPatch(commit: () => Promise<unknown> = async () => ({})) {
+    const patch = {
+      set: vi.fn((_ops?: unknown) => patch),
+      commit: vi.fn(commit),
+    }
+    writeMock.patch.mockReturnValue(patch)
+    return patch
+  }
+
+  it('ADD direction: patches participants[] up to the new speaker set + organizers', async () => {
+    readMock.fetch.mockResolvedValueOnce('conversation.proposal.prop-1')
+    const patch = installPatch()
+
+    await syncProposalConversationParticipants('prop-1', ['sp-1', 'sp-2'])
+
+    // Only PATCHES an existing thread (probe first, no createIfNotExists).
+    expect(writeMock.patch).toHaveBeenCalledWith('conversation.proposal.prop-1')
+    expect(patch.set).toHaveBeenCalledWith({
+      participants: [
+        storedSpeaker('sp-1'),
+        storedSpeaker('sp-2'),
+        storedOrganizersGroup,
+      ],
+    })
+    expect(patch.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('REMOVE direction: patches participants[] down to the remaining speakers + organizers', async () => {
+    readMock.fetch.mockResolvedValueOnce('conversation.proposal.prop-1')
+    const patch = installPatch()
+
+    await syncProposalConversationParticipants('prop-1', ['sp-1'])
+
+    expect(patch.set).toHaveBeenCalledWith({
+      participants: [storedSpeaker('sp-1'), storedOrganizersGroup],
+    })
+  })
+
+  it('NO-OP when the proposal has no thread yet (never conjures one)', async () => {
+    readMock.fetch.mockResolvedValueOnce(null)
+    const patch = installPatch()
+
+    await syncProposalConversationParticipants('prop-x', ['sp-1'])
+
+    expect(writeMock.patch).not.toHaveBeenCalled()
+    expect(patch.commit).not.toHaveBeenCalled()
+  })
+
+  it('NEVER-FAIL: swallows a patch/commit failure (must not fail the co-speaker mutation)', async () => {
+    readMock.fetch.mockResolvedValueOnce('conversation.proposal.prop-1')
+    installPatch(async () => {
+      throw new Error('boom')
+    })
+
+    await expect(
+      syncProposalConversationParticipants('prop-1', ['sp-1']),
+    ).resolves.toBeUndefined()
   })
 })
 

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -150,9 +150,13 @@ describe('resolveRecipients — excludes the actor', () => {
     ])
   })
   it('drops an organizer author from a general thread fan-out', () => {
-    expect(resolveRecipients(generalConv, 'org-1', ['org-1', 'org-2'])).toEqual(
-      ['sp-9', 'org-2'].sort((a, b) => a.localeCompare(b)),
-    )
+    // Order-insensitive (like the sibling cases): the G2a read flip resolves ids
+    // in PARTY order (speakers, then the expanded organizers group) rather than
+    // the legacy organizers-first SEED order. The RECIPIENT SET is unchanged —
+    // only the iteration order moved — so we compare sorted sets.
+    expect(
+      resolveRecipients(generalConv, 'org-1', ['org-1', 'org-2']).sort(),
+    ).toEqual(['sp-9', 'org-2'].sort())
   })
   it('organizer-initiated general thread → subjectSpeaker ∪ other organizers (author excluded, de-duplicated)', () => {
     // org-1 authored → excluded; the subject sp-7 and the other organizer remain.

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -129,6 +129,18 @@ const NEEDS_REPLY = `${STATUS_NOT_RESOLVED} && count($organizerIds) > 0 && defin
  * ONE string so the inbox list and the view-count projection (S7) apply the
  * IDENTICAL scope — the tab badges can never count threads the list wouldn't
  * show. Binds `$speakerId`.
+ *
+ * G2a DECISION — KEPT on the legacy fields (NOT flipped to `participants[]`).
+ * This GROQ predicate keys on `createdBy`/`subjectSpeaker`/`proposal->speakers`,
+ * which stay correct: dual-write + migration 043 keep `createdBy`/
+ * `subjectSpeaker` in sync, and `proposal->speakers[]._ref` is the LIVE source
+ * (dereferenced per query). A `participants[]`-based predicate would (a) be a
+ * snapshot that could diverge for proposal speaker changes made through paths
+ * G2a does not sync (e.g. an admin proposal edit), and (b) be unable to express
+ * the derive-fallback the JS resolver provides for a participants-less doc — so
+ * it could not match legacy semantics exactly. Correctness over purity: the
+ * predicate keeps reading the live legacy fields; the JS authz/recipient path
+ * (which CAN express the fallback) is the one that flipped.
  */
 export const SPEAKER_SCOPE_PREDICATE =
   '(createdBy._ref == $speakerId || subjectSpeaker._ref == $speakerId || $speakerId in proposal->speakers[]._ref)'
@@ -215,12 +227,20 @@ function buildViewPredicate(
 // ---------------------------------------------------------------------------
 
 /**
- * Every participant of a conversation:
+ * Every participant of a conversation, as concrete speaker ids:
  * - proposal thread → the proposal's speakers ∪ organizers;
  * - general thread  → the creator ∪ subjectSpeaker ∪ organizers.
  * De-duplicated (a speaker who is also an organizer appears once). A general
  * thread's `subjectSpeaker` is the speaker an organizer targeted; it is absent
  * on speaker-created threads (where the creator IS the subject).
+ *
+ * READ FLIP (G2a): the id set is now expanded from the PARTY list
+ * ({@link resolveParticipants}: dual-written `participants[]` preferred, legacy
+ * derive as the safety-net fallback) rather than re-read straight off the legacy
+ * fields. The `organizers` group expands via the caller-supplied `organizerIds`
+ * at the SAME point the legacy logic seeded them, so WHO resolves is unchanged.
+ * A `sponsor` party (reserved for G2b) carries no speaker id and is skipped by
+ * the speaker system.
  */
 export function resolveParticipantIds(
   conversation: Pick<
@@ -229,29 +249,44 @@ export function resolveParticipantIds(
     | 'proposalSpeakerIds'
     | 'createdById'
     | 'subjectSpeakerId'
+    | 'participants'
   >,
   organizerIds: string[],
 ): string[] {
-  const ids = new Set<string>(organizerIds)
-  if (conversation.conversationType === 'proposal') {
-    for (const id of conversation.proposalSpeakerIds) ids.add(id)
-  } else {
-    ids.add(conversation.createdById)
-    if (conversation.subjectSpeakerId) ids.add(conversation.subjectSpeakerId)
+  const ids = new Set<string>()
+  for (const party of resolveParticipants(conversation)) {
+    if (party.partyType === 'speaker') {
+      ids.add(party.speakerId)
+    } else if (
+      party.partyType === 'group' &&
+      party.group === ORGANIZERS_GROUP
+    ) {
+      for (const id of organizerIds) ids.add(id)
+    }
   }
   return Array.from(ids)
 }
 
 // ---------------------------------------------------------------------------
-// Party model (G1): the GENERAL participant representation.
+// Party model (G1 representation, G2a read flip).
 //
 // A conversation's participants are expressed as a list of PARTIES (speaker /
-// sponsor / group). G1 introduces this representation and DUAL-WRITES it (below)
-// alongside the legacy createdBy/subjectSpeaker/proposal fields; the read path
-// is UNCHANGED (canAccessConversation / resolveRecipients / the GROQ scope
-// predicates all keep their legacy logic). The read path flips to prefer
-// participants[] in G2 (with the sponsor branch), after migration 043 backfills
-// existing documents.
+// sponsor / group). G1 introduced this representation and DUAL-WRITES it (below)
+// alongside the legacy createdBy/subjectSpeaker/proposal fields; migration 043
+// backfilled every existing document.
+//
+// G2a FLIPS the participant/authz READS onto {@link resolveParticipants}:
+// `canAccessConversation`, `resolveParticipantIds` (⇒ `resolveRecipients`,
+// `getConversationParticipants`) now prefer the stored `participants[]` and only
+// DERIVE from the legacy fields as a safety-net fallback. The legacy fields and
+// their projection are RETAINED (never removed) — they remain the fallback and
+// still back the GROQ scope predicates, which stay on the legacy fields on
+// purpose (they key on the LIVE `proposal->speakers[]`, and dual-write + 043
+// keep them correct; a participants[]-based predicate could not express the
+// derive fallback and would diverge for speaker edits G2a does not sync). The
+// proposal thread's `participants[]` snapshot is kept in step with the live
+// speaker set by {@link syncProposalConversationParticipants} on co-speaker
+// add/remove. The `sponsor` party branch is exercised by SPONSOR features (G2b).
 // ---------------------------------------------------------------------------
 
 /**
@@ -405,6 +440,7 @@ export function resolveRecipients(
     | 'proposalSpeakerIds'
     | 'createdById'
     | 'subjectSpeakerId'
+    | 'participants'
   >,
   actorId: string,
   organizerIds: string[],
@@ -420,6 +456,15 @@ export function resolveRecipients(
  * - a proposal thread where the speaker is on the proposal; OR
  * - a general thread the speaker created OR is the subject speaker of (an
  *   organizer-initiated general thread targets a `subjectSpeaker`).
+ *
+ * READ FLIP (G2a): a non-organizer's access is now decided by SPEAKER-party
+ * membership of the resolved party set ({@link resolveParticipants}:
+ * `participants[]` preferred, legacy derive fallback) rather than a direct read
+ * of the legacy fields. For a proposal thread the speaker parties ARE the
+ * proposal speakers; for a general thread they are the creator (+ subject
+ * speaker) — the same set the legacy field checks expressed. Organizer access
+ * still short-circuits on the server-derived `isOrganizer` flag (the
+ * `organizers` group party is never expanded here).
  */
 export function canAccessConversation(
   conversation: Pick<
@@ -428,16 +473,13 @@ export function canAccessConversation(
     | 'proposalSpeakerIds'
     | 'createdById'
     | 'subjectSpeakerId'
+    | 'participants'
   >,
   speaker: AccessSpeaker,
 ): boolean {
   if (speaker.isOrganizer) return true
-  if (conversation.conversationType === 'proposal') {
-    return conversation.proposalSpeakerIds.includes(speaker._id)
-  }
-  return (
-    conversation.createdById === speaker._id ||
-    conversation.subjectSpeakerId === speaker._id
+  return resolveParticipants(conversation).some(
+    (party) => party.partyType === 'speaker' && party.speakerId === speaker._id,
   )
 }
 
@@ -1051,6 +1093,49 @@ export async function ensureProposalConversation({
     })
     .commit()
   return id
+}
+
+/**
+ * SNAPSHOT SYNC (G2a): re-derive a proposal thread's dual-written
+ * `participants[]` from the proposal's CURRENT speaker set and patch it onto the
+ * conversation. Call AFTER a co-speaker add/remove commits so the flipped read
+ * path (which now PREFERS `participants[]`) resolves the LIVE speaker set rather
+ * than the snapshot captured when the thread was first created — the divergence
+ * flagged by the #564 badge.
+ *
+ * NO-OP when the proposal has no conversation thread yet: threads are created
+ * lazily on the first message, so a co-speaker change on a never-messaged
+ * proposal must NOT conjure a thread — we only PATCH an existing doc, never
+ * create one (hence the existence probe rather than `createIfNotExists`).
+ * NEVER-FAIL: a sync failure must never fail the (already committed) co-speaker
+ * mutation, mirroring the `deleteMessageNotificationsFor` cleanup contract.
+ */
+export async function syncProposalConversationParticipants(
+  proposalId: string,
+  proposalSpeakerIds: string[],
+): Promise<void> {
+  try {
+    const id = proposalConversationId(proposalId)
+    const existingId = await clientReadUncached.fetch<string | null>(
+      `*[_type == "conversation" && _id == $id][0]._id`,
+      { id },
+      { cache: 'no-store' },
+    )
+    if (!existingId) return
+    // Re-derive THROUGH the resolver on a participants-less context (derive
+    // branch), so the written array is exactly what the legacy read would yield
+    // for these speakers — the same construction ensureProposalConversation uses.
+    const participants = partiesToStored(
+      resolveParticipants({
+        conversationType: 'proposal',
+        proposalSpeakerIds,
+        createdById: '',
+      }),
+    )
+    await clientWrite.patch(id).set({ participants }).commit()
+  } catch (error) {
+    console.error('Failed to sync proposal conversation participants:', error)
+  }
 }
 
 /**

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -74,7 +74,11 @@ import {
 } from '@/lib/proposal/server'
 import { createReview, updateReview } from '@/lib/review/sanity'
 import { getFeaturedTalks } from '@/lib/featured/sanity'
-import { ensureProposalConversation, addMessage } from '@/lib/messaging/sanity'
+import {
+  ensureProposalConversation,
+  addMessage,
+  syncProposalConversationParticipants,
+} from '@/lib/messaging/sanity'
 import '@/lib/events/registry'
 
 /**
@@ -589,6 +593,16 @@ export const proposalRouter = router({
           speakerId: input.speakerId,
         })
 
+        // SNAPSHOT SYNC (G2a): the read path now prefers the conversation's
+        // participants[], so re-derive it from the proposal's REMAINING speakers
+        // — otherwise the removed co-speaker would linger as a thread member (and
+        // a stale snapshot could keep granting them access). Never-fail / no-op
+        // when the proposal has no thread yet.
+        await syncProposalConversationParticipants(
+          input.proposalId,
+          speakerIds.filter((id) => id !== input.speakerId),
+        )
+
         return { success: true }
       } catch (error) {
         if (error instanceof TRPCError) throw error
@@ -974,6 +988,16 @@ export const proposalRouter = router({
               code: 'NOT_FOUND',
               message: 'Proposal not found',
             })
+          }
+
+          // SNAPSHOT SYNC (G2a): an admin speaker swap also changes who is on the
+          // proposal, so keep any existing thread's participants[] in step with
+          // the new set — the read path prefers participants[], and G2a must not
+          // introduce a new divergence for organizer-side speaker edits. Only
+          // when speakers were part of this update. Never-fail / no-op without a
+          // thread.
+          if (speakers && speakers.length > 0) {
+            await syncProposalConversationParticipants(input.id, speakers)
           }
 
           return proposal
@@ -1825,6 +1849,18 @@ export const proposalRouter = router({
             )
 
             await transaction.commit()
+
+            // SNAPSHOT SYNC (G2a): keep the proposal thread's participants[] in
+            // step with the newly-accepted co-speaker so the flipped read path
+            // grants them thread access (and fans messages out to them). The new
+            // speaker set mirrors the append above. Never-fail / no-op without a
+            // thread.
+            await syncProposalConversationParticipants(
+              proposalId,
+              speakerIds.includes(ctx.speaker._id)
+                ? speakerIds
+                : [...speakerIds, ctx.speaker._id],
+            )
           } else {
             // Mark declined (including the optional reason) in one patch
             await clientWrite


### PR DESCRIPTION
## SPONSOR-MESSAGING G2a — read-path flip to the party model

Builds on **G1 (#564)** — dual-write + `resolveParticipants` + `normalizeParties` — and on migration **043** (already run in prod, so every existing conversation carries `participants[]`). This phase **flips the participant/authz READS onto the party model** and fixes the co-speaker snapshot divergence #564 flagged. **SPEAKER-system behavior is unchanged** (full suite green; one legacy-order-encoding assertion adjusted — see below). Sponsor features are out of scope (G2b).

### What FLIPPED (now reads `participants[]`, legacy-derive retained as the safety-net fallback)
- **`resolveParticipantIds`** — the id set is now expanded from the resolved **party list** (`resolveParticipants`: stored `participants[]` preferred, else derive from legacy fields). Speaker parties → their ids; the `organizers` **group** party expands via the caller-supplied `organizerIds` at the *same point* the legacy logic seeded them, so *who* resolves is identical. Sponsor parties (G2b) carry no speaker id and are skipped.
- **`canAccessConversation`** — a non-organizer's access is now decided by **speaker-party membership** of the resolved set (organizer access still short-circuits on the server-derived `isOrganizer` flag).
- **`resolveRecipients`** and **`getConversationParticipants`** flip transitively (both go through `resolveParticipantIds`).

Ordering note: ids now resolve in **party order** (speakers, then the expanded organizers group) instead of the legacy organizers-first seed order. The **set is identical**; only iteration order moved. One test (`resolveRecipients … drops an organizer author`) encoded the old order and was made order-insensitive (`.sort()`), matching its sibling assertions — **flagged loudly** as the only assertion touched by the mechanism change.

### What deliberately did NOT flip (correctness over purity)
- **GROQ scope/view predicates (`SPEAKER_SCOPE_PREDICATE`, view predicates) — KEPT on the legacy fields.** They key on `createdBy` / `subjectSpeaker` / **live** `proposal->speakers[]._ref`, which stay correct (dual-write + 043 keep the scalar fields synced; `proposal->speakers` is dereferenced live per query). A `participants[]`-based predicate would be a **snapshot** that could diverge for proposal-speaker changes made outside the synced paths, and could not express the derive-fallback the JS resolver provides for a participants-less doc — so it could not match legacy semantics exactly. The JS authz/recipient path (which *can* express the fallback) is the one that flipped. The needs-reply / assignee / status predicates never keyed on party membership, so they are untouched. Documented inline at `SPEAKER_SCOPE_PREDICATE`.
- **The inbox-row counterpart projection — KEPT on the legacy GROQ `select()`** over `proposal->speakers[0]` / `subjectSpeaker` / `createdBy`. It is a display-name/avatar concern requiring dereferences (parties store only weak refs), the live primary-speaker rendering is at least as correct as a snapshot, it is dual-write-correct, and it is locked by exact-string test assertions. No correctness gain from flipping. (Task 1 named "counterpart resolution"; this is the deliberate non-flip, flagged here.)
- **`message.authorParty` — reads keep the legacy `author` ref** (thread rendering `authorId`, last-message author). The ref stays dual-written; the author is always a speaker doc, so flipping is a no-op with churn. Not flipped.

### Snapshot sync (the #564 badge)
New never-fail helper **`syncProposalConversationParticipants(proposalId, speakerIds)`** re-derives a proposal thread's `participants[]` from the proposal's current speakers and **patches an existing thread only** (existence probe first — a co-speaker change on a never-messaged proposal must not conjure a thread). Wired at:
1. **Co-speaker REMOVE** (`removeCoSpeaker`, alongside `deleteMessageNotificationsFor`) — resync to the remaining speakers.
2. **Co-speaker ADD** (invitation accept append) — resync to include the new speaker.
3. **Admin proposal `update`** when speakers change — an *additional* wire beyond the two mandated co-speaker paths, so the read flip introduces **no new divergence** for organizer-side speaker swaps (preserves the "behavior identical" invariant). Never-fail / no-op without a thread.

### Tests
- Extended the G1 equivalence matrix with a **read-flip equivalence** section: for every thread shape, `resolveParticipantIds` / `resolveRecipients` / `canAccessConversation` give **identical results** whether reading stored `participants[]` or deriving from legacy; plus organizers-group expansion, sponsor-party skip, and a "prefers stored over stale legacy proposal fields" case documenting *why* the sync is required.
- **Co-speaker sync** tests: ADD direction, REMOVE direction, no-op without a thread, and never-fail on patch failure.
- Full suite: **3346 passed, 5 skipped (232 files)**. tsc / eslint / prettier / knip all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR (G2a) flips the participant/authz READ path from the legacy scalar fields onto the party model introduced in G1, and adds `syncProposalConversationParticipants` to keep the `participants[]` snapshot up-to-date after co-speaker mutations. The GROQ scope predicates are deliberately left on the live legacy fields to avoid snapshot-divergence in the inbox filter, while the JS authz functions now prefer the stored array with a legacy-derive fallback.

- `resolveParticipantIds` and `canAccessConversation` now iterate `resolveParticipants()` (stored `participants[]` preferred, legacy derive as fallback); ordering shifts from organizers-first to speakers-first (set is identical, one test made order-insensitive).
- New `syncProposalConversationParticipants` re-derives and patches `participants[]` after co-speaker add, remove, and admin speaker update; probes for thread existence first (no-op on never-messaged proposals); swallows errors to never fail the committed speaker mutation.
- Equivalence test suite added covering every thread shape through both stored and derived paths, plus the sponsor-party skip and snapshot-preference motivation.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The read-flip is well-contained, thoroughly tested, and the three sync call-sites correctly cover all speaker-mutation paths in the API.

The shift from an unconditional organizerIds seed to party-based expansion is the one spot where a badly formed stored document (non-empty participants[] missing the organizers group) would silently drop organizer fan-out — mitigated by migration 043 and all write paths always including the group party, but without a runtime guard. The admin update guard for empty speaker lists is a minor clarity gap. Neither concern represents a defect in the current code paths.

src/lib/messaging/sanity.ts around resolveParticipantIds and syncProposalConversationParticipants; confirm the assumption that all stored participants[] carry an ORGANIZERS_GROUP entry holds post-migration.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/messaging/sanity.ts | Core read-flip: resolveParticipantIds, canAccessConversation, and resolveRecipients now route through resolveParticipants(); new syncProposalConversationParticipants helper patches participants[] after speaker mutations. One subtle behavioral change: organizer inclusion now depends on ORGANIZERS_GROUP party being present in stored array rather than an unconditional seed. |
| src/server/routers/proposal.ts | Wires syncProposalConversationParticipants at all three speaker-mutating paths (removeCoSpeaker, invite accept, admin update). Each call correctly computes the post-mutation speaker set and is never-fail. Coverage of mutation paths appears complete. |
| __tests__/lib/messaging/party-model.test.ts | Adds comprehensive G2a equivalence tests (stored vs derived paths) and sync tests (ADD, REMOVE, no-op, never-fail). Covers sponsor-party skip and snapshot-preference motivation. |
| __tests__/lib/messaging/sanity.test.ts | Single ordering-only assertion made set-equivalent (both sides .sort()); comment correctly explains the party-order vs legacy seed-order change. No logic change. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Router as proposal.ts Router
    participant Sanity as Sanity (write)
    participant ReadUncached as Sanity (read uncached)
    participant SyncFn as syncProposalConversationParticipants
    participant ResolveP as resolveParticipants / canAccessConversation

    Note over Router,ResolveP: Co-speaker REMOVE
    Router->>Sanity: transaction.commit() (unset speaker, cancel invitation)
    Router->>SyncFn: await syncProposalConversationParticipants(proposalId, remainingIds)
    SyncFn->>ReadUncached: fetch _id probe (no-store)
    alt thread exists
        SyncFn->>SyncFn: "partiesToStored(resolveParticipants({...}))"
        SyncFn->>Sanity: "patch(id).set({ participants }).commit()"
    else no thread yet
        SyncFn-->>Router: no-op
    end
    SyncFn-->>Router: never throws

    Note over Router,ResolveP: Co-speaker ADD (invitation accept)
    Router->>Sanity: transaction.commit() (append speaker, accept invitation)
    Router->>SyncFn: await syncProposalConversationParticipants(proposalId, updatedIds)
    SyncFn->>ReadUncached: fetch _id probe
    SyncFn->>Sanity: "patch(id).set({ participants }).commit()"

    Note over Router,ResolveP: READ PATH (G2a)
    Router->>ReadUncached: getConversationById
    ReadUncached-->>Router: ConversationWithContext (participants normalised)
    Router->>ResolveP: canAccessConversation(conv, speaker)
    ResolveP->>ResolveP: resolveParticipants - prefers participants[] else deriveParties
    ResolveP-->>Router: true / false
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Router as proposal.ts Router
    participant Sanity as Sanity (write)
    participant ReadUncached as Sanity (read uncached)
    participant SyncFn as syncProposalConversationParticipants
    participant ResolveP as resolveParticipants / canAccessConversation

    Note over Router,ResolveP: Co-speaker REMOVE
    Router->>Sanity: transaction.commit() (unset speaker, cancel invitation)
    Router->>SyncFn: await syncProposalConversationParticipants(proposalId, remainingIds)
    SyncFn->>ReadUncached: fetch _id probe (no-store)
    alt thread exists
        SyncFn->>SyncFn: "partiesToStored(resolveParticipants({...}))"
        SyncFn->>Sanity: "patch(id).set({ participants }).commit()"
    else no thread yet
        SyncFn-->>Router: no-op
    end
    SyncFn-->>Router: never throws

    Note over Router,ResolveP: Co-speaker ADD (invitation accept)
    Router->>Sanity: transaction.commit() (append speaker, accept invitation)
    Router->>SyncFn: await syncProposalConversationParticipants(proposalId, updatedIds)
    SyncFn->>ReadUncached: fetch _id probe
    SyncFn->>Sanity: "patch(id).set({ participants }).commit()"

    Note over Router,ResolveP: READ PATH (G2a)
    Router->>ReadUncached: getConversationById
    ReadUncached-->>Router: ConversationWithContext (participants normalised)
    Router->>ResolveP: canAccessConversation(conv, speaker)
    ResolveP->>ResolveP: resolveParticipants - prefers participants[] else deriveParties
    ResolveP-->>Router: true / false
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): party read path + co-sp..."](https://github.com/cloudnativebergen/website/commit/fc623bf86e15e29bdc34007cef64ca566e0bd3e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45481395)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->