### PR TITLE
feat(reminders): speaker prep reminders, day-of agenda, schedule-change alerts (phase 1)

### DIFF
--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -15,6 +15,7 @@ import imageGallery from './schemaTypes/imageGallery'
 import notification from './schemaTypes/notification'
 import review from './schemaTypes/review'
 import schedule from './schemaTypes/schedule'
+import scheduledReminderLog from './schemaTypes/scheduledReminderLog'
 import speaker from './schemaTypes/speaker'
 import speakerBadge from './schemaTypes/speakerBadge'
 import sponsor from './schemaTypes/sponsor'
@@ -42,6 +43,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     // Conference
     conference,
     schedule,
+    scheduledReminderLog,
     dashboardConfig,
     imageGallery,
     volunteer,

--- a/sanity/schemaTypes/scheduledReminderLog.ts
+++ b/sanity/schemaTypes/scheduledReminderLog.ts
@@ -1,0 +1,82 @@
+import { defineField, defineType } from 'sanity'
+
+/**
+ * A tiny dedup marker for the scheduled speaker-reminder cron
+ * (`src/lib/reminders`). One document tracks that a given reminder `key` was
+ * delivered to a given speaker for a given conference, so a daily re-run never
+ * double-sends.
+ *
+ * DETERMINISTIC ID: the document `_id` is derived, not random —
+ * `reminder.<key>.<conferenceId>.<speakerId>` for the recurring speaker
+ * reminders, and `reminder.day-of.<conferenceId>.<speakerId>.<date>` for the
+ * day-of agenda. The cron writes it with `createIfNotExists` + a counter
+ * increment, so concurrent runs converge on ONE marker per (key, conference,
+ * speaker) instead of stacking duplicates.
+ *
+ * `count` supports RE-ARMING reminders (e.g. the confirm-talk nudge fires up to
+ * a capped number of times, spaced apart): the runner reads `count` and
+ * `lastSentAt` to decide whether the cap is reached or the spacing window has
+ * elapsed before sending again.
+ *
+ * This is operational bookkeeping, not user content — it stores only a weak
+ * speaker/conference reference and timestamps, and ages out with the conference.
+ */
+export default defineType({
+  name: 'scheduledReminderLog',
+  title: 'Scheduled Reminder Log',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'key',
+      title: 'Reminder Key',
+      type: 'string',
+      description:
+        'The reminder registry key (e.g. confirm-talk, upload-slides, day-of).',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'conference',
+      title: 'Conference',
+      type: 'reference',
+      to: [{ type: 'conference' }],
+      // Weak so a conference deletion doesn't orphan-block; the marker is
+      // disposable bookkeeping.
+      weak: true,
+    }),
+    defineField({
+      name: 'speaker',
+      title: 'Speaker',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      // Weak so erasing a speaker (GDPR) doesn't orphan-block their deletion.
+      weak: true,
+    }),
+    defineField({
+      name: 'count',
+      title: 'Send Count',
+      type: 'number',
+      description:
+        'How many times this reminder has been delivered to this speaker for this conference.',
+      validation: (Rule) => Rule.min(0).integer(),
+    }),
+    defineField({
+      name: 'lastSentAt',
+      title: 'Last Sent At',
+      type: 'datetime',
+      description: 'When this reminder was last delivered.',
+    }),
+  ],
+  preview: {
+    select: {
+      key: 'key',
+      speaker: 'speaker.name',
+      count: 'count',
+    },
+    prepare({ key, speaker, count }) {
+      return {
+        title: `${key || 'reminder'} → ${speaker || 'speaker'}`,
+        subtitle: `sent ${count ?? 0}×`,
+      }
+    },
+  },
+})

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -360,6 +360,12 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                           • <strong>Read status:</strong> Whether and when you
                           have read the notification
                         </li>
+                        <li>
+                          • <strong>Reminder delivery log:</strong> For
+                          scheduled speaker reminders, a small record of which
+                          reminder was sent to you for an event and when, so the
+                          same reminder is not sent twice
+                        </li>
                       </ul>
                       <div className="mt-3 rounded-lg bg-cyan-100 p-2 dark:bg-cyan-800/30">
                         <p className="text-xs text-cyan-800 dark:text-cyan-200">

