### PR TITLE
fix(dashboard): critical review fixes — Cancel-saves bug, dead links, load-failure wipe, reset confirm

### DIFF
--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -768,7 +768,7 @@ export async function fetchQuickActions(
         label: 'Travel Support',
         shortLabel: 'Travel',
         icon: 'GlobeAltIcon',
-        link: '/admin/travel-support',
+        link: '/admin/speakers/travel-support',
         variant: 'warning',
       },
       {
@@ -836,14 +836,14 @@ export async function fetchQuickActions(
         label: 'Publish Content',
         shortLabel: 'Gallery',
         icon: 'ClipboardDocumentCheckIcon',
-        link: '/admin/gallery',
+        link: '/admin/marketing/gallery',
         variant: 'primary',
       },
       {
         label: 'Travel Expenses',
         shortLabel: 'Expenses',
         icon: 'GlobeAltIcon',
-        link: '/admin/travel-support',
+        link: '/admin/speakers/travel-support',
         variant: 'warning',
       },
       {

--- a/src/components/admin/AdminButton.tsx
+++ b/src/components/admin/AdminButton.tsx
@@ -47,11 +47,17 @@ export function AdminButton({
   variant = 'primary',
   color = 'indigo',
   size = 'sm',
+  // Default to type="button" (native buttons default to type="submit").
+  // Without this, any AdminButton inside a <form> — e.g. a modal's Cancel or
+  // Reset button — implicitly submits the form on click. Buttons that are
+  // meant to submit must pass type="submit" explicitly.
+  type = 'button',
   className,
   ...props
 }: AdminButtonProps) {
   return (
     <button
+      type={type}
       className={clsx(
         'inline-flex items-center justify-center gap-1.5 rounded-md font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
         variant === 'primary' ? colorStyles[color] : variantStyles[variant],

--- a/src/components/admin/ConfirmationModal.stories.tsx
+++ b/src/components/admin/ConfirmationModal.stories.tsx
@@ -35,6 +35,25 @@ export const Danger: Story = {
   },
 }
 
+export const DashboardReset: Story = {
+  args: {
+    isOpen: true,
+    title: 'Reset dashboard layout?',
+    message:
+      'This replaces your current widgets and layout with the default planning preset. This cannot be undone.',
+    confirmButtonText: 'Reset layout',
+    variant: 'danger',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Confirmation shown by the admin dashboard before the Reset control replaces the whole layout with the planning preset (a destructive, persisted action).',
+      },
+    },
+  },
+}
+
 export const Warning: Story = {
   args: {
     isOpen: true,

--- a/src/components/admin/dashboard/AdminDashboard.test.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import type { Widget } from '@/lib/dashboard/types'
+import type { Conference } from '@/lib/conference/types'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import {
+  loadDashboardConfig,
+  saveDashboardConfig,
+} from '@/app/(admin)/admin/actions'
+import { AdminDashboard } from './AdminDashboard'
+
+vi.mock('@/app/(admin)/admin/actions', () => ({
+  loadDashboardConfig: vi.fn(),
+  saveDashboardConfig: vi.fn(),
+}))
+
+// The widget renderer transitively imports every widget implementation
+// (charts, data fetching, …); none of that matters for persistence behavior.
+vi.mock('@/components/admin/dashboard/widget-renderer', () => ({
+  renderWidgetContent: () => null,
+}))
+
+// Replace the dnd-kit grid with a button that simulates the grid reporting a
+// completed user drag — the only code path that calls onWidgetsChange in the
+// real DashboardGrid.
+vi.mock('@/components/admin/dashboard/DashboardGrid', () => ({
+  DashboardGrid: ({
+    widgets,
+    onWidgetsChange,
+  }: {
+    widgets: Widget[]
+    onWidgetsChange: (widgets: Widget[]) => void
+  }) => (
+    <button
+      onClick={() =>
+        onWidgetsChange(
+          widgets.map((w, i) =>
+            i === 0
+              ? { ...w, position: { ...w.position, row: w.position.row + 1 } }
+              : w,
+          ),
+        )
+      }
+    >
+      simulate-drag
+    </button>
+  ),
+}))
+
+const conference = { _id: 'conf-1', title: 'Test Conf' } as Conference
+
+const savedWidgets = [
+  {
+    id: 'review-progress-1',
+    type: 'review-progress',
+    title: 'Review Progress',
+    position: { row: 0, col: 0, rowSpan: 3, colSpan: 3 },
+    config: undefined,
+  },
+]
+
+function renderDashboard() {
+  return render(
+    <NotificationProvider>
+      <AdminDashboard conference={conference} />
+    </NotificationProvider>,
+  )
+}
+
+/** Flush the pending loadDashboardConfig promise chain. */
+async function flushLoad() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+/** Advance past the save debounce and flush any save promise. */
+async function advancePastDebounce(ms = 3000) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+async function simulateDrag() {
+  await act(async () => {
+    fireEvent.click(screen.getByText('simulate-drag'))
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.mocked(saveDashboardConfig).mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('AdminDashboard persistence', () => {
+  it('load failure: performs NO save without user action and warns the user', async () => {
+    // Regression: the load .catch used to enable persistence, which made the
+    // widgets-change effect auto-save DEFAULT_WIDGETS over the stored config.
+    vi.mocked(loadDashboardConfig).mockRejectedValue(new Error('offline'))
+
+    renderDashboard()
+    await flushLoad()
+
+    expect(
+      screen.getByText("Couldn't load your dashboard layout"),
+    ).toBeInTheDocument()
+
+    await advancePastDebounce()
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+  })
+
+  it('load failure: a user drag STILL performs no save (session persistence disabled)', async () => {
+    vi.mocked(loadDashboardConfig).mockRejectedValue(new Error('offline'))
+
+    renderDashboard()
+    await flushLoad()
+
+    await simulateDrag()
+    await advancePastDebounce()
+
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+  })
+
+  it('load success: no echo-write of the freshly loaded layout', async () => {
+    vi.mocked(loadDashboardConfig).mockResolvedValue(savedWidgets)
+
+    renderDashboard()
+    await flushLoad()
+    await advancePastDebounce()
+
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+  })
+
+  it('load success + user drag: exactly one debounced save', async () => {
+    vi.mocked(loadDashboardConfig).mockResolvedValue(savedWidgets)
+
+    renderDashboard()
+    await flushLoad()
+
+    await simulateDrag()
+    // Not yet — the save is debounced
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+
+    await advancePastDebounce()
+    expect(saveDashboardConfig).toHaveBeenCalledTimes(1)
+    expect(saveDashboardConfig).toHaveBeenCalledWith(
+      'conf-1',
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'review-progress-1' }),
+      ]),
+    )
+  })
+
+  it('save failure: surfaces an error toast while keeping local state', async () => {
+    vi.mocked(loadDashboardConfig).mockResolvedValue(savedWidgets)
+    vi.mocked(saveDashboardConfig).mockRejectedValue(new Error('offline'))
+
+    renderDashboard()
+    await flushLoad()
+
+    await simulateDrag()
+    await advancePastDebounce()
+
+    expect(saveDashboardConfig).toHaveBeenCalledTimes(1)
+    expect(
+      screen.getByText("Couldn't save your dashboard layout"),
+    ).toBeInTheDocument()
+  })
+
+  it('reset requires confirmation; cancelling neither resets nor saves', async () => {
+    vi.mocked(loadDashboardConfig).mockResolvedValue(savedWidgets)
+
+    renderDashboard()
+    await flushLoad()
+
+    // Enter edit mode (jsdom innerWidth 1024 → desktop controls visible)
+    fireEvent.click(screen.getByRole('button', { name: /Edit/ }))
+    fireEvent.click(screen.getByRole('button', { name: /^Reset$/ }))
+
+    expect(screen.getByText('Reset dashboard layout?')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await advancePastDebounce()
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+  })
+
+  it('confirming reset applies the default layout and persists it', async () => {
+    vi.mocked(loadDashboardConfig).mockResolvedValue(savedWidgets)
+
+    renderDashboard()
+    await flushLoad()
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit/ }))
+    fireEvent.click(screen.getByRole('button', { name: /^Reset$/ }))
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Reset layout' }))
+    })
+
+    await advancePastDebounce()
+    expect(saveDashboardConfig).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/admin/dashboard/AdminDashboard.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.tsx
@@ -62,7 +62,7 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
   const showNotificationRef = useRef(showNotification)
   useEffect(() => {
     showNotificationRef.current = showNotification
-  })
+  }, [showNotification])
 
   // True once the USER has changed the layout this session (add/remove/drag/
   // resize/config/reset). The persist effect below fires on EVERY `widgets`

--- a/src/components/admin/dashboard/AdminDashboard.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.tsx
@@ -23,6 +23,8 @@ import {
 } from '@heroicons/react/24/outline'
 import { Conference } from '@/lib/conference/types'
 import { getCurrentPhase } from '@/lib/conference/phase'
+import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
+import { useNotification } from '@/components/admin/NotificationProvider'
 import {
   loadDashboardConfig,
   saveDashboardConfig,
@@ -30,6 +32,14 @@ import {
 } from '@/app/(admin)/admin/actions'
 
 const DEFAULT_WIDGETS = PRESET_CONFIGS.planning.widgets
+
+/**
+ * Outcome of the initial loadDashboardConfig call. Persistence is only ever
+ * enabled after a successful load ('loaded'): if the load FAILED we never saw
+ * the stored layout, so any save would overwrite it with local defaults —
+ * a silent data wipe. In that case saves stay disabled for the whole session.
+ */
+type LoadStatus = 'loading' | 'loaded' | 'failed'
 
 interface AdminDashboardProps {
   conference: Conference
@@ -40,8 +50,30 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
   const [editMode, setEditMode] = useState(false)
   const [columnCount, setColumnCount] = useState(4)
   const [showWidgetPicker, setShowWidgetPicker] = useState(false)
-  const [configLoaded, setConfigLoaded] = useState(false)
+  const [showResetConfirm, setShowResetConfirm] = useState(false)
+  const [loadStatus, setLoadStatus] = useState<LoadStatus>('loading')
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // The user must be told when the layout won't persist, but the toast
+  // context value has a new identity on every toast change; going through a
+  // ref (kept current by the effect below) keeps `persistWidgets` (and the
+  // persist effect) stable.
+  const { showNotification } = useNotification()
+  const showNotificationRef = useRef(showNotification)
+  useEffect(() => {
+    showNotificationRef.current = showNotification
+  })
+
+  // True once the USER has changed the layout this session (add/remove/drag/
+  // resize/config/reset). The persist effect below fires on EVERY `widgets`
+  // change — including the mount-time default state and the load-applied
+  // state — so without this flag the dashboard would echo freshly-loaded (or
+  // default) widgets straight back to the server with zero user action.
+  const dirtyRef = useRef(false)
+
+  // Deduplicates the save-failure toast: notify on the first failure of a
+  // burst, then stay quiet until a save succeeds again.
+  const saveFailureNotifiedRef = useRef(false)
 
   const currentPhase = getCurrentPhase(conference)
 
@@ -67,7 +99,13 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
     [visibleWidgets, columnCount],
   )
 
-  // Load saved config on mount
+  // Load saved config on mount.
+  //
+  // Mount-time effect ordering with the persist effect below: this effect and
+  // the persist effect both run on mount, and the persist effect re-runs when
+  // this one resolves (setWidgets and/or setLoadStatus change its deps). None
+  // of those runs may write: `dirtyRef` is still false, so the persist effect
+  // is a no-op until the user actually mutates the layout.
   useEffect(() => {
     loadDashboardConfig(conference._id)
       .then((saved) => {
@@ -82,15 +120,32 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
             })),
           )
         }
-        setConfigLoaded(true)
+        setLoadStatus('loaded')
       })
