### PR TITLE
test(stories): ProposalForm, WorkshopList, CFPProfilePage state coverage

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -55,6 +55,25 @@ const config: StorybookConfig = {
         }
       },
     })
+    // CFPProfilePage imports `startProviderLink` from a `'use server'` module
+    // (`@/app/(cfp)/cfp/profile/link-actions`) that pulls in `next/headers` and
+    // the server-only auth stack — none of which can load in the browser
+    // bundle. Stub it to a browser-safe no-op action so the profile page can be
+    // storied (same aliasing technique as the CloudNativePattern stub below).
+    config.plugins.push({
+      name: 'mock-cfp-link-actions',
+      enforce: 'pre',
+      resolveId(id) {
+        if (id === '@/app/(cfp)/cfp/profile/link-actions') {
+          return '\0mock:cfp-link-actions'
+        }
+      },
+      load(id) {
+        if (id === '\0mock:cfp-link-actions') {
+          return `export async function startProviderLink() { return { ok: true } }`
+        }
+      },
+    })
     config.plugins.push({
       name: 'mock-cloud-native-pattern',
       enforce: 'pre',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -65,12 +65,10 @@ const config: StorybookConfig = {
       enforce: 'pre',
       resolveId(id) {
         if (id === '@/app/(cfp)/cfp/profile/link-actions') {
-          return '\0mock:cfp-link-actions'
-        }
-      },
-      load(id) {
-        if (id === '\0mock:cfp-link-actions') {
-          return `export async function startProviderLink() { return { ok: true } }`
+          // A REAL typed file (not a virtual module) so the stub's export
+          // surface is compile-time-pinned to the actual server module via
+          // its `satisfies typeof import(...)` guard — drift breaks typecheck.
+          return join(__dirname, 'mocks/cfp-link-actions.ts')
         }
       },
     })

--- a/.storybook/mocks/cfp-link-actions.ts
+++ b/.storybook/mocks/cfp-link-actions.ts
@@ -1,0 +1,16 @@
+/**
+ * Browser-safe Storybook stand-in for the 'use server' module
+ * `@/app/(cfp)/cfp/profile/link-actions` (aliased in main.ts). The satisfies
+ * check pins this stub to the REAL module's export surface at compile time, so
+ * a signature/exports change there breaks the typecheck here instead of
+ * silently drifting the stories.
+ */
+export async function startProviderLink(formData: FormData): Promise<void> {
+  void formData
+}
+
+// Compile-time parity guard against the real module.
+const _parity = {
+  startProviderLink,
+} satisfies typeof import('@/app/(cfp)/cfp/profile/link-actions')
+void _parity

--- a/src/components/cfp/CFPProfilePage.stories.tsx
+++ b/src/components/cfp/CFPProfilePage.stories.tsx
@@ -1,0 +1,193 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useEffect } from 'react'
+import { http, HttpResponse } from 'msw'
+import type { Decorator } from '@storybook/nextjs-vite'
+import { userEvent, within } from 'storybook/test'
+import { CFPProfilePage } from './CFPProfilePage'
+import { Speaker, Flags } from '@/lib/speaker/types'
+import { ProfileEmail } from '@/lib/profile/types'
+import { DEFAULT_PUSH_PREFERENCES } from '@/lib/push/types'
+
+// The speaker profile page. On mount it fires `speaker.getCurrent` (seeded from
+// the `initialSpeaker` prop), `speaker.getEmails`, and the push settings card's
+// `push.getVapidKey` / `push.getPreferences` — all mocked at the tRPC HTTP
+// boundary via MSW. `push.getVapidKey` returns an EMPTY key on purpose so the
+// push card renders its "not configured" state without touching the browser
+// push/subscription APIs in Storybook.
+
+const trpc = (data: unknown) => HttpResponse.json({ result: { data } })
+
+const filledSpeaker = {
+  _id: 'speaker-1',
+  _rev: 'rev1',
+  _createdAt: '2026-01-01T00:00:00Z',
+  _updatedAt: '2026-01-01T00:00:00Z',
+  name: 'Alice Johnson',
+  email: 'alice@gmail.com',
+  slug: 'alice-johnson',
+  title: 'Senior Platform Engineer at Google Cloud',
+  bio: 'Alice is a passionate advocate for cloud native technologies with over 10 years of experience in distributed systems and Kubernetes.',
+  image: 'https://placehold.co/200x200/EEE/31343C?text=AJ',
+  flags: [Flags.localSpeaker],
+  gender: 'Woman',
+  country: 'Norway',
+  links: [
+    'https://linkedin.com/in/alicejohnson',
+    'https://github.com/alicejohnson',
+  ],
+  providers: ['github:123', 'linkedin:456'],
+  consent: {
+    dataProcessing: { granted: true, grantedAt: '2026-01-01T00:00:00Z' },
+    marketing: { granted: false },
+    publicProfile: { granted: true, grantedAt: '2026-01-01T00:00:00Z' },
+    photography: { granted: true, grantedAt: '2026-01-01T00:00:00Z' },
+  },
+} as unknown as Speaker
+
+const emptySpeaker = {
+  _id: 'speaker-2',
+  _rev: 'rev1',
+  _createdAt: '2026-01-01T00:00:00Z',
+  _updatedAt: '2026-01-01T00:00:00Z',
+  name: 'New Speaker',
+  email: 'new@example.com',
+  slug: 'new-speaker',
+  providers: ['github:789'],
+} as unknown as Speaker
+
+const mockEmails: ProfileEmail[] = [
+  {
+    email: 'alice@gmail.com',
+    primary: true,
+    verified: true,
+    visibility: 'public',
+  },
+  {
+    email: 'alice.work@company.io',
+    primary: false,
+    verified: true,
+    visibility: 'private',
+  },
+]
+
+const queryHandlersFor = (speaker: Speaker) => [
+  http.get('/api/trpc/:proc', ({ params }) => {
+    switch (params.proc) {
+      case 'speaker.getCurrent':
+        return trpc(speaker)
+      case 'speaker.getEmails':
+        return trpc(mockEmails)
+      case 'push.getVapidKey':
+        // Empty publicKey → push card renders its "not configured" state.
+        return trpc({ publicKey: '' })
+      case 'push.getPreferences':
+        return trpc(DEFAULT_PUSH_PREFERENCES)
+      default:
+        return trpc(null)
+    }
+  }),
+]
+
+const mutationHandlers = [
+  http.post('/api/trpc/speaker.update', () => trpc(filledSpeaker)),
+  http.post('/api/trpc/speaker.setMessagingEmailDefault', () =>
+    trpc({ success: true }),
+  ),
+]
+
+const handlersFor = (speaker: Speaker) => [
+  ...queryHandlersFor(speaker),
+  ...mutationHandlers,
+]
+
+// A component (not just the decorator closure) so the `useEffect` that mirrors
+// `.dark` onto `<html>` — needed for portaled push-permission UI — satisfies
+// the rules-of-hooks lint. Mirrors the `withPortalTheme` helper.
+function ThemeFrame({
+  dark,
+  children,
+}: {
+  dark: boolean
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark)
+    return () => document.documentElement.classList.remove('dark')
+  }, [dark])
+  return (
+    <div className={dark ? 'dark' : ''}>
+      <div className={dark ? 'bg-gray-950 p-4' : 'bg-white p-4'}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+const withTheme: Decorator = (Story, ctx) => (
+  <ThemeFrame dark={!!ctx.parameters.dark}>
+    <Story />
+  </ThemeFrame>
+)
+
+const meta = {
+  title: 'Systems/CFP/CFPProfilePage',
+  component: CFPProfilePage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: handlersFor(filledSpeaker) },
+    docs: {
+      description: {
+        component:
+          'The speaker profile page: identity/email, linked providers, the speaker details form, message-email default, and push settings. Stories cover the filled and near-empty profiles, the provider-link result banners, and a successful save. tRPC is mocked via MSW.',
+      },
+    },
+  },
+  args: {
+    initialSpeaker: filledSpeaker,
+    currentProvider: 'github',
+  },
+  decorators: [withTheme],
+} satisfies Meta<typeof CFPProfilePage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** A complete profile: bio, image, links, two linked providers. */
+export const Filled: Story = {}
+
+export const FilledDark: Story = {
+  parameters: { dark: true, msw: { handlers: handlersFor(filledSpeaker) } },
+}
+
+/** A freshly created profile: name/email only, one linked provider. */
+export const Empty: Story = {
+  args: { initialSpeaker: emptySpeaker },
+  parameters: { msw: { handlers: handlersFor(emptySpeaker) } },
+}
+
+/** Returned from a successful provider link (`?linkResult=linked`). */
+export const LinkedSuccess: Story = {
+  args: { linkResult: 'linked' },
+}
+
+/** The linked account already belongs to another profile (amber notice). */
+export const AlreadyLinked: Story = {
+  args: { linkResult: 'already-linked' },
+}
+
+/** The link attempt failed (red notice). */
+export const LinkError: Story = {
+  args: { linkResult: 'error' },
+}
+
+/** Saving the profile surfaces the green "Profile updated" confirmation. */
+export const SaveSuccess: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      canvas.getByRole('button', { name: /update profile/i }),
+    )
+    await canvas.findByText(/profile updated successfully/i)
+  },
+}

