### PR TITLE
fix(pwa): reliable iOS notification cold/warm deep-link + mark-read via Cache handoff

### DIFF
--- a/__tests__/lib/pwa/sw-source.test.ts
+++ b/__tests__/lib/pwa/sw-source.test.ts
@@ -87,10 +87,18 @@ describe('public/sw.js source invariants', () => {
     // iOS ignores openWindow/navigate, so the click intent is handed off through
     // Cache Storage under a fixed key for the freshly-launched client to read.
     // The write must be feature-detected, awaited, and happen before openWindow.
-    expect(source).toContain("self.caches.open('cndn-pending-nav')")
+    expect(source).toContain("const PENDING_NAV_CACHE = 'cndn-pending-nav'")
+    expect(source).toContain('self.caches.open(PENDING_NAV_CACHE)')
     expect(source).toContain("new Request('/__cndn_pending_notification')")
+    // The handoff cache MUST survive the activate cleanup across worker versions,
+    // so it is listed in EXPECTED_CACHES.
+    expect(source).toContain(
+      'const EXPECTED_CACHES = [PRECACHE, RUNTIME, PENDING_NAV_CACHE]',
+    )
     // The cache write is initiated before the window is opened/focused.
-    const cacheWriteIndex = source.indexOf("caches.open('cndn-pending-nav')")
+    const cacheWriteIndex = source.indexOf(
+      'self.caches.open(PENDING_NAV_CACHE)',
+    )
     const openWindowIndex = source.indexOf('clients.openWindow(openUrl)')
     expect(cacheWriteIndex).toBeGreaterThan(-1)
     expect(openWindowIndex).toBeGreaterThan(-1)

--- a/__tests__/lib/pwa/sw-source.test.ts
+++ b/__tests__/lib/pwa/sw-source.test.ts
@@ -82,4 +82,18 @@ describe('public/sw.js source invariants', () => {
     expect(source).toContain('clients.matchAll')
     expect(source).toContain('clients.openWindow')
   })
+
+  it('stashes the click intent in the pending-nav cache for the iOS cold-open handoff', () => {
+    // iOS ignores openWindow/navigate, so the click intent is handed off through
+    // Cache Storage under a fixed key for the freshly-launched client to read.
+    // The write must be feature-detected, awaited, and happen before openWindow.
+    expect(source).toContain("self.caches.open('cndn-pending-nav')")
+    expect(source).toContain("new Request('/__cndn_pending_notification')")
+    // The cache write is initiated before the window is opened/focused.
+    const cacheWriteIndex = source.indexOf("caches.open('cndn-pending-nav')")
+    const openWindowIndex = source.indexOf('clients.openWindow(openUrl)')
+    expect(cacheWriteIndex).toBeGreaterThan(-1)
+    expect(openWindowIndex).toBeGreaterThan(-1)
+    expect(cacheWriteIndex).toBeLessThan(openWindowIndex)
+  })
 })

