### PR TITLE
fix(admin): city/country clear-to-unset parity

### DIFF
--- a/src/components/admin/EditConferenceCard.tsx
+++ b/src/components/admin/EditConferenceCard.tsx
@@ -72,8 +72,13 @@ export const FIELDSET_DEFS: Record<ConferenceFieldsetKey, FieldsetDef> = {
     fields: [
       { name: 'title', label: 'Title', type: 'text', required: true },
       { name: 'organizer', label: 'Organizer', type: 'text', required: true },
-      { name: 'city', label: 'City', type: 'text' },
-      { name: 'country', label: 'Country', type: 'text' },
+      { name: 'city', label: 'City', type: 'text', nullableWhenEmpty: true },
+      {
+        name: 'country',
+        label: 'Country',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
       {
         name: 'tagline',
         label: 'Tagline',

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -23,8 +23,8 @@ const dateString = z
 export const UpdateBasicInfoSchema = z.object({
   title: z.string().trim().min(1, 'Title is required'),
   organizer: z.string().trim().min(1, 'Organizer is required'),
-  city: z.string().trim().optional(),
-  country: z.string().trim().optional(),
+  city: z.string().trim().nullable().optional(),
+  country: z.string().trim().nullable().optional(),
   tagline: z.string().trim().nullable().optional(),
   description: z.string().trim().nullable().optional(),
 })


### PR DESCRIPTION
The matched #568 badge pair: city and country were the only optional text fields without nullableWhenEmpty on the client and .nullable() on the schema — clearing them sent an empty string instead of a null unset. Both sides aligned with their sibling fields (tagline/description/venue).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a parity gap where clearing the `city` or `country` fields in the admin UI sent an empty string to the server instead of `null` (an unset), unlike sibling optional fields (`tagline`, `description`, venue fields) which already had this behavior.

- **`EditConferenceCard.tsx`**: Adds `nullableWhenEmpty: true` to the `city` and `country` field definitions, so `buildPayload` emits `null` instead of `""` when those inputs are cleared.
- **`conference.ts`**: Adds `.nullable()` to the Zod schema for `city` and `country`, accepting `null` on the server side where only `undefined` was previously allowed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changed lines are mechanical, follow an established pattern, and are already exercised by the existing field machinery.

The two-line schema change and the two-line field-def change are a direct copy of the pattern every sibling optional field already uses. The client's buildPayload logic and the server's patch builder both already handle null correctly; this fix simply opts city and country into that path. No new logic was introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/EditConferenceCard.tsx | Adds nullableWhenEmpty: true to city and country field defs, aligning them with all other optional text fields in the same fieldset. |
| src/server/schemas/conference.ts | Adds .nullable() to city and country Zod validators, matching the pattern used by every other optional string field in the schema. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Form as EditConferenceCard (client)
    participant Schema as UpdateBasicInfoSchema (Zod)
    participant Router as conference.updateBasicInfo (tRPC)
    participant Sanity

    User->>Form: Clears "City" or "Country" input
    Note over Form: buildPayload(): nullableWhenEmpty=true<br/>→ payload.city = null
    Form->>Schema: "Validate { city: null, country: null, ... }"
    Note over Schema: z.string().trim().nullable().optional()<br/>→ null is accepted ✓
    Schema->>Router: Parsed input with null fields
    Note over Router: applyConferencePatch():<br/>null → .unset(['city'])<br/>undefined → untouched
    Router->>Sanity: Patch: unset(['city', 'country'])
    Sanity-->>Router: Updated document
    Router-->>Form: Success
    Form-->>User: Notification + router.refresh()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Form as EditConferenceCard (client)
    participant Schema as UpdateBasicInfoSchema (Zod)
    participant Router as conference.updateBasicInfo (tRPC)
    participant Sanity

    User->>Form: Clears "City" or "Country" input
    Note over Form: buildPayload(): nullableWhenEmpty=true<br/>→ payload.city = null
    Form->>Schema: "Validate { city: null, country: null, ... }"
    Note over Schema: z.string().trim().nullable().optional()<br/>→ null is accepted ✓
    Schema->>Router: Parsed input with null fields
    Note over Router: applyConferencePatch():<br/>null → .unset(['city'])<br/>undefined → untouched
    Router->>Sanity: Patch: unset(['city', 'country'])
    Sanity-->>Router: Updated document
    Router-->>Form: Success
    Form-->>User: Notification + router.refresh()
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): city/country clear-to-unset ..."](https://github.com/cloudnativebergen/website/commit/e9673c1fb365840b10c537e1620420a06d6f54d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45484305)</sub>

<!-- /greptile_comment -->