### PR TITLE
fix(pwa): numeric app-icon badge on push so iOS shows unread count

### DIFF
--- a/__tests__/lib/push/send-bridge.test.ts
+++ b/__tests__/lib/push/send-bridge.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/push/send'
 import { getSpeakerPushState, prunePushSubscription } from '@/lib/push/sanity'
 import { isPushConfigured, getConfiguredWebPush } from '@/lib/push/vapid'
+import { getUnreadCount } from '@/lib/notification/sanity'
 import type { NotificationInput } from '@/lib/notification/types'
 import type { SpeakerPushState } from '@/lib/push/types'
 
@@ -23,11 +24,15 @@ vi.mock('@/lib/push/vapid', () => ({
   isPushConfigured: vi.fn().mockReturnValue(true),
   getConfiguredWebPush: vi.fn(),
 }))
+vi.mock('@/lib/notification/sanity', () => ({
+  getUnreadCount: vi.fn().mockResolvedValue(0),
+}))
 
 const mockGetState = vi.mocked(getSpeakerPushState)
 const mockPrune = vi.mocked(prunePushSubscription)
 const mockIsConfigured = vi.mocked(isPushConfigured)
 const mockGetWebPush = vi.mocked(getConfiguredWebPush)
+const mockGetUnreadCount = vi.mocked(getUnreadCount)
 
 const sendNotification = vi.fn()
 
