### PR TITLE
feat(notifications): standalone notifications page + linkless routing

### DIFF
--- a/__tests__/lib/push/send-bridge.test.ts
+++ b/__tests__/lib/push/send-bridge.test.ts
@@ -171,7 +171,10 @@ describe('sendPushForNotifications', () => {
     expect('tag' in JSON.parse(body as string)).toBe(false)
   })
 
-  it('falls back to an empty body and root url when message/link are absent', async () => {
+  it('defaults a LINKLESS notification to the /notifications page (empty body too)', async () => {
+    // A notification with no deep link (system/announcement types) must push a
+    // url pointing at the standalone notifications page, so a tap on a closed app
+    // opens somewhere the message is readable — never the bare app root.
     mockGetState.mockResolvedValue(state())
     await sendPushForNotifications([
       item({ message: undefined, link: undefined }),
@@ -180,7 +183,7 @@ describe('sendPushForNotifications', () => {
     expect(JSON.parse(body as string)).toEqual({
       title: 'Your talk was accepted',
       body: '',
-      url: '/',
+      url: '/notifications',
     })
   })
 

--- a/__tests__/lib/pwa/push-payload.test.ts
+++ b/__tests__/lib/pwa/push-payload.test.ts
@@ -23,7 +23,7 @@ describe('parsePushPayload', () => {
     const result = parsePushPayload('')
     expect(result.title).toBe('Cloud Native Days')
     expect(result.body).toBe('')
-    expect(result.url).toBe('/')
+    expect(result.url).toBe('/notifications')
     expect(result.tag).toBeUndefined()
   })
 
@@ -31,19 +31,19 @@ describe('parsePushPayload', () => {
     const result = parsePushPayload('just some text')
     expect(result.body).toBe('just some text')
     expect(result.title).toBe('Cloud Native Days')
-    expect(result.url).toBe('/')
+    expect(result.url).toBe('/notifications')
   })
 
-  it('drops an absolute off-origin url in favour of /', () => {
+  it('drops an absolute off-origin url in favour of the notifications page', () => {
     const result = parsePushPayload(
       JSON.stringify({ url: 'https://evil.example/steal' }),
     )
-    expect(result.url).toBe('/')
+    expect(result.url).toBe('/notifications')
   })
 
   it('drops a protocol-relative url', () => {
     const result = parsePushPayload(JSON.stringify({ url: '//evil.example' }))
-    expect(result.url).toBe('/')
+    expect(result.url).toBe('/notifications')
   })
 
   it('drops a backslash-prefixed url that resolves off-origin', () => {
@@ -55,7 +55,9 @@ describe('parsePushPayload', () => {
       '/a\\b',
       '\\\\evil.com',
     ]) {
-      expect(parsePushPayload(JSON.stringify({ url })).url).toBe('/')
+      expect(parsePushPayload(JSON.stringify({ url })).url).toBe(
+        '/notifications',
+      )
     }
   })
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -199,7 +199,10 @@ self.addEventListener('fetch', (event) => {
 // helper in `src/lib/pwa/push-payload.ts` (kept in sync by the sw-source test).
 
 const NOTIFICATION_DEFAULT_TITLE = 'Cloud Native Days'
-const NOTIFICATION_DEFAULT_URL = '/'
+// A push with no (or an unparseable/off-origin) url opens the standalone
+// notifications page — somewhere the notification is readable — not the bare
+// app root. Mirrors DEFAULT_URL in src/lib/pwa/push-payload.ts.
+const NOTIFICATION_DEFAULT_URL = '/notifications'
 
 // Only allow a same-origin absolute PATH ("/..."; never "//..."). Any absolute
 // or protocol-relative URL is dropped so a click can never leave the origin. A
@@ -239,24 +242,27 @@ self.addEventListener('push', (event) => {
   const raw = event.data ? event.data.text() : ''
   const payload = parsePushPayload(raw)
 
-  // Best-effort PWA app-icon badge (Badging API), so the icon reflects "unread
-  // present" even when no tab is open. The SW does not know the exact unread
-  // count, so it shows the generic dot (no-arg setAppBadge); the in-app
-  // AppBadgeSync sets the PRECISE number the next time a tab is focused.
-  // Feature-detected and never throws (the API rejects on unsupported
-  // platforms) — purely additive to the notification display below.
-  if (self.navigator && 'setAppBadge' in self.navigator) {
-    self.navigator.setAppBadge().catch(() => {})
-  }
-
   event.waitUntil(
-    self.registration.showNotification(payload.title, {
-      body: payload.body,
-      icon: '/icon-192.png',
-      badge: '/favicon-32.png',
-      tag: payload.tag,
-      data: { url: payload.url },
-    }),
+    (async () => {
+      // Best-effort PWA app-icon badge (Badging API), so the icon reflects
+      // "unread present" even when no tab is open. The SW does not know the exact
+      // unread count, so it shows the generic dot (no-arg setAppBadge); the in-app
+      // AppBadgeSync sets the PRECISE number the next time a tab is focused.
+      // Feature-detected and never throws (the API rejects on unsupported
+      // platforms). MUST run inside waitUntil: on tight SW lifetimes work started
+      // outside the extended-lifetime promise can be dropped before it settles.
+      if (self.navigator && 'setAppBadge' in self.navigator) {
+        await self.navigator.setAppBadge().catch(() => {})
+      }
+
+      await self.registration.showNotification(payload.title, {
+        body: payload.body,
+        icon: '/icon-192.png',
+        badge: '/favicon-32.png',
+        tag: payload.tag,
+        data: { url: payload.url },
+      })
+    })(),
   )
 })
 

--- a/src/app/(cfp)/notifications/page.tsx
+++ b/src/app/(cfp)/notifications/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import { NotificationInbox } from '@/components/notifications/NotificationInbox'
+
+export const metadata: Metadata = {
+  title: 'Notifications',
+  robots: { index: false, follow: false },
+}
+
+/**
+ * Standalone notification history at the TOP-LEVEL path `/notifications`.
+ *
+ * Route choice: this lives in the `(cfp)` route group but OUTSIDE its `cfp/`
+ * segment, so it resolves to `/notifications` (not `/cfp/notifications`) while
+ * inheriting the group layout's auth guard — any signed-in speaker is admitted
+ * and a signed-out visitor is redirected to sign-in. It is deliberately NOT
+ * admin-gated: the bell (and its notifications) are cross-cutting, and
+ * organizers are speakers too, so both audiences reach the same page. The
+ * audience-aware Messages/settings links inside adapt per user.
+ */
+export default function NotificationsPage() {
+  return <NotificationInbox />
+}

--- a/src/components/notifications/NotificationInbox.tsx
+++ b/src/components/notifications/NotificationInbox.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { api } from '@/lib/trpc/client'
+import type { NotificationItem } from '@/lib/notification/types'
+import { NotificationList } from './NotificationList'
+
+/**
+ * Page size for the standalone inbox. Same as the bell popover, but here a full
+ * page is fetched at a time and every page is kept (infinite scroll via an
+ * explicit "Show more") — the popover renders only the first page.
+ */
+const PAGE_SIZE = 20
+
+/**
+ * Data container for the STANDALONE notifications page (`/notifications`).
+ *
+ * A full-page sibling of {@link NotificationPanel}: it reuses the exact same
+ * `notification.list` infinite query, `markRead` / `markAllRead` mutations, and
+ * the presentational {@link NotificationList}, differing only in that it
+ *   - has no popover to close (activation just marks read; links navigate);
+ *   - reads the unread total from its own `unreadCount` query rather than the
+ *     bell's polled counter;
+ *   - renders "Show more" to page through the WHOLE history, not just 20;
+ *   - lets the PAGE scroll (`disableInnerScroll`) instead of a nested region;
+ *   - keeps linkless rows inert/inline-readable (no `linklessHref`) because the
+ *     user is already on the page where they're readable, and shows no "View all
+ *     notifications" self-link.
+ *
+ * IMPERSONATION mirrors the panel: while an admin impersonates a speaker the
+ * list is read-only, so marking read can never destroy the speaker's real
+ * unread state.
+ */
+export function NotificationInbox() {
+  const utils = api.useUtils()
+  const { data: session, status } = useSession()
+  const isImpersonating = session?.isImpersonating === true
+
+  // Audience-aware Messages quick link, withheld until the session resolves so
+  // an organizer never briefly gets the speaker link (same rule as the panel).
+  const sessionReady = status !== 'loading' && !!session
+  const messagesHref = sessionReady
+    ? session.speaker?.isOrganizer === true
+      ? '/admin/messages'
+      : '/cfp/messages'
+    : undefined
+  const settingsHref = sessionReady
+    ? '/cfp/profile#notification-settings'
+    : undefined
+
+  const { data: unreadData } = api.notification.unreadCount.useQuery(
+    undefined,
+    {
+      staleTime: 10_000,
+    },
+  )
+  const unreadCount = unreadData ?? 0
+
+  const {
+    data,
+    isLoading,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = api.notification.list.useInfiniteQuery(
+    { limit: PAGE_SIZE },
+    {
+      staleTime: 10_000,
+      getNextPageParam: (lastPage) =>
+        lastPage.length === PAGE_SIZE
+          ? lastPage[lastPage.length - 1]?.createdAt
+          : undefined,
+      initialCursor: undefined,
+    },
+  )
+
+  const items = data?.pages.flat() ?? []
+
+  const invalidate = () => {
+    utils.notification.unreadCount.invalidate()
+    utils.notification.list.invalidate()
+  }
+
+  const markRead = api.notification.markRead.useMutation({
+    onSuccess: invalidate,
+  })
+  const markAllRead = api.notification.markAllRead.useMutation({
+    onSuccess: invalidate,
+  })
+
+  const handleItemClick = (item: NotificationItem) => {
+    // Mark read on activation (fire-and-forget). Navigation, if the item has a
+    // link, is handled by the wrapping <Link>. Never mutate while impersonating.
+    if (!isImpersonating && !item.readAt) {
+      markRead.mutate({ ids: [item.id] })
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-white/10">
+        <NotificationList
+          items={items}
+          isLoading={isLoading}
+          isError={isError}
+          unreadCount={unreadCount}
+          onMarkAllRead={() => markAllRead.mutate()}
+          isMarkingAll={markAllRead.isPending}
+          onItemClick={handleItemClick}
+          onShowMore={() => fetchNextPage()}
+          hasMore={hasNextPage}
+          isLoadingMore={isFetchingNextPage}
+          readOnly={isImpersonating}
+          messagesHref={messagesHref}
+          settingsHref={settingsHref}
+          disableInnerScroll
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/notifications/NotificationInboxPage.stories.tsx
+++ b/src/components/notifications/NotificationInboxPage.stories.tsx
@@ -1,0 +1,144 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+import { NotificationList } from './NotificationList'
+import { mockDateBeforeEach } from '@/lib/storybook'
+import type { NotificationItem } from '@/lib/notification/types'
+
+/**
+ * Visual stories for the STANDALONE notifications page (`/notifications`),
+ * rendered through the shared presentational {@link NotificationList} exactly as
+ * {@link NotificationInbox} wires it: full-page card, `disableInnerScroll` so the
+ * page (not a nested region) scrolls, an audience-aware Messages footer, the
+ * settings gear, and — crucially — NO `linklessHref`, so a linkless system row
+ * (e.g. "Test notification") stays an inert, inline-READABLE row on the page.
+ */
+const minutesAgo = (m: number) =>
+  new Date(Date.now() - m * 60_000).toISOString()
+
+const makePageItems = (): NotificationItem[] => [
+  {
+    // A genuinely LINKLESS system notification: on the page it must be readable
+    // inline (an inert row), which is the whole reason the page exists.
+    id: 'notification.system.linkless.1',
+    type: 'system',
+    title: 'Test notification',
+    message:
+      'Your push, hub, and badge are working — and this row has no link.',
+    readAt: null,
+    createdAt: minutesAgo(1),
+    actor: null,
+  },
+  {
+    id: 'p1',
+    type: 'proposal_status_changed',
+    title: 'Your proposal was accepted',
+    message:
+      'Congratulations! "Scaling Kubernetes to 10,000 nodes" has been accepted for the main track.',
+    link: '/cfp/proposal/p1',
+    readAt: null,
+    createdAt: minutesAgo(6),
+    actor: { _id: 'a1', name: 'Program Committee' },
+  },
+  {
+    id: 'm1',
+    type: 'message_received',
+    title: '3 new messages — Scaling Kubernetes to 10,000 nodes',
+    message: 'Sounds great — let’s lock in the demo cluster size today.',
+    link: '/cfp/proposal/p1#messages',
+    readAt: null,
+    createdAt: minutesAgo(24),
+    actor: { _id: 'a3', name: 'Maria Jensen' },
+  },
+  {
+    id: 't1',
+    type: 'travel_support_update',
+    title: 'Travel support approved',
+    message: 'Your travel reimbursement request has been approved.',
+    link: '/cfp/expense',
+    readAt: minutesAgo(60 * 26),
+    createdAt: minutesAgo(60 * 30),
+    actor: null,
+  },
+  {
+    id: 's1',
+    type: 'system',
+    title: 'Schedule published',
+    readAt: minutesAgo(60 * 24 * 9),
+    createdAt: minutesAgo(60 * 24 * 10),
+    actor: null,
+  },
+]
+
+const pageArgs = {
+  onMarkAllRead: fn(),
+  onItemClick: fn(),
+  onMessagesClick: fn(),
+  onSettingsClick: fn(),
+  settingsHref: '/cfp/profile#notification-settings',
+  messagesHref: '/cfp/messages',
+  disableInnerScroll: true,
+}
+
+/** The page shell NotificationInbox renders around the shared list. */
+function PageShell({
+  items,
+  unreadCount,
+}: {
+  items: NotificationItem[]
+  unreadCount: number
+}) {
+  return (
+    <div className="min-h-screen bg-gray-50 px-4 py-8">
+      <div className="mx-auto max-w-3xl">
+        <div className="overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-white/10">
+          <NotificationList
+            {...pageArgs}
+            items={items}
+            unreadCount={unreadCount}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const meta = {
+  title: 'Components/Notifications/NotificationInboxPage',
+  component: NotificationList,
+  beforeEach: mockDateBeforeEach(new Date('2026-07-18T12:00:00Z')),
+  parameters: { layout: 'fullscreen' },
+  // Placeholder required-props; every story below drives the real content via
+  // its own `render`, so these are never actually shown.
+  args: { items: [], unreadCount: 0, onMarkAllRead: fn(), onItemClick: fn() },
+} satisfies Meta<typeof NotificationList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Populated: Story = {
+  render: () => <PageShell items={makePageItems()} unreadCount={3} />,
+}
+
+// Dark variant: a `.dark` ancestor enables every `dark:` utility beneath it
+// (Tailwind class strategy), and the page background matches the dark shell.
+export const PopulatedDark: Story = {
+  parameters: { backgrounds: { default: 'dark' } },
+  render: () => (
+    <div className="dark bg-gray-950">
+      <PageShell items={makePageItems()} unreadCount={3} />
+    </div>
+  ),
+}
+
+export const Empty: Story = {
+  render: () => <PageShell items={[]} unreadCount={0} />,
+}
+
+export const EmptyDark: Story = {
+  parameters: { backgrounds: { default: 'dark' } },
+  render: () => (
+    <div className="dark bg-gray-950">
+      <PageShell items={[]} unreadCount={0} />
+    </div>
+  ),
+}

--- a/src/components/notifications/NotificationList.stories.tsx
+++ b/src/components/notifications/NotificationList.stories.tsx
@@ -133,6 +133,11 @@ export const UnreadAndRead: Story = {
     onMessagesClick: fn(),
     settingsHref: '/cfp/profile#notification-settings',
     onSettingsClick: fn(),
+    // Panel wiring: a "View all notifications" footer link, and linkless rows
+    // route to the standalone page where they're readable.
+    viewAllHref: '/notifications',
+    onViewAllClick: fn(),
+    linklessHref: '/notifications',
   },
   render: (args) => <NotificationList {...args} items={makeItems()} />,
 }

--- a/src/components/notifications/NotificationList.test.tsx
+++ b/src/components/notifications/NotificationList.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { NotificationList } from './NotificationList'
+import type { NotificationItem } from '@/lib/notification/types'
+
+afterEach(cleanup)
+
+const linked: NotificationItem = {
+  id: 'linked',
+  type: 'proposal_status_changed',
+  title: 'Your proposal was accepted',
+  message: 'Congratulations!',
+  link: '/cfp/proposal/1',
+  readAt: null,
+  createdAt: new Date().toISOString(),
+  actor: null,
+}
+
+const linkless: NotificationItem = {
+  id: 'linkless',
+  type: 'system',
+  title: 'Test notification',
+  message: 'Your push, hub, and badge are working.',
+  readAt: null,
+  createdAt: new Date().toISOString(),
+  actor: null,
+}
+
+function renderList(
+  props: Partial<React.ComponentProps<typeof NotificationList>>,
+) {
+  return render(
+    <NotificationList
+      items={[]}
+      unreadCount={0}
+      onMarkAllRead={vi.fn()}
+      onItemClick={vi.fn()}
+      {...props}
+    />,
+  )
+}
+
+describe('NotificationList row linking', () => {
+  it('renders a linked notification as a Link to its deep link', () => {
+    renderList({ items: [linked] })
+    const row = screen.getByRole('link', { name: /accepted/i })
+    expect(row).toHaveAttribute('href', '/cfp/proposal/1')
+  })
+
+  it('renders a linkless notification as an inert button when no linklessHref is given', () => {
+    renderList({ items: [linkless] })
+    // Readable inline (e.g. on the standalone page): a button, not a link.
+    expect(
+      screen.getByRole('button', { name: /test notification/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: /test notification/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('routes a linkless notification to linklessHref when provided (the popover case)', () => {
+    renderList({ items: [linkless], linklessHref: '/notifications' })
+    const row = screen.getByRole('link', { name: /test notification/i })
+    expect(row).toHaveAttribute('href', '/notifications')
+  })
+
+  it('fires onItemClick when a linkless row is activated', () => {
+    const onItemClick = vi.fn()
+    renderList({ items: [linkless], onItemClick })
+    fireEvent.click(screen.getByRole('button', { name: /test notification/i }))
+    expect(onItemClick).toHaveBeenCalledWith(linkless)
+  })
+})
+
+describe('NotificationList footer', () => {
+  it('renders a "View all notifications" link when viewAllHref is set', () => {
+    renderList({ items: [linked], viewAllHref: '/notifications' })
+    expect(
+      screen.getByRole('link', { name: /view all notifications/i }),
+    ).toHaveAttribute('href', '/notifications')
+  })
+
+  it('omits the "View all notifications" link when viewAllHref is absent', () => {
+    renderList({ items: [linked] })
+    expect(
+      screen.queryByRole('link', { name: /view all notifications/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/notifications/NotificationList.tsx
+++ b/src/components/notifications/NotificationList.tsx
@@ -61,6 +61,32 @@ export interface NotificationListProps {
    * popover (same flow as item clicks); navigation is handled by the `<Link>`.
    */
   onSettingsClick?: () => void
+  /**
+   * When set, a row that has NO `item.link` renders as a `<Link>` to this href
+   * (the standalone notifications page) instead of an inert `<button>`. A
+   * linkless notification has nowhere to deep-link, so in the cramped popover we
+   * send the click to the full page where it's comfortably readable. The bell
+   * panel passes `/notifications`; the page itself OMITS this so its own linkless
+   * rows stay inert buttons (they're already readable inline on the page).
+   */
+  linklessHref?: string
+  /**
+   * Href of the full notifications page. When set, a "View all notifications"
+   * quick link is rendered in the footer (the popover shows one page, the page
+   * shows all). The bell panel passes `/notifications`; the page omits it.
+   */
+  viewAllHref?: string
+  /**
+   * Fired when the "View all notifications" link is activated — the container
+   * closes the popover (same flow as item clicks); navigation is the `<Link>`.
+   */
+  onViewAllClick?: () => void
+  /**
+   * Drops the inner `max-height`/scroll on the list region so the surrounding
+   * PAGE scrolls as one document instead of a nested scroll area. The bell
+   * popover keeps the default bounded height; the full-page inbox sets this.
+   */
+  disableInnerScroll?: boolean
 }
 
 function SkeletonRow() {
@@ -163,20 +189,30 @@ function ItemBody({ item }: { item: NotificationItem }) {
 const rowClasses =
   'flex w-full gap-3 px-4 py-3 text-left transition hover:bg-gray-50 focus-visible:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-cloud-blue dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60'
 
+// Footer quick link ("View all notifications" / "View all messages").
+// min-h-11 keeps the tap target ≥44px.
+const footerLinkClass =
+  'flex min-h-11 items-center justify-center px-4 py-3 text-xs font-medium text-brand-cloud-blue transition hover:bg-gray-50 hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60'
+
 function ListItem({
   item,
   onItemClick,
+  linklessHref,
 }: {
   item: NotificationItem
   onItemClick: (item: NotificationItem) => void
+  linklessHref?: string
 }) {
   const unread = !item.readAt
   const wrapperClass = `${rowClasses} ${unread ? 'bg-blue-50/40 dark:bg-blue-900/10' : ''}`
 
-  if (item.link) {
+  // A linkless row falls back to `linklessHref` (the full notifications page)
+  // when the container supplies one, so it's readable somewhere off the popover.
+  const href = item.link ?? linklessHref
+  if (href) {
     return (
       <Link
-        href={item.link}
+        href={href}
         prefetch={false}
         onClick={() => onItemClick(item)}
         className={wrapperClass}
@@ -219,6 +255,10 @@ export function NotificationList({
   onMessagesClick,
   settingsHref,
   onSettingsClick,
+  linklessHref,
+  viewAllHref,
+  onViewAllClick,
+  disableInnerScroll = false,
 }: NotificationListProps) {
   return (
     // `role="region"` makes the aria-label an actual named landmark — on a
@@ -261,7 +301,11 @@ export function NotificationList({
         </div>
       </div>
 
-      <div className="max-h-[70vh] divide-y divide-gray-100 overflow-y-auto dark:divide-gray-800/70">
+      <div
+        className={`divide-y divide-gray-100 dark:divide-gray-800/70 ${
+          disableInnerScroll ? '' : 'max-h-[70vh] overflow-y-auto'
+        }`}
+      >
         {isLoading ? (
           <>
             <SkeletonRow />
@@ -275,7 +319,12 @@ export function NotificationList({
         ) : (
           <>
             {items.map((item) => (
-              <ListItem key={item.id} item={item} onItemClick={onItemClick} />
+              <ListItem
+                key={item.id}
+                item={item}
+                onItemClick={onItemClick}
+                linklessHref={linklessHref}
+              />
             ))}
             {hasMore && (
               <div className="p-2">
@@ -293,17 +342,30 @@ export function NotificationList({
         )}
       </div>
 
-      {messagesHref && (
-        <div className="border-t border-gray-200 dark:border-gray-800">
-          <Link
-            href={messagesHref}
-            prefetch={false}
-            onClick={onMessagesClick}
-            // min-h-11 keeps the tap target ≥44px.
-            className="flex min-h-11 items-center justify-center px-4 py-3 text-xs font-medium text-brand-cloud-blue transition hover:bg-gray-50 hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-inset dark:hover:bg-gray-800/60"
-          >
-            View all messages &rarr;
-          </Link>
+      {(viewAllHref || messagesHref) && (
+        // A single footer holding up to two audience-agnostic quick links,
+        // separated by a hairline when both are present.
+        <div className="divide-y divide-gray-100 border-t border-gray-200 dark:divide-gray-800/70 dark:border-gray-800">
+          {viewAllHref && (
+            <Link
+              href={viewAllHref}
+              prefetch={false}
+              onClick={onViewAllClick}
+              className={footerLinkClass}
+            >
+              View all notifications &rarr;
+            </Link>
+          )}
+          {messagesHref && (
+            <Link
+              href={messagesHref}
+              prefetch={false}
+              onClick={onMessagesClick}
+              className={footerLinkClass}
+            >
+              View all messages &rarr;
+            </Link>
+          )}
         </div>
       )}
     </div>

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -121,6 +121,13 @@ export function NotificationPanel({
       onMessagesClick={onClose}
       settingsHref={settingsHref}
       onSettingsClick={onClose}
+      // Linkless rows have no deep link, so in the popover they route to the
+      // standalone page where the notification is readable. The route is
+      // audience-agnostic (any signed-in speaker/organizer), so unlike the
+      // messages quick link it needs no session gate.
+      linklessHref="/notifications"
+      viewAllHref="/notifications"
+      onViewAllClick={onClose}
     />
   )
 }

--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -290,8 +290,11 @@ async function deliverPushToRecipient(
       title: item.title,
       body: item.message ?? '',
       // The SW re-sanitises this to a same-origin path; hub links are already
-      // app-relative (e.g. /cfp/proposal/<id>). Fall back to the app root.
-      url: item.link ?? '/',
+      // app-relative (e.g. /cfp/proposal/<id>). A notification with NO deep link
+      // (system/announcement types) targets the standalone notifications page
+      // so a push tap on a closed app opens somewhere the message is readable —
+      // never the bare app root, where it would be lost.
+      url: item.link ?? '/notifications',
       // Stable per-thread tag (message notifications) → the SW passes it to
       // showNotification so repeat pushes for the same thread REPLACE the prior
       // one instead of stacking. Undefined for one-shot types (they stack).

--- a/src/lib/pwa/push-payload.ts
+++ b/src/lib/pwa/push-payload.ts
@@ -17,7 +17,10 @@ export interface ParsedPushNotification {
 }
 
 const DEFAULT_TITLE = 'Cloud Native Days'
-const DEFAULT_URL = '/'
+// A missing/malformed/off-origin url falls back to the standalone notifications
+// page so a linkless or unparseable push still opens somewhere readable, never
+// the bare app root. Mirrored inline by NOTIFICATION_DEFAULT_URL in public/sw.js.
+const DEFAULT_URL = '/notifications'
 
 /**
  * Parse a push message body. Tolerates malformed / empty payloads by falling


### PR DESCRIPTION
## What & why

Notifications with a deep link already do the right thing (deep-link-to-resource + mark-read-on-open). But notifications **without** a link were dead ends: a linkless row in the bell popover was an inert button, and a linkless **push** (app closed) opened `/` — losing the message. This PR gives linkless notifications a real home: a standalone **`/notifications`** page, and routes every linkless surface to it.

## Route choice — why a top-level `/notifications`, not admin-gated

The page lives in the `(cfp)` route group but **outside** its `cfp/` segment, so it resolves to the top-level path **`/notifications`** while inheriting the group layout's auth guard.

- **Behind sign-in, not admin-only.** The `(cfp)` layout redirects a signed-out visitor to sign-in and admits any signed-in **speaker**. Organizers are speakers too (they carry `session.speaker` with `isOrganizer`), so **both audiences reach the same page** — correct, because the bell and its notifications are cross-cutting (both shells render the bell). A single audience-agnostic route is the simplest thing that works for both; the Messages/settings links inside adapt per user.
- There is no middleware auth wall; auth is enforced by the group layout's server-side redirect, so `/notifications` is gated exactly like every other CFP page.

## Linkless → `/notifications` routing (panel + push + SW default)

Three surfaces, one destination:

1. **Panel (bell popover)** — `NotificationList` gains a `linklessHref` prop; when set, a row with **no** `item.link` renders as a `<Link>` to it instead of an inert button. The panel passes `/notifications`, so tapping a linkless popover row opens the page where it's readable. (I opted **in** to point 3's uniform behavior rather than leaving popover rows inert.)
2. **Push bridge** (`src/lib/push/send.ts`) — a notification with no link now builds its push `url` as `/notifications` (was `/`), so a push tap on a closed app opens somewhere the message is readable. Message pushes are unaffected (they always carry a conversation link).
3. **SW default** (`public/sw.js` `NOTIFICATION_DEFAULT_URL`) → `/notifications`, so any missing/unparseable/off-origin push url opens the page, not `/`. The pure mirror `src/lib/pwa/push-payload.ts` `DEFAULT_URL` is kept in sync (documented mirror pair).

The **page itself** intentionally does **not** set `linklessHref` — its linkless rows stay inert and inline-readable (you're already where they're readable), and it shows no "View all notifications" self-link.

## `setAppBadge` waitUntil fix (folds in #580 follow-up)

In the SW `push` handler, `navigator.setAppBadge()` ran **outside** `event.waitUntil`, so on tight SW lifetimes the badge write could be dropped before it settled. Moved it **into** the `waitUntil` async chain (before `showNotification`), still feature-detected and non-throwing.

## Also

- **Standalone page** (`/notifications`): reuses the `notification.list` infinite query with **"Show more"** (whole history, not just 20), the shared presentational `NotificationList`, a header + settings gear (→ `/cfp/profile#notification-settings`), audience-aware Messages footer, and empty/loading/error states. Marks read on activation and is read-only under impersonation — consistent with the panel.
- **Panel footer** gains a **"View all notifications"** link (audience-agnostic) next to "View all messages".

## Tests

- `NotificationList.test.tsx` (new): linked row → Link; linkless row → inert button by default; linkless row → Link when `linklessHref` set; activation fires `onItemClick`; footer "View all notifications" presence.
- `send-bridge.test.ts`: linkless notification push `url` defaults to `/notifications`.
- `push-payload.test.ts`: updated for the new `/notifications` default (empty/non-JSON/off-origin/backslash cases).
- Full suite green: **3697 passed, 5 skipped** (267 files).

## Visual QA

`pnpm shoot` at 393px, light + dark, for the new page stories (populated incl. a linkless "Test notification" row readable inline, and empty). No overflow; dark mode renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gives linkless notifications a real destination by introducing a standalone `/notifications` page and routing all linkless surfaces (bell popover rows, push taps on closed apps, and the SW default URL) to it instead of the bare app root. It also folds in a correctness fix for the Service Worker's `push` handler, moving `setAppBadge` inside `event.waitUntil` so the badge write is no longer at risk of being dropped on tight SW lifetimes.

- **New `/notifications` page** (`src/app/(cfp)/notifications/page.tsx` + `NotificationInbox`): reuses the existing `notification.list` infinite query and `NotificationList` presenter with `disableInnerScroll`; auth-guarded via the `(cfp)` group layout; linkless rows are intentionally inert (inline-readable); impersonation is read-only, consistent with the panel.
- **Linkless routing** (`NotificationList`, `NotificationPanel`, `send.ts`, `push-payload.ts`, `sw.js`): three new props (`linklessHref`, `viewAllHref`, `onViewAllClick`) plus a `disableInnerScroll` flag extend the presenter without breaking existing callers; default URL in both the TS helper and the SW hand-written mirror updated to `/notifications`.
- **Tests and stories**: new `NotificationList.test.tsx` covers all four row-linking cases; `send-bridge` and `push-payload` tests updated; Storybook stories for populated/empty × light/dark added.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all surfaces route correctly, the auth guard is applied via the existing group layout, and the SW fix is strictly additive.

The changes are well-scoped: new props are additive and optional, existing callers are unaffected, the standalone page inherits the proven (cfp) auth guard, the sanitizeUrl off-origin protection is unchanged, and the full test suite (3697 tests) is green. The setAppBadge move inside waitUntil is a correctness improvement with no regressions. No data-mutation paths or auth boundaries changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(cfp)/notifications/page.tsx | New page at `/notifications` (via `(cfp)` route group); correctly inherits the group's server-side auth guard and sets `robots: noindex`. |
| src/components/notifications/NotificationInbox.tsx | New data container for the standalone page; mirrors NotificationPanel's query/mutation pattern with correct impersonation guard, audience-aware hrefs, and `disableInnerScroll`; omits `linklessHref` / `viewAllHref` intentionally. |
| src/components/notifications/NotificationList.tsx | Adds `linklessHref`, `viewAllHref`, `onViewAllClick`, and `disableInnerScroll` props; linkless rows correctly fall back to `linklessHref` via `item.link ?? linklessHref`; footer refactored to support two links separated by a divider. |
| src/components/notifications/NotificationPanel.tsx | Passes the three new props to `NotificationList`; `linklessHref` and `viewAllHref` are hardcoded `/notifications` (audience-agnostic, no session gate needed). |
| public/sw.js | Default URL changed to `/notifications`; `setAppBadge` correctly moved inside `waitUntil` IIFE and awaited, preventing the badge write from being dropped on tight SW lifetimes. |
| src/lib/push/send.ts | Linkless push URL changed from `/` to `/notifications`; message notifications are unaffected as they always carry a conversation link. |
| src/lib/pwa/push-payload.ts | `DEFAULT_URL` updated to `/notifications`; `sanitizeUrl` fallback now points to the notifications page; mirrors `NOTIFICATION_DEFAULT_URL` in `sw.js` as documented. |
| src/components/notifications/NotificationList.test.tsx | New test file covering linked-row Link, inert-button default for linkless rows, `linklessHref` upgrade to Link, `onItemClick` fire, and footer `viewAllHref` presence/absence. |
| __tests__/lib/push/send-bridge.test.ts | Test description and assertion updated to expect `/notifications` instead of `/` for linkless notifications. |
| __tests__/lib/pwa/push-payload.test.ts | All off-origin / malformed / empty URL fallback assertions updated to expect `/notifications`; backslash and protocol-relative cases covered. |
| src/components/notifications/NotificationInboxPage.stories.tsx | New Storybook stories for the standalone page (populated, empty, light/dark); `PageShell` faithfully reproduces the `NotificationInbox` wiring including `disableInnerScroll` and no `linklessHref`. |
| src/components/notifications/NotificationList.stories.tsx | Existing `UnreadAndRead` story updated to pass `viewAllHref`, `onViewAllClick`, and `linklessHref` to demonstrate the panel wiring. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Notification triggered] --> B{Has deep link?}
    B -- Yes --> C[Push url = item.link]
    B -- No --> D[Push url = '/notifications']

    C --> E[SW push handler]
    D --> E

    E --> F{url valid & same-origin?}
    F -- Yes --> G[Show notification with url]
    F -- No / malformed --> H[Fallback url = '/notifications']
    H --> G

    G --> I[User taps notification]
    I --> J[Navigate to url]

    subgraph Bell Popover
        K[Linked row] --> L[Link to item.link]
        M[Linkless row] --> N{linklessHref set?}
        N -- Yes panel --> O[Link to '/notifications']
        N -- No page --> P[Inert button inline-readable]
    end

    subgraph Standalone Page /notifications
        Q[NotificationInbox] --> R[NotificationList
disableInnerScroll
no linklessHref
no viewAllHref]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Notification triggered] --> B{Has deep link?}
    B -- Yes --> C[Push url = item.link]
    B -- No --> D[Push url = '/notifications']

    C --> E[SW push handler]
    D --> E

    E --> F{url valid & same-origin?}
    F -- Yes --> G[Show notification with url]
    F -- No / malformed --> H[Fallback url = '/notifications']
    H --> G

    G --> I[User taps notification]
    I --> J[Navigate to url]

    subgraph Bell Popover
        K[Linked row] --> L[Link to item.link]
        M[Linkless row] --> N{linklessHref set?}
        N -- Yes panel --> O[Link to '/notifications']
        N -- No page --> P[Inert button inline-readable]
    end

    subgraph Standalone Page /notifications
        Q[NotificationInbox] --> R[NotificationList
disableInnerScroll
no linklessHref
no viewAllHref]
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(notifications): standalone notifica..."](https://github.com/cloudnativebergen/website/commit/691574e025828f5c868bd533aa9639f867392977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45577145)</sub>

<!-- /greptile_comment -->