### PR TITLE
fix(travel-support): brand palette on the speaker surface

### DIFF
--- a/src/components/travel-support/BankingDetailsDisplay.tsx
+++ b/src/components/travel-support/BankingDetailsDisplay.tsx
@@ -68,8 +68,9 @@ export function BankingDetailsDisplay({
         {canEdit && onEdit && (
           <div className="mt-4">
             <button
+              type="button"
               onClick={onEdit}
-              className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+              className="inline-flex items-center gap-2 rounded-md bg-brand-cloud-blue px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-cloud-blue-hover"
             >
               <PlusIcon className="h-4 w-4" />
               Add Banking Details

--- a/src/components/travel-support/BankingDetailsForm.tsx
+++ b/src/components/travel-support/BankingDetailsForm.tsx
@@ -295,7 +295,7 @@ export function BankingDetailsForm({
           <button
             type="submit"
             disabled={isLoading}
-            className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:shadow-none dark:focus-visible:outline-indigo-500"
+            className="rounded-md bg-brand-cloud-blue px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-brand-cloud-blue-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-cloud-blue disabled:cursor-not-allowed disabled:opacity-50 dark:shadow-none"
           >
             {isLoading ? 'Saving...' : 'Save Banking Details'}
           </button>

--- a/src/components/travel-support/TravelSupportPageClient.tsx
+++ b/src/components/travel-support/TravelSupportPageClient.tsx
@@ -278,9 +278,10 @@ export function TravelSupportPageClient({
             />
           )}
           <button
+            type="button"
             onClick={createTravelSupport}
             disabled={createMutation.isPending}
-            className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+            className="inline-flex items-center gap-2 rounded-md bg-brand-cloud-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-cloud-blue-hover disabled:cursor-not-allowed disabled:opacity-50"
           >
             {createMutation.isPending
               ? 'Setting up...'
@@ -389,8 +390,9 @@ export function TravelSupportPageClient({
                   </div>
                   {canEdit && !showExpenseForm && (
                     <button
+                      type="button"
                       onClick={() => setShowExpenseForm(true)}
-                      className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+                      className="inline-flex items-center gap-2 rounded-md bg-brand-cloud-blue px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-cloud-blue-hover"
                     >
                       <PlusIcon className="h-4 w-4" />
                       Add Expense


### PR DESCRIPTION
## What

The travel-support components render inside the speaker-facing `(cfp)` layout (`src/app/(cfp)/cfp/expense/page.tsx`) but styled their primary action buttons with admin-indigo, clashing with the brand-blue used across every other speaker surface.

This swaps the indigo button palette to the `brand-cloud-blue` tokens (the same tokens the public `Button` primitive uses for its `primary` variant), preserving each button's existing compact shape so there are **no layout shifts**.

### Buttons changed (all speaker-facing)
- **TravelSupportPageClient**: "Start Travel Support Request" (empty state) and "Add Expense" (expenses header)
- **BankingDetailsForm**: "Save Banking Details" (form submit)
- **BankingDetailsDisplay**: "Add Banking Details" (empty state)

The adjacent green "Submit Travel Support Request" (semantic success) and gray "Cancel"/"Edit" buttons are intentionally left unchanged — they are not indigo and are out of scope for this palette fix.

### Scope note
`TravelSupportPageClient`, `BankingDetailsForm`, and `BankingDetailsDisplay` are used **only** on the speaker surface — the admin surface (`TravelSupportAdminPage`) imports none of them — so no admin styling is affected and no per-surface prop was needed.

House rule: added explicit `type="button"` to the touched non-submit buttons.

## Verification
- Storybook visual check at 393px, light + dark: `BankingDetailsDisplay` ("Add Banking Details") and `BankingDetailsForm` ("Save Banking Details") now read brand-blue; computed `background-color` confirmed `rgb(29, 78, 216)` (`#1d4ed8`). No layout shifts. The two `TravelSupportPageClient` buttons have no isolated story (page-level client needs tRPC/session); verified statically — identical class swap using the same verified tokens.
- `mise run check`: format, lint, typecheck, knip all green.
- `mise run test`: 281 files / 3875 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)