--- a/src/app/api/cron/reminders/route.test.ts
+++ b/src/app/api/cron/reminders/route.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The route calls `noStore()` (a request-scoped Next helper) — no-op it in tests.
+vi.mock('next/cache', () => ({ unstable_noStore: () => {} }))
+
+const resolveMock = vi.fn()
+const runSpeakerRemindersMock = vi.fn()
+const runDayOfAgendaMock = vi.fn()
+vi.mock('@/lib/reminders', () => ({
+  resolveActiveReminderConference: (...a: unknown[]) => resolveMock(...a),
+  runSpeakerReminders: (...a: unknown[]) => runSpeakerRemindersMock(...a),
+  runDayOfAgenda: (...a: unknown[]) => runDayOfAgendaMock(...a),
+}))
+
+import { GET } from './route'
+
+const URL = 'https://cloudnativebergen.dev/api/cron/reminders'
+const req = (headers?: Record<string, string>) =>
+  new Request(URL, { headers }) as unknown as Parameters<typeof GET>[0]
+
+const OLD_ENV = process.env.CRON_SECRET
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.CRON_SECRET = 'top-secret'
+  resolveMock.mockResolvedValue({
+    _id: 'conf-1',
+    title: 'X',
+    startDate: '2026-09-10',
+    endDate: '2026-09-11',
+  })
+  runSpeakerRemindersMock.mockResolvedValue({
+    candidates: 1,
+    sent: 1,
+    skipped: 0,
+    failed: 0,
+    perReminder: [],
+  })
+  runDayOfAgendaMock.mockResolvedValue({
+    isScheduleDay: false,
+    presenting: 0,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+  })
+})
+
+afterEach(() => {
+  process.env.CRON_SECRET = OLD_ENV
+})
+
+describe('/api/cron/reminders — auth guard', () => {
+  it('rejects a request with no bearer token', async () => {
+    const res = await GET(req())
+    expect(res.status).toBe(401)
+    expect(resolveMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a wrong token', async () => {
+    const res = await GET(req({ authorization: 'Bearer nope' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('errors 500 when CRON_SECRET is unset', async () => {
+    delete process.env.CRON_SECRET
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(500)
+  })
+
+  it('runs both jobs for a valid token', async () => {
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.conference).toBe('conf-1')
+    expect(runSpeakerRemindersMock).toHaveBeenCalledTimes(1)
+    expect(runDayOfAgendaMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('short-circuits when no conference is active', async () => {
+    resolveMock.mockResolvedValue(null)
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(200)
+    expect(runSpeakerRemindersMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { unstable_noStore as noStore } from 'next/cache'
+import {
+  resolveActiveReminderConference,
+  runSpeakerReminders,
+  runDayOfAgenda,
+} from '@/lib/reminders'
+
+/**
+ * Daily scheduled-reminders cron.
+ *
+ * Runs the fixed speaker-prep reminder registry and then the day-of agenda for
+ * the single ACTIVE conference (earliest not-yet-ended edition — see
+ * `resolveActiveReminderConference`). Auth mirrors the other crons: a
+ * `Bearer ${CRON_SECRET}` header.
+ *
+ * TZ ASSUMPTION: scheduled at 06:00 UTC (see `vercel.json`). Our events run in
+ * Central European time (CET/CEST), where 06:00 UTC is 07:00–08:00 local — the
+ * same calendar date. Reminders are DAY-OF granularity, so this early-morning
+ * delivery lands before the conference day for the day-of agenda and tolerates
+ * the fixed offset.
+ */
+export async function GET(request: NextRequest) {
+  noStore()
+  try {
+    const authHeader = request.headers.get('authorization')
+    const cronSecret = process.env.CRON_SECRET
+
+    if (!cronSecret) {
+      console.error('CRON_SECRET environment variable is not set')
+      return NextResponse.json(
+        { error: 'Server configuration error' },
+        { status: 500 },
+      )
+    }
+
+    if (!authHeader || authHeader !== `Bearer ${cronSecret}`) {
+      console.error('Invalid or missing authorization token')
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const conference = await resolveActiveReminderConference()
+    if (!conference) {
+      return NextResponse.json({
+        success: true,
+        message: 'No active conference — nothing to remind',
+      })
+    }
+
+    // Never-throw jobs: each returns a summary even on internal failure.
+    const reminders = await runSpeakerReminders(conference)
+    const dayOf = await runDayOfAgenda(conference)
+
+    console.log(
+      `Reminders cron for ${conference._id}: sent=${reminders.sent} skipped=${reminders.skipped} failed=${reminders.failed}` +
+        ` | day-of: scheduleDay=${dayOf.isScheduleDay} sent=${dayOf.sent} skipped=${dayOf.skipped} failed=${dayOf.failed}`,
+    )
+
+    return NextResponse.json({
+      success: true,
+      conference: conference._id,
+      reminders,
+      dayOf,
+    })
+  } catch (error) {
+    console.error('Error in reminders cron job:', error)
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/src/lib/reminders/__tests__/conference.test.ts
+++ b/src/lib/reminders/__tests__/conference.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientWrite: {},
+}))
+
+import { resolveActiveReminderConference } from '../conference'
+
+describe('resolveActiveReminderConference', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("queries with today's UTC date and orders by earliest not-yet-ended start", async () => {
+    fetchMock.mockResolvedValue({
+      _id: 'conf-next',
+      title: 'Next',
+      startDate: '2026-09-10',
+      endDate: '2026-09-11',
+    })
+    const result = await resolveActiveReminderConference(
+      new Date('2026-07-20T06:00:00Z'),
+    )
+    expect(result?._id).toBe('conf-next')
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(params.today).toBe('2026-07-20')
+    expect(query).toContain('endDate >= $today')
+    expect(query).toContain('order(startDate asc)')
+  })
+
+  it('returns null when no conference is active', async () => {
+    fetchMock.mockResolvedValue(null)
+    expect(await resolveActiveReminderConference(new Date())).toBeNull()
+  })
+})

--- a/src/lib/reminders/__tests__/marker.test.ts
+++ b/src/lib/reminders/__tests__/marker.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { shouldSendReminder, reminderLogId, dayOfLogId } from '../marker'
+import type { Reminder } from '../types'
+
+const rearming: Reminder = {
+  key: 'confirm-talk',
+  notificationType: 'proposal_status_changed',
+  maxSends: 2,
+  spacingDays: 7,
+  evaluate: () => null,
+}
+
+const NOW = new Date('2026-08-20T06:00:00Z')
+
+describe('shouldSendReminder — cap + spacing gate', () => {
+  it('sends when no marker exists', () => {
+    expect(shouldSendReminder(undefined, rearming, NOW)).toBe(true)
+  })
+  it('does not send once the cap is reached', () => {
+    expect(
+      shouldSendReminder(
+        { _id: 'x', count: 2, lastSentAt: '2026-01-01T00:00:00Z' },
+        rearming,
+        NOW,
+      ),
+    ).toBe(false)
+  })
+  it('does not send inside the spacing window', () => {
+    // Sent 2 days ago, spacing is 7 days.
+    expect(
+      shouldSendReminder(
+        { _id: 'x', count: 1, lastSentAt: '2026-08-18T06:00:00Z' },
+        rearming,
+        NOW,
+      ),
+    ).toBe(false)
+  })
+  it('sends again once spacing has elapsed and cap not reached', () => {
+    // Sent 10 days ago, count 1 < 2.
+    expect(
+      shouldSendReminder(
+        { _id: 'x', count: 1, lastSentAt: '2026-08-10T06:00:00Z' },
+        rearming,
+        NOW,
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('deterministic marker ids', () => {
+  it('composes a stable recurring-reminder id', () => {
+    expect(reminderLogId('confirm-talk', 'conf-1', 's1')).toBe(
+      'reminder.confirm-talk.conf-1.s1',
+    )
+  })
+  it('composes a day-scoped day-of id', () => {
+    expect(dayOfLogId('conf-1', 's1', '2026-09-10')).toBe(
+      'reminder.day-of.conf-1.s1.2026-09-10',
+    )
+  })
+})

--- a/src/lib/reminders/__tests__/registry.test.ts
+++ b/src/lib/reminders/__tests__/registry.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import { REMINDER_REGISTRY } from '../registry'
+import type { ReminderConference, ReminderSpeaker } from '../types'
+
+const reminder = (key: string) => {
+  const found = REMINDER_REGISTRY.find((r) => r.key === key)
+  if (!found) throw new Error(`no reminder ${key}`)
+  return found
+}
+
+const CONF: ReminderConference = {
+  _id: 'conf-1',
+  title: 'CloudNative Days',
+  startDate: '2026-09-10',
+  endDate: '2026-09-11',
+  travelSupportPaymentDate: '2026-09-11',
+}
+
+const speaker = (over: Partial<ReminderSpeaker>): ReminderSpeaker => ({
+  speakerId: 's1',
+  talks: [],
+  travelSupportStatus: null,
+  ...over,
+})
+
+const accepted = {
+  _id: 't1',
+  title: 'My Talk',
+  status: 'accepted',
+  hasSlides: false,
+}
+const confirmedNoSlides = {
+  _id: 't1',
+  title: 'My Talk',
+  status: 'confirmed',
+  hasSlides: false,
+}
+const confirmedWithSlides = {
+  _id: 't1',
+  title: 'My Talk',
+  status: 'confirmed',
+  hasSlides: true,
+}
+
+describe('confirm-talk', () => {
+  const r = reminder('confirm-talk')
+  it('is due for an accepted talk before the conference ends', () => {
+    const copy = r.evaluate(speaker({ talks: [accepted] }), CONF, '2026-08-01')
+    expect(copy).not.toBeNull()
+    expect(copy!.link).toBe('/cfp/proposal/t1')
+  })
+  it('is not due once the conference has ended', () => {
+    expect(
+      r.evaluate(speaker({ talks: [accepted] }), CONF, '2026-09-12'),
+    ).toBeNull()
+  })
+  it('is not due for a confirmed talk', () => {
+    expect(
+      r.evaluate(speaker({ talks: [confirmedWithSlides] }), CONF, '2026-08-01'),
+    ).toBeNull()
+  })
+})
+
+describe('upload-slides', () => {
+  const r = reminder('upload-slides')
+  it('is due inside the T-7d window for a confirmed talk without slides', () => {
+    const copy = r.evaluate(
+      speaker({ talks: [confirmedNoSlides] }),
+      CONF,
+      '2026-09-05',
+    )
+    expect(copy).not.toBeNull()
+    expect(copy!.link).toBe('/cfp/proposal/t1')
+  })
+  it('is not due before the window opens', () => {
+    expect(
+      r.evaluate(speaker({ talks: [confirmedNoSlides] }), CONF, '2026-08-20'),
+    ).toBeNull()
+  })
+  it('is not due when slides are already uploaded', () => {
+    expect(
+      r.evaluate(speaker({ talks: [confirmedWithSlides] }), CONF, '2026-09-05'),
+    ).toBeNull()
+  })
+  it('is not due for a merely accepted (unconfirmed) talk', () => {
+    expect(
+      r.evaluate(speaker({ talks: [accepted] }), CONF, '2026-09-05'),
+    ).toBeNull()
+  })
+})
+
+describe('travel-reminder', () => {
+  const r = reminder('travel-reminder')
+  it('is due for a draft travel-support request', () => {
+    const copy = r.evaluate(
+      speaker({ talks: [confirmedWithSlides], travelSupportStatus: 'draft' }),
+      CONF,
+      '2026-08-01',
+    )
+    expect(copy).not.toBeNull()
+    expect(copy!.link).toBe('/cfp/expense')
+  })
+  it('is due for an approved request near the payment date', () => {
+    // 09-08 is 3 days before the 09-11 payout window.
+    const copy = r.evaluate(
+      speaker({
+        talks: [confirmedWithSlides],
+        travelSupportStatus: 'approved',
+      }),
+      CONF,
+      '2026-09-08',
+    )
+    expect(copy).not.toBeNull()
+  })
+  it('is not due for an approved request far from the payment date', () => {
+    expect(
+      r.evaluate(
+        speaker({
+          talks: [confirmedWithSlides],
+          travelSupportStatus: 'approved',
+        }),
+        CONF,
+        '2026-08-01',
+      ),
+    ).toBeNull()
+  })
+  it('is not due when there is no travel support at all', () => {
+    expect(
+      r.evaluate(speaker({ talks: [confirmedWithSlides] }), CONF, '2026-08-01'),
+    ).toBeNull()
+  })
+  it('is not due for a paid request', () => {
+    expect(
+      r.evaluate(
+        speaker({ talks: [confirmedWithSlides], travelSupportStatus: 'paid' }),
+        CONF,
+        '2026-08-01',
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('logistics', () => {
+  const r = reminder('logistics')
+  it('is due within T-2d for a confirmed speaker', () => {
+    const copy = r.evaluate(
+      speaker({ talks: [confirmedWithSlides] }),
+      CONF,
+      '2026-09-09',
+    )
+    expect(copy).not.toBeNull()
+    expect(copy!.link).toBe('/program')
+  })
+  it('is not due 3 days out', () => {
+    expect(
+      r.evaluate(speaker({ talks: [confirmedWithSlides] }), CONF, '2026-09-07'),
+    ).toBeNull()
+  })
+  it('is not due for an accepted-only speaker', () => {
+    expect(
+      r.evaluate(speaker({ talks: [accepted] }), CONF, '2026-09-09'),
+    ).toBeNull()
+  })
+})

--- a/src/lib/reminders/__tests__/runner.test.ts
+++ b/src/lib/reminders/__tests__/runner.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReminderConference } from '../types'
+
+// --- Boundary mocks --------------------------------------------------------
+const createNotificationsMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: (...a: unknown[]) => createNotificationsMock(...a),
+}))
+
+// Routed fetch: the runner issues several distinct GROQ reads; dispatch by a
+// signature substring of each query so one mock serves them all.
+let talkRows: unknown[] = []
+let travelRows: unknown[] = []
+let markerRows: unknown[] = []
+let agendaRows: unknown[] = []
+const fetchMock = vi.fn((query: string) => {
+  if (query.includes('scheduledReminderLog')) return Promise.resolve(markerRows)
+  if (query.includes('travelSupport')) return Promise.resolve(travelRows)
+  if (query.includes('hasSlides')) return Promise.resolve(talkRows)
+  if (query.includes('_type == "schedule"')) return Promise.resolve(agendaRows)
+  return Promise.resolve([])
+})
+
+const commitMock = vi.fn().mockResolvedValue({})
+const patchBuilder = { set: () => patchBuilder, inc: () => patchBuilder }
+const txBuilder = {
+  createIfNotExists: () => txBuilder,
+  patch: (_id: string, fn?: (p: typeof patchBuilder) => unknown) => {
+    if (typeof fn === 'function') fn(patchBuilder)
+    return txBuilder
+  },
+  commit: () => commitMock(),
+}
+const createIfNotExistsMock = vi.fn().mockResolvedValue({})
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (q: string) => fetchMock(q) },
+  clientWrite: {
+    transaction: () => txBuilder,
+    createIfNotExists: (doc: unknown) => createIfNotExistsMock(doc),
+  },
+}))
+
+import { runSpeakerReminders, runDayOfAgenda } from '../runner'
+
+const CONF: ReminderConference = {
+  _id: 'conf-1',
+  title: 'CloudNative Days',
+  startDate: '2026-09-10',
+  endDate: '2026-09-11',
+}
+
+// Pre-conference date where ONLY confirm-talk is due for an accepted-talk speaker.
+const PRE = new Date('2026-08-20T06:00:00Z')
+const CONFIRM_ID = 'reminder.confirm-talk.conf-1.s1'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  talkRows = [
+    {
+      _id: 't1',
+      title: 'My Talk',
+      status: 'accepted',
+      speakerIds: ['s1'],
+      hasSlides: false,
+    },
+  ]
+  travelRows = []
+  markerRows = []
+  agendaRows = []
+})
+
+describe('runSpeakerReminders — dedup + re-arming', () => {
+  it('sends a due reminder on the first run and stamps a marker', async () => {
+    const summary = await runSpeakerReminders(CONF, PRE)
+    expect(summary.sent).toBe(1)
+    expect(createNotificationsMock).toHaveBeenCalledTimes(1)
+    const inputs = createNotificationsMock.mock.calls[0][0]
+    expect(inputs[0].recipientId).toBe('s1')
+    expect(inputs[0].link).toBe('/cfp/proposal/t1')
+    // Marker stamped via transaction commit.
+    expect(commitMock).toHaveBeenCalledTimes(1)
+    const confirm = summary.perReminder.find((r) => r.key === 'confirm-talk')!
+    expect(confirm.sent).toBe(1)
+  })
+
+  it('does not re-send inside the spacing window', async () => {
+    markerRows = [
+      { _id: CONFIRM_ID, count: 1, lastSentAt: '2026-08-18T06:00:00Z' }, // 2 days ago
+    ]
+    const summary = await runSpeakerReminders(CONF, PRE)
+    expect(summary.sent).toBe(0)
+    expect(summary.skipped).toBe(1)
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+  })
+
+  it('re-sends once the spacing has elapsed and the cap is not reached', async () => {
+    markerRows = [
+      { _id: CONFIRM_ID, count: 1, lastSentAt: '2026-08-08T06:00:00Z' }, // 12 days ago
+    ]
+    const summary = await runSpeakerReminders(CONF, PRE)
+    expect(summary.sent).toBe(1)
+  })
+
+  it('does not send once the cap is reached', async () => {
+    markerRows = [
+      { _id: CONFIRM_ID, count: 2, lastSentAt: '2026-08-08T06:00:00Z' },
+    ]
+    const summary = await runSpeakerReminders(CONF, PRE)
+    expect(summary.sent).toBe(0)
+    expect(summary.skipped).toBe(1)
+  })
+
+  it('never throws when the emit fails; isolates and counts it', async () => {
+    createNotificationsMock.mockRejectedValueOnce(new Error('boom'))
+    const summary = await runSpeakerReminders(CONF, PRE)
+    expect(summary.failed).toBe(1)
+    expect(summary.sent).toBe(0)
+  })
+
+  it('never throws when the candidate read fails', async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.reject(new Error('read fail')),
+    )
+    const summary = await runSpeakerReminders(CONF, PRE)
+    expect(summary).toBeDefined()
+    expect(summary.sent).toBe(0)
+  })
+})
+
+describe('runDayOfAgenda — presenting-today selection + dedup', () => {
+  const DAY = new Date('2026-09-10T06:00:00Z')
+  beforeEach(() => {
+    agendaRows = [
+      {
+        tracks: [
+          {
+            trackTitle: 'Track A',
+            talks: [
+              { startTime: '09:00', talkTitle: 'My Talk', speakerIds: ['s1'] },
+            ],
+          },
+        ],
+      },
+    ]
+  })
+
+  it('notifies a speaker presenting today when no marker exists', async () => {
+    const summary = await runDayOfAgenda(CONF, DAY)
+    expect(summary.isScheduleDay).toBe(true)
+    expect(summary.sent).toBe(1)
+    const inputs = createNotificationsMock.mock.calls[0][0]
+    expect(inputs[0].recipientId).toBe('s1')
+    expect(inputs[0].message).toContain('09:00')
+    expect(createIfNotExistsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a speaker already notified today (marker present)', async () => {
+    markerRows = [{ _id: 'reminder.day-of.conf-1.s1.2026-09-10', count: 1 }]
+    const summary = await runDayOfAgenda(CONF, DAY)
+    expect(summary.sent).toBe(0)
+    expect(summary.skipped).toBe(1)
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a non-schedule day and sends nothing', async () => {
+    agendaRows = []
+    const summary = await runDayOfAgenda(CONF, DAY)
+    expect(summary.isScheduleDay).toBe(false)
+    expect(summary.sent).toBe(0)
+  })
+})

--- a/src/lib/reminders/__tests__/schedule-alerts.test.ts
+++ b/src/lib/reminders/__tests__/schedule-alerts.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Boundary mocks --------------------------------------------------------
+const createNotificationsMock = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/notification/sanity', () => ({
+  createNotifications: (...a: unknown[]) => createNotificationsMock(...a),
+}))
+
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientWrite: {},
+}))
+
+import { diffScheduleSlots, notifyScheduleChanges } from '../schedule-alerts'
+import type { SlotPlacement } from '../types'
+
+const slot = (
+  talkId: string,
+  startTime: string,
+  trackTitle: string,
+  date = '2026-09-10',
+): SlotPlacement => ({ talkId, date, startTime, trackTitle })
+
+describe('diffScheduleSlots', () => {
+  it('detects a time move', () => {
+    const moved = diffScheduleSlots(
+      [slot('t1', '09:00', 'Track A')],
+      [slot('t1', '10:00', 'Track A')],
+    )
+    expect(moved).toHaveLength(1)
+    expect(moved[0].to.startTime).toBe('10:00')
+  })
+  it('detects a track move', () => {
+    const moved = diffScheduleSlots(
+      [slot('t1', '09:00', 'Track A')],
+      [slot('t1', '09:00', 'Track B')],
+    )
+    expect(moved).toHaveLength(1)
+    expect(moved[0].to.trackTitle).toBe('Track B')
+  })
+  it('detects a date move', () => {
+    const moved = diffScheduleSlots(
+      [slot('t1', '09:00', 'Track A', '2026-09-10')],
+      [slot('t1', '09:00', 'Track A', '2026-09-11')],
+    )
+    expect(moved).toHaveLength(1)
+  })
+  it('ignores an unchanged slot', () => {
+    expect(
+      diffScheduleSlots(
+        [slot('t1', '09:00', 'Track A')],
+        [slot('t1', '09:00', 'Track A')],
+      ),
+    ).toEqual([])
+  })
+  it('ignores a newly-placed talk (only in next)', () => {
+    expect(diffScheduleSlots([], [slot('t1', '09:00', 'Track A')])).toEqual([])
+  })
+  it('ignores a removed talk (only in prior)', () => {
+    expect(diffScheduleSlots([slot('t1', '09:00', 'Track A')], [])).toEqual([])
+  })
+})
+
+describe('notifyScheduleChanges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchMock.mockResolvedValue([
+      { _id: 't1', title: 'Moved Talk', speakerIds: ['s1', 's2'] },
+    ])
+  })
+
+  it('notifies each speaker of a moved talk, excluding the actor', async () => {
+    const summary = await notifyScheduleChanges({
+      prior: [slot('t1', '09:00', 'Track A')],
+      next: [slot('t1', '10:00', 'Track A')],
+      conferenceId: 'conf-1',
+      actorId: 's2',
+    })
+    expect(summary.moved).toBe(1)
+    expect(summary.notified).toBe(1)
+    const inputs = createNotificationsMock.mock.calls[0][0]
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0].recipientId).toBe('s1')
+    expect(inputs[0].notificationType).toBe('schedule_update')
+    expect(inputs[0].link).toBe('/program')
+  })
+
+  it('emits nothing when nothing moved', async () => {
+    const summary = await notifyScheduleChanges({
+      prior: [slot('t1', '09:00', 'Track A')],
+      next: [slot('t1', '09:00', 'Track A')],
+      conferenceId: 'conf-1',
+    })
+    expect(summary.moved).toBe(0)
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('never throws when the emit fails', async () => {
+    createNotificationsMock.mockRejectedValueOnce(new Error('boom'))
+    await expect(
+      notifyScheduleChanges({
+        prior: [slot('t1', '09:00', 'Track A')],
+        next: [slot('t1', '10:00', 'Track A')],
+        conferenceId: 'conf-1',
+      }),
+    ).resolves.toBeDefined()
+  })
+})

--- a/src/lib/reminders/conference.ts
+++ b/src/lib/reminders/conference.ts
@@ -1,0 +1,39 @@
+import { clientReadUncached } from '@/lib/sanity/client'
+import { toDateString } from './dates'
+import type { ReminderConference } from './types'
+
+/**
+ * Resolve the single ACTIVE conference the reminder cron targets.
+ *
+ * SELECTION: among every conference that has NOT yet ended (`endDate >= today`),
+ * pick the one with the EARLIEST `startDate`. This yields:
+ *   - a currently-ongoing edition (its start is in the past but end is today or
+ *     later, and its start precedes any future edition's), or
+ *   - otherwise the nearest upcoming edition.
+ * A fully-past conference (`endDate < today`) is never selected — its speakers
+ * need no prep reminders. When several unrelated editions overlap (multi-tenant
+ * domains), the earliest-starting not-yet-ended one wins; Phase 1 deliberately
+ * targets ONE active conference per run.
+ *
+ * Dates are Sanity `date` values (YYYY-MM-DD) compared lexicographically, which
+ * is order-preserving for that format.
+ */
+export async function resolveActiveReminderConference(
+  now: Date = new Date(),
+): Promise<ReminderConference | null> {
+  const today = toDateString(now)
+  const conference = await clientReadUncached.fetch<ReminderConference | null>(
+    `*[_type == "conference" && defined(startDate) && defined(endDate) && endDate >= $today]
+      | order(startDate asc)[0]{
+        _id,
+        title,
+        startDate,
+        endDate,
+        programDate,
+        travelSupportPaymentDate
+      }`,
+    { today },
+    { cache: 'no-store' },
+  )
+  return conference ?? null
+}

--- a/src/lib/reminders/dates.ts
+++ b/src/lib/reminders/dates.ts
@@ -1,0 +1,37 @@
+/**
+ * Date-only helpers for the reminder engine. Everything works on calendar dates
+ * (YYYY-MM-DD) at UTC midnight so comparisons are timezone-stable — see the
+ * TZ ASSUMPTION documented on the cron route: the cron fires at an early-morning
+ * UTC hour and the events run in Central European time, so the UTC calendar date
+ * equals the local calendar date at run time and DAY-OF granularity tolerates
+ * the offset.
+ */
+
+/** The calendar date (YYYY-MM-DD) of `now`, in UTC. */
+export function toDateString(now: Date): string {
+  return now.toISOString().slice(0, 10)
+}
+
+/** UTC-midnight epoch millis for a YYYY-MM-DD date string. */
+function dateOnlyMs(dateStr: string): number {
+  return Date.parse(`${dateStr}T00:00:00Z`)
+}
+
+/**
+ * Whole days from `fromDate` to `toDate` (both YYYY-MM-DD): positive when
+ * `toDate` is in the future relative to `fromDate`. Returns `NaN` if either
+ * input is not a parseable date.
+ */
+export function daysUntil(fromDate: string, toDate: string): number {
+  const from = dateOnlyMs(fromDate)
+  const to = dateOnlyMs(toDate)
+  if (Number.isNaN(from) || Number.isNaN(to)) return NaN
+  return Math.round((to - from) / 86_400_000)
+}
+
+/** Whole days elapsed between an ISO timestamp `sinceIso` and `now`. */
+export function daysSince(sinceIso: string, now: Date): number {
+  const since = Date.parse(sinceIso)
+  if (Number.isNaN(since)) return Infinity
+  return (now.getTime() - since) / 86_400_000
+}

--- a/src/lib/reminders/index.ts
+++ b/src/lib/reminders/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Scheduled speaker reminders (Phase 1): speaker-prep reminders, a day-of
+ * agenda, and event-driven schedule-change alerts. Server-only; every job is
+ * never-throw and cadence-deduped via `scheduledReminderLog` markers.
+ *
+ * The fixed default reminder schedule lives in `registry.ts` — the one place to
+ * tune timing/cadence/copy (no config UI in Phase 1).
+ */
+export { resolveActiveReminderConference } from './conference'
+export { runSpeakerReminders, runDayOfAgenda } from './runner'
+export { notifyScheduleChanges } from './schedule-alerts'
+export type { SlotPlacement } from './types'

--- a/src/lib/reminders/marker.ts
+++ b/src/lib/reminders/marker.ts
@@ -1,0 +1,127 @@
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { createReference } from '@/lib/sanity/helpers'
+import { daysSince } from './dates'
+import type { Reminder, ReminderLog } from './types'
+
+/**
+ * Deterministic dedup-marker id for a recurring speaker reminder. Derived (never
+ * random) so a daily re-run resolves to the SAME `scheduledReminderLog` document
+ * and `createIfNotExists` collapses concurrent runs onto one marker.
+ */
+export function reminderLogId(
+  key: string,
+  conferenceId: string,
+  speakerId: string,
+): string {
+  return `reminder.${key}.${conferenceId}.${speakerId}`
+}
+
+/**
+ * Deterministic marker id for the day-of agenda: scoped additionally by the
+ * schedule date so a multi-day event re-arms per presenting day.
+ */
+export function dayOfLogId(
+  conferenceId: string,
+  speakerId: string,
+  date: string,
+): string {
+  return `reminder.day-of.${conferenceId}.${speakerId}.${date}`
+}
+
+/**
+ * Batch-read the existing markers for a set of deterministic ids, keyed by id.
+ * A single GROQ read for the whole run (mirrors the message-collapse read).
+ */
+export async function readReminderLogs(
+  ids: string[],
+): Promise<Map<string, ReminderLog>> {
+  if (ids.length === 0) return new Map()
+  const rows = await clientReadUncached.fetch<ReminderLog[]>(
+    `*[_type == "scheduledReminderLog" && _id in $ids]{ _id, count, lastSentAt }`,
+    { ids },
+    { cache: 'no-store' },
+  )
+  return new Map((rows ?? []).map((row) => [row._id, row]))
+}
+
+/**
+ * The cap + spacing gate for a re-arming reminder: send only if the send count
+ * is below the reminder's cap AND enough days have elapsed since the last send.
+ * A missing marker (never sent) always passes.
+ */
+export function shouldSendReminder(
+  existing: ReminderLog | undefined,
+  reminder: Reminder,
+  now: Date,
+): boolean {
+  const count = existing?.count ?? 0
+  if (count >= reminder.maxSends) return false
+  if (
+    existing?.lastSentAt &&
+    daysSince(existing.lastSentAt, now) < reminder.spacingDays
+  ) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Stamp a recurring reminder marker after a successful send: create the marker
+ * if missing (count 0) then increment the counter and record `lastSentAt`, in
+ * ONE transaction. Idempotent under the deterministic id.
+ */
+export async function stampReminderLog({
+  id,
+  key,
+  conferenceId,
+  speakerId,
+  now,
+}: {
+  id: string
+  key: string
+  conferenceId: string
+  speakerId: string
+  now: Date
+}): Promise<void> {
+  await clientWrite
+    .transaction()
+    .createIfNotExists({
+      _id: id,
+      _type: 'scheduledReminderLog',
+      key,
+      conference: { ...createReference(conferenceId), _weak: true },
+      speaker: { ...createReference(speakerId), _weak: true },
+      count: 0,
+    })
+    .patch(id, (patch) =>
+      patch.set({ lastSentAt: now.toISOString() }).inc({ count: 1 }),
+    )
+    .commit()
+}
+
+/**
+ * Create a single-shot day-of marker (count 1) if it does not already exist.
+ * The deterministic id per (conference, speaker, date) is the whole dedup
+ * mechanism — no counter needed.
+ */
+export async function createDayOfLog({
+  id,
+  conferenceId,
+  speakerId,
+  now,
+}: {
+  id: string
+  conferenceId: string
+  speakerId: string
+  now: Date
+}): Promise<void> {
+  await clientWrite.createIfNotExists({
+    _id: id,
+    _type: 'scheduledReminderLog',
+    key: 'day-of',
+    conference: { ...createReference(conferenceId), _weak: true },
+    speaker: { ...createReference(speakerId), _weak: true },
+    count: 1,
+    lastSentAt: now.toISOString(),
+  })
+}

--- a/src/lib/reminders/registry.ts
+++ b/src/lib/reminders/registry.ts
@@ -1,0 +1,191 @@
+import { daysUntil } from './dates'
+import type { Reminder, ReminderSpeaker } from './types'
+
+/**
+ * THE FIXED DEFAULT REMINDER SCHEDULE.
+ *
+ * This registry is the single, hardcoded source of truth for speaker-prep
+ * reminders (Phase 1: no config UI — tune the defaults here in code). Each entry
+ * decides, purely from a speaker's talks + the conference date anchors + today's
+ * date, whether it is due — cadence/dedup is enforced separately by the runner
+ * via the `scheduledReminderLog` marker (see `marker.ts`).
+ *
+ * Timing windows are DAY-OF granularity (no minute-level), matching the cron's
+ * once-a-day cadence.
+ */
+
+/** The confirm-talk nudge re-fires at most this many times... */
+const CONFIRM_MAX_SENDS = 2
+/** ...spaced at least this many days apart. Mirrors the contract-reminders cron. */
+const CONFIRM_SPACING_DAYS = 7
+
+/** The upload-slides window opens this many days before the conference starts. */
+const SLIDES_WINDOW_DAYS = 7
+const SLIDES_MAX_SENDS = 2
+const SLIDES_SPACING_DAYS = 3
+
+const TRAVEL_MAX_SENDS = 2
+const TRAVEL_SPACING_DAYS = 7
+/** Travel payment reminder arms when the payout date is within this many days. */
+const TRAVEL_PAYMENT_WINDOW_DAYS = 7
+
+/** The logistics note fires within this many days of the start (T-2d). */
+const LOGISTICS_WINDOW_DAYS = 2
+
+/** The conference display name used in warm copy. */
+function confName(title?: string): string {
+  return title || 'the conference'
+}
+
+/** True while `today` is on or before the conference's last day. */
+function conferenceNotEnded(today: string, endDate: string): boolean {
+  const days = daysUntil(today, endDate)
+  return !Number.isNaN(days) && days >= 0
+}
+
+/** The speaker's first talk in a given status, if any. */
+function talkInStatus(speaker: ReminderSpeaker, status: string) {
+  return speaker.talks.find((talk) => talk.status === status)
+}
+
+/**
+ * (a) confirm-talk — an accepted (but not yet confirmed) talk needs the speaker
+ * to confirm participation. Due from acceptance onward; re-nudged up to
+ * {@link CONFIRM_MAX_SENDS} times, {@link CONFIRM_SPACING_DAYS} days apart.
+ */
+const confirmTalk: Reminder = {
+  key: 'confirm-talk',
+  notificationType: 'proposal_status_changed',
+  maxSends: CONFIRM_MAX_SENDS,
+  spacingDays: CONFIRM_SPACING_DAYS,
+  evaluate(speaker, conference, today) {
+    if (!conferenceNotEnded(today, conference.endDate)) return null
+    const talk = talkInStatus(speaker, 'accepted')
+    if (!talk) return null
+    return {
+      title: `Please confirm your talk at ${confName(conference.title)}`,
+      message: `Great news — your talk "${talk.title}" was accepted! Please confirm your participation so we can lock it into the program. It only takes a moment.`,
+      link: `/cfp/proposal/${talk._id}`,
+    }
+  },
+}
+
+/**
+ * (b) upload-slides — a confirmed talk with no slides attachment, from T-7d.
+ * Re-nudged up to {@link SLIDES_MAX_SENDS} times inside the window.
+ */
+const uploadSlides: Reminder = {
+  key: 'upload-slides',
+  notificationType: 'proposal_status_changed',
+  maxSends: SLIDES_MAX_SENDS,
+  spacingDays: SLIDES_SPACING_DAYS,
+  evaluate(speaker, conference, today) {
+    if (!conferenceNotEnded(today, conference.endDate)) return null
+    const daysToStart = daysUntil(today, conference.startDate)
+    if (Number.isNaN(daysToStart) || daysToStart > SLIDES_WINDOW_DAYS) {
+      return null
+    }
+    const talk = speaker.talks.find(
+      (candidate) => candidate.status === 'confirmed' && !candidate.hasSlides,
+    )
+    if (!talk) return null
+    return {
+      title: `Time to upload your slides for ${confName(conference.title)}`,
+      message: `Your talk "${talk.title}" is coming up soon. Please upload your slides through your proposal page so our AV team can have everything ready for you.`,
+      link: `/cfp/proposal/${talk._id}`,
+    }
+  },
+}
+
+/**
+ * (c) travel-reminder — the organizer-sensible trigger, in priority order:
+ *   1. a travel-support request left in `draft` (the speaker still has to submit
+ *      it — the clearest speaker-actionable state); or
+ *   2. an already-submitted/approved (not yet `paid`) request when the
+ *      conference's `travelSupportPaymentDate` is within
+ *      {@link TRAVEL_PAYMENT_WINDOW_DAYS} days (nudge to verify banking details
+ *      before payout).
+ * Re-nudged up to {@link TRAVEL_MAX_SENDS} times, {@link TRAVEL_SPACING_DAYS}
+ * apart.
+ */
+const travelReminder: Reminder = {
+  key: 'travel-reminder',
+  notificationType: 'travel_support_update',
+  maxSends: TRAVEL_MAX_SENDS,
+  spacingDays: TRAVEL_SPACING_DAYS,
+  // NOTE: no conference-ended guard here — travel support has a lifecycle that
+  // extends toward the payout, and the cron already only runs for the ACTIVE
+  // (not-yet-ended) conference. The payment-date branch therefore only fires
+  // while the conference is still active; a payout scheduled AFTER the event is
+  // out of Phase-1 scope (post-conference reminders would need the conference to
+  // remain "active", which it does not). The primary, always-actionable trigger
+  // is the `draft` state (the speaker still has to submit).
+  evaluate(speaker, conference, today) {
+    const status = speaker.travelSupportStatus
+    if (!status) return null
+
+    if (status === 'draft') {
+      return {
+        title: `Finish your travel support request`,
+        message: `You started a travel support request for ${confName(conference.title)} but haven't submitted it yet. Complete it so we can review and arrange your reimbursement.`,
+        link: '/cfp/expense',
+      }
+    }
+
+    if (
+      conference.travelSupportPaymentDate &&
+      (status === 'submitted' || status === 'approved')
+    ) {
+      const daysToPay = daysUntil(today, conference.travelSupportPaymentDate)
+      if (
+        !Number.isNaN(daysToPay) &&
+        daysToPay >= 0 &&
+        daysToPay <= TRAVEL_PAYMENT_WINDOW_DAYS
+      ) {
+        return {
+          title: `Travel support payment coming up`,
+          message: `We're preparing travel support payments for ${confName(conference.title)} soon. Please double-check your banking details are complete and correct so we can pay you on time.`,
+          link: '/cfp/expense',
+        }
+      }
+    }
+
+    return null
+  },
+}
+
+/**
+ * (d) logistics — a warm venue/arrival/AV one-liner to every confirmed speaker
+ * at T-2d. Single-shot (once per conference).
+ */
+const logistics: Reminder = {
+  key: 'logistics',
+  notificationType: 'proposal_status_changed',
+  maxSends: 1,
+  spacingDays: 0,
+  evaluate(speaker, conference, today) {
+    const daysToStart = daysUntil(today, conference.startDate)
+    if (
+      Number.isNaN(daysToStart) ||
+      daysToStart < 0 ||
+      daysToStart > LOGISTICS_WINDOW_DAYS
+    ) {
+      return null
+    }
+    const talk = talkInStatus(speaker, 'confirmed')
+    if (!talk) return null
+    return {
+      title: `See you soon at ${confName(conference.title)}!`,
+      message: `${confName(conference.title)} is almost here. Check the venue and plan your arrival, and when you get there drop by the speaker room so we can set up your AV. The full schedule is on the program page.`,
+      link: '/program',
+    }
+  },
+}
+
+/** The fixed default schedule, evaluated in order. */
+export const REMINDER_REGISTRY: Reminder[] = [
+  confirmTalk,
+  uploadSlides,
+  travelReminder,
+  logistics,
+]

--- a/src/lib/reminders/runner.ts
+++ b/src/lib/reminders/runner.ts
@@ -1,0 +1,360 @@
+import 'server-only'
+import { clientReadUncached } from '@/lib/sanity/client'
+import { createNotifications } from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
+import { toDateString } from './dates'
+import { REMINDER_REGISTRY } from './registry'
+import {
+  reminderLogId,
+  dayOfLogId,
+  readReminderLogs,
+  shouldSendReminder,
+  stampReminderLog,
+  createDayOfLog,
+} from './marker'
+import type {
+  CandidateTalk,
+  DayOfAgendaSummary,
+  ReminderConference,
+  ReminderKeyResult,
+  ReminderSpeaker,
+  SpeakerRemindersSummary,
+} from './types'
+
+/**
+ * Server-only scheduled speaker reminders. Both entry points wrap their whole
+ * run in a never-throw envelope and isolate every per-speaker emit, so the cron
+ * (whose steps must all complete) can never be failed by one bad speaker, a read
+ * error, or a notification failure. `createNotifications` already never throws;
+ * the marker write can, so it is inside the per-item try/catch.
+ */
+
+/** Hard cap on sends per run, so a backlog can never fan out unbounded. */
+const MAX_SENDS_PER_RUN = 500
+
+/** Raw talk row for the candidate projection. */
+interface TalkRow {
+  _id: string
+  title: string | null
+  status: string | null
+  speakerIds: string[] | null
+  hasSlides: boolean
+}
+
+/** Raw travel-support row. */
+interface TravelRow {
+  speakerId: string | null
+  status: string | null
+}
+
+/**
+ * Build the per-speaker candidate set for a conference: every speaker on an
+ * accepted or confirmed talk, with their talks and travel-support status folded
+ * in. One read for talks, one for travel support.
+ */
+export async function fetchReminderSpeakers(
+  conferenceId: string,
+): Promise<ReminderSpeaker[]> {
+  const [talkRows, travelRows] = await Promise.all([
+    clientReadUncached.fetch<TalkRow[]>(
+      `*[_type == "talk" && conference._ref == $conferenceId && status in ["accepted", "confirmed"]]{
+        _id,
+        title,
+        status,
+        "speakerIds": speakers[]._ref,
+        "hasSlides": count(attachments[attachmentType == "slides"]) > 0
+      }`,
+      { conferenceId },
+      { cache: 'no-store' },
+    ),
+    clientReadUncached.fetch<TravelRow[]>(
+      `*[_type == "travelSupport" && conference._ref == $conferenceId]{
+        "speakerId": speaker._ref,
+        status
+      }`,
+      { conferenceId },
+      { cache: 'no-store' },
+    ),
+  ])
+
+  const travelBySpeaker = new Map<string, string>()
+  for (const row of travelRows ?? []) {
+    if (row.speakerId && row.status) {
+      travelBySpeaker.set(row.speakerId, row.status)
+    }
+  }
+
+  const bySpeaker = new Map<string, ReminderSpeaker>()
+  for (const row of talkRows ?? []) {
+    if (!row.status) continue
+    const talk: CandidateTalk = {
+      _id: row._id,
+      title: row.title || 'your talk',
+      status: row.status,
+      hasSlides: row.hasSlides === true,
+    }
+    for (const speakerId of row.speakerIds ?? []) {
+      if (!speakerId) continue
+      let speaker = bySpeaker.get(speakerId)
+      if (!speaker) {
+        speaker = {
+          speakerId,
+          talks: [],
+          travelSupportStatus: travelBySpeaker.get(speakerId) ?? null,
+        }
+        bySpeaker.set(speakerId, speaker)
+      }
+      speaker.talks.push(talk)
+    }
+  }
+
+  return Array.from(bySpeaker.values())
+}
+
+/**
+ * Evaluate the fixed reminder registry against the conference's speakers and
+ * emit every due, not-already-sent reminder (one hub notification per speaker;
+ * push + email ride free through `createNotifications`). Deduped and cadence-
+ * gated by the `scheduledReminderLog` marker.
+ */
+export async function runSpeakerReminders(
+  conference: ReminderConference,
+  now: Date = new Date(),
+): Promise<SpeakerRemindersSummary> {
+  const perReminder = new Map<string, ReminderKeyResult>(
+    REMINDER_REGISTRY.map((reminder) => [
+      reminder.key,
+      { key: reminder.key, due: 0, sent: 0, skipped: 0, failed: 0 },
+    ]),
+  )
+  const summary: SpeakerRemindersSummary = {
+    candidates: 0,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+    perReminder: Array.from(perReminder.values()),
+  }
+
+  try {
+    const today = toDateString(now)
+    const speakers = await fetchReminderSpeakers(conference._id)
+    summary.candidates = speakers.length
+
+    // Collect every (reminder, speaker) that evaluates as due, with its id.
+    const due: {
+      reminderIndex: number
+      key: string
+      speakerId: string
+      id: string
+      copy: { title: string; message: string; link: string }
+    }[] = []
+
+    for (let i = 0; i < REMINDER_REGISTRY.length; i++) {
+      const reminder = REMINDER_REGISTRY[i]
+      for (const speaker of speakers) {
+        const copy = reminder.evaluate(speaker, conference, today)
+        if (!copy) continue
+        perReminder.get(reminder.key)!.due += 1
+        due.push({
+          reminderIndex: i,
+          key: reminder.key,
+          speakerId: speaker.speakerId,
+          id: reminderLogId(reminder.key, conference._id, speaker.speakerId),
+          copy,
+        })
+      }
+    }
+
+    // One batched read of every candidate marker, then apply the cap/spacing
+    // gate to decide who actually gets sent this run.
+    const existing = await readReminderLogs(due.map((item) => item.id))
+
+    let sends = 0
+    for (const item of due) {
+      const reminder = REMINDER_REGISTRY[item.reminderIndex]
+      const result = perReminder.get(item.key)!
+      if (!shouldSendReminder(existing.get(item.id), reminder, now)) {
+        result.skipped += 1
+        summary.skipped += 1
+        continue
+      }
+      if (sends >= MAX_SENDS_PER_RUN) {
+        result.skipped += 1
+        summary.skipped += 1
+        continue
+      }
+      try {
+        const input: NotificationInput = {
+          recipientId: item.speakerId,
+          conferenceId: conference._id,
+          notificationType: reminder.notificationType,
+          title: item.copy.title.slice(0, 200),
+          message: item.copy.message,
+          link: item.copy.link,
+        }
+        await createNotifications([input])
+        await stampReminderLog({
+          id: item.id,
+          key: reminder.key,
+          conferenceId: conference._id,
+          speakerId: item.speakerId,
+          now,
+        })
+        sends += 1
+        result.sent += 1
+        summary.sent += 1
+      } catch (error) {
+        result.failed += 1
+        summary.failed += 1
+        console.error(
+          `Speaker reminder '${reminder.key}' failed for speaker ${item.speakerId}:`,
+          error,
+        )
+      }
+    }
+  } catch (error) {
+    console.error('runSpeakerReminders: run failed:', error)
+  }
+
+  summary.perReminder = Array.from(perReminder.values())
+  return summary
+}
+
+/** One speaker's earliest talk on today's schedule, for the day-of copy. */
+interface AgendaEntry {
+  speakerId: string
+  talkTitle: string
+  startTime: string
+  trackTitle: string
+}
+
+/** Raw schedule projection for today's agenda. */
+interface AgendaScheduleRow {
+  tracks:
+    | {
+        trackTitle: string | null
+        talks:
+          | {
+              startTime: string | null
+              talkTitle: string | null
+              speakerIds: string[] | null
+            }[]
+          | null
+      }[]
+    | null
+}
+
+/**
+ * Build one agenda entry per (speaker) presenting today, keeping each speaker's
+ * EARLIEST slot (so a speaker with two talks today gets one notification about
+ * the first). Fetches only schedule docs whose `date` is today.
+ */
+export async function fetchTodaysAgenda(
+  conferenceId: string,
+  today: string,
+): Promise<AgendaEntry[]> {
+  const rows = await clientReadUncached.fetch<AgendaScheduleRow[]>(
+    `*[_type == "schedule" && conference._ref == $conferenceId && date == $today]{
+      tracks[]{
+        trackTitle,
+        "talks": talks[defined(talk)]{
+          startTime,
+          "talkTitle": talk->title,
+          "speakerIds": talk->speakers[]._ref
+        }
+      }
+    }`,
+    { conferenceId, today },
+    { cache: 'no-store' },
+  )
+
+  const bySpeaker = new Map<string, AgendaEntry>()
+  for (const row of rows ?? []) {
+    for (const track of row.tracks ?? []) {
+      for (const slot of track.talks ?? []) {
+        if (!slot.startTime) continue
+        for (const speakerId of slot.speakerIds ?? []) {
+          if (!speakerId) continue
+          const existing = bySpeaker.get(speakerId)
+          if (!existing || slot.startTime < existing.startTime) {
+            bySpeaker.set(speakerId, {
+              speakerId,
+              talkTitle: slot.talkTitle || 'your talk',
+              startTime: slot.startTime,
+              trackTitle: track.trackTitle || 'the schedule',
+            })
+          }
+        }
+      }
+    }
+  }
+
+  return Array.from(bySpeaker.values())
+}
+
+/**
+ * When today matches a schedule day, send each speaker presenting today ONE
+ * "you're presenting today" notification, deduped per (speaker, date) by a
+ * deterministic day-of marker.
+ */
+export async function runDayOfAgenda(
+  conference: ReminderConference,
+  now: Date = new Date(),
+): Promise<DayOfAgendaSummary> {
+  const summary: DayOfAgendaSummary = {
+    isScheduleDay: false,
+    presenting: 0,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+  }
+
+  try {
+    const today = toDateString(now)
+    const agenda = await fetchTodaysAgenda(conference._id, today)
+    summary.isScheduleDay = agenda.length > 0
+    summary.presenting = agenda.length
+    if (agenda.length === 0) return summary
+
+    const withIds = agenda.map((entry) => ({
+      entry,
+      id: dayOfLogId(conference._id, entry.speakerId, today),
+    }))
+    const existing = await readReminderLogs(withIds.map((item) => item.id))
+
+    for (const { entry, id } of withIds) {
+      if (existing.has(id)) {
+        summary.skipped += 1
+        continue
+      }
+      try {
+        const input: NotificationInput = {
+          recipientId: entry.speakerId,
+          conferenceId: conference._id,
+          notificationType: 'proposal_status_changed',
+          title: `You're presenting today at ${conference.title || 'the conference'}!`,
+          message: `"${entry.talkTitle}" at ${entry.startTime} on ${entry.trackTitle}. Break a leg!`,
+          link: '/program',
+        }
+        await createNotifications([input])
+        await createDayOfLog({
+          id,
+          conferenceId: conference._id,
+          speakerId: entry.speakerId,
+          now,
+        })
+        summary.sent += 1
+      } catch (error) {
+        summary.failed += 1
+        console.error(
+          `Day-of agenda failed for speaker ${entry.speakerId}:`,
+          error,
+        )
+      }
+    }
+  } catch (error) {
+    console.error('runDayOfAgenda: run failed:', error)
+  }
+
+  return summary
+}

--- a/src/lib/reminders/schedule-alerts.ts
+++ b/src/lib/reminders/schedule-alerts.ts
@@ -1,0 +1,134 @@
+import 'server-only'
+import { clientReadUncached } from '@/lib/sanity/client'
+import { createNotifications } from '@/lib/notification/sanity'
+import type { NotificationInput } from '@/lib/notification/types'
+import type { MovedTalk, SlotPlacement } from './types'
+
+/**
+ * Event-driven schedule-change alerts (activates the reserved `schedule_update`
+ * notification type). The schedule SAVE path captures a day's talk placements
+ * BEFORE the write and calls {@link notifyScheduleChanges} AFTER it; a talk whose
+ * slot genuinely MOVED (date, start time, or track changed) and that was
+ * previously placed earns one notification to its speakers. Newly-placed and
+ * removed talks do NOT fire (only a move is a move).
+ */
+
+/**
+ * Pure diff: talks present in BOTH the prior and next placement sets whose
+ * date, startTime, or trackTitle changed. A talk only in `next` (newly placed)
+ * or only in `prior` (removed) is excluded. Last placement wins if a talk id
+ * appears more than once in a set (defensive — a valid schedule places a talk
+ * once).
+ */
+export function diffScheduleSlots(
+  prior: SlotPlacement[],
+  next: SlotPlacement[],
+): MovedTalk[] {
+  const priorById = new Map<string, SlotPlacement>()
+  for (const slot of prior) {
+    if (slot.talkId) priorById.set(slot.talkId, slot)
+  }
+  const nextById = new Map<string, SlotPlacement>()
+  for (const slot of next) {
+    if (slot.talkId) nextById.set(slot.talkId, slot)
+  }
+
+  const moved: MovedTalk[] = []
+  for (const [talkId, to] of nextById) {
+    const from = priorById.get(talkId)
+    if (!from) continue // newly placed — not a move
+    if (
+      from.date !== to.date ||
+      from.startTime !== to.startTime ||
+      from.trackTitle !== to.trackTitle
+    ) {
+      moved.push({
+        talkId,
+        from: {
+          date: from.date,
+          startTime: from.startTime,
+          trackTitle: from.trackTitle,
+        },
+        to: {
+          date: to.date,
+          startTime: to.startTime,
+          trackTitle: to.trackTitle,
+        },
+      })
+    }
+  }
+  return moved
+}
+
+/** Result of a schedule-change notification pass. */
+export interface ScheduleChangeSummary {
+  moved: number
+  notified: number
+}
+
+interface TalkSpeakerRow {
+  _id: string
+  title: string | null
+  speakerIds: string[] | null
+}
+
+/**
+ * Diff `prior` vs `next` placements and notify the speakers of every moved talk.
+ *
+ * NEVER-FAIL: wrapped so a notification (or the speaker lookup) can never fail
+ * the schedule save that triggered it. `actorId`, when known (the acting
+ * organizer), is excluded from recipients and recorded as the notification actor.
+ */
+export async function notifyScheduleChanges({
+  prior,
+  next,
+  conferenceId,
+  actorId,
+}: {
+  prior: SlotPlacement[]
+  next: SlotPlacement[]
+  conferenceId: string
+  actorId?: string
+}): Promise<ScheduleChangeSummary> {
+  const summary: ScheduleChangeSummary = { moved: 0, notified: 0 }
+  try {
+    const moved = diffScheduleSlots(prior, next)
+    summary.moved = moved.length
+    if (moved.length === 0) return summary
+
+    const movedById = new Map(moved.map((m) => [m.talkId, m]))
+    const rows = await clientReadUncached.fetch<TalkSpeakerRow[]>(
+      `*[_type == "talk" && _id in $ids]{ _id, title, "speakerIds": speakers[]._ref }`,
+      { ids: Array.from(movedById.keys()) },
+      { cache: 'no-store' },
+    )
+
+    const inputs: NotificationInput[] = []
+    for (const row of rows ?? []) {
+      const move = movedById.get(row._id)
+      if (!move) continue
+      const title = row.title || 'your talk'
+      for (const speakerId of row.speakerIds ?? []) {
+        if (!speakerId || speakerId === actorId) continue
+        inputs.push({
+          recipientId: speakerId,
+          conferenceId,
+          notificationType: 'schedule_update',
+          title: `Your talk "${title}" was moved`,
+          message: `"${title}" is now at ${move.to.startTime} on ${move.to.trackTitle}. Check the program for the latest schedule.`,
+          link: '/program',
+          relatedProposalId: row._id,
+          ...(actorId ? { actorId } : {}),
+        })
+      }
+    }
+
+    if (inputs.length > 0) {
+      await createNotifications(inputs)
+      summary.notified = inputs.length
+    }
+  } catch (error) {
+    console.error('notifyScheduleChanges failed:', error)
+  }
+  return summary
+}

--- a/src/lib/reminders/types.ts
+++ b/src/lib/reminders/types.ts
@@ -1,0 +1,132 @@
+import type { NotificationType } from '@/lib/notification/types'
+
+/**
+ * The active conference a reminder run targets, projected down to the date
+ * anchors the registry needs. See `resolveActiveReminderConference`.
+ */
+export interface ReminderConference {
+  _id: string
+  title?: string
+  /** Conference start (YYYY-MM-DD). */
+  startDate: string
+  /** Conference end (YYYY-MM-DD). */
+  endDate: string
+  /** When the program is published (YYYY-MM-DD), if set. */
+  programDate?: string
+  /** When travel-support payouts are made (YYYY-MM-DD), if set. */
+  travelSupportPaymentDate?: string
+}
+
+/** A talk this speaker is presenting, projected for reminder evaluation. */
+export interface CandidateTalk {
+  _id: string
+  title: string
+  /** Proposal workflow status (e.g. 'accepted', 'confirmed'). */
+  status: string
+  /** True when the talk already has an attachment of type 'slides'. */
+  hasSlides: boolean
+}
+
+/** One speaker (with their accepted/confirmed talks) evaluated by the registry. */
+export interface ReminderSpeaker {
+  speakerId: string
+  talks: CandidateTalk[]
+  /** This speaker's travel-support status for the conference, if any. */
+  travelSupportStatus?: string | null
+}
+
+/** The rendered copy a due reminder produces for one speaker. */
+export interface ReminderCopy {
+  title: string
+  message: string
+  /** App-relative deep link to the relevant resource. */
+  link: string
+}
+
+/**
+ * A single fixed reminder in the registry. This is the ONE place to tune the
+ * default schedule: change the predicate, timing window, cadence, or copy here.
+ */
+export interface Reminder {
+  /** Stable key — part of the dedup marker id. Never rename in place. */
+  key: string
+  notificationType: NotificationType
+  /**
+   * Maximum times this reminder may fire per speaker per conference.
+   * 1 = single-shot (once per conference); >1 = re-arming up to the cap.
+   */
+  maxSends: number
+  /**
+   * Minimum whole days between successive sends of a re-arming reminder. 0 for
+   * single-shot reminders (they never re-send anyway once the cap of 1 is hit).
+   */
+  spacingDays: number
+  /**
+   * Returns the copy when this reminder is due for `speaker` on `today`, or
+   * `null` when it does not apply. Pure — no clock/network access; `today` and
+   * the conference dates are passed in (all YYYY-MM-DD).
+   */
+  evaluate(
+    speaker: ReminderSpeaker,
+    conference: ReminderConference,
+    today: string,
+  ): ReminderCopy | null
+}
+
+/** The dedup marker document as read back for a send decision. */
+export interface ReminderLog {
+  _id: string
+  count?: number | null
+  lastSentAt?: string | null
+}
+
+/** Aggregate per-reminder outcome for structured cron logging. */
+export interface ReminderKeyResult {
+  key: string
+  /** Speakers for whom the reminder evaluated as due this run. */
+  due: number
+  /** Of those, how many were actually sent (passed the dedup/spacing gate). */
+  sent: number
+  /** Skipped by the cap/spacing gate. */
+  skipped: number
+  /** Failed and isolated (logged). */
+  failed: number
+}
+
+/** Summary returned by `runSpeakerReminders`. */
+export interface SpeakerRemindersSummary {
+  candidates: number
+  sent: number
+  skipped: number
+  failed: number
+  perReminder: ReminderKeyResult[]
+}
+
+/** Summary returned by `runDayOfAgenda`. */
+export interface DayOfAgendaSummary {
+  /** Whether today matched a schedule day for the conference. */
+  isScheduleDay: boolean
+  /** Distinct speakers presenting today. */
+  presenting: number
+  sent: number
+  skipped: number
+  failed: number
+}
+
+/** A talk's placement in the schedule, used by the schedule-change diff. */
+export interface SlotPlacement {
+  talkId: string
+  /** Schedule day (YYYY-MM-DD). */
+  date: string
+  /** Slot start time (HH:mm). */
+  startTime: string
+  /** Track the slot sits in. */
+  trackTitle: string
+}
+
+/** A talk whose placement changed between two saves of a schedule day. */
+export interface MovedTalk {
+  talkId: string
+  from: Omit<SlotPlacement, 'talkId'>
+  to: Omit<SlotPlacement, 'talkId'>
+}

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -7,6 +7,7 @@ import {
   createReference,
   createReferenceWithKey,
 } from '@/lib/sanity/helpers'
+import { notifyScheduleChanges, type SlotPlacement } from '@/lib/reminders'
 
 export interface SaveScheduleResult {
   schedule?: ConferenceSchedule
@@ -48,6 +49,82 @@ function resolveTalkId(talk: {
   return talk.talk?._id || talk.talk?._ref || ''
 }
 
+/**
+ * Flatten a schedule day's real (non-placeholder, resolvable) talk slots to the
+ * placement tuples the schedule-change diff compares. Placeholders and ghost
+ * slots (no resolvable talk) are skipped — they have no speakers to alert.
+ */
+function collectPlacements(
+  date: string,
+  tracks: ConferenceSchedule['tracks'] | undefined,
+): SlotPlacement[] {
+  const placements: SlotPlacement[] = []
+  for (const track of tracks || []) {
+    for (const talk of track.talks || []) {
+      if (talk.placeholder) continue
+      const talkId = resolveTalkId(talk)
+      if (!talkId) continue
+      placements.push({
+        talkId,
+        date,
+        startTime: talk.startTime,
+        trackTitle: track.trackTitle,
+      })
+    }
+  }
+  return placements
+}
+
+/** The raw prior-schedule projection used to diff talk placements on save. */
+interface PriorScheduleSlots {
+  date: string | null
+  tracks:
+    | {
+        trackTitle: string | null
+        talks: { startTime: string | null; talkId: string | null }[] | null
+      }[]
+    | null
+}
+
+/**
+ * Fetch the CURRENT persisted placements of a schedule day (before it is
+ * overwritten), so the save can diff moved talks afterwards. Best-effort: any
+ * failure yields an empty set (no false "moved" alerts), never a save failure.
+ */
+async function fetchPriorPlacements(
+  scheduleId: string,
+): Promise<SlotPlacement[]> {
+  try {
+    const doc = await clientWrite.fetch<PriorScheduleSlots | null>(
+      `*[_id == $id][0]{
+        date,
+        tracks[]{
+          trackTitle,
+          "talks": talks[defined(talk)]{ startTime, "talkId": talk._ref }
+        }
+      }`,
+      { id: scheduleId },
+    )
+    if (!doc?.date) return []
+    const placements: SlotPlacement[] = []
+    for (const track of doc.tracks || []) {
+      for (const slot of track.talks || []) {
+        if (!slot.talkId || !slot.startTime) continue
+        placements.push({
+          talkId: slot.talkId,
+          date: doc.date,
+          startTime: slot.startTime,
+          trackTitle: track.trackTitle || '',
+        })
+      }
+    }
+    return placements
+  } catch (error) {
+    console.error('Failed to read prior schedule placements:', error)
+    return []
+  }
+}
+
 /** True when a Sanity write failed because `ifRevisionId` did not match (409). */
 function isRevisionMismatch(error: unknown): boolean {
   const statusCode = (error as { statusCode?: number })?.statusCode
@@ -59,6 +136,7 @@ function isRevisionMismatch(error: unknown): boolean {
 export async function saveScheduleToSanity(
   schedule: ConferenceSchedule,
   conference: Conference,
+  options?: { actorId?: string },
 ): Promise<SaveScheduleResult> {
   try {
     // Compact save log — the full payload used to be dumped every save, leaking
@@ -149,6 +227,11 @@ export async function saveScheduleToSanity(
         return { error: 'Schedule not found or not accessible' }
       }
 
+      // Capture the CURRENT placements before the overwrite so we can alert
+      // speakers whose talk genuinely moved (see `notifyScheduleChanges` after
+      // the commit). Best-effort — never blocks or fails the save.
+      const priorPlacements = await fetchPriorPlacements(schedule._id)
+
       // Optimistic concurrency: `_rev` is guaranteed present (rejected above),
       // so ALWAYS patch with `ifRevisionId` — a save is rejected if the day
       // changed since it was loaded (two organizers editing the same day).
@@ -166,6 +249,17 @@ export async function saveScheduleToSanity(
         .commit()
 
       savedSchedule = { ...schedule, _rev: committed._rev }
+
+      // SCHEDULE-CHANGE ALERTS: diff prior vs saved placements and notify the
+      // speakers of any talk whose slot actually moved. Never-throw (a failure
+      // here must not fail the already-committed save); a run where nothing
+      // moved emits nothing.
+      await notifyScheduleChanges({
+        prior: priorPlacements,
+        next: collectPlacements(schedule.date, schedule.tracks),
+        conferenceId: conference._id,
+        actorId: options?.actorId,
+      })
     } else {
       // DUPLICATE-DAY GUARD: any payload with `_id: ''` creates a fresh schedule
       // doc and appends it to `conference.schedules`. Two organizers saving the

--- a/src/server/routers/schedule.ts
+++ b/src/server/routers/schedule.ts
@@ -8,54 +8,58 @@ import { revalidateTag } from 'next/cache'
 import type { ConferenceSchedule } from '@/lib/conference/types'
 
 export const scheduleRouter = router({
-  save: adminProcedure.input(SaveScheduleSchema).mutation(async ({ input }) => {
-    const { conference, error: conferenceError } =
-      await getConferenceForCurrentDomain()
+  save: adminProcedure
+    .input(SaveScheduleSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { conference, error: conferenceError } =
+        await getConferenceForCurrentDomain()
 
-    if (conferenceError || !conference) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Failed to fetch conference',
+      if (conferenceError || !conference) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to fetch conference',
+        })
+      }
+
+      const payload = input as ConferenceSchedule
+
+      // Validate the incoming payload BEFORE persisting: reject malformed times,
+      // out-of-bounds/overlapping slots, ambiguous slots (both/neither talk and
+      // placeholder), and dangling/foreign talk refs. The talk-id set is fetched
+      // once and passed to the pure validator.
+      const validTalkIds = await getValidTalkIds(conference._id)
+      const validationError = validateSchedulePayload(payload, validTalkIds)
+      if (validationError) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: validationError })
+      }
+
+      const {
+        schedule,
+        error: saveError,
+        conflict,
+      } = await saveScheduleToSanity(payload, conference, {
+        actorId: ctx.speaker?._id,
       })
-    }
 
-    const payload = input as ConferenceSchedule
+      if (conflict) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message:
+            saveError || 'This day was changed elsewhere since you loaded it.',
+        })
+      }
 
-    // Validate the incoming payload BEFORE persisting: reject malformed times,
-    // out-of-bounds/overlapping slots, ambiguous slots (both/neither talk and
-    // placeholder), and dangling/foreign talk refs. The talk-id set is fetched
-    // once and passed to the pure validator.
-    const validTalkIds = await getValidTalkIds(conference._id)
-    const validationError = validateSchedulePayload(payload, validTalkIds)
-    if (validationError) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: validationError })
-    }
+      if (saveError || !schedule) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: saveError || 'Failed to save schedule',
+        })
+      }
 
