### PR TITLE
feat(push): test notification in hub + PWA app-icon badge

### DIFF
--- a/__tests__/api/trpc/push.test.ts
+++ b/__tests__/api/trpc/push.test.ts
@@ -51,6 +51,17 @@ vi.mock('@/lib/push/send', () => ({
     .fn()
     .mockResolvedValue({ ok: true, statusCode: 201, gone: false }),
 }))
+// sendTest now ALSO mirrors the test into the hub (skipPush). Mock both the hub
+// writer and the conference resolver so this suite stays hermetic (no real
+// Sanity) and the never-fail hub write can't interfere with the send assertions.
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: vi
+    .fn()
+    .mockResolvedValue({ conference: { _id: 'conf-test' } }),
+}))
 
 const mockAdd = vi.mocked(addPushSubscription)
 const mockRemove = vi.mocked(removePushSubscription)
@@ -202,11 +213,13 @@ describe('push router', () => {
       expect(mockGetState).toHaveBeenCalledWith(speakerA)
       expect(mockSendPush).toHaveBeenCalledTimes(2)
       // Uses the production payload shape: deep link + collapse tag, bypassing
-      // per-category preferences (explicit user action).
+      // per-category preferences (explicit user action). The url is ALIGNED with
+      // the hub item's link (#notification-settings) so push-tap and hub-click
+      // land on the same settings card.
       const [, payload] = mockSendPush.mock.calls[0]
       expect(payload).toMatchObject({
         title: 'Test notification',
-        url: '/cfp/profile',
+        url: '/cfp/profile#notification-settings',
         tag: 'test-notification',
       })
       expect(mockPrune).not.toHaveBeenCalled()

--- a/public/sw.js
+++ b/public/sw.js
@@ -239,6 +239,16 @@ self.addEventListener('push', (event) => {
   const raw = event.data ? event.data.text() : ''
   const payload = parsePushPayload(raw)
 
+  // Best-effort PWA app-icon badge (Badging API), so the icon reflects "unread
+  // present" even when no tab is open. The SW does not know the exact unread
+  // count, so it shows the generic dot (no-arg setAppBadge); the in-app
+  // AppBadgeSync sets the PRECISE number the next time a tab is focused.
+  // Feature-detected and never throws (the API rejects on unsupported
+  // platforms) — purely additive to the notification display below.
+  if (self.navigator && 'setAppBadge' in self.navigator) {
+    self.navigator.setAppBadge().catch(() => {})
+  }
+
   event.waitUntil(
     self.registration.showNotification(payload.title, {
       body: payload.body,
@@ -276,6 +286,19 @@ self.addEventListener('notificationclick', (event) => {
         type: 'window',
         includeUncontrolled: true,
       })
+
+      // Tell open page(s) which notification was clicked so the in-app
+      // NotificationClickSync can mark the caller's matching hub notification
+      // read — universally, for EVERY type (message pushes already self-clear on
+      // thread open; this closes the gap for resource-page pushes like proposal
+      // decisions / travel / sponsor / system). We post the ORIGINAL app-relative
+      // `target` (a sanitized "/..." path), which is exactly the notification's
+      // stored `link`, so the client's markReadByLink matches precisely.
+      for (const client of allClients) {
+        if ('postMessage' in client) {
+          client.postMessage({ type: 'notification-click', url: target })
+        }
+      }
 
       // Focus an existing tab already on the target URL if there is one.
       for (const client of allClients) {

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -39,6 +39,19 @@ const makeItems = (): NotificationItem[] => [
     actor: { _id: 'a4', name: 'Ola Organizer' },
   },
   {
+    // The self-notification written by `push.sendTest` (a `system` type) so a
+    // speaker's "send test" appears in the hub, not just as an OS push. Renders
+    // generically (title/message, no actor) and deep-links to the settings card.
+    id: 'notification.test.sp-1',
+    type: 'system',
+    title: 'Test notification',
+    message: 'Your push, hub, and badge are working.',
+    link: '/cfp/profile#notification-settings',
+    readAt: null,
+    createdAt: minutesAgo(1),
+    actor: null,
+  },
+  {
     id: '1',
     type: 'proposal_status_changed',
     title: 'Your proposal was accepted',

--- a/src/components/providers/SessionProviderWrapper.tsx
+++ b/src/components/providers/SessionProviderWrapper.tsx
@@ -2,6 +2,7 @@ import { SessionProvider } from 'next-auth/react'
 import type { Session } from 'next-auth'
 import { auth } from '@/lib/auth'
 import { SessionRefreshOnRestore } from './SessionRefreshOnRestore'
+import { AppBadgeSync, NotificationClickSync } from '@/components/pwa'
 
 /**
  * Narrow the server session into what is safe to serialize to the client, and
@@ -56,6 +57,17 @@ async function SessionLoader({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider session={sanitizeSession(session)}>
       <SessionRefreshOnRestore />
+      {/*
+        App-wide, signed-in-only PWA side effects. Both render null and self-gate
+        on the session, so they are inert for signed-out visitors:
+          - AppBadgeSync mirrors the unread count to the app-icon badge;
+          - NotificationClickSync marks a notification read when its push is
+            clicked (see public/sw.js postMessage).
+        Mounted here so they run on EVERY page (the bell only mounts in some
+        shells), inside SessionProvider + the layout's TRPCProvider.
+      */}
+      <AppBadgeSync />
+      <NotificationClickSync />
       {children}
     </SessionProvider>
   )

--- a/src/components/pwa/AppBadgeSync.test.tsx
+++ b/src/components/pwa/AppBadgeSync.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import type { Session } from 'next-auth'
+
+let mockSession: Session | null = null
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: mockSession,
+    status: mockSession ? 'authenticated' : 'unauthenticated',
+  }),
+}))
+
+// The badge query returns whatever `mockCount` is at render time.
+let mockCount: number | undefined = 0
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    notification: {
+      unreadCount: { useQuery: () => ({ data: mockCount }) },
+    },
+  },
+}))
+
+import { AppBadgeSync } from './AppBadgeSync'
+
+const setAppBadge = vi.fn().mockResolvedValue(undefined)
+const clearAppBadge = vi.fn().mockResolvedValue(undefined)
+
+function installBadgingApi() {
+  Object.defineProperty(navigator, 'setAppBadge', {
+    value: setAppBadge,
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(navigator, 'clearAppBadge', {
+    value: clearAppBadge,
+    configurable: true,
+    writable: true,
+  })
+}
+
+function uninstallBadgingApi() {
+  // @ts-expect-error — deleting the optional test shims.
+  delete navigator.setAppBadge
+  // @ts-expect-error — deleting the optional test shims.
+  delete navigator.clearAppBadge
+}
+
+function signedIn(): Session {
+  return {
+    expires: new Date(Date.now() + 60_000).toISOString(),
+    user: { name: 'Jane' },
+    speaker: { _id: 'sp-1', name: 'Jane', isOrganizer: false },
+  } as unknown as Session
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSession = null
+  mockCount = 0
+  installBadgingApi()
+})
+
+afterEach(() => {
+  cleanup()
+  uninstallBadgingApi()
+})
+
+describe('AppBadgeSync', () => {
+  it('renders nothing', () => {
+    const { container } = render(<AppBadgeSync />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('sets the badge to the unread count when signed in with unread > 0', () => {
+    mockSession = signedIn()
+    mockCount = 3
+    render(<AppBadgeSync />)
+    expect(setAppBadge).toHaveBeenCalledWith(3)
+    expect(clearAppBadge).not.toHaveBeenCalled()
+  })
+
+  it('clears the badge when signed in with zero unread', () => {
+    mockSession = signedIn()
+    mockCount = 0
+    render(<AppBadgeSync />)
+    expect(clearAppBadge).toHaveBeenCalled()
+    expect(setAppBadge).not.toHaveBeenCalled()
+  })
+
+  it('clears the badge when signed out (regardless of any stale count)', () => {
+    mockSession = null
+    mockCount = 5
+    render(<AppBadgeSync />)
+    expect(clearAppBadge).toHaveBeenCalled()
+    expect(setAppBadge).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when the Badging API is unsupported (feature-detect)', () => {
+    uninstallBadgingApi()
+    mockSession = signedIn()
+    mockCount = 4
+    expect(() => render(<AppBadgeSync />)).not.toThrow()
+    expect(setAppBadge).not.toHaveBeenCalled()
+    expect(clearAppBadge).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when setAppBadge rejects (reject-safe)', () => {
+    setAppBadge.mockRejectedValueOnce(new Error('not allowed'))
+    mockSession = signedIn()
+    mockCount = 2
+    expect(() => render(<AppBadgeSync />)).not.toThrow()
+    expect(setAppBadge).toHaveBeenCalledWith(2)
+  })
+
+  it('clears the badge on unmount', () => {
+    mockSession = signedIn()
+    mockCount = 1
+    const { unmount } = render(<AppBadgeSync />)
+    clearAppBadge.mockClear()
+    unmount()
+    expect(clearAppBadge).toHaveBeenCalled()
+  })
+})

--- a/src/components/pwa/AppBadgeSync.tsx
+++ b/src/components/pwa/AppBadgeSync.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { api } from '@/lib/trpc/client'
+
+/**
+ * The Badging API surface we use, declared locally so we don't depend on the
+ * ambient DOM lib exposing it (it isn't in every TS version's `Navigator`).
+ * Both methods return a promise that CAN reject on unsupported/blocked
+ * platforms, so every call site swallows rejection.
+ */
+interface NavigatorBadging {
+  setAppBadge?: (contents?: number) => Promise<void>
+  clearAppBadge?: () => Promise<void>
+}
+
+function badgingNavigator(): (Navigator & NavigatorBadging) | null {
+  if (typeof navigator === 'undefined') return null
+  if (!('setAppBadge' in navigator)) return null
+  return navigator as Navigator & NavigatorBadging
+}
+
+/**
+ * Keeps the PWA app-icon badge (Badging API) in sync with the signed-in
+ * speaker's unread notification count.
+ *
+ * - Reads the SAME `notification.unreadCount` query the bell uses, so react-query
+ *   dedupes it — no extra network. The query is gated on a signed-in session so
+ *   signed-out public pages (where this still mounts, app-wide) never fire the
+ *   protected request.
+ * - `setAppBadge(count)` when count > 0, `clearAppBadge()` when 0.
+ * - FEATURE-DETECTED: a no-op when the API is absent (iOS < 16.4, most desktop
+ *   browsers). Never throws — the API can reject, and every call catches.
+ * - The badge is a SIGNED-IN concept: it is cleared on sign-out and on unmount.
+ *
+ * Renders nothing. Mounted once app-wide (see SessionProviderWrapper) so it runs
+ * on every authenticated page, alongside — not inside — the bell.
+ */
+export function AppBadgeSync() {
+  const { data: session } = useSession()
+  const isSignedIn = Boolean(session?.speaker)
+
+  const { data } = api.notification.unreadCount.useQuery(undefined, {
+    // Never fire the protected query for a signed-out visitor.
+    enabled: isSignedIn,
+    // Mirror the bell's cadence so the shared query key resolves to one poll.
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+    staleTime: 10_000,
+  })
+
+  useEffect(() => {
+    const nav = badgingNavigator()
+    if (!nav) return
+
+    // Signed out → clear. (Also covers the moment a sign-out lands before the
+    // gated query has any data.)
+    if (!isSignedIn) {
+      nav.clearAppBadge?.().catch(() => {})
+      return
+    }
+
+    const count = data ?? 0
+    const result = count > 0 ? nav.setAppBadge?.(count) : nav.clearAppBadge?.()
+    // The API returns a promise that can reject on unsupported platforms.
+    Promise.resolve(result).catch(() => {})
+  }, [isSignedIn, data])
+
+  // Clear the badge when this component leaves the tree (full app teardown).
+  useEffect(() => {
+    return () => {
+      const nav = badgingNavigator()
+      nav?.clearAppBadge?.().catch(() => {})
+    }
+  }, [])
+
+  return null
+}

--- a/src/components/pwa/NotificationClickSync.test.tsx
+++ b/src/components/pwa/NotificationClickSync.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import type { Session } from 'next-auth'
+
+let mockSession: Session | null = null
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: mockSession,
+    status: mockSession ? 'authenticated' : 'unauthenticated',
+  }),
+}))
+
+const markReadMutate = vi.fn()
+const invalidateUnread = vi.fn()
+const invalidateList = vi.fn()
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    useUtils: () => ({
+      notification: {
+        unreadCount: { invalidate: invalidateUnread },
+        list: { invalidate: invalidateList },
+      },
+    }),
+    notification: {
+      markReadByLink: {
+        useMutation: () => ({ mutate: markReadMutate }),
+      },
+    },
+  },
+}))
+
+import { NotificationClickSync } from './NotificationClickSync'
+
+/** A fresh EventTarget standing in for navigator.serviceWorker. */
+function installServiceWorker() {
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: new EventTarget(),
+    configurable: true,
+    writable: true,
+  })
+}
+
+function postFromSW(data: unknown) {
+  const event = new MessageEvent('message', { data })
+  ;(navigator.serviceWorker as unknown as EventTarget).dispatchEvent(event)
+}
+
+function signedIn(): Session {
+  return {
+    expires: new Date(Date.now() + 60_000).toISOString(),
+    user: { name: 'Jane' },
+    speaker: { _id: 'sp-1', name: 'Jane', isOrganizer: false },
+  } as unknown as Session
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSession = signedIn()
+  installServiceWorker()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('NotificationClickSync', () => {
+  it('renders nothing', () => {
+    const { container } = render(<NotificationClickSync />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('marks read by the clicked notification url on a notification-click message', () => {
+    render(<NotificationClickSync />)
+    postFromSW({ type: 'notification-click', url: '/cfp/proposal/1' })
+    expect(markReadMutate).toHaveBeenCalledWith({ links: ['/cfp/proposal/1'] })
+  })
+
+  it('ignores messages that are not notification clicks', () => {
+    render(<NotificationClickSync />)
+    postFromSW({ type: 'SKIP_WAITING' })
+    postFromSW({ type: 'notification-click' }) // missing url
+    postFromSW('a raw string')
+    expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  it('does not register / fire when signed out', () => {
+    mockSession = null
+    render(<NotificationClickSync />)
+    postFromSW({ type: 'notification-click', url: '/cfp/proposal/1' })
+    expect(markReadMutate).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/pwa/NotificationClickSync.tsx
+++ b/src/components/pwa/NotificationClickSync.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { api } from '@/lib/trpc/client'
+
+/** The message the service worker posts on a notificationclick (see public/sw.js). */
+interface NotificationClickMessage {
+  type: 'notification-click'
+  url: string
+}
+
+function isNotificationClickMessage(
+  data: unknown,
+): data is NotificationClickMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { type?: unknown }).type === 'notification-click' &&
+    typeof (data as { url?: unknown }).url === 'string'
+  )
+}
+
+/**
+ * Marks the caller's matching hub notification READ when the app is opened or
+ * focused via a notification click — for EVERY notification type, not just
+ * messages.
+ *
+ * Gap this closes: opening a message thread self-clears its notification
+ * (`ConversationThread` fires `markReadByLink` on mount), but a proposal-decision
+ * / travel / sponsor / system push lands on its resource page which does NOT,
+ * so the bell stayed lit. The service worker now posts the clicked notification's
+ * app-relative url to the page; here we mark the caller's notification(s) with a
+ * matching `link` read and refresh the bell.
+ *
+ * `markReadByLink` is recipient-guarded, link-matched, and app-relative-validated
+ * server-side, so firing it for the landing url is safe and precise — it can only
+ * ever clear the CALLER'S OWN notification whose link equals that url. It is also
+ * idempotent, so double-handling a message click (the thread also marks it read)
+ * is harmless.
+ *
+ * Renders nothing. Mounted once app-wide (see SessionProviderWrapper).
+ */
+export function NotificationClickSync() {
+  const { data: session } = useSession()
+  const isSignedIn = Boolean(session?.speaker)
+  const utils = api.useUtils()
+  const markReadByLink = api.notification.markReadByLink.useMutation({
+    onSuccess: () => {
+      utils.notification.unreadCount.invalidate()
+      utils.notification.list.invalidate()
+    },
+  })
+  const mutate = markReadByLink.mutate
+
+  useEffect(() => {
+    if (!isSignedIn) return
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+      return
+    }
+
+    const onMessage = (event: MessageEvent) => {
+      if (!isNotificationClickMessage(event.data)) return
+      // The url is the notification's app-relative link (the SW only ever posts
+      // a sanitized "/..." path). The schema re-validates it; a non-matching url
+      // (e.g. the "/" fallback) simply clears nothing.
+      mutate({ links: [event.data.url] })
+    }
+
+    navigator.serviceWorker.addEventListener('message', onMessage)
+    return () => {
+      navigator.serviceWorker.removeEventListener('message', onMessage)
+    }
+  }, [isSignedIn, mutate])
+
+  return null
+}

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -12,6 +12,8 @@ export {
 export { UpdateBanner } from './UpdateBanner'
 export type { UpdateBannerProps } from './UpdateBanner'
 export { ServiceWorkerRegistrar } from './ServiceWorkerRegistrar'
+export { AppBadgeSync } from './AppBadgeSync'
+export { NotificationClickSync } from './NotificationClickSync'
 export { PwaInstallProvider, usePwaInstall } from './PwaInstallProvider'
 export type { InstallPlatform } from './PwaInstallProvider'
 export {

--- a/src/lib/notification/sanity.skipPush.test.ts
+++ b/src/lib/notification/sanity.skipPush.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Boundary mocks --------------------------------------------------------
+
+const commitMock = vi.fn().mockResolvedValue({})
+const createMock = vi.fn()
+const tx = {
+  create: (...a: unknown[]) => {
+    createMock(...a)
+    return tx
+  },
+  commit: () => commitMock(),
+}
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { transaction: () => tx },
+  clientReadUncached: { fetch: vi.fn() },
+}))
+
+const sendPushForNotificationsMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/push/send', () => ({
+  sendPushForNotifications: (...a: unknown[]) =>
+    sendPushForNotificationsMock(...a),
+}))
+
+import { createNotifications } from './sanity'
+import type { NotificationInput } from './types'
+
+const ITEMS: NotificationInput[] = [
+  {
+    recipientId: 'sp-1',
+    conferenceId: 'conf-1',
+    notificationType: 'system',
+    title: 'Test notification',
+    message: 'Your push, hub, and badge are working.',
+    link: '/cfp/profile#notification-settings',
+  },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createNotifications — skipPush', () => {
+  it('bridges to web push by default', async () => {
+    await createNotifications(ITEMS)
+
+    expect(commitMock).toHaveBeenCalledTimes(1)
+    expect(sendPushForNotificationsMock).toHaveBeenCalledTimes(1)
+    expect(sendPushForNotificationsMock).toHaveBeenCalledWith(ITEMS)
+  })
+
+  it('writes the hub doc but SUPPRESSES the push bridge when skipPush is true', async () => {
+    await createNotifications(ITEMS, { skipPush: true })
+
+    // The document is still written…
+    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(commitMock).toHaveBeenCalledTimes(1)
+    // …but no second push is fired.
+    expect(sendPushForNotificationsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -36,9 +36,16 @@ import type {
  * triggered it (a submitted proposal is still submitted even if the organizer
  * notification write fails). Callers therefore do not (and must not) wrap this
  * in a try/catch expecting to react to failures.
+ *
+ * `options.skipPush` writes the hub document(s) WITHOUT firing the web-push
+ * bridge. Used by `push.sendTest`, which already delivered its OWN direct test
+ * push (bypassing category prefs) and only wants the hub/badge side effect — so
+ * bridging here would deliver a SECOND, duplicate push. Default (unset) keeps
+ * the normal bridge for every other caller.
  */
 export async function createNotifications(
   items: NotificationInput[],
+  options?: { skipPush?: boolean },
 ): Promise<void> {
   if (items.length === 0) {
     return
@@ -84,10 +91,15 @@ export async function createNotifications(
     // never-throw contract: `sendPushForNotifications` never throws, but we also
     // isolate it so that even an unexpected failure can neither fail the
     // (already committed) notification write nor the business mutation.
-    try {
-      await sendPushForNotifications(items)
-    } catch (pushError) {
-      console.error('Failed to send web push for notifications:', pushError)
+    //
+    // `skipPush` suppresses the bridge entirely (see the doc): the test-send
+    // path has already delivered its own direct push and must not double up.
+    if (!options?.skipPush) {
+      try {
+        await sendPushForNotifications(items)
+      } catch (pushError) {
+        console.error('Failed to send web push for notifications:', pushError)
+      }
     }
   } catch (error) {
     // Never propagate — see the contract above.

--- a/src/server/routers/push.test.ts
+++ b/src/server/routers/push.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+// --- Boundary mocks --------------------------------------------------------
+
+const isPushConfiguredMock = vi.fn(() => true)
+vi.mock('@/lib/push/vapid', () => ({
+  isPushConfigured: () => isPushConfiguredMock(),
+  getVapidPublicKey: () => 'vapid-public-key',
+}))
+
+const getSpeakerPushStateMock = vi.fn()
+const prunePushSubscriptionMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/push/sanity', () => ({
+  getSpeakerPushState: (...a: unknown[]) => getSpeakerPushStateMock(...a),
+  prunePushSubscription: (...a: unknown[]) => prunePushSubscriptionMock(...a),
+  addPushSubscription: vi.fn(),
+  removePushSubscription: vi.fn(),
+  getPushPreferences: vi.fn(),
+  setPushPreferences: vi.fn(),
+}))
+
+const sendPushMock = vi.fn()
+const sendPushForNotificationsMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/push/send', () => ({
+  sendPush: (...a: unknown[]) => sendPushMock(...a),
+  sendPushForNotifications: (...a: unknown[]) =>
+    sendPushForNotificationsMock(...a),
+}))
+
+vi.mock('@/lib/push/validate', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/push/validate')>()),
+  isValidPushEndpoint: () => true,
+}))
+
+const createNotificationsMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: (...a: unknown[]) => createNotificationsMock(...a),
+}))
+
+// resolveConferenceId (in @/server/trpc) reads the current domain's conference.
+const getConferenceForCurrentDomainMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: () => getConferenceForCurrentDomainMock(),
+}))
+
+import { pushRouter } from './push'
+
+// Distinct speaker per test so the module-level `sendTest` cooldown never
+// collides across cases.
+function callerFor(speakerId: string) {
+  const speaker = { _id: speakerId, name: 'Test Speaker', isOrganizer: false }
+  const ctx = {
+    session: { speaker, user: { name: 'Test Speaker' } },
+    speaker,
+  } as unknown as Context
+  return pushRouter.createCaller(ctx)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  isPushConfiguredMock.mockReturnValue(true)
+  sendPushMock.mockResolvedValue({ ok: true })
+  getConferenceForCurrentDomainMock.mockResolvedValue({
+    conference: { _id: 'conf-1' },
+  })
+  getSpeakerPushStateMock.mockResolvedValue({
+    subscriptions: [
+      {
+        endpoint: 'https://push.example/ep-1',
+        keys: { p256dh: 'p', auth: 'a' },
+      },
+    ],
+    preferences: {},
+  })
+})
+
+describe('push.sendTest — hub mirror', () => {
+  it('writes exactly ONE self `system` hub notification with the settings deep link', async () => {
+    const caller = callerFor('sp-hub-1')
+    const result = await caller.sendTest()
+
+    // Existing send contract is intact.
+    expect(result).toMatchObject({
+      sent: 1,
+      gone: 0,
+      total: 1,
+      configured: true,
+    })
+
+    // Exactly one hub write, to the caller, as a `system` notification.
+    expect(createNotificationsMock).toHaveBeenCalledTimes(1)
+    const [items, options] = createNotificationsMock.mock.calls[0]
+    expect(items).toEqual([
+      {
+        recipientId: 'sp-hub-1',
+        conferenceId: 'conf-1',
+        notificationType: 'system',
+        title: 'Test notification',
+        message: 'Your push, hub, and badge are working.',
+        link: '/cfp/profile#notification-settings',
+      },
+    ])
+    // NO actor (self/system) and NO relatedProposal.
+    expect(items[0].actorId).toBeUndefined()
+
+    // CRITICAL: the hub write must NOT bridge a SECOND push.
+    expect(options).toEqual({ skipPush: true })
+    expect(sendPushForNotificationsMock).not.toHaveBeenCalled()
+  })
+
+  it('aligns the direct test push url with the hub item deep link', async () => {
+    const caller = callerFor('sp-hub-2')
+    await caller.sendTest()
+
+    expect(sendPushMock).toHaveBeenCalledTimes(1)
+    const [, payload] = sendPushMock.mock.calls[0]
+    expect(payload).toMatchObject({
+      title: 'Test notification',
+      url: '/cfp/profile#notification-settings',
+      tag: 'test-notification',
+    })
+  })
+
+  it('NEVER-FAIL: a hub-write failure (conference resolve throws) does not fail the send', async () => {
+    getConferenceForCurrentDomainMock.mockResolvedValueOnce({
+      conference: null,
+      error: new Error('no domain'),
+    })
+    const caller = callerFor('sp-hub-3')
+
+    const result = await caller.sendTest()
+
+    // The send still succeeded — the button reads this result.
+    expect(result).toMatchObject({ sent: 1, total: 1, configured: true })
+    // The hub write was never attempted (conference could not resolve).
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+    // And still no second push.
+    expect(sendPushForNotificationsMock).not.toHaveBeenCalled()
+  })
+
+  it('does not write a hub notification when push is unconfigured', async () => {
+    isPushConfiguredMock.mockReturnValue(false)
+    const caller = callerFor('sp-hub-4')
+
+    const result = await caller.sendTest()
+
+    expect(result).toEqual({ sent: 0, gone: 0, total: 0, configured: false })
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+  })
+
+  it('does not write a hub notification when the caller has no subscriptions', async () => {
+    getSpeakerPushStateMock.mockResolvedValueOnce({
+      subscriptions: [],
+      preferences: {},
+    })
+    const caller = callerFor('sp-hub-5')
+
+    const result = await caller.sendTest()
+
+    expect(result).toEqual({ sent: 0, gone: 0, total: 0, configured: true })
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/routers/push.ts
+++ b/src/server/routers/push.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server'
-import { router, protectedProcedure } from '../trpc'
+import { router, protectedProcedure, resolveConferenceId } from '../trpc'
+import { createNotifications } from '@/lib/notification/sanity'
 import {
   PushSubscriptionInputSchema,
   PushUnsubscribeSchema,
@@ -189,10 +190,13 @@ export const pushRouter = router({
     // preferences entirely (unlike sendPushForNotifications, which gates each
     // notification on the speaker's category prefs). If a speaker taps "send
     // test", they get the test regardless of which categories they've muted.
+    // The deep link is ALIGNED with the hub item written below
+    // (`#notification-settings`) so a push-tap and a hub-item click both land on
+    // the push-settings card — the exact resource this test is about.
     const payload: PushMessagePayload = {
       title: 'Test notification',
       body: 'Push notifications are working on this device 🎉',
-      url: '/cfp/profile',
+      url: '/cfp/profile#notification-settings',
       tag: 'test-notification',
     }
 
@@ -283,6 +287,41 @@ export const pushRouter = router({
       if (seen.has(key)) continue
       seen.add(key)
       dedupedFailures.push(failure)
+    }
+
+    // ALSO mirror the test into the persistent hub so it shows in the bell/panel
+    // and drives the PWA app-icon badge — not just the transient OS push above.
+    // ONE self-recipient `system` notification.
+    //
+    // NO DOUBLE PUSH: the direct test push already fired for THIS device above
+    // (bypassing category prefs). We therefore write the hub doc with
+    // `skipPush: true` so `createNotifications` does NOT bridge a second push.
+    //
+    // NEVER-FAIL: a hub-write failure must not fail the test send (the button
+    // reads the send result below). `resolveConferenceId()` CAN throw, so the
+    // whole side effect is folded into its own try/catch and logged on failure.
+    // (`createNotifications` itself already never throws.)
+    try {
+      const conferenceId = await resolveConferenceId()
+      await createNotifications(
+        [
+          {
+            recipientId: ctx.speaker._id,
+            conferenceId,
+            notificationType: 'system',
+            title: 'Test notification',
+            message: 'Your push, hub, and badge are working.',
+            // Same target as the push above so both land on the settings card.
+            link: '/cfp/profile#notification-settings',
+          },
+        ],
+        { skipPush: true },
+      )
+    } catch (error) {
+      console.error(
+        `Failed to write test hub notification for speaker ${ctx.speaker._id}:`,
+        error,
+      )
     }
 
     // `total` lets the client distinguish "no devices subscribed" (total 0)


### PR DESCRIPTION
## What & why

The push "send test" now ALSO lands in the persistent notification hub (bell/panel), drives the unread count, and triggers the PWA app-icon badge — and the app-icon badge reflects real unread count generally.

## TASK 1 — Test appears in the hub

`push.sendTest` now writes ONE self-recipient `system` hub notification (title "Test notification", message "Your push, hub, and badge are working.", link `/cfp/profile#notification-settings`, no actor). `system` was already in the `NotificationType` union and maps to the `otherUpdates` push category; the hub renders it generically (no dedicated icon).

### No double push (skipPush mechanism)

`sendTest` already fires its own direct always-on web-push (bypassing category prefs — unchanged). To mirror it into the hub WITHOUT delivering a second push, `createNotifications` gained an `options.skipPush` flag: it still commits the hub document in the same never-fail transaction envelope but skips the `sendPushForNotifications` bridge. `sendTest` calls `createNotifications([item], { skipPush: true })`. This is the cleanest option (one threaded flag; the bridge is the only thing suppressed) and is unit-tested at the sanity layer (skipPush → bridge not called; default → bridge called).

### Deep-link alignment

The direct test push url was aligned from `/cfp/profile` to `/cfp/profile#notification-settings` so a push-tap and a hub-item click both land on the push-settings card (the resource the test is about).

### Never-fail

The hub write (incl. `resolveConferenceId()`, which can throw) is folded into its own try/catch inside `sendTest`; a failure logs and leaves the send result — which the button reads — intact. The `{sent,gone,total,configured,failures}` contract is unchanged.

## TASK 2 — PWA app-icon badge (Badging API)

Two-part approach:

- **In-app, precise** — `AppBadgeSync` (renders null, mounted app-wide in `SessionProviderWrapper` alongside `SessionRefreshOnRestore`, so it runs on every authenticated page). It reads the SAME `notification.unreadCount` query the bell uses (react-query dedupes — no extra network; gated on a signed-in session so signed-out public pages never fire the protected query), then `setAppBadge(count)` when >0 / `clearAppBadge()` when 0. Feature-detected (`'setAppBadge' in navigator`) — no-op on iOS <16.4 / desktop browsers without the API. Reject-safe (every call catches). Clears on sign-out and on unmount.
- **Service worker, best-effort** — the `push` handler sets a generic dot via no-arg `self.navigator.setAppBadge()` (guarded + catch) so the icon updates even with no tab open. The SW doesn't know the exact count; the in-app `AppBadgeSync` sets the precise number the next time a tab is focused. Deliberately not over-engineered (no count added to the push payload).

## ADDENDUM A — universal mark-read on notification click

Closes the reported gap: only MESSAGE pushes self-cleared (ConversationThread marks read on mount); a proposal-decision/travel/sponsor/system push landed on its page and left the bell lit. Now the SW `notificationclick` posts `{type:'notification-click', url}` (the app-relative link) to open clients; a new app-wide `NotificationClickSync` (renders null, signed-in only) calls `notification.markReadByLink({links:[url]})` and invalidates `unreadCount`+`list`. `markReadByLink` is recipient-guarded, link-matched, and app-relative-validated server-side, so it can only clear the caller's own matching notification. Double-handling a message click is harmless (idempotent). Best-effort limitation: a cold-open (no existing tab) opens a new window that isn't listening at post time — noted.

## ADDENDUM B — sw.js ownership

All `public/sw.js` edits (push-handler badge + notificationclick postMessage) are in this PR. No `/launch` never-cache entry was needed/added here — leaving that to the parallel /launch+manifest agent.

## TASK 3 — deep-link verified

`/cfp/profile` route exists (`src/app/(cfp)/cfp/profile/page.tsx`) and `id="notification-settings"` is a real anchor in `CFPProfilePage.tsx` (already used by `NotificationPanel` as its settingsHref). The SW click sanitizes + navigates same-origin. Both the test push url and the hub item link resolve to the same real page + anchor. No fix required.

## Tests & checks

- New: push router hub-mirror suite (5), `createNotifications` skipPush suite (2), `AppBadgeSync` (7), `NotificationClickSync` (4). Updated the existing `__tests__/api/trpc/push.test.ts` for the aligned url + hermetic hub mocks.
- Full suite: 265 files, 3684 passed / 5 skipped. tsc, eslint, prettier, knip all clean.
- Visual: shot the NotificationList story (new `system` test row) light + dark — renders generically and consistently in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes three related notification pipeline improvements: test-push now mirrors into the persistent hub (with `skipPush` to avoid double-delivery), a new `AppBadgeSync` component keeps the PWA app-icon badge in sync with the unread count, and a new `NotificationClickSync` component universally marks hub notifications read on push-tap — closing the gap for non-message notification types.

- **Hub mirror + `skipPush`**: `push.sendTest` writes one `system` hub notification via `createNotifications({ skipPush: true })`; the new flag suppresses the web-push bridge while committing the Sanity document, preserving the never-fail contract throughout.
- **`AppBadgeSync`**: mounts app-wide in `SessionProviderWrapper`, reuses the bell's deduplicated `unreadCount` query (no extra network), feature-detects the Badging API, and clears on sign-out / unmount.
- **`NotificationClickSync`**: listens for `notification-click` postMessages from the service worker and calls `markReadByLink` for the clicked URL; the server-side guard ensures only the caller's own notification is cleared.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the three features are independently guarded, never-fail contracts are maintained throughout, and the test suite is comprehensive

The hub write in `sendTest` fires even when every push subscription was gone/expired, leaving a "Your push, hub, and badge are working" hub entry despite no OS push reaching the device. The SW `setAppBadge()` call sits outside `event.waitUntil`, making it technically droppable under tight SW lifetimes. Both are edge cases with no data loss, but they represent small gaps between the feature's stated intent and its actual behaviour in degraded conditions.

src/server/routers/push.ts (hub write guard when sent===0) and public/sw.js (setAppBadge placement relative to waitUntil)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/routers/push.ts | Adds hub mirror + skipPush flag to sendTest; hub write fires even when sent===0 (misleading "working" message in edge case) |
| src/lib/notification/sanity.ts | Adds optional skipPush option to createNotifications; clean, backward-compatible, never-fail contract preserved |
| public/sw.js | Adds setAppBadge() on push (outside event.waitUntil, intentionally best-effort) and postMessage notification-click to open clients |
| src/components/pwa/AppBadgeSync.tsx | New null-rendering client component; feature-detected, reject-safe, session-gated, properly clears on sign-out and unmount |
| src/components/pwa/NotificationClickSync.tsx | New null-rendering client component; correctly registers/removes SW message listener, guards on isSignedIn, delegates mark-read to server-validated mutation |
| src/components/providers/SessionProviderWrapper.tsx | Mounts AppBadgeSync and NotificationClickSync inside SessionProvider; correct placement for app-wide signed-in side effects |
| src/components/pwa/AppBadgeSync.test.tsx | Thorough 7-case test suite covering sign-in/out, zero/nonzero count, API absence, reject-safety, and unmount cleanup |
| src/components/pwa/NotificationClickSync.test.tsx | 4-case suite covering happy path, message filtering, and signed-out guard; missing unmount/cleanup assertion |
| src/lib/notification/sanity.skipPush.test.ts | Clean 2-case skipPush test: verifies default bridges push and skipPush=true suppresses bridge while still committing hub doc |
| src/server/routers/push.test.ts | New hermetic 5-case suite covering hub write shape, deep-link alignment, never-fail, unconfigured push, and no-subscription cases |
| __tests__/api/trpc/push.test.ts | Adds hermetic mocks for hub writer and conference resolver; updates url assertion for the aligned #notification-settings deep link |
| src/components/notifications/NotificationList.stories.tsx | Adds system-type test notification story item; correctly uses null actor and the aligned deep link |
| src/components/pwa/index.ts | Barrel export additions for AppBadgeSync and NotificationClickSync; clean |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (browser)
    participant SW as Service Worker
    participant App as AppBadgeSync / NotificationClickSync
    participant RQ as React Query (unreadCount)
    participant API as tRPC push.sendTest
    participant DB as Sanity (hub)

    U->>API: sendTest()
    API->>SW: sendPush() per subscription (OS push)
    API->>DB: "createNotifications([system], {skipPush:true})"
    DB-->>API: committed (no 2nd push)
    API-->>U: "{sent, gone, total, configured}"

    SW-->>U: OS notification shown
    SW->>SW: setAppBadge() [best-effort, outside waitUntil]

    U->>SW: notificationclick
    SW->>App: "postMessage({type:'notification-click', url})"
    App->>API: "notification.markReadByLink({links:[url]})"
    API-->>App: ok (recipient-guarded)
    App->>RQ: invalidate unreadCount + list
    RQ-->>App: fresh count
    App->>U: setAppBadge(count) / clearAppBadge()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (browser)
    participant SW as Service Worker
    participant App as AppBadgeSync / NotificationClickSync
    participant RQ as React Query (unreadCount)
    participant API as tRPC push.sendTest
    participant DB as Sanity (hub)

    U->>API: sendTest()
    API->>SW: sendPush() per subscription (OS push)
    API->>DB: "createNotifications([system], {skipPush:true})"
    DB-->>API: committed (no 2nd push)
    API-->>U: "{sent, gone, total, configured}"

    SW-->>U: OS notification shown
    SW->>SW: setAppBadge() [best-effort, outside waitUntil]

    U->>SW: notificationclick
    SW->>App: "postMessage({type:'notification-click', url})"
    App->>API: "notification.markReadByLink({links:[url]})"
    API-->>App: ok (recipient-guarded)
    App->>RQ: invalidate unreadCount + list
    RQ-->>App: fresh count
    App->>U: setAppBadge(count) / clearAppBadge()
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/pwa/NotificationClickSync.test.tsx`, line 425-451 ([link](https://github.com/cloudnativebergen/website/blob/ab438377e57a6afeaa3cb0439adf42284c79292d/src/components/pwa/NotificationClickSync.test.tsx#L425-L451)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Missing test: listener cleanup on unmount / session change

   `AppBadgeSync.test.tsx` includes a dedicated "clears the badge on unmount" test verifying the cleanup `useEffect`. `NotificationClickSync.test.tsx` has no analogous case checking that `navigator.serviceWorker.removeEventListener` is called when the component unmounts or `isSignedIn` flips back to `false`. If the cleanup ever regresses, the listener would accumulate across re-mounts and fire `markReadByLink` multiple times per click.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(push): test notification in hub + P..."](https://github.com/cloudnativebergen/website/commit/ab438377e57a6afeaa3cb0439adf42284c79292d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45573418)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->