### PR TITLE
fix(modals): repair broken admin drivers — search palette z/overflow, CRM dirty guards, confirm rebuild

### DIFF
--- a/src/components/admin/SearchModal.stories.tsx
+++ b/src/components/admin/SearchModal.stories.tsx
@@ -7,12 +7,20 @@ import {
   UserGroupIcon,
   HomeIcon,
 } from '@heroicons/react/24/outline'
+import { http, HttpResponse } from 'msw'
+import { fn, userEvent, waitFor, within } from 'storybook/test'
 import { SkeletonSearchResult } from './LoadingSkeleton'
+import { SearchModal } from './SearchModal'
 
 const meta = {
   title: 'Systems/Proposals/Admin/SearchModal',
   parameters: {
-    layout: 'centered',
+    // 'padded', not 'centered': the centered layout makes <body> a flex
+    // centering context that sizes the story to its min-content width, which
+    // let long nowrap result titles inflate the replica past the viewport
+    // (scrollWidth 484 at a 393px viewport) — a situation the real dialog's
+    // `fixed inset-0` container can never produce. Padded mirrors the app.
+    layout: 'padded',
     options: { showPanel: false },
     docs: {
       description: {
@@ -34,7 +42,7 @@ function SearchModalShell({
   children: React.ReactNode
 }) {
   return (
-    <div className="mx-auto w-full max-w-xl divide-y divide-gray-100 overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-black/5 dark:divide-gray-700 dark:bg-gray-900 dark:ring-gray-700">
+    <div className="mx-auto w-full max-w-xl min-w-0 divide-y divide-gray-100 overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-black/5 dark:divide-gray-700 dark:bg-gray-900 dark:ring-gray-700">
       <div className="grid grid-cols-1">
         <input
           className="col-start-1 row-start-1 h-12 w-full pr-4 pl-11 text-base text-gray-900 outline-hidden placeholder:text-gray-400 sm:text-sm dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
@@ -97,17 +105,17 @@ function ResultsList({ groups }: { groups: ResultGroup[] }) {
                 <div className="flex size-6 flex-none items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700">
                   <item.icon className="size-4 text-gray-400 dark:text-gray-500" />
                 </div>
-                <div className="ml-3 flex-auto truncate">
-                  <div className="font-medium dark:text-white">
+                <div className="ml-3 min-w-0 flex-auto">
+                  <div className="truncate font-medium dark:text-white">
                     {item.title}
                   </div>
                   {item.subtitle && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                    <div className="truncate text-xs text-gray-500 dark:text-gray-400">
                       {item.subtitle}
                     </div>
                   )}
                   {item.description && (
-                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                    <div className="truncate text-xs text-gray-500 dark:text-gray-400">
                       {item.description}
                     </div>
                   )}
@@ -261,6 +269,86 @@ export const SearchError: Story = {
       </div>
     </SearchModalShell>
   ),
+}
+
+/**
+ * The REAL portalled dialog (not the markup replica used by the state stories
+ * above), rendered open with MSW-mocked search endpoints. The play function
+ * types a query so the results list renders. Used for visual QA of z-index,
+ * width containment and mobile overflow — shoot this story at 393px.
+ */
+export const LiveWithResults: Story = {
+  render: () => <SearchModal open={true} onClose={fn()} />,
+  parameters: {
+    layout: 'fullscreen',
+    msw: {
+      handlers: [
+        http.get('/api/trpc/proposal.admin.search', () =>
+          HttpResponse.json({
+            result: {
+              data: [
+                {
+                  _id: 'prop-1',
+                  title: 'Building Resilient Microservices with Kubernetes',
+                  status: 'accepted',
+                  format: 'presentation_45',
+                  speakers: [{ _id: 'spk-1', name: 'Jane Doe' }],
+                },
+                {
+                  _id: 'prop-2',
+                  title: 'Kubernetes Security Best Practices',
+                  status: 'submitted',
+                  format: 'presentation_25',
+                  speakers: [{ _id: 'spk-2', name: 'John Smith' }],
+                },
+              ],
+            },
+          }),
+        ),
+        http.get('/api/trpc/sponsor.list', () =>
+          HttpResponse.json({
+            result: {
+              data: [
+                {
+                  _id: 'sponsor-1',
+                  name: 'Kubernetes Foundation',
+                  website: 'https://kubernetes.io',
+                },
+              ],
+            },
+          }),
+        ),
+        http.get('/api/trpc/speaker.admin.search', () =>
+          HttpResponse.json({
+            result: {
+              data: [
+                {
+                  _id: 'spk-1',
+                  name: 'Jane Kubernetes Expert',
+                  title: 'Cloud Architect',
+                },
+              ],
+            },
+          }),
+        ),
+      ],
+    },
+  },
+  play: async () => {
+    // The dialog portals to document.body, outside the story canvas.
+    const body = within(document.body)
+    const input = await body.findByPlaceholderText(
+      'Search pages, proposals, speakers, sponsors...',
+    )
+    await userEvent.type(input, 'kubernetes')
+    // Debounced 300ms + parallel provider fetches.
+    await waitFor(
+      async () => {
+        await body.findByText('Kubernetes Foundation')
+      },
+      { timeout: 5000 },
+    )
+  },
 }
 
 export const PagesOnly: Story = {

--- a/src/components/admin/SearchModal.stories.tsx
+++ b/src/components/admin/SearchModal.stories.tsx
@@ -8,12 +8,28 @@ import {
   HomeIcon,
 } from '@heroicons/react/24/outline'
 import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
 import { fn, userEvent, waitFor, within } from 'storybook/test'
 import { SkeletonSearchResult } from './LoadingSkeleton'
 import { SearchModal } from './SearchModal'
 
 const meta = {
   title: 'Systems/Proposals/Admin/SearchModal',
+  decorators: [
+    // SearchModal reads `next-themes`; HeadlessUI portals the dialog to
+    // document.body, so the toolbar's `.dark` wrapper never reaches it.
+    // React context DOES cross portals, so forcing next-themes here (synced to
+    // the Storybook theme global) is what actually renders the portalled
+    // dialog dark for the Live* stories.
+    (Story, context) => (
+      <ThemeProvider
+        attribute="class"
+        forcedTheme={context.globals.theme === 'dark' ? 'dark' : 'light'}
+      >
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
   parameters: {
     // 'padded', not 'centered': the centered layout makes <body> a flex
     // centering context that sizes the story to its min-content width, which

--- a/src/components/admin/SearchModal.tsx
+++ b/src/components/admin/SearchModal.tsx
@@ -68,9 +68,11 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
 
   return (
     <Transition appear show={open}>
+      {/* z-50 matches the ModalShell family — the palette must layer above the
+          admin's sticky headers (z-40), which previously overlapped it. */}
       <Dialog
         as="div"
-        className={`relative z-10 ${theme === 'dark' ? 'dark' : ''}`}
+        className={`relative z-50 ${theme === 'dark' ? 'dark' : ''}`}
         onClose={handleClose}
       >
         <TransitionChild
@@ -84,7 +86,7 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
           <div className="fixed inset-0 bg-gray-500/25 dark:bg-gray-900/50" />
         </TransitionChild>
 
-        <div className="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+        <div className="fixed inset-0 overflow-y-auto p-4 sm:p-6 md:p-20">
           <TransitionChild
             enter="ease-out duration-300"
             enterFrom="opacity-0 scale-95"
@@ -95,7 +97,7 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
           >
             <DialogPanel
               transition
-              className="mx-auto max-w-xl transform divide-y divide-gray-100 overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:divide-gray-700 dark:bg-gray-900 dark:ring-gray-700"
+              className="mx-auto w-full max-w-xl min-w-0 transform divide-y divide-gray-100 overflow-hidden rounded-xl bg-white shadow-2xl ring-1 ring-black/5 transition-all data-closed:scale-95 data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in dark:divide-gray-700 dark:bg-gray-900 dark:ring-gray-700"
             >
               <Combobox
                 onChange={(item) => {
@@ -144,17 +146,22 @@ export function SearchModal({ open, onClose }: SearchModalProps) {
                                     <Icon className="size-4 text-gray-400 group-data-focus:text-white dark:text-gray-500" />
                                   </div>
                                 </div>
-                                <div className="ml-3 flex-auto truncate">
-                                  <div className="font-medium dark:text-white">
+                                {/* min-w-0 on the container + truncate on each
+                                    text line: truncating only the wrapper clips
+                                    child blocks without an ellipsis and lets
+                                    long nowrap titles dictate the row's
+                                    min-content width (mobile overflow). */}
+                                <div className="ml-3 min-w-0 flex-auto">
+                                  <div className="truncate font-medium dark:text-white">
                                     {item.title}
                                   </div>
                                   {item.subtitle && (
-                                    <div className="text-xs text-gray-500 group-data-focus:text-white/70 dark:text-gray-400">
+                                    <div className="truncate text-xs text-gray-500 group-data-focus:text-white/70 dark:text-gray-400">
                                       {item.subtitle}
                                     </div>
                                   )}
                                   {item.description && (
-                                    <div className="text-xs text-gray-500 group-data-focus:text-white/70 dark:text-gray-400">
+                                    <div className="truncate text-xs text-gray-500 group-data-focus:text-white/70 dark:text-gray-400">
                                       {item.description}
                                     </div>
                                   )}

--- a/src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.stories.tsx
+++ b/src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.stories.tsx
@@ -5,6 +5,9 @@ import {
   XCircleIcon,
 } from '@heroicons/react/24/outline'
 import { useState } from 'react'
+import { fn, userEvent, within } from 'storybook/test'
+import { ImportHistoricSponsorsButton } from './ImportHistoricSponsorsButton'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
 
 const meta = {
   title: 'Systems/Sponsors/Admin/Pipeline/ImportHistoricSponsorsButton',
@@ -224,4 +227,26 @@ export const Documentation: Story = {
       </div>
     </div>
   ),
+}
+
+/**
+ * The REAL component (not the markup replicas above), with its confirmation
+ * dialog opened by the play function. The confirm is built on the canonical
+ * ConfirmationModal/ModalShell stack — shoot this story at 393px for
+ * mobile/dark QA of the live dialog.
+ */
+export const LiveConfirmDialog: Story = {
+  render: () => (
+    <NotificationProvider>
+      <ImportHistoricSponsorsButton conferenceId="conf-2026" onSuccess={fn()} />
+    </NotificationProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /import historic/i }),
+    )
+    // Dialog portals to document.body.
+    await within(document.body).findByText('Sponsors will be tagged:')
+  },
 }

--- a/src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.stories.tsx
+++ b/src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.stories.tsx
@@ -5,6 +5,7 @@ import {
   XCircleIcon,
 } from '@heroicons/react/24/outline'
 import { useState } from 'react'
+import { ThemeProvider } from 'next-themes'
 import { fn, userEvent, within } from 'storybook/test'
 import { ImportHistoricSponsorsButton } from './ImportHistoricSponsorsButton'
 import { NotificationProvider } from '@/components/admin/NotificationProvider'
@@ -12,6 +13,19 @@ import { NotificationProvider } from '@/components/admin/NotificationProvider'
 const meta = {
   title: 'Systems/Sponsors/Admin/Pipeline/ImportHistoricSponsorsButton',
   tags: ['autodocs'],
+  decorators: [
+    // The confirm dialog portals to document.body, outside the toolbar's
+    // `.dark` wrapper. next-themes context crosses the portal, so force it
+    // (synced to the Storybook theme global) for LiveConfirmDialog's dark QA.
+    (Story, context) => (
+      <ThemeProvider
+        attribute="class"
+        forcedTheme={context.globals.theme === 'dark' ? 'dark' : 'light'}
+      >
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
   parameters: {
     layout: 'centered',
     options: { showPanel: false },

--- a/src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.tsx
+++ b/src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.tsx
@@ -1,22 +1,14 @@
 'use client'
 
-import { useState, Fragment } from 'react'
+import { useState } from 'react'
 import {
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-  Transition,
-  TransitionChild,
-} from '@headlessui/react'
-import {
-  ArrowPathIcon,
   DocumentDuplicateIcon,
-  XMarkIcon,
   ExclamationTriangleIcon,
   CheckCircleIcon,
 } from '@heroicons/react/24/outline'
 import { api } from '@/lib/trpc/client'
 import { useNotification } from '@/components/admin/NotificationProvider'
+import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 
 interface ImportHistoricSponsorsButtonProps {
   conferenceId: string
@@ -95,113 +87,51 @@ export function ImportHistoricSponsorsButton({
         Import Historic
       </button>
 
-      <Transition show={isOpen} as={Fragment}>
-        <Dialog onClose={() => setIsOpen(false)} className="relative z-50">
-          <TransitionChild
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
-          </TransitionChild>
-
-          <div className="fixed inset-0 flex items-center justify-center overflow-y-auto p-4">
-            <TransitionChild
-              as={Fragment}
-              enter="ease-out duration-300"
-              enterFrom="opacity-0 scale-95"
-              enterTo="opacity-100 scale-100"
-              leave="ease-in duration-200"
-              leaveFrom="opacity-100 scale-100"
-              leaveTo="opacity-0 scale-95"
-            >
-              <DialogPanel className="mx-auto max-h-[90dvh] w-full max-w-md overflow-y-auto rounded-xl bg-white p-6 shadow-xl dark:bg-gray-800">
-                <div className="flex items-start justify-between">
-                  <DialogTitle className="text-lg font-semibold text-gray-900 dark:text-white">
-                    Import Historic Sponsors
-                  </DialogTitle>
-                  <button
-                    type="button"
-                    onClick={() => setIsOpen(false)}
-                    className="flex h-11 w-11 items-center justify-center rounded-md text-gray-400 hover:bg-gray-100 hover:text-gray-500 dark:hover:bg-gray-700"
-                  >
-                    <XMarkIcon className="h-5 w-5" />
-                  </button>
-                </div>
-
-                <div className="mt-4 space-y-4">
-                  <p className="text-sm text-gray-600 dark:text-gray-300">
-                    This will import all sponsors from previous conferences into
-                    the Prospect column.
-                  </p>
-
-                  <div className="rounded-lg bg-amber-50 p-4 dark:bg-amber-900/20">
-                    <div className="flex gap-3">
-                      <ExclamationTriangleIcon className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
-                      <div className="text-sm text-amber-800 dark:text-amber-200">
-                        <p className="font-medium">Sponsors will be tagged:</p>
-                        <ul className="mt-1 list-inside list-disc space-y-1">
-                          <li>
-                            <span className="font-medium">
-                              Returning Sponsor
-                            </span>{' '}
-                            — previously confirmed sponsors
-                          </li>
-                          <li>
-                            <span className="font-medium">
-                              Previously Declined
-                            </span>{' '}
-                            — sponsors who declined in all previous years
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
-                    <div className="flex gap-3">
-                      <CheckCircleIcon className="h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400" />
-                      <p className="text-sm text-blue-800 dark:text-blue-200">
-                        Sponsors already in your pipeline will be skipped.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="mt-6 flex justify-end gap-3">
-                  <button
-                    onClick={() => setIsOpen(false)}
-                    className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    onClick={handleImport}
-                    disabled={importMutation.isPending}
-                    className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
-                  >
-                    {importMutation.isPending ? (
-                      <>
-                        <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                        Importing...
-                      </>
-                    ) : (
-                      <>
-                        <DocumentDuplicateIcon className="h-4 w-4" />
-                        Import Sponsors
-                      </>
-                    )}
-                  </button>
-                </div>
-              </DialogPanel>
-            </TransitionChild>
+      {/* House confirm: ConfirmationModal (on ModalShell) supplies the
+          canonical backdrop, footer order (Cancel left / primary right,
+          stacked-reverse on mobile), brand-cloud-blue primary via the `info`
+          variant, dark gray-900 surface and theme-class portal handling. The
+          tag/skip explainer panels ride in as children. */}
+      <ConfirmationModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onConfirm={handleImport}
+        title="Import Historic Sponsors"
+        message="This will import all sponsors from previous conferences into the Prospect column."
+        confirmButtonText="Import Sponsors"
+        variant="info"
+        isLoading={importMutation.isPending}
+      >
+        <div className="space-y-4">
+          <div className="rounded-lg bg-amber-50 p-4 dark:bg-amber-900/20">
+            <div className="flex gap-3">
+              <ExclamationTriangleIcon className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
+              <div className="text-sm text-amber-800 dark:text-amber-200">
+                <p className="font-medium">Sponsors will be tagged:</p>
+                <ul className="mt-1 list-inside list-disc space-y-1">
+                  <li>
+                    <span className="font-medium">Returning Sponsor</span> —
+                    previously confirmed sponsors
+                  </li>
+                  <li>
+                    <span className="font-medium">Previously Declined</span> —
+                    sponsors who declined in all previous years
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
-        </Dialog>
-      </Transition>
+
+          <div className="rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
+            <div className="flex gap-3">
+              <CheckCircleIcon className="h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400" />
+              <p className="text-sm text-blue-800 dark:text-blue-200">
+                Sponsors already in your pipeline will be skipped.
+              </p>
+            </div>
+          </div>
+        </div>
+      </ConfirmationModal>
     </>
   )
 }

--- a/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
@@ -1,13 +1,7 @@
 'use client'
 
-import { useState, useEffect, useMemo, useCallback, Fragment } from 'react'
-import {
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-  Transition,
-  TransitionChild,
-} from '@headlessui/react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { ModalShell } from '@/components/ModalShell'
 import { api } from '@/lib/trpc/client'
 import type {
   SponsorForConferenceExpanded,
@@ -18,11 +12,7 @@ import type {
 } from '@/lib/sponsor-crm/types'
 import { sortSponsorTiers } from '@/components/admin/sponsor-crm/utils'
 import { getPrimaryAction } from './form/deal-status'
-import {
-  XMarkIcon,
-  ChevronLeftIcon,
-  ArrowRightIcon,
-} from '@heroicons/react/24/outline'
+import { ChevronLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline'
 import clsx from 'clsx'
 import { SponsorContactEditor } from '../sponsor/SponsorContactEditor'
 import { SponsorLogoEditor } from '../sponsor/SponsorLogoEditor'
@@ -73,6 +63,12 @@ export function SponsorCRMForm({
   )
   const [userHasEditedValue, setUserHasEditedValue] = useState(false)
 
+  // Unsaved-changes flag driving ModalShell's dirty-close guard. Only USER
+  // edits arm it (via updateFormData below) — programmatic writes like the
+  // tier-price auto-fill effect keep using setFormData directly so merely
+  // opening a sponsor never triggers the "Discard changes?" confirm.
+  const [isDirty, setIsDirty] = useState(false)
+
   const [formData, setFormData] = useState({
     sponsorId: sponsor?.sponsor._id || '',
     name: sponsor?.sponsor.name || '',
@@ -92,6 +88,12 @@ export function SponsorCRMForm({
     tags: sponsor?.tags || ([] as SponsorTag[]),
     assignedTo: sponsor?.assignedTo?._id || '',
   })
+
+  // User-initiated form updates: mark the form dirty and apply the change.
+  const updateFormData: typeof setFormData = useCallback((value) => {
+    setIsDirty(true)
+    setFormData(value)
+  }, [])
 
   const { data: allSponsors = [] } = api.sponsor.list.useQuery()
 
@@ -210,7 +212,14 @@ export function SponsorCRMForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await submitForm(formData)
+    try {
+      await submitForm(formData)
+      // Saved: the form is clean again, so closing needs no confirm.
+      setIsDirty(false)
+    } catch {
+      // Errors already surface via the mutation onError notifications;
+      // keep the dirty flag so unsaved edits stay guarded.
+    }
   }
 
   // The single most-relevant next step for this sponsor, shown as a contextual
@@ -225,9 +234,12 @@ export function SponsorCRMForm({
     if (primaryAction.kind === 'view') {
       setView(primaryAction.target)
     } else if (primaryAction.kind === 'status') {
-      setFormData((prev) => ({ ...prev, status: primaryAction.target }))
+      updateFormData((prev) => ({ ...prev, status: primaryAction.target }))
     } else {
-      setFormData((prev) => ({ ...prev, invoiceStatus: primaryAction.target }))
+      updateFormData((prev) => ({
+        ...prev,
+        invoiceStatus: primaryAction.target,
+      }))
     }
   }
 
@@ -244,174 +256,137 @@ export function SponsorCRMForm({
     messages: 'Messages',
   }
 
+  // ModalShell hosts the canonical header (title + subtitle + guarded 44px
+  // close). The back-button and the contextual primary action ("Mark as
+  // Won" etc.) can't be slotted into ModalShell's header, so they live in a
+  // compliant toolbar row at the top of the body instead — this keeps EVERY
+  // close path (backdrop, Escape, header X) routed through the shell's
+  // dirty-close guard.
+  const showToolbar =
+    view !== 'pipeline' ||
+    Boolean(view === 'pipeline' && sponsor && primaryAction)
+
   return (
-    <>
-      <Transition show={isOpen} as={Fragment}>
-        <Dialog as="div" className="relative z-50" onClose={handleClose}>
-          <TransitionChild
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-gray-500/75 transition-opacity dark:bg-gray-900/75" />
-          </TransitionChild>
-
-          <div className="fixed inset-0 z-10 overflow-y-auto">
-            <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-start sm:p-0 sm:pt-16">
-              <TransitionChild
-                as={Fragment}
-                enter="ease-out duration-300"
-                enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                enterTo="opacity-100 translate-y-0 sm:scale-100"
-                leave="ease-in duration-200"
-                leaveFrom="opacity-100 translate-y-0 sm:scale-100"
-                leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+    <ModalShell
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="3xl"
+      padded={false}
+      title={
+        view === 'pipeline'
+          ? sponsor
+            ? 'Sponsor Details'
+            : 'Add Sponsor to Pipeline'
+          : SUBVIEW_TITLES[view]
+      }
+      subtitle={sponsor ? sponsor.sponsor.name : undefined}
+      confirmOnDirtyClose
+      isDirty={isDirty}
+      className="border border-brand-frosted-steel bg-brand-glacier-white dark:border-gray-700"
+    >
+      {showToolbar && (
+        <div className="flex shrink-0 items-center justify-between gap-2 border-b border-gray-200 px-6 py-2.5 dark:border-gray-700">
+          {view !== 'pipeline' ? (
+            <button
+              type="button"
+              onClick={() => setView('pipeline')}
+              className="-ml-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 text-sm font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              <ChevronLeftIcon className="h-4 w-4" />
+              Back to details
+            </button>
+          ) : (
+            <span aria-hidden="true" />
+          )}
+          {view === 'pipeline' && sponsor && primaryAction && (
+            // Tooltip lives on the wrapper span: a disabled <button> doesn't
+            // receive pointer events, so its own `title` wouldn't show the
+            // blocked reason on hover.
+            <span title={primaryBlocked}>
+              <button
+                type="button"
+                onClick={handlePrimaryAction}
+                disabled={Boolean(primaryBlocked)}
+                className={clsx(
+                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-semibold shadow-sm transition-colors',
+                  primaryBlocked
+                    ? 'cursor-not-allowed bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-600'
+                    : 'cursor-pointer bg-brand-cloud-blue text-white hover:bg-primary-700 dark:bg-indigo-600 dark:hover:bg-indigo-500',
+                )}
               >
-                <DialogPanel className="relative flex max-h-[85dvh] w-full max-w-3xl transform flex-col overflow-hidden rounded-2xl border border-brand-frosted-steel bg-brand-glacier-white shadow-2xl transition-all dark:border-gray-700 dark:bg-gray-900">
-                  <div className="shrink-0 border-b border-gray-200 p-6 dark:border-gray-700">
-                    <div className="flex items-start justify-between">
-                      <div className="min-w-0 text-left">
-                        {view === 'pipeline' ? (
-                          <DialogTitle className="text-lg leading-6 font-semibold text-gray-900 dark:text-white">
-                            {sponsor
-                              ? 'Sponsor Details'
-                              : 'Add Sponsor to Pipeline'}
-                          </DialogTitle>
-                        ) : (
-                          <>
-                            <button
-                              type="button"
-                              onClick={() => setView('pipeline')}
-                              className="mb-1 -ml-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 text-sm font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-                            >
-                              <ChevronLeftIcon className="h-4 w-4" />
-                              Back to details
-                            </button>
-                            <DialogTitle className="text-lg leading-6 font-semibold text-gray-900 dark:text-white">
-                              {SUBVIEW_TITLES[view]}
-                            </DialogTitle>
-                          </>
-                        )}
-                        {sponsor && (
-                          <p className="mt-1 truncate text-sm text-gray-500 dark:text-gray-400">
-                            {sponsor.sponsor.name}
-                          </p>
-                        )}
-                      </div>
+                {primaryAction.label}
+                {primaryAction.kind === 'view' && (
+                  <ArrowRightIcon className="h-4 w-4" />
+                )}
+              </button>
+            </span>
+          )}
+        </div>
+      )}
 
-                      <div className="flex shrink-0 items-center gap-2">
-                        {view === 'pipeline' && sponsor && primaryAction && (
-                          // Tooltip lives on the wrapper span: a disabled
-                          // <button> doesn't receive pointer events, so its own
-                          // `title` wouldn't show the blocked reason on hover.
-                          <span title={primaryBlocked}>
-                            <button
-                              type="button"
-                              onClick={handlePrimaryAction}
-                              disabled={Boolean(primaryBlocked)}
-                              className={clsx(
-                                'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-semibold shadow-sm transition-colors',
-                                primaryBlocked
-                                  ? 'cursor-not-allowed bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-600'
-                                  : 'cursor-pointer bg-indigo-600 text-white hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400',
-                              )}
-                            >
-                              {primaryAction.label}
-                              {primaryAction.kind === 'view' && (
-                                <ArrowRightIcon className="h-4 w-4" />
-                              )}
-                            </button>
-                          </span>
-                        )}
-                        <button
-                          type="button"
-                          onClick={handleClose}
-                          className="flex h-11 w-11 cursor-pointer items-center justify-center rounded-md text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none dark:text-gray-500 dark:hover:text-gray-400"
-                        >
-                          <span className="sr-only">Close</span>
-                          <XMarkIcon className="h-6 w-6" />
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="flex-1 overflow-y-auto overscroll-contain p-6">
-                    <div className="min-h-100 text-left">
-                      {view === 'contacts' && sponsor ? (
-                        <SponsorContactEditor
-                          sponsorForConference={sponsor}
-                          onSuccess={() => {
-                            utils.sponsor.crm.list.invalidate()
-                            utils.sponsor.crm.healthViolations.invalidate()
-                          }}
-                          onCancel={handleClose}
-                        />
-                      ) : view === 'logo' ? (
-                        <SponsorLogoEditor
-                          logo={formData.logo}
-                          logoBright={formData.logoBright}
-                          name={formData.name}
-                          onChange={(updates) =>
-                            setFormData((prev) => ({
-                              ...prev,
-                              ...updates,
-                            }))
-                          }
-                          className="py-4"
-                        />
-                      ) : view === 'history' && sponsor ? (
-                        <div className="py-4">
-                          <SponsorActivityTimeline
-                            sponsorForConferenceId={sponsor._id}
-                            showHeaderFooter={false}
-                            limit={20}
-                          />
-                        </div>
-                      ) : view === 'contract' && sponsor ? (
-                        <SponsorContractView
-                          conferenceId={conferenceId}
-                          sponsor={sponsor}
-                          onSuccess={() => {
-                            utils.sponsor.crm.list.invalidate()
-                            utils.sponsor.crm.healthViolations.invalidate()
-                          }}
-                        />
-                      ) : view === 'messages' && sponsor ? (
-                        // Sponsor↔organizer thread (messaging G2b): ensured on
-                        // open, then embedded for the organizer audience.
-                        <SponsorMessagesPanel
-                          sponsorForConferenceId={sponsor._id}
-                        />
-                      ) : (
-                        <SponsorPipelineView
-                          formData={formData}
-                          onFormDataChange={setFormData}
-                          onContractValueEdited={() =>
-                            setUserHasEditedValue(true)
-                          }
-                          sponsor={sponsor}
-                          availableSponsors={availableSponsors}
-                          regularTiers={regularTiers}
-                          addonTiers={addonTiers}
-                          organizers={organizers}
-                          isPending={isPending}
-                          onSubmit={handleSubmit}
-                          onCancel={handleClose}
-                          onOpenView={setView}
-                        />
-                      )}
-                    </div>
-                  </div>
-                </DialogPanel>
-              </TransitionChild>
+      <div className="p-6">
+        <div className="min-h-100 text-left">
+          {view === 'contacts' && sponsor ? (
+            <SponsorContactEditor
+              sponsorForConference={sponsor}
+              onSuccess={() => {
+                utils.sponsor.crm.list.invalidate()
+                utils.sponsor.crm.healthViolations.invalidate()
+              }}
+              onCancel={handleClose}
+            />
+          ) : view === 'logo' ? (
+            <SponsorLogoEditor
+              logo={formData.logo}
+              logoBright={formData.logoBright}
+              name={formData.name}
+              onChange={(updates) =>
+                updateFormData((prev) => ({
+                  ...prev,
+                  ...updates,
+                }))
+              }
+              className="py-4"
+            />
+          ) : view === 'history' && sponsor ? (
+            <div className="py-4">
+              <SponsorActivityTimeline
+                sponsorForConferenceId={sponsor._id}
+                showHeaderFooter={false}
+                limit={20}
+              />
             </div>
-          </div>
-        </Dialog>
-      </Transition>
-    </>
+          ) : view === 'contract' && sponsor ? (
+            <SponsorContractView
+              conferenceId={conferenceId}
+              sponsor={sponsor}
+              onSuccess={() => {
+                utils.sponsor.crm.list.invalidate()
+                utils.sponsor.crm.healthViolations.invalidate()
+              }}
+            />
+          ) : view === 'messages' && sponsor ? (
+            // Sponsor↔organizer thread (messaging G2b): ensured on
+            // open, then embedded for the organizer audience.
+            <SponsorMessagesPanel sponsorForConferenceId={sponsor._id} />
+          ) : (
+            <SponsorPipelineView
+              formData={formData}
+              onFormDataChange={updateFormData}
+              onContractValueEdited={() => setUserHasEditedValue(true)}
+              sponsor={sponsor}
+              availableSponsors={availableSponsors}
+              regularTiers={regularTiers}
+              addonTiers={addonTiers}
+              organizers={organizers}
+              isPending={isPending}
+              onSubmit={handleSubmit}
+              onCancel={handleClose}
+              onOpenView={setView}
+            />
+          )}
+        </div>
+      </div>
+    </ModalShell>
   )
 }

--- a/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
@@ -308,7 +308,7 @@ export function SponsorCRMForm({
                 onClick={handlePrimaryAction}
                 disabled={Boolean(primaryBlocked)}
                 className={clsx(
-                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-semibold shadow-sm transition-colors',
+                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-semibold shadow-xs transition-colors',
                   primaryBlocked
                     ? 'cursor-not-allowed bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-600'
                     : 'cursor-pointer bg-brand-cloud-blue text-white hover:bg-primary-700 dark:bg-indigo-600 dark:hover:bg-indigo-500',

--- a/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
+++ b/src/components/admin/sponsor-crm/SponsorCRMForm.tsx
@@ -68,6 +68,11 @@ export function SponsorCRMForm({
   // tier-price auto-fill effect keep using setFormData directly so merely
   // opening a sponsor never triggers the "Discard changes?" confirm.
   const [isDirty, setIsDirty] = useState(false)
+  // The Contacts & billing subview edits state INSIDE SponsorContactEditor,
+  // not via updateFormData, so its dirtiness can't ride `isDirty`. The editor
+  // reports its own unsaved-changes state through onDirtyChange; we OR it into
+  // the shell's guard so closing after a contact edit still prompts.
+  const [isContactsDirty, setIsContactsDirty] = useState(false)
 
   const [formData, setFormData] = useState({
     sponsorId: sponsor?.sponsor._id || '',
@@ -131,6 +136,9 @@ export function SponsorCRMForm({
 
   const handleClose = () => {
     setView('pipeline')
+    // Leaving the modal drops the contacts editor's in-progress state, so its
+    // dirty flag must not survive to over-prompt on the next open.
+    setIsContactsDirty(false)
     onClose()
   }
 
@@ -281,7 +289,7 @@ export function SponsorCRMForm({
       }
       subtitle={sponsor ? sponsor.sponsor.name : undefined}
       confirmOnDirtyClose
-      isDirty={isDirty}
+      isDirty={isDirty || isContactsDirty}
       className="border border-brand-frosted-steel bg-brand-glacier-white dark:border-gray-700"
     >
       {showToolbar && (
@@ -289,7 +297,12 @@ export function SponsorCRMForm({
           {view !== 'pipeline' ? (
             <button
               type="button"
-              onClick={() => setView('pipeline')}
+              onClick={() => {
+                // Back to details discards any in-progress contact edits, so
+                // clear their dirty flag as we leave the subview.
+                setIsContactsDirty(false)
+                setView('pipeline')
+              }}
               className="-ml-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 text-sm font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
             >
               <ChevronLeftIcon className="h-4 w-4" />
@@ -334,6 +347,7 @@ export function SponsorCRMForm({
                 utils.sponsor.crm.healthViolations.invalidate()
               }}
               onCancel={handleClose}
+              onDirtyChange={setIsContactsDirty}
             />
           ) : view === 'logo' ? (
             <SponsorLogoEditor

--- a/src/components/admin/sponsor-crm/SponsorPipelineView.tsx
+++ b/src/components/admin/sponsor-crm/SponsorPipelineView.tsx
@@ -262,7 +262,8 @@ export function SponsorPipelineView({
             'inline-flex cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm',
             isPending
               ? 'bg-gray-400 dark:bg-gray-600'
-              : 'bg-indigo-600 hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400',
+              : // House primary-footer-button color (brand-cloud-blue).
+                'bg-brand-cloud-blue hover:bg-primary-700 dark:bg-indigo-600 dark:hover:bg-indigo-500',
           )}
         >
           {isPending ? (

--- a/src/components/admin/sponsor/SponsorContactEditor.tsx
+++ b/src/components/admin/sponsor/SponsorContactEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ContactPerson } from '@/lib/sponsor/types'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 import {
@@ -23,6 +23,12 @@ interface SponsorContactEditorProps {
   onSuccess?: () => void
   onCancel?: () => void
   className?: string
+  /**
+   * Notifies the host whenever the editor's unsaved-changes state flips
+   * (compared against the initial contacts/billing snapshot). Lets modal
+   * hosts drive ModalShell's dirty-close guard for this editor's state.
+   */
+  onDirtyChange?: (dirty: boolean) => void
 }
 
 export function SponsorContactEditor({
@@ -30,6 +36,7 @@ export function SponsorContactEditor({
   onSuccess,
   onCancel,
   className = '',
+  onDirtyChange,
 }: SponsorContactEditorProps) {
   const [contacts, setContacts] = useState<ContactPerson[]>(
     sponsorForConference.contactPersons || [],
@@ -40,6 +47,20 @@ export function SponsorContactEditor({
     reference: sponsorForConference.billing?.reference || '',
     comments: sponsorForConference.billing?.comments || '',
   })
+
+  // Dirty tracking: compare against the state captured on mount. The callback
+  // lives in a ref so a host passing an inline lambda doesn't re-run the
+  // effect on every render.
+  const onDirtyChangeRef = useRef(onDirtyChange)
+  useEffect(() => {
+    onDirtyChangeRef.current = onDirtyChange
+  })
+  const [initialSnapshot] = useState(() => JSON.stringify([contacts, billing]))
+  useEffect(() => {
+    onDirtyChangeRef.current?.(
+      JSON.stringify([contacts, billing]) !== initialSnapshot,
+    )
+  }, [contacts, billing, initialSnapshot])
   const { showNotification } = useNotification()
   const utils = api.useUtils()
 

--- a/src/components/admin/sponsor/SponsorContactEditor.tsx
+++ b/src/components/admin/sponsor/SponsorContactEditor.tsx
@@ -55,12 +55,12 @@ export function SponsorContactEditor({
   useEffect(() => {
     onDirtyChangeRef.current = onDirtyChange
   })
-  const [initialSnapshot] = useState(() => JSON.stringify([contacts, billing]))
+  const initialSnapshotRef = useRef(JSON.stringify([contacts, billing]))
   useEffect(() => {
     onDirtyChangeRef.current?.(
-      JSON.stringify([contacts, billing]) !== initialSnapshot,
+      JSON.stringify([contacts, billing]) !== initialSnapshotRef.current,
     )
-  }, [contacts, billing, initialSnapshot])
+  }, [contacts, billing])
   const { showNotification } = useNotification()
   const utils = api.useUtils()
 
@@ -164,6 +164,9 @@ export function SponsorContactEditor({
           }
         : undefined,
     })
+
+    initialSnapshotRef.current = JSON.stringify([contacts, billing])
+    onDirtyChangeRef.current?.(false)
   }
 
   return (

--- a/src/components/admin/sponsor/SponsorContactTable.stories.tsx
+++ b/src/components/admin/sponsor/SponsorContactTable.stories.tsx
@@ -1,4 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { userEvent, within } from 'storybook/test'
+import { SponsorContactTable } from './SponsorContactTable'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import { mockSponsor } from '@/__mocks__/sponsor-data'
 import {
   EnvelopeIcon,
   BuildingOffice2Icon,
@@ -342,4 +346,31 @@ export const Documentation: Story = {
       </div>
     </div>
   ),
+}
+
+/**
+ * The REAL component (not the markup replicas above) with the edit dialog
+ * opened by the play function. The dialog is built on the canonical
+ * ModalShell (house header, mobile sheet, dirty-close guard fed by the
+ * embedded SponsorContactEditor) — shoot this story at 393px for QA.
+ */
+export const LiveEditDialog: Story = {
+  render: () => (
+    <NotificationProvider>
+      <div className="p-4">
+        <SponsorContactTable sponsors={[mockSponsor()]} />
+      </div>
+    </NotificationProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const editButtons = await canvas.findAllByTitle('Manage contacts')
+    // Click whichever affordance is visible at the current viewport
+    // (mobile card button below md, table-row button at md+).
+    const visible =
+      editButtons.find((b) => b.offsetParent !== null) ?? editButtons[0]
+    await userEvent.click(visible)
+    // Dialog portals to document.body.
+    await within(document.body).findByText('Contact Persons')
+  },
 }

--- a/src/components/admin/sponsor/SponsorContactTable.stories.tsx
+++ b/src/components/admin/sponsor/SponsorContactTable.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ThemeProvider } from 'next-themes'
 import { userEvent, within } from 'storybook/test'
 import { SponsorContactTable } from './SponsorContactTable'
 import { NotificationProvider } from '@/components/admin/NotificationProvider'
@@ -13,6 +14,19 @@ import {
 const meta = {
   title: 'Systems/Sponsors/Admin/Contacts/SponsorContactTable',
   tags: ['autodocs'],
+  decorators: [
+    // The edit dialog portals to document.body, outside the toolbar's `.dark`
+    // wrapper. next-themes context crosses the portal, so force it (synced to
+    // the Storybook theme global) for LiveEditDialog's dark QA.
+    (Story, context) => (
+      <ThemeProvider
+        attribute="class"
+        forcedTheme={context.globals.theme === 'dark' ? 'dark' : 'light'}
+      >
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
   parameters: {
     layout: 'fullscreen',
     options: { showPanel: false },

--- a/src/components/admin/sponsor/SponsorContactTable.tsx
+++ b/src/components/admin/sponsor/SponsorContactTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, Fragment } from 'react'
+import { useState, useEffect } from 'react'
 import { ContactPerson } from '@/lib/sponsor/types'
 import type { SponsorForConferenceExpanded } from '@/lib/sponsor-crm/types'
 import {
@@ -8,20 +8,13 @@ import {
   BuildingOffice2Icon,
   ClipboardIcon,
   PencilIcon,
-  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { CheckIcon } from '@heroicons/react/24/solid'
 import { api } from '@/lib/trpc/client'
 import { useNotification } from '@/components/admin'
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 import { SponsorContactEditor } from './SponsorContactEditor'
-import {
-  Dialog,
-  DialogPanel,
-  DialogTitle,
-  Transition,
-  TransitionChild,
-} from '@headlessui/react'
+import { ModalShell } from '@/components/ModalShell'
 import {
   TableContainer,
   TableHeader,
@@ -85,6 +78,9 @@ export function SponsorContactTable({
     useState<SponsorForConferenceExpanded[]>(initialSponsors)
   const [editingSponsor, setEditingSponsor] =
     useState<SponsorForConferenceExpanded | null>(null)
+  // Unsaved-changes state reported by the embedded SponsorContactEditor;
+  // drives ModalShell's dirty-close guard.
+  const [isEditorDirty, setIsEditorDirty] = useState(false)
   const utils = api.useUtils()
 
   useEffect(() => {
@@ -93,11 +89,13 @@ export function SponsorContactTable({
   }, [initialSponsors])
 
   const handleStartEdit = (sfc: SponsorForConferenceExpanded) => {
+    setIsEditorDirty(false)
     setEditingSponsor(sfc)
   }
 
   const handleCloseEdit = () => {
     setEditingSponsor(null)
+    setIsEditorDirty(false)
   }
 
   const handleUpdateSuccess = () => {
@@ -142,63 +140,29 @@ export function SponsorContactTable({
 
   return (
     <div>
-      {/* Editor Modal */}
-      <Transition appear show={!!editingSponsor} as={Fragment}>
-        <Dialog as="div" className="relative z-50" onClose={handleCloseEdit}>
-          <TransitionChild
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-black/25 backdrop-blur-xs dark:bg-black/50" />
-          </TransitionChild>
-
-          <div className="fixed inset-0 overflow-y-auto">
-            <div className="flex min-h-full items-center justify-center p-4 text-center">
-              <TransitionChild
-                as={Fragment}
-                enter="ease-out duration-300"
-                enterFrom="opacity-0 scale-95"
-                enterTo="opacity-100 scale-100"
-                leave="ease-in duration-200"
-                leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
-              >
-                <DialogPanel className="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-gray-900">
-                  <div className="mb-4 flex items-center justify-between">
-                    <DialogTitle
-                      as="h3"
-                      className="font-space-grotesk text-xl font-bold text-gray-900 dark:text-white"
-                    >
-                      Manage Contacts: {editingSponsor?.sponsor.name}
-                    </DialogTitle>
-                    <button
-                      onClick={handleCloseEdit}
-                      className="cursor-pointer rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-                    >
-                      <XMarkIcon className="h-6 w-6" />
-                    </button>
-                  </div>
-
-                  {editingSponsor && (
-                    <div className="mt-2">
-                      <SponsorContactEditor
-                        sponsorForConference={editingSponsor}
-                        onSuccess={handleUpdateSuccess}
-                        onCancel={handleCloseEdit}
-                      />
-                    </div>
-                  )}
-                </DialogPanel>
-              </TransitionChild>
-            </div>
+      {/* Editor Modal — canonical ModalShell (house header with a labeled
+          44px close, sheet presentation on mobile with internal scroll, and a
+          dirty-close guard fed by the editor's unsaved-changes state). */}
+      <ModalShell
+        isOpen={!!editingSponsor}
+        onClose={handleCloseEdit}
+        size="2xl"
+        title="Manage Contacts"
+        subtitle={editingSponsor?.sponsor.name}
+        confirmOnDirtyClose
+        isDirty={isEditorDirty}
+      >
+        {editingSponsor && (
+          <div className="text-left">
+            <SponsorContactEditor
+              sponsorForConference={editingSponsor}
+              onSuccess={handleUpdateSuccess}
+              onCancel={handleCloseEdit}
+              onDirtyChange={setIsEditorDirty}
+            />
           </div>
-        </Dialog>
-      </Transition>
+        )}
+      </ModalShell>
 
       <div className="space-y-3 md:hidden">
         {contactRows.map((row, index) => (


### PR DESCRIPTION
Batch 2 of the modal audit: repairs the four broken admin drivers flagged with measured evidence, on the ModalShell / ConfirmationModal house stack.

## 1. SearchModal — the ⌘K palette (daily driver)

- **z-index**: dialog sat at `z-10`, *under* the admin sticky headers (`z-40`). Now `z-50`, matching the ModalShell family. Verified in-browser: dialog root computed z-index 10 → 50.
- **Width containment**: panel gains `w-full min-w-0`; result titles/subtitles/descriptions now truncate at the leaf elements (`min-w-0` container + per-line `truncate`) instead of a wrapper-level clip. Long titles previously hard-clipped with no ellipsis; they now ellipsize.
- **The measured 393px overflow**: reproduced at scrollWidth **484px vs 393** on the `with-results` story. Root cause: the story's `layout: 'centered'` makes `<body>` a flex centering context that sizes the story to its min-content width, letting nowrap result titles inflate it — an environment the real dialog's `fixed inset-0` container can never produce (the live dialog measured 361px panel / 393 scrollWidth even before the fix). Replica stories now use the padded layout that mirrors the app, and the replica markup mirrors the fixed leaf-truncation.
- **After (measured at 393×852, light + dark)**: `with-results` scrollWidth **393 == viewport**; new `LiveWithResults` story (real portalled dialog + MSW-mocked search endpoints + play-typed query) scrollWidth **393 == viewport**, panel 361px.
- Palette idiom kept: no bottom sheet, esc-only close.

## 2. SponsorCRMForm — dirty guard + ModalShell adoption

- Rebuilt the hand-rolled dialog on ModalShell (`size="3xl"`, house header with title/subtitle + labeled 44px close, bottom sheet on mobile, `confirmOnDirtyClose`).
- **Dirty tracking**: user-initiated edits route through an `updateFormData` wrapper that arms the guard; the tier-price auto-fill effect keeps raw `setFormData` so merely opening a sponsor never arms it. Guard resets after a successful save (and `submitForm` failures no longer produce an unhandled rejection).
- **Header action approach**: ModalShell's header has no action slot (ModalShell untouched — parallel branches), so the back-button and the contextual primary action ("Mark as Won" etc.) live in a compliant toolbar row at the top of the body. This keeps *every* close path (backdrop, Escape, header X) behind the shell's dirty guard — a custom header close button would have bypassed it.
- Primary action + pipeline Save footer → `bg-brand-cloud-blue` per the house convention (Save footer lives in `SponsorPipelineView.tsx`, touched for the color only).
- Verified via Playwright: clean Esc closes; dirty Esc shows the in-dialog "Discard unsaved changes?"; Keep editing keeps the form; Discard dismisses and invokes close.

## 3. SponsorContactTable edit dialog — kept and rebuilt (not deleted)

Evaluated deletion first. **Decision: keep, rebuild on ModalShell.** Rationale:

- Sole render site is the standalone `/admin/sponsors/contacts` overview page. Deep-linking to the CRM form's contacts view is not currently possible: `SponsorCRMPipeline`'s URL restore only honors `view=history|contract` (a `?view=contacts` link opens the pipeline view), and extending it would touch files outside this batch's scope.
- Even with a deep link, jumping from the contacts overview to the CRM board modal loses the organizer's place/context — a real UX loss for a page whose job is bulk contact review.
- The duplication is only modal *chrome*; both hosts embed the same shared `SponsorContactEditor`. The rebuild deletes the hand-rolled chrome (32px unlabeled no-type close, `/25` backdrop, no scroll containment) in favor of ModalShell's house header/sheet/scroll handling.
- **Dirty guard**: added an optional `onDirtyChange` callback to `SponsorContactEditor` (snapshot comparison against mount state) — the one deviation from the strict file list, needed because the editor owns its own state. The CRM form's contacts view is unaffected (it doesn't pass the prop).

## 4. ImportHistoricSponsorsButton — confirm rebuilt on ConfirmationModal

- The content (tagging rules + skip note panels) fits ConfirmationModal's `children` slot, so the canonical confirm is used rather than raw ModalShell: house backdrop, dark gray-900 surface, theme-class portal handling, Cancel-left / primary-right footer (stacked-reverse on mobile) with explicit `type=`, and a brand-cloud-blue primary via the `info` variant.
- Minor behavior notes: pending label is ConfirmationModal's standard "Processing..." (was "Importing..."), and the confirm shape uses the house icon-circle header (no separate X button — Esc/backdrop/Cancel close, per every other ConfirmationModal).

## QA

- `pnpm shoot`-style captures at 393×852 (DPR 2), light + dark, for all four dialogs via new/existing stories (`LiveWithResults`, `EditExisting`, `ContactsView`, `LiveEditDialog`, `LiveConfirmDialog`); every capture measured scrollWidth == 393 (no horizontal overflow) and was visually inspected.
- New cheap live stories render the *real* components (play functions open the dialogs) alongside the existing markup replicas.
- `tsc --noEmit` clean, ESLint clean on all touched files, Prettier applied, full Vitest run green (281 files, 3869 passed / 5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves four admin dialogs onto the shared modal components and repairs the search palette layout. The main changes are:

- Raises SearchModal above sticky headers and fixes result truncation.
- Adds ModalShell and dirty-close handling to the sponsor CRM form.
- Rebuilds the standalone contact editor dialog on ModalShell.
- Replaces the historic-sponsor prompt with ConfirmationModal.
- Adds live Storybook states for visual checks.

<h3>Confidence Score: 4/5</h3>

The CRM contacts close path can discard unsaved edits without confirmation.

- Pipeline and logo edits correctly arm the new dirty guard.
- Contact edits remain inside `SponsorContactEditor` and never update the parent guard.
- The other modal and SearchModal changes match the inspected shared-component contracts.

src/components/admin/sponsor-crm/SponsorCRMForm.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/SearchModal.tsx | Raises the palette stacking level and constrains result text to prevent horizontal overflow. |
| src/components/admin/sponsor-crm/ImportHistoricSponsorsButton.tsx | Replaces the custom confirmation dialog with the shared ConfirmationModal. |
| src/components/admin/sponsor-crm/SponsorCRMForm.tsx | Adds ModalShell and dirty tracking, but contact changes are not connected to the close guard. |
| src/components/admin/sponsor/SponsorContactEditor.tsx | Adds optional snapshot-based dirty-state reporting for modal hosts. |
| src/components/admin/sponsor/SponsorContactTable.tsx | Moves contact editing to ModalShell and wires the editor's dirty state into its close guard. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(modals): repair broken admin drivers..."](https://github.com/cloudnativebergen/website/commit/3ae4307ccd250abc6150db1c1954ee59e8a2d885) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46286052)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/cloudnativedays/github/cloudnativebergen/website/-/custom-context?memory=be794683-cdaf-402d-8a40-c798b2c157c4))

<!-- /greptile_comment -->