--- a/src/components/cfp/ProposalForm.stories.tsx
+++ b/src/components/cfp/ProposalForm.stories.tsx
@@ -54,9 +54,16 @@ const mockEmails: ProfileEmail[] = [
 // A GET catch-all so no on-mount query (currently only `speaker.getEmails`)
 // hits the network unhandled. Mutations get their own POST handlers per story.
 const queryHandlers = [
-  http.get('/api/trpc/:proc', ({ params }) =>
-    params.proc === 'speaker.getEmails' ? trpc(mockEmails) : trpc(null),
-  ),
+  http.get('/api/trpc/:proc', ({ params }) => {
+    if (params.proc === 'speaker.getEmails') return trpc(mockEmails)
+    // Benign null for procs the form incidentally fires — but SAY SO, so a
+    // missing mock surfaces in the story logs instead of silently rendering
+    // empty (the catch-all must not hide unmocked queries).
+    console.warn(
+      `[ProposalForm.stories] unmocked tRPC query: ${String(params.proc)}`,
+    )
+    return trpc(null)
+  }),
 ]
 
 const okMutationHandlers = [

--- a/src/components/cfp/ProposalForm.stories.tsx
+++ b/src/components/cfp/ProposalForm.stories.tsx
@@ -1,0 +1,412 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useEffect } from 'react'
+import { http, HttpResponse, delay } from 'msw'
+import type { Decorator } from '@storybook/nextjs-vite'
+import { userEvent, within } from 'storybook/test'
+import { ProposalForm } from './ProposalForm'
+import {
+  Audience,
+  Format,
+  Language,
+  Level,
+  ProposalInput,
+  Status,
+} from '@/lib/proposal/types'
+import { SpeakerInput, Speaker } from '@/lib/speaker/types'
+import { Conference } from '@/lib/conference/types'
+import { Topic } from '@/lib/topic/types'
+import { ProfileEmail } from '@/lib/profile/types'
+import { convertStringToPortableTextBlocks } from '@/lib/proposal'
+import { mockDateBeforeEach } from '@/lib/storybook'
+
+// ProposalForm is THE speaker submission form. Every data need is met at the
+// tRPC HTTP boundary via MSW (the global TRPCDecorator uses `httpLink`, so each
+// procedure is its own request at `/api/trpc/<proc>`). The only query that
+// fires on mount is `speaker.getEmails` (user mode); the mutations below back
+// the submit/draft/withdraw flows exercised by the play functions.
+
+const NOW = new Date('2026-09-01T12:00:00Z')
+
+const trpc = (data: unknown) => HttpResponse.json({ result: { data } })
+const trpcError = (message = 'The server ran into a problem. Please retry.') =>
+  HttpResponse.json(
+    {
+      error: { message, code: -32603, data: { code: 'INTERNAL_SERVER_ERROR' } },
+    },
+    { status: 500 },
+  )
+
+const mockEmails: ProfileEmail[] = [
+  {
+    email: 'alice@gmail.com',
+    primary: true,
+    verified: true,
+    visibility: 'public',
+  },
+  {
+    email: 'alice.work@company.io',
+    primary: false,
+    verified: true,
+    visibility: 'private',
+  },
+]
+
+// A GET catch-all so no on-mount query (currently only `speaker.getEmails`)
+// hits the network unhandled. Mutations get their own POST handlers per story.
+const queryHandlers = [
+  http.get('/api/trpc/:proc', ({ params }) =>
+    params.proc === 'speaker.getEmails' ? trpc(mockEmails) : trpc(null),
+  ),
+]
+
+const okMutationHandlers = [
+  http.post('/api/trpc/speaker.update', () => trpc({ _id: 'speaker-1' })),
+  http.post('/api/trpc/proposal.create', () => trpc({ _id: 'new-proposal-1' })),
+  http.post('/api/trpc/proposal.update', () => trpc({ _id: 'proposal-1' })),
+  http.post('/api/trpc/proposal.action', () => trpc({ success: true })),
+]
+
+const mockTopics: Topic[] = [
+  {
+    _id: 'topic-1',
+    _type: 'topic',
+    title: 'Kubernetes',
+    color: '#326CE5',
+    slug: { current: 'kubernetes' },
+  },
+  {
+    _id: 'topic-2',
+    _type: 'topic',
+    title: 'Observability',
+    color: '#2A9D8F',
+    slug: { current: 'observability' },
+  },
+]
+
+const baseConference = {
+  _id: 'conf-1',
+  title: 'Cloud Native Days Norway 2026',
+  organizer: 'Cloud Native Days Norway',
+  city: 'Bergen',
+  country: 'Norway',
+  startDate: '2026-12-01',
+  endDate: '2026-12-01',
+  cfpStartDate: '2026-06-01',
+  cfpEndDate: '2026-12-31',
+  cfpNotifyDate: '2026-11-15',
+  cfpEmail: 'cfp@cloudnativebergen.no',
+  sponsorEmail: 'sponsors@cloudnativebergen.no',
+  programDate: '2026-11-01',
+  contactEmail: 'info@cloudnativebergen.no',
+  registrationEnabled: true,
+  domains: ['cloudnativedaybergen.no'],
+  formats: [
+    Format.lightning_10,
+    Format.presentation_25,
+    Format.presentation_45,
+    Format.workshop_120,
+  ],
+  topics: mockTopics,
+  organizers: [],
+} as unknown as Conference
+
+// CFP open, event far off → withdrawals still allowed.
+const conferenceCfpOpen = baseConference
+// Event within the 14-day withdrawal cutoff.
+const conferenceWithdrawClosed = {
+  ...baseConference,
+  startDate: '2026-09-08',
+  endDate: '2026-09-08',
+} as unknown as Conference
+
+const allowedFormats = [
+  Format.lightning_10,
+  Format.presentation_25,
+  Format.presentation_45,
+]
+
+const emptyProposal: ProposalInput = {
+  title: '',
+  language: Language.norwegian,
+  description: [],
+  format: Format.lightning_10,
+  level: Level.beginner,
+  audiences: [],
+  outline: '',
+  topics: [],
+  tos: false,
+}
+
+const filledProposal: ProposalInput = {
+  title: 'Building Scalable Kubernetes Applications',
+  language: Language.english,
+  description: convertStringToPortableTextBlocks(
+    'This talk explores modern approaches to building and deploying scalable applications on Kubernetes using platform engineering principles.',
+  ),
+  format: Format.presentation_45,
+  level: Level.intermediate,
+  audiences: [Audience.developer, Audience.operator],
+  outline:
+    '1. Introduction (5 min)\n2. Challenges at Scale (10 min)\n3. Golden Paths (15 min)\n4. Demo (10 min)\n5. Q&A (5 min)',
+  topics: [mockTopics[0], mockTopics[1]],
+  tos: true,
+}
+
+const emptySpeaker: SpeakerInput = { name: '' }
+
+const consentedSpeaker: SpeakerInput = {
+  name: 'Alice Johnson',
+  title: 'Senior Platform Engineer',
+  bio: 'Cloud native advocate with a decade in distributed systems.',
+  consent: {
+    dataProcessing: { granted: true, grantedAt: '2026-01-01T00:00:00Z' },
+    marketing: { granted: false },
+    publicProfile: { granted: true, grantedAt: '2026-01-01T00:00:00Z' },
+    photography: { granted: true, grantedAt: '2026-01-01T00:00:00Z' },
+  },
+}
+
+const makeSpeaker = (id: string, name: string, email: string): Speaker =>
+  ({
+    _id: id,
+    _rev: 'rev1',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    name,
+    email,
+    title: 'Engineer at TechCorp',
+    slug: name.toLowerCase().replace(/\s+/g, '-'),
+  }) as Speaker
+
+const currentUserSpeaker = makeSpeaker(
+  'speaker-1',
+  'Alice Johnson',
+  'alice@gmail.com',
+)
+const coSpeaker = makeSpeaker('speaker-2', 'Erik Larsen', 'erik@techcorp.no')
+
+// Proposal that already has a primary + co-speaker (edit view).
+const proposalWithSpeakers = {
+  ...filledProposal,
+  speakers: [currentUserSpeaker, coSpeaker],
+} as unknown as ProposalInput
+
+/**
+ * Wraps the story in an explicit theme so light/dark captures are deterministic
+ * (via `parameters.dark`), and mirrors `.dark` onto `<html>` so the withdraw
+ * ConfirmationModal — which portals to `document.body` — also themes correctly.
+ * A component (not the bare decorator closure) so `useEffect` is rules-of-hooks
+ * clean.
+ */
+function ThemeFrame({
+  dark,
+  children,
+}: {
+  dark: boolean
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark)
+    return () => document.documentElement.classList.remove('dark')
+  }, [dark])
+  return (
+    <div className={dark ? 'dark' : ''}>
+      <div className={dark ? 'bg-gray-950 p-4' : 'bg-white p-4'}>
+        <div className="mx-auto max-w-3xl">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+const withTheme: Decorator = (Story, ctx) => (
+  <ThemeFrame dark={!!ctx.parameters.dark}>
+    <Story />
+  </ThemeFrame>
+)
+
+const meta = {
+  title: 'Systems/CFP/ProposalForm',
+  component: ProposalForm,
+  beforeEach: mockDateBeforeEach(NOW),
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: [...queryHandlers, ...okMutationHandlers] },
+    docs: {
+      description: {
+        component:
+          'The speaker CFP submission form. Stories cover the create / edit / draft / read-only variants and the validation, server-error, and in-flight submit surfaces. tRPC is mocked at the HTTP boundary via MSW.',
+      },
+    },
+  },
+  args: {
+    userEmail: 'alice@gmail.com',
+    conference: conferenceCfpOpen,
+    allowedFormats,
+    currentUserSpeaker,
+  },
+  decorators: [withTheme],
+} satisfies Meta<typeof ProposalForm>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** New submission: empty proposal + speaker, Save Draft + Submit actions. */
+export const NewSubmission: Story = {
+  args: {
+    initialProposal: emptyProposal,
+    initialSpeaker: emptySpeaker,
+    mode: 'user',
+  },
+}
+
+export const NewSubmissionDark: Story = {
+  args: NewSubmission.args,
+  parameters: { dark: true },
+}
+
+/** Editing a submitted proposal: shows the Unsubmit action + a co-speaker. */
+export const EditSubmitted: Story = {
+  args: {
+    initialProposal: proposalWithSpeakers,
+    initialSpeaker: consentedSpeaker,
+    proposalId: 'proposal-1',
+    initialStatus: Status.submitted,
+    mode: 'user',
+  },
+}
+
+export const EditSubmittedDark: Story = {
+  args: EditSubmitted.args,
+  parameters: { dark: true },
+}
+
+/** An existing draft: Delete Draft + Save Draft + Submit are all available. */
+export const ExistingDraft: Story = {
+  args: {
+    initialProposal: filledProposal,
+    initialSpeaker: consentedSpeaker,
+    proposalId: 'proposal-1',
+    initialStatus: Status.draft,
+    mode: 'user',
+  },
+}
+
+/** Accepted proposal outside the cutoff: the Withdraw action is offered. */
+export const AcceptedWithdrawable: Story = {
+  args: {
+    initialProposal: filledProposal,
+    initialSpeaker: consentedSpeaker,
+    proposalId: 'proposal-1',
+    initialStatus: Status.accepted,
+    mode: 'user',
+  },
+}
+
+/** Accepted proposal inside the 14-day cutoff: withdrawal is closed (notice). */
+export const WithdrawalClosed: Story = {
+  args: {
+    initialProposal: filledProposal,
+    initialSpeaker: consentedSpeaker,
+    proposalId: 'proposal-1',
+    initialStatus: Status.accepted,
+    conference: conferenceWithdrawClosed,
+    mode: 'user',
+  },
+}
+
+/** Read-only view (e.g. an organizer inspecting): speakers list, no actions. */
+export const ReadOnly: Story = {
+  args: {
+    initialProposal: proposalWithSpeakers,
+    initialSpeaker: consentedSpeaker,
+    proposalId: 'proposal-1',
+    initialStatus: Status.submitted,
+    mode: 'readOnly',
+  },
+}
+
+/** Admin edit: no speaker/co-speaker sections, Update saves the proposal. */
+export const AdminEdit: Story = {
+  args: {
+    initialProposal: filledProposal,
+    initialSpeaker: consentedSpeaker,
+    proposalId: 'proposal-1',
+    initialStatus: Status.submitted,
+    mode: 'admin',
+  },
+}
+
+/**
+ * Submitting an empty form surfaces the consent validation error box
+ * (missing data-processing + public-profile consents).
+ */
+export const ValidationError: Story = {
+  args: {
+    initialProposal: { ...emptyProposal, title: 'My Talk' },
+    initialSpeaker: emptySpeaker,
+    mode: 'user',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /^submit$/i }))
+    await canvas.findByText(/Submission failed/i)
+    await canvas.findByText(/required consents/i)
+  },
+}
+
+/**
+ * The server rejects the create: the red "Submission failed" box shows the
+ * mutation error message.
+ */
+export const ServerError: Story = {
+  args: {
+    initialProposal: { ...filledProposal, title: 'Talk That Fails To Save' },
+    initialSpeaker: consentedSpeaker,
+    mode: 'user',
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        ...queryHandlers,
+        http.post('/api/trpc/speaker.update', () => trpc({ _id: 'speaker-1' })),
+        http.post('/api/trpc/proposal.create', () => trpcError()),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /^submit$/i }))
+    await canvas.findByText(/Submission failed/i)
+  },
+}
+
+/**
+ * In-flight submit: the update never resolves, so the primary button reads
+ * "Updating…" and every action is disabled.
+ */
+export const SubmittingPending: Story = {
+  args: {
+    initialProposal: filledProposal,
+    initialSpeaker: consentedSpeaker,
+    proposalId: 'proposal-1',
+    initialStatus: Status.submitted,
+    mode: 'admin',
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        ...queryHandlers,
+        http.post('/api/trpc/proposal.update', async () => {
+          await delay('infinite')
+          return trpc({})
+        }),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /^update$/i }))
+    await canvas.findByRole('button', { name: /updating/i })
+  },
+}