-    const {
-      schedule,
-      error: saveError,
-      conflict,
-    } = await saveScheduleToSanity(payload, conference)
+      revalidateTag('content:program', 'default')
+      revalidateTag('content:conferences', 'default')
+      revalidateTag(`sanity:conference-${conference._id}`, 'default')
 
-    if (conflict) {
-      throw new TRPCError({
-        code: 'CONFLICT',
-        message:
-          saveError || 'This day was changed elsewhere since you loaded it.',
-      })
-    }
-
-    if (saveError || !schedule) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: saveError || 'Failed to save schedule',
-      })
-    }
-
-    revalidateTag('content:program', 'default')
-    revalidateTag('content:conferences', 'default')
-    revalidateTag(`sanity:conference-${conference._id}`, 'default')
-
-    return { schedule }
-  }),
+      return { schedule }
+    }),
 })

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,10 @@
     {
       "path": "/api/cron/cleanup-notifications",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 6 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Scheduled Reminders — Phase 1

Speaker-facing scheduled reminders riding the existing notification hub (+ push + email bridge). Speakers only; fixed hardcoded default schedule (no config UI); day-of granularity. Attendee personalization is deferred (see below).

### The reminder registry (`src/lib/reminders/registry.ts`)
One place to tune the fixed defaults. Each entry decides purely from a speaker's talks + the conference date anchors + today's date whether it is due; cadence/dedup is enforced separately by the runner.

| key | trigger | timing | cadence | link |
| --- | --- | --- | --- | --- |
| `confirm-talk` | talk `accepted` (not yet `confirmed`) | from acceptance onward, until conference ends | re-nudge, cap 2, 7d apart | `/cfp/proposal/<id>` |
| `upload-slides` | `confirmed` talk with no `slides` attachment | from T-7d | re-nudge, cap 2, 3d apart | `/cfp/proposal/<id>` |
| `travel-reminder` | travel-support `draft` (needs submitting) **or** `submitted`/`approved` within 7d of `travelSupportPaymentDate` | see note | re-nudge, cap 2, 7d apart | `/cfp/expense` |
| `logistics` | any `confirmed` talk (venue/arrival/AV one-liner) | T-2d | once per conference | `/program` |

Travel note: the organizer-sensible primary trigger is the `draft` state (speaker-actionable — they still have to submit). The payment-date branch only fires while the conference is still active, because the cron targets the active (not-yet-ended) conference; a payout scheduled after the event is out of Phase-1 scope. Documented inline.

Copy is warm + specific and links to the relevant resource.

### Runners (`src/lib/reminders/runner.ts`)
- `runSpeakerReminders(conference)` — evaluates the registry against every speaker with an accepted/confirmed talk, selects due + not-already-sent recipients, emits one hub notification per speaker via `createNotifications` (push + email ride free), stamps a dedup marker. Never-throw envelope, per-recipient isolation, bounded to 500 sends/run.
- `runDayOfAgenda(conference)` — when today matches a schedule day, each speaker presenting today gets ONE "you're presenting today" notification (`"<title>" at <startTime> on <trackTitle>`), deduped per (speaker, scheduleDate).

### Dedup-marker design
A tiny new document type `scheduledReminderLog` `{ key, conference (weak), speaker (weak), count, lastSentAt }` with a **deterministic id**:
- recurring: `reminder.<key>.<conferenceId>.<speakerId>`
- day-of: `reminder.day-of.<conferenceId>.<speakerId>.<date>`

Written with `createIfNotExists` + a counter increment, so a re-run never double-sends and concurrent runs converge on one marker. Re-arming reminders read `count`/`lastSentAt` to enforce the cap + spacing window before sending again (mirrors the contract-reminders cron + the deterministic-id backfill dedup).

### Conference selection
`resolveActiveReminderConference` picks the single conference with the **earliest `startDate` among all not-yet-ended editions** (`endDate >= today`, order by `startDate asc`, take first) — i.e. the currently-ongoing edition, else the nearest upcoming one. A fully-past conference is never selected. Phase 1 deliberately targets one active conference per run.

### Cron (`src/app/api/cron/reminders/route.ts`)
`Bearer ${CRON_SECRET}` guard + `noStore`, runs `runSpeakerReminders` then `runDayOfAgenda`, returns a summary. Scheduled `0 6 * * *` in `vercel.json`.

TZ assumption: 06:00 UTC ≈ 07:00–08:00 CET/CEST (same calendar date). Day-of granularity tolerates the fixed offset and lands before the conference day.

### Schedule-change alerts (event-driven)
Activates the reserved `schedule_update` notification type. In the schedule save path (`saveScheduleToSanity`, update branch), prior placements are captured **before** the write; **after** a successful commit, `notifyScheduleChanges` diffs prior vs saved placements and alerts the speakers of any talk whose slot (date, start time, or track) genuinely **moved** and was previously placed. Newly-placed / removed / unchanged talks fire nothing. Never-fail — a notification failure can't fail the save. Actor = the acting organizer (excluded from recipients, recorded as actor). The new-day create branch has no prior, so no false alerts.

### Schema & privacy
- Registered `scheduledReminderLog`; `schedule_update` was already in the notification enum (now emitted).
- Privacy page: added one line under In-App Notifications for the reminder delivery log (speaker weak-ref + timestamps).

### Tests
46 new tests across 6 files: per-reminder due-evaluation (mocked clock), dedup + re-arming cap/spacing, day-of selection + dedup, schedule-diff (moved / unchanged / newly-placed / removed), never-throw on emit and read failure, and cron auth (401/500/200/no-active-conference). Full suite green (3743 passed, 5 pre-existing skips). tsc / eslint / prettier / knip all clean.

### Deferred
Feature B — attendee personalization (per-attendee agendas / favourite-talk reminders) is intentionally out of Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces Phase 1 of scheduled speaker reminders: a daily cron that evaluates a fixed four-entry registry (confirm-talk, upload-slides, travel-reminder, logistics) against every accepted/confirmed speaker for the active conference, a day-of agenda notification, and event-driven schedule-change alerts wired into the schedule save path.

- A new `scheduledReminderLog` Sanity document type provides deterministic dedup markers (`createIfNotExists` + counter) so re-runs never double-send; the registry, runner, marker, conference resolver, and type definitions are cleanly modularised under `src/lib/reminders/`.
- Schedule-change alerts diff placements before and after each save and fan out `schedule_update` notifications to speakers of moved talks, with the acting organizer correctly excluded as actor.
- 46 new tests covering reminder evaluation, dedup + re-arming, day-of dedup, schedule diff, never-throw envelopes, and cron auth all pass; the cron is wired into `vercel.json` at `0 6 * * *`.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The new reminder system is well-isolated, never-throw throughout, and covered by 46 tests.

The implementation is thorough — deterministic dedup IDs, per-speaker error isolation, cron auth mirroring existing routes, and a clean never-throw envelope. The three flagged items are all minor: a silent-drop edge case for the day-of marker, a fractional-days inconsistency that could shift a spacing window by one day at most, and an undocumented but probably intentional behaviour where upload-slides can fire during a multi-day conference. None affect correctness under normal operating conditions.

src/lib/reminders/runner.ts and src/lib/reminders/dates.ts are worth a second look due to the marker-write-after-silent-failure and fractional-day concerns.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/reminders/runner.ts | Core runner for both speaker reminders and day-of agenda. Never-throw envelope and per-speaker isolation are sound; minor: the day-of marker is stamped even when `createNotifications` swallows a failure silently. |
| src/lib/reminders/registry.ts | Fixed reminder schedule with four entries. `upload-slides` has no lower-bound guard on `daysToStart`, so it evaluates as due during multi-day conferences; this appears intentional but is undocumented. |
| src/lib/reminders/dates.ts | `daysUntil` rounds, `daysSince` returns fractional days — inconsistency that creates a narrow edge case on spacing window boundaries. |
| src/lib/reminders/marker.ts | Deterministic dedup IDs, `createIfNotExists`+increment pattern, and per-speaker isolation are all well-designed. No issues found. |
| src/lib/reminders/schedule-alerts.ts | Pure diff + never-fail notification fan-out. Actor exclusion and batch notification input are correctly implemented. |
| src/lib/schedule/sanity.ts | Adds pre-write placement capture and post-commit schedule-change alerts. Capture is best-effort (never blocks save); pattern follows existing `clientWrite.fetch` usage in this file. |
| src/server/routers/schedule.ts | Passes `ctx.speaker?._id` as `actorId` to exclude organizer-speakers from schedule-change notifications. Correct for both pure-organizer and organizer+speaker cases. |
| src/app/api/cron/reminders/route.ts | Bearer auth guard mirrors other cron routes; never-throw jobs return summary JSON; no issues found. |
| sanity/schemaTypes/scheduledReminderLog.ts | New dedup-marker schema with weak references for GDPR-safe deletion and meaningful preview configuration. |
| src/lib/reminders/conference.ts | Resolves earliest not-yet-ended conference; GROQ query correctly orders by `startDate asc` and filters `endDate >= today`. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/reminders/registry.ts`, line 196-211 ([link](https://github.com/cloudnativebergen/website/blob/7429c5a96b9af9676a6cae6482b10984024bbc33/src/lib/reminders/registry.ts#L196-L211)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`upload-slides` window has no lower bound — fires during the conference**

   The gate `daysToStart > SLIDES_WINDOW_DAYS` opens the window at T-7 but doesn't close it once the conference starts (`daysToStart < 0`). For a multi-day event, the reminder evaluates as due on every day from T-7 through `endDate`. With `maxSends: 2` and `spacingDays: 3`, this is capped, but speakers can receive a "Time to upload your slides" notification on day 1 or day 2 of the conference if their first nudge came after T-4. If the intent is to stop nudging once the event is underway, add a `daysToStart < 0` guard. If firing during the conference is intentional (still valid for multi-day events), a comment here would make the choice explicit — the PR table says "from T-7d" without a lower bound note.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(reminders): speaker prep reminders,..."](https://github.com/cloudnativebergen/website/commit/7429c5a96b9af9676a6cae6482b10984024bbc33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45613622)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->