### PR TITLE
fix(svg): sanitize root <svg> attributes — stored-XSS bypass

### DIFF
--- a/src/lib/svg/upload.test.ts
+++ b/src/lib/svg/upload.test.ts
@@ -164,6 +164,23 @@ describe('sanitizeSvgUpload', () => {
       expect(r.removed).toContain('<style> element')
       expect(r.removed).toContain('<image> element')
     })
+
+    it('strips an event handler on the ROOT <svg> element', () => {
+      const r = sanitizeSvgUpload(
+        `<svg xmlns="http://www.w3.org/2000/svg" onload="steal()"><rect width="10"/></svg>`,
+      )
+      expect(r.ok).toBe(true)
+      expect(r.svg).not.toMatch(/onload/i)
+      expect(r.removed).toContain('onload event handler')
+    })
+
+    it('strips a dangerous inline style on the ROOT <svg> element', () => {
+      const r = sanitizeSvgUpload(
+        `<svg xmlns="http://www.w3.org/2000/svg" style="background:url(https://evil.example/x)"><rect width="10"/></svg>`,
+      )
+      expect(r.svg).not.toMatch(/evil\.example/)
+      expect(r.removed).toContain('unsafe inline style')
+    })
   })
 })
 

--- a/src/lib/svg/upload.ts
+++ b/src/lib/svg/upload.ts
@@ -189,6 +189,12 @@ export function sanitizeSvgUpload(
   }
 
   const removed = new Set<string>()
+  // Clean the ROOT <svg>'s own attributes first — cleanElement only visits a
+  // node's CHILDREN, so without this an `onload` / dangerous `style` /
+  // `javascript:` xlink:href placed directly on <svg …> would persist through
+  // the authoritative write gate (a stored-XSS bypass) and the preview would
+  // falsely report nothing removed.
+  cleanAttributes(root, removed)
   cleanElement(root, removed)
 
   if (removed.size === 0) {


### PR DESCRIPTION
Found in the session quality review (P1, security core). `cleanElement` only visits a node's CHILDREN and cleans their attributes — the ROOT `<svg>`'s own attributes were never sanitized. So `<svg onload="...">`, a dangerous `style`, or a `javascript:` xlink:href placed directly on the root element persisted verbatim through `sanitizeSvgUpload` (the authoritative WRITE gate), and `sanitizeSvgPreview` falsely reported `removed: []`. render.ts is client-side defence-in-depth only (and doesn't catch expression()-styles), and the module's own doc says it must never be the sole write gate.

Reachable from every logo-persistence path incl. the public sponsor self-registration (registration.complete). Fix: call `cleanAttributes(root)` before recursing into children. Tests added for onload + dangerous style on the root element.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a stored-XSS bypass in the server-side SVG sanitizer where the root `<svg>` element's own attributes were never cleaned — `cleanElement` only walks children, so event handlers or dangerous styles placed directly on `<svg>` survived the authoritative write gate unchanged. The one-line fix calls `cleanAttributes(root, removed)` before the recursive `cleanElement` call, closing the gap for all attribute categories already covered by the allowlist.

- **`upload.ts`**: Adds `cleanAttributes(root, removed)` immediately before `cleanElement(root, removed)`, so the root element's `on*` handlers, dangerous `style` values, external `href`/`xlink:href` references, and active-content URL schemes are now stripped at the write gate.
- **`upload.test.ts`**: Two new regression tests assert that `onload` and a `url()`-bearing `style` on the root `<svg>` are stripped and reported in `removed`; root-level `href`/`xlink:href` vectors mentioned in the PR description remain untested.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the one-line fix is correct and targeted, and the test gaps are in coverage breadth only, not in the fix itself.

The core fix is minimal and correct — `cleanAttributes` was already battle-tested on every child element, and adding it for the root uses the exact same code path. The two new tests verify the primary attack vectors. The only weak spot is that the root-level `href`/`xlink:href` path the PR description calls out explicitly has no dedicated test, and one of the two new tests omits an `ok` assertion, so a regression on that narrow path would be harder to catch.

The test file warrants a second look for the missing `href`/`xlink:href` root-element coverage and the absent `r.ok` assertion in the style test.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/svg/upload.ts | Adds `cleanAttributes(root, removed)` before `cleanElement(root, removed)` to sanitize the root `<svg>` element's own attributes; the one-line fix is correct and targets the exact gap described. |
| src/lib/svg/upload.test.ts | Two new tests cover `onload` and dangerous `style` on the root `<svg>`; the `href`/`xlink:href` root vector mentioned in the PR description is not exercised, and the second test omits an `r.ok` assertion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(svg): sanitize the root &lt;svg&gt; elemen..."](https://github.com/cloudnativebergen/website/commit/5125ef7058eabda35f43fb85e9363276b9fd37bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45700596)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->