### PR TITLE
fix(dashboard): widget height contract, size calibration, minima enforcement, fetch gating

### DIFF
--- a/__tests__/components/admin/dashboard/widget-shared.test.tsx
+++ b/__tests__/components/admin/dashboard/widget-shared.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * WidgetBody is THE height contract for dashboard widgets: variable-height
+ * content lives inside it so overflow scrolls (overflow-y-auto) instead of
+ * silently clipping against WidgetContainer's overflow-hidden. These tests
+ * pin the contract classes so a refactor can't quietly drop the scroll.
+ */
+import { render, screen } from '@testing-library/react'
+
+import { WidgetBody } from '@/components/admin/dashboard/widgets/shared'
+
+describe('WidgetBody', () => {
+  it('renders children inside the scroll region', () => {
+    render(
+      <WidgetBody>
+        <span>body content</span>
+      </WidgetBody>,
+    )
+    expect(screen.getByText('body content')).toBeInTheDocument()
+  })
+
+  it('carries the height-contract classes (min-h-0 flex-1 overflow-y-auto)', () => {
+    const { container } = render(<WidgetBody>content</WidgetBody>)
+    const region = container.firstElementChild!
+    expect(region.className).toContain('min-h-0')
+    expect(region.className).toContain('flex-1')
+    expect(region.className).toContain('overflow-y-auto')
+    expect(region.className).toContain('overscroll-contain')
+  })
+
+  it('merges extra layout classes without losing the contract', () => {
+    const { container } = render(
+      <WidgetBody className="flex flex-col gap-2">content</WidgetBody>,
+    )
+    const region = container.firstElementChild!
+    expect(region.className).toContain('flex flex-col gap-2')
+    expect(region.className).toContain('overflow-y-auto')
+  })
+})

--- a/__tests__/lib/dashboard/actions.test.ts
+++ b/__tests__/lib/dashboard/actions.test.ts
@@ -1140,6 +1140,43 @@ describe('Dashboard Server Actions', () => {
         expect(mockCreateOrReplace).not.toHaveBeenCalled()
       })
 