-      .catch(() => setConfigLoaded(true))
+      .catch(() => {
+        // Load failed: we never saw the stored layout, so persisting anything
+        // this session could overwrite it with defaults. Editing still works
+        // locally; tell the user once that changes won't stick.
+        setLoadStatus('failed')
+        showNotificationRef.current({
+          type: 'warning',
+          title: "Couldn't load your dashboard layout",
+          message:
+            'Showing the default layout. Changes you make will not be saved this session.',
+        })
+      })
   }, [conference._id])
 
-  // Debounced save whenever widgets change (after initial load)
+  // Debounced save after user edits (see gates below)
   const persistWidgets = useCallback(
     (widgetsToSave: Widget[]) => {
-      if (!configLoaded) return
+      // Persistence gates:
+      // - loadStatus 'loading'/'failed': never save before a SUCCESSFUL load
+      //   (saving would overwrite the stored layout with local state).
+      // - dirtyRef false: this `widgets` change came from mount or from
+      //   applying the loaded config, not from the user — persisting it would
+      //   be a pointless echo-write of what the server just sent us.
+      if (loadStatus !== 'loaded' || !dirtyRef.current) return
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
       saveTimerRef.current = setTimeout(() => {
         const serialized: SerializedWidget[] = widgetsToSave.map((w) => ({
@@ -100,12 +155,27 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
           position: w.position,
           config: w.config as Record<string, unknown> | undefined,
         }))
-        saveDashboardConfig(conference._id, serialized).catch(() => {
-          // Silently fail — widget state is still in React
-        })
+        saveDashboardConfig(conference._id, serialized)
+          .then(() => {
+            saveFailureNotifiedRef.current = false
+          })
+          .catch(() => {
+            // Widget state is still in React, so the layout keeps working
+            // locally — but the user must know it didn't persist. Notify once
+            // per failure burst, not on every debounced retry.
+            if (!saveFailureNotifiedRef.current) {
+              saveFailureNotifiedRef.current = true
+              showNotificationRef.current({
+                type: 'error',
+                title: "Couldn't save your dashboard layout",
+                message:
+                  'Your latest changes are visible here but were not saved.',
+              })
+            }
+          })
       }, DASHBOARD_SAVE_DEBOUNCE_MS)
     },
-    [conference._id, configLoaded],
+    [conference._id, loadStatus],
   )
 
   useEffect(() => {
@@ -128,8 +198,12 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
     return () => window.removeEventListener('resize', handleResize)
   }, [])
 
