### PR TITLE
fix(dashboard): widget matrix residuals — post-merge sweep, dark gauge, edit-chrome sync

### DIFF
--- a/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
+++ b/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
@@ -329,8 +329,16 @@ export function CFPHealthWidget({ conference, config }: CFPHealthWidgetProps) {
               {data.submissionsPerDay.map((day, index) => {
                 const height = (day.count / maxSubmissions) * 100
                 const date = new Date(day.date + 'T00:00:00Z')
-                const dateLabel = date.toLocaleDateString('en-US', {
+                // Month and day rendered as two fixed lines: a single-line
+                // "Jun 10" wraps in narrow columns while "Jun 1" does not,
+                // and in a bottom-aligned flex row that mixed 1-/2-line
+                // wrapping made columns ragged (value labels at differing
+                // heights, adjacent date labels colliding).
+                const monthLabel = date.toLocaleDateString('en-US', {
                   month: 'short',
+                  timeZone: 'UTC',
+                })
+                const dayLabel = date.toLocaleDateString('en-US', {
                   day: 'numeric',
                   timeZone: 'UTC',
                 })
@@ -349,8 +357,10 @@ export function CFPHealthWidget({ conference, config }: CFPHealthWidgetProps) {
                         style={{ height: `${height}%`, minHeight: '4px' }}
                       />
                     </div>
-                    <span className="mt-0.5 text-[8px] leading-tight text-gray-400 dark:text-gray-500">
-                      {dateLabel}
+                    <span className="mt-0.5 text-center text-[8px] leading-tight text-gray-400 dark:text-gray-500">
+                      {monthLabel}
+                      <br />
+                      {dayLabel}
                     </span>
                   </div>
                 )

--- a/src/components/admin/dashboard/widgets/QuickActionsWidget.tsx
+++ b/src/components/admin/dashboard/widgets/QuickActionsWidget.tsx
@@ -20,6 +20,7 @@ import {
   WidgetEmptyState,
   WidgetErrorState,
   WidgetHeader,
+  WidgetBody,
 } from './shared'
 
 const iconMap = {
@@ -69,35 +70,41 @@ export function QuickActionsWidget({ conference }: QuickActionsWidgetProps) {
   return (
     <div className="flex h-full flex-col">
       <WidgetHeader title="Quick Actions" />
-      {/* Compact 3-column grid to show all 6 actions */}
-      <div className="grid flex-1 auto-rows-fr grid-cols-3 gap-1.5 @[300px]:gap-2">
-        {actions.map((action) => {
-          const IconComponent =
-            iconMap[action.icon as keyof typeof iconMap] || CalendarIcon
-          const variantClass =
-            variantStyles[action.variant] || variantStyles.secondary
+      {/* Compact 3-column grid to show all 6 actions. Wrapped in WidgetBody
+          (min-h-0 flex-1 overflow-y-auto) so a squeezed cell — e.g. edit
+          mode's pt-10 strip at the 3x2 default — scrolls instead of
+          hard-clipping the second action row; min-h-full keeps auto-rows-fr
+          filling the body when everything fits. */}
+      <WidgetBody>
+        <div className="grid min-h-full auto-rows-fr grid-cols-3 gap-1.5 @[300px]:gap-2">
+          {actions.map((action) => {
+            const IconComponent =
+              iconMap[action.icon as keyof typeof iconMap] || CalendarIcon
+            const variantClass =
+              variantStyles[action.variant] || variantStyles.secondary
 
-          return (
-            <Link
-              key={action.label}
-              href={action.link}
-              className={`group relative flex flex-col items-center justify-center gap-1 rounded-lg p-2 transition-all @[300px]:gap-1.5 @[300px]:p-2.5 ${variantClass}`}
-            >
-              {action.badge !== undefined && action.badge > 0 && (
-                <span className="absolute top-1 right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-white px-1 text-[10px] font-bold text-gray-900 @[300px]:top-1.5 @[300px]:right-1.5">
-                  {action.badge > 99 ? '99+' : action.badge}
+            return (
+              <Link
+                key={action.label}
+                href={action.link}
+                className={`group relative flex flex-col items-center justify-center gap-1 rounded-lg p-2 transition-all @[300px]:gap-1.5 @[300px]:p-2.5 ${variantClass}`}
+              >
+                {action.badge !== undefined && action.badge > 0 && (
+                  <span className="absolute top-1 right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-white px-1 text-[10px] font-bold text-gray-900 @[300px]:top-1.5 @[300px]:right-1.5">
+                    {action.badge > 99 ? '99+' : action.badge}
+                  </span>
+                )}
+                {/* Responsive icon sizing */}
+                <IconComponent className="h-5 w-5 shrink-0 @[250px]:h-6 @[250px]:w-6 @[400px]:h-7 @[400px]:w-7" />
+                {/* Use short labels for compact display */}
+                <span className="text-center text-[10px] leading-tight font-medium @[300px]:text-[11px]">
+                  {action.shortLabel || action.label}
                 </span>
-              )}
-              {/* Responsive icon sizing */}
-              <IconComponent className="h-5 w-5 shrink-0 @[250px]:h-6 @[250px]:w-6 @[400px]:h-7 @[400px]:w-7" />
-              {/* Use short labels for compact display */}
-              <span className="text-center text-[10px] leading-tight font-medium @[300px]:text-[11px]">
-                {action.shortLabel || action.label}
-              </span>
-            </Link>
-          )
-        })}
-      </div>
+              </Link>
+            )
+          })}
+        </div>
+      </WidgetBody>
     </div>
   )
 }

--- a/src/components/admin/dashboard/widgets/__matrix__/RecentActivity.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/RecentActivity.matrix.stories.tsx
@@ -169,7 +169,7 @@ export const KnownRiskCells: Story = {
     docs: {
       description: {
         story:
-          'The two flagged cells: 3x2 with a dense paginated feed (header + pager chrome in a 2-row cell) and the 3x10 default with only 2 items (dead space).',
+          'The two flagged cells: 3x2 with a dense paginated feed (header + pager chrome in a 2-row cell) and 3x10 with only 2 items (the pre-recalibration default, now a user-chosen oversize; the registry default is 3x4, covered sparse in AllStatesDefaultSize).',
       },
     },
   },

--- a/src/components/admin/dashboard/widgets/__matrix__/ReviewProgress.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/ReviewProgress.matrix.stories.tsx
@@ -149,7 +149,7 @@ export const Phases: Story = {
 export const KnownRiskCells: Story = {
   render: () => (
     <MatrixGrid>
-      <WidgetFrame label="min operational" colSpan={2} rowSpan={2}>
+      <WidgetFrame label="min operational" colSpan={3} rowSpan={2}>
         <ReviewProgressWidget conference={dense} />
       </WidgetFrame>
     </MatrixGrid>
@@ -158,7 +158,7 @@ export const KnownRiskCells: Story = {
     docs: {
       description: {
         story:
-          'The true 2x2 registry minimum with the full operational view (progress ring + stats + CTA) — the known layout-stress cell for this widget.',
+          'The true 3x2 registry minimum (minCols was raised from 2 to 3) with the full operational view (progress ring + stats + CTA) — the known layout-stress cell for this widget.',
       },
     },
   },

--- a/src/components/admin/dashboard/widgets/__matrix__/SponsorPipeline.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/SponsorPipeline.matrix.stories.tsx
@@ -143,7 +143,7 @@ export const KnownRiskCells: Story = {
       <WidgetFrame label="min/compact operational" colSpan={5} rowSpan={4}>
         <SponsorPipelineWidget conference={dense} />
       </WidgetFrame>
-      <WidgetFrame label="default/tall operational" colSpan={6} rowSpan={9}>
+      <WidgetFrame label="oversized (old default)" colSpan={6} rowSpan={9}>
         <SponsorPipelineWidget conference={dense} />
       </WidgetFrame>
     </MatrixGrid>
@@ -152,7 +152,7 @@ export const KnownRiskCells: Story = {
     docs: {
       description: {
         story:
-          'The two flagged operational cells: 5x4 (compact/min — 4 pipeline stages in 4 rows) and 6x9 (the tall default — check for dead space below the stages).',
+          'The two flagged operational cells: 5x4 (compact/min — 4 pipeline stages in 4 rows) and 6x9 (the pre-recalibration default, now a user-chosen oversize — dead space below the stages is inherent to the fixed content).',
       },
     },
   },

--- a/src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx
@@ -67,15 +67,29 @@ setMockActionFor(
   mockResolved(ticketSalesUnconfigured),
 )
 
-/** The widget calls next-themes useTheme() for chart theming. */
-const withNextThemes: Decorator = (Story, ctx) => (
-  <ThemeProvider
-    attribute="class"
-    forcedTheme={ctx.globals.theme === 'dark' ? 'dark' : 'light'}
-  >
-    <Story />
-  </ThemeProvider>
-)
+/**
+ * The widget calls next-themes useTheme().resolvedTheme for chart theming.
+ * NOT forcedTheme: next-themes does not reflect a forced theme into
+ * resolvedTheme (it stays on the stored/system value — light in headless
+ * browsers), so a forcedTheme decorator renders dark stories with
+ * light-themed charts. defaultTheme + enableSystem=false makes
+ * resolvedTheme follow the toolbar; the per-theme storageKey and key
+ * ensure no persisted value or stale provider wins over a toolbar switch.
+ */
+const withNextThemes: Decorator = (Story, ctx) => {
+  const theme = ctx.globals.theme === 'dark' ? 'dark' : 'light'
+  return (
+    <ThemeProvider
+      key={theme}
+      attribute="class"
+      defaultTheme={theme}
+      enableSystem={false}
+      storageKey={`sb-matrix-theme-${theme}`}
+    >
+      <Story />
+    </ThemeProvider>
+  )
+}
 
 const meta = {
   title: 'Systems/Proposals/Admin/Dashboard/Matrix/TicketSales',

--- a/src/components/admin/dashboard/widgets/__matrix__/WidgetFrame.tsx
+++ b/src/components/admin/dashboard/widgets/__matrix__/WidgetFrame.tsx
@@ -11,8 +11,8 @@
  * - Mobile: single-column behaviour (columnCount === 1) — auto height, NO
  *   container-type (container queries fall back to the viewport), 361px wide
  *   (393px iPhone-portrait viewport minus 2x16px page padding).
- * - Edit chrome: the macOS-dots overlay plus the `[&_h3:first-of-type]:ml-20`
- *   header-indent hack, so dot/header overlap cells are inspectable.
+ * - Edit chrome: the macOS-dots overlay plus the uniform `pt-10` top strip
+ *   that edit mode reserves so the dots never overlap widget content.
  *
  * CELL_W = 92px: a 1280px desktop grid with 12 columns and 16px gaps gives
  * (1280 - 11*16) / 12 = 92px per column — the representative desktop cell.
@@ -88,9 +88,7 @@ export function WidgetFrame({
 
         <div
           className={`h-full p-2 ${
-            editMode
-              ? 'pointer-events-none select-none [&_h3:first-of-type]:ml-20'
-              : ''
+            editMode ? 'pointer-events-none pt-10 select-none' : ''
           }`}
         >
           {children}

--- a/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
+++ b/src/components/admin/dashboard/widgets/__matrix__/fixtures.ts
@@ -420,9 +420,14 @@ export const speakerEngagementSparse: SpeakerEngagementData = {
   averageProposalsPerSpeaker: 1.0,
 }
 
-/** Tiny inline SVG the SponsorLogo/InlineSvg pipeline can render offline. */
+/**
+ * Tiny inline SVG the SponsorLogo/InlineSvg pipeline can render offline.
+ * The explicit width/height matter: with only a viewBox the SVG has no
+ * intrinsic size, and inside the logo chip's shrink-to-fit flex context it
+ * resolved to 0x0 (blank chips). Real sponsor logos carry intrinsic sizes.
+ */
 const sponsorLogoSvg = (fill: string): string =>
-  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 16"><rect width="48" height="16" rx="3" fill="${fill}"/><text x="24" y="11.5" font-size="8" fill="#ffffff" text-anchor="middle" font-family="sans-serif">LOGO</text></svg>`
+  `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="16" viewBox="0 0 48 16"><rect width="48" height="16" rx="3" fill="${fill}"/><text x="24" y="11.5" font-size="8" fill="#ffffff" text-anchor="middle" font-family="sans-serif">LOGO</text></svg>`
 
 export const sponsorPipelineDense: SponsorPipelineWidgetData = {
   stages: [

--- a/src/lib/dashboard/chart-theme.ts
+++ b/src/lib/dashboard/chart-theme.ts
@@ -61,6 +61,12 @@ export function getBaseChartOptions(isDark = false): ApexOptions {
   return {
     chart: {
       fontFamily: 'inherit',
+      // Setting `theme.mode` makes ApexCharts paint its own opaque background
+      // panel (white in light, dark gray in dark) behind the plot area — in
+      // dark mode the gauge/trend charts sat on a white rectangle instead of
+      // the card. Force transparency so charts always sit on the card's own
+      // background in both themes.
+      background: 'transparent',
       toolbar: {
         show: false,
       },

--- a/src/lib/dashboard/widget-registry.ts
+++ b/src/lib/dashboard/widget-registry.ts
@@ -779,7 +779,9 @@ export const MY_AREAS_WIDGET = defineWidget({
     minCols: 3,
     maxCols: 6,
     minRows: 2,
-    maxRows: 4,
+    // Content is team-count-driven (realistically ≤3 team cards): at 4 rows
+    // the card is mostly dead space, so cap height at 3 (matrix-sweep verdict).
+    maxRows: 3,
     prefersLandscape: true,
   },
   defaultSize: {


### PR DESCRIPTION
Final residuals pass of the widget state×size audit, run against merged `main` (matrix harness #596 + structural height fixes #597). Every previously-confirmed-broken cell was re-captured light+dark from the matrix stories and inspected; a programmatic clip diagnostic (content overflowing the frame with no scrollable ancestor = HARD-CLIP) backed the visual pass.

## Per-cell classification (post-#597 re-sweep)

| Widget | Cell | Pre-fix finding (#596) | Verdict |
|---|---|---|---|
| workshop-capacity | 4×2 | hard-clip mid-card | **FIXED** — stats + first card, clean card-boundary fold, scrolls |
| workshop-capacity | 3×2 | hard-clip mid-card | **FIXED** — same |
| review-progress | 2×2 | CTA clipped | **FIXED / OBSOLETE** — registry min raised to 3×2; at 3×2 CTA reachable by scroll (risk-cell story synced to 3×2) |
| recent-activity | 3×2 dense | clip + chevron overlap | **FIXED** — 2 items + pager render clean, rest scrolls; chevron is the standard floating pager affordance, no longer colliding |
| recent-activity | 3×4 (new default) dense/sparse | (3×10 was old default) | **FIXED** — dense scrolls, sparse fits with no dead space |
| recent-activity | 3×10 sparse | dead space | **RECLASSIFIED** — 3×10 is no longer the default; dead space at a user-chosen oversize is inherent (story description updated) |
| sponsor-pipeline | 5×4 | "Signed" row clipped | **FIXED** — Signed title + kr 460k visible, only subtext below fold, scrolls |
| sponsor-pipeline | 6×9 | dead space | **RECLASSIFIED** — default is now 6×4 (fits); 6×9 documented as pre-recalibration oversize |
| travel-support | 3×3 | request clipped mid-name | **FIXED** — clean card-top boundary at the fold, queue scrolls |
| ticket-sales | 3×3 / 3×4 | content below fold | **FIXED (by contract)** — scrolls (475px / 363px reachable below fold) |
| cfp-health | 3×3 | legend clip + trend label collision | **FIXED** — legend scrolls; label collision fixed in this PR (see below) |
| schedule-builder | 3×3 | footer clipped | **FIXED** — day rows fit, footer reachable by scroll |
| speaker-engagement | 3×2 init | second card + CTA lost | **FIXED** — card scrolls, "Manage speakers" CTA pinned visible; operational 3×2 fits |
| upcoming-deadlines | 3×2 | 4th row clipped | **FIXED** — 4th row peeks at fold, scrolls |
| my-areas | 3×2 | second card lost | **FIXED** — both team cards render side-by-side |
| my-areas | 6×4 | dead space | **KNOWN-REMAINING** — content is team-count-driven; two-team fixture leaves the max cell sparse. Not touched (see below) |
| edit-chrome overlay cells (all widgets) | dot overlap | **FIXED** — harness synced to the real pt-10 contract; no dot/content overlap in any widget; one real bug found + fixed (quick-actions, below) |

Diagnostic summary after this PR: **zero HARD-CLIP cells** across all captured matrix stories, light and dark.

## Dark-mode gauge root cause (ticket-sales)

Two stacked causes:

1. **App bug** — `theme: { mode }` makes ApexCharts paint its own opaque background panel behind the plot area, so the gauge/trend never sat on the card's background. Fixed in `chart-theme.ts` with `chart.background: 'transparent'` in the shared base options (covers radialBar + line/area for all consumers).
2. **Harness bug** — the matrix story drove next-themes with `forcedTheme`, but next-themes does **not** reflect a forced theme into `resolvedTheme` (which the widget reads), so dark stories rendered light-themed chart options — that's why the panel was *white* rather than apex's dark gray. Story decorator now uses `defaultTheme` + `enableSystem=false` + per-theme `storageKey`/`key` so `resolvedTheme` follows the toolbar.

Verified light+dark: gauge track/labels and the trend chart now follow the palette and sit on the card in both themes.

## Edit-chrome sync + the bug it exposed

`WidgetFrame` now mirrors the current `WidgetContainer` contract exactly: dots overlay + uniform `pt-10` content strip (the `[&_h3:first-of-type]:ml-20` hack is gone). Re-capture of all 13 edit-chrome cells: no overlap anywhere.

The synced harness exposed one real bug: **quick-actions at its 3×2 default hard-clipped its second action row in edit mode** (25px, no scroll path) because the widget bypassed the WidgetBody scroll contract with a bare `flex-1` grid. Fixed by wrapping the grid in `WidgetBody` (with `min-h-full` so `auto-rows-fr` still fills the cell when content fits).

## Other fixes

- **cfp-health trend label raggedness** (visible at 4×4): date labels mixed 1-line ("Jun 1") and 2-line ("Jun 10" wrapped) rendering in bottom-aligned columns, pushing value labels to differing heights and colliding adjacent labels. Now always two fixed lines (month / day) — uniform at every size.
- **Sponsor logo fixtures rendered blank**: the fixture SVG had only a `viewBox`; with no intrinsic size it resolved to 0×0 inside the logo chip's shrink-to-fit flex context. Added `width`/`height` — chips now render (real sponsor logos carry intrinsic sizes, so this was fixture-only).
- **Risk-cell stories synced to the recalibrated registry**: review-progress pinned 2×2 (now below the registry minimum) moved to the true 3×2 min; sponsor-pipeline 6×9 and recent-activity 3×10 relabelled as pre-recalibration oversizes.

## Remaining known issues (not touched, by design)

- **my-areas 6×4 dead space with few teams** — content scales with team count; stretching two cards to fill the max cell would be an opinionated design change. Option if desired: cap `maxRows` at 3.
- **Oversized cells (sponsor 6×9, recent-activity 3×10, ticket-sales 8×6, schedule-builder 6×5) show bottom whitespace** — inherent to fixed-content widgets in user-chosen oversizes; the defaults all fit.
- **Ticket-sales mobile trend chart** — rotated x-labels crowd the y-axis at 361px; cosmetic, readable, out of scope for this pass.
- Fold can land mid-text at extreme minima (e.g. review-progress 3×2 cuts "7.6/10" at the fold) — content is reachable by scroll per the WidgetBody contract; a per-widget compact layout would be structural.

## Verification

- `storybook build --test` green; `test-storybook` full run green (247 suites / 1228 tests, includes all 59 matrix stories)
- `tsc --noEmit`, `eslint`, `prettier --check` green
- `vitest run` green (281 files, 3869 passed / 5 skipped)
- Manual light+dark screenshot inspection of every cell listed above


**Post-review addition:** the `my-areas` maxRows cap (4 → 3) WAS applied in a follow-up commit (contrary to the original text above listing it as untouched) — consistent with the registry-calibration policy. Compat: existing stored 4-row my-areas layouts are clamped to 3 on load by the (designed) load-normalization path from #597; the clamp is render-side only and never echo-saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the dashboard widget matrix cleanup. The main changes are:

- Adds scrolling to the constrained Quick Actions grid.
- Aligns the matrix edit frame with production padding.
- Normalizes CFP trend labels and sponsor-logo fixtures.
- Makes ApexCharts backgrounds transparent and updates dark-theme stories.
- Syncs risk-cell stories with current widget dimensions.

<h3>Confidence Score: 4/5</h3>

The constrained Quick Actions edit-mode path needs a fix before merging.

- The new scroll body addresses clipping in normal mode.
- Edit mode disables pointer input for the whole widget, so the overflow region cannot expose actions below the fold.
- The other changed presentation and fixture paths are consistent with their existing contracts.

src/components/admin/dashboard/widgets/QuickActionsWidget.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/dashboard/widgets/QuickActionsWidget.tsx | Adds a scroll body around the action grid, but edit-mode pointer suppression prevents users from operating that scroll region. |
| src/components/admin/dashboard/widgets/CFPHealthWidget.tsx | Splits trend dates into fixed UTC month and day lines. |
| src/components/admin/dashboard/widgets/__matrix__/WidgetFrame.tsx | Mirrors the production edit-mode top padding in matrix stories. |
| src/components/admin/dashboard/widgets/__matrix__/TicketSales.matrix.stories.tsx | Updates the theme decorator so chart options follow the Storybook toolbar theme. |
| src/components/admin/dashboard/widgets/__matrix__/fixtures.ts | Adds intrinsic dimensions to the inline sponsor-logo fixture. |
| src/lib/dashboard/chart-theme.ts | Makes the shared ApexCharts background transparent. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): cap my-areas maxRows at ..."](https://github.com/cloudnativebergen/website/commit/42457c2a594ef167bb7f306ba25c409fc7acf36f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46139711)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->
