### PR TITLE
feat(teams): team-aware notification routing (TEAMS-2)

### DIFF
--- a/docs/MESSAGING_SYSTEM.md
+++ b/docs/MESSAGING_SYSTEM.md
@@ -256,6 +256,18 @@ the hub rule — you are never notified about your own message). Participants ar
 proposal threads → proposal speakers ∪ organizers; general threads → creator ∪
 subjectSpeaker ∪ organizers.
 
+**Team routing (TEAMS-2).** The `organizers` half of that recipient set is
+expanded through the `cfp` team (`resolveRoutedOrganizerIds`,
+`src/lib/teams/routing.ts`): when a conference configures a non-empty `cfp` team,
+only its members receive the organizer fan-out; **with no team the set is exactly
+all organizers, as before**. This is the routing column only — the speaker
+participants, `canAccessConversation`, and inbox visibility are untouched (the
+FULL organizer set still classifies who is an organizer for the email-default and
+link columns below). Sponsor threads (`notifySponsorMessage`) route the same way
+through the `sponsors` team; see the sponsor fan-out matrix. See
+`docs/ORGANIZER_TEAMS.md` for the full routing map and the single fallback
+contract.
+
 ### Contract table (per new message)
 
 Columns are the recipient's per-conversation state. "hub", "push", "email",
@@ -300,7 +312,9 @@ Notes on each channel:
   conference contact address instead of each organizer — landing in
   `fix/messaging-ux-server`.
 - **SLACK.** Fires **only for speaker-authored** messages (`!authorIsOrganizer`),
-  one post to `conference.cfpNotificationChannel`, and is **independent of every
+  one post to the `cfp` team's Slack channel — `resolveTeamSlackChannel({ teamKey:
+'cfp', kind: 'cfp' })`, which falls back to `conference.cfpNotificationChannel`
+  (today's channel) when no team channel is set — and is **independent of every
   per-recipient preference** — muting your own hub/email does not silence the
   organizer channel. All interpolated fields are `escapeMrkdwn`-escaped. Slack is
   the one channel that is **mute-independent**.
@@ -514,18 +528,20 @@ id.
 A sibling of `notifyNewMessage` (integrated, not forked — reuses
 `upsertMessageNotifications`, bounded-concurrency email, `createSponsorActivity`).
 
-| Author        | Hub (+push)                                                                                   | Email                                                                                                                                 | Slack                                                                 | Activity                     |
-| ------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------- |
-| **Sponsor**   | ALL organizers, title `New message from <name> (Sponsor) — <subject>`, `/admin/messages/<id>` | — (no speaker/contact emails)                                                                                                         | **sales** channel (`sendSalesNotification`, "💬 New sponsor message") | `message` (system)           |
-| **Organizer** | the OTHER organizers (author excluded, mute-respected)                                        | ALL `contactPersons` via `sponsorEmail` from-address, deep-linked to the portal (`buildPortalUrl` + `#messages`), bounded concurrency | — (no Slack)                                                          | `message` (acting organizer) |
+| Author        | Hub (+push)                                                                                                                        | Email                                                                                                                                 | Slack                                                                                                   | Activity                     |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| **Sponsor**   | the `sponsors` **team** (all organizers when unset), title `New message from <name> (Sponsor) — <subject>`, `/admin/messages/<id>` | — (no speaker/contact emails)                                                                                                         | **sales** channel (`sendSalesNotification` → `sponsors`/`sales` team channel, "💬 New sponsor message") | `message` (system)           |
+| **Organizer** | the `sponsors` **team** minus the author (mute-respected)                                                                          | ALL `contactPersons` via `sponsorEmail` from-address, deep-linked to the portal (`buildPortalUrl` + `#messages`), bounded concurrency | — (no Slack)                                                                                            | `message` (acting organizer) |
 
 **Preferences.** `conversationPreference` (mute/email) applies to the ORGANIZER
 participants exactly as for speaker threads. **Sponsors have no preference
 documents** (no speaker id to key one on) — they always receive the email.
 
-**Hub routing note.** Sponsor hub notifications currently route to **ALL
-organizers**. When the sponsors TEAM lands (**TEAMS-2**) this should route to that
-team instead of the whole organizer set (noted inline in `notify.ts`).
+**Hub routing note (TEAMS-2, implemented).** Sponsor hub notifications route
+through the `sponsors` team via `resolveRoutedOrganizerIds`, falling back to
+**ALL organizers** when that team is not configured (the single fallback
+contract). Team routing is recipient-only and adds no access boundary — see
+`docs/ORGANIZER_TEAMS.md`.
 
 ## Related documents
 

--- a/docs/ORGANIZER_TEAMS.md
+++ b/docs/ORGANIZER_TEAMS.md
@@ -53,18 +53,69 @@ team-specific routing, fall back to all organizers." Keeping that decision at th
 call site makes absent-means-today a single, auditable choice rather than a
 hidden default buried in the resolver.
 
-## Adopted routing map (implemented in TEAMS-2)
+## Adopted routing map (IMPLEMENTED — TEAMS-2)
 
-The consumption layer (a separate change) wires message kinds to well-known team
-keys, each with the all-organizers fallback:
+The consumption layer wires message kinds to well-known team keys, each with the
+all-organizers fallback. Every rule is INERT until its team is configured: with
+no team the recipient set is exactly today's all-organizers behaviour.
 
-- **proposal** → `cfp`
-- **sponsor** → `sponsors`
-- **volunteers** → `volunteers`
-- **nudge / assignee** → the assignee's team → all organizers
+| Message kind                         | Team key                                          |
+| ------------------------------------ | ------------------------------------------------- |
+| proposal events                      | `cfp`                                             |
+| speaker threads (proposal + general) | `cfp`                                             |
+| travel-support (new request)         | `cfp`                                             |
+| sponsor events + sponsor threads     | `sponsors`                                        |
+| volunteer signups                    | `volunteers`                                      |
+| stale nudge                          | assignee → thread's team (`sponsors`/`cfp`) → all |
 
 Arbitrary additional keys beyond the well-known four are allowed; the constant is
 the routing map's anchor, not an allow-list.
