### PR TITLE
feat(teams): the four team lenses (TEAMS-3)

### DIFF
--- a/__tests__/app/admin/myAreas.test.ts
+++ b/__tests__/app/admin/myAreas.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock only the sources fetchMyAreasData touches. The heavier sibling actions in
+// the same file aren't exercised here.
+const getAuthSession = vi.fn()
+vi.mock('@/lib/auth', () => ({ getAuthSession: () => getAuthSession() }))
+
+const getConferenceTeams = vi.fn()
+vi.mock('@/lib/teams', () => ({
+  getConferenceTeams: (id: string) => getConferenceTeams(id),
+}))
+
+const getConversationViewCounts = vi.fn()
+vi.mock('@/lib/messaging/sanity', () => ({
+  getConversationViewCounts: (a: unknown) => getConversationViewCounts(a),
+}))
+
+const listSponsorsForConference = vi.fn()
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  listSponsorsForConference: (id: string, f: unknown) =>
+    listSponsorsForConference(id, f),
+}))
+
+const getVolunteersByConference = vi.fn()
+vi.mock('@/lib/volunteer/sanity', () => ({
+  getVolunteersByConference: (id: string) => getVolunteersByConference(id),
+}))
+
+import { fetchMyAreasData } from '@/app/(admin)/admin/actions'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getAuthSession.mockResolvedValue({
+    speaker: { _id: 'org-1', isOrganizer: true },
+  })
+  getConversationViewCounts.mockResolvedValue({
+    active: 0,
+    archived: 0,
+    needsReply: 4,
+    unassigned: 2,
+  })
+  listSponsorsForConference.mockResolvedValue({ sponsors: [{}, {}, {}] })
+  getVolunteersByConference.mockResolvedValue({
+    volunteers: [
+      { status: 'pending' },
+      { status: 'pending' },
+      { status: 'approved' },
+    ],
+    error: null,
+  })
+})
+
+describe('fetchMyAreasData (L4 My areas)', () => {
+  it('returns empty areas when the viewer is on no team (widget inert)', async () => {
+    getConferenceTeams.mockResolvedValue([
+      { key: 'cfp', title: 'Programme', members: ['someone-else'] },
+    ])
+    const data = await fetchMyAreasData('conf-1')
+    expect(data.areas).toEqual([])
+    // No area sources read when the viewer is on no team.
+    expect(getConversationViewCounts).not.toHaveBeenCalled()
+    expect(listSponsorsForConference).not.toHaveBeenCalled()
+  })
+
+  it('wires cfp counts to inbox deep links', async () => {
+    getConferenceTeams.mockResolvedValue([
+      { key: 'cfp', title: 'Programme', members: ['org-1'] },
+    ])
+    const data = await fetchMyAreasData('conf-1')
+    expect(data.areas).toHaveLength(1)
+    const cfp = data.areas[0]
+    expect(cfp.title).toBe('Programme')
+    expect(cfp.metrics).toEqual([
+      {
+        label: 'Needs reply',
+        count: 4,
+        href: '/admin/messages?view=needs-reply',
+      },
+      {
+        label: 'Unassigned',
+        count: 2,
+        href: '/admin/messages?view=unassigned',
+      },
+    ])
+    // Sponsor / volunteer sources are NOT read for a cfp-only member.
+    expect(listSponsorsForConference).not.toHaveBeenCalled()
+    expect(getVolunteersByConference).not.toHaveBeenCalled()
+  })
+
+  it('counts unassigned sponsors and pending volunteers for those teams', async () => {
+    getConferenceTeams.mockResolvedValue([
+      { key: 'sponsors', title: 'Sales', members: ['org-1'] },
+      { key: 'volunteers', title: 'Crew', members: ['org-1'] },
+    ])
+    const data = await fetchMyAreasData('conf-1')
+
+    const sponsors = data.areas.find((a) => a.key === 'sponsors')
+    expect(sponsors?.metrics[0]).toEqual({
+      label: 'Unassigned sponsors',
+      count: 3,
+      href: '/admin/sponsors/crm?assignedTo=unassigned',
+    })
+    expect(listSponsorsForConference).toHaveBeenCalledWith('conf-1', {
+      unassignedOnly: true,
+    })
+
+    const volunteers = data.areas.find((a) => a.key === 'volunteers')
+    expect(volunteers?.metrics[0]).toEqual({
+      label: 'Pending volunteers',
+      count: 2,
+      href: '/admin/volunteers',
+    })
+    // cfp source not read — the viewer is on neither cfp.
+    expect(getConversationViewCounts).not.toHaveBeenCalled()
+  })
+
+  it('renders a titled but metric-less card for an unknown team key', async () => {
+    getConferenceTeams.mockResolvedValue([
+      { key: 'workshops', title: 'Workshops', members: ['org-1'] },
+    ])
+    const data = await fetchMyAreasData('conf-1')
+    expect(data.areas).toEqual([
+      { key: 'workshops', title: 'Workshops', metrics: [] },
+    ])
+  })
+})

