### PR TITLE
fix(admin): honest push-subscription check

### DIFF
--- a/src/lib/system-status/checks.test.ts
+++ b/src/lib/system-status/checks.test.ts
@@ -166,6 +166,9 @@ describe('buildSystemChecks — live probes', () => {
 
   it('reports an ok Sanity read probe with latency', async () => {
     fetchMock.mockImplementation((query: string) => {
+      // The subscription stats query returns a {total, speakers} object.
+      if (query.includes('"total"'))
+        return Promise.resolve({ total: 5, speakers: 3 })
       if (query.includes('count(')) return Promise.resolve(5)
       return Promise.resolve('conf-1')
     })
@@ -173,7 +176,7 @@ describe('buildSystemChecks — live probes', () => {
     const probe = byId(checks, 'sanity.readProbe')
     expect(probe.status).toBe('ok')
     expect(probe.value).toMatch(/\d+ ms/)
-    expect(byId(checks, 'push.subscriptions').value).toBe('5')
+    expect(byId(checks, 'push.subscriptions').value).toBe('5 across 3 speakers')
   })
 
   it('reports an error Sanity read probe when the fetch throws', async () => {

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -700,17 +700,31 @@ async function pushSubscriptionCount(): Promise<SystemCheck> {
   const meta = {
     id: 'push.subscriptions',
     group: 'push' as const,
-    label: 'Active subscriptions',
+    label: 'Stored subscriptions',
   }
   try {
-    const count = await clientReadUncached.fetch<number>(
-      `count(*[_type == "speaker"].pushSubscriptions[])`,
+    // Subscriptions + how many speakers hold them. HONESTY NOTE baked into the
+    // detail: dead subscriptions are only pruned when a real send gets a
+    // 404/410 back from the push service — during any period when sends fail
+    // earlier (e.g. an invalid VAPID config), stale device rows accumulate
+    // unpruned, so this number can far exceed live devices.
+    const stats = await clientReadUncached.fetch<{
+      total: number
+      speakers: number
+    }>(
+      `{
+        "total": count(*[_type == "speaker"].pushSubscriptions[]),
+        "speakers": count(*[_type == "speaker" && count(pushSubscriptions) > 0])
+      }`,
     )
+    const total = stats?.total ?? 0
+    const speakers = stats?.speakers ?? 0
     return {
       ...meta,
       status: 'ok',
-      value: String(count ?? 0),
-      detail: 'Registered devices across all speakers',
+      value: `${total} across ${speakers} speaker${speakers === 1 ? '' : 's'}`,
+      detail:
+        'Includes stale devices — rows are only pruned when a delivered send returns 404/410, so periods of failing sends inflate this count',
     }
   } catch (err) {
     return { ...meta, status: 'warn', value: 'unknown', detail: errMsg(err) }


### PR DESCRIPTION
Maintainer questioned the '347 registered devices' figure — rightly. The number is stored subscription ROWS, not live devices: rows are only pruned when a delivered send returns 404/410 from the push service, and every send since launch failed at the VAPID-config layer (fixed via #565 + the mailto: env fix), so stale devices from key rotations and testing accumulated unpruned.

The check now reports 'N across M speakers' under the label 'Stored subscriptions' with a detail line explaining the staleness mechanics. The count will self-correct once valid sends start pruning.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a misleading admin dashboard metric by replacing a bare subscription row count with a richer, honestly-labeled `"Stored subscriptions"` check that reports both total rows and distinct speaker count, along with a detail line explaining why the number can exceed live devices.

- **`checks.ts`**: Swaps the single `count(*[_type == \"speaker\"].pushSubscriptions[])` query for a GROQ projection returning `{total, speakers}`, relabels the check from \"Active subscriptions\" to \"Stored subscriptions\", and adds staleness context to the `detail` field.
- **`checks.test.ts`**: Adds a mock branch keyed on `\"total\"` to return the new object shape and updates the expected value assertion to `\"5 across 3 speakers\"`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is display-only and the null-safe fallbacks ensure no regressions if the Sanity query ever returns an unexpected shape.

Both the production query and the null-coalescing fallbacks (stats?.total ?? 0) are correct. The test mock correctly intercepts the new GROQ projection ahead of the generic count( branch. The only gap is a one-line JSDoc comment that still says active instead of stored.

No files require special attention beyond the minor JSDoc comment in checks.ts.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/system-status/checks.ts | Rewrites pushSubscriptionCount to query both total rows and distinct speaker count, relabels the check "Stored subscriptions", and adds a detail line explaining staleness mechanics — logic is correct and null-safe. |
| src/lib/system-status/checks.test.ts | Updates the fetchMock to dispatch the new GROQ projection by inspecting for the "total" key, and asserts the new "N across M speakers" value format — mock ordering is correct. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin UI
    participant Check as pushSubscriptionCount()
    participant Sanity as Sanity (GROQ)

    Admin->>Check: buildSystemChecks()
    Check->>Sanity: "fetch({ "total": count(*.pushSubscriptions[]), "speakers": count(*[count(pushSubscriptions)>0]) })"
    Sanity-->>Check: "{ total: N, speakers: M }"
    Check-->>Admin: "{ label: "Stored subscriptions", value: "N across M speakers", detail: "Includes stale devices…" }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin UI
    participant Check as pushSubscriptionCount()
    participant Sanity as Sanity (GROQ)

    Admin->>Check: buildSystemChecks()
    Check->>Sanity: "fetch({ "total": count(*.pushSubscriptions[]), "speakers": count(*[count(pushSubscriptions)>0]) })"
    Sanity-->>Check: "{ total: N, speakers: M }"
    Check-->>Admin: "{ label: "Stored subscriptions", value: "N across M speakers", detail: "Includes stale devices…" }"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/system-status/checks.ts`, line 698 ([link](https://github.com/cloudnativebergen/website/blob/9d36666188f555796e85481c53345486b5a2f1d0/src/lib/system-status/checks.ts#L698)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The JSDoc comment above the function still says "active web-push subscriptions", which contradicts the new label "Stored subscriptions". Small inconsistency that could mislead a future reader.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(admin): honest push-subscription che..."](https://github.com/cloudnativebergen/website/commit/9d36666188f555796e85481c53345486b5a2f1d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45490754)</sub>

<!-- /greptile_comment -->