+
+### The single fallback contract
+
+One helper — `resolveRoutedOrganizerIds({ conferenceId, teamKey })`
+(`src/lib/teams/routing.ts`) — is the ONLY place ABSENT-MEANS-TODAY becomes a
+concrete recipient set. It returns the team's members when the team is configured
+with **≥1 member**, otherwise the FULL organizer set (`getOrganizerSpeakerIds`).
+An empty team is treated identically to an absent one (routing to zero organizers
+is never the intent). It is **never-fail**: a teams-fetch error logs and falls
+back to all organizers rather than mis-routing to a partial set. Teams are
+**routing only** here — the helper's output is a notification recipient list and
+never touches access, inbox visibility, or participant/party resolution.
+
+### Routing sites
+
+Every all-organizer notification fan-out now resolves its recipients through the
+helper with the mapped key (actor-exclusion and each site's never-fail envelope
+are unchanged):
+
+- `src/lib/events/handlers/persistNotification.ts` — `submit` and
+  `confirm`/`withdraw` organizer fan-outs → `cfp`.
+- `src/server/routers/proposal.ts` — direct-create submission fan-out → `cfp`.
+- `src/server/routers/travelSupport.ts` — NEW-request organizer alert → `cfp`
+  (travel support is speaker-facing, CFP-side work). Its two speaker-facing
+  status notifications are NOT organizer fan-outs and stay unrouted.
+- `src/server/routers/volunteer.ts` — signup organizer mirror → `volunteers`.
+- `src/server/routers/sponsor.ts` — stage-move fan-out → `sponsors`.
+- `src/lib/messaging/notify.ts` — `notifyNewMessage` (speaker threads) routes the
+  organizer-group RECIPIENT expansion through `cfp`; `notifySponsorMessage` →
+  `sponsors`. See the access-vs-routing split note below.
+- `src/lib/messaging/nudge.ts` — assignee → thread's team → all organizers.
+- Slack: `sendSalesNotification` (sponsor message + sponsor events) resolves the
+  `sponsors`/`sales` channel; speaker-message Slack resolves the `cfp`/`cfp`
+  channel. Both fall back to today's conference channels exactly.
+
+### Access vs routing in `notify.ts`
+
+`notifyNewMessage` seeds TWO organizer id sets. The FULL set
+(`getOrganizerSpeakerIds`) stays the **classifier** — it decides whether the
+author is an organizer and whether each recipient is an organizer (which drives
+the audience-dependent email default and the per-audience deep link). The ROUTED
+set (`resolveRoutedOrganizerIds({ teamKey: 'cfp' })`) is used ONLY to expand the
+`organizers` group party into notification RECIPIENTS. Speaker parties are
+untouched by routing; only which organizers receive the fan-out narrows. Access,
+`canAccessConversation`, participant/party resolution, and inbox visibility are
+left entirely alone — this change adds no access boundary.
 
 ## Greenlit lenses (TEAMS-3)
 

--- a/src/lib/events/handlers/persistNotification.ts
+++ b/src/lib/events/handlers/persistNotification.ts
@@ -1,9 +1,7 @@
 import { ProposalStatusChangeEvent } from '@/lib/events/types'
 import { Action } from '@/lib/proposal/types'
