### PR TITLE
feat(messaging): sponsor threads — portal messages, unified inbox, fan-out (G2b)

### DIFF
--- a/docs/MESSAGING_SYSTEM.md
+++ b/docs/MESSAGING_SYSTEM.md
@@ -116,11 +116,12 @@ per-user. Messaging uses two of its types:
 
 ### Deterministic-id schemes
 
-| Id                                                    | Purpose                        | Race safety                                        |
-| ----------------------------------------------------- | ------------------------------ | -------------------------------------------------- |
-| `conversation.proposal.<proposalId>`                  | The single proposal thread     | `createIfNotExists` — concurrent starters converge |
-| `convpref.<conversationId>.<speakerId>`               | One preference per participant | doc-per-pair, no array RMW                         |
-| `notification.message.<conversationId>.<recipientId>` | The one collapsed hub item     | `createIfNotExists` + patch                        |
+| Id                                                    | Purpose                         | Race safety                                        |
+| ----------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
+| `conversation.proposal.<proposalId>`                  | The single proposal thread      | `createIfNotExists` — concurrent starters converge |
+| `conversation.sponsor.<sfcId>`                        | The single sponsor thread (G2b) | `createIfNotExists` — portal + organizer converge  |
+| `convpref.<conversationId>.<speakerId>`               | One preference per participant  | doc-per-pair, no array RMW                         |
+| `notification.message.<conversationId>.<recipientId>` | The one collapsed hub item      | `createIfNotExists` + patch                        |
 
 `conversation.<nanoid>` (general threads) and `message.<nanoid>` are random —
 there is nothing to converge on.
@@ -459,6 +460,72 @@ Multi-tenant isolation and no-oracle authorization are the two pillars.
   a speaker who messaged before the schema change can still be an erasure trap on
   those pre-existing strong refs. The 24-month purge is the documented retention
   window.
+
+## Sponsor threads (party model, G2b)
+
+A **third thread shape**, `conversationType: 'sponsor'`, extends the two speaker
+shapes with a **sponsor↔organizer** thread. It reuses the whole machinery
+(deterministic id, `participants[]` party model, hub/push/email/Slack fan-out,
+`ConversationThread`) with these sponsor-specific rules. **Maintainer-locked:**
+there is **one thread per `sponsorForConference`** as a UI guarantee — the model
+stays multi-thread-general, and the single thread is simply the only id a sponsor
+ever gets (`conversation.sponsor.<sfcId>`). No special-casing beyond deriving that
+id.
+
+- **Id scheme.** `conversation.sponsor.<sfcId>` (`sponsorConversationId` in
+  `links.ts`), created via `ensureSponsorConversation` with `createIfNotExists`, so
+  the portal-send and organizer-send paths converge on one document.
+- **Participants.** `[{ sponsor: <sfcId> }, { group: 'organizers' }]`, written
+  directly at creation (the sponsor party id is not expressible from the legacy
+  fields, so `participants[]` is authoritative — `deriveParties` returns only the
+  organizers group for a hypothetical participants-less sponsor doc).
+- **Author model.** ORGANIZER authors keep the legacy `author` speaker ref +
+  speaker `authorParty`. SPONSOR authors have **no speaker doc**: the message
+  carries `authorParty = { sponsor }` + an `authorName` **string snapshot** (the
+  contact person the portal sender picked) with `author` UNSET. The thread render
+  shows `authorName` + a "Sponsor" badge for these.
+- **Schema requiredness relaxations.** `conversation.createdBy` and
+  `message.author` were **required → optional** (documented in the schema files) —
+  a portal-initiated sponsor thread has no speaker creator, and a sponsor-authored
+  message has no speaker author. An **organizer-initiated** thread still records the
+  acting organizer as `createdBy` (the audit trail names a human when one exists).
+  `message.authorName` was **added**. `conversation.conversationType` gained
+  `'sponsor'`; `sponsorActivity.activityType` gained `'message'`.
+- **Authorization.** The sponsor side is authed **only** by the portal token
+  (`validateSponsorMessagingToken`, per-request GROQ on `registrationToken`) — never
+  a speaker/organizer session. A SPEAKER accesses a sponsor thread **iff** organizer
+  (the existing `canAccessConversation` short-circuit). Speaker-audience inbox
+  queries never return sponsor threads: `SPEAKER_SCOPE_PREDICATE` keys on
+  `createdBy`/`subjectSpeaker`/`proposal->speakers` (a sponsor thread has none) and
+  **also** carries an explicit `conversationType != "sponsor"` guard as
+  defence-in-depth. The organizer inbox has no type restriction, so it **includes**
+  sponsor threads (amber "Sponsor" chip, counterpart = sponsor company name).
+- **Portal API (public, token-authed, rate-limited).** `sponsorMessages.list
+{ token }` → validate → thread messages + contact-person names for the author
+  picker. `sponsorMessages.send { token, body, authorName }` → validate + rate limit
+  - body 1..5000 trimmed + `authorName` **STRICT-matched** to a contact person →
+    `ensureSponsorConversation` → `addMessage` (sponsor author) → fan-out. **No
+    conversation id is accepted from the client — the token IS the thread selector.**
+    Rate limits (module-Map, per-token, per-instance): validate **30/min**, send
+    **5/min**.
+
+### Sponsor fan-out matrix (`notifySponsorMessage`)
+
+A sibling of `notifyNewMessage` (integrated, not forked — reuses
+`upsertMessageNotifications`, bounded-concurrency email, `createSponsorActivity`).
+
+| Author        | Hub (+push)                                                                                   | Email                                                                                                                                 | Slack                                                                 | Activity                     |
+| ------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------- |
+| **Sponsor**   | ALL organizers, title `New message from <name> (Sponsor) — <subject>`, `/admin/messages/<id>` | — (no speaker/contact emails)                                                                                                         | **sales** channel (`sendSalesNotification`, "💬 New sponsor message") | `message` (system)           |
+| **Organizer** | the OTHER organizers (author excluded, mute-respected)                                        | ALL `contactPersons` via `sponsorEmail` from-address, deep-linked to the portal (`buildPortalUrl` + `#messages`), bounded concurrency | — (no Slack)                                                          | `message` (acting organizer) |
+
+**Preferences.** `conversationPreference` (mute/email) applies to the ORGANIZER
+participants exactly as for speaker threads. **Sponsors have no preference
+documents** (no speaker id to key one on) — they always receive the email.
+
+**Hub routing note.** Sponsor hub notifications currently route to **ALL
+organizers**. When the sponsors TEAM lands (**TEAMS-2**) this should route to that
+team instead of the whole organizer set (noted inline in `notify.ts`).
 
 ## Related documents
 

