### PR TITLE
fix(messaging): quality-review fixes — sponsor mute/reopen/needs-reply, merge dedup (batch M)

### DIFF
--- a/__tests__/lib/messaging/nudge.test.ts
+++ b/__tests__/lib/messaging/nudge.test.ts
@@ -33,7 +33,7 @@ import {
 } from '@/lib/messaging/nudge'
 // The nudge selection MUST use the SAME last-author projection as the inbox
 // needs-reply filter (single home — R1).
-import { LAST_AUTHOR_REF } from '@/lib/messaging/sanity'
+import { LAST_AUTHOR_REF, HAS_ANY_MESSAGE } from '@/lib/messaging/sanity'
 import type { NotificationInput } from '@/lib/notification/types'
 
 type LooseMock = ReturnType<typeof vi.fn>
@@ -110,15 +110,17 @@ describe('selection GROQ encodes the stale policy', () => {
     expect(typeof params.cutoff).toBe('string')
   })
 
-  it('uses the SHARED LAST_AUTHOR_REF projection (single home, R1)', async () => {
+  it('uses the SHARED LAST_AUTHOR_REF + HAS_ANY_MESSAGE projections (single home, R1/M3)', async () => {
     readMock.fetch.mockResolvedValueOnce([])
     await nudgeStaleConversations()
     const [query] = readMock.fetch.mock.calls[0]
-    // The exact exported string appears (both in `defined(...)` and the
-    // `!(... in $organizerIds)` clauses), proving the nudge never re-declares a
-    // divergent copy.
+    // Existence is gated by the shared HAS_ANY_MESSAGE (so a SPONSOR-authored
+    // last message, which has no author ref, still qualifies — M3), and the
+    // author-is-organizer check reuses the exact LAST_AUTHOR_REF once, proving the
+    // nudge never re-declares a divergent copy of either projection.
+    expect(query).toContain(HAS_ANY_MESSAGE)
     expect(query).toContain(LAST_AUTHOR_REF)
-    expect(query.split(LAST_AUTHOR_REF).length - 1).toBe(2)
+    expect(query.split(LAST_AUTHOR_REF).length - 1).toBe(1)
   })
 
   it('no-ops (no notifications, no writes) when nothing is stale', async () => {

--- a/src/lib/messaging/needsReply.test.ts
+++ b/src/lib/messaging/needsReply.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// M3: a SPONSOR-authored last message (no author._ref) must be treated as
+// "needs reply" CONSISTENTLY across the GROQ needs-reply predicate (tab + count
+// + nudge, via the shared HAS_ANY_MESSAGE existence gate) and the JS per-row
+// derivation (the Active-view badge). This test pins BOTH sides.
+
+vi.mock('@/lib/sanity/helpers', () => ({
+  createReference: (id: string) => ({ _type: 'reference', _ref: id }),
+}))
+
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { transaction: vi.fn(), create: vi.fn(), patch: vi.fn() },
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn(async () => ['org-1']),
+}))
+
+vi.mock('@/lib/teams', () => ({
+  getViewerTeamKeys: vi.fn(async () => []),
+}))
+
+import {
+  rawViewPredicate,
+  HAS_ANY_MESSAGE,
+  listConversationsForSpeaker,
+} from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('needs-reply GROQ predicate (M3)', () => {
+  it('gates on message EXISTENCE (HAS_ANY_MESSAGE), not on a defined author ref', () => {
+    const { predicate, needsOrganizerIds } = rawViewPredicate(
+      'needs-reply',
+      true,
+    )
+    expect(needsOrganizerIds).toBe(true)
+    // The existence gate is the shared HAS_ANY_MESSAGE (also used by the nudge),
+    // so a sponsor-authored last message still qualifies.
+    expect(predicate).toContain(HAS_ANY_MESSAGE)
+    // The OLD bug — gating existence on `defined(<last author._ref>)`, which is
+    // FALSE for a sponsor message — must be gone.
+    expect(predicate).not.toContain('defined(*[_type == "message"')
+    // Still excludes threads whose last author IS an organizer.
+    expect(predicate).toContain('in $organizerIds')
+  })
+})
+
+describe('needs-reply JS row derivation (M3)', () => {
+  // Route the reads listConversationsForSpeaker performs: the main conversation
+  // query returns our single row; the unread + preference reads return empty.
+  function routeRows(rows: unknown[]) {
+    fetchMock.mockImplementation((query: string) => {
+      if (query.includes('notification')) return Promise.resolve([])
+      if (query.includes('conversationPreference')) return Promise.resolve([])
+      return Promise.resolve(rows)
+    })
+  }
+
+  const baseRow = {
+    _id: 'conversation.sponsor.sfc-1',
+    conversationType: 'sponsor',
+    subject: 'Acme Corp',
+    proposalId: null,
+    proposalTitle: null,
+    subjectSpeakerId: null,
+    createdAt: '2026-07-01T00:00:00Z',
+    lastMessageAt: '2026-07-02T00:00:00Z',
+    status: 'open',
+    assignedTo: null,
+    archivedAt: null,
+    speakerSideName: 'Acme Corp',
+    speakerSideImage: null,
+  }
+
+  it('flags a SPONSOR-last-message thread (null author) as needsReply', async () => {
+    routeRows([
+      {
+        ...baseRow,
+        lastMessage: {
+          authorId: null,
+          authorName: null,
+          authorImage: null,
+          body: 'Question from the sponsor',
+        },
+      },
+    ])
+
+    const items = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'active',
+    })
+    expect(items).toHaveLength(1)
+    expect(items[0].needsReply).toBe(true)
+  })
+
+  it('does NOT flag a thread whose last author is an organizer', async () => {
+    routeRows([
+      {
+        ...baseRow,
+        lastMessage: {
+          authorId: 'org-1',
+          authorName: 'Olga Organizer',
+          authorImage: null,
+          body: 'Replied',
+        },
+      },
+    ])
+
+    const items = await listConversationsForSpeaker({
+      speakerId: 'org-1',
+      isOrganizer: true,
+      conferenceId: 'conf-1',
+      view: 'active',
+    })
+    expect(items[0].needsReply).toBe(false)
+  })
+})

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -345,11 +345,21 @@ export async function notifySponsorMessage({
     if (authorOrganizerId === undefined) {
       // ---- SPONSOR-authored ------------------------------------------------
       const authorName = message.authorName ?? sfc.sponsorName
-      // HUB (+push) to ALL organizers. Sponsor authors have no speaker id, so
-      // there is no actor to exclude and no `actorId` on the input. The
-      // "(Sponsor)" suffix on the author name yields the required title
-      // "New message from <authorName> (Sponsor) — <subject>".
-      const items: MessageNotificationInput[] = organizerIds.map((id) => ({
+      // HUB (+push) to the routed organizers, MINUS anyone who MUTED this thread
+      // — mirror the organizer-authored branch below and honour the module
+      // docstring's mute contract (a muted organizer must get nothing on any
+      // channel, sponsor-authored included). Sponsors have no preference docs, so
+      // only the organizer recipients are filtered. (M1)
+      const prefs = await getConversationPreferencesFor(
+        conversation._id,
+        organizerIds,
+      )
+      const active = organizerIds.filter((id) => !prefs.get(id)?.muted)
+      // Sponsor authors have no speaker id, so there is no actor to exclude and
+      // no `actorId` on the input. The "(Sponsor)" suffix on the author name
+      // yields the required title "New message from <authorName> (Sponsor) —
+      // <subject>".
+      const items: MessageNotificationInput[] = active.map((id) => ({
         recipientId: id,
         conversationId: conversation._id,
         conferenceId: conversation.conferenceId,
@@ -400,6 +410,21 @@ export async function notifySponsorMessage({
       await sendSponsorMessageEmails(
         sfc.contactPersons.map((c) => ({ email: c.email, name: c.name })),
         { authorName, subject, excerpt, portalUrl, conference },
+      )
+    } else if (sfc.contactPersons.length > 0 && !sfc.registrationToken) {
+      // OBSERVABILITY (M5): there ARE contact persons but NO registration token,
+      // so there is no portal link to build — the sponsor-side email silently
+      // never sends. Surface the drop (server warning + a sponsorActivity `note`)
+      // so it is diagnosable. We do NOT block the thread message: the hub still
+      // notifies the other organizers below, and the reply is already committed.
+      console.warn(
+        `notifySponsorMessage: sfc ${sfc.sfcId} has ${sfc.contactPersons.length} contact(s) but no registrationToken; the organizer reply was NOT emailed (no portal link).`,
+      )
+      await createSponsorActivity(
+        sfc.sfcId,
+        'note',
+        `Reply from ${authorName} could not be emailed to the sponsor: no portal registration token on file.`,
+        'system',
       )
     }
 

--- a/src/lib/messaging/notifySponsor.test.ts
+++ b/src/lib/messaging/notifySponsor.test.ts
@@ -132,6 +132,25 @@ describe('notifySponsorMessage — SPONSOR-authored', () => {
     // NO sponsor emails on a sponsor-authored message.
     expect(sponsorEmailMock).not.toHaveBeenCalled()
   })
+
+  it('EXCLUDES an organizer who MUTED the thread from the hub fan-out (M1)', async () => {
+    // org-2 muted this conversation → sponsor-authored hub must skip them,
+    // mirroring the organizer-authored branch and the module mute contract. The
+    // sponsor-authored branch makes exactly one read (the preference lookup), so
+    // a single `mockImplementationOnce` targets it without leaking to later tests.
+    fetchMock.mockImplementationOnce(() =>
+      Promise.resolve([
+        { speakerId: 'org-2', muted: true },
+      ] as unknown as never[]),
+    )
+
+    await notifySponsorMessage({ conversation, message, sfc })
+
+    expect(upsertMock).toHaveBeenCalledOnce()
+    const items = upsertMock.mock.calls[0][0] as { recipientId: string }[]
+    // Only the NON-muted organizer is hubbed.
+    expect(items.map((i) => i.recipientId)).toEqual(['org-1'])
+  })
 })
 
 describe('notifySponsorMessage — ORGANIZER-authored', () => {

--- a/src/lib/messaging/nudge.ts
+++ b/src/lib/messaging/nudge.ts
@@ -10,7 +10,7 @@ import { conversationLinkPath } from './links'
 // Single home for the last-author projection (R1): sharing the exact string with
 // the inbox `needs-reply` filter guarantees the nudge selection and the inbox can
 // never disagree on which thread's ball is in the organizers' court.
-import { LAST_AUTHOR_REF } from './sanity'
+import { LAST_AUTHOR_REF, HAS_ANY_MESSAGE } from './sanity'
 
 /**
  * Server-only stale-thread nudge for speaker↔organizer messaging (ticketing).
@@ -96,7 +96,10 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
     // Selection: open (or absent status) AND no activity since the cutoff AND
     // NOT globally archived (archivedAt >= lastMessageAt) AND not already nudged
     // for this trailing message (lastStaleNudgeAt < lastMessageAt) AND a last
-    // message exists whose author is NOT an organizer.
+    // message exists whose author is NOT an organizer. HAS_ANY_MESSAGE (not
+    // `defined(LAST_AUTHOR_REF)`) gates existence so a SPONSOR-authored last
+    // message — which has no author ref — still qualifies, keeping the nudge
+    // consistent with the inbox needs-reply tab/badge. (M3)
     const conversations =
       (await clientReadUncached.fetch<StaleConversation[]>(
         `*[_type == "conversation"
@@ -104,7 +107,7 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
           && lastMessageAt < $cutoff
           && (!defined(archivedAt) || archivedAt < lastMessageAt)
           && (!defined(lastStaleNudgeAt) || lastStaleNudgeAt < lastMessageAt)
-          && defined(${LAST_AUTHOR_REF})
+          && ${HAS_ANY_MESSAGE}
           && !(${LAST_AUTHOR_REF} in $organizerIds)
         ] | order(lastMessageAt asc) [0...${MAX_CONVERSATIONS_PER_RUN}] {
           "_id": _id,

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -116,14 +116,27 @@ const GLOBALLY_ARCHIVED = '(defined(archivedAt) && archivedAt >= lastMessageAt)'
 // drift between the inbox needs-reply filter and the nudge selection (R1).
 export const LAST_AUTHOR_REF =
   '*[_type == "message" && conversation._ref == ^._id] | order(createdAt desc, _id desc)[0].author._ref'
+// Whether the thread has ANY message at all. EXPORTED and shared with the nudge
+// job for the SAME reason as LAST_AUTHOR_REF (R1): both must agree on "a message
+// exists". This gate replaces the old `defined(LAST_AUTHOR_REF)` existence
+// check, which conflated "a message exists" with "its author has an author._ref"
+// — a SPONSOR-authored message has NO `author` ref (sponsors have no speaker
+// doc), so `defined(LAST_AUTHOR_REF)` was FALSE for a sponsor-last-message thread
+// and the needs-reply tab/count/nudge silently dropped it while the Active-view
+// row still showed a needs-reply badge (badge vs tab disagreed). (M3)
+export const HAS_ANY_MESSAGE =
+  'count(*[_type == "message" && conversation._ref == ^._id]) > 0'
 // Needs an organizer reply: not resolved AND at least one organizer exists AND a
-// message exists whose author is not an organizer. Uses $organizerIds — bound
-// only for the `needs-reply` view. The `count($organizerIds) > 0` guard is
-// LOAD-BEARING: with an empty organizer set `x in []` is false, so the negation
-// would match EVERY thread vacuously (a misconfigured conference would flood the
-// needs-reply view). No organizers means nobody can reply → needs-reply is empty
-// (mirrors the JS derivation below and the nudge job's routing skip). (R2)
-const NEEDS_REPLY = `${STATUS_NOT_RESOLVED} && count($organizerIds) > 0 && defined(${LAST_AUTHOR_REF}) && !(${LAST_AUTHOR_REF} in $organizerIds)`
+// message EXISTS whose author is not an organizer. A sponsor-authored last
+// message (null author ref) counts as non-organizer — `null in $organizerIds` is
+// false, so `!(... in $organizerIds)` is true — so it correctly needs a reply,
+// matching the JS derivation below. Uses $organizerIds — bound only for the
+// `needs-reply` view. The `count($organizerIds) > 0` guard is LOAD-BEARING: with
+// an empty organizer set `x in []` is false, so the negation would match EVERY
+// thread vacuously (a misconfigured conference would flood the needs-reply view).
+// No organizers means nobody can reply → needs-reply is empty (mirrors the JS
+// derivation below and the nudge job's routing skip). (R2, M3)
+const NEEDS_REPLY = `${STATUS_NOT_RESOLVED} && count($organizerIds) > 0 && ${HAS_ANY_MESSAGE} && !(${LAST_AUTHOR_REF} in $organizerIds)`
 
 /**
  * The non-organizer access scope: a speaker sees only conversations they
@@ -849,6 +862,12 @@ export async function listConversationsForSpeaker({
     // (misconfigured conference or a transient organizer-fetch failure)
     // `!organizerSet.has(...)` is vacuously true, which would flag every thread —
     // nobody can reply, so needs-reply must be FALSE. (R2)
+    //
+    // A SPONSOR-authored last message has a null `authorId` (no author ref);
+    // `organizerSet.has(null)` is false, so `!organizerSet.has(...)` is true and
+    // the thread needs a reply — deliberately CONSISTENT with the GROQ
+    // NEEDS_REPLY (HAS_ANY_MESSAGE + `!(LAST_AUTHOR_REF in $organizerIds)`) so the
+    // row badge, the needs-reply tab, its count, and the nudge never disagree. (M3)
     const needsReply =
       isOrganizer &&
       organizerSet.size > 0 &&

--- a/src/lib/speaker/merge.sanity.test.ts
+++ b/src/lib/speaker/merge.sanity.test.ts
@@ -9,29 +9,38 @@ const deleteMock = vi.fn()
 
 // Ordered record of every op staged on the transaction, so tests can assert
 // not just WHAT was staged but the ORDER (delete must come last).
-const txOrder: Array<'patch' | 'delete'> = []
+const txOrder: Array<'patch' | 'delete' | 'create'> = []
 
 // Each `.patch(id, fn)` invokes `fn` with a fake, chainable patch builder whose
-// `.set()`/`.ifRevisionId()` record their arguments, so tests can assert the
-// exact ops AND that each referencing-doc patch is revision-guarded.
+// `.set()`/`.unset()`/`.ifRevisionId()` record their arguments, so tests can
+// assert the exact ops AND that each referencing-doc patch is revision-guarded.
 const patchOps: Array<{
   id: string
   set: Record<string, unknown>
+  unset?: string[]
   rev?: string
 }> = []
 const patchMock = vi.fn(
   (
     id: string,
-    fn: (p: { set: (o: Record<string, unknown>) => unknown }) => unknown,
+    fn: (p: {
+      set: (o: Record<string, unknown>) => unknown
+      unset: (keys: string[]) => unknown
+    }) => unknown,
   ) => {
-    const op = { id, set: {} as Record<string, unknown>, rev: undefined } as {
+    const op = { id, set: {} as Record<string, unknown> } as {
       id: string
       set: Record<string, unknown>
+      unset?: string[]
       rev?: string
     }
     const builder = {
       set: (o: Record<string, unknown>) => {
         op.set = o
+        return builder
+      },
+      unset: (keys: string[]) => {
+        op.unset = keys
         return builder
       },
       ifRevisionId: (rev: string) => {
@@ -46,9 +55,15 @@ const patchMock = vi.fn(
   },
 )
 
+const createdDocs: Array<Record<string, unknown>> = []
 const deletedIds: string[] = []
 const transactionApi = {
   patch: patchMock,
+  create: (doc: Record<string, unknown>) => {
+    createdDocs.push(doc)
+    txOrder.push('create')
+    return transactionApi
+  },
   delete: (id: string) => {
     deletedIds.push(id)
     deleteMock(id)
@@ -133,6 +148,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   patchOps.length = 0
   deletedIds.length = 0
+  createdDocs.length = 0
   txOrder.length = 0
   fetchMock.mockImplementation(routeFetch)
 })
@@ -240,5 +256,106 @@ describe('mergeSpeakers (transaction wrapper)', () => {
     expect(committed).toBe(false)
     expect(err?.message).toMatch(/Loser speaker not found/)
     expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('mergeSpeakers — deterministic-doc reconciliation (M4)', () => {
+  const CONVPREF_LOSER = `convpref.conv-1.${LOSER}`
+  const CONVPREF_SURVIVOR = `convpref.conv-1.${SURVIVOR}`
+  const NOTIF_LOSER = `notification.message.conv-1.${LOSER}`
+  const NOTIF_SURVIVOR = `notification.message.conv-1.${SURVIVOR}`
+
+  // The loser's deterministic docs, repointed-in-place by the generic path would
+  // strand them under the loser key. One MERGES (survivor pref exists), one
+  // RECREATEs (no survivor notification yet).
+  const collisionDocs = [
+    {
+      _id: CONVPREF_LOSER,
+      _type: 'conversationPreference',
+      _rev: 'rev-cp-loser',
+      conversation: ref('conv-1'),
+      speaker: ref(LOSER),
+      muted: true,
+    },
+    {
+      _id: NOTIF_LOSER,
+      _type: 'notification',
+      _rev: 'rev-nt-loser',
+      conversation: ref('conv-1'),
+      recipient: ref(LOSER),
+      notificationType: 'message_received',
+      count: 2,
+    },
+  ]
+
+  // The survivor's canonical pref exists (NOT muted) → MERGE to muted. The
+  // survivor has NO canonical notification → the loser's is RECREATED.
+  const survivorCanonicalDocs = [
+    {
+      _id: CONVPREF_SURVIVOR,
+      _type: 'conversationPreference',
+      _rev: 'rev-cp-surv',
+      conversation: ref('conv-1'),
+      speaker: ref(SURVIVOR),
+      muted: false,
+    },
+  ]
+
+  beforeEach(() => {
+    fetchMock.mockImplementation(
+      (query: string, params: Record<string, unknown> = {}) => {
+        if (query.includes('_id == $id')) {
+          if (params.id === SURVIVOR) return Promise.resolve(survivorDoc)
+          if (params.id === LOSER) return Promise.resolve(loserDoc)
+          return Promise.resolve(null)
+        }
+        if (query.includes('references($loserId)')) {
+          return Promise.resolve(collisionDocs)
+        }
+        if (query.includes('_id in $ids')) {
+          return Promise.resolve(survivorCanonicalDocs)
+        }
+        return Promise.resolve(null)
+      },
+    )
+  })
+
+  it('MERGEs the loser pref onto the canonical id (more-restrictive mute wins) and deletes the loser doc', async () => {
+    const { committed, err } = await mergeSpeakers({
+      survivorId: SURVIVOR,
+      loserId: LOSER,
+      actor: { _id: 'admin-1' },
+    })
+    expect(err).toBeNull()
+    expect(committed).toBe(true)
+
+    // The canonical survivor pref is patched to muted; NO patch keyed by the
+    // loser-suffixed id survives.
+    const prefPatch = patchOps.find((p) => p.id === CONVPREF_SURVIVOR)!
+    expect(prefPatch.set.muted).toBe(true)
+    expect(patchOps.some((p) => p.id === CONVPREF_LOSER)).toBe(false)
+
+    // The loser-suffixed pref doc is deleted (never left repointed-but-stranded).
+    expect(deletedIds).toContain(CONVPREF_LOSER)
+  })
+
+  it('RECREATEs a loser notification under the canonical id with the recipient repointed, and deletes the loser doc', async () => {
+    await mergeSpeakers({
+      survivorId: SURVIVOR,
+      loserId: LOSER,
+      actor: { _id: 'admin-1' },
+    })
+
+    const recreated = createdDocs.find((d) => d._id === NOTIF_SURVIVOR)!
+    expect(recreated).toBeDefined()
+    // Recipient ref now points at the survivor; system meta is stripped.
+    expect(recreated.recipient).toEqual({ _type: 'reference', _ref: SURVIVOR })
+    expect(recreated._rev).toBeUndefined()
+    expect(recreated.count).toBe(2)
+
+    expect(deletedIds).toContain(NOTIF_LOSER)
+    // The loser SPEAKER doc is still deleted LAST.
+    expect(txOrder[txOrder.length - 1]).toBe('delete')
+    expect(deletedIds[deletedIds.length - 1]).toBe(LOSER)
   })
 })

--- a/src/lib/speaker/merge.test.ts
+++ b/src/lib/speaker/merge.test.ts
@@ -4,6 +4,7 @@ import {
   computeSurvivorFieldMerge,
   assertMergeable,
   buildMergePlan,
+  reconcileDeterministicDoc,
   MergeValidationError,
   type MergeSpeakerDoc,
 } from './merge'
@@ -313,5 +314,172 @@ describe('buildMergePlan', () => {
     )
     expect(plan.summary.referenceRepointsByType).toEqual(actualByType)
     expect(plan.summary.willDeleteLoserId).toBe(LOSER)
+  })
+})
+
+// --- reconcileDeterministicDoc (M4) ----------------------------------------
+
+describe('reconcileDeterministicDoc', () => {
+  it('MERGEs a convpref: more-restrictive mute wins, loser doc deleted', () => {
+    const rec = reconcileDeterministicDoc(
+      {
+        _id: `convpref.c1.${LOSER}`,
+        _type: 'conversationPreference',
+        muted: true,
+      },
+      {
+        _id: `convpref.c1.${SURVIVOR}`,
+        _type: 'conversationPreference',
+        muted: false,
+      },
+      LOSER,
+      SURVIVOR,
+    )
+    expect(rec.deleteId).toBe(`convpref.c1.${LOSER}`)
+    expect(rec.canonicalId).toBe(`convpref.c1.${SURVIVOR}`)
+    expect(rec.mergeSet).toEqual({ muted: true })
+    expect(rec.createDoc).toBeUndefined()
+  })
+
+  it('MERGEs a convpref with no mute change → empty patch', () => {
+    const rec = reconcileDeterministicDoc(
+      {
+        _id: `convpref.c1.${LOSER}`,
+        _type: 'conversationPreference',
+        muted: false,
+      },
+      {
+        _id: `convpref.c1.${SURVIVOR}`,
+        _type: 'conversationPreference',
+        muted: true,
+      },
+      LOSER,
+      SURVIVOR,
+    )
+    // Survivor already muted (more restrictive) → nothing to change.
+    expect(rec.mergeSet).toEqual({})
+  })
+
+  it('RECREATEs a convpref when the survivor has no canonical doc, repointing the speaker ref', () => {
+    const rec = reconcileDeterministicDoc(
+      {
+        _id: `convpref.c1.${LOSER}`,
+        _type: 'conversationPreference',
+        _rev: 'r1',
+        speaker: { _type: 'reference', _ref: LOSER },
+        muted: true,
+      },
+      undefined,
+      LOSER,
+      SURVIVOR,
+    )
+    expect(rec.createDoc).toEqual({
+      _id: `convpref.c1.${SURVIVOR}`,
+      _type: 'conversationPreference',
+      speaker: { _type: 'reference', _ref: SURVIVOR },
+      muted: true,
+    })
+    expect(rec.deleteId).toBe(`convpref.c1.${LOSER}`)
+  })
+
+  it('MERGEs a message notification: SUMS unread piles, keeps unread', () => {
+    const rec = reconcileDeterministicDoc(
+      {
+        _id: `notification.message.c1.${LOSER}`,
+        _type: 'notification',
+        count: 2,
+      },
+      {
+        _id: `notification.message.c1.${SURVIVOR}`,
+        _type: 'notification',
+        count: 3,
+      },
+      LOSER,
+      SURVIVOR,
+    )
+    // Both unread (no readAt) → 3 + 2 = 5, still unread.
+    expect(rec.mergeSet).toEqual({ count: 5 })
+    expect(rec.mergeUnset ?? []).toEqual([])
+  })
+
+  it('MERGEs a message notification: a READ survivor + unread loser becomes unread', () => {
+    const rec = reconcileDeterministicDoc(
+      {
+        _id: `notification.message.c1.${LOSER}`,
+        _type: 'notification',
+        count: 4,
+      },
+      {
+        _id: `notification.message.c1.${SURVIVOR}`,
+        _type: 'notification',
+        count: 1,
+        readAt: '2026-07-01T00:00:00Z',
+      },
+      LOSER,
+      SURVIVOR,
+    )
+    // Survivor was read (0 unread) + loser 4 unread → 4, and readAt is cleared.
+    expect(rec.mergeSet).toEqual({ count: 4 })
+    expect(rec.mergeUnset).toEqual(['readAt'])
+  })
+
+  it('MERGEs a message notification: both READ → no count/readAt change', () => {
+    const rec = reconcileDeterministicDoc(
+      {
+        _id: `notification.message.c1.${LOSER}`,
+        _type: 'notification',
+        count: 2,
+        readAt: '2026-07-01T00:00:00Z',
+      },
+      {
+        _id: `notification.message.c1.${SURVIVOR}`,
+        _type: 'notification',
+        count: 1,
+        readAt: '2026-07-02T00:00:00Z',
+      },
+      LOSER,
+      SURVIVOR,
+    )
+    expect(rec.mergeSet).toEqual({})
+    expect(rec.mergeUnset ?? []).toEqual([])
+  })
+})
+
+describe('buildMergePlan — deterministic reconciliation (M4)', () => {
+  const survivor = speaker({ _id: SURVIVOR })
+  const loser = speaker({ _id: LOSER })
+
+  it('pulls convpref/notification collision docs OUT of the generic repoint into reconciliations', () => {
+    const referencingDocs = [
+      { _id: 'talk-1', _type: 'talk', speakers: [ref(LOSER, 'k1')] },
+      {
+        _id: `convpref.c1.${LOSER}`,
+        _type: 'conversationPreference',
+        speaker: ref(LOSER),
+        muted: true,
+      },
+    ]
+    const survivorDeterministicDocs = [
+      {
+        _id: `convpref.c1.${SURVIVOR}`,
+        _type: 'conversationPreference',
+        speaker: ref(SURVIVOR),
+        muted: false,
+      },
+    ]
+    const plan = buildMergePlan(
+      survivor,
+      loser,
+      referencingDocs,
+      survivorDeterministicDocs,
+    )
+    // The convpref is NOT a generic documentPatch.
+    expect(plan.documentPatches.map((p) => p.id)).toEqual(['talk-1'])
+    // It IS a reconciliation (merge to muted).
+    expect(plan.deterministicReconciliations).toHaveLength(1)
+    expect(plan.deterministicReconciliations[0].mergeSet).toEqual({
+      muted: true,
+    })
+    expect(plan.summary.reconciledDeterministicDocCount).toBe(1)
   })
 })

--- a/src/lib/speaker/merge.ts
+++ b/src/lib/speaker/merge.ts
@@ -314,6 +314,156 @@ export function assertMergeable(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Deterministic-id doc reconciliation (QR-M4)
+//
+// Some messaging docs use a DETERMINISTIC id that ENCODES the speaker/recipient
+// id as the trailing segment: `<prefix>.<conversationId>.<speakerId>`:
+//   - conversationPreference → `convpref.<conv>.<speakerId>`
+//   - collapsed message notification → `notification.message.<conv>.<recipientId>`
+// A plain reference repoint (the generic path) rewrites the inner ref to the
+// survivor but LEAVES the doc keyed by the loser id. If the survivor already
+// holds the canonical-id sibling for the same conversation, BOTH docs then point
+// at the survivor and:
+//   - listConversations sums `coalesce(count,1)` across both notification links →
+//     DOUBLED unread;
+//   - getConversationPreference reads ONLY the canonical id → a mute recorded on
+//     the loser-suffixed pref is SILENTLY IGNORED.
+// So these docs must be RECONCILED onto the survivor's canonical id (merged when
+// it exists, recreated otherwise) and the loser-suffixed doc deleted — never left
+// repointed-but-loser-keyed.
+// ---------------------------------------------------------------------------
+
+const DETERMINISTIC_ID_PREFIXES = [
+  'convpref.',
+  'notification.message.',
+] as const
+
+/**
+ * Whether `id` is a deterministic messaging doc whose trailing segment is the
+ * LOSER id — i.e. a repoint would strand it under the loser key. (A notification
+ * whose recipient is a THIRD speaker but whose ACTOR is the loser ends with that
+ * third speaker's id, so it is NOT a collision and keeps the generic actor
+ * repoint.)
+ */
+function isDeterministicCollisionDoc(id: string, loserId: string): boolean {
+  return (
+    id.endsWith(`.${loserId}`) &&
+    DETERMINISTIC_ID_PREFIXES.some((prefix) => id.startsWith(prefix))
+  )
+}
+
+/** Swap the trailing loser-id segment of a deterministic id for the survivor's. */
+function canonicalDeterministicId(
+  loserDocId: string,
+  loserId: string,
+  survivorId: string,
+): string {
+  return loserDocId.slice(0, loserDocId.length - loserId.length) + survivorId
+}
+
+/** A sane ceiling so a merge can never mint an absurd unread badge count. */
+const MERGED_UNREAD_COUNT_CAP = 999
+
+function toPositiveCount(value: unknown): number {
+  return typeof value === 'number' && value > 0 ? value : 1
+}
+
+/** The later of two (optional) ISO timestamps — ISO strings sort lexically. */
+function laterIso(a: unknown, b: unknown): string | undefined {
+  const av = typeof a === 'string' ? a : undefined
+  const bv = typeof b === 'string' ? b : undefined
+  if (av && bv) return av >= bv ? av : bv
+  return av ?? bv
+}
+
+/** Strip Sanity system meta so a fetched doc can be re-created under a new id. */
+function stripSystemMeta(
+  doc: Record<string, unknown>,
+): Record<string, unknown> {
+  const clone = { ...doc }
+  delete clone._rev
+  delete clone._createdAt
+  delete clone._updatedAt
+  return clone
+}
+
+/**
+ * The reconciliation of ONE loser-suffixed deterministic doc onto the survivor's
+ * canonical id. The loser doc is ALWAYS deleted (`deleteId`); the canonical doc
+ * is either MERGED (`mergeSet`/`mergeUnset` patched onto an existing survivor
+ * doc) or RECREATED (`createDoc`).
+ */
+export interface DeterministicReconciliation {
+  /** The loser-suffixed doc id to delete. */
+  deleteId: string
+  /** The canonical (survivor-suffixed) id being written/merged. */
+  canonicalId: string
+  /** MERGE: fields to `.set()` on the existing canonical doc (may be empty). */
+  mergeSet?: Record<string, unknown>
+  /** MERGE: keys to `.unset()` on the canonical doc (e.g. clear `readAt`). */
+  mergeUnset?: string[]
+  /** RECREATE: the full doc to create under the canonical id (survivor refs). */
+  createDoc?: Record<string, unknown>
+}
+
+/**
+ * Reconcile one loser deterministic doc against the survivor's canonical doc.
+ * Pure: given the two docs it decides MERGE vs RECREATE deterministically.
+ *
+ * MERGE rules:
+ *  - conversationPreference: the more-restrictive MUTE wins (`||`); an archive on
+ *    either side is preserved (latest `archivedAt`); the survivor's email
+ *    override is kept.
+ *  - message notification: UNREAD if EITHER side is unread; the two unread piles
+ *    are SUMMED (clamped) so the survivor's badge reflects both, never doubles.
+ */
+export function reconcileDeterministicDoc(
+  loserDoc: Record<string, unknown>,
+  survivorDoc: Record<string, unknown> | undefined,
+  loserId: string,
+  survivorId: string,
+): DeterministicReconciliation {
+  const deleteId = String(loserDoc._id)
+  const canonicalId = canonicalDeterministicId(deleteId, loserId, survivorId)
+
+  // RECREATE: no canonical sibling — carry the loser doc over under the canonical
+  // id with every loser ref repointed to the survivor.
+  if (!survivorDoc) {
+    const { doc } = repointReferencesInDocument(loserDoc, loserId, survivorId)
+    const createDoc = { ...stripSystemMeta(doc), _id: canonicalId }
+    return { deleteId, canonicalId, createDoc }
+  }
+
+  // MERGE onto the existing canonical doc.
+  if (deleteId.startsWith('notification.message.')) {
+    const survivorUnread = !survivorDoc.readAt
+    const loserUnread = !loserDoc.readAt
+    const mergeSet: Record<string, unknown> = {}
+    const mergeUnset: string[] = []
+    if (survivorUnread || loserUnread) {
+      // Keep unread if EITHER was unread; sum the two unread piles (clamped).
+      const summed =
+        (survivorUnread ? toPositiveCount(survivorDoc.count) : 0) +
+        (loserUnread ? toPositiveCount(loserDoc.count) : 0)
+      mergeSet.count = Math.min(Math.max(summed, 1), MERGED_UNREAD_COUNT_CAP)
+      if (survivorDoc.readAt) mergeUnset.push('readAt')
+    }
+    // Both already read → leave the survivor doc's readAt/count untouched.
+    return { deleteId, canonicalId, mergeSet, mergeUnset }
+  }
+
+  // conversationPreference.
+  const mergeSet: Record<string, unknown> = {}
+  const mergedMuted = Boolean(survivorDoc.muted) || Boolean(loserDoc.muted)
+  if (mergedMuted !== Boolean(survivorDoc.muted)) mergeSet.muted = mergedMuted
+  const mergedArchivedAt = laterIso(survivorDoc.archivedAt, loserDoc.archivedAt)
+  if (mergedArchivedAt && mergedArchivedAt !== survivorDoc.archivedAt) {
+    mergeSet.archivedAt = mergedArchivedAt
+  }
+  return { deleteId, canonicalId, mergeSet }
+}
+
 /** Per-referencing-document patch produced by the plan. */
 export interface MergeDocumentPatch {
   id: string
@@ -333,6 +483,11 @@ export interface MergePreview {
   referencingDocCount: number
   /** Per document `_type`, how many individual references were repointed. */
   referenceRepointsByType: Record<string, number>
+  /**
+   * Deterministic-id docs (convpref / message notification) reconciled onto the
+   * survivor's canonical id rather than repointed in place (QR-M4).
+   */
+  reconciledDeterministicDocCount: number
   fieldChanges: {
     providers: IdentityFieldChange
     knownEmails: IdentityFieldChange
@@ -348,6 +503,8 @@ export interface MergePlan {
   loserId: string
   survivorSet: Record<string, unknown>
   documentPatches: MergeDocumentPatch[]
+  /** Deterministic-id docs reconciled onto the survivor's canonical id (QR-M4). */
+  deterministicReconciliations: DeterministicReconciliation[]
   summary: MergePreview
 }
 
@@ -360,6 +517,14 @@ export function buildMergePlan(
   survivor: MergeSpeakerDoc,
   loser: MergeSpeakerDoc,
   referencingDocs: Array<Record<string, unknown>>,
+  /**
+   * The survivor's CANONICAL deterministic docs (convpref / message notification)
+   * for the conversations the loser also has one in — fetched by the wrapper from
+   * the canonical ids of the loser's collision docs. Absent ones simply take the
+   * RECREATE branch. Defaults to `[]` so existing 3-arg callers/tests are
+   * unaffected. (QR-M4)
+   */
+  survivorDeterministicDocs: Array<Record<string, unknown>> = [],
 ): MergePlan {
   assertMergeable(survivor, loser)
 
@@ -367,10 +532,18 @@ export function buildMergePlan(
 
   const documentPatches: MergeDocumentPatch[] = []
   const referenceRepointsByType: Record<string, number> = {}
+  // Loser-suffixed deterministic docs are pulled OUT of the generic repoint (it
+  // would strand them under the loser key) and reconciled onto the canonical id.
+  const deterministicLoserDocs: Array<Record<string, unknown>> = []
 
   for (const doc of referencingDocs) {
     // The loser is deleted, and the survivor's own fields are handled separately.
     if (doc._id === loser._id || doc._id === survivor._id) continue
+
+    if (isDeterministicCollisionDoc(String(doc._id), loser._id)) {
+      deterministicLoserDocs.push(doc)
+      continue
+    }
 
     const {
       changedKeys,
@@ -388,11 +561,30 @@ export function buildMergePlan(
       (referenceRepointsByType[type] ?? 0) + repointed
   }
 
+  const survivorDeterministicById = new Map(
+    survivorDeterministicDocs.map((doc) => [String(doc._id), doc]),
+  )
+  const deterministicReconciliations: DeterministicReconciliation[] =
+    deterministicLoserDocs.map((loserDoc) => {
+      const canonicalId = canonicalDeterministicId(
+        String(loserDoc._id),
+        loser._id,
+        survivor._id,
+      )
+      return reconcileDeterministicDoc(
+        loserDoc,
+        survivorDeterministicById.get(canonicalId),
+        loser._id,
+        survivor._id,
+      )
+    })
+
   const summary: MergePreview = {
     survivorId: survivor._id,
     loserId: loser._id,
     referencingDocCount: documentPatches.length,
     referenceRepointsByType,
+    reconciledDeterministicDocCount: deterministicReconciliations.length,
     fieldChanges: {
       providers: fieldMerge.identity.providers,
       knownEmails: fieldMerge.identity.knownEmails,
@@ -407,6 +599,7 @@ export function buildMergePlan(
     loserId: loser._id,
     survivorSet: fieldMerge.set,
     documentPatches,
+    deterministicReconciliations,
     summary,
   }
 }
@@ -466,10 +659,29 @@ export async function mergeSpeakers(
         { cache: 'no-store' },
       )) ?? []
 
+    // QR-M4: for every loser-suffixed deterministic doc (convpref / message
+    // notification), also fetch the survivor's CANONICAL sibling so the plan can
+    // MERGE (mute/unread) rather than strand a repointed loser-keyed doc. One
+    // extra bounded read, only when such docs exist.
+    const survivorDeterministicIds = referencingDocs
+      .filter((doc) => isDeterministicCollisionDoc(String(doc._id), loserId))
+      .map((doc) =>
+        canonicalDeterministicId(String(doc._id), loserId, survivorId),
+      )
+    const survivorDeterministicDocs =
+      survivorDeterministicIds.length > 0
+        ? ((await clientRead.fetch<Array<Record<string, unknown>>>(
+            groq`*[_id in $ids]`,
+            { ids: survivorDeterministicIds },
+            { cache: 'no-store' },
+          )) ?? [])
+        : []
+
     const plan = buildMergePlan(
       survivor as MergeSpeakerDoc,
       loser as MergeSpeakerDoc,
       referencingDocs,
+      survivorDeterministicDocs,
     )
 
     if (dryRun) {
@@ -495,6 +707,33 @@ export async function mergeSpeakers(
     if (Object.keys(plan.survivorSet).length > 0) {
       transaction.patch(survivorId, (p) => p.set(plan.survivorSet))
     }
+    // QR-M4: reconcile deterministic docs onto the survivor's canonical id.
+    // RECREATE with `create` (not createOrReplace): the survivor had NO canonical
+    // sibling at read time, so a concurrent creation must 409 the whole tx (admin
+    // retries → MERGE branch) rather than clobber fresh survivor state. Each
+    // loser-suffixed doc is deleted so none survives repointed-but-loser-keyed.
+    for (const rec of plan.deterministicReconciliations) {
+      if (rec.createDoc) {
+        transaction.create(
+          rec.createDoc as { _type: string } & Record<string, unknown>,
+        )
+      } else if (
+        (rec.mergeSet && Object.keys(rec.mergeSet).length > 0) ||
+        (rec.mergeUnset && rec.mergeUnset.length > 0)
+      ) {
+        transaction.patch(rec.canonicalId, (p) => {
+          let applied = p
+          if (rec.mergeSet && Object.keys(rec.mergeSet).length > 0) {
+            applied = applied.set(rec.mergeSet)
+          }
+          if (rec.mergeUnset && rec.mergeUnset.length > 0) {
+            applied = applied.unset(rec.mergeUnset)
+          }
+          return applied
+        })
+      }
+      transaction.delete(rec.deleteId)
+    }
     // Delete the loser LAST so all inbound references are already repointed.
     transaction.delete(loserId)
     await transaction.commit()
@@ -507,6 +746,8 @@ export async function mergeSpeakers(
       loserId,
       referencingDocCount: plan.summary.referencingDocCount,
       referenceRepointsByType: plan.summary.referenceRepointsByType,
+      reconciledDeterministicDocCount:
+        plan.summary.reconciledDeterministicDocCount,
       filledFromLoser: plan.summary.fieldChanges.filledFromLoser,
     })
 

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -111,6 +111,16 @@ function claimSendSlot(speakerId: string): boolean {
  * kept rejecting picker-offered organizers with "Speaker not found".)
  * Cross-conference targeting stays blocked: a talk-less non-organizer from
  * another edition has no standing here.
+ *
+ * ANY-CONFERENCE ORGANIZER MATCH IS INTENTIONAL (QR-M6, verified not a leak):
+ * the organizer clause matches an organizer of ANY edition on purpose because
+ * `isOrganizer` is GLOBAL in this app — it is derived as `_id in
+ * *[_type == "conference"].organizers[]._ref` (see `lib/speaker/sanity.ts`), and
+ * `canAccessConversation` short-circuits `if (speaker.isOrganizer) return true`.
+ * So a global organizer can ALREADY read/write every thread; naming them the
+ * subjectSpeaker of a new general thread grants no access they lack. Scoping this
+ * clause to `$conferenceId` would instead REJECT a legitimate organizer the admin
+ * picker offers. Not a cross-tenant leak; do not narrow it.
  */
 async function speakerHasStandingInConference(
   speakerId: string,

--- a/src/server/routers/sponsorMessages.test.ts
+++ b/src/server/routers/sponsorMessages.test.ts
@@ -137,6 +137,45 @@ describe('sponsorMessages.send — token + validation', () => {
   })
 })
 
+describe('sponsorMessages.send — reopen on reply (M2)', () => {
+  it('REOPENS a resolved thread (sponsor is a non-organizer author)', async () => {
+    getConversationMock.mockResolvedValue({
+      _id: 'conversation.sponsor.sfc-1',
+      status: 'resolved',
+    })
+    await caller.send({
+      token: 'reopen-1',
+      body: 'Following up',
+      authorName: 'Dana Diaz',
+    })
+    expect(addMessageMock).toHaveBeenCalledOnce()
+    expect(addMessageMock.mock.calls[0][0]).toMatchObject({ reopen: true })
+  })
+
+  it('does NOT reopen an already-open thread', async () => {
+    getConversationMock.mockResolvedValue({
+      _id: 'conversation.sponsor.sfc-1',
+      status: 'open',
+    })
+    await caller.send({
+      token: 'reopen-2',
+      body: 'Another message',
+      authorName: 'Dana Diaz',
+    })
+    expect(addMessageMock.mock.calls[0][0]).toMatchObject({ reopen: false })
+  })
+
+  it('does NOT reopen a brand-new thread (no prior conversation)', async () => {
+    // getConversationMock defaults to null (thread just created) → reopen false.
+    await caller.send({
+      token: 'reopen-3',
+      body: 'First contact',
+      authorName: 'Dana Diaz',
+    })
+    expect(addMessageMock.mock.calls[0][0]).toMatchObject({ reopen: false })
+  })
+})
+
 describe('sponsorMessages.send — rate limit (5/min per token)', () => {
   it('allows a burst of 5 then rejects the 6th', async () => {
     const token = 'rate-limit-token'

--- a/src/server/routers/sponsorMessages.ts
+++ b/src/server/routers/sponsorMessages.ts
@@ -144,6 +144,16 @@ export const sponsorMessagesRouter = router({
         sponsorName: ctx.sponsorName,
       })
 
+      // Read the thread ONCE (it exists now — ensure is createIfNotExists): its
+      // PRE-reply status decides reopen, and the same object seeds the fan-out.
+      const conversation = await getConversationById(conversationId)
+
+      // REOPEN-ON-REPLY (S3): a sponsor is a NON-organizer author, so a reply to
+      // a RESOLVED thread must reopen it — atomically with the message write, so
+      // the follow-up re-enters the organizer active/needs-reply views instead of
+      // silently staying resolved (mirrors message.send's non-organizer reopen).
+      const reopen = conversation?.status === 'resolved'
+
       const message = await addMessage({
         conversationId,
         sponsorAuthor: {
@@ -151,11 +161,11 @@ export const sponsorMessagesRouter = router({
           authorName: match.name,
         },
         body: input.body,
+        reopen,
       })
 
       // Detach the (never-fail) fan-out from the response path (mirrors
       // message.send): the message is already committed and returned below.
-      const conversation = await getConversationById(conversationId)
       if (conversation) {
         const fanoutCtx = await getSponsorFanoutContext(ctx.sfcId)
         if (fanoutCtx) {


### PR DESCRIPTION
Quality-review fix batch M (messaging / sponsor). Each finding was verified against the code before fixing; cite ids below.

## M1 — sponsor-authored mute violation (P1) — FIXED
`notifySponsorMessage` SPONSOR-authored branch mapped every routed organizer into `upsertMessageNotifications` with NO mute filter, while the organizer-authored branch (and the module docstring's mute contract) filter mute. Now fetches `getConversationPreferencesFor(conversation._id, organizerIds)` and drops muted recipients before the hub/push upsert, mirroring the organizer-authored branch.
Test: sponsor-authored message + a muted organizer → that organizer excluded from the hub items.

## M2 — no reopen on portal reply (P2) — FIXED
`sponsorMessages.send` called `addMessage` without `reopen`, so a sponsor replying to a RESOLVED thread left it resolved (dropped from active/needs-reply). A sponsor is a non-organizer author, so — mirroring `message.send`'s `reopen = !isOrganizer && status === 'resolved'` — it now reads the thread's pre-reply status once and passes `reopen: true` when the existing thread is resolved (also reused as the fan-out conversation, removing a redundant read).
Tests: reopens a resolved thread; does NOT reopen an open thread; does NOT reopen a brand-new thread.

## M3 — needs-reply blind to sponsor authors (P2) — FIXED
Sponsor messages have no `author._ref`, so the GROQ `NEEDS_REPLY` (and the stale-nudge) gated existence on `defined(LAST_AUTHOR_REF)` — FALSE for a sponsor-last-message thread — while the JS per-row derivation evaluated TRUE (null authorId not in organizerSet). Row badge vs tab/count/nudge disagreed. Introduced a shared exported `HAS_ANY_MESSAGE` existence gate and switched both the inbox `NEEDS_REPLY` predicate and the nudge selection to `HAS_ANY_MESSAGE && !(LAST_AUTHOR_REF in $organizerIds)`, so a sponsor-authored last message (null author) counts as needs-reply everywhere. The JS derivation already agreed; added a clarifying comment. viewCounts reuse `rawViewPredicate`, so the tab count follows automatically.
Tests: predicate uses `HAS_ANY_MESSAGE` (not `defined(...author._ref)`); JS row flags a sponsor-last-message thread as needsReply and an organizer-last-message thread as not; nudge query reuses both shared projections.

## M4 — speaker-merge duplicates deterministic-id docs (P2) — FIXED
The merge repointed loser→survivor refs generically but left `convpref.<conv>.<loserId>` and `notification.message.<conv>.<loserId>` docs keyed by the loser id while their inner ref now pointed at the survivor. If the survivor held the canonical-id sibling, both resolved to the survivor → doubled unread (listConversations sums `coalesce(count,1)` across both notification links) and a mute on the loser pref silently ignored (getConversationPreference reads only the canonical id). Now these deterministic docs are pulled OUT of the generic repoint and reconciled onto the survivor's canonical id inside the same transaction: MERGE when the canonical doc exists (more-restrictive mute wins; unread piles summed and kept unread if either was unread; archive preserved), else RECREATE under the canonical id with refs repointed — and the loser-suffixed doc is always deleted. The wrapper fetches the survivor's canonical siblings; `buildMergePlan` gained a defaulted 4th arg so existing callers/tests are unaffected. Never-fail envelope preserved.
Tests: pure `reconcileDeterministicDoc` (mute-wins, unread-sum, read→unread transition, both-read no-op, recreate repoints ref + strips meta); `buildMergePlan` pulls collision docs into reconciliations; wrapper MERGEs a pref to muted + deletes the loser doc, RECREATEs a notification under the canonical id with recipient repointed, loser speaker deleted LAST.

## M5 — sponsor reply silent-drop on null token (P3) — FIXED
The organizer-authored sponsor email is guarded by `contactPersons.length > 0 && registrationToken`; with contacts but a null token, no email and no portal link were produced — a silent no-op. Added an observability branch: a `console.warn` plus a `sponsorActivity` `note` recording the drop. Does NOT block the thread message (the hub still notifies the other organizers).

## M6 — standing any-conference (P3) — REFUTED (no behavior change)
Verified: `speakerHasStandingInConference`'s organizer clause matches organizers of ANY edition, but `isOrganizer` is GLOBAL in this app — derived as `_id in *[_type == "conference"].organizers[]._ref` (`lib/speaker/sanity.ts`) — and `canAccessConversation` short-circuits `if (speaker.isOrganizer) return true`. So a global organizer already reads/writes every thread; naming them a subjectSpeaker grants nothing new. Not a cross-tenant leak. Scoping the clause to `$conferenceId` would instead reject legitimate picker-offered organizers. Left behavior unchanged and added a code comment documenting that the any-conference match is intentional.

## Checks
tsc, eslint, prettier, knip all clean. Full `pnpm vitest run`: 274 files, 3759 passed / 5 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses six quality-review findings (M1–M6) across the sponsor-messaging and speaker-merge subsystems, fixing mute enforcement, thread-reopen, needs-reply consistency, and deterministic-doc deduplication during speaker merges.

- **M1**: `notifySponsorMessage` sponsor-authored branch now calls `getConversationPreferencesFor` before building the hub fan-out, mirroring the organizer-authored branch and honoring the module's mute contract.
- **M2**: `sponsorMessages.send` reads the conversation pre-reply to pass `reopen: true` when the thread is resolved, matching `message.send`'s non-organizer reopen logic and removing a redundant post-reply read.
- **M3**: Introduces the exported `HAS_ANY_MESSAGE` GROQ constant (shared with the nudge job) and switches `NEEDS_REPLY` from `defined(LAST_AUTHOR_REF)` to `HAS_ANY_MESSAGE`, so sponsor-last-message threads (null author ref) correctly appear in the needs-reply tab, count, and nudge.
- **M4**: Adds `reconcileDeterministicDoc` and wires it into `buildMergePlan`/`mergeSpeakers` so `convpref.*` and `notification.message.*` docs are reconciled onto the survivor's canonical id rather than left stranded under the loser key after a generic repoint.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all fixes address pre-existing silent bugs with verified test coverage and the two observations are unlikely edge cases that do not affect the core happy paths.

The changes are tightly scoped, well-tested (274 files, 3759 passing), and each fix mirrors an already-established pattern. The two observations are both low-probability: the MERGE revision-guard gap requires a concurrent preference change to land inside the millisecond window of a rare admin merge operation, and the count() vs. existence-check difference is negligible at conference scale.

src/lib/speaker/merge.ts (reconciliation MERGE patches) and src/lib/messaging/sanity.ts (HAS_ANY_MESSAGE correlated subquery) deserve a second look if merge throughput or nudge query latency becomes a concern in production.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/messaging/notify.ts | M1: adds mute filter to sponsor-authored hub fan-out using existing `getConversationPreferencesFor`; M5: adds observability branch for missing registration token. Both changes mirror established patterns in the organizer-authored branch. |
| src/lib/messaging/sanity.ts | M3: introduces `HAS_ANY_MESSAGE` exported constant and switches `NEEDS_REPLY` predicate from `defined(LAST_AUTHOR_REF)` to `HAS_ANY_MESSAGE`. Fixes badge/tab disagreement for sponsor-last-message threads. Minor: `count()` correlated subquery is slightly more expensive than the previous single-element existence check in the nudge path. |
| src/lib/messaging/nudge.ts | M3: switches existence gate from `defined(LAST_AUTHOR_REF)` to shared `HAS_ANY_MESSAGE`, keeping nudge consistent with the inbox needs-reply tab for sponsor-last-message threads. |
| src/lib/speaker/merge.ts | M4: adds `reconcileDeterministicDoc` and wires it into `buildMergePlan`/`mergeSpeakers` to handle `convpref.*` and `notification.message.*` docs. Logic is sound and well-tested. MERGE patches on survivor's canonical docs lack `ifRevisionId` revision guards, unlike generic doc patches, leaving a small window where a concurrent preference/read-state change can be silently overwritten. |
| src/server/routers/sponsorMessages.ts | M2: reads the conversation before `addMessage` to capture pre-reply status and set `reopen: true` for resolved threads, removing the redundant post-reply read. Pattern mirrors `message.send`; tests cover open, resolved, and brand-new thread cases. |
| src/server/routers/message.ts | M6: adds a code comment documenting that the any-conference organizer match in `speakerHasStandingInConference` is intentional, not a cross-tenant leak. No behavioral change. |
| src/lib/speaker/merge.test.ts | Adds thorough unit tests for `reconcileDeterministicDoc` (mute-wins, unread-sum, read-to-unread transition, both-read no-op, RECREATE) and `buildMergePlan` deterministic reconciliation routing. |
| src/lib/speaker/merge.sanity.test.ts | Extends the integration-level mock harness with `create`/`unset` support and adds end-to-end tests for MERGE and RECREATE paths. |
| src/lib/messaging/needsReply.test.ts | New test file for M3: pins both the GROQ predicate and the JS row derivation for sponsor-last-message threads. |
| src/server/routers/sponsorMessages.test.ts | Adds reopen-on-reply tests for M2: resolved thread reopens, open thread does not, brand-new thread does not. |
| src/lib/messaging/notifySponsor.test.ts | Adds M1 test: sponsor-authored message with a muted organizer results in only the non-muted organizer in the hub fan-out. |
| __tests__/lib/messaging/nudge.test.ts | Updates nudge projection test to assert `HAS_ANY_MESSAGE` appears in the query and `LAST_AUTHOR_REF` appears exactly once. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph M1 ["M1 - Sponsor-authored mute"]
        A[sponsorAuthor branch] --> B[getConversationPreferencesFor]
        B --> C[filter muted organizers]
        C --> D[upsertMessageNotifications active only]
    end
    subgraph M2 ["M2 - Reopen on sponsor reply"]
        E[sponsorMessages.send] --> F[getConversationById pre-reply]
        F --> G{status == resolved?}
        G -- yes --> H[addMessage reopen=true]
        G -- no --> I[addMessage reopen=false]
    end
    subgraph M3 ["M3 - needs-reply GROQ fix"]
        K[HAS_ANY_MESSAGE] --> L[NEEDS_REPLY predicate]
        K --> M[nudge selection]
        L --> N[inbox tab + count badge]
    end
    subgraph M4 ["M4 - deterministic-doc reconciliation"]
        Q[referencingDocs] --> R{isDeterministicCollisionDoc?}
        R -- yes --> S[deterministicLoserDocs]
        R -- no --> T[generic patches with ifRevisionId]
        S --> U{survivorDoc exists?}
        U -- yes --> V[MERGE onto canonical id]
        U -- no --> W[RECREATE under canonical id]
        V & W --> X[DELETE loser-keyed doc]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph M1 ["M1 - Sponsor-authored mute"]
        A[sponsorAuthor branch] --> B[getConversationPreferencesFor]
        B --> C[filter muted organizers]
        C --> D[upsertMessageNotifications active only]
    end
    subgraph M2 ["M2 - Reopen on sponsor reply"]
        E[sponsorMessages.send] --> F[getConversationById pre-reply]
        F --> G{status == resolved?}
        G -- yes --> H[addMessage reopen=true]
        G -- no --> I[addMessage reopen=false]
    end
    subgraph M3 ["M3 - needs-reply GROQ fix"]
        K[HAS_ANY_MESSAGE] --> L[NEEDS_REPLY predicate]
        K --> M[nudge selection]
        L --> N[inbox tab + count badge]
    end
    subgraph M4 ["M4 - deterministic-doc reconciliation"]
        Q[referencingDocs] --> R{isDeterministicCollisionDoc?}
        R -- yes --> S[deterministicLoserDocs]
        R -- no --> T[generic patches with ifRevisionId]
        S --> U{survivorDoc exists?}
        U -- yes --> V[MERGE onto canonical id]
        U -- no --> W[RECREATE under canonical id]
        V & W --> X[DELETE loser-keyed doc]
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/speaker/merge.ts`, line 994-1013 ([link](https://github.com/cloudnativebergen/website/blob/a86fe6254282917f011bc708fe3411f5953cab45/src/lib/speaker/merge.ts#L994-L1013)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **MERGE patches lack revision guards unlike generic repoints**

   Generic document repoints are wrapped with `ifRevisionId(rev)` so a concurrent edit to that document causes the whole transaction to 409 instead of clobbering the concurrent change. The new MERGE patches on the survivor's canonical convpref/notification docs skip this guard. If a user changes their mute preference or marks a notification as read between the wrapper's fetch and the transaction commit, the merge patch silently overwrites that change — e.g. the user un-mutes the thread between read and commit, but the merge lands `muted: true` on top of it because `mergeSet` was computed from the stale read.


2. `src/lib/messaging/sanity.ts`, line 301-302 ([link](https://github.com/cloudnativebergen/website/blob/a86fe6254282917f011bc708fe3411f5953cab45/src/lib/messaging/sanity.ts#L301-L302)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`count()` correlated subquery is more expensive than the previous existence check**

   The old `defined(LAST_AUTHOR_REF)` fetched a single element (`[0]`) and checked its existence — early-exit semantics. `HAS_ANY_MESSAGE` uses `count(*)`, which enumerates every message for each filtered conversation before returning a boolean. In the nudge query this predicate runs across every open, non-archived conversation in the dataset. At low message volumes the difference is negligible, but `count()` without a limit will scan all messages per conversation rather than stopping at the first hit. Consider `count(*[... ][0..0]) > 0` or checking `defined(*[...][0])` if nudge query latency becomes a concern.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(messaging): quality-review fixes — s..."](https://github.com/cloudnativebergen/website/commit/a86fe6254282917f011bc708fe3411f5953cab45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45707261)</sub>

<!-- /greptile_comment -->