--- a/public/sw.js
+++ b/public/sw.js
@@ -322,6 +322,30 @@ self.addEventListener('notificationclick', (event) => {
         openUrl = targetUrl
       }
 
+      // iOS PWA handoff: iOS launches the installed app at its start_url and
+      // IGNORES the SW's openWindow()/WindowClient.navigate() calls, so neither
+      // the deep-link navigation nor the `markread` param below ever reaches the
+      // window on iOS (cold OR warm). To survive that, stash the click intent in
+      // the Cache API under a fixed synthetic key BEFORE opening any window; the
+      // freshly-launched client (NotificationClickSync) reads it on boot, then
+      // navigates + marks read itself. Awaited so the write is durable before we
+      // hand off to the (Android-honoured) openWindow. Feature-detected and fully
+      // guarded so it can never throw on platforms without Cache Storage.
+      if (self.caches) {
+        try {
+          const cache = await self.caches.open('cndn-pending-nav')
+          await cache.put(
+            new Request('/__cndn_pending_notification'),
+            new Response(JSON.stringify({ link: target, ts: Date.now() }), {
+              headers: { 'content-type': 'application/json' },
+            }),
+          )
+        } catch (e) {
+          // Cache write failed (private mode / quota); Android still works via
+          // the openWindow markread param below.
+        }
+      }
+
       // Focus an existing tab already on the target URL if there is one (it was
       // already cleared by the postMessage; no need to carry the param).
       for (const client of allClients) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -34,6 +34,13 @@
 const CACHE_VERSION = 'cndn-dev'
 const PRECACHE = `${CACHE_VERSION}-precache`
 const RUNTIME = `${CACHE_VERSION}-runtime`
+// UNVERSIONED cache holding the pending notification-click intent for the iOS
+// cold-open handoff (see notificationclick). It must PERSIST across worker
+// versions — the active worker writes it at click time and a freshly launched
+// client reads it after a deploy may have activated a new worker — so it is
+// never version-stamped and is listed in EXPECTED_CACHES below so the activate
+// cleanup does not delete it.
+const PENDING_NAV_CACHE = 'cndn-pending-nav'
 
 // The offline shell: the fallback page plus committed static PWA icons. We do
 // NOT precache `/` or any HTML document other than `/offline`.
@@ -51,7 +58,7 @@ const PRECACHE_URLS = [
 
 // The set of cache names this worker version is allowed to keep. Any cache not
 // in this list is deleted on activate (cleans up caches from older versions).
-const EXPECTED_CACHES = [PRECACHE, RUNTIME]
+const EXPECTED_CACHES = [PRECACHE, RUNTIME, PENDING_NAV_CACHE]
 
 // --- Request classification (mirror of request-classification.ts) ----------
 
@@ -333,7 +340,7 @@ self.addEventListener('notificationclick', (event) => {
       // guarded so it can never throw on platforms without Cache Storage.
       if (self.caches) {
         try {
-          const cache = await self.caches.open('cndn-pending-nav')
+          const cache = await self.caches.open(PENDING_NAV_CACHE)
           await cache.put(
             new Request('/__cndn_pending_notification'),
             new Response(JSON.stringify({ link: target, ts: Date.now() }), {

--- a/src/components/pwa/NotificationClickSync.test.tsx
+++ b/src/components/pwa/NotificationClickSync.test.tsx
@@ -6,10 +6,14 @@ import { render, cleanup, waitFor } from '@testing-library/react'
 import type { Session } from 'next-auth'
 
 let mockSession: Session | null = null
+// Overridable so a test can simulate the iOS cold-open race where the session
+// is still `loading` (data null) on first render before the cookie-backed
+// session resolves.
+let mockStatus: 'authenticated' | 'loading' | 'unauthenticated' | null = null
 vi.mock('next-auth/react', () => ({
   useSession: () => ({
     data: mockSession,
-    status: mockSession ? 'authenticated' : 'unauthenticated',
+    status: mockStatus ?? (mockSession ? 'authenticated' : 'unauthenticated'),
   }),
 }))
 
@@ -97,6 +101,7 @@ function signedIn(): Session {
 beforeEach(() => {
   vi.clearAllMocks()
   mockSession = signedIn()
+  mockStatus = null
   mockPathname = '/'
   pendingStore = new Map<string, string>()
   installServiceWorker()
@@ -246,11 +251,29 @@ describe('NotificationClickSync', () => {
 
   it('clears a pending entry when signed out but fires no mutation', async () => {
     mockSession = null
+    mockStatus = 'unauthenticated'
     mockPathname = '/'
     seedPendingNav('/cfp/proposal/9', Date.now())
     render(<NotificationClickSync />)
     await waitFor(() => expect(pendingStore.has(PENDING_NAV_KEY)).toBe(false))
     expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  it('still marks read on cold open while the session is loading (iOS race)', async () => {
+    // The deep-link page seeded `undefined` (auth() read falsy under
+    // cacheComponents), so useSession is `loading`/null on first render even
+    // though the request carries a valid auth cookie. The mark-read must still
+    // fire — the mutation authenticates via the cookie server-side.
+    mockSession = null
+    mockStatus = 'loading'
+    mockPathname = '/'
+    seedPendingNav('/cfp/proposal/9', Date.now())
+    render(<NotificationClickSync />)
+    await waitFor(() =>
+      expect(routerPush).toHaveBeenCalledWith('/cfp/proposal/9'),
+    )
+    expect(markReadMutate).toHaveBeenCalledWith({ links: ['/cfp/proposal/9'] })
+    await waitFor(() => expect(pendingStore.has(PENDING_NAV_KEY)).toBe(false))
   })
 
   it('does not navigate for a non-app-relative pending link, but deletes it', async () => {

--- a/src/components/pwa/NotificationClickSync.test.tsx
+++ b/src/components/pwa/NotificationClickSync.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, cleanup } from '@testing-library/react'
+import { render, cleanup, waitFor } from '@testing-library/react'
 import type { Session } from 'next-auth'
 
 let mockSession: Session | null = null
@@ -14,8 +14,10 @@ vi.mock('next-auth/react', () => ({
 }))
 
 let mockPathname = '/'
+const routerPush = vi.fn()
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
+  useRouter: () => ({ push: routerPush }),
 }))
 
 const markReadMutate = vi.fn()
@@ -53,6 +55,37 @@ function postFromSW(data: unknown) {
   ;(navigator.serviceWorker as unknown as EventTarget).dispatchEvent(event)
 }
 
+// --- Fake Cache Storage for the pending-nav handoff -------------------------
+
+const PENDING_NAV_KEY = '/__cndn_pending_notification'
+
+/** Body JSON keyed by request key; models a single `cndn-pending-nav` cache. */
+let pendingStore = new Map<string, string>()
+const cacheDelete = vi.fn(async (key: string) => pendingStore.delete(key))
+
+/** Install a minimal Cache Storage shim on the global. */
+function installCaches() {
+  const cache = {
+    match: async (key: string) => {
+      const body = pendingStore.get(key)
+      if (body === undefined) return undefined
+      return { json: async () => JSON.parse(body) }
+    },
+    delete: cacheDelete,
+    put: async () => undefined,
+  }
+  Object.defineProperty(globalThis, 'caches', {
+    value: { open: async () => cache },
+    configurable: true,
+    writable: true,
+  })
+}
+
+/** Seed a pending-nav entry as the SW would have written it. */
+function seedPendingNav(link: string, ts: number) {
+  pendingStore.set(PENDING_NAV_KEY, JSON.stringify({ link, ts }))
+}
+
 function signedIn(): Session {
   return {
     expires: new Date(Date.now() + 60_000).toISOString(),
@@ -65,7 +98,9 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockSession = signedIn()
   mockPathname = '/'
+  pendingStore = new Map<string, string>()
   installServiceWorker()
+  installCaches()
   window.history.replaceState(null, '', '/')
 })
 
@@ -151,5 +186,79 @@ describe('NotificationClickSync', () => {
     // The param must be stripped even when signed out, so it can't linger and
     // re-fire on a later authenticated reload/share.
     expect(window.location.search).not.toContain('markread')
+  })
+
+  // --- Warm navigation via the notification-click postMessage ---------------
+
+  it('navigates and clears the pending-nav cache on a warm notification-click', async () => {
+    mockPathname = '/'
+    render(<NotificationClickSync />)
+    postFromSW({ type: 'notification-click', url: '/cfp/proposal/2' })
+    // Marks read AND drives the deep-link navigation itself (iOS ignores the
+    // SW's own navigate()).
+    expect(markReadMutate).toHaveBeenCalledWith({ links: ['/cfp/proposal/2'] })
+    expect(routerPush).toHaveBeenCalledWith('/cfp/proposal/2')
+    // The warm tab handled it, so the cold-open handoff must be cleared.
+    await waitFor(() =>
+      expect(cacheDelete).toHaveBeenCalledWith(PENDING_NAV_KEY),
+    )
+  })
+
+  it('does not navigate on a warm click already on the target page', () => {
+    mockPathname = '/cfp/proposal/2'
+    render(<NotificationClickSync />)
+    postFromSW({ type: 'notification-click', url: '/cfp/proposal/2' })
+    expect(markReadMutate).toHaveBeenCalledWith({ links: ['/cfp/proposal/2'] })
+    expect(routerPush).not.toHaveBeenCalled()
+  })
+
+  // --- Cold-open consumer of the Cache-API pending-nav handoff ---------------
+
+  it('consumes a fresh pending entry on mount: navigates, marks read, deletes it', async () => {
+    mockPathname = '/'
+    seedPendingNav('/cfp/proposal/9', Date.now())
+    render(<NotificationClickSync />)
+    await waitFor(() =>
+      expect(routerPush).toHaveBeenCalledWith('/cfp/proposal/9'),
+    )
+    expect(markReadMutate).toHaveBeenCalledWith({ links: ['/cfp/proposal/9'] })
+    await waitFor(() => expect(pendingStore.has(PENDING_NAV_KEY)).toBe(false))
+  })
+
+  it('deletes a stale pending entry without navigating', async () => {
+    mockPathname = '/'
+    // Older than the 5-minute freshness window.
+    seedPendingNav('/cfp/proposal/9', Date.now() - 6 * 60 * 1000)
+    render(<NotificationClickSync />)
+    await waitFor(() => expect(pendingStore.has(PENDING_NAV_KEY)).toBe(false))
+    expect(routerPush).not.toHaveBeenCalled()
+    expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate when the pending entry is already the current page', async () => {
+    mockPathname = '/cfp/proposal/9'
+    window.history.replaceState(null, '', '/cfp/proposal/9')
+    seedPendingNav('/cfp/proposal/9', Date.now())
+    render(<NotificationClickSync />)
+    await waitFor(() => expect(pendingStore.has(PENDING_NAV_KEY)).toBe(false))
+    expect(routerPush).not.toHaveBeenCalled()
+  })
+
+  it('clears a pending entry when signed out but fires no mutation', async () => {
+    mockSession = null
+    mockPathname = '/'
+    seedPendingNav('/cfp/proposal/9', Date.now())
+    render(<NotificationClickSync />)
+    await waitFor(() => expect(pendingStore.has(PENDING_NAV_KEY)).toBe(false))
+    expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate for a non-app-relative pending link, but deletes it', async () => {
+    mockPathname = '/'
+    seedPendingNav('https://evil.com', Date.now())
+    render(<NotificationClickSync />)
+    await waitFor(() => expect(pendingStore.has(PENDING_NAV_KEY)).toBe(false))
+    expect(routerPush).not.toHaveBeenCalled()
+    expect(markReadMutate).not.toHaveBeenCalled()
   })
 })

--- a/src/components/pwa/NotificationClickSync.test.tsx
+++ b/src/components/pwa/NotificationClickSync.test.tsx
@@ -133,11 +133,22 @@ describe('NotificationClickSync', () => {
     expect(markReadMutate).not.toHaveBeenCalled()
   })
 
-  it('does not register / fire when signed out', () => {
+  it('does not mark read on a warm click when definitively signed out', () => {
     mockSession = null
+    mockStatus = 'unauthenticated'
     render(<NotificationClickSync />)
     postFromSW({ type: 'notification-click', url: '/cfp/proposal/1' })
     expect(markReadMutate).not.toHaveBeenCalled()
+  })
+
+  it('marks read on a warm click while the session is still loading', () => {
+    // Cookie-authed server-side, so a `loading` client must still mark read
+    // (mirrors the iOS cold-open race).
+    mockSession = null
+    mockStatus = 'loading'
+    render(<NotificationClickSync />)
+    postFromSW({ type: 'notification-click', url: '/cfp/proposal/1' })
+    expect(markReadMutate).toHaveBeenCalledWith({ links: ['/cfp/proposal/1'] })
   })
 
   // --- Cold-open mark-read via the `markread` query param (N1) --------------
@@ -217,6 +228,31 @@ describe('NotificationClickSync', () => {
     expect(routerPush).not.toHaveBeenCalled()
   })
 
+  it('a BACKGROUND tab marks read but does NOT navigate or clear the handoff', () => {
+    // The SW broadcasts to every window; a background tab must not hijack-
+    // navigate nor delete the cold-open handoff (the launched window needs it).
+    const restore = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'visibilityState',
+    )
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    })
+    try {
+      mockPathname = '/'
+      render(<NotificationClickSync />)
+      postFromSW({ type: 'notification-click', url: '/cfp/proposal/2' })
+      expect(markReadMutate).toHaveBeenCalledWith({
+        links: ['/cfp/proposal/2'],
+      })
+      expect(routerPush).not.toHaveBeenCalled()
+      expect(cacheDelete).not.toHaveBeenCalled()
+    } finally {
+      if (restore) Object.defineProperty(document, 'visibilityState', restore)
+    }
+  })
+
   // --- Cold-open consumer of the Cache-API pending-nav handoff ---------------
 
   it('consumes a fresh pending entry on mount: navigates, marks read, deletes it', async () => {
@@ -240,12 +276,15 @@ describe('NotificationClickSync', () => {
     expect(markReadMutate).not.toHaveBeenCalled()
   })
 
-  it('does not navigate when the pending entry is already the current page', async () => {
+  it('marks read but does not navigate when the pending entry is the current page', async () => {
     mockPathname = '/cfp/proposal/9'
     window.history.replaceState(null, '', '/cfp/proposal/9')
     seedPendingNav('/cfp/proposal/9', Date.now())
     render(<NotificationClickSync />)
     await waitFor(() => expect(pendingStore.has(PENDING_NAV_KEY)).toBe(false))
+    // Redundant navigation is suppressed, but the notification must STILL be
+    // marked read (the user is looking at the resource).
+    expect(markReadMutate).toHaveBeenCalledWith({ links: ['/cfp/proposal/9'] })
     expect(routerPush).not.toHaveBeenCalled()
   })
 

--- a/src/components/pwa/NotificationClickSync.tsx
+++ b/src/components/pwa/NotificationClickSync.tsx
@@ -105,8 +105,11 @@ function isNotificationClickMessage(
  * Renders nothing. Mounted once app-wide (see SessionProviderWrapper).
  */
 export function NotificationClickSync() {
-  const { data: session, status } = useSession()
-  const isSignedIn = Boolean(session?.speaker)
+  // Only `status` is needed: mark-read is a cookie-authenticated server mutation,
+  // so the client's session DATA never gates it — we fire unless the client is
+  // DEFINITIVELY unauthenticated (`status`), which also survives the iOS
+  // cold-open `loading` window (see the cold-open effect below).
+  const { status } = useSession()
   const pathname = usePathname()
   const router = useRouter()
   const utils = api.useUtils()
@@ -143,16 +146,16 @@ export function NotificationClickSync() {
     window.history.replaceState(window.history.state, '', stripped)
 
     // Only mark-read for a signed-in caller (markReadByLink is a protected
-    // procedure); a signed-out visitor just gets the param stripped above.
-    if (isSignedIn && isAppRelativeLink(link)) {
+    // procedure); a definitively signed-out visitor just gets the param stripped
+    // above.
+    if (status !== 'unauthenticated' && isAppRelativeLink(link)) {
       // Recipient-guarded + link-matched + re-validated server-side, so this can
       // only ever clear the CALLER'S OWN notification whose link equals `link`.
       mutate({ links: [link] })
     }
-  }, [isSignedIn, pathname, mutate])
+  }, [status, pathname, mutate])
 
   useEffect(() => {
-    if (!isSignedIn) return
     if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
       return
     }
@@ -160,21 +163,31 @@ export function NotificationClickSync() {
     const onMessage = (event: MessageEvent) => {
       if (!isNotificationClickMessage(event.data)) return
       const { url } = event.data
-      // The url is the notification's app-relative link (the SW only ever posts
-      // a sanitized "/..." path). The schema re-validates it; a non-matching url
-      // (e.g. the "/" fallback) simply clears nothing.
-      mutate({ links: [url] })
+      // Mark read in EVERY receiving tab (idempotent) so each open tab's bell
+      // clears. Cookie-authenticated server-side, so gate only on a definitively
+      // unauthenticated client (mirrors the cold-open path).
+      if (status !== 'unauthenticated') mutate({ links: [url] })
+
+      // The SW broadcasts this to ALL window clients. Only the FOREGROUND tab may
+      // navigate and clear the cold-open handoff: a background tab must not
+      // hijack-navigate every open window, and must not delete the pending-nav
+      // entry — an iOS cold-launched window may still need to consume it.
+      if (
+        typeof document !== 'undefined' &&
+        document.visibilityState !== 'visible'
+      ) {
+        return
+      }
 
       // WARM navigation: iOS ignores the SW's `existing.navigate()`, so drive the
-      // deep-link navigation from here instead of relying on the worker. Only for
-      // an app-relative link that isn't already the current page (avoid redundant
-      // navigations / loops).
+      // deep-link navigation from here. Skip when already on the target page
+      // (avoid redundant navigations / loops).
       if (isAppRelativeLink(url) && url !== pathname) {
         router.push(url)
       }
 
-      // This warm tab handled the click, so a later COLD boot must NOT re-consume
-      // the same intent from the Cache-API handoff. Clear it best-effort.
+      // This foreground tab handled the click, so a later COLD boot must NOT
+      // re-consume the same intent from the Cache-API handoff. Clear it.
       void clearPendingNav()
     }
 
@@ -182,7 +195,7 @@ export function NotificationClickSync() {
     return () => {
       navigator.serviceWorker.removeEventListener('message', onMessage)
     }
-  }, [isSignedIn, mutate, pathname, router])
+  }, [status, mutate, pathname, router])
 
   // COLD-OPEN path (iOS-critical): when a tap launches the app from closed, iOS
   // boots it at the start_url and ignores the SW's openWindow/navigate, so the
@@ -222,21 +235,18 @@ export function NotificationClickSync() {
         ) {
           const { link, ts } = payload as { link: string; ts: number }
           const isFresh = Date.now() - ts <= PENDING_NAV_MAX_AGE_MS
-          if (
-            isAppRelativeLink(link) &&
-            isFresh &&
-            link !== window.location.pathname
-          ) {
-            router.push(link)
-            // Recipient-guarded + link-matched + re-validated server-side, so
-            // the mutation's REAL auth is the request cookie, not this client's
-            // `useSession` state. On an iOS cold open the session is often still
-            // `loading` (the deep-link page seeded `undefined` because `auth()`
-            // read falsy under cacheComponents — see SessionProviderWrapper), and
-            // gating on `isSignedIn` here would delete the entry mid-load and drop
-            // the mark-read. Fire whenever we're NOT definitively signed out; the
-            // cookie authenticates the request server-side either way.
+          if (isAppRelativeLink(link) && isFresh) {
+            // MARK READ even when we're already on the target page — the
+            // navigation guard below only suppresses a redundant push, it must
+            // not suppress the mark-read. The mutation's REAL auth is the request
+            // cookie, not this client's `useSession` state: on an iOS cold open
+            // the session is often still `loading` (the deep-link page seeded
+            // `undefined` because `auth()` read falsy under cacheComponents — see
+            // SessionProviderWrapper), so gating on session DATA would drop the
+            // mark-read. Fire unless DEFINITIVELY unauthenticated.
             if (status !== 'unauthenticated') mutate({ links: [link] })
+            // Navigate only when not already there (avoid a redundant push/loop).
+            if (link !== window.location.pathname) router.push(link)
           }
         }
         return true

--- a/src/components/pwa/NotificationClickSync.tsx
+++ b/src/components/pwa/NotificationClickSync.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { api } from '@/lib/trpc/client'
 
@@ -13,6 +13,44 @@ import { api } from '@/lib/trpc/client'
  * `link`.
  */
 const MARK_READ_PARAM = 'markread'
+
+/**
+ * Cache-API handoff for the notification click intent (see public/sw.js). iOS
+ * launches the installed PWA at its start_url and IGNORES the service worker's
+ * `openWindow()` / `WindowClient.navigate()`, so on iOS neither the deep-link
+ * navigation nor the `markread` query param ever reaches the window (cold OR
+ * warm). To survive that, the SW stashes `{ link, ts }` in this cache under a
+ * fixed synthetic key BEFORE opening any window; the freshly-launched client
+ * reads it here and does the navigation + mark-read itself.
+ */
+const PENDING_NAV_CACHE = 'cndn-pending-nav'
+const PENDING_NAV_KEY = '/__cndn_pending_notification'
+
+/** How long a stashed click intent is honoured. Anything older is discarded. */
+const PENDING_NAV_MAX_AGE_MS = 5 * 60 * 1000
+
+/**
+ * iOS may boot the app in parallel with the SW's cache write, so the entry can
+ * be absent on the very first read. Re-check after these delays (ms), stopping
+ * as soon as an entry is found & consumed.
+ */
+const PENDING_NAV_RETRY_DELAYS_MS = [600, 1600]
+
+/** Whether Cache Storage is usable in this environment (no-op on the server). */
+function hasCacheStorage(): boolean {
+  return typeof window !== 'undefined' && typeof caches !== 'undefined'
+}
+
+/** Best-effort delete of the pending-nav entry; never throws. */
+async function clearPendingNav(): Promise<void> {
+  if (!hasCacheStorage()) return
+  try {
+    const cache = await caches.open(PENDING_NAV_CACHE)
+    await cache.delete(PENDING_NAV_KEY)
+  } catch {
+    // Cache unavailable (private mode / quota); nothing to clear.
+  }
+}
 
 /**
  * True for an app-relative deep link ("/..."; never "//..." or a backslash
@@ -70,6 +108,7 @@ export function NotificationClickSync() {
   const { data: session } = useSession()
   const isSignedIn = Boolean(session?.speaker)
   const pathname = usePathname()
+  const router = useRouter()
   const utils = api.useUtils()
   const markReadByLink = api.notification.markReadByLink.useMutation({
     onSuccess: () => {
@@ -120,17 +159,108 @@ export function NotificationClickSync() {
 
     const onMessage = (event: MessageEvent) => {
       if (!isNotificationClickMessage(event.data)) return
+      const { url } = event.data
       // The url is the notification's app-relative link (the SW only ever posts
       // a sanitized "/..." path). The schema re-validates it; a non-matching url
       // (e.g. the "/" fallback) simply clears nothing.
-      mutate({ links: [event.data.url] })
+      mutate({ links: [url] })
+
+      // WARM navigation: iOS ignores the SW's `existing.navigate()`, so drive the
+      // deep-link navigation from here instead of relying on the worker. Only for
+      // an app-relative link that isn't already the current page (avoid redundant
+      // navigations / loops).
+      if (isAppRelativeLink(url) && url !== pathname) {
+        router.push(url)
+      }
+
+      // This warm tab handled the click, so a later COLD boot must NOT re-consume
+      // the same intent from the Cache-API handoff. Clear it best-effort.
+      void clearPendingNav()
     }
 
     navigator.serviceWorker.addEventListener('message', onMessage)
     return () => {
       navigator.serviceWorker.removeEventListener('message', onMessage)
     }
-  }, [isSignedIn, mutate])
+  }, [isSignedIn, mutate, pathname, router])
+
+  // COLD-OPEN path (iOS-critical): when a tap launches the app from closed, iOS
+  // boots it at the start_url and ignores the SW's openWindow/navigate, so the
+  // deep link never loads and nothing is marked read. Recover the click intent
+  // the SW stashed in the Cache API: navigate to it and mark it read here.
+  //
+  // Runs regardless of sign-in so the entry is always consumed (never lingers to
+  // re-fire on a later boot); the mutation only fires when signed in.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    let cancelled = false
+    const timers: ReturnType<typeof setTimeout>[] = []
+
+    const consume = async (): Promise<boolean> => {
+      if (cancelled || !hasCacheStorage()) return false
+      try {
+        const cache = await caches.open(PENDING_NAV_CACHE)
+        const res = await cache.match(PENDING_NAV_KEY)
+        if (!res) return false
+
+        // An entry exists — consume it EXACTLY once, whatever its contents.
+        let payload: unknown = null
+        try {
+          payload = await res.json()
+        } catch {
+          payload = null
+        }
+        await cache.delete(PENDING_NAV_KEY)
+
+        if (cancelled) return true
+        if (
+          payload &&
+          typeof payload === 'object' &&
+          typeof (payload as { link?: unknown }).link === 'string' &&
+          typeof (payload as { ts?: unknown }).ts === 'number'
+        ) {
+          const { link, ts } = payload as { link: string; ts: number }
+          const isFresh = Date.now() - ts <= PENDING_NAV_MAX_AGE_MS
+          if (
+            isAppRelativeLink(link) &&
+            isFresh &&
+            link !== window.location.pathname
+          ) {
+            router.push(link)
+            // Recipient-guarded + link-matched + re-validated server-side.
+            if (isSignedIn) mutate({ links: [link] })
+          }
+        }
+        return true
+      } catch {
+        // Cache unavailable; nothing to consume.
+        return false
+      }
+    }
+
+    const attempt = async () => {
+      if (cancelled) return
+      const found = await consume()
+      if (found) {
+        // Consumed — cancel any still-pending retries.
+        cancelled = true
+        for (const t of timers) clearTimeout(t)
+      }
+    }
+
+    // Check immediately, then re-check on a bounded schedule to cover the iOS
+    // race where the app boots before the SW's cache write lands.
+    void attempt()
+    for (const delay of PENDING_NAV_RETRY_DELAYS_MS) {
+      timers.push(setTimeout(() => void attempt(), delay))
+    }
+
+    return () => {
+      cancelled = true
+      for (const t of timers) clearTimeout(t)
+    }
+  }, [isSignedIn, mutate, router])
 
   return null
 }

--- a/src/components/pwa/NotificationClickSync.tsx
+++ b/src/components/pwa/NotificationClickSync.tsx
@@ -105,7 +105,7 @@ function isNotificationClickMessage(
  * Renders nothing. Mounted once app-wide (see SessionProviderWrapper).
  */
 export function NotificationClickSync() {
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
   const isSignedIn = Boolean(session?.speaker)
   const pathname = usePathname()
   const router = useRouter()
@@ -228,8 +228,15 @@ export function NotificationClickSync() {
             link !== window.location.pathname
           ) {
             router.push(link)
-            // Recipient-guarded + link-matched + re-validated server-side.
-            if (isSignedIn) mutate({ links: [link] })
+            // Recipient-guarded + link-matched + re-validated server-side, so
+            // the mutation's REAL auth is the request cookie, not this client's
+            // `useSession` state. On an iOS cold open the session is often still
+            // `loading` (the deep-link page seeded `undefined` because `auth()`
+            // read falsy under cacheComponents — see SessionProviderWrapper), and
+            // gating on `isSignedIn` here would delete the entry mid-load and drop
+            // the mark-read. Fire whenever we're NOT definitively signed out; the
+            // cookie authenticates the request server-side either way.
+            if (status !== 'unauthenticated') mutate({ links: [link] })
           }
         }
         return true
@@ -260,7 +267,7 @@ export function NotificationClickSync() {
       cancelled = true
       for (const t of timers) clearTimeout(t)
     }
-  }, [isSignedIn, mutate, router])
+  }, [status, mutate, router])
 
   return null
 }


### PR DESCRIPTION
## The bug (iOS PWA)

When a user taps a web-push notification for the installed iOS PWA, iOS launches the app at its `start_url` (`/launch`, which server-redirects to the role home) and **ignores the service worker's `clients.openWindow()` / `WindowClient.navigate()` calls**. The result: the app "opens into the void" — it lands on the start page, never navigates to the notification's deep link, and never marks the notification read. Warm taps (app already open) fail the same way because iOS also ignores the SW's `existing.navigate()`.

Android/Chrome honours `openWindow`/`navigate`, so both worked there. This fix is cross-platform and does not change Android's working path.

## The fix — a Cache-API pending-navigation handoff

Instead of depending on the SW to navigate the window, the click intent is handed off through Cache Storage, which the freshly-launched client reads on boot.

### `public/sw.js` — `notificationclick`
- Before opening/focusing any window, **`await` a write of `{ link, ts }`** to a dedicated `cndn-pending-nav` cache under a fixed synthetic key `/__cndn_pending_notification`. It is feature-detected (`self.caches`) and fully `try/catch`-guarded so it can never throw. The write is awaited **before** `openWindow`, so on Android it is durable and on iOS it is initiated before the app boots.
- Everything that already worked is kept: closing the notification, the sanitized `target`/`targetUrl` resolution, the `notification-click` postMessage to open clients, and the best-effort `openWindow`/focus+navigate carrying the `?markread=` param (Android belt-and-braces, harmless on iOS).

### `src/components/pwa/NotificationClickSync.tsx` — client consumer
- **Warm path (postMessage):** in addition to `markReadByLink`, it now performs the navigation itself — `router.push(url)` for an app-relative link that differs from the current page — and clears the pending-nav cache entry so a later cold boot cannot re-consume it. No longer relies on the SW to navigate.
- **Cold-open path (new mount effect):** reads the pending-nav entry on mount; if the link is app-relative, **fresh** (`Date.now() - ts <= 5min`), and differs from the current path, it `router.push`es and (when signed in) fires `markReadByLink`. The entry is then deleted regardless, so it is consumed exactly once.
  - **iOS race:** iOS can boot the app in parallel with the SW's cache write, so the entry may be absent on the first read. A small bounded retry re-checks at ~600ms and ~1600ms, stopping as soon as an entry is found & consumed (timers cleared on unmount).
- Runs regardless of sign-in so the entry never lingers; the mutation only fires when signed in. The existing `?markread=` query-param effect is kept (harmless, helps Android).

## Security

The link originates from the SW, which already ran `sanitizeNotificationUrl`, but it is **re-validated with `isAppRelativeLink`** on the client before any `router.push` or `markReadByLink`. A non-app-relative value is never navigated to.

## Tests

- `__tests__/lib/pwa/sw-source.test.ts`: asserts the handler writes to the `cndn-pending-nav` cache under the synthetic key, and that the cache write precedes `openWindow`.
- `src/components/pwa/NotificationClickSync.test.tsx`: added cold-open consumer (fresh → push + mark-read + delete; stale → delete, no nav; already-on-page → no nav; non-app-relative → no nav; signed-out → cleared, no mutation) and warm-path (push + cache clear; no redundant nav when already on target). Cache Storage and `useRouter` are mocked in the file's existing style.

All affected suites green (27 tests). `tsc --noEmit`, `eslint`, and `prettier` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Cache Storage handoff for reliable notification taps in iOS PWAs. The main changes are:

- Stores notification links before opening or focusing a window.
- Handles warm navigation from service-worker messages.
- Consumes cold-start links with freshness checks and retries.
- Adds tests for warm, cold, stale, invalid, and signed-out paths.

<h3>Confidence Score: 4/5</h3>

The notification handoff can lose mark-read state or navigate the wrong set of windows, so these paths need fixes before merging.

- Cold startup can consume an intent before authentication finishes.
- Same-page cold taps skip the required mark-read mutation.
- Broadcast handling redirects every open tab and can delete another window's handoff.
- Worker activation can remove the pending cache before it is read.

src/components/pwa/NotificationClickSync.tsx and public/sw.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| public/sw.js | Adds the pending-navigation cache write, but the fixed key and activation cleanup can lose pending intents. |
| src/components/pwa/NotificationClickSync.tsx | Adds warm and cold client handling, with bugs around session loading, same-page taps, and multiple windows. |
| src/components/pwa/NotificationClickSync.test.tsx | Adds broad single-window coverage but omits session-loading and multi-window races. |
| __tests__/lib/pwa/sw-source.test.ts | Checks write ordering but does not verify that activation preserves the new cache. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant N as Notification tap
    participant SW as Service worker
    participant C as Cache Storage
    participant W as PWA client
    participant API as Notification API
    N->>SW: notificationclick(link)
    SW->>C: Store pending link
    SW-->>W: Broadcast click message
    alt Warm client
        W->>W: Navigate to link
        W->>API: Mark read
        W->>C: Delete pending link
    else Cold iOS launch
        W->>C: Read pending link
        W->>C: Delete pending link
        W->>W: Navigate to link
        W->>API: Mark read if signed in
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant N as Notification tap
    participant SW as Service worker
    participant C as Cache Storage
    participant W as PWA client
    participant API as Notification API
    N->>SW: notificationclick(link)
    SW->>C: Store pending link
    SW-->>W: Broadcast click message
    alt Warm client
        W->>W: Navigate to link
        W->>API: Mark read
        W->>C: Delete pending link
    else Cold iOS launch
        W->>C: Read pending link
        W->>C: Delete pending link
        W->>W: Navigate to link
        W->>API: Mark read if signed in
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(pwa): reliable iOS notification cold..."](https://github.com/cloudnativebergen/website/commit/23e87926959dbd3e55912d8a432cdaa9f7917f1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45871852)</sub>

> Greptile also left **6 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->