### PR TITLE
feat(admin): create-next-edition wizard (SE-5)

### DIFF
--- a/src/app/(admin)/admin/settings/new-edition/page.tsx
+++ b/src/app/(admin)/admin/settings/new-edition/page.tsx
@@ -1,0 +1,93 @@
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { clientReadUncached } from '@/lib/sanity/client'
+import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
+import { NewEditionWizard } from '@/components/admin/new-edition'
+import { nextEditionDefaults, type CloneFamily } from '@/lib/conference/edition'
+import { SparklesIcon } from '@heroicons/react/24/outline'
+
+export const metadata = {
+  title: 'Create next edition',
+}
+
+/**
+ * SE-5 — the "Create next edition" wizard page. The last hard Studio dependency
+ * was seeding a new conference document; this page clones the CURRENT edition's
+ * structure into a fresh document with new dates + domains. The current edition
+ * is the SOURCE and is never modified.
+ */
+export default async function NewEditionPage() {
+  const { conference, error } = await getConferenceForCurrentDomain({
+    organizers: true,
+    sponsorTiers: true,
+    topics: true,
+  })
+
+  if (error) {
+    return (
+      <ErrorDisplay title="Error Loading Conference" message={error.message} />
+    )
+  }
+  if (!conference?._id) {
+    return (
+      <ErrorDisplay
+        title="No Conference Found"
+        message="No conference configuration found for the current domain."
+      />
+    )
+  }
+
+  // A single count the normalized projection doesn't carry.
+  const contractTemplateCount = await clientReadUncached.fetch<number>(
+    `count(*[_type == "contractTemplate" && conference._ref == $id])`,
+    { id: conference._id },
+  )
+
+  const numericGoals = [
+    conference.cfpSubmissionGoal,
+    conference.cfpLightningGoal,
+    conference.cfpPresentationGoal,
+    conference.cfpWorkshopGoal,
+    conference.sponsorRevenueGoal,
+    conference.travelSupportBudget,
+  ].filter((v) => typeof v === 'number').length
+
+  const emailChannelCount = [
+    conference.contactEmail,
+    conference.cfpEmail,
+    conference.sponsorEmail,
+    conference.salesNotificationChannel,
+    conference.cfpNotificationChannel,
+    ...(conference.socialLinks ?? []),
+  ].filter(Boolean).length
+
+  const cloneCounts: Partial<Record<CloneFamily, number>> = {
+    topics: conference.topics?.length ?? 0,
+    formats: conference.formats?.length ?? 0,
+    organizers: conference.organizers?.length ?? 0,
+    teams: conference.teams?.length ?? 0,
+    sponsorTiers: conference.sponsorTiers?.length ?? 0,
+    contractTemplates: contractTemplateCount ?? 0,
+    sponsorshipCopy: conference.sponsorBenefits?.length ?? 0,
+    cfpGoals: numericGoals,
+    agentConfig: conference.agentConfig ? 1 : 0,
+    emailsAndChannels: emailChannelCount,
+  }
+
+  const defaults = nextEditionDefaults(conference)
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <AdminPageHeader
+        icon={<SparklesIcon />}
+        title="Create next edition"
+        description="Clone this edition's structure into a new conference with fresh dates and domains."
+        backLink={{ href: '/admin/settings', label: 'Back to settings' }}
+      />
+      <NewEditionWizard
+        defaults={defaults}
+        sourceTitle={conference.title}
+        cloneCounts={cloneCounts}
+      />
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -40,6 +40,7 @@ import {
   ServerStackIcon,
   BeakerIcon,
   SwatchIcon,
+  SparklesIcon,
 } from '@heroicons/react/24/outline'
 
 interface NamedItem {
@@ -393,6 +394,14 @@ export default async function AdminSettings() {
             <span className="font-semibold">{conference.title}</span>
           </>
         }
+        actionItems={[
+          {
+            label: 'New edition',
+            href: '/admin/settings/new-edition',
+            icon: <SparklesIcon />,
+            variant: 'secondary',
+          },
+        ]}
       />
 
       <SectionNav />

--- a/src/components/admin/new-edition/NewEditionWizard.stories.tsx
+++ b/src/components/admin/new-edition/NewEditionWizard.stories.tsx
@@ -122,6 +122,8 @@ export const SuccessSummary: Story = {
     })
     await waitFor(() => expect(create).toBeEnabled())
     await userEvent.click(create)
-    await canvas.findByText(/created/i)
+    // Assert the success HEADING specifically — several elements in the
+    // summary contain the word 'created', so a bare text query is ambiguous.
+    await canvas.findByRole('heading', { name: /created/i })
   },
 }

--- a/src/components/admin/new-edition/NewEditionWizard.stories.tsx
+++ b/src/components/admin/new-edition/NewEditionWizard.stories.tsx
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { within, userEvent, waitFor, expect } from 'storybook/test'
+import { NewEditionWizard } from './NewEditionWizard'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import type { EditionDefaults, CloneFamily } from '@/lib/conference/edition'
+
+const defaults: EditionDefaults = {
+  title: 'Cloud Native Days Bergen 2026',
+  organizer: 'Cloud Native Bergen',
+  startDate: '2026-06-01',
+  endDate: '2026-06-02',
+  cfpStartDate: '2026-01-01',
+  cfpEndDate: '2026-03-01',
+  cfpNotifyDate: '2026-03-15',
+  programDate: '2026-04-01',
+}
+
+const cloneCounts: Partial<Record<CloneFamily, number>> = {
+  topics: 8,
+  formats: 4,
+  organizers: 5,
+  teams: 2,
+  sponsorTiers: 3,
+  contractTemplates: 2,
+  sponsorshipCopy: 4,
+  cfpGoals: 5,
+  agentConfig: 1,
+  emailsAndChannels: 6,
+}
+
+// No domain is ever "taken" in the happy path; createEdition echoes a summary.
+const handlers = [
+  http.get('/api/trpc/conference.validateNewDomains', () =>
+    HttpResponse.json({ result: { data: { taken: [] } } }),
+  ),
+  http.post('/api/trpc/conference.createEdition', () =>
+    HttpResponse.json({
+      result: {
+        data: {
+          conferenceId: 'conference-abc123',
+          summary: {
+            conference: 1,
+            topics: 8,
+            formats: 4,
+            organizers: 5,
+            teams: 2,
+            sponsorTiers: 3,
+            contractTemplates: 2,
+            sponsorshipCopy: 1,
+            cfpGoals: 1,
+            agentConfig: 1,
+            emailsAndChannels: 1,
+          },
+        },
+      },
+    }),
+  ),
+]
+
+const meta = {
+  title: 'Systems/Admin/Settings/New Edition Wizard',
+  component: NewEditionWizard,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+  },
+  decorators: [
+    (Story) => (
+      <NotificationProvider>
+        <div className="mx-auto max-w-3xl p-4">
+          <Story />
+        </div>
+      </NotificationProvider>
+    ),
+  ],
+  args: { defaults, sourceTitle: 'Cloud Native Days Bergen 2025', cloneCounts },
+} satisfies Meta<typeof NewEditionWizard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Step 1 — Basics, prefilled one year ahead. */
+export const Basics: Story = {
+  args: { initialStep: 'basics' },
+}
+
+/** Step 2 — Domains list with the availability check. */
+export const Domains: Story = {
+  args: { initialStep: 'domains', initialDomains: ['2026.cnb.no'] },
+}
+
+/** Step 3 — Clone checklist, structure defaults ON with per-family counts. */
+export const CloneChecklist: Story = {
+  args: { initialStep: 'clone' },
+}
+
+/** Step 4 — Review with the type-to-confirm gate satisfied (red Create armed). */
+export const ReviewConfirmed: Story = {
+  args: { initialStep: 'review', initialDomains: ['2026.cnb.no'] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const confirm = await canvas.findByLabelText('Confirm title')
+    await userEvent.type(confirm, 'Cloud Native Days Bergen 2026')
+    await waitFor(() =>
+      expect(
+        canvas.getByRole('button', { name: /create edition/i }),
+      ).toBeEnabled(),
+    )
+  },
+}
+
+/** The success panel: clone summary + the DNS/Vercel caveat. */
+export const SuccessSummary: Story = {
+  args: { initialStep: 'review', initialDomains: ['2026.cnb.no'] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const confirm = await canvas.findByLabelText('Confirm title')
+    await userEvent.type(confirm, 'Cloud Native Days Bergen 2026')
+    const create = await canvas.findByRole('button', {
+      name: /create edition/i,
+    })
+    await waitFor(() => expect(create).toBeEnabled())
+    await userEvent.click(create)
+    await canvas.findByText(/created/i)
+  },
+}

