### PR TITLE
fix(dashboard): widget data-path correctness — wire/remove config knobs, chart theming, math guards

### DIFF
--- a/__tests__/components/admin/dashboard/widget-render-guards.test.tsx
+++ b/__tests__/components/admin/dashboard/widget-render-guards.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Render-guard regressions for dashboard widgets:
+ *  - ProposalPipelineWidget must not render a stray literal "0" when
+ *    `data.total` is 0 (the classic `{count && <X/>}` JSX pitfall).
+ *  - TravelSupportQueueWidget must not render NaN%/Infinity% when the
+ *    conference has no travel budget configured, and its post-conference
+ *    tiles must use the approved aggregates (not the pending queue).
+ */
+import { render, screen } from '@testing-library/react'
+import type { Conference } from '@/lib/conference/types'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyFn = (...args: any[]) => any
+
+const mockFetchProposalPipeline = vi.fn<AnyFn>()
+const mockFetchTravelSupport = vi.fn<AnyFn>()
+vi.mock('@/app/(admin)/admin/actions', () => ({
+  fetchProposalPipeline: (...args: unknown[]) =>
+    mockFetchProposalPipeline(...args),
+  fetchTravelSupport: (...args: unknown[]) => mockFetchTravelSupport(...args),
+}))
+
+const mockGetCurrentPhase = vi.fn<AnyFn>()
+vi.mock('@/lib/conference/phase', () => ({
+  getCurrentPhase: (...args: unknown[]) => mockGetCurrentPhase(...args),
+}))
+
+import { ProposalPipelineWidget } from '@/components/admin/dashboard/widgets/ProposalPipelineWidget'
+import { TravelSupportQueueWidget } from '@/components/admin/dashboard/widgets/TravelSupportQueueWidget'
+
+const conference = {
+  _id: 'conf-1',
+  title: 'Test Conference',
+  cfpStartDate: '2099-01-01',
+  cfpEndDate: '2099-02-01',
+} as unknown as Conference
+
+describe('ProposalPipelineWidget', () => {
+  it('does not render a stray "0" in planning phase when total is 0', async () => {
+    mockGetCurrentPhase.mockReturnValue('planning')
+    mockFetchProposalPipeline.mockResolvedValue({
+      submitted: 0,
+      accepted: 0,
+      rejected: 0,
+      confirmed: 0,
+      total: 0,
+      acceptanceRate: 0,
+      pendingDecisions: 0,
+      distinctSpeakers: 0,
+    })
+
+    render(<ProposalPipelineWidget conference={conference} />)
+
+    await screen.findByText('CFP Planning')
+    expect(screen.queryByText('Early Submissions')).toBeNull()
+    // The old `{data?.total && ...}` guard leaked a literal "0" text node
+    expect(screen.queryByText('0')).toBeNull()
+  })
+})
+
+describe('TravelSupportQueueWidget', () => {
+  it('renders an em dash instead of NaN% when no budget is configured', async () => {
+    mockGetCurrentPhase.mockReturnValue('post-conference')
+    mockFetchTravelSupport.mockResolvedValue({
+      pendingApprovals: 1,
+      approvedCount: 2,
+      totalRequested: 16000,
+      totalApproved: 10000,
+      budgetAllocated: 0,
+      averageRequest: 5333,
+      requests: [
+        {
+          id: 'ts1',
+          speaker: 'Alice',
+          amount: 5000,
+          status: 'submitted',
+          submittedAt: '2 days ago',
+        },
+      ],
+    })
+
+    const { container } = render(
+      <TravelSupportQueueWidget conference={conference} />,
+    )
+
+    await screen.findByText('Budget Used')
+    expect(container.textContent).not.toContain('NaN')
+    expect(container.textContent).not.toContain('Infinity')
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('post-conference tiles use approved aggregates, not the pending queue', async () => {
+    mockGetCurrentPhase.mockReturnValue('post-conference')
+    mockFetchTravelSupport.mockResolvedValue({
+      pendingApprovals: 1,
+      approvedCount: 3,
+      totalRequested: 30000,
+      totalApproved: 15000,
+      budgetAllocated: 50000,
+      averageRequest: 6000,
+      requests: [
+        // Only ONE pending request — must not drive "Speakers Supported"
+        {
+          id: 'ts1',
+          speaker: 'Alice',
+          amount: 5000,
+          status: 'submitted',
+          submittedAt: '2 days ago',
+        },
+      ],
+    })
+
+    render(<TravelSupportQueueWidget conference={conference} />)
+
+    await screen.findByText('Speakers Supported')
+    // 3 approved/paid speakers, not the 1 pending request
+    expect(screen.getByText('3')).toBeInTheDocument()
+    // Budget used = 15000/50000 = 30%
+    expect(screen.getByText('30%')).toBeInTheDocument()
+  })
+})

--- a/__tests__/lib/dashboard/actions.test.ts
+++ b/__tests__/lib/dashboard/actions.test.ts
@@ -62,8 +62,9 @@ vi.mock('@/lib/sponsor-crm/activities', () => ({
 }))
 
 // Tickets
+const mockFetchEventTickets = vi.fn<AnyFn>()
 vi.mock('@/lib/tickets/api', () => ({
-  fetchEventTickets: vi.fn(() => Promise.resolve([])),
+  fetchEventTickets: (...args: unknown[]) => mockFetchEventTickets(...args),
 }))
 
 vi.mock('@/lib/tickets/processor', () => ({
@@ -95,7 +96,8 @@ vi.mock('@/lib/workshop/sanity', () => ({
     mockGetWorkshopStatistics(...args),
 }))
 
-// Sanity client (for dashboard config persistence)
+// Sanity client (dashboard config persistence + trimmed dashboard reads)
+const mockClientReadFetch = vi.fn<AnyFn>()
 vi.mock('@/lib/sanity/client', () => ({
   clientWrite: {
     fetch: vi.fn(() => Promise.resolve(null)),
@@ -105,6 +107,9 @@ vi.mock('@/lib/sanity/client', () => ({
         commit: vi.fn(() => Promise.resolve()),
       })),
     })),
+  },
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => mockClientReadFetch(...args),
   },
 }))
 
@@ -209,6 +214,8 @@ describe('Dashboard Server Actions', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2025-02-15T12:00:00Z'))
     vi.clearAllMocks()
+    mockFetchEventTickets.mockResolvedValue([])
+    mockClientReadFetch.mockResolvedValue([])
     mockGetAuthSession.mockResolvedValue({
       user: { name: 'Admin', email: 'admin@test.com' },
       expires: '2099-01-01T00:00:00Z',
@@ -357,6 +364,34 @@ describe('Dashboard Server Actions', () => {
       expect(pipeline.acceptanceRate).toBe(40)
     })
 
+    it('counts distinct speakers across confirmed talks only, deduped', async () => {
+      mockGetProposals.mockResolvedValue({
+        proposals: [
+          makeProposal({
+            status: Status.confirmed,
+            speakers: [{ _id: 'sp-1', name: 'Alice' }],
+          }),
+          makeProposal({
+            status: Status.confirmed,
+            // Alice co-speaks again + Bob — Alice must not double count
+            speakers: [
+              { _id: 'sp-1', name: 'Alice' },
+              { _id: 'sp-2', name: 'Bob' },
+            ],
+          }),
+          makeProposal({
+            // accepted (not confirmed) — excluded from the speaker count
+            status: Status.accepted,
+            speakers: [{ _id: 'sp-3', name: 'Carol' }],
+          }),
+        ],
+        proposalsError: null,
+      })
+
+      const pipeline = await fetchProposalPipeline('conf-1')
+      expect(pipeline.distinctSpeakers).toBe(2) // Alice + Bob
+    })
+
     it('returns zero acceptance rate when no proposals', async () => {
       mockGetProposals.mockResolvedValue({
         proposals: [],
@@ -384,23 +419,24 @@ describe('Dashboard Server Actions', () => {
   })
 
   describe('fetchReviewProgress', () => {
+    // fetchReviewProgress uses a trimmed GROQ projection (status + review
+    // scores only, drafts excluded in the query) via the read client.
+    const reviewRow = (overrides: Record<string, unknown> = {}) => ({
+      _id: `proposal-${Math.random().toString(36).slice(2)}`,
+      title: 'Test Talk',
+      status: Status.submitted,
+      reviews: [],
+      ...overrides,
+    })
+
     it('computes percentage of reviewed proposals', async () => {
-      mockGetProposals.mockResolvedValue({
-        proposals: [
-          makeProposal({
-            status: Status.submitted,
-            reviews: [
-              {
-                score: { content: 4, relevance: 4, speaker: 4 },
-              },
-            ],
-          }),
-          makeProposal({ status: Status.submitted, reviews: [] }),
-          makeProposal({ status: Status.submitted }),
-          makeProposal({ status: Status.draft }), // excluded
-        ],
-        proposalsError: null,
-      })
+      mockClientReadFetch.mockResolvedValue([
+        reviewRow({
+          reviews: [{ score: { content: 4, relevance: 4, speaker: 4 } }],
+        }),
+        reviewRow({ reviews: [] }),
+        reviewRow({ reviews: undefined }),
+      ])
 
       const progress = await fetchReviewProgress('conf-1')
       // 3 non-draft, 1 has reviews
@@ -409,23 +445,29 @@ describe('Dashboard Server Actions', () => {
       expect(progress.percentage).toBeCloseTo(33.33, 0)
     })
 
+    it('requests only a trimmed projection without reviewer joins', async () => {
+      mockClientReadFetch.mockResolvedValue([])
+      await fetchReviewProgress('conf-1')
+
+      expect(mockClientReadFetch).toHaveBeenCalledTimes(1)
+      const [query] = mockClientReadFetch.mock.calls[0]
+      expect(query).toContain('{ score }')
+      expect(query).not.toContain('reviewer')
+      expect(query).toContain('status != "draft"')
+    })
+
     it('finds the next unreviewed submitted proposal', async () => {
-      mockGetProposals.mockResolvedValue({
-        proposals: [
-          makeProposal({
-            _id: 'reviewed-1',
-            status: Status.submitted,
-            reviews: [{ score: { content: 3, relevance: 3, speaker: 3 } }],
-          }),
-          makeProposal({
-            _id: 'unreviewed-1',
-            title: 'Needs Review',
-            status: Status.submitted,
-            reviews: [],
-          }),
-        ],
-        proposalsError: null,
-      })
+      mockClientReadFetch.mockResolvedValue([
+        reviewRow({
+          _id: 'reviewed-1',
+          reviews: [{ score: { content: 3, relevance: 3, speaker: 3 } }],
+        }),
+        reviewRow({
+          _id: 'unreviewed-1',
+          title: 'Needs Review',
+          reviews: [],
+        }),
+      ])
 
       const progress = await fetchReviewProgress('conf-1')
       expect(progress.nextUnreviewed).toEqual({
@@ -435,15 +477,11 @@ describe('Dashboard Server Actions', () => {
     })
 
     it('returns no nextUnreviewed when all are reviewed', async () => {
-      mockGetProposals.mockResolvedValue({
-        proposals: [
-          makeProposal({
-            status: Status.submitted,
-            reviews: [{ score: { content: 5, relevance: 5, speaker: 5 } }],
-          }),
-        ],
-        proposalsError: null,
-      })
+      mockClientReadFetch.mockResolvedValue([
+        reviewRow({
+          reviews: [{ score: { content: 5, relevance: 5, speaker: 5 } }],
+        }),
+      ])
 
       const progress = await fetchReviewProgress('conf-1')
       expect(progress.nextUnreviewed).toBeUndefined()
@@ -488,7 +526,8 @@ describe('Dashboard Server Actions', () => {
       expect(data.diverseSpeakers).toBe(1) // Alice
       expect(data.localSpeakers).toBe(1) // Alice
       expect(data.newSpeakers).toBe(1) // Bob (first-time)
-      expect(data.returningSpeakers).toBe(2) // Alice + Carol
+      // No derived "returning" stat: untagged speakers are not assumed returning
+      expect(data).not.toHaveProperty('returningSpeakers')
       expect(data.awaitingConfirmation).toBe(1) // Bob (status=accepted)
       expect(data.featuredCount).toBe(1)
       // totalProposals = 2+1+1 = 4, speakers = 3, avg = 1.3
@@ -543,6 +582,7 @@ describe('Dashboard Server Actions', () => {
 
       const data = await fetchTravelSupport(confWithBudget)
       expect(data.pendingApprovals).toBe(1) // submitted only
+      expect(data.approvedCount).toBe(2) // approved + paid
       expect(data.totalRequested).toBe(16000) // 5000+8000+3000
       expect(data.totalApproved).toBe(10500) // 7500+3000 (approved+paid)
       expect(data.budgetAllocated).toBe(50000)
@@ -703,6 +743,8 @@ describe('Dashboard Server Actions', () => {
   })
 
   describe('fetchRecentActivity', () => {
+    // Proposals come from an ordered + limited GROQ query (read client),
+    // not from the full getProposals corpus.
     it('merges sponsor activities and proposals sorted by date', async () => {
       mockListActivities.mockResolvedValue({
         activities: [
@@ -718,28 +760,39 @@ describe('Dashboard Server Actions', () => {
         error: null,
       })
 
-      mockGetProposals.mockResolvedValue({
-        proposals: [
-          makeProposal({
-            _id: 'p1',
-            title: 'Latest Talk',
-            _createdAt: '2025-02-15T09:00:00Z',
-            speakers: [{ name: 'Speaker A' }],
-          }),
-        ],
-        proposalsError: null,
-      })
+      mockClientReadFetch.mockResolvedValue([
+        {
+          _id: 'p1',
+          title: 'Latest Talk',
+          _createdAt: '2025-02-15T09:00:00Z',
+          speakers: [{ name: 'Speaker A' }],
+        },
+      ])
 
       const items = await fetchRecentActivity('conf-1')
       expect(items.length).toBeGreaterThanOrEqual(2)
       // Most recent first
       expect(items[0].type).toBe('proposal') // Feb 15
       expect(items[1].type).toBe('sponsor') // Feb 14
+      expect(items[0].user).toBe('Speaker A')
     })
 
-    it('returns at most 10 items', async () => {
+    it('pushes ordering and limits into the proposal query', async () => {
+      mockListActivities.mockResolvedValue({ activities: [], error: null })
+      mockClientReadFetch.mockResolvedValue([])
+
+      await fetchRecentActivity('conf-1')
+
+      const [query] = mockClientReadFetch.mock.calls[0]
+      expect(query).toContain('order(_createdAt desc)')
+      expect(query).toContain('[0...5]')
+      // Bounded activity fetch on the other source
+      expect(mockListActivities).toHaveBeenCalledWith('conf-1', 15)
+    })
+
+    it('returns at most 15 items', async () => {
       mockListActivities.mockResolvedValue({
-        activities: Array.from({ length: 10 }, (_, i) => ({
+        activities: Array.from({ length: 15 }, (_, i) => ({
           _id: `a${i}`,
           description: `Activity ${i}`,
           createdAt: `2025-02-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
@@ -750,15 +803,14 @@ describe('Dashboard Server Actions', () => {
         error: null,
       })
 
-      mockGetProposals.mockResolvedValue({
-        proposals: Array.from({ length: 5 }, (_, i) =>
-          makeProposal({
-            _id: `p${i}`,
-            _createdAt: `2025-02-${String(i + 1).padStart(2, '0')}T12:00:00Z`,
-          }),
-        ),
-        proposalsError: null,
-      })
+      mockClientReadFetch.mockResolvedValue(
+        Array.from({ length: 5 }, (_, i) => ({
+          _id: `p${i}`,
+          title: `Talk ${i}`,
+          _createdAt: `2025-02-${String(i + 1).padStart(2, '0')}T12:00:00Z`,
+          speakers: [{ name: 'Speaker' }],
+        })),
+      )
 
       const items = await fetchRecentActivity('conf-1')
       expect(items.length).toBeLessThanOrEqual(15)
@@ -812,12 +864,12 @@ describe('Dashboard Server Actions', () => {
   })
 
   describe('fetchTicketSales', () => {
-    it('returns null when conference lacks ticket config', async () => {
+    it('returns unconfigured when conference lacks checkin IDs', async () => {
       const result = await fetchTicketSales(baseConference)
-      expect(result).toBeNull()
+      expect(result).toEqual({ status: 'unconfigured' })
     })
 
-    it('returns ticket data when conference has checkin IDs', async () => {
+    it('returns ok with ticket data when conference has checkin IDs', async () => {
       const confWithTickets: Conference = {
         ...baseConference,
         checkinCustomerId: 123,
@@ -826,10 +878,27 @@ describe('Dashboard Server Actions', () => {
       }
 
       const result = await fetchTicketSales(confWithTickets)
-      expect(result).not.toBeNull()
-      expect(result!.capacity).toBe(500)
-      expect(result!.milestones).toHaveLength(3)
-      expect(result!.milestones[0].name).toBe('Early Bird')
+      expect(result.status).toBe('ok')
+      if (result.status !== 'ok') throw new Error('expected ok result')
+      expect(result.data.capacity).toBe(500)
+      expect(result.data.milestones).toHaveLength(3)
+      expect(result.data.milestones[0].name).toBe('Early Bird')
+    })
+
+    it('returns error (not unconfigured) when the ticket API fails', async () => {
+      const confWithTickets: Conference = {
+        ...baseConference,
+        checkinCustomerId: 123,
+        checkinEventId: 456,
+      }
+      mockFetchEventTickets.mockRejectedValueOnce(new Error('API down'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = await fetchTicketSales(confWithTickets)
+      expect(result).toEqual({ status: 'error' })
+      expect(consoleSpy).toHaveBeenCalled()
+
+      consoleSpy.mockRestore()
     })
   })
 

--- a/__tests__/lib/dashboard/widget-registry.test.ts
+++ b/__tests__/lib/dashboard/widget-registry.test.ts
@@ -74,6 +74,34 @@ describe('Widget Registry', () => {
       ([, meta]) => meta.configSchema,
     )
 
+    it('does not double-source canonical conference settings as config knobs', () => {
+      // These come from conference settings via the fetch actions:
+      // ticketCapacity/ticketTargets, sponsorRevenueGoal, travelSupportBudget.
+      expect(
+        WIDGET_REGISTRY['ticket-sales'].configSchema!.fields,
+      ).not.toHaveProperty('capacityTarget')
+      expect(
+        WIDGET_REGISTRY['ticket-sales'].configSchema!.fields,
+      ).not.toHaveProperty('revenueTarget')
+      expect(
+        WIDGET_REGISTRY['sponsor-pipeline'].configSchema!.fields,
+      ).not.toHaveProperty('revenueTarget')
+      expect(
+        WIDGET_REGISTRY['travel-support'].configSchema!.fields,
+      ).not.toHaveProperty('totalBudget')
+    })
+
+    it('stored configs containing removed keys still validate field-by-field lookups', () => {
+      // Old stored configs may still carry removed keys; config is passed
+      // through opaquely and unknown keys must be harmless.
+      const legacyConfig = { showTrend: true, capacityTarget: 500 }
+      const schema = WIDGET_REGISTRY['ticket-sales'].configSchema!
+      const result = schema.schema.safeParse(legacyConfig)
+      expect(result.success).toBe(true)
+      // Zod strips unknown keys on parse
+      expect(result.data).toEqual({ showTrend: true })
+    })
+
     it('at least some widgets have config schemas', () => {
       expect(widgetsWithConfig.length).toBeGreaterThan(0)
     })

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -23,7 +23,12 @@ import { getConversationViewCounts } from '@/lib/messaging/sanity'
 import { getVolunteersByConference } from '@/lib/volunteer/sanity'
 import { VolunteerStatus } from '@/lib/volunteer/types'
 import { getAuthSession } from '@/lib/auth'
-import { clientWrite } from '@/lib/sanity/client'
+import {
+  clientWrite,
+  clientReadUncached as clientRead,
+} from '@/lib/sanity/client'
+import { groq } from 'next-sanity'
+import type { ProposalExisting } from '@/lib/proposal/types'
 import {
   formatRelativeTime,
   formatLabel,
@@ -35,7 +40,7 @@ import type {
   ActivityItem,
   CFPHealthData,
   SpeakerEngagementData,
-  TicketSalesData,
+  TicketSalesResult,
   ProposalPipelineData,
   ReviewProgressData,
   TravelSupportData,
@@ -433,14 +438,13 @@ export async function fetchSpeakerEngagement(
     }
   }
 
-  // Returning speakers have proposals in other conferences
-  const returningCount = speakers.length - firstTimeCount
-
+  // NOTE: we intentionally do NOT derive a "returning speakers" number.
+  // `total - firstTimeFlagged` would mislabel every untagged speaker as
+  // returning; only the explicit first-time flag is a trustworthy signal.
   return {
     totalSpeakers: speakers.length,
     featuredCount: featured?.length || 0,
     newSpeakers: firstTimeCount,
-    returningSpeakers: returningCount,
     diverseSpeakers: diverseCount,
     localSpeakers: localCount,
     awaitingConfirmation,
@@ -455,11 +459,11 @@ export async function fetchSpeakerEngagement(
 
 export async function fetchTicketSales(
   conference: Conference,
-): Promise<TicketSalesData | null> {
+): Promise<TicketSalesResult> {
   await requireOrganizer()
 
   if (!conference.checkinCustomerId || !conference.checkinEventId) {
-    return null
+    return { status: 'unconfigured' }
   }
 
   try {
@@ -472,26 +476,29 @@ export async function fetchTicketSales(
 
     if (!tickets || tickets.length === 0) {
       return {
-        currentSales: 0,
-        capacity,
-        percentage: 0,
-        revenue: 0,
-        salesByDate: [],
-        milestones: [
-          {
-            name: 'Early Bird',
-            target: Math.round(capacity * 0.2),
-            reached: false,
-          },
-          {
-            name: 'Break Even',
-            target: Math.round(capacity * 0.5),
-            reached: false,
-          },
-          { name: 'Sell Out', target: capacity, reached: false },
-        ],
-        daysUntilEvent: getPhaseContext(conference).daysUntilConference ?? 0,
-        salesVelocity: 0,
+        status: 'ok',
+        data: {
+          currentSales: 0,
+          capacity,
+          percentage: 0,
+          revenue: 0,
+          salesByDate: [],
+          milestones: [
+            {
+              name: 'Early Bird',
+              target: Math.round(capacity * 0.2),
+              reached: false,
+            },
+            {
+              name: 'Break Even',
+              target: Math.round(capacity * 0.5),
+              reached: false,
+            },
+            { name: 'Sell Out', target: capacity, reached: false },
+          ],
+          daysUntilEvent: getPhaseContext(conference).daysUntilConference ?? 0,
+          salesVelocity: 0,
+        },
       }
     }
 
@@ -534,59 +541,78 @@ export async function fetchTicketSales(
         : 0
 
     return {
-      currentSales: stats.totalPaidTickets,
-      capacity,
-      percentage:
-        capacity > 0
-          ? Math.round((stats.totalPaidTickets / capacity) * 1000) / 10
-          : 0,
-      revenue: stats.totalRevenue,
-      salesByDate,
-      milestones: [
-        {
-          name: 'Early Bird',
-          target: Math.round(capacity * 0.2),
-          reached: stats.totalPaidTickets >= Math.round(capacity * 0.2),
-        },
-        {
-          name: 'Break Even',
-          target: Math.round(capacity * 0.5),
-          reached: stats.totalPaidTickets >= Math.round(capacity * 0.5),
-        },
-        {
-          name: 'Sell Out',
-          target: capacity,
-          reached: stats.totalPaidTickets >= capacity,
-        },
-      ],
-      daysUntilEvent: getPhaseContext(conference).daysUntilConference ?? 0,
-      salesVelocity,
+      status: 'ok',
+      data: {
+        currentSales: stats.totalPaidTickets,
+        capacity,
+        percentage:
+          capacity > 0
+            ? Math.round((stats.totalPaidTickets / capacity) * 1000) / 10
+            : 0,
+        revenue: stats.totalRevenue,
+        salesByDate,
+        milestones: [
+          {
+            name: 'Early Bird',
+            target: Math.round(capacity * 0.2),
+            reached: stats.totalPaidTickets >= Math.round(capacity * 0.2),
+          },
+          {
+            name: 'Break Even',
+            target: Math.round(capacity * 0.5),
+            reached: stats.totalPaidTickets >= Math.round(capacity * 0.5),
+          },
+          {
+            name: 'Sell Out',
+            target: capacity,
+            reached: stats.totalPaidTickets >= capacity,
+          },
+        ],
+        daysUntilEvent: getPhaseContext(conference).daysUntilConference ?? 0,
+        salesVelocity,
+      },
     }
-  } catch {
-    return null
+  } catch (error) {
+    console.error('Failed to fetch ticket sales:', error)
+    return { status: 'error' }
   }
 }
 
 // --- Recent Activity ---
+
+const RECENT_ACTIVITY_LIMIT = 15
+const RECENT_PROPOSALS_LIMIT = 5
+
+interface RecentProposalRow {
+  _id: string
+  title: string
+  _createdAt: string
+  speakers?: { name?: string }[]
+}
 
 export async function fetchRecentActivity(
   conferenceId: string,
 ): Promise<ActivityItem[]> {
   await requireOrganizer()
 
-  const [activityResult, proposalResult] = await Promise.all([
-    listActivitiesForConference(conferenceId, 15),
-    getProposals({ conferenceId, returnAll: true }),
+  // Both sources are ordered + limited in GROQ — we never pull the full
+  // proposal corpus just to slice the newest few afterwards.
+  const [activityResult, recentProposals] = await Promise.all([
+    listActivitiesForConference(conferenceId, RECENT_ACTIVITY_LIMIT),
+    clientRead.fetch<RecentProposalRow[]>(
+      groq`*[_type == "talk" && conference._ref == $conferenceId && status != "${Status.draft}"]
+        | order(_createdAt desc)[0...${RECENT_PROPOSALS_LIMIT}]{
+        _id, title, _createdAt,
+        speakers[]-> { name }
+      }`,
+      { conferenceId },
+      { cache: 'no-store' },
+    ),
   ])
 
   if (activityResult.error) {
     throw new Error(
       `Failed to fetch activities: ${activityResult.error.message}`,
-    )
-  }
-  if (proposalResult.proposalsError) {
-    throw new Error(
-      `Failed to fetch proposals: ${proposalResult.proposalsError.message}`,
     )
   }
 
@@ -607,22 +633,12 @@ export async function fetchRecentActivity(
     })
   }
 
-  const proposals = proposalResult.proposals || []
-  const recentProposals = [...proposals]
-    .sort(
-      (a, b) =>
-        new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime(),
-    )
-    .slice(0, 5)
-
-  for (const p of recentProposals) {
+  for (const p of recentProposals || []) {
     items.push({
       id: `proposal-${p._id}`,
       type: 'proposal',
       description: `New proposal: \u201C${p.title}\u201D`,
-      user:
-        (p.speakers as Array<{ name?: string }>)?.[0]?.name ||
-        'Unknown Speaker',
+      user: p.speakers?.[0]?.name || 'Unknown Speaker',
       timestamp: formatRelativeTime(p._createdAt),
       link: `/admin/proposals/${p._id}`,
       _sortDate: p._createdAt,
@@ -635,7 +651,7 @@ export async function fetchRecentActivity(
       (a, b) =>
         new Date(b._sortDate).getTime() - new Date(a._sortDate).getTime(),
     )
-    .slice(0, 15)
+    .slice(0, RECENT_ACTIVITY_LIMIT)
     .map((item): ActivityItem => ({
       id: item.id,
       type: item.type,
@@ -907,6 +923,17 @@ export async function fetchProposalPipeline(
     (p) => p.status === Status.submitted,
   ).length
 
+  // Distinct speakers across confirmed talks (co-speakers deduped).
+  const speakerIds = new Set<string>()
+  for (const p of nonDraft) {
+    if (p.status !== Status.confirmed) continue
+    for (const speaker of p.speakers || []) {
+      const s = speaker as { _id?: string; _ref?: string }
+      const id = s._id ?? s._ref
+      if (id) speakerIds.add(id)
+    }
+  }
+
   return {
     submitted,
     accepted,
@@ -916,32 +943,42 @@ export async function fetchProposalPipeline(
     acceptanceRate:
       submitted > 0 ? ((accepted + confirmed) / submitted) * 100 : 0,
     pendingDecisions,
+    distinctSpeakers: speakerIds.size,
   }
 }
 
 // --- Review Progress ---
+
+interface ReviewProgressRow {
+  _id: string
+  title: string
+  status: Status
+  reviews?: {
+    score?: { content: number; relevance: number; speaker: number }
+  }[]
+}
 
 export async function fetchReviewProgress(
   conferenceId: string,
 ): Promise<ReviewProgressData> {
   await requireOrganizer()
 
-  const { proposals, proposalsError } = await getProposals({
-    conferenceId,
-    returnAll: true,
-    includeReviews: true,
-  })
+  // Trimmed projection: the math only needs status + review scores — no
+  // speaker/reviewer joins, topics, or co-speaker invitations.
+  const nonDraft = await clientRead.fetch<ReviewProgressRow[]>(
+    groq`*[_type == "talk" && conference._ref == $conferenceId && status != "${Status.draft}"]
+      | order(_updatedAt desc){
+      _id, title, status,
+      "reviews": *[_type == "review" && proposal._ref == ^._id]{ score }
+    }`,
+    { conferenceId },
+    { cache: 'no-store' },
+  )
 
-  if (proposalsError) {
-    throw new Error(`Failed to fetch proposals: ${proposalsError.message}`)
-  }
-
-  const allProposals = proposals || []
-  const nonDraft = allProposals.filter((p) => p.status !== Status.draft)
   const reviewed = nonDraft.filter((p) => p.reviews && p.reviews.length > 0)
 
   const totalScores = reviewed.reduce(
-    (sum, p) => sum + calculateAverageRating(p),
+    (sum, p) => sum + calculateAverageRating(p as unknown as ProposalExisting),
     0,
   )
   const averageScore =
@@ -1002,6 +1039,7 @@ export async function fetchTravelSupport(
 
   return {
     pendingApprovals: pending.length,
+    approvedCount: approved.length,
     totalRequested,
     totalApproved,
     budgetAllocated,

--- a/src/components/admin/dashboard/WidgetErrorBoundary.stories.tsx
+++ b/src/components/admin/dashboard/WidgetErrorBoundary.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { WidgetErrorBoundary } from './WidgetErrorBoundary'
+
+/**
+ * Fallback card shown when a widget crashes during render. It must be legible
+ * in BOTH themes and offer a "Try again" reset so a transient crash does not
+ * require a full page reload. (The data-fetching widgets themselves are not
+ * storyable in isolation — they call server actions internally.)
+ */
+const meta = {
+  title: 'Admin/Dashboard/WidgetErrorBoundary',
+  component: WidgetErrorBoundary,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story, ctx) => (
+      <div className={ctx.parameters.dark ? 'dark bg-gray-950 p-4' : 'p-4'}>
+        <div className="mx-auto h-full w-full max-w-md">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WidgetErrorBoundary>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Bomb(): React.ReactNode {
+  throw new Error('Simulated widget render crash')
+}
+
+export const Fallback: Story = {
+  args: {
+    widgetName: 'Ticket Sales',
+    children: <Bomb />,
+  },
+}
+
+export const FallbackDark: Story = {
+  args: {
+    widgetName: 'Ticket Sales',
+    children: <Bomb />,
+  },
+  parameters: { dark: true },
+}

--- a/src/components/admin/dashboard/WidgetErrorBoundary.tsx
+++ b/src/components/admin/dashboard/WidgetErrorBoundary.tsx
@@ -30,22 +30,33 @@ export class WidgetErrorBoundary extends Component<
     console.error(`Widget error in ${this.props.widgetName}:`, error, errorInfo)
   }
 
+  handleReset = () => {
+    this.setState({ hasError: false, error: undefined })
+  }
+
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex h-full min-h-[200px] flex-col items-center justify-center rounded-lg border-2 border-dashed border-red-300 bg-red-50 p-6 text-center">
-          <ExclamationTriangleIcon className="mb-3 h-12 w-12 text-red-400" />
-          <h3 className="mb-1 text-sm font-semibold text-red-900">
+        <div className="flex h-full min-h-[200px] flex-col items-center justify-center rounded-lg border-2 border-dashed border-red-300 bg-red-50 p-6 text-center dark:border-red-800 dark:bg-red-900/20">
+          <ExclamationTriangleIcon className="mb-3 h-12 w-12 text-red-400 dark:text-red-500" />
+          <h3 className="mb-1 text-sm font-semibold text-red-900 dark:text-red-200">
             Widget Error
           </h3>
-          <p className="text-xs text-red-700">
+          <p className="text-xs text-red-700 dark:text-red-300">
             {this.props.widgetName} failed to load
           </p>
           {this.state.error && (
-            <p className="mt-2 text-xs text-red-600">
+            <p className="mt-2 text-xs text-red-600 dark:text-red-400">
               {this.state.error.message}
             </p>
           )}
+          <button
+            type="button"
+            onClick={this.handleReset}
+            className="mt-3 rounded-md bg-red-100 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-200 dark:bg-red-900/40 dark:text-red-300 dark:hover:bg-red-900/60"
+          >
+            Try again
+          </button>
         </div>
       )
     }

--- a/src/components/admin/dashboard/widgets/ProposalPipelineWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ProposalPipelineWidget.tsx
@@ -94,13 +94,13 @@ export function ProposalPipelineWidget({
             </div>
           </div>
 
-          {data?.total && data.total > 0 && (
+          {(data?.total ?? 0) > 0 && (
             <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
               <div className="text-[10px] font-medium text-gray-500 uppercase dark:text-gray-400">
                 Early Submissions
               </div>
               <div className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
-                {data.total}
+                {data?.total}
               </div>
             </div>
           )}
@@ -153,7 +153,7 @@ export function ProposalPipelineWidget({
               Speakers
             </div>
             <div className="mt-1 text-3xl font-bold text-gray-900 dark:text-gray-100">
-              {data?.confirmed}
+              {data?.distinctSpeakers}
             </div>
           </div>
         </div>
@@ -170,6 +170,7 @@ export function ProposalPipelineWidget({
   const rejectedPercentage = (data.rejected / data.total) * 100
   const confirmedPercentage = (data.confirmed / data.total) * 100
   const showPercentages = config?.showPercentages ?? true
+  const targetAcceptanceRate = config?.targetAcceptanceRate ?? 30
 
   return (
     <div className="flex h-full flex-col">
@@ -203,6 +204,9 @@ export function ProposalPipelineWidget({
               </div>
               <div className="mt-1 text-3xl font-black text-green-900 @[400px]:text-4xl dark:text-green-100">
                 {data.acceptanceRate.toFixed(0)}%
+              </div>
+              <div className="mt-0.5 text-[10px] text-green-700 dark:text-green-300">
+                target {targetAcceptanceRate}%
               </div>
             </div>
             <CheckCircleIcon className="absolute -right-2 -bottom-2 h-16 w-16 text-green-300/40 @[400px]:h-20 @[400px]:w-20 dark:text-green-600/30" />

--- a/src/components/admin/dashboard/widgets/RecentActivityFeedWidget.tsx
+++ b/src/components/admin/dashboard/widgets/RecentActivityFeedWidget.tsx
@@ -98,7 +98,7 @@ export function RecentActivityFeedWidget({
   }
 
   // Split activities into pages
-  const itemsPerPage = config?.maxActivities ?? 8
+  const itemsPerPage = config?.maxActivities ?? 10 // matches the registry defaultValue
   const pages = []
   for (let i = 0; i < activities.length; i += itemsPerPage) {
     const pageActivities = activities.slice(i, i + itemsPerPage)

--- a/src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx
@@ -118,6 +118,11 @@ export function ReviewProgressWidget({
   const strokeDashoffset =
     circumference - (data.percentage / 100) * circumference
 
+  // Pace estimate driven by the configured daily review target
+  const targetReviewsPerDay = config?.targetReviewsPerDay ?? 5
+  const remainingReviews = data.totalProposals - data.reviewedCount
+  const daysToFinish = Math.ceil(remainingReviews / targetReviewsPerDay)
+
   return (
     <div className="flex h-full flex-col">
       <h3 className="mb-2 shrink-0 text-xs font-semibold text-gray-900 dark:text-gray-100">
@@ -178,6 +183,14 @@ export function ReviewProgressWidget({
                   /10
                 </span>
               </div>
+            </div>
+          )}
+
+          {/* Pace toward the configured daily review target */}
+          {remainingReviews > 0 && (
+            <div className="text-[10px] text-gray-500 @[200px]:text-xs dark:text-gray-400">
+              ~{daysToFinish} day{daysToFinish !== 1 ? 's' : ''} left at{' '}
+              {targetReviewsPerDay}/day
             </div>
           )}
 

--- a/src/components/admin/dashboard/widgets/SpeakerEngagementWidget.tsx
+++ b/src/components/admin/dashboard/widgets/SpeakerEngagementWidget.tsx
@@ -5,7 +5,6 @@ import {
   UserGroupIcon,
   SparklesIcon,
   MapPinIcon,
-  ArrowPathIcon,
   CheckCircleIcon,
   ChartBarIcon,
 } from '@heroicons/react/24/outline'
@@ -183,7 +182,7 @@ export function SpeakerEngagementWidget({
             </div>
             <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
               <div className="text-[10px] font-medium text-gray-500 uppercase dark:text-gray-400">
-                New Speakers
+                First-Time Speakers
               </div>
               <div className="mt-1 text-2xl font-bold text-green-600 dark:text-green-400">
                 {data.newSpeakers}
@@ -193,8 +192,8 @@ export function SpeakerEngagementWidget({
           <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-900/20">
             <CheckCircleIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
             <p className="text-xs text-green-800 dark:text-green-300">
-              {data.returningSpeakers} returning, {data.diverseSpeakers}{' '}
-              diverse, {data.localSpeakers} local
+              {data.newSpeakers} first-time, {data.diverseSpeakers} diverse,{' '}
+              {data.localSpeakers} local
             </p>
           </div>
         </div>
@@ -210,7 +209,7 @@ export function SpeakerEngagementWidget({
   const showFirstTimers = config?.showFirstTimers ?? true
   const showDiversity = config?.showDiversityMetrics ?? true
   const showGeo = config?.showGeography ?? true
-  const statColumns = [showFirstTimers, true, showDiversity, showGeo].filter(
+  const statColumns = [showFirstTimers, showDiversity, showGeo].filter(
     Boolean,
   ).length
 
@@ -248,30 +247,22 @@ export function SpeakerEngagementWidget({
       <div
         className={`mt-1.5 grid min-h-0 flex-1 gap-1.5`}
         style={{
-          gridTemplateColumns: `repeat(${statColumns}, minmax(0, 1fr))`,
+          gridTemplateColumns: `repeat(${Math.max(statColumns, 1)}, minmax(0, 1fr))`,
         }}
       >
+        {/* NOTE: no "returning" tile — `total - firstTimeFlagged` would count
+            every untagged speaker as returning, which is not a real signal. */}
         {showFirstTimers && (
           <div className="flex flex-col items-center justify-center rounded-lg bg-green-50 text-center dark:bg-green-900/20">
             <SparklesIcon className="mb-0.5 h-3.5 w-3.5 text-green-600 dark:text-green-400" />
             <div className="text-[9px] text-green-600 dark:text-green-400">
-              New
+              First-time
             </div>
             <div className="text-lg font-bold text-green-900 dark:text-green-100">
               {data.newSpeakers}
             </div>
           </div>
         )}
-
-        <div className="flex flex-col items-center justify-center rounded-lg bg-blue-50 text-center dark:bg-blue-900/20">
-          <ArrowPathIcon className="mb-0.5 h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
-          <div className="text-[9px] text-blue-600 dark:text-blue-400">
-            Return
-          </div>
-          <div className="text-lg font-bold text-blue-900 dark:text-blue-100">
-            {data.returningSpeakers}
-          </div>
-        </div>
 
         {showDiversity && (
           <div className="flex flex-col items-center justify-center rounded-lg bg-purple-50 text-center dark:bg-purple-900/20">

--- a/src/components/admin/dashboard/widgets/SponsorPipelineWidget.tsx
+++ b/src/components/admin/dashboard/widgets/SponsorPipelineWidget.tsx
@@ -23,7 +23,6 @@ import {
 } from './shared'
 
 interface SponsorPipelineConfig {
-  revenueTarget?: number
   showPipeline?: boolean
   showContractStatus?: boolean
 }

--- a/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { useMemo, useSyncExternalStore } from 'react'
+import { useMemo } from 'react'
+import { useTheme } from 'next-themes'
 import type { ApexOptions } from 'apexcharts'
 import {
   BanknotesIcon,
@@ -19,7 +20,7 @@ import {
 import { getCurrentPhase } from '@/lib/conference/phase'
 import { BaseWidgetProps } from '@/lib/dashboard/types'
 import { fetchTicketSales } from '@/app/(admin)/admin/actions'
-import { TicketSalesData } from '@/lib/dashboard/data-types'
+import { TicketSalesResult } from '@/lib/dashboard/data-types'
 import { useWidgetData } from '@/hooks/dashboard/useWidgetData'
 import {
   WidgetSkeleton,
@@ -32,19 +33,7 @@ import {
 
 const Chart = dynamic(() => import('react-apexcharts'), { ssr: false })
 
-function subscribeDarkMode(callback: () => void) {
-  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-  mediaQuery.addEventListener('change', callback)
-  return () => mediaQuery.removeEventListener('change', callback)
-}
-
-function getSnapshotDarkMode() {
-  return window.matchMedia('(prefers-color-scheme: dark)').matches
-}
-
 interface TicketSalesConfig {
-  capacityTarget?: number
-  revenueTarget?: number
   showTrend?: boolean
 }
 
@@ -54,17 +43,21 @@ export function TicketSalesDashboardWidget({
   conference,
   config,
 }: TicketSalesDashboardWidgetProps) {
-  const { data, loading, error, refetch } =
-    useWidgetData<TicketSalesData | null>(
-      conference ? () => fetchTicketSales(conference) : null,
-      [conference],
-    )
-
-  const isDark = useSyncExternalStore(
-    subscribeDarkMode,
-    getSnapshotDarkMode,
-    () => false,
+  const {
+    data: result,
+    loading,
+    error,
+    refetch,
+  } = useWidgetData<TicketSalesResult>(
+    conference ? () => fetchTicketSales(conference) : null,
+    [conference],
   )
+  const data = result?.status === 'ok' ? result.data : null
+
+  // Follow the app's class-based theme (next-themes), not the OS preference —
+  // the in-app toggle can differ from `prefers-color-scheme`.
+  const { resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
   const phase = conference ? getCurrentPhase(conference) : null
 
   const gaugeOptions: ApexOptions = useMemo(() => {
@@ -127,7 +120,9 @@ export function TicketSalesDashboardWidget({
     return <WidgetSkeleton />
   }
 
-  if (error) {
+  // A failed ticket-API call is an error with retry — NOT the amber
+  // "Not Configured" card (that is reserved for missing checkin IDs).
+  if (error || result?.status === 'error') {
     return <WidgetErrorState onRetry={refetch} />
   }
 
@@ -207,7 +202,8 @@ export function TicketSalesDashboardWidget({
     )
   }
 
-  // Planning & Execution phases: Not configured
+  // Planning & Execution phases: the conference genuinely lacks checkin
+  // customer/event IDs (result.status === 'unconfigured')
   if (!data) {
     return (
       <div className="flex h-full flex-col">

--- a/src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx
@@ -22,7 +22,6 @@ import {
 } from './shared'
 
 interface TravelSupportConfig {
-  totalBudget?: number
   showPendingRequests?: boolean
   showBudgetUtilization?: boolean
 }
@@ -38,6 +37,22 @@ export function TravelSupportQueueWidget({
     conference ? () => fetchTravelSupport(conference) : null,
     [conference],
   )
+
+  // Loading and error come FIRST — phase branches must not mask fetch
+  // errors as setup cards or flash wrong content while loading.
+  if (loading) {
+    return <WidgetSkeleton />
+  }
+
+  if (error) {
+    return <WidgetErrorState onRetry={refetch} />
+  }
+
+  // Fraction of budget used; null when no budget is configured (avoid NaN/∞)
+  const budgetUsed =
+    data && data.budgetAllocated > 0
+      ? (data.totalApproved / data.budgetAllocated) * 100
+      : null
 
   // Phase-specific: Initialization/Planning - Show setup guidance
   if (
@@ -83,8 +98,6 @@ export function TravelSupportQueueWidget({
 
   // Phase-specific: Post-conference - Show final summary
   if (phase === 'post-conference' && data) {
-    const budgetUsed = (data.totalApproved / data.budgetAllocated) * 100
-
     return (
       <div className="flex h-full flex-col">
         <WidgetHeader
@@ -108,7 +121,7 @@ export function TravelSupportQueueWidget({
               Budget Used
             </div>
             <div className="mt-1 text-3xl font-bold text-blue-900 dark:text-blue-100">
-              {budgetUsed.toFixed(0)}%
+              {budgetUsed !== null ? `${budgetUsed.toFixed(0)}%` : '—'}
             </div>
           </div>
 
@@ -117,7 +130,7 @@ export function TravelSupportQueueWidget({
               Speakers Supported
             </div>
             <div className="mt-1 text-3xl font-bold text-purple-900 dark:text-purple-100">
-              {data.requests.length}
+              {data.approvedCount}
             </div>
           </div>
 
@@ -126,10 +139,9 @@ export function TravelSupportQueueWidget({
               Avg per Speaker
             </div>
             <div className="mt-1 text-3xl font-bold text-gray-900 dark:text-gray-100">
-              kr{' '}
-              {data.requests.length > 0
-                ? Math.round(data.totalApproved / data.requests.length)
-                : 0}
+              {data.approvedCount > 0
+                ? `kr ${formatNumber(Math.round(data.totalApproved / data.approvedCount))}`
+                : '—'}
             </div>
           </div>
         </div>
@@ -137,21 +149,11 @@ export function TravelSupportQueueWidget({
     )
   }
 
-  if (loading) {
-    return <WidgetSkeleton />
-  }
-
-  if (error) {
-    return <WidgetErrorState onRetry={refetch} />
-  }
-
   if (!data) {
     return <WidgetEmptyState message="No travel support data available" />
   }
 
   // Default operational view (execution phase)
-
-  const budgetUsed = (data.totalApproved / data.budgetAllocated) * 100
 
   return (
     <div className="flex h-full flex-col">
@@ -190,7 +192,7 @@ export function TravelSupportQueueWidget({
         </div>
       </div>
 
-      {(config?.showBudgetUtilization ?? true) && (
+      {(config?.showBudgetUtilization ?? true) && budgetUsed !== null && (
         <div className="mb-3">
           <div className="mb-1.5 flex items-center justify-between">
             <h4 className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">

--- a/src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx
+++ b/src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx
@@ -103,6 +103,15 @@ export function UpcomingDeadlinesWidget({
   }
 
   const maxDeadlines = config?.maxDeadlines ?? 5
+  // Re-derive urgency from the configured threshold (the action's default
+  // urgency assumes 7 days). The 30-day "medium" band is kept as-is.
+  const urgentThreshold = config?.urgentThreshold ?? 7
+  const getUrgency = (daysRemaining: number): DeadlineData['urgency'] =>
+    daysRemaining <= urgentThreshold
+      ? 'high'
+      : daysRemaining <= 30
+        ? 'medium'
+        : 'low'
 
   return (
     <div className="flex h-full flex-col">
@@ -112,8 +121,9 @@ export function UpcomingDeadlinesWidget({
 
       <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
         {deadlines.slice(0, maxDeadlines).map((deadline) => {
-          const urgencyClass = urgencyStyles[deadline.urgency]
-          const badgeClass = urgencyBadgeStyles[deadline.urgency]
+          const urgency = getUrgency(deadline.daysRemaining)
+          const urgencyClass = urgencyStyles[urgency]
+          const badgeClass = urgencyBadgeStyles[urgency]
 
           return (
             <div

--- a/src/components/admin/dashboard/widgets/WorkshopCapacityWidget.tsx
+++ b/src/components/admin/dashboard/widgets/WorkshopCapacityWidget.tsx
@@ -29,6 +29,16 @@ export function WorkshopCapacityWidget({
     [conference],
   )
 
+  // Loading and error come FIRST — phase branches must not mask fetch
+  // errors as setup cards or flash wrong content while loading.
+  if (loading) {
+    return <WidgetSkeleton />
+  }
+
+  if (error) {
+    return <WidgetErrorState onRetry={refetch} />
+  }
+
   // Phase-specific: Initialization/Planning - Show workshop planning
   if (
     (phase === 'initialization' || phase === 'planning') &&
@@ -133,14 +143,6 @@ export function WorkshopCapacityWidget({
         </div>
       </div>
     )
-  }
-
-  if (loading) {
-    return <WidgetSkeleton />
-  }
-
-  if (error) {
-    return <WidgetErrorState onRetry={refetch} />
   }
 
   if (!data || data.workshops.length === 0) {

--- a/src/lib/dashboard/data-types.ts
+++ b/src/lib/dashboard/data-types.ts
@@ -17,8 +17,9 @@ export interface ReviewProgressData {
 export interface SpeakerEngagementData {
   totalSpeakers: number
   featuredCount: number
+  /** Speakers explicitly flagged as first-time. Untagged speakers are NOT
+   * assumed to be returning — there is no reliable "returning" signal. */
   newSpeakers: number
-  returningSpeakers: number
   diverseSpeakers: number
   localSpeakers: number
   awaitingConfirmation: number
@@ -59,6 +60,8 @@ export interface SponsorPipelineWidgetData {
 
 export interface TravelSupportData {
   pendingApprovals: number
+  /** Number of requests approved or paid (used for "speakers supported"). */
+  approvedCount: number
   totalRequested: number
   totalApproved: number
   budgetAllocated: number
@@ -111,6 +114,16 @@ export interface TicketSalesData {
   salesVelocity: number
 }
 
+/**
+ * Discriminated result for ticket sales so the widget can distinguish
+ * "integration not configured" (no checkin IDs on the conference) from
+ * "the ticket API call failed" — previously both collapsed to `null`.
+ */
+export type TicketSalesResult =
+  | { status: 'unconfigured' }
+  | { status: 'error' }
+  | { status: 'ok'; data: TicketSalesData }
+
 export interface CFPHealthData {
   totalSubmissions: number
   submissionGoal: number
@@ -128,6 +141,8 @@ export interface ProposalPipelineData {
   total: number
   acceptanceRate: number
   pendingDecisions: number
+  /** Distinct speakers across confirmed talks (a talk can have co-speakers). */
+  distinctSpeakers: number
 }
 
 /**

--- a/src/lib/dashboard/widget-registry.ts
+++ b/src/lib/dashboard/widget-registry.ts
@@ -402,30 +402,11 @@ export const TICKET_SALES_WIDGET = defineWidget({
     hideInIrrelevantPhases: false,
     isPhaseAdaptive: true,
   },
+  // NOTE: capacity and revenue targets deliberately have NO config knobs here —
+  // they come from canonical conference settings (ticketCapacity/ticketTargets)
+  // via the fetch action. Double-sourcing them in widget config was removed.
   configSchema: {
     fields: {
-      capacityTarget: {
-        type: 'number',
-        label: 'Capacity Target',
-        description: 'Total ticket capacity for the event',
-        defaultValue: 500,
-        min: 50,
-        max: 10000,
-        step: 50,
-        unit: 'tickets',
-        schema: z.number().min(50).max(10000),
-      },
-      revenueTarget: {
-        type: 'number',
-        label: 'Revenue Target',
-        description: 'Target revenue in local currency',
-        defaultValue: 100000,
-        min: 1000,
-        max: 10000000,
-        step: 1000,
-        unit: 'NOK',
-        schema: z.number().min(1000).max(10000000),
-      },
       showTrend: {
         type: 'boolean',
         label: 'Show Sales Trend',
@@ -435,8 +416,6 @@ export const TICKET_SALES_WIDGET = defineWidget({
       },
     },
     schema: z.object({
-      capacityTarget: z.number().min(50).max(10000),
-      revenueTarget: z.number().min(1000).max(10000000),
       showTrend: z.boolean(),
     }),
   } satisfies WidgetConfigSchema,
@@ -552,19 +531,10 @@ export const SPONSOR_PIPELINE_WIDGET = defineWidget({
     hideInIrrelevantPhases: false,
     isPhaseAdaptive: true,
   },
+  // NOTE: the revenue target has NO config knob here — it comes from the
+  // canonical conference setting (sponsorRevenueGoal) via the fetch action.
   configSchema: {
     fields: {
-      revenueTarget: {
-        type: 'number',
-        label: 'Sponsorship Revenue Target',
-        description: 'Target sponsorship revenue',
-        defaultValue: 500000,
-        min: 10000,
-        max: 10000000,
-        step: 10000,
-        unit: 'NOK',
-        schema: z.number().min(10000).max(10000000),
-      },
       showPipeline: {
         type: 'boolean',
         label: 'Show Pipeline Stages',
@@ -581,7 +551,6 @@ export const SPONSOR_PIPELINE_WIDGET = defineWidget({
       },
     },
     schema: z.object({
-      revenueTarget: z.number().min(10000).max(10000000),
       showPipeline: z.boolean(),
       showContractStatus: z.boolean(),
     }),
@@ -666,19 +635,10 @@ export const TRAVEL_SUPPORT_WIDGET = defineWidget({
     hideInIrrelevantPhases: false,
     isPhaseAdaptive: true,
   },
+  // NOTE: the travel budget has NO config knob here — it comes from the
+  // canonical conference setting (travelSupportBudget) via the fetch action.
   configSchema: {
     fields: {
-      totalBudget: {
-        type: 'number',
-        label: 'Total Travel Budget',
-        description: 'Total budget allocated for travel support',
-        defaultValue: 100000,
-        min: 1000,
-        max: 1000000,
-        step: 1000,
-        unit: 'NOK',
-        schema: z.number().min(1000).max(1000000),
-      },
       showPendingRequests: {
         type: 'boolean',
         label: 'Show Pending Requests',
@@ -695,7 +655,6 @@ export const TRAVEL_SUPPORT_WIDGET = defineWidget({
       },
     },
     schema: z.object({
-      totalBudget: z.number().min(1000).max(1000000),
       showPendingRequests: z.boolean(),
       showBudgetUtilization: z.boolean(),
     }),
@@ -744,10 +703,12 @@ export const RECENT_ACTIVITY_WIDGET = defineWidget({
   },
   configSchema: {
     fields: {
+      // Key kept as `maxActivities` for stored-config compatibility; the
+      // widget paginates all fetched activities, so this is a page size.
       maxActivities: {
         type: 'number',
-        label: 'Maximum Activities',
-        description: 'Number of activity items to display',
+        label: 'Items Per Page',
+        description: 'Number of activity items shown per page',
         defaultValue: 10,
         min: 5,
         max: 50,


### PR DESCRIPTION
Batch 3 of the dashboard review fix plan: widget data-path correctness. Does not touch AdminDashboard persistence, AdminButton, WidgetConfigModal form structure, or deep-link hrefs (owned by a parallel branch).

## Fix 1 — Dead config knobs: wired or removed

**Wired (display-side thresholds):**
- `UpcomingDeadlinesWidget` `urgentThreshold` — urgency is now re-derived client-side from the configured threshold (the action's hardcoded 7-day default remains the fallback; the 30-day medium band is unchanged)
- `ReviewProgressWidget` `targetReviewsPerDay` — new pace line "~N days left at X/day" in the operational view
- `ProposalPipelineWidget` `targetAcceptanceRate` — rendered as "target N%" under the actual acceptance rate tile
- `RecentActivityFeedWidget` `maxActivities` — behavior kept as page size (matches the widget's swipeable pagination UX); registry label/description renamed to "Items Per Page" / "Number of activity items shown per page"; key kept for stored-config compat

**Removed (double-sourced canonical conference settings):**
- `ticket-sales` `capacityTarget`/`revenueTarget` (source of truth: `conference.ticketCapacity`/`ticketTargets`)
- `sponsor-pipeline` `revenueTarget` (`conference.sponsorRevenueGoal`)
- `travel-support` `totalBudget` (`conference.travelSupportBudget`)

Removed from the registry configSchema AND the widget config interfaces. Old stored configs with removed keys stay harmless: the modal only reads schema-declared fields and Zod strips unknown keys on save (covered by a new registry test).

## Fix 2 — Chart theme follows the app theme
`TicketSalesDashboardWidget` now uses `useTheme().resolvedTheme` from next-themes (class-based) instead of `window.matchMedia('(prefers-color-scheme: dark)')`. It was the only chart consumer using the media query (verified by grep); charts remain `dynamic(..., { ssr: false })`.

## Fix 3 — Math/copy correctness
- `TravelSupportQueueWidget`: budget divisions guarded — "—" instead of NaN%/Infinity% when no budget is configured; operational budget bar hidden when budget is 0; post-conference "Speakers Supported"/"Avg per Speaker" now use the approved/paid aggregates via a new `approvedCount` field on `TravelSupportData` (was counting the *pending* queue)
- `ProposalPipelineWidget`: stray literal `0` render fixed (`{(data?.total ?? 0) > 0 && …}`); post-conference "Speakers" tile now shows a real `distinctSpeakers` count (confirmed talks' speakers deduped server-side — no extra query needed, speakers were already in the projection) instead of duplicating "Talks Delivered"
- `SpeakerEngagementWidget` + `fetchSpeakerEngagement`: the derived "returning = total − first-time-flagged" stat is dropped entirely (it mislabeled untagged speakers); the flagged count is labeled "First-time"
- `fetchTicketSales` now returns a discriminated result: `{ status: 'unconfigured' } | { status: 'error' } | { status: 'ok', data }` — API failures log via `console.error` and render the shared `WidgetErrorState` with retry, distinct from the amber "Not Configured" card (which now only appears when checkin IDs are genuinely missing)
- `TravelSupportQueueWidget` + `WorkshopCapacityWidget`: loading → error → phase branches, so fetch errors are no longer masked as setup cards and no wrong content flashes during load (shared skeleton confirmed)
- `WidgetErrorBoundary`: dark-mode classes + "Try again" button that resets the boundary (with a Storybook story)

## Fix 4 — Bounded efficiency wins
- `fetchRecentActivity`: proposals now come from an ordered + limited GROQ (`order(_createdAt desc)[0...5]`, minimal projection) instead of the full `getProposals` corpus; sponsor activities stay bounded at 15; merge+slice unchanged, return shape identical
- `fetchReviewProgress`: trimmed GROQ projection (status + review `score` only — no reviewer name/email/image joins); return shape identical
- No cross-widget `getProposals` dedupe (noted as follow-up, out of scope)

## Tests & QA
- `__tests__/lib/dashboard/actions.test.ts` updated for the new result shapes/queries + new cases (ticket API error vs unconfigured, distinct-speaker dedupe, trimmed projections)
- `__tests__/lib/dashboard/widget-registry.test.ts`: asserts removed knobs stay gone and legacy stored configs still parse
- New `__tests__/components/admin/dashboard/widget-render-guards.test.tsx` (jsdom): stray-'0' guard, NaN-guard, approved-aggregate tiles
- `tsc --noEmit`, eslint, prettier, full vitest suite (277 files / 3812 tests) all green
- Visual QA: the data-fetching widgets have no Storybook stories (they call server actions internally), so `pnpm shoot` captures were only possible for the new `WidgetErrorBoundary` fallback story — verified at 393px in light and dark, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects dashboard widget data paths and rendering behavior. The main changes are:

- Wires active widget settings and removes duplicated conference settings.
- Adds bounded Sanity queries and corrected dashboard aggregates.
- Separates ticket API failures from missing configuration.
- Adds theme-aware charts, loading and error states, and numeric guards.
- Expands tests for result shapes, legacy configuration, queries, and rendering.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Updated action result shapes match their widget consumers.
- Query projections include the fields used by the dashboard calculations.
- Numeric and loading-state guards cover the changed rendering paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(admin)/admin/actions.ts | Adds bounded dashboard queries, corrected aggregates, and a discriminated ticket-sales result. |
| src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx | Uses the application theme and separates loading, failure, success, and unconfigured states. |
| src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx | Guards zero-budget calculations and uses approved aggregates in the final summary. |
| src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx | Displays a completion estimate using the configured daily review target. |
| src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx | Applies the configured urgent-deadline threshold to widget styling. |
| src/lib/dashboard/widget-registry.ts | Removes duplicate configuration fields while preserving legacy stored configuration parsing. |
| src/components/admin/dashboard/WidgetErrorBoundary.tsx | Adds dark-theme styling and a user-triggered boundary reset. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): widget data-path correct..."](https://github.com/cloudnativebergen/website/commit/be1c022b16e3c5fb50e08e5b27c3fedb9c05fb11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46091591)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->