--- a/__tests__/components/messaging/MessagesInbox.test.tsx
+++ b/__tests__/components/messaging/MessagesInbox.test.tsx
@@ -39,6 +39,9 @@ vi.mock('@/lib/trpc/client', () => ({
       viewCounts: {
         useQuery: () => ({ data: undefined }),
       },
+      teamLens: {
+        useQuery: () => ({ data: undefined }),
+      },
       listConversations: {
         useInfiniteQuery: (input: { view: string }) => {
           listInputs.push(input)

--- a/__tests__/lib/dashboard/widget-registry.test.ts
+++ b/__tests__/lib/dashboard/widget-registry.test.ts
@@ -9,8 +9,8 @@ import {
 const registryEntries = Object.entries(WIDGET_REGISTRY)
 
 describe('Widget Registry', () => {
-  it('contains exactly 12 registered widget types', () => {
-    expect(registryEntries).toHaveLength(12)
+  it('contains exactly 13 registered widget types', () => {
+    expect(registryEntries).toHaveLength(13)
   })
 
   it('getWidgetMetadata returns metadata for registered types', () => {

--- a/__tests__/lib/messaging/ticketing.test.ts
+++ b/__tests__/lib/messaging/ticketing.test.ts
@@ -28,6 +28,12 @@ vi.mock('@/lib/notification/sanity', () => ({
   getOrganizerSpeakerIds: vi.fn(async () => [] as string[]),
 }))
 
+// The `my-teams` view count binds the caller's team keys; stub the resolver so
+// the shared clientReadUncached mock isn't consumed by a teams read here.
+vi.mock('@/lib/teams', () => ({
+  getViewerTeamKeys: vi.fn(async () => [] as string[]),
+}))
+
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
 import {
@@ -574,6 +580,8 @@ describe('getConversationViewCounts — one GROQ round trip (S7)', () => {
     expect(counts).toEqual({
       active: 3,
       needsReply: 2,
+      // `my-teams` count: the mocked fetch omits it ⇒ coalesced to 0.
+      myTeams: 0,
       unassigned: 6,
       mine: 1,
       resolved: 4,
@@ -583,6 +591,7 @@ describe('getConversationViewCounts — one GROQ round trip (S7)', () => {
     // ONE object projection with a count() per view.
     expect(query).toContain('"active": count(')
     expect(query).toContain('"needsReply": count(')
+    expect(query).toContain('"myTeams": count(')
     expect(query).toContain('"unassigned": count(')
     expect(query).toContain('"mine": count(')
     expect(query).toContain('"resolved": count(')

--- a/__tests__/lib/sponsor-crm/filtering.test.ts
+++ b/__tests__/lib/sponsor-crm/filtering.test.ts
@@ -72,4 +72,28 @@ describe('listSponsorsForConference filtering', () => {
       expect.objectContaining({ assignedTo: 'user-1' }),
     )
   })
+
+  it('should apply the team assignedToIds filter (L3)', async () => {
+    mockFetch.mockResolvedValue([])
+    await listSponsorsForConference('conf-123', {
+      assignedToIds: ['user-1', 'user-2'],
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('&& assignedTo._ref in $assignedToIds'),
+      expect.objectContaining({ assignedToIds: ['user-1', 'user-2'] }),
+    )
+  })
+
+  it('should prefer the team filter over a bare assignedTo when both are set', async () => {
+    mockFetch.mockResolvedValue([])
+    await listSponsorsForConference('conf-123', {
+      assignedTo: 'user-1',
+      assignedToIds: ['user-2', 'user-3'],
+    })
+
+    const [query] = mockFetch.mock.calls[0]
+    expect(query).toContain('&& assignedTo._ref in $assignedToIds')
+    expect(query).not.toContain('&& assignedTo._ref == $assignedTo')
+  })
 })

--- a/docs/ORGANIZER_TEAMS.md
+++ b/docs/ORGANIZER_TEAMS.md
@@ -117,11 +117,26 @@ untouched by routing; only which organizers receive the fan-out narrows. Access,
 `canAccessConversation`, participant/party resolution, and inbox visibility are
 left entirely alone — this change adds no access boundary.
 
-## Greenlit lenses (TEAMS-3)
+## Lenses (TEAMS-3 — IMPLEMENTED)
 
-Four further lenses are greenlit on this foundation, all still soft: a team
-inbox/triage view, per-team dashboards, per-team digest scheduling, and
-team-scoped assignment suggestions. None of them introduce access boundaries.
+The four shipped lenses, all soft (visible only when teams are configured;
+none introduce access boundaries):
+
+1. **Inbox "My teams" view** — an organizer inbox tab filtering active threads
+   whose ROUTING team (sponsor threads → `sponsors`, everything else → `cfp`)
+   is one of the caller's teams. Inert (matches all active) for organizers on
+   no team; the tab is hidden entirely when the conference has no teams.
+2. **Team chips on inbox rows** — a sponsor row's amber chip shows the
+   sponsors-team TITLE (fallback "Sponsor"); other rows get a quiet cfp-team
+   chip. No chips when teams aren't configured.
+3. **CRM team filter** — a Teams option group in the sponsor pipeline's Owner
+   filter (`team=<key>` URL param → the team's member set).
+4. **Dashboard "My areas" widget** — per-team needs-attention cards
+   (needs-reply threads, unassigned sponsors, pending volunteers) with
+   deep links, visible when the viewer belongs to ≥1 team.
+
+Earlier aspirational candidates (per-team digest scheduling, assignment
+suggestions) remain unbuilt and unscheduled.
 
 ## Foundation scope (TEAMS-1)
 

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -18,6 +18,10 @@ import { DEFAULT_TARGET_CONFIG, DEFAULT_CAPACITY } from '@/lib/tickets/config'
 import { getAllTravelSupport } from '@/lib/travel-support/sanity'
 import { TravelSupportStatus } from '@/lib/travel-support/types'
 import { getWorkshopStatistics } from '@/lib/workshop/sanity'
+import { getConferenceTeams } from '@/lib/teams'
+import { getConversationViewCounts } from '@/lib/messaging/sanity'
+import { getVolunteersByConference } from '@/lib/volunteer/sanity'
+import { VolunteerStatus } from '@/lib/volunteer/types'
 import { getAuthSession } from '@/lib/auth'
 import { clientWrite } from '@/lib/sanity/client'
 import {
@@ -37,6 +41,8 @@ import type {
   TravelSupportData,
   ScheduleStatusData,
   QuickAction,
+  MyAreasData,
+  MyAreaCard,
 } from '@/lib/dashboard/data-types'
 import type { WorkshopStatistics } from '@/lib/workshop/types'
 
@@ -47,6 +53,113 @@ async function requireOrganizer(): Promise<void> {
   if (!session?.speaker?.isOrganizer) {
     throw new Error('Unauthorized: organizer access required')
   }
+}
+
+// --- My Areas (TEAMS-3, L4) ---
+
+/**
+ * The viewer's "My areas": one card per team the CURRENT organizer belongs to,
+ * each with a couple of needs-attention counts that deep-link to the filtered
+ * surface. A SOFT LENS — read-only convenience scoped to the viewer's teams, no
+ * access implications (docs/ORGANIZER_TEAMS.md).
+ *
+ * COST: gated on membership so only the teams the viewer is actually on trigger
+ * a read, and every count reuses an EXISTING source (no new aggregate query):
+ *  - `cfp`        → `getConversationViewCounts` (one bounded GROQ; needs-reply +
+ *                   unassigned inbox threads),
+ *  - `sponsors`   → `listSponsorsForConference({ unassignedOnly })` length,
+ *  - `volunteers` → `getVolunteersByConference` filtered to PENDING.
+ * A viewer on none of these well-known teams still gets a titled card (no
+ * metrics). Returns `{ areas: [] }` when the viewer is on no team at all.
+ */
+export async function fetchMyAreasData(
+  conferenceId: string,
+): Promise<MyAreasData> {
+  await requireOrganizer()
+  const session = await getAuthSession()
+  const speakerId = session?.speaker?._id
+  if (!speakerId) return { areas: [] }
+
+  const teams = await getConferenceTeams(conferenceId)
+  const myTeams = teams.filter((t) => t.members.includes(speakerId))
+  if (myTeams.length === 0) return { areas: [] }
+
+  const myKeys = new Set(myTeams.map((t) => t.key))
+
+  // Fetch each area's source ONCE, and only when the viewer is on that team.
+  const viewCounts = myKeys.has('cfp')
+    ? await getConversationViewCounts({
+        speakerId,
+        isOrganizer: true,
+        conferenceId,
+      })
+    : null
+
+  let unassignedSponsors = 0
+  if (myKeys.has('sponsors')) {
+    const { sponsors } = await listSponsorsForConference(conferenceId, {
+      unassignedOnly: true,
+    })
+    unassignedSponsors = sponsors?.length ?? 0
+  }
+
+  let pendingVolunteers = 0
+  if (myKeys.has('volunteers')) {
+    const { volunteers } = await getVolunteersByConference(conferenceId)
+    pendingVolunteers = volunteers.filter(
+      (v) => v.status === VolunteerStatus.PENDING,
+    ).length
+  }
+
+  const areas: MyAreaCard[] = myTeams.map((team) => {
+    switch (team.key) {
+      case 'cfp':
+        return {
+          key: team.key,
+          title: team.title,
+          metrics: [
+            {
+              label: 'Needs reply',
+              count: viewCounts?.needsReply ?? 0,
+              href: '/admin/messages?view=needs-reply',
+            },
+            {
+              label: 'Unassigned',
+              count: viewCounts?.unassigned ?? 0,
+              href: '/admin/messages?view=unassigned',
+            },
+          ],
+        }
+      case 'sponsors':
+        return {
+          key: team.key,
+          title: team.title,
+          metrics: [
+            {
+              label: 'Unassigned sponsors',
+              count: unassignedSponsors,
+              href: '/admin/sponsors/crm?assignedTo=unassigned',
+            },
+          ],
+        }
+      case 'volunteers':
+        return {
+          key: team.key,
+          title: team.title,
+          metrics: [
+            {
+              label: 'Pending volunteers',
+              count: pendingVolunteers,
+              href: '/admin/volunteers',
+            },
+          ],
+        }
+      default:
+        return { key: team.key, title: team.title, metrics: [] }
+    }
+  })
+
+  return { areas }
 }
 
 // --- Sponsor Pipeline ---

--- a/src/components/admin/AdminButton.stories.tsx
+++ b/src/components/admin/AdminButton.stories.tsx
@@ -144,3 +144,35 @@ export const ModalFooterExample: Story = {
     </div>
   ),
 }
+
+/**
+ * Rider proof (TEAMS-3): the `secondary` and `ghost` variants inside a DARK-mode
+ * modal surface. Before the dark-mode classes landed, `secondary` rendered as an
+ * illegible white-on-light chip on the dark panel; it must now read clearly.
+ */
+export const DarkModalFooter: Story = {
+  parameters: { backgrounds: { default: 'dark' } },
+  render: () => (
+    <div className="dark">
+      <div className="w-96 rounded-xl bg-gray-800 p-6 shadow-xl">
+        <h3 className="mb-1 text-base font-semibold text-white">
+          Announce to participants
+        </h3>
+        <p className="mb-4 text-sm text-gray-400">
+          Secondary and ghost buttons must stay legible on this dark panel.
+        </p>
+        <div className="flex justify-end gap-3 border-t border-gray-700 pt-4">
+          <AdminButton variant="ghost" size="md">
+            Reset
+          </AdminButton>
+          <AdminButton variant="secondary" size="md">
+            Cancel
+          </AdminButton>
+          <AdminButton color="blue" size="md">
+            Send
+          </AdminButton>
+        </div>
+      </div>
+    </div>
+  ),
+}

--- a/src/components/admin/AdminButton.tsx
+++ b/src/components/admin/AdminButton.tsx
@@ -27,9 +27,14 @@ const colorStyles: Record<AdminButtonColor, string> = {
 }
 
 const variantStyles: Record<Exclude<AdminButtonVariant, 'primary'>, string> = {
+  // Dark-mode classes matter: `secondary`/`ghost` are the default footer buttons
+  // of admin modals that render on a dark surface (AnnounceModal,
+  // EditConferenceCard, …). Without them the light `bg-white`/`text-gray-700`
+  // pair sat on a dark panel as an illegible white-on-light chip.
   secondary:
-    'bg-white text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50',
-  ghost: 'text-gray-700 hover:bg-gray-100',
+    'bg-white text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-gray-100 dark:ring-white/15 dark:hover:bg-white/20',
+  ghost:
+    'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-white/10',
 }
 
 const sizeStyles: Record<AdminButtonSize, string> = {

--- a/src/components/admin/dashboard/widget-renderer.tsx
+++ b/src/components/admin/dashboard/widget-renderer.tsx
@@ -10,6 +10,7 @@ import { ReviewProgressWidget } from '@/components/admin/dashboard/widgets/Revie
 import { TravelSupportQueueWidget } from '@/components/admin/dashboard/widgets/TravelSupportQueueWidget'
 import { WorkshopCapacityWidget } from '@/components/admin/dashboard/widgets/WorkshopCapacityWidget'
 import { ScheduleBuilderStatusWidget } from '@/components/admin/dashboard/widgets/ScheduleBuilderStatusWidget'
+import { MyAreasWidget } from '@/components/admin/dashboard/widgets/MyAreasWidget'
 import type { Conference } from '@/lib/conference/types'
 import type { Widget } from '@/lib/dashboard/types'
 
@@ -61,6 +62,8 @@ export function renderWidgetContent(
       return <WorkshopCapacityWidget conference={conference} />
     case 'schedule-builder':
       return <ScheduleBuilderStatusWidget conference={conference} />
+    case 'my-areas':
+      return <MyAreasWidget conference={conference} config={config} />
     default:
       return (
         <div className="flex h-full items-center justify-center text-sm text-gray-500 dark:text-gray-400">

--- a/src/components/admin/dashboard/widgets/MyAreasView.stories.tsx
+++ b/src/components/admin/dashboard/widgets/MyAreasView.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { MyAreasView } from './MyAreasView'
+import type { MyAreasData } from '@/lib/dashboard/data-types'
+
+/**
+ * TEAMS-3 (L4) "My areas" — per-team needs-attention counts for the teams the
+ * viewer belongs to, each deep-linking to its filtered surface. Stories exercise
+ * the presentational {@link MyAreasView} (the widget's data wrapper hits a server
+ * action). Empty `areas` is the inert state for a viewer on no team.
+ */
+const meta = {
+  title: 'Admin/Dashboard/MyAreasWidget',
+  component: MyAreasView,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story, ctx) => (
+      <div className={ctx.parameters.dark ? 'dark bg-gray-950 p-4' : 'p-4'}>
+        <div className="mx-auto h-full w-full max-w-md">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MyAreasView>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const data: MyAreasData = {
+  areas: [
+    {
+      key: 'cfp',
+      title: 'Programme',
+      metrics: [
+        {
+          label: 'Needs reply',
+          count: 4,
+          href: '/admin/messages?view=needs-reply',
+        },
+        {
+          label: 'Unassigned',
+          count: 2,
+          href: '/admin/messages?view=unassigned',
+        },
+      ],
+    },
+    {
+      key: 'sponsors',
+      title: 'Sales',
+      metrics: [
+        {
+          label: 'Unassigned sponsors',
+          count: 0,
+          href: '/admin/sponsors/crm?assignedTo=unassigned',
+        },
+      ],
+    },
+    {
+      key: 'volunteers',
+      title: 'Crew',
+      metrics: [
+        {
+          label: 'Pending volunteers',
+          count: 7,
+          href: '/admin/volunteers',
+        },
+      ],
+    },
+  ],
+}
+
+export const Default: Story = { args: { data } }
+
+export const Dark: Story = {
+  args: { data },
+  parameters: { dark: true },
+}
+
+export const NoTeams: Story = {
+  args: { data: { areas: [] } },
+}

--- a/src/components/admin/dashboard/widgets/MyAreasView.tsx
+++ b/src/components/admin/dashboard/widgets/MyAreasView.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import Link from 'next/link'
+import { UserGroupIcon } from '@heroicons/react/24/outline'
+import { type MyAreasData } from '@/lib/dashboard/data-types'
+import { WidgetEmptyState, WidgetHeader } from './shared'
+
+/**
+ * Presentational body of the "My areas" widget (TEAMS-3, L4). Pure over
+ * {@link MyAreasData} — free of the server action — so it renders in Storybook
+ * and tests directly. Empty `areas` is the inert state (viewer on no team).
+ */
+export function MyAreasView({ data }: { data: MyAreasData | null }) {
+  if (!data || data.areas.length === 0) {
+    return (
+      <WidgetEmptyState
+        message="You're not on any team yet. Team areas show up here once you're a member."
+        icon={<UserGroupIcon className="h-8 w-8 text-gray-300" />}
+      />
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <WidgetHeader title="My Areas" />
+      <div className="grid grid-cols-1 gap-2 @[300px]:grid-cols-2">
+        {data.areas.map((area) => (
+          <div
+            key={area.key}
+            className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div className="mb-2 flex items-center gap-1.5">
+              <UserGroupIcon className="h-3.5 w-3.5 text-indigo-500 dark:text-indigo-400" />
+              <h4 className="truncate text-[13px] font-semibold text-gray-900 dark:text-white">
+                {area.title}
+              </h4>
+            </div>
+            {area.metrics.length === 0 ? (
+              <p className="text-[11px] text-gray-400 dark:text-gray-500">
+                Nothing to action
+              </p>
+            ) : (
+              <ul className="space-y-1">
+                {area.metrics.map((metric) => (
+                  <li key={metric.label}>
+                    <Link
+                      href={metric.href}
+                      className="flex items-center justify-between gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    >
+                      <span className="truncate text-[11px] text-gray-600 dark:text-gray-300">
+                        {metric.label}
+                      </span>
+                      <span
+                        className={`inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full px-1.5 text-[11px] font-bold ${
+                          metric.count > 0
+                            ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+                            : 'bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
+                        }`}
+                      >
+                        {metric.count > 99 ? '99+' : metric.count}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/dashboard/widgets/MyAreasWidget.tsx
+++ b/src/components/admin/dashboard/widgets/MyAreasWidget.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { fetchMyAreasData } from '@/app/(admin)/admin/actions'
+import { type MyAreasData } from '@/lib/dashboard/data-types'
+import { BaseWidgetProps } from '@/lib/dashboard/types'
+import { useWidgetData } from '@/hooks/dashboard/useWidgetData'
+import { WidgetSkeleton, WidgetErrorState } from './shared'
+import { MyAreasView } from './MyAreasView'
+
+type MyAreasWidgetProps = BaseWidgetProps
+
+/**
+ * "My areas" (TEAMS-3, L4): a per-team card of needs-attention counts for the
+ * teams the current organizer belongs to, each count deep-linking to the
+ * filtered surface. Renders an inert empty state when the viewer is on no team —
+ * a soft lens, never an access boundary. The presentational body lives in
+ * {@link MyAreasView} (kept free of the server-action import so it stories).
+ */
+export function MyAreasWidget({ conference }: MyAreasWidgetProps) {
+  const { data, loading, error, refetch } = useWidgetData<MyAreasData>(
+    conference ? () => fetchMyAreasData(conference._id) : null,
+    [conference],
+  )
+
+  if (loading) return <WidgetSkeleton />
+  if (error) return <WidgetErrorState onRetry={refetch} />
+  return <MyAreasView data={data} />
+}

--- a/src/components/admin/sponsor-crm/SponsorCRMFilterBar.stories.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMFilterBar.stories.tsx
@@ -45,6 +45,11 @@ const mockOrganizers = [
   { _id: 'org-3', name: 'Carol Williams', email: 'carol@example.com' },
 ]
 
+const mockTeams = [
+  { key: 'sponsors', title: 'Sales' },
+  { key: 'cfp', title: 'Programme' },
+]
+
 const meta = {
   title: 'Systems/Sponsors/Admin/Pipeline/SponsorCRMFilterBar',
   component: SponsorCRMFilterBar,
@@ -69,6 +74,8 @@ const meta = {
     organizers: mockOrganizers,
     assignedToFilter: undefined,
     onSetOrganizer: fn(),
+    teams: mockTeams,
+    onSetTeam: fn(),
     tagsFilter: [],
     onToggleTag: fn(),
     onClearAllFilters: fn(),
@@ -115,6 +122,16 @@ export const WithOwnerFilter: Story = {
 export const WithUnassignedFilter: Story = {
   args: {
     assignedToFilter: 'unassigned',
+  },
+}
+
+/**
+ * TEAMS-3 (L3): the Owner dropdown gains a "Teams" option group; selecting a
+ * team filters owners to that team's members. Shown as an active Team pill here.
+ */
+export const WithTeamFilter: Story = {
+  args: {
+    teamFilter: 'sponsors',
   },
 }
 

--- a/src/components/admin/sponsor-crm/SponsorCRMFilterBar.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMFilterBar.tsx
@@ -43,6 +43,12 @@ export interface SponsorCRMFilterBarProps {
   assignedToFilter?: string
   /** Callback to set organizer filter */
   onSetOrganizer: (organizerId: string | null) => void
+  /** TEAMS-3 (L3): configured teams; when present an owner "Teams" group is shown. */
+  teams?: { key: string; title: string }[]
+  /** Currently selected team key (mutually exclusive with assignedToFilter). */
+  teamFilter?: string
+  /** Callback to set the team filter (null clears it). */
+  onSetTeam?: (teamKey: string | null) => void
   /** Currently selected tags */
   tagsFilter: SponsorTag[]
   /** Callback to toggle a tag filter */
@@ -72,6 +78,9 @@ export function SponsorCRMFilterBar({
   organizers,
   assignedToFilter,
   onSetOrganizer,
+  teams,
+  teamFilter,
+  onSetTeam,
   tagsFilter,
   onToggleTag,
   onClearAllFilters,
@@ -81,8 +90,12 @@ export function SponsorCRMFilterBar({
   isMobileSearchOpen = false,
   onToggleMobileSearch,
 }: SponsorCRMFilterBarProps) {
+  const hasTeams = !!teams && teams.length > 0
   const activeFilterCount =
-    tiersFilter.length + (assignedToFilter ? 1 : 0) + tagsFilter.length
+    tiersFilter.length +
+    (assignedToFilter ? 1 : 0) +
+    (teamFilter ? 1 : 0) +
+    tagsFilter.length
 
   return (
     <div className="shrink-0 rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
@@ -157,13 +170,26 @@ export function SponsorCRMFilterBar({
               options: [
                 { value: '', label: 'All Owners' },
                 { value: 'unassigned', label: 'Unassigned' },
+                // TEAMS-3 (L3): team options carry a `team:` prefix so the shared
+                // single-select owner group routes them apart from organizers.
+                ...(hasTeams
+                  ? teams!.map((t) => ({
+                      value: `team:${t.key}`,
+                      label: `Team: ${t.title}`,
+                    }))
+                  : []),
                 ...organizers.map((organizer) => ({
                   value: organizer._id,
                   label: organizer.name,
                 })),
               ],
-              selected: [assignedToFilter ?? ''],
-              onChange: (value) => onSetOrganizer(value === '' ? null : value),
+              selected: [
+                teamFilter ? `team:${teamFilter}` : (assignedToFilter ?? ''),
+              ],
+              onChange: (value) => {
+                if (value.startsWith('team:')) onSetTeam?.(value.slice(5))
+                else onSetOrganizer(value === '' ? null : value)
+              },
               multi: false,
             },
             {
@@ -254,6 +280,17 @@ export function SponsorCRMFilterBar({
               }
               category="Owner"
               onRemove={() => onSetOrganizer(null)}
+            />
+          )}
+
+          {/* Team pill (L3) */}
+          {teamFilter && (
+            <FilterPill
+              label={
+                teams?.find((t) => t.key === teamFilter)?.title || teamFilter
+              }
+              category="Team"
+              onRemove={() => onSetTeam?.(null)}
             />
           )}
 

--- a/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx
@@ -36,6 +36,7 @@ import {
   FunnelIcon,
 } from '@heroicons/react/20/solid'
 import { Conference } from '@/lib/conference/types'
+import { teamMembersForKey } from '@/lib/teams/members'
 import { SponsorTier } from '@/lib/sponsor/types'
 import { useSponsorDragDrop } from '@/hooks/useSponsorDragDrop'
 import { SponsorDeleteModal } from '@/components/admin/sponsor-crm/SponsorDeleteModal'
@@ -119,6 +120,19 @@ export function SponsorCRMPipeline({
     () => searchParams.get('assignedTo') || undefined,
     [searchParams],
   )
+  // TEAMS-3 (L3): the configured teams and the selected `team=<key>` filter. A
+  // team filter resolves to its member id set (server matches assignee ∈ set);
+  // it is mutually exclusive with the per-owner/unassigned assignedTo filter.
+  const teams = useMemo(() => conference.teams ?? [], [conference.teams])
+  const hasTeams = teams.length > 0
+  const teamFilter = useMemo(
+    () => searchParams.get('team') || undefined,
+    [searchParams],
+  )
+  const teamMemberIds = useMemo(
+    () => teamMembersForKey(teams, teamFilter),
+    [teams, teamFilter],
+  )
   const tagsFilter = useMemo(
     () =>
       (searchParams.get('tags')?.split(',').filter(Boolean) ||
@@ -141,9 +155,14 @@ export function SponsorCRMPipeline({
   // Fetch with filters
   const { data: sponsors = [], isLoading } = api.sponsor.crm.list.useQuery(
     {
+      // A team filter (assignedToIds) takes precedence and clears the per-owner
+      // assignedTo — the two are mutually exclusive at the URL level too.
       assignedTo:
-        assignedToFilter === 'unassigned' ? undefined : assignedToFilter,
-      unassignedOnly: assignedToFilter === 'unassigned',
+        teamMemberIds || assignedToFilter === 'unassigned'
+          ? undefined
+          : assignedToFilter,
+      assignedToIds: teamMemberIds,
+      unassignedOnly: !teamMemberIds && assignedToFilter === 'unassigned',
       tags: tagsFilter.length > 0 ? tagsFilter : undefined,
       tiers: tiersFilter.length > 0 ? tiersFilter : undefined,
       searchQuery:
@@ -299,7 +318,9 @@ export function SponsorCRMPipeline({
     if (hasDefaultedRef.current) return
     if (!session?.speaker?._id) return
 
-    if (!searchParams.has('assignedTo')) {
+    // Don't default to "my sponsors" when a team filter is already active — the
+    // team is the intended owner lens for this visit.
+    if (!searchParams.has('assignedTo') && !searchParams.has('team')) {
       const params = new URLSearchParams(searchParams.toString())
       params.set('assignedTo', session.speaker._id)
       router.replace(`?${params.toString()}`, { scroll: false })
@@ -350,6 +371,7 @@ export function SponsorCRMPipeline({
   }, [
     tiersFilter.length,
     assignedToFilter,
+    teamFilter,
     tagsFilter.length,
     currentView,
     handleClearSelection,
@@ -418,9 +440,27 @@ export function SponsorCRMPipeline({
 
   const setOrganizerFilter = useCallback(
     (organizerId: string | null) => {
-      updateFilters('assignedTo', organizerId)
+      // Selecting an owner / Unassigned / All clears any active team filter
+      // (mutually exclusive owner axis).
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete('team')
+      if (organizerId) params.set('assignedTo', organizerId)
+      else params.delete('assignedTo')
+      router.push(`?${params.toString()}`, { scroll: false })
     },
-    [updateFilters],
+    [router, searchParams],
+  )
+
+  const setTeamFilter = useCallback(
+    (teamKey: string | null) => {
+      // Selecting a team clears the per-owner assignedTo (and vice versa).
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete('assignedTo')
+      if (teamKey) params.set('team', teamKey)
+      else params.delete('team')
+      router.push(`?${params.toString()}`, { scroll: false })
+    },
+    [router, searchParams],
   )
 
   const toggleTagFilter = useCallback(
@@ -444,6 +484,7 @@ export function SponsorCRMPipeline({
   const activeFilterCount =
     tiersFilter.length +
     (assignedToFilter ? 1 : 0) +
+    (teamFilter ? 1 : 0) +
     tagsFilter.length +
     (needsFollowUpFilter ? 1 : 0)
 
@@ -647,13 +688,13 @@ export function SponsorCRMPipeline({
 
             <FilterDropdown
               label="Owner"
-              activeCount={assignedToFilter ? 1 : 0}
+              activeCount={assignedToFilter || teamFilter ? 1 : 0}
               position="left"
               size="sm"
             >
               <FilterOption
                 onClick={() => setOrganizerFilter(null)}
-                checked={!assignedToFilter}
+                checked={!assignedToFilter && !teamFilter}
                 type="radio"
               >
                 All Owners
@@ -665,6 +706,26 @@ export function SponsorCRMPipeline({
               >
                 Unassigned
               </FilterOption>
+              {/* TEAMS-3 (L3): a Teams option group — selecting a team filters
+                  owners to its member set. Hidden when no team is configured. */}
+              {hasTeams && (
+                <>
+                  <div className="my-1 border-t border-gray-100 dark:border-gray-700" />
+                  <div className="px-3 py-1 text-[10px] font-semibold tracking-wide text-gray-400 uppercase dark:text-gray-500">
+                    Teams
+                  </div>
+                  {teams.map((team) => (
+                    <FilterOption
+                      key={`team-${team.key}`}
+                      onClick={() => setTeamFilter(team.key)}
+                      checked={teamFilter === team.key}
+                      type="radio"
+                    >
+                      {team.title}
+                    </FilterOption>
+                  ))}
+                </>
+              )}
               <div className="my-1 border-t border-gray-100 dark:border-gray-700" />
               {organizers.map((organizer) => (
                 <FilterOption
@@ -806,6 +867,17 @@ export function SponsorCRMPipeline({
               />
             )}
 
+            {/* Team pill (L3) */}
+            {teamFilter && (
+              <FilterPill
+                label={
+                  teams.find((t) => t.key === teamFilter)?.title || teamFilter
+                }
+                category="Team"
+                onRemove={() => setTeamFilter(null)}
+              />
+            )}
+
             {/* Tag pills */}
             {tagsFilter.map((tag) => {
               const tagDef = TAGS.find((t) => t.value === tag)
@@ -873,11 +945,23 @@ export function SponsorCRMPipeline({
             options: [
               { value: '', label: 'All' },
               { value: 'unassigned', label: 'Unassigned' },
+              // TEAMS-3 (L3): team options carry a `team:` prefix so the shared
+              // single-select owner group can route them apart from organizers.
+              ...(hasTeams
+                ? teams.map((t) => ({
+                    value: `team:${t.key}`,
+                    label: `Team: ${t.title}`,
+                  }))
+                : []),
               ...organizers.map((org) => ({ value: org._id, label: org.name })),
             ],
-            selected: [assignedToFilter ?? ''],
-            onChange: (value) =>
-              setOrganizerFilter(value === '' ? null : value),
+            selected: [
+              teamFilter ? `team:${teamFilter}` : (assignedToFilter ?? ''),
+            ],
+            onChange: (value) => {
+              if (value.startsWith('team:')) setTeamFilter(value.slice(5))
+              else setOrganizerFilter(value === '' ? null : value)
+            },
             multi: false,
           },
           {

--- a/src/components/messaging/ConversationList.stories.tsx
+++ b/src/components/messaging/ConversationList.stories.tsx
@@ -485,3 +485,33 @@ export const SponsorThreadRowDark: Story = {
   parameters: { dark: true },
   render: (args) => <ConversationList {...args} items={makeSponsorItems()} />,
 }
+
+/**
+ * TEAMS-3 (L2): per-row TEAM chips. With teams configured, the amber sponsor row
+ * chip shows the sponsors-team TITLE ('Sales' — MERGED with, not duplicating,
+ * the "Sponsor" chip) and non-sponsor rows gain an indigo cfp-team chip
+ * ('Programme') beside the gray Proposal type chip. `routingTeamTitles` drives it;
+ * omitting it falls back to today's bare "Sponsor" chip.
+ */
+const TEAM_TITLES = { sponsors: 'Sales', cfp: 'Programme' }
+
+export const TeamChips: Story = {
+  args: {
+    items: [],
+    isOrganizer: true,
+    view: 'active',
+    routingTeamTitles: TEAM_TITLES,
+  },
+  render: (args) => <ConversationList {...args} items={makeSponsorItems()} />,
+}
+
+export const TeamChipsDark: Story = {
+  args: {
+    items: [],
+    isOrganizer: true,
+    view: 'active',
+    routingTeamTitles: TEAM_TITLES,
+  },
+  parameters: { dark: true },
+  render: (args) => <ConversationList {...args} items={makeSponsorItems()} />,
+}

--- a/src/components/messaging/ConversationList.tsx
+++ b/src/components/messaging/ConversationList.tsx
@@ -16,6 +16,10 @@ import type {
   ConversationListItem,
   ConversationView,
 } from '@/lib/messaging/types'
+import {
+  deriveThreadTeamChip,
+  type RoutingTeamTitles,
+} from '@/lib/messaging/threadTeam'
 
 export interface ConversationListProps {
   /** Conversations, newest activity first. Ignored while `isLoading`. */
@@ -62,6 +66,13 @@ export interface ConversationListProps {
   panelId?: string
   /** The id of the currently-selected tab, for the tabpanel's `aria-labelledby`. */
   labelledById?: string
+  /**
+   * TEAMS-3 (L2): resolved routing-team TITLES ({ sponsors, cfp }) for the
+   * per-row team chip. Supplied only for the organizer audience when teams are
+   * configured; `undefined` suppresses chips (no teams configured / speaker
+   * audience), leaving the standalone "Sponsor" chip as today.
+   */
+  routingTeamTitles?: RoutingTeamTitles
 }
 
 /**
@@ -78,6 +89,8 @@ function emptyStateFor(
     switch (view) {
       case 'needs-reply':
         return { headline: 'Nothing needs a reply 🎉' }
+      case 'my-teams':
+        return { headline: 'Nothing active for your teams' }
       case 'unassigned':
         return { headline: 'No unassigned conversations' }
       case 'mine':
@@ -194,6 +207,7 @@ export function ConversationList({
   onNewConversation,
   panelId,
   labelledById,
+  routingTeamTitles,
 }: ConversationListProps) {
   return (
     <div
@@ -273,6 +287,16 @@ export function ConversationList({
             // the viewer gets a brand-blue left edge and a "Direct" chip so it
             // reads distinctly from the organizer broadcast threads.
             const isDirect = item.direct === true
+            // TEAMS-3 (L2): the row's team chip, derived from the thread's
+            // routing team (sponsor → sponsors, else cfp). Organizer-only, and
+            // only when teams are configured (routingTeamTitles set). For a
+            // sponsor row the chip MERGES with — rather than duplicates — the
+            // amber Sponsor chip: the single amber chip shows the team title
+            // (fallback 'Sponsor'). A non-sponsor routed thread gets a quiet
+            // indigo team chip alongside the orthogonal gray 'Proposal' type chip.
+            const teamChip = isOrganizer
+              ? deriveThreadTeamChip(item.conversationType, routingTeamTitles)
+              : null
             return (
               // A `relative` row wrapper so the Unarchive ACTION can be a sibling
               // overlay of the row link rather than a <button> nested inside an
@@ -354,13 +378,25 @@ export function ConversationList({
                         </span>
                       )}
                       {/* SPONSOR thread chip (G2b) — mirrors the Proposal chip,
-                          amber to match the sponsor bubble/badge. The counterpart
-                          is the sponsor company name (server-resolved). */}
+                          amber to match the sponsor bubble/badge. When teams are
+                          configured (L2) this SAME chip shows the sponsors-team
+                          title instead of the bare 'Sponsor', so the team chip
+                          and the Sponsor chip never both appear. */}
                       {item.conversationType === 'sponsor' && (
                         <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
-                          Sponsor
+                          {teamChip?.label ?? 'Sponsor'}
                         </span>
                       )}
+                      {/* Non-sponsor routed thread's team chip (L2): the cfp-team
+                          title, indigo so it reads as a TEAM facet distinct from
+                          the gray 'Proposal' type chip. Hidden when the cfp team
+                          is unnamed/absent (teamChip null). */}
+                      {item.conversationType !== 'sponsor' &&
+                        teamChip?.tone === 'team' && (
+                          <span className="shrink-0 rounded-full bg-indigo-100 px-2 py-0.5 text-[10px] font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+                            {teamChip.label}
+                          </span>
+                        )}
                       {isResolved && (
                         <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-700 dark:text-gray-400">
                           {isOrganizer ? 'Resolved' : 'Closed by organizers'}

--- a/src/components/messaging/MessagesInbox.stories.tsx
+++ b/src/components/messaging/MessagesInbox.stories.tsx
@@ -81,9 +81,15 @@ const makeItems = (): ConversationListItem[] => [
  * BUILDER, invoked per request, so `minutesAgo` timestamps are computed after
  * `mockDateBeforeEach` has pinned the clock — calling `makeItems()` at module
  * load would freeze them against the real wall clock instead. */
+type TeamLens = {
+  teams: { key: string; title: string }[]
+  myTeamKeys: string[]
+}
+
 const conversationHandlers = (
   getItems: () => ConversationListItem[],
   counts?: ConversationViewCounts,
+  teamLens?: TeamLens,
 ) => [
   http.get('/api/trpc/:procs', ({ params }) =>
     HttpResponse.json(
@@ -94,7 +100,9 @@ const conversationHandlers = (
             ? { result: { data: getItems() } }
             : proc === 'message.viewCounts'
               ? { result: { data: counts ?? null } }
-              : { result: { data: null } },
+              : proc === 'message.teamLens'
+                ? { result: { data: teamLens ?? null } }
+                : { result: { data: null } },
         ),
     ),
   ),
@@ -104,10 +112,20 @@ const conversationHandlers = (
 const ORGANIZER_COUNTS: ConversationViewCounts = {
   active: 8,
   needsReply: 3,
+  myTeams: 4,
   unassigned: 2,
   mine: 1,
   resolved: 12,
   archived: 5,
+}
+
+/** A configured team lens: the viewer is on the CFP team. */
+const TEAM_LENS: TeamLens = {
+  teams: [
+    { key: 'cfp', title: 'Programme' },
+    { key: 'sponsors', title: 'Sales' },
+  ],
+  myTeamKeys: ['cfp'],
 }
 
 /** Organizer inbox rows carrying ticketing metadata so the row affordances show
@@ -233,6 +251,40 @@ export const OrganizerPopulatedDark: Story = {
     dark: true,
     msw: {
       handlers: conversationHandlers(makeOrganizerItems, ORGANIZER_COUNTS),
+    },
+  },
+}
+
+/**
+ * TEAMS-3 (L1 + L2): with a team lens configured, the organizer tab bar gains a
+ * "My teams" tab (with its count) between "Needs reply" and "Unassigned", and the
+ * rows carry the indigo cfp-team chip ('Programme'). The tab is hidden entirely
+ * when no team is configured (the other organizer stories, whose teamLens is
+ * null).
+ */
+export const OrganizerWithTeams: Story = {
+  args: { audience: 'organizer', allowNew: true },
+  parameters: {
+    msw: {
+      handlers: conversationHandlers(
+        makeOrganizerItems,
+        ORGANIZER_COUNTS,
+        TEAM_LENS,
+      ),
+    },
+  },
+}
+
+export const OrganizerWithTeamsDark: Story = {
+  args: { audience: 'organizer', allowNew: true },
+  parameters: {
+    dark: true,
+    msw: {
+      handlers: conversationHandlers(
+        makeOrganizerItems,
+        ORGANIZER_COUNTS,
+        TEAM_LENS,
+      ),
     },
   },
 }

--- a/src/components/messaging/MessagesInbox.tsx
+++ b/src/components/messaging/MessagesInbox.tsx
@@ -26,6 +26,7 @@ const tabId = (view: ConversationView) => `messages-tab-${view}`
 const ORGANIZER_TABS: { view: ConversationView; label: string }[] = [
   { view: 'active', label: 'Active' },
   { view: 'needs-reply', label: 'Needs reply' },
+  { view: 'my-teams', label: 'My teams' },
   { view: 'unassigned', label: 'Unassigned' },
   { view: 'mine', label: 'Mine' },
   { view: 'resolved', label: 'Resolved' },
@@ -50,6 +51,8 @@ function countForView(
       return counts.active
     case 'needs-reply':
       return counts.needsReply
+    case 'my-teams':
+      return counts.myTeams
     case 'unassigned':
       return counts.unassigned
     case 'mine':
@@ -96,10 +99,13 @@ function OrganizerViewTabs({
   view,
   counts,
   onChange,
+  tabs,
 }: {
   view: ConversationView
   counts: ConversationViewCounts | undefined
   onChange: (view: ConversationView) => void
+  /** The visible organizer tabs — `My teams` is dropped when no team is configured. */
+  tabs: { view: ConversationView; label: string }[]
 }) {
   return (
     <div
@@ -107,7 +113,7 @@ function OrganizerViewTabs({
       aria-label="Filter conversations"
       className="no-scrollbar flex flex-1 gap-1 overflow-x-auto"
     >
-      {ORGANIZER_TABS.map((tab) => {
+      {tabs.map((tab) => {
         const active = tab.view === view
         const count = countForView(tab.view, counts)
         return (
@@ -202,7 +208,35 @@ export function MessagesInbox({
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const tabs = isOrganizer ? ORGANIZER_TABS : SPEAKER_TABS
+
+  // TEAMS-3 soft lens: the caller's teams + every configured team (key/title).
+  // Organizer-only — speakers never see the team surfaces. When NO team is
+  // configured conference-wide the `My teams` tab is an inert lens, so it (and
+  // the per-row team chips) are hidden entirely rather than cluttering the UI.
+  const { data: teamLens } = api.message.teamLens.useQuery(undefined, {
+    staleTime: 5 * 60_000,
+    enabled: isOrganizer,
+  })
+  const teamsConfigured = (teamLens?.teams.length ?? 0) > 0
+
+  // Drop the `My teams` tab when no team is configured (inert-lens hide). The
+  // same filtered list drives URL-view validation below, so a stale
+  // `?view=my-teams` correctly falls back to `active` on a team-less conference.
+  const organizerTabs = teamsConfigured
+    ? ORGANIZER_TABS
+    : ORGANIZER_TABS.filter((t) => t.view !== 'my-teams')
+
+  // Routing-team TITLES for the per-row chips (L2): a sponsor thread → `sponsors`
+  // team title, everything else → `cfp` team title. Undefined ⇒ no chips.
+  const routingTeamTitles =
+    isOrganizer && teamsConfigured
+      ? {
+          sponsors: teamLens?.teams.find((t) => t.key === 'sponsors')?.title,
+          cfp: teamLens?.teams.find((t) => t.key === 'cfp')?.title,
+        }
+      : undefined
+
+  const tabs = isOrganizer ? organizerTabs : SPEAKER_TABS
   const paramView = searchParams.get('view')
   const urlView: ConversationView =
     paramView && tabs.some((t) => t.view === paramView)
@@ -306,6 +340,7 @@ export function MessagesInbox({
             view={view}
             counts={viewCounts}
             onChange={setView}
+            tabs={organizerTabs}
           />
         ) : (
           <div className="min-w-0 flex-1">
@@ -341,6 +376,7 @@ export function MessagesInbox({
         isOrganizer={isOrganizer}
         callerId={callerId}
         view={view}
+        routingTeamTitles={routingTeamTitles}
         isLoading={isLoading}
         isError={isError}
         hasMore={hasNextPage}

--- a/src/lib/dashboard/data-types.ts
+++ b/src/lib/dashboard/data-types.ts
@@ -129,3 +129,30 @@ export interface ProposalPipelineData {
   acceptanceRate: number
   pendingDecisions: number
 }
+
+/**
+ * TEAMS-3 (L4) — "My areas". One needs-attention metric on a team card, deep
+ * linking to the filtered surface (inbox view / CRM owner / volunteers page).
+ */
+export interface MyAreaMetric {
+  label: string
+  count: number
+  href: string
+}
+
+/** A team the viewer belongs to, with its compact needs-attention metrics. */
+export interface MyAreaCard {
+  key: string
+  title: string
+  metrics: MyAreaMetric[]
+}
+
+/**
+ * The viewer's team areas. `areas` is empty when the viewer is on no team (the
+ * widget then renders its inert empty state). Counts reuse EXISTING sources
+ * (message viewCounts, the sponsor list's unassigned filter, the volunteer
+ * list) — at most one read per area the viewer actually belongs to.
+ */
+export interface MyAreasData {
+  areas: MyAreaCard[]
+}

--- a/src/lib/dashboard/presets.ts
+++ b/src/lib/dashboard/presets.ts
@@ -216,6 +216,12 @@ export const PRESET_CONFIGS: Record<string, PresetConfig> = {
         title: 'Recent Activity',
         position: { row: 12, col: 6, rowSpan: 4, colSpan: 6 },
       },
+      {
+        id: 'my-areas',
+        type: 'my-areas',
+        title: 'My Areas',
+        position: { row: 16, col: 0, rowSpan: 2, colSpan: 4 },
+      },
     ],
   },
 }

--- a/src/lib/dashboard/widget-registry.ts
+++ b/src/lib/dashboard/widget-registry.ts
@@ -785,6 +785,48 @@ export const RECENT_ACTIVITY_WIDGET = defineWidget({
 })
 
 /**
+ * My Areas Widget (TEAMS-3, L4)
+ * Per-team needs-attention counts for the teams the viewer belongs to.
+ */
+export const MY_AREAS_WIDGET = defineWidget({
+  type: 'my-areas',
+  displayName: 'My Areas',
+  description:
+    "Needs-attention counts for the teams you're on, deep-linked to each surface",
+  category: 'operations',
+  icon: 'UserGroupIcon',
+  constraints: {
+    minCols: 3,
+    maxCols: 6,
+    minRows: 2,
+    maxRows: 4,
+    prefersLandscape: true,
+  },
+  defaultSize: {
+    name: 'small',
+    colSpan: 3,
+    rowSpan: 2,
+    description: 'Compact team areas',
+  },
+  availableSizes: [
+    { name: 'compact', colSpan: 3, rowSpan: 2 },
+    { name: 'small', colSpan: 4, rowSpan: 2 },
+    { name: 'wide', colSpan: 6, rowSpan: 2 },
+  ],
+  tags: ['teams', 'triage', 'operations'],
+  phaseConfig: {
+    relevantPhases: [
+      'initialization',
+      'planning',
+      'execution',
+      'post-conference',
+    ],
+    hideInIrrelevantPhases: false,
+    isPhaseAdaptive: false,
+  },
+})
+
+/**
  * Widget Registry
  * Maps widget types to their metadata
  */
@@ -801,6 +843,7 @@ export const WIDGET_REGISTRY: Record<string, WidgetMetadata> = {
   'workshop-capacity': WORKSHOP_CAPACITY_WIDGET,
   'travel-support': TRAVEL_SUPPORT_WIDGET,
   'recent-activity': RECENT_ACTIVITY_WIDGET,
+  'my-areas': MY_AREAS_WIDGET,
 }
 
 /**

--- a/src/lib/messaging/myTeamsView.test.ts
+++ b/src/lib/messaging/myTeamsView.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/sanity/helpers', () => ({
+  createReference: (id: string) => ({ _type: 'reference', _ref: id }),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { transaction: vi.fn(), create: vi.fn(), patch: vi.fn() },
+  clientReadUncached: { fetch: vi.fn() },
+}))
+
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn(async () => ['org-1', 'org-2']),
+}))
+
+// The `my-teams` predicate binds `$myTeamKeys` from the caller's team
+// membership; mock the teams SOURCE so we can assert what gets bound.
+const getConferenceTeamsMock = vi.fn()
+vi.mock('@/lib/teams', () => ({
+  getViewerTeamKeys: async (conferenceId: string, speakerId: string) => {
+    const teams = await getConferenceTeamsMock(conferenceId)
+    return teams
+      .filter((t: { members: string[] }) => t.members.includes(speakerId))
+      .map((t: { key: string }) => t.key)
+  },
+}))
+
+import { clientReadUncached } from '@/lib/sanity/client'
+import {
+  rawViewPredicate,
+  getConversationViewCounts,
+} from '@/lib/messaging/sanity'
+
+type LooseMock = ReturnType<typeof vi.fn>
+const readMock = clientReadUncached as unknown as { fetch: LooseMock }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('rawViewPredicate("my-teams") (L1)', () => {
+  it('is organizer-only, needs myTeamKeys, and maps routing teams', () => {
+    const { predicate, needsOrganizerIds, needsMyTeamKeys } = rawViewPredicate(
+      'my-teams',
+      true,
+    )
+    expect(needsMyTeamKeys).toBe(true)
+    expect(needsOrganizerIds).toBe(false)
+    // Sponsor threads route to `sponsors`, everything else to `cfp`.
+    expect(predicate).toContain('conversationType == "sponsor"')
+    expect(predicate).toContain('"sponsors" in $myTeamKeys')
+    expect(predicate).toContain('conversationType != "sponsor"')
+    expect(predicate).toContain('"cfp" in $myTeamKeys')
+  })
+
+  it('is INERT when the caller is on no team (matches every active thread)', () => {
+    const { predicate } = rawViewPredicate('my-teams', true)
+    // The empty-set escape hatch: count == 0 short-circuits to "all active".
+    expect(predicate).toContain('count($myTeamKeys) == 0')
+  })
+})
+
+describe('getConversationViewCounts myTeams wiring (L1)', () => {
+  it('binds the caller team keys and returns the myTeams count for organizers', async () => {
+    getConferenceTeamsMock.mockResolvedValue([
+      { key: 'cfp', members: ['org-1'] },
+      { key: 'sponsors', members: ['org-2'] },
+    ])
+    readMock.fetch.mockResolvedValue({
+      active: 5,
+      needsReply: 2,
+      myTeams: 3,
+      unassigned: 1,
+      mine: 0,
+      resolved: 4,
+      archived: 6,
+    })
+
+    const counts = await getConversationViewCounts({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+    })
+
+    expect(counts.myTeams).toBe(3)
+    // The GROQ must select a "myTeams" count field and bind $myTeamKeys to the
+    // caller's own membership (org-1 is on the cfp team).
+    const [groq, params] = readMock.fetch.mock.calls[0]
+    expect(groq).toContain('"myTeams"')
+    expect(params.myTeamKeys).toEqual(['cfp'])
+  })
+
+  it('omits myTeams for a speaker caller (organizer-only view)', async () => {
+    readMock.fetch.mockResolvedValue({ active: 1, archived: 2 })
+    const counts = await getConversationViewCounts({
+      speakerId: 's-1',
+      isOrganizer: false,
+      conferenceId: 'conf-1',
+    })
+    expect(counts.myTeams).toBeUndefined()
+    expect(getConferenceTeamsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -122,6 +122,10 @@ export async function notifyNewMessage({
     const routedOrganizerIds = await resolveRoutedOrganizerIds({
       conferenceId: conversation.conferenceId,
       teamKey: 'cfp',
+      // Reuse the full organizer set already fetched above for classification
+      // as the team-else-all fallback, so the no-team path does not read the
+      // organizer set a second time.
+      allOrganizerIds: organizerIds,
     })
     const recipientIds = resolveRecipients(
       conversation,

--- a/src/lib/messaging/nudge.ts
+++ b/src/lib/messaging/nudge.ts
@@ -140,6 +140,10 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
                 conversation.conversationType === 'sponsor'
                   ? 'sponsors'
                   : 'cfp',
+              // Reuse the organizer set fetched once before the loop as the
+              // team-else-all fallback, so each unassigned conversation does not
+              // re-read it.
+              allOrganizerIds: organizerIds,
             })
         if (recipientIds.length === 0) continue
 

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid'
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import { createReference } from '@/lib/sanity/helpers'
 import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import { getViewerTeamKeys } from '@/lib/teams'
 import type {
   AccessSpeaker,
   ConversationListItem,
@@ -166,7 +167,12 @@ export const SPEAKER_SCOPE_PREDICATE =
 export function rawViewPredicate(
   view: ConversationView,
   isOrganizer: boolean,
-): { predicate: string; needsOrganizerIds: boolean } {
+): {
+  predicate: string
+  needsOrganizerIds: boolean
+  /** True only for `my-teams`: the caller binds `$myTeamKeys` for this view. */
+  needsMyTeamKeys?: boolean
+} {
   if (!isOrganizer) {
     // Speakers: only their OWN preference archive hides a thread. Global archive
     // and status are organizer-side concepts a speaker never filters on.
@@ -185,6 +191,18 @@ export function rawViewPredicate(
       return {
         predicate: `${active} && ${NEEDS_REPLY}`,
         needsOrganizerIds: true,
+      }
+    case 'my-teams':
+      // The thread's ROUTING team must be one of the caller's teams: a sponsor
+      // thread maps to `sponsors`, everything else to `cfp` (the TEAMS-2 map).
+      // INERT when the caller is on no team — `count($myTeamKeys) == 0` then
+      // matches every active thread, so the lens is a soft filter that never
+      // hides a thread the caller would otherwise see. `$myTeamKeys` is bound by
+      // the caller (see needsMyTeamKeys).
+      return {
+        predicate: `${active} && (count($myTeamKeys) == 0 || (conversationType == "sponsor" && "sponsors" in $myTeamKeys) || (conversationType != "sponsor" && "cfp" in $myTeamKeys))`,
+        needsOrganizerIds: false,
+        needsMyTeamKeys: true,
       }
     case 'unassigned':
       return {
@@ -221,11 +239,19 @@ export function rawViewPredicate(
 function buildViewPredicate(
   view: ConversationView,
   isOrganizer: boolean,
-): { predicate: string; needsOrganizerIds: boolean } {
-  const { predicate, needsOrganizerIds } = rawViewPredicate(view, isOrganizer)
+): {
+  predicate: string
+  needsOrganizerIds: boolean
+  needsMyTeamKeys?: boolean
+} {
+  const { predicate, needsOrganizerIds, needsMyTeamKeys } = rawViewPredicate(
+    view,
+    isOrganizer,
+  )
   return {
     predicate: predicate ? ` && ${predicate}` : '',
     needsOrganizerIds,
+    needsMyTeamKeys,
   }
 }
 
@@ -668,12 +694,18 @@ export async function listConversationsForSpeaker({
     ? await getOrganizerSpeakerIds()
     : null
 
-  const { predicate: viewPredicate, needsOrganizerIds } = buildViewPredicate(
-    view,
-    isOrganizer,
-  )
+  const {
+    predicate: viewPredicate,
+    needsOrganizerIds,
+    needsMyTeamKeys,
+  } = buildViewPredicate(view, isOrganizer)
   if (needsOrganizerIds) {
     params.organizerIds = organizerIdsUpFront ?? []
+  }
+  // `my-teams` (organizer-only) filters on the caller's team keys; an empty set
+  // makes the view inert (matches every active thread) — see rawViewPredicate.
+  if (needsMyTeamKeys) {
+    params.myTeamKeys = await getViewerTeamKeys(conferenceId, speakerId)
   }
 
   // `lastMessage` is a correlated subquery (newest message per conversation) so
@@ -976,12 +1008,21 @@ export async function getConversationViewCounts({
 
   // Build one `count()` field per relevant view from the shared predicates.
   const views: ConversationView[] = isOrganizer
-    ? ['active', 'needs-reply', 'unassigned', 'mine', 'resolved', 'archived']
+    ? [
+        'active',
+        'needs-reply',
+        'my-teams',
+        'unassigned',
+        'mine',
+        'resolved',
+        'archived',
+      ]
     : ['active', 'archived']
   // Stable field keys (the enum's hyphenated names aren't valid identifiers).
   const KEY: Record<string, keyof ConversationViewCounts> = {
     active: 'active',
     'needs-reply': 'needsReply',
+    'my-teams': 'myTeams',
     unassigned: 'unassigned',
     mine: 'mine',
     resolved: 'resolved',
@@ -990,8 +1031,14 @@ export async function getConversationViewCounts({
 
   const fields: string[] = []
   for (const view of views) {
-    const { predicate, needsOrganizerIds } = rawViewPredicate(view, isOrganizer)
+    const { predicate, needsOrganizerIds, needsMyTeamKeys } = rawViewPredicate(
+      view,
+      isOrganizer,
+    )
     if (needsOrganizerIds) params.organizerIds = await getOrganizerSpeakerIds()
+    if (needsMyTeamKeys) {
+      params.myTeamKeys = await getViewerTeamKeys(conferenceId, speakerId)
+    }
     const filter = predicate ? ` && ${predicate}` : ''
     fields.push(`"${KEY[view]}": count(*[${base}${scope}${filter}])`)
   }
@@ -1006,6 +1053,7 @@ export async function getConversationViewCounts({
   }
   if (isOrganizer) {
     counts.needsReply = result?.needsReply ?? 0
+    counts.myTeams = result?.myTeams ?? 0
     counts.unassigned = result?.unassigned ?? 0
     counts.mine = result?.mine ?? 0
     counts.resolved = result?.resolved ?? 0

--- a/src/lib/messaging/threadTeam.test.ts
+++ b/src/lib/messaging/threadTeam.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import {
+  routingTeamKeyForType,
+  deriveThreadTeamChip,
+} from '@/lib/messaging/threadTeam'
+
+describe('routingTeamKeyForType', () => {
+  it('maps a sponsor thread to the sponsors team', () => {
+    expect(routingTeamKeyForType('sponsor')).toBe('sponsors')
+  })
+
+  it('maps proposal and general threads to the cfp team', () => {
+    expect(routingTeamKeyForType('proposal')).toBe('cfp')
+    expect(routingTeamKeyForType('general')).toBe('cfp')
+  })
+})
+
+describe('deriveThreadTeamChip (L2 badge derivation)', () => {
+  const titles = { sponsors: 'Sales', cfp: 'Programme' }
+
+  it('returns a sponsor-tone chip with the sponsors-team title for a sponsor thread', () => {
+    expect(deriveThreadTeamChip('sponsor', titles)).toEqual({
+      label: 'Sales',
+      tone: 'sponsor',
+    })
+  })
+
+  it('returns a team-tone chip with the cfp-team title for a non-sponsor thread', () => {
+    expect(deriveThreadTeamChip('proposal', titles)).toEqual({
+      label: 'Programme',
+      tone: 'team',
+    })
+    expect(deriveThreadTeamChip('general', titles)).toEqual({
+      label: 'Programme',
+      tone: 'team',
+    })
+  })
+
+  it('returns null when no titles are provided (no teams configured)', () => {
+    expect(deriveThreadTeamChip('sponsor', undefined)).toBeNull()
+    expect(deriveThreadTeamChip('proposal', undefined)).toBeNull()
+  })
+
+  it('returns null when the mapped team has no configured title', () => {
+    // Only cfp configured: a sponsor row falls back (null → caller shows the
+    // bare "Sponsor" chip); a proposal row gets the cfp chip.
+    const cfpOnly = { cfp: 'Programme' }
+    expect(deriveThreadTeamChip('sponsor', cfpOnly)).toBeNull()
+    expect(deriveThreadTeamChip('proposal', cfpOnly)).toEqual({
+      label: 'Programme',
+      tone: 'team',
+    })
+  })
+})

--- a/src/lib/messaging/threadTeam.ts
+++ b/src/lib/messaging/threadTeam.ts
@@ -1,0 +1,60 @@
+/**
+ * Thread → routing-team derivation for the TEAMS-3 inbox lenses.
+ *
+ * A conversation's ROUTING TEAM is the well-known team key its notifications fan
+ * out to (see docs/ORGANIZER_TEAMS.md / TEAMS-2): a `sponsor` thread routes to
+ * the `sponsors` team, everything else (`proposal` / `general`) to `cfp`. These
+ * are the only two keys inbox threads map to, so both the `my-teams` view
+ * predicate and the per-row team CHIP derive from this single mapping.
+ *
+ * This module is intentionally free of any server import so client components
+ * (the inbox rows) and unit tests can use it directly.
+ */
+import type { ConversationType } from './types'
+
+/** The well-known routing team key an inbox thread of this type belongs to. */
+export function routingTeamKeyForType(
+  conversationType: ConversationType,
+): 'sponsors' | 'cfp' {
+  return conversationType === 'sponsor' ? 'sponsors' : 'cfp'
+}
+
+/**
+ * The resolved TITLES of the two routing teams, as configured on the conference
+ * (`undefined` when that team is absent or unnamed). The inbox passes this down
+ * to the rows so a chip can show the human team label; `undefined`/empty means
+ * "no teams configured" and the chips are suppressed entirely.
+ */
+export interface RoutingTeamTitles {
+  sponsors?: string
+  cfp?: string
+}
+
+/**
+ * A row's team chip. `tone` distinguishes the SPONSOR chip (amber — preserves the
+ * existing sponsor visual identity, and REPLACES the standalone "Sponsor" chip so
+ * the two never both shout) from a generic `team` chip (a routed non-sponsor
+ * thread). Returns `null` when no chip should render: the speaker audience, no
+ * teams configured, or the mapped team having no configured title.
+ */
+export interface ThreadTeamChip {
+  label: string
+  tone: 'sponsor' | 'team'
+}
+
+/**
+ * Derive the team chip for one inbox row (organizer audience only). The chip's
+ * label is the mapped routing team's configured TITLE; when that team is not
+ * configured the chip is suppressed (the caller falls back to today's rendering —
+ * a bare "Sponsor" chip for a sponsor row, nothing for the rest).
+ */
+export function deriveThreadTeamChip(
+  conversationType: ConversationType,
+  routingTeamTitles: RoutingTeamTitles | undefined,
+): ThreadTeamChip | null {
+  if (!routingTeamTitles) return null
+  const key = routingTeamKeyForType(conversationType)
+  const title = routingTeamTitles[key]
+  if (!title) return null
+  return { label: title, tone: key === 'sponsors' ? 'sponsor' : 'team' }
+}

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -31,6 +31,10 @@ export type ConversationStatus = 'open' | 'resolved'
  * - `active`      — status open (or absent) AND NOT globally archived AND NOT
  *                   per-user archived;
  * - `needs-reply` — active AND the last message's author is not an organizer;
+ * - `my-teams`    — active AND the thread's ROUTING team (sponsor thread →
+ *                   `sponsors`, everything else → `cfp`) is one of the caller's
+ *                   teams. INERT when the caller belongs to no team (shows every
+ *                   active thread) — a soft lens, never an access gate (TEAMS-3);
  * - `unassigned`  — active AND no organizer is assigned to follow up;
  * - `mine`        — active AND assigned to the caller;
  * - `resolved`    — status resolved AND not archived (neither global nor per-user);
@@ -46,6 +50,7 @@ export type ConversationStatus = 'open' | 'resolved'
 export type ConversationView =
   | 'active'
   | 'needs-reply'
+  | 'my-teams'
   | 'unassigned'
   | 'mine'
   | 'resolved'
@@ -297,6 +302,7 @@ export interface ConversationViewCounts {
   active: number
   archived: number
   needsReply?: number
+  myTeams?: number
   unassigned?: number
   mine?: number
   resolved?: number

--- a/src/lib/sponsor-crm/sanity.ts
+++ b/src/lib/sponsor-crm/sanity.ts
@@ -402,6 +402,8 @@ export async function listSponsorsForConference(
     status?: string[]
     invoiceStatus?: string[]
     assignedTo?: string
+    /** TEAMS-3 (L3): match sponsors whose assignee is any of these ids (a team's members). */
+    assignedToIds?: string[]
     unassignedOnly?: boolean
     tags?: string[]
     tiers?: string[]
@@ -422,6 +424,10 @@ export async function listSponsorsForConference(
     }
     if (filters?.unassignedOnly) {
       filterQuery += ` && !defined(assignedTo)`
+    } else if (filters?.assignedToIds) {
+      // TEAM filter (L3): assignee ∈ the team's member set. Defined-but-empty
+      // (a member-less team) correctly matches nothing (`in []`).
+      filterQuery += ` && assignedTo._ref in $assignedToIds`
     } else if (filters?.assignedTo) {
       filterQuery += ` && assignedTo._ref == $assignedTo`
     }
@@ -449,6 +455,7 @@ export async function listSponsorsForConference(
         statuses: filters?.status,
         invoiceStatuses: filters?.invoiceStatus,
         assignedTo: filters?.assignedTo,
+        assignedToIds: filters?.assignedToIds,
         tags: filters?.tags,
         tierIds: filters?.tiers,
         searchTerm: filters?.searchQuery

--- a/src/lib/teams/index.ts
+++ b/src/lib/teams/index.ts
@@ -18,5 +18,11 @@ export {
   resolveTeamEmailIdentity,
 } from './resolve'
 export { resolveRoutedOrganizerIds } from './routing'
+export {
+  getViewerTeamLens,
+  getViewerTeamKeys,
+  type ViewerTeamLens,
+} from './viewer'
 export { formatTeamSummary } from './format'
+export { teamMembersForKey } from './members'
 export { TEAM_KEY_PATTERN, isValidTeamKey, countTeamKey } from './validation'

--- a/src/lib/teams/members.test.ts
+++ b/src/lib/teams/members.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { teamMembersForKey } from '@/lib/teams/members'
+
+const teams = [
+  { key: 'cfp', members: ['s1', 's2'] },
+  { key: 'sponsors', members: ['s3'] },
+  { key: 'empty-team', members: [] },
+]
+
+describe('teamMembersForKey (L3 CRM team filter → member set)', () => {
+  it('maps a team key to its member id set', () => {
+    expect(teamMembersForKey(teams, 'cfp')).toEqual(['s1', 's2'])
+    expect(teamMembersForKey(teams, 'sponsors')).toEqual(['s3'])
+  })
+
+  it('returns [] for a matched team with no members (match nobody)', () => {
+    expect(teamMembersForKey(teams, 'empty-team')).toEqual([])
+  })
+
+  it('returns undefined for an unknown key, no key, or no teams', () => {
+    expect(teamMembersForKey(teams, 'nope')).toBeUndefined()
+    expect(teamMembersForKey(teams, undefined)).toBeUndefined()
+    expect(teamMembersForKey(teams, null)).toBeUndefined()
+    expect(teamMembersForKey(undefined, 'cfp')).toBeUndefined()
+  })
+})

--- a/src/lib/teams/members.ts
+++ b/src/lib/teams/members.ts
@@ -1,0 +1,19 @@
+import type { OrganizerTeam } from './types'
+
+/**
+ * The member speaker-id set of the team with `key`, or `undefined` when no team
+ * matches (or no key/teams given). Pure and free of any server import so the
+ * sponsor CRM client (TEAMS-3 L3) can map a selected `team=<key>` URL param to
+ * the assignee id set it filters on, and unit tests can exercise the mapping
+ * directly.
+ *
+ * A matched team with zero members returns `[]` (not `undefined`) — the caller
+ * treats that as "match nobody", distinct from "no team filter".
+ */
+export function teamMembersForKey(
+  teams: Pick<OrganizerTeam, 'key' | 'members'>[] | undefined,
+  key: string | undefined | null,
+): string[] | undefined {
+  if (!key || !teams) return undefined
+  return teams.find((t) => t.key === key)?.members
+}

--- a/src/lib/teams/routing.ts
+++ b/src/lib/teams/routing.ts
@@ -26,13 +26,22 @@ import type { TeamKey } from './types'
  * never the intent, so it collapses to all. (A failure of the organizer fetch
  * itself surfaces to the caller's existing never-fail envelope, exactly as it
  * does today.)
+ *
+ * FALLBACK REUSE: a caller that has ALREADY fetched the full organizer set (for
+ * classification, or once before a loop) may pass it as `allOrganizerIds` to
+ * reuse as the team-else-all fallback, avoiding a duplicate
+ * {@link getOrganizerSpeakerIds} read. It is only a hoist of the SAME set — the
+ * absent/empty/failed-team behaviour is identical whether it is passed or
+ * fetched here.
  */
 export async function resolveRoutedOrganizerIds({
   conferenceId,
   teamKey,
+  allOrganizerIds,
 }: {
   conferenceId: string
   teamKey: TeamKey
+  allOrganizerIds?: string[]
 }): Promise<string[]> {
   try {
     const teams = await getConferenceTeams(conferenceId)
@@ -46,5 +55,5 @@ export async function resolveRoutedOrganizerIds({
       error,
     )
   }
-  return getOrganizerSpeakerIds()
+  return allOrganizerIds ?? getOrganizerSpeakerIds()
 }

--- a/src/lib/teams/viewer.test.ts
+++ b/src/lib/teams/viewer.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getConferenceTeamsMock = vi.fn()
+vi.mock('@/lib/teams/sanity', () => ({
+  getConferenceTeams: (id: string) => getConferenceTeamsMock(id),
+}))
+
+import { getViewerTeamLens, getViewerTeamKeys } from '@/lib/teams/viewer'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getConferenceTeamsMock.mockResolvedValue([
+    { key: 'cfp', title: 'Programme', members: ['org-1', 'org-2'] },
+    { key: 'sponsors', title: 'Sales', members: ['org-2'] },
+  ])
+})
+
+describe('getViewerTeamLens', () => {
+  it('returns every team key+title and the caller-owned keys', async () => {
+    const lens = await getViewerTeamLens('conf-1', 'org-2')
+    expect(lens.teams).toEqual([
+      { key: 'cfp', title: 'Programme' },
+      { key: 'sponsors', title: 'Sales' },
+    ])
+    expect(lens.myTeamKeys).toEqual(['cfp', 'sponsors'])
+  })
+
+  it('returns empty myTeamKeys for a caller on no team (inert lens)', async () => {
+    const lens = await getViewerTeamLens('conf-1', 'org-99')
+    expect(lens.teams).toHaveLength(2)
+    expect(lens.myTeamKeys).toEqual([])
+  })
+})
+
+describe('getViewerTeamKeys', () => {
+  it('returns only the keys of teams the caller belongs to', async () => {
+    expect(await getViewerTeamKeys('conf-1', 'org-1')).toEqual(['cfp'])
+    expect(await getViewerTeamKeys('conf-1', 'org-2')).toEqual([
+      'cfp',
+      'sponsors',
+    ])
+  })
+})

--- a/src/lib/teams/viewer.ts
+++ b/src/lib/teams/viewer.ts
@@ -1,0 +1,50 @@
+import { getConferenceTeams } from './sanity'
+
+/**
+ * The viewer-scoped team lens for the TEAMS-3 UI surfaces (inbox `my-teams` tab
+ * + row chips, the "My areas" dashboard section). It carries BOTH the caller's
+ * own team keys (which teams they belong to) and the full set of configured
+ * teams (their `key`/`title`, for chip labels and the tab-visibility check).
+ *
+ * SOFT LENS: nothing here gates access — it only tells the UI which teams exist
+ * and which the caller sits on, so an inert lens (no teams, or a caller on no
+ * team) can be presented as such. See docs/ORGANIZER_TEAMS.md.
+ */
+export interface ViewerTeamLens {
+  /** Every configured team's stable key + human title (order as stored). */
+  teams: { key: string; title: string }[]
+  /** The keys of the teams the viewer is a member of (possibly empty). */
+  myTeamKeys: string[]
+}
+
+/**
+ * Resolve the {@link ViewerTeamLens} for a speaker on a conference. Backed by the
+ * per-instance-cached {@link getConferenceTeams}, so repeated calls within a
+ * request (predicate + tRPC query) collapse to one read.
+ */
+export async function getViewerTeamLens(
+  conferenceId: string,
+  speakerId: string,
+): Promise<ViewerTeamLens> {
+  const teams = await getConferenceTeams(conferenceId)
+  return {
+    teams: teams.map((t) => ({ key: t.key, title: t.title })),
+    myTeamKeys: teams
+      .filter((t) => t.members.includes(speakerId))
+      .map((t) => t.key),
+  }
+}
+
+/**
+ * The keys of the teams a speaker belongs to on a conference — the `$myTeamKeys`
+ * binding the `my-teams` inbox view predicate filters on. Empty when the caller
+ * is on no team (the predicate then treats the lens as inert and matches every
+ * active thread).
+ */
+export async function getViewerTeamKeys(
+  conferenceId: string,
+  speakerId: string,
+): Promise<string[]> {
+  const teams = await getConferenceTeams(conferenceId)
+  return teams.filter((t) => t.members.includes(speakerId)).map((t) => t.key)
+}

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -48,6 +48,7 @@ import {
   truncateToGraphemeBoundary,
 } from '@/lib/messaging/links'
 import { notifyNewMessage, notifySponsorMessage } from '@/lib/messaging/notify'
+import { getViewerTeamLens } from '@/lib/teams'
 import { SPEAKER_ALLOWED_VIEWS } from '@/lib/messaging/types'
 import type {
   AccessSpeaker,
@@ -198,6 +199,18 @@ export const messageRouter = router({
       isOrganizer: ctx.speaker.isOrganizer === true,
       conferenceId,
     })
+  }),
+
+  /**
+   * The caller's TEAM LENS (TEAMS-3): every configured team's key + title, plus
+   * the keys of the teams the caller belongs to. Powers the inbox `My teams` tab
+   * visibility (hidden when no team is configured) and the per-row team chips.
+   * A soft lens — this is read-only convenience, never an access gate. One
+   * per-instance-cached teams read; cache it on the client.
+   */
+  teamLens: protectedProcedure.query(async ({ ctx }) => {
+    const conferenceId = await resolveConferenceId()
+    return getViewerTeamLens(conferenceId, ctx.speaker._id)
   }),
 
   /**

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -667,6 +667,7 @@ export const sponsorRouter = router({
             status,
             invoiceStatus,
             assignedTo,
+            assignedToIds: input?.assignedToIds,
             unassignedOnly: input?.unassignedOnly,
             tags: input?.tags,
             tiers: input?.tiers,

--- a/src/server/schemas/message.ts
+++ b/src/server/schemas/message.ts
@@ -56,6 +56,7 @@ export const ListConversationsSchema = z.object({
     .enum([
       'active',
       'needs-reply',
+      'my-teams',
       'unassigned',
       'mine',
       'resolved',

--- a/src/server/schemas/sponsorForConference.ts
+++ b/src/server/schemas/sponsorForConference.ts
@@ -206,6 +206,11 @@ export const SponsorCRMFilterSchema = z.object({
   status: z.array(z.string()).optional(),
   invoiceStatus: z.array(z.string()).optional(),
   assignedTo: z.string().optional(),
+  // TEAMS-3 (L3): filter to a TEAM — assignee is any of the team's member ids.
+  // The client resolves the selected team key to its member set and sends it
+  // here; empty/absent means no team filter. Mutually exclusive with
+  // assignedTo/unassignedOnly on the client (team clears them and vice versa).
+  assignedToIds: z.array(z.string()).optional(),
   myAssignedOnly: z.boolean().optional(),
   unassignedOnly: z.boolean().optional(),
   tags: z.array(z.string()).optional(),


### PR DESCRIPTION
Builds the four **team lenses** on the TEAMS-1 (#566) / TEAMS-2 (#571) foundation. Every lens is a **soft, read-only convenience** over the existing organizer set — **never access control**. All are gated on teams being configured; a conference with no teams behaves exactly as today.

## L1 — Inbox 'My teams' view
A new organizer inbox view showing **active threads whose routing team is one of the caller's teams** (sponsor thread → `sponsors`, everything else → `cfp`). New tab in the order **Active · Needs reply · My teams · Unassigned · Mine · Resolved · Archived**.
- Server: `ConversationView` gains `my-teams`; `rawViewPredicate` binds the caller's team keys (`$myTeamKeys`) and is **INERT when the caller is on no team** (`count($myTeamKeys) == 0` matches every active thread — a filter, never a gate). `viewCounts` gains `myTeams`.
- Speakers are rejected (organizer-only view).
- **Tab hidden entirely when no team is configured** conference-wide, via a new cached `message.teamLens` tRPC query (`{ teams, myTeamKeys }`).

## L2 — Team badges on rows
Organizer rows show a chip derived from the thread's routing team, using the team **title**.
- **Chip-merge decision:** a sponsor row renders a **single amber chip** whose text is the sponsors-team title (fallback `Sponsor`) — the Sponsor chip and team chip are literally the same chip, no duplication. Non-sponsor rows get a quiet **indigo cfp-team chip** beside the orthogonal gray `Proposal` type chip.
- No chips when no teams configured or for the speaker audience.

## L3 — CRM team filter
The sponsor pipeline **Owner** filter gains a **Teams** option group (hidden when no teams). Selecting a team filters `assignedTo` to its member set — URL param `team=<key>`, mutually exclusive with `assignedTo`/`unassigned`. New `assignedToIds` server filter (`assignedTo._ref in $assignedToIds`); the default-to-me effect is suppressed when a team is active. Parity added to the presentational `SponsorCRMFilterBar` too.

## L4 — Dashboard 'My areas'
A new **registered widget** (`my-areas`, in the `comprehensive` preset) with a per-team card of needs-attention counts for the teams the viewer belongs to, each deep-linking to the filtered surface:
- `cfp` → needs-reply / unassigned inbox threads
- `sponsors` → unassigned sponsors (`?assignedTo=unassigned`)
- `volunteers` → pending volunteers
Reuses **existing** count sources; **at most one read per team the viewer is on** (gated on membership). Inert empty state when the viewer is on no team.

## Riders
- **Hoist duplicate organizer fetches**: `resolveRoutedOrganizerIds` gains an optional `allOrganizerIds` fallback; `notify.ts` (no-team path) and `nudge.ts` (loop) pass the already-fetched organizer set instead of re-reading it.
- **AdminButton dark-mode fix**: the `secondary`/`ghost` variants were illegible white-on-light inside dark modals (AnnounceModal, EditConferenceCard) — added dark-mode classes.

## Tests & visuals
- New/updated tests: view predicate + counts + inert semantics, badge derivation, CRM team member-set mapping + GROQ branch, My-areas visibility + count wiring, viewer lens. Existing rider tests still green.
- Stories + shoots (393px light+dark) for: the My teams tab bar, row team chips, CRM team pill, My areas widget, and the AdminButton secondary-in-dark-modal rider proof.
- `tsc` · `eslint` (0 errors) · `prettier` · `knip` · full `vitest` (3473 passing) all green.

Do not merge — held for review.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four "team lens" features (inbox My-teams tab, per-row team chips, CRM team filter, My-areas dashboard widget) on top of the TEAMS-1/2 foundation, plus a dark-mode fix for `AdminButton` and a small organizer-fetch de-duplication in notify/nudge.

- **L1 / L2**: The `my-teams` inbox view correctly binds `$myTeamKeys` server-side and the chip-merge design (one amber chip replaces both the Sponsor chip and the team chip for sponsor threads) avoids duplication. The tab is hidden conference-wide when no team is configured, but it remains visible to individual organizers who aren't on any team — clicking it then shows all active threads via the GROQ inert escape hatch, which may surprise those users.
- **L3**: The CRM team filter resolves member IDs on the client and sends them as `assignedToIds` to the server rather than sending a `teamKey` and resolving server-side; this is functional but deviates from the server-side filtering principle in AGENTS.md.
- **L4 / riders**: `fetchMyAreasData` is cleanly auth-gated, membership-scoped, and reuses existing count sources with no new aggregate queries; the `resolveRoutedOrganizerIds` hoist in notify/nudge is a correct optimisation.

<h3>Confidence Score: 4/5</h3>

The PR is safe to merge for conferences that have no teams configured — they see no behaviour change. For teams-enabled conferences the new surfaces work correctly; the two points worth discussing before merging are the tab-visibility gap for organizers on no team and the client-side team→member resolution sent to the server.

The core logic — GROQ predicate binding, view counts, chip derivation, CRM filter, and My-areas data — is well-tested and structurally sound. Two design choices introduce mild ambiguity: the 'My teams' tab is shown to organizers who belong to no team (clicking it returns all active threads rather than an empty/informative state), and team member IDs are resolved on the client before being sent as a filter array rather than being resolved server-side from a team key. Neither causes data loss or access widening, but both are worth a deliberate decision before merging.

`src/components/messaging/MessagesInbox.tsx` (tab visibility condition) and `src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx` / `src/server/schemas/sponsorForConference.ts` (client-side ID resolution vs. server-side team key lookup).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/messaging/MessagesInbox.tsx | Adds `teamLens` tRPC query to control tab visibility and chip data; tab is shown whenever any team is configured, even for organizers on no team — inert state shows all threads |
| src/lib/messaging/sanity.ts | Adds `my-teams` view to predicates, query counts, and param binding; well-structured change with correct GROQ param isolation |
| src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx | Adds team filter (L3): client resolves team→member IDs and sends `assignedToIds` to server; routing correctly handles mutual exclusivity with owner/unassigned filters |
| src/server/schemas/sponsorForConference.ts | Adds `assignedToIds` as optional string array — schema correctly accepts client-side-resolved member IDs for the team filter |
| src/app/(admin)/admin/actions.ts | Adds `fetchMyAreasData` server action; auth-gated, membership-scoped, reuses existing count sources, with clean fallback for viewers on no team |
| src/lib/teams/viewer.ts | New module exposing `getViewerTeamLens` and `getViewerTeamKeys`; pure, well-tested, backed by cached `getConferenceTeams` |
| src/lib/messaging/threadTeam.ts | New pure module for thread→team derivation; clean chip-merge design prevents double-chip duplication for sponsor threads |
| src/lib/teams/members.ts | New pure helper `teamMembersForKey`; correctly distinguishes no-team-match (undefined) from empty-member-team ([]) — well-tested |
| src/components/admin/dashboard/widgets/MyAreasWidget.tsx | Thin client shell over `MyAreasView`; correctly gates data fetch on conference prop, delegates to `WidgetSkeleton`/`WidgetErrorState` |
| src/components/admin/AdminButton.tsx | Dark-mode fix for secondary/ghost variants; correct Tailwind dark: classes added |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as Browser (Organizer)
    participant Inbox as MessagesInbox
    participant tRPC as tRPC (message.teamLens)
    participant GROQ as Sanity GROQ
    participant Pipeline as SponsorCRMPipeline
    participant Action as fetchMyAreasData

    Note over Browser,GROQ: L1 — My Teams inbox tab
    Browser->>Inbox: "render (?view=my-teams)"
    Inbox->>tRPC: teamLens.useQuery()
    tRPC->>GROQ: getConferenceTeams(conferenceId)
    GROQ-->>tRPC: "[{key,title,members}]"
    tRPC-->>Inbox: "{teams, myTeamKeys}"
    Inbox->>GROQ: "listConversations(view=my-teams, $myTeamKeys)"
    GROQ-->>Inbox: threads where routing-team in myTeamKeys

    Note over Browser,GROQ: L3 — CRM Team filter
    Browser->>Pipeline: "?team=cfp"
    Pipeline->>Pipeline: teamMembersForKey(conference.teams, cfp)
    Pipeline->>tRPC: "sponsor.crm.list({assignedToIds:[...]})"
    tRPC->>GROQ: assignedTo._ref in $assignedToIds
    GROQ-->>Pipeline: filtered sponsors

    Note over Browser,Action: L4 — My Areas widget
    Browser->>Action: fetchMyAreasData(conferenceId)
    Action->>Action: requireOrganizer() + getAuthSession()
    Action->>GROQ: getConferenceTeams, filter to myTeams
    alt viewer on cfp
        Action->>GROQ: getConversationViewCounts (needsReply, unassigned)
    end
    alt viewer on sponsors
        Action->>GROQ: listSponsorsForConference (unassignedOnly)
    end
    alt viewer on volunteers
        Action->>GROQ: getVolunteersByConference, filter PENDING
    end
    Action-->>Browser: "{areas:[{key,title,metrics}]}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as Browser (Organizer)
    participant Inbox as MessagesInbox
    participant tRPC as tRPC (message.teamLens)
    participant GROQ as Sanity GROQ
    participant Pipeline as SponsorCRMPipeline
    participant Action as fetchMyAreasData

    Note over Browser,GROQ: L1 — My Teams inbox tab
    Browser->>Inbox: "render (?view=my-teams)"
    Inbox->>tRPC: teamLens.useQuery()
    tRPC->>GROQ: getConferenceTeams(conferenceId)
    GROQ-->>tRPC: "[{key,title,members}]"
    tRPC-->>Inbox: "{teams, myTeamKeys}"
    Inbox->>GROQ: "listConversations(view=my-teams, $myTeamKeys)"
    GROQ-->>Inbox: threads where routing-team in myTeamKeys

    Note over Browser,GROQ: L3 — CRM Team filter
    Browser->>Pipeline: "?team=cfp"
    Pipeline->>Pipeline: teamMembersForKey(conference.teams, cfp)
    Pipeline->>tRPC: "sponsor.crm.list({assignedToIds:[...]})"
    tRPC->>GROQ: assignedTo._ref in $assignedToIds
    GROQ-->>Pipeline: filtered sponsors

    Note over Browser,Action: L4 — My Areas widget
    Browser->>Action: fetchMyAreasData(conferenceId)
    Action->>Action: requireOrganizer() + getAuthSession()
    Action->>GROQ: getConferenceTeams, filter to myTeams
    alt viewer on cfp
        Action->>GROQ: getConversationViewCounts (needsReply, unassigned)
    end
    alt viewer on sponsors
        Action->>GROQ: listSponsorsForConference (unassignedOnly)
    end
    alt viewer on volunteers
        Action->>GROQ: getVolunteersByConference, filter PENDING
    end
    Action-->>Browser: "{areas:[{key,title,metrics}]}"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx`, line 136-145 ([link](https://github.com/cloudnativebergen/website/blob/b29565c9767df080477c80e3e36dc63986b81ec7/src/components/admin/sponsor-crm/SponsorCRMPipeline.tsx#L136-L145)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Team member IDs resolved client-side before sending to server**

   `teamMembersForKey(teams, teamFilter)` resolves the team's member set on the client and sends the resulting `assignedToIds` array to the server. The AGENTS.md rule states filtering logic for Sponsors must reside API/server-side. An organizer who intercepts or crafts the tRPC call could pass arbitrary member IDs that don't belong to the selected team — the server applies them without re-validating against the conference's actual team membership. Since this is a read-only display filter the blast radius is small, but the cleaner pattern would be to pass `teamKey` to the server and have it resolve membership there, consistent with how `resolveRoutedOrganizerIds` works.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["docs(teams): lens section reflects the i..."](https://github.com/cloudnativebergen/website/commit/b29565c9767df080477c80e3e36dc63986b81ec7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45494193)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->