### PR TITLE
fix(pwa): redirect installed-app launch from / to /launch (iOS ignores start_url)

### DIFF
--- a/src/components/providers/SessionProviderWrapper.tsx
+++ b/src/components/providers/SessionProviderWrapper.tsx
@@ -2,7 +2,11 @@ import { SessionProvider } from 'next-auth/react'
 import type { Session } from 'next-auth'
 import { auth } from '@/lib/auth'
 import { SessionRefreshOnRestore } from './SessionRefreshOnRestore'
-import { AppBadgeSync, NotificationClickSync } from '@/components/pwa'
+import {
+  AppBadgeSync,
+  NotificationClickSync,
+  StandaloneLaunchRedirect,
+} from '@/components/pwa'
 
 /**
  * Narrow the server session into what is safe to serialize to the client, and
@@ -62,12 +66,15 @@ async function SessionLoader({ children }: { children: React.ReactNode }) {
         on the session, so they are inert for signed-out visitors:
           - AppBadgeSync mirrors the unread count to the app-icon badge;
           - NotificationClickSync marks a notification read when its push is
-            clicked (see public/sw.js postMessage).
+            clicked (see public/sw.js postMessage);
+          - StandaloneLaunchRedirect rescues iOS installed launches that land on
+            `/` instead of the manifest `start_url` (see the component).
         Mounted here so they run on EVERY page (the bell only mounts in some
         shells), inside SessionProvider + the layout's TRPCProvider.
       */}
       <AppBadgeSync />
       <NotificationClickSync />
+      <StandaloneLaunchRedirect />
       {children}
     </SessionProvider>
   )

