### PR TITLE
fix(modals): public-surface compliance — gallery lightbox, workshop signup, dirty guards

### DIFF
--- a/src/components/GalleryModal.stories.tsx
+++ b/src/components/GalleryModal.stories.tsx
@@ -1,143 +1,125 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import {
-  XMarkIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-} from '@heroicons/react/24/outline'
+import { http, HttpResponse } from 'msw'
+import { fn } from 'storybook/test'
+import { GalleryModal } from './GalleryModal'
+import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
+
+// Renders the REAL GalleryModal (previously this story was a static visual
+// mock, so captures never exercised the actual component). The global
+// Session/TRPC decorators provide the providers it needs; MSW serves
+// placeholder images for the Sanity CDN URLs the image builder produces and
+// answers the `gallery.untagSelf` tRPC mutation.
+
+function mockImage(
+  id: string,
+  overrides: Partial<GalleryImageWithSpeakers>,
+): GalleryImageWithSpeakers {
+  return {
+    _id: id,
+    _rev: 'r1',
+    _createdAt: '2025-06-12T10:00:00Z',
+    _updatedAt: '2025-06-12T10:00:00Z',
+    photographer: 'Olav Nordmann',
+    date: '2025-06-12',
+    location: 'Grieghallen, Bergen',
+    featured: false,
+    image: {
+      _type: 'image',
+      asset: {
+        _ref: `image-${id.replace(/-/g, '')}0000000000000000000000000000-1920x1080-jpg`,
+        _type: 'reference',
+      },
+    },
+    speakers: [],
+    ...overrides,
+  } as GalleryImageWithSpeakers
+}
+
+const images: GalleryImageWithSpeakers[] = [
+  mockImage('gal1', {
+    location: 'Grieghallen, Bergen',
+    imageAlt: 'Keynote presentation on the main stage',
+    speakers: [
+      // Matches the global SessionDecorator's speaker id so the
+      // "Remove Me" self-untag affordance is visible in the capture.
+      { _id: 'speaker-storybook', name: 'Storybook User', slug: 'storybook' },
+      { _id: 'sp-2', name: 'Jane Doe', slug: 'jane-doe' },
+    ],
+  }),
+  mockImage('gal2', {
+    location: 'Workshop Room A',
+    photographer: 'Kari Hansen',
+    imageAlt: 'Hands-on workshop session',
+    speakers: [{ _id: 'sp-3', name: 'Alice Johnson', slug: 'alice-johnson' }],
+  }),
+  mockImage('gal3', {
+    location: 'Foyer',
+    imageAlt: 'Networking break',
+  }),
+]
+
+const placeholderSvg = (w: number, h: number, label: string, hue: number) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">` +
+  `<rect width="${w}" height="${h}" fill="hsl(${hue} 40% 30%)"/>` +
+  `<text x="50%" y="50%" fill="hsl(${hue} 30% 75%)" font-family="sans-serif" font-size="${Math.round(h / 12)}" text-anchor="middle" dominant-baseline="middle">${label}</text>` +
+  `</svg>`
+
+const handlers = [
+  // The Sanity image builder emits cdn.sanity.io URLs; serve deterministic
+  // placeholders so the lightbox and thumbnail strip render real <img> content.
+  http.get('https://cdn.sanity.io/images/*', ({ request }) => {
+    const url = new URL(request.url)
+    const match = /gal(\d)/.exec(url.pathname)
+    const n = match ? Number(match[1]) : 1
+    const thumb = url.searchParams.get('w') === '192'
+    return new HttpResponse(
+      placeholderSvg(
+        thumb ? 192 : 1920,
+        thumb ? 128 : 1080,
+        `Photo ${n}`,
+        [210, 150, 30][n - 1] ?? 210,
+      ),
+      { headers: { 'Content-Type': 'image/svg+xml' } },
+    )
+  }),
+  http.post('/api/trpc/gallery.untagSelf', () =>
+    HttpResponse.json({ result: { data: { success: true } } }),
+  ),
+]
 
 const meta = {
   title: 'Components/Feedback/GalleryModal',
+  component: GalleryModal,
   parameters: {
     layout: 'fullscreen',
-    options: { showPanel: false },
+    msw: { handlers },
     docs: {
       description: {
         component:
-          'Full-screen gallery modal with image carousel, thumbnail navigation, speaker tags, and self-untag functionality. Uses `useImageCarousel` for keyboard/touch navigation and `useSession` for identifying the current speaker. Supports swipe gestures on mobile.',
+          'Full-screen gallery lightbox with image carousel, thumbnail navigation, speaker tags, and self-untag. A deliberate ModalShell exception: the full-bleed black lightbox opts out of the shared card/sheet shell but follows the same house bar — modern Headless UI v2 dialog, a labeled 44×44 close button, and a real accessible dialog name ("Photo gallery, image N of M"). Keyboard (← → Esc via `useImageCarousel`) and touch swipe are supported.',
       },
     },
   },
-} satisfies Meta
+  args: {
+    isOpen: true,
+    onClose: fn(),
+    images,
+    onImageUpdated: fn(),
+  },
+} satisfies Meta<typeof GalleryModal>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-const mockImages = [
-  {
-    title: 'Keynote Presentation',
-    photographer: 'Olav Nordmann',
-    location: 'Grieghallen, Bergen',
-    date: 'June 12, 2025',
-    speakers: ['Jane Doe', 'John Smith'],
-  },
-  {
-    title: 'Workshop Session',
-    photographer: 'Olav Nordmann',
-    location: 'Grieghallen, Bergen',
-    date: 'June 12, 2025',
-    speakers: ['Alice Johnson'],
-  },
-  {
-    title: 'Networking Break',
-    photographer: 'Kari Hansen',
-    location: 'Grieghallen, Bergen',
-    date: 'June 12, 2025',
-    speakers: [],
-  },
-]
+/**
+ * The lightbox on its first image. The signed-in mock speaker is tagged in
+ * this photo, so the "Remove Me" self-untag button is visible. The lightbox
+ * uses a fixed black surface in both themes, so light and dark captures are
+ * identical by design.
+ */
+export const Default: Story = {}
 