--- a/src/components/workshop/WorkshopList.stories.tsx
+++ b/src/components/workshop/WorkshopList.stories.tsx
@@ -1,0 +1,300 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useEffect } from 'react'
+import { http, HttpResponse, delay } from 'msw'
+import type { Decorator } from '@storybook/nextjs-vite'
+import { userEvent, within } from 'storybook/test'
+import WorkshopList from './WorkshopList'
+import type { ProposalWithWorkshopData } from '@/lib/workshop/types'
+import { mockDateBeforeEach } from '@/lib/storybook'
+
+// The public attendee workshop signup list. Its three on-mount queries
+// (`workshop.list`, `workshop.getMySignups`, `workshop.announcements` — one per
+// card) plus the signup/cancel mutations are all mocked at the tRPC HTTP
+// boundary via MSW. NOTE #606 removed the `conference` prop; the current props
+// are identity + registration-window only.
+
+const NOW = new Date('2026-09-01T12:00:00Z')
+
+const trpc = (data: unknown) => HttpResponse.json({ result: { data } })
+const listResponse = (workshops: unknown[]) =>
+  trpc({ success: true, data: workshops, count: workshops.length })
+
+const makeWorkshop = (
+  id: string,
+  title: string,
+  available: number,
+  overrides: Partial<Record<string, unknown>> = {},
+) =>
+  ({
+    _id: id,
+    title,
+    format: 'workshop_120',
+    capacity: 30,
+    signups: 30 - available,
+    available,
+    waitlistCount: available === 0 ? 4 : 0,
+    // startTime/endTime are "HH:MM" (the shape `formatTime12Hour` and the
+    // overlap check expect) — NOT full ISO datetimes.
+    date: '2026-09-10',
+    startTime: '09:00',
+    endTime: '11:00',
+    room: 'Workshop Room A',
+    description:
+      'A hands-on introduction with the Operator SDK. Bring a laptop with ' +
+      'kubectl and Docker installed.',
+    speakers: [
+      {
+        _id: `sp-${id}`,
+        name: 'Grace Hopper',
+        slug: 'grace-hopper',
+        title: 'Principal Engineer, CloudCorp',
+        image: 'https://placehold.co/80x80/3b82f6/ffffff?text=GH',
+      },
+    ],
+    topics: [{ _id: 't-1', title: 'Kubernetes', color: '#3b82f6' }],
+    ...overrides,
+  }) as unknown as ProposalWithWorkshopData
+
+const wsAvailableA = makeWorkshop(
+  'ws-1',
+  'Getting Started with Kubernetes Operators',
+  18,
+)
+const wsAvailableB = makeWorkshop(
+  'ws-2',
+  'Progressive Delivery with Argo Rollouts',
+  6,
+  {
+    startTime: '13:00',
+    endTime: '15:00',
+    room: 'Workshop Room B',
+  },
+)
+const wsFull = makeWorkshop('ws-3', 'Zero-Trust Networking Deep Dive', 0, {
+  date: '2026-09-11',
+  startTime: '09:00',
+  endTime: '11:00',
+  room: 'Workshop Room C',
+})
+
+const signup = (
+  id: string,
+  wsId: string,
+  status: 'confirmed' | 'waitlist',
+) => ({
+  _id: id,
+  _type: 'workshopSignup',
+  status,
+  workshop: { _type: 'reference', _ref: wsId },
+})
+
+const signupsResponse = (signups: unknown[]) =>
+  trpc({ success: true, data: signups, count: signups.length })
+
+const announcementsHandler = http.get('/api/trpc/workshop.announcements', () =>
+  trpc({ success: true, data: [], count: 0 }),
+)
+
+/** Base handlers: everything resolves; individual stories override `workshop.list`. */
+const handlersFor = (workshops: unknown[], signups: unknown[] = []) => [
+  http.get('/api/trpc/workshop.list', () => listResponse(workshops)),
+  http.get('/api/trpc/workshop.getMySignups', () => signupsResponse(signups)),
+  announcementsHandler,
+  http.post('/api/trpc/workshop.signup', () =>
+    trpc({ message: 'Successfully signed up for the workshop!' }),
+  ),
+  http.post('/api/trpc/workshop.cancelSignup', () => trpc({ success: true })),
+]
+
+// A component (not the bare decorator closure) so `useEffect` is rules-of-hooks
+// clean. Mirrors `.dark` onto `<html>` for the portaled signup modal.
+function ThemeFrame({
+  dark,
+  children,
+}: {
+  dark: boolean
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark)
+    return () => document.documentElement.classList.remove('dark')
+  }, [dark])
+  return (
+    <div className={dark ? 'dark' : ''}>
+      <div className={dark ? 'bg-gray-950 p-4' : 'bg-white p-4'}>
+        <div className="mx-auto max-w-4xl">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+const withTheme: Decorator = (Story, ctx) => (
+  <ThemeFrame dark={!!ctx.parameters.dark}>
+    <Story />
+  </ThemeFrame>
+)
+
+const signedInArgs = {
+  userWorkOSId: 'workos-1',
+  userEmail: 'attendee@example.com',
+  userName: 'Attendee One',
+}
+
+const meta = {
+  title: 'Systems/Workshops/WorkshopList',
+  component: WorkshopList,
+  beforeEach: mockDateBeforeEach(NOW),
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Attendee-facing workshop signup list: your workshops, available, and full sections, plus loading / empty / registration-window gating and the signup success & error banners. tRPC is mocked via MSW.',
+      },
+    },
+  },
+  decorators: [withTheme],
+} satisfies Meta<typeof WorkshopList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Workshops query in flight → the loading placeholder. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/trpc/workshop.list', async () => {
+          await delay('infinite')
+          return listResponse([])
+        }),
+        http.get('/api/trpc/workshop.getMySignups', () => signupsResponse([])),
+        announcementsHandler,
+      ],
+    },
+  },
+}
+
+/** Guest view: available workshops plus a full one (no personal signups). */
+export const AvailableAndFull: Story = {
+  parameters: {
+    msw: { handlers: handlersFor([wsAvailableA, wsAvailableB, wsFull]) },
+  },
+}
+
+export const AvailableAndFullDark: Story = {
+  parameters: {
+    dark: true,
+    msw: { handlers: handlersFor([wsAvailableA, wsAvailableB, wsFull]) },
+  },
+}
+
+/** Signed-in attendee with a confirmed + a waitlisted signup: "Your Workshops". */
+export const Registered: Story = {
+  args: signedInArgs,
+  parameters: {
+    msw: {
+      handlers: handlersFor(
+        [wsAvailableA, wsAvailableB, wsFull],
+        [
+          signup('su-1', 'ws-1', 'confirmed'),
+          signup('su-2', 'ws-3', 'waitlist'),
+        ],
+      ),
+    },
+  },
+}
+
+export const RegisteredDark: Story = {
+  args: signedInArgs,
+  parameters: {
+    dark: true,
+    msw: {
+      handlers: handlersFor(
+        [wsAvailableA, wsAvailableB, wsFull],
+        [
+          signup('su-1', 'ws-1', 'confirmed'),
+          signup('su-2', 'ws-3', 'waitlist'),
+        ],
+      ),
+    },
+  },
+}
+
+/** No workshops configured → the empty-state card. */
+export const Empty: Story = {
+  parameters: { msw: { handlers: handlersFor([]) } },
+}
+
+/**
+ * Registration window has closed: the available/full sections are gated off,
+ * but a registered attendee still sees "Your Workshops".
+ */
+export const RegistrationClosed: Story = {
+  args: { ...signedInArgs, workshopRegistrationEnd: '2026-08-01T00:00:00Z' },
+  parameters: {
+    msw: {
+      handlers: handlersFor(
+        [wsAvailableA, wsFull],
+        [signup('su-1', 'ws-1', 'confirmed')],
+      ),
+    },
+  },
+}
+
+/** Completing the signup modal surfaces the green success banner. */
+export const SignupSuccess: Story = {
+  args: signedInArgs,
+  parameters: { msw: { handlers: handlersFor([wsAvailableA]) } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const body = within(document.body)
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /register for workshop/i }),
+    )
+    await userEvent.click(
+      await body.findByRole('button', { name: /confirm registration/i }),
+    )
+    await canvas.findByText(/successfully signed up/i)
+  },
+}
+
+/** A failing signup mutation surfaces the red error banner. */
+export const SignupError: Story = {
+  args: signedInArgs,
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/trpc/workshop.list', () => listResponse([wsAvailableA])),
+        http.get('/api/trpc/workshop.getMySignups', () => signupsResponse([])),
+        announcementsHandler,
+        http.post('/api/trpc/workshop.signup', () =>
+          HttpResponse.json(
+            {
+              error: {
+                message: 'This workshop is now full.',
+                code: -32603,
+                data: { code: 'INTERNAL_SERVER_ERROR' },
+              },
+            },
+            { status: 500 },
+          ),
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const body = within(document.body)
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /register for workshop/i }),
+    )
+    await userEvent.click(
+      await body.findByRole('button', { name: /confirm registration/i }),
+    )
+    // The failure text shows both in the modal and in the page-level banner, so
+    // assert on all matches rather than a single one.
+    await body.findAllByText(/this workshop is now full/i)
+  },
+}