-import {
-  createNotifications,
-  getOrganizerSpeakerIds,
-} from '@/lib/notification/sanity'
+import { createNotifications } from '@/lib/notification/sanity'
+import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import type { NotificationInput } from '@/lib/notification/types'
 
 /**
@@ -42,7 +40,12 @@ export async function handlePersistNotification(
   const proposalTitle = event.proposal.title
 
   if (event.action === Action.submit) {
-    const organizerIds = await getOrganizerSpeakerIds()
+    // TEAMS-2: proposal events route to the `cfp` team (all organizers when it
+    // is not configured — the shared fallback contract).
+    const organizerIds = await resolveRoutedOrganizerIds({
+      conferenceId,
+      teamKey: 'cfp',
+    })
     const items: NotificationInput[] = organizerIds
       .filter((id) => id && id !== actorId)
       .map((id): NotificationInput => ({
@@ -62,7 +65,12 @@ export async function handlePersistNotification(
     // Organizer routing is unconditional (like submit) — it mirrors the Slack
     // organizer alert, not the email-gated speaker notification.
     const isWithdraw = event.action === Action.withdraw
-    const organizerIds = await getOrganizerSpeakerIds()
+    // TEAMS-2: proposal events route to the `cfp` team (all organizers when it
+    // is not configured).
+    const organizerIds = await resolveRoutedOrganizerIds({
+      conferenceId,
+      teamKey: 'cfp',
+    })
     const title = isWithdraw
       ? `Proposal withdrawn: "${proposalTitle}"`
       : `Speaker confirmed: "${proposalTitle}"`

--- a/src/lib/messaging/notify.test.ts
+++ b/src/lib/messaging/notify.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Boundary mocks --------------------------------------------------------
+
+const upsertMock = vi.fn().mockResolvedValue(undefined)
+const getOrganizerSpeakerIdsMock = vi
+  .fn()
+  .mockResolvedValue(['org-1', 'org-2', 'org-3'])
+vi.mock('@/lib/notification/sanity', () => ({
+  upsertMessageNotifications: (...a: unknown[]) => upsertMock(...a),
+  getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
+}))
+
+// TEAMS-2 teams SOURCE: default [] ⇒ ABSENT-MEANS-TODAY (all organizers);
+// per-test override narrows to a configured `cfp` team.
+const getConferenceTeamsMock = vi.fn().mockResolvedValue([])
+vi.mock('@/lib/teams/sanity', () => ({
+  getConferenceTeams: (...a: unknown[]) => getConferenceTeamsMock(...a),
+}))
+
+vi.mock('@/lib/slack/notify', () => ({
+  notifyNewSpeakerMessage: vi.fn().mockResolvedValue(undefined),
+  notifySponsorMessage: vi.fn().mockResolvedValue(undefined),
+}))
+
+const emailMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('./email', () => ({
+  sendMessageEmails: (...a: unknown[]) => emailMock(...a),
+}))
+
+// Fetch routing for the REAL ./sanity helpers (prefs) + notify's speaker rows.
+const fetchMock = vi.fn((query: string) => {
+  if (query.includes('conversationPreference')) return Promise.resolve([])
+  if (query.includes('messagingEmailDefault')) {
+    return Promise.resolve([
+      { _id: 'spk-1', name: 'Speaker One', email: 'spk1@ex.test' },
+      { _id: 'spk-2', name: 'Speaker Two', email: 'spk2@ex.test' },
+      { _id: 'org-2', name: 'Org Two', email: 'org2@ex.test' },
+    ])
+  }
+  return Promise.resolve(null)
+})
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(a[0] as string) },
+  clientWrite: {},
+}))
+
+import { notifyNewMessage } from './notify'
+import type { ConversationWithContext, Message } from './types'
+import type { Conference } from '@/lib/conference/types'
+
+const conference = {
+  _id: 'conf-1',
+  domains: ['cnd.example'],
+  contactEmail: 'hei@ex.test',
+} as unknown as Conference
+
+// A proposal thread with two speakers; the organizers group is a party.
+const conversation: ConversationWithContext = {
+  _id: 'conversation.1',
+  conferenceId: 'conf-1',
+  conversationType: 'proposal',
+  proposalId: 'talk-1',
+  proposalSpeakerIds: ['spk-1', 'spk-2'],
+  createdById: 'spk-1',
+  subject: 'A talk',
+  createdAt: '2026-07-01T00:00:00Z',
+  lastMessageAt: '2026-07-01T00:00:00Z',
+  participants: [
+    { partyType: 'speaker', speakerId: 'spk-1' },
+    { partyType: 'speaker', speakerId: 'spk-2' },
+    { partyType: 'group', group: 'organizers' },
+  ],
+}
+
+// Authored by speaker spk-1 (a NON-organizer): the actor is excluded.
+const message: Message = {
+  _id: 'message.1',
+  conversationId: conversation._id,
+  authorId: 'spk-1',
+  body: 'Hello organizers.',
+  createdAt: '2026-07-01T10:00:00Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function hubRecipients(): string[] {
+  const items = upsertMock.mock.calls[0][0] as { recipientId: string }[]
+  return items.map((i) => i.recipientId).sort()
+}
+
+describe('notifyNewMessage — TEAMS-2 access-vs-routing split', () => {
+  it('team ABSENT: organizer group expands to ALL organizers (+ speaker recipient)', async () => {
+    await notifyNewMessage({
+      conversation,
+      message,
+      authorId: 'spk-1',
+      conference,
+    })
+    // spk-2 (speaker party) + every organizer; actor spk-1 excluded.
+    expect(hubRecipients()).toEqual(['org-1', 'org-2', 'org-3', 'spk-2'])
+  })
+
+  it('cfp team configured: organizer expansion NARROWS to team members only', async () => {
+    getConferenceTeamsMock.mockResolvedValue([
+      { key: 'cfp', title: 'CFP', members: ['org-2'] },
+    ])
+    await notifyNewMessage({
+      conversation,
+      message,
+      authorId: 'spk-1',
+      conference,
+    })
+    // org-1 and org-3 are organizers but NOT on the cfp team → dropped. The
+    // speaker party spk-2 is unaffected by routing.
+    expect(hubRecipients()).toEqual(['org-2', 'spk-2'])
+  })
+
+  it('CLASSIFICATION stays on the FULL organizer set: routed org gets no default email, speaker does', async () => {
+    getConferenceTeamsMock.mockResolvedValue([
+      { key: 'cfp', title: 'CFP', members: ['org-2'] },
+    ])
+    await notifyNewMessage({
+      conversation,
+      message,
+      authorId: 'spk-1',
+      conference,
+    })
+    // The individual-recipient email pass: spk-2 (classified SPEAKER via the
+    // full organizer set → default ON) is emailed; org-2 (classified ORGANIZER
+    // → default OFF) is not. If org-2 were mis-classified as a non-organizer it
+    // would wrongly receive the speaker-default email.
+    const individualCall = emailMock.mock.calls.find((c) =>
+      (c[0] as { email: string }[]).some((r) => r.email === 'spk2@ex.test'),
+    )
+    expect(individualCall).toBeDefined()
+    const emails = (individualCall![0] as { email: string }[]).map(
+      (r) => r.email,
+    )
+    expect(emails).toContain('spk2@ex.test')
+    expect(emails).not.toContain('org2@ex.test')
+  })
+})

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -3,6 +3,7 @@ import {
   upsertMessageNotifications,
   getOrganizerSpeakerIds,
 } from '@/lib/notification/sanity'
+import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import { clientReadUncached } from '@/lib/sanity/client'
 import {
   notifyNewSpeakerMessage,
@@ -104,10 +105,29 @@ export async function notifyNewMessage({
   conference: Conference
 }): Promise<void> {
   try {
+    // ACCESS vs ROUTING split (TEAMS-2). `organizerSet` is the FULL organizer
+    // set and is used ONLY to CLASSIFY identities — whether the author is an
+    // organizer, whether a recipient is an organizer (audience-dependent email
+    // default + link variant), whether any recipient is a speaker. That is an
+    // access/participant question and MUST stay the whole organizer set.
     const organizerIds = await getOrganizerSpeakerIds()
     const organizerSet = new Set(organizerIds)
     const authorIsOrganizer = organizerSet.has(authorId)
-    const recipientIds = resolveRecipients(conversation, authorId, organizerIds)
+    // ROUTING: the `organizers` group party is expanded for NOTIFICATION
+    // RECIPIENTS through the `cfp` team (proposal + general speaker threads) —
+    // all organizers when it is not configured. Speaker participants are
+    // `speaker` parties and are unaffected by this; only WHICH organizers get
+    // the fan-out narrows. Every routed id is a real organizer, so the
+    // classification above still resolves it correctly.
+    const routedOrganizerIds = await resolveRoutedOrganizerIds({
+      conferenceId: conversation.conferenceId,
+      teamKey: 'cfp',
+    })
+    const recipientIds = resolveRecipients(
+      conversation,
+      authorId,
+      routedOrganizerIds,
+    )
     const excerpt = messageExcerpt(message.body)
 
     // One read for every speaker we need to name / email (author + recipients).
@@ -282,9 +302,9 @@ export async function notifyNewMessage({
  * preference documents (no speaker id to key one on) — they always receive the
  * email; documented here as the deliberate asymmetry.
  *
- * HUB-ROUTING NOTE: organizer hub notifications currently go to ALL organizers.
- * When the sponsors TEAM lands (TEAMS-2) this fan-out should route to that team
- * instead of the whole organizer set — see the recipient resolution below.
+ * HUB-ROUTING (TEAMS-2): organizer hub notifications route to the `sponsors`
+ * team (via {@link resolveRoutedOrganizerIds}), falling back to ALL organizers
+ * when that team is not configured — see the recipient resolution below.
  *
  * NEVER-FAIL: every channel is wrapped so a failure can't fail the (already
  * committed) message write, identical to {@link notifyNewMessage}.
@@ -308,8 +328,15 @@ export async function notifySponsorMessage({
     const subject = conversation.subject
     const adminLink = conversationLinkPath(conversation, true)
 
-    // TEAMS-2: replace `getOrganizerSpeakerIds()` with the sponsors-team members.
-    const organizerIds = await getOrganizerSpeakerIds()
+    // TEAMS-2: sponsor-thread message fan-out routes to the `sponsors` team
+    // (all organizers when it is not configured — the shared fallback). This is
+    // a PURE recipient set here (author exclusion is applied below via
+    // `authorOrganizerId`), so unlike the speaker fan-out there is no
+    // classification use to keep on the full organizer set.
+    const organizerIds = await resolveRoutedOrganizerIds({
+      conferenceId: conversation.conferenceId,
+      teamKey: 'sponsors',
+    })
 
     if (authorOrganizerId === undefined) {
       // ---- SPONSOR-authored ------------------------------------------------

--- a/src/lib/messaging/notifySponsor.test.ts
+++ b/src/lib/messaging/notifySponsor.test.ts
@@ -9,6 +9,15 @@ vi.mock('@/lib/notification/sanity', () => ({
   getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
 }))
 
+// TEAMS-2: the sponsor fan-out routes its organizer recipients through
+// `resolveRoutedOrganizerIds({ teamKey: 'sponsors' })`. Mock the teams SOURCE so
+// the REAL helper runs: default [] proves the ABSENT-MEANS-TODAY fallback (all
+// organizers), and a per-test override exercises members-only routing.
+const getConferenceTeamsMock = vi.fn().mockResolvedValue([])
+vi.mock('@/lib/teams/sanity', () => ({
+  getConferenceTeams: (...a: unknown[]) => getConferenceTeamsMock(...a),
+}))
+
 const slackMock = vi.fn().mockResolvedValue(undefined)
 vi.mock('@/lib/slack/notify', () => ({
   notifyNewSpeakerMessage: vi.fn(),
@@ -164,5 +173,51 @@ describe('notifySponsorMessage — ORGANIZER-authored', () => {
 
     // NO Slack on an organizer reply.
     expect(slackMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('notifySponsorMessage — sponsors TEAM configured (TEAMS-2 routing)', () => {
+  // A sponsors team that is a strict SUBSET of the organizers (only org-2).
+  beforeEach(() => {
+    getConferenceTeamsMock.mockResolvedValue([
+      { key: 'sponsors', title: 'Sponsors', members: ['org-2'] },
+    ])
+  })
+
+  it('SPONSOR-authored: hubs the sponsors TEAM members only (org-1 excluded)', async () => {
+    const message: Message = {
+      _id: 'message.3',
+      conversationId: conversation._id,
+      authorId: '',
+      body: 'Booth question.',
+      createdAt: '2026-07-01T10:00:00Z',
+      authorName: 'Dana Diaz',
+      authorSponsorId: SFC,
+    }
+    await notifySponsorMessage({ conversation, message, sfc })
+
+    const items = upsertMock.mock.calls[0][0] as { recipientId: string }[]
+    expect(items.map((i) => i.recipientId)).toEqual(['org-2'])
+  })
+
+  it('ORGANIZER-authored: team routing AND actor exclusion compose', async () => {
+    const message: Message = {
+      _id: 'message.4',
+      conversationId: conversation._id,
+      authorId: 'org-2',
+      body: 'Reply from a sponsors-team organizer.',
+      createdAt: '2026-07-01T11:00:00Z',
+    }
+    // Author org-2 is the only team member, so after actor exclusion there is
+    // nobody left to hub — proving the two rules compose (team ∩ not-actor = ∅).
+    await notifySponsorMessage({
+      conversation,
+      message,
+      sfc,
+      authorOrganizerId: 'org-2',
+    })
+    expect(upsertMock).not.toHaveBeenCalled()
+    // The sponsor email to contacts is unaffected by organizer routing.
+    expect(sponsorEmailMock).toHaveBeenCalledOnce()
   })
 })

--- a/src/lib/messaging/nudge.test.ts
+++ b/src/lib/messaging/nudge.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Boundary mocks --------------------------------------------------------
+
+const createNotificationsMock = vi.fn().mockResolvedValue(undefined)
+const getOrganizerSpeakerIdsMock = vi
+  .fn()
+  .mockResolvedValue(['org-1', 'org-2', 'org-3'])
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: (...a: unknown[]) => createNotificationsMock(...a),
+  getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
+}))
+
+// TEAMS-2 teams SOURCE keyed by conference id, so the REAL
+// `resolveRoutedOrganizerIds` runs the assignee → team → all chain.
+const getConferenceTeamsMock = vi.fn((conferenceId: string) => {
+  if (conferenceId === 'conf-cfp')
+    return Promise.resolve([{ key: 'cfp', title: 'CFP', members: ['org-2'] }])
+  if (conferenceId === 'conf-spon')
+    return Promise.resolve([
+      { key: 'sponsors', title: 'Sponsors', members: ['org-3'] },
+    ])
+  return Promise.resolve([])
+})
+vi.mock('@/lib/teams/sanity', () => ({
+  getConferenceTeams: (id: string) => getConferenceTeamsMock(id),
+}))
+
+const commitMock = vi.fn().mockResolvedValue({})
+const patchApi = { set: () => patchApi, commit: () => commitMock() }
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientWrite: { patch: () => patchApi },
+}))
+
+import { nudgeStaleConversations } from './nudge'
+
+interface Row {
+  _id: string
+  conversationType: 'proposal' | 'general' | 'sponsor'
+  subject: string
+  conferenceId: string
+  proposalId?: string
+  assignedToId?: string
+  lastMessageAt: string
+}
+
+const ROWS: Row[] = [
+  // 1. ASSIGNEE wins over everything (its conference even has a cfp team).
+  {
+    _id: 'c-assigned',
+    conversationType: 'proposal',
+    subject: 'Assigned',
+    conferenceId: 'conf-cfp',
+    assignedToId: 'org-9',
+    lastMessageAt: '2026-01-01T00:00:00Z',
+  },
+  // 2. Unassigned, cfp team configured → the cfp TEAM.
+  {
+    _id: 'c-cfp',
+    conversationType: 'proposal',
+    subject: 'Cfp team',
+    conferenceId: 'conf-cfp',
+    lastMessageAt: '2026-01-01T00:00:00Z',
+  },
+  // 3. Unassigned sponsor thread, sponsors team configured → the sponsors TEAM.
+  {
+    _id: 'c-spon',
+    conversationType: 'sponsor',
+    subject: 'Sponsor team',
+    conferenceId: 'conf-spon',
+    lastMessageAt: '2026-01-01T00:00:00Z',
+  },
+  // 4. Unassigned, no team on its conference → ALL organizers.
+  {
+    _id: 'c-all',
+    conversationType: 'general',
+    subject: 'All orgs',
+    conferenceId: 'conf-none',
+    lastMessageAt: '2026-01-01T00:00:00Z',
+  },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockResolvedValue(ROWS)
+})
+
+/** The recipient ids of the createNotifications call whose inputs target `id`. */
+function recipientsFor(convId: string): string[] {
+  for (const call of createNotificationsMock.mock.calls) {
+    const inputs = call[0] as { recipientId: string; link: string }[]
+    if (inputs.length && inputs[0].link.includes(convId)) {
+      return inputs.map((i) => i.recipientId).sort()
+    }
+  }
+  return []
+}
+
+describe('nudgeStaleConversations — assignee → team → all chain', () => {
+  it('routes each stale thread down the chain', async () => {
+    const summary = await nudgeStaleConversations()
+
+    expect(recipientsFor('c-assigned')).toEqual(['org-9'])
+    expect(recipientsFor('c-cfp')).toEqual(['org-2'])
+    expect(recipientsFor('c-spon')).toEqual(['org-3'])
+    expect(recipientsFor('c-all')).toEqual(['org-1', 'org-2', 'org-3'])
+
+    expect(summary.nudged).toBe(4)
+    // 1 (assignee) + 1 (cfp team) + 1 (sponsors team) + 3 (all orgs) = 6.
+    expect(summary.notifications).toBe(6)
+  })
+})

