### PR TITLE
feat(admin): editable organizers, topics, teams, announcement (SE-2)

### DIFF
--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -13,7 +13,11 @@ import {
   SelfCheckPanel,
 } from '@/components/admin/system-status'
 import { StatusBadge } from '@/components/StatusBadge'
+import { getAuthSession } from '@/lib/auth'
 import { EditConferenceCard } from '@/components/admin/EditConferenceCard'
+import { OrganizersEditor } from '@/components/admin/OrganizersEditor'
+import { TopicsEditor } from '@/components/admin/TopicsEditor'
+import { TeamsEditor } from '@/components/admin/TeamsEditor'
 import {
   CalendarIcon,
   GlobeAltIcon,
@@ -364,6 +368,14 @@ export default async function AdminSettings() {
 
   const editUrl = studioEditUrl(conference._id)
   const systemChecks = await buildSystemChecks(conference)
+  const session = await getAuthSession()
+  const currentUserId = session?.speaker?._id ?? ''
+  const organizerRows = (conference.organizers ?? []).map((org) => ({
+    _id: org._id,
+    name: org.name,
+    image: org.image,
+    title: org.title,
+  }))
 
   return (
     <div className="space-y-6">
@@ -658,10 +670,19 @@ export default async function AdminSettings() {
             icon={TagIcon}
             editUrl={editUrl}
             action={
-              <EditConferenceCard
-                fieldset="features"
-                initialValues={{ features: conference.features }}
-              />
+              <>
+                <TopicsEditor
+                  selectedTopics={(conference.topics ?? []).map((t) => ({
+                    _id: t._id,
+                    title: t.title,
+                    color: t.color,
+                  }))}
+                />
+                <EditConferenceCard
+                  fieldset="features"
+                  initialValues={{ features: conference.features }}
+                />
+              </>
             }
           >
             <FieldRow
@@ -681,7 +702,57 @@ export default async function AdminSettings() {
             />
           </InfoCard>
 
-          <InfoCard title="Team" icon={UserGroupIcon} editUrl={editUrl}>
+          <InfoCard
+            title="Announcement"
+            icon={DocumentTextIcon}
+            editUrl={editUrl}
+            action={
+              <EditConferenceCard
+                fieldset="announcement"
+                initialValues={{ announcement: conference.announcement }}
+              />
+            }
+          >
+            <FieldRow
+              label="Landing-page banner"
+              value={
+                Array.isArray(conference.announcement) &&
+                conference.announcement.length > 0
+                  ? 'Configured'
+                  : null
+              }
+            />
+          </InfoCard>
+
+          <InfoCard
+            title="Team"
+            icon={UserGroupIcon}
+            editUrl={editUrl}
+            action={
+              <>
+                <OrganizersEditor
+                  organizers={organizerRows}
+                  currentUserId={currentUserId}
+                />
+                <TeamsEditor
+                  teams={(conference.teams ?? []).map((team) => ({
+                    _key: team._key,
+                    key: team.key,
+                    title: team.title,
+                    members: Array.isArray(team.members)
+                      ? (team.members as unknown as string[])
+                      : [],
+                    slackChannel: team.slackChannel,
+                    emailIdentity: team.emailIdentity,
+                  }))}
+                  organizers={organizerRows.map((o) => ({
+                    _id: o._id,
+                    name: o.name,
+                  }))}
+                />
+              </>
+            }
+          >
             <FieldRow
               label="Organizers"
               value={conference.organizers?.map((org) => org.name)}

--- a/src/components/admin/EditConferenceCard.stories.tsx
+++ b/src/components/admin/EditConferenceCard.stories.tsx
@@ -23,7 +23,27 @@ const handlers = [
   http.post('/api/trpc/conference.updateSponsorBenefits', ok),
   http.post('/api/trpc/conference.updateSponsorshipCustomization', ok),
   http.post('/api/trpc/conference.updateDomains', ok),
+  http.post('/api/trpc/conference.updateAnnouncement', ok),
 ]
+
+const announcementInitial = {
+  announcement: [
+    {
+      _type: 'block',
+      _key: 'b1',
+      style: 'h2',
+      children: [{ _type: 'span', _key: 's1', text: 'Tickets are live!' }],
+    },
+    {
+      _type: 'block',
+      _key: 'b2',
+      style: 'normal',
+      children: [
+        { _type: 'span', _key: 's2', text: 'Early-bird pricing ends soon.' },
+      ],
+    },
+  ],
+}
 
 const meta = {
   title: 'Systems/Settings/Admin/EditConferenceCard',
@@ -268,6 +288,24 @@ export const DomainsDangerousDark: Story = {
     fieldset: 'domains',
     initialValues: domainsInitial,
     currentDomain: 'cloudnativebergen.no',
+    defaultOpen: true,
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+/** The rich-text Announcement fieldset — the portable-text editor + toolbar. */
+export const RichTextAnnouncement: Story = {
+  args: {
+    fieldset: 'announcement',
+    initialValues: announcementInitial,
+    defaultOpen: true,
+  },
+}
+
+export const RichTextAnnouncementDark: Story = {
+  args: {
+    fieldset: 'announcement',
+    initialValues: announcementInitial,
     defaultOpen: true,
   },
   parameters: { theme: 'dark', backgrounds: { default: 'dark' } },

--- a/src/components/admin/EditConferenceCard.tsx
+++ b/src/components/admin/EditConferenceCard.tsx
@@ -13,6 +13,8 @@ import {
 } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
 import { AdminButton } from '@/components/admin/AdminButton'
+import { PortableTextEditor } from '@/components/PortableTextEditor'
+import type { PortableTextBlock } from '@portabletext/editor'
 import { api } from '@/lib/trpc/client'
 import { HEROICON_OPTIONS } from '../../../sanity/schemaTypes/constants'
 import { domainServesHost } from '@/lib/conference/domains'
@@ -45,7 +47,10 @@ import { useNotification } from './NotificationProvider'
  *     currently driving the safeguarded Domains editor (also locks the row that
  *     serves the current host).
  *
- * Still read-only for later phases: teams, organizers, topics, announcement,
+ * SE-2 adds a `rich-text` renderer (the portable-text Announcement) wrapping the
+ * shared {@link PortableTextEditor}. Organizers, topics and teams are richer,
+ * data-fetching editors that live in their own components (OrganizersEditor,
+ * TopicsEditor, TeamsEditor) rather than this fieldset table. Still read-only:
  * logos.
  */
 
@@ -63,6 +68,7 @@ export type ConferenceFieldsetKey =
   | 'sponsorBenefits'
   | 'sponsorshipCustomization'
   | 'domains'
+  | 'announcement'
 
 export type EditFieldType =
   | 'text'
@@ -74,6 +80,7 @@ export type EditFieldType =
   | 'boolean'
   | 'string-list'
   | 'object-list'
+  | 'rich-text'
 
 /** A column within an `object-list` row. */
 export interface ObjectListColumn {
@@ -499,6 +506,19 @@ export const FIELDSET_DEFS: Record<ConferenceFieldsetKey, FieldsetDef> = {
       },
     ],
   },
+  announcement: {
+    title: 'Announcement',
+    subtitle: 'Rich-text banner shown on the landing page',
+    fields: [
+      {
+        name: 'announcement',
+        label: 'Announcement',
+        type: 'rich-text',
+        description:
+          'Leave empty to hide the banner. Supports headings, bold/italic, lists and links.',
+      },
+    ],
+  },
 }
 
 const MUTATION_BY_FIELDSET: Record<
@@ -518,9 +538,10 @@ const MUTATION_BY_FIELDSET: Record<
   sponsorBenefits: 'updateSponsorBenefits',
   sponsorshipCustomization: 'updateSponsorshipCustomization',
   domains: 'updateDomains',
+  announcement: 'updateAnnouncement',
 }
 
-type FormValue = string | boolean | string[] | ListRow[]
+type FormValue = string | boolean | string[] | ListRow[] | PortableTextBlock[]
 type FormValues = Record<string, FormValue>
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -547,6 +568,8 @@ function toFormValues(
     const v = initial[f.name]
     if (f.type === 'boolean') {
       out[f.name] = Boolean(v)
+    } else if (f.type === 'rich-text') {
+      out[f.name] = Array.isArray(v) ? (v as PortableTextBlock[]) : []
     } else if (f.type === 'string-list') {
       out[f.name] = Array.isArray(v) ? v.map((x) => String(x ?? '')) : []
     } else if (f.type === 'object-list') {
@@ -735,6 +758,7 @@ export function EditConferenceCard({
     const errs: Record<string, string> = {}
     for (const f of fields) {
       if (f.type === 'boolean') continue
+      if (f.type === 'rich-text') continue
       if (f.type === 'string-list') {
         Object.assign(errs, validateStringList(f, values[f.name] as string[]))
         continue
@@ -775,6 +799,12 @@ export function EditConferenceCard({
       const raw = values[f.name]
       if (f.type === 'boolean') {
         payload[f.name] = Boolean(raw)
+        continue
+      }
+      if (f.type === 'rich-text') {
+        const blocks = (raw as PortableTextBlock[]) ?? []
+        // Empty → null so the mutation UNSETS the field (banner stops showing).
+        payload[f.name] = blocks.length > 0 ? blocks : null
         continue
       }
       if (f.type === 'string-list') {
@@ -963,6 +993,30 @@ function EditField({
         errors={rowErrors ?? {}}
         onChange={(rows) => onChange(rows)}
       />
+    )
+  }
+
+  if (field.type === 'rich-text') {
+    return (
+      <div>
+        <PortableTextEditor
+          label={
+            <>
+              {field.label}
+              {field.required ? (
+                <span className="text-red-500" aria-hidden="true">
+                  {' '}
+                  *
+                </span>
+              ) : null}
+            </>
+          }
+          value={(value as PortableTextBlock[]) ?? []}
+          onChange={(blocks) => onChange(blocks)}
+          helpText={field.description}
+          compact
+        />
+      </div>
     )
   }
 

--- a/src/components/admin/OrganizersEditor.stories.tsx
+++ b/src/components/admin/OrganizersEditor.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { OrganizersEditor } from './OrganizersEditor'
+import { NotificationProvider } from './NotificationProvider'
+
+const searchResults = [
+  {
+    _id: 'sp-4',
+    name: 'Nadia Okonkwo',
+    title: 'Staff Engineer',
+    isOrganizer: false,
+    proposals: [],
+  },
+  {
+    _id: 'sp-5',
+    name: 'Lars Vik',
+    title: 'Platform Lead',
+    isOrganizer: true,
+    proposals: [],
+  },
+]
+
+const handlers = [
+  http.get('/api/trpc/speaker.admin.search', () =>
+    HttpResponse.json({ result: { data: searchResults } }),
+  ),
+  http.post('/api/trpc/conference.updateOrganizers', () =>
+    HttpResponse.json({ result: { data: { success: true, updated: {} } } }),
+  ),
+]
+
+const organizers = [
+  { _id: 'sp-1', name: 'Hanna Sørensen', title: 'Conference Chair' },
+  { _id: 'sp-2', name: 'Mikael Berg', title: 'Program Committee' },
+  { _id: 'sp-3', name: 'Priya Sharma', title: 'Sponsors Lead' },
+]
+
+const meta = {
+  title: 'Systems/Settings/Admin/OrganizersEditor',
+  component: OrganizersEditor,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'SE-2 — the Organizers editor. `organizers[]` is the canonical organizer set (admin access + notification fan-out). The acting organizer’s own row is LOCKED (lock icon, no remove) so they cannot revoke their own access; the server enforces the same guard.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-white p-6 dark:bg-gray-950">
+                <Story />
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof OrganizersEditor>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Modal open; the caller (sp-1) is the first, locked row. */
+export const Default: Story = {
+  args: { organizers, currentUserId: 'sp-1', defaultOpen: true },
+}
+
+export const Dark: Story = {
+  args: { organizers, currentUserId: 'sp-1', defaultOpen: true },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}

--- a/src/components/admin/OrganizersEditor.tsx
+++ b/src/components/admin/OrganizersEditor.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  PencilSquareIcon,
+  TrashIcon,
+  LockClosedIcon,
+} from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { SpeakerCombobox } from '@/components/messaging/SpeakerCombobox'
+import type { SpeakerOption } from '@/components/messaging/SpeakerCombobox'
+import { api } from '@/lib/trpc/client'
+import { useNotification } from './NotificationProvider'
+import { validateOrganizers } from './editConferenceRefs'
+
+/**
+ * SE-2 — the Organizers editor island.
+ *
+ * `organizers[]` is the CANONICAL organizer definition: it grants `/admin`
+ * access and is the notification fan-out audience. Adding someone grants admin;
+ * removing someone REVOKES their `/admin` access on their next session refresh.
+ *
+ * SELF-LOCKOUT: the acting organizer's own row is LOCKED (a lock icon, no remove)
+ * so they cannot revoke their own access mid-edit; the server enforces the same
+ * guard (BAD_REQUEST) as the authority.
+ *
+ * Members are added with the shared {@link SpeakerCombobox} (the same
+ * `speaker.admin.search` source the messaging composer uses), so no new server
+ * search surface is introduced.
+ */
+export interface OrganizerRow {
+  _id: string
+  name: string
+  /** Resolved avatar URL (from the settings-page projection), if any. */
+  image?: string
+  title?: string
+}
+
+export interface OrganizersEditorProps {
+  organizers: OrganizerRow[]
+  /** The acting organizer's speaker id — their row is locked. */
+  currentUserId: string
+  /** Render the modal open on mount — for stories/tests only. */
+  defaultOpen?: boolean
+}
+
+function Avatar({ name, image }: { name: string; image?: string }) {
+  if (image) {
+    // A resolved remote avatar URL, not a bundled asset — a plain <img> keeps
+    // this small modal row dependency-free (no next/image layout machinery).
+    return (
+      <img
+        src={image}
+        alt=""
+        className="h-8 w-8 shrink-0 rounded-full object-cover"
+      />
+    )
+  }
+  const initials = name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? '')
+    .join('')
+  return (
+    <span
+      aria-hidden="true"
+      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-cloud-blue/10 text-xs font-semibold text-brand-cloud-blue dark:bg-brand-cloud-blue/20"
+    >
+      {initials || '?'}
+    </span>
+  )
+}
+
+export function OrganizersEditor({
+  organizers,
+  currentUserId,
+  defaultOpen = false,
+}: OrganizersEditorProps) {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const [rows, setRows] = useState<OrganizerRow[]>(organizers)
+  const [picked, setPicked] = useState<SpeakerOption | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const ids = rows.map((r) => r._id)
+  const baselineIds = organizers.map((r) => r._id)
+  const isDirty = JSON.stringify(ids) !== JSON.stringify(baselineIds)
+
+  const mutation = api.conference.updateOrganizers.useMutation({
+    onSuccess: () => {
+      void utils.invalidate()
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Organizers updated',
+        message: 'The organizer team was saved.',
+      })
+      setIsOpen(false)
+    },
+    onError: (err) => {
+      setSubmitError(err.message || 'Failed to save organizers.')
+      showNotification({
+        type: 'error',
+        title: 'Could not save',
+        message: err.message || 'Failed to save organizers.',
+      })
+    },
+  })
+
+  const reset = () => {
+    setRows(organizers)
+    setPicked(null)
+    setError(null)
+    setSubmitError(null)
+  }
+  const openModal = () => {
+    reset()
+    setIsOpen(true)
+  }
+  const closeModal = () => {
+    setIsOpen(false)
+    reset()
+  }
+
+  const addPicked = (speaker: SpeakerOption | null) => {
+    setPicked(null)
+    if (!speaker) return
+    if (rows.some((r) => r._id === speaker._id)) return
+    setRows((prev) => [
+      ...prev,
+      { _id: speaker._id, name: speaker.name, title: speaker.title },
+    ])
+    setError(null)
+  }
+
+  const removeRow = (id: string) => {
+    setRows((prev) => prev.filter((r) => r._id !== id))
+    setError(null)
+  }
+
+  const handleSave = () => {
+    setSubmitError(null)
+    const validation = validateOrganizers(ids, currentUserId)
+    if (validation) {
+      setError(validation)
+      return
+    }
+    mutation.mutate({ organizers: ids })
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openModal}
+        aria-label="Edit Organizers"
+        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+      >
+        <PencilSquareIcon className="h-5 w-5" />
+      </button>
+
+      <ModalShell
+        isOpen={isOpen}
+        onClose={closeModal}
+        size="lg"
+        title="Edit Organizers"
+        subtitle="Who has admin access and receives team notifications"
+        icon={<PencilSquareIcon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty && !mutation.isPending}
+      >
+        <form
+          noValidate
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSave()
+          }}
+          className="space-y-4"
+        >
+          <p className="rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
+            Organizers get full admin access and receive team notifications.
+            Removing someone revokes their <code>/admin</code> access on their
+            next session refresh.
+          </p>
+
+          <ul className="space-y-2">
+            {rows.map((row) => {
+              const locked = row._id === currentUserId
+              return (
+                <li
+                  key={row._id}
+                  className="flex items-center gap-3 rounded-lg border border-gray-200 p-2 dark:border-gray-700"
+                >
+                  <Avatar name={row.name} image={row.image} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                      {row.name}
+                    </p>
+                    {row.title ? (
+                      <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {row.title}
+                      </p>
+                    ) : null}
+                  </div>
+                  {locked ? (
+                    <span
+                      className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-gray-400 opacity-70"
+                      title="You cannot remove yourself from the organizer team"
+                      aria-label={`${row.name} is you and cannot be removed`}
+                    >
+                      <LockClosedIcon className="h-5 w-5" />
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => removeRow(row._id)}
+                      aria-label={`Remove ${row.name}`}
+                      className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+                    >
+                      <TrashIcon className="h-5 w-5" />
+                    </button>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+
+          <div>
+            <label
+              htmlFor="organizer-add"
+              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Add an organizer
+            </label>
+            <SpeakerCombobox
+              id="organizer-add"
+              value={picked}
+              onChange={addPicked}
+            />
+          </div>
+
+          {error ? (
+            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+              {error}
+            </p>
+          ) : null}
+          {submitError ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+            <AdminButton
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={closeModal}
+              disabled={mutation.isPending}
+              className="min-h-[44px]"
+            >
+              Cancel
+            </AdminButton>
+            <AdminButton
+              type="submit"
+              color="blue"
+              size="md"
+              disabled={mutation.isPending || !isDirty}
+              className="min-h-[44px]"
+            >
+              {mutation.isPending ? 'Saving…' : 'Save organizers'}
+            </AdminButton>
+          </div>
+        </form>
+      </ModalShell>
+    </>
+  )
+}

--- a/src/components/admin/TeamsEditor.stories.tsx
+++ b/src/components/admin/TeamsEditor.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { TeamsEditor } from './TeamsEditor'
+import { NotificationProvider } from './NotificationProvider'
+
+const handlers = [
+  http.post('/api/trpc/conference.updateTeams', () =>
+    HttpResponse.json({ result: { data: { success: true, updated: {} } } }),
+  ),
+]
+
+const organizers = [
+  { _id: 'sp-1', name: 'Hanna Sørensen' },
+  { _id: 'sp-2', name: 'Mikael Berg' },
+  { _id: 'sp-3', name: 'Priya Sharma' },
+]
+
+const teams = [
+  {
+    _key: 'team-cfp',
+    key: 'cfp',
+    title: 'CFP Team',
+    members: ['sp-1', 'sp-2'],
+    slackChannel: '#cnb-cfp',
+    emailIdentity: ['cfpEmail' as const],
+  },
+  {
+    _key: 'team-sponsors',
+    key: 'sponsors',
+    title: 'Sponsors Team',
+    members: ['sp-3'],
+    slackChannel: '#cnb-sales',
+  },
+]
+
+const meta = {
+  title: 'Systems/Settings/Admin/TeamsEditor',
+  component: TeamsEditor,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'SE-2 — the organizer Teams editor. Teams are a soft lens for routing (never an access boundary). Each team has a kebab `key` (auto-slugged from the title, editable, unique), ≥1 members drawn only from the current organizers, an optional Slack channel and email identity. The server enforces the member ⊆ organizers subset.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-white p-6 dark:bg-gray-950">
+                <Story />
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof TeamsEditor>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { teams, organizers, defaultOpen: true },
+}
+
+export const Dark: Story = {
+  args: { teams, organizers, defaultOpen: true },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}

--- a/src/components/admin/TeamsEditor.tsx
+++ b/src/components/admin/TeamsEditor.tsx
@@ -1,0 +1,426 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  PencilSquareIcon,
+  PlusIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { api } from '@/lib/trpc/client'
+import { useNotification } from './NotificationProvider'
+import {
+  type TeamFormRow,
+  TEAM_EMAIL_IDENTITY_OPTIONS,
+  TEMP_KEY_PREFIX,
+  slugifyTeamKey,
+  validateTeams,
+  buildTeamsPayload,
+} from './editConferenceRefs'
+import type { TeamEmailIdentity } from '@/lib/teams/types'
+
+/**
+ * SE-2 — the organizer Teams editor island.
+ *
+ * Teams are a SOFT LENS over the organizer set (routing / mail defaults), NEVER
+ * an access boundary. Each team has a kebab-case `key` (auto-slugged from the
+ * title, editable, unique), a title, ≥1 members drawn ONLY from the current
+ * organizers, an optional Slack channel, and an optional email identity. The
+ * member sub-picker is limited to organizers; the server ENFORCES that subset.
+ */
+export interface TeamStored {
+  _key?: string
+  key: string
+  title: string
+  /** Member speaker ids. */
+  members: string[]
+  slackChannel?: string
+  emailIdentity?: TeamEmailIdentity[]
+}
+
+export interface TeamsEditorProps {
+  teams: TeamStored[]
+  /** The conference's current organizers (the only eligible team members). */
+  organizers: { _id: string; name: string }[]
+  defaultOpen?: boolean
+}
+
+let tempCounter = 0
+const nextTempKey = () => `${TEMP_KEY_PREFIX}${++tempCounter}`
+
+function toFormRows(teams: TeamStored[]): TeamFormRow[] {
+  return teams.map((t) => ({
+    _key: t._key ?? nextTempKey(),
+    key: t.key ?? '',
+    title: t.title ?? '',
+    members: Array.isArray(t.members) ? t.members : [],
+    slackChannel: t.slackChannel ?? '',
+    emailIdentity: (t.emailIdentity?.[0] ?? '') as TeamFormRow['emailIdentity'],
+  }))
+}
+
+const inputClass =
+  'block w-full min-h-[44px] rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+
+export function TeamsEditor({
+  teams,
+  organizers,
+  defaultOpen = false,
+}: TeamsEditorProps) {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const [rows, setRows] = useState<TeamFormRow[]>(() => toFormRows(teams))
+  // Rows whose key the user typed by hand — those stop auto-slugging from title.
+  const [manualKeys, setManualKeys] = useState<Set<string>>(new Set())
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const organizerIds = organizers.map((o) => o._id)
+
+  const baseline = JSON.stringify(toFormRows(teams).map(stripKey))
+  const isDirty = JSON.stringify(rows.map(stripKey)) !== baseline
+
+  const mutation = api.conference.updateTeams.useMutation({
+    onSuccess: () => {
+      void utils.invalidate()
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Teams updated',
+        message: 'Organizer teams saved.',
+      })
+      setIsOpen(false)
+    },
+    onError: (err) => {
+      setSubmitError(err.message || 'Failed to save teams.')
+      showNotification({
+        type: 'error',
+        title: 'Could not save',
+        message: err.message || 'Failed to save teams.',
+      })
+    },
+  })
+
+  const reset = () => {
+    setRows(toFormRows(teams))
+    setManualKeys(new Set())
+    setErrors({})
+    setSubmitError(null)
+  }
+  const openModal = () => {
+    reset()
+    setIsOpen(true)
+  }
+  const closeModal = () => {
+    setIsOpen(false)
+    reset()
+  }
+
+  const patchRow = (index: number, patch: Partial<TeamFormRow>) =>
+    setRows((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, ...patch } : r)),
+    )
+
+  const setTitle = (index: number, title: string) => {
+    const row = rows[index]
+    const auto = !manualKeys.has(row._key)
+    patchRow(index, {
+      title,
+      ...(auto ? { key: slugifyTeamKey(title) } : {}),
+    })
+  }
+
+  const setKey = (index: number, key: string) => {
+    setManualKeys((prev) => new Set(prev).add(rows[index]._key))
+    patchRow(index, { key })
+  }
+
+  const toggleMember = (index: number, id: string) => {
+    const row = rows[index]
+    const members = row.members.includes(id)
+      ? row.members.filter((m) => m !== id)
+      : [...row.members, id]
+    patchRow(index, { members })
+  }
+
+  const addTeam = () =>
+    setRows((prev) => [
+      ...prev,
+      {
+        _key: nextTempKey(),
+        key: '',
+        title: '',
+        members: [],
+        slackChannel: '',
+        emailIdentity: '',
+      },
+    ])
+  const removeTeam = (index: number) =>
+    setRows((prev) => prev.filter((_, i) => i !== index))
+
+  const handleSave = () => {
+    setSubmitError(null)
+    const errs = validateTeams(rows, organizerIds)
+    setErrors(errs)
+    if (Object.keys(errs).length > 0) return
+    mutation.mutate({ teams: buildTeamsPayload(rows) })
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openModal}
+        aria-label="Edit Teams"
+        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+      >
+        <PencilSquareIcon className="h-5 w-5" />
+      </button>
+
+      <ModalShell
+        isOpen={isOpen}
+        onClose={closeModal}
+        size="lg"
+        title="Edit Teams"
+        subtitle="Sub-teams of organizers for routing notifications and mail"
+        icon={<PencilSquareIcon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty && !mutation.isPending}
+      >
+        <form
+          noValidate
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSave()
+          }}
+          className="space-y-4"
+        >
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Teams are a soft lens for routing — they never change who can access
+            the admin. Members must be current organizers.
+          </p>
+
+          <ul className="space-y-3">
+            {rows.map((row, index) => (
+              <li
+                key={row._key}
+                className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+              >
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                    Team {index + 1}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeTeam(index)}
+                    aria-label={`Remove team ${index + 1}`}
+                    className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+                  >
+                    <TrashIcon className="h-5 w-5" />
+                  </button>
+                </div>
+
+                <div className="space-y-2">
+                  <div>
+                    <label
+                      htmlFor={`team-${index}-title`}
+                      className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                    >
+                      Title <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      id={`team-${index}-title`}
+                      type="text"
+                      value={row.title}
+                      onChange={(e) => setTitle(index, e.target.value)}
+                      aria-invalid={errors[`${index}.title`] ? true : undefined}
+                      className={inputClass}
+                    />
+                    {errors[`${index}.title`] ? (
+                      <p
+                        role="alert"
+                        className="mt-1 text-sm text-red-600 dark:text-red-400"
+                      >
+                        {errors[`${index}.title`]}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor={`team-${index}-key`}
+                      className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                    >
+                      Key <span className="text-red-500">*</span>
+                    </label>
+                    <input
+                      id={`team-${index}-key`}
+                      type="text"
+                      value={row.key}
+                      onChange={(e) => setKey(index, e.target.value)}
+                      aria-invalid={errors[`${index}.key`] ? true : undefined}
+                      className={`${inputClass} font-mono`}
+                    />
+                    {errors[`${index}.key`] ? (
+                      <p
+                        role="alert"
+                        className="mt-1 text-sm text-red-600 dark:text-red-400"
+                      >
+                        {errors[`${index}.key`]}
+                      </p>
+                    ) : (
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Lowercase kebab-case, unique. Well-known: cfp, sponsors,
+                        volunteers, workshops.
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <span className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">
+                      Members <span className="text-red-500">*</span>
+                    </span>
+                    <div className="max-h-40 space-y-1 overflow-auto rounded-lg border border-gray-200 p-2 dark:border-gray-700">
+                      {organizers.length === 0 ? (
+                        <p className="px-1 text-sm text-gray-500 dark:text-gray-400">
+                          No organizers to choose from.
+                        </p>
+                      ) : (
+                        organizers.map((org) => {
+                          const mid = `team-${index}-member-${org._id}`
+                          return (
+                            <label
+                              key={org._id}
+                              htmlFor={mid}
+                              className="flex min-h-[36px] cursor-pointer items-center gap-2 rounded-md px-1 text-sm text-gray-800 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                            >
+                              <input
+                                id={mid}
+                                type="checkbox"
+                                checked={row.members.includes(org._id)}
+                                onChange={() => toggleMember(index, org._id)}
+                                className="h-5 w-5 rounded border-gray-300 text-brand-cloud-blue focus:ring-brand-cloud-blue"
+                              />
+                              <span className="truncate">{org.name}</span>
+                            </label>
+                          )
+                        })
+                      )}
+                    </div>
+                    {errors[`${index}.members`] ? (
+                      <p
+                        role="alert"
+                        className="mt-1 text-sm text-red-600 dark:text-red-400"
+                      >
+                        {errors[`${index}.members`]}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <div className="min-w-0 flex-1">
+                      <label
+                        htmlFor={`team-${index}-slack`}
+                        className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                      >
+                        Slack channel
+                      </label>
+                      <input
+                        id={`team-${index}-slack`}
+                        type="text"
+                        value={row.slackChannel}
+                        onChange={(e) =>
+                          patchRow(index, { slackChannel: e.target.value })
+                        }
+                        placeholder="#team-cfp"
+                        className={inputClass}
+                      />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <label
+                        htmlFor={`team-${index}-email`}
+                        className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                      >
+                        Email identity
+                      </label>
+                      <select
+                        id={`team-${index}-email`}
+                        value={row.emailIdentity}
+                        onChange={(e) =>
+                          patchRow(index, {
+                            emailIdentity: e.target
+                              .value as TeamFormRow['emailIdentity'],
+                          })
+                        }
+                        className={inputClass}
+                      >
+                        <option value="">— Conference default —</option>
+                        {TEAM_EMAIL_IDENTITY_OPTIONS.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.title}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <button
+            type="button"
+            onClick={addTeam}
+            className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 hover:border-brand-cloud-blue hover:text-brand-cloud-blue dark:border-gray-600 dark:text-gray-300"
+          >
+            <PlusIcon className="h-5 w-5" />
+            Add team
+          </button>
+
+          {submitError ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+            <AdminButton
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={closeModal}
+              disabled={mutation.isPending}
+              className="min-h-[44px]"
+            >
+              Cancel
+            </AdminButton>
+            <AdminButton
+              type="submit"
+              color="blue"
+              size="md"
+              disabled={mutation.isPending || !isDirty}
+              className="min-h-[44px]"
+            >
+              {mutation.isPending ? 'Saving…' : 'Save teams'}
+            </AdminButton>
+          </div>
+        </form>
+      </ModalShell>
+    </>
+  )
+}
+
+/** Strip the client-only `_key` so dirty tracking follows content, not identity. */
+function stripKey(row: TeamFormRow): Omit<TeamFormRow, '_key'> {
+  const { _key: _drop, ...rest } = row
+  void _drop
+  return rest
+}

--- a/src/components/admin/TopicsEditor.stories.tsx
+++ b/src/components/admin/TopicsEditor.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { TopicsEditor } from './TopicsEditor'
+import { NotificationProvider } from './NotificationProvider'
+
+const allTopics = [
+  {
+    _id: 't-1',
+    _type: 'topic',
+    title: 'Kubernetes',
+    color: '#2563EB',
+    slug: { current: 'kubernetes' },
+  },
+  {
+    _id: 't-2',
+    _type: 'topic',
+    title: 'Observability',
+    color: '#16A34A',
+    slug: { current: 'observability' },
+  },
+  {
+    _id: 't-3',
+    _type: 'topic',
+    title: 'Platform Engineering',
+    color: '#7C3AED',
+    slug: { current: 'platform-engineering' },
+  },
+  {
+    _id: 't-4',
+    _type: 'topic',
+    title: 'Security',
+    color: '#DC2626',
+    slug: { current: 'security' },
+  },
+  {
+    _id: 't-5',
+    _type: 'topic',
+    title: 'FinOps',
+    color: '#D97706',
+    slug: { current: 'finops' },
+  },
+]
+
+const handlers = [
+  http.get('/api/trpc/topic.list', () =>
+    HttpResponse.json({ result: { data: allTopics } }),
+  ),
+  http.post('/api/trpc/topic.create', () =>
+    HttpResponse.json({
+      result: {
+        data: {
+          _id: 't-new',
+          _type: 'topic',
+          title: 'New Topic',
+          color: '#0891B2',
+          slug: { current: 'new-topic' },
+        },
+      },
+    }),
+  ),
+  http.post('/api/trpc/conference.updateTopics', () =>
+    HttpResponse.json({ result: { data: { success: true, updated: {} } } }),
+  ),
+]
+
+const selectedTopics = [
+  { _id: 't-1', title: 'Kubernetes', color: '#2563EB' },
+  { _id: 't-2', title: 'Observability', color: '#16A34A' },
+]
+
+const meta = {
+  title: 'Systems/Settings/Admin/TopicsEditor',
+  component: TopicsEditor,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'SE-2 — the conference Topics editor. Multi-select from existing topics (each with its color chip) and create a NEW topic inline without leaving the modal. Saving replaces `conference.topics[]` (min 1).',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-white p-6 dark:bg-gray-950">
+                <Story />
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof TopicsEditor>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { selectedTopics, defaultOpen: true },
+}
+
+export const Dark: Story = {
+  args: { selectedTopics, defaultOpen: true },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}

--- a/src/components/admin/TopicsEditor.tsx
+++ b/src/components/admin/TopicsEditor.tsx
@@ -1,0 +1,321 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { PencilSquareIcon, PlusIcon } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { api } from '@/lib/trpc/client'
+import { useNotification } from './NotificationProvider'
+
+/** The minimal topic shape this editor displays and selects. */
+export interface TopicOption {
+  _id: string
+  title: string
+  color?: string
+}
+
+/**
+ * SE-2 — the conference Topics editor island.
+ *
+ * `conference.topics[]` is a reference array into the standalone `topic`
+ * documents. This editor multi-selects from the existing topics (each with its
+ * color chip) and supports creating a NEW topic inline (via `topic.create`)
+ * without leaving the modal. Saving patches `conference.updateTopics` with the
+ * selected ids (non-empty, mirroring the schema's `min(1)`).
+ */
+export interface TopicsEditorProps {
+  /** The conference's currently-referenced topics. */
+  selectedTopics: TopicOption[]
+  defaultOpen?: boolean
+}
+
+/** Union two topic lists by id (fetched entries win), preserving order. */
+function mergeTopics(
+  selected: TopicOption[],
+  fetched: { _id: string; title: string; color?: string }[],
+): TopicOption[] {
+  const byId = new Map<string, TopicOption>()
+  for (const t of selected) byId.set(t._id, t)
+  for (const t of fetched)
+    byId.set(t._id, { _id: t._id, title: t.title, color: t.color })
+  return Array.from(byId.values()).sort((a, b) =>
+    a.title.localeCompare(b.title),
+  )
+}
+
+function ColorChip({ color }: { color?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="inline-block h-3 w-3 shrink-0 rounded-full ring-1 ring-black/10 dark:ring-white/20"
+      style={{ backgroundColor: color || '#9CA3AF' }}
+    />
+  )
+}
+
+export function TopicsEditor({
+  selectedTopics,
+  defaultOpen = false,
+}: TopicsEditorProps) {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const [selectedIds, setSelectedIds] = useState<string[]>(
+    selectedTopics.map((t) => t._id),
+  )
+  const [newTitle, setNewTitle] = useState('')
+  const [newColor, setNewColor] = useState('#2563EB')
+  const [error, setError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const { data: fetchedTopics } = api.topic.list.useQuery(undefined, {
+    enabled: isOpen,
+  })
+
+  // Always show the currently-selected topics even before (or without) a fetch,
+  // merged with every topic in the dataset. Fetched entries win on id.
+  const topics: TopicOption[] = mergeTopics(selectedTopics, fetchedTopics ?? [])
+
+  const baseline = selectedTopics.map((t) => t._id)
+  const isDirty =
+    JSON.stringify([...selectedIds].sort()) !==
+    JSON.stringify([...baseline].sort())
+
+  const createMutation = api.topic.create.useMutation({
+    onSuccess: (topic) => {
+      void utils.topic.list.invalidate()
+      setSelectedIds((prev) =>
+        prev.includes(topic._id) ? prev : [...prev, topic._id],
+      )
+      setNewTitle('')
+      showNotification({
+        type: 'success',
+        title: 'Topic created',
+        message: `“${topic.title}” was added.`,
+      })
+    },
+    onError: (err) => {
+      setError(err.message || 'Failed to create topic.')
+    },
+  })
+
+  const saveMutation = api.conference.updateTopics.useMutation({
+    onSuccess: () => {
+      void utils.invalidate()
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Topics updated',
+        message: 'Conference topics saved.',
+      })
+      setIsOpen(false)
+    },
+    onError: (err) => {
+      setSubmitError(err.message || 'Failed to save topics.')
+      showNotification({
+        type: 'error',
+        title: 'Could not save',
+        message: err.message || 'Failed to save topics.',
+      })
+    },
+  })
+
+  const reset = () => {
+    setSelectedIds(selectedTopics.map((t) => t._id))
+    setNewTitle('')
+    setNewColor('#2563EB')
+    setError(null)
+    setSubmitError(null)
+  }
+  const openModal = () => {
+    reset()
+    setIsOpen(true)
+  }
+  const closeModal = () => {
+    setIsOpen(false)
+    reset()
+  }
+
+  const toggle = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    )
+    setError(null)
+  }
+
+  const createTopic = () => {
+    const title = newTitle.trim()
+    if (title === '') {
+      setError('Enter a title for the new topic.')
+      return
+    }
+    createMutation.mutate({ title, color: newColor })
+  }
+
+  const handleSave = () => {
+    setSubmitError(null)
+    if (selectedIds.length === 0) {
+      setError('At least one topic is required.')
+      return
+    }
+    saveMutation.mutate({ topics: selectedIds })
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openModal}
+        aria-label="Edit Topics"
+        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+      >
+        <PencilSquareIcon className="h-5 w-5" />
+      </button>
+
+      <ModalShell
+        isOpen={isOpen}
+        onClose={closeModal}
+        size="lg"
+        title="Edit Topics"
+        subtitle="Topics available for CFP submissions and the agenda"
+        icon={<PencilSquareIcon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty && !saveMutation.isPending}
+      >
+        <form
+          noValidate
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSave()
+          }}
+          className="space-y-4"
+        >
+          <fieldset>
+            <legend className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+              Select topics
+            </legend>
+            <ul className="max-h-64 space-y-1 overflow-auto rounded-lg border border-gray-200 p-2 dark:border-gray-700">
+              {topics.length === 0 ? (
+                <li className="px-2 py-2 text-sm text-gray-500 dark:text-gray-400">
+                  No topics yet — create one below.
+                </li>
+              ) : (
+                topics.map((topic) => {
+                  const cid = `topic-${topic._id}`
+                  return (
+                    <li key={topic._id}>
+                      <label
+                        htmlFor={cid}
+                        className="flex min-h-[44px] cursor-pointer items-center gap-2 rounded-md px-2 text-sm text-gray-800 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                      >
+                        <input
+                          id={cid}
+                          type="checkbox"
+                          checked={selectedIds.includes(topic._id)}
+                          onChange={() => toggle(topic._id)}
+                          className="h-5 w-5 rounded border-gray-300 text-brand-cloud-blue focus:ring-brand-cloud-blue"
+                        />
+                        <ColorChip color={topic.color} />
+                        <span className="truncate">{topic.title}</span>
+                      </label>
+                    </li>
+                  )
+                })
+              )}
+            </ul>
+          </fieldset>
+
+          <fieldset className="rounded-lg border border-dashed border-gray-300 p-3 dark:border-gray-600">
+            <legend className="px-1 text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+              New topic
+            </legend>
+            <div className="flex flex-wrap items-end gap-2">
+              <div className="min-w-0 flex-1">
+                <label
+                  htmlFor="new-topic-title"
+                  className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                >
+                  Title
+                </label>
+                <input
+                  id="new-topic-title"
+                  type="text"
+                  value={newTitle}
+                  onChange={(e) => setNewTitle(e.target.value)}
+                  placeholder="e.g. Platform Engineering"
+                  className="block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="new-topic-color"
+                  className="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400"
+                >
+                  Color
+                </label>
+                <input
+                  id="new-topic-color"
+                  type="color"
+                  value={newColor}
+                  onChange={(e) => setNewColor(e.target.value)}
+                  aria-label="New topic color"
+                  className="h-11 w-14 cursor-pointer rounded-lg border border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700"
+                />
+              </div>
+              <AdminButton
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={createTopic}
+                disabled={createMutation.isPending}
+                className="min-h-[44px]"
+              >
+                <PlusIcon className="mr-1 h-4 w-4" />
+                {createMutation.isPending ? 'Adding…' : 'Add'}
+              </AdminButton>
+            </div>
+          </fieldset>
+
+          {error ? (
+            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+              {error}
+            </p>
+          ) : null}
+          {submitError ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+            <AdminButton
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={closeModal}
+              disabled={saveMutation.isPending}
+              className="min-h-[44px]"
+            >
+              Cancel
+            </AdminButton>
+            <AdminButton
+              type="submit"
+              color="blue"
+              size="md"
+              disabled={saveMutation.isPending || !isDirty}
+              className="min-h-[44px]"
+            >
+              {saveMutation.isPending ? 'Saving…' : 'Save topics'}
+            </AdminButton>
+          </div>
+        </form>
+      </ModalShell>
+    </>
+  )
+}

--- a/src/components/admin/editConferenceRefs.test.ts
+++ b/src/components/admin/editConferenceRefs.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateOrganizers,
+  slugifyTeamKey,
+  isValidTeamKeyClient,
+  validateTeams,
+  buildTeamsPayload,
+  type TeamFormRow,
+} from './editConferenceRefs'
+
+describe('validateOrganizers', () => {
+  it('accepts a list that includes the caller', () => {
+    expect(validateOrganizers(['sp-1', 'sp-2'], 'sp-1')).toBeNull()
+  })
+
+  it('rejects an empty list', () => {
+    expect(validateOrganizers([], 'sp-1')).toMatch(/at least one organizer/i)
+  })
+
+  it('rejects removing yourself', () => {
+    expect(validateOrganizers(['sp-2', 'sp-3'], 'sp-1')).toMatch(
+      /cannot remove yourself/i,
+    )
+  })
+})
+
+describe('slugifyTeamKey', () => {
+  it('kebab-cases a title', () => {
+    expect(slugifyTeamKey('CFP Team')).toBe('cfp-team')
+    expect(slugifyTeamKey('  Sponsors & Sales  ')).toBe('sponsors-sales')
+  })
+
+  it('collapses repeats and trims dashes', () => {
+    expect(slugifyTeamKey('A -- B')).toBe('a-b')
+  })
+})
+
+describe('isValidTeamKeyClient', () => {
+  it('accepts kebab-case', () => {
+    expect(isValidTeamKeyClient('cfp')).toBe(true)
+    expect(isValidTeamKeyClient('team-2')).toBe(true)
+  })
+  it('rejects non-kebab', () => {
+    expect(isValidTeamKeyClient('CFP')).toBe(false)
+    expect(isValidTeamKeyClient('a--b')).toBe(false)
+    expect(isValidTeamKeyClient('-a')).toBe(false)
+    expect(isValidTeamKeyClient('')).toBe(false)
+  })
+})
+
+function row(overrides: Partial<TeamFormRow>): TeamFormRow {
+  return {
+    _key: 'k',
+    key: 'cfp',
+    title: 'CFP',
+    members: ['sp-1'],
+    slackChannel: '',
+    emailIdentity: '',
+    ...overrides,
+  }
+}
+
+describe('validateTeams', () => {
+  const organizers = ['sp-1', 'sp-2']
+
+  it('accepts a valid team', () => {
+    expect(validateTeams([row({})], organizers)).toEqual({})
+  })
+
+  it('flags a missing title', () => {
+    const errs = validateTeams([row({ title: '  ' })], organizers)
+    expect(errs['0.title']).toBeTruthy()
+  })
+
+  it('flags a non-kebab key', () => {
+    const errs = validateTeams([row({ key: 'CFP Team' })], organizers)
+    expect(errs['0.key']).toMatch(/kebab/i)
+  })
+
+  it('flags duplicate keys on both rows', () => {
+    const errs = validateTeams(
+      [
+        row({ _key: 'a', key: 'cfp' }),
+        row({ _key: 'b', key: 'cfp', members: ['sp-2'] }),
+      ],
+      organizers,
+    )
+    expect(errs['0.key']).toMatch(/duplicate/i)
+    expect(errs['1.key']).toMatch(/duplicate/i)
+  })
+
+  it('flags an empty member list', () => {
+    const errs = validateTeams([row({ members: [] })], organizers)
+    expect(errs['0.members']).toMatch(/at least one member/i)
+  })
+
+  it('flags a member who is not an organizer (subset)', () => {
+    const errs = validateTeams([row({ members: ['sp-9'] })], organizers)
+    expect(errs['0.members']).toMatch(/must be organizers/i)
+  })
+})
+
+describe('buildTeamsPayload', () => {
+  it('trims and drops empty optionals; forwards a real _key', () => {
+    const payload = buildTeamsPayload([
+      row({
+        _key: 'real-key',
+        key: ' cfp ',
+        title: ' CFP ',
+        slackChannel: '  ',
+        emailIdentity: '',
+      }),
+    ])
+    expect(payload[0]).toEqual({
+      key: 'cfp',
+      title: 'CFP',
+      members: ['sp-1'],
+      _key: 'real-key',
+    })
+  })
+
+  it('includes slackChannel and a single-element emailIdentity array', () => {
+    const payload = buildTeamsPayload([
+      row({ slackChannel: '#cfp', emailIdentity: 'cfpEmail' }),
+    ])
+    expect(payload[0].slackChannel).toBe('#cfp')
+    expect(payload[0].emailIdentity).toEqual(['cfpEmail'])
+  })
+
+  it('strips a temp _key so the server re-keys', () => {
+    const payload = buildTeamsPayload([row({ _key: 'tmp-3' })])
+    expect(payload[0]).not.toHaveProperty('_key')
+  })
+})

--- a/src/components/admin/editConferenceRefs.ts
+++ b/src/components/admin/editConferenceRefs.ts
@@ -1,0 +1,138 @@
+/**
+ * Pure, React-free helpers for the SE-2 reference/teams editors
+ * ({@link ./OrganizersEditor}, {@link ./TopicsEditor}, {@link ./TeamsEditor}).
+ * Extracted so payload-shaping and validation are unit-testable under vitest
+ * without rendering — the components wire these into form state and the tests
+ * assert them directly (the SE-1b `editConferenceLists` pattern).
+ *
+ * The SERVER (conference router + zod schemas) is the authority; these mirror it
+ * for immediate client feedback only.
+ */
+
+import { TEAM_KEY_PATTERN } from '@/lib/teams/validation'
+import type { TeamEmailIdentity } from '@/lib/teams/types'
+
+/** A `_key` minted client-side for a brand-new row; the server re-keys these. */
+export const TEMP_KEY_PREFIX = 'tmp-'
+
+/** The three conference email identities a team may send as. */
+export const TEAM_EMAIL_IDENTITY_OPTIONS: readonly {
+  value: TeamEmailIdentity
+  title: string
+}[] = [
+  { value: 'contactEmail', title: 'Contact Email' },
+  { value: 'cfpEmail', title: 'CFP Email' },
+  { value: 'sponsorEmail', title: 'Sponsor Email' },
+]
+
+// === Organizers ============================================================
+
+/**
+ * Validate the organizer id list against the acting organizer's id. Mirrors the
+ * server: non-empty ALWAYS, and the caller may not remove THEMSELVES (that would
+ * revoke their own admin access). Removing other organizers is allowed.
+ */
+export function validateOrganizers(
+  ids: string[],
+  selfId: string,
+): string | null {
+  if (ids.length === 0) return 'At least one organizer is required'
+  if (!ids.includes(selfId)) {
+    return 'You cannot remove yourself from the organizer team'
+  }
+  return null
+}
+
+// === Team key ==============================================================
+
+/** Reduce a title to a lowercase kebab-case team key candidate. */
+export function slugifyTeamKey(title: string): string {
+  return (title ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+/** True when `key` is a non-empty lowercase kebab-case string. */
+export function isValidTeamKeyClient(key: string): boolean {
+  return TEAM_KEY_PATTERN.test(key)
+}
+
+// === Teams =================================================================
+
+/** A team row in the editor's form state (single-select email identity). */
+export interface TeamFormRow {
+  _key: string
+  key: string
+  title: string
+  members: string[]
+  slackChannel: string
+  /** Single-select in the UI; serialized to a 0/1-length array on save. */
+  emailIdentity: '' | TeamEmailIdentity
+}
+
+/** The wire shape one team is submitted as. */
+export interface TeamPayload {
+  key: string
+  title: string
+  members: string[]
+  slackChannel?: string
+  emailIdentity?: TeamEmailIdentity[]
+  _key?: string
+}
+
+/**
+ * Validate the whole teams form against the current organizer id set. Errors are
+ * keyed `<rowIndex>.<field>` (`title`, `key`, `members`). Mirrors the server:
+ *   - title required
+ *   - key required, kebab-case, UNIQUE across rows
+ *   - members ≥1 and every member ∈ organizers (subset)
+ */
+export function validateTeams(
+  rows: TeamFormRow[],
+  organizerIds: string[],
+): Record<string, string> {
+  const errs: Record<string, string> = {}
+  const organizerSet = new Set(organizerIds)
+  const keyCounts = new Map<string, number>()
+  for (const r of rows) {
+    const k = r.key.trim()
+    if (k) keyCounts.set(k, (keyCounts.get(k) ?? 0) + 1)
+  }
+  rows.forEach((row, i) => {
+    if (row.title.trim() === '') errs[`${i}.title`] = 'Title is required'
+    const key = row.key.trim()
+    if (key === '') {
+      errs[`${i}.key`] = 'Key is required'
+    } else if (!isValidTeamKeyClient(key)) {
+      errs[`${i}.key`] = 'Key must be lowercase kebab-case'
+    } else if ((keyCounts.get(key) ?? 0) > 1) {
+      errs[`${i}.key`] = `Duplicate key "${key}"`
+    }
+    if (row.members.length === 0) {
+      errs[`${i}.members`] = 'A team needs at least one member'
+    } else if (row.members.some((m) => !organizerSet.has(m))) {
+      errs[`${i}.members`] = 'Members must be organizers of this conference'
+    }
+  })
+  return errs
+}
+
+/** Shape the teams form into the mutation payload (drops empty optionals). */
+export function buildTeamsPayload(rows: TeamFormRow[]): TeamPayload[] {
+  return rows.map((row) => {
+    const slack = row.slackChannel.trim()
+    const payload: TeamPayload = {
+      key: row.key.trim(),
+      title: row.title.trim(),
+      members: row.members,
+    }
+    if (slack !== '') payload.slackChannel = slack
+    if (row.emailIdentity !== '') payload.emailIdentity = [row.emailIdentity]
+    if (row._key && !row._key.startsWith(TEMP_KEY_PREFIX)) {
+      payload._key = row._key
+    }
+    return payload
+  })
+}

--- a/src/lib/topic/create.test.ts
+++ b/src/lib/topic/create.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import {
+  defaultTopicColor,
+  slugifyTopicTitle,
+  TOPIC_COLOR_PALETTE,
+  FALLBACK_TOPIC_SLUG,
+} from './create'
+
+describe('defaultTopicColor', () => {
+  it('is deterministic for a given title', () => {
+    expect(defaultTopicColor('Security')).toBe(defaultTopicColor('Security'))
+  })
+
+  it('always returns a palette color', () => {
+    for (const title of ['a', 'Platform Engineering', 'Observability', '']) {
+      expect(TOPIC_COLOR_PALETTE).toContain(defaultTopicColor(title))
+    }
+  })
+})
+
+describe('slugifyTopicTitle', () => {
+  it('lowercases and kebab-cases', () => {
+    expect(slugifyTopicTitle('Platform Engineering')).toBe(
+      'platform-engineering',
+    )
+    expect(slugifyTopicTitle('  AI / ML  ')).toBe('ai-ml')
+  })
+
+  it('falls back for a title with no slug-safe characters', () => {
+    expect(slugifyTopicTitle('🎉')).toBe(FALLBACK_TOPIC_SLUG)
+    expect(slugifyTopicTitle('')).toBe(FALLBACK_TOPIC_SLUG)
+  })
+
+  it('caps length at 96 characters', () => {
+    expect(slugifyTopicTitle('a'.repeat(200)).length).toBeLessThanOrEqual(96)
+  })
+})

--- a/src/lib/topic/create.ts
+++ b/src/lib/topic/create.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure helpers for creating a topic (SE-2). Kept free of any Sanity/server
+ * import so both the `topic` router and unit tests can use them.
+ */
+
+/**
+ * Default chip colors assigned round-robin (by title hash) when an admin creates
+ * a topic without picking one. The Sanity topic schema REQUIRES a color, so we
+ * never persist an empty one; a deterministic hash keeps distinct topics
+ * visually distinguishable without a color picker in the minimal create flow.
+ */
+export const TOPIC_COLOR_PALETTE = [
+  '#2563EB', // blue
+  '#16A34A', // green
+  '#DC2626', // red
+  '#D97706', // amber
+  '#7C3AED', // violet
+  '#DB2777', // pink
+  '#0891B2', // cyan
+  '#4B5563', // gray
+] as const
+
+/** Deterministic default color for a title (stable across calls). */
+export function defaultTopicColor(title: string): string {
+  let hash = 0
+  for (let i = 0; i < title.length; i++) {
+    hash = (hash * 31 + title.charCodeAt(i)) | 0
+  }
+  const index = Math.abs(hash) % TOPIC_COLOR_PALETTE.length
+  return TOPIC_COLOR_PALETTE[index]
+}
+
+/** Stable fallback when a title reduces to an empty slug. */
+export const FALLBACK_TOPIC_SLUG = 'topic'
+
+/**
+ * Reduce a topic title to a URL-safe lowercase slug. Never empty: falls back to
+ * {@link FALLBACK_TOPIC_SLUG} for a title with no slug-safe characters.
+ */
+export function slugifyTopicTitle(title: string): string {
+  const base = (title ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return (base || FALLBACK_TOPIC_SLUG).slice(0, 96)
+}

--- a/src/server/_app.ts
+++ b/src/server/_app.ts
@@ -18,6 +18,7 @@ import { notificationRouter } from './routers/notification'
 import { pushRouter } from './routers/push'
 import { messageRouter } from './routers/message'
 import { conferenceRouter } from './routers/conference'
+import { topicRouter } from './routers/topic'
 import { sponsorMessagesRouter } from './routers/sponsorMessages'
 
 export const appRouter = router({
@@ -40,6 +41,7 @@ export const appRouter = router({
   push: pushRouter,
   message: messageRouter,
   conference: conferenceRouter,
+  topic: topicRouter,
   sponsorMessages: sponsorMessagesRouter,
 })
 

--- a/src/server/routers/conference.test.ts
+++ b/src/server/routers/conference.test.ts
@@ -21,6 +21,8 @@ vi.mock('@/lib/conference/sanity', () => ({
 
 // --- Sanity write client: capture the patch shape ---------------------------
 const commitMock = vi.fn()
+// Drives clientReadUncached.fetch — updateTeams reads the current organizer ids.
+const uncachedFetchMock = vi.fn()
 let lastPatchId: string | undefined
 let lastSet: Record<string, unknown> | undefined
 let lastUnset: string[] | undefined
@@ -48,6 +50,15 @@ vi.mock('@/lib/sanity/client', () => ({
       return builder
     },
   },
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => uncachedFetchMock(...args),
+  },
+}))
+
+// The teams cache clear is a side effect updateTeams performs on success.
+const clearTeamsCacheMock = vi.fn()
+vi.mock('@/lib/teams', () => ({
+  clearConferenceTeamsCache: () => clearTeamsCacheMock(),
 }))
 
 import { conferenceRouter } from './conference'
@@ -73,6 +84,8 @@ beforeEach(() => {
   lastSetIfMissing = undefined
   hostMock.mockReturnValue('cloudnativebergen.no')
   commitMock.mockResolvedValue({ _id: CONFERENCE_ID })
+  // Default organizer set for the teams subset check: the caller (sp-1) + sp-2.
+  uncachedFetchMock.mockResolvedValue(['sp-1', 'sp-2'])
   getConferenceMock.mockResolvedValue({
     conference: { _id: CONFERENCE_ID },
     error: null,
@@ -471,5 +484,177 @@ describe('conference router — domains (safeguarded)', () => {
       domains: [`${CURRENT.toUpperCase()}`, 'Other.Example.COM'],
     })
     expect(lastSet).toEqual({ domains: [CURRENT, 'other.example.com'] })
+  })
+})
+
+// === SE-2: organizers, topics, teams & announcement ========================
+
+describe('conference router — organizers (self-lockout guard)', () => {
+  it('rejects removing yourself (BAD_REQUEST with the exact message)', async () => {
+    // Caller is sp-1; a payload that omits sp-1 would revoke their own access.
+    await expect(
+      makeCaller({ isOrganizer: true }).updateOrganizers({
+        organizers: ['sp-2', 'sp-3'],
+      }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'You cannot remove yourself from the organizer team',
+    })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('allows removing OTHER organizers while keeping yourself', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateOrganizers({
+      organizers: ['sp-1', 'sp-3'],
+    })
+    expect(result.success).toBe(true)
+    const rows = lastSet!.organizers as Array<Record<string, unknown>>
+    expect(rows.map((r) => r._ref)).toEqual(['sp-1', 'sp-3'])
+    expect(rows.every((r) => r._type === 'reference')).toBe(true)
+    expect(rows.every((r) => typeof r._key === 'string')).toBe(true)
+  })
+
+  it('rejects an empty organizer list (non-empty ALWAYS)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateOrganizers({ organizers: [] }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects duplicate organizer ids', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateOrganizers({
+        organizers: ['sp-1', 'sp-1'],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('conference router — topics', () => {
+  it('replaces the topics reference array (keyed references)', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateTopics({
+      topics: ['topic-a', 'topic-b'],
+    })
+    expect(result.success).toBe(true)
+    const rows = lastSet!.topics as Array<Record<string, unknown>>
+    expect(rows.map((r) => r._ref)).toEqual(['topic-a', 'topic-b'])
+    expect(rows.every((r) => r._type === 'reference')).toBe(true)
+  })
+
+  it('rejects an empty topic list (min 1)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateTopics({ topics: [] }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects duplicate topic ids', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateTopics({
+        topics: ['topic-a', 'topic-a'],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('conference router — teams', () => {
+  const validTeam = {
+    key: 'cfp',
+    title: 'CFP Team',
+    members: ['sp-1'],
+  }
+
+  it('saves teams, keys members, and clears the teams cache', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateTeams({
+      teams: [
+        { ...validTeam, slackChannel: '#cfp', emailIdentity: ['cfpEmail'] },
+      ],
+    })
+    expect(result.success).toBe(true)
+    const rows = lastSet!.teams as Array<Record<string, unknown>>
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      key: 'cfp',
+      title: 'CFP Team',
+      slackChannel: '#cfp',
+      emailIdentity: ['cfpEmail'],
+    })
+    const members = rows[0].members as Array<Record<string, unknown>>
+    expect(members[0]).toMatchObject({ _type: 'reference', _ref: 'sp-1' })
+    expect(typeof rows[0]._key).toBe('string')
+    expect(clearTeamsCacheMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('enforces the member ⊆ organizers subset (BAD_REQUEST, no commit)', async () => {
+    // sp-9 is not in the organizer set (['sp-1','sp-2']).
+    await expect(
+      makeCaller({ isOrganizer: true }).updateTeams({
+        teams: [{ key: 'cfp', title: 'CFP', members: ['sp-9'] }],
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(commitMock).not.toHaveBeenCalled()
+    expect(clearTeamsCacheMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-kebab key', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateTeams({
+        teams: [{ key: 'CFP Team', title: 'CFP', members: ['sp-1'] }],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects duplicate team keys', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateTeams({
+        teams: [
+          { key: 'cfp', title: 'One', members: ['sp-1'] },
+          { key: 'cfp', title: 'Two', members: ['sp-2'] },
+        ],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a team with no members', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateTeams({
+        teams: [{ key: 'cfp', title: 'CFP', members: [] }],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('conference router — announcement', () => {
+  it('sets the portable-text blocks (with keys) when non-empty', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateAnnouncement({
+      announcement: [
+        { _type: 'block', children: [{ _type: 'span', text: 'Hi' }] },
+      ],
+    })
+    expect(result.success).toBe(true)
+    const blocks = lastSet!.announcement as Array<Record<string, unknown>>
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ _type: 'block' })
+    expect(typeof blocks[0]._key).toBe('string')
+  })
+
+  it('UNSETS the field when given an empty array', async () => {
+    await makeCaller({ isOrganizer: true }).updateAnnouncement({
+      announcement: [],
+    })
+    expect(lastUnset).toEqual(['announcement'])
+    expect(lastSet).toBeUndefined()
+  })
+
+  it('UNSETS the field when given null', async () => {
+    await makeCaller({ isOrganizer: true }).updateAnnouncement({
+      announcement: null,
+    })
+    expect(lastUnset).toEqual(['announcement'])
   })
 })

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -2,8 +2,9 @@ import { TRPCError } from '@trpc/server'
 import { revalidateTag } from 'next/cache'
 import { headers } from 'next/headers'
 import { router, adminProcedure, resolveConferenceId } from '../trpc'
-import { clientWrite } from '@/lib/sanity/client'
-import { ensureArrayKeys } from '@/lib/sanity/helpers'
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { ensureArrayKeys, createReferenceWithKey } from '@/lib/sanity/helpers'
+import { clearConferenceTeamsCache } from '@/lib/teams'
 import {
   CANNOT_REMOVE_CURRENT_DOMAIN,
   domainsWouldStrandHost,
@@ -22,7 +23,15 @@ import {
   UpdateSponsorBenefitsSchema,
   UpdateSponsorshipCustomizationSchema,
   UpdateDomainsSchema,
+  UpdateOrganizersSchema,
+  UpdateTopicsSchema,
+  UpdateTeamsSchema,
+  UpdateAnnouncementSchema,
 } from '../schemas/conference'
+
+/** The message the self-lockout guard rejects a self-removal with. */
+export const CANNOT_REMOVE_SELF_ORGANIZER =
+  'You cannot remove yourself from the organizer team'
 
 /**
  * Field-scoped conference settings mutations (SE-1a).
@@ -219,5 +228,116 @@ export const conferenceRouter = router({
         })
       }
       return applyConferencePatch(conferenceId, { domains: input.domains })
+    }),
+
+  // === SE-2: organizers, topics, teams & announcement ======================
+
+  /**
+   * SAFEGUARDED. `organizers[]` is the CANONICAL organizer set — it drives
+   * `/admin` access and notification fan-out. Removing someone revokes their
+   * admin access on their next session refresh.
+   *
+   * SELF-LOCKOUT GUARD: the acting organizer cannot remove THEMSELVES (they'd
+   * lose their own admin access mid-edit). Removing OTHER organizers is allowed.
+   * The guard binds to the server-derived caller identity (`ctx.speaker._id`),
+   * so a crafted payload cannot bypass it. Non-empty + uniqueness are enforced by
+   * the schema.
+   */
+  updateOrganizers: adminProcedure
+    .input(UpdateOrganizersSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!input.organizers.includes(ctx.speaker._id)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: CANNOT_REMOVE_SELF_ORGANIZER,
+        })
+      }
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, {
+        organizers: input.organizers.map((id) =>
+          createReferenceWithKey(id, 'organizer'),
+        ),
+      })
+    }),
+
+  updateTopics: adminProcedure
+    .input(UpdateTopicsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, {
+        topics: input.topics.map((id) => createReferenceWithKey(id, 'topic')),
+      })
+    }),
+
+  /**
+   * Organizer teams — a SOFT LENS over the organizer set (routing / mail
+   * defaults), NEVER an access boundary. Full-array replace.
+   *
+   * SUBSET ENFORCEMENT: every team member must be one of THIS conference's
+   * current organizers. The Sanity schema only documents this (Studio filters
+   * the picker); the router ENFORCES it against the live organizer set so a
+   * crafted payload cannot add a non-organizer. Key uniqueness/kebab and
+   * members≥1 come from the schema.
+   *
+   * On success the per-instance teams cache is cleared so routing/lenses observe
+   * the change immediately on this instance (other instances refresh within the
+   * cache TTL).
+   */
+  updateTeams: adminProcedure
+    .input(UpdateTeamsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      const organizerIds = await clientReadUncached.fetch<string[] | null>(
+        `*[_type == "conference" && _id == $id][0].organizers[]._ref`,
+        { id: conferenceId },
+      )
+      const organizerSet = new Set(organizerIds ?? [])
+      for (const team of input.teams) {
+        const strays = team.members.filter((m) => !organizerSet.has(m))
+        if (strays.length > 0) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: `Team "${team.title}" has ${strays.length} member${
+              strays.length === 1 ? '' : 's'
+            } who ${strays.length === 1 ? 'is' : 'are'} not an organizer of this conference`,
+          })
+        }
+      }
+      const teams = ensureArrayKeys(
+        input.teams.map((team) => ({
+          _type: 'organizerTeam',
+          key: team.key,
+          title: team.title,
+          members: team.members.map((id) =>
+            createReferenceWithKey(id, 'member'),
+          ),
+          ...(team.slackChannel ? { slackChannel: team.slackChannel } : {}),
+          ...(team.emailIdentity && team.emailIdentity.length > 0
+            ? { emailIdentity: team.emailIdentity }
+            : {}),
+          ...(team._key ? { _key: team._key } : {}),
+        })),
+        'team',
+      )
+      const result = await applyConferencePatch(conferenceId, { teams })
+      // Routing/lenses read a short-TTL per-instance cache; clear it so this
+      // instance reflects the edit without waiting out the TTL.
+      clearConferenceTeamsCache()
+      return result
+    }),
+
+  /**
+   * Announcement rich text (portable text). A full replace; an empty/`null`
+   * array UNSETS the field so the landing-page banner stops rendering (see
+   * `Hero.tsx`).
+   */
+  updateAnnouncement: adminProcedure
+    .input(UpdateAnnouncementSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      const blocks = input.announcement
+      const value =
+        !blocks || blocks.length === 0 ? null : ensureArrayKeys(blocks, 'block')
+      return applyConferencePatch(conferenceId, { announcement: value })
     }),
 })

--- a/src/server/routers/topic.test.ts
+++ b/src/server/routers/topic.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+// Sanity clients: capture writes and drive reads (slug probe + ref counts).
+const createMock = vi.fn()
+const deleteMock = vi.fn()
+const commitMock = vi.fn()
+const fetchMock = vi.fn()
+let lastPatchId: string | undefined
+let lastSet: Record<string, unknown> | undefined
+let lastUnset: string[] | undefined
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    create: (doc: Record<string, unknown>) => createMock(doc),
+    delete: (id: string) => deleteMock(id),
+    patch: (id: string) => {
+      lastPatchId = id
+      const builder = {
+        set: (obj: Record<string, unknown>) => {
+          lastSet = obj
+          return builder
+        },
+        unset: (keys: string[]) => {
+          lastUnset = keys
+          return builder
+        },
+        commit: () => commitMock(),
+      }
+      return builder
+    },
+  },
+  clientReadUncached: {
+    fetch: (query: string, params?: Record<string, unknown>) =>
+      fetchMock(query, params),
+  },
+}))
+
+import { topicRouter } from './topic'
+
+function makeCaller(isOrganizer = true) {
+  const speaker = { _id: 'sp-1', name: 'Org', isOrganizer }
+  const ctx = {
+    session: { speaker, user: { name: 'Org' } },
+    speaker,
+  } as unknown as Context
+  return topicRouter.createCaller(ctx)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  lastPatchId = undefined
+  lastSet = undefined
+  lastUnset = undefined
+  commitMock.mockResolvedValue({ _id: 'topic-1' })
+  createMock.mockResolvedValue({ _id: 'topic-new', color: '#2563EB' })
+  deleteMock.mockResolvedValue({})
+  // Default reads: no slug clash, and no references (counts = 0).
+  fetchMock.mockImplementation((query: string) => {
+    if (query.includes('slug.current')) return Promise.resolve(null)
+    if (query.includes('count(')) return Promise.resolve(0)
+    return Promise.resolve([])
+  })
+})
+
+describe('topic router — authorization', () => {
+  it('rejects a non-organizer (FORBIDDEN)', async () => {
+    await expect(
+      makeCaller(false).create({ title: 'X' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('topic router — create', () => {
+  it('creates a topic with a derived slug and a default color', async () => {
+    const result = await makeCaller().create({ title: 'Platform Engineering' })
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const doc = createMock.mock.calls[0][0]
+    expect(doc._type).toBe('topic')
+    expect(doc.title).toBe('Platform Engineering')
+    expect(doc.slug).toEqual({
+      _type: 'slug',
+      current: 'platform-engineering',
+    })
+    expect(doc.color).toMatch(/^#[0-9A-Fa-f]{6}$/)
+    expect(result._id).toBe('topic-new')
+  })
+
+  it('honors an explicit color', async () => {
+    await makeCaller().create({ title: 'Security', color: '#FF0000' })
+    expect(createMock.mock.calls[0][0].color).toBe('#FF0000')
+  })
+
+  it('probes for a unique slug on collision', async () => {
+    // First slug probe hits an existing doc; the second is free.
+    let calls = 0
+    fetchMock.mockImplementation((query: string) => {
+      if (query.includes('slug.current')) {
+        calls += 1
+        return Promise.resolve(calls === 1 ? 'existing-id' : null)
+      }
+      return Promise.resolve(0)
+    })
+    await makeCaller().create({ title: 'Security' })
+    expect(createMock.mock.calls[0][0].slug.current).toBe('security-2')
+  })
+
+  it('rejects a blank title', async () => {
+    await expect(makeCaller().create({ title: '   ' })).rejects.toBeTruthy()
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid hex color', async () => {
+    await expect(
+      makeCaller().create({ title: 'X', color: 'blue' }),
+    ).rejects.toBeTruthy()
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('topic router — update', () => {
+  it('patches only provided fields; unsets description on null', async () => {
+    await makeCaller().update({
+      id: 'topic-1',
+      title: 'Renamed',
+      description: null,
+    })
+    expect(lastPatchId).toBe('topic-1')
+    expect(lastSet).toEqual({ title: 'Renamed' })
+    expect(lastUnset).toEqual(['description'])
+  })
+
+  it('does not regenerate the slug on rename (stable URL)', async () => {
+    await makeCaller().update({ id: 'topic-1', title: 'Renamed' })
+    expect(lastSet).not.toHaveProperty('slug')
+  })
+
+  it('rejects an update with nothing to change', async () => {
+    await expect(makeCaller().update({ id: 'topic-1' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('topic router — delete (reference guard)', () => {
+  it('deletes an unreferenced topic', async () => {
+    const result = await makeCaller().delete({ id: 'topic-1' })
+    expect(result.success).toBe(true)
+    expect(deleteMock).toHaveBeenCalledWith('topic-1')
+  })
+
+  it('refuses to delete a referenced topic, naming the counts', async () => {
+    fetchMock.mockImplementation((query: string) => {
+      if (query.includes('_type == "talk"')) return Promise.resolve(3)
+      if (query.includes('_type == "conference"')) return Promise.resolve(1)
+      return Promise.resolve(null)
+    })
+    await expect(makeCaller().delete({ id: 'topic-1' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    })
+    try {
+      await makeCaller().delete({ id: 'topic-1' })
+    } catch (e) {
+      expect((e as Error).message).toContain('3 talks')
+      expect((e as Error).message).toContain('1 conference')
+    }
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses when only talks reference it', async () => {
+    fetchMock.mockImplementation((query: string) => {
+      if (query.includes('_type == "talk"')) return Promise.resolve(1)
+      if (query.includes('_type == "conference"')) return Promise.resolve(0)
+      return Promise.resolve(null)
+    })
+    await expect(makeCaller().delete({ id: 'topic-1' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    })
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/routers/topic.ts
+++ b/src/server/routers/topic.ts
@@ -1,0 +1,164 @@
+import { TRPCError } from '@trpc/server'
+import { revalidateTag } from 'next/cache'
+import { router, adminProcedure } from '../trpc'
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import {
+  TopicCreateSchema,
+  TopicUpdateSchema,
+  TopicDeleteSchema,
+} from '../schemas/topic'
+import { defaultTopicColor, slugifyTopicTitle } from '@/lib/topic/create'
+import type { Topic } from '@/lib/topic/types'
+
+/**
+ * Topic CRUD (SE-2). Topics are standalone documents referenced by
+ * `conference.topics[]` and `talk.topics[]`. This router replaces editing them
+ * in Sanity Studio; `conference.updateTopics` (the conference router) manages
+ * which topics a conference references.
+ *
+ * DELETE GUARD: a topic that is still referenced by any talk or conference is
+ * refused (BAD_REQUEST naming the count) — deleting it would strand those
+ * references. The count is read fresh (uncached) so the guard is never stale.
+ */
+
+/** Reduce a title to a slug that does not collide with an existing topic. */
+async function uniqueTopicSlug(title: string): Promise<string> {
+  const base = slugifyTopicTitle(title)
+  let candidate = base
+  for (let suffix = 2; suffix < 1000; suffix++) {
+    const clash = await clientReadUncached.fetch<string | null>(
+      `*[_type == "topic" && slug.current == $slug][0]._id`,
+      { slug: candidate },
+    )
+    if (!clash) return candidate
+    candidate = `${base.slice(0, 96 - 1 - String(suffix).length)}-${suffix}`
+  }
+  return `${base.slice(0, 80)}-${Date.now()}`
+}
+
+export const topicRouter = router({
+  /** Every topic, ordered by title — the pick-list source for the editor. */
+  list: adminProcedure.query(async () => {
+    const topics = await clientReadUncached.fetch<Topic[]>(
+      `*[_type == "topic"] | order(title asc){
+        _id,
+        _type,
+        title,
+        description,
+        color,
+        slug
+      }`,
+    )
+    return topics ?? []
+  }),
+
+  create: adminProcedure
+    .input(TopicCreateSchema)
+    .mutation(async ({ input }) => {
+      try {
+        const slug = await uniqueTopicSlug(input.title)
+        const created = await clientWrite.create({
+          _type: 'topic',
+          title: input.title,
+          color: input.color ?? defaultTopicColor(input.title),
+          slug: { _type: 'slug', current: slug },
+          ...(input.description ? { description: input.description } : {}),
+        })
+        revalidateTag('content:conferences', 'default')
+        return {
+          _id: created._id,
+          _type: 'topic' as const,
+          title: input.title,
+          color: (created.color as string) ?? defaultTopicColor(input.title),
+          description: input.description ?? undefined,
+          slug: { current: slug },
+        } satisfies Topic
+      } catch (error) {
+        if (error instanceof TRPCError) throw error
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to create topic',
+          cause: error,
+        })
+      }
+    }),
+
+  update: adminProcedure
+    .input(TopicUpdateSchema)
+    .mutation(async ({ input }) => {
+      const { id, ...rest } = input
+      const set: Record<string, unknown> = {}
+      const unset: string[] = []
+      // Slug is intentionally NOT regenerated on rename — it is a stable public
+      // identifier; changing it would break existing topic URLs.
+      if (rest.title !== undefined) set.title = rest.title
+      if (rest.color !== undefined) set.color = rest.color
+      if (rest.description === null) unset.push('description')
+      else if (rest.description !== undefined)
+        set.description = rest.description
+
+      if (Object.keys(set).length === 0 && unset.length === 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No updates provided',
+        })
+      }
+      try {
+        let patch = clientWrite.patch(id)
+        if (Object.keys(set).length > 0) patch = patch.set(set)
+        if (unset.length > 0) patch = patch.unset(unset)
+        await patch.commit()
+        revalidateTag('content:conferences', 'default')
+        return { success: true }
+      } catch (error) {
+        if (error instanceof TRPCError) throw error
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to update topic',
+          cause: error,
+        })
+      }
+    }),
+
+  delete: adminProcedure
+    .input(TopicDeleteSchema)
+    .mutation(async ({ input }) => {
+      const [talkCount, conferenceCount] = await Promise.all([
+        clientReadUncached.fetch<number>(
+          `count(*[_type == "talk" && references($id)])`,
+          { id: input.id },
+        ),
+        clientReadUncached.fetch<number>(
+          `count(*[_type == "conference" && references($id)])`,
+          { id: input.id },
+        ),
+      ])
+      const talks = talkCount ?? 0
+      const conferences = conferenceCount ?? 0
+      const total = talks + conferences
+      if (total > 0) {
+        const parts: string[] = []
+        if (talks > 0) parts.push(`${talks} talk${talks === 1 ? '' : 's'}`)
+        if (conferences > 0)
+          parts.push(`${conferences} conference${conferences === 1 ? '' : 's'}`)
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `Cannot delete a topic still referenced by ${parts.join(
+            ' and ',
+          )}. Remove those references first.`,
+        })
+      }
+      try {
+        await clientWrite.delete(input.id)
+        revalidateTag('content:conferences', 'default')
+        return { success: true }
+      } catch (error) {
+        if (error instanceof TRPCError) throw error
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to delete topic',
+          cause: error,
+        })
+      }
+    }),
+})

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { HEROICON_OPTIONS } from '../../../sanity/schemaTypes/constants'
 import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
+import { isValidTeamKey } from '@/lib/teams/validation'
 
 /**
  * Field-scoped conference settings schemas (SE-1a + SE-1b). Each schema mirrors
@@ -255,4 +256,114 @@ export const UpdateDomainsSchema = z.object({
         seen.add(entry)
       })
     }),
+})
+
+// === SE-2: reference arrays, teams & rich text ===========================
+
+/**
+ * A speaker `_id`. References are stored by the router as
+ * `{ _type: 'reference', _ref: <id>, _key }` — the client only ever sends the
+ * id string, never a whole reference object.
+ */
+const documentId = z.string().trim().min(1, 'An id is required')
+
+/**
+ * Organizers — the CANONICAL organizer set (auth + notification fan-out). A full
+ * replace of the reference array. Non-empty ALWAYS and de-duplicated. The
+ * self-lockout guard (the acting organizer may not remove themselves) needs the
+ * caller identity, so it lives in the router — see `updateOrganizers`.
+ */
+export const UpdateOrganizersSchema = z.object({
+  organizers: z
+    .array(documentId)
+    .min(1, 'At least one organizer is required')
+    .refine((ids) => new Set(ids).size === ids.length, {
+      message: 'Organizers must be unique',
+    }),
+})
+
+/**
+ * Topics — the conference's `topics[]` reference array. Mirrors the Sanity
+ * schema's `required().min(1).unique()`: at least one, no duplicates.
+ */
+export const UpdateTopicsSchema = z.object({
+  topics: z
+    .array(documentId)
+    .min(1, 'At least one topic is required')
+    .refine((ids) => new Set(ids).size === ids.length, {
+      message: 'Topics must be unique',
+    }),
+})
+
+/** The conference email identities a team's outbound mail may be sent as. */
+const TEAM_EMAIL_IDENTITIES = [
+  'contactEmail',
+  'cfpEmail',
+  'sponsorEmail',
+] as const
+
+/**
+ * Organizer teams — the `teams[]` object array (a SOFT LENS for routing, never
+ * an access boundary — see `src/lib/teams`). Full-array replace. Per team:
+ *   - `key`      lowercase kebab-case, UNIQUE within the list (checked below).
+ *   - `title`    required.
+ *   - `members`  ≥1 speaker ids; the SUBSET-of-organizers rule needs the current
+ *                organizer set, so it is enforced in the router.
+ *   - `slackChannel`  optional free text.
+ *   - `emailIdentity` 0..n of the three conference identities (the UI offers a
+ *                single select, but the field is an array per the Sanity schema).
+ */
+export const UpdateTeamsSchema = z.object({
+  teams: z
+    .array(
+      z.object({
+        key: z
+          .string()
+          .trim()
+          .min(1, 'Key is required')
+          .refine(isValidTeamKey, {
+            message:
+              'Key must be lowercase kebab-case (letters, numbers and single hyphens)',
+          }),
+        title: z.string().trim().min(1, 'Title is required'),
+        members: z
+          .array(documentId)
+          .min(1, 'A team needs at least one member')
+          .refine((ids) => new Set(ids).size === ids.length, {
+            message: 'Team members must be unique',
+          }),
+        slackChannel: z.string().trim().nullable().optional(),
+        emailIdentity: z.array(z.enum(TEAM_EMAIL_IDENTITIES)).optional(),
+        _key: z.string().optional(),
+      }),
+    )
+    .superRefine((teams, ctx) => {
+      const seen = new Set<string>()
+      teams.forEach((team, i) => {
+        if (seen.has(team.key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Duplicate team key "${team.key}" — keys must be unique`,
+            path: [i, 'key'],
+          })
+        }
+        seen.add(team.key)
+      })
+    }),
+})
+
+/**
+ * Announcement — the portable-text `announcement` field shown on the landing
+ * page (see `Hero.tsx`). A full replace; an empty/omitted array UNSETS the field
+ * (`null`) so the announcement banner stops rendering. Blocks are validated
+ * loosely (each carries a `_type`) — the shape is owned by the shared
+ * `PortableTextEditor`, whose schema (h1-h3, strong/em/underline, bullet/number
+ * lists, link) is the source of truth.
+ */
+const PortableTextBlockSchema = z
+  .object({ _type: z.string().min(1) })
+  .catchall(z.unknown())
+
+export const UpdateAnnouncementSchema = z.object({
+  announcement: z.array(PortableTextBlockSchema).nullable(),
 })

--- a/src/server/schemas/topic.ts
+++ b/src/server/schemas/topic.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+/**
+ * Schemas for the `topic` router (SE-2). Topics are standalone documents
+ * referenced by `conference.topics[]` and `talk.topics[]`; the admin now creates
+ * and edits them here instead of in Sanity Studio. Mirrors
+ * `sanity/schemaTypes/topic.ts`: `title` + `color` are required (color is a hex
+ * string), `description` is optional, and `slug` is derived from the title.
+ */
+
+/** Hex color, matching the Sanity topic schema (`#RGB` or `#RRGGBB`). */
+export const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+
+const hexColor = z
+  .string()
+  .trim()
+  .regex(HEX_COLOR_RE, 'Must be a valid hex color (e.g., #FF5733 or #F00)')
+
+export const TopicCreateSchema = z.object({
+  title: z.string().trim().min(1, 'Title is required'),
+  // Optional on the wire so the inline "New topic" affordance can be
+  // title-only; the router assigns a deterministic default when omitted (the
+  // Sanity schema requires a color).
+  color: hexColor.optional(),
+  description: z.string().trim().nullable().optional(),
+})
+
+export const TopicUpdateSchema = z.object({
+  id: z.string().trim().min(1, 'A topic id is required'),
+  title: z.string().trim().min(1, 'Title is required').optional(),
+  color: hexColor.optional(),
+  description: z.string().trim().nullable().optional(),
+})
+
+export const TopicDeleteSchema = z.object({
+  id: z.string().trim().min(1, 'A topic id is required'),
+})


### PR DESCRIPTION
## Summary

Continues the settings-tier **Studio elimination** (after SE-1a #568 / SE-1b #574). Makes the last four rich conference fieldsets editable from `/admin/settings` and adds a standalone **topic CRUD** router.

## What changed

### 1. Organizers — `conference.updateOrganizers` (self-lockout guard)
- Full replace of the `organizers[]` reference array. Non-empty ALWAYS + de-duped (schema).
- **Self-lockout guard (server authority):** the acting organizer (`ctx.speaker._id`, server-derived) **cannot remove themselves** → `BAD_REQUEST "You cannot remove yourself from the organizer team"`. Removing *other* organizers is allowed.
- UI: an object-list-like editor whose rows are speakers (name + avatar). Adds via the shared `SpeakerCombobox` (reuses `speaker.admin.search` — no new search surface). The caller's own row is **locked** (lock icon, no remove). Copy states that organizers get full admin access + team notifications and that removal revokes `/admin` on next session refresh.

### 2. Topics — new `topic` router + `conference.updateTopics`
- `topic` router (adminProcedure): `list`, `create` (`{title, color?}` — color defaults deterministically since the Sanity schema requires it; slug derived + collision-probed), `update` (slug intentionally NOT regenerated on rename — stable URL), `delete`.
- **Delete guard:** refuses to delete a topic still referenced by any talk/conference → `BAD_REQUEST` naming the count (e.g. *"…referenced by 3 talks and 1 conference"*). Counts read fresh (uncached).
- `conference.updateTopics`: ref-array multi-select with topic **color chips** + inline **New topic** creation in the same modal.

### 3. Teams — `conference.updateTeams` (subset enforcement + cache invalidation)
- Full replace of the `teams[]` object array (key/title/members/slackChannel/emailIdentity per `organizerTeam`).
- **Subset ENFORCED server-side:** every team member must be a current organizer of this conference (read fresh from `organizers[]._ref`) → `BAD_REQUEST`. Key uniqueness + kebab-case + members≥1 mirror the schema.
- On save the per-instance teams cache (`clearConferenceTeamsCache`) is cleared so routing/lenses observe the edit immediately (other instances refresh within the TTL).
- UI: object-list editor; member sub-picker limited to organizers; key auto-slugged from title (editable, kebab-validated, unique); slackChannel free text; emailIdentity select.

### 4. Announcement — `conference.updateAnnouncement` (rich text)
- New `rich-text` fieldset type in `EditConferenceCard` reusing the shared `PortableTextEditor`. Empty content **unsets** the field so the landing-page banner stops rendering.
- **Render-compat note:** the editor exposes h1–h3, strong/em/underline, bullet/number lists and links. `Hero.tsx` gives bespoke styling to `normal`/`h1`/`h2`/`strong`/`link`; the rest (h3, em, underline, lists) fall back to `@portabletext/react` defaults — `underline` is a non-standard decorator that renders unstyled. All are valid portable text; nothing is dropped.

## Tests
- Router: organizers lockout + non-empty + unique; topics replace + min-1 + unique; teams subset/kebab/unique/members + **cache-clear side effect**; announcement set-with-keys / empty→unset / null→unset. Topic router: create slug/color + collision probe, update patch shape (no slug regen), **delete guard counts**.
- Pure logic (SE-1b pattern): `editConferenceRefs` (validateOrganizers, validateTeams, buildTeamsPayload, slugify) and `topic/create` (deterministic color, slug).
- **86 new tests; full suite green (3556 passed, 5 pre-existing skips).** tsc / eslint / prettier / knip all clean.

## Visual QA
`pnpm shoot` at 393×852, light + dark, for all four editors (organizers with locked self row, topics multi-select with chips + inline create, teams editor, rich-text modal). No viewport overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C