### PR TITLE
fix(modals): migrate schedule AddTrack/ServiceSession onto ModalShell

### DIFF
--- a/src/components/admin/schedule/AddTrackModal.stories.tsx
+++ b/src/components/admin/schedule/AddTrackModal.stories.tsx
@@ -1,10 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { fn } from 'storybook/test'
+import { ThemeProvider } from 'next-themes'
+import { fn, userEvent } from 'storybook/test'
 import { AddTrackModal } from './AddTrackModal'
 
-// The REAL modal — it renders its own fixed overlay and manages its own form
-// state, so it stands alone with just the two callbacks. Footer order follows
-// the house convention: Cancel on the left, the primary action on the right.
+// The REAL modal — it rides on ModalShell (house header with labelled 44px
+// close, backdrop click-to-close, bottom sheet below `sm`, dirty-close guard)
+// and manages its own form state, so it stands alone with just the two
+// callbacks. Footer order follows the house convention: Cancel on the left,
+// the primary action on the right (stacked primary-on-top on mobile).
 
 const meta = {
   title: 'Systems/Program/Admin/AddTrackModal',
@@ -14,10 +17,24 @@ const meta = {
     docs: {
       description: {
         component:
-          'Modal for adding a new track to the schedule editor: a title (required) and an optional description. Escape closes, focus is trapped and restored, and the title input is auto-focused on open.',
+          'Modal for adding a new track to the schedule editor: a title (required) and an optional description. Escape closes, focus is trapped and restored, the title input takes initial focus, and closing with typed-but-unsaved input first asks to confirm discarding.',
       },
     },
   },
+  decorators: [
+    // ModalShell reads `next-themes`; HeadlessUI portals the dialog to
+    // document.body, so the toolbar's decorator wrapper never reaches it.
+    // React context DOES cross portals, so forcing the theme here (synced to
+    // the Storybook theme global) is what actually renders the modal dark.
+    (Story, context) => (
+      <ThemeProvider
+        attribute="class"
+        forcedTheme={context.globals.theme === 'dark' ? 'dark' : 'light'}
+      >
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
   args: {
     onAdd: fn(),
     onCancel: fn(),
@@ -32,4 +49,16 @@ export const Default: Story = {}
 
 export const Mobile: Story = {
   parameters: { viewport: { defaultViewport: 'mobile1' } },
+}
+
+/**
+ * The dirty-close guard: a play function types into the title field and then
+ * presses Escape, so the in-dialog "Discard unsaved changes?" confirm is
+ * captured in screenshots.
+ */
+export const DirtyCloseConfirm: Story = {
+  play: async () => {
+    await userEvent.keyboard('Platform Engineering')
+    await userEvent.keyboard('{Escape}')
+  },
 }

--- a/src/components/admin/schedule/AddTrackModal.stories.tsx
+++ b/src/components/admin/schedule/AddTrackModal.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { ThemeProvider } from 'next-themes'
-import { fn, userEvent } from 'storybook/test'
+import { fn, userEvent, waitFor, within } from 'storybook/test'
 import { AddTrackModal } from './AddTrackModal'
 
 // The REAL modal — it rides on ModalShell (house header with labelled 44px
@@ -58,7 +58,15 @@ export const Mobile: Story = {
  */
 export const DirtyCloseConfirm: Story = {
   play: async () => {
-    await userEvent.keyboard('Platform Engineering')
+    // The dialog is PORTALED to document.body — query there, not the canvas,
+    // and type into the labelled input rather than relying on implicit focus.
+    const body = within(document.body)
+    const input = await body.findByLabelText(/track title/i)
+    await userEvent.type(input, 'Platform Engineering')
     await userEvent.keyboard('{Escape}')
+    // Wait for the dirty-close confirm so the story settles deterministically.
+    await waitFor(() =>
+      body.getByRole('alertdialog', { name: /discard unsaved changes/i }),
+    )
   },
 }

--- a/src/components/admin/schedule/AddTrackModal.tsx
+++ b/src/components/admin/schedule/AddTrackModal.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import React, { useCallback, useRef, useState } from 'react'
-import { useModalA11y } from './useModalA11y'
-
-const CANCEL_BUTTON_STYLE =
-  'flex-1 rounded-md bg-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 dark:bg-gray-600 dark:text-gray-300 dark:hover:bg-gray-500'
+import React, { useCallback, useState } from 'react'
+import { ViewColumnsIcon } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
 
 export const AddTrackModal = ({
   onAdd,
@@ -15,12 +14,6 @@ export const AddTrackModal = ({
 }) => {
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
-  const dialogRef = useRef<HTMLDivElement>(null)
-
-  // Modal semantics: Escape closes, focus moves in (preferring the autoFocus
-  // title input) and is restored on close, Tab is trapped. Shared with
-  // ServiceSessionModal and the mobile BottomSheet.
-  useModalA11y(dialogRef, onCancel)
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -47,77 +40,82 @@ export const AddTrackModal = ({
   )
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="add-track-modal-title"
-        className="mx-4 w-full max-w-md rounded-lg bg-white p-6 dark:bg-gray-800"
-      >
-        <h3
-          id="add-track-modal-title"
-          className="mb-4 text-lg font-semibold text-gray-900 dark:text-white"
-        >
-          Add New Track
-        </h3>
+    // ModalShell provides the house dialog semantics this modal used to
+    // hand-roll via useModalA11y: focus trap + restore, Escape close, scroll
+    // lock, labelled 44px header close, backdrop click-to-close, and a bottom
+    // sheet below `sm`. The caller mounts us only while open, so `isOpen` is
+    // constant and the `appear` transition still animates the entry.
+    <ModalShell
+      isOpen
+      onClose={onCancel}
+      size="md"
+      title="Add New Track"
+      icon={<ViewColumnsIcon className="h-5 w-5" />}
+      confirmOnDirtyClose
+      isDirty={title.trim().length > 0 || description.trim().length > 0}
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="title"
+            className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Track Title
+          </label>
+          <input
+            type="text"
+            id="title"
+            value={title}
+            onChange={handleTitleChange}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 transition-colors focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+            placeholder="e.g., Platform Engineering"
+            required
+            // HeadlessUI's focus trap sends initial focus to the first
+            // focusable (the header Close button) unless an element opts in
+            // with data-autofocus — keep the title input as the landing spot.
+            data-autofocus
+          />
+        </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label
-              htmlFor="title"
-              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Track Title
-            </label>
-            <input
-              type="text"
-              id="title"
-              value={title}
-              onChange={handleTitleChange}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 transition-colors focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
-              placeholder="e.g., Platform Engineering"
-              required
-              autoFocus
-            />
-          </div>
+        <div>
+          <label
+            htmlFor="description"
+            className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Description
+          </label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={handleDescriptionChange}
+            className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 transition-colors focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+            rows={3}
+            placeholder="Track description..."
+          />
+        </div>
 
-          <div>
-            <label
-              htmlFor="description"
-              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Description
-            </label>
-            <textarea
-              id="description"
-              value={description}
-              onChange={handleDescriptionChange}
-              className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 transition-colors focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
-              rows={3}
-              placeholder="Track description..."
-            />
-          </div>
-
-          {/* Cancel LEFT, primary RIGHT — mirrors the SendMessageModal footer
-              (the house order); a primary-on-the-left footer read as a bug. */}
-          <div className="flex gap-3 pt-4">
-            <button
-              type="button"
-              onClick={onCancel}
-              className={CANCEL_BUTTON_STYLE}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:bg-blue-700 dark:hover:bg-blue-600"
-            >
-              Add Track
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+        {/* House footer: right-aligned on sm+, stacked with the primary on top
+            on mobile (flex-col-reverse). Cancel stays type="button" (the
+            AdminButton default) so it never submits the form. */}
+        <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row sm:justify-end">
+          <AdminButton
+            variant="secondary"
+            size="md"
+            onClick={onCancel}
+            className="min-h-[44px]"
+          >
+            Cancel
+          </AdminButton>
+          <AdminButton
+            type="submit"
+            color="blue"
+            size="md"
+            className="min-h-[44px]"
+          >
+            Add Track
+          </AdminButton>
+        </div>
+      </form>
+    </ModalShell>
   )
 }

--- a/src/components/admin/schedule/track/ServiceSessionModal.stories.tsx
+++ b/src/components/admin/schedule/track/ServiceSessionModal.stories.tsx
@@ -1,12 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { fn } from 'storybook/test'
+import { ThemeProvider } from 'next-themes'
+import { fn, userEvent } from 'storybook/test'
 import { ServiceSessionModal } from './ServiceSessionModal'
 import type { ScheduleTrack } from '@/lib/conference/types'
 
-// The REAL modal — it renders its own fixed overlay and derives the fitting
-// duration options from the LIVE track passed in, so it stands alone with a
-// small track fixture. Footer order follows the house convention: Cancel left,
-// primary right.
+// The REAL modal — it rides on ModalShell (house header with labelled 44px
+// close, backdrop click-to-close, bottom sheet below `sm`, dirty-close guard)
+// and derives the fitting duration options from the LIVE track passed in, so
+// it stands alone with a small track fixture. Footer order follows the house
+// convention: Cancel left, primary right (stacked primary-on-top on mobile).
 
 // A track with a talk at 10:00–10:30 leaves a 60-minute gap from the 09:00
 // start, so the standard 5/10/15/… duration options that fit are offered.
@@ -30,10 +32,24 @@ const meta = {
     docs: {
       description: {
         component:
-          'Modal for creating a service session (coffee break, lunch, networking, …) in a track. Only durations that fit the free gap until the next item are offered; the create action re-validates against the live track so a rejected add surfaces an inline error instead of silently closing.',
+          'Modal for creating a service session (coffee break, lunch, networking, …) in a track. Only durations that fit the free gap until the next item are offered; the create action re-validates against the live track so a rejected add surfaces an inline error instead of silently closing. Closing with a typed-but-unsaved title first asks to confirm discarding.',
       },
     },
   },
+  decorators: [
+    // ModalShell reads `next-themes`; HeadlessUI portals the dialog to
+    // document.body, so the toolbar's decorator wrapper never reaches it.
+    // React context DOES cross portals, so forcing the theme here (synced to
+    // the Storybook theme global) is what actually renders the modal dark.
+    (Story, context) => (
+      <ThemeProvider
+        attribute="class"
+        forcedTheme={context.globals.theme === 'dark' ? 'dark' : 'light'}
+      >
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
   args: {
     isOpen: true,
     timeSlot: '09:00',
@@ -51,4 +67,16 @@ export const Default: Story = {}
 
 export const Mobile: Story = {
   parameters: { viewport: { defaultViewport: 'mobile1' } },
+}
+
+/**
+ * The dirty-close guard: a play function types into the title field and then
+ * presses Escape, so the in-dialog "Discard unsaved changes?" confirm is
+ * captured in screenshots.
+ */
+export const DirtyCloseConfirm: Story = {
+  play: async () => {
+    await userEvent.keyboard('Coffee Break')
+    await userEvent.keyboard('{Escape}')
+  },
 }

--- a/src/components/admin/schedule/track/ServiceSessionModal.stories.tsx
+++ b/src/components/admin/schedule/track/ServiceSessionModal.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { ThemeProvider } from 'next-themes'
-import { fn, userEvent } from 'storybook/test'
+import { fn, userEvent, waitFor, within } from 'storybook/test'
 import { ServiceSessionModal } from './ServiceSessionModal'
 import type { ScheduleTrack } from '@/lib/conference/types'
 
@@ -76,7 +76,14 @@ export const Mobile: Story = {
  */
 export const DirtyCloseConfirm: Story = {
   play: async () => {
-    await userEvent.keyboard('Coffee Break')
+    // The dialog is PORTALED to document.body — query there, type into the
+    // labelled input, and await the confirm so the story settles.
+    const body = within(document.body)
+    const input = await body.findByLabelText(/session title/i)
+    await userEvent.type(input, 'Coffee Break')
     await userEvent.keyboard('{Escape}')
+    await waitFor(() =>
+      body.getByRole('alertdialog', { name: /discard unsaved changes/i }),
+    )
   },
 }

--- a/src/components/admin/schedule/track/ServiceSessionModal.tsx
+++ b/src/components/admin/schedule/track/ServiceSessionModal.tsx
@@ -51,7 +51,8 @@ const ServiceSessionDialog = ({
   onSave,
 }: Omit<ServiceSessionModalProps, 'isOpen'>) => {
   const [title, setTitle] = useState('')
-  const [duration, setDuration] = useState('10')
+  const DEFAULT_DURATION = '10'
+  const [duration, setDuration] = useState(DEFAULT_DURATION)
   const [error, setError] = useState<string | null>(null)
 
   // Free minutes from the chosen start until the next talk/session (or the end
@@ -133,7 +134,9 @@ const ServiceSessionDialog = ({
       }
       icon={<ClockIcon className="h-5 w-5" />}
       confirmOnDirtyClose
-      isDirty={title.trim().length > 0}
+      // A changed duration is ALSO unsaved intent — without it, Escape/backdrop
+      // after picking a duration (but before typing a title) discards silently.
+      isDirty={title.trim().length > 0 || duration !== DEFAULT_DURATION}
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>

--- a/src/components/admin/schedule/track/ServiceSessionModal.tsx
+++ b/src/components/admin/schedule/track/ServiceSessionModal.tsx
@@ -1,8 +1,11 @@
 'use client'
 
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
+import { ClockIcon } from '@heroicons/react/24/outline'
 import { ScheduleTrack } from '@/lib/conference/types'
 import { Dropdown } from '@/components/Form'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
 import { SERVICE_DURATION_OPTIONS } from '@/lib/schedule/constants'
 import {
   SCHEDULE_END,
@@ -11,7 +14,6 @@ import {
   toMinutes,
 } from '@/lib/schedule/time'
 import { isTrackIntervalFree } from '@/lib/schedule/rules'
-import { useModalA11y } from '../useModalA11y'
 
 interface ServiceSessionModalProps {
   isOpen: boolean
@@ -28,8 +30,9 @@ export const ServiceSessionModal = ({
   onClose,
   onSave,
 }: ServiceSessionModalProps) => {
-  // The dialog is an inner component so its hooks (modal a11y, per-open state)
-  // only run while the modal is actually open.
+  // The dialog is an inner component so its per-open state (title, duration,
+  // error) resets between opens. ModalShell's `appear` transition still
+  // animates the entry on mount.
   if (!isOpen) return null
   return (
     <ServiceSessionDialog
@@ -50,12 +53,6 @@ const ServiceSessionDialog = ({
   const [title, setTitle] = useState('')
   const [duration, setDuration] = useState('10')
   const [error, setError] = useState<string | null>(null)
-  const dialogRef = useRef<HTMLDivElement>(null)
-
-  // Modal semantics: Escape closes, focus moves in (preferring the autoFocus
-  // title input) and is restored on close, Tab is trapped. Shared with
-  // AddTrackModal and the mobile BottomSheet.
-  useModalA11y(dialogRef, onClose)
 
   // Free minutes from the chosen start until the next talk/session (or the end
   // of the day). Recomputed from the LIVE track so a schedule change while the
@@ -117,90 +114,98 @@ const ServiceSessionDialog = ({
   )
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="service-session-modal-title"
-        className="mx-4 w-full max-w-md rounded-lg bg-white p-6 dark:bg-gray-800"
-      >
-        <h3
-          id="service-session-modal-title"
-          className="mb-4 text-lg font-semibold text-gray-900 dark:text-white"
-        >
-          Create Service Session
-        </h3>
-        <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+    // ModalShell provides the house dialog semantics this modal used to
+    // hand-roll via useModalA11y: focus trap + restore, Escape close, scroll
+    // lock, labelled 44px header close, backdrop click-to-close, and a bottom
+    // sheet below `sm`. HeadlessUI's Dialog portals to document.body — outside
+    // the schedule editor's DndContext DOM, which is fine: React context flows
+    // through portals and the modal only opens from a click, never mid-drag.
+    <ModalShell
+      isOpen
+      onClose={onClose}
+      size="md"
+      title="Create Service Session"
+      subtitle={
+        <>
           Starting at {timeSlot}
           {maxDurationMin > 0 && ` · up to ${maxDurationMin} min available`}
-        </p>
+        </>
+      }
+      icon={<ClockIcon className="h-5 w-5" />}
+      confirmOnDirtyClose
+      isDirty={title.trim().length > 0}
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="title"
+            className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Session Title
+          </label>
+          <input
+            type="text"
+            id="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 transition-colors focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+            placeholder="e.g., Coffee Break, Lunch, Networking"
+            required
+            // HeadlessUI's focus trap sends initial focus to the first
+            // focusable (the header Close button) unless an element opts in
+            // with data-autofocus — keep the title input as the landing spot.
+            data-autofocus
+          />
+        </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label
-              htmlFor="title"
-              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Session Title
-            </label>
-            <input
-              type="text"
-              id="title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 transition-colors focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
-              placeholder="e.g., Coffee Break, Lunch, Networking"
-              required
-              autoFocus
-            />
-          </div>
+        <div>
+          <Dropdown
+            name="duration"
+            label="Duration (minutes)"
+            options={durationOptions}
+            value={effectiveDuration}
+            setValue={(val) => {
+              setDuration(val)
+              setError(null)
+            }}
+            disabled={nothingFits}
+          />
+        </div>
 
-          <div>
-            <Dropdown
-              name="duration"
-              label="Duration (minutes)"
-              options={durationOptions}
-              value={effectiveDuration}
-              setValue={(val) => {
-                setDuration(val)
-                setError(null)
-              }}
-              disabled={nothingFits}
-            />
-          </div>
+        {(error || nothingFits) && (
+          <p
+            role="alert"
+            className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
+          >
+            {nothingFits
+              ? 'This slot is no longer free — close and pick another.'
+              : error}
+          </p>
+        )}
 
-          {(error || nothingFits) && (
-            <p
-              role="alert"
-              className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-300"
-            >
-              {nothingFits
-                ? 'This slot is no longer free — close and pick another.'
-                : error}
-            </p>
-          )}
-
-          {/* Cancel LEFT, primary RIGHT — mirrors the SendMessageModal footer
-              (the house order); a primary-on-the-left footer read as a bug. */}
-          <div className="flex gap-3 pt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 rounded-md bg-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-400 focus:ring-2 focus:ring-gray-500 focus:outline-none dark:bg-gray-600 dark:text-gray-300 dark:hover:bg-gray-500"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={nothingFits}
-              className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
-            >
-              Create Session
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+        {/* House footer: right-aligned on sm+, stacked with the primary on top
+            on mobile (flex-col-reverse). Cancel stays type="button" (the
+            AdminButton default) so it never submits the form. */}
+        <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row sm:justify-end">
+          <AdminButton
+            variant="secondary"
+            size="md"
+            onClick={onClose}
+            className="min-h-[44px]"
+          >
+            Cancel
+          </AdminButton>
+          <AdminButton
+            type="submit"
+            color="blue"
+            size="md"
+            disabled={nothingFits}
+            className="min-h-[44px]"
+          >
+            Create Session
+          </AdminButton>
+        </div>
+      </form>
+    </ModalShell>
   )
 }


### PR DESCRIPTION
Batch 3 of the modal audit: migrates the desktop schedule editor's modal pair — **AddTrackModal** and **ServiceSessionModal** — off their bespoke fixed-overlay shell and onto the canonical `ModalShell`.

## What was wrong (audit findings, re-verified)

- Backdrop was a plain `div` — clicking it did nothing, unlike every other modal in the app.
- No close control at all (no header X).
- Centered `mx-4` card at `<sm` instead of the house bottom sheet.
- Dark panel `bg-gray-800` vs the house `gray-900`.
- Full-width paired footer buttons instead of the right-aligned house bar.
- No dirty-close guard: typed-but-unsaved form input was silently discarded.

## What changed

- Both modals render through `ModalShell`: standard header (icon + title + labelled 44×44 close), backdrop/Escape close, bottom sheet below `sm` (rounded top, flush to the viewport bottom, safe-area padded), house dark palette.
- `confirmOnDirtyClose` wired to form state (track title/description; session title) — backdrop click / Escape / header X first show the in-dialog "Discard unsaved changes?" confirm.
- House footer: right-aligned on `sm+`, `flex-col-reverse` stacked with the primary on top on mobile; `AdminButton` blue primary with `type="submit"`, secondary Cancel (`type="button"` via the AdminButton default).
- Initial focus stays on the title input via `data-autofocus` (HeadlessUI's trap would otherwise land on the header close button).
- `useModalA11y` dropped here — HeadlessUI Dialog provides the trap/Escape/scroll-lock/focus-restore. (The hook remains; the mobile BottomSheet and SendMessageModal still use it.)

## What was deliberately preserved

- Form semantics and schedule-editor callbacks are byte-for-byte: `onAdd`/`onCancel`, `onClose`/`onSave`, the ServiceSession duration-fitting from the LIVE track, and the reducer-rule re-validation with inline errors.
- Cancel-left/primary-right order, explicit button types.

## Drag-drop / portal interaction

`ServiceSessionModal` mounts inside the editor's `DndContext` (via `DroppableTrack`); HeadlessUI portals the dialog to `document.body`, outside that DOM tree. This is safe: React context crosses portals, the modal only opens from a click (never mid-drag), and dnd-kit sensors only attach to draggable elements. `AddTrackModal` was already rendered outside the `DndContext`. The mobile schedule flow's `BottomSheet` is untouched.

## QA

- `pnpm shoot` (via a scratchpad twin on :6016 — :6006 was occupied by another worktree's Storybook) at 393×852 and 1280×800, light + dark, for both modals plus the new `DirtyCloseConfirm` stories. Verified: full-width sheet flush to the bottom edge at 393px, centered 448px card on desktop, 44×44 labelled close, stacked/right-aligned footers, gray-900 dark panel, discard confirm rendering in both themes.
- Stories updated: next-themes decorator (the portal escapes Storybook's theme wrapper) + a `DirtyCloseConfirm` play story per modal.
- `tsc`, `eslint`, `prettier` clean; full vitest suite green (281 files, 3869 passed / 5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the schedule editor’s Add Track and Service Session dialogs onto the shared modal shell. The main changes are:

- Standard responsive modal presentation and accessible close controls.
- Dirty-close confirmation for unsaved form state.
- Shared admin footer buttons and initial title-field focus.
- Portal-aware Storybook themes and dirty-close stories.

<h3>Confidence Score: 4/5</h3>

The dirty-close flow needs fixes before merging because several close paths can still discard edited form state.

- Both footer Cancel buttons bypass ModalShell’s confirmation handler.
- A duration-only Service Session edit is treated as clean and can be discarded immediately.
- The remaining modal migration and import changes appear compatible with current callers.

src/components/admin/schedule/AddTrackModal.tsx; src/components/admin/schedule/track/ServiceSessionModal.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/schedule/AddTrackModal.tsx | Migrates the form to ModalShell, but footer cancellation bypasses dirty-close confirmation. |
| src/components/admin/schedule/track/ServiceSessionModal.tsx | Migrates the form to ModalShell, but footer cancellation and duration-only edits are not guarded. |
| src/components/admin/schedule/AddTrackModal.stories.tsx | Adds portal-aware theme handling and a dirty-close interaction story. |
| src/components/admin/schedule/track/ServiceSessionModal.stories.tsx | Adds portal-aware theme handling and a dirty-close interaction story. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(modals): migrate schedule AddTrack/S..."](https://github.com/cloudnativebergen/website/commit/733360929821f11211f6e14fa3f6fb89e51fd655) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46275647)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->