@@ -70,6 +75,9 @@ function item(over: Partial<NotificationInput> = {}): NotificationInput {
 beforeEach(() => {
   vi.clearAllMocks()
   mockIsConfigured.mockReturnValue(true)
+  // Default: recipient has no unread notifications, so no badge is added to the
+  // payload. Individual badge tests override this.
+  mockGetUnreadCount.mockResolvedValue(0)
   // A minimal web-push client whose sendNotification resolves with a 201.
   sendNotification.mockResolvedValue({ statusCode: 201 })
   mockGetWebPush.mockReturnValue({
@@ -169,6 +177,50 @@ describe('sendPushForNotifications', () => {
     await sendPushForNotifications([item()])
     const [, body] = sendNotification.mock.calls[0]
     expect('tag' in JSON.parse(body as string)).toBe(false)
+  })
+
+  it('carries the recipient unread count as the numeric app-icon badge', async () => {
+    // iOS ignores the arg-less badge form, so a closed-app push must carry the
+    // count for the SW to set the numeric app-icon badge.
+    mockGetState.mockResolvedValue(state())
+    mockGetUnreadCount.mockResolvedValue(3)
+    await sendPushForNotifications([item()])
+    expect(mockGetUnreadCount).toHaveBeenCalledWith({
+      speakerId: 'speaker-1',
+      conferenceId: 'conf-1',
+    })
+    const [, body] = sendNotification.mock.calls[0]
+    expect(JSON.parse(body as string).badge).toBe(3)
+  })
+
+  it('omits badge from the payload when the unread count is zero', async () => {
+    mockGetState.mockResolvedValue(state())
+    mockGetUnreadCount.mockResolvedValue(0)
+    await sendPushForNotifications([item()])
+    const [, body] = sendNotification.mock.calls[0]
+    expect('badge' in JSON.parse(body as string)).toBe(false)
+  })
+
+  it('computes the unread count once for a recipient with two notifications', async () => {
+    mockGetState.mockResolvedValue(state())
+    mockGetUnreadCount.mockResolvedValue(2)
+    await sendPushForNotifications([
+      item({
+        recipientId: 'speaker-1',
+        notificationType: 'proposal_status_changed',
+      }),
+      item({ recipientId: 'speaker-1', notificationType: 'gallery_tagged' }),
+    ])
+    expect(mockGetUnreadCount).toHaveBeenCalledTimes(1)
+  })
+
+  it('never breaks delivery when the unread-count query fails (no badge)', async () => {
+    mockGetState.mockResolvedValue(state())
+    mockGetUnreadCount.mockRejectedValue(new Error('sanity down'))
+    await expect(sendPushForNotifications([item()])).resolves.toBeUndefined()
+    expect(sendNotification).toHaveBeenCalledTimes(1)
+    const [, body] = sendNotification.mock.calls[0]
+    expect('badge' in JSON.parse(body as string)).toBe(false)
   })
 
   it('defaults a LINKLESS notification to the /notifications page (empty body too)', async () => {

--- a/__tests__/lib/pwa/sw-source.test.ts
+++ b/__tests__/lib/pwa/sw-source.test.ts
@@ -59,6 +59,30 @@ describe('public/sw.js source invariants', () => {
     expect(source).toContain('self.registration.showNotification')
   })
 
+  it('sets a NUMERIC app-icon badge (iOS ignores the arg-less flag form)', () => {
+    // The push handler must call setAppBadge WITH an argument. iOS does not
+    // support the arg-less "flag" form of the Badging API, so a closed-app push
+    // has to set a number for the app-icon badge to appear.
+    expect(source).toContain('self.navigator.setAppBadge(badgeCount)')
+    // Guard against a regression to the arg-less call.
+    expect(source).not.toContain('setAppBadge()')
+  })
+
+  it('derives the badge count from the payload, falling back to 1', () => {
+    // The count comes from the push payload (the recipient's unread total); when
+    // absent it falls back to 1 so a closed-app push still shows a badge.
+    expect(source).toContain('payload.badge')
+    expect(source).toContain('? payload.badge')
+    expect(source).toContain(': 1')
+  })
+
+  it('parses a numeric badge out of the push payload', () => {
+    // parsePushPayload must read the numeric badge (unread count) so the push
+    // handler can set it as the app-icon badge.
+    expect(source).toContain("typeof data.badge === 'number'")
+    expect(source).toContain('data.badge > 0')
+  })
+
   it('constrains a notification click to a same-origin path', () => {
     // Mirrors src/lib/pwa/push-payload.ts sanitizeUrl: reject "//..." absolute
     // and protocol-relative URLs so a click can never leave the origin.

--- a/public/sw.js
+++ b/public/sw.js
@@ -241,8 +241,13 @@ function parsePushPayload(raw) {
       : NOTIFICATION_DEFAULT_TITLE
   const body = typeof data.body === 'string' ? data.body : ''
   const tag = typeof data.tag === 'string' ? data.tag : undefined
+  // The recipient's unread count for the NUMERIC app-icon badge (Badging API).
+  // iOS ignores the arg-less badge form, so a closed-app push must carry a
+  // number for the icon badge to show. Omitted (undefined) when absent/zero.
+  const badge =
+    typeof data.badge === 'number' && data.badge > 0 ? data.badge : undefined
 
-  return { title, body, url: sanitizeNotificationUrl(data.url), tag }
+  return { title, body, url: sanitizeNotificationUrl(data.url), tag, badge }
 }
 
 self.addEventListener('push', (event) => {
@@ -252,14 +257,20 @@ self.addEventListener('push', (event) => {
   event.waitUntil(
     (async () => {
       // Best-effort PWA app-icon badge (Badging API), so the icon reflects
-      // "unread present" even when no tab is open. The SW does not know the exact
-      // unread count, so it shows the generic dot (no-arg setAppBadge); the in-app
-      // AppBadgeSync sets the PRECISE number the next time a tab is focused.
-      // Feature-detected and never throws (the API rejects on unsupported
-      // platforms). MUST run inside waitUntil: on tight SW lifetimes work started
-      // outside the extended-lifetime promise can be dropped before it settles.
+      // unread notifications even when no tab is open. Feature-detected and
+      // never throws (the API rejects on unsupported platforms). MUST run inside
+      // waitUntil: on tight SW lifetimes work started outside the
+      // extended-lifetime promise can be dropped before it settles.
       if (self.navigator && 'setAppBadge' in self.navigator) {
-        await self.navigator.setAppBadge().catch(() => {})
+        // iOS requires a numeric badge (it ignores the arg-less flag form). Fall
+        // back to 1 when the payload carries no count so a closed-app push still
+        // shows a badge; the in-app AppBadgeSync corrects it to the exact count on
+        // next focus.
+        const badgeCount =
+          typeof payload.badge === 'number' && payload.badge > 0
+            ? payload.badge
+            : 1
+        await self.navigator.setAppBadge(badgeCount).catch(() => {})
       }
 
       await self.registration.showNotification(payload.title, {

--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -6,6 +6,7 @@ import {
 } from './vapid'
 import { getSpeakerPushState, prunePushSubscription } from './sanity'
 import { isValidPushEndpoint } from './validate'
+import { getUnreadCount } from '@/lib/notification/sanity'
 import type {
   PushCategory,
   PushMessagePayload,
@@ -282,6 +283,19 @@ async function deliverPushToRecipient(
   }
   if (subscriptions.length === 0) return
 
+  // Compute the recipient's unread count ONCE (all items in this call go to the
+  // same recipient/conference) and carry it in every payload so the service
+  // worker can set the NUMERIC app-icon badge even when the app is closed — iOS
+  // ignores the arg-less badge form. Notifications are persisted before this
+  // bridge runs, so the count already includes the just-created ones. A failure
+  // here must never break delivery, hence the `.catch(() => 0)`.
+  const conferenceId = items[0]?.conferenceId
+  const badge = conferenceId
+    ? await getUnreadCount({ speakerId: recipientId, conferenceId }).catch(
+        () => 0,
+      )
+    : 0
+
   for (const item of items) {
     const category = pushCategoryForNotificationType(item.notificationType)
     if (!state.preferences[category]) continue
@@ -299,6 +313,8 @@ async function deliverPushToRecipient(
       // showNotification so repeat pushes for the same thread REPLACE the prior
       // one instead of stacking. Undefined for one-shot types (they stack).
       ...(item.tag ? { tag: item.tag } : {}),
+      // Numeric app-icon badge for the closed-app case (see above).
+      ...(badge > 0 ? { badge } : {}),
     }
 
     const results = await Promise.allSettled(

--- a/src/lib/push/types.ts
+++ b/src/lib/push/types.ts
@@ -85,6 +85,13 @@ export interface PushMessagePayload {
   url: string
   /** Optional category tag, used to collapse/replace prior notifications. */
   tag?: string
+  /**
+   * The recipient's current unread-notification count, when > 0. The service
+   * worker sets this as the numeric app-icon badge (Badging API). iOS ignores
+   * the arg-less "flag" form of `setAppBadge`, so a closed-app push MUST carry a
+   * number for the icon badge to appear. Omitted when zero/unknown.
+   */
+  badge?: number
 }
 
 /** Normalises an arbitrary stored value into a complete PushPreferences. */


### PR DESCRIPTION
## The bug (iOS PWA)

An installed PWA never showed an unread app-icon badge when a push arrived while the app was **closed**. The service worker's `push` handler called `self.navigator.setAppBadge()` with **no argument** — the generic "flag/dot" form of the Badging API.

**iOS does not support the flag form** — it only renders the app-icon badge when `setAppBadge(n)` is given a numeric `n > 0`. While the app is running, `AppBadgeSync` sets the exact numeric count, but that can't run when the app is closed. So a closed-app push produced no badge at all on iOS.

## The fix

The push payload now carries the recipient's unread count, and the service worker sets it numerically.

- **`PushMessagePayload`** (`src/lib/push/types.ts`): add optional `badge?: number`.
- **`deliverPushToRecipient`** (`src/lib/push/send.ts`): compute the unread count **once per recipient** (all items in one call go to the same recipient/conference) via the existing cheap `getUnreadCount({ speakerId, conferenceId })`. Notifications are persisted **before** the push bridge runs, so the count already includes the just-created ones. Guarded with `.catch(() => 0)` so a query failure never breaks delivery; only included in the payload when `> 0`.
- **`public/sw.js`**: `parsePushPayload` parses the numeric `badge`; the `push` handler sets `setAppBadge(badgeCount)`, **falling back to `1`** when the payload carries no count so a closed-app push still shows *a* badge — `AppBadgeSync` corrects it to the exact count on next focus. Kept inside `waitUntil` with the feature-detect + `.catch`.

Note: this touches only `navigator.setAppBadge` (the **app-icon** badge). The unrelated `badge:` option of `showNotification` (the monochrome status-bar icon) is left untouched.

## Tests

- `__tests__/lib/pwa/sw-source.test.ts` — drift-guard assertions that the push handler calls `setAppBadge(badgeCount)` (never the bare `setAppBadge()`), derives the count from `payload.badge` with a fallback to `1`, and that `parsePushPayload` parses a numeric `badge`.
- `__tests__/lib/push/send-bridge.test.ts` — cases asserting the payload carries `badge` = the recipient unread count, omits it when zero, computes it once for a multi-notification recipient, and never breaks delivery when the count query fails.

`tsc --noEmit`, `eslint`, `vitest` (46 passed), and `prettier` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds numeric app-icon badges to closed-app push delivery. The main changes are:

- Adds an optional unread count to push payloads.
- Queries the recipient's unread count before sending pushes.
- Parses and applies numeric badges in the service worker.
- Falls back to a badge of 1 when no count is available.
- Adds coverage for payload generation and service-worker source invariants.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge with a small batching hardening opportunity.

- Current notification callers keep each batch within one conference.
- Badge API failures are isolated from notification display.
- Recipient batches containing multiple conferences could show the wrong count.

src/lib/push/send.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/push/send.ts | Adds one unread-count query per recipient batch and includes positive counts in each push payload. |
| src/lib/push/types.ts | Adds the optional numeric badge field to the push payload contract. |
| public/sw.js | Parses positive badge counts and safely applies a numeric app badge before showing the notification. |
| __tests__/lib/push/send-bridge.test.ts | Covers positive, zero, failed-query, and multi-notification unread-count behavior. |
| __tests__/lib/pwa/sw-source.test.ts | Adds source guards for numeric badge parsing, fallback behavior, and API invocation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pwa): numeric app-icon badge on push..."](https://github.com/cloudnativebergen/website/commit/c1d16a321c9bae3678baefaa2d2d7470c79a9b32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45895173)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->