### PR TITLE
fix: do not show speaker promo image if no accepted proposals

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -28,7 +28,6 @@
     "migrations/**",
     "src/lib/empty-module.ts",
     "src/components/admin/dashboard/widgets/__matrix__/mock-admin-actions.ts",
-    "src/components/email/CoSpeakerResponseTemplate.tsx",
     "src/lib/sponsor-crm/contract-send.ts"
   ],
   "ignoreDependencies": ["eslint-config-next", "ts-node", "chromatic"],

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@vercel/blob": "^2.5.0",
     "@vercel/speed-insights": "^2.0.0",
     "@workos-inc/authkit-nextjs": "^4.2.0",
-    "@workos-inc/node": "^10.7.0",
     "@xmldom/xmldom": "^0.9.10",
     "apexcharts": "^5.15.2",
     "bs58": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,10 +106,7 @@ importers:
         version: 2.0.0(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@workos-inc/authkit-nextjs':
         specifier: ^4.2.0
-        version: 4.2.0(@workos-inc/node@10.7.0)(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@workos-inc/node':
-        specifier: ^10.7.0
-        version: 10.7.0
+        version: 4.2.0(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@xmldom/xmldom':
         specifier: ^0.9.10
         version: 0.9.10
@@ -5120,10 +5117,6 @@ packages:
       next: ^13.5.9 || ^14.2.26 || ^15.2.3 || ^16
       react: ^18.0 || ^19.0.0
       react-dom: ^18.0 || ^19.0.0
-
-  '@workos-inc/node@10.7.0':
-    resolution: {integrity: sha512-rffa9znZuIv4yo+9JRxGOLTTSxh0XhOT6jlsktgqEi9MuB9V0VFHRzLd3bTpkq+J9sgrPZNGpvX4aWNfMqt5cQ==}
-    engines: {node: '>=22.11.0'}
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
@@ -16224,10 +16217,9 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@workos-inc/authkit-nextjs@4.2.0(@workos-inc/node@10.7.0)(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@workos-inc/authkit-nextjs@4.2.0(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
     dependencies:
       '@sindresorhus/fnv1a': 3.1.0
-      '@workos-inc/node': 10.7.0
       iron-session: 8.0.4
       jose: 5.10.0
       next: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -16237,8 +16229,6 @@ snapshots:
       valibot: 1.4.2(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
-
-  '@workos-inc/node@10.7.0': {}
 
   '@xmldom/xmldom@0.9.10': {}
 

--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -292,7 +292,6 @@ export default async function SpeakerDashboard() {
             onLinkAction={startProviderLink}
           />
         </div>
-
       </div>
     )
   }

--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -293,9 +293,6 @@ export default async function SpeakerDashboard() {
           />
         </div>
 
-        <div className="mt-6 max-w-md">
-          <SpeakerShare speaker={speakerWithTalks} />
-        </div>
       </div>
     )
   }
@@ -349,7 +346,7 @@ export default async function SpeakerDashboard() {
               />
             )}
 
-            {(confirmedTalks.length > 0 || !latestBadge) && (
+            {confirmedTalks.length > 0 && (
               <SpeakerShareSidebar
                 speaker={speakerWithTalks}
                 talkTitle={talkTitle}

--- a/src/components/admin/sponsor/SponsorActivityInput.tsx
+++ b/src/components/admin/sponsor/SponsorActivityInput.tsx
@@ -99,7 +99,7 @@ export function SponsorActivityInput({
             </button>
           </div>
         </div>
-        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/admin/sponsor/SponsorActivityInput.tsx
+++ b/src/components/admin/sponsor/SponsorActivityInput.tsx
@@ -40,8 +40,8 @@ export function SponsorActivityInput({
       },
     })
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSubmit = (e?: React.FormEvent | React.MouseEvent) => {
+    if (e) e.preventDefault()
     if (!description.trim() || isPending) return
 
     createActivity({
@@ -53,7 +53,7 @@ export function SponsorActivityInput({
 
   return (
     <div className="mb-6 rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-800 dark:bg-white/5">
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-4">
         <div className="flex flex-wrap gap-2">
           {ACTIVITY_TYPES.map((type) => (
             <button
@@ -85,7 +85,8 @@ export function SponsorActivityInput({
           />
           <div className="absolute right-2 bottom-2">
             <button
-              type="submit"
+              type="button"
+              onClick={handleSubmit}
               disabled={!description.trim() || isPending}
               className="flex size-8 items-center justify-center rounded-full bg-indigo-600 text-white shadow-xs transition-colors hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
               title="Post activity"
@@ -98,7 +99,7 @@ export function SponsorActivityInput({
             </button>
           </div>
         </div>
-      </form>
+        </div>
     </div>
   )
 }


### PR DESCRIPTION
Fixes issue where the speaker promo image is displayed to speakers that have not yet been accepted for the current year's conference. Removed from the empty state and updated sidebar condition to require at least one confirmed talk.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the speaker promo image (`SpeakerShareSidebar`) was incorrectly shown to speakers with no accepted proposals. The old sidebar condition `(confirmedTalks.length > 0 || !latestBadge)` would render the promo image whenever a speaker had no badge, even with zero confirmed talks; the new `confirmedTalks.length > 0` guard is correct.

- `page.tsx`: promo image removed from the zero-conferences empty state and sidebar gated on at least one confirmed/accepted talk.
- `SponsorActivityInput.tsx`: `<form>` replaced by `<div>`, converting submission from native form submit to an `onClick` handler — the fix works but loses the semantic form landmark.
- `package.json` / `pnpm-lock.yaml`: removes `@workos-inc/node` (confirmed unused in source); `knip.json` drops a now-unnecessary ignore entry for `CoSpeakerResponseTemplate.tsx`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core speaker promo fix is correct and the dependency cleanup is verified unused.

The sidebar condition change and empty-state removal are both correct and address the described bug. The unrelated SponsorActivityInput form-to-div refactor is functionally equivalent but loses the semantic HTML form landmark, which is a minor accessibility trade-off worth noting before merging.

src/components/admin/sponsor/SponsorActivityInput.tsx — the removal of the form element is worth a second look for accessibility implications.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/(cfp)/cfp/list/page.tsx | Removes SpeakerShare from empty state and tightens sidebar condition to require confirmed talks, correctly fixing the premature promo image display |
| src/components/admin/sponsor/SponsorActivityInput.tsx | Replaces <form> with <div> and changes submit button from type="submit" to type="button" with onClick; loses semantic form landmark but is functionally equivalent for this textarea-based component |
| package.json | Removes @workos-inc/node direct dependency; confirmed unused in application source code |
| knip.json | Removes CoSpeakerResponseTemplate.tsx from knip ignore list; the file is now referenced in the email barrel export so the ignore was no longer needed |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Speaker Dashboard loads] --> B{activeConferences.length == 0?}
    B -- Yes --> C[Show empty state\nNo SpeakerShare shown]
    B -- No --> D[Render main layout]
    D --> E[Sidebar]
    E --> F{latestBadge?}
    F -- Yes --> G[Show BadgeShare]
    F -- No --> H[Skip BadgeShare]
    G --> I{confirmedTalks.length > 0?}
    H --> I
    I -- Yes --> J[Show SpeakerShareSidebar ✅]
    I -- No --> K[Skip SpeakerShareSidebar\nFix: was shown here before\nwhen latestBadge was falsy]
```

<sub>Reviews (1): Last reviewed commit: ["style: run prettier"](https://github.com/cloudnativebergen/website/commit/6d3f321685a2cfc1844221c5fc7e89cf89695d32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46816509)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->