-function MockGalleryModal() {
-  const currentImage = mockImages[0]
-
-  return (
-    <div className="relative h-150 w-full bg-black">
-      <div className="flex h-full flex-col">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-gray-800 bg-black/50 px-4 py-3 backdrop-blur-sm sm:px-6">
-          <div className="flex items-center space-x-4">
-            <h2 className="text-lg font-semibold text-white">
-              1 of {mockImages.length}
-            </h2>
-            <span className="hidden text-sm text-gray-300/90 sm:block">
-              {currentImage.location}
-            </span>
-          </div>
-          <button className="rounded-md p-2 text-gray-400 hover:bg-gray-800 hover:text-white">
-            <XMarkIcon className="h-6 w-6" />
-          </button>
-        </div>
-
-        {/* Image area */}
-        <div className="relative flex flex-1 items-center justify-center overflow-hidden">
-          <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-gray-800 to-gray-900">
-            <div className="text-center text-gray-500">
-              <div className="mx-auto mb-2 h-32 w-48 rounded-lg bg-gray-700/50" />
-              <p className="text-sm">Gallery image placeholder</p>
-            </div>
-          </div>
-
-          {/* Navigation arrows */}
-          <button className="absolute top-1/2 left-4 -translate-y-1/2 rounded-full bg-black/50 p-3 text-white backdrop-blur-sm">
-            <ChevronLeftIcon className="h-6 w-6" />
-          </button>
-          <button className="absolute top-1/2 right-4 -translate-y-1/2 rounded-full bg-black/50 p-3 text-white backdrop-blur-sm">
-            <ChevronRightIcon className="h-6 w-6" />
-          </button>
-        </div>
-
-        {/* Info panel */}
-        <div className="border-t border-gray-800 bg-black/50 backdrop-blur-sm">
-          <div className="px-4 py-4 sm:px-6">
-            <div className="mb-4 space-y-2">
-              <h3 className="text-xl font-semibold text-white">
-                {currentImage.location}
-              </h3>
-              <div className="flex flex-wrap items-center gap-4 text-sm text-gray-300/90">
-                <span>Photo by {currentImage.photographer}</span>
-                <span>{currentImage.date}</span>
-              </div>
-              <div className="flex flex-wrap gap-2 pt-2">
-                {currentImage.speakers.map((speaker) => (
-                  <span
-                    key={speaker}
-                    className="rounded-full bg-blue-500/20 px-3 py-1 text-xs font-medium text-blue-400"
-                  >
-                    {speaker}
-                  </span>
-                ))}
-              </div>
-            </div>
-
-            {/* Thumbnails */}
-            <div className="flex space-x-2 overflow-x-auto pb-2">
-              {mockImages.map((img, index) => (
-                <div
-                  key={img.title}
-                  className={`relative h-16 w-24 shrink-0 overflow-hidden rounded ${
-                    index === 0
-                      ? 'ring-2 ring-white ring-offset-2 ring-offset-black'
-                      : 'opacity-50'
-                  }`}
-                >
-                  <div className="h-full w-full bg-gray-700" />
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-export const Default: Story = {
-  render: () => <MockGalleryModal />,
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Full-screen gallery modal showing the first image in a carousel. Includes navigation arrows, photographer credit, speaker tags, and thumbnail strip. The actual component uses Sanity image URLs and supports keyboard navigation (← → arrows) and touch swipe gestures.',
-      },
-    },
-  },
+/** Opened at the second image via `initialIndex`. */
+export const SecondImage: Story = {
+  args: { initialIndex: 1 },
 }

--- a/src/components/GalleryModal.tsx
+++ b/src/components/GalleryModal.tsx
@@ -1,7 +1,13 @@
 'use client'
 
-import React, { Fragment, useState, useEffect } from 'react'
-import { Dialog, Transition } from '@headlessui/react'
+import React, { useState, useEffect } from 'react'
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from '@headlessui/react'
 import {
   XMarkIcon,
   ChevronLeftIcon,
@@ -113,10 +119,9 @@ export function GalleryModal({
   }
 
   return (
-    <Transition.Root show={isOpen} as={Fragment}>
+    <Transition show={isOpen}>
       <Dialog as="div" className="relative z-50" onClose={onClose}>
-        <Transition.Child
-          as={Fragment}
+        <TransitionChild
           enter="ease-out duration-300"
           enterFrom="opacity-0"
           enterTo="opacity-100"
@@ -125,12 +130,11 @@ export function GalleryModal({
           leaveTo="opacity-0"
         >
           <div className="fixed inset-0 bg-black/95 backdrop-blur-sm" />
-        </Transition.Child>
+        </TransitionChild>
 
         <div className="fixed inset-0 z-50 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center">
-            <Transition.Child
-              as={Fragment}
+            <TransitionChild
               enter="ease-out duration-300"
               enterFrom="opacity-0 scale-95"
               enterTo="opacity-100 scale-100"
@@ -138,13 +142,14 @@ export function GalleryModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="relative h-screen w-screen bg-black">
+              <DialogPanel className="relative h-screen w-screen bg-black">
                 <div className="flex h-full flex-col">
                   <div className="flex items-center justify-between border-b border-gray-800 bg-black/50 px-4 py-3 backdrop-blur-sm sm:px-6">
                     <div className="flex items-center space-x-4">
-                      <Dialog.Title className="font-space-grotesk text-lg font-semibold text-white">
+                      <DialogTitle className="font-space-grotesk text-lg font-semibold text-white">
+                        <span className="sr-only">Photo gallery, image </span>
                         {currentIndex + 1} of {localImages.length}
-                      </Dialog.Title>
+                      </DialogTitle>
                       {currentImage?.location && (
                         <span className="hidden text-sm text-gray-300/90 sm:block">
                           {currentImage.location}
@@ -153,10 +158,10 @@ export function GalleryModal({
                     </div>
                     <button
                       type="button"
-                      className="rounded-md p-2 text-gray-400 hover:bg-gray-800 hover:text-white focus:ring-2 focus:ring-white focus:outline-none"
+                      aria-label="Close photo gallery"
+                      className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-gray-400 hover:bg-gray-800 hover:text-white focus:ring-2 focus:ring-white focus:outline-none"
                       onClick={onClose}
                     >
-                      <span className="sr-only">Close</span>
                       <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                     </button>
                   </div>
@@ -307,6 +312,11 @@ export function GalleryModal({
                           {localImages.map((image, index) => (
                             <button
                               key={image._id}
+                              type="button"
+                              aria-label={`Go to image ${index + 1}`}
+                              aria-current={
+                                index === currentIndex ? 'true' : undefined
+                              }
                               onClick={() => goToIndex(index)}
                               className={cn(
                                 'relative h-16 w-24 shrink-0 cursor-pointer overflow-hidden rounded',
@@ -341,11 +351,11 @@ export function GalleryModal({
                     </div>
                   </div>
                 </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              </DialogPanel>
+            </TransitionChild>
           </div>
         </div>
       </Dialog>
-    </Transition.Root>
+    </Transition>
   )
 }

--- a/src/components/admin/workshop/AddParticipantModal.tsx
+++ b/src/components/admin/workshop/AddParticipantModal.tsx
@@ -59,7 +59,8 @@ export function AddParticipantModal({
     onClose()
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
     if (!formData.userName || !formData.userEmail) {
       setValidationError('Please fill in both name and email.')
       return
@@ -68,6 +69,12 @@ export function AddParticipantModal({
     onSubmit(formData)
   }
 
+  // Any edit away from the pristine defaults guards the close (ModalShell
+  // shows a discard confirm on backdrop/Escape/header-close).
+  const isDirty = (
+    Object.keys(DEFAULT_PARTICIPANT) as (keyof ParticipantFormData)[]
+  ).some((key) => formData[key] !== DEFAULT_PARTICIPANT[key])
+
   return (
     <ModalShell
       isOpen={isOpen}
@@ -75,8 +82,10 @@ export function AddParticipantModal({
       size="lg"
       title={`Add Participant to ${workshopTitle}`}
       icon={<UserPlusIcon className="h-5 w-5" />}
+      confirmOnDirtyClose
+      isDirty={isDirty}
     >
-      <div>
+      <form onSubmit={handleSubmit}>
         <div className="space-y-4">
           <div>
             <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -180,25 +189,28 @@ export function AddParticipantModal({
           </p>
         )}
 
-        <div className="mt-6 flex justify-end gap-3">
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           <AdminButton
+            type="button"
             variant="secondary"
             size="md"
             onClick={handleClose}
             disabled={isSubmitting}
+            className="min-h-[44px]"
           >
             Cancel
           </AdminButton>
           <AdminButton
+            type="submit"
             color="blue"
             size="md"
-            onClick={handleSubmit}
             disabled={isSubmitting}
+            className="min-h-[44px]"
           >
             {isSubmitting ? 'Adding...' : 'Add Participant'}
           </AdminButton>
         </div>
-      </div>
+      </form>
     </ModalShell>
   )
 }

--- a/src/components/admin/workshop/AddParticipantModal.tsx
+++ b/src/components/admin/workshop/AddParticipantModal.tsx
@@ -83,7 +83,7 @@ export function AddParticipantModal({
       title={`Add Participant to ${workshopTitle}`}
       icon={<UserPlusIcon className="h-5 w-5" />}
       confirmOnDirtyClose
-      isDirty={isDirty}
+      isDirty={isDirty && !isSubmitting}
     >
       <form onSubmit={handleSubmit}>
         <div className="space-y-4">

--- a/src/components/volunteer/VolunteerEditModal.tsx
+++ b/src/components/volunteer/VolunteerEditModal.tsx
@@ -72,6 +72,12 @@ export function VolunteerEditModal({
     setError(null)
   }
 
+  // Unsaved edits guard the close (ModalShell shows a discard confirm).
+  const pristine = draftFrom(volunteer)
+  const isDirty = (Object.keys(pristine) as (keyof Draft)[]).some(
+    (key) => draft[key] !== pristine[key],
+  )
+
   const updateMutation = api.volunteer.admin.update.useMutation({
     onSuccess: async () => {
       await Promise.all([
@@ -128,6 +134,8 @@ export function VolunteerEditModal({
       title="Edit volunteer details"
       subtitle={volunteer.name}
       icon={<PencilSquareIcon className="h-5 w-5" />}
+      confirmOnDirtyClose
+      isDirty={isDirty}
     >
       <form noValidate onSubmit={handleSubmit} className="space-y-4">
         <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/volunteer/VolunteerEditModal.tsx
+++ b/src/components/volunteer/VolunteerEditModal.tsx
@@ -62,20 +62,25 @@ export function VolunteerEditModal({
   const utils = api.useUtils()
   const { showNotification } = useNotification()
   const [draft, setDraft] = useState<Draft>(() => draftFrom(volunteer))
+  // Snapshot of the values the draft was initialized from. Kept in state (not
+  // recomputed from the live prop) so a background refetch of the same
+  // volunteer can't shift the dirty baseline mid-edit.
+  const [baseline, setBaseline] = useState<Draft>(() => draftFrom(volunteer))
   const [error, setError] = useState<string | null>(null)
 
   // Reset the draft whenever a different volunteer is opened.
   const [lastId, setLastId] = useState(volunteer._id)
   if (lastId !== volunteer._id) {
     setLastId(volunteer._id)
-    setDraft(draftFrom(volunteer))
+    const next = draftFrom(volunteer)
+    setDraft(next)
+    setBaseline(next)
     setError(null)
   }
 
   // Unsaved edits guard the close (ModalShell shows a discard confirm).
-  const pristine = draftFrom(volunteer)
-  const isDirty = (Object.keys(pristine) as (keyof Draft)[]).some(
-    (key) => draft[key] !== pristine[key],
+  const isDirty = (Object.keys(baseline) as (keyof Draft)[]).some(
+    (key) => draft[key] !== baseline[key],
   )
 
   const updateMutation = api.volunteer.admin.update.useMutation({

--- a/src/components/volunteer/VolunteerEditModal.tsx
+++ b/src/components/volunteer/VolunteerEditModal.tsx
@@ -68,14 +68,18 @@ export function VolunteerEditModal({
   const [baseline, setBaseline] = useState<Draft>(() => draftFrom(volunteer))
   const [error, setError] = useState<string | null>(null)
 
-  // Reset the draft whenever a different volunteer is opened.
+  const [wasOpen, setWasOpen] = useState(isOpen)
   const [lastId, setLastId] = useState(volunteer._id)
-  if (lastId !== volunteer._id) {
+
+  if (lastId !== volunteer._id || (!wasOpen && isOpen)) {
     setLastId(volunteer._id)
+    setWasOpen(isOpen)
     const next = draftFrom(volunteer)
     setDraft(next)
     setBaseline(next)
     setError(null)
+  } else if (wasOpen !== isOpen) {
+    setWasOpen(isOpen)
   }
 
   // Unsaved edits guard the close (ModalShell shows a discard confirm).

--- a/src/components/volunteer/VolunteerEditModal.tsx
+++ b/src/components/volunteer/VolunteerEditModal.tsx
@@ -144,7 +144,7 @@ export function VolunteerEditModal({
       subtitle={volunteer.name}
       icon={<PencilSquareIcon className="h-5 w-5" />}
       confirmOnDirtyClose
-      isDirty={isDirty}
+      isDirty={isDirty && !updateMutation.isPending}
     >
       <form noValidate onSubmit={handleSubmit} className="space-y-4">
         <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/workshop/WorkshopCard.tsx
+++ b/src/components/workshop/WorkshopCard.tsx
@@ -148,7 +148,12 @@ export default function WorkshopCard({
       subtitle="Complete your registration"
       icon={<AcademicCapIcon className="h-5 w-5" />}
     >
-      <div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          void handleSignupSubmit()
+        }}
+      >
         <div className="space-y-4">
           <div>
             <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -245,24 +250,22 @@ export default function WorkshopCard({
             </div>
           )}
 
-          <div className="flex gap-3 pt-2">
+          <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row sm:justify-end">
             <Button
-              onClick={handleSignupSubmit}
-              disabled={isLoading}
-              className="flex-1"
-            >
-              {isLoading ? 'Registering...' : 'Confirm Registration'}
-            </Button>
-            <Button
+              type="button"
               onClick={() => setShowSignupModal(false)}
               disabled={isLoading}
               variant="outline"
+              className="min-h-11"
             >
               Cancel
             </Button>
+            <Button type="submit" disabled={isLoading} className="min-h-11">
+              {isLoading ? 'Registering...' : 'Confirm Registration'}
+            </Button>
           </div>
         </div>
-      </div>
+      </form>
     </ModalShell>
   )
 


### PR DESCRIPTION
Batch 1 of the modal audit: public-surface modals brought up to the ModalShell house bar.

## Changes

### GalleryModal (public gallery lightbox)
- Migrated the **last consumer of the legacy Headless UI namespace API** (`Transition.Root` / `Dialog.Panel` / `Dialog.Title`) to the modern v2 named components, matching ModalShell's own transition pattern.
- **Shell decision:** stays a hand-rolled full-bleed dialog by design. ModalShell's card/sheet contract (max-width panel, white surface, rounded corners, mobile bottom sheet) fundamentally fights a full-screen black lightbox — same category of exception as ReceiptViewer's `presentation="centered"`, but further out. It now follows the house bar (modern dialog, labeled 44px close) without the shared shell.
- Close button: 40px sr-only X → **44×44 labeled** ("Close photo gallery").
- Dialog accessible name: bare "1 of 3" → **"Photo gallery, image 1 of 3"** (sr-only prefix inside `DialogTitle`; visual header unchanged).
- Thumbnails get `type="button"`, `aria-label`, `aria-current`.
- Carousel keyboard handling (`useImageCarousel` + `onEscape`), touch swipe, thumbnails, untag flow, and `z-50` preserved.
- **Story rewritten to render the real component** (it was a hand-built visual mock, so captures never exercised the actual modal): global Session/TRPC decorators supply providers, MSW serves placeholder SVGs for the Sanity CDN URLs and answers `gallery.untagSelf`, and the mock speaker id matches the session so the "Remove Me" affordance is visible. Added a `SecondImage` story.

### WorkshopCard signup modal (public signup)
- Footer order was **inverted** (primary left, Cancel right) → house order: Cancel left / primary right, right-aligned on desktop, `flex-col-reverse` full-width stack on mobile (primary on top), `min-h-11`.
- Fields now live in a real `<form onSubmit>` — **Enter submits**; explicit `type="submit"` / `type="button"`.
- Keeps its existing ModalShell + house header.

### Dirty-close guards
- **VolunteerEditModal**: `confirmOnDirtyClose` wired to draft-vs-volunteer diff.
- **AddParticipantModal**: `confirmOnDirtyClose` wired to fields-vs-pristine diff; inputs wrapped in a `<form>` with explicit `type="submit"` (AdminButton defaults to `type="button"`); footer stacks `flex-col-reverse` with 44px minimum heights on mobile.
- Footer Cancel still closes directly, matching the AnnounceModal precedent (guard covers backdrop/Escape/header-close).

## QA
- Storybook captures at 393×852 (DPR ≥2), light + dark, for all four modals — real components, portaled theme verified: 44×44 closes, no footer wrap, correct mobile stacking (primary above Cancel), no horizontal overflow.
- Playwright drive-throughs: pristine Escape closes without confirm; dirty Escape shows the discard confirm; "Keep editing" dismisses (both guarded modals). Enter submits in both new forms (AddParticipant surfaces validation; WorkshopCard signup resolves and closes).
- `tsc` clean, `eslint src` 0 errors (one pre-existing unused-directive warning in `DiscountCodeManager.tsx`, untouched), prettier clean, full vitest suite green (281 files / 3869 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR brings several public modals in line with the shared modal conventions. The main changes are:

- Migrates the gallery lightbox to Headless UI v2 named components.
- Replaces the gallery visual mock with a real Storybook component setup.
- Adds native form submission and responsive footer actions to signup flows.
- Adds dirty-close guards to participant and volunteer editing modals.

<h3>Confidence Score: 5/5</h3>

The changes look mergeable after stabilizing the volunteer form's dirty baseline.

- The Headless UI imports and structure match the existing ModalShell implementation.
- The form conversions preserve validation and use explicit button types.
- A same-volunteer query refresh can make the new dirty guard report the wrong state.

src/components/volunteer/VolunteerEditModal.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/GalleryModal.stories.tsx | Replaces the static mock with the real gallery component and provider-backed request handlers. |
| src/components/GalleryModal.tsx | Migrates the lightbox to Headless UI v2 components and improves accessible labels and controls. |
| src/components/admin/workshop/AddParticipantModal.tsx | Adds native form submission, responsive actions, explicit button types, and dirty-close protection. |
| src/components/volunteer/VolunteerEditModal.tsx | Adds dirty-close protection, but the pristine baseline can shift during same-volunteer query refreshes. |
| src/components/workshop/WorkshopCard.tsx | Adds native signup form submission and standardizes responsive action ordering. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(modals): dirty-close guards on volun..."](https://github.com/cloudnativebergen/website/commit/3e284b062d1414e8eb8bb224c71f6b8399fc2a71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46279555)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->