### PR TITLE
feat(dashboard): widget state×size matrix stories + action-mock harness

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,6 +19,24 @@ const config: StorybookConfig = {
     // CloudNativePattern imports static CNCF SVGs that Vite cannot resolve.
     // Replace with a lightweight stub so stories using BackgroundImage can build.
     config.plugins = config.plugins || []
+    // The admin dashboard widgets import their fetchers from the
+    // `@/app/(admin)/admin/actions` server-action module ('use server'),
+    // which cannot load in the browser bundle. Re-resolve that module id to a
+    // browser-safe mock with a per-story registry (same technique as the
+    // CloudNativePattern stub below). Stories import the registry helpers
+    // from the mock file directly — Vite resolves both to the same module.
+    config.plugins.push({
+      name: 'mock-admin-actions',
+      enforce: 'pre',
+      resolveId(id) {
+        if (id === '@/app/(admin)/admin/actions') {
+          return join(
+            __dirname,
+            '../src/components/admin/dashboard/widgets/__matrix__/mock-admin-actions.ts',
+          )
+        }
+      },
+    })
     config.plugins.push({
       name: 'mock-cloud-native-pattern',
       enforce: 'pre',

--- a/knip.json
+++ b/knip.json
@@ -27,6 +27,7 @@
     "sanity/**",
     "migrations/**",
     "src/lib/empty-module.ts",
+    "src/components/admin/dashboard/widgets/__matrix__/mock-admin-actions.ts",
     "src/components/email/CoSpeakerResponseTemplate.tsx",
     "src/lib/sponsor-crm/contract-send.ts"
   ],

--- a/src/components/admin/dashboard/widgets/__matrix__/CFPHealth.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/CFPHealth.matrix.stories.tsx
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { CFPHealthWidget } from '../CFPHealthWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  cfpHealthDense,
+  cfpHealthSparse,
+  cfpHealthZero,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'cfp-health'
+
+// Operational (trend + format breakdown) view renders in planning phase.
+const dense = conferenceInPhase('planning', 'cfp-health/dense')
+const sparse = conferenceInPhase('planning', 'cfp-health/sparse')
+const zero = conferenceInPhase('planning', 'cfp-health/zero')
+const empty = conferenceInPhase('planning', 'cfp-health/empty')
+const loading = conferenceInPhase('planning', 'cfp-health/loading')
+const failing = conferenceInPhase('planning', 'cfp-health/error')
+const init = conferenceInPhase('initialization', 'cfp-health/init')
+const execution = conferenceInPhase('execution', 'cfp-health/execution')
+const post = conferenceInPhase('post-conference', 'cfp-health/post')
+
+setMockActionFor(dense._id, 'fetchCFPHealth', mockResolved(cfpHealthDense))
+setMockActionFor(sparse._id, 'fetchCFPHealth', mockResolved(cfpHealthSparse))
+setMockActionFor(zero._id, 'fetchCFPHealth', mockResolved(cfpHealthZero))
+setMockActionFor(empty._id, 'fetchCFPHealth', mockResolved(null))
+setMockActionFor(loading._id, 'fetchCFPHealth', mockPending)
+setMockActionFor(failing._id, 'fetchCFPHealth', mockFailure)
+setMockActionFor(init._id, 'fetchCFPHealth', mockResolved(cfpHealthZero))
+setMockActionFor(execution._id, 'fetchCFPHealth', mockResolved(cfpHealthDense))
+setMockActionFor(post._id, 'fetchCFPHealth', mockResolved(cfpHealthDense))
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/CFPHealth',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for CFPHealthWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <CFPHealthWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every registry size with dense data: a 14-day submissions trend and 6 talk formats — the trend row is the layout-stress axis in narrow cells.',
+      },
+    },
+  },
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <CFPHealthWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <CFPHealthWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty (null data)" {...size}>
+          <CFPHealthWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="zero submissions" {...size}>
+          <CFPHealthWidget conference={zero} />
+        </WidgetFrame>
+        <WidgetFrame label="sparse" {...size}>
+          <CFPHealthWidget conference={sparse} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <CFPHealthWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <CFPHealthWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization (preparing card)" {...size}>
+          <CFPHealthWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="planning (operational)" {...size}>
+          <CFPHealthWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (complete grid)" {...size}>
+          <CFPHealthWidget conference={execution} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (archived)" {...size}>
+          <CFPHealthWidget conference={post} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="14-day trend" colSpan={4} rowSpan={4}>
+        <CFPHealthWidget conference={dense} />
+      </WidgetFrame>
+      <WidgetFrame label="min + 14-day trend" colSpan={3} rowSpan={3}>
+        <CFPHealthWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The 4x4 cell with a 14-day trend — the flagged risk cell — plus the true 3x3 minimum with the same data.',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <CFPHealthWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile zero" mode="mobile">
+          <CFPHealthWidget conference={zero} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode showConfigDot>
+          <CFPHealthWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/MyAreas.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/MyAreas.matrix.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { MyAreasWidget } from '../MyAreasWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import { conferenceInPhase, myAreasTwoTeams } from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'my-areas'
+
+// Not phase-adaptive: only the useWidgetData states matter here. The
+// presentational body already has its own stories (MyAreasView.stories.tsx);
+// this file covers the widget THROUGH the action boundary + the size axis.
+const twoTeams = conferenceInPhase('planning', 'my-areas/two-teams')
+const noTeams = conferenceInPhase('planning', 'my-areas/no-teams')
+const loading = conferenceInPhase('planning', 'my-areas/loading')
+const failing = conferenceInPhase('planning', 'my-areas/error')
+
+setMockActionFor(
+  twoTeams._id,
+  'fetchMyAreasData',
+  mockResolved(myAreasTwoTeams),
+)
+setMockActionFor(noTeams._id, 'fetchMyAreasData', mockResolved({ areas: [] }))
+setMockActionFor(loading._id, 'fetchMyAreasData', mockPending)
+setMockActionFor(failing._id, 'fetchMyAreasData', mockFailure)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/MyAreas',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for MyAreasWidget (through the mocked action boundary) inside the real WidgetContainer geometry. The 3x2 two-team cell is the flagged known-risk cell — it is also the registry minimum AND default.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesTwoTeams: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <MyAreasWidget conference={twoTeams} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every registry size with two teams and four metrics (one 99+ badge, long labels). The min/default 3x2 cell is the flagged known-risk cell.',
+      },
+    },
+  },
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <MyAreasWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <MyAreasWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="no teams (inert empty)" {...size}>
+          <MyAreasWidget conference={noTeams} />
+        </WidgetFrame>
+        <WidgetFrame label="two teams" {...size}>
+          <MyAreasWidget conference={twoTeams} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <MyAreasWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile two teams" mode="mobile">
+          <MyAreasWidget conference={twoTeams} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile no teams" mode="mobile">
+          <MyAreasWidget conference={noTeams} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode>
+          <MyAreasWidget conference={twoTeams} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/ProposalPipeline.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/ProposalPipeline.matrix.stories.tsx
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ProposalPipelineWidget } from '../ProposalPipelineWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  proposalPipelineDense,
+  proposalPipelineSparse,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'proposal-pipeline'
+
+// Operational view only renders in execution (init/planning show the CFP setup
+// card, post-conference shows the summary), so dense cells use execution.
+const dense = conferenceInPhase('execution', 'proposal-pipeline/dense')
+const sparse = conferenceInPhase('execution', 'proposal-pipeline/sparse')
+const empty = conferenceInPhase('execution', 'proposal-pipeline/empty')
+const loading = conferenceInPhase('execution', 'proposal-pipeline/loading')
+const failing = conferenceInPhase('execution', 'proposal-pipeline/error')
+const init = conferenceInPhase('initialization', 'proposal-pipeline/init')
+const planningEarly = conferenceInPhase(
+  'planning',
+  'proposal-pipeline/planning',
+)
+const post = conferenceInPhase('post-conference', 'proposal-pipeline/post')
+
+setMockActionFor(
+  dense._id,
+  'fetchProposalPipeline',
+  mockResolved(proposalPipelineDense),
+)
+setMockActionFor(
+  sparse._id,
+  'fetchProposalPipeline',
+  mockResolved(proposalPipelineSparse),
+)
+setMockActionFor(empty._id, 'fetchProposalPipeline', mockResolved(null))
+setMockActionFor(loading._id, 'fetchProposalPipeline', mockPending)
+setMockActionFor(failing._id, 'fetchProposalPipeline', mockFailure)
+setMockActionFor(init._id, 'fetchProposalPipeline', mockResolved(null))
+setMockActionFor(
+  planningEarly._id,
+  'fetchProposalPipeline',
+  mockResolved(proposalPipelineSparse),
+)
+setMockActionFor(
+  post._id,
+  'fetchProposalPipeline',
+  mockResolved(proposalPipelineDense),
+)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/ProposalPipeline',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for ProposalPipelineWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <ProposalPipelineWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <ProposalPipelineWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <ProposalPipelineWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty (null data)" {...size}>
+          <ProposalPipelineWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="sparse" {...size}>
+          <ProposalPipelineWidget conference={sparse} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <ProposalPipelineWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <ProposalPipelineWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization (CFP setup card)" {...size}>
+          <ProposalPipelineWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="planning + early submissions" {...size}>
+          <ProposalPipelineWidget conference={planningEarly} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (operational)" {...size}>
+          <ProposalPipelineWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (summary)" {...size}>
+          <ProposalPipelineWidget conference={post} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Phase branches at default size. Planning shows the setup card with the "Early Submissions" box because total > 0.',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <ProposalPipelineWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile loading" mode="mobile">
+          <ProposalPipelineWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode showConfigDot>
+          <ProposalPipelineWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/QuickActions.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/QuickActions.matrix.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { QuickActionsWidget } from '../QuickActionsWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  quickActionsDense,
+  quickActionsSparse,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'quick-actions'
+
+const dense = conferenceInPhase('planning', 'quick-actions/dense')
+const sparse = conferenceInPhase('planning', 'quick-actions/sparse')
+const empty = conferenceInPhase('planning', 'quick-actions/empty')
+const loading = conferenceInPhase('planning', 'quick-actions/loading')
+const failing = conferenceInPhase('planning', 'quick-actions/error')
+
+setMockActionFor(
+  dense._id,
+  'fetchQuickActions',
+  mockResolved(quickActionsDense),
+)
+setMockActionFor(
+  sparse._id,
+  'fetchQuickActions',
+  mockResolved(quickActionsSparse),
+)
+setMockActionFor(empty._id, 'fetchQuickActions', mockResolved([]))
+setMockActionFor(loading._id, 'fetchQuickActions', mockPending)
+setMockActionFor(failing._id, 'fetchQuickActions', mockFailure)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/QuickActions',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for QuickActionsWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <QuickActionsWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every registry size (true min, default, all presets, true max) with dense data: 6 actions, long labels, a 99+ badge.',
+      },
+    },
+  },
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <QuickActionsWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <QuickActionsWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty" {...size}>
+          <QuickActionsWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="sparse" {...size}>
+          <QuickActionsWidget conference={sparse} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <QuickActionsWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <QuickActionsWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every useWidgetData state at the registry default size, plus the null-conference no-op (renders the empty state).',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <QuickActionsWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile loading" mode="mobile">
+          <QuickActionsWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode>
+          <QuickActionsWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Mobile auto-height column (no size containment, 361px) and the edit-mode chrome with the mac-dots overlay + h3 indent hack.',
+      },
+    },
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/RecentActivity.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/RecentActivity.matrix.stories.tsx
@@ -1,0 +1,198 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { RecentActivityFeedWidget } from '../RecentActivityFeedWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  recentActivityDense,
+  recentActivitySparse,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'recent-activity'
+
+const dense = conferenceInPhase('planning', 'recent-activity/dense')
+const sparse = conferenceInPhase('planning', 'recent-activity/sparse')
+const empty = conferenceInPhase('planning', 'recent-activity/empty')
+const loading = conferenceInPhase('planning', 'recent-activity/loading')
+const failing = conferenceInPhase('planning', 'recent-activity/error')
+const initMasked = conferenceInPhase(
+  'initialization',
+  'recent-activity/init-masked-error',
+)
+const postEmpty = conferenceInPhase(
+  'post-conference',
+  'recent-activity/post-empty',
+)
+const postData = conferenceInPhase(
+  'post-conference',
+  'recent-activity/post-data',
+)
+
+setMockActionFor(
+  dense._id,
+  'fetchRecentActivity',
+  mockResolved(recentActivityDense),
+)
+setMockActionFor(
+  sparse._id,
+  'fetchRecentActivity',
+  mockResolved(recentActivitySparse),
+)
+setMockActionFor(empty._id, 'fetchRecentActivity', mockResolved([]))
+setMockActionFor(loading._id, 'fetchRecentActivity', mockPending)
+setMockActionFor(failing._id, 'fetchRecentActivity', mockFailure)
+setMockActionFor(initMasked._id, 'fetchRecentActivity', mockFailure)
+setMockActionFor(postEmpty._id, 'fetchRecentActivity', mockResolved([]))
+setMockActionFor(
+  postData._id,
+  'fetchRecentActivity',
+  mockResolved(recentActivitySparse),
+)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/RecentActivity',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for RecentActivityFeedWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module. Dense = 24 items (3 swipeable pages at the default 10/page).',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <RecentActivityFeedWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <RecentActivityFeedWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <RecentActivityFeedWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty" {...size}>
+          <RecentActivityFeedWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="sparse (2 items)" {...size}>
+          <RecentActivityFeedWidget conference={sparse} />
+        </WidgetFrame>
+        <WidgetFrame label="dense (24 items)" {...size}>
+          <RecentActivityFeedWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <RecentActivityFeedWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame
+          label="initialization + REJECTING fetch (masked)"
+          {...size}
+        >
+          <RecentActivityFeedWidget conference={initMasked} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference, empty (complete card)" {...size}>
+          <RecentActivityFeedWidget conference={postEmpty} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference, with data" {...size}>
+          <RecentActivityFeedWidget conference={postData} />
+        </WidgetFrame>
+        <WidgetFrame label="planning (feed)" {...size}>
+          <RecentActivityFeedWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'PHASE-MASKED ERROR (documented current behaviour): the initialization branch returns the "Getting Started" card BEFORE the loading/error checks, so a rejecting fetch is silently masked in that phase — that cell uses a rejecting fetcher on purpose.',
+      },
+    },
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="compact 3x2, dense feed" colSpan={3} rowSpan={2}>
+        <RecentActivityFeedWidget conference={dense} />
+      </WidgetFrame>
+      <WidgetFrame label="narrow-tall 3x10, sparse" colSpan={3} rowSpan={10}>
+        <RecentActivityFeedWidget conference={sparse} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The two flagged cells: 3x2 with a dense paginated feed (header + pager chrome in a 2-row cell) and the 3x10 default with only 2 items (dead space).',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="mobile dense" mode="mobile">
+        <RecentActivityFeedWidget conference={dense} />
+      </WidgetFrame>
+      <WidgetFrame label="mobile empty" mode="mobile">
+        <RecentActivityFeedWidget conference={empty} />
+      </WidgetFrame>
+      <WidgetFrame
+        label="edit chrome"
+        colSpan={3}
+        rowSpan={5}
+        editMode
+        showConfigDot
+      >
+        <RecentActivityFeedWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/ReviewProgress.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/ReviewProgress.matrix.stories.tsx
@@ -1,0 +1,184 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ReviewProgressWidget } from '../ReviewProgressWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  reviewProgressDense,
+  reviewProgressSparse,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'review-progress'
+
+const dense = conferenceInPhase('planning', 'review-progress/dense')
+const sparse = conferenceInPhase('planning', 'review-progress/sparse')
+const empty = conferenceInPhase('planning', 'review-progress/empty')
+const loading = conferenceInPhase('planning', 'review-progress/loading')
+const failing = conferenceInPhase('planning', 'review-progress/error')
+const init = conferenceInPhase('initialization', 'review-progress/init')
+const execution = conferenceInPhase('execution', 'review-progress/execution')
+const post = conferenceInPhase('post-conference', 'review-progress/post')
+const postNoData = conferenceInPhase(
+  'post-conference',
+  'review-progress/post-empty',
+)
+
+setMockActionFor(
+  dense._id,
+  'fetchReviewProgress',
+  mockResolved(reviewProgressDense),
+)
+setMockActionFor(
+  sparse._id,
+  'fetchReviewProgress',
+  mockResolved(reviewProgressSparse),
+)
+setMockActionFor(empty._id, 'fetchReviewProgress', mockResolved(null))
+setMockActionFor(loading._id, 'fetchReviewProgress', mockPending)
+setMockActionFor(failing._id, 'fetchReviewProgress', mockFailure)
+setMockActionFor(init._id, 'fetchReviewProgress', mockResolved(null))
+setMockActionFor(
+  execution._id,
+  'fetchReviewProgress',
+  mockResolved(reviewProgressDense),
+)
+setMockActionFor(
+  post._id,
+  'fetchReviewProgress',
+  mockResolved(reviewProgressDense),
+)
+setMockActionFor(postNoData._id, 'fetchReviewProgress', mockResolved(null))
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/ReviewProgress',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for ReviewProgressWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <ReviewProgressWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <ReviewProgressWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <ReviewProgressWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty (null data)" {...size}>
+          <ReviewProgressWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="sparse" {...size}>
+          <ReviewProgressWidget conference={sparse} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <ReviewProgressWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <ReviewProgressWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization (setup card)" {...size}>
+          <ReviewProgressWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="planning (operational)" {...size}>
+          <ReviewProgressWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (operational)" {...size}>
+          <ReviewProgressWidget conference={execution} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (summary)" {...size}>
+          <ReviewProgressWidget conference={post} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference, no data" {...size}>
+          <ReviewProgressWidget conference={postNoData} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="min operational" colSpan={2} rowSpan={2}>
+        <ReviewProgressWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The true 2x2 registry minimum with the full operational view (progress ring + stats + CTA) — the known layout-stress cell for this widget.',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <ReviewProgressWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile error" mode="mobile">
+          <ReviewProgressWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode showConfigDot>
+          <ReviewProgressWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/ScheduleBuilder.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/ScheduleBuilder.matrix.stories.tsx
@@ -1,0 +1,184 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ScheduleBuilderStatusWidget } from '../ScheduleBuilderStatusWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  scheduleStatusDense,
+  scheduleStatusSparse,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'schedule-builder'
+
+const dense = conferenceInPhase('planning', 'schedule-builder/dense')
+const sparse = conferenceInPhase('planning', 'schedule-builder/sparse')
+const empty = conferenceInPhase('planning', 'schedule-builder/empty')
+const loading = conferenceInPhase('planning', 'schedule-builder/loading')
+const failing = conferenceInPhase('planning', 'schedule-builder/error')
+const init = conferenceInPhase('initialization', 'schedule-builder/init')
+const execution = conferenceInPhase('execution', 'schedule-builder/execution')
+const post = conferenceInPhase('post-conference', 'schedule-builder/post')
+
+setMockActionFor(
+  dense._id,
+  'fetchScheduleStatus',
+  mockResolved(scheduleStatusDense),
+)
+setMockActionFor(
+  sparse._id,
+  'fetchScheduleStatus',
+  mockResolved(scheduleStatusSparse),
+)
+setMockActionFor(empty._id, 'fetchScheduleStatus', mockResolved(null))
+setMockActionFor(loading._id, 'fetchScheduleStatus', mockPending)
+setMockActionFor(failing._id, 'fetchScheduleStatus', mockFailure)
+setMockActionFor(init._id, 'fetchScheduleStatus', mockResolved(null))
+setMockActionFor(
+  execution._id,
+  'fetchScheduleStatus',
+  mockResolved(scheduleStatusDense),
+)
+setMockActionFor(
+  post._id,
+  'fetchScheduleStatus',
+  mockResolved(scheduleStatusDense),
+)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/ScheduleBuilder',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for ScheduleBuilderStatusWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <ScheduleBuilderStatusWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every registry size with 3 conference days, unassigned talks and placeholder slots all present.',
+      },
+    },
+  },
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <ScheduleBuilderStatusWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <ScheduleBuilderStatusWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty (null data)" {...size}>
+          <ScheduleBuilderStatusWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="sparse (1 day, 1 slot)" {...size}>
+          <ScheduleBuilderStatusWidget conference={sparse} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <ScheduleBuilderStatusWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <ScheduleBuilderStatusWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization (planning guide)" {...size}>
+          <ScheduleBuilderStatusWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="planning (operational)" {...size}>
+          <ScheduleBuilderStatusWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (operational)" {...size}>
+          <ScheduleBuilderStatusWidget conference={execution} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (archived)" {...size}>
+          <ScheduleBuilderStatusWidget conference={post} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="min planning" colSpan={3} rowSpan={3}>
+        <ScheduleBuilderStatusWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The flagged 3x3 planning-phase cell: header, stat cards, overall bar, by-day list and the unassigned/placeholder footer competing for 3 rows.',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <ScheduleBuilderStatusWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile empty" mode="mobile">
+          <ScheduleBuilderStatusWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode>
+          <ScheduleBuilderStatusWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/SpeakerEngagement.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/SpeakerEngagement.matrix.stories.tsx
@@ -1,0 +1,191 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SpeakerEngagementWidget } from '../SpeakerEngagementWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  speakerEngagementDense,
+  speakerEngagementSparse,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'speaker-engagement'
+
+const dense = conferenceInPhase('planning', 'speaker-engagement/dense')
+const sparse = conferenceInPhase('planning', 'speaker-engagement/sparse')
+const empty = conferenceInPhase('planning', 'speaker-engagement/empty')
+const loading = conferenceInPhase('planning', 'speaker-engagement/loading')
+const failing = conferenceInPhase('planning', 'speaker-engagement/error')
+const init = conferenceInPhase('initialization', 'speaker-engagement/init')
+const initZero = conferenceInPhase(
+  'initialization',
+  'speaker-engagement/init-zero',
+)
+const execution = conferenceInPhase('execution', 'speaker-engagement/execution')
+const post = conferenceInPhase('post-conference', 'speaker-engagement/post')
+
+setMockActionFor(
+  dense._id,
+  'fetchSpeakerEngagement',
+  mockResolved(speakerEngagementDense),
+)
+setMockActionFor(
+  sparse._id,
+  'fetchSpeakerEngagement',
+  mockResolved(speakerEngagementSparse),
+)
+setMockActionFor(empty._id, 'fetchSpeakerEngagement', mockResolved(null))
+setMockActionFor(loading._id, 'fetchSpeakerEngagement', mockPending)
+setMockActionFor(failing._id, 'fetchSpeakerEngagement', mockFailure)
+setMockActionFor(
+  init._id,
+  'fetchSpeakerEngagement',
+  mockResolved(speakerEngagementDense),
+)
+setMockActionFor(initZero._id, 'fetchSpeakerEngagement', mockResolved(null))
+setMockActionFor(
+  execution._id,
+  'fetchSpeakerEngagement',
+  mockResolved(speakerEngagementDense),
+)
+setMockActionFor(
+  post._id,
+  'fetchSpeakerEngagement',
+  mockResolved(speakerEngagementDense),
+)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/SpeakerEngagement',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for SpeakerEngagementWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <SpeakerEngagementWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <SpeakerEngagementWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <SpeakerEngagementWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty (null data)" {...size}>
+          <SpeakerEngagementWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="sparse (2 speakers)" {...size}>
+          <SpeakerEngagementWidget conference={sparse} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <SpeakerEngagementWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <SpeakerEngagementWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization + data (outreach)" {...size}>
+          <SpeakerEngagementWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="initialization, no data" {...size}>
+          <SpeakerEngagementWidget conference={initZero} />
+        </WidgetFrame>
+        <WidgetFrame label="planning (engagement)" {...size}>
+          <SpeakerEngagementWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (status)" {...size}>
+          <SpeakerEngagementWidget conference={execution} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (summary)" {...size}>
+          <SpeakerEngagementWidget conference={post} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="min, initialization" colSpan={3} rowSpan={2}>
+        <SpeakerEngagementWidget conference={init} />
+      </WidgetFrame>
+      <WidgetFrame label="min, operational" colSpan={3} rowSpan={2}>
+        <SpeakerEngagementWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The flagged 3x2 initialization cell: the tall outreach card content inside the 2-row minimum, plus the operational view at the same minimum.',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <SpeakerEngagementWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile init" mode="mobile">
+          <SpeakerEngagementWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode showConfigDot>
+          <SpeakerEngagementWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/SponsorPipeline.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/SponsorPipeline.matrix.stories.tsx
@@ -1,0 +1,181 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SponsorPipelineWidget } from '../SponsorPipelineWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  sponsorPipelineDense,
+  sponsorPipelineEmptyGoalSet,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'sponsor-pipeline'
+
+// Operational view renders in execution (or planning once deals exist).
+const dense = conferenceInPhase('execution', 'sponsor-pipeline/dense')
+const empty = conferenceInPhase('execution', 'sponsor-pipeline/empty')
+const loading = conferenceInPhase('execution', 'sponsor-pipeline/loading')
+const failing = conferenceInPhase('execution', 'sponsor-pipeline/error')
+const init = conferenceInPhase('initialization', 'sponsor-pipeline/init')
+const planningZero = conferenceInPhase(
+  'planning',
+  'sponsor-pipeline/planning-zero',
+)
+const post = conferenceInPhase('post-conference', 'sponsor-pipeline/post')
+
+setMockActionFor(
+  dense._id,
+  'fetchSponsorPipelineData',
+  mockResolved(sponsorPipelineDense),
+)
+setMockActionFor(empty._id, 'fetchSponsorPipelineData', mockResolved(null))
+setMockActionFor(loading._id, 'fetchSponsorPipelineData', mockPending)
+setMockActionFor(failing._id, 'fetchSponsorPipelineData', mockFailure)
+setMockActionFor(
+  init._id,
+  'fetchSponsorPipelineData',
+  mockResolved(sponsorPipelineEmptyGoalSet),
+)
+setMockActionFor(
+  planningZero._id,
+  'fetchSponsorPipelineData',
+  mockResolved(sponsorPipelineEmptyGoalSet),
+)
+setMockActionFor(
+  post._id,
+  'fetchSponsorPipelineData',
+  mockResolved(sponsorPipelineDense),
+)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/SponsorPipeline',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for SponsorPipelineWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module. Dense data includes stages with 5-6 sponsors (logo chips + text pills, one absurdly long name).',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <SponsorPipelineWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <SponsorPipelineWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <SponsorPipelineWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty (null data)" {...size}>
+          <SponsorPipelineWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <SponsorPipelineWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <SponsorPipelineWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization (prospecting)" {...size}>
+          <SponsorPipelineWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="planning, zero deals (prospecting)" {...size}>
+          <SponsorPipelineWidget conference={planningZero} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (operational)" {...size}>
+          <SponsorPipelineWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (final summary)" {...size}>
+          <SponsorPipelineWidget conference={post} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="min/compact operational" colSpan={5} rowSpan={4}>
+        <SponsorPipelineWidget conference={dense} />
+      </WidgetFrame>
+      <WidgetFrame label="default/tall operational" colSpan={6} rowSpan={9}>
+        <SponsorPipelineWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The two flagged operational cells: 5x4 (compact/min — 4 pipeline stages in 4 rows) and 6x9 (the tall default — check for dead space below the stages).',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="mobile dense" mode="mobile">
+        <SponsorPipelineWidget conference={dense} />
+      </WidgetFrame>
+      <WidgetFrame label="mobile prospecting" mode="mobile">
+        <SponsorPipelineWidget conference={planningZero} />
+      </WidgetFrame>
+      <WidgetFrame
+        label="edit chrome"
+        colSpan={6}
+        rowSpan={5}
+        editMode
+        showConfigDot
+      >
+        <SponsorPipelineWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx
@@ -1,0 +1,222 @@
+import type { Meta, StoryObj, Decorator } from '@storybook/nextjs-vite'
+import { ThemeProvider } from 'next-themes'
+import { TicketSalesDashboardWidget } from '../TicketSalesDashboardWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  ticketSalesSelling,
+  ticketSalesZero,
+  ticketSalesUnconfigured,
+  ticketSalesApiError,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'ticket-sales'
+
+// Selling view renders in planning/execution; use execution for dense cells.
+const selling = conferenceInPhase('execution', 'ticket-sales/selling')
+const zero = conferenceInPhase('execution', 'ticket-sales/zero')
+const unconfigured = conferenceInPhase('execution', 'ticket-sales/unconfigured')
+const apiError = conferenceInPhase('execution', 'ticket-sales/api-error')
+const loading = conferenceInPhase('execution', 'ticket-sales/loading')
+const failing = conferenceInPhase('execution', 'ticket-sales/error')
+const init = conferenceInPhase('initialization', 'ticket-sales/init')
+const post = conferenceInPhase('post-conference', 'ticket-sales/post')
+const postNoData = conferenceInPhase(
+  'post-conference',
+  'ticket-sales/post-empty',
+)
+
+setMockActionFor(
+  selling._id,
+  'fetchTicketSales',
+  mockResolved(ticketSalesSelling),
+)
+setMockActionFor(zero._id, 'fetchTicketSales', mockResolved(ticketSalesZero))
+setMockActionFor(
+  unconfigured._id,
+  'fetchTicketSales',
+  mockResolved(ticketSalesUnconfigured),
+)
+setMockActionFor(
+  apiError._id,
+  'fetchTicketSales',
+  mockResolved(ticketSalesApiError),
+)
+setMockActionFor(loading._id, 'fetchTicketSales', mockPending)
+setMockActionFor(failing._id, 'fetchTicketSales', mockFailure)
+setMockActionFor(
+  init._id,
+  'fetchTicketSales',
+  mockResolved(ticketSalesUnconfigured),
+)
+setMockActionFor(post._id, 'fetchTicketSales', mockResolved(ticketSalesSelling))
+setMockActionFor(
+  postNoData._id,
+  'fetchTicketSales',
+  mockResolved(ticketSalesUnconfigured),
+)
+
+/** The widget calls next-themes useTheme() for chart theming. */
+const withNextThemes: Decorator = (Story, ctx) => (
+  <ThemeProvider
+    attribute="class"
+    forcedTheme={ctx.globals.theme === 'dark' ? 'dark' : 'light'}
+  >
+    <Story />
+  </ThemeProvider>
+)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/TicketSales',
+  tags: ['matrix'],
+  decorators: [withNextThemes],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for TicketSalesDashboardWidget inside the real WidgetContainer geometry. The fetcher returns a discriminated TicketSalesResult (unconfigured | error | ok), all three arms are covered. Wrapped in a next-themes ThemeProvider because the widget calls useTheme() for ApexCharts theming.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesSelling: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <TicketSalesDashboardWidget conference={selling} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every registry size in the selling state: stat cards, radial capacity gauge, milestones and the 14-day sales-vs-target line chart.',
+      },
+    },
+  },
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <TicketSalesDashboardWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error (rejected fetch)" {...size}>
+          <TicketSalesDashboardWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="error (status:'error')" {...size}>
+          <TicketSalesDashboardWidget conference={apiError} />
+        </WidgetFrame>
+        <WidgetFrame label="unconfigured" {...size}>
+          <TicketSalesDashboardWidget conference={unconfigured} />
+        </WidgetFrame>
+        <WidgetFrame label="zero sales" {...size}>
+          <TicketSalesDashboardWidget conference={zero} />
+        </WidgetFrame>
+        <WidgetFrame label="selling" {...size}>
+          <TicketSalesDashboardWidget conference={selling} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <TicketSalesDashboardWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'All states at default size. Note (current behaviour): with NO conference the widget falls through to the amber "Not Configured" card, since data is null and no phase branch applies.',
+      },
+    },
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization (setup guide)" {...size}>
+          <TicketSalesDashboardWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (selling)" {...size}>
+          <TicketSalesDashboardWidget conference={selling} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (final report)" {...size}>
+          <TicketSalesDashboardWidget conference={post} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference, no data" {...size}>
+          <TicketSalesDashboardWidget conference={postNoData} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="true min, selling" colSpan={3} rowSpan={3}>
+        <TicketSalesDashboardWidget conference={selling} />
+      </WidgetFrame>
+      <WidgetFrame label="narrow, selling" colSpan={3} rowSpan={4}>
+        <TicketSalesDashboardWidget conference={selling} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The flagged narrow cells (3x3 true minimum and the 3x4 narrow preset) with the full selling view: gauge + charts squeezed into one column span of 3.',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile selling" mode="mobile">
+          <TicketSalesDashboardWidget conference={selling} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile unconfigured" mode="mobile">
+          <TicketSalesDashboardWidget conference={unconfigured} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode showConfigDot>
+          <TicketSalesDashboardWidget conference={selling} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/TravelSupport.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/TravelSupport.matrix.stories.tsx
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { TravelSupportQueueWidget } from '../TravelSupportQueueWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import {
+  conferenceInPhase,
+  travelSupportPending,
+  travelSupportQuiet,
+} from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'travel-support'
+
+// Operational view renders in execution (init/planning show the setup card
+// while totalRequested is 0).
+const dense = conferenceInPhase('execution', 'travel-support/dense')
+const quiet = conferenceInPhase('execution', 'travel-support/quiet')
+const empty = conferenceInPhase('execution', 'travel-support/empty')
+const loading = conferenceInPhase('execution', 'travel-support/loading')
+const failing = conferenceInPhase('execution', 'travel-support/error')
+const init = conferenceInPhase('initialization', 'travel-support/init')
+const planningCard = conferenceInPhase('planning', 'travel-support/planning')
+const post = conferenceInPhase('post-conference', 'travel-support/post')
+
+setMockActionFor(
+  dense._id,
+  'fetchTravelSupport',
+  mockResolved(travelSupportPending),
+)
+setMockActionFor(
+  quiet._id,
+  'fetchTravelSupport',
+  mockResolved(travelSupportQuiet),
+)
+setMockActionFor(empty._id, 'fetchTravelSupport', mockResolved(null))
+setMockActionFor(loading._id, 'fetchTravelSupport', mockPending)
+setMockActionFor(failing._id, 'fetchTravelSupport', mockFailure)
+setMockActionFor(
+  init._id,
+  'fetchTravelSupport',
+  mockResolved(travelSupportQuiet),
+)
+setMockActionFor(planningCard._id, 'fetchTravelSupport', mockResolved(null))
+setMockActionFor(
+  post._id,
+  'fetchTravelSupport',
+  mockResolved(travelSupportPending),
+)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/TravelSupport',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for TravelSupportQueueWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <TravelSupportQueueWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every registry size with 6 pending requests (long speaker names), budget bar at 64% and the amber pending-approvals callout.',
+      },
+    },
+  },
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <TravelSupportQueueWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <TravelSupportQueueWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty (null data)" {...size}>
+          <TravelSupportQueueWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="quiet (no pending)" {...size}>
+          <TravelSupportQueueWidget conference={quiet} />
+        </WidgetFrame>
+        <WidgetFrame label="dense (pending queue)" {...size}>
+          <TravelSupportQueueWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <TravelSupportQueueWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization + budget (setup card)" {...size}>
+          <TravelSupportQueueWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="planning, no data (setup card)" {...size}>
+          <TravelSupportQueueWidget conference={planningCard} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (operational)" {...size}>
+          <TravelSupportQueueWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (final summary)" {...size}>
+          <TravelSupportQueueWidget conference={post} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="min 3x3 with pending queue" colSpan={3} rowSpan={3}>
+        <TravelSupportQueueWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The flagged 3x3 cell with pending requests: amber callout + stat cards + budget bar + request list competing for 3 rows.',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <TravelSupportQueueWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile quiet" mode="mobile">
+          <TravelSupportQueueWidget conference={quiet} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode showConfigDot>
+          <TravelSupportQueueWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/UpcomingDeadlines.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/UpcomingDeadlines.matrix.stories.tsx
@@ -1,0 +1,161 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { UpcomingDeadlinesWidget } from '../UpcomingDeadlinesWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import { conferenceInPhase, deadlinesDense } from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'upcoming-deadlines'
+
+const dense = conferenceInPhase('planning', 'upcoming-deadlines/dense')
+const empty = conferenceInPhase('planning', 'upcoming-deadlines/empty')
+const loading = conferenceInPhase('planning', 'upcoming-deadlines/loading')
+const failing = conferenceInPhase('planning', 'upcoming-deadlines/error')
+const execution = conferenceInPhase('execution', 'upcoming-deadlines/execution')
+const initMasked = conferenceInPhase(
+  'initialization',
+  'upcoming-deadlines/init-masked-error',
+)
+const postMasked = conferenceInPhase(
+  'post-conference',
+  'upcoming-deadlines/post-masked-error',
+)
+
+setMockActionFor(dense._id, 'fetchDeadlines', mockResolved(deadlinesDense))
+setMockActionFor(empty._id, 'fetchDeadlines', mockResolved([]))
+setMockActionFor(loading._id, 'fetchDeadlines', mockPending)
+setMockActionFor(failing._id, 'fetchDeadlines', mockFailure)
+setMockActionFor(execution._id, 'fetchDeadlines', mockResolved(deadlinesDense))
+setMockActionFor(initMasked._id, 'fetchDeadlines', mockFailure)
+setMockActionFor(postMasked._id, 'fetchDeadlines', mockFailure)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/UpcomingDeadlines',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for UpcomingDeadlinesWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <UpcomingDeadlinesWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every registry size with 8 deadlines (default config caps the list at 5), long names, mixed urgencies and inline action links.',
+      },
+    },
+  },
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <UpcomingDeadlinesWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <UpcomingDeadlinesWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty" {...size}>
+          <UpcomingDeadlinesWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <UpcomingDeadlinesWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <UpcomingDeadlinesWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame
+          label="initialization + REJECTING fetch (masked)"
+          {...size}
+        >
+          <UpcomingDeadlinesWidget conference={initMasked} />
+        </WidgetFrame>
+        <WidgetFrame
+          label="post-conference + REJECTING fetch (masked)"
+          {...size}
+        >
+          <UpcomingDeadlinesWidget conference={postMasked} />
+        </WidgetFrame>
+        <WidgetFrame label="planning (operational)" {...size}>
+          <UpcomingDeadlinesWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (operational)" {...size}>
+          <UpcomingDeadlinesWidget conference={execution} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'PHASE-MASKED ERROR (documented current behaviour): the initialization and post-conference branches return their phase cards BEFORE the loading/error checks, so a rejecting fetch is silently masked in those phases. Both masked cells here use a rejecting fetcher on purpose.',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <UpcomingDeadlinesWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile empty" mode="mobile">
+          <UpcomingDeadlinesWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode showConfigDot>
+          <UpcomingDeadlinesWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/WidgetFrame.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/WidgetFrame.tsx
@@ -1,0 +1,189 @@
+/**
+ * Story-side replica of the REAL WidgetContainer box contract
+ * (src/components/admin/dashboard/WidgetContainer.tsx:262-345), so matrix
+ * stories exercise widgets inside the exact geometry the dashboard gives them:
+ *
+ * - Desktop cell: fixed box of `colSpan x rowSpan` grid cells
+ *   (width = colSpan*CELL_W + (colSpan-1)*gap, height = rowSpan*96 + (rowSpan-1)*16),
+ *   `border-2 rounded-lg overflow-hidden`, inner `h-full p-2`, and
+ *   `container-type: size` + `contain: layout style paint` — identical to the
+ *   grid path, so the widgets' @container queries respond to the cell.
+ * - Mobile: single-column behaviour (columnCount === 1) — auto height, NO
+ *   container-type (container queries fall back to the viewport), 361px wide
+ *   (393px iPhone-portrait viewport minus 2x16px page padding).
+ * - Edit chrome: the macOS-dots overlay plus the `[&_h3:first-of-type]:ml-20`
+ *   header-indent hack, so dot/header overlap cells are inspectable.
+ *
+ * CELL_W = 92px: a 1280px desktop grid with 12 columns and 16px gaps gives
+ * (1280 - 11*16) / 12 = 92px per column — the representative desktop cell.
+ */
+
+import { CogIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { GRID_CONFIG } from '@/lib/dashboard/constants'
+import { getWidgetMetadata } from '@/lib/dashboard/widget-registry'
+
+export const DESKTOP_CELL_WIDTH = 92
+export const MOBILE_FRAME_WIDTH = 361
+
+interface WidgetFrameProps {
+  /** Columns spanned (desktop mode). */
+  colSpan?: number
+  /** Rows spanned (desktop mode). */
+  rowSpan?: number
+  /** 'desktop' = fixed cell + size containment; 'mobile' = auto-height column. */
+  mode?: 'desktop' | 'mobile'
+  /** Replicate edit-mode chrome (mac dots + header indent + resize handle). */
+  editMode?: boolean
+  /** Show the green config dot too (widgets with a configSchema). */
+  showConfigDot?: boolean
+  /** Caption rendered under the frame. */
+  label?: string
+  children: React.ReactNode
+}
+
+export function WidgetFrame({
+  colSpan = 3,
+  rowSpan = 3,
+  mode = 'desktop',
+  editMode = false,
+  showConfigDot = false,
+  label,
+  children,
+}: WidgetFrameProps) {
+  const isMobile = mode === 'mobile'
+  const width = isMobile
+    ? MOBILE_FRAME_WIDTH
+    : colSpan * DESKTOP_CELL_WIDTH + (colSpan - 1) * GRID_CONFIG.gap
+  const height = isMobile
+    ? undefined
+    : rowSpan * GRID_CONFIG.cellSize + (rowSpan - 1) * GRID_CONFIG.gap
+
+  return (
+    <figure className="m-0 shrink-0" style={{ width }}>
+      <div
+        style={{
+          width,
+          height,
+          containerType: isMobile ? undefined : ('size' as const),
+          contain: isMobile ? undefined : 'layout style paint',
+        }}
+        className="relative overflow-hidden rounded-lg border-2 border-gray-200 bg-white shadow-sm transition-colors dark:border-gray-700 dark:bg-gray-800"
+      >
+        {editMode && (
+          <div className="absolute top-0 left-0 z-10 flex">
+            <span className="flex h-11 w-11 items-center justify-center">
+              <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 shadow-sm dark:bg-red-600">
+                <XMarkIcon className="h-2.5 w-2.5 stroke-[2.5] text-red-950" />
+              </span>
+            </span>
+            {showConfigDot && (
+              <span className="flex h-11 w-11 items-center justify-center">
+                <span className="flex h-3.5 w-3.5 items-center justify-center rounded-full bg-green-500 shadow-sm dark:bg-green-600">
+                  <CogIcon className="h-2.5 w-2.5 stroke-[2.5] text-green-950" />
+                </span>
+              </span>
+            )}
+          </div>
+        )}
+
+        <div
+          className={`h-full p-2 ${
+            editMode
+              ? 'pointer-events-none select-none [&_h3:first-of-type]:ml-20'
+              : ''
+          }`}
+        >
+          {children}
+        </div>
+
+        {editMode && !isMobile && (
+          <div
+            className="pointer-events-none absolute right-0 bottom-0 h-6 w-6"
+            style={{
+              background:
+                'linear-gradient(135deg, transparent 0%, transparent 50%, rgb(59, 130, 246) 50%, rgb(59, 130, 246) 100%)',
+            }}
+          />
+        )}
+      </div>
+      {label && (
+        <figcaption className="mt-1.5 font-mono text-[10px] text-gray-500 dark:text-gray-400">
+          {label}
+          {!isMobile && ` · ${colSpan}×${rowSpan}`}
+          {isMobile && ' · mobile auto-height'}
+        </figcaption>
+      )}
+    </figure>
+  )
+}
+
+/** Flow layout for a set of frames within one story. */
+export function MatrixGrid({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-wrap items-start gap-6">{children}</div>
+}
+
+export interface MatrixSize {
+  name: string
+  colSpan: number
+  rowSpan: number
+}
+
+/**
+ * The size axis for a widget, derived FROM THE REGISTRY so stories cannot
+ * drift from it: true minimum (constraints.minCols x minRows), the default
+ * preset, every available preset, and the true maximum
+ * (constraints.maxCols x maxRows). Deduplicated by dimensions (labels merged).
+ */
+export function matrixSizesFor(type: string): MatrixSize[] {
+  const meta = getWidgetMetadata(type)
+  if (!meta) {
+    throw new Error(`[matrix] unknown widget type "${type}"`)
+  }
+  const { constraints, defaultSize, availableSizes } = meta
+  const raw: MatrixSize[] = [
+    {
+      name: 'min',
+      colSpan: constraints.minCols,
+      rowSpan: constraints.minRows,
+    },
+    {
+      name: `default/${defaultSize.name}`,
+      colSpan: defaultSize.colSpan,
+      rowSpan: defaultSize.rowSpan,
+    },
+    ...availableSizes.map((s) => ({
+      name: s.name,
+      colSpan: s.colSpan,
+      rowSpan: s.rowSpan,
+    })),
+    {
+      name: 'max',
+      colSpan: constraints.maxCols,
+      rowSpan: constraints.maxRows,
+    },
+  ]
+  const byDims = new Map<string, MatrixSize>()
+  for (const size of raw) {
+    const key = `${size.colSpan}x${size.rowSpan}`
+    const existing = byDims.get(key)
+    if (existing) {
+      existing.name = `${existing.name}=${size.name}`
+    } else {
+      byDims.set(key, { ...size })
+    }
+  }
+  return [...byDims.values()]
+}
+
+/** The registry defaultSize for a widget (throws on unknown type). */
+export function defaultSizeFor(type: string): MatrixSize {
+  const meta = getWidgetMetadata(type)
+  if (!meta) {
+    throw new Error(`[matrix] unknown widget type "${type}"`)
+  }
+  return {
+    name: `default/${meta.defaultSize.name}`,
+    colSpan: meta.defaultSize.colSpan,
+    rowSpan: meta.defaultSize.rowSpan,
+  }
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/WorkshopCapacity.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/WorkshopCapacity.matrix.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { WorkshopCapacityWidget } from '../WorkshopCapacityWidget'
+import {
+  setMockActionFor,
+  mockPending,
+  mockFailure,
+  mockResolved,
+} from './mock-admin-actions'
+import { conferenceInPhase, workshopCapacityDense } from './fixtures'
+import {
+  WidgetFrame,
+  MatrixGrid,
+  matrixSizesFor,
+  defaultSizeFor,
+} from './WidgetFrame'
+
+const TYPE = 'workshop-capacity'
+
+// Operational view renders in execution (init/planning show the planning card
+// when the workshop list is empty).
+const dense = conferenceInPhase('execution', 'workshop-capacity/dense')
+const empty = conferenceInPhase('execution', 'workshop-capacity/empty')
+const loading = conferenceInPhase('execution', 'workshop-capacity/loading')
+const failing = conferenceInPhase('execution', 'workshop-capacity/error')
+const init = conferenceInPhase('initialization', 'workshop-capacity/init')
+const planningCard = conferenceInPhase('planning', 'workshop-capacity/planning')
+const post = conferenceInPhase('post-conference', 'workshop-capacity/post')
+
+setMockActionFor(
+  dense._id,
+  'fetchWorkshopCapacity',
+  mockResolved(workshopCapacityDense),
+)
+setMockActionFor(empty._id, 'fetchWorkshopCapacity', mockResolved(null))
+setMockActionFor(loading._id, 'fetchWorkshopCapacity', mockPending)
+setMockActionFor(failing._id, 'fetchWorkshopCapacity', mockFailure)
+setMockActionFor(init._id, 'fetchWorkshopCapacity', mockResolved(null))
+setMockActionFor(planningCard._id, 'fetchWorkshopCapacity', mockResolved(null))
+setMockActionFor(
+  post._id,
+  'fetchWorkshopCapacity',
+  mockResolved(workshopCapacityDense),
+)
+
+const meta = {
+  title: 'Systems/Proposals/Admin/Dashboard/Matrix/WorkshopCapacity',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'State x size matrix for WorkshopCapacityWidget inside the real WidgetContainer geometry. Sizes come from the widget registry; per-cell data is forced through the mocked admin-actions module.',
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllSizesDense: Story = {
+  render: () => (
+    <MatrixGrid>
+      {matrixSizesFor(TYPE).map((s) => (
+        <WidgetFrame
+          key={s.name}
+          label={s.name}
+          colSpan={s.colSpan}
+          rowSpan={s.rowSpan}
+        >
+          <WorkshopCapacityWidget conference={dense} />
+        </WidgetFrame>
+      ))}
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Every registry size with 6 workshops (long titles, two full with waitlists) — the list plus 3 stat cards is the layout-stress axis in 2-row cells.',
+      },
+    },
+  },
+}
+
+export const AllStatesDefaultSize: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="loading" {...size}>
+          <WorkshopCapacityWidget conference={loading} />
+        </WidgetFrame>
+        <WidgetFrame label="error" {...size}>
+          <WorkshopCapacityWidget conference={failing} />
+        </WidgetFrame>
+        <WidgetFrame label="empty (null data)" {...size}>
+          <WorkshopCapacityWidget conference={empty} />
+        </WidgetFrame>
+        <WidgetFrame label="dense" {...size}>
+          <WorkshopCapacityWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="no conference" {...size}>
+          <WorkshopCapacityWidget />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const Phases: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="initialization (planning card)" {...size}>
+          <WorkshopCapacityWidget conference={init} />
+        </WidgetFrame>
+        <WidgetFrame label="planning, no workshops (planning card)" {...size}>
+          <WorkshopCapacityWidget conference={planningCard} />
+        </WidgetFrame>
+        <WidgetFrame label="execution (operational)" {...size}>
+          <WorkshopCapacityWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="post-conference (summary)" {...size}>
+          <WorkshopCapacityWidget conference={post} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}
+
+export const KnownRiskCells: Story = {
+  render: () => (
+    <MatrixGrid>
+      <WidgetFrame label="default 4x2 operational" colSpan={4} rowSpan={2}>
+        <WorkshopCapacityWidget conference={dense} />
+      </WidgetFrame>
+      <WidgetFrame label="min 3x2 operational" colSpan={3} rowSpan={2}>
+        <WorkshopCapacityWidget conference={dense} />
+      </WidgetFrame>
+    </MatrixGrid>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The flagged 4x2 DEFAULT cell with the operational view: header + 3 stat cards + workshop list inside only 2 rows (208px inner height).',
+      },
+    },
+  },
+}
+
+export const MobileAndEditChrome: Story = {
+  render: () => {
+    const size = defaultSizeFor(TYPE)
+    return (
+      <MatrixGrid>
+        <WidgetFrame label="mobile dense" mode="mobile">
+          <WorkshopCapacityWidget conference={dense} />
+        </WidgetFrame>
+        <WidgetFrame label="mobile planning card" mode="mobile">
+          <WorkshopCapacityWidget conference={planningCard} />
+        </WidgetFrame>
+        <WidgetFrame label="edit chrome" {...size} editMode>
+          <WorkshopCapacityWidget conference={dense} />
+        </WidgetFrame>
+      </MatrixGrid>
+    )
+  },
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
+++ b/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
@@ -1,0 +1,719 @@
+/**
+ * Deterministic fixtures for the widget state x size matrix stories.
+ *
+ * Conference phase is DERIVED from dates via `getCurrentPhase()`, and the
+ * phase helpers in `src/lib/conference/state.ts` compare against the real
+ * clock. Fixture dates are therefore computed RELATIVE to `new Date()` at
+ * module-load time so each fixture always lands in the intended phase, on any
+ * day the stories are built. Displayed values that must stay pixel-stable
+ * (counts, day totals, trend data) are fixed numbers in the data fixtures.
+ */
+
+import type { Conference } from '@/lib/conference/types'
+import type { ConferencePhase } from '@/lib/conference/phase'
+import type {
+  ActivityItem,
+  CFPHealthData,
+  DeadlineData,
+  MyAreasData,
+  ProposalPipelineData,
+  QuickAction,
+  ReviewProgressData,
+  ScheduleStatusData,
+  SpeakerEngagementData,
+  SponsorPipelineWidgetData,
+  TicketSalesResult,
+  TravelSupportData,
+} from '@/lib/dashboard/data-types'
+import type { WorkshopStatistics } from '@/lib/workshop/types'
+
+/* ---------- Conference-in-phase builders ---------- */
+
+const DAY_MS = 86_400_000
+
+/** Date-only ISO string N days from now (cfp fields require date-only). */
+const isoDate = (offsetDays: number): string =>
+  new Date(Date.now() + offsetDays * DAY_MS).toISOString().slice(0, 10)
+
+interface PhaseDates {
+  cfpStartDate: string
+  cfpEndDate: string
+  cfpNotifyDate: string
+  programDate: string
+  startDate: string
+  endDate: string
+  workshopRegistrationStart?: string
+  workshopRegistrationEnd?: string
+}
+
+/**
+ * Phase boundaries (see src/lib/conference/phase.ts + state.ts):
+ * - initialization: before cfpStartDate
+ * - planning:       CFP open (cfpStart..cfpEnd) or closed-but-unpublished
+ * - execution:      programDate passed, conference not over
+ * - post-conference: day after endDate passed
+ */
+const PHASE_DATES: Record<ConferencePhase, () => PhaseDates> = {
+  initialization: () => ({
+    cfpStartDate: isoDate(30),
+    cfpEndDate: isoDate(60),
+    cfpNotifyDate: isoDate(75),
+    programDate: isoDate(100),
+    startDate: isoDate(130),
+    endDate: isoDate(131),
+    workshopRegistrationStart: isoDate(90),
+    workshopRegistrationEnd: isoDate(120),
+  }),
+  planning: () => ({
+    cfpStartDate: isoDate(-10),
+    cfpEndDate: isoDate(20),
+    cfpNotifyDate: isoDate(35),
+    programDate: isoDate(50),
+    startDate: isoDate(90),
+    endDate: isoDate(91),
+    workshopRegistrationStart: isoDate(55),
+    workshopRegistrationEnd: isoDate(85),
+  }),
+  execution: () => ({
+    cfpStartDate: isoDate(-90),
+    cfpEndDate: isoDate(-50),
+    cfpNotifyDate: isoDate(-35),
+    programDate: isoDate(-10),
+    startDate: isoDate(14),
+    endDate: isoDate(15),
+    workshopRegistrationStart: isoDate(-10),
+    workshopRegistrationEnd: isoDate(10),
+  }),
+  'post-conference': () => ({
+    cfpStartDate: isoDate(-200),
+    cfpEndDate: isoDate(-160),
+    cfpNotifyDate: isoDate(-140),
+    programDate: isoDate(-100),
+    startDate: isoDate(-31),
+    endDate: isoDate(-30),
+    workshopRegistrationStart: isoDate(-120),
+    workshopRegistrationEnd: isoDate(-40),
+  }),
+}
+
+/**
+ * A valid Conference whose dates put `getCurrentPhase()` in `phase`.
+ * The `id` doubles as the mock-action dispatch key (see mock-admin-actions.ts)
+ * — give every state cell in a story its own id.
+ */
+export function conferenceInPhase(
+  phase: ConferencePhase,
+  id: string,
+): Conference {
+  return {
+    _id: id,
+    title: 'Cloud Native Days Bergen 2026',
+    organizer: 'Cloud Native Bergen',
+    city: 'Bergen',
+    country: 'Norway',
+    cfpEmail: 'cfp@example.org',
+    sponsorEmail: 'sponsor@example.org',
+    contactEmail: 'contact@example.org',
+    registrationEnabled: true,
+    ticketCapacity: 400,
+    sponsorRevenueGoal: 1_000_000,
+    travelSupportBudget: 150_000,
+    organizers: [],
+    domains: ['cloudnativebergen.dev'],
+    formats: [],
+    topics: [],
+    ...PHASE_DATES[phase](),
+  }
+}
+
+/* ---------- Widget data fixtures ---------- */
+
+/** Fixed dates for trend axes (display-only; no phase logic reads them). */
+const trendDate = (i: number): string =>
+  `2026-06-${String(i + 1).padStart(2, '0')}`
+
+export const quickActionsDense: QuickAction[] = [
+  {
+    label: 'Review pending proposals for the programme committee',
+    shortLabel: 'Review proposals',
+    icon: 'ClipboardDocumentCheckIcon',
+    link: '/admin/proposals',
+    badge: 128,
+    variant: 'primary',
+  },
+  {
+    label: 'Confirm speakers awaiting response',
+    shortLabel: 'Confirm speakers',
+    icon: 'UserGroupIcon',
+    link: '/admin/speakers',
+    badge: 12,
+    variant: 'warning',
+  },
+  {
+    label: 'Sponsor pipeline follow-ups',
+    shortLabel: 'Sponsors',
+    icon: 'CurrencyDollarIcon',
+    link: '/admin/sponsors/crm',
+    badge: 7,
+    variant: 'success',
+  },
+  {
+    label: 'Travel support requests',
+    shortLabel: 'Travel',
+    icon: 'GlobeAltIcon',
+    link: '/admin/speakers/travel-support',
+    badge: 3,
+    variant: 'secondary',
+  },
+  {
+    label: 'Build the conference schedule',
+    shortLabel: 'Schedule',
+    icon: 'CalendarIcon',
+    link: '/admin/schedule',
+    variant: 'secondary',
+  },
+  {
+    label: 'Conference settings and configuration',
+    shortLabel: 'Settings',
+    icon: 'Cog6ToothIcon',
+    link: '/admin/settings',
+    variant: 'secondary',
+  },
+]
+
+export const quickActionsSparse: QuickAction[] = quickActionsDense.slice(0, 2)
+
+export const reviewProgressDense: ReviewProgressData = {
+  reviewedCount: 132,
+  totalProposals: 180,
+  percentage: 73.3,
+  averageScore: 7.6,
+  nextUnreviewed: {
+    id: 'proposal-1',
+    title:
+      'Kubernetes multi-cluster fleet management with GitOps at planet scale — lessons from 400 clusters',
+  },
+}
+
+export const reviewProgressSparse: ReviewProgressData = {
+  reviewedCount: 2,
+  totalProposals: 41,
+  percentage: 4.9,
+  averageScore: 6.0,
+}
+
+export const proposalPipelineDense: ProposalPipelineData = {
+  submitted: 180,
+  accepted: 58,
+  rejected: 70,
+  confirmed: 46,
+  total: 180,
+  acceptanceRate: 32.2,
+  pendingDecisions: 52,
+  distinctSpeakers: 41,
+}
+
+export const proposalPipelineSparse: ProposalPipelineData = {
+  submitted: 3,
+  accepted: 0,
+  rejected: 0,
+  confirmed: 0,
+  total: 3,
+  acceptanceRate: 0,
+  pendingDecisions: 3,
+  distinctSpeakers: 3,
+}
+
+export const deadlinesDense: DeadlineData[] = [
+  {
+    name: 'CFP closes — final call for lightning talks and workshops',
+    date: '2026-08-11',
+    daysRemaining: 2,
+    urgency: 'high',
+    phase: 'CFP & Review',
+    action: 'Review',
+    actionLink: '/admin/proposals',
+  },
+  {
+    name: 'Speaker notification emails',
+    date: '2026-08-15',
+    daysRemaining: 6,
+    urgency: 'high',
+    phase: 'CFP & Review',
+    action: 'Notify',
+    actionLink: '/admin/speakers',
+  },
+  {
+    name: 'Early-bird ticket price ends',
+    date: '2026-08-21',
+    daysRemaining: 12,
+    urgency: 'medium',
+    phase: 'Tickets',
+  },
+  {
+    name: 'Program publication',
+    date: '2026-09-03',
+    daysRemaining: 25,
+    urgency: 'medium',
+    phase: 'Schedule',
+    action: 'Build',
+    actionLink: '/admin/schedule',
+  },
+  {
+    name: 'Sponsor contract signing deadline for profiling in print material',
+    date: '2026-09-18',
+    daysRemaining: 40,
+    urgency: 'low',
+    phase: 'Sponsors',
+  },
+  {
+    name: 'Workshop registration opens',
+    date: '2026-10-13',
+    daysRemaining: 65,
+    urgency: 'low',
+    phase: 'Workshops',
+  },
+  {
+    name: 'Travel support payment run',
+    date: '2026-11-07',
+    daysRemaining: 90,
+    urgency: 'low',
+    phase: 'Travel',
+  },
+  {
+    name: 'Conference day',
+    date: '2026-12-07',
+    daysRemaining: 120,
+    urgency: 'low',
+    phase: 'Event',
+  },
+]
+
+export const cfpHealthDense: CFPHealthData = {
+  totalSubmissions: 124,
+  submissionGoal: 150,
+  // 14-day trend — the known-risk axis for narrow cells.
+  submissionsPerDay: [3, 5, 2, 0, 7, 9, 4, 6, 12, 8, 0, 11, 18, 14].map(
+    (count, i) => ({ date: trendDate(i), count }),
+  ),
+  formatDistribution: [
+    { format: 'Presentation (40 min)', count: 52 },
+    { format: 'Lightning Talk (10 min)', count: 31 },
+    { format: 'Workshop (2 hours)', count: 17 },
+    { format: 'Panel Discussion', count: 11 },
+    { format: 'Keynote', count: 7 },
+    { format: 'Birds of a Feather', count: 6 },
+  ],
+  daysRemaining: 9,
+  averagePerDay: 6.4,
+}
+
+export const cfpHealthSparse: CFPHealthData = {
+  totalSubmissions: 3,
+  submissionGoal: 150,
+  submissionsPerDay: [1, 0, 2].map((count, i) => ({
+    date: trendDate(i),
+    count,
+  })),
+  formatDistribution: [{ format: 'Presentation (40 min)', count: 3 }],
+  daysRemaining: 27,
+  averagePerDay: 1.0,
+}
+
+export const cfpHealthZero: CFPHealthData = {
+  totalSubmissions: 0,
+  submissionGoal: 150,
+  submissionsPerDay: [],
+  formatDistribution: [],
+  daysRemaining: 30,
+  averagePerDay: 0,
+}
+
+export const scheduleStatusDense: ScheduleStatusData = {
+  totalSlots: 54,
+  filledSlots: 31,
+  percentage: 57.4,
+  byDay: [
+    { day: 'Wed Oct 28', filled: 14, total: 18 },
+    { day: 'Thu Oct 29', filled: 11, total: 18 },
+    { day: 'Fri Oct 30', filled: 6, total: 18 },
+  ],
+  unassignedConfirmedTalks: 7,
+  placeholderSlots: 4,
+}
+
+export const scheduleStatusSparse: ScheduleStatusData = {
+  totalSlots: 18,
+  filledSlots: 1,
+  percentage: 5.6,
+  byDay: [{ day: 'Wed Oct 28', filled: 1, total: 18 }],
+  unassignedConfirmedTalks: 0,
+  placeholderSlots: 0,
+}
+
+export const ticketSalesSelling: TicketSalesResult = {
+  status: 'ok',
+  data: {
+    currentSales: 264,
+    capacity: 400,
+    percentage: 66,
+    revenue: 792_000,
+    salesByDate: [
+      12, 18, 25, 31, 44, 58, 71, 90, 118, 147, 172, 201, 233, 264,
+    ].map((sales, i) => ({
+      date: trendDate(i),
+      sales,
+      target: 20 + i * 19,
+    })),
+    milestones: [
+      { name: 'Early bird sold out', target: 100, reached: true },
+      { name: 'Break-even', target: 200, reached: true },
+      { name: 'Regular target', target: 320, reached: false },
+      { name: 'Sold out', target: 400, reached: false },
+    ],
+    daysUntilEvent: 23,
+    salesVelocity: 5.8,
+  },
+}
+
+export const ticketSalesZero: TicketSalesResult = {
+  status: 'ok',
+  data: {
+    currentSales: 0,
+    capacity: 400,
+    percentage: 0,
+    revenue: 0,
+    salesByDate: [],
+    milestones: [
+      { name: 'Early bird sold out', target: 100, reached: false },
+      { name: 'Break-even', target: 200, reached: false },
+      { name: 'Sold out', target: 400, reached: false },
+    ],
+    daysUntilEvent: 88,
+    salesVelocity: 0,
+  },
+}
+
+export const ticketSalesUnconfigured: TicketSalesResult = {
+  status: 'unconfigured',
+}
+
+export const ticketSalesApiError: TicketSalesResult = { status: 'error' }
+
+export const speakerEngagementDense: SpeakerEngagementData = {
+  totalSpeakers: 87,
+  featuredCount: 6,
+  newSpeakers: 24,
+  diverseSpeakers: 31,
+  localSpeakers: 40,
+  awaitingConfirmation: 9,
+  averageProposalsPerSpeaker: 1.6,
+}
+
+export const speakerEngagementSparse: SpeakerEngagementData = {
+  totalSpeakers: 2,
+  featuredCount: 0,
+  newSpeakers: 1,
+  diverseSpeakers: 0,
+  localSpeakers: 2,
+  awaitingConfirmation: 0,
+  averageProposalsPerSpeaker: 1.0,
+}
+
+/** Tiny inline SVG the SponsorLogo/InlineSvg pipeline can render offline. */
+const sponsorLogoSvg = (fill: string): string =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 16"><rect width="48" height="16" rx="3" fill="${fill}"/><text x="24" y="11.5" font-size="8" fill="#ffffff" text-anchor="middle" font-family="sans-serif">LOGO</text></svg>`
+
+export const sponsorPipelineDense: SponsorPipelineWidgetData = {
+  stages: [
+    {
+      name: 'Prospect',
+      count: 12,
+      value: 240_000,
+      sponsors: [
+        { name: 'Fjordtech Consulting Scandinavia ASA' },
+        { name: 'Nordlys', logo: sponsorLogoSvg('#1d4ed8') },
+        { name: 'Bryggen Systems' },
+        { name: 'Vestland Cloud', logo: sponsorLogoSvg('#0e7490') },
+        { name: 'Hanseatic Hosting' },
+        { name: 'Skyfri' },
+      ],
+    },
+    {
+      name: 'Contacted',
+      count: 8,
+      value: 310_000,
+      sponsors: [
+        { name: 'Aurora DevOps', logo: sponsorLogoSvg('#7c3aed') },
+        { name: 'Bergen Bits' },
+        { name: 'Trollfjord Technologies International AS' },
+        { name: 'Kystnett', logo: sponsorLogoSvg('#b45309') },
+        { name: 'Regnvær Labs' },
+      ],
+    },
+    {
+      name: 'Negotiating',
+      count: 5,
+      value: 275_000,
+      sponsors: [
+        { name: 'Grieg Digital', logo: sponsorLogoSvg('#15803d') },
+        { name: 'Sjøkanten Software' },
+        { name: 'Platform Company With A Remarkably Long Name GmbH' },
+      ],
+    },
+    {
+      name: 'Signed',
+      count: 9,
+      value: 460_000,
+      sponsors: [
+        { name: 'Fløyen Cloud', logo: sponsorLogoSvg('#be123c') },
+        { name: 'Ulriken Compute', logo: sponsorLogoSvg('#0f766e') },
+        { name: 'Damsgård Data' },
+        { name: 'Sandviken Solutions' },
+        { name: 'Laksevåg Logic' },
+        { name: 'Åsane Analytics' },
+      ],
+    },
+  ],
+  totalValue: 745_000,
+  wonDeals: 9,
+  lostDeals: 4,
+  revenueGoal: 1_000_000,
+  recentActivity: [
+    {
+      id: 'act-1',
+      sponsor: 'Grieg Digital',
+      activity: 'Moved to negotiating',
+      timestamp: '2 hours ago',
+    },
+    {
+      id: 'act-2',
+      sponsor: 'Fløyen Cloud',
+      activity: 'Contract signed',
+      timestamp: 'Yesterday',
+    },
+  ],
+}
+
+export const sponsorPipelineEmptyGoalSet: SponsorPipelineWidgetData = {
+  stages: [
+    { name: 'Prospect', count: 0, value: 0, sponsors: [] },
+    { name: 'Contacted', count: 0, value: 0, sponsors: [] },
+    { name: 'Negotiating', count: 0, value: 0, sponsors: [] },
+    { name: 'Signed', count: 0, value: 0, sponsors: [] },
+  ],
+  totalValue: 0,
+  wonDeals: 0,
+  lostDeals: 0,
+  revenueGoal: 1_000_000,
+  recentActivity: [],
+}
+
+export const travelSupportPending: TravelSupportData = {
+  pendingApprovals: 6,
+  approvedCount: 9,
+  totalRequested: 187_000,
+  totalApproved: 96_000,
+  budgetAllocated: 150_000,
+  averageRequest: 8_900,
+  requests: [
+    {
+      id: 'ts-1',
+      speaker: 'Ingrid Johannessen-Bakkelund',
+      amount: 12_400,
+      status: 'pending',
+      submittedAt: '2 days ago',
+    },
+    {
+      id: 'ts-2',
+      speaker: 'Aleksander Nygaardsvold',
+      amount: 8_750,
+      status: 'pending',
+      submittedAt: '3 days ago',
+    },
+    {
+      id: 'ts-3',
+      speaker: 'María Fernanda de la Cruz Villanueva',
+      amount: 15_900,
+      status: 'pending',
+      submittedAt: '5 days ago',
+    },
+    {
+      id: 'ts-4',
+      speaker: 'Bartholomew Featherstonehaugh III',
+      amount: 6_200,
+      status: 'pending',
+      submittedAt: '1 week ago',
+    },
+    {
+      id: 'ts-5',
+      speaker: 'Liv Ullmann-Strand',
+      amount: 9_800,
+      status: 'pending',
+      submittedAt: '1 week ago',
+    },
+    {
+      id: 'ts-6',
+      speaker: 'Chidi Okonkwo-Adeyemi',
+      amount: 11_300,
+      status: 'pending',
+      submittedAt: '2 weeks ago',
+    },
+  ],
+}
+
+export const travelSupportQuiet: TravelSupportData = {
+  pendingApprovals: 0,
+  approvedCount: 3,
+  totalRequested: 31_000,
+  totalApproved: 24_000,
+  budgetAllocated: 150_000,
+  averageRequest: 8_000,
+  requests: [],
+}
+
+export const workshopCapacityDense: WorkshopStatistics = {
+  workshops: [
+    {
+      workshopId: 'ws-1',
+      workshopTitle:
+        'Hands-on Kubernetes security hardening: from Pod Security Standards to runtime detection',
+      capacity: 30,
+      totalSignups: 42,
+      confirmedSignups: 30,
+      pendingSignups: 2,
+      waitlistSignups: 8,
+      cancelledSignups: 2,
+      utilization: 100,
+    },
+    {
+      workshopId: 'ws-2',
+      workshopTitle: 'GitOps with Flux and OpenTofu',
+      capacity: 25,
+      totalSignups: 26,
+      confirmedSignups: 24,
+      pendingSignups: 1,
+      waitlistSignups: 1,
+      cancelledSignups: 0,
+      utilization: 96,
+    },
+    {
+      workshopId: 'ws-3',
+      workshopTitle: 'Observability with OpenTelemetry, Prometheus and Grafana',
+      capacity: 28,
+      totalSignups: 25,
+      confirmedSignups: 23,
+      pendingSignups: 2,
+      waitlistSignups: 0,
+      cancelledSignups: 0,
+      utilization: 82,
+    },
+    {
+      workshopId: 'ws-4',
+      workshopTitle: 'Platform engineering on Backstage',
+      capacity: 20,
+      totalSignups: 12,
+      confirmedSignups: 11,
+      pendingSignups: 1,
+      waitlistSignups: 0,
+      cancelledSignups: 1,
+      utilization: 55,
+    },
+    {
+      workshopId: 'ws-5',
+      workshopTitle: 'WebAssembly on the server with wasmCloud',
+      capacity: 24,
+      totalSignups: 8,
+      confirmedSignups: 7,
+      pendingSignups: 1,
+      waitlistSignups: 0,
+      cancelledSignups: 0,
+      utilization: 30,
+    },
+    {
+      workshopId: 'ws-6',
+      workshopTitle: 'Chaos engineering for distributed systems practitioners',
+      capacity: 18,
+      totalSignups: 23,
+      confirmedSignups: 18,
+      pendingSignups: 0,
+      waitlistSignups: 5,
+      cancelledSignups: 0,
+      utilization: 100,
+    },
+  ],
+  totals: {
+    totalWorkshops: 6,
+    totalCapacity: 145,
+    totalSignups: 136,
+    uniqueParticipants: 121,
+    totalConfirmed: 113,
+    totalPending: 7,
+    totalWaitlist: 14,
+    totalCancelled: 3,
+    averageUtilization: 77.2,
+  },
+}
+
+const activityTypes = ['proposal', 'review', 'sponsor', 'speaker'] as const
+
+export const recentActivityDense: ActivityItem[] = Array.from(
+  { length: 24 },
+  (_, i) => ({
+    id: `activity-${i + 1}`,
+    type: activityTypes[i % activityTypes.length],
+    description: [
+      'New proposal submitted: "Scaling stateful workloads across availability zones without tears"',
+      'Review completed for "eBPF-powered networking deep dive" (score 8/10)',
+      'Sponsor "Fløyen Cloud" signed the gold-tier contract with booth add-on',
+      'Speaker Ingrid Johannessen-Bakkelund confirmed her keynote slot',
+    ][i % 4],
+    user: ['Kari Nordmann', 'Ola Nordmann', 'Ada Lovelace', 'Grace Hopper'][
+      i % 4
+    ],
+    timestamp: `${i + 1}h ago`,
+    link: i % 3 === 0 ? '/admin/proposals' : undefined,
+  }),
+)
+
+export const recentActivitySparse: ActivityItem[] = recentActivityDense.slice(
+  0,
+  2,
+)
+
+export const myAreasTwoTeams: MyAreasData = {
+  areas: [
+    {
+      key: 'cfp',
+      title: 'Programme Committee',
+      metrics: [
+        {
+          label: 'Messages needing reply',
+          count: 4,
+          href: '/admin/messages?view=needs-reply',
+        },
+        {
+          label: 'Unassigned conversations',
+          count: 128,
+          href: '/admin/messages?view=unassigned',
+        },
+      ],
+    },
+    {
+      key: 'sponsors',
+      title: 'Sales & Partnerships',
+      metrics: [
+        {
+          label: 'Unassigned sponsors',
+          count: 0,
+          href: '/admin/sponsors/crm?assignedTo=unassigned',
+        },
+        {
+          label: 'Contracts awaiting signature',
+          count: 3,
+          href: '/admin/sponsors/crm?state=contract',
+        },
+      ],
+    },
+  ],
+}

--- a/src/components/admin/dashboard/widgets/__matrix__/mock-admin-actions.ts
+++ b/src/components/admin/dashboard/widgets/__matrix__/mock-admin-actions.ts
@@ -1,0 +1,161 @@
+/**
+ * Browser-safe stand-in for `@/app/(admin)/admin/actions`.
+ *
+ * The real module is a `'use server'` action module — it can never load in the
+ * Storybook browser bundle, which is why the widget state x size matrix was
+ * unrenderable. `.storybook/main.ts` re-resolves the module id
+ * `@/app/(admin)/admin/actions` to THIS file for Storybook builds, so every
+ * widget's `import { fetchX } from '@/app/(admin)/admin/actions'` lands here.
+ * Matrix stories import the registration helpers below via a relative import,
+ * which Vite resolves to the same absolute file — i.e. the exact same module
+ * instance the widgets see.
+ *
+ * Dispatch is keyed by CONFERENCE IDENTITY: every dashboard fetcher receives
+ * either the `Conference` object or a conference `_id` string as its first
+ * argument. A single story can therefore render many widget instances in
+ * different states side by side by giving each instance a conference fixture
+ * with a distinct `_id` and registering a mock per id.
+ *
+ * If a fetcher fires for a conference id with no registered mock the promise
+ * rejects loudly, so a forgotten registration shows up as a visible error
+ * state in the story instead of silently rendering something plausible.
+ */
+
+export type MockableAction =
+  | 'fetchMyAreasData'
+  | 'fetchSponsorPipelineData'
+  | 'fetchDeadlines'
+  | 'fetchCFPHealth'
+  | 'fetchSpeakerEngagement'
+  | 'fetchTicketSales'
+  | 'fetchRecentActivity'
+  | 'fetchQuickActions'
+  | 'fetchProposalPipeline'
+  | 'fetchReviewProgress'
+  | 'fetchTravelSupport'
+  | 'fetchWorkshopCapacity'
+  | 'fetchScheduleStatus'
+
+type MockImpl = (...args: unknown[]) => Promise<unknown>
+
+const registry = new Map<string, MockImpl>()
+
+const keyOf = (conferenceId: string, action: MockableAction) =>
+  `${conferenceId}::${action}`
+
+/**
+ * Register a mock implementation for one action, scoped to the conference
+ * fixture whose `_id` is `conferenceId`. Stories call this at module scope —
+ * each story file uses ids namespaced by widget type (`cfp-health/dense`) so
+ * registrations from different story modules can never collide.
+ */
+export function setMockActionFor(
+  conferenceId: string,
+  action: MockableAction,
+  impl: MockImpl,
+): void {
+  registry.set(keyOf(conferenceId, action), impl)
+}
+
+/** Remove every registered mock (only needed by tests, not by stories). */
+export function resetMockActions(): void {
+  registry.clear()
+}
+
+/* ---------- Result helpers for stories ---------- */
+
+/** A promise that never settles — pins `useWidgetData` in its loading state. */
+export const mockPending = (): Promise<never> => new Promise<never>(() => {})
+
+/** A rejecting fetcher — drives `useWidgetData` into its error state. */
+export const mockFailure = (): Promise<never> =>
+  Promise.reject(new Error('[matrix] simulated fetch failure'))
+
+/** A fetcher resolving to the given fixture. */
+export const mockResolved =
+  <T>(value: T) =>
+  (): Promise<T> =>
+    Promise.resolve(value)
+
+/* ---------- Dispatch ---------- */
+
+function conferenceIdFrom(arg: unknown): string {
+  if (typeof arg === 'string') return arg
+  if (
+    arg !== null &&
+    typeof arg === 'object' &&
+    '_id' in arg &&
+    typeof (arg as { _id: unknown })._id === 'string'
+  ) {
+    return (arg as { _id: string })._id
+  }
+  return '(unknown)'
+}
+
+function dispatch(action: MockableAction, args: unknown[]): Promise<unknown> {
+  const conferenceId = conferenceIdFrom(args[0])
+  const impl = registry.get(keyOf(conferenceId, action))
+  if (!impl) {
+    return Promise.reject(
+      new Error(
+        `[matrix] no mock registered for ${action} (conference "${conferenceId}"). ` +
+          `Call setMockActionFor('${conferenceId}', '${action}', …) in the story module.`,
+      ),
+    )
+  }
+  return impl(...args)
+}
+
+/* ---------- Mirrored exports of @/app/(admin)/admin/actions ---------- */
+/* One export per symbol any dashboard code imports from the actions module.  */
+
+export function fetchMyAreasData(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchMyAreasData', args)
+}
+export function fetchSponsorPipelineData(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchSponsorPipelineData', args)
+}
+export function fetchDeadlines(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchDeadlines', args)
+}
+export function fetchCFPHealth(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchCFPHealth', args)
+}
+export function fetchSpeakerEngagement(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchSpeakerEngagement', args)
+}
+export function fetchTicketSales(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchTicketSales', args)
+}
+export function fetchRecentActivity(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchRecentActivity', args)
+}
+export function fetchQuickActions(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchQuickActions', args)
+}
+export function fetchProposalPipeline(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchProposalPipeline', args)
+}
+export function fetchReviewProgress(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchReviewProgress', args)
+}
+export function fetchTravelSupport(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchTravelSupport', args)
+}
+export function fetchWorkshopCapacity(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchWorkshopCapacity', args)
+}
+export function fetchScheduleStatus(...args: unknown[]): Promise<unknown> {
+  return dispatch('fetchScheduleStatus', args)
+}
+
+/**
+ * Dashboard-config no-ops so ANY import path that pulls in `AdminDashboard`
+ * (which imports these) still bundles. `null` = "no stored layout".
+ */
+export function loadDashboardConfig(): Promise<null> {
+  return Promise.resolve(null)
+}
+export function saveDashboardConfig(): Promise<void> {
+  return Promise.resolve()
+}


### PR DESCRIPTION
## Why

The 13 dashboard widgets have a states × sizes matrix that was never renderable in isolation: every widget imports its fetcher from `@/app/(admin)/admin/actions`, a `'use server'` module that cannot load in the browser, so no story could mount them and layout breakage at off-nominal cells went unseen. This PR makes **every cell renderable deterministically in Storybook** and turns the matrix into a permanent visual-regression net. It adds **only new files** plus a minimal `.storybook/main.ts` edit and a `knip.json` ignore — no widget, `src/lib/dashboard/`, or container code is touched (a parallel branch owns those).

## Harness architecture

- **Action-module stub** (`.storybook/main.ts`): a `viteFinal` `resolveId` plugin (same technique as the existing `CloudNativePattern` stub) re-resolves the module id `@/app/(admin)/admin/actions` to `src/components/admin/dashboard/widgets/__matrix__/mock-admin-actions.ts`. Stories import the registry helpers from that file via a relative path — Vite resolves both to the same module instance the widgets see.
- **Per-conference mock registry** (`mock-admin-actions.ts`): mirrors every export of the real actions module (13 fetchers + `loadDashboardConfig`/`saveDashboardConfig` no-ops). Every dashboard fetcher receives the `Conference` (or its `_id`) as first argument, so dispatch is keyed by conference id: `setMockActionFor('cfp-health/loading', 'fetchCFPHealth', mockPending)`. One story can therefore render many widget instances in different states side by side. Loading = never-settling promise, error = rejection, data = resolved fixture; an unregistered fetch rejects loudly.
- **Phase control by dates** (`fixtures.ts`): `conferenceInPhase('initialization' | 'planning' | 'execution' | 'post-conference', id)` builds valid `Conference` objects whose dates are computed **relative to `new Date()` at module load** — `getCurrentPhase()`/`state.ts` compare against the real clock, so fixed dates would rot. Pixel-relevant values (counts, trend series, daysRemaining) are fixed numbers. Dense fixtures stress layout (14-day CFP trend, 6 formats, 24 activity items, 6 workshops with long titles, 4 sponsor stages with 5–6 sponsors, 99+ badges).
- **`WidgetFrame` decorator** (`WidgetFrame.tsx`): replicates `WidgetContainer`'s real box contract instead of approximating it — desktop cell = `colSpan×92px + gaps` wide (92px = (1280 − 11×16)/12 at a representative 1280px/12-col grid), `rowSpan×96px + gaps` tall, `border-2 rounded-lg overflow-hidden`, inner `h-full p-2`, `container-type: size` + `contain: layout style paint`; mobile mode = 361px auto-height with **no** containment (the `columnCount === 1` behaviour); edit-chrome variant replicates the mac-dots overlay, the `[&_h3:first-of-type]:ml-20` header-indent hack and the resize handle. `matrixSizesFor(type)` derives the size axis **from the widget registry** (true min, default, every preset, true max, deduped), so stories cannot drift from registry constraints.
- **Stories**: 13 `*.matrix.stories.tsx` files under `src/components/admin/dashboard/widgets/__matrix__/`, titled `Systems/Proposals/Admin/Dashboard/Matrix/*`. Pattern per widget (not a full combinatorial cross): all sizes × one dense state, all states × default size, phase branches, the specific known-risk cells, and mobile + edit chrome. Ticket-sales gets a `next-themes` `ThemeProvider` decorator (it calls `useTheme()` for ApexCharts theming) and covers all three arms of `TicketSalesResult`.

## Story count + CI impact

- **59 new stories** (repo total: 1228). All pass the Storybook test runner (smoke render): `test-storybook --includeTags matrix` → 59/59 green; `storybook build` succeeds (the hard gate that the mock resolves in-browser).
- **Storybook Tests job** (`pr-checks.yml` → `storybook:test-ci`): +59 stories ≈ +36 s of runner time at 4 workers locally; proportionally less at CI's `--maxWorkers=50%`.
- **Chromatic**: +59 snapshots on the first build; afterwards `onlyChanged: true` (TurboSnap) re-snapshots them only when the dashboard/widget dependency graph changes — which is exactly when this net should fire. Stories are tagged `matrix` so they can be excluded later via `--excludeTags` if snapshot budget becomes a concern; they are intentionally **not** excluded now, since being the regression net is the point.
- `public/mockServiceWorker.js` stays gitignored; CI already runs `msw init public` before building.

## Confirmed visually broken cells (found by this harness — NOT fixed here; that's the widget branch's job)

Swept 81 captures (all known-risk cells light+dark, all sizes/states/phases/mobile+edit-chrome stories) from the built Storybook:

1. **workshop-capacity 4×2 (DEFAULT) + 3×2, operational dense** — hard clip: header + 3 stat cards leave room for ~1.2 workshop rows; the second card is cut mid-border; the list has no scroll, so content is simply lost at the widget's default size.
2. **review-progress 2×2 (true min), operational** — the "Review next →" CTA is clipped mid-button at the bottom edge; ring + stats barely fit.
3. **recent-activity 3×2, dense feed** — pagination chrome in a 2-row cell: third card clipped mid-border behind the "1/3" footer; the next-page chevron overlaps card text.
4. **recent-activity 3×10 (DEFAULT), sparse (2 items)** — ~75 % dead space below the two items. Also at 3×10 dense the "1/3" pager pins to the very bottom with a large gap after page items, and the chevron overlaps the row edge.
5. **sponsor-pipeline 5×4 (min/compact), operational** — the "Signed" stage row is clipped in half at the bottom; no scroll.
6. **sponsor-pipeline 6×9 (DEFAULT/tall), operational** — ~45 % dead space below the four stage rows.
7. **travel-support 3×3, with pending queue** — "Pending Requests" list header renders but the first request card is clipped mid-name at the bottom; no scroll affordance.
8. **ticket-sales 3×3 (true min) + 3×4 (narrow), selling** — stat cards stack single-column and the gauge/milestones/trend/days-until-event are below the fold (3×3 shows only the three stat cards and the "Capacity" heading; the gauge itself is invisible).
9. **ticket-sales selling, DARK mode** — the ApexCharts radial gauge renders on a solid **white** panel inside the dark card (chart background/theming not applied in dark). Reproduced at 6×3 with `next-themes` forced dark; worth a look on the widget branch.
10. **cfp-health 3×3 (min), dense** — format-distribution legend clipped at the bottom (only 4 of 6 legend entries visible); 14-day trend date labels wrap and collide ("Jun 11"/"Jun 12" run together). At 4×4 the same label collision appears milder, plus bottom dead space.
11. **schedule-builder 3×3, planning dense** — the Unassigned/Placeholders footer cards are clipped mid-number at the bottom.
12. **speaker-engagement 3×2, initialization** — the outreach card's second info box and the "Manage speakers →" link are cut off entirely; only the first card fits. (3×2 operational fits fine.)
13. **upcoming-deadlines 3×2 (DEFAULT), operational dense** — 4th deadline row clipped mid-card (list is scrollable but visually cut at rest with 5 items configured).
14. **my-areas 6×4 (max), two teams** — ~65 % dead space; at 3×2 the team titles/metric labels truncate heavily ("Messages n…", "Unassign…") though nothing clips.
15. **Documented current behaviour (intentional story cells): phase-masked errors** — upcoming-deadlines (initialization AND post-conference) and recent-activity (initialization) return their phase cards **before** the loading/error checks, so a rejecting fetch is silently masked; the matrix cells force a rejecting fetcher and their story descriptions call this out. Similarly, ticket-sales with **no conference** falls through to the amber "Not Configured" card.

Healthy under stress, for the record: quick-actions (all sizes), proposal-pipeline, my-areas ≤ 6×2, speaker-engagement operational, all loading/error/empty states, mobile auto-height cells, and the edit-chrome header-indent cells.

One harness note: the sponsor logo chips in the dense fixture render as blank pills — `InlineSvg` doesn't render the raw inline-SVG fixture string. Cosmetic for the matrix (text pills + long-name overflow still exercised); can be revisited if logo-chip layout needs pixel coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a visual-regression matrix for all dashboard widgets. The main changes are:

- A Storybook alias for browser-safe dashboard action mocks.
- Per-conference loading, error, and resolved action fixtures.
- Registry-derived widget size frames and phase fixtures.
- State, phase, mobile, and edit-mode stories for 13 widgets.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small cleanup to snapshot determinism.

- Current widget fetch calls match the mock registry's conference-key contract.
- The Storybook action replacement covers the runtime exports used by the widgets.
- The live clock can cause avoidable visual snapshot updates, but it does not affect production behavior.

src/components/admin/dashboard/widgets/__matrix__/fixtures.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .storybook/main.ts | Redirects the server-only dashboard actions module to a browser-safe Storybook mock. |
| src/components/admin/dashboard/widgets/__matrix__/mock-admin-actions.ts | Adds keyed mock dispatch for all dashboard widget fetchers and dashboard configuration actions. |
| src/components/admin/dashboard/widgets/__matrix__/WidgetFrame.tsx | Adds representative dashboard geometry and registry-derived size matrices. |
| src/components/admin/dashboard/widgets/__matrix__/fixtures.ts | Adds dense widget and phase fixtures, but derives visible dates from an unfrozen clock. |
| src/components/admin/dashboard/widgets/__matrix__/*.matrix.stories.tsx | Adds state, size, phase, mobile, and edit-mode coverage for all 13 dashboard widgets. |

</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Stories[Matrix stories] --> Frames[WidgetFrame sizes]
  Stories --> Fixtures[Conference and data fixtures]
  Widgets[Dashboard widgets] --> Alias[Storybook action alias]
  Alias --> Registry[Per-conference mock registry]
  Registry --> States[Pending, rejected, or resolved result]
  Frames --> Render[Visual snapshots]
  Fixtures --> Render
  States --> Render
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
  Stories[Matrix stories] --> Frames[WidgetFrame sizes]
  Stories --> Fixtures[Conference and data fixtures]
  Widgets[Dashboard widgets] --> Alias[Storybook action alias]
  Alias --> Registry[Per-conference mock registry]
  Registry --> States[Pending, rejected, or resolved result]
  Frames --> Render[Visual snapshots]
  Fixtures --> Render
  States --> Render
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/admin/dashboard/widgets/__matrix__/fixtures.ts`, line 2649-2650 ([link](https://github.com/cloudnativebergen/website/blob/9819fd5cf6bffbed9aa6531515db5784f0abf079/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts#L2649-L2650)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Live Clock Changes Snapshots**

   `isoDate()` derives conference dates from the current day, and no story-level clock is frozen. Phase cards that display these dates therefore produce different Chromatic pixels on different days, causing snapshot churn even when the code is unchanged; freeze `globalThis.Date` in Storybook and derive the offsets from that fixed time.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): widget state×size matri..."](https://github.com/cloudnativebergen/website/commit/9819fd5cf6bffbed9aa6531515db5784f0abf079) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46128274)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->