--- a/src/components/pwa/StandaloneLaunchRedirect.test.tsx
+++ b/src/components/pwa/StandaloneLaunchRedirect.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+import { StandaloneLaunchRedirect } from './StandaloneLaunchRedirect'
+
+const LAUNCH_REDIRECT_HANDLED_KEY = 'cndn:launch-redirect-handled'
+
+const replace = vi.fn()
+
+/** Point `window.location` at a mock with a `replace` spy and the given path. */
+function setLocation(pathname: string) {
+  Object.defineProperty(window, 'location', {
+    value: { pathname, replace },
+    configurable: true,
+    writable: true,
+  })
+}
+
+/** Install a `matchMedia` whose `(display-mode: standalone)` matches `standalone`. */
+function setStandaloneDisplayMode(standalone: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    value: (query: string) => ({
+      matches: query === '(display-mode: standalone)' ? standalone : false,
+      media: query,
+    }),
+    configurable: true,
+    writable: true,
+  })
+}
+
+/** Set the legacy iOS `navigator.standalone` flag. */
+function setNavigatorStandalone(standalone: boolean) {
+  Object.defineProperty(window.navigator, 'standalone', {
+    value: standalone,
+    configurable: true,
+    writable: true,
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  window.sessionStorage.clear()
+  setStandaloneDisplayMode(false)
+  setNavigatorStandalone(false)
+  setLocation('/')
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('StandaloneLaunchRedirect', () => {
+  it('renders nothing', () => {
+    const { container } = render(<StandaloneLaunchRedirect />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('redirects to /launch when standalone, on `/`, and the session is fresh', () => {
+    setStandaloneDisplayMode(true)
+    setLocation('/')
+    render(<StandaloneLaunchRedirect />)
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledWith('/launch')
+    // The launch is now marked handled for the rest of the session.
+    expect(
+      window.sessionStorage.getItem(LAUNCH_REDIRECT_HANDLED_KEY),
+    ).not.toBeNull()
+  })
+
+  it('honors the legacy navigator.standalone flag', () => {
+    setStandaloneDisplayMode(false)
+    setNavigatorStandalone(true)
+    setLocation('/')
+    render(<StandaloneLaunchRedirect />)
+    expect(replace).toHaveBeenCalledWith('/launch')
+  })
+
+  it('does NOT redirect when the session guard is already set', () => {
+    window.sessionStorage.setItem(LAUNCH_REDIRECT_HANDLED_KEY, '1')
+    setStandaloneDisplayMode(true)
+    setLocation('/')
+    render(<StandaloneLaunchRedirect />)
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it('does NOT redirect a normal (non-standalone) browser visitor', () => {
+    setStandaloneDisplayMode(false)
+    setNavigatorStandalone(false)
+    setLocation('/')
+    render(<StandaloneLaunchRedirect />)
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it('does NOT redirect a deep launch (pathname other than `/`)', () => {
+    setStandaloneDisplayMode(true)
+    setLocation('/admin')
+    render(<StandaloneLaunchRedirect />)
+    expect(replace).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/pwa/StandaloneLaunchRedirect.tsx
+++ b/src/components/pwa/StandaloneLaunchRedirect.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * sessionStorage key marking that this app SESSION's launch has already been
+ * evaluated. In a standalone PWA, sessionStorage is empty on every cold launch
+ * and persists across in-app navigations — exactly the "fire once per genuine
+ * launch, never on later navigations" semantics we want.
+ */
+const LAUNCH_REDIRECT_HANDLED_KEY = 'cndn:launch-redirect-handled'
+
+/**
+ * iOS `start_url` fallback.
+ *
+ * The manifest sets `start_url: /launch` (a Route Handler that 307-redirects by
+ * role — see `src/app/launch/route.ts`), but iOS does NOT reliably honor
+ * `start_url`: "Add to Home Screen" launches the installed app at the URL the
+ * user added it from (typically the marketing front page `/`), not `/launch`,
+ * and a reinstall does not fix it. So the role-aware launcher never runs and the
+ * app opens on the wrong page.
+ *
+ * This client-side fallback runs ONCE per app session (guarded by a fresh
+ * sessionStorage key) and, only when the app is running installed/standalone and
+ * the launch landed on the front page, does a FULL navigation to `/launch` so the
+ * server redirect logic runs and role-routes correctly.
+ *
+ * Why the ordering:
+ *   1. Set the session guard on the very first mount, unconditionally, so we
+ *      evaluate the launch EXACTLY once per session and never re-fire on a later
+ *      in-app navigation back to `/`.
+ *   2. Bail if not standalone — a normal browser visitor on `/` must never be
+ *      redirected away from the marketing page.
+ *   3. Bail if the launch page isn't `/` — if iOS DID honor `start_url`, or a
+ *      notification cold-opened a deep link, the pathname won't be `/` and we
+ *      leave it alone.
+ *
+ * `window.location.replace` (not the Next router): `/launch` is a server Route
+ * Handler returning a 307, so a full navigation is required to run it; `replace`
+ * (not `assign`) so the front page isn't left in history. No redirect loop is
+ * possible — `/launch` always resolves to `/admin`, `/cfp/list`, or `/program`,
+ * never back to `/`.
+ *
+ * Renders nothing. Mounted once app-wide (see SessionProviderWrapper).
+ */
+export function StandaloneLaunchRedirect() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    // Fresh-launch guard FIRST, unconditionally: only ever act on the first page
+    // of a session (a genuine launch), never on later in-app navigations to `/`.
+    try {
+      if (window.sessionStorage.getItem(LAUNCH_REDIRECT_HANDLED_KEY) !== null) {
+        return
+      }
+      window.sessionStorage.setItem(LAUNCH_REDIRECT_HANDLED_KEY, '1')
+    } catch {
+      // sessionStorage unavailable (private mode / disabled): fall through and
+      // evaluate the launch this once; without the guard we can't dedupe, but
+      // the standalone + pathname checks below still bound when we act.
+    }
+
+    const standalone =
+      window.matchMedia?.('(display-mode: standalone)').matches === true ||
+      (window.navigator as { standalone?: boolean }).standalone === true
+
+    // A normal browser visitor must never be redirected.
+    if (!standalone) return
+
+    // Only rescue the case where the launch landed on the front page.
+    if (window.location.pathname !== '/') return
+
+    window.location.replace('/launch')
+  }, [])
+
+  return null
+}

--- a/src/components/pwa/index.ts
+++ b/src/components/pwa/index.ts
@@ -14,6 +14,7 @@ export type { UpdateBannerProps } from './UpdateBanner'
 export { ServiceWorkerRegistrar } from './ServiceWorkerRegistrar'
 export { AppBadgeSync } from './AppBadgeSync'
 export { NotificationClickSync } from './NotificationClickSync'
+export { StandaloneLaunchRedirect } from './StandaloneLaunchRedirect'
 export { PwaInstallProvider, usePwaInstall } from './PwaInstallProvider'
 export type { InstallPlatform } from './PwaInstallProvider'
 export {


### PR DESCRIPTION
## The bug (iOS PWA)

The installed PWA opens on the marketing front page (`/`) instead of the role-aware home. The manifest already sets `start_url: /launch` — a Route Handler (`src/app/launch/route.ts`) that 307-redirects by role (organizer → `/admin`, signed-in speaker → `/cfp/list`, logged-out → `/program`).

But **iOS does not reliably honor manifest `start_url`**. "Add to Home Screen" launches the installed app at the URL it was added from (typically `/`), not `/launch`, and a reinstall does not fix it. So the role-aware launcher never runs and the app opens on the wrong page.

## The fix

A new `'use client'` component `StandaloneLaunchRedirect` (renders `null`), mounted app-wide in `SessionProviderWrapper` alongside `AppBadgeSync` / `NotificationClickSync`. In a `useEffect` it does this once per app session:

1. **Fresh-launch guard first, unconditionally.** A `sessionStorage` key (`cndn:launch-redirect-handled`) is checked/set on the very first mount. In a standalone PWA, `sessionStorage` is empty on every cold launch and persists across in-app navigations — so we evaluate the launch *exactly once per session* and never re-fire on a later in-app navigation back to `/`.
2. **Standalone detection.** `matchMedia('(display-mode: standalone)').matches === true || navigator.standalone === true` (the second covers legacy iOS). If not standalone, bail — a normal browser visitor on `/` must never be redirected off the marketing page.
3. **Front-page only.** If `location.pathname !== '/'`, bail — if iOS *did* honor `start_url`, or a notification cold-opened a deep link, the pathname won't be `/`, so we leave it alone.
4. **`window.location.replace('/launch')`** — a full navigation (not the Next router) so the server 307 Route Handler actually runs and role-routes; `replace` (not `assign`) so the front page isn't left in history.

No redirect loop is possible: `/launch` always resolves to `/admin`, `/cfp/list`, or `/program` — never back to `/`.

## Tests

`src/components/pwa/StandaloneLaunchRedirect.test.tsx` (jsdom) mocks `matchMedia`, `location` (pathname + `replace` spy), `navigator.standalone`, and `sessionStorage`, covering: standalone + `/` + fresh → `replace('/launch')` once; legacy `navigator.standalone`; guard already set → not called; non-standalone → not called; deep launch (`/admin`) → not called. All 6 pass. `tsc --noEmit`, ESLint, and Prettier are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a fallback for iOS installed-app launches that land on the marketing page. The main changes are:

- Adds a session-scoped standalone launch redirect from `/` to `/launch`.
- Mounts the redirect app-wide with the existing PWA synchronization components.
- Exports the component through the PWA barrel.
- Adds tests for standalone detection, session handling, and deep links.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The redirect is limited to fresh standalone mounts at `/`.
- The server route redirects to non-root destinations, preventing a loop.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/pwa/StandaloneLaunchRedirect.tsx | Adds the session-guarded standalone launch redirect with root-path gating. |
| src/components/providers/SessionProviderWrapper.tsx | Mounts the new client component in the app-wide session provider. |
| src/components/pwa/StandaloneLaunchRedirect.test.tsx | Tests the main redirect and suppression paths. |
| src/components/pwa/index.ts | Re-exports the new PWA component. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pwa): redirect installed-app launch ..."](https://github.com/cloudnativebergen/website/commit/8ea83348341ab73de7880abad04709e4880301ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45894838)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->