### PR TITLE
feat(admin): editable conference settings — arrays + safeguarded domains (SE-1b)

### DIFF
--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -339,7 +339,7 @@ function SectionHeading({
 }
 
 export default async function AdminSettings() {
-  const { conference, error } = await getConferenceForCurrentDomain({
+  const { conference, domain, error } = await getConferenceForCurrentDomain({
     organizers: true,
     schedule: true,
     sponsors: true,
@@ -568,6 +568,19 @@ export default async function AdminSettings() {
             title="Domain Configuration"
             icon={GlobeAltIcon}
             editUrl={editUrl}
+            action={
+              <>
+                <EditConferenceCard
+                  fieldset="socialLinks"
+                  initialValues={{ socialLinks: conference.socialLinks }}
+                />
+                <EditConferenceCard
+                  fieldset="domains"
+                  initialValues={{ domains: conference.domains }}
+                  currentDomain={domain}
+                />
+              </>
+            }
           >
             <FieldRow label="Domains" value={conference.domains} type="array" />
             <FieldRow
@@ -644,6 +657,12 @@ export default async function AdminSettings() {
             title="Content Configuration"
             icon={TagIcon}
             editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="features"
+                initialValues={{ features: conference.features }}
+              />
+            }
           >
             <FieldRow
               label="Available Formats"
@@ -745,17 +764,85 @@ export default async function AdminSettings() {
             </InfoCard>
           )}
 
-          {conference.vanityMetrics && conference.vanityMetrics.length > 0 && (
-            <InfoCard
-              title="Vanity Metrics"
-              icon={ChartPieIcon}
-              editUrl={editUrl}
-            >
-              {conference.vanityMetrics.map((metric, idx) => (
+          <InfoCard
+            title="Sponsor Benefits"
+            icon={CurrencyDollarIcon}
+            editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="sponsorBenefits"
+                initialValues={{ sponsorBenefits: conference.sponsorBenefits }}
+              />
+            }
+          >
+            {conference.sponsorBenefits &&
+            conference.sponsorBenefits.length > 0 ? (
+              conference.sponsorBenefits.map((benefit, idx) => (
+                <FieldRow
+                  key={idx}
+                  label={benefit.title}
+                  value={benefit.description}
+                />
+              ))
+            ) : (
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                None
+              </span>
+            )}
+          </InfoCard>
+
+          <InfoCard
+            title="Sponsorship Page"
+            icon={DocumentTextIcon}
+            editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="sponsorshipCustomization"
+                initialValues={
+                  (conference.sponsorshipCustomization ?? {}) as Record<
+                    string,
+                    unknown
+                  >
+                }
+              />
+            }
+          >
+            <FieldRow
+              label="Hero Headline"
+              value={conference.sponsorshipCustomization?.heroHeadline}
+            />
+            <FieldRow
+              label="Philosophy Title"
+              value={conference.sponsorshipCustomization?.philosophyTitle}
+            />
+            <FieldRow
+              label="Prospectus Link"
+              value={conference.sponsorshipCustomization?.prospectusUrl}
+              type="url"
+            />
+          </InfoCard>
+
+          <InfoCard
+            title="Vanity Metrics"
+            icon={ChartPieIcon}
+            editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="vanityMetrics"
+                initialValues={{ vanityMetrics: conference.vanityMetrics }}
+              />
+            }
+          >
+            {conference.vanityMetrics && conference.vanityMetrics.length > 0 ? (
+              conference.vanityMetrics.map((metric, idx) => (
                 <FieldRow key={idx} label={metric.label} value={metric.value} />
-              ))}
-            </InfoCard>
-          )}
+              ))
+            ) : (
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                None
+              </span>
+            )}
+          </InfoCard>
         </div>
       </section>
 

--- a/src/components/admin/EditConferenceCard.stories.tsx
+++ b/src/components/admin/EditConferenceCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { userEvent, screen } from 'storybook/test'
+import { userEvent, screen, expect } from 'storybook/test'
 import { http, HttpResponse } from 'msw'
 import { ThemeProvider } from 'next-themes'
 import { EditConferenceCard } from './EditConferenceCard'
@@ -17,6 +17,12 @@ const handlers = [
   http.post('/api/trpc/conference.updateCommunication', ok),
   http.post('/api/trpc/conference.updateTicketingIds', ok),
   http.post('/api/trpc/conference.updateCfpGoals', ok),
+  http.post('/api/trpc/conference.updateSocialLinks', ok),
+  http.post('/api/trpc/conference.updateFeatures', ok),
+  http.post('/api/trpc/conference.updateVanityMetrics', ok),
+  http.post('/api/trpc/conference.updateSponsorBenefits', ok),
+  http.post('/api/trpc/conference.updateSponsorshipCustomization', ok),
+  http.post('/api/trpc/conference.updateDomains', ok),
 ]
 
 const meta = {
@@ -122,5 +128,175 @@ export const EmailFieldsetErrorDark: Story = {
     await userEvent.type(contact, 'not-an-email')
     await userEvent.click(screen.getByRole('button', { name: 'Save' }))
     await screen.findByText('Enter a valid email address')
+  },
+}
+
+// === SE-1b: array & object fieldsets ======================================
+
+const socialLinksInitial = {
+  socialLinks: [
+    'https://bsky.app/profile/cloudnativebergen.no',
+    'https://www.linkedin.com/company/cloud-native-bergen',
+  ],
+}
+
+/** The string-list editor (Social Links) — add/remove/reorder + URL rows. */
+export const StringListEditor: Story = {
+  args: {
+    fieldset: 'socialLinks',
+    initialValues: socialLinksInitial,
+    defaultOpen: true,
+  },
+}
+
+export const StringListEditorDark: Story = {
+  args: {
+    fieldset: 'socialLinks',
+    initialValues: socialLinksInitial,
+    defaultOpen: true,
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+/** Adds a row, then removes it — asserting the row count via inputs. */
+export const StringListAddRemove: Story = {
+  args: {
+    fieldset: 'socialLinks',
+    initialValues: socialLinksInitial,
+    defaultOpen: true,
+  },
+  play: async () => {
+    const rowsBefore = screen.getAllByLabelText(/^link \d+$/)
+    expect(rowsBefore).toHaveLength(2)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add link' }))
+    expect(screen.getAllByLabelText(/^link \d+$/)).toHaveLength(3)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove link 3' }))
+    expect(screen.getAllByLabelText(/^link \d+$/)).toHaveLength(2)
+  },
+}
+
+/** Moving row 1 down swaps it with row 2. */
+export const StringListReorder: Story = {
+  args: {
+    fieldset: 'socialLinks',
+    initialValues: socialLinksInitial,
+    defaultOpen: true,
+  },
+  play: async () => {
+    const first = screen.getByLabelText('link 1') as HTMLInputElement
+    const second = screen.getByLabelText('link 2') as HTMLInputElement
+    const firstValue = first.value
+    const secondValue = second.value
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Move link 1 down' }),
+    )
+
+    expect((screen.getByLabelText('link 1') as HTMLInputElement).value).toBe(
+      secondValue,
+    )
+    expect((screen.getByLabelText('link 2') as HTMLInputElement).value).toBe(
+      firstValue,
+    )
+  },
+}
+
+const vanityMetricsInitial = {
+  vanityMetrics: [
+    { _key: 'k1', label: 'Attendees', value: '400+' },
+    { _key: 'k2', label: 'Talks', value: '32' },
+  ],
+}
+
+/** The object-list editor (Vanity Metrics) — two-column rows. */
+export const ObjectListEditor: Story = {
+  args: {
+    fieldset: 'vanityMetrics',
+    initialValues: vanityMetricsInitial,
+    defaultOpen: true,
+  },
+}
+
+export const ObjectListEditorDark: Story = {
+  args: {
+    fieldset: 'vanityMetrics',
+    initialValues: vanityMetricsInitial,
+    defaultOpen: true,
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+/** Sponsor Benefits — object-list with a Heroicon select column. */
+export const ObjectListWithSelect: Story = {
+  args: {
+    fieldset: 'sponsorBenefits',
+    initialValues: {
+      sponsorBenefits: [
+        {
+          _key: 'b1',
+          title: 'Reach senior engineers',
+          description: 'Speak to the people who build the platforms.',
+          icon: 'RocketLaunchIcon',
+        },
+      ],
+    },
+    defaultOpen: true,
+  },
+}
+
+const domainsInitial = {
+  domains: ['cloudnativebergen.no', 'cloudnativeday.no'],
+}
+
+/**
+ * The safeguarded Domains modal: red warning banner, a LOCKED current-domain row
+ * (lock icon, non-removable), a type-to-confirm input and a disabled red Save.
+ */
+export const DomainsDangerous: Story = {
+  args: {
+    fieldset: 'domains',
+    initialValues: domainsInitial,
+    currentDomain: 'cloudnativebergen.no',
+    defaultOpen: true,
+  },
+}
+
+export const DomainsDangerousDark: Story = {
+  args: {
+    fieldset: 'domains',
+    initialValues: domainsInitial,
+    currentDomain: 'cloudnativebergen.no',
+    defaultOpen: true,
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+/** Save stays disabled until the current domain is typed verbatim. */
+export const DomainsConfirmGating: Story = {
+  args: {
+    fieldset: 'domains',
+    initialValues: domainsInitial,
+    currentDomain: 'cloudnativebergen.no',
+    defaultOpen: true,
+  },
+  play: async () => {
+    // The current-domain row is locked (no remove button, a lock affordance).
+    expect(screen.queryByRole('button', { name: 'Remove domain 1' })).toBeNull()
+
+    // Make a change (add a domain) so only the confirm gate blocks Save.
+    await userEvent.click(screen.getByRole('button', { name: 'Add domain' }))
+    const newRow = screen.getByLabelText('domain 3')
+    await userEvent.type(newRow, 'cnd.example.com')
+
+    const save = screen.getByRole('button', { name: 'Save domains' })
+    expect(save).toBeDisabled()
+
+    const confirm = screen.getByLabelText(
+      /Type cloudnativebergen\.no to confirm/,
+    )
+    await userEvent.type(confirm, 'cloudnativebergen.no')
+    expect(save).toBeEnabled()
   },
 }

--- a/src/components/admin/EditConferenceCard.tsx
+++ b/src/components/admin/EditConferenceCard.tsx
@@ -2,24 +2,51 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { PencilSquareIcon } from '@heroicons/react/24/outline'
+import {
+  PencilSquareIcon,
+  PlusIcon,
+  TrashIcon,
+  ChevronUpIcon,
+  ChevronDownIcon,
+  LockClosedIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
 import { AdminButton } from '@/components/admin/AdminButton'
 import { api } from '@/lib/trpc/client'
+import { HEROICON_OPTIONS } from '../../../sanity/schemaTypes/constants'
+import { domainServesHost } from '@/lib/conference/domains'
+import {
+  type ListRow,
+  TEMP_KEY_PREFIX,
+  buildStringListPayload,
+  buildObjectListPayload,
+  validateStringList,
+  validateObjectList,
+  moveRow,
+} from './editConferenceLists'
 import { useNotification } from './NotificationProvider'
 
 /**
- * SE-1a — the settings tier's first storied, editable component. One shared,
- * fieldset-parameterized editor: an Edit button on a read-only settings
- * InfoCard opens a ModalShell form scoped to a single scalar fieldset, patches
- * ONLY that fieldset via the matching `conference.*` mutation, then
- * `router.refresh()`es the server-rendered card. It is deliberately generic —
- * every fieldset drives the same code path from the `FIELDSET_DEFS` table
- * rather than a bespoke component per card.
+ * SE-1a/SE-1b — the settings tier's shared, fieldset-parameterized editor. An
+ * Edit button on a read-only settings InfoCard opens a ModalShell form scoped to
+ * a single fieldset, patches ONLY that fieldset via the matching `conference.*`
+ * mutation, then `router.refresh()`es the server-rendered card. It is
+ * deliberately generic — every fieldset drives the same code path from the
+ * `FIELDSET_DEFS` table rather than a bespoke component per card.
  *
- * Scope: SCALAR fieldsets only. Arrays/objects (social links, domains,
- * features, vanity metrics, sponsor benefits, teams, organizers, topics,
- * announcement, logos) stay read-only for later phases.
+ * SE-1a covered SCALAR fieldsets. SE-1b adds three renderers:
+ *   - `string-list`  — an add/remove/reorder list of strings (social links,
+ *     features, domains), with per-row URL/hostname validation and an optional
+ *     known-value checkbox set (features).
+ *   - `object-list`  — the same row machinery over multi-column objects (vanity
+ *     metrics, sponsor benefits) with text / textarea / select columns.
+ *   - a `dangerous` fieldset option — a type-to-confirm gate + red Save,
+ *     currently driving the safeguarded Domains editor (also locks the row that
+ *     serves the current host).
+ *
+ * Still read-only for later phases: teams, organizers, topics, announcement,
+ * logos.
  */
 
 export type ConferenceFieldsetKey =
@@ -30,9 +57,33 @@ export type ConferenceFieldsetKey =
   | 'communication'
   | 'ticketingIds'
   | 'cfpGoals'
+  | 'socialLinks'
+  | 'features'
+  | 'vanityMetrics'
+  | 'sponsorBenefits'
+  | 'sponsorshipCustomization'
+  | 'domains'
 
 export type EditFieldType =
-  'text' | 'textarea' | 'date' | 'email' | 'url' | 'number' | 'boolean'
+  | 'text'
+  | 'textarea'
+  | 'date'
+  | 'email'
+  | 'url'
+  | 'number'
+  | 'boolean'
+  | 'string-list'
+  | 'object-list'
+
+/** A column within an `object-list` row. */
+export interface ObjectListColumn {
+  name: string
+  label: string
+  type: 'text' | 'textarea' | 'select'
+  required?: boolean
+  /** Options for a `select` column (value stored, title shown). */
+  options?: readonly { value: string; title: string }[]
+}
 
 export interface EditFieldDef {
   name: string
@@ -50,6 +101,22 @@ export interface EditFieldDef {
   positive?: boolean
   /** Optional helper text rendered under the control. */
   description?: string
+  // --- list options (`string-list` / `object-list`) ---
+  /** Per-row validation for a `string-list`. */
+  itemType?: 'text' | 'url' | 'hostname'
+  /** Singular noun for the "Add <itemLabel>" button and row aria-labels. */
+  itemLabel?: string
+  /** Known togg[e]able values rendered as checkboxes above a `string-list`. */
+  knownValues?: readonly { value: string; title: string }[]
+  /** `false` requires at least one row (default: empty list allowed). */
+  allowEmptyList?: boolean
+  /**
+   * `string-list` only: lock (make non-removable) the row that serves the
+   * current request host. Drives the Domains safeguard.
+   */
+  lockCurrent?: boolean
+  /** Columns for an `object-list`. */
+  columns?: ObjectListColumn[]
 }
 
 interface FieldsetDef {
@@ -57,6 +124,13 @@ interface FieldsetDef {
   /** Short line under the modal title. */
   subtitle: string
   fields: EditFieldDef[]
+  /**
+   * Marks a destructive fieldset. When set, the modal shows a warning banner and
+   * a type-to-confirm input gating a RED Save button — reusable for any future
+   * dangerous fieldset. The Domains fieldset uses it with the current host as the
+   * confirm token (supplied at runtime via the `currentDomain` prop).
+   */
+  dangerous?: { warning: string }
 }
 
 /**
@@ -269,6 +343,162 @@ export const FIELDSET_DEFS: Record<ConferenceFieldsetKey, FieldsetDef> = {
       },
     ],
   },
+  socialLinks: {
+    title: 'Social Links',
+    subtitle: 'Public social profile URLs',
+    fields: [
+      {
+        name: 'socialLinks',
+        label: 'Social Links',
+        type: 'string-list',
+        itemType: 'url',
+        itemLabel: 'link',
+        description: 'Full URLs, e.g. https://bsky.app/profile/…',
+      },
+    ],
+  },
+  features: {
+    title: 'Features',
+    subtitle: 'Experimental feature flags',
+    fields: [
+      {
+        name: 'features',
+        label: 'Features',
+        type: 'string-list',
+        itemType: 'text',
+        itemLabel: 'flag',
+        // Only one known flag exists today (`test_feature`) and nothing reads
+        // the field at runtime, so the UI offers the known toggle plus a free
+        // list for custom/unknown flags.
+        knownValues: [{ value: 'test_feature', title: 'Test Feature' }],
+        description: 'Toggle a known flag, or add a custom flag string.',
+      },
+    ],
+  },
+  vanityMetrics: {
+    title: 'Vanity Metrics',
+    subtitle: 'Landing-page highlight numbers',
+    fields: [
+      {
+        name: 'vanityMetrics',
+        label: 'Metrics',
+        type: 'object-list',
+        itemLabel: 'metric',
+        columns: [
+          { name: 'label', label: 'Label', type: 'text', required: true },
+          { name: 'value', label: 'Value', type: 'text', required: true },
+        ],
+      },
+    ],
+  },
+  sponsorBenefits: {
+    title: 'Sponsor Benefits',
+    subtitle: '“Why sponsor” selling points',
+    fields: [
+      {
+        name: 'sponsorBenefits',
+        label: 'Benefits',
+        type: 'object-list',
+        itemLabel: 'benefit',
+        columns: [
+          { name: 'title', label: 'Title', type: 'text', required: true },
+          {
+            name: 'description',
+            label: 'Description',
+            type: 'textarea',
+            required: true,
+          },
+          {
+            name: 'icon',
+            label: 'Icon',
+            type: 'select',
+            options: HEROICON_OPTIONS,
+          },
+        ],
+      },
+    ],
+  },
+  sponsorshipCustomization: {
+    title: 'Sponsorship Page',
+    subtitle: 'Hero, philosophy & prospectus copy',
+    fields: [
+      {
+        name: 'heroHeadline',
+        label: 'Hero Headline',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'heroSubheadline',
+        label: 'Hero Subheadline',
+        type: 'textarea',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'packageSectionTitle',
+        label: 'Package Section Title',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'addonSectionTitle',
+        label: 'Addon Section Title',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'philosophyTitle',
+        label: 'Philosophy Title',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'philosophyDescription',
+        label: 'Philosophy Description',
+        type: 'textarea',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'closingQuote',
+        label: 'Closing Quote',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'closingCtaText',
+        label: 'Closing CTA Text',
+        type: 'text',
+        nullableWhenEmpty: true,
+      },
+      {
+        name: 'prospectusUrl',
+        label: 'Prospectus PDF/Link',
+        type: 'url',
+        nullableWhenEmpty: true,
+        description: 'Optional link to the full sponsorship prospectus',
+      },
+    ],
+  },
+  domains: {
+    title: 'Domains',
+    subtitle: 'Hostnames that route to this conference',
+    dangerous: {
+      warning:
+        'Domains control which conference this site serves. Removing a wrong entry can take the site down.',
+    },
+    fields: [
+      {
+        name: 'domains',
+        label: 'Domains',
+        type: 'string-list',
+        itemType: 'hostname',
+        itemLabel: 'domain',
+        allowEmptyList: false,
+        lockCurrent: true,
+        description: 'Bare hostnames, e.g. cloudnativebergen.no (no https://).',
+      },
+    ],
+  },
 }
 
 const MUTATION_BY_FIELDSET: Record<
@@ -282,9 +512,15 @@ const MUTATION_BY_FIELDSET: Record<
   communication: 'updateCommunication',
   ticketingIds: 'updateTicketingIds',
   cfpGoals: 'updateCfpGoals',
+  socialLinks: 'updateSocialLinks',
+  features: 'updateFeatures',
+  vanityMetrics: 'updateVanityMetrics',
+  sponsorBenefits: 'updateSponsorBenefits',
+  sponsorshipCustomization: 'updateSponsorshipCustomization',
+  domains: 'updateDomains',
 }
 
-type FormValue = string | boolean
+type FormValue = string | boolean | string[] | ListRow[]
 type FormValues = Record<string, FormValue>
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -297,7 +533,11 @@ function isValidUrl(value: string): boolean {
   }
 }
 
-/** Project the stored conference values into editable form strings/booleans. */
+/** A row's `_key` we minted client-side for a brand-new row (server re-keys). */
+let tempKeyCounter = 0
+const nextTempKey = () => `${TEMP_KEY_PREFIX}${++tempKeyCounter}`
+
+/** Project the stored conference values into editable form values. */
 function toFormValues(
   fields: EditFieldDef[],
   initial: Record<string, unknown>,
@@ -307,8 +547,45 @@ function toFormValues(
     const v = initial[f.name]
     if (f.type === 'boolean') {
       out[f.name] = Boolean(v)
+    } else if (f.type === 'string-list') {
+      out[f.name] = Array.isArray(v) ? v.map((x) => String(x ?? '')) : []
+    } else if (f.type === 'object-list') {
+      const cols = f.columns ?? []
+      out[f.name] = Array.isArray(v)
+        ? (v as Record<string, unknown>[]).map((row) => {
+            const r: ListRow = {}
+            for (const c of cols) {
+              const cell = row?.[c.name]
+              r[c.name] =
+                cell === null || cell === undefined ? '' : String(cell)
+            }
+            // Preserve the real Sanity `_key` so unchanged rows keep it.
+            const key = row?._key
+            r._key = typeof key === 'string' ? key : nextTempKey()
+            return r
+          })
+        : []
     } else {
       out[f.name] = v === null || v === undefined ? '' : String(v)
+    }
+  }
+  return out
+}
+
+/** Strip client-only `_key`s so dirty-comparison tracks content, not identity. */
+function comparable(values: FormValues): FormValues {
+  const out: FormValues = {}
+  for (const [k, v] of Object.entries(values)) {
+    if (Array.isArray(v) && v.length > 0 && typeof v[0] === 'object') {
+      out[k] = (v as ListRow[]).map((row) => {
+        const rest: ListRow = {}
+        for (const [ck, cv] of Object.entries(row)) {
+          if (ck !== '_key') rest[ck] = cv
+        }
+        return rest
+      })
+    } else {
+      out[k] = v
     }
   }
   return out
@@ -341,6 +618,13 @@ export interface EditConferenceCardProps {
   initialValues: Record<string, unknown>
   /** Render the modal open on mount — for stories/tests only. */
   defaultOpen?: boolean
+  /**
+   * The host the request is currently served on. For the safeguarded Domains
+   * fieldset this both LOCKS the row that serves it (can't be removed) and is the
+   * literal string the user must type to confirm a destructive save. Supplied by
+   * the server settings page from the resolved request domain.
+   */
+  currentDomain?: string
 }
 
 /**
@@ -353,6 +637,7 @@ export function EditConferenceCard({
   fieldset,
   initialValues,
   defaultOpen = false,
+  currentDomain,
 }: EditConferenceCardProps) {
   const def = FIELDSET_DEFS[fieldset]
   const { fields } = def
@@ -366,9 +651,19 @@ export function EditConferenceCard({
   )
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [submitError, setSubmitError] = useState<string | null>(null)
+  // Type-to-confirm input for a `dangerous` fieldset (empty otherwise).
+  const [confirmInput, setConfirmInput] = useState('')
 
   const baseline = toFormValues(fields, initialValues)
-  const isDirty = JSON.stringify(values) !== JSON.stringify(baseline)
+  const isDirty =
+    JSON.stringify(comparable(values)) !== JSON.stringify(comparable(baseline))
+
+  // A dangerous fieldset gates Save behind typing the confirm token (the current
+  // host). Without a token to type against, the gate can't be satisfied.
+  const dangerous = def.dangerous
+  const confirmToken = currentDomain ?? ''
+  const confirmSatisfied =
+    !dangerous || (confirmToken !== '' && confirmInput.trim() === confirmToken)
 
   // `api.conference[procName]` narrows to a union of procedures; select the
   // proc first (plain property access, not a hook) then call `.useMutation`
@@ -408,6 +703,7 @@ export function EditConferenceCard({
     setValues(toFormValues(fields, initialValues))
     setErrors({})
     setSubmitError(null)
+    setConfirmInput('')
   }
 
   const openModal = () => {
@@ -422,10 +718,15 @@ export function EditConferenceCard({
 
   const setValue = (name: string, value: FormValue) => {
     setValues((prev) => ({ ...prev, [name]: value }))
+    // Clear the field's own error and any per-row errors keyed under it
+    // (`<name>.<row>` / `<name>.<row>.<col>`) so edits dismiss stale messages.
     setErrors((prev) => {
-      if (!prev[name]) return prev
+      const keys = Object.keys(prev).filter(
+        (k) => k === name || k.startsWith(`${name}.`),
+      )
+      if (keys.length === 0) return prev
       const next = { ...prev }
-      delete next[name]
+      for (const k of keys) delete next[k]
       return next
     })
   }
@@ -434,6 +735,14 @@ export function EditConferenceCard({
     const errs: Record<string, string> = {}
     for (const f of fields) {
       if (f.type === 'boolean') continue
+      if (f.type === 'string-list') {
+        Object.assign(errs, validateStringList(f, values[f.name] as string[]))
+        continue
+      }
+      if (f.type === 'object-list') {
+        Object.assign(errs, validateObjectList(f, values[f.name] as ListRow[]))
+        continue
+      }
       const raw = values[f.name]
       const s = typeof raw === 'string' ? raw.trim() : ''
       if (f.required && s === '') {
@@ -468,6 +777,17 @@ export function EditConferenceCard({
         payload[f.name] = Boolean(raw)
         continue
       }
+      if (f.type === 'string-list') {
+        payload[f.name] = buildStringListPayload(raw as string[])
+        continue
+      }
+      if (f.type === 'object-list') {
+        payload[f.name] = buildObjectListPayload(
+          f.columns ?? [],
+          raw as ListRow[],
+        )
+        continue
+      }
       const s = typeof raw === 'string' ? raw.trim() : ''
       if (f.type === 'number') {
         if (s === '') {
@@ -488,6 +808,7 @@ export function EditConferenceCard({
 
   const handleSave = () => {
     setSubmitError(null)
+    if (!confirmSatisfied) return
     const errs = validate()
     setErrors(errs)
     if (Object.keys(errs).length > 0) return
@@ -523,15 +844,38 @@ export function EditConferenceCard({
           }}
           className="space-y-4"
         >
+          {dangerous ? (
+            <div
+              role="alert"
+              className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-300"
+            >
+              <ExclamationTriangleIcon
+                className="mt-0.5 h-5 w-5 shrink-0"
+                aria-hidden="true"
+              />
+              <span>{dangerous.warning}</span>
+            </div>
+          ) : null}
+
           {fields.map((f) => (
             <EditField
               key={f.name}
               field={f}
               value={values[f.name]}
               error={errors[f.name]}
+              rowErrors={errors}
+              currentDomain={currentDomain}
               onChange={(v) => setValue(f.name, v)}
             />
           ))}
+
+          {dangerous ? (
+            <DangerousConfirm
+              token={confirmToken}
+              value={confirmInput}
+              onChange={setConfirmInput}
+            />
+          ) : null}
 
           {submitError ? (
             <p
@@ -555,12 +899,16 @@ export function EditConferenceCard({
             </AdminButton>
             <AdminButton
               type="submit"
-              color="blue"
+              color={dangerous ? 'red' : 'blue'}
               size="md"
-              disabled={mutation.isPending || !isDirty}
+              disabled={mutation.isPending || !isDirty || !confirmSatisfied}
               className="min-h-[44px]"
             >
-              {mutation.isPending ? 'Saving…' : 'Save'}
+              {mutation.isPending
+                ? 'Saving…'
+                : dangerous
+                  ? 'Save domains'
+                  : 'Save'}
             </AdminButton>
           </div>
         </form>
@@ -576,11 +924,16 @@ function EditField({
   field,
   value,
   error,
+  rowErrors,
+  currentDomain,
   onChange,
 }: {
   field: EditFieldDef
   value: FormValue
   error?: string
+  /** The full error map, so list editors can pull their `<name>.<row>` keys. */
+  rowErrors?: Record<string, string>
+  currentDomain?: string
   onChange: (value: FormValue) => void
 }) {
   const id = `conf-field-${field.name}`
@@ -589,6 +942,29 @@ function EditField({
     : field.description
       ? `${id}-desc`
       : undefined
+
+  if (field.type === 'string-list') {
+    return (
+      <StringListEditor
+        field={field}
+        rows={(value as string[]) ?? []}
+        errors={rowErrors ?? {}}
+        currentDomain={currentDomain}
+        onChange={(rows) => onChange(rows)}
+      />
+    )
+  }
+
+  if (field.type === 'object-list') {
+    return (
+      <ObjectListEditor
+        field={field}
+        rows={(value as ListRow[]) ?? []}
+        errors={rowErrors ?? {}}
+        onChange={(rows) => onChange(rows)}
+      />
+    )
+  }
 
   if (field.type === 'boolean') {
     return (
@@ -674,5 +1050,395 @@ function EditField({
         </p>
       ) : null}
     </div>
+  )
+}
+
+// Shared 44×44 row-control button (reorder / delete / lock).
+const rowBtnClass =
+  'inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800'
+
+/** Reorder up/down controls shared by both list editors. */
+function ReorderControls({
+  index,
+  count,
+  label,
+  onMove,
+}: {
+  index: number
+  count: number
+  label: string
+  onMove: (from: number, to: number) => void
+}) {
+  return (
+    <>
+      <button
+        type="button"
+        className={rowBtnClass}
+        onClick={() => onMove(index, index - 1)}
+        disabled={index === 0}
+        aria-label={`Move ${label} up`}
+      >
+        <ChevronUpIcon className="h-5 w-5" />
+      </button>
+      <button
+        type="button"
+        className={rowBtnClass}
+        onClick={() => onMove(index, index + 1)}
+        disabled={index === count - 1}
+        aria-label={`Move ${label} down`}
+      >
+        <ChevronDownIcon className="h-5 w-5" />
+      </button>
+    </>
+  )
+}
+
+/**
+ * Type-to-confirm gate for a `dangerous` fieldset. Save stays disabled until the
+ * user types `token` (the current host) verbatim. When no token is available it
+ * says so, keeping Save disabled.
+ */
+function DangerousConfirm({
+  token,
+  value,
+  onChange,
+}: {
+  token: string
+  value: string
+  onChange: (v: string) => void
+}) {
+  const id = 'conf-danger-confirm'
+  if (token === '') {
+    return (
+      <p className="text-sm text-red-600 dark:text-red-400">
+        The current domain could not be determined, so saving is disabled.
+      </p>
+    )
+  }
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        Type{' '}
+        <code className="font-mono text-red-600 dark:text-red-400">
+          {token}
+        </code>{' '}
+        to confirm
+      </label>
+      <input
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoComplete="off"
+        aria-label={`Type ${token} to confirm`}
+        className={inputClass}
+      />
+    </div>
+  )
+}
+
+/** Add/remove/reorder editor for an array of strings (URLs, hostnames, flags). */
+function StringListEditor({
+  field,
+  rows,
+  errors,
+  currentDomain,
+  onChange,
+}: {
+  field: EditFieldDef
+  rows: string[]
+  errors: Record<string, string>
+  currentDomain?: string
+  onChange: (rows: string[]) => void
+}) {
+  const noun = field.itemLabel ?? 'entry'
+  const listErr = errors[field.name]
+  const knownValues = field.knownValues ?? []
+  const knownSet = new Set(knownValues.map((k) => k.value))
+  // Rows shown as editable text inputs — known values are represented by the
+  // checkbox strip instead, so they're excluded here.
+  const visible = rows
+    .map((value, index) => ({ value, index }))
+    .filter(({ value }) => !knownSet.has(value))
+
+  const inputType =
+    field.itemType === 'url'
+      ? 'url'
+      : field.itemType === 'hostname'
+        ? 'url'
+        : 'text'
+
+  const setRow = (index: number, v: string) =>
+    onChange(rows.map((r, i) => (i === index ? v : r)))
+  const removeRow = (index: number) =>
+    onChange(rows.filter((_, i) => i !== index))
+  const addRow = () => onChange([...rows, ''])
+  // Reorder within the visible sublist maps to swapping the two real indices.
+  const moveVisible = (fromPos: number, toPos: number) => {
+    if (toPos < 0 || toPos >= visible.length) return
+    onChange(moveRow(rows, visible[fromPos].index, visible[toPos].index))
+  }
+  const toggleKnown = (val: string) => {
+    onChange(
+      rows.includes(val) ? rows.filter((r) => r !== val) : [...rows, val],
+    )
+  }
+
+  return (
+    <fieldset className="space-y-3">
+      <legend className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        {field.label}
+      </legend>
+
+      {knownValues.length > 0 ? (
+        <div className="flex flex-wrap gap-3">
+          {knownValues.map((k) => {
+            const cid = `conf-known-${field.name}-${k.value}`
+            return (
+              <label
+                key={k.value}
+                htmlFor={cid}
+                className="flex min-h-[44px] items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
+              >
+                <input
+                  id={cid}
+                  type="checkbox"
+                  checked={rows.includes(k.value)}
+                  onChange={() => toggleKnown(k.value)}
+                  className="h-5 w-5 rounded border-gray-300 text-brand-cloud-blue focus:ring-brand-cloud-blue"
+                />
+                {k.title}
+              </label>
+            )
+          })}
+        </div>
+      ) : null}
+
+      <ul className="space-y-2">
+        {visible.map(({ value, index }, pos) => {
+          const rowErr = errors[`${field.name}.${index}`]
+          const locked = Boolean(
+            field.lockCurrent &&
+            currentDomain &&
+            domainServesHost(value, currentDomain),
+          )
+          const rowId = `conf-${field.name}-${index}`
+          return (
+            <li key={index}>
+              <div className="flex items-start gap-1">
+                <input
+                  id={rowId}
+                  type={inputType}
+                  value={value}
+                  onChange={(e) => setRow(index, e.target.value)}
+                  aria-label={`${noun} ${pos + 1}`}
+                  aria-invalid={rowErr ? true : undefined}
+                  className={inputClass}
+                />
+                <ReorderControls
+                  index={pos}
+                  count={visible.length}
+                  label={`${noun} ${pos + 1}`}
+                  onMove={moveVisible}
+                />
+                {locked ? (
+                  <span
+                    className={`${rowBtnClass} cursor-not-allowed opacity-70`}
+                    title="You cannot remove the domain you are currently using"
+                    aria-label={`${noun} ${pos + 1} is the current domain and cannot be removed`}
+                  >
+                    <LockClosedIcon className="h-5 w-5" />
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    className={`${rowBtnClass} hover:text-red-600`}
+                    onClick={() => removeRow(index)}
+                    aria-label={`Remove ${noun} ${pos + 1}`}
+                  >
+                    <TrashIcon className="h-5 w-5" />
+                  </button>
+                )}
+              </div>
+              {rowErr ? (
+                <p
+                  role="alert"
+                  className="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {rowErr}
+                </p>
+              ) : null}
+            </li>
+          )
+        })}
+      </ul>
+
+      <button
+        type="button"
+        onClick={addRow}
+        className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 hover:border-brand-cloud-blue hover:text-brand-cloud-blue dark:border-gray-600 dark:text-gray-300"
+      >
+        <PlusIcon className="h-5 w-5" />
+        Add {noun}
+      </button>
+
+      {listErr ? (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          {listErr}
+        </p>
+      ) : field.description ? (
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {field.description}
+        </p>
+      ) : null}
+    </fieldset>
+  )
+}
+
+/** Add/remove/reorder editor for an array of multi-column objects. */
+function ObjectListEditor({
+  field,
+  rows,
+  errors,
+  onChange,
+}: {
+  field: EditFieldDef
+  rows: ListRow[]
+  errors: Record<string, string>
+  onChange: (rows: ListRow[]) => void
+}) {
+  const noun = field.itemLabel ?? 'row'
+  const cols = field.columns ?? []
+
+  const setCell = (index: number, col: string, v: string) =>
+    onChange(rows.map((r, i) => (i === index ? { ...r, [col]: v } : r)))
+  const removeRow = (index: number) =>
+    onChange(rows.filter((_, i) => i !== index))
+  const addRow = () => {
+    const blank: ListRow = { _key: nextTempKey() }
+    for (const c of cols) blank[c.name] = ''
+    onChange([...rows, blank])
+  }
+  const move = (from: number, to: number) => onChange(moveRow(rows, from, to))
+
+  return (
+    <fieldset className="space-y-3">
+      <legend className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        {field.label}
+      </legend>
+
+      <ul className="space-y-3">
+        {rows.map((row, index) => (
+          <li
+            key={row._key ?? index}
+            className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                {noun} {index + 1}
+              </span>
+              <div className="flex items-center gap-1">
+                <ReorderControls
+                  index={index}
+                  count={rows.length}
+                  label={`${noun} ${index + 1}`}
+                  onMove={move}
+                />
+                <button
+                  type="button"
+                  className={`${rowBtnClass} hover:text-red-600`}
+                  onClick={() => removeRow(index)}
+                  aria-label={`Remove ${noun} ${index + 1}`}
+                >
+                  <TrashIcon className="h-5 w-5" />
+                </button>
+              </div>
+            </div>
+            <div className="space-y-2">
+              {cols.map((c) => {
+                const cellId = `conf-${field.name}-${index}-${c.name}`
+                const cellErr = errors[`${field.name}.${index}.${c.name}`]
+                return (
+                  <div key={c.name}>
+                    <label
+                      htmlFor={cellId}
+                      className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                    >
+                      {c.label}
+                      {c.required ? (
+                        <span className="text-red-500" aria-hidden="true">
+                          {' '}
+                          *
+                        </span>
+                      ) : null}
+                    </label>
+                    {c.type === 'textarea' ? (
+                      <textarea
+                        id={cellId}
+                        value={row[c.name] ?? ''}
+                        onChange={(e) => setCell(index, c.name, e.target.value)}
+                        rows={3}
+                        aria-invalid={cellErr ? true : undefined}
+                        className={inputClass}
+                      />
+                    ) : c.type === 'select' ? (
+                      <select
+                        id={cellId}
+                        value={row[c.name] ?? ''}
+                        onChange={(e) => setCell(index, c.name, e.target.value)}
+                        aria-invalid={cellErr ? true : undefined}
+                        className={inputClass}
+                      >
+                        <option value="">— None —</option>
+                        {(c.options ?? []).map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.title}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        id={cellId}
+                        type="text"
+                        value={row[c.name] ?? ''}
+                        onChange={(e) => setCell(index, c.name, e.target.value)}
+                        aria-invalid={cellErr ? true : undefined}
+                        className={inputClass}
+                      />
+                    )}
+                    {cellErr ? (
+                      <p
+                        role="alert"
+                        className="mt-1 text-sm text-red-600 dark:text-red-400"
+                      >
+                        {cellErr}
+                      </p>
+                    ) : null}
+                  </div>
+                )
+              })}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <button
+        type="button"
+        onClick={addRow}
+        className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 hover:border-brand-cloud-blue hover:text-brand-cloud-blue dark:border-gray-600 dark:text-gray-300"
+      >
+        <PlusIcon className="h-5 w-5" />
+        Add {noun}
+      </button>
+
+      {field.description ? (
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {field.description}
+        </p>
+      ) : null}
+    </fieldset>
   )
 }

--- a/src/components/admin/editConferenceLists.test.ts
+++ b/src/components/admin/editConferenceLists.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildStringListPayload,
+  buildObjectListPayload,
+  validateStringList,
+  validateObjectList,
+  moveRow,
+  type ListRow,
+} from './editConferenceLists'
+
+const metricCols = [
+  { name: 'label', label: 'Label', required: true },
+  { name: 'value', label: 'Value', required: true },
+]
+const benefitCols = [
+  { name: 'title', label: 'Title', required: true },
+  { name: 'description', label: 'Description', required: true },
+  { name: 'icon', label: 'Icon' },
+]
+
+describe('buildStringListPayload', () => {
+  it('trims and drops blank rows, keeping order', () => {
+    expect(buildStringListPayload(['  a ', '', '  ', 'b'])).toEqual(['a', 'b'])
+  })
+
+  it('yields an empty array for an all-blank list', () => {
+    expect(buildStringListPayload(['', '   '])).toEqual([])
+  })
+})
+
+describe('buildObjectListPayload', () => {
+  it('drops fully-empty rows and trims cells', () => {
+    const rows: ListRow[] = [
+      { label: ' Talks ', value: '30', _key: 'k1' },
+      { label: '', value: '', _key: 'tmp-9' },
+    ]
+    expect(buildObjectListPayload(metricCols, rows)).toEqual([
+      { label: 'Talks', value: '30', _key: 'k1' },
+    ])
+  })
+
+  it('preserves a real _key but strips a temp one', () => {
+    const rows: ListRow[] = [
+      { label: 'A', value: '1', _key: 'real-1' },
+      { label: 'B', value: '2', _key: 'tmp-3' },
+    ]
+    const out = buildObjectListPayload(metricCols, rows)
+    expect(out[0]._key).toBe('real-1')
+    expect(out[1]).not.toHaveProperty('_key')
+  })
+
+  it('omits an empty optional column (icon) but keeps required empties', () => {
+    const rows: ListRow[] = [
+      { title: 'T', description: 'D', icon: '', _key: 'tmp-1' },
+    ]
+    const out = buildObjectListPayload(benefitCols, rows)
+    expect(out[0]).not.toHaveProperty('icon')
+    expect(out[0]).toMatchObject({ title: 'T', description: 'D' })
+  })
+})
+
+describe('validateStringList', () => {
+  it('flags an invalid URL row by index', () => {
+    const errs = validateStringList({ name: 'socialLinks', itemType: 'url' }, [
+      'https://ok.example',
+      'nope',
+    ])
+    expect(errs['socialLinks.1']).toMatch(/valid URL/)
+    expect(errs['socialLinks.0']).toBeUndefined()
+  })
+
+  it('flags a scheme-carrying hostname row', () => {
+    const errs = validateStringList({ name: 'domains', itemType: 'hostname' }, [
+      'https://example.com',
+    ])
+    expect(errs['domains.0']).toMatch(/bare hostname/)
+  })
+
+  it('flags duplicates (hostname is normalized case-insensitively)', () => {
+    const errs = validateStringList({ name: 'domains', itemType: 'hostname' }, [
+      'example.com',
+      'EXAMPLE.com',
+    ])
+    expect(errs['domains.1']).toBe('Duplicate entry')
+  })
+
+  it('requires a non-empty list when allowEmptyList is false', () => {
+    const errs = validateStringList(
+      {
+        name: 'domains',
+        itemType: 'hostname',
+        allowEmptyList: false,
+        itemLabel: 'domain',
+      },
+      ['', '  '],
+    )
+    expect(errs.domains).toMatch(/At least one domain/)
+  })
+
+  it('accepts a valid list with no errors', () => {
+    expect(
+      validateStringList({ name: 'domains', itemType: 'hostname' }, [
+        'example.com',
+        'localhost:3000',
+        '*.example.com',
+      ]),
+    ).toEqual({})
+  })
+})
+
+describe('validateObjectList', () => {
+  it('requires each required column on a non-empty row', () => {
+    const errs = validateObjectList(
+      { name: 'vanityMetrics', columns: metricCols },
+      [{ label: 'Attendees', value: '', _key: 'k' }],
+    )
+    expect(errs['vanityMetrics.0.value']).toMatch(/required/)
+  })
+
+  it('ignores a fully-empty row', () => {
+    expect(
+      validateObjectList({ name: 'vanityMetrics', columns: metricCols }, [
+        { label: '', value: '', _key: 'k' },
+      ]),
+    ).toEqual({})
+  })
+})
+
+describe('moveRow', () => {
+  it('swaps two positions immutably', () => {
+    const src = ['a', 'b', 'c']
+    expect(moveRow(src, 0, 2)).toEqual(['c', 'b', 'a'])
+    expect(src).toEqual(['a', 'b', 'c'])
+  })
+
+  it('is a no-op when out of bounds', () => {
+    const src = ['a', 'b']
+    expect(moveRow(src, 0, -1)).toBe(src)
+    expect(moveRow(src, 1, 2)).toBe(src)
+  })
+})

--- a/src/components/admin/editConferenceLists.ts
+++ b/src/components/admin/editConferenceLists.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure, React-free list helpers for the SE-1b array/object fieldsets in
+ * {@link ./EditConferenceCard}. Extracted so the payload-shaping and per-row
+ * validation can be unit-tested under `vitest` (node env) without rendering —
+ * the component wires these into its form state, the tests assert them directly.
+ */
+
+import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
+
+/** An `object-list` row: column-name → value, plus a stable Sanity `_key`. */
+export type ListRow = Record<string, string>
+
+/** A `_key` minted client-side for a brand-new row; the server re-keys these. */
+export const TEMP_KEY_PREFIX = 'tmp-'
+
+/** The subset of a field definition the list helpers need. */
+export interface ListFieldSpec {
+  name: string
+  itemType?: 'text' | 'url' | 'hostname'
+  itemLabel?: string
+  allowEmptyList?: boolean
+  columns?: { name: string; label: string; required?: boolean }[]
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    return Boolean(new URL(value))
+  } catch {
+    return false
+  }
+}
+
+/** Drop blank rows and trim; preserves order. Used for `string-list` payloads. */
+export function buildStringListPayload(rows: string[]): string[] {
+  return rows.map((s) => s.trim()).filter((s) => s !== '')
+}
+
+/**
+ * Shape an `object-list` payload: drop fully-empty rows, trim cells, omit empty
+ * optional columns, and forward a real `_key` (temp keys are stripped so the
+ * server mints a fresh one).
+ */
+export function buildObjectListPayload(
+  columns: NonNullable<ListFieldSpec['columns']>,
+  rows: ListRow[],
+): Record<string, string>[] {
+  return rows
+    .filter((row) => columns.some((c) => (row[c.name] ?? '').trim() !== ''))
+    .map((row) => {
+      const out: Record<string, string> = {}
+      for (const c of columns) {
+        const v = (row[c.name] ?? '').trim()
+        if (v !== '' || c.required) out[c.name] = v
+      }
+      if (row._key && !row._key.startsWith(TEMP_KEY_PREFIX)) {
+        out._key = row._key
+      }
+      return out
+    })
+}
+
+/**
+ * Validate a `string-list`. Errors are keyed `<field>` (list-level) and
+ * `<field>.<rowIndex>` (per row). Blank rows are ignored (dropped on save),
+ * except that an `allowEmptyList: false` list with no non-blank rows errors.
+ */
+export function validateStringList(
+  f: ListFieldSpec,
+  rows: string[],
+): Record<string, string> {
+  const errs: Record<string, string> = {}
+  const nonEmpty = rows.map((r) => r.trim()).filter((r) => r !== '')
+
+  if (f.allowEmptyList === false && nonEmpty.length === 0) {
+    errs[f.name] = `At least one ${f.itemLabel ?? 'entry'} is required`
+  }
+
+  const seen = new Set<string>()
+  rows.forEach((rawRow, i) => {
+    const s = rawRow.trim()
+    if (s === '') return
+    if (f.itemType === 'url' && !isValidUrl(s)) {
+      errs[`${f.name}.${i}`] = 'Enter a valid URL'
+    } else if (
+      f.itemType === 'hostname' &&
+      !isValidDomainEntry(normalizeDomain(s))
+    ) {
+      errs[`${f.name}.${i}`] =
+        'Enter a bare hostname (no https://, no path), e.g. example.com'
+    }
+    const norm = f.itemType === 'hostname' ? normalizeDomain(s) : s
+    if (seen.has(norm)) errs[`${f.name}.${i}`] = 'Duplicate entry'
+    seen.add(norm)
+  })
+  return errs
+}
+
+/** Validate an `object-list`: required columns per non-empty row. */
+export function validateObjectList(
+  f: ListFieldSpec,
+  rows: ListRow[],
+): Record<string, string> {
+  const errs: Record<string, string> = {}
+  const cols = f.columns ?? []
+  rows.forEach((row, i) => {
+    const rowHasContent = cols.some((c) => (row[c.name] ?? '').trim() !== '')
+    if (!rowHasContent) return // fully-empty rows are dropped on save
+    for (const c of cols) {
+      if (c.required && (row[c.name] ?? '').trim() === '') {
+        errs[`${f.name}.${i}.${c.name}`] = `${c.label} is required`
+      }
+    }
+  })
+  return errs
+}
+
+/** Move the item at `from` to `to`, returning a new array (no-op if OOB). */
+export function moveRow<T>(rows: T[], from: number, to: number): T[] {
+  if (to < 0 || to >= rows.length || from < 0 || from >= rows.length)
+    return rows
+  const next = [...rows]
+  ;[next[from], next[to]] = [next[to], next[from]]
+  return next
+}

--- a/src/lib/conference/domains.ts
+++ b/src/lib/conference/domains.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared, dependency-free helpers for the conference `domains[]` field (SE-1b).
+ *
+ * `domains` drives domain→conference routing: a request's `Host` header is
+ * matched against this list (exact, or via a single-label wildcard) to decide
+ * which conference document serves the site. Because a wrong edit here can take
+ * the site down, these helpers are used verbatim on BOTH sides of the safeguard
+ * — the server mutation guard AND the client editor's row-lock — so the two can
+ * never disagree about which entry is "the domain you are currently using".
+ *
+ * Keep this module pure and client-safe (no server-only imports): the admin
+ * editor bundles it.
+ */
+
+/** BAD_REQUEST message thrown when a payload removes the current request host. */
+export const CANNOT_REMOVE_CURRENT_DOMAIN =
+  'You cannot remove the domain you are currently using'
+
+// A bare hostname, lowercase, optionally with a `:port` (dev entries such as
+// `localhost:3000`) or a leading `*.` wildcard label (the routing matches a
+// request's `*.<rest>` subdomain form against such entries). No scheme, no path,
+// no whitespace, no leading/trailing dot or hyphen per label. Mirrors what the
+// routing GROQ can actually match.
+const HOSTNAME_RE =
+  /^(?=.{1,253}$)(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*(:\d{1,5})?$/
+
+/** Trim + lowercase an entry to its canonical stored form. */
+export function normalizeDomain(entry: string): string {
+  return entry.trim().toLowerCase()
+}
+
+/**
+ * True when `entry` is a bare hostname (optionally with a dev `:port`). Assumes
+ * the caller passes an already-{@link normalizeDomain}d value. Rejects anything
+ * carrying a scheme (`https://…`) or a path (`example.com/foo`).
+ */
+export function isValidDomainEntry(entry: string): boolean {
+  return HOSTNAME_RE.test(entry)
+}
+
+/**
+ * The single-label wildcard form of a host, or `null` when the host has ≤2
+ * labels (nothing to wildcard). e.g. `foo.example.com` → `*.example.com`.
+ * Mirrors `getConferenceForDomain`'s `wildcardSubdomain` derivation so the
+ * guard matches exactly what the router uses to resolve the conference.
+ */
+export function wildcardFormForHost(host: string): string | null {
+  return host.split('.').length > 2 ? host.replace(/^[^.]+/, '*') : null
+}
+
+/**
+ * True when a `domains[]` entry would serve `host` — an exact match, or the
+ * wildcard entry (`*.example.com`) that covers the host's subdomain. This is the
+ * predicate the site's routing uses (`host in domains || wildcard in domains`),
+ * reused so the safeguard locks/keeps exactly the entries that keep the site up.
+ */
+export function domainServesHost(entry: string, host: string): boolean {
+  if (!entry || !host) return false
+  const e = normalizeDomain(entry)
+  const h = normalizeDomain(host)
+  if (e === h) return true
+  const wild = wildcardFormForHost(h)
+  return wild !== null && e === wild
+}
+
+/**
+ * True when NONE of the entries would serve `host` — i.e. saving this list would
+ * strand the current request. The server guard rejects such a payload and the
+ * client disables removing the last serving row.
+ */
+export function domainsWouldStrandHost(
+  domains: readonly string[],
+  host: string,
+): boolean {
+  if (!host) return false
+  return !domains.some((d) => domainServesHost(d, host))
+}

--- a/src/server/routers/conference.test.ts
+++ b/src/server/routers/conference.test.ts
@@ -4,6 +4,14 @@ import type { Context } from '@/server/trpc'
 // --- next/cache -------------------------------------------------------------
 vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
 
+// --- next/headers: drives the domains current-host guard --------------------
+const hostMock = vi.fn<() => string | null>(() => 'cloudnativebergen.no')
+vi.mock('next/headers', () => ({
+  headers: async () => ({
+    get: (key: string) => (key === 'host' ? hostMock() : null),
+  }),
+}))
+
 // --- Conference resolution (drives resolveConferenceId) ---------------------
 const getConferenceMock = vi.fn()
 vi.mock('@/lib/conference/sanity', () => ({
@@ -16,12 +24,17 @@ const commitMock = vi.fn()
 let lastPatchId: string | undefined
 let lastSet: Record<string, unknown> | undefined
 let lastUnset: string[] | undefined
+let lastSetIfMissing: Record<string, unknown> | undefined
 
 vi.mock('@/lib/sanity/client', () => ({
   clientWrite: {
     patch: (id: string) => {
       lastPatchId = id
       const builder = {
+        setIfMissing: (obj: Record<string, unknown>) => {
+          lastSetIfMissing = obj
+          return builder
+        },
         set: (obj: Record<string, unknown>) => {
           lastSet = obj
           return builder
@@ -57,6 +70,8 @@ beforeEach(() => {
   lastPatchId = undefined
   lastSet = undefined
   lastUnset = undefined
+  lastSetIfMissing = undefined
+  hostMock.mockReturnValue('cloudnativebergen.no')
   commitMock.mockResolvedValue({ _id: CONFERENCE_ID })
   getConferenceMock.mockResolvedValue({
     conference: { _id: CONFERENCE_ID },
@@ -241,5 +256,220 @@ describe('conference router — validation', () => {
         checkinEventId: 0,
       }),
     ).rejects.toBeTruthy()
+  })
+})
+
+// === SE-1b: array & object fieldsets =======================================
+
+describe('conference router — social links', () => {
+  it('replaces the whole array (empty allowed)', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateSocialLinks({
+      socialLinks: [],
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toEqual({ socialLinks: [] })
+  })
+
+  it('rejects an invalid URL row', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateSocialLinks({
+        socialLinks: ['https://ok.example', 'not-a-url'],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('sets only the socialLinks key (field-scoped)', async () => {
+    await makeCaller({ isOrganizer: true }).updateSocialLinks({
+      socialLinks: ['https://bsky.app/profile/x'],
+    })
+    expect(Object.keys(lastSet!)).toEqual(['socialLinks'])
+  })
+})
+
+describe('conference router — features', () => {
+  it('accepts a mix of known and custom flags', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateFeatures({
+      features: ['test_feature', 'custom_flag'],
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toEqual({ features: ['test_feature', 'custom_flag'] })
+  })
+
+  it('rejects duplicate flags', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateFeatures({
+        features: ['a', 'a'],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('conference router — vanity metrics', () => {
+  it('adds a _key to every row', async () => {
+    await makeCaller({ isOrganizer: true }).updateVanityMetrics({
+      vanityMetrics: [{ label: 'Attendees', value: '400' }],
+    })
+    const rows = lastSet!.vanityMetrics as Array<Record<string, unknown>>
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ label: 'Attendees', value: '400' })
+    expect(typeof rows[0]._key).toBe('string')
+  })
+
+  it('preserves an existing _key', async () => {
+    await makeCaller({ isOrganizer: true }).updateVanityMetrics({
+      vanityMetrics: [{ label: 'Talks', value: '30', _key: 'existing-1' }],
+    })
+    const rows = lastSet!.vanityMetrics as Array<Record<string, unknown>>
+    expect(rows[0]._key).toBe('existing-1')
+  })
+
+  it('rejects a row with a blank required column', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateVanityMetrics({
+        vanityMetrics: [{ label: 'x', value: '   ' }],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('conference router — sponsor benefits', () => {
+  it('accepts a valid icon and keys the row', async () => {
+    await makeCaller({ isOrganizer: true }).updateSponsorBenefits({
+      sponsorBenefits: [
+        {
+          title: 'Reach',
+          description: 'Great reach',
+          icon: 'RocketLaunchIcon',
+        },
+      ],
+    })
+    const rows = lastSet!.sponsorBenefits as Array<Record<string, unknown>>
+    expect(rows[0]).toMatchObject({
+      title: 'Reach',
+      description: 'Great reach',
+      icon: 'RocketLaunchIcon',
+    })
+    expect(typeof rows[0]._key).toBe('string')
+  })
+
+  it('rejects an unknown icon value', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateSponsorBenefits({
+        sponsorBenefits: [
+          { title: 'x', description: 'y', icon: 'NotARealIcon' },
+        ],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('allows an omitted icon', async () => {
+    const result = await makeCaller({
+      isOrganizer: true,
+    }).updateSponsorBenefits({
+      sponsorBenefits: [{ title: 'x', description: 'y' }],
+    })
+    expect(result.success).toBe(true)
+    const rows = lastSet!.sponsorBenefits as Array<Record<string, unknown>>
+    expect(rows[0]).not.toHaveProperty('icon')
+  })
+})
+
+describe('conference router — sponsorship customization (object)', () => {
+  it('patches field-scoped dot paths under a setIfMissing parent', async () => {
+    await makeCaller({ isOrganizer: true }).updateSponsorshipCustomization({
+      heroHeadline: 'New headline',
+      philosophyTitle: null,
+    })
+    expect(lastSetIfMissing).toEqual({ sponsorshipCustomization: {} })
+    expect(lastSet).toEqual({
+      'sponsorshipCustomization.heroHeadline': 'New headline',
+    })
+    expect(lastUnset).toEqual(['sponsorshipCustomization.philosophyTitle'])
+  })
+
+  it('rejects an invalid prospectus URL', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateSponsorshipCustomization({
+        prospectusUrl: 'notaurl',
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('conference router — domains (safeguarded)', () => {
+  const CURRENT = 'cloudnativebergen.no'
+  const other = 'cloudnativeday.no'
+
+  it('happy path: keeps the current domain', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: [CURRENT, other],
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toEqual({ domains: [CURRENT, other] })
+  })
+
+  it('rejects an empty list (BAD_REQUEST)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({ domains: [] }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a duplicate entry', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({
+        domains: [CURRENT, CURRENT],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a scheme-carrying entry', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({
+        domains: [`https://${CURRENT}`],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a path-carrying entry', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({
+        domains: [`${CURRENT}/admin`],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses to remove the current domain (BAD_REQUEST with the exact message)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({ domains: [other] }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'You cannot remove the domain you are currently using',
+    })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('allows removal when a wildcard entry still serves the current host', async () => {
+    hostMock.mockReturnValue('cfp.example.com')
+    const result = await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: ['*.example.com'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('normalizes entries to lowercase before storing', async () => {
+    hostMock.mockReturnValue(CURRENT)
+    await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: [`${CURRENT.toUpperCase()}`, 'Other.Example.COM'],
+    })
+    expect(lastSet).toEqual({ domains: [CURRENT, 'other.example.com'] })
   })
 })

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -1,7 +1,13 @@
 import { TRPCError } from '@trpc/server'
 import { revalidateTag } from 'next/cache'
+import { headers } from 'next/headers'
 import { router, adminProcedure, resolveConferenceId } from '../trpc'
 import { clientWrite } from '@/lib/sanity/client'
+import { ensureArrayKeys } from '@/lib/sanity/helpers'
+import {
+  CANNOT_REMOVE_CURRENT_DOMAIN,
+  domainsWouldStrandHost,
+} from '@/lib/conference/domains'
 import {
   UpdateBasicInfoSchema,
   UpdateVenueSchema,
@@ -10,6 +16,12 @@ import {
   UpdateCommunicationSchema,
   UpdateTicketingIdsSchema,
   UpdateCfpGoalsSchema,
+  UpdateSocialLinksSchema,
+  UpdateFeaturesSchema,
+  UpdateVanityMetricsSchema,
+  UpdateSponsorBenefitsSchema,
+  UpdateSponsorshipCustomizationSchema,
+  UpdateDomainsSchema,
 } from '../schemas/conference'
 
 /**
@@ -28,16 +40,27 @@ import {
 async function applyConferencePatch(
   conferenceId: string,
   input: Record<string, unknown>,
+  opts: {
+    /**
+     * When set, each input key is patched as a dot path under this parent
+     * object (`<pathPrefix>.<key>`) and the parent is `setIfMissing`-ed first.
+     * Used by object fieldsets (e.g. `sponsorshipCustomization`) so a save only
+     * touches the subfields it knows about and never clobbers siblings.
+     */
+    pathPrefix?: string
+  } = {},
 ) {
+  const { pathPrefix } = opts
   const set: Record<string, unknown> = {}
   const unset: string[] = []
 
   for (const [key, value] of Object.entries(input)) {
     if (value === undefined) continue
+    const path = pathPrefix ? `${pathPrefix}.${key}` : key
     if (value === null) {
-      unset.push(key)
+      unset.push(path)
     } else {
-      set[key] = value
+      set[path] = value
     }
   }
 
@@ -50,6 +73,7 @@ async function applyConferencePatch(
 
   try {
     let patch = clientWrite.patch(conferenceId)
+    if (pathPrefix) patch = patch.setIfMissing({ [pathPrefix]: {} })
     if (Object.keys(set).length > 0) patch = patch.set(set)
     if (unset.length > 0) patch = patch.unset(unset)
     const result = await patch.commit()
@@ -118,5 +142,82 @@ export const conferenceRouter = router({
     .mutation(async ({ input }) => {
       const conferenceId = await resolveConferenceId()
       return applyConferencePatch(conferenceId, input)
+    }),
+
+  // === SE-1b: array & object fieldsets =====================================
+
+  updateSocialLinks: adminProcedure
+    .input(UpdateSocialLinksSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, {
+        socialLinks: input.socialLinks,
+      })
+    }),
+
+  updateFeatures: adminProcedure
+    .input(UpdateFeaturesSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, { features: input.features })
+    }),
+
+  updateVanityMetrics: adminProcedure
+    .input(UpdateVanityMetricsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      // Object array items need a stable `_key`; preserve any existing key and
+      // mint one for new rows.
+      return applyConferencePatch(conferenceId, {
+        vanityMetrics: ensureArrayKeys(input.vanityMetrics, 'metric'),
+      })
+    }),
+
+  updateSponsorBenefits: adminProcedure
+    .input(UpdateSponsorBenefitsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      // Drop optional `icon` when absent so we never store `icon: undefined`.
+      const rows = input.sponsorBenefits.map((b) => ({
+        title: b.title,
+        description: b.description,
+        ...(b.icon ? { icon: b.icon } : {}),
+        ...(b._key ? { _key: b._key } : {}),
+      }))
+      return applyConferencePatch(conferenceId, {
+        sponsorBenefits: ensureArrayKeys(rows, 'benefit'),
+      })
+    }),
+
+  updateSponsorshipCustomization: adminProcedure
+    .input(UpdateSponsorshipCustomizationSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      // Field-scoped: patch dot paths under the parent object so sibling
+      // subfields we don't render are never touched.
+      return applyConferencePatch(conferenceId, input, {
+        pathPrefix: 'sponsorshipCustomization',
+      })
+    }),
+
+  /**
+   * SAFEGUARDED. In addition to the schema's shape/duplicate/hostname checks,
+   * this mutation derives the request's current host SERVER-SIDE and refuses any
+   * payload that would strand it (BAD_REQUEST). The client mirrors this with a
+   * locked, non-removable row + a type-to-confirm gate, but the server is the
+   * authority — a crafted request cannot bypass the guard.
+   */
+  updateDomains: adminProcedure
+    .input(UpdateDomainsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      const host = (await headers()).get('host') || ''
+      if (domainsWouldStrandHost(input.domains, host)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: CANNOT_REMOVE_CURRENT_DOMAIN,
+        })
+      }
+      return applyConferencePatch(conferenceId, { domains: input.domains })
     }),
 })

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -1,17 +1,22 @@
 import { z } from 'zod'
+import { HEROICON_OPTIONS } from '../../../sanity/schemaTypes/constants'
+import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
 
 /**
- * Field-scoped conference settings schemas (SE-1a). Each schema mirrors ONE
- * fieldset group of scalar fields from `sanity/schemaTypes/conference.ts` and is
- * consumed by exactly one mutation in `src/server/routers/conference.ts`. Only
- * scalar field groups are covered here; arrays/objects (social links, domains,
- * features, vanity metrics, sponsor benefits, teams, organizers, topics,
- * announcement, logos) are LATER phases and deliberately excluded.
+ * Field-scoped conference settings schemas (SE-1a + SE-1b). Each schema mirrors
+ * ONE fieldset group from `sanity/schemaTypes/conference.ts` and is consumed by
+ * exactly one mutation in `src/server/routers/conference.ts`.
  *
- * UNSET SEMANTICS (shared across every schema): a field left `undefined` is
- * untouched; an explicit `null` unsets the (optional) field. The router's patch
- * builder translates these to Sanity `.set()` / `.unset()` respectively — see
- * `applyConferencePatch`.
+ * SE-1a covered SCALAR field groups. SE-1b adds the array/object groups:
+ * `socialLinks`, `features`, `vanityMetrics`, `sponsorBenefits`,
+ * `sponsorshipCustomization` and the safeguarded `domains`. Still excluded:
+ * teams, organizers, topics, announcement, logos (later phases).
+ *
+ * UNSET SEMANTICS (shared across scalar schemas): a field left `undefined` is
+ * untouched; an explicit `null` unsets the (optional) field. Array schemas set
+ * the WHOLE array (a full replace); the object schema patches field-scoped dot
+ * paths under its parent. The router's patch builder translates these to Sanity
+ * `.set()` / `.unset()` — see `applyConferencePatch`.
  */
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
@@ -131,4 +136,123 @@ export const UpdateCfpGoalsSchema = z.object({
   cfpPresentationGoal: nonNegativeGoal,
   cfpWorkshopGoal: nonNegativeGoal,
   sponsorRevenueGoal: nonNegativeGoal,
+})
+
+// === Social Links (array of URL strings) ===
+// A full-array replace. Empty list allowed (the field is optional). Every row
+// must be a valid URL — blank rows are a client concern (stripped before send).
+export const UpdateSocialLinksSchema = z.object({
+  socialLinks: z.array(z.string().trim().url('Enter a valid URL')),
+})
+
+// === Features (array of string flags) ===
+// See EditConferenceCard for the "known + freeform" UI. The Sanity schema
+// declares a single known value (`test_feature`) and there are NO runtime
+// consumers, so the server stays permissive: any non-empty flag string, unique,
+// empty list allowed.
+export const UpdateFeaturesSchema = z.object({
+  features: z
+    .array(z.string().trim().min(1, 'Feature flag cannot be empty'))
+    .refine((f) => new Set(f).size === f.length, {
+      message: 'Feature flags must be unique',
+    }),
+})
+
+// === Vanity Metrics (array of {label, value}) ===
+// Both fields required per row; empty list allowed.
+export const UpdateVanityMetricsSchema = z.object({
+  vanityMetrics: z.array(
+    z.object({
+      label: z.string().trim().min(1, 'Label is required'),
+      value: z.string().trim().min(1, 'Value is required'),
+      _key: z.string().optional(),
+    }),
+  ),
+})
+
+// === Sponsor Benefits (array of {title, description, icon?}) ===
+// `icon` is an optional Heroicon key constrained to the shared `HEROICON_OPTIONS`
+// list the public "Why Sponsor" section renders (a `<select>` on the client).
+const HEROICON_VALUES = HEROICON_OPTIONS.map((o) => o.value) as [
+  string,
+  ...string[],
+]
+export const UpdateSponsorBenefitsSchema = z.object({
+  sponsorBenefits: z.array(
+    z.object({
+      title: z.string().trim().min(1, 'Title is required'),
+      description: z.string().trim().min(1, 'Description is required'),
+      icon: z
+        .enum(HEROICON_VALUES)
+        .nullable()
+        .optional()
+        // Treat an empty select as "no icon".
+        .or(z.literal('').transform(() => undefined)),
+      _key: z.string().optional(),
+    }),
+  ),
+})
+
+// === Sponsorship Page Customization (object of string fields) ===
+// Flattened: the mutation patches field-scoped dot paths
+// (`sponsorshipCustomization.<field>`) under a `setIfMissing` parent, so it never
+// clobbers sibling subfields it doesn't know about. Every field optional;
+// `null`/empty unsets that subfield.
+const optionalText = z.string().trim().nullable().optional()
+export const UpdateSponsorshipCustomizationSchema = z.object({
+  heroHeadline: optionalText,
+  heroSubheadline: optionalText,
+  packageSectionTitle: optionalText,
+  addonSectionTitle: optionalText,
+  philosophyTitle: optionalText,
+  philosophyDescription: optionalText,
+  closingQuote: optionalText,
+  closingCtaText: optionalText,
+  prospectusUrl: z
+    .string()
+    .trim()
+    .url('Enter a valid URL')
+    .nullable()
+    .optional(),
+})
+
+// === Domains (SAFEGUARDED array of hostname strings) ===
+// Drives domain→conference routing. Non-empty ALWAYS; each entry a bare,
+// lowercase hostname (scheme/path rejected; dev `:port` allowed); no duplicates.
+// The current-request-host guard lives in the router (it needs the request
+// headers) — see `updateDomains`.
+export const UpdateDomainsSchema = z.object({
+  domains: z
+    .array(z.string())
+    .min(1, 'At least one domain is required')
+    .transform((list) => list.map(normalizeDomain))
+    .superRefine((list, ctx) => {
+      const seen = new Set<string>()
+      list.forEach((entry, i) => {
+        if (entry === '') {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Domain cannot be empty',
+            path: [i],
+          })
+          return
+        }
+        if (!isValidDomainEntry(entry)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              'Enter a bare hostname (no https://, no path), e.g. example.com',
+            path: [i],
+          })
+        }
+        if (seen.has(entry)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Duplicate domain "${entry}"`,
+            path: [i],
+          })
+        }
+        seen.add(entry)
+      })
+    }),
 })


### PR DESCRIPTION
## SE-1b — Editable conference settings: arrays + safeguarded domains

Extends the SE-1a parameterized `EditConferenceCard` (ModalShell + dirty-guard + field-scoped patches + cache-tag revalidation) to the array/object fieldsets. One component, one router — no forks.

### New fieldsets (verified against `sanity/schemaTypes/conference.ts`)
| Fieldset | Mutation | Shape | Editor |
|---|---|---|---|
| Social Links | `updateSocialLinks` | `socialLinks: string[]` (URLs) | string-list, empty allowed |
| Features | `updateFeatures` | `features: string[]` | string-list + known-value checkbox |
| Vanity Metrics | `updateVanityMetrics` | `{label, value}[]` | object-list (2 required cols) |
| Sponsor Benefits | `updateSponsorBenefits` | `{title, description, icon?}[]` | object-list; `icon` = Heroicon `<select>` |
| Sponsorship Page | `updateSponsorshipCustomization` | object of 9 string fields | flat multi-field modal |
| Domains | `updateDomains` | `domains: string[]` | **safeguarded** string-list |

### The `features` finding
`features` is `array<string>` with a Sanity `options.list` of exactly **one** known value (`test_feature`), and a full grep found **no runtime consumers** (no `features.includes(...)` / feature-flag checks anywhere; the field is only stored and shown read-only on the settings page). So the UI renders the known value as a checkbox plus a free-form list for custom/unknown flags, and the server stays permissive (any non-empty unique flag string, empty list allowed).

### Domains safeguard design
- **Validation** (`UpdateDomainsSchema`): non-empty list always (BAD_REQUEST on empty); each entry a bare, lowercased hostname (scheme/path rejected, dev `:port` and `*.` wildcard allowed); no duplicates.
- **Current-domain guard**: the mutation derives the request host server-side from `headers()` and refuses any payload that would strand it — `domainsWouldStrandHost` reuses the exact routing predicate (exact **or** wildcard match), throwing BAD_REQUEST `You cannot remove the domain you are currently using`. The client mirrors this: the serving row is locked (lock icon, no remove button) — but the server is the authority.
- **Type-to-confirm**: a reusable `dangerous` fieldset option adds a red warning banner, a confirm input (must type the current host verbatim) and a red Save; Save stays disabled until dirty **and** confirmed. Purely server-independent gating, reusable for future dangerous fieldsets.
- Shared, dependency-free helpers live in `src/lib/conference/domains.ts` so server guard + client lock can never disagree.

### Object-patch strategy
- **Arrays** (`socialLinks`/`features`/`domains`/`vanityMetrics`/`sponsorBenefits`) are a full-array `.set()` of the single top-level key — field-scoped by construction. Object-array rows get `_key`s via `ensureArrayKeys` (real keys preserved, temp client keys re-minted server-side).
- **`sponsorshipCustomization`** flattens cleanly, so it reuses the scalar fieldset machinery but patches **field-scoped dot paths** (`sponsorshipCustomization.<field>`) under a `setIfMissing` parent — chosen over a whole-object `.set()` so a save never clobbers sibling subfields the form doesn't render.

### Component
`EditConferenceCard` gains `type: 'string-list' | 'object-list'` renderers and a `dangerous` fieldset option — still one parameterized component. List rows use ≥44px add/remove/reorder controls, accessible aria-labels, mobile-sheet friendly. Pure payload/validation logic extracted to `editConferenceLists.ts` for unit testing.

### Tests
- Router (`conference.test.ts`, 38 total): per-mutation validation incl. **every domains safeguard** (empty, duplicate, scheme/path-carrying entry, current-domain removal with exact message, happy path, wildcard-still-serves, lowercase normalization), object-list row validation, sponsorship dot-path patch shape, field-scoped patches.
- List logic (`editConferenceLists.test.ts`, 14): payload shaping (order, drop-blank, `_key` preserve/strip, optional-column omission), string/object validators, `moveRow`.
- Stories/play-functions (14, all green via `test-storybook`): string-list add/remove/reorder, object-list, and the Domains dangerous modal — confirm-gating enables Save only after the token is typed; locked current-domain row.

### Screenshots (393px, light + dark)
`SHOOT_OUT` captures inspected for string-list, object-list, and the Domains dangerous modal in both themes — no card exceeds the 393px viewport; all controls ≥44px.

Checks: tsc, eslint, prettier, knip, full `vitest run` (251 files, 3508 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