--- a/src/lib/messaging/nudge.ts
+++ b/src/lib/messaging/nudge.ts
@@ -4,6 +4,7 @@ import {
   createNotifications,
   getOrganizerSpeakerIds,
 } from '@/lib/notification/sanity'
+import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import type { NotificationInput } from '@/lib/notification/types'
 import { conversationLinkPath } from './links'
 // Single home for the last-author projection (R1): sharing the exact string with
@@ -16,9 +17,12 @@ import { LAST_AUTHOR_REF } from './sanity'
  *
  * POLICY: a conversation that is still OPEN, whose LAST message is from a
  * non-organizer (so the ball is in the organizers' court), and which has seen no
- * new activity for {@link STALE_AFTER_DAYS} days gets ONE hub notification —
- * routed to the assigned organizer when set, otherwise to every organizer — with
- * a deep link to the admin thread. The conversation's `lastStaleNudgeAt` is then
+ * new activity for {@link STALE_AFTER_DAYS} days gets ONE hub notification. It is
+ * routed down the TEAMS-2 chain (each step falling through to the next): the
+ * assigned organizer when set → else the thread's team (`sponsors` for a sponsor
+ * thread, `cfp` otherwise) → else every organizer (the team-else-all fallback of
+ * {@link resolveRoutedOrganizerIds}). A deep link to the admin thread rides
+ * along. The conversation's `lastStaleNudgeAt` is then
  * stamped so it is not nudged again until a NEWER message arrives
  * (`lastStaleNudgeAt < lastMessageAt` re-arms it); a globally-archived thread is
  * never nudged.