--- a/sanity/schemaTypes/conversation.ts
+++ b/sanity/schemaTypes/conversation.ts
@@ -35,6 +35,10 @@ export default defineType({
         list: [
           { title: 'Proposal', value: 'proposal' },
           { title: 'General', value: 'general' },
+          // A sponsor↔organizer thread (messaging party model, G2b). One per
+          // sponsorForConference; the sponsor side is a `sponsor` participant
+          // party (no speaker doc), authed by the portal token, never a session.
+          { title: 'Sponsor', value: 'sponsor' },
         ],
         layout: 'radio',
       },
@@ -67,8 +71,8 @@ export default defineType({
       // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion; a
       // dangling creator ref is tolerated.
       weak: true,
-      description: 'The speaker who started this conversation.',
-      validation: (Rule) => Rule.required(),
+      description:
+        'The speaker who started this conversation. OPTIONAL as of G2b: a sponsor thread has no speaker creator — an organizer-initiated sponsor thread records the acting organizer here, but a portal-initiated one (the sponsor sending the first message) leaves it unset. proposal/general threads still always carry it.',
     }),
     defineField({
       name: 'subjectSpeaker',

--- a/sanity/schemaTypes/message.ts
+++ b/sanity/schemaTypes/message.ts
@@ -27,8 +27,16 @@ export default defineType({
       // messages are immortal, so a dangling author ref is tolerated (it simply
       // no longer resolves to a speaker).
       weak: true,
-      description: 'The speaker (or organizer) who wrote this message.',
-      validation: (Rule) => Rule.required(),
+      description:
+        'The speaker (or organizer) who wrote this message. OPTIONAL as of G2b: a SPONSOR-authored message (portal side) has no speaker doc — it carries `authorParty = { sponsor }` plus an `authorName` snapshot instead, with this ref unset. Speaker/organizer authors still always set it.',
+    }),
+    defineField({
+      name: 'authorName',
+      title: 'Author Name (snapshot)',
+      type: 'string',
+      description:
+        'Display-name SNAPSHOT of the author, written for SPONSOR-authored messages where there is no `author` speaker doc to dereference (the contact person the portal sender picked). Unset for speaker/organizer authors — the thread derives their name from the `author` ref. Written by the server, not edited in Studio.',
+      readOnly: true,
     }),
     defineField({
       name: 'body',
@@ -57,15 +65,17 @@ export default defineType({
     select: {
       body: 'body',
       author: 'author.name',
+      authorName: 'authorName',
       createdAt: 'createdAt',
     },
-    prepare({ body, author, createdAt }) {
+    prepare({ body, author, authorName, createdAt }) {
       const when = createdAt
         ? new Date(createdAt).toLocaleString()
         : 'Unknown date'
       return {
         title: body ? String(body).slice(0, 80) : 'Message',
-        subtitle: `By ${author || 'Unknown'} · ${when}`,
+        // `authorName` snapshot covers sponsor authors (no `author` ref).
+        subtitle: `By ${author || authorName || 'Unknown'} · ${when}`,
       }
     },
   },

--- a/sanity/schemaTypes/sponsorActivity.ts
+++ b/sanity/schemaTypes/sponsorActivity.ts
@@ -26,6 +26,8 @@ export default defineType({
           { title: 'Email', value: 'email' },
           { title: 'Call', value: 'call' },
           { title: 'Meeting', value: 'meeting' },
+          // A sponsor↔organizer thread message was posted (messaging G2b).
+          { title: 'Message', value: 'message' },
         ],
         layout: 'dropdown',
       },

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -397,6 +397,12 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                           account-level default for whether new message
                           conversations also email you
                         </li>
+                        <li>
+                          • <strong>Sponsor messages:</strong> If you are a
+                          sponsor contact, the text you write in your sponsor
+                          portal thread with the organizers, along with the
+                          contact name you send it under and the timestamp
+                        </li>
                       </ul>
                       <div className="mt-3 rounded-lg bg-sky-100 p-2 dark:bg-sky-800/30">
                         <p className="text-xs text-sky-800 dark:text-sky-200">
@@ -404,8 +410,11 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                           thread are visible to that proposal&apos;s speakers
                           and all conference organizers; messages in a general
                           thread are visible to their author and all conference
-                          organizers. <strong>Purpose:</strong> Coordinating
-                          proposals and conference logistics.{' '}
+                          organizers; messages in a sponsor portal thread are
+                          visible to that sponsor&apos;s contacts (via the
+                          portal link) and all conference organizers.{' '}
+                          <strong>Purpose:</strong> Coordinating proposals,
+                          sponsorships and conference logistics.{' '}
                           <strong>Legal Basis:</strong> Legitimate interest in
                           conference coordination. Messages and conversations
                           are retained for 24 months after the conference ends,

--- a/src/components/admin/sponsor-crm/ManageCards.tsx
+++ b/src/components/admin/sponsor-crm/ManageCards.tsx
@@ -5,6 +5,7 @@ import {
   UserGroupIcon,
   PhotoIcon,
   ClockIcon,
+  ChatBubbleLeftRightIcon,
 } from '@heroicons/react/24/outline'
 import clsx from 'clsx'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
@@ -90,6 +91,14 @@ export function ManageCards({ sponsor, hasLogo, onOpen }: ManageCardsProps) {
       label: 'History',
       icon: ClockIcon,
       status: activityCount > 0 ? `${activityCount} events` : 'View activity',
+      dot: null,
+    },
+    {
+      // Sponsor↔organizer message thread (messaging G2b).
+      view: 'messages',
+      label: 'Messages',
+      icon: ChatBubbleLeftRightIcon,
+      status: 'Open thread',
       dot: null,
     },
   ]

--- a/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
@@ -31,8 +31,16 @@ import { SponsorContractView } from './SponsorContractView'
 import { SponsorPipelineView } from './SponsorPipelineView'
 import { SponsorTier } from '@/lib/sponsor/types'
 import { useSponsorCRMFormMutations } from '@/hooks/useSponsorCRMFormMutations'
+import { SponsorMessagesPanel } from './SponsorMessagesPanel'
 
-type FormView = 'pipeline' | 'contacts' | 'logo' | 'history' | 'contract'
+type FormView =
+  | 'pipeline'
+  | 'contacts'
+  | 'logo'
+  | 'history'
+  | 'contract'
+  // The sponsor↔organizer message thread (messaging G2b).
+  | 'messages'
 
 interface SponsorCRMFormProps {
   conferenceId: string
@@ -233,6 +241,7 @@ export function SponsorCRMForm({
     contacts: 'Contacts & billing',
     logo: 'Logo',
     history: 'History',
+    messages: 'Messages',
   }
 
   return (
@@ -370,6 +379,12 @@ export function SponsorCRMForm({
                             utils.sponsor.crm.list.invalidate()
                             utils.sponsor.crm.healthViolations.invalidate()
                           }}
+                        />
+                      ) : view === 'messages' && sponsor ? (
+                        // Sponsor↔organizer thread (messaging G2b): ensured on
+                        // open, then embedded for the organizer audience.
+                        <SponsorMessagesPanel
+                          sponsorForConferenceId={sponsor._id}
                         />
                       ) : (
                         <SponsorPipelineView

--- a/src/components/admin/sponsor-crm/SponsorMessagesPanel.tsx
+++ b/src/components/admin/sponsor-crm/SponsorMessagesPanel.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { api } from '@/lib/trpc/client'
+import { ConversationThread } from '@/components/messaging'
+import { sponsorConversationId } from '@/lib/messaging/links'
+
+/**
+ * The sponsor CRM "Messages" sub-view (messaging G2b): the sponsor↔organizer
+ * thread embedded by its deterministic id. On open it ENSURES the thread exists
+ * (organizer-initiated create with the acting organizer as `createdBy`) so the
+ * organizer can start the conversation before the sponsor has posted — then
+ * mounts {@link ConversationThread} for the organizer audience. The sponsor
+ * reads/answers the same thread through their portal.
+ */
+export function SponsorMessagesPanel({
+  sponsorForConferenceId,
+}: {
+  sponsorForConferenceId: string
+}) {
+  const conversationId = sponsorConversationId(sponsorForConferenceId)
+  const utils = api.useUtils()
+  const ensure = api.message.ensureSponsorThread.useMutation({
+    onSuccess: () => {
+      // The doc now exists — let the thread's queries pick it up.
+      utils.message.getConversation.invalidate({ id: conversationId })
+      utils.message.listMessages.invalidate({ conversationId })
+    },
+  })
+
+  // Ensure exactly once per mount.
+  const ensuredRef = useRef(false)
+  const ensureMutate = ensure.mutate
+  useEffect(() => {
+    if (ensuredRef.current) return
+    ensuredRef.current = true
+    ensureMutate({ sponsorForConferenceId })
+  }, [ensureMutate, sponsorForConferenceId])
+
+  return (
+    <div className="py-2">
+      <ConversationThread
+        conversationId={conversationId}
+        audience="organizer"
+      />
+    </div>
+  )
+}

--- a/src/components/admin/sponsor-crm/form/deal-status.ts
+++ b/src/components/admin/sponsor-crm/form/deal-status.ts
@@ -24,7 +24,13 @@ export interface DealStatusFormData {
 }
 
 /** Sub-views the header CTA / Manage cards can open (never the main pipeline). */
-export type SponsorSubView = 'contract' | 'contacts' | 'logo' | 'history'
+export type SponsorSubView =
+  | 'contract'
+  | 'contacts'
+  | 'logo'
+  | 'history'
+  // The sponsor↔organizer message thread (messaging G2b).
+  | 'messages'
 
 /**
  * Project the staged form + persisted sponsor into the shape the state-machine

--- a/src/components/admin/sponsor-crm/utils.ts
+++ b/src/components/admin/sponsor-crm/utils.ts
@@ -18,6 +18,7 @@ import {
   DocumentCheckIcon,
   PencilIcon,
   ChatBubbleLeftIcon,
+  ChatBubbleLeftRightIcon,
   PhoneIcon,
   CalendarIcon,
   FireIcon,
@@ -84,6 +85,8 @@ export function getActivityIcon(type: ActivityType) {
       return CheckCircleIcon
     case 'contract_reminder_sent':
       return BellAlertIcon
+    case 'message':
+      return ChatBubbleLeftRightIcon
   }
 }
 
@@ -111,6 +114,8 @@ export function getActivityColor(type: ActivityType): string {
       return 'text-emerald-600 bg-emerald-100 dark:text-emerald-400 dark:bg-emerald-900/20'
     case 'contract_reminder_sent':
       return 'text-amber-600 bg-amber-100 dark:text-amber-400 dark:bg-amber-900/20'
+    case 'message':
+      return 'text-sky-600 bg-sky-100 dark:text-sky-400 dark:bg-sky-900/20'
   }
 }
 

--- a/src/components/email/SponsorMessageNotificationTemplate.tsx
+++ b/src/components/email/SponsorMessageNotificationTemplate.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import { BaseEmailTemplate } from './BaseEmailTemplate'
+import {
+  EmailSection,
+  EmailSectionHeader,
+  EmailText,
+  EmailButton,
+} from './EmailComponents'
+
+export interface SponsorMessageNotificationTemplateProps {
+  /** The contact person this copy is addressed to. */
+  recipientName: string
+  /** The organizer who wrote the message. */
+  authorName: string
+  /** Thread subject (the sponsor company name). */
+  subject: string
+  /** Excerpt of the message body. */
+  excerpt: string
+  /** Absolute portal deep link (`…/sponsor/portal/<token>#messages`). */
+  portalUrl: string
+  eventName: string
+  eventLocation: string
+  eventDate: string
+  eventUrl: string
+  socialLinks?: string[]
+}
+
+/**
+ * Organizer→sponsor new-message email (messaging G2b). Sent to every contact
+ * person from the conference `sponsorEmail` from-address when an ORGANIZER posts
+ * into a sponsor thread; the reply link is the sponsor PORTAL (`#messages`), the
+ * sponsor's only messaging surface. Mirrors the compact
+ * `SponsorPortalInviteTemplate` styling for a consistent sponsor-email look.
+ */
+export function SponsorMessageNotificationTemplate({
+  recipientName,
+  authorName,
+  subject,
+  excerpt,
+  portalUrl,
+  eventName,
+  eventLocation,
+  eventDate,
+  eventUrl,
+  socialLinks = [],
+}: SponsorMessageNotificationTemplateProps) {
+  const textStyle: React.CSSProperties = {
+    fontSize: '16px',
+    lineHeight: '1.6',
+    marginBottom: '16px',
+    marginTop: '0',
+    color: '#334155',
+  }
+
+  return (
+    <BaseEmailTemplate
+      title={`New message about ${subject}`}
+      titleColor="#1D4ED8"
+      eventName={eventName}
+      eventLocation={eventLocation}
+      eventDate={eventDate}
+      eventUrl={eventUrl}
+      socialLinks={socialLinks}
+      customContent={{
+        heading: `New message from the ${eventName} organizers`,
+        body: (
+          <>
+            <p style={textStyle}>Hi {recipientName},</p>
+            <p style={textStyle}>
+              <strong>{authorName}</strong> sent your team a message about your
+              sponsorship of {eventName}.
+            </p>
+
+            <EmailSection backgroundColor="#F8FAFC" borderColor="#E5E7EB">
+              <EmailSectionHeader>Message</EmailSectionHeader>
+              <EmailText>{excerpt}</EmailText>
+            </EmailSection>
+
+            <p style={textStyle}>
+              Open your sponsor portal to read the full thread and reply.
+            </p>
+
+            <EmailButton href={portalUrl}>View &amp; reply</EmailButton>
+          </>
+        ),
+      }}
+    />
+  )
+}

--- a/src/components/messaging/ConversationList.stories.tsx
+++ b/src/components/messaging/ConversationList.stories.tsx
@@ -446,3 +446,42 @@ export const SpeakerEmptyPitchDark: Story = {
   },
   parameters: { dark: true },
 }
+
+/**
+ * SPONSOR THREADS in the organizer inbox (messaging G2b): a sponsor row carries
+ * an amber "Sponsor" chip (mirroring the Proposal chip) and its counterpart is
+ * the sponsor company name (initials avatar — sponsor logos are inline SVG, not
+ * a URL). Shown alongside a proposal and a general row so the chip reads
+ * distinctly.
+ */
+const makeSponsorItems = (): ConversationListItem[] => [
+  {
+    _id: 'conversation.sponsor.sfc-1',
+    conversationType: 'sponsor',
+    subject: 'Acme Corp',
+    createdAt: minutesAgo(60 * 24 * 2),
+    lastMessageAt: minutesAgo(15),
+    unreadCount: 2,
+    lastMessage: {
+      authorId: '',
+      authorName: 'Dana Diaz',
+      excerpt: 'Could you confirm the booth dimensions for our stand?',
+    },
+    counterpart: { name: 'Acme Corp' },
+    status: 'open',
+    needsReply: true,
+    archived: false,
+  },
+  ...makeOrganizerItems().slice(0, 2),
+]
+
+export const SponsorThreadRow: Story = {
+  args: { items: [], isOrganizer: true, view: 'active' },
+  render: (args) => <ConversationList {...args} items={makeSponsorItems()} />,
+}
+
+export const SponsorThreadRowDark: Story = {
+  args: { items: [], isOrganizer: true, view: 'active' },
+  parameters: { dark: true },
+  render: (args) => <ConversationList {...args} items={makeSponsorItems()} />,
+}

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -353,6 +353,14 @@ export function ConversationList({
                           Proposal
                         </span>
                       )}
+                      {/* SPONSOR thread chip (G2b) — mirrors the Proposal chip,
+                          amber to match the sponsor bubble/badge. The counterpart
+                          is the sponsor company name (server-resolved). */}
+                      {item.conversationType === 'sponsor' && (
+                        <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
+                          Sponsor
+                        </span>
+                      )}
                       {isResolved && (
                         <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
                           {isOrganizer ? 'Resolved' : 'Closed by organizers'}

--- a/src/components/messaging/ConversationThread.stories.tsx
+++ b/src/components/messaging/ConversationThread.stories.tsx
@@ -497,3 +497,53 @@ export const MutedEmailsDisabled: Story = {
     <ConversationThreadView {...args} messages={makeMessages()} />
   ),
 }
+
+/**
+ * SPONSOR THREAD (messaging G2b), organizer viewpoint: sponsor-authored messages
+ * render the contact person's snapshot name with an amber "Sponsor" badge (no
+ * speaker doc / avatar); the organizer's own replies are right-aligned. The
+ * subject is the sponsor company name.
+ */
+const makeSponsorMessages = (): DisplayMessage[] => [
+  {
+    id: 's1',
+    authorName: 'Dana Diaz',
+    isOrganizer: false,
+    isSponsor: true,
+    isOwn: false,
+    body: 'Hi! Could you confirm the booth dimensions and power supply for our stand?',
+    createdAt: minutesAgo(200),
+  },
+  {
+    id: 's2',
+    authorName: 'Ola Organizer',
+    isOrganizer: true,
+    isOwn: true,
+    body: 'Of course — the standard booth is 3×2m with two power sockets. I will email the full spec sheet today.',
+    createdAt: minutesAgo(90),
+  },
+  {
+    id: 's3',
+    authorName: 'Dana Diaz',
+    isOrganizer: false,
+    isSponsor: true,
+    isOwn: false,
+    body: 'Perfect, thank you!',
+    createdAt: minutesAgo(20),
+  },
+]
+
+export const SponsorThread: Story = {
+  args: { messages: [], subject: 'Acme Corp', preference: defaultPreference },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeSponsorMessages()} />
+  ),
+}
+
+export const SponsorThreadDark: Story = {
+  args: { messages: [], subject: 'Acme Corp', preference: defaultPreference },
+  parameters: { dark: true },
+  render: (args) => (
+    <ConversationThreadView {...args} messages={makeSponsorMessages()} />
+  ),
+}

--- a/src/components/messaging/ConversationThread.tsx
+++ b/src/components/messaging/ConversationThread.tsx
@@ -47,6 +47,12 @@ export interface DisplayMessage {
   authorName: string
   authorImage?: string
   isOrganizer: boolean
+  /**
+   * True when the message was authored from the SPONSOR portal (G2b). It has no
+   * speaker doc — the name is the `authorName` snapshot — and renders a
+   * "(Sponsor)" badge instead of the organizer badge.
+   */
+  isSponsor?: boolean
   /** True when the current viewer authored the message (right-aligned accent). */
   isOwn: boolean
   body: string
@@ -177,10 +183,16 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
           <span className="text-xs font-semibold text-gray-700 dark:text-gray-200">
             {message.authorName}
           </span>
-          {message.isOrganizer && (
-            <span className="rounded-full bg-brand-cloud-blue/10 px-1.5 py-0.5 text-[10px] font-medium text-brand-cloud-blue dark:bg-blue-400/10 dark:text-blue-300">
-              Organizer
+          {message.isSponsor ? (
+            <span className="rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-400/10 dark:text-amber-300">
+              Sponsor
             </span>
+          ) : (
+            message.isOrganizer && (
+              <span className="rounded-full bg-brand-cloud-blue/10 px-1.5 py-0.5 text-[10px] font-medium text-brand-cloud-blue dark:bg-blue-400/10 dark:text-blue-300">
+                Organizer
+              </span>
+            )
           )}
           <span className="text-xs text-gray-400 dark:text-gray-500">
             {formatRelativeTime(message.createdAt)}
@@ -1055,6 +1067,20 @@ export function ConversationThread({
     // oldest-first (chat convention, newest at the bottom).
     const flat = pages?.flat() ?? []
     return [...flat].reverse().map((msg) => {
+      // SPONSOR-authored (G2b): no speaker doc / participant — render the
+      // snapshot name and a "(Sponsor)" badge. Never "own" (the viewer here is
+      // always an organizer/speaker session, never the token-authed sponsor).
+      if (msg.authorSponsorId) {
+        return {
+          id: msg._id,
+          authorName: msg.authorName ?? 'Sponsor',
+          isOrganizer: false,
+          isSponsor: true,
+          isOwn: false,
+          body: msg.body,
+          createdAt: msg.createdAt,
+        }
+      }
       const p = participantById.get(msg.authorId)
       return {
         id: msg._id,

--- a/src/components/sponsor/SponsorPortal.tsx
+++ b/src/components/sponsor/SponsorPortal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { SponsorContactRoleSelect } from '@/components/admin/sponsor/SponsorContactRoleSelect'
 import { SponsorRegistrationLogoUpload } from '@/components/sponsor/SponsorRegistrationLogoUpload'
+import { SponsorPortalMessages } from '@/components/sponsor/SponsorPortalMessages'
 import { formatNumber } from '@/lib/format'
 import { nanoid } from 'nanoid'
 
@@ -157,6 +158,7 @@ export function SponsorPortal({ token }: { token: string }) {
   if (submitted || sponsor?.registrationComplete) {
     return (
       <PortalStatusDashboard
+        token={token}
         sponsorName={sponsor?.sponsorName}
         conferenceName={sponsor?.conferenceName}
         tierTitle={sponsor?.tierTitle}
@@ -651,11 +653,29 @@ export function SponsorPortal({ token }: { token: string }) {
           </div>
         </div>
       </form>
+
+      {/* Messages: a collapsed-by-default disclosure below the form so it doesn't
+          distract from the primary registration task (messaging G2b). */}
+      <details
+        id="messages"
+        className="mt-8 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+      >
+        <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-900 select-none dark:text-white">
+          Message the organizers
+        </summary>
+        <div className="border-t border-gray-200 p-4 dark:border-gray-700">
+          <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+            Have a question before you finish? Send the organizers a message.
+          </p>
+          <SponsorPortalMessages token={token} />
+        </div>
+      </details>
     </div>
   )
 }
 
 function PortalStatusDashboard({
+  token,
   sponsorName,
   conferenceName,
   tierTitle,
@@ -667,6 +687,7 @@ function PortalStatusDashboard({
   contractValue,
   contractCurrency,
 }: {
+  token: string
   sponsorName?: string
   conferenceName?: string
   tierTitle?: string | null
@@ -791,6 +812,20 @@ function PortalStatusDashboard({
           </div>
         </div>
       )}
+
+      {/* Messages: a proper card in the status dashboard (messaging G2b). */}
+      <section
+        id="messages"
+        className="rounded-lg border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+      >
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Messages
+        </h2>
+        <p className="mt-1 mb-4 text-sm text-gray-600 dark:text-gray-400">
+          Questions about your sponsorship? Message the organizers here.
+        </p>
+        <SponsorPortalMessages token={token} />
+      </section>
     </div>
   )
 }

--- a/src/components/sponsor/SponsorPortalMessages.stories.tsx
+++ b/src/components/sponsor/SponsorPortalMessages.stories.tsx
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse, delay } from 'msw'
+import { SponsorPortalMessages } from './SponsorPortalMessages'
+
+/**
+ * The sponsor-side message thread on the portal (messaging G2b). Token-authed via
+ * the public `sponsorMessages` router. These stories mock that router with MSW.
+ */
+const meta = {
+  title: 'Systems/Sponsors/Portal/SponsorPortalMessages',
+  component: SponsorPortalMessages,
+  parameters: { layout: 'padded' },
+  decorators: [
+    // Apply `.dark` at the outermost node (via `parameters.dark`) so every
+    // `dark:` variant inside activates for the dark capture.
+    (Story, ctx) => (
+      <div className={ctx.parameters.dark ? 'dark bg-gray-950 p-4' : ''}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SponsorPortalMessages>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function trpcResponse(data: unknown) {
+  return { result: { data } }
+}
+
+// Server returns newest-first (the component reverses for display).
+const thread = {
+  sponsorName: 'Acme Corp',
+  subject: 'Acme Corp',
+  contactNames: ['Dana Diaz', 'Sam Stone'],
+  messages: [
+    {
+      _id: 'm3',
+      body: 'Perfect, thank you! We will send the artwork by Friday.',
+      createdAt: '2026-07-01T12:00:00Z',
+      authorName: 'Dana Diaz',
+      fromSponsor: true,
+    },
+    {
+      _id: 'm2',
+      body: 'The standard booth is 3×2m with two power sockets — full spec sheet on its way to your inbox.',
+      createdAt: '2026-07-01T11:00:00Z',
+      authorName: null,
+      fromSponsor: false,
+    },
+    {
+      _id: 'm1',
+      body: 'Hi! Could you confirm the booth dimensions and power supply for our stand?',
+      createdAt: '2026-07-01T10:00:00Z',
+      authorName: 'Dana Diaz',
+      fromSponsor: true,
+    },
+  ],
+}
+
+const handlers = [
+  http.get('/api/trpc/sponsorMessages.list', () =>
+    HttpResponse.json(trpcResponse(thread)),
+  ),
+  http.post('/api/trpc/sponsorMessages.send', async () => {
+    await delay(500)
+    return HttpResponse.json(
+      trpcResponse({
+        message: {
+          _id: 'm4',
+          body: 'Sent!',
+          createdAt: '2026-07-01T13:00:00Z',
+          authorName: 'Dana Diaz',
+          fromSponsor: true,
+        },
+      }),
+    )
+  }),
+]
+
+const empty = { ...thread, messages: [] }
+
+/** Card variant (as rendered on the portal STATUS DASHBOARD). */
+export const DashboardCard: Story = {
+  args: { token: 'valid' },
+  parameters: { msw: { handlers } },
+  render: (args) => (
+    <div className="mx-auto max-w-3xl">
+      <section className="rounded-lg border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Messages
+        </h2>
+        <p className="mt-1 mb-4 text-sm text-gray-600 dark:text-gray-400">
+          Questions about your sponsorship? Message the organizers here.
+        </p>
+        <SponsorPortalMessages {...args} />
+      </section>
+    </div>
+  ),
+}
+
+export const DashboardCardDark: Story = {
+  ...DashboardCard,
+  parameters: { msw: { handlers }, dark: true },
+}
+
+/** Disclosure variant (as rendered below the registration FORM). */
+export const FormDisclosure: Story = {
+  args: { token: 'valid' },
+  parameters: { msw: { handlers } },
+  render: (args) => (
+    <div className="mx-auto max-w-3xl">
+      <details
+        open
+        className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+      >
+        <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-900 select-none dark:text-white">
+          Message the organizers
+        </summary>
+        <div className="border-t border-gray-200 p-4 dark:border-gray-700">
+          <SponsorPortalMessages {...args} />
+        </div>
+      </details>
+    </div>
+  ),
+}
+
+/** Empty thread (no messages posted yet). */
+export const EmptyThread: Story = {
+  args: { token: 'valid' },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/trpc/sponsorMessages.list', () =>
+          HttpResponse.json(trpcResponse(empty)),
+        ),
+      ],
+    },
+  },
+  render: (args) => (
+    <div className="mx-auto max-w-3xl">
+      <SponsorPortalMessages {...args} />
+    </div>
+  ),
+}

--- a/src/components/sponsor/SponsorPortalMessages.tsx
+++ b/src/components/sponsor/SponsorPortalMessages.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { PaperAirplaneIcon } from '@heroicons/react/24/outline'
+import { api } from '@/lib/trpc/client'
+
+/** The maximum message body length (mirrors SponsorMessagesSendSchema). */
+const MAX_BODY = 5000
+
+/**
+ * The sponsor-side message thread on the portal (messaging G2b). Token-authed
+ * (no session): reads/sends via the public `sponsorMessages` router, which
+ * derives the thread from the token — no conversation id ever leaves the client.
+ *
+ * Renders a read-only thread + a composer with an author-name picker sourced
+ * from the sponsor's contact persons (the server STRICTLY validates the chosen
+ * name). Plain, mobile-first styling consistent with the rest of the portal; no
+ * ModalShell (an inline section). Polls lightly (20s) while the tab is visible
+ * and the composer is idle. Anchored `#messages` by the parent.
+ */
+export function SponsorPortalMessages({ token }: { token: string }) {
+  const [isComposing, setIsComposing] = useState(false)
+  const listQuery = api.sponsorMessages.list.useQuery(
+    { token },
+    {
+      // Poll only while visible AND not typing, so a refetch never yanks the
+      // composer out from under the sender.
+      refetchInterval: () =>
+        !isComposing &&
+        (typeof document === 'undefined' ||
+          document.visibilityState === 'visible')
+          ? 20_000
+          : false,
+      staleTime: 10_000,
+    },
+  )
+
+  const contactNames = useMemo(
+    () => listQuery.data?.contactNames ?? [],
+    [listQuery.data?.contactNames],
+  )
+  const [authorName, setAuthorName] = useState('')
+  const [draft, setDraft] = useState('')
+
+  // Default the author to the first contact once names load.
+  useEffect(() => {
+    if (!authorName && contactNames.length > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setAuthorName(contactNames[0])
+    }
+  }, [contactNames, authorName])
+
+  const utils = api.useUtils()
+  const sendMutation = api.sponsorMessages.send.useMutation({
+    onSuccess: () => {
+      setDraft('')
+      utils.sponsorMessages.list.invalidate({ token })
+    },
+  })
+
+  // Oldest-first for display (the server returns newest-first).
+  const messages = useMemo(
+    () => [...(listQuery.data?.messages ?? [])].reverse(),
+    [listQuery.data?.messages],
+  )
+
+  const scrollRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [messages.length])
+
+  const canSend =
+    draft.trim().length > 0 && authorName.length > 0 && !sendMutation.isPending
+
+  const submit = () => {
+    if (!canSend) return
+    sendMutation.mutate({ token, body: draft.trim(), authorName })
+  }
+
+  return (
+    <div>
+      {sendMutation.isError && (
+        <div
+          role="alert"
+          className="mb-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300"
+        >
+          {sendMutation.error?.message ??
+            'Could not send your message. Please try again.'}
+        </div>
+      )}
+
+      <div
+        ref={scrollRef}
+        className="max-h-96 space-y-3 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/60"
+      >
+        {listQuery.isLoading ? (
+          <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+            Loading messages&hellip;
+          </p>
+        ) : messages.length === 0 ? (
+          <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+            No messages yet. Send a message to the organizers below.
+          </p>
+        ) : (
+          messages.map((m) => (
+            <div
+              key={m._id}
+              className={
+                m.fromSponsor ? 'flex justify-end' : 'flex justify-start'
+              }
+            >
+              <div className="max-w-[85%]">
+                <p
+                  className={`text-xs font-semibold text-gray-600 dark:text-gray-300 ${
+                    m.fromSponsor ? 'text-right' : 'text-left'
+                  }`}
+                >
+                  {m.fromSponsor ? m.authorName || 'You' : 'Organizers'}
+                </p>
+                <div
+                  className={`mt-1 rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap ${
+                    m.fromSponsor
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white text-gray-900 ring-1 ring-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:ring-gray-600'
+                  }`}
+                >
+                  {m.body}
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {contactNames.length > 1 && (
+          <div>
+            <label className="block text-xs font-medium text-gray-600 dark:text-gray-300">
+              Sending as
+            </label>
+            <select
+              value={authorName}
+              onChange={(e) => setAuthorName(e.target.value)}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            >
+              {contactNames.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        <label htmlFor="sponsor-message-composer" className="sr-only">
+          Write a message
+        </label>
+        <textarea
+          id="sponsor-message-composer"
+          value={draft}
+          maxLength={MAX_BODY}
+          rows={3}
+          onChange={(e) => setDraft(e.target.value)}
+          onFocus={() => setIsComposing(true)}
+          onBlur={() => setIsComposing(false)}
+          placeholder="Write a message to the organizers…"
+          className="block w-full resize-y rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            {draft.length}/{MAX_BODY}
+          </span>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!canSend}
+            className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50"
+          >
+            <PaperAirplaneIcon className="h-4 w-4" aria-hidden="true" />
+            {sendMutation.isPending ? 'Sending…' : 'Send'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/messaging/links.ts
+++ b/src/lib/messaging/links.ts
@@ -25,6 +25,20 @@ export function proposalConversationId(proposalId: string): string {
 }
 
 /**
+ * Deterministic id for the SINGLE sponsor↔organizer conversation attached to a
+ * `sponsorForConference` (messaging G2b). EXTENDS the id scheme alongside
+ * {@link proposalConversationId} (`conversation.proposal.<proposalId>`): a
+ * sponsor thread is `conversation.sponsor.<sfcId>`, created via
+ * `createIfNotExists` so the portal-send and organizer-send paths converge on
+ * one document (the maintainer-locked "one thread per sponsorForConference" UI).
+ * The model stays multi-thread-general — this is the only id a sponsor thread
+ * ever gets, so there is no special-casing beyond deriving THIS id.
+ */
+export function sponsorConversationId(sfcId: string): string {
+  return `conversation.sponsor.${sfcId}`
+}
+
+/**
  * The longest prefix of `text` that is at most `max` UTF-16 code units long AND
  * ends on a grapheme-cluster boundary, so truncation never splits a multi-code-
  * unit cluster (emoji, flags, combined sequences) into a lone surrogate — which
@@ -68,6 +82,11 @@ export function truncateToGraphemeBoundary(text: string, max: number): string {
  * - proposal + speaker   → `/cfp/proposal/<proposalId>#messages`
  * - general  + organizer → `/admin/messages/<conversationId>`
  * - general  + speaker   → `/cfp/messages/<conversationId>`
+ * - sponsor  + (either)  → `/admin/messages/<conversationId>` — a sponsor thread
+ *   has NO speaker/CFP surface (the sponsor side is token-authed via the portal,
+ *   never a session), so BOTH audience variants point at the admin thread. The
+ *   only in-app consumer is the organizer hub/inbox; the sponsor reaches the
+ *   thread through the portal, not this path (G2b).
  */
 export function conversationLinkPath(
   conversation: Pick<
@@ -80,6 +99,10 @@ export function conversationLinkPath(
     return isOrganizer
       ? `/admin/proposals/${conversation.proposalId}#messages`
       : `/cfp/proposal/${conversation.proposalId}#messages`
+  }
+  // Sponsor threads are organizer-surface only (no speaker/CFP route).
+  if (conversation.conversationType === 'sponsor') {
+    return `/admin/messages/${conversation._id}`
   }
   return isOrganizer
     ? `/admin/messages/${conversation._id}`

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -4,7 +4,10 @@ import {
   getOrganizerSpeakerIds,
 } from '@/lib/notification/sanity'
 import { clientReadUncached } from '@/lib/sanity/client'
-import { notifyNewSpeakerMessage } from '@/lib/slack/notify'
+import {
+  notifyNewSpeakerMessage,
+  notifySponsorMessage as notifySponsorMessageSlack,
+} from '@/lib/slack/notify'
 import type { MessageNotificationInput } from '@/lib/notification/types'
 import type { Conference } from '@/lib/conference/types'
 import {
@@ -18,6 +21,10 @@ import {
   ORGANIZERS_LABEL,
 } from './links'
 import { sendMessageEmails, type MessageEmailRecipient } from './email'
+import { sendSponsorMessageEmails } from './sponsorEmail'
+import { createSponsorActivity } from '@/lib/sponsor-crm/activity'
+import { buildPortalUrl } from '@/lib/sponsor-crm/registration'
+import type { SponsorFanoutContext } from './sponsor'
 import type { ConversationWithContext, Message } from './types'
 
 /** How many characters of the message body ride into the notification/email. */
@@ -242,5 +249,161 @@ export async function notifyNewMessage({
     }
   } catch (error) {
     console.error('Failed to fan out new-message notifications:', error)
+  }
+}
+
+/**
+ * Fan a new SPONSOR-thread message out (messaging G2b). A sibling of
+ * {@link notifyNewMessage} — the sponsor thread's channel matrix differs enough
+ * (no speaker emails, sponsor-side emails via `sponsorEmail`, Slack on the SALES
+ * channel, a sponsorActivity row) that it is its own orchestrator rather than a
+ * branch inside the speaker fan-out — but it REUSES the same primitives
+ * (`upsertMessageNotifications`, bounded-concurrency email, `createSponsorActivity`).
+ *
+ * Direction is decided by `authorOrganizerId`:
+ *
+ * SPONSOR-authored (`authorOrganizerId` undefined):
+ * - HUB (+push): one collapsed `message_received` per organizer, title
+ *   "New message from <authorName> (Sponsor) — <subject>", admin deep link.
+ * - SLACK: the SALES channel ("💬 New sponsor message").
+ * - sponsorActivity: a `message` row (system-authored).
+ * - NO speaker emails, NO contact emails.
+ *
+ * ORGANIZER-authored (`authorOrganizerId` set):
+ * - EMAIL: every contact person, from the conference `sponsorEmail`, deep-linked
+ *   to the sponsor PORTAL (`#messages`) — the sponsor's only messaging surface.
+ * - HUB (+push): the OTHER organizers (the author is excluded, mirroring the
+ *   actor-exclusion of the speaker fan-out).
+ * - sponsorActivity: a `message` row attributed to the acting organizer.
+ * - NO Slack.
+ *
+ * PREFERENCES: `conversationPreference` (mute / email override) applies to the
+ * ORGANIZER participants exactly as in {@link notifyNewMessage}. SPONSORS have no
+ * preference documents (no speaker id to key one on) — they always receive the
+ * email; documented here as the deliberate asymmetry.
+ *
+ * HUB-ROUTING NOTE: organizer hub notifications currently go to ALL organizers.
+ * When the sponsors TEAM lands (TEAMS-2) this fan-out should route to that team
+ * instead of the whole organizer set — see the recipient resolution below.
+ *
+ * NEVER-FAIL: every channel is wrapped so a failure can't fail the (already
+ * committed) message write, identical to {@link notifyNewMessage}.
+ */
+export async function notifySponsorMessage({
+  conversation,
+  message,
+  sfc,
+  authorOrganizerId,
+}: {
+  conversation: ConversationWithContext
+  message: Message
+  sfc: SponsorFanoutContext
+  /** The acting organizer id for an ORG-authored message; undefined ⇒ sponsor. */
+  authorOrganizerId?: string
+}): Promise<void> {
+  try {
+    const conference = sfc.conference
+    if (!conference) return
+    const excerpt = messageExcerpt(message.body)
+    const subject = conversation.subject
+    const adminLink = conversationLinkPath(conversation, true)
+
+    // TEAMS-2: replace `getOrganizerSpeakerIds()` with the sponsors-team members.
+    const organizerIds = await getOrganizerSpeakerIds()
+
+    if (authorOrganizerId === undefined) {
+      // ---- SPONSOR-authored ------------------------------------------------
+      const authorName = message.authorName ?? sfc.sponsorName
+      // HUB (+push) to ALL organizers. Sponsor authors have no speaker id, so
+      // there is no actor to exclude and no `actorId` on the input. The
+      // "(Sponsor)" suffix on the author name yields the required title
+      // "New message from <authorName> (Sponsor) — <subject>".
+      const items: MessageNotificationInput[] = organizerIds.map((id) => ({
+        recipientId: id,
+        conversationId: conversation._id,
+        conferenceId: conversation.conferenceId,
+        authorName: `${authorName} (Sponsor)`,
+        subject,
+        message: excerpt,
+        link: adminLink,
+      }))
+      await upsertMessageNotifications(items)
+
+      // SLACK: sales channel.
+      await notifySponsorMessageSlack(
+        {
+          authorName,
+          sponsorName: sfc.sponsorName,
+          excerpt,
+          adminPath: adminLink,
+        },
+        conference,
+      )
+
+      // sponsorActivity: a `message` row (system-authored — no organizer acted).
+      await createSponsorActivity(
+        sfc.sfcId,
+        'message',
+        `Sponsor message from ${authorName}: ${excerpt}`,
+        'system',
+      )
+      return
+    }
+
+    // ---- ORGANIZER-authored ------------------------------------------------
+    // Resolve the acting organizer's display name for the hub title + activity.
+    const authorRow = await clientReadUncached.fetch<{ name?: string } | null>(
+      `*[_type == "speaker" && _id == $id][0]{ name }`,
+      { id: authorOrganizerId },
+      { cache: 'no-store' },
+    )
+    const authorName = authorRow?.name ?? 'Organizer'
+
+    // EMAIL every contact person from the `sponsorEmail` from-address, linking to
+    // the sponsor portal (`#messages`). Sponsors have no preferences → all get it.
+    if (sfc.contactPersons.length > 0 && sfc.registrationToken) {
+      const domain = conference.domains?.[0]
+      const portalUrl = domain
+        ? `${buildPortalUrl(`https://${domain}`, sfc.registrationToken)}#messages`
+        : `${buildPortalUrl('', sfc.registrationToken)}#messages`
+      await sendSponsorMessageEmails(
+        sfc.contactPersons.map((c) => ({ email: c.email, name: c.name })),
+        { authorName, subject, excerpt, portalUrl, conference },
+      )
+    }
+
+    // HUB (+push) to the OTHER organizers (exclude the author — actor exclusion),
+    // respecting each recipient's mute preference.
+    const otherOrganizerIds = organizerIds.filter(
+      (id) => id !== authorOrganizerId,
+    )
+    if (otherOrganizerIds.length > 0) {
+      const prefs = await getConversationPreferencesFor(
+        conversation._id,
+        otherOrganizerIds,
+      )
+      const active = otherOrganizerIds.filter((id) => !prefs.get(id)?.muted)
+      const items: MessageNotificationInput[] = active.map((id) => ({
+        recipientId: id,
+        conversationId: conversation._id,
+        conferenceId: conversation.conferenceId,
+        authorName,
+        subject,
+        message: excerpt,
+        link: adminLink,
+        actorId: authorOrganizerId,
+      }))
+      await upsertMessageNotifications(items)
+    }
+
+    // sponsorActivity attributed to the acting organizer.
+    await createSponsorActivity(
+      sfc.sfcId,
+      'message',
+      `Reply from ${authorName}: ${excerpt}`,
+      authorOrganizerId,
+    )
+  } catch (error) {
+    console.error('Failed to fan out sponsor-message notifications:', error)
   }
 }

--- a/src/lib/messaging/notifySponsor.test.ts
+++ b/src/lib/messaging/notifySponsor.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Mocks (channel boundaries) --------------------------------------------
+
+const upsertMock = vi.fn().mockResolvedValue(undefined)
+const getOrganizerSpeakerIdsMock = vi.fn().mockResolvedValue(['org-1', 'org-2'])
+vi.mock('@/lib/notification/sanity', () => ({
+  upsertMessageNotifications: (...a: unknown[]) => upsertMock(...a),
+  getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
+}))
+
+const slackMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/slack/notify', () => ({
+  notifyNewSpeakerMessage: vi.fn(),
+  notifySponsorMessage: (...a: unknown[]) => slackMock(...a),
+}))
+
+const activityMock = vi.fn().mockResolvedValue({ activityId: 'act-1' })
+vi.mock('@/lib/sponsor-crm/activity', () => ({
+  createSponsorActivity: (...a: unknown[]) => activityMock(...a),
+}))
+
+const sponsorEmailMock = vi.fn().mockResolvedValue(2)
+vi.mock('./sponsorEmail', () => ({
+  sendSponsorMessageEmails: (...a: unknown[]) => sponsorEmailMock(...a),
+}))
+
+// Fetch routing: author-name lookup + (empty) preference lookup.
+const fetchMock = vi.fn((query: string) => {
+  if (query.includes('conversationPreference')) return Promise.resolve([])
+  if (query.includes('_type == "speaker"')) {
+    return Promise.resolve({ name: 'Olga Organizer' })
+  }
+  return Promise.resolve(null)
+})
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(a[0] as string) },
+  clientWrite: {},
+}))
+
+import { notifySponsorMessage } from './notify'
+import { sponsorConversationId } from './links'
+import type { ConversationWithContext, Message } from './types'
+import type { SponsorFanoutContext } from './sponsor'
+import type { Conference } from '@/lib/conference/types'
+
+const SFC = 'sfc-42'
+
+const conference = {
+  _id: 'conf-1',
+  title: 'CloudNativeDay',
+  organizer: 'CNB',
+  sponsorEmail: 'sponsors@example.com',
+  cfpEmail: 'cfp@example.com',
+  city: 'Bergen',
+  country: 'Norway',
+  domains: ['cnd.example'],
+  socialLinks: [],
+} as unknown as Conference
+
+const sfc: SponsorFanoutContext = {
+  sfcId: SFC,
+  sponsorName: 'Acme Corp',
+  registrationToken: 'tok-123',
+  contactPersons: [
+    { name: 'Dana Diaz', email: 'dana@acme.test' },
+    { name: 'Sam Stone', email: 'sam@acme.test' },
+  ],
+  conference,
+}
+
+const conversation: ConversationWithContext = {
+  _id: sponsorConversationId(SFC),
+  conferenceId: 'conf-1',
+  conversationType: 'sponsor',
+  proposalSpeakerIds: [],
+  createdById: '',
+  subject: 'Acme Corp',
+  createdAt: '2026-07-01T00:00:00Z',
+  lastMessageAt: '2026-07-01T00:00:00Z',
+  participants: [
+    { partyType: 'sponsor', sponsorForConferenceId: SFC },
+    { partyType: 'group', group: 'organizers' },
+  ],
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('notifySponsorMessage — SPONSOR-authored', () => {
+  const message: Message = {
+    _id: 'message.1',
+    conversationId: conversation._id,
+    authorId: '',
+    body: 'Hi organizers, a question about our booth.',
+    createdAt: '2026-07-01T10:00:00Z',
+    authorName: 'Dana Diaz',
+    authorSponsorId: SFC,
+  }
+
+  it('hubs ALL organizers with a "(Sponsor)" title, Slacks sales, logs activity, sends NO emails', async () => {
+    await notifySponsorMessage({ conversation, message, sfc })
+
+    // HUB to both organizers, with the "(Sponsor)" author suffix + admin link.
+    expect(upsertMock).toHaveBeenCalledOnce()
+    const items = upsertMock.mock.calls[0][0] as {
+      recipientId: string
+      authorName: string
+      link: string
+    }[]
+    expect(items.map((i) => i.recipientId).sort()).toEqual(['org-1', 'org-2'])
+    expect(items[0].authorName).toBe('Dana Diaz (Sponsor)')
+    expect(items[0].link).toBe(`/admin/messages/${conversation._id}`)
+
+    // SLACK on the sales channel.
+    expect(slackMock).toHaveBeenCalledOnce()
+
+    // ACTIVITY: a system-authored `message` row.
+    expect(activityMock).toHaveBeenCalledOnce()
+    expect(activityMock.mock.calls[0][0]).toBe(SFC)
+    expect(activityMock.mock.calls[0][1]).toBe('message')
+    expect(activityMock.mock.calls[0][3]).toBe('system')
+
+    // NO sponsor emails on a sponsor-authored message.
+    expect(sponsorEmailMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('notifySponsorMessage — ORGANIZER-authored', () => {
+  const message: Message = {
+    _id: 'message.2',
+    conversationId: conversation._id,
+    authorId: 'org-1',
+    body: 'Thanks Dana, here are the details.',
+    createdAt: '2026-07-01T11:00:00Z',
+  }
+
+  it('emails ALL contacts, hubs the OTHER organizers, logs activity, does NOT Slack', async () => {
+    await notifySponsorMessage({
+      conversation,
+      message,
+      sfc,
+      authorOrganizerId: 'org-1',
+    })
+
+    // EMAIL every contact person from the sponsor from-address.
+    expect(sponsorEmailMock).toHaveBeenCalledOnce()
+    const recipients = sponsorEmailMock.mock.calls[0][0] as { email: string }[]
+    expect(recipients.map((r) => r.email).sort()).toEqual([
+      'dana@acme.test',
+      'sam@acme.test',
+    ])
+    const ctx = sponsorEmailMock.mock.calls[0][1] as { portalUrl: string }
+    expect(ctx.portalUrl).toContain('/sponsor/portal/tok-123')
+    expect(ctx.portalUrl).toContain('#messages')
+
+    // HUB only the OTHER organizer (author excluded).
+    expect(upsertMock).toHaveBeenCalledOnce()
+    const items = upsertMock.mock.calls[0][0] as { recipientId: string }[]
+    expect(items.map((i) => i.recipientId)).toEqual(['org-2'])
+
+    // ACTIVITY attributed to the acting organizer.
+    expect(activityMock).toHaveBeenCalledOnce()
+    expect(activityMock.mock.calls[0][3]).toBe('org-1')
+
+    // NO Slack on an organizer reply.
+    expect(slackMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -19,6 +19,7 @@ import type {
 import { DEFAULT_CONVERSATION_PREFERENCE, ORGANIZERS_GROUP } from './types'
 import {
   proposalConversationId,
+  sponsorConversationId,
   conversationLinkPath,
   truncateToGraphemeBoundary,
   ORGANIZERS_LABEL,
@@ -26,7 +27,7 @@ import {
 
 // Re-export the client-safe pure helpers so existing server importers keep
 // their `./sanity` import surface (the definitions live in `./links`).
-export { proposalConversationId, conversationLinkPath }
+export { proposalConversationId, sponsorConversationId, conversationLinkPath }
 
 /**
  * Server-only data layer for speaker↔organizer messaging (M1).
@@ -143,7 +144,13 @@ const NEEDS_REPLY = `${STATUS_NOT_RESOLVED} && count($organizerIds) > 0 && defin
  * (which CAN express the fallback) is the one that flipped.
  */
 export const SPEAKER_SCOPE_PREDICATE =
-  '(createdBy._ref == $speakerId || subjectSpeaker._ref == $speakerId || $speakerId in proposal->speakers[]._ref)'
+  '(conversationType != "sponsor" && (createdBy._ref == $speakerId || subjectSpeaker._ref == $speakerId || $speakerId in proposal->speakers[]._ref))'
+// ^ The `conversationType != "sponsor"` clause is DEFENCE-IN-DEPTH (G2b). A
+// sponsor thread has no `createdBy`/`subjectSpeaker`/`proposal->speakers` that
+// could name a speaker, so it is ALREADY excluded from a speaker's scope by the
+// three field checks; the explicit type guard makes that guarantee independent
+// of a future field change and is covered by a test. The sponsor side is
+// token-authed via the portal and never reaches a speaker inbox.
 
 /**
  * The RAW GROQ predicate for an inbox `view` (no leading ` && `, empty for
@@ -318,6 +325,15 @@ function deriveParties(
     for (const id of conversation.proposalSpeakerIds) {
       parties.push({ partyType: 'speaker', speakerId: id })
     }
+  } else if (conversation.conversationType === 'sponsor') {
+    // A sponsor thread's non-organizer party is a `sponsor` party whose id
+    // (the `sponsorForConference`) is NOT expressible from the legacy fields —
+    // so it is ALWAYS written into `participants[]` at creation
+    // ({@link ensureSponsorConversation}) and the stored array is authoritative.
+    // This derive branch is unreachable for a real sponsor thread (they never
+    // lack `participants[]`); it returns just the organizers group so a
+    // hypothetical participants-less sponsor doc still resolves to a valid,
+    // speaker-free party set rather than a bogus empty-id speaker party.
   } else {
     parties.push({ partyType: 'speaker', speakerId: conversation.createdById })
     if (conversation.subjectSpeakerId) {
@@ -683,10 +699,15 @@ export async function listConversationsForSpeaker({
       body
     },
     "speakerSideName": select(
+      conversationType == "sponsor" => coalesce(participants[partyType == "sponsor"][0].sponsorForConference->sponsor->name, subject),
       conversationType == "proposal" => proposal->speakers[0]->name,
       defined(subjectSpeaker) => subjectSpeaker->name,
       createdBy->name
     ),
+    // Sponsor logos are stored as inline SVG (not a URL usable in an <img>), so a
+    // sponsor row deliberately has no counterpart image and falls back to an
+    // initials avatar (the "else initial" branch) — the select() has no sponsor
+    // case, so a sponsor thread yields null here.
     "speakerSideImage": select(
       conversationType == "proposal" => coalesce(proposal->speakers[0]->image.asset->url, proposal->speakers[0]->imageURL),
       defined(subjectSpeaker) => coalesce(subjectSpeaker->image.asset->url, subjectSpeaker->imageURL),
@@ -992,6 +1013,17 @@ export async function getConversationViewCounts({
   return counts
 }
 
+/** A message row as projected by {@link listMessages} (before normalization). */
+interface RawMessageRow {
+  _id: string
+  conversationId: string
+  authorId: string | null
+  body: string
+  createdAt: string
+  authorName?: string | null
+  authorSponsorId?: string | null
+}
+
 /**
  * A conversation's messages, NEWEST first, keyset-paginated by `before` (the
  * `createdAt` of the last item on the previous page). M2 reverses for display.
@@ -1026,15 +1058,27 @@ export async function listMessages({
   const query = `*[_type == "message" && conversation._ref == $conversationId${cursor}] | order(createdAt desc, _id desc) [0...${PAGE_SIZE}] {
     "_id": _id,
     "conversationId": conversation._ref,
-    "authorId": author._ref,
+    "authorId": coalesce(author._ref, ""),
     body,
-    createdAt
+    createdAt,
+    authorName,
+    "authorSponsorId": authorParty.sponsorForConference._ref
   }`
 
-  const results = await clientReadUncached.fetch<Message[]>(query, params, {
-    cache: 'no-store',
-  })
-  return results ?? []
+  const results = await clientReadUncached.fetch<RawMessageRow[]>(
+    query,
+    params,
+    { cache: 'no-store' },
+  )
+  return (results ?? []).map((row) => ({
+    _id: row._id,
+    conversationId: row.conversationId,
+    authorId: row.authorId ?? '',
+    body: row.body,
+    createdAt: row.createdAt,
+    ...(row.authorName ? { authorName: row.authorName } : {}),
+    ...(row.authorSponsorId ? { authorSponsorId: row.authorSponsorId } : {}),
+  }))
 }
 
 // ---------------------------------------------------------------------------
@@ -1090,6 +1134,61 @@ export async function ensureProposalConversation({
       createdAt: now,
       lastMessageAt: now,
       participants,
+    })
+    .commit()
+  return id
+}
+
+/**
+ * Ensure the SINGLE sponsor↔organizer conversation for a `sponsorForConference`
+ * exists and return its id (messaging G2b). Deterministic id
+ * `conversation.sponsor.<sfcId>` + `createIfNotExists`, so the portal-send and
+ * organizer-send paths converge on ONE document (the maintainer-locked
+ * "one thread per sponsorForConference" UI; the model stays multi-thread-general
+ * — this is simply the only thread a sponsor ever gets).
+ *
+ * PARTICIPANTS are the sponsor party + the organizers group, written directly
+ * (NOT through {@link deriveParties}, which can't reconstruct a sponsor party
+ * from the legacy fields — `participants[]` is authoritative for sponsor
+ * threads). `subject` is the sponsor company name (snapshotted so the thread
+ * renders without a deref, mirroring the proposal-title snapshot).
+ *
+ * CREATED-BY: unset for a PORTAL-initiated thread (a sponsor has no speaker doc;
+ * schema `createdBy` relaxed to optional for exactly this). An ORGANIZER-
+ * initiated thread passes `createdById` (the acting organizer) so the audit
+ * trail still names a human when one exists — the cleaner of the two documented
+ * options (relax-to-optional + acting-organizer-when-known).
+ */
+export async function ensureSponsorConversation({
+  conferenceId,
+  sponsorForConferenceId,
+  sponsorName,
+  createdById,
+}: {
+  conferenceId: string
+  sponsorForConferenceId: string
+  sponsorName: string
+  /** The acting organizer for an ORG-initiated thread; omitted portal-side. */
+  createdById?: string
+}): Promise<string> {
+  const id = sponsorConversationId(sponsorForConferenceId)
+  const now = new Date().toISOString()
+  const participants = partiesToStored([
+    { partyType: 'sponsor', sponsorForConferenceId },
+    { partyType: 'group', group: ORGANIZERS_GROUP },
+  ])
+  await clientWrite
+    .transaction()
+    .createIfNotExists({
+      _id: id,
+      _type: 'conversation',
+      conference: createReference(conferenceId),
+      conversationType: 'sponsor',
+      subject: (sponsorName || 'Sponsor').slice(0, 200),
+      createdAt: now,
+      lastMessageAt: now,
+      participants,
+      ...(createdById ? { createdBy: createReference(createdById) } : {}),
     })
     .commit()
   return id
@@ -1211,16 +1310,49 @@ export async function speakerExists(speakerId: string): Promise<boolean> {
 export async function addMessage({
   conversationId,
   authorId,
+  sponsorAuthor,
   body,
   reopen = false,
 }: {
   conversationId: string
-  authorId: string
+  /**
+   * The SPEAKER/organizer author id. Provide this OR {@link sponsorAuthor},
+   * never both. A speaker author writes the legacy `author` ref plus a speaker
+   * `authorParty`.
+   */
+  authorId?: string
+  /**
+   * A SPONSOR author (portal side, G2b): no speaker doc exists, so the message
+   * stores a `sponsor` `authorParty` plus an `authorName` snapshot (the contact
+   * person the sender picked) and leaves the `author` ref UNSET. Provide this OR
+   * {@link authorId}, never both.
+   */
+  sponsorAuthor?: { sponsorForConferenceId: string; authorName: string }
   body: string
   reopen?: boolean
 }): Promise<Message> {
   const now = new Date().toISOString()
   const messageId = `message.${nanoid()}`
+
+  // Build the author fields for the two shapes. A speaker author keeps the
+  // legacy `author` ref + speaker `authorParty` (unchanged); a sponsor author
+  // sets a `sponsor` `authorParty` + `authorName` snapshot with NO `author` ref
+  // (relaxed to optional in the schema for exactly this case).
+  const authorFields: Record<string, unknown> = sponsorAuthor
+    ? {
+        authorParty: partyToStored({
+          partyType: 'sponsor',
+          sponsorForConferenceId: sponsorAuthor.sponsorForConferenceId,
+        }),
+        authorName: sponsorAuthor.authorName,
+      }
+    : {
+        author: createReference(authorId as string),
+        authorParty: partyToStored({
+          partyType: 'speaker',
+          speakerId: authorId as string,
+        }),
+      }
 
   await clientWrite
     .transaction()
@@ -1228,14 +1360,9 @@ export async function addMessage({
       _id: messageId,
       _type: 'message',
       conversation: createReference(conversationId),
-      author: createReference(authorId),
       body,
       createdAt: now,
-      // Party model (G1): dual-write `authorParty` next to the legacy `author`
-      // ref. Only speaker parties are produced in G1 (the author is always a
-      // speaker/organizer speaker doc). Not yet read — `author` still drives
-      // fan-out; the read path flips in G2.
-      authorParty: partyToStored({ partyType: 'speaker', speakerId: authorId }),
+      ...authorFields,
     })
     .patch(conversationId, (patch) =>
       patch.set(
@@ -1246,7 +1373,19 @@ export async function addMessage({
     )
     .commit()
 
-  return { _id: messageId, conversationId, authorId, body, createdAt: now }
+  return {
+    _id: messageId,
+    conversationId,
+    authorId: sponsorAuthor ? '' : (authorId as string),
+    body,
+    createdAt: now,
+    ...(sponsorAuthor
+      ? {
+          authorName: sponsorAuthor.authorName,
+          authorSponsorId: sponsorAuthor.sponsorForConferenceId,
+        }
+      : {}),
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/messaging/sponsor-thread.test.ts
+++ b/src/lib/messaging/sponsor-thread.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Sanity client mock (capture writes) -----------------------------------
+
+const fetchMock = vi.fn()
+const createdDocs: Record<string, unknown>[] = []
+const createIfNotExistsDocs: Record<string, unknown>[] = []
+const patchCalls: { id: string }[] = []
+const commitMock = vi.fn().mockResolvedValue({ transactionId: 'tx-1' })
+
+const transactionApi = {
+  create: (doc: Record<string, unknown>) => {
+    createdDocs.push(doc)
+    return transactionApi
+  },
+  createIfNotExists: (doc: Record<string, unknown>) => {
+    createIfNotExistsDocs.push(doc)
+    return transactionApi
+  },
+  patch: (id: string) => {
+    patchCalls.push({ id })
+    return transactionApi
+  },
+  commit: () => commitMock(),
+}
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientWrite: { transaction: () => transactionApi },
+}))
+
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn().mockResolvedValue(['org-1', 'org-2']),
+}))
+
+import {
+  canAccessConversation,
+  resolveParticipants,
+  resolveParticipantIds,
+  resolveRecipients,
+  SPEAKER_SCOPE_PREDICATE,
+  ensureSponsorConversation,
+  addMessage,
+} from './sanity'
+import { sponsorConversationId, conversationLinkPath } from './links'
+import type { ConversationWithContext } from './types'
+
+const SFC = 'sfc-42'
+
+function sponsorConversation(): ConversationWithContext {
+  return {
+    _id: sponsorConversationId(SFC),
+    conferenceId: 'conf-1',
+    conversationType: 'sponsor',
+    proposalSpeakerIds: [],
+    createdById: '',
+    subject: 'Acme Corp',
+    createdAt: '2026-07-01T00:00:00Z',
+    lastMessageAt: '2026-07-01T00:00:00Z',
+    participants: [
+      { partyType: 'sponsor', sponsorForConferenceId: SFC },
+      { partyType: 'group', group: 'organizers' },
+    ],
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  createdDocs.length = 0
+  createIfNotExistsDocs.length = 0
+  patchCalls.length = 0
+})
+
+describe('sponsor thread — id scheme + links', () => {
+  it('derives the deterministic id conversation.sponsor.<sfcId>', () => {
+    expect(sponsorConversationId(SFC)).toBe('conversation.sponsor.sfc-42')
+  })
+
+  it('links a sponsor thread to the admin thread for BOTH audiences', () => {
+    const conv = sponsorConversation()
+    expect(conversationLinkPath(conv, true)).toBe(`/admin/messages/${conv._id}`)
+    // No speaker/CFP surface — the sponsor reaches it via the portal.
+    expect(conversationLinkPath(conv, false)).toBe(
+      `/admin/messages/${conv._id}`,
+    )
+  })
+})
+
+describe('sponsor thread — authorization', () => {
+  it('lets any organizer access a sponsor thread', () => {
+    expect(
+      canAccessConversation(sponsorConversation(), {
+        _id: 'org-1',
+        isOrganizer: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('DENIES a non-organizer speaker (no speaker party exists)', () => {
+    expect(
+      canAccessConversation(sponsorConversation(), {
+        _id: 'sp-1',
+        isOrganizer: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('excludes sponsor threads from the speaker scope predicate (defence-in-depth)', () => {
+    expect(SPEAKER_SCOPE_PREDICATE).toContain('conversationType != "sponsor"')
+  })
+})
+
+describe('sponsor thread — participant/recipient resolution', () => {
+  it('prefers the stored sponsor participants (no derive)', () => {
+    const parties = resolveParticipants(sponsorConversation())
+    expect(parties).toEqual([
+      { partyType: 'sponsor', sponsorForConferenceId: SFC },
+      { partyType: 'group', group: 'organizers' },
+    ])
+  })
+
+  it('derive-fallback for a participants-less sponsor doc yields ONLY the organizers group (no bogus speaker)', () => {
+    const parties = resolveParticipants({
+      conversationType: 'sponsor',
+      proposalSpeakerIds: [],
+      createdById: '',
+    })
+    expect(parties).toEqual([{ partyType: 'group', group: 'organizers' }])
+  })
+
+  it('expands recipients to organizers only — the sponsor party carries no speaker id', () => {
+    const ids = resolveParticipantIds(sponsorConversation(), ['org-1', 'org-2'])
+    expect(ids.sort()).toEqual(['org-1', 'org-2'])
+    // An organizer author is excluded from the recipient set.
+    expect(
+      resolveRecipients(sponsorConversation(), 'org-1', ['org-1', 'org-2']),
+    ).toEqual(['org-2'])
+  })
+})
+
+describe('ensureSponsorConversation', () => {
+  it('creates the deterministic doc with sponsor+organizers participants and NO createdBy (portal)', async () => {
+    const id = await ensureSponsorConversation({
+      conferenceId: 'conf-1',
+      sponsorForConferenceId: SFC,
+      sponsorName: 'Acme Corp',
+    })
+    expect(id).toBe(sponsorConversationId(SFC))
+    expect(createIfNotExistsDocs).toHaveLength(1)
+    const doc = createIfNotExistsDocs[0] as Record<string, unknown>
+    expect(doc._id).toBe(sponsorConversationId(SFC))
+    expect(doc.conversationType).toBe('sponsor')
+    expect(doc.subject).toBe('Acme Corp')
+    expect(doc.createdBy).toBeUndefined()
+    const participants = doc.participants as Record<string, unknown>[]
+    expect(participants.map((p) => p.partyType)).toEqual(['sponsor', 'group'])
+  })
+
+  it('sets createdBy to the acting organizer when org-initiated', async () => {
+    await ensureSponsorConversation({
+      conferenceId: 'conf-1',
+      sponsorForConferenceId: SFC,
+      sponsorName: 'Acme Corp',
+      createdById: 'org-1',
+    })
+    const doc = createIfNotExistsDocs[0] as Record<string, unknown>
+    expect(doc.createdBy).toBeDefined()
+  })
+
+  it('is idempotent — uses createIfNotExists (a second call converges on the same id)', async () => {
+    const a = await ensureSponsorConversation({
+      conferenceId: 'conf-1',
+      sponsorForConferenceId: SFC,
+      sponsorName: 'Acme Corp',
+    })
+    const b = await ensureSponsorConversation({
+      conferenceId: 'conf-1',
+      sponsorForConferenceId: SFC,
+      sponsorName: 'Acme Corp',
+    })
+    expect(a).toBe(b)
+    expect(createIfNotExistsDocs).toHaveLength(2)
+    expect(createdDocs).toHaveLength(0) // never a plain create (race-safe)
+  })
+})
+
+describe('addMessage — sponsor author', () => {
+  it('writes a sponsor authorParty + authorName snapshot and NO author ref', async () => {
+    const msg = await addMessage({
+      conversationId: sponsorConversationId(SFC),
+      sponsorAuthor: { sponsorForConferenceId: SFC, authorName: 'Dana Diaz' },
+      body: 'Hello from the sponsor',
+    })
+    expect(createdDocs).toHaveLength(1)
+    const doc = createdDocs[0] as Record<string, unknown>
+    expect(doc.author).toBeUndefined()
+    expect(doc.authorName).toBe('Dana Diaz')
+    const party = doc.authorParty as Record<string, unknown>
+    expect(party.partyType).toBe('sponsor')
+    // Return value carries the snapshot + sponsor id for the thread render.
+    expect(msg.authorId).toBe('')
+    expect(msg.authorName).toBe('Dana Diaz')
+    expect(msg.authorSponsorId).toBe(SFC)
+  })
+
+  it('still writes a speaker author ref for an organizer author', async () => {
+    await addMessage({
+      conversationId: sponsorConversationId(SFC),
+      authorId: 'org-1',
+      body: 'Organizer reply',
+    })
+    const doc = createdDocs[0] as Record<string, unknown>
+    expect(doc.author).toBeDefined()
+    expect(doc.authorName).toBeUndefined()
+    const party = doc.authorParty as Record<string, unknown>
+    expect(party.partyType).toBe('speaker')
+  })
+})

--- a/src/lib/messaging/sponsor.ts
+++ b/src/lib/messaging/sponsor.ts
@@ -1,0 +1,120 @@
+import 'server-only'
+import { groq } from 'next-sanity'
+import { clientReadUncached } from '@/lib/sanity/client'
+import type { Conference } from '@/lib/conference/types'
+
+/**
+ * Server-only token-authorization + context resolution for the sponsor↔organizer
+ * messaging portal (messaging G2b).
+ *
+ * The sponsor side of a thread is reached ONLY through the per-sponsor portal
+ * token (the `sponsorForConference.registrationToken`), never a speaker/organizer
+ * session — so this is the sole authorization gate for the public
+ * `sponsorMessages` procedures. It mirrors `validateRegistrationToken`
+ * (per-request GROQ on `registrationToken`) and returns the thread context every
+ * portal procedure needs: the sponsorForConference id (thread selector), its
+ * conference, the sponsor company name (thread subject), and the contact-person
+ * NAMES that gate the author-name picker. NO conversation id ever comes from the
+ * client — the token IS the thread selector (one-thread UI).
+ */
+
+/** The minimal context a portal read/send needs after a token validates. */
+export interface SponsorThreadContext {
+  sfcId: string
+  conferenceId: string
+  sponsorName: string
+  /** Contact persons with BOTH a name and an email (the author-picker options). */
+  contactPersons: { name: string; email: string }[]
+}
+
+/**
+ * Validate a portal token and resolve its thread context, or `null` when the
+ * token matches no sponsor (the caller maps null → NOT_FOUND with no
+ * enumeration oracle — an absent and an invalid token are indistinguishable).
+ */
+export async function validateSponsorMessagingToken(
+  token: string,
+): Promise<SponsorThreadContext | null> {
+  if (!token) return null
+  const row = await clientReadUncached.fetch<{
+    sfcId: string | null
+    conferenceId: string | null
+    sponsorName: string | null
+    contactPersons: { name: string | null; email: string | null }[] | null
+  } | null>(
+    // NB: the GROQ param is `$registrationToken`, NOT `$token` — the typed client
+    // treats a `token` param name specially and rejects the call (mirrors
+    // `validateRegistrationToken`).
+    groq`*[_type == "sponsorForConference" && registrationToken == $registrationToken][0]{
+      "sfcId": _id,
+      "conferenceId": conference._ref,
+      "sponsorName": sponsor->name,
+      "contactPersons": coalesce(contactPersons[]{ name, email }, [])
+    }`,
+    { registrationToken: token },
+    { cache: 'no-store' },
+  )
+  if (!row?.sfcId || !row.conferenceId) return null
+  const contactPersons = (row.contactPersons ?? [])
+    .filter(
+      (c): c is { name: string; email: string } =>
+        Boolean(c.name?.trim()) && Boolean(c.email?.trim()),
+    )
+    .map((c) => ({ name: c.name.trim(), email: c.email.trim() }))
+  return {
+    sfcId: row.sfcId,
+    conferenceId: row.conferenceId,
+    sponsorName: row.sponsorName?.trim() || 'Sponsor',
+    contactPersons,
+  }
+}
+
+/**
+ * The context the sponsor-message FAN-OUT needs (both directions): the sponsor
+ * name, the portal token (to build the sponsor deep link), every contact
+ * person's email (organizer→sponsor emails), and the full conference (Slack
+ * sales channel, `sponsorEmail` from-address, domains for absolute links).
+ * Resolved through the sfc so it works from the public portal context without a
+ * domain round-trip.
+ */
+export interface SponsorFanoutContext {
+  sfcId: string
+  sponsorName: string
+  registrationToken: string | null
+  contactPersons: { name: string; email: string }[]
+  conference: Conference | null
+}
+
+export async function getSponsorFanoutContext(
+  sfcId: string,
+): Promise<SponsorFanoutContext | null> {
+  const row = await clientReadUncached.fetch<{
+    sponsorName: string | null
+    registrationToken: string | null
+    contactPersons: { name: string | null; email: string | null }[] | null
+    conference: Conference | null
+  } | null>(
+    groq`*[_type == "sponsorForConference" && _id == $sfcId][0]{
+      "sponsorName": sponsor->name,
+      registrationToken,
+      "contactPersons": coalesce(contactPersons[]{ name, email }, []),
+      "conference": conference->{ ... }
+    }`,
+    { sfcId },
+    { cache: 'no-store' },
+  )
+  if (!row) return null
+  const contactPersons = (row.contactPersons ?? [])
+    .filter(
+      (c): c is { name: string; email: string } =>
+        Boolean(c.name?.trim()) && Boolean(c.email?.trim()),
+    )
+    .map((c) => ({ name: c.name.trim(), email: c.email.trim() }))
+  return {
+    sfcId,
+    sponsorName: row.sponsorName?.trim() || 'Sponsor',
+    registrationToken: row.registrationToken,
+    contactPersons,
+    conference: row.conference,
+  }
+}

--- a/src/lib/messaging/sponsorEmail.ts
+++ b/src/lib/messaging/sponsorEmail.ts
@@ -1,0 +1,108 @@
+import 'server-only'
+import React from 'react'
+import { resend, retryWithBackoff } from '@/lib/email/config'
+import { SponsorMessageNotificationTemplate } from '@/components/email/SponsorMessageNotificationTemplate'
+import type { Conference } from '@/lib/conference/types'
+import { formatConferenceDateLong } from '@/lib/time'
+
+/** One contact-person recipient of an organizer→sponsor message email. */
+export interface SponsorMessageEmailRecipient {
+  email: string
+  name: string
+}
+
+/** How many recipient emails to have in flight at once (mirrors messaging email.ts). */
+const EMAIL_CONCURRENCY = 3
+
+/**
+ * Send an ORGANIZER→SPONSOR new-message email to a single contact person from
+ * the conference `sponsorEmail` from-address. Never throws — an email failure
+ * must not fail the (already committed) message write.
+ */
+async function sendOne(
+  recipient: SponsorMessageEmailRecipient,
+  {
+    authorName,
+    subject,
+    excerpt,
+    portalUrl,
+    conference,
+  }: {
+    authorName: string
+    subject: string
+    excerpt: string
+    portalUrl: string
+    conference: Conference
+  },
+): Promise<boolean> {
+  try {
+    await retryWithBackoff(async () => {
+      const fromEmail = conference.sponsorEmail || conference.cfpEmail
+      const fromName = conference.organizer || conference.title
+      const result = await resend.emails.send({
+        from: `${fromName} <${fromEmail}>`,
+        to: [recipient.email],
+        subject: `New message about "${subject}"`,
+        react: React.createElement(SponsorMessageNotificationTemplate, {
+          recipientName: recipient.name,
+          authorName,
+          subject,
+          excerpt,
+          portalUrl,
+          eventName: conference.title,
+          eventLocation: `${conference.city}, ${conference.country}`,
+          eventDate: conference.startDate
+            ? formatConferenceDateLong(conference.startDate)
+            : '',
+          eventUrl: conference.domains?.[0]
+            ? `https://${conference.domains[0]}`
+            : '',
+          socialLinks: conference.socialLinks || [],
+        }),
+      })
+      if (result.error) {
+        throw new Error(`Failed to send email: ${result.error.message}`)
+      }
+      return result
+    })
+    return true
+  } catch (error) {
+    console.error('Failed to send sponsor message email:', error)
+    return false
+  }
+}
+
+/**
+ * Send organizer→sponsor new-message emails to every contact person with
+ * BOUNDED CONCURRENCY (mirrors `sendMessageEmails`): at most
+ * {@link EMAIL_CONCURRENCY} in-flight sends. `sendOne` never throws and
+ * `retryWithBackoff` absorbs Resend 429s. Returns how many were delivered.
+ */
+export async function sendSponsorMessageEmails(
+  recipients: SponsorMessageEmailRecipient[],
+  context: {
+    authorName: string
+    subject: string
+    excerpt: string
+    portalUrl: string
+    conference: Conference
+  },
+): Promise<number> {
+  let sent = 0
+  let cursor = 0
+
+  async function worker(): Promise<void> {
+    while (cursor < recipients.length) {
+      const index = cursor++
+      const ok = await sendOne(recipients[index], context)
+      if (ok) sent++
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(EMAIL_CONCURRENCY, recipients.length) },
+    () => worker(),
+  )
+  await Promise.allSettled(workers)
+  return sent
+}

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -7,7 +7,13 @@
  * id) — see `canAccessConversation` / `resolveRecipients` in `./sanity`.
  */
 
-export type ConversationType = 'proposal' | 'general'
+/**
+ * The thread shapes. `proposal` / `general` are the original speaker↔organizer
+ * shapes; `sponsor` (G2b) is a sponsor↔organizer thread — one per
+ * `sponsorForConference`, whose non-organizer side is a `sponsor` participant
+ * party (no speaker doc) reached only via the portal token, never a session.
+ */
+export type ConversationType = 'proposal' | 'general' | 'sponsor'
 
 /**
  * Ticketing status of a thread for the ORGANIZER audience. `'open'` is the
@@ -300,9 +306,26 @@ export interface ConversationViewCounts {
 export interface Message {
   _id: string
   conversationId: string
+  /**
+   * The author speaker `_ref` (empty string for a SPONSOR-authored message,
+   * which has no speaker doc — see {@link authorName}/{@link authorSponsorId}).
+   */
   authorId: string
   body: string
   createdAt: string
+  /**
+   * Display-name snapshot for a SPONSOR-authored message (the contact person the
+   * portal sender picked). Undefined for speaker/organizer authors — the thread
+   * derives their name from the `authorId` speaker ref (G2b).
+   */
+  authorName?: string
+  /**
+   * The `sponsorForConference` id when this message was authored from the sponsor
+   * portal (its `authorParty` is a `sponsor` party). Undefined for
+   * speaker/organizer authors. Lets the thread render a "(Sponsor)" badge and
+   * suppress the speaker-avatar lookup (G2b).
+   */
+  authorSponsorId?: string
 }
 
 /** A participant sub-object projected for a conversation view. */

--- a/src/lib/slack/notify.ts
+++ b/src/lib/slack/notify.ts
@@ -286,6 +286,69 @@ export async function notifyNewSpeakerMessage(
   await sendSlackNotification(message, conference)
 }
 
+/**
+ * Sponsor→organizer new-message Slack post (messaging G2b). Mirrors
+ * {@link notifyNewSpeakerMessage} but routes to the SALES channel
+ * ({@link sendSalesNotification}) — a sponsor message is a sales-team concern —
+ * and is fired ONLY for sponsor-authored messages (an organizer's own reply
+ * doesn't Slack). `authorName` is the contact person who wrote it.
+ */
+export async function notifySponsorMessage(
+  {
+    authorName,
+    sponsorName,
+    excerpt,
+    adminPath,
+  }: {
+    authorName: string
+    sponsorName: string
+    excerpt: string
+    adminPath: string
+  },
+  conference: Conference,
+) {
+  const domain = getDomainFromConference(conference)
+
+  const blocks: SlackBlock[] = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: '💬 New sponsor message',
+        emoji: true,
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: `*From:*\n${escapeMrkdwn(authorName)}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*Sponsor:*\n${escapeMrkdwn(sponsorName)}`,
+        },
+      ],
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Message:*\n${escapeMrkdwn(excerpt)}`,
+      },
+    },
+  ]
+
+  if (domain) {
+    blocks.push(
+      createAdminLinkButton(domain, adminPath, 'View in Admin', 'view_message'),
+    )
+  }
+
+  await sendSalesNotification({ blocks }, conference)
+}
+
 export async function notifyNewVolunteer(
   volunteer: Volunteer,
   conference: Conference,

--- a/src/lib/sponsor-crm/types.ts
+++ b/src/lib/sponsor-crm/types.ts
@@ -28,6 +28,8 @@ export type ActivityType =
   | 'signature_status_change'
   | 'registration_complete'
   | 'contract_reminder_sent'
+  // A sponsor↔organizer thread message (messaging G2b).
+  | 'message'
 
 export type SponsorTag =
   | 'warm-lead'

--- a/src/server/_app.ts
+++ b/src/server/_app.ts
@@ -18,6 +18,7 @@ import { notificationRouter } from './routers/notification'
 import { pushRouter } from './routers/push'
 import { messageRouter } from './routers/message'
 import { conferenceRouter } from './routers/conference'
+import { sponsorMessagesRouter } from './routers/sponsorMessages'
 
 export const appRouter = router({
   badge: badgeRouter,
@@ -39,6 +40,7 @@ export const appRouter = router({
   push: pushRouter,
   message: messageRouter,
   conference: conferenceRouter,
+  sponsorMessages: sponsorMessagesRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -23,6 +23,7 @@ import {
   listMessages,
   addMessage,
   ensureProposalConversation,
+  ensureSponsorConversation,
   createGeneralConversation,
   getProposalForConversation,
   setConversationPreference,
@@ -34,6 +35,11 @@ import {
   canAccessConversation,
 } from '@/lib/messaging/sanity'
 import {
+  getSponsorFanoutContext,
+  type SponsorFanoutContext,
+} from '@/lib/messaging/sponsor'
+import { z } from 'zod'
+import {
   getOrganizerSpeakerIds,
   createNotifications,
 } from '@/lib/notification/sanity'
@@ -41,7 +47,7 @@ import {
   conversationLinkPath,
   truncateToGraphemeBoundary,
 } from '@/lib/messaging/links'
-import { notifyNewMessage } from '@/lib/messaging/notify'
+import { notifyNewMessage, notifySponsorMessage } from '@/lib/messaging/notify'
 import { SPEAKER_ALLOWED_VIEWS } from '@/lib/messaging/types'
 import type {
   AccessSpeaker,
@@ -416,16 +422,69 @@ export const messageRouter = router({
       // runs AFTER the response so a large recipient set can't hang the Send
       // button. `runAfterResponse` uses Next's `after()` in a request scope and
       // falls back to a self-catching detachment elsewhere.
-      runAfterResponse(() =>
-        notifyNewMessage({
-          conversation,
-          message,
-          authorId: actorId,
-          conference,
-        }),
-      )
+      //
+      // SPONSOR threads (G2b) route to the sponsor fan-out instead of the speaker
+      // one: this actor is an ORGANIZER (only organizers can access a sponsor
+      // thread via a session), so it is the organizer-authored direction —
+      // email every contact person, hub the other organizers, NO Slack.
+      if (conversation.conversationType === 'sponsor') {
+        const sfcId = conversation.participants?.find(
+          (p) => p.partyType === 'sponsor',
+        )?.sponsorForConferenceId
+        runAfterResponse(async () => {
+          const sfc = sfcId ? await getSponsorFanoutContext(sfcId) : null
+          if (!sfc) return
+          await notifySponsorMessage({
+            conversation,
+            message,
+            sfc,
+            authorOrganizerId: actorId,
+          })
+        })
+      } else {
+        runAfterResponse(() =>
+          notifyNewMessage({
+            conversation,
+            message,
+            authorId: actorId,
+            conference,
+          }),
+        )
+      }
 
       return { conversationId: conversation._id, message }
+    }),
+
+  /**
+   * Organizer-only: ensure the SINGLE sponsor↔organizer thread for a
+   * `sponsorForConference` exists and return its id (messaging G2b). Lets an
+   * organizer OPEN (and thereby start) the thread from the sponsor CRM before the
+   * sponsor has posted anything — the thread is created with the acting organizer
+   * as `createdBy` (org-initiated). Idempotent: a second call returns the same
+   * deterministic id. The sfc MUST belong to the current-domain conference
+   * (multi-tenant isolation).
+   */
+  ensureSponsorThread: protectedProcedure
+    .input(z.object({ sponsorForConferenceId: z.string().min(1).max(200) }))
+    .mutation(async ({ ctx, input }) => {
+      if (ctx.speaker.isOrganizer !== true) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
+      }
+      const conferenceId = await resolveConferenceId()
+      const sfc: SponsorFanoutContext | null = await getSponsorFanoutContext(
+        input.sponsorForConferenceId,
+      )
+      // Collapse absent + wrong-conference into NOT_FOUND (no cross-tenant probe).
+      if (!sfc || !sfc.conference || sfc.conference._id !== conferenceId) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Sponsor not found' })
+      }
+      const conversationId = await ensureSponsorConversation({
+        conferenceId,
+        sponsorForConferenceId: input.sponsorForConferenceId,
+        sponsorName: sfc.sponsorName,
+        createdById: ctx.speaker._id,
+      })
+      return { conversationId }
     }),
 
   /** Set the caller's mute / email preference for a conversation. Authz-checked. */

--- a/src/server/routers/sponsorMessages.test.ts
+++ b/src/server/routers/sponsorMessages.test.ts
@@ -128,7 +128,10 @@ describe('sponsorMessages.send — token + validation', () => {
     expect(ensureMock).toHaveBeenCalledOnce()
     expect(addMessageMock).toHaveBeenCalledOnce()
     expect(addMessageMock.mock.calls[0][0]).toMatchObject({
-      sponsorAuthor: { sponsorForConferenceId: 'sfc-1', authorName: 'Dana Diaz' },
+      sponsorAuthor: {
+        sponsorForConferenceId: 'sfc-1',
+        authorName: 'Dana Diaz',
+      },
     })
     expect(res.message.fromSponsor).toBe(true)
   })

--- a/src/server/routers/sponsorMessages.test.ts
+++ b/src/server/routers/sponsorMessages.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+// --- Mocks (data layer + fan-out boundaries) -------------------------------
+
+const validateMock = vi.fn()
+const getFanoutMock = vi.fn()
+vi.mock('@/lib/messaging/sponsor', () => ({
+  validateSponsorMessagingToken: (...a: unknown[]) => validateMock(...a),
+  getSponsorFanoutContext: (...a: unknown[]) => getFanoutMock(...a),
+}))
+
+const ensureMock = vi.fn()
+const getConversationMock = vi.fn()
+const listMessagesMock = vi.fn()
+const addMessageMock = vi.fn()
+vi.mock('@/lib/messaging/sanity', () => ({
+  sponsorConversationId: (id: string) => `conversation.sponsor.${id}`,
+  ensureSponsorConversation: (...a: unknown[]) => ensureMock(...a),
+  getConversationById: (...a: unknown[]) => getConversationMock(...a),
+  listMessages: (...a: unknown[]) => listMessagesMock(...a),
+  addMessage: (...a: unknown[]) => addMessageMock(...a),
+}))
+
+vi.mock('@/lib/messaging/notify', () => ({
+  notifySponsorMessage: vi.fn(),
+}))
+
+// runAfterResponse: noop (fan-out wiring is covered by notifySponsor.test.ts).
+vi.mock('@/server/runAfterResponse', () => ({ runAfterResponse: vi.fn() }))
+
+import { sponsorMessagesRouter } from './sponsorMessages'
+
+const caller = sponsorMessagesRouter.createCaller({} as unknown as Context)
+
+const CTX = {
+  sfcId: 'sfc-1',
+  conferenceId: 'conf-1',
+  sponsorName: 'Acme Corp',
+  contactPersons: [
+    { name: 'Dana Diaz', email: 'dana@acme.test' },
+    { name: 'Sam Stone', email: 'sam@acme.test' },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  validateMock.mockResolvedValue(CTX)
+  ensureMock.mockResolvedValue('conversation.sponsor.sfc-1')
+  addMessageMock.mockResolvedValue({
+    _id: 'message.1',
+    body: 'hi',
+    createdAt: '2026-07-01T00:00:00Z',
+    authorName: 'Dana Diaz',
+    authorSponsorId: 'sfc-1',
+  })
+  getConversationMock.mockResolvedValue(null)
+  listMessagesMock.mockResolvedValue([])
+  getFanoutMock.mockResolvedValue(null)
+})
+
+describe('sponsorMessages.list', () => {
+  it('404s an invalid token with no enumeration oracle', async () => {
+    validateMock.mockResolvedValueOnce(null)
+    await expect(caller.list({ token: 'bad-token' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+  })
+
+  it('returns contact names + an empty thread when nothing posted yet', async () => {
+    const res = await caller.list({ token: 'valid-list-1' })
+    expect(res.contactNames).toEqual(['Dana Diaz', 'Sam Stone'])
+    expect(res.messages).toEqual([])
+    expect(res.sponsorName).toBe('Acme Corp')
+  })
+
+  it('maps sponsor vs organizer messages (fromSponsor flag)', async () => {
+    getConversationMock.mockResolvedValueOnce({
+      _id: 'conversation.sponsor.sfc-1',
+      subject: 'Acme Corp',
+    })
+    listMessagesMock.mockResolvedValueOnce([
+      {
+        _id: 'm2',
+        body: 'org reply',
+        createdAt: '2026-07-02',
+        authorId: 'org-1',
+      },
+      {
+        _id: 'm1',
+        body: 'sponsor msg',
+        createdAt: '2026-07-01',
+        authorName: 'Dana Diaz',
+        authorSponsorId: 'sfc-1',
+      },
+    ])
+    const res = await caller.list({ token: 'valid-list-2' })
+    expect(res.messages.find((m) => m._id === 'm1')?.fromSponsor).toBe(true)
+    expect(res.messages.find((m) => m._id === 'm2')?.fromSponsor).toBe(false)
+  })
+})
+
+describe('sponsorMessages.send — token + validation', () => {
+  it('404s an invalid token', async () => {
+    validateMock.mockResolvedValueOnce(null)
+    await expect(
+      caller.send({ token: 'bad-send', body: 'hi', authorName: 'Dana Diaz' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('rejects an authorName that is not a contact person (STRICT match)', async () => {
+    await expect(
+      caller.send({
+        token: 'strict-1',
+        body: 'hi',
+        authorName: 'Mallory Malware',
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(addMessageMock).not.toHaveBeenCalled()
+  })
+
+  it('appends a sponsor-authored message on a valid contact name', async () => {
+    const res = await caller.send({
+      token: 'happy-1',
+      body: 'A real question',
+      authorName: 'Dana Diaz',
+    })
+    expect(ensureMock).toHaveBeenCalledOnce()
+    expect(addMessageMock).toHaveBeenCalledOnce()
+    expect(addMessageMock.mock.calls[0][0]).toMatchObject({
+      sponsorAuthor: { sponsorForConferenceId: 'sfc-1', authorName: 'Dana Diaz' },
+    })
+    expect(res.message.fromSponsor).toBe(true)
+  })
+})
+
+describe('sponsorMessages.send — rate limit (5/min per token)', () => {
+  it('allows a burst of 5 then rejects the 6th', async () => {
+    const token = 'rate-limit-token'
+    for (let i = 0; i < 5; i++) {
+      await caller.send({ token, body: `msg ${i}`, authorName: 'Dana Diaz' })
+    }
+    await expect(
+      caller.send({ token, body: 'over', authorName: 'Dana Diaz' }),
+    ).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' })
+  })
+})

--- a/src/server/routers/sponsorMessages.ts
+++ b/src/server/routers/sponsorMessages.ts
@@ -1,0 +1,183 @@
+import { TRPCError } from '@trpc/server'
+import { router, publicProcedure } from '../trpc'
+import { runAfterResponse } from '@/server/runAfterResponse'
+import {
+  SponsorMessagesListSchema,
+  SponsorMessagesSendSchema,
+} from '../schemas/sponsorMessages'
+import {
+  validateSponsorMessagingToken,
+  getSponsorFanoutContext,
+} from '@/lib/messaging/sponsor'
+import {
+  sponsorConversationId,
+  ensureSponsorConversation,
+  getConversationById,
+  listMessages,
+  addMessage,
+} from '@/lib/messaging/sanity'
+import { notifySponsorMessage } from '@/lib/messaging/notify'
+
+/**
+ * Per-token sliding-window rate limiter (messaging G2b). The public portal
+ * procedures have NO session to throttle on, so the TOKEN is the key. Two
+ * limiters: token validation (cheap GROQ, generous) and sends (fan out to Slack
+ * + N contact emails + hub, so tight). Module-memory, so PER-INSTANCE on
+ * serverless — a burst spread across instances sees a higher effective ceiling,
+ * acceptable here for the same reason as `message.send`'s limiter (the email and
+ * Slack providers rate-limit further downstream). The map is size-capped so it
+ * can never grow without bound.
+ */
+const VALIDATE_WINDOW_MS = 60_000
+const VALIDATE_MAX_IN_WINDOW = 30
+const SEND_WINDOW_MS = 60_000
+const SEND_MAX_IN_WINDOW = 5
+const MAX_RATE_ENTRIES = 10_000
+
+function makeLimiter(windowMs: number, maxInWindow: number) {
+  const recent = new Map<string, number[]>()
+  return function claim(token: string): boolean {
+    const now = Date.now()
+    const cutoff = now - windowMs
+    const hits = (recent.get(token) ?? []).filter((t) => t > cutoff)
+    recent.delete(token)
+    if (hits.length >= maxInWindow) {
+      recent.set(token, hits)
+      return false
+    }
+    hits.push(now)
+    if (recent.size >= MAX_RATE_ENTRIES) {
+      const oldest = recent.keys().next().value
+      if (oldest !== undefined) recent.delete(oldest)
+    }
+    recent.set(token, hits)
+    return true
+  }
+}
+
+const claimValidateSlot = makeLimiter(
+  VALIDATE_WINDOW_MS,
+  VALIDATE_MAX_IN_WINDOW,
+)
+const claimSendSlot = makeLimiter(SEND_WINDOW_MS, SEND_MAX_IN_WINDOW)
+
+const TOO_MANY = new TRPCError({
+  code: 'TOO_MANY_REQUESTS',
+  message: 'Too many requests. Please wait a moment and try again.',
+})
+// A single NOT_FOUND for an absent/invalid token — no enumeration oracle.
+const NOT_FOUND = new TRPCError({
+  code: 'NOT_FOUND',
+  message: 'This link is invalid or has expired.',
+})
+
+/**
+ * Public sponsor↔organizer messaging (messaging G2b). The sponsor side is
+ * authed ONLY by the portal token (never a session): every procedure validates
+ * the token, resolves the sponsorForConference (the thread selector), and never
+ * accepts a conversation id from the client — the token IS the thread.
+ */
+export const sponsorMessagesRouter = router({
+  /**
+   * The sponsor thread for a token: its messages (bounded, newest first — the
+   * portal reverses for display) plus the contact-person names that populate the
+   * author-name picker. Returns an empty thread when no message has been posted
+   * yet (the thread is created lazily on the first send).
+   */
+  list: publicProcedure
+    .input(SponsorMessagesListSchema)
+    .query(async ({ input }) => {
+      if (!claimValidateSlot(input.token)) throw TOO_MANY
+      const ctx = await validateSponsorMessagingToken(input.token)
+      if (!ctx) throw NOT_FOUND
+
+      const conversationId = sponsorConversationId(ctx.sfcId)
+      // Read messages only if the thread exists yet (no lazy create on a read).
+      const existing = await getConversationById(conversationId)
+      const messages = existing ? await listMessages({ conversationId }) : []
+
+      return {
+        sponsorName: ctx.sponsorName,
+        subject: existing?.subject ?? ctx.sponsorName,
+        // Author-picker options (names only — the portal never needs emails).
+        contactNames: ctx.contactPersons.map((c) => c.name),
+        messages: messages.map((m) => ({
+          _id: m._id,
+          body: m.body,
+          createdAt: m.createdAt,
+          // Sponsor authors carry a snapshot name; organizer authors resolve to
+          // the collective 'Organizers' label (the portal never names an
+          // individual organizer).
+          authorName: m.authorName ?? null,
+          fromSponsor: Boolean(m.authorSponsorId),
+        })),
+      }
+    }),
+
+  /**
+   * Post a sponsor-authored message. Validates the token + rate limit, requires
+   * `authorName` to STRICTLY match one of the sponsor's contact-person names
+   * (chosen over free-text so a portal sender can only attribute a message to a
+   * real, organizer-visible contact — no spoofed identities on the thread), then
+   * ensures the single sponsor thread exists and appends the message. NO
+   * conversation id is accepted — the token selects the thread.
+   */
+  send: publicProcedure
+    .input(SponsorMessagesSendSchema)
+    .mutation(async ({ input }) => {
+      if (!claimSendSlot(input.token)) throw TOO_MANY
+      const ctx = await validateSponsorMessagingToken(input.token)
+      if (!ctx) throw NOT_FOUND
+
+      // STRICT author-name match: the sender must pick a real contact person.
+      const match = ctx.contactPersons.find((c) => c.name === input.authorName)
+      if (!match) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Select your name from the contact list before sending.',
+        })
+      }
+
+      const conversationId = await ensureSponsorConversation({
+        conferenceId: ctx.conferenceId,
+        sponsorForConferenceId: ctx.sfcId,
+        sponsorName: ctx.sponsorName,
+      })
+
+      const message = await addMessage({
+        conversationId,
+        sponsorAuthor: {
+          sponsorForConferenceId: ctx.sfcId,
+          authorName: match.name,
+        },
+        body: input.body,
+      })
+
+      // Detach the (never-fail) fan-out from the response path (mirrors
+      // message.send): the message is already committed and returned below.
+      const conversation = await getConversationById(conversationId)
+      if (conversation) {
+        const fanoutCtx = await getSponsorFanoutContext(ctx.sfcId)
+        if (fanoutCtx) {
+          runAfterResponse(() =>
+            notifySponsorMessage({
+              conversation,
+              message,
+              sfc: fanoutCtx,
+              // undefined ⇒ sponsor-authored direction.
+            }),
+          )
+        }
+      }
+
+      return {
+        message: {
+          _id: message._id,
+          body: message.body,
+          createdAt: message.createdAt,
+          authorName: match.name,
+          fromSponsor: true,
+        },
+      }
+    }),
+})

--- a/src/server/schemas/sponsorMessages.ts
+++ b/src/server/schemas/sponsorMessages.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+/**
+ * Zod schemas for the public, token-authed `sponsorMessages` router (messaging
+ * G2b). NO schema carries a conversation id — the portal TOKEN is the sole thread
+ * selector (the maintainer-locked one-thread-per-sponsor UI), so a portal client
+ * can never address another sponsor's thread.
+ */
+
+/** Read a sponsor thread by its portal token. */
+export const SponsorMessagesListSchema = z.object({
+  token: z.string().min(1).max(200),
+})
+
+/**
+ * Send a sponsor-authored message. `authorName` is validated in the router to be
+ * one of the sponsor's contact-person names (STRICT match — see the router), so
+ * the loose bound here is only a length guard.
+ */
+export const SponsorMessagesSendSchema = z.object({
+  token: z.string().min(1).max(200),
+  // Trim BEFORE the non-empty check so a whitespace-only body can never fan out
+  // empty content; interior whitespace is preserved and the 5000-char cap holds
+  // (mirrors SendMessageSchema).
+  body: z.string().trim().min(1).max(5000),
+  authorName: z.string().trim().min(1).max(100),
+})


### PR DESCRIPTION
## SPONSOR-MESSAGING G2b — the sponsor party feature

Delivers sponsor↔organizer threads end-to-end on top of the live party model (G1 #564, 043, G2a #567). **Maintainer-locked decisions honoured:** ONE thread per `sponsorForConference` as a UI guarantee (model stays multi-thread-general, no special-casing); portal-token auth for the sponsor side; the org side is the unified `/admin/messages` inbox + the sponsor CRM with a "Sponsor" identity; sponsor emails via `conference.sponsorEmail` to all `contactPersons`; sales-channel Slack; `sponsorActivity` `message` entries. Hub notifications route to **ALL organizers for now** (TEAMS-2 will route to the sponsors team — noted inline in `notify.ts`).

### What's in it
- **Schema/data:** `conversationType` gains `'sponsor'`; deterministic id `conversation.sponsor.<sfcId>` (`ensureSponsorConversation`, `createIfNotExists`); `sponsorActivity.activityType` gains `'message'`. Sponsor authors write `authorParty = { sponsor }` + an `authorName` snapshot with the `author` ref unset.
- **Authz:** sponsor side is token-only (`validateSponsorMessagingToken`); `canAccessConversation` covers it via the organizer short-circuit; `SPEAKER_SCOPE_PREDICATE` gains an explicit `conversationType != "sponsor"` guard (defence-in-depth); organizer inbox includes sponsor threads (amber "Sponsor" chip).
- **Portal API** (`sponsorMessages` public router): `list`/`send`, token-authed, per-token rate-limited (validate 30/min, send 5/min), strict `authorName` ∈ contact persons, no conversation id from the client.
- **Fan-out** (`notifySponsorMessage`): sponsor-authored → hub(all orgs) + sales Slack + activity, no emails; organizer-authored → emails all contacts (portal `#messages` deep link) + hub(other orgs) + activity, no Slack.
- **UI:** portal Messages section in **both** states (form disclosure + dashboard card); sponsor bubble with "Sponsor" badge; sponsor CRM "Messages" sub-view (ensures thread on open, embeds `ConversationThread`).
- **Tests/stories/docs:** 22 new tests (authz, rate limits, strict authorName, fan-out matrix both directions, `ensureSponsorConversation` idempotency, schema relaxations); Storybook stories + 393 light/dark screenshots inspected; `docs/MESSAGING_SYSTEM.md` sponsor section + `/privacy` clause.

### Schema requiredness decisions
- `conversation.createdBy`: **required → optional** — portal-initiated threads have no speaker creator; organizer-initiated records the acting organizer.
- `message.author`: **required → optional** — sponsor authors have no speaker doc; `authorName` snapshot added instead.
- `authorName` strict match: send validates the chosen name against the sfc's contact persons (no spoofed identities).

### Checks
tsc, eslint, prettier, knip clean. Full `pnpm vitest run` green (239 files / 3406 tests, 5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the sponsor↔organizer messaging feature (G2b): a token-authed public portal API (`sponsorMessages` router), a unified admin inbox that includes sponsor threads, bidirectional fan-out (hub notifications, sales Slack, contact-person emails, `sponsorActivity` rows), and a deterministic one-thread-per-`sponsorForConference` model via `conversation.sponsor.<sfcId>`.

- **Portal API**: `list`/`send` procedures are token-authed with per-token sliding-window rate limiting; `authorName` is strictly validated against the sfc's contact persons so sponsors cannot spoof identities; no conversation id ever comes from the client — the token IS the thread selector.
- **Fan-out**: `notifySponsorMessage` correctly splits on `authorOrganizerId` — sponsor-authored goes to hub (all orgs) + sales Slack + activity; organizer-authored goes to contact-person emails + hub (other orgs, mute-filtered) + activity. Actor exclusion, never-fail contract, and bounded-concurrency email all mirror the existing speaker fan-out.
- **Auth/scope**: `SPEAKER_SCOPE_PREDICATE` gains an explicit `conversationType != \"sponsor\"` guard; `canAccessConversation` covers organizer access via short-circuit; the `ensureSponsorThread` mutation checks multi-tenant isolation against `resolveConferenceId()`.

<h3>Confidence Score: 4/5</h3>

The feature is well-constructed and security boundaries are solid; the NEEDS_REPLY GROQ predicate gap means sponsor threads don't surface in the Needs Reply tab or badge count even though the active-view row correctly shows the amber indicator — organizers can still read and reply, but the filter tab is unreliable for sponsor conversations.

The NEEDS_REPLY GROQ predicate uses defined(author._ref) to detect messages requiring an organizer reply, but sponsor-authored messages deliberately omit the author ref. This makes the predicate return false for sponsor threads, so the Needs Reply tab and badge count exclude sponsor conversations while the per-row JS flag marks them correctly. The gap is limited to the inbox filter tab and count — the underlying fan-out, auth, and data writes are correct. The inbox lastMessage preview also shows Unknown for the contact-person name on sponsor-authored messages because the projection uses author->name rather than the authorName snapshot.

src/lib/messaging/sanity.ts — the NEEDS_REPLY GROQ predicate (around line 125) and the lastMessage GROQ projection (around line 695–700) both need small adjustments to handle sponsor-authored messages correctly.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/messaging/sanity.ts | Core messaging data layer extended with sponsor thread support; two issues: NEEDS_REPLY GROQ predicate misses sponsor-authored messages (author._ref is null), and the inbox lastMessage projection uses author->name instead of the authorName snapshot for sponsor messages. |
| src/server/routers/sponsorMessages.ts | New public token-authed router for sponsor-organizer messaging; rate-limiting, strict authorName validation against contact persons, deterministic thread selection via token — all correctly implemented. |
| src/lib/messaging/notify.ts | New notifySponsorMessage fan-out orchestrator; direction correctly split via authorOrganizerId; actor exclusion, mute preferences, never-fail contract all properly implemented. |
| src/lib/messaging/sponsor.ts | Token validation and fanout context resolution; uses cache: 'no-store', strict contact-person filtering, correct null-to-NOT_FOUND mapping with no enumeration oracle. |
| src/server/routers/message.ts | Sponsor thread routing added to the organizer send path; ensureSponsorThread mutation has correct multi-tenant isolation check. |
| src/lib/messaging/sponsorEmail.ts | Organizer-to-sponsor email with bounded concurrency; never-fail contract, fallback from sponsorEmail to cfpEmail from-address. |
| src/server/schemas/sponsorMessages.ts | Correct Zod schemas; body trimmed before non-empty check; authorName length-bounded with strict server-side match; no conversation id accepted from client. |
| src/lib/messaging/links.ts | sponsorConversationId and conversationLinkPath extended cleanly; sponsor threads correctly route both audience variants to the admin path. |
| src/components/messaging/ConversationThread.tsx | Sponsor-authored message rendering added via authorSponsorId guard; Sponsor amber badge replaces organizer badge; isOwn always false for sponsor portal authors. |
| src/components/sponsor/SponsorPortalMessages.tsx | Portal-side message UI with 20s polling, author-name picker, and draft composer; setIsComposing guard prevents refetch interrupting an active compose session. |
| src/lib/slack/notify.ts | notifySponsorMessage added; correctly routes to sales channel, escapes all user-controlled strings via escapeMrkdwn, only fires for sponsor-authored direction. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SP as Sponsor Portal
    participant SR as sponsorMessages router
    participant SAN as Sanity
    participant FO as notifySponsorMessage
    participant HUB as Notification Hub
    participant SLK as Slack sales
    participant ACT as sponsorActivity
    participant ORG as Organizer Session
    participant MR as message router
    participant EMAIL as Contact Email

    Note over SP,SR: Sponsor-authored direction
    SP->>SR: send token body authorName
    SR->>SR: validateSponsorMessagingToken
    SR->>SR: strict authorName in contactPersons
    SR->>SAN: ensureSponsorConversation
    SR->>SAN: addMessage sponsor authorParty
    SR-->>SP: message
    SR-)FO: runAfterResponse notifySponsorMessage
    FO->>HUB: upsertMessageNotifications all organizers
    FO->>SLK: notifySponsorMessageSlack
    FO->>ACT: createSponsorActivity system

    Note over ORG,EMAIL: Organizer-authored direction
    ORG->>MR: message.send conversationId body
    MR->>SAN: addMessage speaker authorParty
    MR-->>ORG: message
    MR-)FO: runAfterResponse notifySponsorMessage authorOrganizerId
    FO->>EMAIL: sendSponsorMessageEmails contactPersons
    FO->>HUB: upsertMessageNotifications other organizers
    FO->>ACT: createSponsorActivity organizerId
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SP as Sponsor Portal
    participant SR as sponsorMessages router
    participant SAN as Sanity
    participant FO as notifySponsorMessage
    participant HUB as Notification Hub
    participant SLK as Slack sales
    participant ACT as sponsorActivity
    participant ORG as Organizer Session
    participant MR as message router
    participant EMAIL as Contact Email

    Note over SP,SR: Sponsor-authored direction
    SP->>SR: send token body authorName
    SR->>SR: validateSponsorMessagingToken
    SR->>SR: strict authorName in contactPersons
    SR->>SAN: ensureSponsorConversation
    SR->>SAN: addMessage sponsor authorParty
    SR-->>SP: message
    SR-)FO: runAfterResponse notifySponsorMessage
    FO->>HUB: upsertMessageNotifications all organizers
    FO->>SLK: notifySponsorMessageSlack
    FO->>ACT: createSponsorActivity system

    Note over ORG,EMAIL: Organizer-authored direction
    ORG->>MR: message.send conversationId body
    MR->>SAN: addMessage speaker authorParty
    MR-->>ORG: message
    MR-)FO: runAfterResponse notifySponsorMessage authorOrganizerId
    FO->>EMAIL: sendSponsorMessageEmails contactPersons
    FO->>HUB: upsertMessageNotifications other organizers
    FO->>ACT: createSponsorActivity organizerId
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/messaging/sanity.ts`, line 116-125 ([link](https://github.com/cloudnativebergen/website/blob/3c3d65696d336b1b340fc59aaf791fdf123d2315/src/lib/messaging/sanity.ts#L116-L125)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`needs-reply` GROQ predicate silently excludes sponsor-authored messages**

   `LAST_AUTHOR_REF` resolves to `author._ref`, which is `null` for sponsor-authored messages (they have no `author` ref — only `authorParty`). GROQ's `defined(null)` evaluates to `false`, so the entire `NEEDS_REPLY` predicate is `false` for any thread whose last message came from the sponsor. This means: (1) the "Needs Reply" tab never shows sponsor threads awaiting organizer response, and (2) the badge count from `getConversationViewCounts` is wrong for those threads. Meanwhile, the JS `needsReply` computation at line 820 correctly flags sponsor threads — `organizerSet.has(null)` is `false`, so `!false = true` — creating a visible inconsistency: an organizer sees the amber "needs reply" indicator on active-tab rows but clicks the "Needs Reply" tab and the thread is absent.


2. `src/lib/messaging/sanity.ts`, line 695-700 ([link](https://github.com/cloudnativebergen/website/blob/3c3d65696d336b1b340fc59aaf791fdf123d2315/src/lib/messaging/sanity.ts#L695-L700)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inbox preview shows 'Unknown' for sponsor-authored last messages**

   The `lastMessage.authorName` projection uses `author->name`, but sponsor-authored messages have no `author` ref — their display name is stored in the document field `authorName` (the contact-person snapshot). The JS fallback at line 846 (`?? 'Unknown'`) then renders "Unknown" in the inbox snippet instead of the contact person's name. Using `coalesce(authorName, author->name)` picks up the snapshot for sponsor messages while remaining correct for speaker/organizer messages.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(messaging): sponsor threads — porta..."](https://github.com/cloudnativebergen/website/commit/3c3d65696d336b1b340fc59aaf791fdf123d2315) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45485808)</sub>

<!-- /greptile_comment -->