### PR TITLE
fix(crons): iterate all active conferences in reminders + weekly-update

### DIFF
--- a/docs/SPEAKER_REMINDERS.md
+++ b/docs/SPEAKER_REMINDERS.md
@@ -20,9 +20,10 @@ schedule is a hardcoded registry, tuned in code, with no Studio UI.
 │                       Speaker Reminders (Phase 1)                      │
 ├──────────────────────────────────────────────────────────────────────┤
 │  Cron:  src/app/api/cron/reminders  (Bearer CRON_SECRET, 06:00 UTC)   │
-│  ├── resolveActiveReminderConference()  → the single active edition    │
-│  ├── runSpeakerReminders(conf)   → the fixed registry, deduped         │
-│  └── runDayOfAgenda(conf)        → "you're presenting today"           │
+│  ├── resolveActiveReminderConferences() → ALL not-yet-ended editions   │
+│  └── for each edition (sequential, isolated):                          │
+│      ├── runSpeakerReminders(conf) → the fixed registry, deduped       │
+│      └── runDayOfAgenda(conf)      → "you're presenting today"         │
 ├──────────────────────────────────────────────────────────────────────┤
 │  Registry (registry.ts): confirm-talk · upload-slides ·               │
 │                          travel-reminder · logistics                  │
@@ -87,14 +88,23 @@ in one transaction).
 ## The cron route & the active conference
 
 `src/app/api/cron/reminders` is the daily entry point. Auth mirrors the other
-crons — a `Bearer ${CRON_SECRET}` header. It resolves **one** active conference
-(`resolveActiveReminderConference`: among editions that have **not** ended
-(`endDate >= today`), the one with the **earliest** `startDate` — a currently
-ongoing edition, else the nearest upcoming one), then runs
-`runSpeakerReminders` followed by `runDayOfAgenda`. Both jobs are wrapped in a
-**never-throw** envelope and isolate every per-speaker emit, so one bad speaker,
-read error or notification failure can never fail the cron. A run is capped at
-`MAX_SENDS_PER_RUN` (500) so a backlog can never fan out unbounded.
+crons — a `Bearer ${CRON_SECRET}` header. The deployment serves **multiple**
+conferences (domain-based resolution), so the cron resolves **every** active
+edition (`resolveActiveReminderConferences`: all editions that have **not** ended
+(`endDate >= today`), ordered by `startDate`) and iterates them
+**sequentially**, running `runSpeakerReminders` followed by `runDayOfAgenda` for
+each. Each conference runs under its own `try/catch` so one tenant's failure
+cannot abort the rest, and the route returns a structured per-conference summary
+(`{ conferenceId, ok, durationMs, … }`) with per-conference duration logged.
+Both jobs are themselves wrapped in a **never-throw** envelope and isolate every
+per-speaker emit, so one bad speaker, read error or notification failure can
+never fail the run. A run is capped at `MAX_SENDS_PER_RUN` (500) **per
+conference** so a backlog can never fan out unbounded.
+
+**Multi-tenant dedup.** Iterating multiple conferences never double-sends: the
+markers are scoped per conference (`reminder.<key>.<conferenceId>.<speakerId>`
+and `reminder.day-of.<conferenceId>.<speakerId>.<date>`), so each edition's
+sends are gated by its own markers, fully independent of the others.
 
 **TZ ASSUMPTION.** The cron is scheduled at **06:00 UTC** (`vercel.json`). Our
 events run in Central European time (CET/CEST), where 06:00 UTC is 07:00–08:00

--- a/src/app/api/cron/reminders/route.test.ts
+++ b/src/app/api/cron/reminders/route.test.ts
@@ -7,7 +7,7 @@ const resolveMock = vi.fn()
 const runSpeakerRemindersMock = vi.fn()
 const runDayOfAgendaMock = vi.fn()
 vi.mock('@/lib/reminders', () => ({
-  resolveActiveReminderConference: (...a: unknown[]) => resolveMock(...a),
+  resolveActiveReminderConferences: (...a: unknown[]) => resolveMock(...a),
   runSpeakerReminders: (...a: unknown[]) => runSpeakerRemindersMock(...a),
   runDayOfAgenda: (...a: unknown[]) => runDayOfAgendaMock(...a),
 }))
@@ -20,29 +20,34 @@ const req = (headers?: Record<string, string>) =>
 
 const OLD_ENV = process.env.CRON_SECRET
 
