### PR TITLE
feat(admin): editable conference settings — scalar fieldsets (SE-1a)

### DIFF
--- a/__tests__/components/admin/EditConferenceCard.test.tsx
+++ b/__tests__/components/admin/EditConferenceCard.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { EditConferenceCard } from '@/components/admin/EditConferenceCard'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+
+// Capture the payload each fieldset mutation is called with.
+const mutateMocks = vi.hoisted(() => ({
+  updateBasicInfo: vi.fn(),
+  updateVenue: vi.fn(),
+  updateDates: vi.fn(),
+  updateRegistration: vi.fn(),
+  updateCommunication: vi.fn(),
+  updateTicketingIds: vi.fn(),
+  updateCfpGoals: vi.fn(),
+}))
+
+vi.mock('@/lib/trpc/client', () => {
+  const make = (mutate: (input: unknown) => void) => ({
+    useMutation: () => ({ mutate, isPending: false }),
+  })
+  return {
+    api: {
+      conference: {
+        updateBasicInfo: make(mutateMocks.updateBasicInfo),
+        updateVenue: make(mutateMocks.updateVenue),
+        updateDates: make(mutateMocks.updateDates),
+        updateRegistration: make(mutateMocks.updateRegistration),
+        updateCommunication: make(mutateMocks.updateCommunication),
+        updateTicketingIds: make(mutateMocks.updateTicketingIds),
+        updateCfpGoals: make(mutateMocks.updateCfpGoals),
+      },
+      useUtils: () => ({ invalidate: vi.fn() }),
+    },
+  }
+})
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}))
+
+function renderCard(props: Parameters<typeof EditConferenceCard>[0]) {
+  return render(
+    <NotificationProvider>
+      <EditConferenceCard {...props} />
+    </NotificationProvider>,
+  )
+}
+
+beforeEach(() => {
+  Object.values(mutateMocks).forEach((m) => m.mockReset())
+})
+afterEach(() => cleanup())
+
+describe('EditConferenceCard', () => {
+  it('opens the modal from the pencil trigger', () => {
+    renderCard({
+      fieldset: 'basicInfo',
+      initialValues: { title: 'DevOpsDays', organizer: 'CNB' },
+    })
+    // Modal not shown until the trigger is clicked.
+    expect(screen.queryByText('Edit Basic Information')).not.toBeInTheDocument()
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Edit Basic Information' }),
+    )
+    expect(screen.getByText('Edit Basic Information')).toBeInTheDocument()
+  })
+
+  it('blocks submit and shows an inline error when a required field is cleared', () => {
+    renderCard({
+      fieldset: 'basicInfo',
+      initialValues: { title: 'DevOpsDays', organizer: 'CNB' },
+      defaultOpen: true,
+    })
+    const title = screen.getByLabelText(/Title/) as HTMLInputElement
+    fireEvent.change(title, { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(screen.getByText('Title is required')).toBeInTheDocument()
+    expect(mutateMocks.updateBasicInfo).not.toHaveBeenCalled()
+  })
+
+  it('shows an inline error for an invalid email (communication fieldset)', () => {
+    renderCard({
+      fieldset: 'communication',
+      initialValues: {
+        contactEmail: 'hi@example.com',
+        cfpEmail: 'cfp@example.com',
+        sponsorEmail: 'sponsor@example.com',
+      },
+      defaultOpen: true,
+    })
+    const contact = screen.getByLabelText(/Contact Email/) as HTMLInputElement
+    fireEvent.change(contact, { target: { value: 'broken' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(screen.getByText('Enter a valid email address')).toBeInTheDocument()
+    expect(mutateMocks.updateCommunication).not.toHaveBeenCalled()
+  })
+
+  it('submits a field-scoped payload (keys ⊆ fieldset, trimmed, null-unset)', () => {
+    renderCard({
+      fieldset: 'basicInfo',
+      initialValues: {
+        title: 'DevOpsDays',
+        organizer: 'CNB',
+        city: 'Bergen',
+        country: 'Norway',
+        tagline: 'Old tagline',
+        description: 'Desc',
+      },
+      defaultOpen: true,
+    })
+    // Edit the title (with padding to prove trimming) and clear the tagline.
+    fireEvent.change(screen.getByLabelText(/Title/), {
+      target: { value: '  DevOpsDays 2026  ' },
+    })
+    fireEvent.change(screen.getByLabelText(/Tagline/), {
+      target: { value: '' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(mutateMocks.updateBasicInfo).toHaveBeenCalledTimes(1)
+    const payload = mutateMocks.updateBasicInfo.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >
+    const allowed = [
+      'title',
+      'organizer',
+      'city',
+      'country',
+      'tagline',
+      'description',
+    ]
+    for (const key of Object.keys(payload)) {
+      expect(allowed).toContain(key)
+    }
+    expect(payload.title).toBe('DevOpsDays 2026')
+    // A cleared nullable field is sent as null (unset), not empty string.
+    expect(payload.tagline).toBeNull()
+  })
+
+  it('wires the dirty-close guard: editing then closing prompts a discard confirm', () => {
+    renderCard({
+      fieldset: 'venue',
+      initialValues: { venueName: 'Grieghallen', venueAddress: 'Bergen' },
+      defaultOpen: true,
+    })
+    // Pristine: the Save button is disabled until something changes.
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/Venue Name/), {
+      target: { value: 'New Hall' },
+    })
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+
+    // Closing a dirty modal reveals the in-dialog discard confirm.
+    fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }))
+    expect(screen.getByText('Discard unsaved changes?')).toBeInTheDocument()
+  })
+})

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -13,6 +13,7 @@ import {
   SelfCheckPanel,
 } from '@/components/admin/system-status'
 import { StatusBadge } from '@/components/StatusBadge'
+import { EditConferenceCard } from '@/components/admin/EditConferenceCard'
 import {
   CalendarIcon,
   GlobeAltIcon,
@@ -59,32 +60,42 @@ function InfoCard({
   children,
   icon: Icon,
   editUrl,
+  action,
 }: {
   title: string
   children: React.ReactNode
   icon: React.ComponentType<{ className?: string }>
   editUrl?: string | null
+  /**
+   * Optional inline edit affordance (an {@link EditConferenceCard} island). When
+   * present it sits beside the Studio deep-link; the card body keeps rendering
+   * the read-only values and refreshes after a save.
+   */
+  action?: React.ReactNode
 }) {
   return (
     <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex items-center justify-between gap-2">
         <div className="flex items-center">
           <Icon className="mr-2 h-5 w-5 text-gray-400 dark:text-gray-500" />
           <h3 className="text-lg font-medium text-gray-900 dark:text-white">
             {title}
           </h3>
         </div>
-        {editUrl && (
-          <a
-            href={editUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
-          >
-            <PencilSquareIcon className="h-4 w-4" />
-            Edit in Studio
-          </a>
-        )}
+        <div className="flex shrink-0 items-center gap-2">
+          {editUrl && (
+            <a
+              href={editUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+            >
+              <PencilSquareIcon className="h-4 w-4" />
+              Edit in Studio
+            </a>
+          )}
+          {action}
+        </div>
       </div>
       <div className="space-y-3">{children}</div>
     </div>
@@ -383,6 +394,19 @@ export default async function AdminSettings() {
             title="Basic Information"
             icon={InformationCircleIcon}
             editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="basicInfo"
+                initialValues={{
+                  title: conference.title,
+                  organizer: conference.organizer,
+                  city: conference.city,
+                  country: conference.country,
+                  tagline: conference.tagline,
+                  description: conference.description,
+                }}
+              />
+            }
           >
             <FieldRow label="Title" value={conference.title} />
             <FieldRow label="Organizer" value={conference.organizer} />
@@ -396,6 +420,15 @@ export default async function AdminSettings() {
             title="Venue Information"
             icon={MapPinIcon}
             editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="venue"
+                initialValues={{
+                  venueName: conference.venueName,
+                  venueAddress: conference.venueAddress,
+                }}
+              />
+            }
           >
             <FieldRow label="Venue Name" value={conference.venueName} />
             <FieldRow label="Venue Address" value={conference.venueAddress} />
@@ -405,6 +438,21 @@ export default async function AdminSettings() {
             title="Dates & Timeline"
             icon={CalendarIcon}
             editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="dates"
+                initialValues={{
+                  startDate: conference.startDate,
+                  endDate: conference.endDate,
+                  cfpStartDate: conference.cfpStartDate,
+                  cfpEndDate: conference.cfpEndDate,
+                  cfpNotifyDate: conference.cfpNotifyDate,
+                  programDate: conference.programDate,
+                  travelSupportPaymentDate: conference.travelSupportPaymentDate,
+                  travelSupportBudget: conference.travelSupportBudget,
+                }}
+              />
+            }
           >
             <FieldRow
               label="Start Date"
@@ -432,12 +480,30 @@ export default async function AdminSettings() {
               value={conference.programDate}
               type="date"
             />
+            <FieldRow
+              label="Travel Support Payment Date"
+              value={conference.travelSupportPaymentDate}
+              type="date"
+            />
+            <FieldRow
+              label="Travel Support Budget"
+              value={conference.travelSupportBudget}
+            />
           </InfoCard>
 
           <InfoCard
-            title="Configuration"
+            title="Registration"
             icon={DocumentTextIcon}
             editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="registration"
+                initialValues={{
+                  registrationEnabled: conference.registrationEnabled,
+                  registrationLink: conference.registrationLink,
+                }}
+              />
+            }
           >
             <FieldRow
               label="Registration Enabled"
@@ -449,10 +515,47 @@ export default async function AdminSettings() {
               value={conference.registrationLink}
               type="url"
             />
+          </InfoCard>
+
+          <InfoCard
+            title="Communication"
+            icon={EnvelopeIcon}
+            editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="communication"
+                initialValues={{
+                  contactEmail: conference.contactEmail,
+                  cfpEmail: conference.cfpEmail,
+                  sponsorEmail: conference.sponsorEmail,
+                  salesNotificationChannel: conference.salesNotificationChannel,
+                  cfpNotificationChannel: conference.cfpNotificationChannel,
+                }}
+              />
+            }
+          >
             <FieldRow
               label="Contact Email"
               value={conference.contactEmail}
               type="email"
+            />
+            <FieldRow
+              label="CFP Email"
+              value={conference.cfpEmail}
+              type="email"
+            />
+            <FieldRow
+              label="Sponsor Email"
+              value={conference.sponsorEmail}
+              type="email"
+            />
+            <FieldRow
+              label="Sales / Weekly Update Channel"
+              value={conference.salesNotificationChannel}
+            />
+            <FieldRow
+              label="CFP Notification Channel"
+              value={conference.cfpNotificationChannel}
             />
           </InfoCard>
 
@@ -478,6 +581,15 @@ export default async function AdminSettings() {
             title="External Integrations"
             icon={LinkIcon}
             editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="ticketingIds"
+                initialValues={{
+                  checkinCustomerId: conference.checkinCustomerId,
+                  checkinEventId: conference.checkinEventId,
+                }}
+              />
+            }
           >
             <FieldRow
               label="Checkin Customer ID"
@@ -486,6 +598,45 @@ export default async function AdminSettings() {
             <FieldRow
               label="Checkin Event ID"
               value={conference.checkinEventId}
+            />
+          </InfoCard>
+
+          <InfoCard
+            title="CFP & Revenue Goals"
+            icon={CurrencyDollarIcon}
+            editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="cfpGoals"
+                initialValues={{
+                  cfpSubmissionGoal: conference.cfpSubmissionGoal,
+                  cfpLightningGoal: conference.cfpLightningGoal,
+                  cfpPresentationGoal: conference.cfpPresentationGoal,
+                  cfpWorkshopGoal: conference.cfpWorkshopGoal,
+                  sponsorRevenueGoal: conference.sponsorRevenueGoal,
+                }}
+              />
+            }
+          >
+            <FieldRow
+              label="CFP Submission Goal"
+              value={conference.cfpSubmissionGoal}
+            />
+            <FieldRow
+              label="Lightning Talk Goal"
+              value={conference.cfpLightningGoal}
+            />
+            <FieldRow
+              label="Presentation Goal"
+              value={conference.cfpPresentationGoal}
+            />
+            <FieldRow
+              label="Workshop Goal"
+              value={conference.cfpWorkshopGoal}
+            />
+            <FieldRow
+              label="Sponsor Revenue Goal"
+              value={conference.sponsorRevenueGoal}
             />
           </InfoCard>
 

--- a/src/components/admin/EditConferenceCard.stories.tsx
+++ b/src/components/admin/EditConferenceCard.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { userEvent, screen } from 'storybook/test'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { EditConferenceCard } from './EditConferenceCard'
+import { NotificationProvider } from './NotificationProvider'
+
+// Every fieldset mutation resolves successfully so a Save in a story never
+// hits the network unhandled.
+const ok = () =>
+  HttpResponse.json({ result: { data: { success: true, updated: {} } } })
+const handlers = [
+  http.post('/api/trpc/conference.updateBasicInfo', ok),
+  http.post('/api/trpc/conference.updateVenue', ok),
+  http.post('/api/trpc/conference.updateDates', ok),
+  http.post('/api/trpc/conference.updateRegistration', ok),
+  http.post('/api/trpc/conference.updateCommunication', ok),
+  http.post('/api/trpc/conference.updateTicketingIds', ok),
+  http.post('/api/trpc/conference.updateCfpGoals', ok),
+]
+
+const meta = {
+  title: 'Systems/Settings/Admin/EditConferenceCard',
+  component: EditConferenceCard,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'SE-1a — the shared, fieldset-parameterized editor behind each admin settings InfoCard. A 44px pencil opens a mobile-sheet ModalShell form scoped to ONE scalar fieldset; Save patches only that fieldset and refreshes the server-rendered card. Stories open the modal on mount (`defaultOpen`) so the form is the subject.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        // ModalShell reads next-themes and HeadlessUI portals the dialog to
+        // <body> (outside any wrapper div), so forcing the theme here is what
+        // actually renders the modal dark — a plain `.dark` wrapper wouldn't
+        // reach the portal.
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-white p-6 dark:bg-gray-950">
+                <Story />
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof EditConferenceCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const datesInitial = {
+  startDate: '2026-10-15',
+  endDate: '2026-10-16',
+  cfpStartDate: '2026-01-10',
+  cfpEndDate: '2026-05-01',
+  cfpNotifyDate: '2026-06-15',
+  programDate: '2026-07-01',
+  travelSupportPaymentDate: '2026-11-01',
+  travelSupportBudget: 50000,
+}
+
+const communicationInitial = {
+  contactEmail: 'hello@cloudnativebergen.dev',
+  cfpEmail: 'cfp@cloudnativebergen.dev',
+  sponsorEmail: 'sponsors@cloudnativebergen.dev',
+  salesNotificationChannel: '#cnb-sales',
+  cfpNotificationChannel: '#cnb-cfp',
+}
+
+/** A text + date + number fieldset (the Dates & Timeline card), modal open. */
+export const TextDateFieldset: Story = {
+  args: { fieldset: 'dates', initialValues: datesInitial, defaultOpen: true },
+}
+
+export const TextDateFieldsetDark: Story = {
+  args: { fieldset: 'dates', initialValues: datesInitial, defaultOpen: true },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+/** An email fieldset (Communication) showing the inline validation error state. */
+export const EmailFieldsetError: Story = {
+  args: {
+    fieldset: 'communication',
+    initialValues: communicationInitial,
+    defaultOpen: true,
+  },
+  play: async () => {
+    // ModalShell portals to <body>, so query the whole document, not the canvas.
+    const contact = await screen.findByLabelText(/Contact Email/)
+    await userEvent.clear(contact)
+    await userEvent.type(contact, 'not-an-email')
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await screen.findByText('Enter a valid email address')
+  },
+}
+
+export const EmailFieldsetErrorDark: Story = {
+  args: {
+    fieldset: 'communication',
+    initialValues: communicationInitial,
+    defaultOpen: true,
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  play: async () => {
+    // ModalShell portals to <body>, so query the whole document, not the canvas.
+    const contact = await screen.findByLabelText(/Contact Email/)
+    await userEvent.clear(contact)
+    await userEvent.type(contact, 'not-an-email')
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await screen.findByText('Enter a valid email address')
+  },
+}

--- a/src/components/admin/EditConferenceCard.tsx
+++ b/src/components/admin/EditConferenceCard.tsx
@@ -1,0 +1,673 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { PencilSquareIcon } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { api } from '@/lib/trpc/client'
+import { useNotification } from './NotificationProvider'
+
+/**
+ * SE-1a — the settings tier's first storied, editable component. One shared,
+ * fieldset-parameterized editor: an Edit button on a read-only settings
+ * InfoCard opens a ModalShell form scoped to a single scalar fieldset, patches
+ * ONLY that fieldset via the matching `conference.*` mutation, then
+ * `router.refresh()`es the server-rendered card. It is deliberately generic —
+ * every fieldset drives the same code path from the `FIELDSET_DEFS` table
+ * rather than a bespoke component per card.
+ *
+ * Scope: SCALAR fieldsets only. Arrays/objects (social links, domains,
+ * features, vanity metrics, sponsor benefits, teams, organizers, topics,
+ * announcement, logos) stay read-only for later phases.
+ */
+
+export type ConferenceFieldsetKey =
+  | 'basicInfo'
+  | 'venue'
+  | 'dates'
+  | 'registration'
+  | 'communication'
+  | 'ticketingIds'
+  | 'cfpGoals'
+
+export type EditFieldType =
+  'text' | 'textarea' | 'date' | 'email' | 'url' | 'number' | 'boolean'
+
+export interface EditFieldDef {
+  name: string
+  label: string
+  type: EditFieldType
+  /** Empty value blocks submit with a "<label> is required" error. */
+  required?: boolean
+  /** When empty, send `null` to UNSET the field rather than an empty string. */
+  nullableWhenEmpty?: boolean
+  /** Numeric floor (inclusive) for `number` fields. */
+  min?: number
+  /** `number` field must be a whole number. */
+  integer?: boolean
+  /** `number` field must be strictly greater than zero. */
+  positive?: boolean
+  /** Optional helper text rendered under the control. */
+  description?: string
+}
+
+interface FieldsetDef {
+  title: string
+  /** Short line under the modal title. */
+  subtitle: string
+  fields: EditFieldDef[]
+}
+
+/**
+ * The single source of truth for what each scalar fieldset contains. Field
+ * `name`s are verified against `sanity/schemaTypes/conference.ts`; the server
+ * Zod schemas in `src/server/schemas/conference.ts` are the authoritative
+ * validators (this table only drives the form + light client-side hints).
+ */
+export const FIELDSET_DEFS: Record<ConferenceFieldsetKey, FieldsetDef> = {
+  basicInfo: {
+    title: 'Basic Information',
+    subtitle: 'Conference name, host and location',
+    fields: [
+      { name: 'title', label: 'Title', type: 'text', required: true },
+      { name: 'organizer', label: 'Organizer', type: 'text', required: true },
+      { name: 'city', label: 'City', type: 'text' },
+      { name: 'country', label: 'Country', type: 'text' },
+      {
+        name: 'tagline',
+        label: 'Tagline',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'description',
+        label: 'Description',
+        type: 'textarea',
+        nullableWhenEmpty: true,
+      },
+    ],
+  },
+  venue: {
+    title: 'Venue Information',
+    subtitle: 'Where the conference is held',
+    fields: [
+      {
+        name: 'venueName',
+        label: 'Venue Name',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'venueAddress',
+        label: 'Venue Address',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+    ],
+  },
+  dates: {
+    title: 'Dates & Timeline',
+    subtitle: 'Key conference and CFP dates',
+    fields: [
+      { name: 'startDate', label: 'Start Date', type: 'date', required: true },
+      { name: 'endDate', label: 'End Date', type: 'date', required: true },
+      {
+        name: 'cfpStartDate',
+        label: 'CFP Start Date',
+        type: 'date',
+        required: true,
+      },
+      {
+        name: 'cfpEndDate',
+        label: 'CFP End Date',
+        type: 'date',
+        required: true,
+      },
+      {
+        name: 'cfpNotifyDate',
+        label: 'CFP Notify Date',
+        type: 'date',
+        required: true,
+      },
+      {
+        name: 'programDate',
+        label: 'Program Release Date',
+        type: 'date',
+        required: true,
+      },
+      {
+        name: 'travelSupportPaymentDate',
+        label: 'Travel Support Payment Date',
+        type: 'date',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'travelSupportBudget',
+        label: 'Travel Support Budget',
+        type: 'number',
+        min: 0,
+        nullableWhenEmpty: true,
+      },
+    ],
+  },
+  registration: {
+    title: 'Registration',
+    subtitle: 'Ticket registration link and toggle',
+    fields: [
+      {
+        name: 'registrationEnabled',
+        label: 'Registration Enabled',
+        type: 'boolean',
+      },
+      {
+        name: 'registrationLink',
+        label: 'Registration Link',
+        type: 'url',
+        nullableWhenEmpty: true,
+      },
+    ],
+  },
+  communication: {
+    title: 'Communication',
+    subtitle: 'From-addresses and Slack channels',
+    fields: [
+      {
+        name: 'contactEmail',
+        label: 'Contact Email',
+        type: 'email',
+        required: true,
+      },
+      { name: 'cfpEmail', label: 'CFP Email', type: 'email', required: true },
+      {
+        name: 'sponsorEmail',
+        label: 'Sponsor Email',
+        type: 'email',
+        required: true,
+      },
+      {
+        name: 'salesNotificationChannel',
+        label: 'Sales / Weekly Update Channel',
+        type: 'text',
+        nullableWhenEmpty: true,
+        description: 'Slack channel, e.g. #conference-updates',
+      },
+      {
+        name: 'cfpNotificationChannel',
+        label: 'CFP Notification Channel',
+        type: 'text',
+        nullableWhenEmpty: true,
+        description: 'Slack channel, e.g. #conference-cfp',
+      },
+    ],
+  },
+  ticketingIds: {
+    title: 'External Integrations',
+    subtitle: 'Checkin.no API identifiers',
+    fields: [
+      {
+        name: 'checkinCustomerId',
+        label: 'Checkin Customer ID',
+        type: 'number',
+        integer: true,
+        positive: true,
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'checkinEventId',
+        label: 'Checkin Event ID',
+        type: 'number',
+        integer: true,
+        positive: true,
+        nullableWhenEmpty: true,
+      },
+    ],
+  },
+  cfpGoals: {
+    title: 'CFP & Revenue Goals',
+    subtitle: 'Dashboard tracking targets',
+    fields: [
+      {
+        name: 'cfpSubmissionGoal',
+        label: 'CFP Submission Goal',
+        type: 'number',
+        min: 0,
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'cfpLightningGoal',
+        label: 'Lightning Talk Goal',
+        type: 'number',
+        min: 0,
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'cfpPresentationGoal',
+        label: 'Presentation Goal',
+        type: 'number',
+        min: 0,
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'cfpWorkshopGoal',
+        label: 'Workshop Goal',
+        type: 'number',
+        min: 0,
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'sponsorRevenueGoal',
+        label: 'Sponsor Revenue Goal',
+        type: 'number',
+        min: 0,
+        nullableWhenEmpty: true,
+      },
+    ],
+  },
+}
+
+const MUTATION_BY_FIELDSET: Record<
+  ConferenceFieldsetKey,
+  keyof typeof api.conference
+> = {
+  basicInfo: 'updateBasicInfo',
+  venue: 'updateVenue',
+  dates: 'updateDates',
+  registration: 'updateRegistration',
+  communication: 'updateCommunication',
+  ticketingIds: 'updateTicketingIds',
+  cfpGoals: 'updateCfpGoals',
+}
+
+type FormValue = string | boolean
+type FormValues = Record<string, FormValue>
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function isValidUrl(value: string): boolean {
+  try {
+    return Boolean(new URL(value))
+  } catch {
+    return false
+  }
+}
+
+/** Project the stored conference values into editable form strings/booleans. */
+function toFormValues(
+  fields: EditFieldDef[],
+  initial: Record<string, unknown>,
+): FormValues {
+  const out: FormValues = {}
+  for (const f of fields) {
+    const v = initial[f.name]
+    if (f.type === 'boolean') {
+      out[f.name] = Boolean(v)
+    } else {
+      out[f.name] = v === null || v === undefined ? '' : String(v)
+    }
+  }
+  return out
+}
+
+/** Cross-field rules that can't be expressed per-input. Mirrors the server. */
+function crossFieldErrors(
+  fieldset: ConferenceFieldsetKey,
+  values: FormValues,
+): Record<string, string> {
+  const errs: Record<string, string> = {}
+  if (fieldset === 'dates') {
+    const start = values.startDate as string
+    const end = values.endDate as string
+    const cfpStart = values.cfpStartDate as string
+    const cfpEnd = values.cfpEndDate as string
+    if (start && end && end < start) {
+      errs.endDate = 'End date must be on or after the start date'
+    }
+    if (cfpStart && cfpEnd && cfpEnd < cfpStart) {
+      errs.cfpEndDate = 'CFP end date must be on or after the CFP start date'
+    }
+  }
+  return errs
+}
+
+export interface EditConferenceCardProps {
+  fieldset: ConferenceFieldsetKey
+  /** Current stored values (a superset is fine — only fieldset fields are read). */
+  initialValues: Record<string, unknown>
+  /** Render the modal open on mount — for stories/tests only. */
+  defaultOpen?: boolean
+}
+
+/**
+ * The Edit affordance for one settings InfoCard. Renders a 44px pencil trigger
+ * and, when opened, a ModalShell form for the fieldset. Placed in a card's
+ * header on the (server) settings page — the card body keeps rendering the
+ * read-only values and re-renders fresh after a successful save.
+ */
+export function EditConferenceCard({
+  fieldset,
+  initialValues,
+  defaultOpen = false,
+}: EditConferenceCardProps) {
+  const def = FIELDSET_DEFS[fieldset]
+  const { fields } = def
+  const router = useRouter()
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const [values, setValues] = useState<FormValues>(() =>
+    toFormValues(fields, initialValues),
+  )
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const baseline = toFormValues(fields, initialValues)
+  const isDirty = JSON.stringify(values) !== JSON.stringify(baseline)
+
+  // `api.conference[procName]` narrows to a union of procedures; select the
+  // proc first (plain property access, not a hook) then call `.useMutation`
+  // exactly once so the hook order is stable regardless of `fieldset`.
+  const proc = api.conference[MUTATION_BY_FIELDSET[fieldset]] as unknown as {
+    useMutation: (opts: {
+      onSuccess?: () => void
+      onError?: (error: { message: string }) => void
+    }) => {
+      mutate: (input: Record<string, unknown>) => void
+      isPending: boolean
+    }
+  }
+
+  const mutation = proc.useMutation({
+    onSuccess: () => {
+      void utils.invalidate()
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Settings updated',
+        message: `${def.title} saved.`,
+      })
+      setIsOpen(false)
+    },
+    onError: (error) => {
+      setSubmitError(error.message || 'Failed to save. Please try again.')
+      showNotification({
+        type: 'error',
+        title: 'Could not save',
+        message: error.message || 'Failed to save conference settings.',
+      })
+    },
+  })
+
+  const resetForm = () => {
+    setValues(toFormValues(fields, initialValues))
+    setErrors({})
+    setSubmitError(null)
+  }
+
+  const openModal = () => {
+    resetForm()
+    setIsOpen(true)
+  }
+
+  const closeModal = () => {
+    setIsOpen(false)
+    resetForm()
+  }
+
+  const setValue = (name: string, value: FormValue) => {
+    setValues((prev) => ({ ...prev, [name]: value }))
+    setErrors((prev) => {
+      if (!prev[name]) return prev
+      const next = { ...prev }
+      delete next[name]
+      return next
+    })
+  }
+
+  const validate = (): Record<string, string> => {
+    const errs: Record<string, string> = {}
+    for (const f of fields) {
+      if (f.type === 'boolean') continue
+      const raw = values[f.name]
+      const s = typeof raw === 'string' ? raw.trim() : ''
+      if (f.required && s === '') {
+        errs[f.name] = `${f.label} is required`
+        continue
+      }
+      if (s === '') continue
+      if (f.type === 'email' && !EMAIL_RE.test(s)) {
+        errs[f.name] = 'Enter a valid email address'
+      } else if (f.type === 'url' && !isValidUrl(s)) {
+        errs[f.name] = 'Enter a valid URL'
+      } else if (f.type === 'number') {
+        const n = Number(s)
+        if (!Number.isFinite(n)) errs[f.name] = 'Enter a number'
+        else if (f.integer && !Number.isInteger(n))
+          errs[f.name] = 'Must be a whole number'
+        else if (f.positive && n <= 0)
+          errs[f.name] = 'Must be a positive number'
+        else if (f.min !== undefined && n < f.min)
+          errs[f.name] = `Must be at least ${f.min}`
+      }
+    }
+    Object.assign(errs, crossFieldErrors(fieldset, values))
+    return errs
+  }
+
+  const buildPayload = (): Record<string, unknown> => {
+    const payload: Record<string, unknown> = {}
+    for (const f of fields) {
+      const raw = values[f.name]
+      if (f.type === 'boolean') {
+        payload[f.name] = Boolean(raw)
+        continue
+      }
+      const s = typeof raw === 'string' ? raw.trim() : ''
+      if (f.type === 'number') {
+        if (s === '') {
+          if (f.nullableWhenEmpty) payload[f.name] = null
+        } else {
+          payload[f.name] = Number(s)
+        }
+        continue
+      }
+      if (s === '') {
+        payload[f.name] = f.nullableWhenEmpty ? null : ''
+      } else {
+        payload[f.name] = s
+      }
+    }
+    return payload
+  }
+
+  const handleSave = () => {
+    setSubmitError(null)
+    const errs = validate()
+    setErrors(errs)
+    if (Object.keys(errs).length > 0) return
+    mutation.mutate(buildPayload())
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openModal}
+        aria-label={`Edit ${def.title}`}
+        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+      >
+        <PencilSquareIcon className="h-5 w-5" />
+      </button>
+
+      <ModalShell
+        isOpen={isOpen}
+        onClose={closeModal}
+        size="lg"
+        title={`Edit ${def.title}`}
+        subtitle={def.subtitle}
+        icon={<PencilSquareIcon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty && !mutation.isPending}
+      >
+        <form
+          noValidate
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSave()
+          }}
+          className="space-y-4"
+        >
+          {fields.map((f) => (
+            <EditField
+              key={f.name}
+              field={f}
+              value={values[f.name]}
+              error={errors[f.name]}
+              onChange={(v) => setValue(f.name, v)}
+            />
+          ))}
+
+          {submitError ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+            <AdminButton
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={closeModal}
+              disabled={mutation.isPending}
+              className="min-h-[44px]"
+            >
+              Cancel
+            </AdminButton>
+            <AdminButton
+              type="submit"
+              color="blue"
+              size="md"
+              disabled={mutation.isPending || !isDirty}
+              className="min-h-[44px]"
+            >
+              {mutation.isPending ? 'Saving…' : 'Save'}
+            </AdminButton>
+          </div>
+        </form>
+      </ModalShell>
+    </>
+  )
+}
+
+const inputClass =
+  'block w-full min-h-[44px] rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+
+function EditField({
+  field,
+  value,
+  error,
+  onChange,
+}: {
+  field: EditFieldDef
+  value: FormValue
+  error?: string
+  onChange: (value: FormValue) => void
+}) {
+  const id = `conf-field-${field.name}`
+  const describedBy = error
+    ? `${id}-error`
+    : field.description
+      ? `${id}-desc`
+      : undefined
+
+  if (field.type === 'boolean') {
+    return (
+      <div className="flex min-h-[44px] items-center gap-3">
+        <input
+          id={id}
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+          className="h-5 w-5 rounded border-gray-300 text-brand-cloud-blue focus:ring-brand-cloud-blue"
+        />
+        <label
+          htmlFor={id}
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {field.label}
+        </label>
+      </div>
+    )
+  }
+
+  const stringValue = typeof value === 'string' ? value : ''
+
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        {field.label}
+        {field.required ? (
+          <span className="text-red-500" aria-hidden="true">
+            {' '}
+            *
+          </span>
+        ) : null}
+      </label>
+      {field.type === 'textarea' ? (
+        <textarea
+          id={id}
+          value={stringValue}
+          onChange={(e) => onChange(e.target.value)}
+          rows={4}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          className={inputClass}
+        />
+      ) : (
+        <input
+          id={id}
+          type={
+            field.type === 'number'
+              ? 'number'
+              : field.type === 'date'
+                ? 'date'
+                : field.type === 'email'
+                  ? 'email'
+                  : field.type === 'url'
+                    ? 'url'
+                    : 'text'
+          }
+          value={stringValue}
+          onChange={(e) => onChange(e.target.value)}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={describedBy}
+          className={inputClass}
+        />
+      )}
+      {error ? (
+        <p
+          id={`${id}-error`}
+          role="alert"
+          className="mt-1 text-sm text-red-600 dark:text-red-400"
+        >
+          {error}
+        </p>
+      ) : field.description ? (
+        <p
+          id={`${id}-desc`}
+          className="mt-1 text-xs text-gray-500 dark:text-gray-400"
+        >
+          {field.description}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -131,6 +131,7 @@ export interface Conference {
   checkinEventId?: number
   ticketCapacity?: number
   ticketTargets?: SalesTargetConfig
+  travelSupportPaymentDate?: string
   travelSupportBudget?: number
   cfpSubmissionGoal?: number
   cfpLightningGoal?: number

--- a/src/lib/teams/format.test.ts
+++ b/src/lib/teams/format.test.ts
@@ -25,6 +25,25 @@ describe('formatTeamSummary', () => {
     expect(formatTeamSummary(team)).toBe('Volunteers (volunteers) — 1 member')
   })
 
+  it('treats null/undefined members as an empty roster (#566)', () => {
+    // The settings projection can dereference a deleted member to null, or omit
+    // the array entirely — the formatter must not crash on either.
+    const nullMembers = {
+      key: 'ghosts',
+      title: 'Ghosts',
+      members: null,
+    } as unknown as OrganizerTeam
+    expect(formatTeamSummary(nullMembers)).toBe('Ghosts (ghosts) — 0 members')
+
+    const missingMembers = {
+      key: 'phantoms',
+      title: 'Phantoms',
+    } as unknown as OrganizerTeam
+    expect(formatTeamSummary(missingMembers)).toBe(
+      'Phantoms (phantoms) — 0 members',
+    )
+  })
+
   it('prefixes a missing # on the channel', () => {
     const team: OrganizerTeam = {
       key: 'sponsors',

--- a/src/lib/teams/format.ts
+++ b/src/lib/teams/format.ts
@@ -7,7 +7,11 @@ import type { OrganizerTeam } from './types'
  * React. Optional segments (channel, email identity) are omitted when unset.
  */
 export function formatTeamSummary(team: OrganizerTeam): string {
-  const count = team.members.length
+  // The settings teams projection can yield `null` members (a stored reference
+  // whose target was deleted dereferences to null, and an empty team omits the
+  // array entirely). Treat null/undefined as an empty roster so the count and
+  // the page never crash on it.
+  const count = team.members?.length ?? 0
   const parts: string[] = [`${count} member${count === 1 ? '' : 's'}`]
   if (team.slackChannel) {
     parts.push(

--- a/src/server/_app.ts
+++ b/src/server/_app.ts
@@ -17,6 +17,7 @@ import { agentsRouter } from './routers/agents'
 import { notificationRouter } from './routers/notification'
 import { pushRouter } from './routers/push'
 import { messageRouter } from './routers/message'
+import { conferenceRouter } from './routers/conference'
 
 export const appRouter = router({
   badge: badgeRouter,
@@ -37,6 +38,7 @@ export const appRouter = router({
   notification: notificationRouter,
   push: pushRouter,
   message: messageRouter,
+  conference: conferenceRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/server/routers/conference.test.ts
+++ b/src/server/routers/conference.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+// --- next/cache -------------------------------------------------------------
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+// --- Conference resolution (drives resolveConferenceId) ---------------------
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+// --- Sanity write client: capture the patch shape ---------------------------
+const commitMock = vi.fn()
+let lastPatchId: string | undefined
+let lastSet: Record<string, unknown> | undefined
+let lastUnset: string[] | undefined
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    patch: (id: string) => {
+      lastPatchId = id
+      const builder = {
+        set: (obj: Record<string, unknown>) => {
+          lastSet = obj
+          return builder
+        },
+        unset: (keys: string[]) => {
+          lastUnset = keys
+          return builder
+        },
+        commit: () => commitMock(),
+      }
+      return builder
+    },
+  },
+}))
+
+import { conferenceRouter } from './conference'
+
+const CONFERENCE_ID = 'conf-1'
+
+function makeCaller(opts: { isOrganizer?: boolean } | null) {
+  const speaker = opts
+    ? { _id: 'sp-1', name: 'Org', isOrganizer: opts.isOrganizer ?? false }
+    : undefined
+  const ctx = {
+    session: speaker ? { speaker, user: { name: 'Org' } } : null,
+    speaker,
+  } as unknown as Context
+  return conferenceRouter.createCaller(ctx)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  lastPatchId = undefined
+  lastSet = undefined
+  lastUnset = undefined
+  commitMock.mockResolvedValue({ _id: CONFERENCE_ID })
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: CONFERENCE_ID },
+    error: null,
+  })
+})
+
+describe('conference router — authorization', () => {
+  it('rejects a non-organizer speaker (FORBIDDEN)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: false }).updateBasicInfo({
+        title: 'DevOpsDays',
+        organizer: 'CNB',
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unauthenticated caller (UNAUTHORIZED)', async () => {
+    await expect(
+      makeCaller(null).updateBasicInfo({ title: 'X', organizer: 'Y' }),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('allows an organizer', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateBasicInfo({
+      title: 'DevOpsDays',
+      organizer: 'CNB',
+    })
+    expect(result.success).toBe(true)
+    expect(lastPatchId).toBe(CONFERENCE_ID)
+  })
+})
+
+describe('conference router — field-scoped patch shape', () => {
+  it('only sets the fieldset keys that were provided (⊆ provided)', async () => {
+    await makeCaller({ isOrganizer: true }).updateBasicInfo({
+      title: 'DevOpsDays',
+      organizer: 'CNB',
+      city: 'Bergen',
+      country: 'Norway',
+    })
+    const provided = ['title', 'organizer', 'city', 'country']
+    expect(lastSet).toBeDefined()
+    for (const key of Object.keys(lastSet!)) {
+      expect(provided).toContain(key)
+    }
+    // Never touches fields outside the fieldset.
+    expect(lastSet).not.toHaveProperty('venueName')
+    expect(lastSet).not.toHaveProperty('cfpEmail')
+  })
+
+  it('never derives the conference id from client input', async () => {
+    await makeCaller({ isOrganizer: true }).updateVenue({
+      venueName: 'Grieghallen',
+    })
+    // The id is the one resolveConferenceId returned, not anything client-sent.
+    expect(lastPatchId).toBe(CONFERENCE_ID)
+    expect(getConferenceMock).toHaveBeenCalled()
+  })
+})
+
+describe('conference router — unset semantics', () => {
+  it('routes explicit null to .unset() and omits it from .set()', async () => {
+    await makeCaller({ isOrganizer: true }).updateTicketingIds({
+      checkinCustomerId: 42,
+      checkinEventId: null,
+    })
+    expect(lastSet).toEqual({ checkinCustomerId: 42 })
+    expect(lastUnset).toEqual(['checkinEventId'])
+  })
+
+  it('leaves omitted optional fields untouched (neither set nor unset)', async () => {
+    await makeCaller({ isOrganizer: true }).updateCfpGoals({
+      cfpSubmissionGoal: 100,
+    })
+    expect(lastSet).toEqual({ cfpSubmissionGoal: 100 })
+    expect(lastUnset).toBeUndefined()
+  })
+
+  it('rejects an empty input with BAD_REQUEST (nothing to set or unset)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateCfpGoals({}),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('conference router — validation', () => {
+  it('rejects a blank required title', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateBasicInfo({
+        title: '   ',
+        organizer: 'CNB',
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid contact email', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateCommunication({
+        contactEmail: 'not-an-email',
+        cfpEmail: 'cfp@example.com',
+        sponsorEmail: 'sponsor@example.com',
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid registration URL', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateRegistration({
+        registrationEnabled: true,
+        registrationLink: 'notaurl',
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects end date before start date', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDates({
+        startDate: '2026-10-10',
+        endDate: '2026-10-09',
+        cfpStartDate: '2026-01-01',
+        cfpEndDate: '2026-05-01',
+        cfpNotifyDate: '2026-06-01',
+        programDate: '2026-07-01',
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects cfp end date before cfp start date', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDates({
+        startDate: '2026-10-10',
+        endDate: '2026-10-11',
+        cfpStartDate: '2026-05-01',
+        cfpEndDate: '2026-01-01',
+        cfpNotifyDate: '2026-06-01',
+        programDate: '2026-07-01',
+      }),
+    ).rejects.toBeTruthy()
+  })
+
+  it('accepts a valid, correctly-ordered dates payload', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateDates({
+      startDate: '2026-10-10',
+      endDate: '2026-10-11',
+      cfpStartDate: '2026-01-01',
+      cfpEndDate: '2026-05-01',
+      cfpNotifyDate: '2026-06-01',
+      programDate: '2026-07-01',
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toMatchObject({ startDate: '2026-10-10' })
+  })
+
+  it('rejects a negative goal', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateCfpGoals({
+        cfpSubmissionGoal: -5,
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-integer checkin id', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateTicketingIds({
+        checkinCustomerId: 3.5,
+      }),
+    ).rejects.toBeTruthy()
+  })
+
+  it('rejects a non-positive checkin id', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateTicketingIds({
+        checkinEventId: 0,
+      }),
+    ).rejects.toBeTruthy()
+  })
+})

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -1,0 +1,122 @@
+import { TRPCError } from '@trpc/server'
+import { revalidateTag } from 'next/cache'
+import { router, adminProcedure, resolveConferenceId } from '../trpc'
+import { clientWrite } from '@/lib/sanity/client'
+import {
+  UpdateBasicInfoSchema,
+  UpdateVenueSchema,
+  UpdateDatesSchema,
+  UpdateRegistrationSchema,
+  UpdateCommunicationSchema,
+  UpdateTicketingIdsSchema,
+  UpdateCfpGoalsSchema,
+} from '../schemas/conference'
+
+/**
+ * Field-scoped conference settings mutations (SE-1a).
+ *
+ * INVARIANT: every mutation resolves the conference id from the request domain
+ * via {@link resolveConferenceId} (NEVER from client input) and patches ONLY the
+ * fields of its own fieldset — following the tickets router precedent. A
+ * whole-document replace is never performed.
+ *
+ * UNSET SEMANTICS: within a validated input, `undefined` leaves a field
+ * untouched, whereas an explicit `null` unsets it. {@link applyConferencePatch}
+ * routes provided-non-null values through Sanity `.set()` and nulls through
+ * `.unset()`.
+ */
+async function applyConferencePatch(
+  conferenceId: string,
+  input: Record<string, unknown>,
+) {
+  const set: Record<string, unknown> = {}
+  const unset: string[] = []
+
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined) continue
+    if (value === null) {
+      unset.push(key)
+    } else {
+      set[key] = value
+    }
+  }
+
+  if (Object.keys(set).length === 0 && unset.length === 0) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No updates provided',
+    })
+  }
+
+  try {
+    let patch = clientWrite.patch(conferenceId)
+    if (Object.keys(set).length > 0) patch = patch.set(set)
+    if (unset.length > 0) patch = patch.unset(unset)
+    const result = await patch.commit()
+
+    // Bust the cached conference read so the server-rendered settings page (and
+    // every other `getConferenceForCurrentDomain` consumer) reflects the change.
+    revalidateTag('content:conferences', 'default')
+    revalidateTag(`sanity:conference-${conferenceId}`, 'default')
+
+    return { success: true, updated: result }
+  } catch (error) {
+    if (error instanceof TRPCError) throw error
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to update conference settings',
+      cause: error,
+    })
+  }
+}
+
+export const conferenceRouter = router({
+  updateBasicInfo: adminProcedure
+    .input(UpdateBasicInfoSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+
+  updateVenue: adminProcedure
+    .input(UpdateVenueSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+
+  updateDates: adminProcedure
+    .input(UpdateDatesSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+
+  updateRegistration: adminProcedure
+    .input(UpdateRegistrationSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+
+  updateCommunication: adminProcedure
+    .input(UpdateCommunicationSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+
+  updateTicketingIds: adminProcedure
+    .input(UpdateTicketingIdsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+
+  updateCfpGoals: adminProcedure
+    .input(UpdateCfpGoalsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+})

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod'
+
+/**
+ * Field-scoped conference settings schemas (SE-1a). Each schema mirrors ONE
+ * fieldset group of scalar fields from `sanity/schemaTypes/conference.ts` and is
+ * consumed by exactly one mutation in `src/server/routers/conference.ts`. Only
+ * scalar field groups are covered here; arrays/objects (social links, domains,
+ * features, vanity metrics, sponsor benefits, teams, organizers, topics,
+ * announcement, logos) are LATER phases and deliberately excluded.
+ *
+ * UNSET SEMANTICS (shared across every schema): a field left `undefined` is
+ * untouched; an explicit `null` unsets the (optional) field. The router's patch
+ * builder translates these to Sanity `.set()` / `.unset()` respectively — see
+ * `applyConferencePatch`.
+ */
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const dateString = z
+  .string()
+  .regex(DATE_RE, 'Date must be in YYYY-MM-DD format')
+
+// === Basic Information ===
+export const UpdateBasicInfoSchema = z.object({
+  title: z.string().trim().min(1, 'Title is required'),
+  organizer: z.string().trim().min(1, 'Organizer is required'),
+  city: z.string().trim().optional(),
+  country: z.string().trim().optional(),
+  tagline: z.string().trim().nullable().optional(),
+  description: z.string().trim().nullable().optional(),
+})
+
+// === Venue ===
+export const UpdateVenueSchema = z.object({
+  venueName: z.string().trim().nullable().optional(),
+  venueAddress: z.string().trim().nullable().optional(),
+})
+
+// === Dates ===
+export const UpdateDatesSchema = z
+  .object({
+    startDate: dateString,
+    endDate: dateString,
+    cfpStartDate: dateString,
+    cfpEndDate: dateString,
+    cfpNotifyDate: dateString,
+    programDate: dateString,
+    travelSupportPaymentDate: dateString.nullable().optional(),
+    travelSupportBudget: z
+      .number()
+      .min(0, 'Budget must be zero or more')
+      .nullable()
+      .optional(),
+  })
+  // YYYY-MM-DD compares correctly with lexical `<`, so ordering needs no Date
+  // parsing. Guarded on presence so the rule only fires "when both provided".
+  .refine((d) => !d.startDate || !d.endDate || d.endDate >= d.startDate, {
+    message: 'End date must be on or after the start date',
+    path: ['endDate'],
+  })
+  .refine(
+    (d) => !d.cfpStartDate || !d.cfpEndDate || d.cfpEndDate >= d.cfpStartDate,
+    {
+      message: 'CFP end date must be on or after the CFP start date',
+      path: ['cfpEndDate'],
+    },
+  )
+
+// === Registration ===
+export const UpdateRegistrationSchema = z.object({
+  registrationLink: z
+    .string()
+    .trim()
+    .url('Enter a valid URL')
+    .nullable()
+    .optional(),
+  registrationEnabled: z.boolean(),
+})
+
+// === Communication ===
+// The three emails drive outbound from-addresses, so they are required and must
+// be valid. The two Slack channels are optional free-form strings; a leading `#`
+// is tolerated (stored verbatim — callers already normalize on read).
+export const UpdateCommunicationSchema = z.object({
+  contactEmail: z
+    .string()
+    .trim()
+    .min(1, 'Contact email is required')
+    .email('Enter a valid email address'),
+  cfpEmail: z
+    .string()
+    .trim()
+    .min(1, 'CFP email is required')
+    .email('Enter a valid email address'),
+  sponsorEmail: z
+    .string()
+    .trim()
+    .min(1, 'Sponsor email is required')
+    .email('Enter a valid email address'),
+  salesNotificationChannel: z.string().trim().nullable().optional(),
+  cfpNotificationChannel: z.string().trim().nullable().optional(),
+})
+
+// === Ticketing IDs ===
+// Positive integers; clearing is allowed by sending `null` (unset).
+export const UpdateTicketingIdsSchema = z.object({
+  checkinCustomerId: z
+    .number()
+    .int('Must be a whole number')
+    .positive('Must be a positive number')
+    .nullable()
+    .optional(),
+  checkinEventId: z
+    .number()
+    .int('Must be a whole number')
+    .positive('Must be a positive number')
+    .nullable()
+    .optional(),
+})
+
+// === CFP & Revenue Goals ===
+// Non-negative numbers; every field is optional and unsettable via `null`.
+const nonNegativeGoal = z
+  .number()
+  .min(0, 'Must be zero or more')
+  .nullable()
+  .optional()
+
+export const UpdateCfpGoalsSchema = z.object({
+  cfpSubmissionGoal: nonNegativeGoal,
+  cfpLightningGoal: nonNegativeGoal,
+  cfpPresentationGoal: nonNegativeGoal,
+  cfpWorkshopGoal: nonNegativeGoal,
+  sponsorRevenueGoal: nonNegativeGoal,
+})


### PR DESCRIPTION
## Summary

First phase of making the read-only `/admin/settings` config cards editable, a step toward eliminating Sanity Studio. This phase covers **scalar field groups only**.

## The field-scoped-patch invariant

Every mutation follows the `tickets.updateSettings` precedent exactly:

- The conference id comes from `resolveConferenceId()` (domain-resolved on the server) — **never** from client input.
- `adminProcedure` + a Zod schema per fieldset.
- `clientWrite.patch(id).set(only-provided-fields)` / `.unset(...)` — **never** a whole-document replace, and never a key outside the fieldset.

## Fieldsets (7 mutations in the new `conference` router)

| Mutation | Fields | Validation |
|---|---|---|
| `updateBasicInfo` | title, organizer, city, country, tagline, description | title/organizer required non-empty |
| `updateVenue` | venueName, venueAddress | optional |
| `updateDates` | startDate, endDate, cfpStartDate, cfpEndDate, cfpNotifyDate, programDate, travelSupportPaymentDate, travelSupportBudget | YYYY-MM-DD; end ≥ start, cfpEnd ≥ cfpStart; budget ≥ 0 |
| `updateRegistration` | registrationLink (url), registrationEnabled (bool) | url format |
| `updateCommunication` | contactEmail, cfpEmail, sponsorEmail, salesNotificationChannel, cfpNotificationChannel | three emails required + valid (they drive from-addresses); channels optional, leading-`#` tolerated |
| `updateTicketingIds` | checkinCustomerId, checkinEventId | positive integers, optional/unsettable |
| `updateCfpGoals` | cfpSubmissionGoal, cfpLightningGoal, cfpPresentationGoal, cfpWorkshopGoal, sponsorRevenueGoal | non-negative, optional/unsettable |

Field names verified against `sanity/schemaTypes/conference.ts`.

## Unset semantics

Within a validated input: an **explicit `null` unsets** the optional field (Sanity `.unset()`); an **omitted field is untouched**; a provided non-null value is `.set()`. The generic editor sends `null` when a nullable field is cleared.

## UI

Each editable InfoCard gains a 44px pencil that opens one shared, fieldset-parameterized `EditConferenceCard` (no per-card special-casing): a `ModalShell` form (mobile sheet, dirty-close guard, inline validation errors, Save/Cancel). After a successful save it invalidates + `router.refresh()`es so the server-rendered card shows fresh values, and toasts via the admin `NotificationProvider`. The settings page is restructured slightly: the old "Configuration" card is split into **Registration** + a new **Communication** card, and a new **CFP & Revenue Goals** card is added, so all seven fieldsets have a home. This gives the settings tier its first storied component (closing part of the visual-QA gap).

## Rider (#566)

`formatTeamSummary` now null-guards `members` (the settings teams projection can dereference a deleted member to `null`).

## What stays read-only (later phases)

Social links, domains, features, vanity metrics, sponsor benefits, teams, organizers, topics, announcement, logos — every array/object group.

## Checks

tsc, eslint, prettier, knip clean. Full `vitest run` green (238 files, 3386 passed). Router tests cover validation/authz/unset/patch-shape; a jsdom component test covers the shared form (validation display, dirty-guard wiring, submit payload shape). Shared editor storied + shot at 393 light+dark (text/date + email-error) — no viewport overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces SE-1a: the first phase of making the admin settings page editable, covering seven scalar fieldset mutations (`conference.*`) behind `adminProcedure`, a shared `EditConferenceCard` client component, Zod schemas, and a null-guard fix for `formatTeamSummary`. Conference IDs are always resolved server-side via `resolveConferenceId()`, and mutations use `.set()`/`.unset()` rather than whole-document replaces.

- Seven new tRPC mutations are added under a new `conferenceRouter`, each field-scoped to its own Zod schema and using the same `applyConferencePatch` helper that routes `null` values to Sanity `.unset()` and non-null values to `.set()`.
- A single generic `EditConferenceCard` component, parameterized by `fieldset`, drives all seven edit modals via a FIELDSET_DEFS lookup table — avoiding per-card bespoke components.
- The settings page is restructured to add a new "Communication" and "CFP & Revenue Goals" card, and each InfoCard gains an optional `action` prop to mount the edit island alongside the existing Studio deep-link.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the auth model, multi-tenant isolation, and unset semantics are all correctly implemented and well-tested.

The `city` and `country` fields are the only two optional text fields in the basic-info fieldset that don't have `nullableWhenEmpty: true` in FIELDSET_DEFS and lack `.nullable()` in the server schema. Clearing either field stores an empty string in Sanity rather than unsetting it, which is inconsistent with every other clearable optional field in this PR. Everything else — auth, multi-tenant isolation, cross-field date validation, the null-guard fix, and test coverage — looks solid.

src/components/admin/EditConferenceCard.tsx and src/server/schemas/conference.ts — specifically the `city` and `country` field definitions in FIELDSET_DEFS and UpdateBasicInfoSchema.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/conference.ts | New router with seven field-scoped mutations; correctly resolves conference ID server-side, follows adminProcedure pattern, and delegates all patch logic to a single tested helper. |
| src/server/schemas/conference.ts | Seven Zod schemas covering all scalar fieldsets; cross-field date ordering enforced with .refine(); minor inconsistency: `city` and `country` accept empty strings via optional() without min(1), while similarly optional fields use .nullable() and are unset via null. |
| src/components/admin/EditConferenceCard.tsx | New shared edit component; well-structured with FIELDSET_DEFS table, dirty-close guard, and inline validation. `city`/`country` fields send empty string on clear instead of null, diverging from the null-unset semantics used for every other optional field. |
| src/server/routers/conference.test.ts | Comprehensive test coverage for auth, field-scoped patch shape, unset semantics, and per-fieldset validation; mock captures patch builder calls faithfully. |
| __tests__/components/admin/EditConferenceCard.test.tsx | Good component-level coverage: modal open/close, required-field blocking, email validation, payload shape, and dirty-close guard; uses fireEvent + cleanup correctly. |
| src/lib/teams/format.ts | Null-guard fix for `members` — correctly uses optional chaining + nullish coalescing to prevent crash when a team member reference dereferences to null in the settings projection. |
| src/app/(admin)/admin/settings/page.tsx | Settings page restructured to wire EditConferenceCard into each InfoCard header; new Communication and CFP & Revenue Goals cards added cleanly. |
| src/lib/conference/types.ts | Adds missing travelSupportPaymentDate field to the Conference interface, aligning the type with the Sanity schema and the new dates fieldset. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as EditConferenceCard (client)
    participant tRPC as /api/trpc/conference.*
    participant Sanity as Sanity Write Client
    participant Cache as Next.js Cache

    UI->>UI: buildPayload() — null for cleared nullable fields
    UI->>tRPC: mutation.mutate(payload)
    tRPC->>tRPC: adminProcedure — requireAuth + requireAdmin
    tRPC->>tRPC: Zod schema validation (per fieldset)
    tRPC->>tRPC: resolveConferenceId() — domain-resolved, never from client
    tRPC->>tRPC: applyConferencePatch() — split payload into set/unset
    tRPC->>Sanity: "patch(id).set({...}).unset([...]).commit()"
    Sanity-->>tRPC: "{ _id, ... }"
    tRPC->>Cache: revalidateTag('content:conferences', 'default')
    tRPC->>Cache: "revalidateTag('sanity:conference-{id}', 'default')"
    tRPC-->>UI: "{ success: true, updated: {...} }"
    UI->>UI: utils.invalidate() + router.refresh()
    UI->>UI: showNotification('Settings updated')
    UI->>UI: setIsOpen(false)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as EditConferenceCard (client)
    participant tRPC as /api/trpc/conference.*
    participant Sanity as Sanity Write Client
    participant Cache as Next.js Cache

    UI->>UI: buildPayload() — null for cleared nullable fields
    UI->>tRPC: mutation.mutate(payload)
    tRPC->>tRPC: adminProcedure — requireAuth + requireAdmin
    tRPC->>tRPC: Zod schema validation (per fieldset)
    tRPC->>tRPC: resolveConferenceId() — domain-resolved, never from client
    tRPC->>tRPC: applyConferencePatch() — split payload into set/unset
    tRPC->>Sanity: "patch(id).set({...}).unset([...]).commit()"
    Sanity-->>tRPC: "{ _id, ... }"
    tRPC->>Cache: revalidateTag('content:conferences', 'default')
    tRPC->>Cache: "revalidateTag('sanity:conference-{id}', 'default')"
    tRPC-->>UI: "{ success: true, updated: {...} }"
    UI->>UI: utils.invalidate() + router.refresh()
    UI->>UI: showNotification('Settings updated')
    UI->>UI: setIsOpen(false)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(admin): editable conference setting..."](https://github.com/cloudnativebergen/website/commit/c76cd05a81a6da968190a70a8a171f14b7b36ed0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45483247)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->