### PR DESCRIPTION
Adds Storybook state coverage for the three highest-risk uncovered speaker-facing components. tRPC is mocked at the MSW HTTP boundary — the house pattern for data-backed component stories (the dashboard `__matrix__` alias harness is dashboard-widget-specific and doesn't apply here). Stories are tagged `autodocs`, consistent with the sibling MSW+tRPC component stories.

## Components & states
- **ProposalForm** (12 stories): new submission, edit-submitted (with co-speaker + unsubmit), existing draft, accepted/withdrawable, withdrawal-closed cutoff, read-only, admin edit, plus play-driven validation-error, server-error, and in-flight "Updating…" surfaces. Light + dark variants for the key states.
- **WorkshopList** (9 stories): loading, available + full, registered (your-workshops summary with confirmed + waitlist), empty, registration-closed gating, plus play-driven signup success & error banners. Light + dark variants. Reflects the post-#606 prop shape (no `conference` prop).
- **CFPProfilePage** (7 stories): filled and near-empty profiles, the three provider link-result banners (`linked` / `already-linked` / `error`), and a play-driven successful save.

## Mocking boundary
MSW `http.get`/`http.post` against `/api/trpc/<proc>` returning `{ result: { data } }` (the global `TRPCDecorator` uses `httpLink`, so each procedure is its own request). Dates are pinned via `mockDateBeforeEach` so CFP-open / withdrawal-cutoff states are deterministic. `push.getVapidKey` is mocked with an empty key so the profile page's push card renders its "not configured" state without touching browser push APIs.

## Test-infra note (no app-code changes)
`.storybook/main.ts` gains one browser-safe alias stubbing the CFP `link-actions` `'use server'` module (which pulls in `next/headers` + the server auth stack) — same technique as the existing `CloudNativePattern` stub.

## Checks
- `storybook build` green; `build-storybook:test` + test-runner green on all new stories (12 + 9 + 7 = 28 passing).
- `mise run check` (typecheck/lint/knip/format) green; full vitest green (3871 passed).
- Shot every new story at 393px in light + dark and inspected — all render correctly, no overflow.

## Observations (report-only, not fixed here)
- `WorkshopCard`/`WorkshopList` time badge: `formatTime12Hour` expects an `"HH:MM"` string, but the **existing** `WorkshopCard.stories` fixture passes a full ISO datetime, so its badge renders the garbage `"2014:00 PM"`. My WorkshopList fixtures use the correct `"HH:MM"` shape (badge reads `9:00 AM - 11:00 AM`); the pre-existing WorkshopCard story fixture is still wrong and could be corrected separately.
- `CFPProfilePage`: the `getCurrent` query is seeded with `initialData: initialSpeaker`, so `profile` is never falsy — the "Loading Error" branch (`profileError && !profile`) is effectively unreachable, and would in any case crash first on `speaker._id` if `initialSpeaker` were null. Dead error UI worth a follow-up.
- Minor responsive nit: at 393px the profile's "Email Address" row squeezes the "Managed by GitHub and LinkedIn" label into a very narrow column (one word per line) because the input is `flex-1` beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)