+const remindersSummary = {
+  candidates: 1,
+  sent: 1,
+  skipped: 0,
+  failed: 0,
+  perReminder: [],
+}
+const dayOfSummary = {
+  isScheduleDay: false,
+  presenting: 0,
+  sent: 0,
+  skipped: 0,
+  failed: 0,
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   process.env.CRON_SECRET = 'top-secret'
-  resolveMock.mockResolvedValue({
-    _id: 'conf-1',
-    title: 'X',
-    startDate: '2026-09-10',
-    endDate: '2026-09-11',
-  })
-  runSpeakerRemindersMock.mockResolvedValue({
-    candidates: 1,
-    sent: 1,
-    skipped: 0,
-    failed: 0,
-    perReminder: [],
-  })
-  runDayOfAgendaMock.mockResolvedValue({
-    isScheduleDay: false,
-    presenting: 0,
-    sent: 0,
-    skipped: 0,
-    failed: 0,
-  })
+  resolveMock.mockResolvedValue([
+    {
+      _id: 'conf-1',
+      title: 'X',
+      startDate: '2026-09-10',
+      endDate: '2026-09-11',
+    },
+  ])
+  runSpeakerRemindersMock.mockResolvedValue(remindersSummary)
+  runDayOfAgendaMock.mockResolvedValue(dayOfSummary)
 })
 
 afterEach(() => {
@@ -72,15 +77,124 @@ describe('/api/cron/reminders — auth guard', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.success).toBe(true)
-    expect(body.conference).toBe('conf-1')
+    expect(body.summary.conferences).toBe(1)
+    expect(body.results[0].conferenceId).toBe('conf-1')
+    expect(body.results[0].ok).toBe(true)
     expect(runSpeakerRemindersMock).toHaveBeenCalledTimes(1)
     expect(runDayOfAgendaMock).toHaveBeenCalledTimes(1)
   })
 
   it('short-circuits when no conference is active', async () => {
-    resolveMock.mockResolvedValue(null)
+    resolveMock.mockResolvedValue([])
     const res = await GET(req({ authorization: 'Bearer top-secret' }))
     expect(res.status).toBe(200)
     expect(runSpeakerRemindersMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('/api/cron/reminders — multi-conference iteration', () => {
+  it('runs both jobs for EVERY active conference', async () => {
+    resolveMock.mockResolvedValue([
+      {
+        _id: 'conf-1',
+        title: 'A',
+        startDate: '2026-08-01',
+        endDate: '2026-08-02',
+      },
+      {
+        _id: 'conf-2',
+        title: 'B',
+        startDate: '2026-09-10',
+        endDate: '2026-09-11',
+      },
+      {
+        _id: 'conf-3',
+        title: 'C',
+        startDate: '2026-10-10',
+        endDate: '2026-10-11',
+      },
+    ])
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.summary.conferences).toBe(3)
+    expect(body.summary.failed).toBe(0)
+    expect(runSpeakerRemindersMock).toHaveBeenCalledTimes(3)
+    expect(runDayOfAgendaMock).toHaveBeenCalledTimes(3)
+    // Each conference was passed through to the runner.
+    expect(runSpeakerRemindersMock.mock.calls.map((c) => c[0]._id)).toEqual([
+      'conf-1',
+      'conf-2',
+      'conf-3',
+    ])
+  })
+
+  it('ISOLATES a failing conference so the others still run', async () => {
+    resolveMock.mockResolvedValue([
+      {
+        _id: 'conf-1',
+        title: 'A',
+        startDate: '2026-08-01',
+        endDate: '2026-08-02',
+      },
+      {
+        _id: 'conf-2',
+        title: 'B',
+        startDate: '2026-09-10',
+        endDate: '2026-09-11',
+      },
+      {
+        _id: 'conf-3',
+        title: 'C',
+        startDate: '2026-10-10',
+        endDate: '2026-10-11',
+      },
+    ])
+    // The middle conference throws; the first and third must still complete.
+    runSpeakerRemindersMock.mockImplementation(
+      (conference: { _id: string }) => {
+        if (conference._id === 'conf-2') {
+          return Promise.reject(new Error('conf-2 boom'))
+        }
+        return Promise.resolve(remindersSummary)
+      },
+    )
+
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.summary.conferences).toBe(3)
+    expect(body.summary.failed).toBe(1)
+
+    const byId = Object.fromEntries(
+      body.results.map((r: { conferenceId: string }) => [r.conferenceId, r]),
+    )
+    expect(byId['conf-1'].ok).toBe(true)
+    expect(byId['conf-2'].ok).toBe(false)
+    expect(byId['conf-2'].error).toContain('conf-2 boom')
+    expect(byId['conf-3'].ok).toBe(true)
+    // conf-3 ran despite conf-2 throwing (day-of only runs on the two OK confs).
+    expect(runDayOfAgendaMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('aggregates a structured per-conference summary shape', async () => {
+    resolveMock.mockResolvedValue([
+      {
+        _id: 'conf-1',
+        title: 'A',
+        startDate: '2026-08-01',
+        endDate: '2026-08-02',
+      },
+    ])
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    const body = await res.json()
+    expect(body.results[0]).toMatchObject({
+      conferenceId: 'conf-1',
+      ok: true,
+    })
+    expect(typeof body.results[0].durationMs).toBe('number')
+    expect(body.results[0].reminders).toBeDefined()
+    expect(body.results[0].dayOf).toBeDefined()
   })
 })

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { unstable_noStore as noStore } from 'next/cache'
 import {
-  resolveActiveReminderConference,
+  resolveActiveReminderConferences,
   runSpeakerReminders,
   runDayOfAgenda,
 } from '@/lib/reminders'
@@ -10,9 +10,19 @@ import {
  * Daily scheduled-reminders cron.
  *
  * Runs the fixed speaker-prep reminder registry and then the day-of agenda for
- * the single ACTIVE conference (earliest not-yet-ended edition — see
- * `resolveActiveReminderConference`). Auth mirrors the other crons: a
- * `Bearer ${CRON_SECRET}` header.
+ * EVERY active conference (every not-yet-ended edition — see
+ * `resolveActiveReminderConferences`). The deployment serves multiple
+ * conferences, so the cron iterates all qualifying editions rather than a single
+ * one; each is processed under its own try/catch so one tenant's failure cannot
+ * abort the rest. Dedup markers are scoped per conference, so iterating never
+ * double-sends. Auth mirrors the other crons: a `Bearer ${CRON_SECRET}` header.
+ *
+ * Conferences are processed SEQUENTIALLY: each edition does per-speaker work
+ * (reads + notification writes), and running them in series keeps the Sanity/hub
+ * write load bounded and predictable. With the current handful of active
+ * editions this stays well inside the Vercel function timeout; if the active set
+ * grows large enough to approach it, move to a per-conference fan-out/queue
+ * (out of scope for this change).
  *
  * TZ ASSUMPTION: scheduled at 06:00 UTC (see `vercel.json`). Our events run in
  * Central European time (CET/CEST), where 06:00 UTC is 07:00–08:00 local — the
@@ -39,28 +49,80 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const conference = await resolveActiveReminderConference()
-    if (!conference) {
+    const conferences = await resolveActiveReminderConferences()
+    if (conferences.length === 0) {
       return NextResponse.json({
         success: true,
         message: 'No active conference — nothing to remind',
+        conferences: [],
       })
     }
 
-    // Never-throw jobs: each returns a summary even on internal failure.
-    const reminders = await runSpeakerReminders(conference)
-    const dayOf = await runDayOfAgenda(conference)
+    // Process each active edition SEQUENTIALLY and ISOLATED: a failure loading or
+    // running one conference is caught here so the remaining editions still run.
+    // (runSpeakerReminders/runDayOfAgenda are themselves never-throw, so this
+    // per-conference guard only trips on an unexpected throw — but it keeps the
+    // tenant boundary hard.)
+    const results: Array<{
+      conferenceId: string
+      ok: boolean
+      durationMs: number
+      reminders?: Awaited<ReturnType<typeof runSpeakerReminders>>
+      dayOf?: Awaited<ReturnType<typeof runDayOfAgenda>>
+      error?: string
+    }> = []
 
+    for (const conference of conferences) {
+      const startedAt = Date.now()
+      try {
+        const reminders = await runSpeakerReminders(conference)
+        const dayOf = await runDayOfAgenda(conference)
+        const durationMs = Date.now() - startedAt
+
+        console.log(
+          `Reminders cron for ${conference._id}: sent=${reminders.sent} skipped=${reminders.skipped} failed=${reminders.failed}` +
+            ` | day-of: scheduleDay=${dayOf.isScheduleDay} sent=${dayOf.sent} skipped=${dayOf.skipped} failed=${dayOf.failed}` +
+            ` | ${durationMs}ms`,
+        )
+
+        results.push({
+          conferenceId: conference._id,
+          ok: true,
+          durationMs,
+          reminders,
+          dayOf,
+        })
+      } catch (error) {
+        const durationMs = Date.now() - startedAt
+        console.error(
+          `Reminders cron failed for conference ${conference._id} after ${durationMs}ms:`,
+          error,
+        )
+        results.push({
+          conferenceId: conference._id,
+          ok: false,
+          durationMs,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        })
+      }
+    }
+
+    const summary = {
+      conferences: results.length,
+      failed: results.filter((r) => !r.ok).length,
+      sent: results.reduce(
+        (acc, r) => acc + (r.reminders?.sent ?? 0) + (r.dayOf?.sent ?? 0),
+        0,
+      ),
+    }
     console.log(
-      `Reminders cron for ${conference._id}: sent=${reminders.sent} skipped=${reminders.skipped} failed=${reminders.failed}` +
-        ` | day-of: scheduleDay=${dayOf.isScheduleDay} sent=${dayOf.sent} skipped=${dayOf.skipped} failed=${dayOf.failed}`,
+      `Reminders cron summary: conferences=${summary.conferences} sent=${summary.sent} failedConferences=${summary.failed}`,
     )
 
     return NextResponse.json({
       success: true,
-      conference: conference._id,
-      reminders,
-      dayOf,
+      summary,
+      results,
     })
   } catch (error) {
     console.error('Error in reminders cron job:', error)

--- a/src/app/api/cron/weekly-update/route.test.ts
+++ b/src/app/api/cron/weekly-update/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The route calls `noStore()` (a request-scoped Next helper) — no-op it in tests.
+vi.mock('next/cache', () => ({ unstable_noStore: () => {} }))
+
+const getConferencesMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferencesForWeeklyUpdate: (...a: unknown[]) => getConferencesMock(...a),
+}))
+
+const buildSummaryMock = vi.fn()
+vi.mock('@/lib/status/summary', () => ({
+  buildConferenceStatusSummary: (...a: unknown[]) => buildSummaryMock(...a),
+}))
+
+const sendSlackMock = vi.fn()
+vi.mock('@/lib/slack/weeklyUpdate', () => ({
+  sendWeeklyUpdateToSlack: (...a: unknown[]) => sendSlackMock(...a),
+}))
+
+import { GET } from './route'
+
+const URL = 'https://cloudnativebergen.dev/api/cron/weekly-update'
+const req = (headers?: Record<string, string>) =>
+  new Request(URL, { headers }) as unknown as Parameters<typeof GET>[0]
+
+const OLD_ENV = process.env.CRON_SECRET
+
+const conf = (id: string, title: string) => ({
+  _id: id,
+  title,
+  endDate: '2099-01-01',
+  salesNotificationChannel: `#${id}`,
+})
+
+const summary = (title: string) => ({
+  conferenceTitle: title,
+  lastUpdated: '2026-07-20T09:00:00.000Z',
+  sponsors: null,
+  proposals: null,
+  tickets: null,
+  targetProgress: null,
+  errors: [],
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.CRON_SECRET = 'top-secret'
+  getConferencesMock.mockResolvedValue([conf('conf-1', 'A')])
+  buildSummaryMock.mockImplementation((c: { title: string }) =>
+    Promise.resolve(summary(c.title)),
+  )
+  sendSlackMock.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  process.env.CRON_SECRET = OLD_ENV
+})
+
+describe('/api/cron/weekly-update — auth guard', () => {
+  it('rejects a request with no bearer token', async () => {
+    const res = await GET(req())
+    expect(res.status).toBe(401)
+    expect(getConferencesMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a wrong token', async () => {
+    const res = await GET(req({ authorization: 'Bearer nope' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('errors 500 when CRON_SECRET is unset', async () => {
+    delete process.env.CRON_SECRET
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(500)
+  })
+
+  it('short-circuits when no qualifying conference', async () => {
+    getConferencesMock.mockResolvedValue([])
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(200)
+    expect(sendSlackMock).not.toHaveBeenCalled()
+    const body = await res.json()
+    expect(body.results).toEqual([])
+  })
+})
+
+describe('/api/cron/weekly-update — multi-conference iteration', () => {
+  it('sends the update to EVERY qualifying conference', async () => {
+    getConferencesMock.mockResolvedValue([
+      conf('conf-1', 'A'),
+      conf('conf-2', 'B'),
+      conf('conf-3', 'C'),
+    ])
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.summary.conferences).toBe(3)
+    expect(body.summary.failed).toBe(0)
+    expect(sendSlackMock).toHaveBeenCalledTimes(3)
+    expect(sendSlackMock.mock.calls.map((c) => c[0].conference._id)).toEqual([
+      'conf-1',
+      'conf-2',
+      'conf-3',
+    ])
+  })
+
+  it('ISOLATES a failing conference so the others still send', async () => {
+    getConferencesMock.mockResolvedValue([
+      conf('conf-1', 'A'),
+      conf('conf-2', 'B'),
+      conf('conf-3', 'C'),
+    ])
+    sendSlackMock.mockImplementation(
+      (data: { conference: { _id: string } }) => {
+        if (data.conference._id === 'conf-2') {
+          return Promise.reject(new Error('conf-2 slack down'))
+        }
+        return Promise.resolve(undefined)
+      },
+    )
+
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.summary.conferences).toBe(3)
+    expect(body.summary.failed).toBe(1)
+
+    const byId = Object.fromEntries(
+      body.results.map((r: { conferenceId: string }) => [r.conferenceId, r]),
+    )
+    expect(byId['conf-1'].ok).toBe(true)
+    expect(byId['conf-2'].ok).toBe(false)
+    expect(byId['conf-2'].error).toContain('conf-2 slack down')
+    expect(byId['conf-3'].ok).toBe(true)
+    // All three were attempted despite conf-2 throwing.
+    expect(sendSlackMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('reports a structured per-conference summary shape', async () => {
+    const res = await GET(req({ authorization: 'Bearer top-secret' }))
+    const body = await res.json()
+    expect(body.results[0]).toMatchObject({
+      conferenceId: 'conf-1',
+      title: 'A',
+      ok: true,
+    })
+    expect(typeof body.results[0].durationMs).toBe('number')
+  })
+})

--- a/src/app/api/cron/weekly-update/route.ts
+++ b/src/app/api/cron/weekly-update/route.ts
@@ -1,9 +1,85 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
-import { isConferenceOver } from '@/lib/conference/state'
+import type { Conference } from '@/lib/conference/types'
+import { getConferencesForWeeklyUpdate } from '@/lib/conference/sanity'
 import { buildConferenceStatusSummary } from '@/lib/status/summary'
 import { sendWeeklyUpdateToSlack } from '@/lib/slack/weeklyUpdate'
 import { unstable_noStore as noStore } from 'next/cache'
+
+/**
+ * Send the weekly Slack status update for ONE conference. Isolated so a caller
+ * can run it under a per-conference try/catch and continue with the rest.
+ */
+async function sendWeeklyUpdateForConference(conference: Conference) {
+  const summary = await buildConferenceStatusSummary(conference)
+
+  for (const err of summary.errors) {
+    console.log(
+      `[${conference.title}] ${err.section} fetch failed:`,
+      err.message,
+    )
+  }
+
+  await sendWeeklyUpdateToSlack({
+    conference,
+    ticketsByCategory: summary.tickets?.categoryBreakdown ?? {},
+    paidTickets: summary.tickets?.paidTickets ?? 0,
+    sponsorTickets: summary.tickets?.sponsorTickets ?? 0,
+    speakerTickets: summary.tickets?.speakerTickets ?? 0,
+    organizerTickets: summary.tickets?.organizerTickets ?? 0,
+    freeTicketsClaimed: summary.tickets?.freeTicketsClaimed ?? 0,
+    totalTickets: summary.tickets?.totalTickets ?? 0,
+    totalRevenue: summary.tickets?.totalRevenue ?? 0,
+    targetAnalysis: summary.targetProgress
+      ? {
+          progression: [],
+          capacity: summary.targetProgress.capacity,
+          performance: {
+            currentPercentage: summary.targetProgress.currentPercentage,
+            targetPercentage: summary.targetProgress.targetPercentage,
+            variance: summary.targetProgress.variance,
+            isOnTrack: summary.targetProgress.isOnTrack,
+            nextMilestone: summary.targetProgress.nextMilestone
+              ? {
+                  date: '',
+                  label: summary.targetProgress.nextMilestone.label,
+                  daysAway: summary.targetProgress.nextMilestone.daysAway,
+                }
+              : null,
+          },
+          statistics: {
+            totalPaidTickets: summary.tickets?.paidTickets ?? 0,
+            totalRevenue: summary.tickets?.totalRevenue ?? 0,
+            totalOrders: 0,
+            averageTicketPrice: 0,
+            categoryBreakdown: summary.tickets?.categoryBreakdown ?? {},
+            sponsorTickets: summary.tickets?.sponsorTickets ?? 0,
+            speakerTickets: summary.tickets?.speakerTickets ?? 0,
+            totalCapacityUsed: summary.tickets?.totalTickets ?? 0,
+          },
+        }
+      : null,
+    sponsorPipeline: summary.sponsors,
+    proposalSummary: summary.proposals
+      ? {
+          submitted: summary.proposals.submitted,
+          accepted: summary.proposals.accepted,
+          confirmed: summary.proposals.confirmed,
+          rejected: summary.proposals.rejected,
+          withdrawn: summary.proposals.withdrawn,
+          total: summary.proposals.total,
+        }
+      : null,
+    lastUpdated: summary.lastUpdated,
+  })
+
+  return {
+    conference: summary.conferenceTitle,
+    paidTickets: summary.tickets?.paidTickets ?? 0,
+    totalTickets: summary.tickets?.totalTickets ?? 0,
+    totalRevenue: summary.tickets?.totalRevenue ?? 0,
+    errors: summary.errors.length,
+  }
+}
 
 export async function GET(request: NextRequest) {
   noStore()
@@ -24,133 +100,73 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const url = new URL(request.url)
-    const hostname = request.headers.get('host') || url.hostname
+    // The deployment serves multiple conferences: send the weekly update to
+    // EVERY qualifying edition, not just the one owning the request Host.
+    const conferences = await getConferencesForWeeklyUpdate()
 
-    const { conference, error: conferenceError } =
-      await getConferenceForCurrentDomain({
-        sponsors: true,
-        organizers: true,
-        featuredSpeakers: false,
-        featuredTalks: false,
+    if (conferences.length === 0) {
+      return NextResponse.json({
+        success: true,
+        message: 'No active conference with a sales channel — nothing to send.',
+        results: [],
       })
-
-    if (conferenceError || !conference) {
-      console.error(
-        `Failed to load conference for domain ${hostname}:`,
-        conferenceError,
-      )
-      return NextResponse.json(
-        { error: 'Failed to load conference configuration' },
-        { status: 500 },
-      )
     }
 
-    if (isConferenceOver(conference)) {
-      console.log(
-        `Conference ${conference.title} has ended. Skipping weekly update.`,
-      )
-      return NextResponse.json(
-        {
-          success: true,
-          message: 'Conference has ended. Weekly updates are no longer sent.',
-          conference: conference.title,
-        },
-        { status: 200 },
-      )
+    // Process SEQUENTIALLY and ISOLATED per conference: one tenant's failure
+    // (a bad config, a Slack error, a status-summary throw) must not abort the
+    // weekly update for the others.
+    const results: Array<{
+      conferenceId: string
+      title?: string
+      ok: boolean
+      durationMs: number
+      data?: Awaited<ReturnType<typeof sendWeeklyUpdateForConference>>
+      error?: string
+    }> = []
+
+    for (const conference of conferences) {
+      const startedAt = Date.now()
+      try {
+        const data = await sendWeeklyUpdateForConference(conference)
+        const durationMs = Date.now() - startedAt
+        console.log(
+          `Weekly update sent for ${conference.title} (${conference._id}) in ${durationMs}ms`,
+        )
+        results.push({
+          conferenceId: conference._id,
+          title: conference.title,
+          ok: true,
+          durationMs,
+          data,
+        })
+      } catch (error) {
+        const durationMs = Date.now() - startedAt
+        console.error(
+          `Weekly update failed for ${conference.title} (${conference._id}) after ${durationMs}ms:`,
+          error,
+        )
+        results.push({
+          conferenceId: conference._id,
+          title: conference.title,
+          ok: false,
+          durationMs,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        })
+      }
     }
 
-    const summary = await buildConferenceStatusSummary(conference)
-
-    for (const err of summary.errors) {
-      console.log(`${err.section} fetch failed:`, err.message)
+    const summary = {
+      conferences: results.length,
+      failed: results.filter((r) => !r.ok).length,
     }
-
-    const complimentary =
-      (summary.tickets?.speakerTickets ?? 0) +
-      (summary.tickets?.organizerTickets ?? 0) +
-      (summary.tickets?.sponsorTickets ?? 0)
-
-    await sendWeeklyUpdateToSlack({
-      conference,
-      ticketsByCategory: summary.tickets?.categoryBreakdown ?? {},
-      paidTickets: summary.tickets?.paidTickets ?? 0,
-      sponsorTickets: summary.tickets?.sponsorTickets ?? 0,
-      speakerTickets: summary.tickets?.speakerTickets ?? 0,
-      organizerTickets: summary.tickets?.organizerTickets ?? 0,
-      freeTicketsClaimed: summary.tickets?.freeTicketsClaimed ?? 0,
-      totalTickets: summary.tickets?.totalTickets ?? 0,
-      totalRevenue: summary.tickets?.totalRevenue ?? 0,
-      targetAnalysis: summary.targetProgress
-        ? {
-            progression: [],
-            capacity: summary.targetProgress.capacity,
-            performance: {
-              currentPercentage: summary.targetProgress.currentPercentage,
-              targetPercentage: summary.targetProgress.targetPercentage,
-              variance: summary.targetProgress.variance,
-              isOnTrack: summary.targetProgress.isOnTrack,
-              nextMilestone: summary.targetProgress.nextMilestone
-                ? {
-                    date: '',
-                    label: summary.targetProgress.nextMilestone.label,
-                    daysAway: summary.targetProgress.nextMilestone.daysAway,
-                  }
-                : null,
-            },
-            statistics: {
-              totalPaidTickets: summary.tickets?.paidTickets ?? 0,
-              totalRevenue: summary.tickets?.totalRevenue ?? 0,
-              totalOrders: 0,
-              averageTicketPrice: 0,
-              categoryBreakdown: summary.tickets?.categoryBreakdown ?? {},
-              sponsorTickets: summary.tickets?.sponsorTickets ?? 0,
-              speakerTickets: summary.tickets?.speakerTickets ?? 0,
-              totalCapacityUsed: summary.tickets?.totalTickets ?? 0,
-            },
-          }
-        : null,
-      sponsorPipeline: summary.sponsors,
-      proposalSummary: summary.proposals
-        ? {
-            submitted: summary.proposals.submitted,
-            accepted: summary.proposals.accepted,
-            confirmed: summary.proposals.confirmed,
-            rejected: summary.proposals.rejected,
-            withdrawn: summary.proposals.withdrawn,
-            total: summary.proposals.total,
-          }
-        : null,
-      lastUpdated: summary.lastUpdated,
-    })
+    console.log(
+      `Weekly update summary: conferences=${summary.conferences} failed=${summary.failed}`,
+    )
 
     return NextResponse.json({
       success: true,
-      data: {
-        conference: summary.conferenceTitle,
-        paidTickets: summary.tickets?.paidTickets ?? 0,
-        sponsorTickets: summary.tickets?.sponsorTickets ?? 0,
-        speakerTickets: summary.tickets?.speakerTickets ?? 0,
-        totalTickets: summary.tickets?.totalTickets ?? 0,
-        totalRevenue: summary.tickets?.totalRevenue ?? 0,
-        categories: summary.tickets?.categoryBreakdown ?? {},
-        targetAnalysis: summary.targetProgress
-          ? {
-              enabled: true,
-              capacity: summary.targetProgress.capacity,
-              currentTargetPercentage: summary.targetProgress.targetPercentage,
-              actualPercentage: summary.targetProgress.currentPercentage,
-              variance: summary.targetProgress.variance,
-              isOnTrack: summary.targetProgress.isOnTrack,
-              nextMilestone: summary.targetProgress.nextMilestone,
-            }
-          : null,
-        sponsorPipeline: summary.sponsors,
-        proposalSummary: summary.proposals,
-        complimentary,
-        lastUpdated: summary.lastUpdated,
-        errors: summary.errors,
-      },
+      summary,
+      results,
     })
   } catch (error) {
     console.error('Error in weekly update cron job:', error)

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -1,6 +1,7 @@
-import { clientWrite } from '../sanity/client'
+import { clientWrite, clientReadUncached } from '../sanity/client'
 import { Conference } from './types'
 import { normalizeDomain } from './domains'
+import { isConferenceOver } from './state'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
 import {
@@ -346,6 +347,49 @@ export async function getConferenceForDomain(
   }
 
   return { conference, domain, error }
+}
+
+/**
+ * Load EVERY conference that qualifies for the weekly Slack update, independent
+ * of the request Host.
+ *
+ * The deployment serves multiple conferences via domain-based resolution, so a
+ * Host-scoped loader (`getConferenceForCurrentDomain`) would only ever update the
+ * one edition that owns the cron request's production domain and silently starve
+ * all the others. The weekly-update cron iterates the set this returns instead.
+ *
+ * QUALIFYING SET: a conference is included when it has a `salesNotificationChannel`
+ * configured (the weekly update has nowhere to post without one) AND it has not
+ * yet ended (`isConferenceOver` — the same "over" rule the single-conference path
+ * used to skip finished editions). Ordered by `startDate` for stable, readable
+ * cron logs. Fetched uncached so the cron always sees current configuration.
+ *
+ * The projection is the full conference document (`...`): `organizers` stays as
+ * references, whose length is all the status summary needs for the organizer
+ * ticket count, so no expansion is required.
+ */
+export async function getConferencesForWeeklyUpdate(): Promise<Conference[]> {
+  const query = `*[_type == "conference" && defined(endDate) && defined(salesNotificationChannel)] | order(startDate asc){
+    ...,
+    teams[]{
+      _key,
+      key,
+      title,
+      slackChannel,
+      emailIdentity,
+      "members": members[]._ref
+    }
+  }`
+
+  const conferences = await clientReadUncached.fetch<Conference[]>(
+    query,
+    {},
+    { cache: 'no-store' },
+  )
+
+  return (conferences ?? []).filter(
+    (conference) => !isConferenceOver(conference),
+  )
 }
 
 export async function getConferenceByCheckinEventId(eventId: number): Promise<{

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -369,7 +369,10 @@ export async function getConferenceForDomain(
  * ticket count, so no expansion is required.
  */
 export async function getConferencesForWeeklyUpdate(): Promise<Conference[]> {
-  const query = `*[_type == "conference" && defined(endDate) && defined(salesNotificationChannel)] | order(startDate asc){
+  // NOTE: an empty string passes defined() in GROQ — require a non-empty
+  // channel so a blanked-out field doesn't qualify a conference for a post
+  // that postSlackMessage would no-op anyway.
+  const query = `*[_type == "conference" && defined(endDate) && defined(salesNotificationChannel) && salesNotificationChannel != ""] | order(startDate asc){
     ...,
     teams[]{
       _key,

--- a/src/lib/reminders/__tests__/conference.test.ts
+++ b/src/lib/reminders/__tests__/conference.test.ts
@@ -6,30 +6,40 @@ vi.mock('@/lib/sanity/client', () => ({
   clientWrite: {},
 }))
 
-import { resolveActiveReminderConference } from '../conference'
+import { resolveActiveReminderConferences } from '../conference'
 
-describe('resolveActiveReminderConference', () => {
+describe('resolveActiveReminderConferences', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it("queries with today's UTC date and orders by earliest not-yet-ended start", async () => {
-    fetchMock.mockResolvedValue({
-      _id: 'conf-next',
-      title: 'Next',
-      startDate: '2026-09-10',
-      endDate: '2026-09-11',
-    })
-    const result = await resolveActiveReminderConference(
+  it("queries with today's UTC date and returns ALL not-yet-ended editions ordered by start", async () => {
+    fetchMock.mockResolvedValue([
+      {
+        _id: 'conf-a',
+        title: 'A',
+        startDate: '2026-08-01',
+        endDate: '2026-08-02',
+      },
+      {
+        _id: 'conf-b',
+        title: 'B',
+        startDate: '2026-09-10',
+        endDate: '2026-09-11',
+      },
+    ])
+    const result = await resolveActiveReminderConferences(
       new Date('2026-07-20T06:00:00Z'),
     )
-    expect(result?._id).toBe('conf-next')
+    expect(result.map((c) => c._id)).toEqual(['conf-a', 'conf-b'])
     const [query, params] = fetchMock.mock.calls[0]
     expect(params.today).toBe('2026-07-20')
     expect(query).toContain('endDate >= $today')
     expect(query).toContain('order(startDate asc)')
+    // Must NOT collapse to a single edition.
+    expect(query).not.toContain('[0]')
   })
 
-  it('returns null when no conference is active', async () => {
+  it('returns an empty array when no conference is active', async () => {
     fetchMock.mockResolvedValue(null)
-    expect(await resolveActiveReminderConference(new Date())).toBeNull()
+    expect(await resolveActiveReminderConferences(new Date())).toEqual([])
   })
 })

--- a/src/lib/reminders/conference.ts
+++ b/src/lib/reminders/conference.ts
@@ -3,28 +3,30 @@ import { toDateString } from './dates'
 import type { ReminderConference } from './types'
 
 /**
- * Resolve the single ACTIVE conference the reminder cron targets.
+ * Resolve EVERY active conference the reminder cron targets.
  *
- * SELECTION: among every conference that has NOT yet ended (`endDate >= today`),
- * pick the one with the EARLIEST `startDate`. This yields:
- *   - a currently-ongoing edition (its start is in the past but end is today or
- *     later, and its start precedes any future edition's), or
- *   - otherwise the nearest upcoming edition.
- * A fully-past conference (`endDate < today`) is never selected — its speakers
- * need no prep reminders. When several unrelated editions overlap (multi-tenant
- * domains), the earliest-starting not-yet-ended one wins; Phase 1 deliberately
- * targets ONE active conference per run.
+ * SELECTION: every conference that has NOT yet ended (`endDate >= today`),
+ * ordered by `startDate` ascending. Each yields either a currently-ongoing
+ * edition (start in the past, end today-or-later) or an upcoming one. A
+ * fully-past conference (`endDate < today`) is never selected — its speakers
+ * need no prep reminders.
+ *
+ * The deployment serves MULTIPLE conferences (domain-based resolution), so the
+ * cron must iterate ALL of them: a single-conference resolver would starve every
+ * edition but one whenever unrelated editions overlap. Dedup markers are scoped
+ * per conference (`reminder.<key>.<conferenceId>.<speakerId>`), so iterating the
+ * full set never double-sends across editions.
  *
  * Dates are Sanity `date` values (YYYY-MM-DD) compared lexicographically, which
  * is order-preserving for that format.
  */
-export async function resolveActiveReminderConference(
+export async function resolveActiveReminderConferences(
   now: Date = new Date(),
-): Promise<ReminderConference | null> {
+): Promise<ReminderConference[]> {
   const today = toDateString(now)
-  const conference = await clientReadUncached.fetch<ReminderConference | null>(
+  const conferences = await clientReadUncached.fetch<ReminderConference[]>(
     `*[_type == "conference" && defined(startDate) && defined(endDate) && endDate >= $today]
-      | order(startDate asc)[0]{
+      | order(startDate asc){
         _id,
         title,
         startDate,
@@ -35,5 +37,5 @@ export async function resolveActiveReminderConference(
     { today },
     { cache: 'no-store' },
   )
-  return conference ?? null
+  return conferences ?? []
 }

--- a/src/lib/reminders/index.ts
+++ b/src/lib/reminders/index.ts
@@ -6,7 +6,7 @@
  * The fixed default reminder schedule lives in `registry.ts` — the one place to
  * tune timing/cadence/copy (no config UI in Phase 1).
  */
-export { resolveActiveReminderConference } from './conference'
+export { resolveActiveReminderConferences } from './conference'
 export { runSpeakerReminders, runDayOfAgenda } from './runner'
 export { notifyScheduleChanges } from './schedule-alerts'
 export type { SlotPlacement } from './types'

--- a/src/lib/reminders/types.ts
+++ b/src/lib/reminders/types.ts
@@ -2,7 +2,7 @@ import type { NotificationType } from '@/lib/notification/types'
 
 /**
  * The active conference a reminder run targets, projected down to the date
- * anchors the registry needs. See `resolveActiveReminderConference`.
+ * anchors the registry needs. See `resolveActiveReminderConferences`.
  */
 export interface ReminderConference {
   _id: string


### PR DESCRIPTION
## The bugs

The deployment serves **multiple conferences** via domain-based resolution, but two crons resolved a **single** conference and silently starved every other edition.

1. **`/api/cron/weekly-update`** called `getConferenceForCurrentDomain()`, keyed on the cron request's `Host` header. The cron always hits the project's one production domain, so **only the conference that owns that domain** got its weekly Slack status update — every other conference's organizers got nothing.
2. **`/api/cron/reminders`** used `resolveActiveReminderConference()`, a dataset-wide "earliest not-yet-ended edition" query. **One** conference globally received speaker prep reminders + the day-of agenda; any overlapping/other edition was starved.

**Who was starved:** any conference other than the single resolved one — i.e. every additional tenant on the shared deployment (overlapping editions, or non-primary-domain conferences).

## The fix

Both routes now iterate **all qualifying editions**:

- `resolveActiveReminderConferences()` (plural) — every conference with `endDate >= today`, ordered by `startDate`. Same `ReminderConference` projection as before, minus the `[0]` collapse.
- `getConferencesForWeeklyUpdate()` (new) — every conference that has **not ended** (same `isConferenceOver` rule the single path used) **and** has a `salesNotificationChannel` configured. **Qualifying-set choice:** a `salesNotificationChannel` is required because `sendWeeklyUpdateToSlack` posts to exactly that channel and `postSlackMessage` no-ops without one — a conference without it has nowhere to receive the update, so including it would only produce noise in the summary.

The existing delivery functions already take a conference (`runSpeakerReminders(conference)`, `runDayOfAgenda(conference)`, `sendWeeklyUpdateToSlack({ conference, ... })`), so the blast radius is **resolver + route** only.

### Isolation per tenant
Each conference is processed inside its own `try/catch`; one conference's failure (bad config, Slack error, status-summary throw) cannot abort the rest. Each route aggregates a structured `{ conferenceId, ok, durationMs, ... }` summary, logs it, and returns it.

### Timeout safety
Conferences are processed **sequentially** (reminders do per-speaker reads + notification writes) with per-conference duration logged. With the current handful of active editions this stays well inside the Vercel function timeout. If the active set ever grows large enough to approach it, move to a per-conference fan-out/queue — deliberately **not** built here.

### Dedup safety
Confirmed unaffected: reminder markers are already scoped per conference (`reminder.<key>.<conferenceId>.<speakerId>` and `reminder.day-of.<conferenceId>.<speakerId>.<date>` in `src/lib/reminders/marker.ts`), so each edition's sends are gated by its own markers. Iterating multiple conferences **cannot** double-send across editions.

## Tests

- Reminders resolver test rewritten for the plural resolver (returns all editions, ordered; `[]` when none).
- Reminders route test: multi-conference iteration, per-conference failure isolation (middle conference throws → first + third still run), structured aggregate summary shape.
- Weekly-update route: added a focused route test (none existed) — auth guards, iterate-all, failure isolation, summary shape.
- `mise run check` (format/typecheck/lint/knip) green. Full suite: **3885 tests / 282 files passing**.

> Build fails only at page-data collection for `/api/cron/weekly-update` with `RESEND_API_KEY is not set` — the known keychain-secret unavailability on this machine (TypeScript itself compiles clean; the old route imported the same module chain), not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)