### PR TITLE
feat(admin): staff CRUD + announcement/volunteer/activity editing (SE-4)

### DIFF
--- a/src/app/(admin)/admin/staff/page.tsx
+++ b/src/app/(admin)/admin/staff/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const StaffManager = dynamic(
+  () => import('@/components/admin/StaffManager').then((m) => m.StaffManager),
+  { ssr: false },
+)
+
+export default function Page() {
+  return <StaffManager />
+}

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -14,6 +14,7 @@ import {
   AcademicCapIcon,
   CpuChipIcon,
   EnvelopeIcon,
+  IdentificationIcon,
 } from '@heroicons/react/24/outline'
 import {
   DashboardLayout,
@@ -36,6 +37,7 @@ const navigation: NavigationSection[] = [
     label: 'People',
     items: [
       { name: 'Speakers', href: '/admin/speakers', icon: UsersIcon },
+      { name: 'Staff', href: '/admin/staff', icon: IdentificationIcon },
       { name: 'Volunteers', href: '/admin/volunteers', icon: UserGroupIcon },
       { name: 'Workshops', href: '/admin/workshops', icon: AcademicCapIcon },
     ],

--- a/src/components/admin/StaffManager.stories.tsx
+++ b/src/components/admin/StaffManager.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { StaffManager } from './StaffManager'
+import { NotificationProvider } from './NotificationProvider'
+
+const staff = [
+  {
+    _id: 'staff-1',
+    name: 'Ada Lovelace',
+    role: 'organizer',
+    email: 'ada@example.com',
+    company: 'Analytical Engines',
+    link: 'https://example.com/ada',
+    imageURL: 'https://i.pravatar.cc/80?u=ada',
+    imageAssetId: 'image-ada-200x200-png',
+  },
+  {
+    _id: 'staff-2',
+    name: 'Grace Hopper',
+    role: 'organizer',
+    email: 'grace@example.com',
+    company: 'US Navy',
+    link: 'https://example.com/grace',
+  },
+  {
+    _id: 'staff-3',
+    name: 'Katherine Johnson',
+    role: 'volunteer coordinator',
+    link: 'https://example.com/katherine',
+  },
+]
+
+const handlers = [
+  http.get('/api/trpc/staff.list', () =>
+    HttpResponse.json({ result: { data: staff } }),
+  ),
+  http.post('/api/trpc/staff.create', () =>
+    HttpResponse.json({ result: { data: { _id: 'staff-new' } } }),
+  ),
+  http.post('/api/trpc/staff.update', () =>
+    HttpResponse.json({ result: { data: { success: true } } }),
+  ),
+  http.post('/api/trpc/staff.delete', () =>
+    HttpResponse.json({ result: { data: { success: true } } }),
+  ),
+]
+
+const meta = {
+  title: 'Systems/People/Admin/StaffManager',
+  component: StaffManager,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'SE-4 — the Staff admin surface. A table of every staff document with create/edit/delete, all editing through a shared ModalShell form (image uploads via /api/admin/speaker-image).',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-white p-6 dark:bg-gray-950">
+                <Story />
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof StaffManager>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Table: Story = {}
+
+export const TableDark: Story = {
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+export const Form: Story = {
+  args: { defaultOpen: true },
+}
+
+export const FormDark: Story = {
+  args: { defaultOpen: true },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}

--- a/src/components/admin/StaffManager.tsx
+++ b/src/components/admin/StaffManager.tsx
@@ -1,0 +1,499 @@
+'use client'
+
+import { useState } from 'react'
+import Image from 'next/image'
+import {
+  PencilSquareIcon,
+  PlusIcon,
+  TrashIcon,
+  UserCircleIcon,
+  UsersIcon,
+} from '@heroicons/react/24/outline'
+import { AdminPageHeader } from '@/components/admin'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
+import { ModalShell } from '@/components/ModalShell'
+import { EmptyState } from '@/components/EmptyState'
+import { api } from '@/lib/trpc/client'
+import { useNotification } from './NotificationProvider'
+import type { StaffAdmin } from '@/lib/staff/types'
+
+/** Draft form state for the create/edit modal (all strings for inputs). */
+interface StaffDraft {
+  name: string
+  role: string
+  link: string
+  email: string
+  company: string
+  imageAssetId: string
+  imageURL: string
+}
+
+const EMPTY_DRAFT: StaffDraft = {
+  name: '',
+  role: '',
+  link: '',
+  email: '',
+  company: '',
+  imageAssetId: '',
+  imageURL: '',
+}
+
+function draftFrom(member: StaffAdmin): StaffDraft {
+  return {
+    name: member.name ?? '',
+    role: member.role ?? '',
+    link: member.link ?? '',
+    email: member.email ?? '',
+    company: member.company ?? '',
+    imageAssetId: member.imageAssetId ?? '',
+    imageURL: member.imageURL ?? '',
+  }
+}
+
+/**
+ * SE-4 — the Staff admin surface. A simple table of every staff document with a
+ * create button and per-row edit/delete affordances, all editing through a
+ * shared ModalShell form. Replaces editing `staff` docs in Sanity Studio.
+ */
+export function StaffManager({
+  defaultOpen = false,
+}: {
+  /** Opens the create form on mount — for stories/visual capture. */
+  defaultOpen?: boolean
+}) {
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+
+  const { data: staff, isLoading } = api.staff.list.useQuery()
+
+  const [isFormOpen, setFormOpen] = useState(defaultOpen)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draft, setDraft] = useState<StaffDraft>(EMPTY_DRAFT)
+  const [error, setError] = useState<string | null>(null)
+  const [isUploading, setUploading] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<StaffAdmin | null>(null)
+
+  const invalidate = () => void utils.staff.list.invalidate()
+
+  const createMutation = api.staff.create.useMutation({
+    onSuccess: () => {
+      invalidate()
+      closeForm()
+      showNotification({
+        type: 'success',
+        title: 'Staff added',
+        message: 'The staff member was created.',
+      })
+    },
+    onError: (err) => setError(err.message || 'Failed to create staff member.'),
+  })
+
+  const updateMutation = api.staff.update.useMutation({
+    onSuccess: () => {
+      invalidate()
+      closeForm()
+      showNotification({
+        type: 'success',
+        title: 'Staff updated',
+        message: 'The staff member was saved.',
+      })
+    },
+    onError: (err) => setError(err.message || 'Failed to update staff member.'),
+  })
+
+  const deleteMutation = api.staff.delete.useMutation({
+    onSuccess: () => {
+      invalidate()
+      setDeleteTarget(null)
+      showNotification({
+        type: 'success',
+        title: 'Staff removed',
+        message: 'The staff member was deleted.',
+      })
+    },
+    onError: (err) =>
+      showNotification({
+        type: 'error',
+        title: 'Could not delete',
+        message: err.message || 'Failed to delete staff member.',
+      }),
+  })
+
+  const isSaving = createMutation.isPending || updateMutation.isPending
+
+  const openCreate = () => {
+    setEditingId(null)
+    setDraft(EMPTY_DRAFT)
+    setError(null)
+    setFormOpen(true)
+  }
+
+  const openEdit = (member: StaffAdmin) => {
+    setEditingId(member._id)
+    setDraft(draftFrom(member))
+    setError(null)
+    setFormOpen(true)
+  }
+
+  const closeForm = () => {
+    setFormOpen(false)
+    setEditingId(null)
+    setDraft(EMPTY_DRAFT)
+    setError(null)
+  }
+
+  const handleImageChange = async (file: File | undefined) => {
+    if (!file) return
+    setUploading(true)
+    setError(null)
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const res = await fetch('/api/admin/speaker-image', {
+        method: 'POST',
+        body: formData,
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(body.error || 'Upload failed')
+      }
+      const { assetId, url } = (await res.json()) as {
+        assetId: string
+        url: string
+      }
+      setDraft((prev) => ({ ...prev, imageAssetId: assetId, imageURL: url }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to upload image.')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    setError(null)
+
+    const name = draft.name.trim()
+    const role = draft.role.trim()
+    const link = draft.link.trim()
+    if (!name || !role || !link) {
+      setError('Name, role and link are required.')
+      return
+    }
+
+    const email = draft.email.trim()
+    const company = draft.company.trim()
+
+    if (editingId) {
+      updateMutation.mutate({
+        id: editingId,
+        name,
+        role,
+        link,
+        email: email === '' ? null : email,
+        company: company === '' ? null : company,
+        image: draft.imageAssetId === '' ? null : draft.imageAssetId,
+      })
+    } else {
+      createMutation.mutate({
+        name,
+        role,
+        link,
+        ...(email ? { email } : {}),
+        ...(company ? { company } : {}),
+        ...(draft.imageAssetId ? { image: draft.imageAssetId } : {}),
+      })
+    }
+  }
+
+  const members = staff ?? []
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title="Staff"
+        description="Manage the people listed on the public staff pages"
+        icon={<UsersIcon className="h-6 w-6" />}
+        actions={
+          <AdminButton color="blue" size="md" onClick={openCreate}>
+            <PlusIcon className="mr-1 h-4 w-4" />
+            Add staff
+          </AdminButton>
+        }
+      />
+
+      {isLoading ? (
+        <div className="h-64 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800" />
+      ) : members.length === 0 ? (
+        <EmptyState
+          icon={UsersIcon}
+          title="No staff yet"
+          description="Add the first staff member to populate the public staff pages."
+          className="rounded-lg bg-gray-50 p-8 dark:bg-gray-800"
+        />
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="bg-gray-50 dark:bg-gray-800">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                  Name
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                  Role
+                </th>
+                <th className="hidden px-4 py-3 text-left text-xs font-medium tracking-wide text-gray-500 uppercase sm:table-cell dark:text-gray-400">
+                  Company
+                </th>
+                <th className="hidden px-4 py-3 text-left text-xs font-medium tracking-wide text-gray-500 uppercase md:table-cell dark:text-gray-400">
+                  Email
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 bg-white dark:divide-gray-800 dark:bg-gray-900">
+              {members.map((member) => (
+                <tr key={member._id}>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      {member.imageURL ? (
+                        <Image
+                          src={member.imageURL}
+                          alt={member.name}
+                          width={36}
+                          height={36}
+                          className="h-9 w-9 shrink-0 rounded-full object-cover"
+                        />
+                      ) : (
+                        <UserCircleIcon className="h-9 w-9 shrink-0 text-gray-300 dark:text-gray-600" />
+                      )}
+                      <span className="font-medium text-gray-900 dark:text-white">
+                        {member.name}
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                    {member.role}
+                  </td>
+                  <td className="hidden px-4 py-3 text-sm text-gray-700 sm:table-cell dark:text-gray-300">
+                    {member.company || '—'}
+                  </td>
+                  <td className="hidden px-4 py-3 text-sm text-gray-700 md:table-cell dark:text-gray-300">
+                    {member.email || '—'}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-1">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(member)}
+                        aria-label={`Edit ${member.name}`}
+                        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+                      >
+                        <PencilSquareIcon className="h-5 w-5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteTarget(member)}
+                        aria-label={`Delete ${member.name}`}
+                        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-red-500 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 dark:text-red-400 dark:hover:bg-red-900/20"
+                      >
+                        <TrashIcon className="h-5 w-5" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <ModalShell
+        isOpen={isFormOpen}
+        onClose={closeForm}
+        size="lg"
+        title={editingId ? 'Edit staff member' : 'Add staff member'}
+        subtitle="Shown on the public staff pages"
+        icon={<UsersIcon className="h-5 w-5" />}
+      >
+        <form noValidate onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Name" htmlFor="staff-name" required>
+              <input
+                id="staff-name"
+                type="text"
+                value={draft.name}
+                onChange={(e) =>
+                  setDraft((p) => ({ ...p, name: e.target.value }))
+                }
+                className={inputClass}
+              />
+            </Field>
+            <Field label="Role" htmlFor="staff-role" required>
+              <input
+                id="staff-role"
+                type="text"
+                value={draft.role}
+                onChange={(e) =>
+                  setDraft((p) => ({ ...p, role: e.target.value }))
+                }
+                placeholder="e.g. organizer"
+                className={inputClass}
+              />
+            </Field>
+            <Field label="Email" htmlFor="staff-email">
+              <input
+                id="staff-email"
+                type="email"
+                value={draft.email}
+                onChange={(e) =>
+                  setDraft((p) => ({ ...p, email: e.target.value }))
+                }
+                className={inputClass}
+              />
+            </Field>
+            <Field label="Company" htmlFor="staff-company">
+              <input
+                id="staff-company"
+                type="text"
+                value={draft.company}
+                onChange={(e) =>
+                  setDraft((p) => ({ ...p, company: e.target.value }))
+                }
+                className={inputClass}
+              />
+            </Field>
+          </div>
+
+          <Field label="Link" htmlFor="staff-link" required>
+            <input
+              id="staff-link"
+              type="url"
+              value={draft.link}
+              onChange={(e) =>
+                setDraft((p) => ({ ...p, link: e.target.value }))
+              }
+              placeholder="https://…"
+              className={inputClass}
+            />
+          </Field>
+
+          <div>
+            <span className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Image
+            </span>
+            <div className="flex items-center gap-3">
+              {draft.imageURL ? (
+                <Image
+                  src={draft.imageURL}
+                  alt="Staff preview"
+                  width={48}
+                  height={48}
+                  className="h-12 w-12 rounded-full object-cover"
+                />
+              ) : (
+                <UserCircleIcon className="h-12 w-12 text-gray-300 dark:text-gray-600" />
+              )}
+              <label className="inline-flex min-h-[44px] cursor-pointer items-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
+                {isUploading ? 'Uploading…' : 'Choose image'}
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="sr-only"
+                  disabled={isUploading}
+                  onChange={(e) => handleImageChange(e.target.files?.[0])}
+                />
+              </label>
+              {draft.imageAssetId ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setDraft((p) => ({ ...p, imageAssetId: '', imageURL: '' }))
+                  }
+                  className="text-sm font-medium text-red-600 hover:text-red-500 dark:text-red-400"
+                >
+                  Remove
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          {error ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {error}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+            <AdminButton
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={closeForm}
+              disabled={isSaving}
+              className="min-h-[44px]"
+            >
+              Cancel
+            </AdminButton>
+            <AdminButton
+              type="submit"
+              color="blue"
+              size="md"
+              disabled={isSaving || isUploading}
+              className="min-h-[44px]"
+            >
+              {isSaving ? 'Saving…' : editingId ? 'Save changes' : 'Add staff'}
+            </AdminButton>
+          </div>
+        </form>
+      </ModalShell>
+
+      <ConfirmationModal
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() =>
+          deleteTarget && deleteMutation.mutate({ id: deleteTarget._id })
+        }
+        isLoading={deleteMutation.isPending}
+        title="Delete staff member"
+        message={`Are you sure you want to delete ${deleteTarget?.name ?? 'this staff member'}? This action cannot be undone.`}
+        confirmButtonText="Delete"
+        variant="danger"
+      />
+    </div>
+  )
+}
+
+const inputClass =
+  'block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+
+function Field({
+  label,
+  htmlFor,
+  required,
+  children,
+}: {
+  label: string
+  htmlFor: string
+  required?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={htmlFor}
+        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        {label}
+        {required ? <span className="text-red-500"> *</span> : null}
+      </label>
+      {children}
+    </div>
+  )
+}

--- a/src/components/admin/sponsor/SponsorActivityTimeline.stories.tsx
+++ b/src/components/admin/sponsor/SponsorActivityTimeline.stories.tsx
@@ -1,5 +1,51 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { BoltIcon } from '@heroicons/react/24/solid'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { within, userEvent, waitFor } from 'storybook/test'
+import { SponsorActivityTimeline } from './SponsorActivityTimeline'
+
+const now = new Date().toISOString()
+
+// A user-authored note (editable) and a system stage_change (locked). Only the
+// note exposes the edit pencil; SE-4's edit affordance is type-gated.
+const editableActivities = [
+  {
+    _id: 'act-note',
+    _createdAt: now,
+    _updatedAt: now,
+    sponsorForConference: {
+      _id: 'sfc-1',
+      sponsor: { _id: 'sp-1', name: 'Tieto Tech Consulting' },
+    },
+    activityType: 'note',
+    description: 'Met at the booth — very interested in the Gold tier.',
+    createdBy: { _id: 'org-1', name: 'Hans K.', email: 'hans@example.com' },
+    createdAt: now,
+  },
+  {
+    _id: 'act-stage',
+    _createdAt: now,
+    _updatedAt: now,
+    sponsorForConference: {
+      _id: 'sfc-1',
+      sponsor: { _id: 'sp-1', name: 'Tieto Tech Consulting' },
+    },
+    activityType: 'stage_change',
+    description: 'Status changed from Prospect to Negotiating',
+    createdBy: null,
+    createdAt: now,
+  },
+]
+
+const editHandlers = [
+  http.get('/api/trpc/sponsor.crm.activities.list', () =>
+    HttpResponse.json({ result: { data: editableActivities } }),
+  ),
+  http.post('/api/trpc/sponsor.crm.activities.update', () =>
+    HttpResponse.json({ result: { data: { success: true } } }),
+  ),
+]
 
 const meta = {
   title: 'Systems/Sponsors/Admin/Dashboard/Activity Timeline',
@@ -287,4 +333,66 @@ export const ActivityTimeline: Story = {
       </div>
     </div>
   ),
+}
+
+/**
+ * SE-4 — real component with the inline edit affordance. The play function
+ * opens the editor on the user-authored note so the shoot captures the edit UI.
+ */
+export const EditActivity: Story = {
+  parameters: {
+    layout: 'centered',
+    msw: { handlers: editHandlers },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider attribute="class" forcedTheme="light" enableSystem={false}>
+        <div className="w-[32rem] bg-white p-6">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+  render: () => (
+    <SponsorActivityTimeline sponsorForConferenceId="sfc-1" showHeaderFooter />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const editButton = await waitFor(() =>
+      canvas.getByLabelText('Edit activity'),
+    )
+    await userEvent.click(editButton)
+    await canvas.findByLabelText('Edit activity description')
+  },
+}
+
+export const EditActivityDark: Story = {
+  parameters: {
+    layout: 'centered',
+    theme: 'dark',
+    backgrounds: { default: 'dark' },
+    msw: { handlers: editHandlers },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider attribute="class" forcedTheme="dark" enableSystem={false}>
+        <div className="dark">
+          <div className="w-[32rem] bg-gray-950 p-6">
+            <Story />
+          </div>
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+  render: () => (
+    <SponsorActivityTimeline sponsorForConferenceId="sfc-1" showHeaderFooter />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const editButton = await waitFor(() =>
+      canvas.getByLabelText('Edit activity'),
+    )
+    await userEvent.click(editButton)
+    await canvas.findByLabelText('Edit activity description')
+  },
 }

--- a/src/components/admin/sponsor/SponsorActivityTimeline.tsx
+++ b/src/components/admin/sponsor/SponsorActivityTimeline.tsx
@@ -1,11 +1,18 @@
 'use client'
 
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { api } from '@/lib/trpc/client'
 import Image from 'next/image'
 import Link from 'next/link'
-import type { SponsorActivityExpanded } from '@/lib/sponsor-crm/types'
-import { ArrowPathIcon, UserIcon } from '@heroicons/react/24/outline'
+import type {
+  ActivityType,
+  SponsorActivityExpanded,
+} from '@/lib/sponsor-crm/types'
+import {
+  ArrowPathIcon,
+  PencilSquareIcon,
+  UserIcon,
+} from '@heroicons/react/24/outline'
 import { BoltIcon } from '@heroicons/react/24/solid'
 import { formatDistanceToNow, isToday, isYesterday, format } from 'date-fns'
 import clsx from 'clsx'
@@ -153,12 +160,25 @@ function UserAvatar({
   )
 }
 
+/** Activity types a user authored by hand — the only ones the UI lets you edit. */
+const EDITABLE_ACTIVITY_TYPES: ReadonlySet<ActivityType> = new Set([
+  'note',
+  'call',
+  'meeting',
+  'email',
+])
+
 function ActivityLine({
   activity,
   compact,
+  onSave,
+  isSaving,
 }: {
   activity: SponsorActivityExpanded
   compact?: boolean
+  /** Persist an edited description; omitted in compact/read-only contexts. */
+  onSave?: (activityId: string, description: string) => void
+  isSaving?: boolean
 }) {
   const iconType = useMemo(
     () => getActivityIcon(activity.activityType),
@@ -167,6 +187,68 @@ function ActivityLine({
   const timeAgo = formatDistanceToNow(new Date(activity.createdAt), {
     addSuffix: true,
   })
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(activity.description)
+
+  // Editing is offered only for user-authored types (server re-checks type AND
+  // creator; a non-owner's save is rejected there).
+  const isEditable =
+    !compact && !!onSave && EDITABLE_ACTIVITY_TYPES.has(activity.activityType)
+
+  const startEdit = () => {
+    setDraft(activity.description)
+    setIsEditing(true)
+  }
+  const cancelEdit = () => setIsEditing(false)
+  const saveEdit = () => {
+    const next = draft.trim()
+    if (next.length === 0) return
+    onSave?.(activity._id, next)
+    setIsEditing(false)
+  }
+
+  if (isEditing) {
+    return (
+      <div className="flex items-start gap-2.5 py-1.5">
+        <div
+          className={clsx(
+            'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full',
+            getActivityColor(activity.activityType),
+          )}
+        >
+          {React.createElement(iconType, { className: 'h-3 w-3' })}
+        </div>
+        <div className="min-w-0 flex-1">
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={2}
+            aria-label="Edit activity description"
+            className="w-full rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+          />
+          <div className="mt-1.5 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={cancelEdit}
+              disabled={isSaving}
+              className="rounded-md px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={saveEdit}
+              disabled={isSaving || draft.trim().length === 0}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-500 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+            >
+              {isSaving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div
@@ -197,6 +279,16 @@ function ActivityLine({
           : activity.description}
       </p>
       <div className="flex shrink-0 items-center gap-1.5">
+        {isEditable && (
+          <button
+            type="button"
+            onClick={startEdit}
+            aria-label="Edit activity"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-gray-400 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-gray-100 hover:text-gray-600 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          >
+            <PencilSquareIcon className="h-4 w-4" />
+          </button>
+        )}
         {!compact && (
           <UserAvatar
             name={activity.createdBy?.name ?? 'Automatic'}
@@ -224,12 +316,16 @@ function SponsorCard({
   activities,
   hideSponsorName,
   compact,
+  onSave,
+  isSaving,
 }: {
   sponsorName: string
   sponsorForConferenceId: string
   activities: SponsorActivityExpanded[]
   hideSponsorName: boolean
   compact?: boolean
+  onSave?: (activityId: string, description: string) => void
+  isSaving?: boolean
 }) {
   return (
     <div>
@@ -259,6 +355,8 @@ function SponsorCard({
             key={activity._id}
             activity={activity}
             compact={compact}
+            onSave={onSave}
+            isSaving={isSaving}
           />
         ))}
       </div>
@@ -272,11 +370,22 @@ export function SponsorActivityTimeline({
   showHeaderFooter = true,
   compact = false,
 }: SponsorActivityTimelineProps) {
+  const utils = api.useUtils()
   const { data: activities = [], isLoading } =
     api.sponsor.crm.activities.list.useQuery({
       sponsorForConferenceId,
       limit,
     })
+
+  const updateMutation = api.sponsor.crm.activities.update.useMutation({
+    onSuccess: () => {
+      utils.sponsor.crm.activities.list.invalidate()
+    },
+  })
+
+  const handleSaveEdit = (activityId: string, description: string) => {
+    updateMutation.mutate({ id: activityId, description })
+  }
 
   const grouped = useMemo(() => groupActivities(activities), [activities])
 
@@ -369,6 +478,8 @@ export function SponsorActivityTimeline({
                     activities={group.activities}
                     hideSponsorName={!!sponsorForConferenceId}
                     compact={compact}
+                    onSave={handleSaveEdit}
+                    isSaving={updateMutation.isPending}
                   />
                 ))}
               </div>

--- a/src/components/admin/workshop/AnnounceModal.stories.tsx
+++ b/src/components/admin/workshop/AnnounceModal.stories.tsx
@@ -53,6 +53,8 @@ const meta = {
     confirmedCount: 24,
     onClose: fn(),
     onSubmit: fn(),
+    onEditAnnouncement: fn(),
+    onDeleteAnnouncement: fn(),
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof AnnounceModal>
@@ -72,4 +74,28 @@ export const Submitting: Story = {
 
 export const SingleParticipant: Story = {
   args: { confirmedCount: 1 },
+}
+
+const announcements = [
+  {
+    _id: 'ann-1',
+    body: 'Please install Docker Desktop and kubectl before the session. A verification script is linked in the prerequisites doc.',
+    createdAt: '2026-09-05T09:30:00Z',
+    authorName: 'Hans K.',
+  },
+  {
+    _id: 'ann-2',
+    body: 'Room change: we have moved to Room B3 on the second floor.',
+    createdAt: '2026-09-06T14:15:00Z',
+    authorName: 'Hans K.',
+  },
+]
+
+export const WithAnnouncements: Story = {
+  args: { announcements },
+}
+
+export const WithAnnouncementsDark: Story = {
+  args: { announcements },
+  parameters: { dark: true },
 }

--- a/src/components/admin/workshop/AnnounceModal.tsx
+++ b/src/components/admin/workshop/AnnounceModal.tsx
@@ -1,9 +1,15 @@
 'use client'
 
 import { useState } from 'react'
-import { MegaphoneIcon } from '@heroicons/react/24/outline'
+import {
+  MegaphoneIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
 import { AdminButton } from '@/components/admin/AdminButton'
+import { formatDateTimeSafe } from '@/lib/time'
+import type { WorkshopAnnouncementView } from '@/lib/workshop/announcements'
 
 const MAX_BODY_LENGTH = 2000
 
@@ -15,12 +21,24 @@ interface AnnounceModalProps {
   confirmedCount: number
   onSubmit: (body: string) => void
   isSubmitting?: boolean
+  /** Previously-sent announcements for this workshop, newest first (SE-4). */
+  announcements?: WorkshopAnnouncementView[]
+  /** Save an edited announcement body (no re-email). */
+  onEditAnnouncement?: (announcementId: string, body: string) => void
+  /** Request deletion of an announcement (parent opens a ConfirmationModal). */
+  onDeleteAnnouncement?: (announcement: WorkshopAnnouncementView) => void
+  /** True while an edit is in flight (disables the inline editor's Save). */
+  isEditingAnnouncement?: boolean
 }
 
 /**
  * Compose + send a one-way broadcast announcement to a workshop's CONFIRMED
- * participants. The author sees exactly how many people will be emailed before
- * sending. Deliberately no recipient list / no reply UI — this is a broadcast.
+ * participants, and manage previously-sent announcements (SE-4). The author
+ * sees exactly how many people will be emailed before sending. Deliberately no
+ * recipient list / no reply UI — this is a broadcast.
+ *
+ * Editing an announcement corrects the persisted copy ONLY — it does NOT
+ * re-email participants (the original was already sent).
  */
 export function AnnounceModal({
   isOpen,
@@ -29,15 +47,25 @@ export function AnnounceModal({
   confirmedCount,
   onSubmit,
   isSubmitting = false,
+  announcements = [],
+  onEditAnnouncement,
+  onDeleteAnnouncement,
+  isEditingAnnouncement = false,
 }: AnnounceModalProps) {
   const [body, setBody] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editBody, setEditBody] = useState('')
 
-  // Reset the textarea whenever the modal transitions open (React-blessed
+  // Reset local state whenever the modal transitions open (React-blessed
   // "reset on prop change" so a previous draft never lingers).
   const [wasOpen, setWasOpen] = useState(isOpen)
   if (wasOpen !== isOpen) {
     setWasOpen(isOpen)
-    if (isOpen) setBody('')
+    if (isOpen) {
+      setBody('')
+      setEditingId(null)
+      setEditBody('')
+    }
   }
 
   const trimmed = body.trim()
@@ -47,6 +75,23 @@ export function AnnounceModal({
   const handleSubmit = () => {
     if (!canSend) return
     onSubmit(trimmed)
+  }
+
+  const startEdit = (announcement: WorkshopAnnouncementView) => {
+    setEditingId(announcement._id)
+    setEditBody(announcement.body)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditBody('')
+  }
+
+  const saveEdit = (announcementId: string) => {
+    const next = editBody.trim()
+    if (next.length === 0 || next.length > MAX_BODY_LENGTH) return
+    onEditAnnouncement?.(announcementId, next)
+    cancelEdit()
   }
 
   return (
@@ -122,6 +167,95 @@ export function AnnounceModal({
               : `Send to ${confirmedCount} participant${confirmedCount === 1 ? '' : 's'}`}
           </AdminButton>
         </div>
+
+        {announcements.length > 0 && (
+          <div className="border-t border-gray-200 pt-4 dark:border-gray-700">
+            <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+              Sent announcements
+            </h3>
+            <ul className="space-y-3">
+              {announcements.map((announcement) => {
+                const isEditing = editingId === announcement._id
+                const nextBody = editBody.trim()
+                const canSave =
+                  nextBody.length > 0 &&
+                  nextBody.length <= MAX_BODY_LENGTH &&
+                  !isEditingAnnouncement
+                return (
+                  <li
+                    key={announcement._id}
+                    className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+                  >
+                    {isEditing ? (
+                      <div className="space-y-2">
+                        <textarea
+                          value={editBody}
+                          onChange={(e) => setEditBody(e.target.value)}
+                          rows={4}
+                          maxLength={MAX_BODY_LENGTH}
+                          aria-label="Edit announcement message"
+                          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                        />
+                        <div className="flex justify-end gap-2">
+                          <AdminButton
+                            variant="secondary"
+                            size="sm"
+                            onClick={cancelEdit}
+                            disabled={isEditingAnnouncement}
+                            className="min-h-[44px]"
+                          >
+                            Cancel
+                          </AdminButton>
+                          <AdminButton
+                            color="blue"
+                            size="sm"
+                            onClick={() => saveEdit(announcement._id)}
+                            disabled={!canSave}
+                            className="min-h-[44px]"
+                          >
+                            {isEditingAnnouncement ? 'Saving…' : 'Save'}
+                          </AdminButton>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <p className="text-sm whitespace-pre-wrap text-gray-700 dark:text-gray-300">
+                            {announcement.body}
+                          </p>
+                          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            {formatDateTimeSafe(announcement.createdAt)}
+                            {announcement.authorName
+                              ? ` · ${announcement.authorName}`
+                              : ''}
+                          </p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
+                          <button
+                            type="button"
+                            onClick={() => startEdit(announcement)}
+                            aria-label="Edit announcement"
+                            className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+                          >
+                            <PencilSquareIcon className="h-5 w-5" />
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onDeleteAnnouncement?.(announcement)}
+                            aria-label="Delete announcement"
+                            className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-red-500 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 dark:text-red-400 dark:hover:bg-red-900/20"
+                          >
+                            <TrashIcon className="h-5 w-5" />
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        )}
       </div>
     </ModalShell>
   )

--- a/src/components/admin/workshop/WorkshopsClientPage.tsx
+++ b/src/components/admin/workshop/WorkshopsClientPage.tsx
@@ -13,10 +13,12 @@ import {
 import type { ParticipantFormData } from '@/components/admin/workshop'
 import { api } from '@/lib/trpc/client'
 import { useNotification } from '@/components/admin/NotificationProvider'
+import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import type {
   WorkshopSignupStatus,
   ProposalWithWorkshopData,
 } from '@/lib/workshop/types'
+import type { WorkshopAnnouncementView } from '@/lib/workshop/announcements'
 import { useQueryClient } from '@tanstack/react-query'
 import { EmptyState } from '@/components/EmptyState'
 
@@ -58,6 +60,7 @@ export function WorkshopsClientPage({
   initialWorkshops,
 }: WorkshopsClientPageProps) {
   const queryClient = useQueryClient()
+  const utils = api.useUtils()
   const { showNotification } = useNotification()
   const [announceModal, setAnnounceModal] = useState<AnnounceModalState>({
     isOpen: false,
@@ -65,6 +68,8 @@ export function WorkshopsClientPage({
     workshopTitle: '',
     confirmedCount: 0,
   })
+  const [deleteAnnouncementTarget, setDeleteAnnouncementTarget] =
+    useState<WorkshopAnnouncementView | null>(null)
   const [signupModal, setSignupModal] = useState<SignupModalState>({
     isOpen: false,
     workshopId: '',
@@ -162,9 +167,16 @@ export function WorkshopsClientPage({
     },
   })
 
+  const { data: announcementsData } = api.workshop.announcements.useQuery(
+    { workshopId: announceModal.workshopId },
+    { enabled: announceModal.isOpen && !!announceModal.workshopId },
+  )
+
   const announceMutation = api.workshop.announce.useMutation({
     onSuccess: (result) => {
-      setAnnounceModal((prev) => ({ ...prev, isOpen: false }))
+      utils.workshop.announcements.invalidate({
+        workshopId: announceModal.workshopId,
+      })
       showNotification({
         type: result.failed > 0 ? 'warning' : 'success',
         title: 'Announcement sent',
@@ -182,6 +194,49 @@ export function WorkshopsClientPage({
       })
     },
   })
+
+  const updateAnnouncementMutation =
+    api.workshop.updateAnnouncement.useMutation({
+      onSuccess: () => {
+        utils.workshop.announcements.invalidate({
+          workshopId: announceModal.workshopId,
+        })
+        showNotification({
+          type: 'success',
+          title: 'Announcement updated',
+          message: 'The announcement copy was updated (no email was re-sent).',
+        })
+      },
+      onError: (error) => {
+        showNotification({
+          type: 'error',
+          title: 'Could not update announcement',
+          message: error.message,
+        })
+      },
+    })
+
+  const deleteAnnouncementMutation =
+    api.workshop.deleteAnnouncement.useMutation({
+      onSuccess: () => {
+        setDeleteAnnouncementTarget(null)
+        utils.workshop.announcements.invalidate({
+          workshopId: announceModal.workshopId,
+        })
+        showNotification({
+          type: 'success',
+          title: 'Announcement deleted',
+          message: 'The announcement was removed from the workshop page.',
+        })
+      },
+      onError: (error) => {
+        showNotification({
+          type: 'error',
+          title: 'Could not delete announcement',
+          message: error.message,
+        })
+      },
+    })
 
   const signups = useMemo(() => signupsData?.data || [], [signupsData?.data])
 
@@ -413,6 +468,30 @@ export function WorkshopsClientPage({
         confirmedCount={announceModal.confirmedCount}
         onSubmit={handleAnnounce}
         isSubmitting={announceMutation.isPending}
+        announcements={announcementsData?.data ?? []}
+        onEditAnnouncement={(announcementId, body) =>
+          updateAnnouncementMutation.mutate({ announcementId, body })
+        }
+        onDeleteAnnouncement={(announcement) =>
+          setDeleteAnnouncementTarget(announcement)
+        }
+        isEditingAnnouncement={updateAnnouncementMutation.isPending}
+      />
+
+      <ConfirmationModal
+        isOpen={!!deleteAnnouncementTarget}
+        onClose={() => setDeleteAnnouncementTarget(null)}
+        onConfirm={() =>
+          deleteAnnouncementTarget &&
+          deleteAnnouncementMutation.mutate({
+            announcementId: deleteAnnouncementTarget._id,
+          })
+        }
+        isLoading={deleteAnnouncementMutation.isPending}
+        title="Delete announcement"
+        message="Are you sure you want to delete this announcement? It will be removed from the workshop page. Participants who already received the email will not be notified."
+        confirmButtonText="Delete"
+        variant="danger"
       />
     </div>
   )

--- a/src/components/volunteer/VolunteerAdminPage.tsx
+++ b/src/components/volunteer/VolunteerAdminPage.tsx
@@ -17,6 +17,8 @@ import { FilterDropdown, FilterOption } from '@/components/admin/FilterDropdown'
 import { AdminPageHeader } from '@/components/admin'
 import { EmailModal } from '@/components/admin/EmailModal'
 import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
+import { VolunteerEditModal } from '@/components/volunteer/VolunteerEditModal'
+import { PencilSquareIcon } from '@heroicons/react/24/outline'
 import { PortableTextBlock } from '@sanity/types'
 import { portableTextToHTML } from '@/lib/email/portableTextToHTML'
 import { StatusBadge, type BadgeColor } from '@/components/StatusBadge'
@@ -49,6 +51,7 @@ export default function VolunteerAdminPage() {
   const [deleteVolunteerId, setDeleteVolunteerId] = useState<string | null>(
     null,
   )
+  const [editModalOpen, setEditModalOpen] = useState(false)
 
   const {
     data: volunteers,
@@ -301,9 +304,21 @@ export default function VolunteerAdminPage() {
         </div>
 
         <div>
-          <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
-            Volunteer Details
-          </h2>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              Volunteer Details
+            </h2>
+            {selectedVolunteer ? (
+              <button
+                type="button"
+                onClick={() => setEditModalOpen(true)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+              >
+                <PencilSquareIcon className="h-4 w-4" />
+                Edit Details
+              </button>
+            ) : null}
+          </div>
           {detailsError ? (
             <div className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20">
               <p className="text-sm text-red-800 dark:text-red-300">
@@ -546,6 +561,14 @@ export default function VolunteerAdminPage() {
             subject: `Welcome to the ${emailModalVolunteer.conference?.title || 'Conference'} Volunteer Team`,
             message: `Dear ${emailModalVolunteer.name},\n\nWe are delighted to confirm that your application to volunteer at ${emailModalVolunteer.conference?.title || 'our conference'} has been approved!\n\nWe will be in touch soon with more details about volunteer orientation and your specific assignments.\n\nThank you for offering your time and support!`,
           }}
+        />
+      )}
+
+      {selectedVolunteer && (
+        <VolunteerEditModal
+          isOpen={editModalOpen}
+          onClose={() => setEditModalOpen(false)}
+          volunteer={selectedVolunteer}
         />
       )}
 

--- a/src/components/volunteer/VolunteerEditModal.stories.tsx
+++ b/src/components/volunteer/VolunteerEditModal.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { fn } from 'storybook/test'
+import { VolunteerEditModal } from './VolunteerEditModal'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import {
+  Occupation,
+  TShirtSize,
+  VolunteerStatus,
+  type VolunteerWithConference,
+} from '@/lib/volunteer/types'
+
+const volunteer: VolunteerWithConference = {
+  _id: 'vol-1',
+  _rev: 'r1',
+  _createdAt: '2026-06-01T10:00:00Z',
+  _updatedAt: '2026-06-01T10:00:00Z',
+  name: 'Ada Lovelace',
+  email: 'ada@example.com',
+  phone: '+47 111 11 111',
+  occupation: Occupation.WORKING,
+  availability: 'Weekends and Friday afternoon',
+  preferredTasks: ['registration', 'catering'],
+  tshirtSize: TShirtSize.M,
+  dietaryRestrictions: 'Vegetarian',
+  otherInfo: 'Happy to help with anything.',
+  status: VolunteerStatus.PENDING,
+  conference: { _id: 'conf-1', title: 'Cloud Native Day' },
+}
+
+const handlers = [
+  http.post('/api/trpc/volunteer.admin.update', () =>
+    HttpResponse.json({ result: { data: { success: true } } }),
+  ),
+]
+
+const meta = {
+  title: 'Systems/People/Admin/VolunteerEditModal',
+  component: VolunteerEditModal,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'SE-4 — organizer edit of a volunteer’s own detail fields. Status and review provenance are managed elsewhere and are intentionally absent.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-gray-100 dark:bg-gray-950" />
+              <Story />
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  args: {
+    isOpen: true,
+    volunteer,
+    onClose: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof VolunteerEditModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Dark: Story = {
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}

--- a/src/components/volunteer/VolunteerEditModal.tsx
+++ b/src/components/volunteer/VolunteerEditModal.tsx
@@ -1,0 +1,315 @@
+'use client'
+
+import { useState } from 'react'
+import { PencilSquareIcon } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { useNotification } from '@/components/admin/NotificationProvider'
+import { api } from '@/lib/trpc/client'
+import {
+  Occupation,
+  TShirtSize,
+  type VolunteerWithConference,
+} from '@/lib/volunteer/types'
+
+interface VolunteerEditModalProps {
+  isOpen: boolean
+  onClose: () => void
+  volunteer: VolunteerWithConference
+}
+
+interface Draft {
+  name: string
+  email: string
+  phone: string
+  occupation: Occupation
+  availability: string
+  preferredTasks: string
+  tshirtSize: string
+  dietaryRestrictions: string
+  otherInfo: string
+}
+
+function draftFrom(v: VolunteerWithConference): Draft {
+  return {
+    name: v.name ?? '',
+    email: v.email ?? '',
+    phone: v.phone ?? '',
+    occupation: v.occupation ?? Occupation.OTHER,
+    availability: v.availability ?? '',
+    preferredTasks: (v.preferredTasks ?? []).join(', '),
+    tshirtSize: v.tshirtSize ?? '',
+    dietaryRestrictions: v.dietaryRestrictions ?? '',
+    otherInfo: v.otherInfo ?? '',
+  }
+}
+
+/** Trim to `null` (clear) when empty, else the trimmed value. */
+function nullable(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+/**
+ * SE-4 — organizer edit of a volunteer's own detail fields. Status and review
+ * provenance are edited elsewhere and are intentionally absent here.
+ */
+export function VolunteerEditModal({
+  isOpen,
+  onClose,
+  volunteer,
+}: VolunteerEditModalProps) {
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+  const [draft, setDraft] = useState<Draft>(() => draftFrom(volunteer))
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset the draft whenever a different volunteer is opened.
+  const [lastId, setLastId] = useState(volunteer._id)
+  if (lastId !== volunteer._id) {
+    setLastId(volunteer._id)
+    setDraft(draftFrom(volunteer))
+    setError(null)
+  }
+
+  const updateMutation = api.volunteer.admin.update.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.volunteer.admin.list.invalidate(),
+        utils.volunteer.admin.getById.invalidate({ id: volunteer._id }),
+      ])
+      showNotification({
+        type: 'success',
+        title: 'Volunteer updated',
+        message: 'The volunteer details were saved.',
+      })
+      onClose()
+    },
+    onError: (err) => setError(err.message || 'Failed to update volunteer.'),
+  })
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    setError(null)
+
+    const name = draft.name.trim()
+    const email = draft.email.trim()
+    const phone = draft.phone.trim()
+    if (!name || !email || !phone) {
+      setError('Name, email and phone are required.')
+      return
+    }
+
+    const preferredTasks = draft.preferredTasks
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0)
+
+    updateMutation.mutate({
+      volunteerId: volunteer._id,
+      name,
+      email,
+      phone,
+      occupation: draft.occupation,
+      availability: nullable(draft.availability),
+      preferredTasks: preferredTasks.length > 0 ? preferredTasks : null,
+      tshirtSize:
+        draft.tshirtSize === '' ? null : (draft.tshirtSize as TShirtSize),
+      dietaryRestrictions: nullable(draft.dietaryRestrictions),
+      otherInfo: nullable(draft.otherInfo),
+    })
+  }
+
+  return (
+    <ModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      size="lg"
+      title="Edit volunteer details"
+      subtitle={volunteer.name}
+      icon={<PencilSquareIcon className="h-5 w-5" />}
+    >
+      <form noValidate onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="Name" htmlFor="vol-name" required>
+            <input
+              id="vol-name"
+              type="text"
+              value={draft.name}
+              onChange={(e) =>
+                setDraft((p) => ({ ...p, name: e.target.value }))
+              }
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Email" htmlFor="vol-email" required>
+            <input
+              id="vol-email"
+              type="email"
+              value={draft.email}
+              onChange={(e) =>
+                setDraft((p) => ({ ...p, email: e.target.value }))
+              }
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Phone" htmlFor="vol-phone" required>
+            <input
+              id="vol-phone"
+              type="tel"
+              value={draft.phone}
+              onChange={(e) =>
+                setDraft((p) => ({ ...p, phone: e.target.value }))
+              }
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Occupation" htmlFor="vol-occupation" required>
+            <select
+              id="vol-occupation"
+              value={draft.occupation}
+              onChange={(e) =>
+                setDraft((p) => ({
+                  ...p,
+                  occupation: e.target.value as Occupation,
+                }))
+              }
+              className={inputClass}
+            >
+              {Object.values(Occupation).map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="T-shirt size" htmlFor="vol-tshirt">
+            <select
+              id="vol-tshirt"
+              value={draft.tshirtSize}
+              onChange={(e) =>
+                setDraft((p) => ({ ...p, tshirtSize: e.target.value }))
+              }
+              className={inputClass}
+            >
+              <option value="">Not set</option>
+              {Object.values(TShirtSize).map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <Field label="Availability" htmlFor="vol-availability">
+          <textarea
+            id="vol-availability"
+            rows={2}
+            value={draft.availability}
+            onChange={(e) =>
+              setDraft((p) => ({ ...p, availability: e.target.value }))
+            }
+            className={inputClass}
+          />
+        </Field>
+
+        <Field label="Preferred tasks (comma-separated)" htmlFor="vol-tasks">
+          <input
+            id="vol-tasks"
+            type="text"
+            value={draft.preferredTasks}
+            onChange={(e) =>
+              setDraft((p) => ({ ...p, preferredTasks: e.target.value }))
+            }
+            placeholder="e.g. registration, catering"
+            className={inputClass}
+          />
+        </Field>
+
+        <Field label="Dietary restrictions" htmlFor="vol-dietary">
+          <textarea
+            id="vol-dietary"
+            rows={2}
+            value={draft.dietaryRestrictions}
+            onChange={(e) =>
+              setDraft((p) => ({ ...p, dietaryRestrictions: e.target.value }))
+            }
+            className={inputClass}
+          />
+        </Field>
+
+        <Field label="Other information" htmlFor="vol-other">
+          <textarea
+            id="vol-other"
+            rows={2}
+            value={draft.otherInfo}
+            onChange={(e) =>
+              setDraft((p) => ({ ...p, otherInfo: e.target.value }))
+            }
+            className={inputClass}
+          />
+        </Field>
+
+        {error ? (
+          <p
+            role="alert"
+            className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+          >
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+          <AdminButton
+            type="button"
+            variant="secondary"
+            size="md"
+            onClick={onClose}
+            disabled={updateMutation.isPending}
+            className="min-h-[44px]"
+          >
+            Cancel
+          </AdminButton>
+          <AdminButton
+            type="submit"
+            color="blue"
+            size="md"
+            disabled={updateMutation.isPending}
+            className="min-h-[44px]"
+          >
+            {updateMutation.isPending ? 'Saving…' : 'Save changes'}
+          </AdminButton>
+        </div>
+      </form>
+    </ModalShell>
+  )
+}
+
+const inputClass =
+  'block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+
+function Field({
+  label,
+  htmlFor,
+  required,
+  children,
+}: {
+  label: string
+  htmlFor: string
+  required?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={htmlFor}
+        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        {label}
+        {required ? <span className="text-red-500"> *</span> : null}
+      </label>
+      {children}
+    </div>
+  )
+}

--- a/src/lib/sponsor-crm/activity.test.ts
+++ b/src/lib/sponsor-crm/activity.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Sanity write client: drive the pre-check fetch and capture the patch.
+const fetchMock = vi.fn()
+const commitMock = vi.fn()
+const deleteMock = vi.fn()
+let lastPatchId: string | undefined
+const lastSets: Record<string, unknown>[] = []
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    fetch: (query: string, params?: Record<string, unknown>) =>
+      fetchMock(query, params),
+    delete: (id: string) => deleteMock(id),
+    patch: (id: string) => {
+      lastPatchId = id
+      const builder = {
+        set: (obj: Record<string, unknown>) => {
+          lastSets.push(obj)
+          return builder
+        },
+        commit: () => commitMock(),
+      }
+      return builder
+    },
+  },
+}))
+
+import { updateSponsorActivity, deleteSponsorActivity } from './activity'
+
+const USER_ID = 'sp-1'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  lastPatchId = undefined
+  lastSets.length = 0
+  commitMock.mockResolvedValue({})
+  deleteMock.mockResolvedValue({})
+})
+
+describe('updateSponsorActivity — type + creator gating', () => {
+  it('updates a user-authored activity owned by the caller', async () => {
+    fetchMock.mockResolvedValue({
+      activityType: 'note',
+      createdBy: { _ref: USER_ID },
+    })
+    const result = await updateSponsorActivity('act-1', USER_ID, 'Updated note')
+    expect(result.success).toBe(true)
+    expect(lastPatchId).toBe('act-1')
+    expect(lastSets[0]).toEqual({ description: 'Updated note' })
+    expect(commitMock).toHaveBeenCalledOnce()
+  })
+
+  it('also patches metadata when provided', async () => {
+    fetchMock.mockResolvedValue({
+      activityType: 'call',
+      createdBy: { _ref: USER_ID },
+    })
+    await updateSponsorActivity('act-1', USER_ID, 'Called', {
+      additionalData: 'left voicemail',
+    })
+    expect(lastSets).toEqual([
+      { description: 'Called' },
+      { metadata: { additionalData: 'left voicemail' } },
+    ])
+  })
+
+  it.each(['stage_change', 'invoice_status_change', 'contract_signed'])(
+    'refuses to edit system-generated type: %s',
+    async (activityType) => {
+      fetchMock.mockResolvedValue({
+        activityType,
+        createdBy: { _ref: USER_ID },
+      })
+      const result = await updateSponsorActivity('act-1', USER_ID, 'x')
+      expect(result.success).toBe(false)
+      expect(result.error?.message).toMatch(/system-generated/i)
+      expect(commitMock).not.toHaveBeenCalled()
+    },
+  )
+
+  it('refuses to edit another user’s activity', async () => {
+    fetchMock.mockResolvedValue({
+      activityType: 'note',
+      createdBy: { _ref: 'someone-else' },
+    })
+    const result = await updateSponsorActivity('act-1', USER_ID, 'x')
+    expect(result.success).toBe(false)
+    expect(result.error?.message).toMatch(/your own/i)
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('404s when the activity does not exist', async () => {
+    fetchMock.mockResolvedValue(null)
+    const result = await updateSponsorActivity('missing', USER_ID, 'x')
+    expect(result.success).toBe(false)
+    expect(result.error?.message).toMatch(/not found/i)
+  })
+})
+
+describe('deleteSponsorActivity — gating mirrors update', () => {
+  it('deletes a user-authored activity owned by the caller', async () => {
+    fetchMock.mockResolvedValue({
+      activityType: 'meeting',
+      createdBy: { _ref: USER_ID },
+    })
+    const result = await deleteSponsorActivity('act-1', USER_ID)
+    expect(result.success).toBe(true)
+    expect(deleteMock).toHaveBeenCalledWith('act-1')
+  })
+
+  it('refuses a system-generated type', async () => {
+    fetchMock.mockResolvedValue({
+      activityType: 'stage_change',
+      createdBy: { _ref: USER_ID },
+    })
+    const result = await deleteSponsorActivity('act-1', USER_ID)
+    expect(result.success).toBe(false)
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/sponsor-crm/activity.ts
+++ b/src/lib/sponsor-crm/activity.ts
@@ -229,6 +229,70 @@ export async function logBulkEmailSent(
   }
 }
 
+/** Activity types a user authored by hand — the only ones editable/deletable. */
+const USER_AUTHORED_ACTIVITY_TYPES: ActivityType[] = [
+  'note',
+  'call',
+  'meeting',
+  'email',
+]
+
+export async function updateSponsorActivity(
+  activityId: string,
+  userId: string,
+  description: string,
+  metadata?: {
+    oldValue?: string
+    newValue?: string
+    timestamp?: string
+    additionalData?: string
+  },
+): Promise<{ success: boolean; error?: Error }> {
+  try {
+    // Fetch the activity to check its type and creator before editing. Gating
+    // MIRRORS deleteSponsorActivity: only user-authored types, only by their
+    // creator — system-generated audit entries stay immutable.
+    const activity = await clientWrite.fetch<{
+      activityType: ActivityType
+      createdBy?: { _ref: string }
+    }>(
+      `*[_type == "sponsorActivity" && _id == $activityId][0]{ activityType, createdBy }`,
+      {
+        activityId,
+      },
+    )
+
+    if (!activity) {
+      return { success: false, error: new Error('Activity not found') }
+    }
+
+    if (!USER_AUTHORED_ACTIVITY_TYPES.includes(activity.activityType)) {
+      return {
+        success: false,
+        error: new Error(
+          `Cannot edit system-generated activity of type: ${activity.activityType}`,
+        ),
+      }
+    }
+
+    if (activity.createdBy?._ref !== userId) {
+      return {
+        success: false,
+        error: new Error('You can only edit your own activities'),
+      }
+    }
+
+    let patch = clientWrite.patch(activityId).set({ description })
+    if (metadata !== undefined) patch = patch.set({ metadata })
+    await patch.commit()
+
+    return { success: true }
+  } catch (error) {
+    console.error('Failed to update sponsor activity:', error)
+    return { success: false, error: error as Error }
+  }
+}
+
 export async function deleteSponsorActivity(
   activityId: string,
   userId: string,

--- a/src/lib/staff/sanity.ts
+++ b/src/lib/staff/sanity.ts
@@ -1,6 +1,29 @@
-import { Staff } from '@/lib/staff/types'
+import { Staff, StaffAdmin } from '@/lib/staff/types'
 import { clientReadUncached as clientRead } from '@/lib/sanity/client'
 import { defineQuery } from 'next-sanity'
+
+/**
+ * Every staff member across all roles, ordered for the admin table (SE-4).
+ * Projects the raw image asset id alongside the resolved URL so the editor can
+ * both preview the image and re-submit it unchanged.
+ */
+export async function getAllStaffMembers(): Promise<StaffAdmin[]> {
+  const query = defineQuery(`
+    * [_type == "staff"] | order(role asc, name asc)
+    {
+      "_id": _id,
+      name,
+      role,
+      email,
+      company,
+      link,
+      "imageAssetId": image.asset._ref,
+      "imageURL": image.asset->url
+    }
+  `)
+
+  return await clientRead.fetch<StaffAdmin[]>(query)
+}
 
 export async function getStaffMembers(
   role: string,

--- a/src/lib/staff/types.ts
+++ b/src/lib/staff/types.ts
@@ -7,3 +7,21 @@ export interface Staff {
   imageURL?: URL
   link: URL
 }
+
+/**
+ * Admin projection of a staff document (SE-4). Unlike {@link Staff}, this keeps
+ * the raw image ASSET id (needed to re-submit an unchanged image on edit) and
+ * uses plain strings so it round-trips cleanly through tRPC.
+ */
+export interface StaffAdmin {
+  _id: string
+  name: string
+  role: string
+  email?: string
+  company?: string
+  link: string
+  /** Sanity image asset id (`image-…`), or undefined when no image is set. */
+  imageAssetId?: string
+  /** Resolved asset URL for preview, or undefined when no image is set. */
+  imageURL?: string
+}

--- a/src/lib/volunteer/sanity.ts
+++ b/src/lib/volunteer/sanity.ts
@@ -170,6 +170,64 @@ export async function updateVolunteerStatus(
   }
 }
 
+/** The organizer-editable subset of a volunteer's detail fields (SE-4). */
+export interface VolunteerDetailsUpdate {
+  name: string
+  email: string
+  phone: string
+  occupation: string
+  availability?: string | null
+  preferredTasks?: string[] | null
+  tshirtSize?: string | null
+  dietaryRestrictions?: string | null
+  otherInfo?: string | null
+}
+
+/**
+ * Patch a volunteer's own detail fields (SE-4). Required fields are always set;
+ * nullable optional fields are UNSET when explicitly `null` and left untouched
+ * when absent (a `.set(null)` would be ignored by Sanity, stranding stale
+ * values). Never touches status/review provenance.
+ */
+export async function updateVolunteerDetails(
+  volunteerId: string,
+  data: VolunteerDetailsUpdate,
+): Promise<{ success: boolean; error: Error | null }> {
+  try {
+    const set: Record<string, unknown> = {
+      name: data.name,
+      email: data.email,
+      phone: data.phone,
+      occupation: data.occupation,
+    }
+    const unset: string[] = []
+
+    const optional: Array<keyof VolunteerDetailsUpdate> = [
+      'availability',
+      'preferredTasks',
+      'tshirtSize',
+      'dietaryRestrictions',
+      'otherInfo',
+    ]
+    for (const key of optional) {
+      const value = data[key]
+      if (value === null) unset.push(key)
+      else if (value !== undefined) set[key] = value
+    }
+
+    let patch = clientWrite.patch(volunteerId).set(set)
+    if (unset.length > 0) patch = patch.unset(unset)
+    await patch.commit()
+
+    return { success: true, error: null }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error : new Error('Unknown error'),
+    }
+  }
+}
+
 export async function deleteVolunteer(
   volunteerId: string,
 ): Promise<{ success: boolean; error: Error | null }> {

--- a/src/lib/workshop/announcements.ts
+++ b/src/lib/workshop/announcements.ts
@@ -111,6 +111,55 @@ export async function createWorkshopAnnouncement(input: {
   }
 }
 
+/** The workshop + author an announcement belongs to — used to authorize edits. */
+export interface AnnouncementForAuthz {
+  _id: string
+  workshopId: string | null
+  authorId: string | null
+  conferenceId: string | null
+}
+
+/**
+ * Fetch the ownership context of a single announcement so the `updateAnnouncement`
+ * / `deleteAnnouncement` mutations can authorize the caller (owner ∨ organizer)
+ * and re-check multi-tenant isolation. Returns null when the id does not exist.
+ */
+export async function getWorkshopAnnouncementForAuthz(
+  announcementId: string,
+): Promise<AnnouncementForAuthz | null> {
+  const query = groq`*[_type == "workshopAnnouncement" && _id == $announcementId][0]{
+    _id,
+    "workshopId": workshop._ref,
+    "authorId": author._ref,
+    "conferenceId": conference._ref
+  }`
+
+  const result = await clientWrite.fetch<AnnouncementForAuthz | null>(query, {
+    announcementId,
+  })
+  return result ?? null
+}
+
+/**
+ * Patch ONLY the body of an announcement. Author + createdAt are immutable and
+ * are never touched here. Editing does NOT re-email participants (see the
+ * mutation JSDoc) — the persisted body just changes, so the workshop page shows
+ * the corrected copy on its next render.
+ */
+export async function updateWorkshopAnnouncementBody(
+  announcementId: string,
+  body: string,
+): Promise<void> {
+  await clientWrite.patch(announcementId).set({ body }).commit()
+}
+
+/** Hard-delete an announcement document. */
+export async function deleteWorkshopAnnouncement(
+  announcementId: string,
+): Promise<void> {
+  await clientWrite.delete(announcementId)
+}
+
 /** Read announcements for a workshop, newest first, bounded to `limit`. */
 export async function getWorkshopAnnouncements(
   workshopId: string,

--- a/src/server/_app.ts
+++ b/src/server/_app.ts
@@ -19,6 +19,7 @@ import { pushRouter } from './routers/push'
 import { messageRouter } from './routers/message'
 import { conferenceRouter } from './routers/conference'
 import { topicRouter } from './routers/topic'
+import { staffRouter } from './routers/staff'
 import { sponsorMessagesRouter } from './routers/sponsorMessages'
 
 export const appRouter = router({
@@ -42,6 +43,7 @@ export const appRouter = router({
   message: messageRouter,
   conference: conferenceRouter,
   topic: topicRouter,
+  staff: staffRouter,
   sponsorMessages: sponsorMessagesRouter,
 })
 

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -68,6 +68,7 @@ import {
   logAssignmentChange,
   logSignatureStatusChange,
   createSponsorActivity,
+  updateSponsorActivity,
   deleteSponsorActivity,
 } from '@/lib/sponsor-crm/activity'
 import { createNotifications } from '@/lib/notification/sanity'
@@ -86,6 +87,7 @@ import {
   BulkUpdateSponsorCRMSchema,
   BulkDeleteSponsorCRMSchema,
   CreateSponsorActivitySchema,
+  UpdateSponsorActivitySchema,
   SponsorCRMFilterSchema,
 } from '@/server/schemas/sponsorForConference'
 import {
@@ -1604,6 +1606,27 @@ export const sponsorRouter = router({
           }
 
           return { activityId }
+        }),
+
+      update: adminProcedure
+        .input(UpdateSponsorActivitySchema)
+        .mutation(async ({ input, ctx }) => {
+          const { success, error } = await updateSponsorActivity(
+            input.id,
+            ctx.speaker._id,
+            input.description,
+            input.metadata,
+          )
+
+          if (error || !success) {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: error?.message || 'Failed to update sponsor activity',
+              cause: error,
+            })
+          }
+
+          return { success: true }
         }),
 
       delete: adminProcedure

--- a/src/server/routers/staff.test.ts
+++ b/src/server/routers/staff.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+// Sanity write client: capture create/patch/delete.
+const createMock = vi.fn()
+const deleteMock = vi.fn()
+const commitMock = vi.fn()
+let lastPatchId: string | undefined
+let lastSet: Record<string, unknown> | undefined
+let lastUnset: string[] | undefined
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    create: (doc: Record<string, unknown>) => createMock(doc),
+    delete: (id: string) => deleteMock(id),
+    patch: (id: string) => {
+      lastPatchId = id
+      const builder = {
+        set: (obj: Record<string, unknown>) => {
+          lastSet = { ...(lastSet ?? {}), ...obj }
+          return builder
+        },
+        unset: (keys: string[]) => {
+          lastUnset = keys
+          return builder
+        },
+        commit: () => commitMock(),
+      }
+      return builder
+    },
+  },
+}))
+
+// Admin list reads through the data layer.
+const getAllStaffMock = vi.fn()
+vi.mock('@/lib/staff/sanity', () => ({
+  getAllStaffMembers: () => getAllStaffMock(),
+}))
+
+import { staffRouter } from './staff'
+
+function makeCaller(isOrganizer = true) {
+  const speaker = { _id: 'sp-1', name: 'Org', isOrganizer }
+  const ctx = {
+    session: { speaker, user: { name: 'Org' } },
+    speaker,
+  } as unknown as Context
+  return staffRouter.createCaller(ctx)
+}
+
+const validCreate = {
+  name: 'Ada Lovelace',
+  role: 'organizer',
+  link: 'https://example.com/ada',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  lastPatchId = undefined
+  lastSet = undefined
+  lastUnset = undefined
+  createMock.mockResolvedValue({ _id: 'staff-new' })
+  deleteMock.mockResolvedValue({})
+  commitMock.mockResolvedValue({ _id: 'staff-1' })
+  getAllStaffMock.mockResolvedValue([])
+})
+
+describe('staff router — authorization', () => {
+  it('rejects a non-organizer (FORBIDDEN)', async () => {
+    await expect(makeCaller(false).create(validCreate)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('staff router — create', () => {
+  it('creates a staff doc with required fields', async () => {
+    const result = await makeCaller().create(validCreate)
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const doc = createMock.mock.calls[0][0]
+    expect(doc._type).toBe('staff')
+    expect(doc.name).toBe('Ada Lovelace')
+    expect(doc.role).toBe('organizer')
+    expect(doc.link).toBe('https://example.com/ada')
+    expect(doc).not.toHaveProperty('image')
+    expect(result._id).toBe('staff-new')
+  })
+
+  it('stores the image as an asset reference when provided', async () => {
+    await makeCaller().create({
+      ...validCreate,
+      image: 'image-abc-200x200-png',
+      email: 'ada@example.com',
+      company: 'Analytical Engines',
+    })
+    const doc = createMock.mock.calls[0][0]
+    expect(doc.image).toEqual({
+      _type: 'image',
+      asset: { _type: 'reference', _ref: 'image-abc-200x200-png' },
+    })
+    expect(doc.email).toBe('ada@example.com')
+    expect(doc.company).toBe('Analytical Engines')
+  })
+
+  it('rejects a missing name', async () => {
+    await expect(
+      makeCaller().create({ ...validCreate, name: '' }),
+    ).rejects.toBeTruthy()
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid link URL', async () => {
+    await expect(
+      makeCaller().create({ ...validCreate, link: 'not-a-url' }),
+    ).rejects.toBeTruthy()
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an image that is not a Sanity asset id', async () => {
+    await expect(
+      makeCaller().create({ ...validCreate, image: 'https://cdn/x.png' }),
+    ).rejects.toBeTruthy()
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('staff router — update', () => {
+  it('patches only provided fields', async () => {
+    await makeCaller().update({ id: 'staff-1', name: 'Grace Hopper' })
+    expect(lastPatchId).toBe('staff-1')
+    expect(lastSet).toEqual({ name: 'Grace Hopper' })
+    expect(lastUnset).toBeUndefined()
+  })
+
+  it('unsets optional fields sent as null', async () => {
+    await makeCaller().update({ id: 'staff-1', email: null, company: null })
+    expect(lastUnset).toEqual(['email', 'company'])
+    expect(commitMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsets the image when sent as null', async () => {
+    await makeCaller().update({ id: 'staff-1', image: null })
+    expect(lastUnset).toEqual(['image'])
+  })
+
+  it('sets a new image asset reference', async () => {
+    await makeCaller().update({ id: 'staff-1', image: 'image-xyz-100x100-png' })
+    expect(lastSet).toEqual({
+      image: {
+        _type: 'image',
+        asset: { _type: 'reference', _ref: 'image-xyz-100x100-png' },
+      },
+    })
+  })
+
+  it('rejects an update with nothing to change', async () => {
+    await expect(makeCaller().update({ id: 'staff-1' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('staff router — delete (unguarded)', () => {
+  it('deletes without any reference check', async () => {
+    const result = await makeCaller().delete({ id: 'staff-1' })
+    expect(result.success).toBe(true)
+    expect(deleteMock).toHaveBeenCalledWith('staff-1')
+  })
+})

--- a/src/server/routers/staff.ts
+++ b/src/server/routers/staff.ts
@@ -1,0 +1,129 @@
+import { TRPCError } from '@trpc/server'
+import { revalidateTag } from 'next/cache'
+import { router, adminProcedure } from '../trpc'
+import { clientWrite } from '@/lib/sanity/client'
+import { getAllStaffMembers } from '@/lib/staff/sanity'
+import {
+  StaffCreateSchema,
+  StaffUpdateSchema,
+  StaffDeleteSchema,
+} from '../schemas/staff'
+
+/**
+ * Staff CRUD (SE-4). `staff` are flat, standalone documents listed publicly at
+ * `/staff/[role]`; this router replaces editing them in Sanity Studio.
+ *
+ * IMAGE: `image` is a Sanity image ASSET id (from `/api/admin/speaker-image`),
+ * stored as `{ _type: 'image', asset: { _type: 'reference', _ref } }` — the
+ * same shape the speaker editor uses.
+ *
+ * DELETE is UNGUARDED: nothing references a staff document, so removing one can
+ * never strand a reference (contrast the topic router's reference guard).
+ */
+
+/** Build the stored `image` object from an asset id, or `undefined`. */
+function imageField(assetId: string | undefined) {
+  if (!assetId) return undefined
+  return {
+    _type: 'image' as const,
+    asset: { _type: 'reference' as const, _ref: assetId },
+  }
+}
+
+export const staffRouter = router({
+  /** Every staff member, ordered by role then name — the admin table source. */
+  list: adminProcedure.query(async () => {
+    try {
+      return await getAllStaffMembers()
+    } catch (error) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to fetch staff',
+        cause: error,
+      })
+    }
+  }),
+
+  create: adminProcedure
+    .input(StaffCreateSchema)
+    .mutation(async ({ input }) => {
+      try {
+        const created = await clientWrite.create({
+          _type: 'staff',
+          name: input.name,
+          role: input.role,
+          link: input.link,
+          ...(input.email ? { email: input.email } : {}),
+          ...(input.company ? { company: input.company } : {}),
+          ...(imageField(input.image)
+            ? { image: imageField(input.image) }
+            : {}),
+        })
+        revalidateTag('content:staff', 'default')
+        return { _id: created._id }
+      } catch (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to create staff member',
+          cause: error,
+        })
+      }
+    }),
+
+  update: adminProcedure
+    .input(StaffUpdateSchema)
+    .mutation(async ({ input }) => {
+      const { id, ...rest } = input
+      const set: Record<string, unknown> = {}
+      const unset: string[] = []
+
+      if (rest.name !== undefined) set.name = rest.name
+      if (rest.role !== undefined) set.role = rest.role
+      if (rest.link !== undefined) set.link = rest.link
+      // Optional fields: null clears (unset), a value sets, absent leaves as-is.
+      if (rest.email === null) unset.push('email')
+      else if (rest.email !== undefined) set.email = rest.email
+      if (rest.company === null) unset.push('company')
+      else if (rest.company !== undefined) set.company = rest.company
+      if (rest.image === null) unset.push('image')
+      else if (rest.image !== undefined) set.image = imageField(rest.image)
+
+      if (Object.keys(set).length === 0 && unset.length === 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No updates provided',
+        })
+      }
+
+      try {
+        let patch = clientWrite.patch(id)
+        if (Object.keys(set).length > 0) patch = patch.set(set)
+        if (unset.length > 0) patch = patch.unset(unset)
+        await patch.commit()
+        revalidateTag('content:staff', 'default')
+        return { success: true }
+      } catch (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to update staff member',
+          cause: error,
+        })
+      }
+    }),
+
+  delete: adminProcedure
+    .input(StaffDeleteSchema)
+    .mutation(async ({ input }) => {
+      try {
+        await clientWrite.delete(input.id)
+        revalidateTag('content:staff', 'default')
+        return { success: true }
+      } catch (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to delete staff member',
+          cause: error,
+        })
+      }
+    }),
+})

--- a/src/server/routers/volunteer.test.ts
+++ b/src/server/routers/volunteer.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+import { Occupation } from '@/lib/volunteer/types'
+
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+// Volunteer data layer — only the pieces admin.update touches.
+const getVolunteerByIdMock = vi.fn()
+const updateVolunteerDetailsMock = vi.fn()
+vi.mock('@/lib/volunteer/sanity', () => ({
+  getVolunteersByConference: vi.fn(),
+  getVolunteerById: (...a: unknown[]) => getVolunteerByIdMock(...a),
+  updateVolunteerStatus: vi.fn(),
+  updateVolunteerDetails: (...a: unknown[]) => updateVolunteerDetailsMock(...a),
+  deleteVolunteer: vi.fn(),
+  createVolunteer: vi.fn(),
+}))
+
+import { volunteerRouter } from './volunteer'
+
+function makeCaller(isOrganizer = true) {
+  const speaker = { _id: 'sp-1', name: 'Org', isOrganizer }
+  const ctx = {
+    session: { speaker, user: { name: 'Org' } },
+    speaker,
+  } as unknown as Context
+  return volunteerRouter.createCaller(ctx)
+}
+
+const validInput = {
+  volunteerId: 'vol-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  phone: '+4711111111',
+  occupation: Occupation.WORKING,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getVolunteerByIdMock.mockResolvedValue({
+    volunteer: { _id: 'vol-1', name: 'Ada' },
+    error: null,
+  })
+  updateVolunteerDetailsMock.mockResolvedValue({ success: true, error: null })
+})
+
+describe('volunteer.admin.update — authorization', () => {
+  it('rejects a non-organizer (FORBIDDEN)', async () => {
+    await expect(
+      makeCaller(false).admin.update(validInput),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(updateVolunteerDetailsMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('volunteer.admin.update — behavior', () => {
+  it('forwards the editable fields (minus volunteerId) to the data layer', async () => {
+    const result = await makeCaller().admin.update({
+      ...validInput,
+      availability: 'weekends',
+      preferredTasks: ['registration'],
+      tshirtSize: null,
+      dietaryRestrictions: null,
+      otherInfo: null,
+    })
+    expect(result.success).toBe(true)
+    expect(updateVolunteerDetailsMock).toHaveBeenCalledWith('vol-1', {
+      name: 'Ada',
+      email: 'ada@example.com',
+      phone: '+4711111111',
+      occupation: Occupation.WORKING,
+      availability: 'weekends',
+      preferredTasks: ['registration'],
+      tshirtSize: null,
+      dietaryRestrictions: null,
+      otherInfo: null,
+    })
+  })
+
+  it('404s when the volunteer does not exist', async () => {
+    getVolunteerByIdMock.mockResolvedValue({ volunteer: null, error: null })
+    await expect(makeCaller().admin.update(validInput)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    })
+    expect(updateVolunteerDetailsMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a blank name (validation)', async () => {
+    await expect(
+      makeCaller().admin.update({ ...validInput, name: '' }),
+    ).rejects.toBeTruthy()
+    expect(updateVolunteerDetailsMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid email (validation)', async () => {
+    await expect(
+      makeCaller().admin.update({ ...validInput, email: 'not-an-email' }),
+    ).rejects.toBeTruthy()
+    expect(updateVolunteerDetailsMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects more than 10 preferred tasks (validation)', async () => {
+    await expect(
+      makeCaller().admin.update({
+        ...validInput,
+        preferredTasks: Array.from({ length: 11 }, (_, i) => `task-${i}`),
+      }),
+    ).rejects.toBeTruthy()
+    expect(updateVolunteerDetailsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/routers/volunteer.ts
+++ b/src/server/routers/volunteer.ts
@@ -8,6 +8,7 @@ import {
 import {
   GetVolunteerByIdSchema,
   UpdateVolunteerStatusSchema,
+  UpdateVolunteerDetailsSchema,
   SendVolunteerEmailSchema,
   DeleteVolunteerSchema,
   CreateVolunteerSchema,
@@ -16,6 +17,7 @@ import {
   getVolunteersByConference,
   getVolunteerById,
   updateVolunteerStatus,
+  updateVolunteerDetails,
   deleteVolunteer,
   createVolunteer,
 } from '@/lib/volunteer/sanity'
@@ -221,6 +223,54 @@ export const volunteerRouter = router({
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Failed to update volunteer status',
+            cause: error,
+          })
+        }
+      }),
+
+    update: adminProcedure
+      .input(UpdateVolunteerDetailsSchema)
+      .mutation(async ({ input }) => {
+        try {
+          const { volunteer, error: fetchError } = await getVolunteerById(
+            input.volunteerId,
+          )
+
+          if (fetchError) {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: 'Failed to fetch volunteer',
+              cause: fetchError,
+            })
+          }
+
+          if (!volunteer) {
+            throw new TRPCError({
+              code: 'NOT_FOUND',
+              message: 'Volunteer not found',
+            })
+          }
+
+          const { volunteerId, ...details } = input
+          const { success, error } = await updateVolunteerDetails(
+            volunteerId,
+            details,
+          )
+
+          if (error || !success) {
+            throw new TRPCError({
+              code: 'INTERNAL_SERVER_ERROR',
+              message: 'Failed to update volunteer details',
+              cause: error,
+            })
+          }
+
+          return { success }
+        } catch (error) {
+          if (error instanceof TRPCError) throw error
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Failed to update volunteer details',
             cause: error,
           })
         }

--- a/src/server/routers/workshop.announce.test.ts
+++ b/src/server/routers/workshop.announce.test.ts
@@ -23,6 +23,9 @@ const getConfirmedRecipientsMock = vi.fn()
 const createAnnouncementMock = vi.fn()
 const getAnnouncementsMock = vi.fn()
 const fanOutMock = vi.fn()
+const getAnnouncementForAuthzMock = vi.fn()
+const updateAnnouncementBodyMock = vi.fn()
+const deleteAnnouncementMock = vi.fn()
 vi.mock('@/lib/workshop/announcements', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@/lib/workshop/announcements')>()
@@ -35,6 +38,12 @@ vi.mock('@/lib/workshop/announcements', async (importOriginal) => {
     createWorkshopAnnouncement: (...a: unknown[]) =>
       createAnnouncementMock(...a),
     getWorkshopAnnouncements: (...a: unknown[]) => getAnnouncementsMock(...a),
+    getWorkshopAnnouncementForAuthz: (...a: unknown[]) =>
+      getAnnouncementForAuthzMock(...a),
+    updateWorkshopAnnouncementBody: (...a: unknown[]) =>
+      updateAnnouncementBodyMock(...a),
+    deleteWorkshopAnnouncement: (...a: unknown[]) =>
+      deleteAnnouncementMock(...a),
     sendAnnouncementToConfirmedParticipants: (...a: unknown[]) =>
       fanOutMock(...a),
   }
@@ -89,6 +98,14 @@ beforeEach(() => {
   })
   fanOutMock.mockResolvedValue({ sent: 1, failed: 0 })
   consumeRateLimitMock.mockReturnValue({ allowed: true, retryAfterMs: 0 })
+  getAnnouncementForAuthzMock.mockResolvedValue({
+    _id: 'ann-1',
+    workshopId: 'ws-1',
+    authorId: OWNER_ID,
+    conferenceId: CONFERENCE_ID,
+  })
+  updateAnnouncementBodyMock.mockResolvedValue(undefined)
+  deleteAnnouncementMock.mockResolvedValue(undefined)
 })
 
 describe('workshop.announce — authorization', () => {
@@ -193,5 +210,109 @@ describe('workshop.announcements — public query bounds', () => {
     await expect(
       makeCaller(null).announcements({ workshopId: 'ws-1', limit: 51 }),
     ).rejects.toBeTruthy()
+  })
+})
+
+describe('workshop.updateAnnouncement — authorization + immutability', () => {
+  it('allows the workshop OWNER and patches only the body', async () => {
+    const result = await makeCaller(OWNER_ID).updateAnnouncement({
+      announcementId: 'ann-1',
+      body: 'Corrected copy',
+    })
+    expect(result.success).toBe(true)
+    expect(updateAnnouncementBodyMock).toHaveBeenCalledWith(
+      'ann-1',
+      'Corrected copy',
+    )
+    // Owner is authorized without the organizer lookup.
+    expect(getOrganizerSpeakerIdsMock).not.toHaveBeenCalled()
+  })
+
+  it('allows an ORGANIZER who is not a workshop speaker', async () => {
+    const result = await makeCaller(ORGANIZER_ID).updateAnnouncement({
+      announcementId: 'ann-1',
+      body: 'Room change',
+    })
+    expect(result.success).toBe(true)
+    expect(getOrganizerSpeakerIdsMock).toHaveBeenCalledOnce()
+  })
+
+  it('rejects an unrelated speaker (FORBIDDEN)', async () => {
+    await expect(
+      makeCaller(STRANGER_ID).updateAnnouncement({
+        announcementId: 'ann-1',
+        body: 'hi',
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(updateAnnouncementBodyMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unauthenticated caller', async () => {
+    await expect(
+      makeCaller(null).updateAnnouncement({
+        announcementId: 'ann-1',
+        body: 'hi',
+      }),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
+  })
+
+  it('rejects an announcement in a different conference (multi-tenant)', async () => {
+    getAnnouncementForAuthzMock.mockResolvedValue({
+      _id: 'ann-1',
+      workshopId: 'ws-1',
+      authorId: OWNER_ID,
+      conferenceId: 'conf-OTHER',
+    })
+    await expect(
+      makeCaller(OWNER_ID).updateAnnouncement({
+        announcementId: 'ann-1',
+        body: 'hi',
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(updateAnnouncementBodyMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing announcement', async () => {
+    getAnnouncementForAuthzMock.mockResolvedValue(null)
+    await expect(
+      makeCaller(OWNER_ID).updateAnnouncement({
+        announcementId: 'nope',
+        body: 'hi',
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('rejects a blank body (validation)', async () => {
+    await expect(
+      makeCaller(OWNER_ID).updateAnnouncement({
+        announcementId: 'ann-1',
+        body: '   ',
+      }),
+    ).rejects.toBeTruthy()
+    expect(updateAnnouncementBodyMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('workshop.deleteAnnouncement — authorization', () => {
+  it('allows the workshop OWNER', async () => {
+    const result = await makeCaller(OWNER_ID).deleteAnnouncement({
+      announcementId: 'ann-1',
+    })
+    expect(result.success).toBe(true)
+    expect(deleteAnnouncementMock).toHaveBeenCalledWith('ann-1')
+  })
+
+  it('allows an ORGANIZER', async () => {
+    const result = await makeCaller(ORGANIZER_ID).deleteAnnouncement({
+      announcementId: 'ann-1',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an unrelated speaker (FORBIDDEN)', async () => {
+    await expect(
+      makeCaller(STRANGER_ID).deleteAnnouncement({ announcementId: 'ann-1' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(deleteAnnouncementMock).not.toHaveBeenCalled()
   })
 })

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -25,6 +25,8 @@ import {
   batchCancelSignupsSchema,
   WorkshopSignupIdSchema,
   workshopAnnounceSchema,
+  workshopUpdateAnnouncementSchema,
+  workshopDeleteAnnouncementSchema,
   workshopAnnouncementsQuerySchema,
 } from '@/server/schemas/workshop'
 import {
@@ -50,6 +52,9 @@ import {
   getConfirmedAnnouncementRecipients,
   createWorkshopAnnouncement,
   getWorkshopAnnouncements,
+  getWorkshopAnnouncementForAuthz,
+  updateWorkshopAnnouncementBody,
+  deleteWorkshopAnnouncement,
   sendAnnouncementToConfirmedParticipants,
   isWorkshopFormat,
 } from '@/lib/workshop/announcements'
@@ -70,6 +75,54 @@ function requireWorkshopUser(ctx: Context): WorkshopUserIdentity {
     })
   }
   return user
+}
+
+/**
+ * Authorize an announcement edit/delete: the caller must OWN the workshop the
+ * announcement belongs to (be one of its speakers) OR be an organizer — the
+ * SAME rule as `announce`. Also re-checks multi-tenant isolation (the
+ * announcement must live in the caller's resolved conference). Throws
+ * NOT_FOUND / FORBIDDEN; returns nothing on success. Author/createdAt are NOT
+ * consulted — ownership is by the workshop, not the original author.
+ */
+async function authorizeAnnouncementMutation(
+  speakerId: string,
+  announcementId: string,
+): Promise<void> {
+  const conferenceId = await resolveConferenceId()
+  const announcement = await getWorkshopAnnouncementForAuthz(announcementId)
+
+  if (
+    !announcement ||
+    !announcement.workshopId ||
+    announcement.conferenceId !== conferenceId
+  ) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Announcement not found for this conference',
+    })
+  }
+
+  const workshop = await getWorkshopForAnnouncement(announcement.workshopId)
+  if (!workshop || workshop.conferenceId !== conferenceId) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Workshop not found for this conference',
+    })
+  }
+
+  const isOwner = workshop.speakerIds.includes(speakerId)
+  const isOrganizer = isOwner
+    ? false
+    : (await getOrganizerSpeakerIds()).includes(speakerId)
+
+  if (!isOwner && !isOrganizer) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message:
+        'Only the workshop owner or an organizer can manage announcements',
+    })
+  }
 }
 
 /** Display name for a signup doc, mirroring the workshop page's fallback order. */
@@ -228,6 +281,67 @@ export const workshopRouter = router({
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: 'Failed to send workshop announcement',
+          cause: error,
+        })
+      }
+    }),
+
+  // Edit an existing announcement's BODY only. Author + createdAt are immutable
+  // (never sent, never patched). Authz mirrors `announce`: workshop owner ∨
+  // organizer.
+  //
+  // NO RE-EMAIL POLICY: editing does NOT re-send emails. The announcement was
+  // already emailed to confirmed participants when it was created; an edit is a
+  // copy correction that only updates the persisted body (and thus the workshop
+  // page). Re-emailing on every typo fix would spam participants, so it is
+  // deliberately omitted.
+  updateAnnouncement: protectedProcedure
+    .input(workshopUpdateAnnouncementSchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        await authorizeAnnouncementMutation(
+          ctx.speaker._id,
+          input.announcementId,
+        )
+
+        await updateWorkshopAnnouncementBody(input.announcementId, input.body)
+
+        revalidateTag('content:workshops', 'default')
+
+        return { success: true }
+      } catch (error) {
+        if (error instanceof TRPCError) throw error
+
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to update workshop announcement',
+          cause: error,
+        })
+      }
+    }),
+
+  // Delete an announcement. Authz mirrors `announce`: workshop owner ∨
+  // organizer. No re-email; the announcement simply disappears from the page.
+  deleteAnnouncement: protectedProcedure
+    .input(workshopDeleteAnnouncementSchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        await authorizeAnnouncementMutation(
+          ctx.speaker._id,
+          input.announcementId,
+        )
+
+        await deleteWorkshopAnnouncement(input.announcementId)
+
+        revalidateTag('content:workshops', 'default')
+
+        return { success: true }
+      } catch (error) {
+        if (error instanceof TRPCError) throw error
+
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to delete workshop announcement',
           cause: error,
         })
       }

--- a/src/server/schemas/sponsorForConference.ts
+++ b/src/server/schemas/sponsorForConference.ts
@@ -202,6 +202,25 @@ export const CreateSponsorActivitySchema = z.object({
   description: z.string().min(1, 'Description is required'),
 })
 
+/**
+ * Edit of a user-authored activity (SE-4). Only `note`/`call`/`meeting`/`email`
+ * activities are editable, and only by their creator — the server re-checks
+ * both against the stored doc (mirroring the delete gating). The `activityType`
+ * is NOT editable here.
+ */
+export const UpdateSponsorActivitySchema = z.object({
+  id: z.string().min(1, 'Activity ID is required'),
+  description: z.string().min(1, 'Description is required'),
+  metadata: z
+    .object({
+      oldValue: z.string().optional(),
+      newValue: z.string().optional(),
+      timestamp: z.string().optional(),
+      additionalData: z.string().optional(),
+    })
+    .optional(),
+})
+
 export const SponsorCRMFilterSchema = z.object({
   status: z.array(z.string()).optional(),
   invoiceStatus: z.array(z.string()).optional(),

--- a/src/server/schemas/staff.ts
+++ b/src/server/schemas/staff.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+/**
+ * Schemas for the `staff` router (SE-4). Staff are flat, standalone documents
+ * surfaced publicly at `/staff/[role]`; the admin now creates and edits them
+ * here instead of in Sanity Studio. Mirrors `sanity/schemaTypes/staff.ts`:
+ * `name`, `role` and `link` are required; `email`, `company` and `image` are
+ * optional. `image` is a Sanity image ASSET id (e.g. `image-abc-200x200-png`),
+ * uploaded via `/api/admin/speaker-image` (a generic organizer-only image
+ * uploader) and stored as an `image` object referencing that asset.
+ */
+
+/** A Sanity image asset id, as returned by the upload route (`image-…`). */
+const imageAssetId = z
+  .string()
+  .trim()
+  .regex(/^image-/, 'Must be a Sanity image asset id')
+
+export const StaffCreateSchema = z.object({
+  name: z.string().trim().min(1, 'Name is required'),
+  role: z.string().trim().min(1, 'Role is required'),
+  link: z.string().trim().url('Must be a valid URL'),
+  email: z.string().trim().email('Must be a valid email').optional(),
+  company: z.string().trim().min(1).optional(),
+  image: imageAssetId.optional(),
+})
+
+export const StaffUpdateSchema = z.object({
+  id: z.string().trim().min(1, 'A staff id is required'),
+  name: z.string().trim().min(1, 'Name is required').optional(),
+  role: z.string().trim().min(1, 'Role is required').optional(),
+  link: z.string().trim().url('Must be a valid URL').optional(),
+  // Optional detail fields are nullable so the editor can CLEAR them: `null`
+  // unsets the field in Sanity, an absent key leaves it untouched.
+  email: z.string().trim().email('Must be a valid email').nullable().optional(),
+  company: z.string().trim().min(1).nullable().optional(),
+  image: imageAssetId.nullable().optional(),
+})
+
+export const StaffDeleteSchema = z.object({
+  id: z.string().trim().min(1, 'A staff id is required'),
+})

--- a/src/server/schemas/volunteer.ts
+++ b/src/server/schemas/volunteer.ts
@@ -21,6 +21,51 @@ export const DeleteVolunteerSchema = z.object({
   volunteerId: z.string(),
 })
 
+/**
+ * Organizer edit of a volunteer's own detail fields (SE-4). Deliberately
+ * EXCLUDES `status` (its own `updateStatus` mutation owns the review workflow),
+ * `reviewedBy`/`reviewedAt` (set by that workflow), and `consent`/`conference`
+ * (immutable provenance). Nullable optional fields can be CLEARED (null unsets;
+ * absent leaves untouched).
+ */
+export const UpdateVolunteerDetailsSchema = z.object({
+  volunteerId: z.string().min(1),
+  name: z
+    .string()
+    .min(1, 'Name is required')
+    .max(100, 'Name must be less than 100 characters'),
+  email: z
+    .string()
+    .email('Please enter a valid email address')
+    .min(1, 'Email is required'),
+  phone: z
+    .string()
+    .min(1, 'Phone number is required')
+    .max(50, 'Phone number must be less than 50 characters'),
+  occupation: z.nativeEnum(Occupation),
+  availability: z
+    .string()
+    .max(1000, 'Availability must be less than 1000 characters')
+    .nullable()
+    .optional(),
+  preferredTasks: z
+    .array(z.string().max(100, 'Each task must be less than 100 characters'))
+    .max(10, 'Maximum 10 tasks allowed')
+    .nullable()
+    .optional(),
+  tshirtSize: z.nativeEnum(TShirtSize).nullable().optional(),
+  dietaryRestrictions: z
+    .string()
+    .max(500, 'Dietary restrictions must be less than 500 characters')
+    .nullable()
+    .optional(),
+  otherInfo: z
+    .string()
+    .max(1000, 'Other information must be less than 1000 characters')
+    .nullable()
+    .optional(),
+})
+
 export const CreateVolunteerSchema = z.object({
   name: z
     .string()

--- a/src/server/schemas/workshop.ts
+++ b/src/server/schemas/workshop.ts
@@ -123,6 +123,21 @@ export const workshopAnnounceSchema = z.object({
     .max(2000, 'Announcement must be 2000 characters or fewer'),
 })
 
+/** Owner/organizer editing an existing announcement's body (SE-4). */
+export const workshopUpdateAnnouncementSchema = z.object({
+  announcementId: z.string().min(1, 'Announcement ID is required'),
+  body: z
+    .string()
+    .trim()
+    .min(1, 'Announcement message is required')
+    .max(2000, 'Announcement must be 2000 characters or fewer'),
+})
+
+/** Owner/organizer deleting an announcement (SE-4). */
+export const workshopDeleteAnnouncementSchema = z.object({
+  announcementId: z.string().min(1, 'Announcement ID is required'),
+})
+
 /** Public read of a workshop's announcements, bounded to [0...50], newest first. */
 export const workshopAnnouncementsQuerySchema = z.object({
   workshopId: z.string().min(1, 'Workshop ID is required'),


### PR DESCRIPTION
## SE-4 — the small-CRUD sweep

Closes the remaining standalone Studio-elimination gaps from the audit. Four independent editing surfaces, all maintainer-greenlit, plus tests, stories, and visual QA.

### 1. Staff CRUD
- New `staff` router (`list`/`create`/`update`/`delete`) — `adminProcedure`, **delete unguarded** (nothing references a staff doc).
- New admin page at `/admin/staff` (nav: **People** section, between Speakers and Volunteers, `IdentificationIcon`).
- `StaffManager` — table + `ModalShell` create/edit form.
- **Image field finding:** `staff.image` is a Sanity **image asset** (`type: 'image'`, hotspot), so the form reuses the `/api/admin/speaker-image` upload route and stores `{ _type:'image', asset:{ _type:'reference', _ref } }` (the speaker-editor shape).

### 2. Workshop announcement edit/delete
- `workshop.updateAnnouncement` (body only; **author + createdAt immutable**) and `workshop.deleteAnnouncement`, both `protectedProcedure` with the **same authz as `announce`** (workshop owner ∨ organizer) + multi-tenant re-check.
- **No re-email on edit** — announcements were already emailed; an edit only corrects the persisted copy. Documented in the mutation JSDoc.
- UI: past-announcements list inside `AnnounceModal` with inline edit + delete (delete via `ConfirmationModal`). Public `WorkshopCard` unchanged.

### 3. Volunteer details edit
- `volunteer.admin.update` for the organizer-sensible subset (name/email/phone/occupation/availability/preferredTasks/tshirtSize/dietaryRestrictions/otherInfo). Excludes `status` (own mutation), `reviewedBy`/`reviewedAt`, consent/conference. Nullable fields clear via unset.
- UI: `VolunteerEditModal` (`ModalShell`), opened from an "Edit Details" affordance in the volunteer detail panel.

### 4. Sponsor activity note edit
- `sponsor.crm.activities.update` — gating **mirrors the delete** (`activity.ts`): only user-authored types (`note`/`call`/`meeting`/`email`), only by the creator (server-enforced); description + optional metadata.
- UI: inline edit affordance on activity-timeline rows, shown only for editable types.

### Tests
- `staff.test.ts` (authz/create/update-patch+unset/delete), `volunteer.test.ts` (authz/validation/field-forwarding), `activity.test.ts` (type+creator gating for update & delete), and announcement update/delete cases added to `workshop.announce.test.ts` (owner∨organizer, immutability, multi-tenant, validation).
- Full suite green: **258 files, 3625 passed / 5 skipped**.

### Stories + visual QA
- Stories for `StaffManager` (table/form), `VolunteerEditModal`, `AnnounceModal` (with-announcements), and a real-component `SponsorActivityTimeline` edit story.
- Shot at 393px, light + dark (`SHOOT_OUT=/tmp/se4-shoot`). Inspected: staff table/form, announcement edit list, volunteer edit modal, activity inline edit (type-gating confirmed — system rows show no edit affordance).

### Checks
`tsc` ✓ · `eslint` ✓ · `prettier` ✓ · `knip` ✓ · `vitest` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four independent CRUD editing surfaces to replace Sanity Studio editing: Staff (new `adminProcedure` router + admin page), Workshop announcement edit/delete, Volunteer details edit, and Sponsor CRM activity edit. Each surface has tests, stories, and authorization parity with its existing mutation.

- **Staff router** adds `list`/`create`/`update`/`delete` via `adminProcedure`; image upload reuses the speaker-image route; delete is intentionally unguarded.
- **Announcement edit/delete** uses `protectedProcedure` with a dedicated `authorizeAnnouncementMutation` helper that correctly mirrors the original `announce` authz (workshop owner ∨ organizer + multi-tenant re-check).
- **Volunteer details update** (`adminProcedure`) and **Sponsor CRM activity update** (`adminProcedure`, creator + type gating in the lib layer) both follow established patterns but the activity timeline component is missing an `onError` handler for the new update mutation.

<h3>Confidence Score: 4/5</h3>

Safe to merge after adding an onError handler to the SponsorActivityTimeline update mutation.

The four editing surfaces are well-isolated and their server-side authorization is solid. The one concrete defect is in SponsorActivityTimeline: the new update mutation has no onError callback, so a failed save produces zero user feedback — the edit form closes optimistically, the draft text is lost, and the tRPC client has no global error handler to catch the gap. All other surfaces (VolunteerEditModal, WorkshopsClientPage, StaffManager) correctly handle errors with either inline messages or toast notifications.

src/components/admin/sponsor/SponsorActivityTimeline.tsx — the update mutation needs an onError handler.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/sponsor/SponsorActivityTimeline.tsx | New inline edit affordance for user-authored activities; missing onError handler means save failures are completely silent to the user. |
| src/server/routers/staff.ts | New adminProcedure CRUD router for staff documents; authorization is correct; imageField() called twice in create path (minor style issue). |
| src/server/routers/workshop.ts | Announcement update/delete mutations with a well-structured authorizeAnnouncementMutation helper that correctly mirrors original announce authz and multi-tenant isolation. |
| src/lib/workshop/announcements.ts | Adds updateWorkshopAnnouncementBody and deleteWorkshopAnnouncement; body-only patch is cleanly scoped, getWorkshopAnnouncementForAuthz projection is correct. |
| src/lib/sponsor-crm/activity.ts | New updateSponsorActivity correctly mirrors delete gating (USER_AUTHORED_ACTIVITY_TYPES + creator check); auth failures surface as INTERNAL_SERVER_ERROR in the router layer, consistent with existing delete behavior. |
| src/server/routers/volunteer.ts | New admin.update mutation follows the same fetch-then-patch pattern as existing admin mutations; proper error propagation and field forwarding. |
| src/components/volunteer/VolunteerEditModal.tsx | Well-structured modal with proper onError handling, inline error display, and draft reset on volunteer change. |
| src/components/admin/workshop/AnnounceModal.tsx | Announcement list with inline edit/delete affordances; edit state cleared optimistically before mutation confirms, but parent component provides onError notification so failures are visible. |
| src/components/admin/StaffManager.tsx | Complete CRUD UI with image upload, form validation, and create/edit/delete mutations; consistent error handling across all three mutations. |
| src/lib/volunteer/sanity.ts | New updateVolunteerDetails cleanly handles set/unset semantics for nullable optional fields, never touching status or review provenance fields. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Admin User] -->|staff CRUD| B[adminProcedure\nstaffRouter]
    A -->|volunteer.admin.update| C[adminProcedure\nvolunteerRouter]
    A -->|sponsor.crm.activities.update| D[adminProcedure\nsponsorRouter]
    E[Speaker/Organizer] -->|updateAnnouncement\ndeleteAnnouncement| F[protectedProcedure\nworkshopRouter]
    B --> B1[clientWrite.create/patch/delete\nSanity staff doc]
    C --> C1[getVolunteerById\nupdateVolunteerDetails]
    D --> D1[updateSponsorActivity\ntype+creator check in lib]
    F --> F2{authorizeAnnouncementMutation}
    F2 -->|resolveConferenceId\nmulti-tenant check| F3{owner OR organizer?}
    F3 -->|yes| F4[updateWorkshopAnnouncementBody\nor deleteWorkshopAnnouncement]
    F3 -->|no| F5[FORBIDDEN]
    D1 --> D2{USER_AUTHORED_TYPES?}
    D2 -->|no| D3[Error: cannot edit system activity]
    D2 -->|yes| D4{createdBy matches userId?}
    D4 -->|no| D5[Error: not your activity]
    D4 -->|yes| D6[clientWrite.patch description]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Admin User] -->|staff CRUD| B[adminProcedure\nstaffRouter]
    A -->|volunteer.admin.update| C[adminProcedure\nvolunteerRouter]
    A -->|sponsor.crm.activities.update| D[adminProcedure\nsponsorRouter]
    E[Speaker/Organizer] -->|updateAnnouncement\ndeleteAnnouncement| F[protectedProcedure\nworkshopRouter]
    B --> B1[clientWrite.create/patch/delete\nSanity staff doc]
    C --> C1[getVolunteerById\nupdateVolunteerDetails]
    D --> D1[updateSponsorActivity\ntype+creator check in lib]
    F --> F2{authorizeAnnouncementMutation}
    F2 -->|resolveConferenceId\nmulti-tenant check| F3{owner OR organizer?}
    F3 -->|yes| F4[updateWorkshopAnnouncementBody\nor deleteWorkshopAnnouncement]
    F3 -->|no| F5[FORBIDDEN]
    D1 --> D2{USER_AUTHORED_TYPES?}
    D2 -->|no| D3[Error: cannot edit system activity]
    D2 -->|yes| D4{createdBy matches userId?}
    D4 -->|no| D5[Error: not your activity]
    D4 -->|yes| D6[clientWrite.patch description]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(admin): staff CRUD + announcement/v..."](https://github.com/cloudnativebergen/website/commit/63c1e9f67f64fadc98a54c2b2d8512fd0974670b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45527454)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->