+      it('rejects spans outside the widget type’s registry constraints', async () => {
+        // quick-actions: minCols 3, maxCols 6, minRows 2, maxRows 4 — all of
+        // these pass the GENERIC bounds but violate the per-widget ones.
+        await expect(
+          saveDashboardConfig([
+            validWidget({
+              position: { row: 0, col: 0, rowSpan: 2, colSpan: 2 },
+            }),
+          ]),
+        ).rejects.toThrow(/"quick-actions" colSpan must be between 3 and 6/)
+
+        await expect(
+          saveDashboardConfig([
+            validWidget({
+              position: { row: 0, col: 0, rowSpan: 5, colSpan: 3 },
+            }),
+          ]),
+        ).rejects.toThrow(/"quick-actions" rowSpan must be between 2 and 4/)
+
+        await expect(
+          saveDashboardConfig([
+            validWidget({
+              position: { row: 0, col: 0, rowSpan: 2, colSpan: 7 },
+            }),
+          ]),
+        ).rejects.toThrow(/"quick-actions" colSpan must be between 3 and 6/)
+
+        expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      })
+
+      it('accepts spans exactly at the widget type’s registry minima', async () => {
+        await saveDashboardConfig([
+          validWidget({ position: { row: 0, col: 0, rowSpan: 2, colSpan: 3 } }),
+        ])
+        expect(mockCreateOrReplace).toHaveBeenCalledTimes(1)
+      })
+
       it('rejects more than 40 widgets', async () => {
         const widgets = Array.from({ length: 41 }, (_, i) =>
           validWidget({ id: `w${i}` }),

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -1294,6 +1294,24 @@ function validateDashboardWidgets(widgets: SerializedWidget[]): void {
       )
     }
 
+    // Per-widget minima/maxima from the registry, on top of the generic
+    // bounds above: a span outside the widget's own constraints can only come
+    // from a bypassed client (the UI clamps resizes and normalizes loads), so
+    // it is rejected like every other invalid payload rather than silently
+    // rewritten. `w.type` is known-valid here (checked above).
+    const { minCols, maxCols, minRows, maxRows } =
+      WIDGET_REGISTRY[w.type].constraints
+    if (!intInRange(rowSpan, minRows, maxRows)) {
+      throw new Error(
+        `Invalid dashboard config: "${w.type}" rowSpan must be between ${minRows} and ${maxRows}`,
+      )
+    }
+    if (!intInRange(colSpan, minCols, maxCols)) {
+      throw new Error(
+        `Invalid dashboard config: "${w.type}" colSpan must be between ${minCols} and ${maxCols}`,
+      )
+    }
+
     if (w.config !== undefined) {
       if (
         typeof w.config !== 'object' ||

--- a/src/components/admin/dashboard/AdminDashboard.test.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.test.tsx
@@ -70,6 +70,11 @@ vi.mock('@/components/admin/dashboard/DashboardGrid', () => ({
           {w.position.colSpan}x{w.position.rowSpan}
         </div>
       ))}
+      {widgets.map((w) => (
+        <div key={`col-${w.id}`} data-testid={`widget-col-${w.id}`}>
+          {w.position.col}
+        </div>
+      ))}
       <button
         onClick={() =>
           onWidgetsChange(
@@ -253,6 +258,31 @@ describe('AdminDashboard persistence', () => {
     // Normalization is not a user edit — it must not be written back
     await advancePastDebounce()
     expect(saveDashboardConfig).not.toHaveBeenCalled()
+  })
+
+  it('pulls a right-edge widget back into the grid when span clamping widens it', async () => {
+    // A stored 1×1 sponsor-pipeline at col 10 clamps UP to colSpan 5; without
+    // a col re-clamp it would span cols 10-14 on a 12-col grid.
+    vi.mocked(loadDashboardConfig).mockResolvedValue([
+      {
+        id: 'sponsor-pipeline-edge',
+        type: 'sponsor-pipeline',
+        title: 'Sponsor Pipeline',
+        position: { row: 0, col: 10, rowSpan: 1, colSpan: 1 },
+        config: undefined,
+      },
+    ])
+
+    renderDashboard()
+    await flushLoad()
+
+    expect(
+      screen.getByTestId('widget-span-sponsor-pipeline-edge').textContent,
+    ).toBe('5x4')
+    // col clamped from 10 to 12 - 5 = 7 so the widget stays inside the grid
+    expect(
+      screen.getByTestId('widget-col-sponsor-pipeline-edge').textContent,
+    ).toBe('7')
   })
 
   it('null load falls back to the default preset widgets', async () => {

--- a/src/components/admin/dashboard/AdminDashboard.test.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.test.tsx
@@ -65,6 +65,11 @@ vi.mock('@/components/admin/dashboard/DashboardGrid', () => ({
   }) => (
     <div>
       <div data-testid="widget-count">{widgets.length}</div>
+      {widgets.map((w) => (
+        <div key={w.id} data-testid={`widget-span-${w.id}`}>
+          {w.position.colSpan}x{w.position.rowSpan}
+        </div>
+      ))}
       <button
         onClick={() =>
           onWidgetsChange(
@@ -211,6 +216,41 @@ describe('AdminDashboard persistence', () => {
 
     expect(screen.getByTestId('widget-count').textContent).toBe('0')
 
+    await advancePastDebounce()
+    expect(saveDashboardConfig).not.toHaveBeenCalled()
+  })
+
+  it('clamps stored spans into registry min/max on load without echo-saving', async () => {
+    // Server-side save validation is generic-bounds only, and registry
+    // constraints tighten over time — a stored 1×1 sponsor-pipeline
+    // (minCols 5, minRows 4) must render at its minimum, not crushed.
+    vi.mocked(loadDashboardConfig).mockResolvedValue([
+      {
+        id: 'sponsor-pipeline-1',
+        type: 'sponsor-pipeline',
+        title: 'Sponsor Pipeline',
+        position: { row: 2, col: 1, rowSpan: 1, colSpan: 1 },
+        config: undefined,
+      },
+      {
+        // Unknown type: spans must pass through untouched (placeholder path)
+        id: 'retired-1',
+        type: 'retired-widget',
+        title: 'Retired',
+        position: { row: 0, col: 0, rowSpan: 1, colSpan: 1 },
+        config: undefined,
+      },
+    ])
+
+    renderDashboard()
+    await flushLoad()
+
+    expect(
+      screen.getByTestId('widget-span-sponsor-pipeline-1').textContent,
+    ).toBe('5x4')
+    expect(screen.getByTestId('widget-span-retired-1').textContent).toBe('1x1')
+
+    // Normalization is not a user edit — it must not be written back
     await advancePastDebounce()
     expect(saveDashboardConfig).not.toHaveBeenCalled()
   })

--- a/src/components/admin/dashboard/AdminDashboard.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.tsx
@@ -146,13 +146,37 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
         // empty grid — defaults apply only when NO config exists (null).
         if (saved) {
           setWidgets(
-            saved.map((w) => ({
-              id: w.id,
-              type: w.type,
-              title: w.title,
-              position: w.position,
-              config: w.config,
-            })),
+            saved.map((w) => {
+              // Normalize stored spans into the widget's registry min/max:
+              // server-side save validation is GENERIC-bounds only, and
+              // registry constraints tighten over time, so persisted layouts
+              // can hold spans below a widget's current minimum (which would
+              // render crushed). Row/col are preserved; unknown types pass
+              // through untouched for the "Widget not available" placeholder.
+              // The normalized layout is NOT echoed back to the server (the
+              // persist effect only fires on user edits).
+              const constraints = getWidgetMetadata(w.type)?.constraints
+              const position = constraints
+                ? {
+                    ...w.position,
+                    colSpan: Math.min(
+                      constraints.maxCols,
+                      Math.max(constraints.minCols, w.position.colSpan),
+                    ),
+                    rowSpan: Math.min(
+                      constraints.maxRows,
+                      Math.max(constraints.minRows, w.position.rowSpan),
+                    ),
+                  }
+                : w.position
+              return {
+                id: w.id,
+                type: w.type,
+                title: w.title,
+                position,
+                config: w.config,
+              }
+            }),
           )
         }
         setLoadStatus('loaded')

--- a/src/components/admin/dashboard/AdminDashboard.tsx
+++ b/src/components/admin/dashboard/AdminDashboard.tsx
@@ -156,19 +156,27 @@ export function AdminDashboard({ conference }: AdminDashboardProps) {
               // The normalized layout is NOT echoed back to the server (the
               // persist effect only fires on user edits).
               const constraints = getWidgetMetadata(w.type)?.constraints
-              const position = constraints
-                ? {
-                    ...w.position,
-                    colSpan: Math.min(
-                      constraints.maxCols,
-                      Math.max(constraints.minCols, w.position.colSpan),
-                    ),
-                    rowSpan: Math.min(
-                      constraints.maxRows,
-                      Math.max(constraints.minRows, w.position.rowSpan),
-                    ),
-                  }
-                : w.position
+              let position = w.position
+              if (constraints) {
+                const colSpan = Math.min(
+                  constraints.maxCols,
+                  Math.max(constraints.minCols, w.position.colSpan),
+                )
+                const rowSpan = Math.min(
+                  constraints.maxRows,
+                  Math.max(constraints.minRows, w.position.rowSpan),
+                )
+                // Clamping a span UP can push a right-edge widget past the
+                // grid (e.g. col 10 + minCols 5 on 12 cols): pull `col` back
+                // so the widget stays inside. colSpan ≤ maxCols ≤ grid cols,
+                // so the result is always ≥ 0.
+                const maxGridCols = GRID_CONFIG.breakpoints.desktop.cols
+                const col = Math.max(
+                  0,
+                  Math.min(w.position.col, maxGridCols - colSpan),
+                )
+                position = { ...w.position, col, colSpan, rowSpan }
+              }
               return {
                 id: w.id,
                 type: w.type,

--- a/src/components/admin/dashboard/WidgetContainer.test.tsx
+++ b/src/components/admin/dashboard/WidgetContainer.test.tsx
@@ -9,7 +9,7 @@ import { WidgetContainer } from './WidgetContainer'
 
 afterEach(cleanup)
 
-// 'review-progress' has real registry constraints: minCols 2, maxCols 4,
+// 'review-progress' has real registry constraints: minCols 3, maxCols 4,
 // minRows 2, maxRows 4.
 const makeWidget = (overrides: Partial<Widget> = {}): Widget => ({
   id: 'w-1',
@@ -71,7 +71,47 @@ describe('WidgetContainer resize', () => {
       row: 0,
       col: 0,
       rowSpan: 3,
-      colSpan: 2, // minCols
+      colSpan: 3, // minCols
+    })
+  })
+
+  it('caps widening at the grid edge without going below minCols', () => {
+    // col 9 in a 12-column grid leaves exactly minCols (3) of space
+    const widget = makeWidget({
+      position: { row: 0, col: 9, rowSpan: 3, colSpan: 3 },
+    })
+    const { onResize, handle } = renderContainer(widget)
+
+    fireEvent.pointerDown(handle, { clientX: 0, clientY: 0, pointerId: 1 })
+    fireEvent.pointerMove(window, { clientX: STEP * 3, clientY: 0 })
+    fireEvent.pointerUp(window)
+
+    expect(onResize).toHaveBeenCalledWith('w-1', {
+      row: 0,
+      col: 9,
+      rowSpan: 3,
+      colSpan: 3, // capped at the edge, still >= minCols
+    })
+  })
+
+  it('freezes colSpan when the space at the edge cannot fit minCols', () => {
+    // col 10 leaves 2 columns < minCols 3: horizontal resize is frozen at the
+    // current span (any clamp would overflow the grid or undercut the
+    // registry minimum); vertical resizing still applies.
+    const widget = makeWidget({
+      position: { row: 0, col: 10, rowSpan: 3, colSpan: 2 },
+    })
+    const { onResize, handle } = renderContainer(widget)
+
+    fireEvent.pointerDown(handle, { clientX: 0, clientY: 0, pointerId: 1 })
+    fireEvent.pointerMove(window, { clientX: STEP * 3, clientY: STEP })
+    fireEvent.pointerUp(window)
+
+    expect(onResize).toHaveBeenCalledWith('w-1', {
+      row: 0,
+      col: 10,
+      rowSpan: 4,
+      colSpan: 2, // frozen, not widened past the edge nor clamped below min
     })
   })
 

--- a/src/components/admin/dashboard/WidgetContainer.tsx
+++ b/src/components/admin/dashboard/WidgetContainer.tsx
@@ -337,8 +337,15 @@ export function WidgetContainer({
         )}
 
         {/* @supports not (container-type: size) fallback handled via CSS cascade */}
+        {/* Edit mode reserves a uniform top strip (pt-10 clears the 44px-tall
+            window-control buttons whose visible dots end ≈29px down) so the
+            dots layer never overlaps ANY widget state. The previous
+            `[&_h3:first-of-type]:ml-20` hack only worked for branches whose
+            first element was an h3 header — on every other state the dots sat
+            on top of the content, and narrow headers were crushed by the
+            margin. View-mode layout is untouched. */}
         <div
-          className={`h-full p-2 ${editMode ? 'pointer-events-none select-none [&_h3:first-of-type]:ml-20' : ''}`}
+          className={`h-full p-2 ${editMode ? 'pointer-events-none pt-10 select-none' : ''}`}
         >
           {children}
         </div>

--- a/src/components/admin/dashboard/WidgetContainer.tsx
+++ b/src/components/admin/dashboard/WidgetContainer.tsx
@@ -146,8 +146,19 @@ export function WidgetContainer({
         newRowSpan = Math.max(1, newRowSpan)
       }
 
-      // Ensure doesn't exceed grid boundaries
-      newColSpan = Math.min(columnCount - resizeStart.position.col, newColSpan)
+      // Grid-boundary cap: never spill past the right edge. This runs AFTER
+      // the registry clamp, so it must not undercut minCols: when the space
+      // right of the widget's column can't even fit minCols (widget parked
+      // near the edge), FREEZE colSpan at its current value — any clamp here
+      // would either overflow the grid or violate the registry minimum, and
+      // keeping the size the user already has is the least surprising of the
+      // three. Vertical resizing still works in that state.
+      const availableCols = columnCount - resizeStart.position.col
+      const minCols = constraints?.minCols ?? 1
+      newColSpan =
+        availableCols < minCols
+          ? resizeStart.position.colSpan
+          : Math.min(availableCols, newColSpan)
 
       const newPosition: GridPosition = {
         ...resizeStart.position,

--- a/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
+++ b/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
@@ -19,6 +19,7 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
 } from './shared'
 
@@ -261,153 +262,157 @@ export function CFPHealthWidget({ conference, config }: CFPHealthWidgetProps) {
         </span>
       </div>
 
-      {/* Main Stats - Gradient cards */}
-      <div className="mb-3 grid grid-cols-3 gap-2">
-        {/* Total */}
-        <div className="group relative overflow-hidden rounded-xl bg-linear-to-br from-blue-100 to-cyan-200 p-2.5 dark:from-blue-900/40 dark:to-cyan-800/40">
-          <div className="relative z-10">
-            <div className="text-[10px] font-medium tracking-wide text-blue-700 uppercase dark:text-blue-400">
-              Total
+      {/* Scrollable body: stats + trend + format distribution together can
+          exceed short slots (the phase views above already scroll). */}
+      <WidgetBody className="flex flex-col">
+        {/* Main Stats - Gradient cards */}
+        <div className="mb-3 grid shrink-0 grid-cols-3 gap-2">
+          {/* Total */}
+          <div className="group relative overflow-hidden rounded-xl bg-linear-to-br from-blue-100 to-cyan-200 p-2.5 dark:from-blue-900/40 dark:to-cyan-800/40">
+            <div className="relative z-10">
+              <div className="text-[10px] font-medium tracking-wide text-blue-700 uppercase dark:text-blue-400">
+                Total
+              </div>
+              <div className="mt-1 text-3xl font-black text-blue-900 dark:text-blue-100">
+                {data.totalSubmissions}
+              </div>
+              <div className="text-[10px] text-blue-600 dark:text-blue-300">
+                of {effectiveGoal} goal
+              </div>
             </div>
-            <div className="mt-1 text-3xl font-black text-blue-900 dark:text-blue-100">
-              {data.totalSubmissions}
-            </div>
-            <div className="text-[10px] text-blue-600 dark:text-blue-300">
-              of {effectiveGoal} goal
-            </div>
+            <DocumentTextIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-blue-300/40 dark:text-blue-600/30" />
           </div>
-          <DocumentTextIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-blue-300/40 dark:text-blue-600/30" />
-        </div>
 
-        {/* Progress */}
-        <div className="group relative overflow-hidden rounded-xl bg-linear-to-br from-green-100 to-emerald-200 p-2.5 dark:from-green-900/40 dark:to-emerald-800/40">
-          <div className="relative z-10">
-            <div className="text-[10px] font-medium tracking-wide text-green-700 uppercase dark:text-green-400">
-              Progress
-            </div>
-            <div className="mt-1 text-3xl font-black text-green-900 dark:text-green-100">
-              {progress.toFixed(0)}%
-            </div>
-            <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-green-300/50 dark:bg-green-900/50">
-              <div
-                className="h-full bg-green-600 transition-all duration-500 dark:bg-green-400"
-                style={{ width: `${Math.min(progress, 100)}%` }}
-              />
-            </div>
-          </div>
-          <ChartBarIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-green-300/40 dark:text-green-600/30" />
-        </div>
-
-        {/* Avg/Day */}
-        <div className="group relative overflow-hidden rounded-xl bg-linear-to-br from-purple-100 to-pink-200 p-2.5 dark:from-purple-900/40 dark:to-pink-800/40">
-          <div className="relative z-10">
-            <div className="text-[10px] font-medium tracking-wide text-purple-700 uppercase dark:text-purple-400">
-              Avg/Day
-            </div>
-            <div className="mt-1 text-3xl font-black text-purple-900 dark:text-purple-100">
-              {data.averagePerDay.toFixed(1)}
-            </div>
-          </div>
-          <ClockIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-purple-300/40 dark:text-purple-600/30" />
-        </div>
-      </div>
-
-      {/* Minimal chart - Sparkline style */}
-      {showTrend && data.submissionsPerDay.length > 0 && (
-        <div className="mb-2">
-          <h4 className="mb-1 text-[11px] font-semibold text-gray-700 dark:text-gray-300">
-            Submissions Trend
-          </h4>
-          <div className="flex items-end gap-1">
-            {data.submissionsPerDay.map((day, index) => {
-              const height = (day.count / maxSubmissions) * 100
-              const date = new Date(day.date + 'T00:00:00Z')
-              const dateLabel = date.toLocaleDateString('en-US', {
-                month: 'short',
-                day: 'numeric',
-                timeZone: 'UTC',
-              })
-              return (
+          {/* Progress */}
+          <div className="group relative overflow-hidden rounded-xl bg-linear-to-br from-green-100 to-emerald-200 p-2.5 dark:from-green-900/40 dark:to-emerald-800/40">
+            <div className="relative z-10">
+              <div className="text-[10px] font-medium tracking-wide text-green-700 uppercase dark:text-green-400">
+                Progress
+              </div>
+              <div className="mt-1 text-3xl font-black text-green-900 dark:text-green-100">
+                {progress.toFixed(0)}%
+              </div>
+              <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-green-300/50 dark:bg-green-900/50">
                 <div
-                  key={index}
-                  className="flex min-w-0 flex-1 flex-col items-center"
-                  style={{ maxWidth: '4rem' }}
-                >
-                  <span className="mb-0.5 text-[9px] font-semibold text-gray-600 dark:text-gray-400">
-                    {day.count}
-                  </span>
-                  <div className="flex h-8 w-full items-end">
-                    <div
-                      className="w-full rounded-t bg-blue-500 transition-all hover:bg-blue-600 dark:bg-blue-400 dark:hover:bg-blue-300"
-                      style={{ height: `${height}%`, minHeight: '4px' }}
-                    />
-                  </div>
-                  <span className="mt-0.5 text-[8px] leading-tight text-gray-400 dark:text-gray-500">
-                    {dateLabel}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* Format Distribution - Compact stacked bar + legend */}
-      {showFormatBreakdown && data.formatDistribution.length > 0 && (
-        <div className="min-h-0 flex-1">
-          <h4 className="mb-1.5 text-[11px] font-semibold text-gray-700 dark:text-gray-300">
-            Format Distribution
-          </h4>
-          {/* Stacked horizontal bar */}
-          <div className="mb-2 flex h-3 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-            {data.formatDistribution.map((format, i) => {
-              const percentage = (format.count / data.totalSubmissions) * 100
-              const colors = [
-                'bg-blue-500 dark:bg-blue-400',
-                'bg-purple-500 dark:bg-purple-400',
-                'bg-cyan-500 dark:bg-cyan-400',
-                'bg-amber-500 dark:bg-amber-400',
-                'bg-rose-500 dark:bg-rose-400',
-                'bg-green-500 dark:bg-green-400',
-              ]
-              return (
-                <div
-                  key={format.format}
-                  className={`h-full transition-all duration-500 ${colors[i % colors.length]}`}
-                  style={{ width: `${percentage}%` }}
-                  title={`${format.format}: ${format.count}`}
+                  className="h-full bg-green-600 transition-all duration-500 dark:bg-green-400"
+                  style={{ width: `${Math.min(progress, 100)}%` }}
                 />
-              )
-            })}
+              </div>
+            </div>
+            <ChartBarIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-green-300/40 dark:text-green-600/30" />
           </div>
-          {/* Legend */}
-          <div className="flex flex-wrap gap-x-3 gap-y-1">
-            {data.formatDistribution.map((format, i) => {
-              const dotColors = [
-                'bg-blue-500 dark:bg-blue-400',
-                'bg-purple-500 dark:bg-purple-400',
-                'bg-cyan-500 dark:bg-cyan-400',
-                'bg-amber-500 dark:bg-amber-400',
-                'bg-rose-500 dark:bg-rose-400',
-                'bg-green-500 dark:bg-green-400',
-              ]
-              return (
-                <div key={format.format} className="flex items-center gap-1">
-                  <div
-                    className={`h-2 w-2 shrink-0 rounded-full ${dotColors[i % dotColors.length]}`}
-                  />
-                  <span className="text-[10px] text-gray-600 dark:text-gray-400">
-                    {format.format}
-                  </span>
-                  <span className="text-[10px] font-bold text-gray-900 dark:text-gray-100">
-                    {format.count}
-                  </span>
-                </div>
-              )
-            })}
+
+          {/* Avg/Day */}
+          <div className="group relative overflow-hidden rounded-xl bg-linear-to-br from-purple-100 to-pink-200 p-2.5 dark:from-purple-900/40 dark:to-pink-800/40">
+            <div className="relative z-10">
+              <div className="text-[10px] font-medium tracking-wide text-purple-700 uppercase dark:text-purple-400">
+                Avg/Day
+              </div>
+              <div className="mt-1 text-3xl font-black text-purple-900 dark:text-purple-100">
+                {data.averagePerDay.toFixed(1)}
+              </div>
+            </div>
+            <ClockIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-purple-300/40 dark:text-purple-600/30" />
           </div>
         </div>
-      )}
+
+        {/* Minimal chart - Sparkline style */}
+        {showTrend && data.submissionsPerDay.length > 0 && (
+          <div className="mb-2">
+            <h4 className="mb-1 text-[11px] font-semibold text-gray-700 dark:text-gray-300">
+              Submissions Trend
+            </h4>
+            <div className="flex items-end gap-1">
+              {data.submissionsPerDay.map((day, index) => {
+                const height = (day.count / maxSubmissions) * 100
+                const date = new Date(day.date + 'T00:00:00Z')
+                const dateLabel = date.toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  timeZone: 'UTC',
+                })
+                return (
+                  <div
+                    key={index}
+                    className="flex min-w-0 flex-1 flex-col items-center"
+                    style={{ maxWidth: '4rem' }}
+                  >
+                    <span className="mb-0.5 text-[9px] font-semibold text-gray-600 dark:text-gray-400">
+                      {day.count}
+                    </span>
+                    <div className="flex h-8 w-full items-end">
+                      <div
+                        className="w-full rounded-t bg-blue-500 transition-all hover:bg-blue-600 dark:bg-blue-400 dark:hover:bg-blue-300"
+                        style={{ height: `${height}%`, minHeight: '4px' }}
+                      />
+                    </div>
+                    <span className="mt-0.5 text-[8px] leading-tight text-gray-400 dark:text-gray-500">
+                      {dateLabel}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Format Distribution - Compact stacked bar + legend */}
+        {showFormatBreakdown && data.formatDistribution.length > 0 && (
+          <div className="min-h-0 flex-1">
+            <h4 className="mb-1.5 text-[11px] font-semibold text-gray-700 dark:text-gray-300">
+              Format Distribution
+            </h4>
+            {/* Stacked horizontal bar */}
+            <div className="mb-2 flex h-3 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+              {data.formatDistribution.map((format, i) => {
+                const percentage = (format.count / data.totalSubmissions) * 100
+                const colors = [
+                  'bg-blue-500 dark:bg-blue-400',
+                  'bg-purple-500 dark:bg-purple-400',
+                  'bg-cyan-500 dark:bg-cyan-400',
+                  'bg-amber-500 dark:bg-amber-400',
+                  'bg-rose-500 dark:bg-rose-400',
+                  'bg-green-500 dark:bg-green-400',
+                ]
+                return (
+                  <div
+                    key={format.format}
+                    className={`h-full transition-all duration-500 ${colors[i % colors.length]}`}
+                    style={{ width: `${percentage}%` }}
+                    title={`${format.format}: ${format.count}`}
+                  />
+                )
+              })}
+            </div>
+            {/* Legend */}
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+              {data.formatDistribution.map((format, i) => {
+                const dotColors = [
+                  'bg-blue-500 dark:bg-blue-400',
+                  'bg-purple-500 dark:bg-purple-400',
+                  'bg-cyan-500 dark:bg-cyan-400',
+                  'bg-amber-500 dark:bg-amber-400',
+                  'bg-rose-500 dark:bg-rose-400',
+                  'bg-green-500 dark:bg-green-400',
+                ]
+                return (
+                  <div key={format.format} className="flex items-center gap-1">
+                    <div
+                      className={`h-2 w-2 shrink-0 rounded-full ${dotColors[i % dotColors.length]}`}
+                    />
+                    <span className="text-[10px] text-gray-600 dark:text-gray-400">
+                      {format.format}
+                    </span>
+                    <span className="text-[10px] font-bold text-gray-900 dark:text-gray-100">
+                      {format.count}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
+++ b/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
@@ -256,15 +256,14 @@ export function CFPHealthWidget({ conference, config }: CFPHealthWidgetProps) {
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-xs font-semibold text-gray-900 dark:text-gray-100">
-          CFP Health
-        </h3>
-        <span className="text-[11px] text-gray-500 dark:text-gray-400">
-          {data.daysRemaining} days remaining
-        </span>
-      </div>
+      <WidgetHeader
+        title="CFP Health"
+        badge={
+          <span className="text-[11px] text-gray-500 dark:text-gray-400">
+            {data.daysRemaining} days remaining
+          </span>
+        }
+      />
 
       {/* Scrollable body: stats + trend + format distribution together can
           exceed short slots (the phase views above already scroll). */}

--- a/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
+++ b/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
@@ -34,9 +34,13 @@ type CFPHealthWidgetProps = BaseWidgetProps<CFPHealthConfig>
 export function CFPHealthWidget({ conference, config }: CFPHealthWidgetProps) {
   const phase = conference ? getCurrentPhase(conference) : null
   const [now] = useState(() => Date.now())
+  // Fetch gating: the initialization view is STATIC (countdown computed from
+  // conference dates alone), so its fetcher is nulled — no skeleton while
+  // fetching data the view won't use. Every other phase renders fetched data.
+  const isStaticPhase = phase === 'initialization'
   const { data, loading, error, refetch } = useWidgetData<CFPHealthData>(
-    conference ? () => fetchCFPHealth(conference) : null,
-    [conference],
+    conference && !isStaticPhase ? () => fetchCFPHealth(conference) : null,
+    [conference, isStaticPhase],
   )
 
   // Apply config defaults

--- a/src/components/admin/dashboard/widgets/MyAreasView.tsx
+++ b/src/components/admin/dashboard/widgets/MyAreasView.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { UserGroupIcon } from '@heroicons/react/24/outline'
 import { type MyAreasData } from '@/lib/dashboard/data-types'
-import { WidgetEmptyState, WidgetHeader } from './shared'
+import { WidgetEmptyState, WidgetHeader, WidgetBody } from './shared'
 
 /**
  * Presentational body of the "My areas" widget (TEAMS-3, L4). Pure over
@@ -23,7 +23,8 @@ export function MyAreasView({ data }: { data: MyAreasData | null }) {
   return (
     <div className="flex h-full flex-col">
       <WidgetHeader title="My Areas" />
-      <div className="grid grid-cols-1 gap-2 @[300px]:grid-cols-2">
+      {/* Scrollable body: the card count grows with team membership. */}
+      <WidgetBody className="grid grid-cols-1 content-start gap-2 @[300px]:grid-cols-2">
         {data.areas.map((area) => (
           <div
             key={area.key}
@@ -66,7 +67,7 @@ export function MyAreasView({ data }: { data: MyAreasData | null }) {
             )}
           </div>
         ))}
-      </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/ProposalPipelineWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ProposalPipelineWidget.tsx
@@ -244,12 +244,11 @@ export function ProposalPipelineWidget({
                 {showPercentages && ' (100%)'}
               </span>
             </div>
-            <div className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-              <div
-                className="h-full rounded-full bg-gray-400 transition-all duration-500 dark:bg-gray-500"
-                style={{ width: '100%' }}
-              />
-            </div>
+            <ProgressBar
+              value={100}
+              color="bg-gray-400 dark:bg-gray-500"
+              label="Submitted proposals"
+            />
           </div>
 
           {/* Accepted */}
@@ -266,12 +265,11 @@ export function ProposalPipelineWidget({
                 {showPercentages && ` (${acceptedPercentage.toFixed(0)}%)`}
               </span>
             </div>
-            <div className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-              <div
-                className="h-full rounded-full bg-green-500 transition-all duration-500 dark:bg-green-400"
-                style={{ width: `${acceptedPercentage}%` }}
-              />
-            </div>
+            <ProgressBar
+              value={acceptedPercentage}
+              color="bg-green-500 dark:bg-green-400"
+              label="Accepted proposals"
+            />
           </div>
 
           {/* Rejected */}
@@ -288,12 +286,11 @@ export function ProposalPipelineWidget({
                 {showPercentages && ` (${rejectedPercentage.toFixed(0)}%)`}
               </span>
             </div>
-            <div className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-              <div
-                className="h-full rounded-full bg-red-500 transition-all duration-500 dark:bg-red-400"
-                style={{ width: `${rejectedPercentage}%` }}
-              />
-            </div>
+            <ProgressBar
+              value={rejectedPercentage}
+              color="bg-red-500 dark:bg-red-400"
+              label="Rejected proposals"
+            />
           </div>
 
           {/* Confirmed */}
@@ -310,12 +307,11 @@ export function ProposalPipelineWidget({
                 {showPercentages && ` (${confirmedPercentage.toFixed(0)}%)`}
               </span>
             </div>
-            <div className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-              <div
-                className="h-full rounded-full bg-blue-500 transition-all duration-500 dark:bg-blue-400"
-                style={{ width: `${confirmedPercentage}%` }}
-              />
-            </div>
+            <ProgressBar
+              value={confirmedPercentage}
+              color="bg-blue-500 dark:bg-blue-400"
+              label="Confirmed proposals"
+            />
           </div>
         </div>
       </WidgetBody>

--- a/src/components/admin/dashboard/widgets/ProposalPipelineWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ProposalPipelineWidget.tsx
@@ -16,7 +16,9 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
+  ProgressBar,
 } from './shared'
 
 interface ProposalPipelineConfig {
@@ -63,7 +65,7 @@ export function ProposalPipelineWidget({
           badge={<PhaseBadge label="Setup" variant="blue" />}
         />
 
-        <div className="flex min-h-0 flex-1 flex-col space-y-3 overflow-y-auto">
+        <WidgetBody className="flex flex-col space-y-3">
           <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-700 dark:bg-blue-800/50">
             <CalendarIcon className="mb-2 h-8 w-8 text-blue-500" />
             <h4 className="mb-1 text-sm font-semibold text-gray-900 dark:text-white">
@@ -104,7 +106,7 @@ export function ProposalPipelineWidget({
               </div>
             </div>
           )}
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -118,7 +120,7 @@ export function ProposalPipelineWidget({
           badge={<PhaseBadge label="Complete" variant="green" />}
         />
 
-        <div className="grid min-h-0 flex-1 grid-cols-2 gap-3 overflow-y-auto">
+        <WidgetBody className="grid grid-cols-2 gap-3">
           <div className="rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
             <PaperAirplaneIcon className="mb-2 h-6 w-6 text-blue-500" />
             <div className="text-[10px] font-medium text-blue-600 uppercase dark:text-blue-400">
@@ -156,7 +158,7 @@ export function ProposalPipelineWidget({
               {data?.distinctSpeakers}
             </div>
           </div>
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -180,7 +182,7 @@ export function ProposalPipelineWidget({
         link={{ href: '/admin/proposals', label: 'View all →' }}
       />
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <WidgetBody className="flex flex-col">
         {/* Main Stats - Redesigned as overlapping cards */}
         <div className="mb-4 grid shrink-0 grid-cols-3 gap-2 @[400px]:gap-3">
           {/* Total */}
@@ -316,7 +318,7 @@ export function ProposalPipelineWidget({
             </div>
           </div>
         </div>
-      </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/QuickActionsWidget.tsx
+++ b/src/components/admin/dashboard/widgets/QuickActionsWidget.tsx
@@ -15,7 +15,12 @@ import { type QuickAction } from '@/lib/dashboard/data-types'
 import { getCurrentPhase } from '@/lib/conference/phase'
 import { BaseWidgetProps } from '@/lib/dashboard/types'
 import { useWidgetData } from '@/hooks/dashboard/useWidgetData'
-import { WidgetSkeleton, WidgetEmptyState, WidgetErrorState } from './shared'
+import {
+  WidgetSkeleton,
+  WidgetEmptyState,
+  WidgetErrorState,
+  WidgetHeader,
+} from './shared'
 
 const iconMap = {
   ClipboardDocumentCheckIcon,
@@ -63,9 +68,7 @@ export function QuickActionsWidget({ conference }: QuickActionsWidgetProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <h3 className="mb-2 text-xs font-semibold text-gray-900 dark:text-gray-100">
-        Quick Actions
-      </h3>
+      <WidgetHeader title="Quick Actions" />
       {/* Compact 3-column grid to show all 6 actions */}
       <div className="grid flex-1 auto-rows-fr grid-cols-3 gap-1.5 @[300px]:gap-2">
         {actions.map((action) => {

--- a/src/components/admin/dashboard/widgets/RecentActivityFeedWidget.tsx
+++ b/src/components/admin/dashboard/widgets/RecentActivityFeedWidget.tsx
@@ -49,14 +49,21 @@ export function RecentActivityFeedWidget({
   config,
 }: RecentActivityFeedWidgetProps) {
   const phase = conference ? getCurrentPhase(conference) : null
+  // Fetch gating: initialization renders a STATIC welcome card, so its
+  // fetcher is nulled (no skeleton, no masked fetch error). Post-conference
+  // KEEPS fetching — its completion card only applies when the fetched feed
+  // is actually empty, and a non-empty feed still renders below.
+  const isStaticPhase = phase === 'initialization'
   const {
     data: activities,
     loading,
     error,
     refetch,
   } = useWidgetData<ActivityItem[]>(
-    conference ? () => fetchRecentActivity(conference._id) : null,
-    [conference],
+    conference && !isStaticPhase
+      ? () => fetchRecentActivity(conference._id)
+      : null,
+    [conference, isStaticPhase],
   )
 
   // Phase-specific: Initialization - Show welcome message
@@ -75,7 +82,13 @@ export function RecentActivityFeedWidget({
     )
   }
 
-  // Phase-specific: Post-conference - Show completion message
+  // Loading and error come BEFORE the data-dependent post-conference branch:
+  // a failed fetch must surface as an error with retry, not be masked by a
+  // "Conference Complete" card it never verified.
+  if (loading) return <WidgetSkeleton />
+  if (error) return <WidgetErrorState onRetry={refetch} />
+
+  // Phase-specific: Post-conference with an empty feed - completion message
   if (phase === 'post-conference' && activities?.length === 0) {
     return (
       <div className="flex h-full flex-col items-center justify-center p-4">
@@ -91,8 +104,6 @@ export function RecentActivityFeedWidget({
     )
   }
 
-  if (loading) return <WidgetSkeleton />
-  if (error) return <WidgetErrorState onRetry={refetch} />
   if (!activities || activities.length === 0) {
     return <WidgetEmptyState message="No recent activity" />
   }

--- a/src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx
@@ -27,11 +27,18 @@ export function ReviewProgressWidget({
   conference,
   config,
 }: ReviewProgressWidgetProps) {
-  const { data, loading, error, refetch } = useWidgetData<ReviewProgressData>(
-    conference ? () => fetchReviewProgress(conference._id) : null,
-    [conference],
-  )
   const phase = conference ? getCurrentPhase(conference) : null
+  // Fetch gating: the initialization view is a STATIC setup guide (no fetched
+  // data at all), so its fetcher is nulled — no skeleton while fetching data
+  // the view won't use. Post-conference and the operational view render
+  // fetched data and keep fetching.
+  const isStaticPhase = phase === 'initialization'
+  const { data, loading, error, refetch } = useWidgetData<ReviewProgressData>(
+    conference && !isStaticPhase
+      ? () => fetchReviewProgress(conference._id)
+      : null,
+    [conference, isStaticPhase],
+  )
 
   const showAverageScore = config?.showAverageScore ?? true
 

--- a/src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx
@@ -12,6 +12,7 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
 } from './shared'
 
@@ -129,104 +130,109 @@ export function ReviewProgressWidget({
         Review Progress
       </h3>
 
-      {/* Vertical layout by default, horizontal when wide enough */}
-      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 overflow-hidden @[400px]:flex-row @[400px]:items-center @[400px]:justify-around">
-        {/* Circle visualization */}
-        <div className="relative flex shrink-0 items-center justify-center">
-          <svg
-            className="h-20 w-20 -rotate-90 transform @[200px]:h-24 @[200px]:w-24 @[280px]:h-28 @[280px]:w-28 @[350px]:h-32 @[350px]:w-32 @[450px]:h-36 @[450px]:w-36"
-            viewBox="0 0 128 128"
-          >
-            <circle
-              cx="64"
-              cy="64"
-              r={radius}
-              stroke="currentColor"
-              strokeWidth="10"
-              fill="transparent"
-              className="text-gray-200 dark:text-gray-700"
-            />
-            <circle
-              cx="64"
-              cy="64"
-              r={radius}
-              stroke="currentColor"
-              strokeWidth="10"
-              fill="transparent"
-              strokeDasharray={circumference}
-              strokeDashoffset={strokeDashoffset}
-              className="text-blue-600 transition-all duration-500 dark:text-blue-500"
-              strokeLinecap="round"
-            />
-          </svg>
-          <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <div className="text-lg font-bold text-gray-900 @[200px]:text-xl @[280px]:text-2xl @[350px]:text-3xl dark:text-gray-100">
-              {Math.round(data.percentage)}%
-            </div>
-            <div className="text-[10px] text-gray-500 @[200px]:text-[11px] @[280px]:text-xs dark:text-gray-400">
-              {data.reviewedCount}/{data.totalProposals}
+      {/* Scrollable body (was overflow-hidden, which clipped the CTA at small
+          sizes). The inner wrapper centers with m-auto — not justify-center,
+          which would clip the top unreachably once the body scrolls.
+          Vertical layout by default, horizontal when wide enough. */}
+      <WidgetBody className="flex">
+        <div className="m-auto flex w-full flex-col items-center gap-3 @[400px]:flex-row @[400px]:items-center @[400px]:justify-around">
+          {/* Circle visualization */}
+          <div className="relative flex shrink-0 items-center justify-center">
+            <svg
+              className="h-20 w-20 -rotate-90 transform @[200px]:h-24 @[200px]:w-24 @[280px]:h-28 @[280px]:w-28 @[350px]:h-32 @[350px]:w-32 @[450px]:h-36 @[450px]:w-36"
+              viewBox="0 0 128 128"
+            >
+              <circle
+                cx="64"
+                cy="64"
+                r={radius}
+                stroke="currentColor"
+                strokeWidth="10"
+                fill="transparent"
+                className="text-gray-200 dark:text-gray-700"
+              />
+              <circle
+                cx="64"
+                cy="64"
+                r={radius}
+                stroke="currentColor"
+                strokeWidth="10"
+                fill="transparent"
+                strokeDasharray={circumference}
+                strokeDashoffset={strokeDashoffset}
+                className="text-blue-600 transition-all duration-500 dark:text-blue-500"
+                strokeLinecap="round"
+              />
+            </svg>
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+              <div className="text-lg font-bold text-gray-900 @[200px]:text-xl @[280px]:text-2xl @[350px]:text-3xl dark:text-gray-100">
+                {Math.round(data.percentage)}%
+              </div>
+              <div className="text-[10px] text-gray-500 @[200px]:text-[11px] @[280px]:text-xs dark:text-gray-400">
+                {data.reviewedCount}/{data.totalProposals}
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Stats section - shows horizontally when widget is wide */}
-        <div className="flex min-w-0 flex-col gap-2 text-center @[400px]:flex-1 @[400px]:text-left">
-          {/* Average score */}
-          {showAverageScore && (
-            <div>
+          {/* Stats section - shows horizontally when widget is wide */}
+          <div className="flex min-w-0 flex-col gap-2 text-center @[400px]:flex-1 @[400px]:text-left">
+            {/* Average score */}
+            {showAverageScore && (
+              <div>
+                <div className="text-[10px] text-gray-500 @[200px]:text-xs dark:text-gray-400">
+                  Average Score
+                </div>
+                <div className="text-xl font-bold text-gray-900 @[280px]:text-2xl dark:text-gray-100">
+                  {data.averageScore.toFixed(1)}
+                  <span className="text-sm text-gray-500 dark:text-gray-400">
+                    /10
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {/* Pace toward the configured daily review target */}
+            {remainingReviews > 0 && (
               <div className="text-[10px] text-gray-500 @[200px]:text-xs dark:text-gray-400">
-                Average Score
+                ~{daysToFinish} day{daysToFinish !== 1 ? 's' : ''} left at{' '}
+                {targetReviewsPerDay}/day
               </div>
-              <div className="text-xl font-bold text-gray-900 @[280px]:text-2xl dark:text-gray-100">
-                {data.averageScore.toFixed(1)}
-                <span className="text-sm text-gray-500 dark:text-gray-400">
-                  /10
-                </span>
-              </div>
-            </div>
-          )}
+            )}
 
-          {/* Pace toward the configured daily review target */}
-          {remainingReviews > 0 && (
-            <div className="text-[10px] text-gray-500 @[200px]:text-xs dark:text-gray-400">
-              ~{daysToFinish} day{daysToFinish !== 1 ? 's' : ''} left at{' '}
-              {targetReviewsPerDay}/day
+            {/* Additional stats when horizontal */}
+            <div className="hidden grid-cols-2 gap-2 @[400px]:grid">
+              <div>
+                <div className="text-[10px] text-gray-500 dark:text-gray-400">
+                  Reviewed
+                </div>
+                <div className="truncate text-lg font-bold text-gray-900 dark:text-gray-100">
+                  {data.reviewedCount}
+                </div>
+              </div>
+              <div>
+                <div className="text-[10px] text-gray-500 dark:text-gray-400">
+                  Remaining
+                </div>
+                <div className="truncate text-lg font-bold text-gray-900 dark:text-gray-100">
+                  {data.totalProposals - data.reviewedCount}
+                </div>
+              </div>
             </div>
-          )}
 
-          {/* Additional stats when horizontal */}
-          <div className="hidden grid-cols-2 gap-2 @[400px]:grid">
-            <div>
-              <div className="text-[10px] text-gray-500 dark:text-gray-400">
-                Reviewed
+            {/* CTA button */}
+            {data.nextUnreviewed && (
+              <div className="@[400px]:mt-auto">
+                <Link
+                  href={`/admin/proposals/${data.nextUnreviewed.id}`}
+                  className="block truncate rounded-lg bg-blue-50 px-3 py-1.5 text-center text-[10px] text-blue-700 transition-colors hover:bg-blue-100 @[250px]:text-xs dark:bg-blue-900/20 dark:text-blue-300 dark:hover:bg-blue-900/30"
+                >
+                  Review next →
+                </Link>
               </div>
-              <div className="truncate text-lg font-bold text-gray-900 dark:text-gray-100">
-                {data.reviewedCount}
-              </div>
-            </div>
-            <div>
-              <div className="text-[10px] text-gray-500 dark:text-gray-400">
-                Remaining
-              </div>
-              <div className="truncate text-lg font-bold text-gray-900 dark:text-gray-100">
-                {data.totalProposals - data.reviewedCount}
-              </div>
-            </div>
+            )}
           </div>
-
-          {/* CTA button */}
-          {data.nextUnreviewed && (
-            <div className="@[400px]:mt-auto">
-              <Link
-                href={`/admin/proposals/${data.nextUnreviewed.id}`}
-                className="block truncate rounded-lg bg-blue-50 px-3 py-1.5 text-center text-[10px] text-blue-700 transition-colors hover:bg-blue-100 @[250px]:text-xs dark:bg-blue-900/20 dark:text-blue-300 dark:hover:bg-blue-900/30"
-              >
-                Review next →
-              </Link>
-            </div>
-          )}
         </div>
-      </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ReviewProgressWidget.tsx
@@ -108,9 +108,7 @@ export function ReviewProgressWidget({
             </div>
           </div>
         ) : (
-          <div className="flex flex-1 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
-            No review data available
-          </div>
+          <WidgetEmptyState message="No review data available" />
         )}
       </div>
     )

--- a/src/components/admin/dashboard/widgets/ScheduleBuilderStatusWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ScheduleBuilderStatusWidget.tsx
@@ -23,9 +23,13 @@ export function ScheduleBuilderStatusWidget({
   conference,
 }: ScheduleBuilderStatusWidgetProps) {
   const phase = conference ? getCurrentPhase(conference) : null
+  // Fetch gating: the initialization view is a STATIC planning guide (no
+  // fetched data at all), so its fetcher is nulled — no skeleton while
+  // fetching data the view won't use. Every other phase renders fetched data.
+  const isStaticPhase = phase === 'initialization'
   const { data, loading, error, refetch } = useWidgetData<ScheduleStatusData>(
-    conference ? () => fetchScheduleStatus(conference) : null,
-    [conference],
+    conference && !isStaticPhase ? () => fetchScheduleStatus(conference) : null,
+    [conference, isStaticPhase],
   )
 
   if (loading) {

--- a/src/components/admin/dashboard/widgets/ScheduleBuilderStatusWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ScheduleBuilderStatusWidget.tsx
@@ -184,12 +184,11 @@ export function ScheduleBuilderStatusWidget({
                       {day.filled}/{day.total}
                     </span>
                   </div>
-                  <div className="h-1.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-                    <div
-                      className="h-full bg-green-600 transition-all dark:bg-green-500"
-                      style={{ width: `${dayProgress}%` }}
-                    />
-                  </div>
+                  <ProgressBar
+                    value={dayProgress}
+                    className="h-1.5"
+                    label={`${day.day} slots filled`}
+                  />
                 </div>
               )
             })}

--- a/src/components/admin/dashboard/widgets/ScheduleBuilderStatusWidget.tsx
+++ b/src/components/admin/dashboard/widgets/ScheduleBuilderStatusWidget.tsx
@@ -12,6 +12,7 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
   ProgressBar,
 } from './shared'
@@ -123,91 +124,97 @@ export function ScheduleBuilderStatusWidget({
         link={{ href: '/admin/schedule', label: 'Build schedule →' }}
       />
 
-      <div className="mb-3 grid grid-cols-2 gap-2">
-        <div className="rounded-lg bg-blue-50 p-2.5 dark:bg-blue-900/20">
-          <div className="text-[11px] text-blue-600 dark:text-blue-400">
-            Slots Filled
+      {/* Scrollable body: multi-day conferences make the By Day list (and the
+          footer stats) taller than small slots — scroll, don't clip. */}
+      <WidgetBody className="flex flex-col">
+        <div className="mb-3 grid shrink-0 grid-cols-2 gap-2">
+          <div className="rounded-lg bg-blue-50 p-2.5 dark:bg-blue-900/20">
+            <div className="text-[11px] text-blue-600 dark:text-blue-400">
+              Slots Filled
+            </div>
+            <div className="mt-0.5 text-xl font-bold text-blue-900 dark:text-blue-100">
+              {data.filledSlots}/{data.totalSlots}
+            </div>
           </div>
-          <div className="mt-0.5 text-xl font-bold text-blue-900 dark:text-blue-100">
-            {data.filledSlots}/{data.totalSlots}
+          <div className="rounded-lg bg-green-50 p-2.5 dark:bg-green-900/20">
+            <div className="text-[11px] text-green-600 dark:text-green-400">
+              Progress
+            </div>
+            <div className="mt-0.5 text-xl font-bold text-green-900 dark:text-green-100">
+              {overallProgress.toFixed(0)}%
+            </div>
           </div>
         </div>
-        <div className="rounded-lg bg-green-50 p-2.5 dark:bg-green-900/20">
-          <div className="text-[11px] text-green-600 dark:text-green-400">
-            Progress
-          </div>
-          <div className="mt-0.5 text-xl font-bold text-green-900 dark:text-green-100">
-            {overallProgress.toFixed(0)}%
-          </div>
-        </div>
-      </div>
 
-      <div className="mb-3">
-        <div className="mb-1.5 flex items-center justify-between">
+        <div className="mb-3">
+          <div className="mb-1.5 flex items-center justify-between">
+            <h4 className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
+              Overall
+            </h4>
+            <span className="text-[11px] text-gray-600 dark:text-gray-300">
+              {overallProgress.toFixed(0)}%
+            </span>
+          </div>
+          <ProgressBar
+            value={overallProgress}
+            color="bg-blue-600 dark:bg-blue-500"
+          />
+        </div>
+
+        <div className="flex-1 space-y-2">
           <h4 className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
-            Overall
+            By Day
           </h4>
-          <span className="text-[11px] text-gray-600 dark:text-gray-300">
-            {overallProgress.toFixed(0)}%
-          </span>
+          {/* No width-keyed item caps (old nth-child hiding) — the body
+            scrolls, so every day row is rendered and reachable. */}
+          <div className="space-y-2">
+            {data.byDay.map((day) => {
+              const dayProgress = (day.filled / day.total) * 100
+              return (
+                <div key={day.day}>
+                  <div className="mb-1 flex items-center justify-between">
+                    <span className="text-[11px] font-medium text-gray-600 dark:text-gray-300">
+                      {day.day}
+                    </span>
+                    <span className="text-[11px] text-gray-500 dark:text-gray-400">
+                      {day.filled}/{day.total}
+                    </span>
+                  </div>
+                  <div className="h-1.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                    <div
+                      className="h-full bg-green-600 transition-all dark:bg-green-500"
+                      style={{ width: `${dayProgress}%` }}
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
         </div>
-        <ProgressBar
-          value={overallProgress}
-          color="bg-blue-600 dark:bg-blue-500"
-        />
-      </div>
 
-      <div className="flex-1 space-y-2">
-        <h4 className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
-          By Day
-        </h4>
-        <div className="space-y-2 [&>*:nth-child(n+3)]:hidden @[300px]:[&>*:nth-child(n+4)]:block">
-          {data.byDay.map((day) => {
-            const dayProgress = (day.filled / day.total) * 100
-            return (
-              <div key={day.day}>
-                <div className="mb-1 flex items-center justify-between">
-                  <span className="text-[11px] font-medium text-gray-600 dark:text-gray-300">
-                    {day.day}
-                  </span>
-                  <span className="text-[11px] text-gray-500 dark:text-gray-400">
-                    {day.filled}/{day.total}
-                  </span>
-                </div>
-                <div className="h-1.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-                  <div
-                    className="h-full bg-green-600 transition-all dark:bg-green-500"
-                    style={{ width: `${dayProgress}%` }}
-                  />
-                </div>
+        <div className="mt-3 flex gap-2 border-t border-gray-200 pt-3 dark:border-gray-700">
+          {data.unassignedConfirmedTalks > 0 && (
+            <div className="flex-1 rounded-lg bg-amber-50 p-2 text-center dark:bg-amber-900/20">
+              <div className="text-[11px] text-amber-600 dark:text-amber-400">
+                Unassigned
               </div>
-            )
-          })}
+              <div className="mt-0.5 text-lg font-bold text-amber-900 dark:text-amber-100">
+                {data.unassignedConfirmedTalks}
+              </div>
+            </div>
+          )}
+          {data.placeholderSlots > 0 && (
+            <div className="flex-1 rounded-lg bg-gray-50 p-2 text-center dark:bg-gray-800">
+              <div className="text-[11px] text-gray-600 dark:text-gray-300">
+                Placeholders
+              </div>
+              <div className="mt-0.5 text-lg font-bold text-gray-900 dark:text-gray-100">
+                {data.placeholderSlots}
+              </div>
+            </div>
+          )}
         </div>
-      </div>
-
-      <div className="mt-3 flex gap-2 border-t border-gray-200 pt-3 dark:border-gray-700">
-        {data.unassignedConfirmedTalks > 0 && (
-          <div className="flex-1 rounded-lg bg-amber-50 p-2 text-center dark:bg-amber-900/20">
-            <div className="text-[11px] text-amber-600 dark:text-amber-400">
-              Unassigned
-            </div>
-            <div className="mt-0.5 text-lg font-bold text-amber-900 dark:text-amber-100">
-              {data.unassignedConfirmedTalks}
-            </div>
-          </div>
-        )}
-        {data.placeholderSlots > 0 && (
-          <div className="flex-1 rounded-lg bg-gray-50 p-2 text-center dark:bg-gray-800">
-            <div className="text-[11px] text-gray-600 dark:text-gray-300">
-              Placeholders
-            </div>
-            <div className="mt-0.5 text-lg font-bold text-gray-900 dark:text-gray-100">
-              {data.placeholderSlots}
-            </div>
-          </div>
-        )}
-      </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/SpeakerEngagementWidget.tsx
+++ b/src/components/admin/dashboard/widgets/SpeakerEngagementWidget.tsx
@@ -13,7 +13,12 @@ import { type SpeakerEngagementData } from '@/lib/dashboard/data-types'
 import { getCurrentPhase } from '@/lib/conference/phase'
 import { BaseWidgetProps } from '@/lib/dashboard/types'
 import { useWidgetData } from '@/hooks/dashboard/useWidgetData'
-import { WidgetSkeleton, WidgetEmptyState, WidgetErrorState } from './shared'
+import {
+  WidgetSkeleton,
+  WidgetEmptyState,
+  WidgetErrorState,
+  WidgetBody,
+} from './shared'
 
 interface SpeakerEngagementConfig {
   showDiversityMetrics?: boolean
@@ -53,66 +58,69 @@ export function SpeakerEngagementWidget({
           </span>
         </div>
 
-        <div className="mb-3 grid grid-cols-2 gap-2">
-          <div className="rounded-lg bg-purple-50 p-2.5 dark:bg-purple-900/20">
-            <div className="text-[10px] text-purple-600 dark:text-purple-400">
-              Featured
+        {/* Scrollable body; the "Manage speakers" link below stays pinned. */}
+        <WidgetBody>
+          <div className="mb-3 grid grid-cols-2 gap-2">
+            <div className="rounded-lg bg-purple-50 p-2.5 dark:bg-purple-900/20">
+              <div className="text-[10px] text-purple-600 dark:text-purple-400">
+                Featured
+              </div>
+              <div className="mt-0.5 text-xl font-bold text-purple-900 dark:text-purple-100">
+                {featuredCount}
+              </div>
             </div>
-            <div className="mt-0.5 text-xl font-bold text-purple-900 dark:text-purple-100">
-              {featuredCount}
+            <div className="rounded-lg bg-green-50 p-2.5 dark:bg-green-900/20">
+              <div className="text-[10px] text-green-600 dark:text-green-400">
+                Registered
+              </div>
+              <div className="mt-0.5 text-xl font-bold text-green-900 dark:text-green-100">
+                {registeredCount}
+              </div>
             </div>
           </div>
-          <div className="rounded-lg bg-green-50 p-2.5 dark:bg-green-900/20">
-            <div className="text-[10px] text-green-600 dark:text-green-400">
-              Registered
-            </div>
-            <div className="mt-0.5 text-xl font-bold text-green-900 dark:text-green-100">
-              {registeredCount}
-            </div>
+
+          <div className="space-y-3">
+            {featuredCount > 0 && (
+              <div className="rounded-lg border border-purple-200 bg-purple-50 p-3 dark:border-purple-800 dark:bg-purple-900/20">
+                <h4 className="mb-1 text-[11px] font-semibold text-purple-900 dark:text-purple-200">
+                  Featured Speakers
+                </h4>
+                <p className="text-[11px] text-purple-700 dark:text-purple-400">
+                  {featuredCount} speaker{featuredCount !== 1 ? 's' : ''}{' '}
+                  featured on the website. Add more via the speakers page to
+                  build early momentum.
+                </p>
+              </div>
+            )}
+
+            {registeredCount > 0 ? (
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
+                <h4 className="mb-1 text-[11px] font-semibold text-gray-900 dark:text-gray-200">
+                  Early Registrations
+                </h4>
+                <p className="text-[11px] text-gray-600 dark:text-gray-400">
+                  {registeredCount} speaker
+                  {registeredCount !== 1 ? 's have' : ' has'} created profiles.
+                  Returning speakers are marked automatically.
+                </p>
+              </div>
+            ) : (
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
+                <h4 className="mb-1 text-[11px] font-semibold text-gray-900 dark:text-gray-200">
+                  Speaker Registrations
+                </h4>
+                <p className="text-[11px] text-gray-600 dark:text-gray-400">
+                  No speakers have registered yet. Feature speakers and open the
+                  CFP to attract submissions.
+                </p>
+              </div>
+            )}
           </div>
-        </div>
-
-        <div className="flex-1 space-y-3">
-          {featuredCount > 0 && (
-            <div className="rounded-lg border border-purple-200 bg-purple-50 p-3 dark:border-purple-800 dark:bg-purple-900/20">
-              <h4 className="mb-1 text-[11px] font-semibold text-purple-900 dark:text-purple-200">
-                Featured Speakers
-              </h4>
-              <p className="text-[11px] text-purple-700 dark:text-purple-400">
-                {featuredCount} speaker{featuredCount !== 1 ? 's' : ''} featured
-                on the website. Add more via the speakers page to build early
-                momentum.
-              </p>
-            </div>
-          )}
-
-          {registeredCount > 0 ? (
-            <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
-              <h4 className="mb-1 text-[11px] font-semibold text-gray-900 dark:text-gray-200">
-                Early Registrations
-              </h4>
-              <p className="text-[11px] text-gray-600 dark:text-gray-400">
-                {registeredCount} speaker
-                {registeredCount !== 1 ? 's have' : ' has'} created profiles.
-                Returning speakers are marked automatically.
-              </p>
-            </div>
-          ) : (
-            <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
-              <h4 className="mb-1 text-[11px] font-semibold text-gray-900 dark:text-gray-200">
-                Speaker Registrations
-              </h4>
-              <p className="text-[11px] text-gray-600 dark:text-gray-400">
-                No speakers have registered yet. Feature speakers and open the
-                CFP to attract submissions.
-              </p>
-            </div>
-          )}
-        </div>
+        </WidgetBody>
 
         <Link
           href="/admin/speakers"
-          className="mt-3 block text-center text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          className="mt-3 block shrink-0 text-center text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
         >
           Manage speakers &rarr;
         </Link>
@@ -227,67 +235,73 @@ export function SpeakerEngagementWidget({
         </Link>
       </div>
 
-      {/* Top half: Total speakers hero */}
-      <div className="flex min-h-0 flex-1 flex-col justify-center rounded-lg bg-linear-to-br from-blue-50 to-purple-50 px-3 dark:from-blue-900/20 dark:to-purple-900/20">
-        <div className="text-3xl font-black text-blue-900 dark:text-blue-100">
-          {data.totalSpeakers}
-        </div>
-        <div className="text-[11px] text-blue-600 dark:text-blue-400">
-          speakers &middot; {data.averageProposalsPerSpeaker.toFixed(1)}{' '}
-          proposals each
-        </div>
-        {data.awaitingConfirmation > 0 && (
-          <div className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
-            {data.awaitingConfirmation} awaiting confirmation
+      {/* Scrollable body. The two halves keep flex-1 (they split spare height
+          when the slot is tall) but drop min-h-0 so they floor at their
+          content height — that's what makes the body scroll instead of
+          crushing the text when the slot is short. */}
+      <WidgetBody className="flex flex-col">
+        {/* Top half: Total speakers hero */}
+        <div className="flex flex-1 flex-col justify-center rounded-lg bg-linear-to-br from-blue-50 to-purple-50 px-3 py-2 dark:from-blue-900/20 dark:to-purple-900/20">
+          <div className="text-3xl font-black text-blue-900 dark:text-blue-100">
+            {data.totalSpeakers}
           </div>
-        )}
-      </div>
+          <div className="text-[11px] text-blue-600 dark:text-blue-400">
+            speakers &middot; {data.averageProposalsPerSpeaker.toFixed(1)}{' '}
+            proposals each
+          </div>
+          {data.awaitingConfirmation > 0 && (
+            <div className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
+              {data.awaitingConfirmation} awaiting confirmation
+            </div>
+          )}
+        </div>
 
-      {/* Bottom half: stat columns */}
-      <div
-        className={`mt-1.5 grid min-h-0 flex-1 gap-1.5`}
-        style={{
-          gridTemplateColumns: `repeat(${Math.max(statColumns, 1)}, minmax(0, 1fr))`,
-        }}
-      >
-        {/* NOTE: no "returning" tile — `total - firstTimeFlagged` would count
+        {/* Bottom half: stat columns */}
+        <div
+          className={`mt-1.5 grid flex-1 gap-1.5`}
+          style={{
+            gridTemplateColumns: `repeat(${Math.max(statColumns, 1)}, minmax(0, 1fr))`,
+          }}
+        >
+          {/* NOTE: no "returning" tile — `total - firstTimeFlagged` would count
             every untagged speaker as returning, which is not a real signal. */}
-        {showFirstTimers && (
-          <div className="flex flex-col items-center justify-center rounded-lg bg-green-50 text-center dark:bg-green-900/20">
-            <SparklesIcon className="mb-0.5 h-3.5 w-3.5 text-green-600 dark:text-green-400" />
-            <div className="text-[9px] text-green-600 dark:text-green-400">
-              First-time
+          {showFirstTimers && (
+            <div className="flex flex-col items-center justify-center rounded-lg bg-green-50 text-center dark:bg-green-900/20">
+              <SparklesIcon className="mb-0.5 h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+              <div className="text-[9px] text-green-600 dark:text-green-400">
+                First-time
+              </div>
+              <div className="text-lg font-bold text-green-900 dark:text-green-100">
+                {data.newSpeakers}
+              </div>
             </div>
-            <div className="text-lg font-bold text-green-900 dark:text-green-100">
-              {data.newSpeakers}
-            </div>
-          </div>
-        )}
+          )}
 
-        {showDiversity && (
-          <div className="flex flex-col items-center justify-center rounded-lg bg-purple-50 text-center dark:bg-purple-900/20">
-            <UserGroupIcon className="mb-0.5 h-3.5 w-3.5 text-purple-600 dark:text-purple-400" />
-            <div className="text-[9px] text-purple-600 dark:text-purple-400">
-              Diverse
+          {showDiversity && (
+            <div className="flex flex-col items-center justify-center rounded-lg bg-purple-50 text-center dark:bg-purple-900/20">
+              <UserGroupIcon className="mb-0.5 h-3.5 w-3.5 text-purple-600 dark:text-purple-400" />
+              <div className="text-[9px] text-purple-600 dark:text-purple-400">
+                Diverse
+              </div>
+              <div className="text-lg font-bold text-purple-900 dark:text-purple-100">
+                {data.diverseSpeakers}
+              </div>
             </div>
-            <div className="text-lg font-bold text-purple-900 dark:text-purple-100">
-              {data.diverseSpeakers}
-            </div>
-          </div>
-        )}
+          )}
 
-        {showGeo && (
-          <div className="flex flex-col items-center justify-center rounded-lg bg-cyan-50 text-center dark:bg-cyan-900/20">
-            <MapPinIcon className="mb-0.5 h-3.5 w-3.5 text-cyan-600 dark:text-cyan-400" />
-            <div className="text-[9px] text-cyan-600 dark:text-cyan-400">
-              Local
+          {showGeo && (
+            <div className="flex flex-col items-center justify-center rounded-lg bg-cyan-50 text-center dark:bg-cyan-900/20">
+              <MapPinIcon className="mb-0.5 h-3.5 w-3.5 text-cyan-600 dark:text-cyan-400" />
+              <div className="text-[9px] text-cyan-600 dark:text-cyan-400">
+                Local
+              </div>
+              <div className="text-lg font-bold text-cyan-900 dark:text-cyan-100">
+                {data.localSpeakers}
+              </div>
             </div>
-            <div className="text-lg font-bold text-cyan-900 dark:text-cyan-100">
-              {data.localSpeakers}
-            </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/SpeakerEngagementWidget.tsx
+++ b/src/components/admin/dashboard/widgets/SpeakerEngagementWidget.tsx
@@ -17,7 +17,9 @@ import {
   WidgetSkeleton,
   WidgetEmptyState,
   WidgetErrorState,
+  WidgetHeader,
   WidgetBody,
+  PhaseBadge,
 } from './shared'
 
 interface SpeakerEngagementConfig {
@@ -53,14 +55,10 @@ export function SpeakerEngagementWidget({
 
     return (
       <div className="flex h-full flex-col">
-        <div className="mb-3 flex items-center justify-between">
-          <h3 className="text-xs font-semibold text-gray-900 dark:text-gray-100">
-            Speaker Outreach
-          </h3>
-          <span className="rounded-full bg-purple-100 px-2 py-0.5 text-[10px] font-medium text-purple-700 dark:bg-purple-900/40 dark:text-purple-400">
-            Early Stage
-          </span>
-        </div>
+        <WidgetHeader
+          title="Speaker Outreach"
+          badge={<PhaseBadge label="Early Stage" variant="purple" />}
+        />
 
         {/* Scrollable body; the "Manage speakers" link below stays pinned. */}
         <WidgetBody>
@@ -227,17 +225,12 @@ export function SpeakerEngagementWidget({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="mb-1.5 flex shrink-0 items-center justify-between">
-        <h3 className="text-xs font-semibold text-gray-900 dark:text-gray-100">
-          Speaker Engagement
-        </h3>
-        <Link
-          href="/admin/speakers"
-          className="text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-        >
-          View all &rarr;
-        </Link>
-      </div>
+      {/* WidgetHeader uses the house mb-3 (this header used a tighter mb-1.5;
+          the flexible halves below absorb the 6px). */}
+      <WidgetHeader
+        title="Speaker Engagement"
+        link={{ href: '/admin/speakers', label: 'View all →' }}
+      />
 
       {/* Scrollable body. The two halves keep flex-1 (they split spare height
           when the slot is tall) but drop min-h-0 so they floor at their

--- a/src/components/admin/dashboard/widgets/SpeakerEngagementWidget.tsx
+++ b/src/components/admin/dashboard/widgets/SpeakerEngagementWidget.tsx
@@ -32,6 +32,10 @@ export function SpeakerEngagementWidget({
   conference,
   config,
 }: SpeakerEngagementWidgetProps) {
+  // Fetch gating: no phase view here is static — even the initialization
+  // view renders fetched counts (featured/registered speakers), and the
+  // execution/post-conference branches require data — so the fetch must
+  // always run.
   const { data, loading, error, refetch } =
     useWidgetData<SpeakerEngagementData>(
       conference ? () => fetchSpeakerEngagement(conference._id) : null,

--- a/src/components/admin/dashboard/widgets/SponsorPipelineWidget.tsx
+++ b/src/components/admin/dashboard/widgets/SponsorPipelineWidget.tsx
@@ -18,13 +18,13 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
   ProgressBar,
 } from './shared'
 
 interface SponsorPipelineConfig {
   showPipeline?: boolean
-  showContractStatus?: boolean
 }
 
 type SponsorPipelineWidgetProps = BaseWidgetProps<SponsorPipelineConfig>
@@ -34,6 +34,9 @@ export function SponsorPipelineWidget({
   config,
 }: SponsorPipelineWidgetProps) {
   const phase = conference ? getCurrentPhase(conference) : null
+  // Fetch gating: every phase branch reads fetched data (the prospecting view
+  // is conditioned on totalDeals and shows data.revenueGoal), so no phase can
+  // skip the fetch.
   const { data, loading, error, refetch } =
     useWidgetData<SponsorPipelineWidgetData>(
       conference
@@ -64,7 +67,7 @@ export function SponsorPipelineWidget({
           badge={<PhaseBadge label="Prospecting" variant="amber" />}
         />
 
-        <div className="space-y-3">
+        <WidgetBody className="space-y-3">
           <div className="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-700 dark:bg-green-800/50">
             <BuildingOffice2Icon className="mb-2 h-8 w-8 text-green-500" />
             <h4 className="mb-1 text-sm font-semibold text-gray-900 dark:text-white">
@@ -89,7 +92,7 @@ export function SponsorPipelineWidget({
               </div>
             </div>
           </div>
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -107,7 +110,7 @@ export function SponsorPipelineWidget({
           badge={<PhaseBadge label="Complete" variant="green" />}
         />
 
-        <div className="grid grid-cols-2 gap-3">
+        <WidgetBody className="grid grid-cols-2 content-start gap-3">
           <div className="rounded-lg bg-green-50 p-4 dark:bg-green-900/20">
             <CheckCircleIcon className="mb-2 h-6 w-6 text-green-500" />
             <div className="text-[10px] font-medium text-green-600 uppercase dark:text-green-400">
@@ -150,7 +153,7 @@ export function SponsorPipelineWidget({
               %
             </div>
           </div>
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -171,138 +174,141 @@ export function SponsorPipelineWidget({
         link={{ href: '/admin/sponsors/crm', label: 'Manage pipeline →' }}
       />
 
-      <div className="mb-3 grid grid-cols-3 gap-2 @[200px]:grid-cols-1 @[400px]:grid-cols-3">
-        <div className="relative overflow-hidden rounded-xl bg-linear-to-br from-green-100 to-emerald-200 p-2.5 dark:from-green-900/40 dark:to-emerald-800/40">
-          <div className="relative z-10">
-            <div className="text-[10px] font-medium tracking-wide text-green-700 uppercase dark:text-green-400">
-              Total Value
-            </div>
-            <div className="mt-1 text-xl font-bold text-green-900 dark:text-green-100">
-              kr {(data.totalValue / 1000).toFixed(0)}k
-            </div>
-            {data.revenueGoal > 0 && (
-              <div className="text-[10px] text-green-600 dark:text-green-300">
-                of kr {(data.revenueGoal / 1000).toFixed(0)}k
+      {/* Stats + stages scroll as one region: the stage list grows with the
+          pipeline and must never clip against the container. */}
+      <WidgetBody>
+        <div className="mb-3 grid grid-cols-3 gap-2 @[200px]:grid-cols-1 @[400px]:grid-cols-3">
+          <div className="relative overflow-hidden rounded-xl bg-linear-to-br from-green-100 to-emerald-200 p-2.5 dark:from-green-900/40 dark:to-emerald-800/40">
+            <div className="relative z-10">
+              <div className="text-[10px] font-medium tracking-wide text-green-700 uppercase dark:text-green-400">
+                Total Value
               </div>
-            )}
+              <div className="mt-1 text-xl font-bold text-green-900 dark:text-green-100">
+                kr {(data.totalValue / 1000).toFixed(0)}k
+              </div>
+              {data.revenueGoal > 0 && (
+                <div className="text-[10px] text-green-600 dark:text-green-300">
+                  of kr {(data.revenueGoal / 1000).toFixed(0)}k
+                </div>
+              )}
+            </div>
+            <BanknotesIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-green-300/40 dark:text-green-600/30" />
           </div>
-          <BanknotesIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-green-300/40 dark:text-green-600/30" />
-        </div>
-        <div className="relative overflow-hidden rounded-xl bg-linear-to-br from-blue-100 to-cyan-200 p-2.5 dark:from-blue-900/40 dark:to-cyan-800/40">
-          <div className="relative z-10">
-            <div className="text-[10px] font-medium tracking-wide text-blue-700 uppercase dark:text-blue-400">
-              Won Deals
+          <div className="relative overflow-hidden rounded-xl bg-linear-to-br from-blue-100 to-cyan-200 p-2.5 dark:from-blue-900/40 dark:to-cyan-800/40">
+            <div className="relative z-10">
+              <div className="text-[10px] font-medium tracking-wide text-blue-700 uppercase dark:text-blue-400">
+                Won Deals
+              </div>
+              <div className="mt-1 text-xl font-bold text-blue-900 dark:text-blue-100">
+                {data.wonDeals}
+              </div>
             </div>
-            <div className="mt-1 text-xl font-bold text-blue-900 dark:text-blue-100">
-              {data.wonDeals}
-            </div>
+            <TrophyIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-blue-300/40 dark:text-blue-600/30" />
           </div>
-          <TrophyIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-blue-300/40 dark:text-blue-600/30" />
-        </div>
-        <div className="relative overflow-hidden rounded-xl border border-red-200 bg-linear-to-br from-red-100 to-rose-200 p-2.5 dark:border-red-800 dark:from-red-900/40 dark:to-rose-800/40">
-          <div className="relative z-10">
-            <div className="text-[10px] font-medium tracking-wide text-red-700 uppercase dark:text-red-400">
-              Lost Deals
+          <div className="relative overflow-hidden rounded-xl border border-red-200 bg-linear-to-br from-red-100 to-rose-200 p-2.5 dark:border-red-800 dark:from-red-900/40 dark:to-rose-800/40">
+            <div className="relative z-10">
+              <div className="text-[10px] font-medium tracking-wide text-red-700 uppercase dark:text-red-400">
+                Lost Deals
+              </div>
+              <div className="mt-1 text-xl font-bold text-red-900 dark:text-red-100">
+                {data.lostDeals}
+              </div>
             </div>
-            <div className="mt-1 text-xl font-bold text-red-900 dark:text-red-100">
-              {data.lostDeals}
-            </div>
+            <XCircleIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-red-300/40 dark:text-red-600/30" />
           </div>
-          <XCircleIcon className="absolute -right-2 -bottom-2 h-14 w-14 text-red-300/40 dark:text-red-600/30" />
         </div>
-      </div>
 
-      {data.revenueGoal > 0 && (
-        <div className="mb-3">
-          <div className="mb-1.5 flex items-center justify-between">
-            <h4 className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
-              Revenue Progress
-            </h4>
-            <span className="text-[11px] text-gray-600 dark:text-gray-300">
-              {progress.toFixed(0)}%
-            </span>
-          </div>
-          <div className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+        {data.revenueGoal > 0 && (
+          <div className="mb-3">
+            <div className="mb-1.5 flex items-center justify-between">
+              <h4 className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
+                Revenue Progress
+              </h4>
+              <span className="text-[11px] text-gray-600 dark:text-gray-300">
+                {progress.toFixed(0)}%
+              </span>
+            </div>
             <ProgressBar
               value={progress}
               color="bg-green-600 dark:bg-green-500"
+              label="Revenue progress"
             />
           </div>
-        </div>
-      )}
+        )}
 
-      {(config?.showPipeline ?? true) && (
-        <div className="mb-3 shrink-0">
-          <h4 className="mb-2 text-[11px] font-semibold text-gray-700 dark:text-gray-200">
-            Pipeline Stages
-          </h4>
-          <div className="space-y-2">
-            {data.stages.map((stage, index) => {
-              const stageColors = [
-                'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600',
-                'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800',
-                'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800',
-                'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800',
-              ]
-              const color = stageColors[index] || stageColors[0]
+        {(config?.showPipeline ?? true) && (
+          <div className="mb-3">
+            <h4 className="mb-2 text-[11px] font-semibold text-gray-700 dark:text-gray-200">
+              Pipeline Stages
+            </h4>
+            <div className="space-y-2">
+              {data.stages.map((stage, index) => {
+                const stageColors = [
+                  'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600',
+                  'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800',
+                  'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800',
+                  'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 border-green-200 dark:border-green-800',
+                ]
+                const color = stageColors[index] || stageColors[0]
 
-              return (
-                <div
-                  key={stage.name}
-                  className={`flex items-center gap-2 rounded-lg border p-2.5 ${color}`}
-                >
-                  <div className="shrink-0">
-                    <div className="text-[13px] leading-tight font-semibold">
-                      {stage.name}
+                return (
+                  <div
+                    key={stage.name}
+                    className={`flex items-center gap-2 rounded-lg border p-2.5 ${color}`}
+                  >
+                    <div className="shrink-0">
+                      <div className="text-[13px] leading-tight font-semibold">
+                        {stage.name}
+                      </div>
+                      <div className="text-[10px] opacity-75">
+                        {stage.count} deals
+                      </div>
                     </div>
-                    <div className="text-[10px] opacity-75">
-                      {stage.count} deals
-                    </div>
-                  </div>
-                  <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
-                    {stage.sponsors.slice(0, 4).map((sponsor, i) =>
-                      sponsor.logo ? (
-                        <div
-                          key={i}
-                          className="flex h-6 w-12 shrink-0 items-center justify-center rounded bg-white/80 px-0.5 dark:bg-gray-900/50"
-                          title={sponsor.name}
-                        >
-                          <SponsorLogo
-                            logo={sponsor.logo}
-                            logoBright={sponsor.logoBright}
-                            name={sponsor.name}
-                            className="max-h-5 max-w-11"
-                          />
-                        </div>
-                      ) : (
-                        <span
-                          key={i}
-                          className="shrink-0 rounded bg-white/60 px-1.5 py-0.5 text-[10px] font-medium dark:bg-gray-900/40"
-                          title={sponsor.name}
-                        >
-                          {sponsor.name.length > 8
-                            ? sponsor.name.slice(0, 8) + '…'
-                            : sponsor.name}
+                    <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+                      {stage.sponsors.slice(0, 4).map((sponsor, i) =>
+                        sponsor.logo ? (
+                          <div
+                            key={i}
+                            className="flex h-6 w-12 shrink-0 items-center justify-center rounded bg-white/80 px-0.5 dark:bg-gray-900/50"
+                            title={sponsor.name}
+                          >
+                            <SponsorLogo
+                              logo={sponsor.logo}
+                              logoBright={sponsor.logoBright}
+                              name={sponsor.name}
+                              className="max-h-5 max-w-11"
+                            />
+                          </div>
+                        ) : (
+                          <span
+                            key={i}
+                            className="shrink-0 rounded bg-white/60 px-1.5 py-0.5 text-[10px] font-medium dark:bg-gray-900/40"
+                            title={sponsor.name}
+                          >
+                            {sponsor.name.length > 8
+                              ? sponsor.name.slice(0, 8) + '…'
+                              : sponsor.name}
+                          </span>
+                        ),
+                      )}
+                      {stage.sponsors.length > 4 && (
+                        <span className="shrink-0 text-[10px] opacity-60">
+                          +{stage.sponsors.length - 4}
                         </span>
-                      ),
-                    )}
-                    {stage.sponsors.length > 4 && (
-                      <span className="shrink-0 text-[10px] opacity-60">
-                        +{stage.sponsors.length - 4}
-                      </span>
-                    )}
-                  </div>
-                  <div className="shrink-0 text-right">
-                    <div className="text-[13px] font-bold">
-                      kr {(stage.value / 1000).toFixed(0)}k
+                      )}
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <div className="text-[13px] font-bold">
+                        kr {(stage.value / 1000).toFixed(0)}k
+                      </div>
                     </div>
                   </div>
-                </div>
-              )
-            })}
+                )
+              })}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/SwipeablePaginationWidget.tsx
+++ b/src/components/admin/dashboard/widgets/SwipeablePaginationWidget.tsx
@@ -173,9 +173,14 @@ export function SwipeablePaginationWidget({
             }}
           >
             {pages.map((page, index) => (
+              /* Each page scrolls vertically: items beyond the visible height
+                 must stay reachable instead of clipping against the carousel's
+                 overflow-hidden. `touch-pan-y` on the swipe container already
+                 hands mostly-vertical touch gestures to native scrolling, so
+                 the horizontal swipe mechanics are unaffected. */
               <div
                 key={index}
-                className="h-full w-full shrink-0"
+                className="h-full w-full shrink-0 overflow-y-auto overscroll-contain"
                 style={{ pointerEvents: isDragging ? 'none' : 'auto' }}
               >
                 {page}

--- a/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
@@ -27,6 +27,7 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
   ProgressBar,
 } from './shared'
@@ -235,7 +236,7 @@ export function TicketSalesDashboardWidget({
           title="Ticket Sales"
           link={{ href: '/admin/tickets', label: 'Manage tickets →' }}
         />
-        <div className="flex min-h-0 flex-1 flex-col justify-between overflow-y-auto">
+        <WidgetBody className="flex flex-col justify-between">
           <div className="grid grid-cols-3 gap-3">
             <div className="relative overflow-hidden rounded-xl bg-linear-to-br from-blue-100 to-cyan-200 p-2.5 dark:from-blue-900/40 dark:to-cyan-800/40">
               <div className="relative z-10">
@@ -302,7 +303,7 @@ export function TicketSalesDashboardWidget({
               )
             })}
           </div>
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -314,7 +315,7 @@ export function TicketSalesDashboardWidget({
         link={{ href: '/admin/tickets', label: 'Manage tickets →' }}
       />
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <WidgetBody className="flex flex-col">
         <div className="mb-3 grid shrink-0 grid-cols-3 gap-2 @[200px]:grid-cols-1 @[400px]:grid-cols-3">
           <div className="relative overflow-hidden rounded-xl bg-linear-to-br from-blue-100 to-cyan-200 p-2.5 dark:from-blue-900/40 dark:to-cyan-800/40">
             <div className="relative z-10">
@@ -424,7 +425,7 @@ export function TicketSalesDashboardWidget({
             {data.daysUntilEvent}
           </div>
         </div>
-      </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
@@ -44,14 +44,20 @@ export function TicketSalesDashboardWidget({
   conference,
   config,
 }: TicketSalesDashboardWidgetProps) {
+  const phase = conference ? getCurrentPhase(conference) : null
+  // Fetch gating: the initialization view is a STATIC setup guide (no fetched
+  // data at all), so its fetcher is nulled — no skeleton while fetching data
+  // the view won't use. Post-conference and the operational views all render
+  // fetched data and keep fetching.
+  const isStaticPhase = phase === 'initialization'
   const {
     data: result,
     loading,
     error,
     refetch,
   } = useWidgetData<TicketSalesResult>(
-    conference ? () => fetchTicketSales(conference) : null,
-    [conference],
+    conference && !isStaticPhase ? () => fetchTicketSales(conference) : null,
+    [conference, isStaticPhase],
   )
   const data = result?.status === 'ok' ? result.data : null
 
@@ -59,7 +65,6 @@ export function TicketSalesDashboardWidget({
   // the in-app toggle can differ from `prefers-color-scheme`.
   const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
-  const phase = conference ? getCurrentPhase(conference) : null
 
   const gaugeOptions: ApexOptions = useMemo(() => {
     const themeColors = getThemeColors(isDark)

--- a/src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx
@@ -17,6 +17,7 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
   ProgressBar,
 } from './shared'
@@ -66,7 +67,7 @@ export function TravelSupportQueueWidget({
           badge={<PhaseBadge label="Planning" variant="blue" />}
         />
 
-        <div className="space-y-3">
+        <WidgetBody className="space-y-3">
           <div className="rounded-lg border border-cyan-200 bg-cyan-50 p-4 dark:border-cyan-700 dark:bg-cyan-800/50">
             <GlobeAltIcon className="mb-2 h-8 w-8 text-cyan-500" />
             <h4 className="mb-1 text-sm font-semibold text-gray-900 dark:text-white">
@@ -91,7 +92,7 @@ export function TravelSupportQueueWidget({
               </div>
             </div>
           )}
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -105,7 +106,7 @@ export function TravelSupportQueueWidget({
           badge={<PhaseBadge label="Complete" variant="green" />}
         />
 
-        <div className="grid grid-cols-2 gap-3">
+        <WidgetBody className="grid grid-cols-2 content-start gap-3">
           <div className="rounded-lg bg-green-50 p-4 dark:bg-green-900/20">
             <CheckCircleIcon className="mb-2 h-6 w-6 text-green-500" />
             <div className="text-[10px] font-medium text-green-600 uppercase dark:text-green-400">
@@ -144,7 +145,7 @@ export function TravelSupportQueueWidget({
                 : '—'}
             </div>
           </div>
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -162,100 +163,107 @@ export function TravelSupportQueueWidget({
         link={{ href: '/admin/speakers/travel-support', label: 'Review →' }}
       />
 
-      {(config?.showPendingRequests ?? true) && data.pendingApprovals > 0 && (
-        <div className="mb-3 rounded-lg bg-amber-50 p-2.5 text-center dark:bg-amber-900/20">
-          <div className="text-[11px] text-amber-600 dark:text-amber-400">
-            Pending Approvals
+      {/* Scrollable body (flex column so the empty state can still center in
+          leftover space); the request list grows unbounded with pending
+          requests and must scroll, not clip. */}
+      <WidgetBody className="flex flex-col">
+        {(config?.showPendingRequests ?? true) && data.pendingApprovals > 0 && (
+          <div className="mb-3 rounded-lg bg-amber-50 p-2.5 text-center dark:bg-amber-900/20">
+            <div className="text-[11px] text-amber-600 dark:text-amber-400">
+              Pending Approvals
+            </div>
+            <div className="mt-1 text-2xl font-bold text-amber-900 dark:text-amber-100">
+              {data.pendingApprovals}
+            </div>
           </div>
-          <div className="mt-1 text-2xl font-bold text-amber-900 dark:text-amber-100">
-            {data.pendingApprovals}
-          </div>
-        </div>
-      )}
+        )}
 
-      <div className="mb-3 grid grid-cols-2 gap-2">
-        <div className="rounded-lg bg-green-50 p-2.5 dark:bg-green-900/20">
-          <div className="text-[11px] text-green-600 dark:text-green-400">
-            Approved
+        <div className="mb-3 grid grid-cols-2 gap-2">
+          <div className="rounded-lg bg-green-50 p-2.5 dark:bg-green-900/20">
+            <div className="text-[11px] text-green-600 dark:text-green-400">
+              Approved
+            </div>
+            <div className="mt-1 text-lg font-bold text-green-900 dark:text-green-100">
+              kr {(data.totalApproved / 1000).toFixed(1)}k
+            </div>
           </div>
-          <div className="mt-1 text-lg font-bold text-green-900 dark:text-green-100">
-            kr {(data.totalApproved / 1000).toFixed(1)}k
+          <div className="rounded-lg bg-gray-50 p-2.5 dark:bg-gray-800">
+            <div className="text-[11px] text-gray-600 dark:text-gray-300">
+              Requested
+            </div>
+            <div className="mt-1 text-lg font-bold text-gray-900 dark:text-gray-100">
+              kr {(data.totalRequested / 1000).toFixed(1)}k
+            </div>
           </div>
         </div>
-        <div className="rounded-lg bg-gray-50 p-2.5 dark:bg-gray-800">
-          <div className="text-[11px] text-gray-600 dark:text-gray-300">
-            Requested
-          </div>
-          <div className="mt-1 text-lg font-bold text-gray-900 dark:text-gray-100">
-            kr {(data.totalRequested / 1000).toFixed(1)}k
-          </div>
-        </div>
-      </div>
 
-      {(config?.showBudgetUtilization ?? true) && budgetUsed !== null && (
-        <div className="mb-3">
-          <div className="mb-1.5 flex items-center justify-between">
-            <h4 className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
-              Budget Usage
+        {(config?.showBudgetUtilization ?? true) && budgetUsed !== null && (
+          <div className="mb-3">
+            <div className="mb-1.5 flex items-center justify-between">
+              <h4 className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
+                Budget Usage
+              </h4>
+              <span className="text-[11px] text-gray-600 dark:text-gray-300">
+                kr {(data.budgetAllocated / 1000).toFixed(0)}k total
+              </span>
+            </div>
+            <ProgressBar
+              value={budgetUsed}
+              color={
+                budgetUsed > 90
+                  ? 'bg-red-600 dark:bg-red-500'
+                  : budgetUsed > 70
+                    ? 'bg-amber-600 dark:bg-amber-500'
+                    : 'bg-green-600 dark:bg-green-500'
+              }
+              className="h-1.5"
+            />
+            <div className="mt-1 text-[11px] text-gray-600 dark:text-gray-300">
+              {budgetUsed.toFixed(0)}% used
+            </div>
+          </div>
+        )}
+
+        {data.requests.length > 0 && (
+          <div>
+            <h4 className="mb-2 text-[11px] font-semibold text-gray-700 dark:text-gray-200">
+              Pending Requests
             </h4>
-            <span className="text-[11px] text-gray-600 dark:text-gray-300">
-              kr {(data.budgetAllocated / 1000).toFixed(0)}k total
-            </span>
+            {/* No width-keyed item caps (old nth-child hiding) — the body
+              scrolls, so every pending request is rendered and reachable. */}
+            <div className="space-y-2">
+              {data.requests.map((request) => (
+                <Link
+                  key={request.id}
+                  href={`/admin/travel-support/${request.id}`}
+                  className="block rounded-lg border border-gray-200 bg-white p-2.5 transition-colors hover:border-blue-300 hover:bg-blue-50 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-blue-600 dark:hover:bg-blue-900/20"
+                >
+                  <div className="mb-0.5 flex items-start justify-between">
+                    <span className="text-[11px] leading-tight font-semibold text-gray-900 dark:text-gray-100">
+                      {request.speaker}
+                    </span>
+                    <span className="ml-2 flex items-center gap-0.5 text-[11px] font-bold text-gray-900 dark:text-gray-100">
+                      <BanknotesIcon className="h-3 w-3" />
+                      {formatNumber(request.amount)}
+                    </span>
+                  </div>
+                  <div className="text-[10px] text-gray-500 dark:text-gray-400">
+                    Submitted {request.submittedAt}
+                  </div>
+                </Link>
+              ))}
+            </div>
           </div>
-          <ProgressBar
-            value={budgetUsed}
-            color={
-              budgetUsed > 90
-                ? 'bg-red-600 dark:bg-red-500'
-                : budgetUsed > 70
-                  ? 'bg-amber-600 dark:bg-amber-500'
-                  : 'bg-green-600 dark:bg-green-500'
-            }
-            className="h-1.5"
-          />
-          <div className="mt-1 text-[11px] text-gray-600 dark:text-gray-300">
-            {budgetUsed.toFixed(0)}% used
-          </div>
-        </div>
-      )}
+        )}
 
-      {data.requests.length > 0 && (
-        <div className="flex-1">
-          <h4 className="mb-2 text-[11px] font-semibold text-gray-700 dark:text-gray-200">
-            Pending Requests
-          </h4>
-          <div className="space-y-2 [&>*:nth-child(n+3)]:hidden @[300px]:[&>*:nth-child(n+4)]:block @[300px]:[&>*:nth-child(n+5)]:hidden @[500px]:[&>*:nth-child(n+5)]:block">
-            {data.requests.map((request) => (
-              <Link
-                key={request.id}
-                href={`/admin/travel-support/${request.id}`}
-                className="block rounded-lg border border-gray-200 bg-white p-2.5 transition-colors hover:border-blue-300 hover:bg-blue-50 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-blue-600 dark:hover:bg-blue-900/20"
-              >
-                <div className="mb-0.5 flex items-start justify-between">
-                  <span className="text-[11px] leading-tight font-semibold text-gray-900 dark:text-gray-100">
-                    {request.speaker}
-                  </span>
-                  <span className="ml-2 flex items-center gap-0.5 text-[11px] font-bold text-gray-900 dark:text-gray-100">
-                    <BanknotesIcon className="h-3 w-3" />
-                    {formatNumber(request.amount)}
-                  </span>
-                </div>
-                <div className="text-[10px] text-gray-500 dark:text-gray-400">
-                  Submitted {request.submittedAt}
-                </div>
-              </Link>
-            ))}
+        {data.requests.length === 0 && data.pendingApprovals === 0 && (
+          <div className="flex flex-1 items-center justify-center rounded-lg bg-gray-50 p-4 text-center dark:bg-gray-800">
+            <p className="text-[11px] text-gray-500 dark:text-gray-400">
+              No pending requests
+            </p>
           </div>
-        </div>
-      )}
-
-      {data.requests.length === 0 && data.pendingApprovals === 0 && (
-        <div className="flex flex-1 items-center justify-center rounded-lg bg-gray-50 p-4 text-center dark:bg-gray-800">
-          <p className="text-[11px] text-gray-500 dark:text-gray-400">
-            No pending requests
-          </p>
-        </div>
-      )}
+        )}
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TravelSupportQueueWidget.tsx
@@ -34,6 +34,10 @@ export function TravelSupportQueueWidget({
   config,
 }: TravelSupportQueueWidgetProps) {
   const phase = conference ? getCurrentPhase(conference) : null
+  // Fetch gating: no phase view here is static — the planning branch is
+  // CONDITIONED on the fetched data (totalRequested) and shows the fetched
+  // budget, and post-conference renders fetched totals, so the fetch must
+  // always run.
   const { data, loading, error, refetch } = useWidgetData<TravelSupportData>(
     conference ? () => fetchTravelSupport(conference) : null,
     [conference],

--- a/src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx
+++ b/src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx
@@ -12,6 +12,7 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
 } from './shared'
 
@@ -119,7 +120,7 @@ export function UpcomingDeadlinesWidget({
         Upcoming Deadlines
       </h3>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto">
+      <WidgetBody className="flex flex-col gap-1.5">
         {deadlines.slice(0, maxDeadlines).map((deadline) => {
           const urgency = getUrgency(deadline.daysRemaining)
           const urgencyClass = urgencyStyles[urgency]
@@ -163,7 +164,7 @@ export function UpcomingDeadlinesWidget({
             </div>
           )
         })}
-      </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx
+++ b/src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx
@@ -47,14 +47,21 @@ export function UpcomingDeadlinesWidget({
   config,
 }: UpcomingDeadlinesWidgetProps) {
   const phase = conference ? getCurrentPhase(conference) : null
+  // Fetch gating: initialization (planning card) and post-conference
+  // (completion card) are STATIC — they render no fetched data, so the
+  // fetcher is nulled for them (useWidgetData then never loads). This also
+  // stops those branches from masking fetch errors: in the remaining phases
+  // the order below is loading → error → data.
+  const isStaticPhase =
+    phase === 'initialization' || phase === 'post-conference'
   const {
     data: deadlines,
     loading,
     error,
     refetch,
   } = useWidgetData<DeadlineData[]>(
-    conference ? () => fetchDeadlines(conference) : null,
-    [conference],
+    conference && !isStaticPhase ? () => fetchDeadlines(conference) : null,
+    [conference, isStaticPhase],
   )
 
   // Phase-specific: Initialization without deadlines - Show planning timeline

--- a/src/components/admin/dashboard/widgets/WorkshopCapacityWidget.tsx
+++ b/src/components/admin/dashboard/widgets/WorkshopCapacityWidget.tsx
@@ -15,7 +15,9 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
   PhaseBadge,
+  ProgressBar,
 } from './shared'
 
 type WorkshopCapacityWidgetProps = BaseWidgetProps
@@ -24,6 +26,9 @@ export function WorkshopCapacityWidget({
   conference,
 }: WorkshopCapacityWidgetProps) {
   const phase = conference ? getCurrentPhase(conference) : null
+  // Fetch gating: no phase view here is static — the initialization/planning
+  // branch is CONDITIONED on the fetched data being empty (and post-conference
+  // renders fetched totals), so the fetch must always run.
   const { data, loading, error, refetch } = useWidgetData<WorkshopStatistics>(
     conference ? () => fetchWorkshopCapacity(conference._id) : null,
     [conference],
@@ -51,7 +56,7 @@ export function WorkshopCapacityWidget({
           badge={<PhaseBadge label="Planning" variant="blue" />}
         />
 
-        <div className="space-y-3">
+        <WidgetBody className="space-y-3">
           <div className="rounded-lg border border-purple-200 bg-purple-50 p-4 dark:border-purple-700 dark:bg-purple-800/50">
             <AcademicCapIcon className="mb-2 h-8 w-8 text-purple-500" />
             <h4 className="mb-1 text-sm font-semibold text-gray-900 dark:text-white">
@@ -83,7 +88,7 @@ export function WorkshopCapacityWidget({
               </div>
             </div>
           )}
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -103,7 +108,7 @@ export function WorkshopCapacityWidget({
           badge={<PhaseBadge label="Complete" variant="green" />}
         />
 
-        <div className="grid grid-cols-2 gap-3">
+        <WidgetBody className="grid grid-cols-2 content-start gap-3">
           <div className="rounded-lg bg-purple-50 p-4 dark:bg-purple-900/20">
             <CheckCircleIcon className="mb-2 h-6 w-6 text-purple-500" />
             <div className="text-[10px] font-medium text-purple-600 uppercase dark:text-purple-400">
@@ -140,7 +145,7 @@ export function WorkshopCapacityWidget({
               {totalCapacity}
             </div>
           </div>
-        </div>
+        </WidgetBody>
       </div>
     )
   }
@@ -158,84 +163,95 @@ export function WorkshopCapacityWidget({
         link={{ href: '/admin/workshops', label: 'Manage →' }}
       />
 
-      <div className="@container:grid-cols-1 mb-3 grid grid-cols-3 gap-2">
-        <div className="rounded-lg bg-blue-50 p-2 text-center dark:bg-blue-900/20">
-          <div className="text-[11px] text-blue-600 dark:text-blue-400">
-            Avg Fill
-          </div>
-          <div className="mt-1 text-lg font-bold text-blue-900 dark:text-blue-100">
-            {data.totals.averageUtilization.toFixed(0)}%
-          </div>
-        </div>
-        <div className="rounded-lg bg-green-50 p-2 text-center dark:bg-green-900/20">
-          <div className="text-[11px] text-green-600 dark:text-green-400">
-            Full
-          </div>
-          <div className="mt-1 text-lg font-bold text-green-900 dark:text-green-100">
-            {data.workshops.filter((w) => w.utilization >= 100).length}
-          </div>
-        </div>
-        <div className="rounded-lg bg-amber-50 p-2 text-center dark:bg-amber-900/20">
-          <div className="text-[11px] text-amber-600 dark:text-amber-400">
-            Waitlist
-          </div>
-          <div className="mt-1 text-lg font-bold text-amber-900 dark:text-amber-100">
-            {data.totals.totalWaitlist}
-          </div>
-        </div>
-      </div>
-
-      <div className="flex-1 space-y-2 [&>*:nth-child(n+4)]:hidden @[300px]:[&>*:nth-child(n+5)]:block @[300px]:[&>*:nth-child(n+6)]:hidden @[400px]:[&>*:nth-child(n+6)]:block @[600px]:[&>*:nth-child(n+7)]:block">
-        {data.workshops.map((workshop) => {
-          const fillColor =
-            workshop.utilization === 100
-              ? 'bg-green-600 dark:bg-green-500'
-              : workshop.utilization >= 80
-                ? 'bg-blue-600 dark:bg-blue-500'
-                : workshop.utilization >= 50
-                  ? 'bg-amber-600 dark:bg-amber-500'
-                  : 'bg-gray-600 dark:bg-gray-500'
-
-          return (
-            <div
-              key={workshop.workshopId}
-              className="rounded-lg border border-gray-200 bg-white p-2.5 dark:border-gray-700 dark:bg-gray-900"
-            >
-              <div className="mb-1.5 flex items-start justify-between">
-                <h4 className="flex-1 truncate text-[11px] leading-tight font-semibold text-gray-900 dark:text-gray-100">
-                  {workshop.workshopTitle}
-                </h4>
-                <span className="ml-2 text-[11px] font-bold text-gray-700 dark:text-gray-200">
-                  {workshop.utilization.toFixed(0)}%
-                </span>
-              </div>
-
-              <div className="mb-1.5 h-1.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-                <div
-                  className={`h-full transition-all ${fillColor}`}
-                  style={{ width: `${workshop.utilization}%` }}
-                />
-              </div>
-
-              <div className="flex items-center justify-between text-[11px] text-gray-600 dark:text-gray-300">
-                {/* Compact mode: just show ratio on small, full details on larger */}
-                <span className="block @[250px]:hidden">
-                  {workshop.confirmedSignups}/{workshop.capacity}
-                </span>
-                <span className="hidden @[250px]:block">
-                  {workshop.confirmedSignups}/{workshop.capacity} confirmed
-                </span>
-                {workshop.waitlistSignups > 0 && (
-                  <span className="text-amber-600 dark:text-amber-400">
-                    {workshop.waitlistSignups}
-                    <span className="hidden @[250px]:inline"> waiting</span>
-                  </span>
-                )}
-              </div>
+      {/* Everything below the header scrolls: workshop lists routinely exceed
+          the slot height, and the container clips (see WidgetBody). */}
+      <WidgetBody>
+        {/* (dead `@container:grid-cols-1` class removed — `@container` is not
+            a Tailwind variant; width adaptation is handled per-card below) */}
+        <div className="mb-3 grid grid-cols-3 gap-2">
+          <div className="rounded-lg bg-blue-50 p-2 text-center dark:bg-blue-900/20">
+            <div className="text-[11px] text-blue-600 dark:text-blue-400">
+              Avg Fill
             </div>
-          )
-        })}
-      </div>
+            <div className="mt-1 text-lg font-bold text-blue-900 dark:text-blue-100">
+              {data.totals.averageUtilization.toFixed(0)}%
+            </div>
+          </div>
+          <div className="rounded-lg bg-green-50 p-2 text-center dark:bg-green-900/20">
+            <div className="text-[11px] text-green-600 dark:text-green-400">
+              Full
+            </div>
+            <div className="mt-1 text-lg font-bold text-green-900 dark:text-green-100">
+              {data.workshops.filter((w) => w.utilization >= 100).length}
+            </div>
+          </div>
+          <div className="rounded-lg bg-amber-50 p-2 text-center dark:bg-amber-900/20">
+            <div className="text-[11px] text-amber-600 dark:text-amber-400">
+              Waitlist
+            </div>
+            <div className="mt-1 text-lg font-bold text-amber-900 dark:text-amber-100">
+              {data.totals.totalWaitlist}
+            </div>
+          </div>
+        </div>
+
+        {/* No width-keyed item caps: the old nth-child hiding limited the list
+            by container WIDTH to dodge vertical clipping — with the body
+            scrolling, every workshop is rendered and reachable. */}
+        <div className="space-y-2">
+          {data.workshops.map((workshop) => {
+            const fillColor =
+              workshop.utilization === 100
+                ? 'bg-green-600 dark:bg-green-500'
+                : workshop.utilization >= 80
+                  ? 'bg-blue-600 dark:bg-blue-500'
+                  : workshop.utilization >= 50
+                    ? 'bg-amber-600 dark:bg-amber-500'
+                    : 'bg-gray-600 dark:bg-gray-500'
+
+            return (
+              <div
+                key={workshop.workshopId}
+                className="rounded-lg border border-gray-200 bg-white p-2.5 dark:border-gray-700 dark:bg-gray-900"
+              >
+                <div className="mb-1.5 flex items-start justify-between">
+                  <h4 className="flex-1 truncate text-[11px] leading-tight font-semibold text-gray-900 dark:text-gray-100">
+                    {workshop.workshopTitle}
+                  </h4>
+                  <span className="ml-2 text-[11px] font-bold text-gray-700 dark:text-gray-200">
+                    {workshop.utilization.toFixed(0)}%
+                  </span>
+                </div>
+
+                <div className="mb-1.5">
+                  <ProgressBar
+                    value={workshop.utilization}
+                    color={fillColor}
+                    className="h-1.5"
+                    label={`${workshop.workshopTitle} capacity`}
+                  />
+                </div>
+
+                <div className="flex items-center justify-between text-[11px] text-gray-600 dark:text-gray-300">
+                  {/* Compact mode: just show ratio on small, full details on larger */}
+                  <span className="block @[250px]:hidden">
+                    {workshop.confirmedSignups}/{workshop.capacity}
+                  </span>
+                  <span className="hidden @[250px]:block">
+                    {workshop.confirmedSignups}/{workshop.capacity} confirmed
+                  </span>
+                  {workshop.waitlistSignups > 0 && (
+                    <span className="text-amber-600 dark:text-amber-400">
+                      {workshop.waitlistSignups}
+                      <span className="hidden @[250px]:inline"> waiting</span>
+                    </span>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/shared.tsx
+++ b/src/components/admin/dashboard/widgets/shared.tsx
@@ -75,6 +75,43 @@ export function WidgetErrorState({
   )
 }
 
+/* ---------- Widget body (the height contract) ---------- */
+
+interface WidgetBodyProps {
+  /** Extra classes merged onto the scroll region (e.g. `flex flex-col`). */
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * THE standard content region of a widget — and the house height contract.
+ *
+ * WidgetContainer clips (`overflow-hidden` + fixed grid height), so any
+ * variable-height widget content MUST live inside a WidgetBody: `min-h-0
+ * flex-1` lets it absorb whatever height the row span grants, and
+ * `overflow-y-auto` makes taller-than-slot content scroll instead of
+ * silently clipping. Fixed chrome (WidgetHeader, pinned footers) stays
+ * OUTSIDE as shrink-0 siblings; the widget root must be `flex h-full
+ * flex-col` for the flex-1 to bite.
+ *
+ * `overscroll-contain` stops a widget's inner scroll from chaining into the
+ * page scroll (same convention as ModalShell/BottomSheet). Scrollbars are the
+ * platform default, matching the widgets that already scrolled.
+ *
+ * Centering caveat: do NOT combine this with `justify-center` on the scroll
+ * region itself — centered overflow clips at the top unreachably. Center an
+ * inner wrapper with `m-auto` instead.
+ */
+export function WidgetBody({ className = '', children }: WidgetBodyProps) {
+  return (
+    <div
+      className={`min-h-0 flex-1 overflow-y-auto overscroll-contain ${className}`}
+    >
+      {children}
+    </div>
+  )
+}
+
 /* ---------- Widget header ---------- */
 
 interface WidgetHeaderProps {

--- a/src/hooks/dashboard/useWidgetData.ts
+++ b/src/hooks/dashboard/useWidgetData.ts
@@ -28,8 +28,14 @@ export function useWidgetData<T>(
   useEffect(() => {
     let isMounted = true
     if (!fetcher) {
+      // No fetch for this render (no conference, or a phase whose view is
+      // static). Reset ALL fetch state — a stale `error`/`data` from a prior
+      // fetcher (e.g. a failed fetch in a data phase before the phase flipped
+      // to a gated static one) must not leak into the fetchless view.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setLoading(false)
+      setError(false)
+      setData(null)
       return
     }
 

--- a/src/lib/dashboard/widget-registry.ts
+++ b/src/lib/dashboard/widget-registry.ts
@@ -9,6 +9,15 @@ import { defineWidget, type WidgetMetadata } from './widget-metadata'
 import { z } from 'zod'
 import type { WidgetConfigSchema } from './types'
 
+/*
+ * Size calibration: with GRID_CONFIG (cellSize 96, gap 16) a widget's inner
+ * content height is ≈ 112·rowSpan − 36 px (row steps minus border/padding).
+ * Defaults below are sized to the measured height of each widget's fullest
+ * operational view so newly added widgets neither clip (content scrolls via
+ * WidgetBody anyway) nor float in dead space. Stored user layouts keep their
+ * persisted spans — defaults only affect newly added widgets.
+ */
+
 /**
  * Quick Actions Widget
  * Essential operations for conference management
@@ -63,7 +72,9 @@ export const REVIEW_PROGRESS_WIDGET = defineWidget({
   category: 'core',
   icon: 'ChartPieIcon',
   constraints: {
-    minCols: 2,
+    // Mins match the smallest availableSize (3×2) — the old minCols 2 was
+    // below every offered size and only reachable via manual resize.
+    minCols: 3,
     maxCols: 4,
     minRows: 2,
     maxRows: 4,
@@ -265,13 +276,14 @@ export const CFP_HEALTH_WIDGET = defineWidget({
     minRows: 3,
     maxRows: 7,
   },
+  // 3×6 (≈636px) was sparse for the ~350px operational view → 3×4 (≈412px).
   defaultSize: {
     name: 'narrow',
     colSpan: 3,
-    rowSpan: 6,
+    rowSpan: 4,
   },
   availableSizes: [
-    { name: 'narrow', colSpan: 3, rowSpan: 6 },
+    { name: 'narrow', colSpan: 3, rowSpan: 4 },
     { name: 'small', colSpan: 4, rowSpan: 4 },
     { name: 'medium', colSpan: 6, rowSpan: 4 },
     { name: 'large', colSpan: 8, rowSpan: 5 },
@@ -378,10 +390,12 @@ export const TICKET_SALES_WIDGET = defineWidget({
     minRows: 3,
     maxRows: 6,
   },
+  // The full sales view (stats + gauge + trend + countdown) measures ≈470px;
+  // the old 6×3 default (≈300px) forced immediate scrolling → 6×4 (≈412px).
   defaultSize: {
-    name: 'compact',
+    name: 'medium',
     colSpan: 6,
-    rowSpan: 3,
+    rowSpan: 4,
   },
   availableSizes: [
     { name: 'narrow', colSpan: 3, rowSpan: 4 },
@@ -508,15 +522,18 @@ export const SPONSOR_PIPELINE_WIDGET = defineWidget({
     maxRows: 10,
     prefersLandscape: true,
   },
+  // The operational view (stats + revenue bar + 4 pipeline stages) measures
+  // ≈420px; the old 6×9 default (≈972px) left over 500px of dead space →
+  // 6×4 (≈412px). The 6×9 'tall' preset is dropped for the same reason.
   defaultSize: {
-    name: 'tall',
+    name: 'medium',
     colSpan: 6,
-    rowSpan: 9,
+    rowSpan: 4,
   },
   availableSizes: [
     { name: 'compact', colSpan: 5, rowSpan: 4 },
-    { name: 'medium', colSpan: 6, rowSpan: 5 },
-    { name: 'tall', colSpan: 6, rowSpan: 9 },
+    { name: 'medium', colSpan: 6, rowSpan: 4 },
+    { name: 'tall', colSpan: 6, rowSpan: 5 },
     { name: 'large', colSpan: 8, rowSpan: 5 },
     { name: 'full', colSpan: 12, rowSpan: 5 },
   ],
@@ -573,10 +590,13 @@ export const WORKSHOP_CAPACITY_WIDGET = defineWidget({
     minRows: 2,
     maxRows: 4,
   },
+  // The operational view (3 stat tiles + 3 workshop cards) measures ≈310px;
+  // the old 4×2 default (≈188px) clipped its own default content → 4×3
+  // (≈300px). 3×2/4×2 stay available — they scroll via WidgetBody.
   defaultSize: {
-    name: 'small',
+    name: 'medium',
     colSpan: 4,
-    rowSpan: 2,
+    rowSpan: 3,
   },
   availableSizes: [
     { name: 'compact', colSpan: 3, rowSpan: 2 },
@@ -677,15 +697,18 @@ export const RECENT_ACTIVITY_WIDGET = defineWidget({
     minRows: 2,
     maxRows: 10,
   },
+  // A 10-item page measures ≈600px, so the old 3×10 default (≈1084px) was
+  // half-empty; pages also scroll now → 3×4 (≈412px, ~6 items visible).
+  // The 3×10 'narrow-tall' preset is dropped for the same reason.
   defaultSize: {
-    name: 'narrow-tall',
+    name: 'small',
     colSpan: 3,
-    rowSpan: 10,
+    rowSpan: 4,
   },
   availableSizes: [
     { name: 'compact', colSpan: 3, rowSpan: 2 },
+    { name: 'small', colSpan: 3, rowSpan: 4 },
     { name: 'narrow', colSpan: 3, rowSpan: 5 },
-    { name: 'narrow-tall', colSpan: 3, rowSpan: 10 },
     { name: 'medium', colSpan: 6, rowSpan: 4 },
     { name: 'large', colSpan: 8, rowSpan: 4 },
     { name: 'wide', colSpan: 12, rowSpan: 4 },

--- a/src/lib/dashboard/widget-registry.ts
+++ b/src/lib/dashboard/widget-registry.ts
@@ -550,6 +550,10 @@ export const SPONSOR_PIPELINE_WIDGET = defineWidget({
   },
   // NOTE: the revenue target has NO config knob here — it comes from the
   // canonical conference setting (sponsorRevenueGoal) via the fetch action.
+  // `showContractStatus` was removed: the widget never rendered contract
+  // status and the fetch action returns no such data, so the knob was a
+  // no-op. Stored configs still carrying the key are harmless — the zod
+  // parse strips unknown keys.
   configSchema: {
     fields: {
       showPipeline: {
@@ -559,17 +563,9 @@ export const SPONSOR_PIPELINE_WIDGET = defineWidget({
         defaultValue: true,
         schema: z.boolean(),
       },
-      showContractStatus: {
-        type: 'boolean',
-        label: 'Show Contract Status',
-        description: 'Display contract signing status',
-        defaultValue: true,
-        schema: z.boolean(),
-      },
     },
     schema: z.object({
       showPipeline: z.boolean(),
-      showContractStatus: z.boolean(),
     }),
   } satisfies WidgetConfigSchema,
 })


### PR DESCRIPTION
Structural height/size fixes for the admin dashboard widgets, from the adversarial widget inventory. All line references re-verified against `main` at branch time.

## A. House height contract — scroll beats clip

New `WidgetBody` primitive in `src/components/admin/dashboard/widgets/shared.tsx`: `min-h-0 flex-1 overflow-y-auto overscroll-contain`, documented as THE contract — a widget's variable-height content lives inside it so overflow scrolls instead of silently clipping against `WidgetContainer`'s `overflow-hidden`. Platform-default scrollbars (matching the widgets that already scrolled), `overscroll-contain` per the ModalShell/BottomSheet convention, and a documented centering caveat (center an inner wrapper with `m-auto`, never `justify-center` on the scroll region — centered overflow clips at the top unreachably).

Applied to every clipping root from the inventory (all confirmed on re-verification):

- workshop-capacity: planning (~l.54), post-conference (~l.106) and operational (~l.161–238) branches
- sponsor-pipeline: prospecting (~l.67), post-conference (~l.110) and operational (~l.174–305) branches
- travel-support: planning (~l.69), post-conference (~l.108) and operational (~l.165–258) branches
- schedule-builder operational (~l.120–211)
- cfp-health operational root (~l.252–411; its phase views already scrolled and are untouched)
- speaker-engagement initialization (~l.45–119; the "Manage speakers" link stays pinned outside the scroll region) and planning (~l.216–291; the two `min-h-0 flex-1` halves keep `flex-1` but drop `min-h-0` so they floor at content height — that is what makes the body scroll instead of crushing text)
- my-areas (`MyAreasView`)
- review-progress operational: the `overflow-hidden` content region (~l.133) is now a scrolling `WidgetBody` with an `m-auto`-centered inner wrapper

Drop-in migrations of already-correct scrolling regions (identical classes, zero behavior change): proposal-pipeline (all three views), upcoming-deadlines list, ticket-sales zero-sales + full views. **Skipped** (not drop-ins): the `justify-center + overflow-y-auto` phase views in cfp-health/review-progress/schedule-builder/ticket-sales — migrating them into WidgetBody would violate its documented centering caveat or require restructuring; they already scroll and are left as-is.

Removed the width-keyed `nth-child` item caps in the workshop-capacity, travel-support and schedule-builder lists: they hid items by container WIDTH to dodge vertical clipping (the exact width-only adaptation the inventory flagged). With a scrolling body every item is rendered and reachable. This is a deliberate behavior change, called out here.

`SwipeablePaginationWidget` (~l.154): each carousel page now has `overflow-y-auto` so items beyond the visible height are reachable; `touch-pan-y` already hands mostly-vertical touch gestures to native scrolling, so the horizontal swipe mechanics are unchanged.

## B. Registry size calibration

Content height ≈ 112·rowSpan − 36 px (cellSize 96, gap 16). **Stored user layouts keep their persisted sizes — defaults only affect newly added widgets.**

| Widget | Default | Why |
|---|---|---|
| workshop-capacity | 4×2 → **4×3** | operational view ≈310px clipped its own default; min 3×2 kept (scrolls via A) |
| sponsor-pipeline | 6×9 → **6×4** | operational ≈420px vs ≈972px slot (~550px dead); `tall` availableSize 6×9 → 6×5 |
| recent-activity | 3×10 → **3×4** | 10-item page ≈600px, half-empty at ≈1084px; pages scroll; `narrow-tall` 3×10 dropped, `small` 3×4 added |
| ticket-sales | 6×3 → **6×4** | full sales view ≈470px vs ≈300px (judgment call beyond the inventory list) |
| cfp-health | 3×6 → **3×4** | operational ≈350px was sparse at ≈636px; `narrow` availableSize follows |
| review-progress | constraints minCols 2 → **3** | old min was below every availableSize (smallest is 3×2) |

All presets in `presets.ts` were checked against the tightened constraints — every preset widget already satisfies them.

## C. Minima enforcement end-to-end

1. **Resize (`WidgetContainer` ~l.150):** the grid-boundary cap ran AFTER the registry clamp and could push `colSpan` below `minCols` near the right edge. New rule (commented in code): if the space right of the widget's column can't fit `minCols`, horizontal resize is **frozen at the current span** — any clamp there would overflow the grid or violate the minimum — while vertical resize still works; otherwise the edge cap applies as before, never below `minCols`.
2. **Load (`AdminDashboard` ~l.147):** stored spans are clamped into each widget's registry min/max on load (row/col preserved; unknown types pass through untouched for the placeholder path). Commented that server validation is generic-bounds only. The normalized layout is not echo-saved.
3. **Save (`actions.ts`, `validateDashboardWidgets`):** spans outside the widget type's own registry constraints are now **rejected** with a descriptive error (consistent with the validator's style), on top of the generic bounds. Unknown types were already rejected.

## D. Fetch/branch normalization

Rule: a phase branch that renders static content neither fetches nor skeletons — `useWidgetData` gets a `null` fetcher for it; remaining branches order loading → error → data. Static-vs-data-dependent was verified per widget:

- **Gated** (static views): upcoming-deadlines (initialization + post-conference — this also kills the error masking, since nothing is fetched there), recent-activity (initialization; its post-conference branch is data-dependent, KEEPS fetching, and now sits after loading/error so a failed fetch shows the error state instead of a "Conference Complete" card), cfp-health (initialization countdown uses conference dates only), schedule-builder, ticket-sales and review-progress (initialization setup guides).
- **Deliberately NOT gated**, with comments in each: workshop-capacity, travel-support, sponsor-pipeline (their init/planning branches are conditioned on fetched data and/or render it) and speaker-engagement (its initialization view renders fetched featured/registered counts). These four **refute** the inventory's blanket claim that they "skeleton static init views while fetching data they won't use" — their init views are not static.

## E. Edit-mode chrome

`WidgetContainer` (~l.330): replaced the `[&_h3:first-of-type]:ml-20` hack (dots overlapped every branch without a leading `h3`, and crushed narrow headers) with a uniform `pt-10` on the content wrapper in edit mode — the window-control dots layer never overlaps any state. View-mode layout is pixel-identical.

## F. Drift cleanup

- workshop-capacity: dead `@container:grid-cols-1` class removed (`@container` is not a Tailwind variant).
- sponsor-pipeline `showContractStatus` knob removed from registry schema + component interface — the widget never rendered contract status and the fetch action returns no such data (verified against `SponsorPipelineWidgetData`), consistent with the batch-3 policy. Stored configs still carrying the key are harmless (zod strips unknown keys — covered by an existing registry test).
- review-progress post-conference inline "no review data" div → `WidgetEmptyState`.
- sponsor-pipeline double-wrapped `ProgressBar` track (~l.225) → `ProgressBar` directly.
- Headers → `WidgetHeader`: quick-actions, cfp-health operational (days-remaining span passed as `badge`), speaker-engagement initialization (its badge markup is an exact `PhaseBadge` purple match) and planning (header margin follows the house `mb-3`, was `mb-1.5` — 6px absorbed by the flexible halves; the one non-pixel-identical migration). **Skipped:** speaker-engagement execution/post-conference headers (icon-led layout, not drop-ins).
- Progress bars → shared `ProgressBar`: proposal-pipeline (all four stage bars, with aria labels), workshop-capacity per-workshop bars, schedule-builder by-day bars. **Skipped:** cfp-health's goal mini-bar (custom green-tinted track `bg-green-300/50`, not a drop-in) and its multi-segment format-distribution bar (not a progress bar).

## Tests & verification

- `WidgetContainer.test.tsx`: edge-cap + freeze cases for the new resize rule; min-clamp expectation updated for minCols 3.
- `AdminDashboard.test.tsx`: load normalization (stored 1×1 sponsor-pipeline → clamped to its 5×4 minimum; unknown type untouched; no echo-save).
- `__tests__/lib/dashboard/actions.test.ts`: per-widget span rejection + at-minimum acceptance.
- New `__tests__/components/admin/dashboard/widget-shared.test.tsx` pinning WidgetBody's contract classes.
- Full suite: 281 files, 3868 passed / 5 skipped. `tsc --noEmit`, eslint (one pre-existing warning in untouched `DiscountCodeManager.tsx`), prettier — all green.
- Visual (`pnpm shoot`, 393px, light + dark): WidgetStates story (skeleton/empty/error/ProgressBar) and MyAreasView (default/dark/no-teams) inspected. **Not visually verified on this branch:** the per-widget operational/phase views, SwipeablePagination scrolling and edit-mode chrome — the widget matrix stories land on the parallel Storybook branch; full visual verification of every widget belongs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes dashboard widget sizing, scrolling, and phase behavior. The main changes are:

- Adds shared scrollable body, header, badge, and progress primitives.
- Recalibrates default widget sizes and registry constraints.
- Enforces widget minima during load, resize, and save.
- Skips data fetching for static phase views.
- Reserves consistent edit-mode space for widget controls.

<h3>Confidence Score: 4/5</h3>

Stored-layout normalization and static-phase error handling need fixes before merging.

- Span expansion can place persisted widgets outside the grid or over neighboring widgets.
- A previous fetch error can mask a later static phase after conference dates change.
- One migrated progress indicator lacks an accessible name.

AdminDashboard.tsx and the widgets that check fetch errors before their static initialization branch.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/admin/dashboard/AdminDashboard.tsx | Normalizes stored spans but does not reconcile the resulting grid placement. |
| src/components/admin/dashboard/WidgetContainer.tsx | Adds minimum-aware edge resizing and uniform edit-mode clearance. |
| src/app/(admin)/admin/actions.ts | Adds registry-specific span validation to dashboard saves. |
| src/lib/dashboard/widget-registry.ts | Updates defaults, constraints, available sizes, and sponsor configuration. |
| src/components/admin/dashboard/widgets/shared.tsx | Introduces the shared widget body and presentation primitives. |
| src/components/admin/dashboard/widgets/CFPHealthWidget.tsx | Adds fetch gating and scrolling but can retain an earlier fetch error in the static phase. |
| src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx | Adds fetch gating and shared primitives, including an unnamed progress indicator. |
| src/components/admin/dashboard/widgets/RecentActivityFeedWidget.tsx | Keeps post-conference fetching and correctly exposes loading and error states. |
| src/components/admin/dashboard/widgets/SwipeablePaginationWidget.tsx | Makes carousel pages vertically scrollable while retaining horizontal swipes. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx`, line 299-306 ([link](https://github.com/cloudnativebergen/website/blob/f9f7b7ee611b317160f8e8c07e915960bfe9db75/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx#L299-L306)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Progress Bar Has No Name**

   This migration adds `role="progressbar"` through the shared component but does not pass its `label` prop. Assistive technology therefore encounters an unnamed progress indicator and cannot identify what the reported percentage represents.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): drift cleanup — shared p..."](https://github.com/cloudnativebergen/website/commit/f9f7b7ee611b317160f8e8c07e915960bfe9db75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46131094)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->