### PR TITLE
fix(pwa): prevent iOS input auto-zoom by forcing ≥16px form controls on touch

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -16,9 +16,17 @@
  * iOS Safari (and installed PWAs) auto-zoom the viewport when a focused
  * input/textarea/select has a font-size < 16px, and the zoom sticks — which
  * breaks the "native app" feel and clips content off the right edge. Many
- * controls in this app use Tailwind `text-sm` (14px), so we force >=16px on
- * touch / coarse-pointer devices only, leaving desktop (`text-sm`, etc.)
- * untouched.
+ * controls in this app use Tailwind `text-sm` (14px), so we pin the font-size
+ * to 16px on touch-capable devices only, leaving desktop (`text-sm`, etc.)
+ * untouched. No form control in the app is intentionally larger than 16px, so
+ * pinning to exactly 16px never shrinks anything; revisit if a >16px input is
+ * ever added.
+ *
+ * `any-pointer: coarse` (not `pointer: coarse`) is deliberate: an iPad with a
+ * Magic Keyboard trackpad reports its PRIMARY pointer as `fine`, so
+ * `pointer: coarse` would miss it — yet iPadOS Safari still auto-zooms. Matching
+ * when ANY available pointer is coarse covers touch-capable devices even when a
+ * fine pointer is primary (a touch laptop harmlessly gets 16px controls too).
  *
  * This block is deliberately UNLAYERED (outside any @layer). Tailwind 4 puts
  * its utilities in the `utilities` cascade layer, and unlayered CSS always
@@ -27,7 +35,7 @@
  * rule still overrides it. Placing it in `@layer base` would LOSE to `text-sm`
  * and the zoom would persist.
  */
-@media (pointer: coarse) {
+@media (any-pointer: coarse) {
   input:not([type='checkbox']):not([type='radio']):not([type='range']):not(
       [type='color']
     ),

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -10,6 +10,33 @@
 /* Use class strategy for dark mode but ensure media query fallback works */
 @custom-variant dark (&:where(.dark, .dark *));
 
+/*
+ * Prevent iOS auto-zoom on focus for form controls.
+ *
+ * iOS Safari (and installed PWAs) auto-zoom the viewport when a focused
+ * input/textarea/select has a font-size < 16px, and the zoom sticks — which
+ * breaks the "native app" feel and clips content off the right edge. Many
+ * controls in this app use Tailwind `text-sm` (14px), so we force >=16px on
+ * touch / coarse-pointer devices only, leaving desktop (`text-sm`, etc.)
+ * untouched.
+ *
+ * This block is deliberately UNLAYERED (outside any @layer). Tailwind 4 puts
+ * its utilities in the `utilities` cascade layer, and unlayered CSS always
+ * wins over any layered CSS regardless of selector specificity. So even though
+ * `.text-sm` is a class (higher specificity than these element selectors), this
+ * rule still overrides it. Placing it in `@layer base` would LOSE to `text-sm`
+ * and the zoom would persist.
+ */
+@media (pointer: coarse) {
+  input:not([type='checkbox']):not([type='radio']):not([type='range']):not(
+      [type='color']
+    ),
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+
 /* Critical chart styles - prevent tree shaking */
 .chart-container {
   min-height: 300px !important;


### PR DESCRIPTION
## Problem

On iOS Safari and installed PWAs, focusing a form control whose `font-size` is **under 16px** triggers an automatic viewport zoom-in — and the zoom **sticks** after blur. This breaks the "native app" illusion and clips content off the right edge. The messaging composer `<textarea>` (`ConversationThread.tsx`) and many inputs/selects/textareas across the app use Tailwind `text-sm` (14px), so they all trip this behavior.

## Fix

Add a global CSS rule that forces form controls to **≥16px on touch / coarse-pointer devices only**, leaving desktop styling (`text-sm`, etc.) unchanged:

```css
@media (pointer: coarse) {
  input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='color']),
  textarea,
  select {
    font-size: 16px;
  }
}
```

- `pointer: coarse` scopes the change to touch devices — desktop (fine pointer) keeps `text-sm`.
- Checkboxes / radios / range / color are excluded (font-size can affect their rendered box; they never cause the zoom).
- **Accessible approach:** this does NOT touch the `viewport` export — no `maximum-scale` / `user-scalable=no`, which would harm accessibility. Enlarging the text is the accessible way to stop the auto-zoom.

## Why the rule is placed UNLAYERED (the important part)

Tailwind 4 emits its utilities (like `.text-sm`) into the `utilities` **cascade layer**. A class selector normally beats a plain element selector on specificity — so if this rule were dropped into `@layer base`, it would **lose** to `.text-sm` and the zoom would persist. **Unlayered CSS always wins over any `@layer`d CSS regardless of specificity.** The rule is therefore added as an unlayered block in `src/styles/tailwind.css` (which already uses unlayered rules to override Tailwind utilities), guaranteeing it overrides `text-sm`.

## Verification (computed style)

Compiled the real project CSS through `@tailwindcss/postcss` and measured `getComputedStyle(el).fontSize` in Playwright on the actual composer textarea classes:

| Context | composer textarea | text input | select | checkbox (`text-sm`) |
|---|---|---|---|---|
| **Fine pointer (desktop)** | 14px | 14px | 14px | 14px |
| **Coarse pointer (iPhone 13)** | **16px** | **16px** | **16px** | 14px (excluded ✓) |

The `text-sm` textarea computes to **16px** under `pointer: coarse` and stays **14px** on desktop — confirming the unlayered rule beats the utilities layer, and that checkboxes are correctly left alone.

## Visual QA

Captured Storybook stories at **393px** width with an **iPhone 13 device descriptor** (so `pointer: coarse` is active and the rule applies) in both light and dark themes: messaging composer (`ConversationThread`), CFP proposal form (`ProposalDetailsForm`), and speaker form (`SpeakerDetailsForm`). All form controls render at 16px, no horizontal overflow on any control (programmatic `getBoundingClientRect().right <= viewport` check passed), and layouts/alignment are intact in both themes.

Note: the repo's `pnpm shoot` helper launches a plain (fine-pointer) context, so it would render 14px and not exercise this rule — the coarse-pointer captures above were used instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents iOS form-control auto-zoom on touch devices. The main changes are:

- Adds a coarse-pointer media query for inputs, textareas, and selects.
- Forces text-entry controls to use a 16px font size.
- Excludes checkbox, radio, range, and color inputs.
- Keeps the override outside Tailwind cascade layers.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/styles/tailwind.css | Adds an unlayered 16px form-control override for coarse-pointer devices; no actionable bug was found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pwa): prevent iOS input auto-zoom by..."](https://github.com/cloudnativebergen/website/commit/abc3c50ba21ef1439b7404ddbe709e460a11a2e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45872312)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->