-  const handleReset = useCallback(() => {
+  // Destructive: replaces the whole layout with the planning preset (and
+  // persists it), so it only runs after explicit confirmation in the modal.
+  const handleConfirmedReset = useCallback(() => {
+    dirtyRef.current = true
     setWidgets(DEFAULT_WIDGETS)
+    setShowResetConfirm(false)
     // persistWidgets will fire via the useEffect on widget change
   }, [])
 
@@ -153,6 +227,7 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
         metadata,
       }
 
+      dirtyRef.current = true
       setWidgets((prev) => [...prev, newWidget])
       setShowWidgetPicker(false)
     },
@@ -160,15 +235,18 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
   )
 
   const handleRemoveWidget = useCallback((widgetId: string) => {
+    dirtyRef.current = true
     setWidgets((prev) => prev.filter((w) => w.id !== widgetId))
   }, [])
 
   const handleWidgetsChange = useCallback((newWidgets: Widget[]) => {
+    dirtyRef.current = true
     setWidgets(newWidgets)
   }, [])
 
   const handleResize = useCallback(
     (widgetId: string, newPosition: Widget['position']) => {
+      dirtyRef.current = true
       setWidgets((prev) =>
         prev.map((w) =>
           w.id === widgetId ? { ...w, position: newPosition } : w,
@@ -180,6 +258,7 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
 
   const handleConfigChange = useCallback(
     (widgetId: string, config: Record<string, unknown>) => {
+      dirtyRef.current = true
       setWidgets((prev) =>
         prev.map((w) => (w.id === widgetId ? { ...w, config } : w)),
       )
@@ -227,13 +306,23 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
         />
       )}
 
+      <ConfirmationModal
+        isOpen={showResetConfirm}
+        onClose={() => setShowResetConfirm(false)}
+        onConfirm={handleConfirmedReset}
+        title="Reset dashboard layout?"
+        message="This replaces your current widgets and layout with the default planning preset. This cannot be undone."
+        confirmButtonText="Reset layout"
+        variant="danger"
+      />
+
       {/* Floating edit controls — desktop only */}
       {isDesktop && (
         <div className="fixed right-6 bottom-6 z-40 flex items-center gap-2">
           {editMode && (
             <>
               <button
-                onClick={handleReset}
+                onClick={() => setShowResetConfirm(true)}
                 className="inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-white px-3 py-2 text-xs font-medium text-gray-700 shadow-lg transition-colors hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
               >
                 <ArrowPathIcon className="h-3.5 w-3.5" />

--- a/src/components/admin/dashboard/WidgetConfigModal.test.tsx
+++ b/src/components/admin/dashboard/WidgetConfigModal.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { WidgetConfigModal } from './WidgetConfigModal'
+
+afterEach(cleanup)
+
+// 'review-progress' has a real config schema in the widget registry:
+// targetReviewsPerDay (number, default 5) and showAverageScore (boolean).
+const baseProps = {
+  isOpen: true,
+  widgetType: 'review-progress',
+  widgetDisplayName: 'Review Progress',
+  currentConfig: { targetReviewsPerDay: 12, showAverageScore: true },
+}
+
+describe('WidgetConfigModal', () => {
+  it('clicking Cancel closes the modal WITHOUT saving', () => {
+    // Regression: Cancel used to be an implicit type="submit" button inside
+    // the config <form>, so clicking it ran handleSubmit and saved the
+    // edits the user was discarding.
+    const onSave = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <WidgetConfigModal {...baseProps} onSave={onSave} onClose={onClose} />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking Reset to Defaults resets fields without saving or closing', () => {
+    // Regression: Reset used to be an implicit type="submit" button, so it
+    // submitted the PRE-reset values and closed the modal.
+    const onSave = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <WidgetConfigModal {...baseProps} onSave={onSave} onClose={onClose} />,
+    )
+
+    const input = screen.getByLabelText<HTMLInputElement>(
+      'Target Reviews Per Day',
+    )
+    expect(input.value).toBe('12')
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset to Defaults/ }))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+    // Modal stays open showing the schema defaults
+    expect(screen.getByText('Configure Widget')).toBeInTheDocument()
+    expect(input.value).toBe('5')
+  })
+
+  it('clicking Save Changes validates and saves, then closes', () => {
+    const onSave = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <WidgetConfigModal {...baseProps} onSave={onSave} onClose={onClose} />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+    expect(onSave).toHaveBeenCalledWith({
+      targetReviewsPerDay: 12,
+      showAverageScore: true,
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx
@@ -157,7 +157,7 @@ export function TravelSupportQueueWidget({
     <div className="flex h-full flex-col">
       <WidgetHeader
         title="Travel Support"
-        link={{ href: '/admin/travel-support', label: 'Review →' }}
+        link={{ href: '/admin/speakers/travel-support', label: 'Review →' }}
       />
 
       {(config?.showPendingRequests ?? true) && data.pendingApprovals > 0 && (

--- a/src/lib/search/providers/AdminPagesSearchProvider.ts
+++ b/src/lib/search/providers/AdminPagesSearchProvider.ts
@@ -135,7 +135,7 @@ const ADMIN_PAGES: AdminPage[] = [
   {
     id: 'gallery',
     title: 'Gallery',
-    url: '/admin/gallery',
+    url: '/admin/marketing/gallery',
     keywords: ['gallery', 'photos', 'images', 'media'],
     icon: PhotoIcon,
   },


### PR DESCRIPTION
Batch 1 of the dashboard review fix plan — five verified critical fixes, nothing else.

## 1. Cancel/Reset in WidgetConfigModal saved the config (AdminButton implicit submit)

`AdminButton` rendered a native `<button>` with no `type`, so every AdminButton inside a `<form>` was an implicit `type="submit"`. In `WidgetConfigModal` this meant clicking **Cancel** ran `handleSubmit` and saved the edits the user was discarding, and **Reset to Defaults** submitted the pre-reset values and closed the modal.

Fixed at the root: `AdminButton` now defaults to `type="button"` and forwards an explicit `type`. Audit of all 28 files using AdminButton: every intended submitter already passes `type="submit"` explicitly, so nothing relied on the implicit default — and the change fixes two more latent implicit-submit bugs for free (`ProposalReviewForm` "Next" and `ExpenseForm` "Cancel" both sat untyped inside forms).

## 2. Five dead admin deep links (production 404s)

- `/admin/travel-support` → `/admin/speakers/travel-support` (quick actions ×2, TravelSupportQueueWidget header link)
- `/admin/gallery` → `/admin/marketing/gallery` (quick actions, admin search provider)

Both target pages verified to exist. A sweep of every `/admin/...` literal in `src/lib/dashboard`, `src/components/admin/dashboard`, the quick-actions/deadlines blocks of `actions.ts`, and the admin search provider against `src/app/(admin)` routes found **no other dead links**.

## 3. Load failure no longer enables persistence (data-wipe bug)

When `loadDashboardConfig` rejected, the catch set `configLoaded(true)`, which re-armed the widgets-change effect and auto-saved `DEFAULT_WIDGETS` over the stored config with zero user action. Now:

- Load outcomes are explicit (`loading` / `loaded` / `failed`); persistence is only ever enabled after a **successful** load. On failure, editing still works locally and a one-time warning toast tells the user changes won't persist this session.
- Echo-writes are gone: saves additionally require a real user mutation (dirty flag set in add/remove/drag/resize/config/reset handlers), so mount- and load-applied widget states are never written back.
- The 1500 ms debounce for real edits is unchanged, and `loadDashboardConfig`/`saveDashboardConfig` signatures are untouched.

## 4. Reset now requires confirmation

One unconfirmed click on the floating **Reset** replaced the whole layout with the planning preset (and, with the dirty flag, persisted it). Reset now goes through the house `ConfirmationModal` (danger variant, "Reset dashboard layout?") before applying anything. Added a `DashboardReset` story; verified at 393 px light + dark.

## 5. Save failures are no longer swallowed

`saveDashboardConfig(...).catch(() => {})` hid every failure. Failures now surface an error toast ("Couldn't save your dashboard layout") once per failure burst — reset on the next successful save — while the layout keeps working from React state.

## Tests

New jsdom suites (10 tests, all green):

- `WidgetConfigModal.test.tsx` — Cancel closes without saving; Reset restores defaults without saving/closing; Save submits validated config.
- `AdminDashboard.test.tsx` — load failure → no save with or without user drag (+ warning toast); load success → no echo-write; load success + drag → exactly one debounced save; save failure → error toast; reset requires confirmation (cancel = no save, confirm = persisted).

`tsc --noEmit`, eslint, prettier, and vitest all pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several dashboard form, navigation, and persistence problems. The main changes are:

- Makes admin buttons non-submitting by default.
- Corrects dashboard and search links to nested admin routes.
- Gates dashboard saves on successful loading and user edits.
- Adds load and save failure notifications.
- Requires confirmation before resetting the dashboard layout.
- Adds tests for modal and persistence behavior.

<h3>Confidence Score: 4/5</h3>

The pending-load edit path needs a fix before merging.

- A user can edit while the initial load is pending.
- A successful response then replaces that edit with the stored layout.
- The dirty flag remains set, so the loaded state can be treated as a user mutation.

src/components/admin/dashboard/AdminDashboard.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/dashboard/AdminDashboard.tsx | Adds load-state and dirty-state persistence gates, failure notifications, and reset confirmation, but successful loading can overwrite edits made while the request is pending. |
| src/components/admin/AdminButton.tsx | Defaults native buttons to type="button" while preserving explicit submit behavior. |
| src/app/(admin)/admin/actions.ts | Corrects quick-action links to existing nested admin routes. |
| src/components/admin/dashboard/AdminDashboard.test.tsx | Covers primary load, save, and reset behavior but not edits made while loading is still pending. |
| src/components/admin/dashboard/WidgetConfigModal.test.tsx | Covers cancellation, restoring defaults, and explicit submission. |
| src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx | Corrects the travel-support header link. |
| src/lib/search/providers/AdminPagesSearchProvider.ts | Corrects the Gallery search destination. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): critical review fixes — ..."](https://github.com/cloudnativebergen/website/commit/359af328eec359985dbdcc46330f2f79efb18ab0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46087882)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->