### PR TITLE
fix(notifications): quality-review fixes — cold-open mark-read, reminder markers/category (batch N)

### DIFF
--- a/__tests__/api/trpc/sponsor-stage-notification.test.ts
+++ b/__tests__/api/trpc/sponsor-stage-notification.test.ts
@@ -91,7 +91,7 @@ beforeEach(() => {
     'actor-1',
     'org-2',
   ])
-  vi.mocked(createNotifications).mockResolvedValue(undefined)
+  vi.mocked(createNotifications).mockResolvedValue(1)
 })
 
 afterEach(() => {

--- a/__tests__/api/trpc/travel-support-notification.test.ts
+++ b/__tests__/api/trpc/travel-support-notification.test.ts
@@ -61,7 +61,7 @@ const lastItems = (): NotificationInput[] =>
 
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.mocked(createNotifications).mockResolvedValue(undefined)
+  vi.mocked(createNotifications).mockResolvedValue(1)
   vi.mocked(getOrganizerSpeakerIds).mockResolvedValue([
     'org-1',
     'actor-1',

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -120,11 +120,21 @@ describe('createNotifications — single-transaction fan-out', () => {
     expect(typeof doc.createdAt).toBe('string')
   })
 
-  it('is a no-op (no transaction) for an empty list', async () => {
+  it('is a no-op (no transaction) for an empty list, returning 0', async () => {
     const tx = installTransaction()
-    await createNotifications([])
+    const persisted = await createNotifications([])
+    expect(persisted).toBe(0)
     expect(writeMock.transaction).not.toHaveBeenCalled()
     expect(tx.commit).not.toHaveBeenCalled()
+  })
+
+  it('returns the number of documents persisted on success (N2)', async () => {
+    installTransaction()
+    const persisted = await createNotifications([
+      input({ recipientId: 'sp-1' }),
+      input({ recipientId: 'sp-2' }),
+    ])
+    expect(persisted).toBe(2)
   })
 
   it('sets optional actor and a WEAK relatedProposal reference only when provided', async () => {
@@ -160,12 +170,14 @@ describe('createNotifications — single-transaction fan-out', () => {
     expect('link' in doc).toBe(false)
   })
 
-  it('NEVER throws when the transaction commit fails — it swallows and logs', async () => {
+  it('NEVER throws when the transaction commit fails — it swallows, logs, and returns 0 (N2)', async () => {
     installTransaction(async () => {
       throw new Error('sanity down')
     })
 
-    await expect(createNotifications([input()])).resolves.toBeUndefined()
+    // Never-throw contract preserved; a caught failure persisted nothing → 0, so
+    // a caller can distinguish a silent failure from a success.
+    await expect(createNotifications([input()])).resolves.toBe(0)
     expect(console.error).toHaveBeenCalled()
   })
 })

--- a/public/sw.js
+++ b/public/sw.js
@@ -306,23 +306,42 @@ self.addEventListener('notificationclick', (event) => {
         }
       }
 
-      // Focus an existing tab already on the target URL if there is one.
+      // COLD-OPEN mark-read: a tap that opens the app from closed spawns a BRAND-
+      // NEW client via openWindow that never received the postMessage above — the
+      // dominant PWA case. So carry the mark-read intent THROUGH the opened URL: a
+      // `markread` query param whose value is the ORIGINAL app-relative `target`
+      // (exactly the notification's stored `link`, NOT this param-appended URL).
+      // On mount / navigation NotificationClickSync reads it, fires markReadByLink,
+      // and strips it. Warm taps are still cleared instantly by the postMessage.
+      let openUrl = targetUrl
+      try {
+        const withParam = new URL(targetUrl)
+        withParam.searchParams.set('markread', target)
+        openUrl = withParam.href
+      } catch (e) {
+        openUrl = targetUrl
+      }
+
+      // Focus an existing tab already on the target URL if there is one (it was
+      // already cleared by the postMessage; no need to carry the param).
       for (const client of allClients) {
         if (client.url === targetUrl && 'focus' in client) {
           return client.focus()
         }
       }
-      // Otherwise focus any open window and navigate it, or open a new one.
+      // Otherwise focus any open window and navigate it, or open a new one — both
+      // carry the mark-read param so a navigation that discards in-page JS state
+      // (or a cold open) still clears the notification once the app boots.
       const existing = allClients[0]
       if (existing && 'focus' in existing) {
         await existing.focus()
         if ('navigate' in existing) {
-          return existing.navigate(targetUrl).catch(() => undefined)
+          return existing.navigate(openUrl).catch(() => undefined)
         }
         return undefined
       }
       if (clients.openWindow) {
-        return clients.openWindow(targetUrl)
+        return clients.openWindow(openUrl)
       }
       return undefined
     })(),

--- a/sanity/schemaTypes/notification.ts
+++ b/sanity/schemaTypes/notification.ts
@@ -52,7 +52,8 @@ export default defineType({
             title: 'Proposal Status Changed',
             value: 'proposal_status_changed',
           },
-          // Reserved for future use — no emitter yet.
+          // Reserved, currently unused — superseded by 'message_received'
+          // (decision comments relay via the message thread). No emitter.
           { title: 'Proposal Comment', value: 'proposal_comment' },
           { title: 'Message Received', value: 'message_received' },
           { title: 'Stale Conversation', value: 'message_stale' },
@@ -60,7 +61,8 @@ export default defineType({
           { title: 'Co-Speaker Response', value: 'cospeaker_response' },
           { title: 'Travel Support Update', value: 'travel_support_update' },
           { title: 'Sponsor Activity', value: 'sponsor_activity' },
-          // Reserved for future use — no emitter yet.
+          // Emitted by src/lib/reminders/schedule-alerts.ts when a talk's slot
+          // moves (date/time/track position) on a schedule save.
           { title: 'Schedule Update', value: 'schedule_update' },
           { title: 'Gallery Tagged', value: 'gallery_tagged' },
           { title: 'System', value: 'system' },

--- a/src/components/pwa/NotificationClickSync.test.tsx
+++ b/src/components/pwa/NotificationClickSync.test.tsx
@@ -138,7 +138,7 @@ describe('NotificationClickSync', () => {
     expect(window.location.search).toBe('')
   })
 
-  it('does not fire the markread param when signed out', () => {
+  it('does not fire the markread param when signed out, but still strips it', () => {
     mockSession = null
     mockPathname = '/cfp/proposal/1'
     window.history.replaceState(
@@ -148,5 +148,8 @@ describe('NotificationClickSync', () => {
     )
     render(<NotificationClickSync />)
     expect(markReadMutate).not.toHaveBeenCalled()
+    // The param must be stripped even when signed out, so it can't linger and
+    // re-fire on a later authenticated reload/share.
+    expect(window.location.search).not.toContain('markread')
   })
 })

--- a/src/components/pwa/NotificationClickSync.test.tsx
+++ b/src/components/pwa/NotificationClickSync.test.tsx
@@ -13,6 +13,11 @@ vi.mock('next-auth/react', () => ({
   }),
 }))
 
+let mockPathname = '/'
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}))
+
 const markReadMutate = vi.fn()
 const invalidateUnread = vi.fn()
 const invalidateList = vi.fn()
@@ -59,7 +64,9 @@ function signedIn(): Session {
 beforeEach(() => {
   vi.clearAllMocks()
   mockSession = signedIn()
+  mockPathname = '/'
   installServiceWorker()
+  window.history.replaceState(null, '', '/')
 })
 
 afterEach(() => {
@@ -90,6 +97,56 @@ describe('NotificationClickSync', () => {
     mockSession = null
     render(<NotificationClickSync />)
     postFromSW({ type: 'notification-click', url: '/cfp/proposal/1' })
+    expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  // --- Cold-open mark-read via the `markread` query param (N1) --------------
+
+  it('marks read from the markread param on mount and strips it', () => {
+    // A cold open lands with the SW-appended param carrying the ORIGINAL link.
+    mockPathname = '/cfp/proposal/1'
+    window.history.replaceState(
+      null,
+      '',
+      '/cfp/proposal/1?markread=%2Fcfp%2Fproposal%2F1&foo=bar',
+    )
+    render(<NotificationClickSync />)
+    // Fires markReadByLink for the DECODED original link (not the current URL).
+    expect(markReadMutate).toHaveBeenCalledWith({ links: ['/cfp/proposal/1'] })
+    // Strips only the markread param, preserving other query + pathname.
+    expect(window.location.search).toBe('?foo=bar')
+    expect(window.location.pathname).toBe('/cfp/proposal/1')
+  })
+
+  it('does nothing when no markread param is present', () => {
+    mockPathname = '/program'
+    window.history.replaceState(null, '', '/program')
+    render(<NotificationClickSync />)
+    expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  it('strips but does not fire for a non-app-relative markread value', () => {
+    mockPathname = '/program'
+    window.history.replaceState(
+      null,
+      '',
+      '/program?markread=https%3A%2F%2Fevil.com',
+    )
+    render(<NotificationClickSync />)
+    expect(markReadMutate).not.toHaveBeenCalled()
+    // The junk param is still removed so it can't linger.
+    expect(window.location.search).toBe('')
+  })
+
+  it('does not fire the markread param when signed out', () => {
+    mockSession = null
+    mockPathname = '/cfp/proposal/1'
+    window.history.replaceState(
+      null,
+      '',
+      '/cfp/proposal/1?markread=%2Fcfp%2Fproposal%2F1',
+    )
+    render(<NotificationClickSync />)
     expect(markReadMutate).not.toHaveBeenCalled()
   })
 })

--- a/src/components/pwa/NotificationClickSync.tsx
+++ b/src/components/pwa/NotificationClickSync.tsx
@@ -85,14 +85,15 @@ export function NotificationClickSync() {
   // original app-relative link — NOT the current URL — so it matches the stored
   // `link` markReadByLink validates against.
   useEffect(() => {
-    if (!isSignedIn) return
     if (typeof window === 'undefined') return
 
     const params = new URLSearchParams(window.location.search)
     const link = params.get(MARK_READ_PARAM)
     if (link === null) return
 
-    // Strip the param regardless of validity so a junk value can't linger.
+    // Strip the param regardless of validity OR sign-in state so a junk value
+    // (or a param that arrived on a signed-out load) can't linger in the URL and
+    // re-fire on a later reload/share.
     params.delete(MARK_READ_PARAM)
     const query = params.toString()
     const stripped =
@@ -101,7 +102,9 @@ export function NotificationClickSync() {
       window.location.hash
     window.history.replaceState(window.history.state, '', stripped)
 
-    if (isAppRelativeLink(link)) {
+    // Only mark-read for a signed-in caller (markReadByLink is a protected
+    // procedure); a signed-out visitor just gets the param stripped above.
+    if (isSignedIn && isAppRelativeLink(link)) {
       // Recipient-guarded + link-matched + re-validated server-side, so this can
       // only ever clear the CALLER'S OWN notification whose link equals `link`.
       mutate({ links: [link] })

--- a/src/components/pwa/NotificationClickSync.tsx
+++ b/src/components/pwa/NotificationClickSync.tsx
@@ -16,8 +16,9 @@ const MARK_READ_PARAM = 'markread'
 
 /**
  * True for an app-relative deep link ("/..."; never "//..." or a backslash
- * trick). Mirrors the SW's `sanitizeNotificationUrl` and the server's
- * `MarkReadByLinkSchema` so we never fire the mutation for a tampered param.
+ * trick). Mirrors — and slightly tightens (it also rejects protocol-relative
+ * "//..." paths) — the SW's `sanitizeNotificationUrl` and the server's
+ * `MarkReadByLinkSchema`, so we never fire the mutation for a tampered param.
  */
 function isAppRelativeLink(value: string): boolean {
   return (

--- a/src/components/pwa/NotificationClickSync.tsx
+++ b/src/components/pwa/NotificationClickSync.tsx
@@ -1,8 +1,32 @@
 'use client'
 
 import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { api } from '@/lib/trpc/client'
+
+/**
+ * The query param the service worker appends to the URL it OPENS on a
+ * notification click (see public/sw.js) so a COLD open — which spawns a brand-new
+ * client that never received the `notification-click` postMessage — can still
+ * clear the notification. Its value is the notification's ORIGINAL app-relative
+ * `link`.
+ */
+const MARK_READ_PARAM = 'markread'
+
+/**
+ * True for an app-relative deep link ("/..."; never "//..." or a backslash
+ * trick). Mirrors the SW's `sanitizeNotificationUrl` and the server's
+ * `MarkReadByLinkSchema` so we never fire the mutation for a tampered param.
+ */
+function isAppRelativeLink(value: string): boolean {
+  return (
+    value.startsWith('/') &&
+    !value.startsWith('//') &&
+    !value.includes('\\') &&
+    !value.includes('://')
+  )
+}
 
 /** The message the service worker posts on a notificationclick (see public/sw.js). */
 interface NotificationClickMessage {
@@ -44,6 +68,7 @@ function isNotificationClickMessage(
 export function NotificationClickSync() {
   const { data: session } = useSession()
   const isSignedIn = Boolean(session?.speaker)
+  const pathname = usePathname()
   const utils = api.useUtils()
   const markReadByLink = api.notification.markReadByLink.useMutation({
     onSuccess: () => {
@@ -52,6 +77,36 @@ export function NotificationClickSync() {
     },
   })
   const mutate = markReadByLink.mutate
+
+  // COLD-OPEN path: on mount and on every navigation, consume a `markread` query
+  // param the SW appended to the opened URL, mark that notification's link read,
+  // and STRIP the param via history.replaceState so it doesn't linger (a reload
+  // or shared URL must not re-fire it). The param carries the notification's
+  // original app-relative link — NOT the current URL — so it matches the stored
+  // `link` markReadByLink validates against.
+  useEffect(() => {
+    if (!isSignedIn) return
+    if (typeof window === 'undefined') return
+
+    const params = new URLSearchParams(window.location.search)
+    const link = params.get(MARK_READ_PARAM)
+    if (link === null) return
+
+    // Strip the param regardless of validity so a junk value can't linger.
+    params.delete(MARK_READ_PARAM)
+    const query = params.toString()
+    const stripped =
+      window.location.pathname +
+      (query ? `?${query}` : '') +
+      window.location.hash
+    window.history.replaceState(window.history.state, '', stripped)
+
+    if (isAppRelativeLink(link)) {
+      // Recipient-guarded + link-matched + re-validated server-side, so this can
+      // only ever clear the CALLER'S OWN notification whose link equals `link`.
+      mutate({ links: [link] })
+    }
+  }, [isSignedIn, pathname, mutate])
 
   useEffect(() => {
     if (!isSignedIn) return

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -37,6 +37,16 @@ import type {
  * notification write fails). Callers therefore do not (and must not) wrap this
  * in a try/catch expecting to react to failures.
  *
+ * RETURN: the number of hub documents actually PERSISTED (the transaction
+ * committed) — `items.length` on success, `0` on an empty input OR a caught
+ * failure. This lets a caller that MUST NOT record success on a silent failure
+ * (e.g. the reminders runner, which stamps a once-only dedup marker) gate its
+ * follow-up write on `> 0`. The never-throw contract is unchanged: failures are
+ * still swallowed and merely reported through the return value. Callers that
+ * don't care may ignore it (a failed notification is still non-fatal). The push
+ * bridge is best-effort and does NOT affect the count — a committed doc counts
+ * even if its push later fails.
+ *
  * `options.skipPush` writes the hub document(s) WITHOUT firing the web-push
  * bridge. Used by `push.sendTest`, which already delivered its OWN direct test
  * push (bypassing category prefs) and only wants the hub/badge side effect — so
@@ -46,9 +56,9 @@ import type {
 export async function createNotifications(
   items: NotificationInput[],
   options?: { skipPush?: boolean },
-): Promise<void> {
+): Promise<number> {
   if (items.length === 0) {
-    return
+    return 0
   }
 
   try {
@@ -101,9 +111,14 @@ export async function createNotifications(
         console.error('Failed to send web push for notifications:', pushError)
       }
     }
+
+    // The transaction committed above; every input became one document.
+    return items.length
   } catch (error) {
-    // Never propagate — see the contract above.
+    // Never propagate — see the contract above. A caught failure persisted
+    // nothing, so report 0 (the caller may retry / skip a success marker).
     console.error('Failed to create notifications:', error)
+    return 0
   }
 }
 

--- a/src/lib/notification/types.ts
+++ b/src/lib/notification/types.ts
@@ -8,7 +8,10 @@
 export type NotificationType =
   | 'proposal_submitted'
   | 'proposal_status_changed'
-  // Reserved for future use — no emitter yet.
+  // Reserved, currently UNUSED: superseded by `message_received` — proposal
+  // decision comments now relay through the speaker↔organizer message thread
+  // rather than a dedicated notification. Kept for back-compat with any legacy
+  // stored documents; no emitter creates it.
   | 'proposal_comment'
   // Speaker↔organizer conversation message (messaging M1).
   | 'message_received'
@@ -21,7 +24,9 @@ export type NotificationType =
   | 'cospeaker_response'
   | 'travel_support_update'
   | 'sponsor_activity'
-  // Reserved for future use — no emitter yet.
+  // Emitted by `src/lib/reminders/schedule-alerts.ts` when a talk's slot moves
+  // (date/time/track position) on a schedule save. Rendered generically by the
+  // hub.
   | 'schedule_update'
   | 'gallery_tagged'
   | 'system'

--- a/src/lib/reminders/__tests__/registry.test.ts
+++ b/src/lib/reminders/__tests__/registry.test.ts
@@ -140,6 +140,31 @@ describe('travel-reminder', () => {
   })
 })
 
+// N3: non-decision prep reminders must NOT ride the `proposalDecisions` push
+// category (mapped from 'proposal_status_changed'). `system` and
+// 'travel_support_update' both map to `otherUpdates` in
+// `pushCategoryForNotificationType`, so a speaker who mutes proposal decisions
+// still receives them. Only confirm-talk (decision-adjacent) stays on
+// 'proposal_status_changed'.
+describe('reminder push categories (N3)', () => {
+  it('keeps confirm-talk on the decision category', () => {
+    expect(reminder('confirm-talk').notificationType).toBe(
+      'proposal_status_changed',
+    )
+  })
+  it('routes upload-slides off the decision category', () => {
+    expect(reminder('upload-slides').notificationType).toBe('system')
+  })
+  it('routes logistics off the decision category', () => {
+    expect(reminder('logistics').notificationType).toBe('system')
+  })
+  it('keeps travel-reminder on its own (non-decision) category', () => {
+    expect(reminder('travel-reminder').notificationType).toBe(
+      'travel_support_update',
+    )
+  })
+})
+
 describe('logistics', () => {
   const r = reminder('logistics')
   it('is due within T-2d for a confirmed speaker', () => {

--- a/src/lib/reminders/__tests__/runner.test.ts
+++ b/src/lib/reminders/__tests__/runner.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { ReminderConference } from '../types'
 
 // --- Boundary mocks --------------------------------------------------------
-const createNotificationsMock = vi.fn().mockResolvedValue(undefined)
+// `createNotifications` now RESOLVES the number of documents persisted (N2). By
+// default it succeeds (returns the input length); tests override per-call to
+// simulate a silent failure (resolves 0) or a throw.
+const createNotificationsMock = vi
+  .fn()
+  .mockImplementation((items: unknown) =>
+    Promise.resolve(Array.isArray(items) ? items.length : 0),
+  )
 vi.mock('@/lib/notification/sanity', () => ({
   createNotifications: (...a: unknown[]) => createNotificationsMock(...a),
 }))
@@ -117,6 +124,23 @@ describe('runSpeakerReminders — dedup + re-arming', () => {
     expect(summary.sent).toBe(0)
   })
 
+  it('does NOT stamp a marker when the emit silently persists nothing (N2)', async () => {
+    // createNotifications never throws — a silent failure resolves 0. The runner
+    // must then NOT stamp the dedup marker, so the reminder retries next run.
+    createNotificationsMock.mockResolvedValueOnce(0)
+    const summary = await runSpeakerReminders(CONF, PRE)
+    expect(summary.sent).toBe(0)
+    expect(summary.failed).toBe(1)
+    // No marker transaction committed.
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('stamps exactly once on a successful emit (N2)', async () => {
+    const summary = await runSpeakerReminders(CONF, PRE)
+    expect(summary.sent).toBe(1)
+    expect(commitMock).toHaveBeenCalledTimes(1)
+  })
+
   it('never throws when the candidate read fails', async () => {
     fetchMock.mockImplementationOnce(() =>
       Promise.reject(new Error('read fail')),
@@ -151,7 +175,18 @@ describe('runDayOfAgenda — presenting-today selection + dedup', () => {
     const inputs = createNotificationsMock.mock.calls[0][0]
     expect(inputs[0].recipientId).toBe('s1')
     expect(inputs[0].message).toContain('09:00')
+    // N3: a day-of ping is not a proposal decision — use 'system' (→
+    // otherUpdates) so it survives a proposalDecisions mute.
+    expect(inputs[0].notificationType).toBe('system')
     expect(createIfNotExistsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT stamp the day-of marker when the emit persists nothing (N2)', async () => {
+    createNotificationsMock.mockResolvedValueOnce(0)
+    const summary = await runDayOfAgenda(CONF, DAY)
+    expect(summary.sent).toBe(0)
+    expect(summary.failed).toBe(1)
+    expect(createIfNotExistsMock).not.toHaveBeenCalled()
   })
 
   it('skips a speaker already notified today (marker present)', async () => {

--- a/src/lib/reminders/__tests__/schedule-alerts.test.ts
+++ b/src/lib/reminders/__tests__/schedule-alerts.test.ts
@@ -20,7 +20,8 @@ const slot = (
   startTime: string,
   trackTitle: string,
   date = '2026-09-10',
-): SlotPlacement => ({ talkId, date, startTime, trackTitle })
+  trackIndex = 0,
+): SlotPlacement => ({ talkId, date, startTime, trackIndex, trackTitle })
 
 describe('diffScheduleSlots', () => {
   it('detects a time move', () => {
@@ -31,13 +32,23 @@ describe('diffScheduleSlots', () => {
     expect(moved).toHaveLength(1)
     expect(moved[0].to.startTime).toBe('10:00')
   })
-  it('detects a track move', () => {
+  it('detects a track move (different track position)', () => {
     const moved = diffScheduleSlots(
-      [slot('t1', '09:00', 'Track A')],
-      [slot('t1', '09:00', 'Track B')],
+      [slot('t1', '09:00', 'Track A', '2026-09-10', 0)],
+      [slot('t1', '09:00', 'Track B', '2026-09-10', 1)],
     )
     expect(moved).toHaveLength(1)
     expect(moved[0].to.trackTitle).toBe('Track B')
+  })
+  it('ignores a pure track-title RENAME (N4: same position, same time)', () => {
+    // Renaming a track's display title while its position (index), date and
+    // start time are unchanged must NOT fire a spurious "moved" alert.
+    expect(
+      diffScheduleSlots(
+        [slot('t1', '09:00', 'Track A', '2026-09-10', 0)],
+        [slot('t1', '09:00', 'Main Stage', '2026-09-10', 0)],
+      ),
+    ).toEqual([])
   })
   it('detects a date move', () => {
     const moved = diffScheduleSlots(

--- a/src/lib/reminders/registry.ts
+++ b/src/lib/reminders/registry.ts
@@ -52,6 +52,12 @@ function talkInStatus(speaker: ReminderSpeaker, status: string) {
  * (a) confirm-talk — an accepted (but not yet confirmed) talk needs the speaker
  * to confirm participation. Due from acceptance onward; re-nudged up to
  * {@link CONFIRM_MAX_SENDS} times, {@link CONFIRM_SPACING_DAYS} days apart.
+ *
+ * PUSH CATEGORY: kept on `proposal_status_changed` (→ `proposalDecisions`)
+ * deliberately — confirming an ACCEPTED talk is decision-adjacent, so it belongs
+ * with a speaker's proposal-decision pushes. The non-decision prep reminders
+ * (upload-slides, logistics, day-of) instead use `system` (→ `otherUpdates`) so
+ * a speaker who mutes proposal decisions still receives them.
  */
 const confirmTalk: Reminder = {
   key: 'confirm-talk',
@@ -76,7 +82,9 @@ const confirmTalk: Reminder = {
  */
 const uploadSlides: Reminder = {
   key: 'upload-slides',
-  notificationType: 'proposal_status_changed',
+  // `system` → push category `otherUpdates`: a slides-upload nudge is not a
+  // proposal decision and must not be muted with `proposalDecisions`.
+  notificationType: 'system',
   maxSends: SLIDES_MAX_SENDS,
   spacingDays: SLIDES_SPACING_DAYS,
   evaluate(speaker, conference, today) {
@@ -160,7 +168,9 @@ const travelReminder: Reminder = {
  */
 const logistics: Reminder = {
   key: 'logistics',
-  notificationType: 'proposal_status_changed',
+  // `system` → push category `otherUpdates`: a venue/arrival/AV note is not a
+  // proposal decision and must not be muted with `proposalDecisions`.
+  notificationType: 'system',
   maxSends: 1,
   spacingDays: 0,
   evaluate(speaker, conference, today) {

--- a/src/lib/reminders/runner.ts
+++ b/src/lib/reminders/runner.ts
@@ -192,17 +192,30 @@ export async function runSpeakerReminders(
           message: item.copy.message,
           link: item.copy.link,
         }
-        await createNotifications([input])
-        await stampReminderLog({
-          id: item.id,
-          key: reminder.key,
-          conferenceId: conference._id,
-          speakerId: item.speakerId,
-          now,
-        })
-        sends += 1
-        result.sent += 1
-        summary.sent += 1
+        // Stamp the dedup marker ONLY when the hub write actually persisted.
+        // `createNotifications` never throws — a silent failure returns 0 — so
+        // stamping unconditionally would mark a failed once-only reminder 'sent'
+        // and permanently suppress it. Gate on the persisted count so a failed
+        // emit retries next run.
+        const persisted = await createNotifications([input])
+        if (persisted > 0) {
+          await stampReminderLog({
+            id: item.id,
+            key: reminder.key,
+            conferenceId: conference._id,
+            speakerId: item.speakerId,
+            now,
+          })
+          sends += 1
+          result.sent += 1
+          summary.sent += 1
+        } else {
+          result.failed += 1
+          summary.failed += 1
+          console.error(
+            `Speaker reminder '${reminder.key}' persisted nothing for speaker ${item.speakerId}; not stamping marker`,
+          )
+        }
       } catch (error) {
         result.failed += 1
         summary.failed += 1
@@ -331,19 +344,32 @@ export async function runDayOfAgenda(
         const input: NotificationInput = {
           recipientId: entry.speakerId,
           conferenceId: conference._id,
-          notificationType: 'proposal_status_changed',
+          // 'system' → push category `otherUpdates`. A day-of agenda ping is NOT
+          // a proposal decision, so it must not be muted by a speaker who turned
+          // off `proposalDecisions` (which 'proposal_status_changed' maps to).
+          notificationType: 'system',
           title: `You're presenting today at ${conference.title || 'the conference'}!`,
           message: `"${entry.talkTitle}" at ${entry.startTime} on ${entry.trackTitle}. Break a leg!`,
           link: '/program',
         }
-        await createNotifications([input])
-        await createDayOfLog({
-          id,
-          conferenceId: conference._id,
-          speakerId: entry.speakerId,
-          now,
-        })
-        summary.sent += 1
+        // Stamp the day-of dedup marker ONLY when the hub write persisted (see
+        // the runSpeakerReminders rationale): a silent failure returns 0, and
+        // stamping anyway would permanently suppress this once-per-day reminder.
+        const persisted = await createNotifications([input])
+        if (persisted > 0) {
+          await createDayOfLog({
+            id,
+            conferenceId: conference._id,
+            speakerId: entry.speakerId,
+            now,
+          })
+          summary.sent += 1
+        } else {
+          summary.failed += 1
+          console.error(
+            `Day-of agenda persisted nothing for speaker ${entry.speakerId}; not stamping marker`,
+          )
+        }
       } catch (error) {
         summary.failed += 1
         console.error(

--- a/src/lib/reminders/schedule-alerts.ts
+++ b/src/lib/reminders/schedule-alerts.ts
@@ -15,10 +15,14 @@ import type { MovedTalk, SlotPlacement } from './types'
 
 /**
  * Pure diff: talks present in BOTH the prior and next placement sets whose
- * date, startTime, or trackTitle changed. A talk only in `next` (newly placed)
- * or only in `prior` (removed) is excluded. Last placement wins if a talk id
- * appears more than once in a set (defensive — a valid schedule places a talk
- * once).
+ * date, startTime, or track POSITION (`trackIndex`) changed. A talk only in
+ * `next` (newly placed) or only in `prior` (removed) is excluded. Last placement
+ * wins if a talk id appears more than once in a set (defensive — a valid
+ * schedule places a talk once).
+ *
+ * The track is compared by INDEX, not display title, so renaming a track fires
+ * no spurious "moved" alerts for its unchanged talks; only an actual position
+ * change (or a date/time change) is a move.
  */
 export function diffScheduleSlots(
   prior: SlotPlacement[],
@@ -40,18 +44,20 @@ export function diffScheduleSlots(
     if (
       from.date !== to.date ||
       from.startTime !== to.startTime ||
-      from.trackTitle !== to.trackTitle
+      from.trackIndex !== to.trackIndex
     ) {
       moved.push({
         talkId,
         from: {
           date: from.date,
           startTime: from.startTime,
+          trackIndex: from.trackIndex,
           trackTitle: from.trackTitle,
         },
         to: {
           date: to.date,
           startTime: to.startTime,
+          trackIndex: to.trackIndex,
           trackTitle: to.trackTitle,
         },
       })

--- a/src/lib/reminders/schedule-alerts.ts
+++ b/src/lib/reminders/schedule-alerts.ts
@@ -22,7 +22,16 @@ import type { MovedTalk, SlotPlacement } from './types'
  *
  * The track is compared by INDEX, not display title, so renaming a track fires
  * no spurious "moved" alerts for its unchanged talks; only an actual position
- * change (or a date/time change) is a move.
+ * change (or a date/time change) is a move. This is the deliberate trade-off for
+ * the common case: post-placement track RENAMES (typo fixes, sponsor room names)
+ * are frequent and touch a whole track, so silencing them matters most.
+ *
+ * KNOWN LIMITATION: there is no stable track identity to compare on — the save
+ * path regenerates each track `_key` from its index, so index IS position. A
+ * post-placement track INSERT/REORDER therefore shifts the indices of unchanged
+ * talks and can emit "moved" alerts whose copy (time + title) looks unchanged.
+ * That edit is rare once talks are placed; a real fix needs a persisted,
+ * index-independent track id (a schema change), tracked separately.
  */
 export function diffScheduleSlots(
   prior: SlotPlacement[],

--- a/src/lib/reminders/types.ts
+++ b/src/lib/reminders/types.ts
@@ -120,7 +120,15 @@ export interface SlotPlacement {
   date: string
   /** Slot start time (HH:mm). */
   startTime: string
-  /** Track the slot sits in. */
+  /**
+   * Zero-based position of the track within the day. This — NOT `trackTitle` —
+   * is the STABLE track identity the move diff compares on: renaming a track
+   * keeps its index (so a rename fires no false "moved" alerts), while moving a
+   * talk to a different track changes its index (a genuine move). `trackTitle`
+   * is display-only (carried for the notification copy).
+   */
+  trackIndex: number
+  /** Display title of the track (for the notification copy). */
   trackTitle: string
 }
 

--- a/src/lib/schedule/sanity.test.ts
+++ b/src/lib/schedule/sanity.test.ts
@@ -33,7 +33,10 @@ let priorFetchImpl: () => Promise<unknown> = () =>
 const commitMock = vi.fn().mockResolvedValue({ _rev: 'r2' })
 const setMock = vi.fn(() => ({ commit: commitMock }))
 const ifRevisionIdMock = vi.fn(() => ({ set: setMock }))
-const patchMock = vi.fn(() => ({ ifRevisionId: ifRevisionIdMock }))
+const patchMock = vi.fn((id?: unknown) => {
+  void id
+  return { ifRevisionId: ifRevisionIdMock }
+})
 
 const fetchMock = vi.fn((query: string) => {
   // Target-existence / scope check.

--- a/src/lib/schedule/sanity.test.ts
+++ b/src/lib/schedule/sanity.test.ts
@@ -33,7 +33,7 @@ let priorFetchImpl: () => Promise<unknown> = () =>
 const commitMock = vi.fn().mockResolvedValue({ _rev: 'r2' })
 const setMock = vi.fn(() => ({ commit: commitMock }))
 const ifRevisionIdMock = vi.fn(() => ({ set: setMock }))
-const patchMock = vi.fn((_id: string) => ({ ifRevisionId: ifRevisionIdMock }))
+const patchMock = vi.fn(() => ({ ifRevisionId: ifRevisionIdMock }))
 
 const fetchMock = vi.fn((query: string) => {
   // Target-existence / scope check.

--- a/src/lib/schedule/sanity.test.ts
+++ b/src/lib/schedule/sanity.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ConferenceSchedule, Conference } from '@/lib/conference/types'
+
+/**
+ * N6: the schedule save must SKIP its move-alert pass (rather than misfire an
+ * all-new diff) when the pre-save prior-placements READ fails — a transient read
+ * failure would otherwise make every talk look newly placed, silently swallowing
+ * any real move. The save itself must still succeed.
+ */
+
+// --- Boundary mocks --------------------------------------------------------
+const notifyScheduleChangesMock = vi
+  .fn()
+  .mockResolvedValue({ moved: 0, notified: 0 })
+vi.mock('@/lib/reminders', () => ({
+  notifyScheduleChanges: (...a: unknown[]) => notifyScheduleChangesMock(...a),
+}))
+
+vi.mock('@/lib/sanity/helpers', () => ({
+  generateKey: (p?: string) => `${p ?? 'k'}-key`,
+  createReference: (ref: string) => ({ _type: 'reference', _ref: ref }),
+  createReferenceWithKey: (ref: string) => ({
+    _type: 'reference',
+    _ref: ref,
+    _key: 'k',
+  }),
+}))
+
+// The prior-placements read is the one whose behaviour each test controls.
+let priorFetchImpl: () => Promise<unknown> = () =>
+  Promise.resolve({ date: '2026-09-10', tracks: [] })
+
+const commitMock = vi.fn().mockResolvedValue({ _rev: 'r2' })
+const setMock = vi.fn(() => ({ commit: commitMock }))
+const ifRevisionIdMock = vi.fn(() => ({ set: setMock }))
+const patchMock = vi.fn((_id: string) => ({ ifRevisionId: ifRevisionIdMock }))
+
+const fetchMock = vi.fn((query: string) => {
+  // Target-existence / scope check.
+  if (query.includes('conferenceRef')) {
+    return Promise.resolve({ _type: 'schedule', conferenceRef: 'conf-1' })
+  }
+  // Prior-placements projection (the one N6 cares about).
+  if (query.includes('trackTitle')) {
+    return priorFetchImpl()
+  }
+  return Promise.resolve(null)
+})
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    fetch: (q: string) => fetchMock(q),
+    patch: (id: string) => patchMock(id),
+  },
+}))
+
+import { saveScheduleToSanity } from './sanity'
+
+const CONF = { _id: 'conf-1', title: 'Conf' } as unknown as Conference
+
+function makeSchedule(): ConferenceSchedule {
+  return {
+    _id: 'sched-1',
+    _rev: 'r1',
+    date: '2026-09-10',
+    tracks: [
+      {
+        trackTitle: 'Track A',
+        talks: [{ startTime: '09:00', endTime: '09:30', talk: { _id: 't1' } }],
+      },
+    ],
+  } as unknown as ConferenceSchedule
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  priorFetchImpl = () =>
+    Promise.resolve({
+      date: '2026-09-10',
+      tracks: [
+        {
+          trackTitle: 'Track A',
+          talks: [{ startTime: '09:00', talkId: 't1' }],
+        },
+      ],
+    })
+})
+
+describe('saveScheduleToSanity — schedule-change alert gating (N6)', () => {
+  it('skips the alert pass and logs when the prior-placements read fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    priorFetchImpl = () => Promise.reject(new Error('read fail'))
+
+    const result = await saveScheduleToSanity(makeSchedule(), CONF)
+
+    // The save still succeeds — the read failure never fails the write.
+    expect(result.error).toBeUndefined()
+    expect(result.schedule).toBeDefined()
+    // No spurious alerts, and the miss is observable.
+    expect(notifyScheduleChangesMock).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+
+    warn.mockRestore()
+    error.mockRestore()
+  })
+
+  it('runs the alert pass normally when the prior read succeeds', async () => {
+    const result = await saveScheduleToSanity(makeSchedule(), CONF)
+    expect(result.schedule).toBeDefined()
+    expect(notifyScheduleChangesMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/schedule/sanity.ts
+++ b/src/lib/schedule/sanity.ts
@@ -59,7 +59,9 @@ function collectPlacements(
   tracks: ConferenceSchedule['tracks'] | undefined,
 ): SlotPlacement[] {
   const placements: SlotPlacement[] = []
-  for (const track of tracks || []) {
+  const trackList = tracks || []
+  for (let trackIndex = 0; trackIndex < trackList.length; trackIndex++) {
+    const track = trackList[trackIndex]
     for (const talk of track.talks || []) {
       if (talk.placeholder) continue
       const talkId = resolveTalkId(talk)
@@ -68,6 +70,7 @@ function collectPlacements(
         talkId,
         date,
         startTime: talk.startTime,
+        trackIndex,
         trackTitle: track.trackTitle,
       })
     }
@@ -88,12 +91,20 @@ interface PriorScheduleSlots {
 
 /**
  * Fetch the CURRENT persisted placements of a schedule day (before it is
- * overwritten), so the save can diff moved talks afterwards. Best-effort: any
- * failure yields an empty set (no false "moved" alerts), never a save failure.
+ * overwritten), so the save can diff moved talks afterwards. Best-effort and
+ * never a save failure.
+ *
+ * RETURN: the placements on success (an empty array for a genuinely empty/new
+ * day), or `null` when the READ ITSELF FAILED. The distinction matters: a failed
+ * read is NOT the same as an empty day. If it silently returned `[]`, the diff
+ * would treat every current talk as "newly placed" and announce NOTHING — so a
+ * real move during a transient read failure would go out unannounced with no
+ * trace. The caller SKIPS the alert pass (and logs) when this is `null`, rather
+ * than diffing against a bogus empty baseline.
  */
 async function fetchPriorPlacements(
   scheduleId: string,
-): Promise<SlotPlacement[]> {
+): Promise<SlotPlacement[] | null> {
   try {
     const doc = await clientWrite.fetch<PriorScheduleSlots | null>(
       `*[_id == $id][0]{
@@ -107,21 +118,26 @@ async function fetchPriorPlacements(
     )
     if (!doc?.date) return []
     const placements: SlotPlacement[] = []
-    for (const track of doc.tracks || []) {
+    const trackList = doc.tracks || []
+    for (let trackIndex = 0; trackIndex < trackList.length; trackIndex++) {
+      const track = trackList[trackIndex]
       for (const slot of track.talks || []) {
         if (!slot.talkId || !slot.startTime) continue
         placements.push({
           talkId: slot.talkId,
           date: doc.date,
           startTime: slot.startTime,
+          trackIndex,
           trackTitle: track.trackTitle || '',
         })
       }
     }
     return placements
   } catch (error) {
+    // Read failure — return the null sentinel so the caller skips (not misfires)
+    // the schedule-change alert pass. Never rethrow: the save must not fail.
     console.error('Failed to read prior schedule placements:', error)
-    return []
+    return null
   }
 }
 
@@ -254,12 +270,23 @@ export async function saveScheduleToSanity(
       // speakers of any talk whose slot actually moved. Never-throw (a failure
       // here must not fail the already-committed save); a run where nothing
       // moved emits nothing.
-      await notifyScheduleChanges({
-        prior: priorPlacements,
-        next: collectPlacements(schedule.date, schedule.tracks),
-        conferenceId: conference._id,
-        actorId: options?.actorId,
-      })
+      //
+      // A `null` prior means the pre-save read FAILED (distinct from an empty
+      // day): diffing against an empty baseline would treat every talk as newly
+      // placed and announce nothing, silently swallowing any real move. Skip the
+      // pass entirely and log so the miss is observable, rather than misfire.
+      if (priorPlacements === null) {
+        console.warn(
+          `Skipping schedule-change alerts for ${schedule._id}: prior placements unavailable (read failed)`,
+        )
+      } else {
+        await notifyScheduleChanges({
+          prior: priorPlacements,
+          next: collectPlacements(schedule.date, schedule.tracks),
+          conferenceId: conference._id,
+          actorId: options?.actorId,
+        })
+      }
     } else {
       // DUPLICATE-DAY GUARD: any payload with `_id: ''` creates a fresh schedule
       // doc and appends it to `conference.schedules`. Two organizers saving the


### PR DESCRIPTION
Quality-review fix batch N — notifications / PWA / reminders. Each finding verified against code before fixing.

## N1 (P1) — cold-open push tap never marks the notification read
`public/sw.js` `notificationclick` captured open clients *before* `openWindow`, so the brand-new client a **cold** open spawns never received the `notification-click` postMessage — the dominant PWA case (only warm foreground taps worked). The SW now also carries the mark-read intent **through the opened URL** as a `markread` query param whose value is the notification's **original app-relative link** (exactly the stored `link`, not the param-appended URL). `NotificationClickSync` consumes it on mount / navigation, fires `markReadByLink`, invalidates unreadCount+list, and strips the param via `history.replaceState`. The existing warm-tab postMessage clearing is kept.

## N2 (P2) — silent-fail marker permanently suppresses once-only reminders
`runner.ts` stamped the dedup marker (`stampReminderLog` / `createDayOfLog`) after `createNotifications`, which never throws — so a silently-failed hub write still marked the reminder sent. `createNotifications` now **returns the number of documents persisted** (`0` on empty or caught failure; never-throw contract preserved). The runner stamps only when `persisted > 0`, so a failed emit retries next run.

**Signature change:** `createNotifications(items, options?): Promise<void>` → `Promise<number>`. Callers ignore it except the runner; test mocks updated.

## N3 (P2) — non-decision reminders used the wrong push category
Day-of agenda, logistics and upload-slides emitted `proposal_status_changed` → `proposalDecisions`, so a speaker who muted proposal decisions lost these. They now use `system` → `otherUpdates`. `confirm-talk` stays on `proposal_status_changed` (confirming an accepted talk is decision-adjacent; documented). `travel-reminder` already used `travel_support_update` (→ otherUpdates).

## N4 (P3) — track renames spammed false "moved" alerts
`diffScheduleSlots` treated any `trackTitle` change as a move. It now diffs on a stable **track position (`trackIndex`)**; `trackTitle` is display-only (carried into the copy). A pure rename fires nothing; a genuine time/day/track-position move still fires. `_key` is unusable as a cross-save identity because the save regenerates keys with `nanoid` every write, hence index.

## N5 (P3) — stale reserved-type comments
`schedule_update` now documents `schedule-alerts.ts` as its emitter; `proposal_comment` is marked reserved-but-unused (superseded by the `message_received` relay). Fixed in `src/lib/notification/types.ts` and `sanity/schemaTypes/notification.ts`. No behavior change.

## N6 (P3) — prior-read failure silently swallowed real move alerts
`fetchPriorPlacements` returned `[]` on read error — indistinguishable from an empty day — making every talk look newly-placed so no move ever announced. It now returns a **null sentinel** on read failure; the save skips the alert pass and logs (observable), rather than diffing an all-new baseline. The save never fails.

## Checks
tsc, eslint, prettier, knip all clean; full `pnpm vitest run` green (274 files, 3758 passed / 5 skipped). Added tests for N1 (param consume/strip/ignore), N2 (no-stamp on 0, stamp once), N3 (categories), N4 (rename fires nothing), N6 (read-failure skips + logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This batch fixes six independently-verified notification/PWA/reminder quality issues: cold-open PWA taps that never marked the notification read (N1), a dedup-marker race that permanently suppressed retried reminders on silent write failures (N2), incorrect push categories that let `proposalDecisions` muting silence unrelated prep reminders (N3), track renames spamming false "moved" alerts (N4), stale type-comment docs (N5), and a read-failure sentinel that prevented a bogus empty diff from swallowing real move alerts (N6).

- **N1**: The SW now appends a `markread` query param to every opened URL; `NotificationClickSync` consumes and strips it on mount/navigation with an `isAppRelativeLink` guard, covering the dominant cold-open case while keeping the warm postMessage path intact.
- **N2**: `createNotifications` returns a persisted count (`0` on empty or caught failure); both runner paths gate their once-only dedup-marker writes on `persisted > 0` so a silent Sanity failure retries next run rather than disappearing permanently.
- **N3/N4/N6**: Push-category corrections (`system` instead of `proposal_status_changed` for non-decision reminders), track-index–based move detection (renames no longer trigger alerts), and a `null` sentinel from `fetchPriorPlacements` that causes the save to skip the alert pass rather than diff against an empty baseline.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all six fixes are well-scoped, individually tested, and address real defects without introducing new failure modes in the critical notification write path.

The cold-open `markread` param is not stripped from the URL when the user is signed out; the param lingers in the address bar and the notification stays unread if the user navigates before signing in. All other changes look correct and are covered by the expanded test suite (274 files, 3758 passing). The never-throw contract on `createNotifications` is preserved, and the `null` sentinel / `trackIndex` changes are cleanly isolated to their respective call sites.

`src/components/pwa/NotificationClickSync.tsx` — the signed-out early-return fires before the `history.replaceState` strip, leaving the `markread` param in the URL for users who land while signed out.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| public/sw.js | Appends `markread` query param to all opened URLs so cold-open PWA taps carry the mark-read intent; correct try/catch guard around URL construction; warm-tab postMessage path preserved. |
| src/components/pwa/NotificationClickSync.tsx | Adds cold-open mark-read via `markread` URL param with `isAppRelativeLink` guard; the param is not stripped when signed out (guard fires before replaceState), leaving the URL polluted if the user navigates before signing in. |
| src/lib/notification/sanity.ts | Return type widened from `void` to `number` (persisted count); never-throw contract preserved; returns 0 on empty input or caught failure as documented. |
| src/lib/reminders/runner.ts | Both `runSpeakerReminders` and `runDayOfAgenda` now gate their dedup-marker writes on `persisted > 0`, preventing permanent suppression of once-only reminders on silent failures. |
| src/lib/reminders/registry.ts | `upload-slides` and `logistics` changed from `proposal_status_changed` to `system`; `confirm-talk` intentionally kept on `proposal_status_changed`; comment explains the decision. |
| src/lib/reminders/schedule-alerts.ts | Diff now compares `trackIndex` instead of `trackTitle`; pure renames no longer trigger alerts; `trackTitle` carried for notification copy only. |
| src/lib/schedule/sanity.ts | `collectPlacements` and `fetchPriorPlacements` both derive `trackIndex` from array position; `fetchPriorPlacements` returns `null` sentinel on read failure; `saveScheduleToSanity` skips alert pass on null rather than diffing a bogus empty baseline. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SW as Service Worker (sw.js)
    participant App as Next.js App
    participant NCS as NotificationClickSync
    participant API as tRPC markReadByLink

    Note over SW,API: N1 — Cold-open mark-read flow
    SW->>SW: notificationclick fired
    SW->>SW: postMessage to ALL open clients (warm path)
    SW->>SW: "Build openUrl = targetUrl + ?markread=target"
    SW->>App: clients.openWindow(openUrl) [cold open]
    App->>NCS: Mount (useEffect on pathname)
    NCS->>NCS: Read window.location.search
    NCS->>NCS: params.get("markread") → link
    NCS->>NCS: history.replaceState (strip param)
    NCS->>NCS: isAppRelativeLink(link)?
    NCS->>API: "mutate({ links: [link] })"
    API-->>NCS: onSuccess → invalidate unreadCount + list

    Note over SW,API: N2 — Dedup-marker guard
    participant Runner as reminders/runner.ts
    participant Sanity as createNotifications
    participant Marker as stampReminderLog

    Runner->>Sanity: createNotifications([input])
    alt "persisted > 0"
        Sanity-->>Runner: returns items.length
        Runner->>Marker: stampReminderLog(...)
        Runner->>Runner: "summary.sent += 1"
    else silent failure
        Sanity-->>Runner: returns 0
        Runner->>Runner: "summary.failed += 1"
        Note over Runner: marker NOT stamped → retries next run
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SW as Service Worker (sw.js)
    participant App as Next.js App
    participant NCS as NotificationClickSync
    participant API as tRPC markReadByLink

    Note over SW,API: N1 — Cold-open mark-read flow
    SW->>SW: notificationclick fired
    SW->>SW: postMessage to ALL open clients (warm path)
    SW->>SW: "Build openUrl = targetUrl + ?markread=target"
    SW->>App: clients.openWindow(openUrl) [cold open]
    App->>NCS: Mount (useEffect on pathname)
    NCS->>NCS: Read window.location.search
    NCS->>NCS: params.get("markread") → link
    NCS->>NCS: history.replaceState (strip param)
    NCS->>NCS: isAppRelativeLink(link)?
    NCS->>API: "mutate({ links: [link] })"
    API-->>NCS: onSuccess → invalidate unreadCount + list

    Note over SW,API: N2 — Dedup-marker guard
    participant Runner as reminders/runner.ts
    participant Sanity as createNotifications
    participant Marker as stampReminderLog

    Runner->>Sanity: createNotifications([input])
    alt "persisted > 0"
        Sanity-->>Runner: returns items.length
        Runner->>Marker: stampReminderLog(...)
        Runner->>Runner: "summary.sent += 1"
    else silent failure
        Sanity-->>Runner: returns 0
        Runner->>Runner: "summary.failed += 1"
        Note over Runner: marker NOT stamped → retries next run
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): quality-review fixes..."](https://github.com/cloudnativebergen/website/commit/2c69f89eafd55686eb0282fbfef9f2c5702eb386) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45706726)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->