@@ -46,7 +50,7 @@ export interface StaleNudgeSummary {
   scanned: number
   /** Conversations for which a notification was emitted AND stamped. */
   nudged: number
-  /** Total hub notifications created (assignee → 1; unassigned → N organizers). */
+  /** Total hub notifications created (assignee → 1; unassigned → team-or-N organizers). */
   notifications: number
   /** Conversations whose nudge failed and were isolated (logged, skipped). */
   failed: number
@@ -66,7 +70,7 @@ export function staleConversationCutoff(now: Date = new Date()): string {
 /** A stale conversation row, projected with what a nudge needs. */
 interface StaleConversation {
   _id: string
-  conversationType: 'proposal' | 'general'
+  conversationType: 'proposal' | 'general' | 'sponsor'
   subject: string | null
   conferenceId: string | null
   proposalId?: string | null
@@ -123,12 +127,20 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
         // notification requires a conference ref); skip without stamping.
         if (!conversation.conferenceId) continue
 
-        // Route to the assignee when set, else to every organizer. If nobody can
-        // be notified (no assignee AND no organizers), skip without stamping so
-        // the thread is retried once organizers exist.
+        // Route down the TEAMS-2 chain: the assignee when set → else the
+        // thread's team (`sponsors` for a sponsor thread, `cfp` otherwise) →
+        // else every organizer (the team-else-all fallback). If nobody can be
+        // notified (no assignee AND no team AND no organizers), skip without
+        // stamping so the thread is retried once organizers exist.
         const recipientIds = conversation.assignedToId
           ? [conversation.assignedToId]
-          : organizerIds
+          : await resolveRoutedOrganizerIds({
+              conferenceId: conversation.conferenceId,
+              teamKey:
+                conversation.conversationType === 'sponsor'
+                  ? 'sponsors'
+                  : 'cfp',
+            })
         if (recipientIds.length === 0) continue
 
         const link = conversationLinkPath(

--- a/src/lib/slack/notify.test.ts
+++ b/src/lib/slack/notify.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Capture the channel each Slack post targets.
+const postMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/slack/client', () => ({
+  postSlackMessage: (msg: unknown, opts: { channel?: string }) =>
+    postMock(msg, opts),
+  escapeMrkdwn: (s: string) => s,
+}))
+vi.mock('@/lib/speaker/sanity', () => ({ getSpeaker: vi.fn() }))
+
+import { notifyNewSpeakerMessage, notifySponsorMessage } from './notify'
+import type { Conference } from '@/lib/conference/types'
+
+function conf(overrides: Partial<Conference>): Conference {
+  return {
+    _id: 'conf-1',
+    domains: ['cnd.example'],
+    cfpNotificationChannel: '#cfp',
+    salesNotificationChannel: '#sales',
+    ...overrides,
+  } as unknown as Conference
+}
+
+const speakerArgs = {
+  authorName: 'Ada',
+  subject: 'Hi',
+  excerpt: 'A message',
+  adminPath: '/admin/messages/x',
+}
+const sponsorArgs = {
+  authorName: 'Dana',
+  sponsorName: 'Acme',
+  excerpt: 'A message',
+  adminPath: '/admin/messages/y',
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('speaker-message Slack — cfp team channel (TEAMS-2)', () => {
+  it('falls back to cfpNotificationChannel when no cfp team is configured', async () => {
+    await notifyNewSpeakerMessage(speakerArgs, conf({}))
+    expect(postMock).toHaveBeenCalledOnce()
+    expect(postMock.mock.calls[0][1]).toEqual({ channel: '#cfp' })
+  })
+
+  it("uses the cfp team's slackChannel override when set", async () => {
+    await notifyNewSpeakerMessage(
+      speakerArgs,
+      conf({
+        teams: [
+          { key: 'cfp', title: 'CFP', members: [], slackChannel: '#cfp-team' },
+        ],
+      }),
+    )
+    expect(postMock.mock.calls[0][1]).toEqual({ channel: '#cfp-team' })
+  })
+})
+
+describe('sponsor-message Slack — sponsors team sales channel (TEAMS-2)', () => {
+  it('falls back to salesNotificationChannel when no sponsors team is configured', async () => {
+    await notifySponsorMessage(sponsorArgs, conf({}))
+    expect(postMock).toHaveBeenCalledOnce()
+    expect(postMock.mock.calls[0][1]).toEqual({ channel: '#sales' })
+  })
+
+  it("uses the sponsors team's slackChannel override when set", async () => {
+    await notifySponsorMessage(
+      sponsorArgs,
+      conf({
+        teams: [
+          {
+            key: 'sponsors',
+            title: 'Sponsors',
+            members: [],
+            slackChannel: '#spon',
+          },
+        ],
+      }),
+    )
+    expect(postMock.mock.calls[0][1]).toEqual({ channel: '#spon' })
+  })
+
+  it('skips the post entirely when neither a team channel nor a sales channel exists', async () => {
+    await notifySponsorMessage(
+      sponsorArgs,
+      conf({ salesNotificationChannel: undefined }),
+    )
+    expect(postMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/slack/notify.ts
+++ b/src/lib/slack/notify.ts
@@ -10,30 +10,44 @@ import {
   type SlackBlock,
   type SlackMessage,
 } from '@/lib/slack/client'
+import { resolveTeamSlackChannel } from '@/lib/teams'
 
+/**
+ * Post to the CFP Slack channel. An explicit `channel` (resolved from a team,
+ * TEAMS-2) overrides the conference default; when omitted the behaviour is
+ * exactly today's (`conference.cfpNotificationChannel`).
+ */
 async function sendSlackNotification(
   message: SlackMessage,
   conference: Conference,
+  channel: string | undefined = conference.cfpNotificationChannel,
 ) {
   try {
-    await postSlackMessage(message, {
-      channel: conference.cfpNotificationChannel,
-    })
+    await postSlackMessage(message, { channel })
   } catch (error) {
     console.error('Error sending Slack notification:', error)
   }
 }
 
+/**
+ * Post to the SALES Slack channel. Every caller is a sponsor concern, so the
+ * channel is resolved through the `sponsors` team (TEAMS-2) — a configured team
+ * `slackChannel` wins, otherwise it falls back to
+ * `conference.salesNotificationChannel`, i.e. exactly today's channel.
+ */
 async function sendSalesNotification(
   message: SlackMessage,
   conference: Conference,
 ) {
-  if (!conference.salesNotificationChannel) return
+  const channel = resolveTeamSlackChannel({
+    conference,
+    teamKey: 'sponsors',
+    kind: 'sales',
+  })
+  if (!channel) return
 
   try {
-    await postSlackMessage(message, {
-      channel: conference.salesNotificationChannel,
-    })
+    await postSlackMessage(message, { channel })
   } catch (error) {
     console.error('Error sending Slack sales notification:', error)
   }
@@ -283,7 +297,13 @@ export async function notifyNewSpeakerMessage(
   }
 
   const message = { blocks }
-  await sendSlackNotification(message, conference)
+  // TEAMS-2: speaker-message Slack routes through the `cfp` team channel,
+  // falling back to `cfpNotificationChannel` (today's channel) when unset.
+  await sendSlackNotification(
+    message,
+    conference,
+    resolveTeamSlackChannel({ conference, teamKey: 'cfp', kind: 'cfp' }),
+  )
 }
 
 /**

--- a/src/lib/teams/index.ts
+++ b/src/lib/teams/index.ts
@@ -17,5 +17,6 @@ export {
   resolveTeamSlackChannel,
   resolveTeamEmailIdentity,
 } from './resolve'
+export { resolveRoutedOrganizerIds } from './routing'
 export { formatTeamSummary } from './format'
 export { TEAM_KEY_PATTERN, isValidTeamKey, countTeamKey } from './validation'

--- a/src/lib/teams/routing.test.ts
+++ b/src/lib/teams/routing.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { OrganizerTeam } from './types'
+
+const getConferenceTeamsMock = vi.fn<(id: string) => Promise<OrganizerTeam[]>>()
+vi.mock('./sanity', () => ({
+  getConferenceTeams: (id: string) => getConferenceTeamsMock(id),
+}))
+
+const getOrganizerSpeakerIdsMock = vi.fn<() => Promise<string[]>>()
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
+}))
+
+import { resolveRoutedOrganizerIds } from './routing'
+
+const ALL_ORGANIZERS = ['org-1', 'org-2', 'org-3']
+
+beforeEach(() => {
+  getConferenceTeamsMock.mockReset()
+  getOrganizerSpeakerIdsMock.mockReset()
+  getOrganizerSpeakerIdsMock.mockResolvedValue([...ALL_ORGANIZERS])
+})
+
+const CFP_TEAM: OrganizerTeam = {
+  key: 'cfp',
+  title: 'CFP',
+  members: ['org-1', 'org-2'],
+}
+
+describe('resolveRoutedOrganizerIds — the single fallback contract', () => {
+  it('routes to the team members ONLY when the team is configured with ≥1 member', async () => {
+    getConferenceTeamsMock.mockResolvedValue([CFP_TEAM])
+    expect(
+      await resolveRoutedOrganizerIds({ conferenceId: 'c1', teamKey: 'cfp' }),
+    ).toEqual(['org-1', 'org-2'])
+    // Fell fully through the team branch — never touched the organizer set.
+    expect(getOrganizerSpeakerIdsMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to ALL organizers when the team is ABSENT', async () => {
+    getConferenceTeamsMock.mockResolvedValue([CFP_TEAM])
+    expect(
+      await resolveRoutedOrganizerIds({
+        conferenceId: 'c1',
+        teamKey: 'sponsors',
+      }),
+    ).toEqual(ALL_ORGANIZERS)
+  })
+
+  it('falls back to ALL organizers when the conference has NO teams at all', async () => {
+    getConferenceTeamsMock.mockResolvedValue([])
+    expect(
+      await resolveRoutedOrganizerIds({ conferenceId: 'c1', teamKey: 'cfp' }),
+    ).toEqual(ALL_ORGANIZERS)
+  })
+
+  it('falls back to ALL organizers when the team is configured but EMPTY', async () => {
+    getConferenceTeamsMock.mockResolvedValue([
+      { key: 'cfp', title: 'CFP', members: [] },
+    ])
+    expect(
+      await resolveRoutedOrganizerIds({ conferenceId: 'c1', teamKey: 'cfp' }),
+    ).toEqual(ALL_ORGANIZERS)
+  })
+
+  it('NEVER-FAILS: a teams-fetch error logs and falls back to ALL organizers', async () => {
+    const err = new Error('sanity down')
+    getConferenceTeamsMock.mockRejectedValue(err)
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(
+      await resolveRoutedOrganizerIds({ conferenceId: 'c1', teamKey: 'cfp' }),
+    ).toEqual(ALL_ORGANIZERS)
+    expect(spy).toHaveBeenCalledOnce()
+    spy.mockRestore()
+  })
+
+  it('returns a fresh copy of the team members (no shared mutable reference)', async () => {
+    const team = { ...CFP_TEAM, members: ['org-1', 'org-2'] }
+    getConferenceTeamsMock.mockResolvedValue([team])
+    const result = await resolveRoutedOrganizerIds({
+      conferenceId: 'c1',
+      teamKey: 'cfp',
+    })
+    expect(result).not.toBe(team.members)
+  })
+})

--- a/src/lib/teams/routing.ts
+++ b/src/lib/teams/routing.ts
@@ -1,0 +1,50 @@
+import { getConferenceTeams } from './sanity'
+import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import type { TeamKey } from './types'
+
+/**
+ * The organizer speaker `_id`s a notification of a given team's kind should be
+ * routed to — the ONE fallback contract every routing site shares (TEAMS-2):
+ *
+ *   team is configured with ≥1 member  → that team's members ONLY;
+ *   team absent / configured but empty → the FULL organizer set
+ *                                        ({@link getOrganizerSpeakerIds}).
+ *
+ * This is the single place ABSENT-MEANS-TODAY (every organizer receives
+ * everything when no team is configured) is turned into a concrete recipient
+ * set, so each call site stays a one-liner: pass the mapped `teamKey` and get
+ * back "the right organizers, or all of them."
+ *
+ * ROUTING ONLY: the returned ids are notification RECIPIENTS. This never gates
+ * access, inbox visibility, or participant membership — a team is a soft lens,
+ * never an access boundary (see docs/ORGANIZER_TEAMS.md).
+ *
+ * NEVER-FAIL: a teams-fetch failure must not change who is notified for the
+ * worse — it logs and falls back to ALL organizers (today's behaviour), rather
+ * than mis-routing to a partial/empty set for the fetch's duration. An empty
+ * team is treated identically to an absent one: routing to zero organizers is
+ * never the intent, so it collapses to all. (A failure of the organizer fetch
+ * itself surfaces to the caller's existing never-fail envelope, exactly as it
+ * does today.)
+ */
+export async function resolveRoutedOrganizerIds({
+  conferenceId,
+  teamKey,
+}: {
+  conferenceId: string
+  teamKey: TeamKey
+}): Promise<string[]> {
+  try {
+    const teams = await getConferenceTeams(conferenceId)
+    const team = teams.find((t) => t.key === teamKey)
+    if (team && team.members.length > 0) {
+      return [...team.members]
+    }
+  } catch (error) {
+    console.error(
+      `resolveRoutedOrganizerIds: teams fetch failed (conference=${conferenceId}, team=${teamKey}); falling back to all organizers`,
+      error,
+    )
+  }
+  return getOrganizerSpeakerIds()
+}

--- a/src/lib/teams/types.ts
+++ b/src/lib/teams/types.ts
@@ -72,7 +72,8 @@ export interface ConferenceTeamsConfig {
  * Arbitrary ADDITIONAL keys are allowed; this constant is the routing map’s
  * anchor, not an allow-list.
  *
- * @public consumed by the TEAMS-2 routing map (not yet wired in this change).
+ * @public consumed by the TEAMS-2 routing map (wired via
+ * {@link import('./routing').resolveRoutedOrganizerIds}).
  */
 export const WELL_KNOWN_TEAM_KEYS = [
   'cfp',

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -50,9 +50,9 @@ import { clientWrite } from '@/lib/sanity/client'
 import { createReference, createReferenceWithKey } from '@/lib/sanity/helpers'
 import {
   createNotifications,
-  getOrganizerSpeakerIds,
   deleteMessageNotificationsFor,
 } from '@/lib/notification/sanity'
+import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import type { NotificationInput } from '@/lib/notification/types'
 import type { ProposalInput, ProposalExisting } from '@/lib/proposal/types'
 import { Action, Status, isInactiveProposal } from '@/lib/proposal/types'
@@ -347,7 +347,12 @@ export const proposalRouter = router({
           // failure here (e.g. the organizer-id fetch) must not surface as a
           // create error to the submitting speaker.
           try {
-            const organizerIds = await getOrganizerSpeakerIds()
+            // TEAMS-2: proposal events route to the `cfp` team (all organizers
+            // when it is not configured — the shared fallback contract).
+            const organizerIds = await resolveRoutedOrganizerIds({
+              conferenceId: conference._id,
+              teamKey: 'cfp',
+            })
             await createNotifications(
               organizerIds
                 .filter((id) => id && id !== ctx.speaker._id)

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -69,10 +69,8 @@ import {
   createSponsorActivity,
   deleteSponsorActivity,
 } from '@/lib/sponsor-crm/activity'
-import {
-  createNotifications,
-  getOrganizerSpeakerIds,
-} from '@/lib/notification/sanity'
+import { createNotifications } from '@/lib/notification/sanity'
+import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import type { NotificationInput } from '@/lib/notification/types'
 import {
   SponsorForConferenceInputSchema,
@@ -1113,7 +1111,12 @@ export const sponsorRouter = router({
             const conferenceId = existing.conference?._id
             if (conferenceId) {
               const sponsorName = existing.sponsor?.name
-              const organizerIds = await getOrganizerSpeakerIds()
+              // TEAMS-2: sponsor events route to the `sponsors` team (all
+              // organizers when it is not configured — the shared fallback).
+              const organizerIds = await resolveRoutedOrganizerIds({
+                conferenceId,
+                teamKey: 'sponsors',
+              })
               await createNotifications(
                 organizerIds
                   .filter((id) => id && id !== userId)

--- a/src/server/routers/travelSupport.ts
+++ b/src/server/routers/travelSupport.ts
@@ -41,10 +41,8 @@ import {
   canAddExpenses,
   verifyTravelSupportOwnership,
 } from '@/lib/travel-support/auth'
-import {
-  createNotifications,
-  getOrganizerSpeakerIds,
-} from '@/lib/notification/sanity'
+import { createNotifications } from '@/lib/notification/sanity'
+import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import type { NotificationInput } from '@/lib/notification/types'
 import { TravelSupportStatus, ExpenseStatus } from '@/lib/travel-support/types'
 
@@ -293,7 +291,16 @@ export const travelSupportRouter = router({
           // conference ref is missing rather than writing a broken reference.
           const conferenceId = travelSupport.conference?._id
           if (conferenceId) {
-            const organizerIds = await getOrganizerSpeakerIds()
+            // TEAMS-2: travel-support is speaker-facing, CFP-side work (it
+            // travels with an accepted proposal's speaker), so its NEW-request
+            // organizer alert routes to the `cfp` team — all organizers when the
+            // team is not configured. The two speaker-facing status
+            // notifications below (recipient = the affected speaker) are NOT
+            // organizer fan-outs and are deliberately left unrouted.
+            const organizerIds = await resolveRoutedOrganizerIds({
+              conferenceId,
+              teamKey: 'cfp',
+            })
             await createNotifications(
               organizerIds
                 .filter((id) => id && id !== ctx.speaker._id)

--- a/src/server/routers/volunteer.ts
+++ b/src/server/routers/volunteer.ts
@@ -26,10 +26,8 @@ import { sendVolunteerApprovalEmail } from '@/lib/email/volunteer'
 import { PRIVACY_POLICY_VERSION } from '@/lib/privacy/config'
 import { notifyNewVolunteer } from '@/lib/slack/notify'
 import { getCurrentDateTime } from '@/lib/time'
-import {
-  createNotifications,
-  getOrganizerSpeakerIds,
-} from '@/lib/notification/sanity'
+import { createNotifications } from '@/lib/notification/sanity'
+import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import type { NotificationInput } from '@/lib/notification/types'
 
 export const volunteerRouter = router({
@@ -83,7 +81,12 @@ export const volunteerRouter = router({
             // there is no actor to exclude. Shares createNotifications'
             // never-fail contract: the volunteer record is already created.
             const volunteerName = result.volunteer.name
-            const organizerIds = await getOrganizerSpeakerIds()
+            // TEAMS-2: volunteer signups route to the `volunteers` team (all
+            // organizers when it is not configured — the shared fallback).
+            const organizerIds = await resolveRoutedOrganizerIds({
+              conferenceId: conference._id,
+              teamKey: 'volunteers',
+            })
             await createNotifications(
               organizerIds
                 .filter((id) => id)


### PR DESCRIPTION
## TEAMS-2 — Team-aware notification routing

Wires the TEAMS-1 foundation (`conference.teams`, `src/lib/teams`) into every all-organizer notification fan-out. Every rule is **inert until its team is configured**: with no team the recipient set is exactly today's all-organizers behaviour.

### The routing map

| Message kind | Team key |
| --- | --- |
| proposal events (`persistNotification`, direct-create submit) | `cfp` |
| speaker threads — proposal + general (`notifyNewMessage`) | `cfp` |
| travel-support new request | `cfp` |
| sponsor events + sponsor threads (`notifySponsorMessage`, stage-move) | `sponsors` |
| volunteer signups | `volunteers` |
| stale nudge | assignee → thread's team (`sponsors`/`cfp`) → all |
| Slack — speaker message | `cfp`/`cfp` channel |
| Slack — sponsor message + sponsor events | `sponsors`/`sales` channel |

### The single fallback contract

One helper — `resolveRoutedOrganizerIds({ conferenceId, teamKey })` (`src/lib/teams/routing.ts`) — is the only place ABSENT-MEANS-TODAY becomes a concrete recipient set: team members when the team exists with **≥1 member**, else the full organizer set (`getOrganizerSpeakerIds`). An empty team is treated identically to an absent one. It is **never-fail**: a teams-fetch error logs and falls back to all organizers rather than mis-routing to a partial set. Every routing site delegates to it; actor-exclusion and each site's never-fail envelope are unchanged.

### Access vs routing separation in `notify.ts`

`notifyNewMessage` seeds **two** organizer id sets:
- The **full** set (`getOrganizerSpeakerIds`) stays the **classifier** — is the author an organizer, is each recipient an organizer (drives audience-dependent email default + per-audience deep link).
- The **routed** set (`resolveRoutedOrganizerIds({ teamKey: 'cfp' })`) is used **only** to expand the `organizers` group party into notification RECIPIENTS.

Speaker parties, `canAccessConversation`, participant/party resolution, and inbox visibility are untouched — teams add **no access boundary**. `notifySponsorMessage` is a pure recipient replacement (`sponsors`), since its author exclusion is applied separately.

### Tests

New: helper fallback matrix (configured/empty/absent/fetch-error), the `notify.ts` access-vs-routing split (team narrows recipients while full set still classifies), the nudge assignee→team→all chain, and Slack channel-resolution fallbacks. Existing sponsor fan-out test gains explicit team-absent + configured-team fixtures. Full suite green (3446 passed / 5 skipped).

### Deviation

`travelSupport.ts` lines ~730/~811 (from the ticket) are **speaker-facing** status notifications (`recipientId: affectedSpeakerId`), not organizer fan-outs — routing a per-speaker notification through a team is nonsensical, so only the new-request organizer alert (~:296) was routed; the two speaker notifications are left unrouted (documented inline).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the TEAMS-1 foundation into every all-organizer notification fan-out via a single `resolveRoutedOrganizerIds` helper. When a team is configured with at least one member the fan-out narrows to that team; otherwise the full organizer set is used unchanged, preserving today's behavior exactly.

- **`src/lib/teams/routing.ts`** — new central fallback helper with a clear never-fail contract; used by all eight routing sites.
- **`src/lib/messaging/notify.ts`** — correctly maintains two separate organizer ID sets: the full set for identity classification and the routed set for hub/push recipient expansion only.
- **`src/lib/messaging/nudge.ts`** — extends the routing chain to assignee → thread-team (`sponsors`/`cfp`) → all organizers, and correctly adds `sponsor` to the `conversationType` union.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is inert for unconfigured teams and the fallback contract is tested at every level.

The routing logic, the access-vs-routing split in notify.ts, and the never-fail guarantees are all sound and well-tested. Two spots worth a follow-up: notifyNewMessage makes two sequential getOrganizerSpeakerIds calls where one parallel call would do, and nudgeStaleConversations now issues up to 200 individual team-fetch round-trips per cron run. Neither affects correctness.

src/lib/messaging/notify.ts and src/lib/messaging/nudge.ts for the redundant/repeated DB fetch patterns.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/teams/routing.ts | New helper implementing the single fallback contract: team members when configured with ≥1 member, else all organizers. Never-fail by design. |
| src/lib/messaging/notify.ts | Correctly maintains two separate organizer sets. Both getOrganizerSpeakerIds and resolveRoutedOrganizerIds are called sequentially, causing a double DB read in the no-team fallback case. |
| src/lib/messaging/nudge.ts | Correctly adds sponsor-conversation routing, but resolveRoutedOrganizerIds is now called inside the conversation loop up to MAX_CONVERSATIONS_PER_RUN times. |
| src/lib/slack/notify.ts | Clean refactor: sendSlackNotification gains an optional channel override, sendSalesNotification delegates to resolveTeamSlackChannel. |
| src/lib/events/handlers/persistNotification.ts | Straightforward swap from getOrganizerSpeakerIds to resolveRoutedOrganizerIds with cfp key. |
| src/lib/teams/routing.test.ts | Covers all fallback states: configured team, absent team, empty team, fetch error, and immutability of returned array. |
| src/lib/messaging/notify.test.ts | Covers the access-vs-routing split; verifies cfp team narrows hub recipients while full organizer set still drives email classification. |
| src/lib/messaging/nudge.test.ts | Exercises the full assignee → team → all chain across four conversation fixtures with different team configurations. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as notifyNewMessage / router
    participant R as resolveRoutedOrganizerIds
    participant TS as teams/sanity
    participant NS as notification/sanity

    Caller->>NS: getOrganizerSpeakerIds() [classification set]
    NS-->>Caller: all organizer ids

    Caller->>R: resolveRoutedOrganizerIds(conferenceId, teamKey)
    R->>TS: getConferenceTeams(conferenceId)
    alt team configured and non-empty
        TS-->>R: [team]
        R-->>Caller: team.members (copy)
    else team absent or empty
        TS-->>R: [] or no match
        R->>NS: getOrganizerSpeakerIds() [fallback]
        NS-->>R: all organizer ids
        R-->>Caller: all organizer ids
    else fetch error
        TS-->>R: throws
        R->>NS: getOrganizerSpeakerIds() [error fallback]
        NS-->>R: all organizer ids
        R-->>Caller: all organizer ids
    end

    Caller->>Caller: resolveRecipients(conversation, authorId, routedIds)
    note over Caller: classification set drives email default and link variant
    note over Caller: routed set drives hub/push recipient expansion only
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as notifyNewMessage / router
    participant R as resolveRoutedOrganizerIds
    participant TS as teams/sanity
    participant NS as notification/sanity

    Caller->>NS: getOrganizerSpeakerIds() [classification set]
    NS-->>Caller: all organizer ids

    Caller->>R: resolveRoutedOrganizerIds(conferenceId, teamKey)
    R->>TS: getConferenceTeams(conferenceId)
    alt team configured and non-empty
        TS-->>R: [team]
        R-->>Caller: team.members (copy)
    else team absent or empty
        TS-->>R: [] or no match
        R->>NS: getOrganizerSpeakerIds() [fallback]
        NS-->>R: all organizer ids
        R-->>Caller: all organizer ids
    else fetch error
        TS-->>R: throws
        R->>NS: getOrganizerSpeakerIds() [error fallback]
        NS-->>R: all organizer ids
        R-->>Caller: all organizer ids
    end

    Caller->>Caller: resolveRecipients(conversation, authorId, routedIds)
    note over Caller: classification set drives email default and link variant
    note over Caller: routed set drives hub/push recipient expansion only
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(teams): team-aware notification rou..."](https://github.com/cloudnativebergen/website/commit/b9ebd217e114f04d42c3cdbf2d50f8c5aeef6b1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45489922)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->