--- a/src/components/admin/new-edition/NewEditionWizard.tsx
+++ b/src/components/admin/new-edition/NewEditionWizard.tsx
@@ -1,0 +1,618 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  CheckCircleIcon,
+  PlusIcon,
+  TrashIcon,
+  ExclamationTriangleIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+} from '@heroicons/react/24/outline'
+import { api } from '@/lib/trpc/client'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { useNotificationSafe } from '@/components/admin/NotificationProvider'
+import {
+  CLONE_FAMILIES,
+  CLONE_FAMILY_META,
+  DEFAULT_CLONE_FLAGS,
+  type CloneFamily,
+  type CloneFlags,
+  type EditionDefaults,
+} from '@/lib/conference/edition'
+import {
+  WIZARD_STEPS,
+  WIZARD_STEP_TITLES,
+  type WizardStepId,
+  type WizardState,
+  stepIndex,
+  validateBasics,
+  domainsLocalErrors,
+  cleanDomains,
+  canProceed,
+  canCreate,
+  typeToConfirmMatches,
+} from './wizardLogic'
+
+export interface NewEditionWizardProps {
+  /** Prefill derived from the current edition (title/year+1, dates+1yr). */
+  defaults: EditionDefaults
+  /** The current edition's title — shown as the source being cloned. */
+  sourceTitle: string
+  /** Per-family item counts from the source, shown in the clone checklist. */
+  cloneCounts: Partial<Record<CloneFamily, number>>
+  /** Storybook/deep-link seam: which step to render first (defaults to Basics). */
+  initialStep?: WizardStepId
+  /** Storybook seam: seed the domain list (defaults to a single empty row). */
+  initialDomains?: string[]
+}
+
+interface FieldProps {
+  label: string
+  children: React.ReactNode
+  error?: string
+  hint?: string
+}
+
+function Field({ label, children, error, hint }: FieldProps) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-200">
+        {label}
+      </span>
+      {children}
+      {hint && !error && (
+        <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+          {hint}
+        </span>
+      )}
+      {error && (
+        <span className="mt-1 block text-xs text-red-600 dark:text-red-400">
+          {error}
+        </span>
+      )}
+    </label>
+  )
+}
+
+const inputClass =
+  'w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+
+function StepIndicator({ current }: { current: WizardStepId }) {
+  const currentIdx = stepIndex(current)
+  return (
+    <ol className="flex flex-wrap items-center gap-2">
+      {WIZARD_STEPS.map((id, i) => {
+        const done = i < currentIdx
+        const active = i === currentIdx
+        return (
+          <li key={id} className="flex items-center gap-2">
+            <span
+              className={[
+                'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
+                active
+                  ? 'bg-indigo-600 text-white'
+                  : done
+                    ? 'bg-green-600 text-white'
+                    : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400',
+              ].join(' ')}
+            >
+              {done ? <CheckCircleIcon className="h-4 w-4" /> : i + 1}
+            </span>
+            <span
+              className={[
+                'text-sm',
+                active
+                  ? 'font-semibold text-gray-900 dark:text-white'
+                  : 'text-gray-500 dark:text-gray-400',
+              ].join(' ')}
+            >
+              {WIZARD_STEP_TITLES[id]}
+            </span>
+            {i < WIZARD_STEPS.length - 1 && (
+              <span className="mx-1 h-px w-4 bg-gray-300 dark:bg-gray-600" />
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+export function NewEditionWizard({
+  defaults,
+  sourceTitle,
+  cloneCounts,
+  initialStep = 'basics',
+  initialDomains,
+}: NewEditionWizardProps) {
+  const notify = useNotificationSafe()
+  const [step, setStep] = useState<WizardStepId>(initialStep)
+  const [state, setState] = useState<WizardState>(() => ({
+    basics: {
+      title: defaults.title,
+      organizer: defaults.organizer,
+      startDate: defaults.startDate,
+      endDate: defaults.endDate,
+      cfpStartDate: defaults.cfpStartDate,
+      cfpEndDate: defaults.cfpEndDate,
+      cfpNotifyDate: defaults.cfpNotifyDate,
+      programDate: defaults.programDate,
+    },
+    domains:
+      initialDomains && initialDomains.length > 0 ? initialDomains : [''],
+    clone: { ...DEFAULT_CLONE_FLAGS },
+    confirmTitle: '',
+  }))
+
+  const [result, setResult] = useState<{
+    conferenceId: string
+    summary: Record<string, number>
+  } | null>(null)
+
+  // Debounce the domain list before the availability probe so keystrokes don't
+  // spam the server.
+  const cleaned = useMemo(() => cleanDomains(state.domains), [state.domains])
+  const [checkList, setCheckList] = useState<string[]>([])
+  useEffect(() => {
+    const t = setTimeout(() => setCheckList(cleaned), 400)
+    return () => clearTimeout(t)
+  }, [cleaned])
+
+  const availability = api.conference.validateNewDomains.useQuery(
+    { domains: checkList },
+    { enabled: checkList.length > 0 },
+  )
+  const takenDomains = availability.data?.taken ?? []
+
+  const createMutation = api.conference.createEdition.useMutation({
+    onSuccess: (data) => {
+      setResult({
+        conferenceId: data.conferenceId,
+        summary: data.summary as Record<string, number>,
+      })
+    },
+    onError: (err) => {
+      notify?.showNotification({
+        type: 'error',
+        title: 'Could not create the edition',
+        message: err.message,
+      })
+    },
+  })
+
+  const basicsErrors = validateBasics(state.basics)
+  const domainErrors = domainsLocalErrors(state.domains)
+
+  function patchBasics(patch: Partial<WizardState['basics']>) {
+    setState((s) => ({ ...s, basics: { ...s.basics, ...patch } }))
+  }
+  function setDomain(i: number, value: string) {
+    setState((s) => {
+      const domains = [...s.domains]
+      domains[i] = value
+      return { ...s, domains }
+    })
+  }
+  function addDomain() {
+    setState((s) => ({ ...s, domains: [...s.domains, ''] }))
+  }
+  function removeDomain(i: number) {
+    setState((s) => ({
+      ...s,
+      domains:
+        s.domains.length > 1 ? s.domains.filter((_, j) => j !== i) : [''],
+    }))
+  }
+  function toggleClone(family: CloneFamily) {
+    setState((s) => ({
+      ...s,
+      clone: { ...s.clone, [family]: !s.clone[family] },
+    }))
+  }
+
+  function submit() {
+    if (!canCreate(state, takenDomains)) return
+    createMutation.mutate({
+      title: state.basics.title.trim(),
+      organizer: state.basics.organizer.trim() || null,
+      startDate: state.basics.startDate,
+      endDate: state.basics.endDate,
+      cfpStartDate: state.basics.cfpStartDate || null,
+      cfpEndDate: state.basics.cfpEndDate || null,
+      cfpNotifyDate: state.basics.cfpNotifyDate || null,
+      programDate: state.basics.programDate || null,
+      domains: cleanDomains(state.domains),
+      clone: state.clone as CloneFlags,
+    })
+  }
+
+  if (result) {
+    return <SuccessPanel result={result} title={state.basics.title} />
+  }
+
+  const idx = stepIndex(step)
+  const canGoNext = canProceed(step, state, takenDomains)
+
+  return (
+    <div className="space-y-6">
+      <StepIndicator current={step} />
+
+      <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+        {step === 'basics' && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Cloning the structure of{' '}
+              <span className="font-semibold text-gray-800 dark:text-gray-200">
+                {sourceTitle}
+              </span>
+              . Title and dates are prefilled one year ahead — adjust as needed.
+            </p>
+            <Field label="Title" error={basicsErrors.title}>
+              <input
+                className={inputClass}
+                value={state.basics.title}
+                onChange={(e) => patchBasics({ title: e.target.value })}
+              />
+            </Field>
+            <Field
+              label="Organizer"
+              hint="Leave as-is to keep the same organizing body."
+            >
+              <input
+                className={inputClass}
+                value={state.basics.organizer}
+                onChange={(e) => patchBasics({ organizer: e.target.value })}
+              />
+            </Field>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Field label="Start date" error={basicsErrors.startDate}>
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={state.basics.startDate}
+                  onChange={(e) => patchBasics({ startDate: e.target.value })}
+                />
+              </Field>
+              <Field label="End date" error={basicsErrors.endDate}>
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={state.basics.endDate}
+                  onChange={(e) => patchBasics({ endDate: e.target.value })}
+                />
+              </Field>
+              <Field label="CFP opens">
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={state.basics.cfpStartDate}
+                  onChange={(e) =>
+                    patchBasics({ cfpStartDate: e.target.value })
+                  }
+                />
+              </Field>
+              <Field label="CFP closes" error={basicsErrors.cfpEndDate}>
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={state.basics.cfpEndDate}
+                  onChange={(e) => patchBasics({ cfpEndDate: e.target.value })}
+                />
+              </Field>
+              <Field label="CFP notify date">
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={state.basics.cfpNotifyDate}
+                  onChange={(e) =>
+                    patchBasics({ cfpNotifyDate: e.target.value })
+                  }
+                />
+              </Field>
+              <Field label="Program date">
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={state.basics.programDate}
+                  onChange={(e) => patchBasics({ programDate: e.target.value })}
+                />
+              </Field>
+            </div>
+          </div>
+        )}
+
+        {step === 'domains' && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Which hostnames will serve this edition? Each must be a bare
+              hostname and not already used by another conference.
+            </p>
+            <div className="space-y-2">
+              {state.domains.map((domain, i) => {
+                const localErr = domainErrors[`domains.${i}`]
+                const trimmed = domain.trim().toLowerCase()
+                const isTaken = trimmed !== '' && takenDomains.includes(trimmed)
+                return (
+                  <div key={i}>
+                    <div className="flex items-center gap-2">
+                      <input
+                        className={inputClass}
+                        placeholder="conference.example.com"
+                        value={domain}
+                        aria-label={`Domain ${i + 1}`}
+                        onChange={(e) => setDomain(i, e.target.value)}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeDomain(i)}
+                        aria-label={`Remove domain ${i + 1}`}
+                        className="shrink-0 rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-red-600 dark:hover:bg-gray-800"
+                      >
+                        <TrashIcon className="h-4 w-4" />
+                      </button>
+                    </div>
+                    {(localErr || isTaken) && (
+                      <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                        {localErr ?? 'Already used by another conference'}
+                      </p>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+            <button
+              type="button"
+              onClick={addDomain}
+              className="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+            >
+              <PlusIcon className="h-4 w-4" /> Add domain
+            </button>
+            {domainErrors.domains && (
+              <p className="text-xs text-red-600 dark:text-red-400">
+                {domainErrors.domains}
+              </p>
+            )}
+            {availability.isFetching && (
+              <p className="text-xs text-gray-400">Checking availability…</p>
+            )}
+          </div>
+        )}
+
+        {step === 'clone' && (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Structure is copied into the new edition. Content — schedules,
+              featured talks, announcements, vanity metrics, ticketing and
+              check-in IDs — always starts empty.
+            </p>
+            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+              {CLONE_FAMILIES.map((family) => {
+                const meta = CLONE_FAMILY_META[family]
+                const count = cloneCounts[family]
+                return (
+                  <li
+                    key={family}
+                    className="flex items-start justify-between gap-3 py-3"
+                  >
+                    <label className="flex flex-1 items-start gap-3">
+                      <input
+                        type="checkbox"
+                        className="mt-0.5 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                        checked={state.clone[family]}
+                        onChange={() => toggleClone(family)}
+                      />
+                      <span>
+                        <span className="block text-sm font-medium text-gray-900 dark:text-white">
+                          {meta.label}
+                        </span>
+                        <span className="block text-xs text-gray-500 dark:text-gray-400">
+                          {meta.description}
+                        </span>
+                      </span>
+                    </label>
+                    {typeof count === 'number' && (
+                      <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                        {count}
+                      </span>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        )}
+
+        {step === 'review' && (
+          <div className="space-y-4">
+            <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <ReviewRow label="Title" value={state.basics.title} />
+              <ReviewRow
+                label="Organizer"
+                value={state.basics.organizer || '—'}
+              />
+              <ReviewRow
+                label="Dates"
+                value={`${state.basics.startDate} → ${state.basics.endDate}`}
+              />
+              <ReviewRow
+                label="Domains"
+                value={cleanDomains(state.domains).join(', ') || '—'}
+              />
+              <ReviewRow
+                label="Cloning"
+                value={
+                  CLONE_FAMILIES.filter((f) => state.clone[f])
+                    .map((f) => CLONE_FAMILY_META[f].label)
+                    .join(', ') || 'Nothing'
+                }
+              />
+            </dl>
+
+            <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-200">
+              <div className="flex items-start gap-2">
+                <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 shrink-0" />
+                <p>
+                  This creates a brand-new conference document. The current
+                  edition is never modified. To confirm, type the new title
+                  exactly.
+                </p>
+              </div>
+            </div>
+
+            <Field label={`Type “${state.basics.title}” to confirm`}>
+              <input
+                className={inputClass}
+                value={state.confirmTitle}
+                aria-label="Confirm title"
+                onChange={(e) =>
+                  setState((s) => ({ ...s, confirmTitle: e.target.value }))
+                }
+              />
+            </Field>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div>
+          {idx > 0 ? (
+            <AdminButton
+              variant="secondary"
+              onClick={() => setStep(WIZARD_STEPS[idx - 1])}
+            >
+              <ArrowLeftIcon className="mr-1 h-4 w-4" /> Back
+            </AdminButton>
+          ) : (
+            <Link
+              href="/admin/settings"
+              className="text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            >
+              Cancel
+            </Link>
+          )}
+        </div>
+        <div>
+          {step !== 'review' ? (
+            <AdminButton
+              disabled={!canGoNext}
+              onClick={() => setStep(WIZARD_STEPS[idx + 1])}
+            >
+              Next <ArrowRightIcon className="ml-1 h-4 w-4" />
+            </AdminButton>
+          ) : (
+            <AdminButton
+              color="red"
+              disabled={
+                !canCreate(state, takenDomains) || createMutation.isPending
+              }
+              onClick={submit}
+            >
+              {createMutation.isPending ? 'Creating…' : 'Create edition'}
+            </AdminButton>
+          )}
+        </div>
+      </div>
+
+      {step === 'review' &&
+        !typeToConfirmMatches(state.confirmTitle, state.basics.title) && (
+          <p className="text-right text-xs text-gray-400">
+            Type the exact title to enable Create.
+          </p>
+        )}
+    </div>
+  )
+}
+
+function ReviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-gray-50 px-3 py-2 dark:bg-gray-800/50">
+      <dt className="text-xs font-medium text-gray-500 dark:text-gray-400">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-sm break-words text-gray-900 dark:text-white">
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+function SuccessPanel({
+  result,
+  title,
+}: {
+  result: { conferenceId: string; summary: Record<string, number> }
+  title: string
+}) {
+  const entries = Object.entries(result.summary).filter(([, n]) => n > 0)
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-green-300 bg-green-50 p-6 dark:border-green-700/60 dark:bg-green-900/20">
+        <div className="flex items-start gap-3">
+          <CheckCircleIcon className="mt-0.5 h-6 w-6 shrink-0 text-green-600 dark:text-green-400" />
+          <div>
+            <h3 className="text-lg font-semibold text-green-900 dark:text-green-100">
+              {title} created
+            </h3>
+            <p className="mt-1 text-sm text-green-800 dark:text-green-200">
+              A new conference document was created (
+              <code className="rounded bg-green-100 px-1 dark:bg-green-800/40">
+                {result.conferenceId}
+              </code>
+              ).
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+        <h4 className="mb-3 text-sm font-semibold text-gray-900 dark:text-white">
+          Cloned
+        </h4>
+        <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {entries.map(([family, n]) => (
+            <li
+              key={family}
+              className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm dark:bg-gray-800/50"
+            >
+              <span className="text-gray-700 dark:text-gray-200">
+                {family === 'conference'
+                  ? 'Conference'
+                  : (CLONE_FAMILY_META[family as CloneFamily]?.label ?? family)}
+              </span>
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {n}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-200">
+        <div className="flex items-start gap-2">
+          <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 shrink-0" />
+          <div>
+            <p className="font-semibold">
+              The new edition is not reachable yet.
+            </p>
+            <p className="mt-1">
+              Serving its domain requires DNS and Vercel domain setup outside
+              this app. Until that domain resolves to the site, the new edition
+              cannot be opened here — there is nothing to link to.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <Link
+          href="/admin/settings"
+          className="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+        >
+          ← Back to settings
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/new-edition/index.ts
+++ b/src/components/admin/new-edition/index.ts
@@ -1,0 +1,2 @@
+export { NewEditionWizard } from './NewEditionWizard'
+export type { NewEditionWizardProps } from './NewEditionWizard'

--- a/src/components/admin/new-edition/wizardLogic.test.ts
+++ b/src/components/admin/new-edition/wizardLogic.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { DEFAULT_CLONE_FLAGS } from '@/lib/conference/edition'
+import {
+  validateBasics,
+  basicsComplete,
+  domainsLocalErrors,
+  domainsComplete,
+  cleanDomains,
+  typeToConfirmMatches,
+  canProceed,
+  canCreate,
+  type BasicsState,
+  type WizardState,
+} from './wizardLogic'
+
+const goodBasics: BasicsState = {
+  title: 'CND Bergen 2026',
+  organizer: 'CNB',
+  startDate: '2026-06-01',
+  endDate: '2026-06-02',
+  cfpStartDate: '2026-01-01',
+  cfpEndDate: '2026-03-01',
+  cfpNotifyDate: '',
+  programDate: '',
+}
+
+function state(overrides: Partial<WizardState> = {}): WizardState {
+  return {
+    basics: goodBasics,
+    domains: ['2026.cnb.no'],
+    clone: { ...DEFAULT_CLONE_FLAGS },
+    confirmTitle: '',
+    ...overrides,
+  }
+}
+
+describe('validateBasics', () => {
+  it('passes a well-formed basics', () => {
+    expect(validateBasics(goodBasics)).toEqual({})
+    expect(basicsComplete(goodBasics)).toBe(true)
+  })
+  it('requires a title', () => {
+    expect(validateBasics({ ...goodBasics, title: '  ' }).title).toBeTruthy()
+  })
+  it('rejects end before start', () => {
+    expect(
+      validateBasics({ ...goodBasics, endDate: '2026-05-01' }).endDate,
+    ).toBeTruthy()
+  })
+  it('rejects a reversed CFP window', () => {
+    expect(
+      validateBasics({
+        ...goodBasics,
+        cfpStartDate: '2026-03-01',
+        cfpEndDate: '2026-01-01',
+      }).cfpEndDate,
+    ).toBeTruthy()
+  })
+})
+
+describe('domains', () => {
+  it('flags a non-hostname row', () => {
+    expect(domainsLocalErrors(['https://x.com/foo'])['domains.0']).toBeTruthy()
+  })
+  it('requires at least one', () => {
+    expect(domainsLocalErrors(['', '  ']).domains).toBeTruthy()
+  })
+  it('cleans + lowercases + drops blanks', () => {
+    expect(cleanDomains([' 2026.CNB.no ', ''])).toEqual(['2026.cnb.no'])
+  })
+  it('is incomplete when a domain is claimed', () => {
+    expect(domainsComplete(['2026.cnb.no'], ['2026.cnb.no'])).toBe(false)
+    expect(domainsComplete(['2026.cnb.no'], [])).toBe(true)
+  })
+})
+
+describe('type-to-confirm', () => {
+  it('matches only the exact trimmed title', () => {
+    expect(typeToConfirmMatches(' CND Bergen 2026 ', 'CND Bergen 2026')).toBe(
+      true,
+    )
+    expect(typeToConfirmMatches('CND Bergen 2025', 'CND Bergen 2026')).toBe(
+      false,
+    )
+    expect(typeToConfirmMatches('', '')).toBe(false)
+  })
+})
+
+describe('step gating', () => {
+  it('basics gate follows basicsComplete', () => {
+    expect(canProceed('basics', state(), [])).toBe(true)
+    expect(
+      canProceed('basics', state({ basics: { ...goodBasics, title: '' } }), []),
+    ).toBe(false)
+  })
+  it('domains gate rejects a claimed domain', () => {
+    expect(canProceed('domains', state(), ['2026.cnb.no'])).toBe(false)
+  })
+  it('clone step always proceeds', () => {
+    expect(canProceed('clone', state(), [])).toBe(true)
+  })
+  it('review has no next', () => {
+    expect(canProceed('review', state(), [])).toBe(false)
+  })
+})
+
+describe('canCreate', () => {
+  it('requires basics, domains AND the confirm title', () => {
+    expect(canCreate(state({ confirmTitle: 'CND Bergen 2026' }), [])).toBe(true)
+    expect(canCreate(state({ confirmTitle: 'wrong' }), [])).toBe(false)
+    expect(
+      canCreate(state({ confirmTitle: 'CND Bergen 2026' }), ['2026.cnb.no']),
+    ).toBe(false)
+  })
+})

--- a/src/components/admin/new-edition/wizardLogic.ts
+++ b/src/components/admin/new-edition/wizardLogic.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure, React-free step logic for the SE-5 "Create next edition" wizard. Kept
+ * separate from the component so the gating/validation can be unit-tested and
+ * exercised by Storybook `play` functions without rendering internals.
+ */
+
+import {
+  validateStringList,
+  buildStringListPayload,
+} from '@/components/admin/editConferenceLists'
+import type { CloneFlags } from '@/lib/conference/edition'
+
+/** The four wizard steps, in order. */
+export const WIZARD_STEPS = ['basics', 'domains', 'clone', 'review'] as const
+export type WizardStepId = (typeof WIZARD_STEPS)[number]
+
+export const WIZARD_STEP_TITLES: Record<WizardStepId, string> = {
+  basics: 'Basics',
+  domains: 'Domains',
+  clone: 'What to clone',
+  review: 'Review & create',
+}
+
+export function stepIndex(id: WizardStepId): number {
+  return WIZARD_STEPS.indexOf(id)
+}
+
+export interface BasicsState {
+  title: string
+  organizer: string
+  startDate: string
+  endDate: string
+  cfpStartDate: string
+  cfpEndDate: string
+  cfpNotifyDate: string
+  programDate: string
+}
+
+export interface WizardState {
+  basics: BasicsState
+  domains: string[]
+  clone: CloneFlags
+  /** The type-to-confirm value the maintainer echoes on the review step. */
+  confirmTitle: string
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Validate the Basics step. Title, start and end dates are required; end must
+ * not precede start, and (when both present) the CFP window must be ordered.
+ * Errors are keyed by field name.
+ */
+export function validateBasics(b: BasicsState): Record<string, string> {
+  const errs: Record<string, string> = {}
+  if (b.title.trim() === '') errs.title = 'Title is required'
+  if (b.startDate === '') errs.startDate = 'Start date is required'
+  else if (!DATE_RE.test(b.startDate)) errs.startDate = 'Invalid date'
+  if (b.endDate === '') errs.endDate = 'End date is required'
+  else if (!DATE_RE.test(b.endDate)) errs.endDate = 'Invalid date'
+  if (!errs.startDate && !errs.endDate && b.endDate < b.startDate) {
+    errs.endDate = 'End date must be on or after the start date'
+  }
+  if (
+    b.cfpStartDate &&
+    b.cfpEndDate &&
+    DATE_RE.test(b.cfpStartDate) &&
+    DATE_RE.test(b.cfpEndDate) &&
+    b.cfpEndDate < b.cfpStartDate
+  ) {
+    errs.cfpEndDate = 'CFP end date must be on or after the CFP start date'
+  }
+  return errs
+}
+
+export function basicsComplete(b: BasicsState): boolean {
+  return Object.keys(validateBasics(b)).length === 0
+}
+
+/**
+ * Local (shape) validation for the Domains list, reusing the SE-1b hostname
+ * list validator. Blank rows are ignored; at least one hostname is required.
+ * GLOBAL uniqueness (claimed by another conference) is a server concern and is
+ * layered on top via `takenDomains`.
+ */
+export function domainsLocalErrors(domains: string[]): Record<string, string> {
+  return validateStringList(
+    {
+      name: 'domains',
+      itemType: 'hostname',
+      itemLabel: 'domain',
+      allowEmptyList: false,
+    },
+    domains,
+  )
+}
+
+/** The cleaned, deduped domain payload sent to the server. */
+export function cleanDomains(domains: string[]): string[] {
+  return buildStringListPayload(domains).map((d) => d.trim().toLowerCase())
+}
+
+/**
+ * The Domains step is complete when the list passes shape validation AND none
+ * of the entered hostnames are already claimed by another conference.
+ */
+export function domainsComplete(
+  domains: string[],
+  takenDomains: readonly string[],
+): boolean {
+  if (Object.keys(domainsLocalErrors(domains)).length > 0) return false
+  const taken = new Set(takenDomains.map((d) => d.trim().toLowerCase()))
+  return cleanDomains(domains).every((d) => !taken.has(d))
+}
+
+/** Trimmed exact match between the echoed title and the intended new title. */
+export function typeToConfirmMatches(input: string, title: string): boolean {
+  return input.trim() === title.trim() && title.trim() !== ''
+}
+
+/**
+ * Whether the wizard may advance FROM `step`. The review step has no "next"
+ * (the Create button is gated separately by {@link canCreate}).
+ */
+export function canProceed(
+  step: WizardStepId,
+  state: WizardState,
+  takenDomains: readonly string[],
+): boolean {
+  switch (step) {
+    case 'basics':
+      return basicsComplete(state.basics)
+    case 'domains':
+      return domainsComplete(state.domains, takenDomains)
+    case 'clone':
+      return true // any subset (including none) is allowed
+    case 'review':
+      return false
+  }
+}
+
+/** The final gate on the red Create button. */
+export function canCreate(
+  state: WizardState,
+  takenDomains: readonly string[],
+): boolean {
+  return (
+    basicsComplete(state.basics) &&
+    domainsComplete(state.domains, takenDomains) &&
+    typeToConfirmMatches(state.confirmTitle, state.basics.title)
+  )
+}

--- a/src/components/admin/sponsor/SponsorActivityTimeline.tsx
+++ b/src/components/admin/sponsor/SponsorActivityTimeline.tsx
@@ -21,6 +21,7 @@ import {
   getActivityColor,
 } from '@/components/admin/sponsor-crm/utils'
 import { SponsorActivityInput } from './SponsorActivityInput'
+import { useNotificationSafe } from '@/components/admin/NotificationProvider'
 
 interface SponsorActivityTimelineProps {
   sponsorForConferenceId?: string
@@ -371,6 +372,7 @@ export function SponsorActivityTimeline({
   compact = false,
 }: SponsorActivityTimelineProps) {
   const utils = api.useUtils()
+  const notify = useNotificationSafe()
   const { data: activities = [], isLoading } =
     api.sponsor.crm.activities.list.useQuery({
       sponsorForConferenceId,
@@ -380,6 +382,15 @@ export function SponsorActivityTimeline({
   const updateMutation = api.sponsor.crm.activities.update.useMutation({
     onSuccess: () => {
       utils.sponsor.crm.activities.list.invalidate()
+    },
+    onError: () => {
+      // The activity may have been deleted underneath the editor; surface a
+      // toast instead of letting the failed save pass silently.
+      notify?.showNotification({
+        type: 'error',
+        title: 'Save failed',
+        message: 'Couldn’t save the change — it may have been deleted.',
+      })
     },
   })
 

--- a/src/lib/conference/edition.test.ts
+++ b/src/lib/conference/edition.test.ts
@@ -271,3 +271,33 @@ describe('buildEditionDocuments — clone flag matrix', () => {
     })
   })
 })
+
+describe('cloned tier soldOut policy (SE-5 badge)', () => {
+  it('never copies soldOut onto a cloned tier (operational state, not structure)', () => {
+    let n = 0
+    const docs = buildEditionDocuments(
+      {
+        conference: SOURCE,
+        sponsorTiers: [
+          { _id: 'tier-sold', title: 'Gold', soldOut: true },
+        ] as SourceSponsorTier[],
+        contractTemplates: [],
+      },
+      {
+        title: 'Next',
+        startDate: '2027-01-01',
+        endDate: '2027-01-02',
+        domains: ['2027.cnb.no'],
+        clone: { ...DEFAULT_CLONE_FLAGS, sponsorTiers: true },
+      } as CreateEditionInput,
+      {
+        newConferenceId: 'new-conf',
+        mintId: () => `id-${++n}`,
+        mintKey: () => `key-${++n}`,
+      },
+    )
+    const tier = docs.sponsorTiers[0]
+    expect(tier).toBeDefined()
+    expect(tier).not.toHaveProperty('soldOut')
+  })
+})

--- a/src/lib/conference/edition.test.ts
+++ b/src/lib/conference/edition.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest'
+import {
+  nextEditionTitle,
+  addYearsToDate,
+  nextEditionDefaults,
+  buildEditionDocuments,
+  DEFAULT_CLONE_FLAGS,
+  type CloneFlags,
+  type SourceConference,
+  type SourceSponsorTier,
+  type SourceContractTemplate,
+  type CreateEditionInput,
+} from './edition'
+
+// A deterministic id/key minter so assertions are stable.
+function minter(prefix: string) {
+  let n = 0
+  return () => `${prefix}-${++n}`
+}
+
+const SOURCE: SourceConference = {
+  _id: 'source-conf',
+  title: 'Cloud Native Days Bergen 2025',
+  organizer: 'Cloud Native Bergen',
+  organizerOrgNumber: '123456789',
+  city: 'Bergen',
+  country: 'Norway',
+  venueName: 'Grieghallen',
+  logoBright: '<svg id="bright" />',
+  logoDark: '<svg id="dark" />',
+  topics: [
+    { _type: 'reference', _ref: 'topic-a', _key: 'k1' },
+    { _type: 'reference', _ref: 'topic-b', _key: 'k2' },
+  ],
+  formats: ['lightning_10', 'presentation_25'],
+  organizers: [
+    { _type: 'reference', _ref: 'sp-1', _key: 'o1' },
+    { _type: 'reference', _ref: 'sp-2', _key: 'o2' },
+  ],
+  teams: [{ _type: 'organizerTeam', key: 'cfp', title: 'CFP', members: [] }],
+  contactEmail: 'hi@cnb.no',
+  cfpEmail: 'cfp@cnb.no',
+  sponsorEmail: 'sales@cnb.no',
+  salesNotificationChannel: '#sales',
+  socialLinks: ['https://x.com/cnb'],
+  cfpSubmissionGoal: 100,
+  sponsorRevenueGoal: 500000,
+  signingProvider: 'self-hosted',
+  sponsorBenefits: [{ title: 'Reach', description: 'Devs' }],
+  sponsorshipCustomization: { heroHeadline: 'Sponsor us' },
+  agentConfig: { conferenceContext: 'A cloud native conf' },
+}
+
+const SOURCE_TIERS: SourceSponsorTier[] = [
+  {
+    _id: 'tier-gold',
+    title: 'Gold',
+    tagline: 'Top',
+    tierType: 'standard',
+    price: [{ amount: 50000, currency: 'NOK' }],
+    perks: [{ label: 'Booth' }],
+  },
+  { _id: 'tier-media', title: 'Media', tierType: 'special' },
+]
+
+const SOURCE_TEMPLATES: SourceContractTemplate[] = [
+  {
+    _id: 'tpl-gold',
+    title: 'Gold contract',
+    tier: { _type: 'reference', _ref: 'tier-gold' },
+    sections: [{ heading: 'Terms' }],
+    isDefault: true,
+  },
+  {
+    _id: 'tpl-generic',
+    title: 'Generic contract',
+    sections: [{ heading: 'Generic' }],
+  },
+]
+
+function makeInput(
+  overrides: Partial<CreateEditionInput> = {},
+): CreateEditionInput {
+  return {
+    title: 'Cloud Native Days Bergen 2026',
+    organizer: null,
+    startDate: '2026-06-01',
+    endDate: '2026-06-02',
+    cfpStartDate: '2026-01-01',
+    cfpEndDate: '2026-03-01',
+    cfpNotifyDate: '2026-03-15',
+    programDate: '2026-04-01',
+    domains: ['2026.cnb.no'],
+    clone: { ...DEFAULT_CLONE_FLAGS },
+    ...overrides,
+  }
+}
+
+function build(input: CreateEditionInput, source = SOURCE) {
+  return buildEditionDocuments(
+    {
+      conference: source,
+      sponsorTiers: SOURCE_TIERS,
+      contractTemplates: SOURCE_TEMPLATES,
+    },
+    input,
+    {
+      newConferenceId: 'new-conf',
+      mintId: minter('doc'),
+      mintKey: minter('key'),
+    },
+  )
+}
+
+describe('nextEditionTitle', () => {
+  it('bumps the first 4-digit year', () => {
+    expect(nextEditionTitle('CND Bergen 2025')).toBe('CND Bergen 2026')
+  })
+  it('leaves titles without a year unchanged', () => {
+    expect(nextEditionTitle('Cloud Native Days')).toBe('Cloud Native Days')
+  })
+})
+
+describe('addYearsToDate', () => {
+  it('adds a year', () => {
+    expect(addYearsToDate('2025-06-15')).toBe('2026-06-15')
+  })
+  it('clamps Feb-29 to Feb-28 in a non-leap target year', () => {
+    expect(addYearsToDate('2024-02-29')).toBe('2025-02-28')
+  })
+  it('returns empty for missing/malformed input', () => {
+    expect(addYearsToDate(undefined)).toBe('')
+    expect(addYearsToDate('nope')).toBe('')
+  })
+})
+
+describe('nextEditionDefaults', () => {
+  it('derives a full prefill from the source', () => {
+    const d = nextEditionDefaults(SOURCE)
+    expect(d.title).toBe('Cloud Native Days Bergen 2026')
+    expect(d.organizer).toBe('Cloud Native Bergen')
+  })
+})
+
+describe('buildEditionDocuments — always-applied invariants', () => {
+  it('creates a fresh conference id distinct from the source', () => {
+    const { conference } = build(makeInput())
+    expect(conference._id).toBe('new-conf')
+    expect(conference._id).not.toBe(SOURCE._id)
+    expect(conference._type).toBe('conference')
+  })
+
+  it('never opens registration on a new edition', () => {
+    const { conference } = build(makeInput())
+    expect(conference.registrationEnabled).toBe(false)
+  })
+
+  it('always copies identity (city, logos) and normalizes domains', () => {
+    const { conference } = build(
+      makeInput({ domains: ['2026.CNB.no', 'ALT.example.com'] }),
+    )
+    expect(conference.city).toBe('Bergen')
+    expect(conference.logoBright).toBe('<svg id="bright" />')
+    expect(conference.domains).toEqual(['2026.cnb.no', 'alt.example.com'])
+  })
+
+  it('uses the input organizer when provided, else the source', () => {
+    expect(build(makeInput({ organizer: null })).conference.organizer).toBe(
+      'Cloud Native Bergen',
+    )
+    expect(
+      build(makeInput({ organizer: 'New Org' })).conference.organizer,
+    ).toBe('New Org')
+  })
+
+  it('never carries source content (schedules/announcement) into the clone', () => {
+    const { conference } = build(makeInput())
+    expect(conference.schedules).toBeUndefined()
+    expect(conference.announcement).toBeUndefined()
+    expect(conference.featuredTalks).toBeUndefined()
+    expect(conference.vanityMetrics).toBeUndefined()
+  })
+})
+
+describe('buildEditionDocuments — clone flag matrix', () => {
+  const allOff: CloneFlags = Object.fromEntries(
+    Object.keys(DEFAULT_CLONE_FLAGS).map((k) => [k, false]),
+  ) as CloneFlags
+
+  it('flag OFF → family absent', () => {
+    const { conference, sponsorTiers, contractTemplates, summary } = build(
+      makeInput({ clone: allOff }),
+    )
+    expect(conference.topics).toBeUndefined()
+    expect(conference.formats).toBeUndefined()
+    expect(conference.organizers).toBeUndefined()
+    expect(conference.teams).toBeUndefined()
+    expect(conference.agentConfig).toBeUndefined()
+    expect(conference.sponsorBenefits).toBeUndefined()
+    expect(conference.contactEmail).toBeUndefined()
+    expect(conference.cfpSubmissionGoal).toBeUndefined()
+    expect(sponsorTiers).toHaveLength(0)
+    expect(contractTemplates).toHaveLength(0)
+    expect(summary).toEqual({})
+  })
+
+  it('flag ON → topics/organizers ref arrays copied by _ref', () => {
+    const { conference } = build(makeInput())
+    expect(conference.topics).toEqual([
+      { _type: 'reference', _ref: 'topic-a', _key: 'key-1' },
+      { _type: 'reference', _ref: 'topic-b', _key: 'key-2' },
+    ])
+    expect(
+      (conference.organizers as Array<{ _ref: string }>).map((o) => o._ref),
+    ).toEqual(['sp-1', 'sp-2'])
+  })
+
+  it('flag ON → sponsor tiers become NEW docs pointing at the new conference', () => {
+    const { sponsorTiers } = build(makeInput())
+    expect(sponsorTiers).toHaveLength(2)
+    for (const tier of sponsorTiers) {
+      expect(tier._type).toBe('sponsorTier')
+      expect(tier._id).not.toBe('tier-gold')
+      expect(tier._id).not.toBe('tier-media')
+      expect(tier.conference).toEqual({
+        _type: 'reference',
+        _ref: 'new-conf',
+      })
+    }
+    expect(sponsorTiers[0].title).toBe('Gold')
+  })
+
+  it('flag ON → contract template conference ref points at new, tier ref remapped', () => {
+    const { sponsorTiers, contractTemplates } = build(makeInput())
+    const goldNewId = sponsorTiers[0]._id
+    const goldTpl = contractTemplates.find((t) => t.title === 'Gold contract')!
+    expect(goldTpl.conference).toEqual({
+      _type: 'reference',
+      _ref: 'new-conf',
+    })
+    expect(goldTpl.tier).toEqual({ _type: 'reference', _ref: goldNewId })
+  })
+
+  it('drops a template tier ref when tiers were NOT cloned (would dangle)', () => {
+    const { contractTemplates } = build(
+      makeInput({
+        clone: { ...DEFAULT_CLONE_FLAGS, sponsorTiers: false },
+      }),
+    )
+    const goldTpl = contractTemplates.find((t) => t.title === 'Gold contract')!
+    expect(goldTpl.tier).toBeUndefined()
+    expect(goldTpl.conference).toEqual({
+      _type: 'reference',
+      _ref: 'new-conf',
+    })
+  })
+
+  it('summary reports per-family counts', () => {
+    const { summary } = build(makeInput())
+    expect(summary).toMatchObject({
+      topics: 2,
+      formats: 2,
+      organizers: 2,
+      teams: 1,
+      sponsorTiers: 2,
+      contractTemplates: 2,
+      sponsorshipCopy: 1,
+      cfpGoals: 1,
+      agentConfig: 1,
+      emailsAndChannels: 1,
+    })
+  })
+})

--- a/src/lib/conference/edition.ts
+++ b/src/lib/conference/edition.ts
@@ -447,7 +447,9 @@ export function buildEditionDocuments(
         ...(tier.maxQuantity !== undefined
           ? { maxQuantity: tier.maxQuantity }
           : {}),
-        ...(tier.soldOut !== undefined ? { soldOut: tier.soldOut } : {}),
+        // soldOut is OPERATIONAL state (last edition's slots filled), not
+        // structure — a cloned tier always starts available for the new
+        // edition, so it is deliberately NOT copied.
         ...(tier.mostPopular !== undefined
           ? { mostPopular: tier.mostPopular }
           : {}),

--- a/src/lib/conference/edition.ts
+++ b/src/lib/conference/edition.ts
@@ -1,0 +1,493 @@
+/**
+ * SE-5 — pure, dependency-light building blocks for the "Create next edition"
+ * wizard. These functions are React-free and Sanity-client-free so they can be
+ * unit-tested directly and reused verbatim by the server mutation
+ * (`conference.createEdition`) AND the client wizard.
+ *
+ * WHAT THE WIZARD DOES: it seeds a NEW conference document that clones the
+ * STRUCTURE of the current edition (topics, formats, teams, tiers, templates,
+ * copy, goals, …) with fresh dates + domains, so an organizer never has to open
+ * Sanity Studio to bootstrap next year. It never touches the source document.
+ *
+ * ── The conference-referencing document map (grounding) ────────────────────
+ * Docs that carry a `conference` reference fall into two buckets:
+ *
+ *   STRUCTURE (cloned → NEW docs pointing at the new conference):
+ *     - sponsorTier          (per-conference; conference._ref)
+ *     - contractTemplate     (per-conference; conference._ref + tier._ref)
+ *
+ *   CONTENT (per-edition; NEVER cloned — a new edition starts empty):
+ *     - talk / schedule / review / speakerBadge / travelSupport / volunteer /
+ *       imageGallery / conversation / message / workshopAnnouncement /
+ *       workshopSignup / coSpeakerInvitation / notification /
+ *       sponsorForConference / dashboardConfig
+ *
+ * GLOBAL docs (shared by every edition; not conference-scoped, so nothing to
+ * clone — they attach to the new edition automatically):
+ *     - topic                (referenced by conference.topics[])
+ *     - sponsorEmailTemplate (NO conference ref — global template library)
+ *     - staff / speaker      (global people)
+ *
+ * On the conference document itself, field groups are copied per the clone
+ * flags; identity fields (city/country/venue/logos/org legal info) are ALWAYS
+ * copied, and content fields (schedules, featured, announcement, vanity
+ * metrics, ticketing, checkin ids, registration link) are NEVER copied.
+ */
+
+import type { Reference } from 'sanity'
+import { normalizeDomain } from './domains'
+
+/** The structural families the wizard can clone. Content is never listed here. */
+export const CLONE_FAMILIES = [
+  'topics',
+  'formats',
+  'organizers',
+  'teams',
+  'sponsorTiers',
+  'contractTemplates',
+  'sponsorshipCopy',
+  'cfpGoals',
+  'agentConfig',
+  'emailsAndChannels',
+] as const
+
+export type CloneFamily = (typeof CLONE_FAMILIES)[number]
+
+export type CloneFlags = Record<CloneFamily, boolean>
+
+/** Human labels + descriptions for the wizard's clone checklist. */
+export const CLONE_FAMILY_META: Record<
+  CloneFamily,
+  { label: string; description: string }
+> = {
+  topics: {
+    label: 'Topics',
+    description: 'The CFP topic tags (shared topic documents, referenced).',
+  },
+  formats: {
+    label: 'Formats',
+    description:
+      'Talk formats offered in the CFP (lightning, talk, workshop…).',
+  },
+  organizers: {
+    label: 'Organizers',
+    description: 'The organizer team — cloned by default for continuity.',
+  },
+  teams: {
+    label: 'Organizer teams',
+    description: 'Sub-teams used for notification routing and mail identities.',
+  },
+  sponsorTiers: {
+    label: 'Sponsor tiers',
+    description: 'Fresh tier documents pointing at the new edition.',
+  },
+  contractTemplates: {
+    label: 'Contract templates',
+    description: 'Fresh contract templates pointing at the new edition.',
+  },
+  sponsorshipCopy: {
+    label: 'Sponsorship copy',
+    description: 'Prospectus copy, benefits, signing provider and CRM cadence.',
+  },
+  cfpGoals: {
+    label: 'CFP & revenue goals',
+    description: 'Submission, format and sponsor-revenue targets.',
+  },
+  agentConfig: {
+    label: 'AI agent configuration',
+    description: 'Conference context and reviewer/CRM agent instructions.',
+  },
+  emailsAndChannels: {
+    label: 'Emails & Slack channels',
+    description: 'From-addresses, notification channels and social links.',
+  },
+}
+
+/** Structure defaults ON; the maintainer can trim before creating. */
+export const DEFAULT_CLONE_FLAGS: CloneFlags = {
+  topics: true,
+  formats: true,
+  organizers: true,
+  teams: true,
+  sponsorTiers: true,
+  contractTemplates: true,
+  sponsorshipCopy: true,
+  cfpGoals: true,
+  agentConfig: true,
+  emailsAndChannels: true,
+}
+
+// ── Next-edition heuristics ────────────────────────────────────────────────
+
+/**
+ * Bump the first 4-digit year (19xx–20xx) found in a title by `by` years, e.g.
+ * "Cloud Native Days Bergen 2025" → "…2026". Titles without a year are returned
+ * unchanged so the maintainer can adjust them by hand.
+ */
+export function nextEditionTitle(title: string, by = 1): string {
+  return title.replace(/\b(19|20)\d{2}\b/, (year) => String(Number(year) + by))
+}
+
+/**
+ * Add `by` calendar years to a `YYYY-MM-DD` date, clamping Feb-29 to Feb-28 in
+ * a non-leap target year. Returns '' for a missing/malformed input so the caller
+ * can leave the field blank.
+ */
+export function addYearsToDate(
+  date: string | undefined | null,
+  by = 1,
+): string {
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return ''
+  const [y, m, d] = date.split('-').map(Number)
+  const targetYear = y + by
+  const lastDay = new Date(targetYear, m, 0).getDate() // day 0 of next month
+  const day = Math.min(d, lastDay)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${targetYear}-${pad(m)}-${pad(day)}`
+}
+
+/** Prefill for the wizard's Basics step, derived from the source edition. */
+export interface EditionDefaults {
+  title: string
+  organizer: string
+  startDate: string
+  endDate: string
+  cfpStartDate: string
+  cfpEndDate: string
+  cfpNotifyDate: string
+  programDate: string
+}
+
+export function nextEditionDefaults(source: {
+  title?: string
+  organizer?: string
+  startDate?: string
+  endDate?: string
+  cfpStartDate?: string
+  cfpEndDate?: string
+  cfpNotifyDate?: string
+  programDate?: string
+}): EditionDefaults {
+  return {
+    title: nextEditionTitle(source.title ?? ''),
+    organizer: source.organizer ?? '',
+    startDate: addYearsToDate(source.startDate),
+    endDate: addYearsToDate(source.endDate),
+    cfpStartDate: addYearsToDate(source.cfpStartDate),
+    cfpEndDate: addYearsToDate(source.cfpEndDate),
+    cfpNotifyDate: addYearsToDate(source.cfpNotifyDate),
+    programDate: addYearsToDate(source.programDate),
+  }
+}
+
+// ── Document builder ───────────────────────────────────────────────────────
+
+/** A subset of the raw source conference document the builder reads. */
+export interface SourceConference {
+  _id: string
+  title?: string
+  organizer?: string
+  organizerOrgNumber?: string
+  organizerAddress?: string
+  city?: string
+  country?: string
+  venueName?: string
+  venueAddress?: string
+  tagline?: string
+  description?: string
+  logoBright?: string
+  logoDark?: string
+  logomarkBright?: string
+  logomarkDark?: string
+  topics?: Array<Reference & { _key?: string }>
+  formats?: string[]
+  organizers?: Array<Reference & { _key?: string }>
+  teams?: Array<Record<string, unknown>>
+  contactEmail?: string
+  cfpEmail?: string
+  sponsorEmail?: string
+  salesNotificationChannel?: string
+  cfpNotificationChannel?: string
+  socialLinks?: string[]
+  cfpSubmissionGoal?: number
+  cfpLightningGoal?: number
+  cfpPresentationGoal?: number
+  cfpWorkshopGoal?: number
+  sponsorRevenueGoal?: number
+  travelSupportBudget?: number
+  signingProvider?: string
+  sponsorBenefits?: Array<Record<string, unknown>>
+  sponsorshipCustomization?: Record<string, unknown>
+  crmInactivityThresholds?: Array<Record<string, unknown>>
+  agentConfig?: Record<string, unknown>
+}
+
+/** A raw sponsorTier document as stored (conference ref points at the source). */
+export interface SourceSponsorTier {
+  _id: string
+  title?: string
+  tagline?: string
+  tierType?: string
+  price?: Array<Record<string, unknown>>
+  perks?: Array<Record<string, unknown>>
+  maxQuantity?: number
+  soldOut?: boolean
+  mostPopular?: boolean
+}
+
+/** A raw contractTemplate document as stored. */
+export interface SourceContractTemplate {
+  _id: string
+  title?: string
+  tier?: Reference
+  language?: string
+  currency?: string
+  sections?: Array<Record<string, unknown>>
+  headerText?: string
+  footerText?: string
+  terms?: unknown
+  isDefault?: boolean
+  isActive?: boolean
+}
+
+export interface CreateEditionInput {
+  title: string
+  organizer?: string | null
+  startDate: string
+  endDate: string
+  cfpStartDate?: string | null
+  cfpEndDate?: string | null
+  cfpNotifyDate?: string | null
+  programDate?: string | null
+  domains: string[]
+  clone: CloneFlags
+}
+
+/** A brand-new Sanity document stub (always carries an `_id` + `_type`). */
+export type NewDocument = Record<string, unknown> & {
+  _id: string
+  _type: string
+}
+
+export interface BuildEditionResult {
+  conference: NewDocument
+  sponsorTiers: NewDocument[]
+  contractTemplates: NewDocument[]
+  /** family → number of items cloned (scalar groups count as 1 when copied). */
+  summary: Partial<Record<CloneFamily, number>>
+}
+
+function reference(id: string, key: string): Reference & { _key: string } {
+  return { _type: 'reference', _ref: id, _key: key }
+}
+
+/** Re-key an array so every item carries a fresh, stable `_key`. */
+function rekey<T extends Record<string, unknown>>(
+  items: T[] | undefined,
+  mintKey: () => string,
+): Array<T & { _key: string }> {
+  return (items ?? []).map((item) => ({ ...item, _key: mintKey() }))
+}
+
+/**
+ * Build the new-edition documents from the source. PURE: takes an id/key minter
+ * so tests are deterministic and the server can pass a real generator. Never
+ * reads or mutates the source; produces brand-new documents only.
+ */
+export function buildEditionDocuments(
+  source: {
+    conference: SourceConference
+    sponsorTiers: SourceSponsorTier[]
+    contractTemplates: SourceContractTemplate[]
+  },
+  input: CreateEditionInput,
+  ids: { newConferenceId: string; mintId: () => string; mintKey: () => string },
+): BuildEditionResult {
+  const {
+    conference: src,
+    sponsorTiers: srcTiers,
+    contractTemplates: srcTpls,
+  } = source
+  const { newConferenceId, mintId, mintKey } = ids
+  const flags = input.clone
+  const summary: Partial<Record<CloneFamily, number>> = {}
+
+  // ── The conference document ──────────────────────────────────────────────
+  const conference: NewDocument = {
+    _id: newConferenceId,
+    _type: 'conference',
+    // Identity — ALWAYS copied (brand + legal details persist across editions).
+    title: input.title,
+    organizer: input.organizer ?? src.organizer,
+    ...(src.organizerOrgNumber
+      ? { organizerOrgNumber: src.organizerOrgNumber }
+      : {}),
+    ...(src.organizerAddress ? { organizerAddress: src.organizerAddress } : {}),
+    ...(src.city ? { city: src.city } : {}),
+    ...(src.country ? { country: src.country } : {}),
+    ...(src.venueName ? { venueName: src.venueName } : {}),
+    ...(src.venueAddress ? { venueAddress: src.venueAddress } : {}),
+    ...(src.tagline ? { tagline: src.tagline } : {}),
+    ...(src.description ? { description: src.description } : {}),
+    ...(src.logoBright ? { logoBright: src.logoBright } : {}),
+    ...(src.logoDark ? { logoDark: src.logoDark } : {}),
+    ...(src.logomarkBright ? { logomarkBright: src.logomarkBright } : {}),
+    ...(src.logomarkDark ? { logomarkDark: src.logomarkDark } : {}),
+    // Fresh dates + domains from the wizard.
+    startDate: input.startDate,
+    endDate: input.endDate,
+    ...(input.cfpStartDate ? { cfpStartDate: input.cfpStartDate } : {}),
+    ...(input.cfpEndDate ? { cfpEndDate: input.cfpEndDate } : {}),
+    ...(input.cfpNotifyDate ? { cfpNotifyDate: input.cfpNotifyDate } : {}),
+    ...(input.programDate ? { programDate: input.programDate } : {}),
+    domains: input.domains.map(normalizeDomain),
+    // A new edition NEVER opens registration on creation.
+    registrationEnabled: false,
+  }
+
+  if (flags.topics && src.topics && src.topics.length > 0) {
+    conference.topics = src.topics.map((t) => reference(t._ref, mintKey()))
+    summary.topics = src.topics.length
+  }
+  if (flags.formats && src.formats && src.formats.length > 0) {
+    conference.formats = [...src.formats]
+    summary.formats = src.formats.length
+  }
+  if (flags.organizers && src.organizers && src.organizers.length > 0) {
+    conference.organizers = src.organizers.map((o) =>
+      reference(o._ref, mintKey()),
+    )
+    summary.organizers = src.organizers.length
+  }
+  if (flags.teams && src.teams && src.teams.length > 0) {
+    conference.teams = rekey(src.teams, mintKey)
+    summary.teams = src.teams.length
+  }
+  if (flags.cfpGoals) {
+    let copied = false
+    for (const key of [
+      'cfpSubmissionGoal',
+      'cfpLightningGoal',
+      'cfpPresentationGoal',
+      'cfpWorkshopGoal',
+      'sponsorRevenueGoal',
+      'travelSupportBudget',
+    ] as const) {
+      const value = src[key]
+      if (typeof value === 'number') {
+        conference[key] = value
+        copied = true
+      }
+    }
+    if (copied) summary.cfpGoals = 1
+  }
+  if (flags.agentConfig && src.agentConfig) {
+    conference.agentConfig = { ...src.agentConfig }
+    summary.agentConfig = 1
+  }
+  if (flags.emailsAndChannels) {
+    let copied = false
+    for (const key of [
+      'contactEmail',
+      'cfpEmail',
+      'sponsorEmail',
+      'salesNotificationChannel',
+      'cfpNotificationChannel',
+    ] as const) {
+      if (src[key]) {
+        conference[key] = src[key]
+        copied = true
+      }
+    }
+    if (src.socialLinks && src.socialLinks.length > 0) {
+      conference.socialLinks = [...src.socialLinks]
+      copied = true
+    }
+    if (copied) summary.emailsAndChannels = 1
+  }
+  if (flags.sponsorshipCopy) {
+    let copied = false
+    if (src.sponsorBenefits && src.sponsorBenefits.length > 0) {
+      conference.sponsorBenefits = rekey(src.sponsorBenefits, mintKey)
+      copied = true
+    }
+    if (src.sponsorshipCustomization) {
+      conference.sponsorshipCustomization = { ...src.sponsorshipCustomization }
+      copied = true
+    }
+    if (src.signingProvider) {
+      conference.signingProvider = src.signingProvider
+      copied = true
+    }
+    if (src.crmInactivityThresholds && src.crmInactivityThresholds.length > 0) {
+      conference.crmInactivityThresholds = rekey(
+        src.crmInactivityThresholds,
+        mintKey,
+      )
+      copied = true
+    }
+    if (copied) summary.sponsorshipCopy = 1
+  }
+
+  // ── Sponsor tiers → NEW docs pointing at the new conference ───────────────
+  const tierIdMap = new Map<string, string>()
+  const sponsorTiers: NewDocument[] = []
+  if (flags.sponsorTiers) {
+    for (const tier of srcTiers) {
+      const newId = mintId()
+      tierIdMap.set(tier._id, newId)
+      sponsorTiers.push({
+        _id: newId,
+        _type: 'sponsorTier',
+        ...(tier.title !== undefined ? { title: tier.title } : {}),
+        ...(tier.tagline !== undefined ? { tagline: tier.tagline } : {}),
+        ...(tier.tierType !== undefined ? { tierType: tier.tierType } : {}),
+        ...(tier.price ? { price: rekey(tier.price, mintKey) } : {}),
+        ...(tier.perks ? { perks: rekey(tier.perks, mintKey) } : {}),
+        ...(tier.maxQuantity !== undefined
+          ? { maxQuantity: tier.maxQuantity }
+          : {}),
+        ...(tier.soldOut !== undefined ? { soldOut: tier.soldOut } : {}),
+        ...(tier.mostPopular !== undefined
+          ? { mostPopular: tier.mostPopular }
+          : {}),
+        conference: { _type: 'reference', _ref: newConferenceId },
+      })
+    }
+    if (sponsorTiers.length > 0) summary.sponsorTiers = sponsorTiers.length
+  }
+
+  // ── Contract templates → NEW docs; remap tier ref to the cloned tier ──────
+  const contractTemplates: NewDocument[] = []
+  if (flags.contractTemplates) {
+    for (const tpl of srcTpls) {
+      // Only carry the tier ref forward when that tier was cloned in THIS run;
+      // otherwise it would dangle against the source edition's tier. The field
+      // is optional, so dropping it keeps the template valid.
+      const mappedTier = tpl.tier?._ref
+        ? tierIdMap.get(tpl.tier._ref)
+        : undefined
+      contractTemplates.push({
+        _id: mintId(),
+        _type: 'contractTemplate',
+        ...(tpl.title !== undefined ? { title: tpl.title } : {}),
+        conference: { _type: 'reference', _ref: newConferenceId },
+        ...(mappedTier
+          ? { tier: { _type: 'reference', _ref: mappedTier } }
+          : {}),
+        ...(tpl.language !== undefined ? { language: tpl.language } : {}),
+        ...(tpl.currency !== undefined ? { currency: tpl.currency } : {}),
+        ...(tpl.sections ? { sections: rekey(tpl.sections, mintKey) } : {}),
+        ...(tpl.headerText !== undefined ? { headerText: tpl.headerText } : {}),
+        ...(tpl.footerText !== undefined ? { footerText: tpl.footerText } : {}),
+        ...(tpl.terms !== undefined ? { terms: tpl.terms } : {}),
+        ...(tpl.isDefault !== undefined ? { isDefault: tpl.isDefault } : {}),
+        ...(tpl.isActive !== undefined ? { isActive: tpl.isActive } : {}),
+      })
+    }
+    if (contractTemplates.length > 0)
+      summary.contractTemplates = contractTemplates.length
+  }
+
+  return { conference, sponsorTiers, contractTemplates, summary }
+}

--- a/src/server/routers/conference.createEdition.test.ts
+++ b/src/server/routers/conference.createEdition.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+import { DEFAULT_CLONE_FLAGS } from '@/lib/conference/edition'
+
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+vi.mock('next/headers', () => ({
+  headers: async () => ({ get: () => 'cloudnativebergen.no' }),
+}))
+
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+const SOURCE_ID = 'source-conf'
+
+const SOURCE_DOC = {
+  _id: SOURCE_ID,
+  title: 'Cloud Native Days Bergen 2025',
+  organizer: 'Cloud Native Bergen',
+  city: 'Bergen',
+  topics: [{ _type: 'reference', _ref: 'topic-a', _key: 'k1' }],
+  organizers: [{ _type: 'reference', _ref: 'sp-1', _key: 'o1' }],
+  contactEmail: 'hi@cnb.no',
+}
+const SOURCE_TIERS = [{ _id: 'tier-gold', title: 'Gold', tierType: 'standard' }]
+const SOURCE_TEMPLATES = [
+  {
+    _id: 'tpl-gold',
+    title: 'Gold contract',
+    tier: { _type: 'reference', _ref: 'tier-gold' },
+  },
+]
+
+// Claimed domains across ALL conferences (global uniqueness source of truth).
+let claimedDomains: string[] = ['cloudnativebergen.no', '2025.cnb.no']
+
+const createSpy = vi.fn()
+const commitMock = vi.fn().mockResolvedValue({})
+const patchSpy = vi.fn()
+
+function makeTransaction() {
+  const tx = {
+    create: (doc: unknown) => {
+      createSpy(doc)
+      return tx
+    },
+    commit: () => commitMock(),
+  }
+  return tx
+}
+
+const fetchMock = vi.fn(async (query: string) => {
+  if (query.includes('_type == "sponsorTier"')) return SOURCE_TIERS
+  if (query.includes('_type == "contractTemplate"')) return SOURCE_TEMPLATES
+  if (query.includes('.domains[]')) return claimedDomains
+  if (query.includes('_id == $id')) return SOURCE_DOC
+  return null
+})
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    transaction: () => makeTransaction(),
+    patch: (id: string) => {
+      patchSpy(id)
+      return { set: () => ({ commit: () => Promise.resolve({}) }) }
+    },
+  },
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => fetchMock(args[0] as string),
+  },
+}))
+
+import { conferenceRouter, DOMAIN_ALREADY_CLAIMED } from './conference'
+
+function makeCaller(opts: { isOrganizer?: boolean } | null) {
+  const speaker = opts
+    ? { _id: 'sp-1', name: 'Org', isOrganizer: opts.isOrganizer ?? false }
+    : undefined
+  const ctx = {
+    session: speaker ? { speaker, user: { name: 'Org' } } : null,
+    speaker,
+  } as unknown as Context
+  return conferenceRouter.createCaller(ctx)
+}
+
+function input(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'Cloud Native Days Bergen 2026',
+    startDate: '2026-06-01',
+    endDate: '2026-06-02',
+    domains: ['2026.cnb.no'],
+    clone: { ...DEFAULT_CLONE_FLAGS },
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  claimedDomains = ['cloudnativebergen.no', '2025.cnb.no']
+  commitMock.mockResolvedValue({})
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: SOURCE_ID },
+    error: null,
+  })
+})
+
+describe('createEdition — authorization', () => {
+  it('rejects a non-organizer (FORBIDDEN)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: false }).createEdition(input()),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('createEdition — domain global uniqueness', () => {
+  it('rejects a domain already claimed by another conference (BAD_REQUEST, named)', async () => {
+    const err = await makeCaller({ isOrganizer: true })
+      .createEdition(input({ domains: ['2025.cnb.no'] }))
+      .catch((e) => e)
+    expect(err.code).toBe('BAD_REQUEST')
+    expect(err.message).toContain(DOMAIN_ALREADY_CLAIMED)
+    expect(err.message).toContain('2025.cnb.no')
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts a domain not claimed by anyone', async () => {
+    const res = await makeCaller({ isOrganizer: true }).createEdition(input())
+    expect(res.conferenceId).toBeTruthy()
+  })
+})
+
+describe('createEdition — writes', () => {
+  it('creates the conference + cloned tiers + templates in one transaction', async () => {
+    await makeCaller({ isOrganizer: true }).createEdition(input())
+    const created = createSpy.mock.calls.map((c) => c[0] as { _type: string })
+    const types = created.map((d) => d._type)
+    expect(types).toContain('conference')
+    expect(types).toContain('sponsorTier')
+    expect(types).toContain('contractTemplate')
+    expect(commitMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('NEVER touches the current conference (no patch, no create with source id)', async () => {
+    await makeCaller({ isOrganizer: true }).createEdition(input())
+    expect(patchSpy).not.toHaveBeenCalled()
+    const created = createSpy.mock.calls.map((c) => c[0] as { _id: string })
+    for (const doc of created) {
+      expect(doc._id).not.toBe(SOURCE_ID)
+      expect(doc._id).not.toBe('tier-gold')
+      expect(doc._id).not.toBe('tpl-gold')
+    }
+  })
+
+  it('cloned tiers/templates point at the NEW conference id', async () => {
+    const res = await makeCaller({ isOrganizer: true }).createEdition(input())
+    const created = createSpy.mock.calls.map(
+      (c) => c[0] as { _type: string; conference?: { _ref: string } },
+    )
+    const nonConf = created.filter((d) => d._type !== 'conference')
+    for (const doc of nonConf) {
+      expect(doc.conference?._ref).toBe(res.conferenceId)
+    }
+  })
+
+  it('returns the new id and a per-family summary including the conference', async () => {
+    const res = await makeCaller({ isOrganizer: true }).createEdition(input())
+    expect(res.summary.conference).toBe(1)
+    expect(res.summary.sponsorTiers).toBe(1)
+    expect(res.summary.topics).toBe(1)
+  })
+
+  it('with sponsorTiers OFF, clones no tier docs', async () => {
+    await makeCaller({ isOrganizer: true }).createEdition(
+      input({ clone: { ...DEFAULT_CLONE_FLAGS, sponsorTiers: false } }),
+    )
+    const types = createSpy.mock.calls.map(
+      (c) => (c[0] as { _type: string })._type,
+    )
+    expect(types).not.toContain('sponsorTier')
+  })
+})
+
+describe('validateNewDomains', () => {
+  it('reports which domains are already claimed', async () => {
+    const res = await makeCaller({ isOrganizer: true }).validateNewDomains({
+      domains: ['2025.cnb.no', 'fresh.example.com'],
+    })
+    expect(res.taken).toEqual(['2025.cnb.no'])
+  })
+})

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -3,12 +3,23 @@ import { revalidateTag } from 'next/cache'
 import { headers } from 'next/headers'
 import { router, adminProcedure, resolveConferenceId } from '../trpc'
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
-import { ensureArrayKeys, createReferenceWithKey } from '@/lib/sanity/helpers'
+import {
+  ensureArrayKeys,
+  createReferenceWithKey,
+  generateKey,
+} from '@/lib/sanity/helpers'
 import { clearConferenceTeamsCache } from '@/lib/teams'
 import {
   CANNOT_REMOVE_CURRENT_DOMAIN,
   domainsWouldStrandHost,
+  normalizeDomain,
 } from '@/lib/conference/domains'
+import {
+  buildEditionDocuments,
+  type SourceConference,
+  type SourceSponsorTier,
+  type SourceContractTemplate,
+} from '@/lib/conference/edition'
 import {
   UpdateBasicInfoSchema,
   UpdateVenueSchema,
@@ -29,6 +40,8 @@ import {
   UpdateAnnouncementSchema,
   UpdateBrandingLogoSchema,
   SanitizeSvgPreviewSchema,
+  CreateEditionSchema,
+  ValidateNewDomainsSchema,
 } from '../schemas/conference'
 import {
   sanitizeSvgUpload,
@@ -39,6 +52,22 @@ import {
 /** The message the self-lockout guard rejects a self-removal with. */
 export const CANNOT_REMOVE_SELF_ORGANIZER =
   'You cannot remove yourself from the organizer team'
+
+/** Prefix for the BAD_REQUEST thrown when a new-edition domain is already taken. */
+export const DOMAIN_ALREADY_CLAIMED = 'Already used by another conference'
+
+/**
+ * Every domain claimed by ANY conference document, normalized. Drives the
+ * wizard's GLOBAL-uniqueness rule: a new edition must never shadow an existing
+ * edition's routing (`getConferenceForDomain` picks the FIRST conference whose
+ * `domains[]` matches the host — a duplicate would silently steal traffic).
+ */
+async function fetchClaimedDomains(): Promise<Set<string>> {
+  const all = await clientReadUncached.fetch<string[] | null>(
+    `*[_type == "conference" && defined(domains)].domains[]`,
+  )
+  return new Set((all ?? []).map(normalizeDomain))
+}
 
 /**
  * Field-scoped conference settings mutations (SE-1a).
@@ -390,5 +419,120 @@ export const conferenceRouter = router({
         throw error
       }
       return applyConferencePatch(conferenceId, { [input.slot]: sanitized })
+    }),
+
+  // === SE-5: create-next-edition wizard ====================================
+
+  /**
+   * Availability probe for the wizard's Domains step. Given the typed hostnames,
+   * returns which are ALREADY claimed by some conference (global uniqueness) and
+   * which are not valid bare hostnames — so the editor can flag them inline
+   * before the maintainer reaches the confirm step. Read-only.
+   */
+  validateNewDomains: adminProcedure
+    .input(ValidateNewDomainsSchema)
+    .query(async ({ input }) => {
+      const claimed = await fetchClaimedDomains()
+      const normalized = input.domains.map(normalizeDomain).filter((d) => d)
+      const taken = Array.from(new Set(normalized)).filter((d) =>
+        claimed.has(d),
+      )
+      return { taken }
+    }),
+
+  /**
+   * Seed a NEW conference edition that clones the CURRENT edition's STRUCTURE
+   * (per the `clone` flags) with fresh dates + domains. The current conference —
+   * resolved from the request domain, exactly like every other mutation — is the
+   * SOURCE and is NEVER modified (no patch/set touches its id).
+   *
+   * DOMAIN VALIDATION: shape/duplicate/hostname come from the schema; here we
+   * add the GLOBAL-uniqueness rule (a domain claimed by any conference is
+   * rejected, BAD_REQUEST naming it) — the server is the authority, the wizard
+   * only mirrors it.
+   *
+   * ATOMICITY: the new conference document and every cloned reference-carrying
+   * document (sponsor tiers, contract templates) are written in ONE Sanity
+   * transaction, which is all-or-nothing. A failure writes NOTHING — there is no
+   * partial-create state to recover, and the wizard is simply re-runnable.
+   *
+   * Returns the new conference `_id` and a per-family clone summary.
+   */
+  createEdition: adminProcedure
+    .input(CreateEditionSchema)
+    .mutation(async ({ input }) => {
+      const sourceId = await resolveConferenceId()
+
+      const [source, sourceTiers, sourceTemplates, claimedDomains] =
+        await Promise.all([
+          clientReadUncached.fetch<SourceConference | null>(
+            `*[_type == "conference" && _id == $id][0]`,
+            { id: sourceId },
+          ),
+          clientReadUncached.fetch<SourceSponsorTier[]>(
+            `*[_type == "sponsorTier" && conference._ref == $id]`,
+            { id: sourceId },
+          ),
+          clientReadUncached.fetch<SourceContractTemplate[]>(
+            `*[_type == "contractTemplate" && conference._ref == $id]`,
+            { id: sourceId },
+          ),
+          fetchClaimedDomains(),
+        ])
+
+      if (!source?._id) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Could not resolve the source conference',
+        })
+      }
+
+      // GLOBAL domain uniqueness — the authority. `input.domains` is already
+      // normalized/validated for shape by the schema.
+      const taken = input.domains.filter((d) => claimedDomains.has(d))
+      if (taken.length > 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `${DOMAIN_ALREADY_CLAIMED}: ${taken.join(', ')}`,
+        })
+      }
+
+      const newConferenceId = generateKey('conference')
+      const { conference, sponsorTiers, contractTemplates, summary } =
+        buildEditionDocuments(
+          {
+            conference: source,
+            sponsorTiers: sourceTiers ?? [],
+            contractTemplates: sourceTemplates ?? [],
+          },
+          input,
+          {
+            newConferenceId,
+            mintId: () => generateKey('doc'),
+            mintKey: () => generateKey('key'),
+          },
+        )
+
+      try {
+        let tx = clientWrite.transaction().create(conference)
+        for (const tier of sponsorTiers) tx = tx.create(tier)
+        for (const tpl of contractTemplates) tx = tx.create(tpl)
+        await tx.commit()
+      } catch (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to create the new edition',
+          cause: error,
+        })
+      }
+
+      // New edition adds a conference document; bust the shared conferences tag
+      // so domain resolution can see it once its domain actually resolves.
+      revalidateTag('content:conferences', 'default')
+
+      return {
+        conferenceId: newConferenceId,
+        summary: { conference: 1, ...summary },
+      }
     }),
 })

--- a/src/server/routers/staff.ts
+++ b/src/server/routers/staff.ts
@@ -48,6 +48,7 @@ export const staffRouter = router({
     .input(StaffCreateSchema)
     .mutation(async ({ input }) => {
       try {
+        const image = imageField(input.image)
         const created = await clientWrite.create({
           _type: 'staff',
           name: input.name,
@@ -55,9 +56,7 @@ export const staffRouter = router({
           link: input.link,
           ...(input.email ? { email: input.email } : {}),
           ...(input.company ? { company: input.company } : {}),
-          ...(imageField(input.image)
-            ? { image: imageField(input.image) }
-            : {}),
+          ...(image ? { image } : {}),
         })
         revalidateTag('content:staff', 'default')
         return { _id: created._id }

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { HEROICON_OPTIONS } from '../../../sanity/schemaTypes/constants'
 import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
 import { isValidTeamKey } from '@/lib/teams/validation'
+import { CLONE_FAMILIES } from '@/lib/conference/edition'
 
 /**
  * Field-scoped conference settings schemas (SE-1a + SE-1b). Each schema mirrors
@@ -394,3 +395,92 @@ export const UpdateBrandingLogoSchema = z.object({
 export const SanitizeSvgPreviewSchema = z.object({
   svg: z.string(),
 })
+
+// === SE-5: create-next-edition wizard ====================================
+
+/**
+ * A `domains[]` list for a NEW edition. Non-empty; each a bare, lowercase,
+ * unique hostname (scheme/path rejected). GLOBAL uniqueness — that no OTHER
+ * conference already claims a domain — needs the datastore and is enforced in
+ * the router (`createEdition` / `validateNewDomains`), never here.
+ */
+const NewEditionDomains = z
+  .array(z.string())
+  .min(1, 'At least one domain is required')
+  .transform((list) => list.map(normalizeDomain))
+  .superRefine((list, ctx) => {
+    const seen = new Set<string>()
+    list.forEach((entry, i) => {
+      if (entry === '') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Domain cannot be empty',
+          path: [i],
+        })
+        return
+      }
+      if (!isValidDomainEntry(entry)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'Enter a bare hostname (no https://, no path), e.g. example.com',
+          path: [i],
+        })
+      }
+      if (seen.has(entry)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate domain "${entry}"`,
+          path: [i],
+        })
+      }
+      seen.add(entry)
+    })
+  })
+
+/** Availability probe for the wizard's Domains step (no writes). */
+export const ValidateNewDomainsSchema = z.object({
+  domains: z.array(z.string()),
+})
+
+const optionalDateString = dateString.nullable().optional()
+
+/** The clone-flag object: one boolean per structural family. */
+const CloneFlagsSchema = z.object(
+  Object.fromEntries(CLONE_FAMILIES.map((f) => [f, z.boolean()])) as Record<
+    (typeof CLONE_FAMILIES)[number],
+    z.ZodBoolean
+  >,
+)
+
+/**
+ * `conference.createEdition` input. `title`, both event dates and a non-empty
+ * `domains` list are required; the organizer name and the CFP/program dates are
+ * optional (blank → the field is simply left unset on the new document). Only
+ * STRUCTURE is cloned, gated by `clone`; content is always empty on a new
+ * edition (see `buildEditionDocuments`).
+ */
+export const CreateEditionSchema = z
+  .object({
+    title: z.string().trim().min(1, 'Title is required'),
+    organizer: z.string().trim().min(1).nullable().optional(),
+    startDate: dateString,
+    endDate: dateString,
+    cfpStartDate: optionalDateString,
+    cfpEndDate: optionalDateString,
+    cfpNotifyDate: optionalDateString,
+    programDate: optionalDateString,
+    domains: NewEditionDomains,
+    clone: CloneFlagsSchema,
+  })
+  .refine((d) => d.endDate >= d.startDate, {
+    message: 'End date must be on or after the start date',
+    path: ['endDate'],
+  })
+  .refine(
+    (d) => !d.cfpStartDate || !d.cfpEndDate || d.cfpEndDate >= d.cfpStartDate,
+    {
+      message: 'CFP end date must be on or after the CFP start date',
+      path: ['cfpEndDate'],
+    },
+  )


### PR DESCRIPTION
## SE-5 — The "Create next edition" wizard (finale of Studio elimination)

Everything else was already admin-editable (SE-1a..SE-4). The last hard Studio dependency was **seeding a new conference document**. This adds a maintainer-locked wizard that clones the current edition's **structure** into a fresh conference with new dates and domains. **The current conference document is never modified.**

### Clone-family map (grounding)

Docs that carry a `conference` reference fall into two buckets:

**STRUCTURE — cloned → NEW docs pointing at the new conference:**
- `sponsorTier` (per-conference `conference._ref`)
- `contractTemplate` (per-conference `conference._ref` + a `tier._ref` → **remapped** to the newly-cloned tier; dropped if tiers weren't cloned, since the field is optional and would otherwise dangle against the source edition)

**CONTENT — per-edition, NEVER cloned (a new edition starts empty):**
`talk`, `schedule`, `review`, `speakerBadge`, `travelSupport`, `volunteer`, `imageGallery`, `conversation`/`message`, `workshopAnnouncement`, `workshopSignup`, `coSpeakerInvitation`, `notification`, `sponsorForConference`, `dashboardConfig`.

**GLOBAL — shared by every edition, nothing to clone (attach automatically):**
- `topic` (referenced by `conference.topics[]` → the ref array is copied as-is)
- `sponsorEmailTemplate` — **has NO conference reference**; it is a global template library. *(Deviation: the task's provisional flag list included `emailTemplates`; grounding shows there is nothing conference-scoped to clone, so that flag was dropped.)*
- `speaker` / `staff` (global people)

On the conference document itself:
- **Always copied (identity):** city, country, venue, tagline, description, org legal info, and the four branding logos (brand identity persists across editions).
- **Copied per clone flag:** `topics`, `formats`, `organizers` (default ON — team continuity), `teams`, `sponsorTiers`, `contractTemplates`, `sponsorshipCopy` (benefits + prospectus copy + signing provider + CRM cadence), `cfpGoals` (submission/format/revenue targets + travel budget), `agentConfig`, `emailsAndChannels` (from-addresses + Slack channels + social links).
- **Never copied (content):** schedules, featured speakers/talks, announcement, vanity metrics, ticketing/checkin IDs, registration link. `registrationEnabled` is forced to `false`.

### Domain validation

`getConferenceForDomain` resolves the **first** conference whose `domains[]` matches the request host (exact or single-label wildcard). A duplicate would silently shadow an existing edition's routing, so every new domain must be (a) a valid bare hostname (schema) and (b) **globally unique across ALL conference docs** — enforced server-side in `createEdition` (BAD_REQUEST naming the offenders) and mirrored inline in the Domains step via a read-only `conference.validateNewDomains` probe. Non-empty required.

### Transaction / failure-recovery policy

The new conference document and every cloned reference-carrying document (tiers, templates) are written in **one Sanity transaction**, which is all-or-nothing. A failure writes **nothing** — there is no partial-create state to recover, and the wizard is simply re-runnable. New document `_id`s are freshly minted, so re-runs never collide.

### UI

Dedicated page `/admin/settings/new-edition` (linked from a "New edition" action on the settings header). A 4-step flow: **Basics** (title/dates prefilled one year ahead), **Domains** (SE-1b hostname list machinery + inline global-uniqueness check), **Clone checklist** (structure defaults ON, per-family counts), **Review + type-to-confirm the new title + red Create**. After create: a success panel with the clone summary and the explicit note that **serving the new domain requires DNS/Vercel setup outside the app** — the edition isn't reachable until its domain resolves, so there is nothing to link to.

### Riders (#577 follow-ups)
- `SponsorActivityTimeline` update mutation gains an `onError` → toast ("Couldn't save the change — it may have been deleted.").
- `staff.ts` create path calls `imageField` once into a local instead of twice.

### Tests & stories
- `edition.test.ts` — heuristics + builder: clone-flag matrix (off → absent; on → cloned with new conference refs), topic/organizer ref copying, tier-ref remap (and drop when tiers off), fresh-id/never-touches-source invariants, summary counts.
- `conference.createEdition.test.ts` — global-uniqueness BAD_REQUEST (named), one-transaction writes, **no patch/create against the source id**, cloned docs point at the new id, `validateNewDomains`.
- `wizardLogic.test.ts` — pure step gating + type-to-confirm.
- Storybook stories for each step incl. the review/type-to-confirm and success states; captured light+dark via `pnpm shoot` (no overflow).

**Checks:** tsc, eslint, prettier, knip clean; full vitest 261 files / 3665 passing.

Do not merge — held for review.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the final Studio-elimination piece (SE-5): a 4-step admin wizard that clones the current edition's **structure** (tiers, templates, topics, teams, goals, etc.) into a brand-new conference document with fresh dates and domains, all in one atomic Sanity transaction that never touches the source document.

- **New `buildEditionDocuments` builder** (`edition.ts`) is pure and React-free, taking a source conference + tiers + templates and producing new documents with remapped IDs and a fresh conference reference, gated by per-family clone flags.
- **New `createEdition` and `validateNewDomains` tRPC mutations** enforce global domain uniqueness server-side (BAD_REQUEST naming the offenders) and write everything atomically; on failure nothing is written and the wizard is re-runnable.
- **Rider fixes** add an `onError` toast to `SponsorActivityTimeline`'s update mutation and deduplicate an `imageField()` call in `staff.ts`.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the soldOut propagation — a new edition immediately inheriting sold-out tiers would block sponsor sign-ups on day one with no obvious cause.

The builder copies the `soldOut` flag verbatim from source sponsor tiers. If last year's gold tier sold all its slots, the new edition starts with that tier marked sold-out, silently closing it to new sponsors. Everything else — the atomic transaction, domain uniqueness enforcement, type-to-confirm gate, and the pure/testable builder — is well-constructed and thoroughly tested.

src/lib/conference/edition.ts — the sponsorTier cloning block around the `soldOut` field (~line 450)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/conference/edition.ts | Pure builder for new-edition documents; `soldOut` is copied verbatim from source tiers, which would start a new edition's tiers as sold-out if they were sold-out in the previous year — blocking sponsor sign-ups. |
| src/server/routers/conference.ts | Adds `validateNewDomains` (read-only probe) and `createEdition` (atomic transaction); domain uniqueness check is a best-effort pre-flight with a theoretical race window between the read and the commit. |
| src/components/admin/new-edition/NewEditionWizard.tsx | 618-line 4-step wizard (Basics → Domains → Clone → Review); debounced availability probe, type-to-confirm gate, and success panel all look correct. |
| src/app/(admin)/admin/settings/new-edition/page.tsx | Server component that resolves the current conference, counts contract templates, and passes prefill data to the wizard; reads live data via `clientReadUncached` as expected for admin pages. |
| src/server/schemas/conference.ts | Adds `CreateEditionSchema` and `ValidateNewDomainsSchema`; schema validation (hostname shape, dedup, date ordering) is thorough. |
| src/lib/conference/edition.test.ts | Comprehensive unit tests for builder heuristics and the full clone-flag matrix, but no test for the `soldOut`-reset invariant. |
| src/components/admin/sponsor/SponsorActivityTimeline.tsx | Minimal rider: adds `onError` toast to the activity update mutation so silent failures surface to the user. |
| src/server/routers/staff.ts | Minor cleanup: `imageField()` is called once into a local in the create path instead of being inlined twice. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin (browser)
    participant Page as NewEditionPage (RSC)
    participant Wizard as NewEditionWizard (client)
    participant tRPC as tRPC / conferenceRouter
    participant Sanity as Sanity CMS

    Admin->>Page: GET /admin/settings/new-edition
    Page->>Sanity: getConferenceForCurrentDomain (source)
    Page->>Sanity: count contractTemplates for conference
    Page-->>Admin: render wizard with defaults + cloneCounts

    Admin->>Wizard: type domains
    Wizard->>tRPC: validateNewDomains (debounced 400ms)
    tRPC->>Sanity: fetch all conference domains[]
    tRPC-->>Wizard: "{ taken: [] }"

    Admin->>Wizard: type-to-confirm title + click Create
    Wizard->>tRPC: createEdition(title, dates, domains, clone)
    tRPC->>Sanity: fetch source conference + tiers + templates
    tRPC->>Sanity: fetch all claimed domains (global uniqueness)
    Note over tRPC: buildEditionDocuments() — pure, no I/O
    tRPC->>Sanity: tx.create(conference).create(tiers).create(templates).commit()
    tRPC->>tRPC: revalidateTag(content:conferences)
    tRPC-->>Wizard: "{ conferenceId, summary }"
    Wizard-->>Admin: SuccessPanel (DNS/Vercel caveat)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin (browser)
    participant Page as NewEditionPage (RSC)
    participant Wizard as NewEditionWizard (client)
    participant tRPC as tRPC / conferenceRouter
    participant Sanity as Sanity CMS

    Admin->>Page: GET /admin/settings/new-edition
    Page->>Sanity: getConferenceForCurrentDomain (source)
    Page->>Sanity: count contractTemplates for conference
    Page-->>Admin: render wizard with defaults + cloneCounts

    Admin->>Wizard: type domains
    Wizard->>tRPC: validateNewDomains (debounced 400ms)
    tRPC->>Sanity: fetch all conference domains[]
    tRPC-->>Wizard: "{ taken: [] }"

    Admin->>Wizard: type-to-confirm title + click Create
    Wizard->>tRPC: createEdition(title, dates, domains, clone)
    tRPC->>Sanity: fetch source conference + tiers + templates
    tRPC->>Sanity: fetch all claimed domains (global uniqueness)
    Note over tRPC: buildEditionDocuments() — pure, no I/O
    tRPC->>Sanity: tx.create(conference).create(tiers).create(templates).commit()
    tRPC->>tRPC: revalidateTag(content:conferences)
    tRPC-->>Wizard: "{ conferenceId, summary }"
    Wizard-->>Admin: SuccessPanel (DNS/Vercel caveat)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(admin): create-next-edition wizard ..."](https://github.com/cloudnativebergen/website/commit/18db311daaeccbb6ec05d006cf19a7a8e4e1e308) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45534956)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->