### PR TITLE
fix(pwa): show updating progress on the version-reload banner

### DIFF
--- a/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
+++ b/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
@@ -145,6 +145,63 @@ describe('ServiceWorkerRegistrar', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('ignores a second Reload click while the swap is already in progress', async () => {
+    const registration = await renderAndRegister()
+
+    container.controller = {}
+    const worker = new FakeWorker()
+    registration.installing = worker
+    registration.dispatch('updatefound')
+    worker.setState('installed')
+
+    await screen.findByRole('status', { name: 'Update available' })
+    fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
+    expect(worker.postMessage).toHaveBeenCalledTimes(1)
+
+    // The action is now the disabled "Updating…" control; clicking it again must
+    // not post SKIP_WAITING (nor arm a second fallback) a second time.
+    fireEvent.click(screen.getByRole('button', { name: /updating/i }))
+    expect(worker.postMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms the banner when a reload is canceled (beforeunload) instead of hanging', async () => {
+    vi.useFakeTimers()
+    try {
+      const registration = container.registration
+      render(<ServiceWorkerRegistrar />)
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      act(() => {
+        container.controller = {}
+        const worker = new FakeWorker()
+        registration.installing = worker
+        registration.dispatch('updatefound')
+        worker.setState('installed')
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
+      // controllerchange calls reload(); the mock does NOT navigate, standing in
+      // for a beforeunload prompt (e.g. unsaved schedule edits) the user cancels.
+      act(() => container.dispatch('controllerchange'))
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+      expect(screen.getByRole('button', { name: /updating/i })).toBeDisabled()
+
+      // After the recovery delay the banner returns to its actionable state
+      // rather than hanging on a dead spinner.
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+      expect(screen.getByRole('button', { name: 'Reload' })).toBeEnabled()
+      expect(
+        screen.queryByRole('button', { name: /updating/i }),
+      ).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('fallback timeout forces a reload when controllerchange never fires', async () => {
     vi.useFakeTimers()
     try {

--- a/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
+++ b/__tests__/components/pwa/ServiceWorkerRegistrar.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import {
+  act,
   render,
   screen,
   fireEvent,
@@ -115,7 +116,7 @@ describe('ServiceWorkerRegistrar', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('posts SKIP_WAITING to the waiting worker when Reload is clicked', async () => {
+  it('posts SKIP_WAITING and enters the pending state when Reload is clicked', async () => {
     const registration = await renderAndRegister()
 
     container.controller = {}
@@ -130,6 +131,83 @@ describe('ServiceWorkerRegistrar', () => {
     expect(worker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
     // Clicking Reload must NOT itself reload — the controllerchange does.
     expect(reloadMock).not.toHaveBeenCalled()
+
+    // The banner now shows in-progress feedback: the action becomes a disabled
+    // "Updating…" control so the user can tell the swap is underway.
+    const updatingButton = screen.getByRole('button', { name: /updating/i })
+    expect(updatingButton).toBeDisabled()
+    expect(updatingButton).toHaveAttribute('aria-busy', 'true')
+    expect(
+      screen.getByRole('button', { name: 'Dismiss update prompt' }),
+    ).toBeDisabled()
+    expect(
+      screen.queryByRole('button', { name: 'Reload' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('fallback timeout forces a reload when controllerchange never fires', async () => {
+    vi.useFakeTimers()
+    try {
+      const registration = container.registration
+      render(<ServiceWorkerRegistrar />)
+      // Flush the async register() promise + effects (microtasks aren't faked).
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(container.register).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        container.controller = {}
+        const worker = new FakeWorker()
+        registration.installing = worker
+        registration.dispatch('updatefound')
+        worker.setState('installed')
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
+      // controllerchange never arrives — the ~4s fallback must reload anyway.
+      expect(reloadMock).not.toHaveBeenCalled()
+
+      act(() => {
+        vi.advanceTimersByTime(4000)
+      })
+
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reloads exactly once when both controllerchange and the fallback would fire', async () => {
+    vi.useFakeTimers()
+    try {
+      const registration = container.registration
+      render(<ServiceWorkerRegistrar />)
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      act(() => {
+        container.controller = {}
+        const worker = new FakeWorker()
+        registration.installing = worker
+        registration.dispatch('updatefound')
+        worker.setState('installed')
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
+
+      // controllerchange fires first and reloads...
+      act(() => container.dispatch('controllerchange'))
+      // ...so advancing past the fallback window must NOT reload a second time.
+      act(() => {
+        vi.advanceTimersByTime(4000)
+      })
+
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('reloads exactly once on controllerchange AFTER the user accepts (guard prevents a second)', async () => {

--- a/src/components/pwa/ServiceWorkerRegistrar.tsx
+++ b/src/components/pwa/ServiceWorkerRegistrar.tsx
@@ -6,6 +6,12 @@ import { UpdateBanner } from './UpdateBanner'
 // How long to wait for `controllerchange` after `SKIP_WAITING` before forcing a
 // reload ourselves, so the "Updating…" spinner can never hang forever.
 const RELOAD_FALLBACK_MS = 4000
+// After we call reload(), a `beforeunload` prompt (e.g. unsaved schedule edits)
+// can cancel the navigation and leave us on the page. If we're still here this
+// long after, treat the reload as canceled and re-arm the banner so it isn't
+// stuck showing a dead spinner. Only ever fires on cancel — a committed reload
+// unloads the page before it can.
+const RELOAD_CANCEL_RECOVERY_MS = 500
 
 /**
  * Registers the service worker and drives the update lifecycle.
@@ -44,6 +50,8 @@ export function ServiceWorkerRegistrar() {
   // Id of the fallback timeout that forces a reload if controllerchange never
   // arrives. Stored in a ref so both paths (and cleanup) can clear it.
   const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Id of the post-reload recovery timeout (see RELOAD_CANCEL_RECOVERY_MS).
+  const recoveryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Reload the page exactly once. Clears any pending fallback timeout so the
   // other path can no longer fire a second reload. Both the controllerchange
@@ -56,6 +64,14 @@ export function ServiceWorkerRegistrar() {
     if (refreshingRef.current) return
     refreshingRef.current = true
     window.location.reload()
+    // Execution only resumes here if the reload was CANCELED by a beforeunload
+    // prompt (a committed reload unloads the page first). Re-arm so the banner
+    // recovers from its disabled "Updating…" state and the user can retry.
+    recoveryTimeoutRef.current = setTimeout(() => {
+      refreshingRef.current = false
+      reloadRequestedRef.current = false
+      setUpdating(false)
+    }, RELOAD_CANCEL_RECOVERY_MS)
   }, [])
 
   useEffect(() => {
@@ -142,10 +158,17 @@ export function ServiceWorkerRegistrar() {
         clearTimeout(fallbackTimeoutRef.current)
         fallbackTimeoutRef.current = null
       }
+      if (recoveryTimeoutRef.current !== null) {
+        clearTimeout(recoveryTimeoutRef.current)
+        recoveryTimeoutRef.current = null
+      }
     }
   }, [doReload])
 
   const handleReload = () => {
+    // Ignore repeat clicks (e.g. a rapid double-tap before the button's disabled
+    // state renders) so we never post SKIP_WAITING or arm the fallback twice.
+    if (reloadRequestedRef.current) return
     // Show the in-progress state immediately so the click has visible feedback
     // even before the worker activates.
     setUpdating(true)

--- a/src/components/pwa/ServiceWorkerRegistrar.tsx
+++ b/src/components/pwa/ServiceWorkerRegistrar.tsx
@@ -1,7 +1,11 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { UpdateBanner } from './UpdateBanner'
+
+// How long to wait for `controllerchange` after `SKIP_WAITING` before forcing a
+// reload ourselves, so the "Updating…" spinner can never hang forever.
+const RELOAD_FALLBACK_MS = 4000
 
 /**
  * Registers the service worker and drives the update lifecycle.
@@ -25,12 +29,34 @@ import { UpdateBanner } from './UpdateBanner'
  */
 export function ServiceWorkerRegistrar() {
   const [updateAvailable, setUpdateAvailable] = useState(false)
+  // True from the moment the user clicks Reload until the page actually reloads.
+  // Drives the banner's in-progress ("Installing…") state.
+  const [updating, setUpdating] = useState(false)
   // The worker that is installed and waiting to activate.
   const waitingWorkerRef = useRef<ServiceWorker | null>(null)
   // Set only when the USER accepts the update (clicks Reload). Gates the
   // controllerchange reload so a first-install `clients.claim()` — which also
   // fires controllerchange — never triggers an unsolicited page reload.
   const reloadRequestedRef = useRef(false)
+  // Shared "already reloading" guard so the controllerchange handler AND the
+  // fallback timeout reload the page EXACTLY ONCE, whichever fires first.
+  const refreshingRef = useRef(false)
+  // Id of the fallback timeout that forces a reload if controllerchange never
+  // arrives. Stored in a ref so both paths (and cleanup) can clear it.
+  const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Reload the page exactly once. Clears any pending fallback timeout so the
+  // other path can no longer fire a second reload. Both the controllerchange
+  // handler and the fallback timeout funnel through here.
+  const doReload = useCallback(() => {
+    if (fallbackTimeoutRef.current !== null) {
+      clearTimeout(fallbackTimeoutRef.current)
+      fallbackTimeoutRef.current = null
+    }
+    if (refreshingRef.current) return
+    refreshingRef.current = true
+    window.location.reload()
+  }, [])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -39,15 +65,13 @@ export function ServiceWorkerRegistrar() {
     if (process.env.NODE_ENV !== 'production') return
 
     // Reload exactly once when the active worker changes AFTER the user accepted
-    // the update. The `refreshing` guard prevents an infinite loop; the
-    // `reloadRequestedRef` guard prevents an unsolicited reload on first install
-    // (where `clients.claim()` also fires controllerchange).
-    let refreshing = false
+    // the update. `doReload`'s `refreshingRef` guard prevents an infinite loop
+    // (and coordinates with the fallback timeout); the `reloadRequestedRef`
+    // guard prevents an unsolicited reload on first install (where
+    // `clients.claim()` also fires controllerchange).
     const onControllerChange = () => {
       if (!reloadRequestedRef.current) return
-      if (refreshing) return
-      refreshing = true
-      window.location.reload()
+      doReload()
     }
     navigator.serviceWorker.addEventListener(
       'controllerchange',
@@ -114,10 +138,17 @@ export function ServiceWorkerRegistrar() {
       window.removeEventListener('focus', onFocusOrVisible)
       document.removeEventListener('visibilitychange', onFocusOrVisible)
       window.removeEventListener('load', register)
+      if (fallbackTimeoutRef.current !== null) {
+        clearTimeout(fallbackTimeoutRef.current)
+        fallbackTimeoutRef.current = null
+      }
     }
-  }, [])
+  }, [doReload])
 
   const handleReload = () => {
+    // Show the in-progress state immediately so the click has visible feedback
+    // even before the worker activates.
+    setUpdating(true)
     // Mark the reload as user-accepted so the controllerchange handler is
     // allowed to reload (an unsolicited first-install controllerchange is not).
     reloadRequestedRef.current = true
@@ -125,9 +156,13 @@ export function ServiceWorkerRegistrar() {
     if (worker) {
       // Tell the waiting worker to activate; `controllerchange` then reloads.
       worker.postMessage({ type: 'SKIP_WAITING' })
+      // Fallback: if `controllerchange` never fires (worker wedged, activation
+      // stalled), force a reload so the spinner always resolves. `doReload`
+      // coordinates with the controllerchange path so we reload exactly once.
+      fallbackTimeoutRef.current = setTimeout(doReload, RELOAD_FALLBACK_MS)
     } else {
       // No tracked worker (edge case) — a plain reload still recovers.
-      window.location.reload()
+      doReload()
     }
   }
 
@@ -142,5 +177,11 @@ export function ServiceWorkerRegistrar() {
 
   if (!updateAvailable) return null
 
-  return <UpdateBanner onReload={handleReload} onDismiss={handleDismiss} />
+  return (
+    <UpdateBanner
+      onReload={handleReload}
+      onDismiss={handleDismiss}
+      pending={updating}
+    />
+  )
 }

--- a/src/components/pwa/UpdateBanner.stories.tsx
+++ b/src/components/pwa/UpdateBanner.stories.tsx
@@ -25,3 +25,14 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+/**
+ * In-progress state after the user clicks Reload: the leading icon and the
+ * Reload button spin, the copy switches to "Installing…", and both actions are
+ * disabled while the waiting worker activates and the page reloads.
+ */
+export const Updating: Story = {
+  args: {
+    pending: true,
+  },
+}

--- a/src/components/pwa/UpdateBanner.tsx
+++ b/src/components/pwa/UpdateBanner.tsx
@@ -78,7 +78,6 @@ export function UpdateBanner({
           onClick={onReload}
           disabled={pending}
           aria-busy={pending}
-          aria-live="polite"
           className="flex min-h-11 flex-none items-center justify-center gap-1.5 rounded-lg bg-brand-cloud-blue px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-default disabled:opacity-90 disabled:hover:bg-brand-cloud-blue"
         >
           {pending ? (

--- a/src/components/pwa/UpdateBanner.tsx
+++ b/src/components/pwa/UpdateBanner.tsx
@@ -8,6 +8,13 @@ export interface UpdateBannerProps {
   onReload: () => void
   /** Invoked by the dismiss control (keeps the current version for now). */
   onDismiss: () => void
+  /**
+   * When true the swap is in progress: the leading icon and the Reload button
+   * spin, the copy switches to "Installing…", and BOTH actions are disabled
+   * (you cannot cancel an activation mid-flight). The parent container owns this
+   * flag — the banner itself has no service-worker logic.
+   */
+  pending?: boolean
 }
 
 /**
@@ -20,7 +27,11 @@ export interface UpdateBannerProps {
  * `transition` utilities. The `motion-reduce:` variant disables the transform
  * and transition entirely for users who prefer reduced motion.
  */
-export function UpdateBanner({ onReload, onDismiss }: UpdateBannerProps) {
+export function UpdateBanner({
+  onReload,
+  onDismiss,
+  pending = false,
+}: UpdateBannerProps) {
   const [entered, setEntered] = useState(false)
 
   useEffect(() => {
@@ -37,6 +48,7 @@ export function UpdateBanner({ onReload, onDismiss }: UpdateBannerProps) {
       // stealing focus. It also sits BELOW open dialogs (shell family is z-50).
       role="status"
       aria-live="polite"
+      aria-busy={pending}
       aria-label="Update available"
       className="fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-[max(1rem,env(safe-area-inset-bottom))]"
     >
@@ -46,26 +58,45 @@ export function UpdateBanner({ onReload, onDismiss }: UpdateBannerProps) {
         }`}
       >
         <div className="flex size-10 flex-none items-center justify-center rounded-xl bg-brand-cloud-blue/10 text-brand-cloud-blue dark:bg-brand-cloud-blue/20">
-          <ArrowPathIcon className="size-5" />
+          <ArrowPathIcon
+            className={`size-5 ${
+              pending ? 'animate-spin motion-reduce:animate-none' : ''
+            }`}
+          />
         </div>
 
         <div className="flex-1 text-sm text-gray-700 dark:text-gray-200">
-          <span>A new version is available.</span>
+          <span>
+            {pending
+              ? 'Installing the new version…'
+              : 'A new version is available.'}
+          </span>
         </div>
 
         <button
           type="button"
           onClick={onReload}
-          className="flex min-h-11 flex-none items-center justify-center rounded-lg bg-brand-cloud-blue px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue"
+          disabled={pending}
+          aria-busy={pending}
+          aria-live="polite"
+          className="flex min-h-11 flex-none items-center justify-center gap-1.5 rounded-lg bg-brand-cloud-blue px-3 py-1.5 text-sm font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-default disabled:opacity-90 disabled:hover:bg-brand-cloud-blue"
         >
-          Reload
+          {pending ? (
+            <>
+              <ArrowPathIcon className="size-4 animate-spin motion-reduce:animate-none" />
+              <span>Updating…</span>
+            </>
+          ) : (
+            <span>Reload</span>
+          )}
         </button>
 
         <button
           type="button"
           onClick={onDismiss}
+          disabled={pending}
           aria-label="Dismiss update prompt"
-          className="flex min-h-11 min-w-11 flex-none items-center justify-center rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:hover:bg-gray-700 dark:hover:text-gray-200"
+          className="flex min-h-11 min-w-11 flex-none items-center justify-center rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:pointer-events-none disabled:opacity-40 dark:hover:bg-gray-700 dark:hover:text-gray-200"
         >
           <XMarkIcon className="size-5" />
         </button>


### PR DESCRIPTION
## Problem

The PWA "new version available" banner (`UpdateBanner`) has a **Reload** button. Clicking it posts `SKIP_WAITING` to the waiting service worker and then silently waits for the worker to activate and fire `controllerchange`, which reloads the page. Between the click and the reload there is **no visual feedback** — the user can't tell anything is happening, and if the worker gets wedged the page never reloads at all.

## Change

**Pending state (`UpdateBanner.tsx`)** — a new optional, purely presentational `pending?: boolean` prop. When true:
- the leading `ArrowPathIcon` spins (`animate-spin motion-reduce:animate-none`),
- the copy switches from "A new version is available." to "Installing the new version…",
- the Reload button becomes `disabled`, shows an inline spinner + "Updating…" and sets `aria-busy`,
- the dismiss (X) control is disabled — you can't cancel a swap in progress,
- `aria-busy` is set on the `role="status"` live region so the change is announced.

The component stays free of any service-worker logic; the parent owns the flag. Entrance animation and reduced-motion handling are preserved.

**Driving the flag + fallback reload (`ServiceWorkerRegistrar.tsx`)** — a new `updating` state is set the instant Reload is clicked and passed as `pending`. After posting `SKIP_WAITING`, a **~4000 ms fallback timeout** forces a reload if `controllerchange` never fires, so the spinner can never hang forever.

**Reload exactly once:** the old effect-local `refreshing` guard is refactored into a shared `refreshingRef` plus a `doReload()` helper. `doReload()` clears the pending fallback timeout and early-returns if a reload is already in flight, otherwise sets the guard and calls `window.location.reload()`. Both the `controllerchange` handler and the fallback timeout funnel through `doReload()`, and the timeout id is cleared on cleanup — so whichever path fires first wins and the page reloads exactly once. The existing `reloadRequestedRef` gating is preserved, so a first-install `clients.claim()` controllerchange still does not reload.

## Tests & QA

- Extended the Reload-click test to assert the banner enters the pending state (disabled "Updating…" button, `aria-busy`, disabled dismiss).
- Added a fake-timer test: the fallback reloads once when `controllerchange` never fires.
- Added a coordination test: when both `controllerchange` and the fallback would fire, reload is called exactly once.
- All PWA registrar tests pass (10/10); `tsc --noEmit` and `eslint` clean.
- Added an `Updating` Storybook story; visually inspected both states at 393px in light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds visible progress and a timed fallback to the PWA update flow. The main changes are:

- A pending state with progress copy, spinners, and disabled actions.
- Shared coordination for controller-change and fallback reloads.
- Tests and a Storybook story for the updating state.

<h3>Confidence Score: 4/5</h3>

The reload lifecycle needs fixes for slow activation and canceled navigation before merging.

- The timed fallback can reload before the new worker controls the page.
- A canceled reload clears all recovery paths and leaves both banner actions disabled.
- The pending UI and duplicate-call guard otherwise follow the intended flow.

src/components/pwa/ServiceWorkerRegistrar.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/pwa/ServiceWorkerRegistrar.tsx | Adds reload coordination and pending state, but slow activation and canceled navigation can leave the update flow incomplete. |
| src/components/pwa/UpdateBanner.tsx | Adds the optional pending presentation with progress text, animation, disabled controls, and busy-state attributes. |
| __tests__/components/pwa/ServiceWorkerRegistrar.test.tsx | Adds coverage for pending UI, fallback timing, and duplicate reload calls, but not navigation before activation or canceled navigation. |
| src/components/pwa/UpdateBanner.stories.tsx | Adds an isolated story for the updating state. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant R as Registrar
    participant W as Waiting worker
    participant B as Browser
    U->>R: Click Reload
    R->>W: SKIP_WAITING
    R->>R: Start 4s fallback
    alt controllerchange arrives first
        W-->>R: controllerchange
        R->>B: Reload under new controller
    else activation exceeds 4s
        R->>B: Fallback reload
        B->>R: Page may still use old controller
        W-->>R: Later controllerchange
        Note over R: Request gate was reset, so reload is skipped
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant R as Registrar
    participant W as Waiting worker
    participant B as Browser
    U->>R: Click Reload
    R->>W: SKIP_WAITING
    R->>R: Start 4s fallback
    alt controllerchange arrives first
        W-->>R: controllerchange
        R->>B: Reload under new controller
    else activation exceeds 4s
        R->>B: Fallback reload
        B->>R: Page may still use old controller
        W-->>R: Later controllerchange
        Note over R: Request gate was reset, so reload is skipped
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(pwa): show updating progress on the ..."](https://github.com/cloudnativebergen/website/commit/be61c93da290d8b586f5112b470a4bdce1db8bdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45905535)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->