### PR TITLE
fix(modals): migrate legacy ModalShell headers, SendMessageModal to canonical shell, brand primary

### DIFF
--- a/src/components/SpeakerProfilePreview.tsx
+++ b/src/components/SpeakerProfilePreview.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { DialogTitle } from '@headlessui/react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
 import { PortableText } from '@portabletext/react'
 import { portableTextComponents } from '@/lib/portabletext/components'
 import { Speaker, Flags, flags } from '@/lib/speaker/types'
@@ -45,26 +43,10 @@ export default function SpeakerProfilePreview({
       isOpen={isOpen}
       onClose={onClose}
       size="5xl"
-      padded={false}
-      className="flex max-h-[90dvh] transform flex-col overflow-hidden bg-brand-glacier-white text-left align-middle transition-all"
+      title="Speaker Profile Preview"
+      className="bg-brand-glacier-white"
     >
-      <div className="flex items-center justify-between border-b border-gray-200 p-6 dark:border-gray-700">
-        <DialogTitle
-          as="h2"
-          className="font-space-grotesk text-2xl font-bold text-brand-slate-gray dark:text-white"
-        >
-          Speaker Profile Preview
-        </DialogTitle>
-        <button
-          onClick={onClose}
-          className="rounded-lg p-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
-          aria-label="Close modal"
-        >
-          <XMarkIcon className="h-6 w-6 text-gray-500 dark:text-gray-400" />
-        </button>
-      </div>
-
-      <div className="flex-1 overflow-y-auto p-6">
+      <div>
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
           <div className="lg:col-span-1">
             <div className="sticky top-8 space-y-6">

--- a/src/components/admin/AdminButton.tsx
+++ b/src/components/admin/AdminButton.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 
 type AdminButtonVariant = 'primary' | 'secondary' | 'ghost'
 type AdminButtonColor =
-  'indigo' | 'blue' | 'green' | 'orange' | 'red' | 'purple' | 'yellow'
+  'brand' | 'indigo' | 'blue' | 'green' | 'orange' | 'red' | 'purple' | 'yellow'
 type AdminButtonSize = 'xs' | 'sm' | 'md'
 
 interface AdminButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -12,6 +12,10 @@ interface AdminButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>
 }
 
 const colorStyles: Record<AdminButtonColor, string> = {
+  // `brand` is the documented primary color for modal footers — it matches the
+  // brand-cloud-blue focus ring ModalShell uses for its header close button.
+  brand:
+    'bg-brand-cloud-blue text-white shadow-sm hover:bg-brand-cloud-blue-hover focus-visible:outline-brand-cloud-blue',
   indigo:
     'bg-indigo-600 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline-indigo-600',
   blue: 'bg-blue-600 text-white shadow-sm hover:bg-blue-700 focus-visible:outline-blue-600',

--- a/src/components/admin/BadgePreviewModal.tsx
+++ b/src/components/admin/BadgePreviewModal.tsx
@@ -1,14 +1,13 @@
 'use client'
 
-import { DialogTitle } from '@headlessui/react'
 import {
-  XMarkIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
   ArrowTopRightOnSquareIcon,
 } from '@heroicons/react/24/outline'
 import type { BadgeRecord } from '@/lib/badge/types'
 import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
 
 interface BadgePreviewModalProps {
   isOpen: boolean
@@ -78,22 +77,9 @@ export function BadgePreviewModal({
       isOpen={isOpen}
       onClose={onClose}
       size="4xl"
-      className="transform overflow-hidden border border-brand-frosted-steel bg-brand-glacier-white transition-all dark:border-gray-700"
+      title="Badge Details"
+      className="border border-brand-frosted-steel bg-brand-glacier-white dark:border-gray-700"
     >
-      <div className="mb-6 flex items-start justify-between">
-        <DialogTitle className="font-space-grotesk text-xl font-semibold text-brand-slate-gray dark:text-white">
-          Badge Details
-        </DialogTitle>
-        <button
-          type="button"
-          className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          <XMarkIcon className="h-6 w-6" />
-        </button>
-      </div>
-
       <div className="grid gap-6 md:grid-cols-2">
         {/* Badge Image */}
         <div className="space-y-4">
@@ -286,12 +272,14 @@ export function BadgePreviewModal({
       </div>
 
       <div className="mt-6 flex justify-end border-t border-brand-frosted-steel pt-4 dark:border-gray-700">
-        <button
+        <AdminButton
+          variant="secondary"
+          size="md"
           onClick={onClose}
-          className="bg-brand-aqua dark:hover:bg-brand-aqua rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-cloud-blue dark:bg-brand-cloud-blue"
+          className="min-h-11"
         >
           Close
-        </button>
+        </AdminButton>
       </div>
     </ModalShell>
   )

--- a/src/components/admin/EmailModal.stories.tsx
+++ b/src/components/admin/EmailModal.stories.tsx
@@ -2,21 +2,25 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { fn } from 'storybook/test'
 import { EmailModal } from './EmailModal'
 import { NotificationProvider } from './NotificationProvider'
+import { withPortalTheme } from '@/lib/storybook'
 
 const meta = {
   title: 'Systems/Sponsors/Admin/Email/EmailModal',
   component: EmailModal,
   tags: ['autodocs'],
   parameters: {
-    layout: 'centered',
+    layout: 'fullscreen',
     docs: {
       description: {
         component:
-          'Generic email composition modal used as the base for all email sending flows. Features a rich text editor (PortableText), auto-save drafts to localStorage, email preview, template selector slot, and configurable fields. Used by SponsorIndividualEmailModal and SponsorDiscountEmailModal.',
+          'Generic email composition modal used as the base for all email sending flows. Built on the shared ModalShell (mobile bottom-sheet); keeps a compliant custom header for the draft-saved pill + clear-draft control. Features a rich text editor (PortableText), auto-save drafts to localStorage, email preview, template selector slot, and configurable fields. Used by SponsorIndividualEmailModal and SponsorDiscountEmailModal. Inspect at 393px and in dark mode.',
       },
     },
   },
   decorators: [
+    // ModalShell portals via HeadlessUI to document.body; mirror the toolbar
+    // theme onto <html> so the portalled modal's dark: classes resolve.
+    withPortalTheme,
     (Story: React.ComponentType) => (
       <NotificationProvider>
         <Story />

--- a/src/components/admin/EmailModal.tsx
+++ b/src/components/admin/EmailModal.tsx
@@ -17,6 +17,7 @@ import { convertStringToPortableTextBlocks } from '@/lib/proposal'
 import { portableTextToHTML } from '@/lib/email/portableTextToHTML'
 import { useEmailModalStorage } from '@/hooks/useEmailModalStorage'
 import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
 
 export interface EmailModalProps {
   isOpen: boolean
@@ -319,13 +320,7 @@ export function EmailModal({
   }
 
   return (
-    <ModalShell
-      isOpen={isOpen}
-      onClose={handleClose}
-      size="3xl"
-      padded={false}
-      className="flex max-h-[90dvh] flex-col"
-    >
+    <ModalShell isOpen={isOpen} onClose={handleClose} size="3xl" padded={false}>
       <div className="flex items-center justify-between border-b border-gray-200 p-6 pb-4 dark:border-gray-700">
         <div className="flex-1">
           <div className="flex items-center gap-3">
@@ -366,7 +361,8 @@ export function EmailModal({
         <button
           onClick={handleClose}
           disabled={isLoading}
-          className="cursor-pointer rounded-xl p-2 transition-colors duration-200 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-gray-800"
+          aria-label="Close dialog"
+          className="-mr-2 inline-flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-lg transition-colors duration-200 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-gray-800"
         >
           <XMarkIcon className="h-5 w-5 text-gray-600 dark:text-gray-400" />
         </button>
@@ -524,17 +520,21 @@ export function EmailModal({
             </button>
           )}
         </div>
-        <div className="flex space-x-4">
-          <button
+        <div className="flex items-center space-x-3">
+          <AdminButton
             type="button"
+            variant="ghost"
+            size="md"
             onClick={handleClose}
             disabled={isLoading}
-            className="cursor-pointer text-sm/6 font-semibold whitespace-nowrap text-gray-900 disabled:opacity-50 dark:text-white"
+            className="min-h-11"
           >
-            <span className="hidden sm:inline">Cancel</span>
-            <span className="sm:hidden">Cancel</span>
-          </button>
-          <button
+            Cancel
+          </AdminButton>
+          <AdminButton
+            type="button"
+            color="brand"
+            size="md"
             onClick={handleSend}
             disabled={
               isLoading ||
@@ -543,9 +543,8 @@ export function EmailModal({
               isLocalhost
             }
             title={isLocalhost ? 'Sending is disabled on localhost' : ''}
-            className="inline-flex cursor-pointer items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 dark:bg-indigo-500 dark:shadow-none dark:focus-visible:outline-indigo-500"
+            className="min-h-11 whitespace-nowrap"
           >
-            {' '}
             {isLoading ? (
               <div className="flex items-center gap-2">
                 <div className="h-4 w-4 animate-pulse rounded bg-white/30" />
@@ -560,7 +559,7 @@ export function EmailModal({
                 <span className="sm:hidden">Send</span>
               </>
             )}
-          </button>
+          </AdminButton>
         </div>
       </div>
     </ModalShell>

--- a/src/components/admin/PaymentDetailsModal.tsx
+++ b/src/components/admin/PaymentDetailsModal.tsx
@@ -273,7 +273,7 @@ export function PaymentDetailsModal({
         )}
       </div>
 
-      <div className="flex justify-end border-t border-gray-200 bg-gray-50 px-6 py-4 dark:border-gray-700 dark:bg-gray-800/50">
+      <div className="flex justify-end border-t border-gray-200 bg-gray-50 px-6 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-4 dark:border-gray-700 dark:bg-gray-800/50">
         <AdminButton
           variant="secondary"
           size="md"

--- a/src/components/admin/PaymentDetailsModal.tsx
+++ b/src/components/admin/PaymentDetailsModal.tsx
@@ -1,8 +1,6 @@
 'use client'
-import { DialogTitle } from '@headlessui/react'
 import { ModalShell } from '@/components/ModalShell'
 import {
-  XMarkIcon,
   ExclamationTriangleIcon,
   CheckCircleIcon,
   ClockIcon,
@@ -60,26 +58,10 @@ export function PaymentDetailsModal({
       onClose={onClose}
       size="2xl"
       padded={false}
-      className="overflow-hidden"
+      title="Payment Details"
+      subtitle={paymentDetails ? `Order #${paymentDetails.orderId}` : undefined}
+      icon={<CreditCardIcon className="h-5 w-5" />}
     >
-      <div className="flex items-center justify-between border-b border-gray-200 p-6 dark:border-gray-700">
-        <DialogTitle className="flex items-center text-lg font-semibold text-gray-900 dark:text-white">
-          <CreditCardIcon className="mr-2 h-6 w-6 text-gray-400 dark:text-gray-500" />
-          Payment Details
-          {paymentDetails && (
-            <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">
-              Order #{paymentDetails.orderId}
-            </span>
-          )}
-        </DialogTitle>
-        <button
-          onClick={onClose}
-          className="rounded-md text-gray-400 hover:text-gray-600 focus:ring-2 focus:ring-indigo-500 focus:outline-none dark:text-gray-500 dark:hover:text-gray-300 dark:focus:ring-indigo-400"
-        >
-          <XMarkIcon className="h-6 w-6" />
-        </button>
-      </div>
-
       <div className="p-6">
         {isLoading && (
           <div className="py-8">
@@ -292,7 +274,12 @@ export function PaymentDetailsModal({
       </div>
 
       <div className="flex justify-end border-t border-gray-200 bg-gray-50 px-6 py-4 dark:border-gray-700 dark:bg-gray-800/50">
-        <AdminButton variant="secondary" size="md" onClick={onClose}>
+        <AdminButton
+          variant="secondary"
+          size="md"
+          onClick={onClose}
+          className="min-h-11"
+        >
           Close
         </AdminButton>
       </div>

--- a/src/components/admin/ProposalActionModal.tsx
+++ b/src/components/admin/ProposalActionModal.tsx
@@ -289,7 +289,7 @@ export function ProposalActionModal({
             actionMutation.isPending || withdrawReasonMissing
               ? 'cursor-not-allowed opacity-50'
               : 'cursor-pointer',
-            'inline-flex w-full justify-center rounded-md px-3 py-2 text-sm/6 font-semibold text-white shadow-sm sm:ml-3 sm:w-auto',
+            'inline-flex min-h-11 w-full items-center justify-center rounded-md px-3 py-2 text-sm/6 font-semibold text-white shadow-sm sm:ml-3 sm:w-auto',
           )}
           onClick={() => submitHandler()}
         >
@@ -299,7 +299,7 @@ export function ProposalActionModal({
         </button>
         <button
           type="button"
-          className="mt-3 inline-flex w-full justify-center rounded-md px-3 py-2 text-sm/6 font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 sm:mt-0 sm:w-auto dark:text-white dark:ring-gray-600 dark:hover:bg-gray-800"
+          className="mt-3 inline-flex min-h-11 w-full items-center justify-center rounded-md px-3 py-2 text-sm/6 font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 sm:mt-0 sm:w-auto dark:text-white dark:ring-gray-600 dark:hover:bg-gray-800"
           onClick={() => close()}
         >
           Cancel

--- a/src/components/admin/ProposalManagementModal.stories.tsx
+++ b/src/components/admin/ProposalManagementModal.stories.tsx
@@ -15,6 +15,7 @@ import { Topic } from '@/lib/topic/types'
 import { convertStringToPortableTextBlocks } from '@/lib/proposal'
 import { fn } from 'storybook/test'
 import { http, HttpResponse } from 'msw'
+import { withPortalTheme } from '@/lib/storybook'
 
 const mockTopics: Topic[] = [
   {
@@ -131,10 +132,11 @@ const meta: Meta<typeof ProposalManagementModal> = {
   component: ProposalManagementModal,
   tags: ['autodocs'],
   parameters: {
+    layout: 'fullscreen',
     docs: {
       description: {
         component:
-          'A full-featured modal for creating or editing proposals from the admin interface. Includes speaker multi-select, the shared ProposalDetailsForm (title, description, format, level, audience, topics, outline), validation errors, and keyboard shortcuts (Cmd+S to save).',
+          'A full-featured modal for creating or editing proposals from the admin interface. Built on the shared ModalShell. Includes speaker multi-select, the shared ProposalDetailsForm (title, description, format, level, audience, topics, outline), validation errors, and keyboard shortcuts (Cmd+S to save). Inspect at 393px and in dark mode.',
       },
     },
     msw: {
@@ -178,6 +180,9 @@ const meta: Meta<typeof ProposalManagementModal> = {
     },
   },
   decorators: [
+    // ModalShell portals via HeadlessUI to document.body; mirror the toolbar
+    // theme onto <html> so the portalled modal's dark: classes resolve.
+    withPortalTheme,
     (Story) => (
       <NotificationProvider>
         <Story />

--- a/src/components/admin/ProposalManagementModal.tsx
+++ b/src/components/admin/ProposalManagementModal.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { DialogTitle } from '@headlessui/react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
+import { useState, useEffect, useMemo } from 'react'
 import { XCircleIcon } from '@heroicons/react/24/solid'
-import { Button } from '@/components/Button'
+import { AdminButton } from '@/components/admin/AdminButton'
 import { ErrorText } from '@/components/Form'
 import { prepareReferenceArray } from '@/lib/sanity/helpers'
 import {
@@ -184,6 +182,24 @@ export function ProposalManagementModal({
   })
 
   const isPending = createMutation.isPending || updateMutation.isPending
+
+  // Snapshot the pristine form so the dirty-close guard only arms once the
+  // organizer has actually changed the proposal fields or its speakers.
+  const initialSnapshot = useMemo(
+    () =>
+      JSON.stringify({
+        proposalData: getInitialProposalData(),
+        speakerIds: getInitialSpeakerIds(),
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- editingProposal & conference are the only inputs to the initial builders
+    [editingProposal, conference],
+  )
+
+  const isDirty =
+    JSON.stringify({
+      proposalData,
+      speakerIds: selectedSpeakerIds,
+    }) !== initialSnapshot
 
   // Reset form when modal opens or when editing a different proposal
   useEffect(() => {
@@ -369,26 +385,13 @@ export function ProposalManagementModal({
       onClose={onClose}
       size="4xl"
       padded={false}
-      className="transform overflow-hidden border border-brand-frosted-steel bg-brand-glacier-white text-left align-middle transition-all dark:border-gray-700"
+      title={editingProposal ? 'Edit Proposal' : 'Create New Proposal'}
+      className="border border-brand-frosted-steel bg-brand-glacier-white dark:border-gray-700"
+      confirmOnDirtyClose
+      isDirty={isDirty && !isPending}
     >
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4 dark:border-gray-700">
-        <DialogTitle className="font-space-grotesk text-xl font-semibold text-brand-slate-gray dark:text-white">
-          {editingProposal ? 'Edit Proposal' : 'Create New Proposal'}
-        </DialogTitle>
-        <button
-          type="button"
-          className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-500 dark:hover:bg-gray-800"
-          onClick={onClose}
-          disabled={isPending}
-        >
-          <XMarkIcon className="h-5 w-5" />
-        </button>
-      </div>
-
-      {/* Scrollable Content Area */}
       <form onSubmit={handleSubmit}>
-        <div className="max-h-[calc(90vh-200px)] overflow-y-auto px-6 py-6">
+        <div className="px-6 py-6">
           {/* Speaker Selection Section */}
           <div className="mb-6">
             <SpeakerMultiSelect
@@ -458,20 +461,23 @@ export function ProposalManagementModal({
 
         {/* Action Buttons Footer */}
         <div className="border-t border-gray-200 px-6 py-4 dark:border-gray-700">
-          <div className="flex justify-end gap-3">
-            <Button
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <AdminButton
               type="button"
-              variant="outline"
+              variant="secondary"
+              size="md"
               onClick={onClose}
               disabled={isPending}
+              className="min-h-11"
             >
               Cancel
-            </Button>
-            <Button
+            </AdminButton>
+            <AdminButton
               type="submit"
-              variant="primary"
+              color="brand"
+              size="md"
               disabled={isPending}
-              className="min-w-35"
+              className="min-h-11 min-w-35"
               title="Save changes"
             >
               {isPending ? (
@@ -484,12 +490,12 @@ export function ProposalManagementModal({
                   <span>
                     {editingProposal ? 'Update Proposal' : 'Create Proposal'}
                   </span>
-                  <kbd className="rounded border border-indigo-400 bg-indigo-500 px-1.5 py-0.5 text-xs font-semibold text-white dark:border-indigo-600 dark:bg-indigo-700">
+                  <kbd className="rounded border border-white/40 bg-white/20 px-1.5 py-0.5 text-xs font-semibold text-white">
                     ⌘S
                   </kbd>
                 </span>
               )}
-            </Button>
+            </AdminButton>
           </div>
         </div>
       </form>

--- a/src/components/admin/ProposalManagementModal.tsx
+++ b/src/components/admin/ProposalManagementModal.tsx
@@ -460,7 +460,7 @@ export function ProposalManagementModal({
         </div>
 
         {/* Action Buttons Footer */}
-        <div className="border-t border-gray-200 px-6 py-4 dark:border-gray-700">
+        <div className="border-t border-gray-200 px-6 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-4 dark:border-gray-700">
           <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
             <AdminButton
               type="button"

--- a/src/components/admin/SendMessageModal.stories.tsx
+++ b/src/components/admin/SendMessageModal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { fn, userEvent, within } from 'storybook/test'
 import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
 import { SendMessageModal } from './SendMessageModal'
 import { NotificationProvider } from './NotificationProvider'
 
@@ -36,18 +37,20 @@ const meta = {
     onClose: fn(),
   },
   decorators: [
+    // SendMessageModal now sits on ModalShell, whose HeadlessUI Dialog portals
+    // to document.body — a wrapper `.dark` class never reaches it. ModalShell
+    // reads next-themes instead, so force the theme (synced to the Storybook
+    // theme global) here; React context crosses the portal. Mirrors
+    // SearchModal.stories.
     (Story, ctx) => (
-      <NotificationProvider>
-        <div
-          className={
-            ctx.parameters.dark
-              ? 'dark min-h-screen bg-gray-950'
-              : 'min-h-screen'
-          }
-        >
+      <ThemeProvider
+        attribute="class"
+        forcedTheme={ctx.globals.theme === 'dark' ? 'dark' : 'light'}
+      >
+        <NotificationProvider>
           <Story />
-        </div>
-      </NotificationProvider>
+        </NotificationProvider>
+      </ThemeProvider>
     ),
   ],
   tags: ['autodocs'],
@@ -57,10 +60,6 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
-
-export const Dark: Story = {
-  parameters: { dark: true },
-}
 
 /** After a successful send: confirmation with a "View conversation" link. */
 export const Sent: Story = {

--- a/src/components/admin/SendMessageModal.stories.tsx
+++ b/src/components/admin/SendMessageModal.stories.tsx
@@ -63,13 +63,15 @@ export const Default: Story = {}
 
 /** After a successful send: confirmation with a "View conversation" link. */
 export const Sent: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
+  play: async () => {
+    // ModalShell PORTALS the dialog to document.body — the canvas element
+    // no longer contains the modal content, so query the body instead.
+    const body = within(document.body)
     await userEvent.type(
-      canvas.getByLabelText('Message'),
+      await body.findByLabelText('Message'),
       'Quick heads-up about your talk slot.',
     )
-    await userEvent.click(canvas.getByRole('button', { name: /send message/i }))
-    await canvas.findByRole('link', { name: /view conversation/i })
+    await userEvent.click(body.getByRole('button', { name: /send message/i }))
+    await body.findByRole('link', { name: /view conversation/i })
   },
 }

--- a/src/components/admin/SendMessageModal.tsx
+++ b/src/components/admin/SendMessageModal.tsx
@@ -1,15 +1,14 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import Link from 'next/link'
 import {
   ChatBubbleLeftRightIcon,
   CheckCircleIcon,
-  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { NewConversationForm } from '@/components/messaging'
+import { ModalShell } from '@/components/ModalShell'
 import { useNotificationSafe } from './NotificationProvider'
-import { useModalA11y } from './schedule/useModalA11y'
 
 export interface SendMessageModalProps {
   /** The proposal whose thread the message is posted to. */
@@ -31,18 +30,15 @@ export function SendMessageModal({
   proposalTitle,
   onClose,
 }: SendMessageModalProps) {
-  const dialogRef = useRef<HTMLDivElement>(null)
   const notifications = useNotificationSafe()
   const [sent, setSent] = useState(false)
-
-  // Escape closes, focus is trapped and restored, body scroll locked; initial
-  // focus prefers the form's autoFocus field over the header Close button.
-  useModalA11y(dialogRef, onClose)
+  const [messageDirty, setMessageDirty] = useState(false)
 
   const threadHref = `/admin/proposals/${proposalId}#messages`
 
   const handleCreated = () => {
     setSent(true)
+    setMessageDirty(false)
     notifications?.showNotification({
       type: 'success',
       title: 'Message sent',
@@ -51,102 +47,62 @@ export function SendMessageModal({
   }
 
   return (
-    // <sm this renders as a BOTTOM SHEET, replicating the schedule editor's
-    // house pattern (src/components/admin/schedule/mobile/BottomSheet.tsx):
-    // rounded-t-2xl, max-h-[85dvh], scrollable overscroll-contained body with
-    // safe-area bottom padding. On sm+ it is a centered dialog.
-    <div className="fixed inset-0 z-50 flex flex-col justify-end sm:items-center sm:justify-center sm:p-4">
-      <button
-        type="button"
-        aria-label="Close"
-        onClick={onClose}
-        className="absolute inset-0 bg-black/50"
-      />
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="send-message-modal-title"
-        tabIndex={-1}
-        className="relative flex max-h-[85dvh] w-full flex-col rounded-t-2xl bg-white shadow-xl focus:outline-none sm:max-w-lg sm:rounded-xl dark:bg-gray-900"
-      >
-        <div className="flex shrink-0 items-start justify-between border-b border-gray-200 px-5 py-4 dark:border-gray-700">
-          <div className="flex min-w-0 items-start gap-2.5">
-            <ChatBubbleLeftRightIcon
-              className="mt-0.5 h-5 w-5 shrink-0 text-brand-cloud-blue dark:text-blue-400"
-              aria-hidden="true"
-            />
-            <div className="min-w-0">
-              <h2
-                id="send-message-modal-title"
-                className="font-space-grotesk text-lg font-semibold text-gray-900 dark:text-white"
-              >
-                Send message
-              </h2>
-              <p className="mt-0.5 truncate text-sm text-gray-500 dark:text-gray-400">
-                Proposal thread: {proposalTitle}
-              </p>
-            </div>
+    <ModalShell
+      isOpen
+      onClose={onClose}
+      size="lg"
+      title="Send message"
+      subtitle={`Proposal thread: ${proposalTitle}`}
+      icon={<ChatBubbleLeftRightIcon className="h-5 w-5" />}
+      confirmOnDirtyClose
+      isDirty={messageDirty && !sent}
+    >
+      {sent ? (
+        <div className="text-center">
+          <CheckCircleIcon
+            className="mx-auto h-10 w-10 text-green-500"
+            aria-hidden="true"
+          />
+          <p className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
+            Message sent
+          </p>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            The speaker(s) will find it in this proposal&apos;s conversation.
+          </p>
+          <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-center">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex min-h-11 w-full items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue sm:w-auto dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Close
+            </button>
+            <Link
+              href={threadHref}
+              onClick={onClose}
+              className="inline-flex min-h-11 w-full items-center justify-center rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue sm:w-auto"
+            >
+              View conversation
+            </Link>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close dialog"
-            className="ml-3 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
         </div>
-
-        <div className="flex-1 overflow-y-auto overscroll-contain p-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] sm:pb-5">
-          {sent ? (
-            <div className="text-center">
-              <CheckCircleIcon
-                className="mx-auto h-10 w-10 text-green-500"
-                aria-hidden="true"
-              />
-              <p className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
-                Message sent
-              </p>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                The speaker(s) will find it in this proposal&apos;s
-                conversation.
-              </p>
-              <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-center">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="inline-flex min-h-[44px] w-full items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue sm:w-auto dark:text-gray-300 dark:hover:bg-gray-800"
-                >
-                  Close
-                </button>
-                <Link
-                  href={threadHref}
-                  onClick={onClose}
-                  className="inline-flex min-h-[44px] w-full items-center justify-center rounded-lg bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-cloud-blue/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue sm:w-auto dark:bg-blue-600 dark:hover:bg-blue-500"
-                >
-                  View conversation
-                </Link>
-              </div>
-            </div>
-          ) : (
-            <>
-              <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
-                Your message is posted in the private thread with the speaker(s)
-                on this proposal — they are notified in the app (and by email,
-                per their preferences).
-              </p>
-              <NewConversationForm
-                basePath="/admin/messages"
-                proposalId={proposalId}
-                autoFocusFirstField
-                onCreated={handleCreated}
-                onCancel={onClose}
-              />
-            </>
-          )}
-        </div>
-      </div>
-    </div>
+      ) : (
+        <>
+          <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
+            Your message is posted in the private thread with the speaker(s) on
+            this proposal — they are notified in the app (and by email, per
+            their preferences).
+          </p>
+          <NewConversationForm
+            basePath="/admin/messages"
+            proposalId={proposalId}
+            autoFocusFirstField
+            onCreated={handleCreated}
+            onCancel={onClose}
+            onDirtyChange={setMessageDirty}
+          />
+        </>
+      )}
+    </ModalShell>
   )
 }

--- a/src/components/admin/SpeakerImageModal.stories.tsx
+++ b/src/components/admin/SpeakerImageModal.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { useState } from 'react'
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test'
 import { SpeakerImageModal } from './SpeakerImageModal'
+import { withPortalTheme } from '@/lib/storybook'
 
 // Inline SVG portrait so the story renders deterministically without any
 // network request (speakerImageUrl returns non-Sanity URLs untouched).
@@ -29,6 +30,10 @@ const meta = {
     },
   },
   tags: ['autodocs'],
+  // ModalShell's HeadlessUI Dialog portals to document.body, escaping the
+  // Storybook theme wrapper; mirror the toolbar theme onto <html> so the
+  // portalled modal's dark: classes resolve.
+  decorators: [withPortalTheme],
   args: {
     onClose: fn(),
   },

--- a/src/components/admin/SpeakerImageModal.tsx
+++ b/src/components/admin/SpeakerImageModal.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { DialogTitle } from '@headlessui/react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
 import { speakerImageUrl } from '@/lib/sanity/client'
 import { ModalShell } from '@/components/ModalShell'
 import { SpeakerAvatarImage } from '@/components/common/SpeakerAvatarImage'
@@ -26,29 +24,10 @@ export function SpeakerImageModal({
       isOpen={isOpen}
       onClose={onClose}
       size="2xl"
-      className="overflow-hidden border border-brand-frosted-steel bg-brand-glacier-white dark:border-gray-700"
+      title={speaker.name}
+      subtitle={speaker.title}
+      className="border border-brand-frosted-steel bg-brand-glacier-white dark:border-gray-700"
     >
-      <div className="mb-4 flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <DialogTitle className="font-space-grotesk truncate text-xl font-semibold text-brand-slate-gray dark:text-white">
-            {speaker.name}
-          </DialogTitle>
-          {speaker.title && (
-            <p className="mt-1 truncate text-sm text-brand-slate-gray/70 dark:text-gray-400">
-              {speaker.title}
-            </p>
-          )}
-        </div>
-        <button
-          type="button"
-          className="shrink-0 rounded text-gray-400 hover:text-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:text-gray-300"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          <XMarkIcon className="h-6 w-6" />
-        </button>
-      </div>
-
       <div className="overflow-hidden rounded-xl border border-brand-frosted-steel bg-white dark:border-gray-700 dark:bg-gray-800">
         <SpeakerAvatarImage
           src={speakerImageUrl(speaker.image, {

--- a/src/components/admin/SpeakerManagementModal.tsx
+++ b/src/components/admin/SpeakerManagementModal.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { DialogTitle } from '@headlessui/react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
+import { useState, useEffect, useMemo } from 'react'
 import { SpeakerDetailsForm } from '@/components/cfp/SpeakerDetailsForm'
-import { Button } from '@/components/Button'
+import { AdminButton } from '@/components/admin/AdminButton'
 import { Input, ErrorText } from '@/components/Form'
 import { SpeakerInput, Speaker } from '@/lib/speaker/types'
 import { api } from '@/lib/trpc/client'
@@ -89,6 +87,36 @@ export function SpeakerManagementModal({
     updateEmailMutation.isPending ||
     isUploading
 
+  // Snapshot the pristine form (mirrors the reset effect below) so the
+  // dirty-close guard only fires once the organizer has actually edited a field.
+  const initialSnapshot = useMemo(() => {
+    const data: SpeakerInput = editingSpeaker
+      ? {
+          name: editingSpeaker.name || '',
+          bio: editingSpeaker.bio || '',
+          title: editingSpeaker.title || '',
+          image: editingSpeaker.image,
+          links: editingSpeaker.links,
+          consent: editingSpeaker.consent || {
+            dataProcessing: { granted: false },
+            publicProfile: { granted: false },
+          },
+        }
+      : {
+          name: '',
+          bio: '',
+          title: '',
+          consent: {
+            dataProcessing: { granted: false },
+            publicProfile: { granted: false },
+          },
+        }
+    return JSON.stringify({ data, email: editingSpeaker?.email || '' })
+  }, [editingSpeaker])
+
+  const isDirty =
+    JSON.stringify({ data: speakerData, email }) !== initialSnapshot
+
   useEffect(() => {
     if (isOpen) {
       if (editingSpeaker) {
@@ -170,24 +198,13 @@ export function SpeakerManagementModal({
       isOpen={isOpen}
       onClose={onClose}
       size="3xl"
-      className="max-h-[90dvh] transform overflow-hidden border border-brand-frosted-steel bg-brand-glacier-white transition-all dark:border-gray-700"
+      title={editingSpeaker ? 'Edit Speaker' : 'Create New Speaker'}
+      className="border border-brand-frosted-steel bg-brand-glacier-white dark:border-gray-700"
+      confirmOnDirtyClose
+      isDirty={isDirty && !isPending}
     >
-      <div className="mb-6 flex items-start justify-between">
-        <DialogTitle className="font-space-grotesk text-xl font-semibold text-brand-slate-gray dark:text-white">
-          {editingSpeaker ? 'Edit Speaker' : 'Create New Speaker'}
-        </DialogTitle>
-        <button
-          type="button"
-          className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          <XMarkIcon className="h-6 w-6" />
-        </button>
-      </div>
-
       <form onSubmit={handleSubmit}>
-        <div className="max-h-[calc(90dvh-200px)] overflow-y-auto py-6">
+        <div className="pb-6">
           <div className="mb-6">
             <Input
               name="email"
@@ -232,16 +249,24 @@ export function SpeakerManagementModal({
           </div>
         )}
 
-        <div className="mt-6 flex justify-end gap-3 pb-[env(safe-area-inset-bottom)]">
-          <Button
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <AdminButton
             type="button"
-            variant="outline"
+            variant="secondary"
+            size="md"
             onClick={onClose}
             disabled={isPending}
+            className="min-h-11"
           >
             Cancel
-          </Button>
-          <Button type="submit" variant="primary" disabled={isPending}>
+          </AdminButton>
+          <AdminButton
+            type="submit"
+            color="brand"
+            size="md"
+            disabled={isPending}
+            className="min-h-11"
+          >
             {isPending
               ? editingSpeaker
                 ? 'Updating...'
@@ -249,7 +274,7 @@ export function SpeakerManagementModal({
               : editingSpeaker
                 ? 'Update Speaker'
                 : 'Create Speaker'}
-          </Button>
+          </AdminButton>
         </div>
       </form>
     </ModalShell>

--- a/src/components/admin/SpeakerMergeModal.tsx
+++ b/src/components/admin/SpeakerMergeModal.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { DialogTitle } from '@headlessui/react'
-import { ArrowRightIcon, XMarkIcon } from '@heroicons/react/24/outline'
+import { ArrowRightIcon } from '@heroicons/react/24/outline'
 import { Button } from '@/components/Button'
 import { ModalShell } from '@/components/ModalShell'
 import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
@@ -102,26 +101,17 @@ export function SpeakerMergeModal({
 
   return (
     <>
-      <ModalShell isOpen={isOpen} onClose={resetAndClose} size="2xl">
-        <div className="flex items-start justify-between">
-          <div>
-            <DialogTitle className="font-space-grotesk text-lg font-semibold text-brand-slate-gray dark:text-white">
-              Merge duplicate speakers
-            </DialogTitle>
-            <p className="font-inter mt-1 text-sm text-brand-slate-gray/70 dark:text-gray-400">
-              Fold a duplicate speaker into a canonical one. All references are
-              repointed to the survivor and the duplicate is deleted. This
-              cannot be undone.
-            </p>
-          </div>
-          <button
-            onClick={resetAndClose}
-            className="ml-4 rounded-lg p-1 text-brand-slate-gray/60 hover:bg-brand-sky-mist dark:hover:bg-gray-800"
-            aria-label="Close"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
-        </div>
+      <ModalShell
+        isOpen={isOpen}
+        onClose={resetAndClose}
+        size="2xl"
+        title="Merge duplicate speakers"
+      >
+        <p className="font-inter text-sm text-brand-slate-gray/70 dark:text-gray-400">
+          Fold a duplicate speaker into a canonical one. All references are
+          repointed to the survivor and the duplicate is deleted. This cannot be
+          undone.
+        </p>
 
         <div className="mt-6 grid grid-cols-1 items-end gap-4 sm:grid-cols-[1fr_auto_1fr]">
           <label className="block">

--- a/src/components/admin/StaffManager.tsx
+++ b/src/components/admin/StaffManager.tsx
@@ -122,6 +122,14 @@ export function StaffManager({
 
   const isSaving = createMutation.isPending || updateMutation.isPending
 
+  // Dirty-close guard: compare the working draft to the pristine baseline
+  // (the edited member's saved values, or the empty draft when creating).
+  const editingMember = editingId
+    ? staff?.find((member) => member._id === editingId)
+    : null
+  const baselineDraft = editingMember ? draftFrom(editingMember) : EMPTY_DRAFT
+  const isDirty = JSON.stringify(draft) !== JSON.stringify(baselineDraft)
+
   const openCreate = () => {
     setEditingId(null)
     setDraft(EMPTY_DRAFT)
@@ -318,6 +326,8 @@ export function StaffManager({
         title={editingId ? 'Edit staff member' : 'Add staff member'}
         subtitle="Shown on the public staff pages"
         icon={<UsersIcon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty && !isSaving && !isUploading}
       >
         <form noValidate onSubmit={handleSubmit} className="space-y-4">
           <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/admin/gallery/ImageMetadataModal.tsx
+++ b/src/components/admin/gallery/ImageMetadataModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import {
   Combobox,
   ComboboxInput,
@@ -19,6 +19,7 @@ import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import { sanityImage } from '@/lib/sanity/client'
 import { ImageHotspotEditor } from './ImageHotspotEditor'
 import { Input } from '@/components/Form'
+import { AdminButton } from '@/components/admin/AdminButton'
 import {
   extractDateFromISO,
   extractTimeFromISO,
@@ -249,29 +250,46 @@ export function ImageMetadataModal({
       (speaker) => !selectedSpeakers.find((s) => s._id === speaker._id),
     ) || []
 
+  // Snapshot the pristine metadata (mirrors the reset effect above) so the
+  // dirty-close guard only arms after a real edit.
+  const initialSnapshot = useMemo(
+    () =>
+      JSON.stringify({
+        formData: {
+          photographer: singleImage?.photographer || '',
+          date: singleImage?.date || '',
+          location: singleImage?.location || '',
+          imageAlt: singleImage?.imageAlt || '',
+          featured: singleImage?.featured || false,
+        },
+        speakers: (singleImage?.speakers || []).map((s) => s._id),
+        hotspot: singleImage?.image?.hotspot || null,
+        crop: singleImage?.image?.crop || null,
+      }),
+    [singleImage],
+  )
+
+  const isDirty =
+    JSON.stringify({
+      formData,
+      speakers: selectedSpeakers.map((s) => s._id),
+      hotspot,
+      crop,
+    }) !== initialSnapshot
+
   return (
     <ModalShell
       isOpen={isOpen}
       onClose={onClose}
       size="2xl"
-      className="max-h-[90dvh] overflow-y-auto rounded-xl shadow-lg"
+      title={
+        isBulkMode
+          ? `Bulk Update ${images!.length} Images`
+          : 'Edit Image Metadata'
+      }
+      confirmOnDirtyClose
+      isDirty={isDirty && !isSubmitting}
     >
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg leading-6 font-semibold text-gray-900 dark:text-white">
-          {isBulkMode
-            ? `Bulk Update ${images!.length} Images`
-            : 'Edit Image Metadata'}
-        </h3>
-        <button
-          type="button"
-          onClick={onClose}
-          className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none dark:bg-white/10 dark:text-gray-300 dark:hover:text-gray-200"
-        >
-          <span className="sr-only">Close</span>
-          <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
-      </div>
-
       {isBulkMode && (
         <div className="mt-4 space-y-3">
           <div className="grid gap-4 sm:grid-cols-2">
@@ -602,16 +620,20 @@ export function ImageMetadataModal({
           )}
         </div>
 
-        <div className="flex justify-end gap-3 pt-6">
-          <button
+        <div className="flex flex-col-reverse gap-3 pt-6 sm:flex-row sm:justify-end">
+          <AdminButton
             type="button"
+            variant="secondary"
+            size="md"
             onClick={onClose}
-            className="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold whitespace-nowrap text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-700 dark:focus-visible:outline-indigo-500"
+            className="min-h-11"
           >
             Cancel
-          </button>
-          <button
+          </AdminButton>
+          <AdminButton
             type="submit"
+            color="brand"
+            size="md"
             disabled={
               isSubmitting ||
               (isBulkMode &&
@@ -619,7 +641,7 @@ export function ImageMetadataModal({
                 !formData.photographer &&
                 !formData.location)
             }
-            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+            className="min-h-11"
           >
             {isSubmitting
               ? isBulkMode
@@ -628,7 +650,7 @@ export function ImageMetadataModal({
               : isBulkMode
                 ? 'Update Images'
                 : 'Save Changes'}
-          </button>
+          </AdminButton>
         </div>
       </form>
     </ModalShell>

--- a/src/components/admin/sponsor/SponsorAddModal.tsx
+++ b/src/components/admin/sponsor/SponsorAddModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useMemo } from 'react'
 import {
   Combobox,
   ComboboxInput,
@@ -10,12 +10,12 @@ import {
 } from '@headlessui/react'
 import {
   BuildingOffice2Icon,
-  XMarkIcon,
   CheckIcon,
   ChevronUpDownIcon,
   PlusIcon,
 } from '@heroicons/react/24/outline'
 import { Dropdown } from '@/components/Form'
+import { AdminButton } from '@/components/admin/AdminButton'
 import {
   ConferenceSponsor,
   SponsorTierExisting,
@@ -339,6 +339,40 @@ export function SponsorAddModal({
       )
     : availableSponsors
 
+  const isSaving =
+    createMutation.isPending ||
+    updateMutation.isPending ||
+    crmCreateMutation.isPending ||
+    crmUpdateMutation.isPending
+
+  // Snapshot the pristine form (mirrors the open effect above) so the
+  // dirty-close guard only arms once the organizer has actually edited fields.
+  const initialSnapshot = useMemo(() => {
+    if (editingSponsor) {
+      const tierMatch = sponsorTiers.find(
+        (tier) => tier.title === editingSponsor.tier?.title,
+      )
+      return JSON.stringify({
+        name: editingSponsor.sponsor.name,
+        website: editingSponsor.sponsor.website || '',
+        logo: editingSponsor.sponsor.logo || null,
+        logoBright: editingSponsor.sponsor.logoBright || null,
+        tierId: tierMatch?._id || '',
+        orgNumber: '',
+      })
+    }
+    return JSON.stringify({
+      name: '',
+      website: '',
+      logo: null,
+      logoBright: null,
+      tierId: preselectedTierId || '',
+      orgNumber: '',
+    })
+  }, [editingSponsor, preselectedTierId, sponsorTiers])
+
+  const isDirty = JSON.stringify(formData) !== initialSnapshot
+
   const isFormValid = () => {
     if (!formData.tierId) return false
 
@@ -358,23 +392,12 @@ export function SponsorAddModal({
       isOpen={isOpen}
       onClose={onClose}
       size="4xl"
-      className="max-h-[90dvh] overflow-y-auto rounded-xl shadow-lg"
+      title={editingSponsor ? 'Edit Sponsor' : 'Add Sponsor'}
+      icon={<BuildingOffice2Icon className="h-5 w-5" />}
+      confirmOnDirtyClose
+      isDirty={isDirty && !isSaving}
     >
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg leading-6 font-semibold text-gray-900 dark:text-white">
-          {editingSponsor ? 'Edit Sponsor' : 'Add Sponsor'}
-        </h3>
-        <button
-          type="button"
-          onClick={onClose}
-          className="flex h-11 w-11 items-center justify-center rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-2 focus:outline-offset-2 focus:outline-indigo-600 dark:bg-white/10 dark:text-gray-300 dark:hover:text-gray-200 dark:focus:outline-indigo-500"
-        >
-          <span className="sr-only">Close</span>
-          <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
-      </div>
-
-      <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <Dropdown
             name="tier"
@@ -597,34 +620,29 @@ export function SponsorAddModal({
           </>
         )}
 
-        <div className="flex justify-end gap-3 pt-6">
-          <button
+        <div className="flex flex-col-reverse gap-3 pt-6 sm:flex-row sm:justify-end">
+          <AdminButton
             type="button"
+            variant="secondary"
+            size="md"
             onClick={onClose}
-            className="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold whitespace-nowrap text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-600 dark:hover:bg-gray-700 dark:focus-visible:outline-indigo-500"
+            className="min-h-11"
           >
             Cancel
-          </button>
-          <button
+          </AdminButton>
+          <AdminButton
             type="submit"
-            disabled={
-              !isFormValid() ||
-              createMutation.isPending ||
-              updateMutation.isPending ||
-              crmCreateMutation.isPending ||
-              crmUpdateMutation.isPending
-            }
-            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold whitespace-nowrap text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+            color="brand"
+            size="md"
+            disabled={!isFormValid() || isSaving}
+            className="min-h-11"
           >
-            {createMutation.isPending ||
-            updateMutation.isPending ||
-            crmCreateMutation.isPending ||
-            crmUpdateMutation.isPending
+            {isSaving
               ? 'Saving...'
               : editingSponsor
                 ? 'Update Sponsor'
                 : 'Add Sponsor'}
-          </button>
+          </AdminButton>
         </div>
       </form>
     </ModalShell>

--- a/src/components/admin/sponsor/SponsorTierEditor.tsx
+++ b/src/components/admin/sponsor/SponsorTierEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { useTheme } from 'next-themes'
 import {
   PlusIcon,
@@ -37,6 +37,41 @@ interface SponsorTierModalProps {
   onDelete?: (tierId: string) => void
 }
 
+/** Builds the pristine form state for a tier (or a blank tier). Shared by the
+ *  reset effect and the dirty-close baseline so they never drift. */
+function buildTierFormData(tier?: SponsorTierExisting): SponsorTierInput {
+  if (tier) {
+    return {
+      title: tier.title,
+      tagline: tier.tagline,
+      tierType: tier.tierType,
+      price: tier.price?.map((p) => ({
+        _key: p._key,
+        amount: p.amount,
+        currency: p.currency,
+      })) || [{ amount: 0, currency: 'NOK' }],
+      perks: tier.perks?.map((p) => ({
+        _key: p._key,
+        label: p.label,
+        description: p.description,
+      })) || [{ label: '', description: '' }],
+      soldOut: tier.soldOut,
+      mostPopular: tier.mostPopular,
+      maxQuantity: tier.maxQuantity,
+    }
+  }
+  return {
+    title: '',
+    tagline: '',
+    tierType: 'standard',
+    price: [{ amount: 0, currency: 'NOK' }],
+    perks: [{ label: '', description: '' }],
+    soldOut: false,
+    mostPopular: false,
+    maxQuantity: undefined,
+  }
+}
+
 function SponsorTierModal({
   isOpen,
   onClose,
@@ -46,15 +81,9 @@ function SponsorTierModal({
 }: SponsorTierModalProps) {
   const { showNotification } = useNotification()
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  const [formData, setFormData] = useState<SponsorTierInput>({
-    title: '',
-    tagline: '',
-    tierType: 'standard',
-    price: [{ amount: 0, currency: 'NOK' }],
-    perks: [{ label: '', description: '' }],
-    soldOut: false,
-    mostPopular: false,
-  })
+  const [formData, setFormData] = useState<SponsorTierInput>(() =>
+    buildTierFormData(tier),
+  )
 
   const createMutation = api.sponsor.tiers.create.useMutation({
     onSuccess: (createdTier) => {
@@ -115,38 +144,8 @@ function SponsorTierModal({
   })
 
   useEffect(() => {
-    if (tier) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Initialize form from tier data
-      setFormData({
-        title: tier.title,
-        tagline: tier.tagline,
-        tierType: tier.tierType,
-        price: tier.price?.map((p) => ({
-          _key: p._key,
-          amount: p.amount,
-          currency: p.currency,
-        })) || [{ amount: 0, currency: 'NOK' }],
-        perks: tier.perks?.map((p) => ({
-          _key: p._key,
-          label: p.label,
-          description: p.description,
-        })) || [{ label: '', description: '' }],
-        soldOut: tier.soldOut,
-        mostPopular: tier.mostPopular,
-        maxQuantity: tier.maxQuantity,
-      })
-    } else {
-      setFormData({
-        title: '',
-        tagline: '',
-        tierType: 'standard',
-        price: [{ amount: 0, currency: 'NOK' }],
-        perks: [{ label: '', description: '' }],
-        soldOut: false,
-        mostPopular: false,
-        maxQuantity: undefined,
-      })
-    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Initialize form from tier data
+    setFormData(buildTierFormData(tier))
   }, [tier])
 
   const handleSubmit = async (event: React.FormEvent) => {
@@ -290,6 +289,12 @@ function SponsorTierModal({
     updateMutation.isPending ||
     deleteMutation.isPending
 
+  const initialSnapshot = useMemo(
+    () => JSON.stringify(buildTierFormData(tier)),
+    [tier],
+  )
+  const isDirty = JSON.stringify(formData) !== initialSnapshot
+
   return (
     <>
       <ModalShell
@@ -298,6 +303,8 @@ function SponsorTierModal({
         size="4xl"
         title={tier ? 'Edit Sponsor Tier' : 'Create Sponsor Tier'}
         icon={<TagIcon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty && !isLoading}
       >
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">

--- a/src/components/admin/workshop/EditCapacityModal.tsx
+++ b/src/components/admin/workshop/EditCapacityModal.tsx
@@ -1,8 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { DialogTitle } from '@headlessui/react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
 import { AdminButton } from '@/components/admin/AdminButton'
 
@@ -49,32 +47,14 @@ export function EditCapacityModal({
       isOpen={isOpen}
       onClose={onClose}
       size="md"
-      padded={false}
-      className="relative overflow-hidden px-4 pt-5 pb-4 sm:p-6"
+      title="Edit Workshop Capacity"
+      subtitle={workshopTitle}
+      confirmOnDirtyClose
+      isDirty={capacity !== currentCapacity && !isSubmitting}
     >
-      <div className="absolute top-0 right-0 pt-4 pr-4">
-        <button
-          type="button"
-          className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none dark:bg-gray-800 dark:text-gray-500 dark:hover:text-gray-400"
-          onClick={onClose}
-        >
-          <span className="sr-only">Close</span>
-          <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
-      </div>
       <div>
-        <DialogTitle
-          as="h3"
-          className="mb-4 text-lg leading-6 font-semibold text-gray-900 dark:text-white"
-        >
-          Edit Workshop Capacity
-        </DialogTitle>
-
         <div className="mb-4">
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            {workshopTitle}
-          </p>
-          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
             Currently {currentSignups} confirmed participants
           </p>
         </div>
@@ -102,20 +82,22 @@ export function EditCapacityModal({
           </div>
         </div>
 
-        <div className="mt-6 flex justify-end gap-3">
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           <AdminButton
             variant="secondary"
             size="md"
             onClick={onClose}
             disabled={isSubmitting}
+            className="min-h-11"
           >
             Cancel
           </AdminButton>
           <AdminButton
-            color="blue"
+            color="brand"
             size="md"
             onClick={handleSubmit}
             disabled={isSubmitting || isInvalid}
+            className="min-h-11"
           >
             {isSubmitting ? 'Updating...' : 'Update Capacity'}
           </AdminButton>

--- a/src/components/admin/workshop/SignupDetailsModal.tsx
+++ b/src/components/admin/workshop/SignupDetailsModal.tsx
@@ -3,8 +3,7 @@
 import { useState } from 'react'
 import { formatDateSafe } from '@/lib/time'
 
-import { DialogTitle } from '@headlessui/react'
-import { XMarkIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { TrashIcon } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
 import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import { DataTable, type Column } from '@/components/DataTable'
@@ -111,40 +110,16 @@ export function SignupDetailsModal({
       isOpen={isOpen}
       onClose={onClose}
       size="4xl"
-      padded={false}
-      className="relative overflow-hidden px-4 pt-5 pb-4 sm:p-6"
+      title={`${workshopTitle} - ${statusLabel} Signups`}
     >
-      <div className="absolute top-0 right-0 pt-4 pr-4">
-        <button
-          type="button"
-          className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none dark:bg-gray-800 dark:text-gray-500 dark:hover:text-gray-400"
-          onClick={onClose}
-        >
-          <span className="sr-only">Close</span>
-          <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-        </button>
-      </div>
-      <div className="sm:flex sm:items-start">
-        <div className="mt-3 w-full text-center sm:mt-0 sm:text-left">
-          <DialogTitle
-            as="h3"
-            className="mb-4 text-lg leading-6 font-semibold text-gray-900 dark:text-white"
-          >
-            {workshopTitle} - {statusLabel} Signups
-          </DialogTitle>
-
-          <div className="mt-4">
-            <DataTable<WorkshopSignupExisting>
-              data={signups}
-              columns={columns}
-              keyExtractor={(signup) => signup._id}
-              emptyState={{
-                title: `No ${status ?? ''} signups for this workshop`,
-              }}
-            />
-          </div>
-        </div>
-      </div>
+      <DataTable<WorkshopSignupExisting>
+        data={signups}
+        columns={columns}
+        keyExtractor={(signup) => signup._id}
+        emptyState={{
+          title: `No ${status ?? ''} signups for this workshop`,
+        }}
+      />
 
       <ConfirmationModal
         isOpen={deleteTarget !== null}

--- a/src/components/messaging/NewConversationForm.tsx
+++ b/src/components/messaging/NewConversationForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { api } from '@/lib/trpc/client'
 import { errorCode } from '@/lib/messaging/trpc'
@@ -49,6 +49,11 @@ export interface NewConversationFormProps {
   onCreated?: (conversationId: string) => void
   /** Optional cancel handler (e.g. to collapse the form). */
   onCancel?: () => void
+  /**
+   * Optional: reports whether the form currently holds unsent content (a typed
+   * subject or body). Lets a hosting modal arm a discard-changes guard.
+   */
+  onDirtyChange?: (dirty: boolean) => void
 }
 
 /**
@@ -67,6 +72,7 @@ export function NewConversationForm({
   autoFocusFirstField = false,
   onCreated,
   onCancel,
+  onDirtyChange,
 }: NewConversationFormProps) {
   const router = useRouter()
   const utils = api.useUtils()
@@ -76,6 +82,13 @@ export function NewConversationForm({
 
   const isProposalThread = Boolean(proposalId)
   const showPicker = requireRecipient && !fixedRecipient && !isProposalThread
+
+  // Report unsent content upward so a hosting modal can guard the close.
+  const isDirty =
+    body.trim().length > 0 || (!isProposalThread && subject.trim().length > 0)
+  useEffect(() => {
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
 
   const sendMutation = api.message.send.useMutation({
     onSuccess: ({ conversationId }) => {


### PR DESCRIPTION
Batch 4 (final) of the modal audit: bring every remaining legacy-header modal onto the canonical `ModalShell`, standardize footers on the new brand primary, and add discard-changes guards to the editing modals that lacked them.

## AdminButton
- New `color="brand"` (`bg-brand-cloud-blue` / hover `brand-cloud-blue-hover`, matching focus outline) — the documented modal-footer primary. Default color (indigo) unchanged; call sites opt in.

## Legacy-header migrations (house `title`/`subtitle`/`icon`)
Moved onto the shell's header props, killing hand-rolled `DialogTitle` blocks and sub-44px/unlabeled closes, dropping `max-h`/`overflow-y-auto` panel overrides that double-scroll against the sheet scroller, and normalizing footers (AdminButton, `color="brand"` primary with explicit `type=`, Cancel left / primary right, `flex-col-reverse` on mobile, `min-h-11`):
EmailModal*, ProposalManagementModal, SpeakerManagementModal, SpeakerMergeModal, SpeakerImageModal, SpeakerProfilePreview, BadgePreviewModal, PaymentDetailsModal, ImageMetadataModal, SponsorAddModal, SignupDetailsModal, EditCapacityModal.

- **EmailModal\*** keeps a compliant custom header *inside* the shell body — its draft-saved pill + clear-draft control are interactive and can't live in the shell's `title` slot. Close upgraded to a 44px labeled target; footer normalized to the brand primary.
- **ProposalActionModal** and **SponsorDeleteModal** are semantic centered-confirm dialogs (matching the canonical `ConfirmationModal`); left in that layout, with 44px footer targets ensured. Migrating them to the top-bar header would have made them inconsistent with the canonical confirm.

## Dirty-close guards
Added `confirmOnDirtyClose` + `isDirty && !isPending` (baseline-vs-current snapshot, per the OrganizersEditor/AnnounceModal pattern) to: ProposalManagementModal, SpeakerManagementModal, ImageMetadataModal, SponsorAddModal, SponsorTierEditor, StaffManager, EditCapacityModal.
- **EmailModal: no guard added** — it already autosaves drafts to localStorage and restores them on reopen, so nothing is actually discarded on close; a "Discard unsaved changes?" prompt would be misleading and double-protect.

## SendMessageModal → ModalShell
Replaced the bespoke bottom-sheet bar (and its `useModalA11y` usage) with the canonical shell, preserving layout/behavior and aligning metrics (p-6, `sm:rounded-2xl`, 1.5rem safe-area). Added the discard guard it lacked: `NewConversationForm` gains an optional `onDirtyChange` callback so the modal confirms on backdrop/Escape once a message is typed. `BottomSheet`/`useModalA11y` remain untouched for the schedule-mobile surface.

## Stories / visual QA
Synced migrated modals' stories to the portal-theme pattern (`withPortalTheme` / next-themes `forcedTheme`) + fullscreen layout so dark mode and 393px capture render correctly (ModalShell portals via HeadlessUI, so a wrapper `.dark` no longer reaches it). Shot SendMessage, SponsorAdd, ImageMetadata, EmailModal, ProposalManagement, SpeakerMerge, SpeakerImage at 393px in light + dark: house headers, 44px labeled closes, brand primaries, correct sheet scroll, no horizontal overflow, dark correct.

## Checks
`mise run check` (typecheck + lint + knip + format) green; full `vitest` green (281 files, 3871 passed / 5 skipped). `mise run build` not run — this machine lacks the keychain secrets (RESEND_API_KEY etc.), a known/accepted env failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
