### PR TITLE
feat(dashboard): per-organizer layout config with server-side validation

### DIFF
--- a/__tests__/lib/dashboard/actions.test.ts
+++ b/__tests__/lib/dashboard/actions.test.ts
@@ -98,19 +98,27 @@ vi.mock('@/lib/workshop/sanity', () => ({
 
 // Sanity client (dashboard config persistence + trimmed dashboard reads)
 const mockClientReadFetch = vi.fn<AnyFn>()
+const mockClientWriteFetch = vi.fn<AnyFn>()
+const mockCreateOrReplace = vi.fn<AnyFn>()
+const mockCreate = vi.fn<AnyFn>()
+const mockPatch = vi.fn<AnyFn>()
 vi.mock('@/lib/sanity/client', () => ({
   clientWrite: {
-    fetch: vi.fn(() => Promise.resolve(null)),
-    create: vi.fn(() => Promise.resolve({ _id: 'new-config' })),
-    patch: vi.fn(() => ({
-      set: vi.fn(() => ({
-        commit: vi.fn(() => Promise.resolve()),
-      })),
-    })),
+    fetch: (...args: unknown[]) => mockClientWriteFetch(...args),
+    create: (...args: unknown[]) => mockCreate(...args),
+    createOrReplace: (...args: unknown[]) => mockCreateOrReplace(...args),
+    patch: (...args: unknown[]) => mockPatch(...args),
   },
   clientReadUncached: {
     fetch: (...args: unknown[]) => mockClientReadFetch(...args),
   },
+}))
+
+// Conference resolution — the persistence actions never accept a client
+// conferenceId; they resolve it from the request domain like the tRPC routers.
+const mockResolveConferenceId = vi.fn<AnyFn>()
+vi.mock('@/server/trpc', () => ({
+  resolveConferenceId: (...args: unknown[]) => mockResolveConferenceId(...args),
 }))
 
 // Time utilities
@@ -216,10 +224,13 @@ describe('Dashboard Server Actions', () => {
     vi.clearAllMocks()
     mockFetchEventTickets.mockResolvedValue([])
     mockClientReadFetch.mockResolvedValue([])
+    mockClientWriteFetch.mockResolvedValue(null)
+    mockCreateOrReplace.mockResolvedValue({ _id: 'personal-config' })
+    mockResolveConferenceId.mockResolvedValue('conf-1')
     mockGetAuthSession.mockResolvedValue({
       user: { name: 'Admin', email: 'admin@test.com' },
       expires: '2099-01-01T00:00:00Z',
-      speaker: { isOrganizer: true },
+      speaker: { _id: 'speaker-1', isOrganizer: true },
     })
   })
 
@@ -903,22 +914,269 @@ describe('Dashboard Server Actions', () => {
   })
 
   describe('Dashboard Config Persistence', () => {
-    it('loadDashboardConfig returns null when no config exists', async () => {
-      const result = await loadDashboardConfig('conf-1')
-      expect(result).toBeNull()
+    const PERSONAL_ID = 'dashboardConfig-conf-1-speaker-1'
+
+    const storedWidget = (overrides: Record<string, unknown> = {}) => ({
+      _key: 'widget-0',
+      widgetId: 'w1',
+      widgetType: 'quick-actions',
+      title: 'Quick Actions',
+      row: 0,
+      col: 0,
+      rowSpan: 2,
+      colSpan: 3,
+      ...overrides,
     })
 
-    it('saveDashboardConfig serializes widget positions', async () => {
-      await expect(
-        saveDashboardConfig('conf-1', [
+    const validWidget = (
+      overrides: Partial<SerializedWidget> = {},
+    ): SerializedWidget => ({
+      id: 'w1',
+      type: 'quick-actions',
+      title: 'Quick Actions',
+      position: { row: 0, col: 0, rowSpan: 2, colSpan: 3 },
+      ...overrides,
+    })
+
+    describe('loadDashboardConfig', () => {
+      it('returns null when neither a personal nor a legacy doc exists', async () => {
+        const result = await loadDashboardConfig()
+        expect(result).toBeNull()
+        // Fallback chain: personal doc by deterministic id, then legacy doc
+        expect(mockClientWriteFetch).toHaveBeenCalledTimes(2)
+        expect(mockClientWriteFetch.mock.calls[0][1]).toEqual({
+          id: PERSONAL_ID,
+        })
+        expect(mockClientWriteFetch.mock.calls[1][0]).toContain(
+          '!defined(speaker)',
+        )
+      })
+
+      it('returns the personal doc without consulting the legacy doc', async () => {
+        mockClientWriteFetch.mockResolvedValueOnce({
+          _id: PERSONAL_ID,
+          _type: 'dashboardConfig',
+          conference: { _ref: 'conf-1', _type: 'reference' },
+          speaker: { _ref: 'speaker-1', _type: 'reference' },
+          widgets: [storedWidget()],
+        })
+
+        const result = await loadDashboardConfig()
+        expect(result).toEqual([
           {
             id: 'w1',
             type: 'quick-actions',
             title: 'Quick Actions',
             position: { row: 0, col: 0, rowSpan: 2, colSpan: 3 },
+            config: undefined,
           },
-        ]),
-      ).resolves.not.toThrow()
+        ])
+        expect(mockClientWriteFetch).toHaveBeenCalledTimes(1)
+      })
+
+      it('falls back to the legacy shared doc when no personal doc exists', async () => {
+        mockClientWriteFetch
+          .mockResolvedValueOnce(null) // personal
+          .mockResolvedValueOnce({
+            _id: 'legacy-config',
+            _type: 'dashboardConfig',
+            conference: { _ref: 'conf-1', _type: 'reference' },
+            widgets: [storedWidget({ widgetId: 'legacy-w1' })],
+          })
+
+        const result = await loadDashboardConfig()
+        expect(result).toEqual([expect.objectContaining({ id: 'legacy-w1' })])
+      })
+
+      it('returns [] for an EMPTY personal doc (deliberately cleared layout)', async () => {
+        mockClientWriteFetch.mockResolvedValueOnce({
+          _id: PERSONAL_ID,
+          _type: 'dashboardConfig',
+          conference: { _ref: 'conf-1', _type: 'reference' },
+          speaker: { _ref: 'speaker-1', _type: 'reference' },
+          widgets: [],
+        })
+
+        const result = await loadDashboardConfig()
+        expect(result).toEqual([])
+        // The legacy default must NOT override a deliberate empty layout
+        expect(mockClientWriteFetch).toHaveBeenCalledTimes(1)
+      })
+
+      it('returns null for an empty LEGACY doc (falls through to preset)', async () => {
+        mockClientWriteFetch
+          .mockResolvedValueOnce(null) // personal
+          .mockResolvedValueOnce({
+            _id: 'legacy-config',
+            _type: 'dashboardConfig',
+            conference: { _ref: 'conf-1', _type: 'reference' },
+            widgets: [],
+          })
+
+        const result = await loadDashboardConfig()
+        expect(result).toBeNull()
+      })
+
+      it('keeps tolerating unknown STORED widget types (load is lenient)', async () => {
+        mockClientWriteFetch.mockResolvedValueOnce({
+          _id: PERSONAL_ID,
+          _type: 'dashboardConfig',
+          conference: { _ref: 'conf-1', _type: 'reference' },
+          speaker: { _ref: 'speaker-1', _type: 'reference' },
+          widgets: [storedWidget({ widgetType: 'retired-widget' })],
+        })
+
+        const result = await loadDashboardConfig()
+        expect(result).toEqual([
+          expect.objectContaining({ type: 'retired-widget' }),
+        ])
+      })
+
+      it('rejects when the caller is not an organizer', async () => {
+        mockGetAuthSession.mockResolvedValue({
+          user: { name: 'User', email: 'user@test.com' },
+          expires: '2099-01-01T00:00:00Z',
+          speaker: { _id: 'speaker-1', isOrganizer: false },
+        })
+
+        await expect(loadDashboardConfig()).rejects.toThrow(/Unauthorized/)
+      })
+    })
+
+    describe('saveDashboardConfig', () => {
+      it('createOrReplaces the personal doc with a deterministic _id and speaker ref', async () => {
+        await saveDashboardConfig([
+          validWidget({ config: { showTrend: true } }),
+        ])
+
+        expect(mockCreateOrReplace).toHaveBeenCalledTimes(1)
+        expect(mockCreateOrReplace).toHaveBeenCalledWith({
+          _id: PERSONAL_ID,
+          _type: 'dashboardConfig',
+          conference: { _ref: 'conf-1', _type: 'reference' },
+          speaker: { _ref: 'speaker-1', _type: 'reference' },
+          widgets: [
+            {
+              _key: 'widget-0',
+              widgetId: 'w1',
+              widgetType: 'quick-actions',
+              title: 'Quick Actions',
+              row: 0,
+              col: 0,
+              rowSpan: 2,
+              colSpan: 3,
+              config: JSON.stringify({ showTrend: true }),
+            },
+          ],
+        })
+      })
+
+      it('NEVER touches the legacy doc: no fetch-then-patch, no create', async () => {
+        await saveDashboardConfig([validWidget()])
+
+        // No lookup of an existing doc (the deterministic id kills the
+        // fetch-then-create race) and no writes via patch/create.
+        expect(mockClientWriteFetch).not.toHaveBeenCalled()
+        expect(mockPatch).not.toHaveBeenCalled()
+        expect(mockCreate).not.toHaveBeenCalled()
+      })
+
+      it('persists a deliberately EMPTY layout', async () => {
+        await saveDashboardConfig([])
+        expect(mockCreateOrReplace).toHaveBeenCalledWith(
+          expect.objectContaining({ _id: PERSONAL_ID, widgets: [] }),
+        )
+      })
+
+      it('rejects unknown widget types on save', async () => {
+        await expect(
+          saveDashboardConfig([validWidget({ type: 'not-a-widget' })]),
+        ).rejects.toThrow(/unknown widget type/)
+        expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      })
+
+      it('rejects oversized spans and out-of-range positions', async () => {
+        await expect(
+          saveDashboardConfig([
+            validWidget({
+              position: { row: 0, col: 0, rowSpan: 25, colSpan: 3 },
+            }),
+          ]),
+        ).rejects.toThrow(/rowSpan/)
+
+        await expect(
+          saveDashboardConfig([
+            validWidget({
+              position: { row: 0, col: 0, rowSpan: 2, colSpan: 13 },
+            }),
+          ]),
+        ).rejects.toThrow(/colSpan/)
+
+        await expect(
+          saveDashboardConfig([
+            validWidget({
+              position: { row: 501, col: 0, rowSpan: 2, colSpan: 3 },
+            }),
+          ]),
+        ).rejects.toThrow(/row/)
+
+        await expect(
+          saveDashboardConfig([
+            validWidget({
+              position: { row: 0, col: 12, rowSpan: 2, colSpan: 3 },
+            }),
+          ]),
+        ).rejects.toThrow(/col/)
+
+        await expect(
+          saveDashboardConfig([
+            validWidget({
+              position: { row: 1.5, col: 0, rowSpan: 2, colSpan: 3 },
+            }),
+          ]),
+        ).rejects.toThrow(/row/)
+
+        expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      })
+
+      it('rejects more than 40 widgets', async () => {
+        const widgets = Array.from({ length: 41 }, (_, i) =>
+          validWidget({ id: `w${i}` }),
+        )
+        await expect(saveDashboardConfig(widgets)).rejects.toThrow(
+          /at most 40 widgets/,
+        )
+        expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      })
+
+      it('rejects a widget config over 8 KB serialized', async () => {
+        await expect(
+          saveDashboardConfig([
+            validWidget({ config: { blob: 'x'.repeat(9000) } }),
+          ]),
+        ).rejects.toThrow(/8192 bytes/)
+        expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      })
+
+      it('rejects an over-long title', async () => {
+        await expect(
+          saveDashboardConfig([validWidget({ title: 'x'.repeat(201) })]),
+        ).rejects.toThrow(/title/)
+        expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      })
+
+      it('rejects when the caller is not an organizer', async () => {
+        mockGetAuthSession.mockResolvedValue({
+          user: { name: 'User', email: 'user@test.com' },
+          expires: '2099-01-01T00:00:00Z',
+          speaker: { _id: 'speaker-1', isOrganizer: false },
+        })
+
+        await expect(saveDashboardConfig([validWidget()])).rejects.toThrow(
+          /Unauthorized/,
+        )
+        expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/__tests__/lib/dashboard/actions.test.ts
+++ b/__tests__/lib/dashboard/actions.test.ts
@@ -914,7 +914,8 @@ describe('Dashboard Server Actions', () => {
   })
 
   describe('Dashboard Config Persistence', () => {
-    const PERSONAL_ID = 'dashboardConfig-conf-1-speaker-1'
+    // Length-prefixed ('conf-1'.length = 6) so ids containing '-' stay unambiguous.
+    const PERSONAL_ID = 'dashboardConfig-6-conf-1-speaker-1'
 
     const storedWidget = (overrides: Record<string, unknown> = {}) => ({
       _key: 'widget-0',

--- a/docs/DASHBOARD_SYSTEM.md
+++ b/docs/DASHBOARD_SYSTEM.md
@@ -55,7 +55,7 @@ AdminDashboard
 
 ### Widget Pattern
 
-All 12 widgets follow the same structure:
+All 13 widgets follow the same structure:
 
 1. **Data fetching** via the `useWidgetData<T>` hook — eliminates boilerplate `useState` + `useEffect` + error/loading patterns.
 2. **Phase detection** via `getCurrentPhase(conference)` — determines which view to render.
@@ -80,7 +80,29 @@ Pre-built widget configurations in `presets.ts` provide ready-made layouts: Plan
 
 ### Layout Persistence
 
-Dashboard layouts are persisted per-conference via Sanity using a `dashboardConfig` document type. Changes are debounced and auto-saved. On mount, the saved layout is loaded; if none exists, the default preset is used.
+Dashboard layouts are persisted **per-organizer** via Sanity using the `dashboardConfig` document type. Each organizer's layout lives in its own document with a deterministic id — `dashboardConfig-<conferenceId>-<speakerId>` — carrying both a `conference` and a `speaker` reference. Saves use `createOrReplace` on that id, so concurrent saves by the same user are race-free and can never create duplicates.
+
+The server actions (`loadDashboardConfig` / `saveDashboardConfig`) accept **no conference id from the client**: the conference is resolved server-side from the request domain (`resolveConferenceId`, the same helper the tRPC routers use) and the organizer's speaker id comes from the server session.
+
+**Load fallback chain:**
+
+1. **Personal doc** (deterministic id) — returned even when its widgets array is empty: `widgets: []` means the organizer deliberately cleared their dashboard, and the client renders an empty grid rather than defaults.
+2. **Legacy shared doc** (matching `conference._ref`, no `speaker` reference) — a read-only first-visit default kept from the pre-per-organizer era. It is never written again; an empty legacy doc falls through to step 3.
+3. **`null`** — the client falls back to the default preset (Planning).
+
+Changes are debounced (1.5 s) and auto-saved; navigating away with a pending edit flushes the save immediately on unmount. Saves are only enabled after a successful initial load.
+
+**Server-side validation (on save):**
+
+| Rule       | Limit                                                                     |
+| ---------- | ------------------------------------------------------------------------- |
+| Widgets    | ≤ 40 per layout                                                           |
+| Type       | Must exist in the widget registry (unknown types rejected)                |
+| Title / id | Strings ≤ 200 characters                                                  |
+| Position   | Integers: 0 ≤ row ≤ 500, 0 ≤ col ≤ 11, 1 ≤ rowSpan ≤ 24, 1 ≤ colSpan ≤ 12 |
+| Config     | ≤ 8 KB serialized JSON per widget                                         |
+
+Save rejects unknown widget types, but **load stays lenient**: unknown stored types render the "Widget not available" placeholder so old documents never break the dashboard.
 
 ### Data Flow
 
@@ -95,7 +117,7 @@ Server actions in `actions.ts` handle all data fetching with `requireOrganizer()
 
 ### Widget Configuration
 
-Widgets with configurable options (8 of 12) define a `configSchema` in the registry using Zod. The `WidgetConfigModal` renders input fields from the schema and persists values alongside the widget layout. Widgets receive config via their `config` prop.
+Widgets with configurable options (9 of 13) define a `configSchema` in the registry using Zod. The `WidgetConfigModal` renders input fields from the schema and persists values alongside the widget layout. Widgets receive config via their `config` prop.
 
 ## Widgets
 
@@ -113,6 +135,7 @@ Widgets with configurable options (8 of 12) define a `configSchema` in the regis
 | Schedule Builder   | Operations | Slot allocation progress by day                             |
 | Workshop Capacity  | Operations | Registration fill rates and waitlists                       |
 | Travel Support     | Operations | Request queue, budget usage, approval workflow              |
+| My Areas           | Operations | Needs-attention counts for the viewer's teams               |
 
 ## File Structure
 
@@ -141,7 +164,7 @@ src/components/admin/dashboard/
 ├── widget-renderer.tsx  # Maps widget type → component
 └── widgets/
     ├── shared.tsx       # Shared UI primitives
-    └── [12 widget components]
+    └── [13 widget components]
 
 src/app/(admin)/admin/
 └── actions.ts           # Server actions for widget data fetching

--- a/sanity/schemaTypes/dashboardConfig.ts
+++ b/sanity/schemaTypes/dashboardConfig.ts
@@ -13,6 +13,16 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'speaker',
+      title: 'Organizer',
+      type: 'reference',
+      to: [{ type: 'speaker' }],
+      description:
+        'The organizer this layout belongs to. Per-organizer configs carry ' +
+        'this reference; the legacy conference-wide doc (no speaker) is kept ' +
+        'read-only as the first-visit default and is never written again.',
+    }),
+    defineField({
       name: 'preset',
       title: 'Preset Name',
       type: 'string',
@@ -77,12 +87,15 @@ export default defineType({
   preview: {
     select: {
       conference: 'conference.title',
+      speaker: 'speaker.name',
       preset: 'preset',
     },
-    prepare({ conference, preset }) {
+    prepare({ conference, speaker, preset }) {
       return {
         title: `Dashboard: ${conference || 'Unknown'}`,
-        subtitle: preset || 'Default',
+        subtitle: speaker
+          ? `${speaker}${preset ? ` — ${preset}` : ''}`
+          : `Shared default${preset ? ` — ${preset}` : ''}`,
       }
     },
   },

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -50,6 +50,8 @@ import type {
   MyAreaCard,
 } from '@/lib/dashboard/data-types'
 import type { WorkshopStatistics } from '@/lib/workshop/types'
+import { WIDGET_REGISTRY } from '@/lib/dashboard/widget-registry'
+import { resolveConferenceId } from '@/server/trpc'
 
 // --- Auth ---
 
@@ -58,6 +60,20 @@ async function requireOrganizer(): Promise<void> {
   if (!session?.speaker?.isOrganizer) {
     throw new Error('Unauthorized: organizer access required')
   }
+}
+
+/**
+ * Like {@link requireOrganizer} but also returns the caller's identity, for
+ * actions that scope data to the CURRENT organizer (e.g. per-organizer
+ * dashboard configs). The speaker id comes from the server session — never
+ * from client input.
+ */
+async function requireOrganizerSession(): Promise<{ speakerId: string }> {
+  const session = await getAuthSession()
+  if (!session?.speaker?.isOrganizer || !session.speaker._id) {
+    throw new Error('Unauthorized: organizer access required')
+  }
+  return { speakerId: session.speaker._id }
 }
 
 // --- My Areas (TEAMS-3, L4) ---
@@ -1144,6 +1160,16 @@ export async function fetchScheduleStatus(
 }
 
 // --- Dashboard Config Persistence ---
+//
+// Layouts are PER-ORGANIZER: each organizer has their own dashboardConfig doc,
+// identified deterministically as `dashboardConfig-<conferenceId>-<speakerId>`
+// and carrying a `speaker` reference. The legacy conference-wide doc (no
+// speaker reference) is kept READ-ONLY as the first-visit default: it is
+// consulted by load when no personal doc exists, and never written again.
+//
+// Both actions take NO conferenceId from the client — the conference is
+// resolved server-side from the request domain (resolveConferenceId, same
+// helper the tRPC routers use) and the speaker id comes from the session.
 
 interface DashboardConfigWidget {
   _key: string
@@ -1161,8 +1187,9 @@ interface DashboardConfigDocument {
   _id: string
   _type: 'dashboardConfig'
   conference: { _ref: string; _type: 'reference' }
+  speaker?: { _ref: string; _type: 'reference' }
   preset?: string
-  widgets: DashboardConfigWidget[]
+  widgets?: DashboardConfigWidget[]
 }
 
 export interface SerializedWidget {
@@ -1173,19 +1200,118 @@ export interface SerializedWidget {
   config?: Record<string, unknown>
 }
 
-export async function loadDashboardConfig(
+/**
+ * Deterministic id for an organizer's personal dashboard config. Both inputs
+ * are Sanity document ids (letters/digits/dots/dashes/underscores), but any
+ * other character is sanitized defensively so the result is always a valid
+ * Sanity `_id`. Determinism makes saves race-free: concurrent saves by the
+ * same user `createOrReplace` the SAME doc instead of racing a
+ * fetch-then-create into duplicates.
+ */
+function personalDashboardConfigId(
   conferenceId: string,
-): Promise<SerializedWidget[] | null> {
-  await requireOrganizer()
+  speakerId: string,
+): string {
+  const clean = (s: string) => s.replace(/[^a-zA-Z0-9._-]/g, '-')
+  return `dashboardConfig-${clean(conferenceId)}-${clean(speakerId)}`
+}
 
-  const doc = await clientWrite.fetch<DashboardConfigDocument | null>(
-    `*[_type == "dashboardConfig" && conference._ref == $conferenceId][0]`,
-    { conferenceId },
-  )
+// --- Server-side validation limits for saved layouts ---
+const MAX_WIDGETS = 40
+const MAX_TITLE_LENGTH = 200
+const MAX_ROW = 500
+const MAX_COL = 11
+const MAX_ROW_SPAN = 24
+const MAX_COL_SPAN = 12
+const MAX_CONFIG_JSON_BYTES = 8 * 1024
 
-  if (!doc?.widgets?.length) return null
+/**
+ * Validates a layout before it is written. The canonical widget-type list is
+ * the registry itself (Object.keys(WIDGET_REGISTRY)) so it can never drift
+ * from the real widget set — the registry module is metadata + zod only (no
+ * React components), so importing it server-side is safe.
+ *
+ * Note the save/load asymmetry: SAVE rejects unknown widget types, but LOAD
+ * keeps tolerating unknown STORED types (the renderer shows a "Widget not
+ * available" placeholder) so old docs never break the dashboard.
+ */
+function validateDashboardWidgets(widgets: SerializedWidget[]): void {
+  if (!Array.isArray(widgets)) {
+    throw new Error('Invalid dashboard config: widgets must be an array')
+  }
+  if (widgets.length > MAX_WIDGETS) {
+    throw new Error(
+      `Invalid dashboard config: at most ${MAX_WIDGETS} widgets allowed (got ${widgets.length})`,
+    )
+  }
 
-  return doc.widgets.map((w) => ({
+  const validTypes = new Set(Object.keys(WIDGET_REGISTRY))
+
+  for (const w of widgets) {
+    if (typeof w.id !== 'string' || !w.id || w.id.length > MAX_TITLE_LENGTH) {
+      throw new Error(
+        `Invalid dashboard config: widget id must be a non-empty string of at most ${MAX_TITLE_LENGTH} characters`,
+      )
+    }
+    if (!validTypes.has(w.type)) {
+      throw new Error(
+        `Invalid dashboard config: unknown widget type "${String(w.type)}"`,
+      )
+    }
+    if (typeof w.title !== 'string' || w.title.length > MAX_TITLE_LENGTH) {
+      throw new Error(
+        `Invalid dashboard config: widget title must be a string of at most ${MAX_TITLE_LENGTH} characters`,
+      )
+    }
+
+    const { row, col, rowSpan, colSpan } = w.position ?? {}
+    const intInRange = (v: unknown, min: number, max: number) =>
+      typeof v === 'number' && Number.isInteger(v) && v >= min && v <= max
+    if (!intInRange(row, 0, MAX_ROW)) {
+      throw new Error(
+        `Invalid dashboard config: widget row must be an integer between 0 and ${MAX_ROW}`,
+      )
+    }
+    if (!intInRange(col, 0, MAX_COL)) {
+      throw new Error(
+        `Invalid dashboard config: widget col must be an integer between 0 and ${MAX_COL}`,
+      )
+    }
+    if (!intInRange(rowSpan, 1, MAX_ROW_SPAN)) {
+      throw new Error(
+        `Invalid dashboard config: widget rowSpan must be an integer between 1 and ${MAX_ROW_SPAN}`,
+      )
+    }
+    if (!intInRange(colSpan, 1, MAX_COL_SPAN)) {
+      throw new Error(
+        `Invalid dashboard config: widget colSpan must be an integer between 1 and ${MAX_COL_SPAN}`,
+      )
+    }
+
+    if (w.config !== undefined) {
+      if (
+        typeof w.config !== 'object' ||
+        w.config === null ||
+        Array.isArray(w.config)
+      ) {
+        throw new Error(
+          'Invalid dashboard config: widget config must be a plain object',
+        )
+      }
+      const serialized = JSON.stringify(w.config)
+      if (serialized.length > MAX_CONFIG_JSON_BYTES) {
+        throw new Error(
+          `Invalid dashboard config: widget config exceeds ${MAX_CONFIG_JSON_BYTES} bytes when serialized`,
+        )
+      }
+    }
+  }
+}
+
+function serializeStoredWidgets(
+  widgets: DashboardConfigWidget[],
+): SerializedWidget[] {
+  return widgets.map((w) => ({
     id: w.widgetId,
     type: w.widgetType,
     title: w.title || w.widgetType,
@@ -1206,16 +1332,53 @@ export async function loadDashboardConfig(
   }))
 }
 
-export async function saveDashboardConfig(
-  conferenceId: string,
-  widgets: SerializedWidget[],
-): Promise<void> {
-  await requireOrganizer()
+/**
+ * Loads the calling organizer's dashboard layout for the current conference.
+ *
+ * Fallback chain:
+ *  1. personal doc (deterministic `_id`) — returned even when its widgets
+ *     array is EMPTY: an existing personal doc with `widgets: []` means the
+ *     user deliberately cleared their dashboard, so `[]` is returned and the
+ *     client renders an empty grid (not defaults);
+ *  2. legacy shared doc (`conference._ref` match, no speaker) as a read-only
+ *     first-visit default — an empty legacy doc falls through to null;
+ *  3. `null` — the client falls back to the default preset.
+ */
+export async function loadDashboardConfig(): Promise<
+  SerializedWidget[] | null
+> {
+  const { speakerId } = await requireOrganizerSession()
+  const conferenceId = await resolveConferenceId()
 
-  const existingId = await clientWrite.fetch<string | null>(
-    `*[_type == "dashboardConfig" && conference._ref == $conferenceId][0]._id`,
+  const personal = await clientWrite.fetch<DashboardConfigDocument | null>(
+    `*[_type == "dashboardConfig" && _id == $id][0]`,
+    { id: personalDashboardConfigId(conferenceId, speakerId) },
+  )
+  if (personal) {
+    return serializeStoredWidgets(personal.widgets ?? [])
+  }
+
+  const legacy = await clientWrite.fetch<DashboardConfigDocument | null>(
+    `*[_type == "dashboardConfig" && conference._ref == $conferenceId && !defined(speaker)][0]`,
     { conferenceId },
   )
+  if (!legacy?.widgets?.length) return null
+  return serializeStoredWidgets(legacy.widgets)
+}
+
+/**
+ * Saves the calling organizer's dashboard layout for the current conference.
+ * Always writes the PERSONAL doc via `createOrReplace` with a deterministic
+ * `_id` (race-free for concurrent same-user saves; the doc IS the whole
+ * layout). The legacy shared doc is never written.
+ */
+export async function saveDashboardConfig(
+  widgets: SerializedWidget[],
+): Promise<void> {
+  const { speakerId } = await requireOrganizerSession()
+  const conferenceId = await resolveConferenceId()
+
+  validateDashboardWidgets(widgets)
 
   const widgetDocs: DashboardConfigWidget[] = widgets.map((w, i) => ({
     _key: `widget-${i}`,
@@ -1229,13 +1392,11 @@ export async function saveDashboardConfig(
     config: w.config ? JSON.stringify(w.config) : undefined,
   }))
 
-  if (existingId) {
-    await clientWrite.patch(existingId).set({ widgets: widgetDocs }).commit()
-  } else {
-    await clientWrite.create({
-      _type: 'dashboardConfig' as const,
-      conference: { _ref: conferenceId, _type: 'reference' },
-      widgets: widgetDocs,
-    })
-  }
+  await clientWrite.createOrReplace({
+    _id: personalDashboardConfigId(conferenceId, speakerId),
+    _type: 'dashboardConfig' as const,
+    conference: { _ref: conferenceId, _type: 'reference' as const },
+    speaker: { _ref: speakerId, _type: 'reference' as const },
+    widgets: widgetDocs,
+  })
 }

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -1213,7 +1213,13 @@ function personalDashboardConfigId(
   speakerId: string,
 ): string {
   const clean = (s: string) => s.replace(/[^a-zA-Z0-9._-]/g, '-')
-  return `dashboardConfig-${clean(conferenceId)}-${clean(speakerId)}`
+  // The conference id's LENGTH is encoded into the id so the two source ids
+  // are unambiguously delimited: because ids may themselves contain "-", a
+  // bare separator would let distinct (conference, speaker) pairs collide
+  // (e.g. "a-b"/"c" vs "a"/"b-c"). With the length prefix the mapping is
+  // injective for any inputs the sanitizer leaves distinct.
+  const conf = clean(conferenceId)
+  return `dashboardConfig-${conf.length}-${conf}-${clean(speakerId)}`
 }
 
 // --- Server-side validation limits for saved layouts ---
@@ -1299,7 +1305,9 @@ function validateDashboardWidgets(widgets: SerializedWidget[]): void {
         )
       }
       const serialized = JSON.stringify(w.config)
-      if (serialized.length > MAX_CONFIG_JSON_BYTES) {
+      // Byte length, not string length: JS .length counts UTF-16 code units,
+      // which undercounts multibyte characters against a BYTE cap.
+      if (Buffer.byteLength(serialized, 'utf8') > MAX_CONFIG_JSON_BYTES) {
         throw new Error(
           `Invalid dashboard config: widget config exceeds ${MAX_CONFIG_JSON_BYTES} bytes when serialized`,
         )

--- a/src/components/admin/dashboard/AdminDashboard.test.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.test.tsx
@@ -35,19 +35,22 @@ vi.mock('@/components/admin/dashboard/DashboardGrid', () => ({
     widgets: Widget[]
     onWidgetsChange: (widgets: Widget[]) => void
   }) => (
-    <button
-      onClick={() =>
-        onWidgetsChange(
-          widgets.map((w, i) =>
-            i === 0
-              ? { ...w, position: { ...w.position, row: w.position.row + 1 } }
-              : w,
-          ),
-        )
-      }
-    >
-      simulate-drag
-    </button>
+    <div>
+      <div data-testid="widget-count">{widgets.length}</div>
+      <button
+        onClick={() =>
+          onWidgetsChange(
+            widgets.map((w, i) =>
+              i === 0
+                ? { ...w, position: { ...w.position, row: w.position.row + 1 } }
+                : w,
+            ),
+          )
+        }
+      >
+        simulate-drag
+      </button>
+    </div>
   ),
 }))
 
@@ -154,11 +157,76 @@ describe('AdminDashboard persistence', () => {
     await advancePastDebounce()
     expect(saveDashboardConfig).toHaveBeenCalledTimes(1)
     expect(saveDashboardConfig).toHaveBeenCalledWith(
-      'conf-1',
       expect.arrayContaining([
         expect.objectContaining({ id: 'review-progress-1' }),
       ]),
     )
+  })
+
+  it('empty-array load renders an EMPTY dashboard (no defaults) and no save', async () => {
+    // An existing personal doc with widgets: [] means the user deliberately
+    // cleared their dashboard — defaults apply only on a null load.
+    vi.mocked(loadDashboardConfig).mockResolvedValue([])
+
+    renderDashboard()
+    await flushLoad()
+
+    expect(screen.getByTestId('widget-count').textContent).toBe('0')
+
+    await advancePastDebounce()
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+  })
+
+  it('null load falls back to the default preset widgets', async () => {
+    vi.mocked(loadDashboardConfig).mockResolvedValue(null)
+
+    renderDashboard()
+    await flushLoad()
+
+    expect(
+      Number(screen.getByTestId('widget-count').textContent),
+    ).toBeGreaterThan(0)
+
+    await advancePastDebounce()
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+  })
+
+  it('unmount with a pending debounced edit FLUSHES the save immediately', async () => {
+    vi.mocked(loadDashboardConfig).mockResolvedValue(savedWidgets)
+
+    const { unmount } = renderDashboard()
+    await flushLoad()
+
+    await simulateDrag()
+    // Still inside the debounce window — nothing sent yet
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+
+    await act(async () => {
+      unmount()
+    })
+
+    expect(saveDashboardConfig).toHaveBeenCalledTimes(1)
+    expect(saveDashboardConfig).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'review-progress-1' }),
+      ]),
+    )
+    // The cleared timer must not fire a second save afterwards
+    await advancePastDebounce()
+    expect(saveDashboardConfig).toHaveBeenCalledTimes(1)
+  })
+
+  it('unmount with no pending edit performs no save', async () => {
+    vi.mocked(loadDashboardConfig).mockResolvedValue(savedWidgets)
+
+    const { unmount } = renderDashboard()
+    await flushLoad()
+
+    await act(async () => {
+      unmount()
+    })
+
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
   })
 
   it('save failure: surfaces an error toast while keeping local state', async () => {

--- a/src/components/admin/dashboard/AdminDashboard.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.tsx
@@ -54,6 +54,11 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
   const [loadStatus, setLoadStatus] = useState<LoadStatus>('loading')
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Widgets scheduled for the debounced save but not yet sent. Lets the
+  // unmount cleanup FLUSH a pending save immediately instead of dropping
+  // edits made less than the debounce interval before navigation.
+  const pendingSaveRef = useRef<Widget[] | null>(null)
+
   // The user must be told when the layout won't persist, but the toast
   // context value has a new identity on every toast change; going through a
   // ref (kept current by the effect below) keeps `persistWidgets` (and the
@@ -107,9 +112,11 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
   // of those runs may write: `dirtyRef` is still false, so the persist effect
   // is a no-op until the user actually mutates the layout.
   useEffect(() => {
-    loadDashboardConfig(conference._id)
+    loadDashboardConfig()
       .then((saved) => {
-        if (saved && saved.length > 0) {
+        // `[]` is a DELIBERATELY EMPTY personal layout and must render an
+        // empty grid — defaults apply only when NO config exists (null).
+        if (saved) {
           setWidgets(
             saved.map((w) => ({
               id: w.id,
@@ -134,7 +141,37 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
             'Showing the default layout. Changes you make will not be saved this session.',
         })
       })
-  }, [conference._id])
+  }, [])
+
+  // Serialize + fire the actual save. Stable helper (refs only) shared by the
+  // debounce timer and the unmount flush so both send the same payload shape.
+  const performSave = useCallback((widgetsToSave: Widget[]) => {
+    pendingSaveRef.current = null
+    const serialized: SerializedWidget[] = widgetsToSave.map((w) => ({
+      id: w.id,
+      type: w.type,
+      title: w.title,
+      position: w.position,
+      config: w.config as Record<string, unknown> | undefined,
+    }))
+    saveDashboardConfig(serialized)
+      .then(() => {
+        saveFailureNotifiedRef.current = false
+      })
+      .catch(() => {
+        // Widget state is still in React, so the layout keeps working
+        // locally — but the user must know it didn't persist. Notify once
+        // per failure burst, not on every debounced retry.
+        if (!saveFailureNotifiedRef.current) {
+          saveFailureNotifiedRef.current = true
+          showNotificationRef.current({
+            type: 'error',
+            title: "Couldn't save your dashboard layout",
+            message: 'Your latest changes are visible here but were not saved.',
+          })
+        }
+      })
+  }, [])
 
   // Debounced save after user edits (see gates below)
   const persistWidgets = useCallback(
@@ -147,47 +184,28 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
       //   be a pointless echo-write of what the server just sent us.
       if (loadStatus !== 'loaded' || !dirtyRef.current) return
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      pendingSaveRef.current = widgetsToSave
       saveTimerRef.current = setTimeout(() => {
-        const serialized: SerializedWidget[] = widgetsToSave.map((w) => ({
-          id: w.id,
-          type: w.type,
-          title: w.title,
-          position: w.position,
-          config: w.config as Record<string, unknown> | undefined,
-        }))
-        saveDashboardConfig(conference._id, serialized)
-          .then(() => {
-            saveFailureNotifiedRef.current = false
-          })
-          .catch(() => {
-            // Widget state is still in React, so the layout keeps working
-            // locally — but the user must know it didn't persist. Notify once
-            // per failure burst, not on every debounced retry.
-            if (!saveFailureNotifiedRef.current) {
-              saveFailureNotifiedRef.current = true
-              showNotificationRef.current({
-                type: 'error',
-                title: "Couldn't save your dashboard layout",
-                message:
-                  'Your latest changes are visible here but were not saved.',
-              })
-            }
-          })
+        saveTimerRef.current = null
+        if (pendingSaveRef.current) performSave(pendingSaveRef.current)
       }, DASHBOARD_SAVE_DEBOUNCE_MS)
     },
-    [conference._id, loadStatus],
+    [loadStatus, performSave],
   )
 
   useEffect(() => {
     persistWidgets(widgets)
   }, [widgets, persistWidgets])
 
-  // Clean up debounce timer on unmount
+  // On unmount: clear the debounce timer, then FLUSH any pending save
+  // (fire-and-forget) so edits made less than the debounce interval before
+  // navigating away are not silently dropped.
   useEffect(() => {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+      if (pendingSaveRef.current) performSave(pendingSaveRef.current)
     }
-  }, [])
+  }, [performSave])
 
   useEffect(() => {
     const handleResize = () => {


### PR DESCRIPTION
## Decision

Dashboard layout config is now **per-organizer** instead of one shared doc per conference (locked decision). Every organizer gets their own `dashboardConfig` document; the legacy conference-wide doc becomes a read-only first-visit default.

## What changed

- **Schema** (`sanity/schemaTypes/dashboardConfig.ts`): optional `speaker` reference. Personal docs carry it; the legacy shared doc (no speaker) is kept only as a first-visit default and is never written again.
- **Server actions** (`src/app/(admin)/admin/actions.ts`):
  - `loadDashboardConfig()` / `saveDashboardConfig(widgets)` take **no conferenceId from the client** — the conference is resolved server-side from the request domain via `resolveConferenceId()` (the same helper the tRPC routers use), and the caller's speaker id comes from the session via a new `requireOrganizerSession()` helper (`requireOrganizer()` is untouched for the other call sites).
  - Personal doc id is deterministic: `dashboardConfig-<conferenceId>-<speakerId>` (sanitized), written with `createOrReplace` — race-free for concurrent same-user saves and kills the old fetch-then-create duplicate race.
- **Load fallback chain**: personal doc by deterministic `_id` → legacy shared doc (`conference._ref` match, `!defined(speaker)`) → `null` (client falls back to the Planning preset). An existing personal doc with `widgets: []` returns `[]` (deliberately empty layout, rendered as an empty grid); an empty legacy doc still falls through to `null`.
- **Server-side validation on save** (unknown types tolerated on LOAD — renderer shows the 'not available' placeholder):
  - ≤ 40 widgets per layout
  - widget type must exist in the widget registry (`Object.keys(WIDGET_REGISTRY)` — the registry module is metadata + zod only, no React, so it is imported directly server-side; no drift-prone static list)
  - title/id strings ≤ 200 chars
  - integer positions: 0 ≤ row ≤ 500, 0 ≤ col ≤ 11, 1 ≤ rowSpan ≤ 24, 1 ≤ colSpan ≤ 12
  - config ≤ 8 KB serialized JSON per widget
- **Client** (`AdminDashboard.tsx`): new action signatures; `[]` load renders an empty dashboard (defaults only on `null`); unmount now **flushes** a pending debounced save instead of dropping edits made < 1.5 s before navigation. All Batch-1 gating (LoadStatus, dirtyRef, toasts, reset confirm) intact.
- **Docs** (`docs/DASHBOARD_SYSTEM.md`): per-organizer persistence section + stale widget counts fixed (12 → 13, config: 9 of 13).

## No data migration

None needed: existing shared docs keep working as the first-visit default source in the load fallback chain. Each organizer's first save materializes their personal doc; the legacy doc is simply never written again.

## Tests

- `__tests__/lib/dashboard/actions.test.ts`: personal-doc load, legacy fallback, empty-personal-doc → `[]`, empty-legacy → `null`, lenient load of unknown stored types, all validation rejections, deterministic-id `createOrReplace`, and that save never touches the legacy doc (no fetch/patch/create).
- `AdminDashboard.test.tsx`: new signatures, empty-array load renders empty (no defaults, no save), null load → defaults, unmount flush fires exactly one save, clean unmount saves nothing.
- Full vitest suite: 279 files, 3840 passed / 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-organizer dashboard layouts with server-side tenant resolution and validation. The main changes are:

- Personal Sanity documents keyed by conference and organizer.
- Legacy conference layouts retained as first-visit defaults.
- Server-side widget type, position, count, and config validation.
- Pending dashboard saves flushed during unmount.
- Updated persistence tests, schema, and documentation.

<h3>Confidence Score: 4/5</h3>

The persistence key and config-size validation need fixes before merging.

- Distinct conference and organizer pairs can resolve to the same personal document ID.
- Multibyte config data can exceed the stated byte limit while passing validation.
- The remaining load fallback and client save lifecycle changes are consistent with the intended behavior.

src/app/(admin)/admin/actions.ts

<details open><summary><h3>Security Review</h3></summary>

The deterministic document ID does not uniquely encode the conference and organizer IDs. Colliding pairs can address the same Sanity document, allowing layouts to be overwritten or read across organizer or conference boundaries.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(admin)/admin/actions.ts | Adds organizer-scoped loading, validation, and deterministic writes; document-key collisions and incorrect byte measurement remain. |
| src/components/admin/dashboard/AdminDashboard.tsx | Updates action calls, preserves empty layouts, and flushes pending debounced saves on unmount. |
| sanity/schemaTypes/dashboardConfig.ts | Adds the optional organizer reference and updates document previews. |
| __tests__/lib/dashboard/actions.test.ts | Covers the fallback chain, authorization, deterministic writes, and most validation rules. |
| src/components/admin/dashboard/AdminDashboard.test.tsx | Covers empty-layout rendering and unmount save flushing. |
| docs/DASHBOARD_SYSTEM.md | Documents per-organizer persistence, fallback behavior, validation, and updated widget counts. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  UI[Admin dashboard] --> Auth[Require organizer session]
  Auth --> Domain[Resolve conference from request domain]
  Domain --> Personal[Build personal document ID]
  Personal --> Existing{Personal document exists?}
  Existing -->|Yes| ReturnPersonal[Return personal widgets]
  Existing -->|No| Legacy{Non-empty legacy document exists?}
  Legacy -->|Yes| ReturnLegacy[Return legacy widgets]
  Legacy -->|No| Defaults[Return null and use preset]
  UI --> Validate[Validate widgets on save]
  Validate --> Replace[Create or replace personal document]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  UI[Admin dashboard] --> Auth[Require organizer session]
  Auth --> Domain[Resolve conference from request domain]
  Domain --> Personal[Build personal document ID]
  Personal --> Existing{Personal document exists?}
  Existing -->|Yes| ReturnPersonal[Return personal widgets]
  Existing -->|No| Legacy{Non-empty legacy document exists?}
  Legacy -->|Yes| ReturnLegacy[Return legacy widgets]
  Legacy -->|No| Defaults[Return null and use preset]
  UI --> Validate[Validate widgets on save]
  Validate --> Replace[Create or replace personal document]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): per-organizer layout co..."](https://github.com/cloudnativebergen/website/commit/2e3dda8458cb4fc08e901dafa9e061511a5cd67a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46103129)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->