### PR TITLE
fix(dates): UTC-noon anchoring (TZ-correct days) + nb-NO house locale adoption

### DIFF
--- a/__tests__/lib/pdf/signature-smoke.test.ts
+++ b/__tests__/lib/pdf/signature-smoke.test.ts
@@ -400,8 +400,8 @@ describe('organizer signature embedding', () => {
 
   it('includes date text in the PDF', async () => {
     const texts = await findTextDraws(new Uint8Array(signedPdf))
-    // formatDate uses en-GB long format: "15 February 2025"
-    const dateText = texts.find((t) => /\d{1,2}\s+\w+\s+\d{4}/.test(t.text))
+    // formatDate uses nb-NO long format: "15. februar 2025"
+    const dateText = texts.find((t) => /\d{1,2}\.\s+\w+\s+\d{4}/.test(t.text))
     expect(dateText).toBeDefined()
   })
 })

--- a/__tests__/lib/sponsor-crm/contract-variables.test.ts
+++ b/__tests__/lib/sponsor-crm/contract-variables.test.ts
@@ -113,25 +113,30 @@ describe('contract-variables', () => {
       expect(vars.CONTRACT_VALUE_NUMBER).toBe('10000')
     })
 
-    it('should build conference date variables', () => {
+    it('should build conference date variables in Norwegian by default', () => {
       const ctx = createBasicContext()
       const vars = buildContractVariables(ctx)
 
-      expect(vars.CONFERENCE_DATE).toContain('10')
-      expect(vars.CONFERENCE_DATE).toContain('June')
-      expect(vars.CONFERENCE_DATE).toContain('2026')
+      // Dates follow the contract language, defaulting to Norwegian: "10. juni 2026"
+      expect(vars.CONFERENCE_DATE).toBe('10. juni 2026')
       expect(vars.CONFERENCE_YEAR).toBe('2026')
+    })
+
+    it('should build conference date variables in English when language is en', () => {
+      const ctx = createBasicContext()
+      ctx.language = 'en'
+      const vars = buildContractVariables(ctx)
+
+      expect(vars.CONFERENCE_DATE).toBe('10 June 2026')
+      expect(vars.CONFERENCE_DATES).toBe('10–11 June 2026')
     })
 
     it('should build date range for multi-day conference in same month', () => {
       const ctx = createBasicContext()
       const vars = buildContractVariables(ctx)
 
-      // 10–11 June 2026
-      expect(vars.CONFERENCE_DATES).toContain('10')
-      expect(vars.CONFERENCE_DATES).toContain('11')
-      expect(vars.CONFERENCE_DATES).toContain('June')
-      expect(vars.CONFERENCE_DATES).toContain('2026')
+      // 10.–11. juni 2026 (Norwegian default)
+      expect(vars.CONFERENCE_DATES).toBe('10.–11. juni 2026')
     })
 
     it('should build date range for conference spanning multiple months', () => {
@@ -141,8 +146,9 @@ describe('contract-variables', () => {
 
       const vars = buildContractVariables(ctx)
 
-      expect(vars.CONFERENCE_DATES).toContain('May')
-      expect(vars.CONFERENCE_DATES).toContain('June')
+      // 31. mai – 1. juni 2026 (Norwegian default)
+      expect(vars.CONFERENCE_DATES).toContain('mai')
+      expect(vars.CONFERENCE_DATES).toContain('juni')
     })
 
     it('should handle single-day conference', () => {
@@ -269,9 +275,18 @@ describe('contract-variables', () => {
       const ctx = createBasicContext()
       const vars = buildContractVariables(ctx)
 
-      // Should be in format "11 February 2026"
-      const dateRegex = /^\d{1,2} [A-Z][a-z]+ \d{4}$/
+      // Norwegian default, e.g. "11. februar 2026"
+      const dateRegex = /^\d{1,2}\. [a-zæøå]+ \d{4}$/
       expect(vars.TODAY_DATE).toMatch(dateRegex)
+    })
+
+    it('should format today date in English when language is en', () => {
+      const ctx = createBasicContext()
+      ctx.language = 'en'
+      const vars = buildContractVariables(ctx)
+
+      // e.g. "11 February 2026"
+      expect(vars.TODAY_DATE).toMatch(/^\d{1,2} [A-Z][a-z]+ \d{4}$/)
     })
   })
 

--- a/__tests__/lib/tickets/public.test.ts
+++ b/__tests__/lib/tickets/public.test.ts
@@ -214,10 +214,10 @@ describe('buildPricingMatrix', () => {
 
     const { tiers } = buildPricingMatrix(tickets)
 
-    expect(tiers[0].dateRange).toContain('Jan')
-    expect(tiers[0].dateRange).toContain('Jun')
-    expect(tiers[1].dateRange).toContain('Jun')
-    expect(tiers[1].dateRange).toContain('Oct')
+    expect(tiers[0].dateRange).toContain('jan.')
+    expect(tiers[0].dateRange).toContain('juni')
+    expect(tiers[1].dateRange).toContain('juni')
+    expect(tiers[1].dateRange).toContain('okt.')
   })
 
   it('should handle colon in category name (split on first colon only)', () => {

--- a/__tests__/lib/time.test.ts
+++ b/__tests__/lib/time.test.ts
@@ -3,6 +3,7 @@
  */
 import {
   formatDate,
+  formatDateLocalized,
   formatDateSafe,
   formatDatesSafe,
   formatDateTimeSafe,
@@ -10,13 +11,15 @@ import {
   formatConferenceDateShort,
   formatConferenceDateLong,
   formatConferenceDateForBadge,
+  formatChartMonth,
+  formatChartDay,
+  formatChartDateShort,
 } from '@/lib/time'
 
 describe('time.ts', () => {
   describe('formatDate', () => {
-    it('should format a valid date string', () => {
-      const result = formatDate('2025-10-27')
-      expect(result).toBe('27 October 2025')
+    it('should format a valid date string in the nb-NO house locale', () => {
+      expect(formatDate('2025-10-27')).toBe('27. oktober 2025')
     })
 
     it('should return TBD for empty string', () => {
@@ -24,10 +27,19 @@ describe('time.ts', () => {
     })
   })
 
+  describe('formatDateLocalized', () => {
+    it('defaults to nb-NO', () => {
+      expect(formatDateLocalized('2026-06-10')).toBe('10. juni 2026')
+    })
+
+    it('honours an explicit locale override (e.g. English contracts)', () => {
+      expect(formatDateLocalized('2026-06-10', 'en-GB')).toBe('10 June 2026')
+    })
+  })
+
   describe('formatDateSafe', () => {
     it('should format a valid date string', () => {
-      const result = formatDateSafe('2025-10-27')
-      expect(result).toMatch(/Oct 27, 2025/)
+      expect(formatDateSafe('2025-10-27')).toBe('27. okt. 2025')
     })
 
     it('should return TBD for empty string', () => {
@@ -41,18 +53,27 @@ describe('time.ts', () => {
 
   describe('formatDatesSafe', () => {
     it('should format a valid date range in same month', () => {
-      const result = formatDatesSafe('2025-10-27', '2025-10-28')
-      expect(result).toBe('27 - 28 October 2025')
+      expect(formatDatesSafe('2025-10-27', '2025-10-28')).toBe(
+        '27.–28. oktober 2025',
+      )
     })
 
     it('should format a valid date range across months', () => {
-      const result = formatDatesSafe('2025-10-27', '2025-11-05')
-      expect(result).toBe('27 October - 5 November 2025')
+      expect(formatDatesSafe('2025-10-27', '2025-11-05')).toBe(
+        '27. oktober – 5. november 2025',
+      )
     })
 
     it('should format a valid date range across years', () => {
-      const result = formatDatesSafe('2025-12-27', '2026-01-05')
-      expect(result).toBe('27 December 2025 - 5 January 2026')
+      expect(formatDatesSafe('2025-12-27', '2026-01-05')).toBe(
+        '27. desember 2025 – 5. januar 2026',
+      )
+    })
+
+    it('should format a single date when both are equal', () => {
+      expect(formatDatesSafe('2025-10-27', '2025-10-27')).toBe(
+        '27. oktober 2025',
+      )
     })
 
     it('should return TBD for empty inputs', () => {
@@ -60,15 +81,14 @@ describe('time.ts', () => {
     })
 
     it('should handle partial invalid input', () => {
-      const result = formatDatesSafe('2025-10-27', '')
-      expect(result).toBe('TBD')
+      expect(formatDatesSafe('2025-10-27', '')).toBe('TBD')
     })
   })
 
   describe('formatDateTimeSafe', () => {
     it('should format a valid datetime string', () => {
-      const result = formatDateTimeSafe('2025-10-27T14:30:00')
-      expect(result).toMatch(/October 27, 2025 at \d{2}:\d{2}/)
+      const result = formatDateTimeSafe('2025-10-27T14:30:00Z')
+      expect(result).toMatch(/27\. oktober 2025 kl\. \d{2}:\d{2}/)
     })
 
     it('should return TBD for empty string', () => {
@@ -82,101 +102,134 @@ describe('time.ts', () => {
 
   describe('formatConferenceDate', () => {
     it('should format date with default long format', () => {
-      const result = formatConferenceDate('2025-10-27')
-      expect(result).toBe('Monday, October 27, 2025')
+      expect(formatConferenceDate('2025-10-27')).toBe('mandag 27. oktober 2025')
     })
 
     it('should format date with custom options', () => {
-      const result = formatConferenceDate('2025-10-27', {
-        month: 'short',
-        day: 'numeric',
-      })
-      expect(result).toBe('Oct 27')
+      expect(
+        formatConferenceDate('2025-10-27', {
+          month: 'short',
+          day: 'numeric',
+        }),
+      ).toBe('27. okt.')
     })
 
     it('should handle single-digit day and month', () => {
-      const result = formatConferenceDate('2025-01-05')
-      expect(result).toBe('Sunday, January 5, 2025')
-    })
-
-    it('should consistently display dates regardless of system timezone', () => {
-      // This test ensures the date is always interpreted as Oslo timezone
-      const result = formatConferenceDate('2025-10-27')
-      expect(result).toBe('Monday, October 27, 2025')
-      // The day of week should be correct for Oslo timezone
-      expect(result).toContain('Monday')
+      expect(formatConferenceDate('2025-01-05')).toBe('søndag 5. januar 2025')
     })
   })
 
   describe('formatConferenceDateShort', () => {
     it('should format date in short format', () => {
-      const result = formatConferenceDateShort('2025-10-27')
-      expect(result).toBe('Mon, Oct 27')
+      expect(formatConferenceDateShort('2025-10-27')).toBe('man. 27. okt.')
     })
 
     it('should handle different dates', () => {
-      expect(formatConferenceDateShort('2025-10-28')).toBe('Tue, Oct 28')
-      expect(formatConferenceDateShort('2025-12-25')).toBe('Thu, Dec 25')
+      expect(formatConferenceDateShort('2025-10-28')).toBe('tir. 28. okt.')
+      expect(formatConferenceDateShort('2025-12-25')).toBe('tor. 25. des.')
     })
   })
 
   describe('formatConferenceDateLong', () => {
     it('should format date in long format', () => {
-      const result = formatConferenceDateLong('2025-10-27')
-      expect(result).toBe('Monday, October 27, 2025')
+      expect(formatConferenceDateLong('2025-10-27')).toBe(
+        'mandag 27. oktober 2025',
+      )
     })
 
     it('should handle different dates', () => {
       expect(formatConferenceDateLong('2025-10-28')).toBe(
-        'Tuesday, October 28, 2025',
+        'tirsdag 28. oktober 2025',
       )
     })
   })
 
   describe('formatConferenceDateForBadge', () => {
     it('should format date for badge display (month and year only)', () => {
-      const result = formatConferenceDateForBadge('2025-10-27')
-      expect(result).toBe('October 2025')
+      expect(formatConferenceDateForBadge('2025-10-27')).toBe('oktober 2025')
     })
 
     it('should handle different months', () => {
-      expect(formatConferenceDateForBadge('2025-01-15')).toBe('January 2025')
-      expect(formatConferenceDateForBadge('2025-12-25')).toBe('December 2025')
+      expect(formatConferenceDateForBadge('2025-01-15')).toBe('januar 2025')
+      expect(formatConferenceDateForBadge('2025-12-25')).toBe('desember 2025')
     })
 
     it('should work across years', () => {
-      expect(formatConferenceDateForBadge('2024-03-10')).toBe('March 2024')
-      expect(formatConferenceDateForBadge('2026-06-20')).toBe('June 2026')
+      expect(formatConferenceDateForBadge('2024-03-10')).toBe('mars 2024')
+      expect(formatConferenceDateForBadge('2026-06-20')).toBe('juni 2026')
     })
   })
 
-  describe('timezone consistency', () => {
-    it('should display same date for conference dates regardless of execution timezone', () => {
-      // These dates are the actual conference dates and should always
-      // display as Monday 27th and Tuesday 28th October 2025
-      const monday = formatConferenceDateLong('2025-10-27')
-      const tuesday = formatConferenceDateLong('2025-10-28')
-
-      expect(monday).toBe('Monday, October 27, 2025')
-      expect(tuesday).toBe('Tuesday, October 28, 2025')
-
-      // Verify the days of week are correct
-      expect(monday).toContain('Monday')
-      expect(tuesday).toContain('Tuesday')
+  describe('chart label helpers', () => {
+    it('formatChartMonth returns the short month', () => {
+      expect(formatChartMonth('2026-06-10')).toBe('jun')
+      expect(formatChartMonth('2025-10-27')).toBe('okt')
     })
 
-    it('should display correct weekday for dates near DST transitions', () => {
-      // October 26, 2025 is when Europe transitions from CEST to CET
-      // Sunday, October 26, 2025
-      const sunday = formatConferenceDateLong('2025-10-26')
-      expect(sunday).toContain('Sunday')
+    it('formatChartDay returns a bare day number (no trailing period)', () => {
+      expect(formatChartDay('2025-10-27')).toBe('27')
+      expect(formatChartDay('2026-06-01')).toBe('1')
+    })
 
-      // The conference dates should still be Monday and Tuesday
-      const monday = formatConferenceDateLong('2025-10-27')
-      const tuesday = formatConferenceDateLong('2025-10-28')
+    it('formatChartDateShort returns a compact single-line label', () => {
+      expect(formatChartDateShort('2025-10-27')).toBe('27. okt.')
+    })
+  })
 
-      expect(monday).toContain('Monday')
-      expect(tuesday).toContain('Tuesday')
+  /**
+   * Timezone-stability regression tests for the UTC-noon anchoring fix.
+   *
+   * Node honours runtime changes to process.env.TZ for Date operations, so we
+   * drive the helpers under extreme timezones east and west of Oslo. Before the
+   * fix, conference dates were parsed at LOCAL midnight, so a viewer far east of
+   * Oslo saw the PREVIOUS calendar day (and it hydration-mismatched). The
+   * anchored implementation must render the same Oslo day everywhere.
+   */
+  describe('timezone stability (UTC-noon anchoring)', () => {
+    const originalTZ = process.env.TZ
+
+    afterEach(() => {
+      process.env.TZ = originalTZ
+    })
+
+    const timezones = [
+      'Pacific/Kiritimati', // UTC+14 (furthest east)
+      'Pacific/Pago_Pago', // UTC-11 (furthest west)
+      'UTC',
+      'America/Los_Angeles',
+      'Asia/Tokyo',
+    ]
+
+    it.each(timezones)(
+      'renders conference dates on the correct Oslo day under %s',
+      (tz) => {
+        process.env.TZ = tz
+        expect(formatConferenceDateLong('2025-10-27')).toBe(
+          'mandag 27. oktober 2025',
+        )
+        expect(formatConferenceDateShort('2025-10-27')).toBe('man. 27. okt.')
+        expect(formatConferenceDate('2025-10-27')).toBe(
+          'mandag 27. oktober 2025',
+        )
+        expect(formatDate('2025-10-27')).toBe('27. oktober 2025')
+        expect(formatDatesSafe('2025-10-27', '2025-10-28')).toBe(
+          '27.–28. oktober 2025',
+        )
+        expect(formatConferenceDateForBadge('2025-10-27')).toBe('oktober 2025')
+      },
+    )
+
+    it('demonstrates the legacy local-midnight parse WOULD shift the day east of Oslo', () => {
+      process.env.TZ = 'Pacific/Kiritimati' // UTC+14
+      // The old implementation: new Date(y, m-1, d) === local midnight.
+      const legacy = new Date(2025, 9, 27).toLocaleDateString('en-US', {
+        timeZone: 'Europe/Oslo',
+        day: 'numeric',
+      })
+      // Local midnight in UTC+14 is the 26th at 10:00 in Oslo -> wrong day.
+      expect(legacy).toBe('26')
+      // The fixed helper stays on the 27th.
+      expect(formatConferenceDate('2025-10-27', { day: 'numeric' })).toBe('27.')
     })
   })
 })

--- a/src/app/(admin)/admin/proposals/[id]/page.tsx
+++ b/src/app/(admin)/admin/proposals/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation'
+import { formatDate } from '@/lib/time'
 import { ClockIcon } from '@heroicons/react/20/solid'
 import { getProposalSanity } from '@/lib/proposal/server'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
@@ -68,9 +69,7 @@ export default async function ProposalDetailPage({
                   <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
                     <ClockIcon className="mr-1 h-4 w-4" />
                     <span className="hidden sm:inline">Last updated: </span>
-                    {new Date(
-                      proposal._updatedAt || proposal._createdAt,
-                    ).toLocaleDateString()}
+                    {formatDate(proposal._updatedAt || proposal._createdAt)}
                   </div>
                 </div>
               </div>

--- a/src/app/(admin)/admin/tickets/types/page.tsx
+++ b/src/app/(admin)/admin/tickets/types/page.tsx
@@ -1,4 +1,5 @@
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { formatDateTimeSafe } from '@/lib/time'
 import {
   fetchTicketTypesFromCheckin,
   getTicketSaleStatus,
@@ -33,13 +34,7 @@ function StatusBadge({
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '—'
-  return new Date(dateStr).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  return formatDateTimeSafe(dateStr)
 }
 
 export default async function TicketTypesAdminPage() {

--- a/src/components/GalleryModal.tsx
+++ b/src/components/GalleryModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
+import { formatDate } from '@/lib/time'
 import {
   Dialog,
   DialogPanel,
@@ -242,13 +243,7 @@ export function GalleryModal({
                               const date = new Date(currentImage.date)
                               if (!isNaN(date.getTime())) {
                                 return (
-                                  <span>
-                                    {date.toLocaleDateString('en-US', {
-                                      year: 'numeric',
-                                      month: 'long',
-                                      day: 'numeric',
-                                    })}
-                                  </span>
+                                  <span>{formatDate(currentImage.date)}</span>
                                 )
                               }
                               return null

--- a/src/components/admin/PaymentDetailsModal.tsx
+++ b/src/components/admin/PaymentDetailsModal.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { ModalShell } from '@/components/ModalShell'
+import { formatDate } from '@/lib/time'
 import {
   ExclamationTriangleIcon,
   CheckCircleIcon,
@@ -29,14 +30,6 @@ export function PaymentDetailsModal({
 }: PaymentDetailsModalProps) {
   const formatCurrencyFromString = (amount: string): string => {
     return formatCurrency(parseFloat(amount))
-  }
-
-  const formatDate = (dateString: string): string => {
-    return new Date(dateString).toLocaleDateString('nb-NO', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    })
   }
 
   const getPaymentStatusColor = (status: string, isOverdue: boolean) => {

--- a/src/components/admin/TicketSalesChartDisplay.tsx
+++ b/src/components/admin/TicketSalesChartDisplay.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useMemo } from 'react'
+import { formatChartDateShort } from '@/lib/time'
 import dynamic from 'next/dynamic'
 import type {
   TicketAnalysisResult,
@@ -72,13 +73,7 @@ interface ChartProps {
   freeTicketAllocation?: FreeTicketAllocation
 }
 
-const formatDate = (dateStr: string): string => {
-  const date = new Date(dateStr)
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-  })
-}
+const formatDate = (dateStr: string): string => formatChartDateShort(dateStr)
 
 const getStatusColors = (variance: number): string => {
   if (variance >= PERFORMANCE_THRESHOLDS.EXCELLENT) {

--- a/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
+++ b/src/components/admin/dashboard/widgets/CFPHealthWidget.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { formatChartMonth, formatChartDay } from '@/lib/time'
 import {
   DocumentTextIcon,
   ChartBarIcon,
@@ -328,20 +329,13 @@ export function CFPHealthWidget({ conference, config }: CFPHealthWidgetProps) {
             <div className="flex items-end gap-1">
               {data.submissionsPerDay.map((day, index) => {
                 const height = (day.count / maxSubmissions) * 100
-                const date = new Date(day.date + 'T00:00:00Z')
                 // Month and day rendered as two fixed lines: a single-line
-                // "Jun 10" wraps in narrow columns while "Jun 1" does not,
+                // "10. jun." wraps in narrow columns while "1. jun." does not,
                 // and in a bottom-aligned flex row that mixed 1-/2-line
                 // wrapping made columns ragged (value labels at differing
                 // heights, adjacent date labels colliding).
-                const monthLabel = date.toLocaleDateString('en-US', {
-                  month: 'short',
-                  timeZone: 'UTC',
-                })
-                const dayLabel = date.toLocaleDateString('en-US', {
-                  day: 'numeric',
-                  timeZone: 'UTC',
-                })
+                const monthLabel = formatChartMonth(day.date)
+                const dayLabel = formatChartDay(day.date)
                 return (
                   <div
                     key={index}

--- a/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
+++ b/src/components/admin/dashboard/widgets/TicketSalesDashboardWidget.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { formatChartDateShort } from '@/lib/time'
 import { useMemo } from 'react'
 import { useTheme } from 'next-themes'
 import type { ApexOptions } from 'apexcharts'
@@ -85,12 +86,7 @@ export function TicketSalesDashboardWidget({
       xaxis: {
         ...baseOptions.xaxis,
         categories:
-          data?.salesByDate.map((d) =>
-            new Date(d.date).toLocaleDateString('en-US', {
-              month: 'short',
-              day: 'numeric',
-            }),
-          ) || [],
+          data?.salesByDate.map((d) => formatChartDateShort(d.date)) || [],
       },
       colors: [themeColors.primary, themeColors.gray[300]],
       stroke: {

--- a/src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx
+++ b/src/components/admin/dashboard/widgets/UpcomingDeadlinesWidget.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { formatChartDateShort } from '@/lib/time'
 import { CheckCircleIcon, CalendarIcon } from '@heroicons/react/24/outline'
 import { fetchDeadlines } from '@/app/(admin)/admin/actions'
 import { type DeadlineData } from '@/lib/dashboard/data-types'
@@ -148,10 +149,7 @@ export function UpcomingDeadlinesWidget({
                   </span>
                   <span className="text-[10px] opacity-60">&middot;</span>
                   <span className="text-[10px] opacity-75">
-                    {new Date(deadline.date).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
+                    {formatChartDateShort(deadline.date)}
                   </span>
                   {deadline.action && deadline.actionLink && (
                     <Link

--- a/src/components/admin/dashboard/widgets/WorkshopCapacityWidget.tsx
+++ b/src/components/admin/dashboard/widgets/WorkshopCapacityWidget.tsx
@@ -8,6 +8,7 @@ import {
 import type { WorkshopStatistics } from '@/lib/workshop/types'
 import { fetchWorkshopCapacity } from '@/app/(admin)/admin/actions'
 import { getCurrentPhase } from '@/lib/conference/phase'
+import { formatChartDateShort } from '@/lib/time'
 import { BaseWidgetProps } from '@/lib/dashboard/types'
 import { useWidgetData } from '@/hooks/dashboard/useWidgetData'
 import {
@@ -77,12 +78,7 @@ export function WorkshopCapacityWidget({
                 <CalendarIcon className="h-4 w-4 text-gray-400" />
                 <div className="text-sm font-bold text-gray-900 dark:text-white">
                   {conference.workshopRegistrationStart
-                    ? new Date(
-                        conference.workshopRegistrationStart,
-                      ).toLocaleDateString('en-US', {
-                        month: 'short',
-                        day: 'numeric',
-                      })
+                    ? formatChartDateShort(conference.workshopRegistrationStart)
                     : 'Not set'}
                 </div>
               </div>

--- a/src/components/admin/sponsor-crm/SponsorContractView.tsx
+++ b/src/components/admin/sponsor-crm/SponsorContractView.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback } from 'react'
+import { formatDate } from '@/lib/time'
 import { useSession } from 'next-auth/react'
 import { api } from '@/lib/trpc/client'
 import { ContractReadinessIndicator } from './ContractReadinessIndicator'
@@ -313,7 +314,7 @@ export function SponsorContractView({
           <p className="text-xs text-gray-500 dark:text-gray-400">
             Company details, contacts, billing, and logo collected.
             {sponsor.registrationCompletedAt &&
-              ` Completed ${new Date(sponsor.registrationCompletedAt).toLocaleDateString()}.`}
+              ` Completed ${formatDate(sponsor.registrationCompletedAt)}.`}
           </p>
         ) : !isSponsorWon ? (
           <p className="text-xs text-amber-600 dark:text-amber-400">
@@ -354,14 +355,14 @@ export function SponsorContractView({
           <p className="text-xs text-gray-500 dark:text-gray-400">
             Contract signed
             {sponsor.contractSignedAt &&
-              ` on ${new Date(sponsor.contractSignedAt).toLocaleDateString()}`}
+              ` on ${formatDate(sponsor.contractSignedAt)}`}
             .
           </p>
         ) : isSent ? (
           <p className="text-xs text-gray-500 dark:text-gray-400">
             Contract sent
             {sponsor.contractSentAt &&
-              ` on ${new Date(sponsor.contractSentAt).toLocaleDateString()}`}
+              ` on ${formatDate(sponsor.contractSentAt)}`}
             .
           </p>
         ) : isPortalComplete ? (
@@ -433,7 +434,7 @@ export function SponsorContractView({
           <p className="text-xs text-gray-500 dark:text-gray-400">
             Signed
             {sponsor.contractSignedAt &&
-              ` on ${new Date(sponsor.contractSignedAt).toLocaleDateString()}`}
+              ` on ${formatDate(sponsor.contractSignedAt)}`}
             .
           </p>
         ) : isPendingSignature ? (
@@ -523,7 +524,7 @@ export function SponsorContractView({
                 <dd className="font-medium text-gray-900 dark:text-white">
                   {sponsor.organizerSignedBy}
                   {sponsor.organizerSignedAt &&
-                    ` on ${new Date(sponsor.organizerSignedAt).toLocaleDateString()}`}
+                    ` on ${formatDate(sponsor.organizerSignedAt)}`}
                 </dd>
               </>
             )}

--- a/src/components/badge/BadgeDisplay.tsx
+++ b/src/components/badge/BadgeDisplay.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { formatDate } from '@/lib/time'
 import {
   ShieldCheckIcon,
   ClipboardIcon,
@@ -44,11 +45,7 @@ export function BadgeDisplay({
   const [copied, setCopied] = useState<'url' | null>(null)
 
   const badgeTypeName = badge.badgeType === 'speaker' ? 'Speaker' : 'Organizer'
-  const issuedDate = new Date(badge.issuedAt).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
+  const issuedDate = formatDate(badge.issuedAt)
 
   const badgeUrl = `/badge/${badgeId}`
   const downloadUrl = `/api/badge/${badgeId}/download`

--- a/src/components/cfp/CompactBadges.tsx
+++ b/src/components/cfp/CompactBadges.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { formatDateSafe } from '@/lib/time'
 import {
   ShieldCheckIcon,
   ArrowDownTrayIcon,
@@ -57,14 +58,7 @@ export function CompactBadges({ badges }: CompactBadgesProps) {
         {badges.map((badge) => {
           const badgeTypeName =
             badge.badgeType === 'speaker' ? 'Speaker' : 'Organizer'
-          const issuedDate = new Date(badge.issuedAt).toLocaleDateString(
-            'en-US',
-            {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-            },
-          )
+          const issuedDate = formatDateSafe(badge.issuedAt)
 
           return (
             <div

--- a/src/components/stream/NextTalkDisplay.tsx
+++ b/src/components/stream/NextTalkDisplay.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { formatDate } from '@/lib/time'
 import clsx from 'clsx'
 import { ClockIcon, CalendarIcon } from '@heroicons/react/24/outline'
 import type { ConferenceSchedule, TrackTalk } from '@/lib/conference/types'
@@ -385,7 +386,7 @@ export default function NextTalkDisplay({
         {!isToday && (
           <div className="flex items-center text-gray-600 dark:text-gray-400">
             <CalendarIcon className="mr-2 h-5 w-5" />
-            <span>{startDate.toLocaleDateString()}</span>
+            <span>{formatDate(scheduleDate)}</span>
           </div>
         )}
       </div>

--- a/src/components/travel-support/ExpenseForm.tsx
+++ b/src/components/travel-support/ExpenseForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { formatDate } from '@/lib/time'
 import { DocumentIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import {
   ExpenseCategory,
@@ -491,7 +492,7 @@ export function ExpenseForm({
                           📎 {receipt.filename}
                         </span>
                         <span className="text-xs text-gray-500 dark:text-gray-400">
-                          {new Date(receipt.uploadedAt).toLocaleDateString()}
+                          {formatDate(receipt.uploadedAt)}
                         </span>
                       </div>
                     ))}

--- a/src/lib/cospeaker/server.ts
+++ b/src/lib/cospeaker/server.ts
@@ -319,7 +319,7 @@ export async function sendInvitationEmail(
         eventLocation,
         eventDate,
         eventUrl,
-        expiresAt: new Date(invitation.expiresAt).toLocaleDateString(),
+        expiresAt: formatDate(invitation.expiresAt),
         socialLinks: conference?.socialLinks || [],
       },
     })

--- a/src/lib/slack/weeklyUpdate.ts
+++ b/src/lib/slack/weeklyUpdate.ts
@@ -249,7 +249,7 @@ export async function sendWeeklyUpdateToSlack(
     lastUpdated,
   } = data
 
-  const formattedDate = new Date(lastUpdated).toLocaleDateString('no-NO', {
+  const formattedDate = new Date(lastUpdated).toLocaleDateString('nb-NO', {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
@@ -400,7 +400,7 @@ export async function sendWeeklyUpdateToSlack(
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `_This report was generated automatically on ${new Date(lastUpdated).toLocaleString('no-NO')}_`,
+        text: `_This report was generated automatically on ${new Date(lastUpdated).toLocaleString('nb-NO')}_`,
       },
     },
   )

--- a/src/lib/sponsor-crm/contract-variables.ts
+++ b/src/lib/sponsor-crm/contract-variables.ts
@@ -2,7 +2,7 @@ import {
   processTemplateVariables,
   processPortableTextVariables,
 } from '@/lib/sponsor/templates'
-import { formatDate, getCurrentDateTime } from '@/lib/time'
+import { formatDateLocalized, getCurrentDateTime } from '@/lib/time'
 import { formatOrgNumber, formatCurrency } from '@/lib/format'
 
 export const CONTRACT_VARIABLE_DESCRIPTIONS: Record<string, string> = {
@@ -71,10 +71,16 @@ export interface ContractVariableContext {
 export function buildContractVariables(
   ctx: ContractVariableContext,
 ): Record<string, string> {
+  // Legal contract dates follow the contract's own language so the document is
+  // internally consistent (an English contract gets English dates, a Norwegian
+  // one gets Norwegian). Language defaults to Norwegian, matching the VAT
+  // suffix default below.
+  const dateLocale = ctx.language === 'en' ? 'en-GB' : 'nb-NO'
+
   const vars: Record<string, string> = {
     SPONSOR_NAME: ctx.sponsor.name,
     CONFERENCE_TITLE: ctx.conference.title,
-    TODAY_DATE: formatDate(getCurrentDateTime()),
+    TODAY_DATE: formatDateLocalized(getCurrentDateTime(), dateLocale),
   }
 
   if (ctx.sponsor.orgNumber) {
@@ -114,16 +120,20 @@ export function buildContractVariables(
   }
 
   if (ctx.conference.startDate) {
-    vars.CONFERENCE_DATE = formatDate(ctx.conference.startDate)
-    vars.CONFERENCE_YEAR = ctx.conference.startDate.slice(0, 4)
+    const startDate = ctx.conference.startDate
+    vars.CONFERENCE_DATE = formatDateLocalized(startDate, dateLocale)
+    vars.CONFERENCE_YEAR = startDate.slice(0, 4)
 
     if (ctx.conference.endDate) {
-      const start = new Date(ctx.conference.startDate)
-      const end = new Date(ctx.conference.endDate)
-      if (start.getMonth() === end.getMonth()) {
-        vars.CONFERENCE_DATES = `${start.getDate()}\u2013${end.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}`
+      const endDate = ctx.conference.endDate
+      const sameMonth = startDate.slice(0, 7) === endDate.slice(0, 7)
+      if (sameMonth) {
+        // Collapse to a compact range, e.g. "10.\u201311. juni 2026" / "10\u201311 June 2026"
+        const startDay = Number(startDate.slice(8, 10))
+        const daySuffix = dateLocale === 'nb-NO' ? '.' : ''
+        vars.CONFERENCE_DATES = `${startDay}${daySuffix}\u2013${formatDateLocalized(endDate, dateLocale)}`
       } else {
-        vars.CONFERENCE_DATES = `${formatDate(ctx.conference.startDate)} \u2013 ${formatDate(ctx.conference.endDate)}`
+        vars.CONFERENCE_DATES = `${formatDateLocalized(startDate, dateLocale)} \u2013 ${formatDateLocalized(endDate, dateLocale)}`
       }
     } else {
       vars.CONFERENCE_DATES = vars.CONFERENCE_DATE

--- a/src/lib/tickets/chart-adapter.ts
+++ b/src/lib/tickets/chart-adapter.ts
@@ -1,3 +1,4 @@
+import { formatConferenceDate } from '@/lib/time'
 import type {
   TicketAnalysisResult,
   ChartData,
@@ -204,7 +205,7 @@ export function createTooltipContent(
   revenue: number,
 ): string {
   const date = new Date(point.date)
-  const formattedDate = date.toLocaleDateString('en-US', {
+  const formattedDate = formatConferenceDate(point.date, {
     weekday: 'short',
     month: 'short',
     day: 'numeric',

--- a/src/lib/tickets/chart-adapter.ts
+++ b/src/lib/tickets/chart-adapter.ts
@@ -1,4 +1,4 @@
-import { formatConferenceDate } from '@/lib/time'
+import { formatConferenceDate, osloTodayDateString } from '@/lib/time'
 import type {
   TicketAnalysisResult,
   ChartData,
@@ -204,7 +204,6 @@ export function createTooltipContent(
   actualTicketCount: number,
   revenue: number,
 ): string {
-  const date = new Date(point.date)
   const formattedDate = formatConferenceDate(point.date, {
     weekday: 'short',
     month: 'short',
@@ -213,9 +212,13 @@ export function createTooltipContent(
   })
 
   const badges: string[] = []
-  const today = new Date()
-  const isToday = date.toDateString() === today.toDateString()
-  const isFuture = date > today
+  // Compare calendar days in the CONFERENCE timezone: point.date is a bare
+  // YYYY-MM-DD, and the displayed date above is Oslo-anchored — comparing via
+  // the viewer's local toDateString() would flip Today/Future near midnight
+  // for viewers outside Oslo. Lexicographic compare works on YYYY-MM-DD.
+  const osloToday = osloTodayDateString()
+  const isToday = point.date === osloToday
+  const isFuture = point.date > osloToday
 
   if (isToday) {
     badges.push(

--- a/src/lib/tickets/public.ts
+++ b/src/lib/tickets/public.ts
@@ -1,3 +1,4 @@
+import { formatDateSafe } from '@/lib/time'
 import { checkinQuery } from './graphql-client'
 import { cacheLife, cacheTag } from 'next/cache'
 
@@ -351,12 +352,7 @@ export function buildPricingMatrix(tickets: PublicTicketType[]): {
 }
 
 function formatShortDate(isoDate: string): string {
-  const date = new Date(isoDate)
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
+  return formatDateSafe(isoDate)
 }
 
 /**

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,139 +1,162 @@
-export function formatDate(dateString: string): string {
-  if (!dateString) return 'TBD'
+/**
+ * House display locale for all UI-facing date formatting: Norwegian Bokmål.
+ * Note: nb-NO renders weekday and month names in lowercase ("27. oktober 2025",
+ * "mandag") — this is correct Norwegian orthography and is accepted as-is.
+ */
+const HOUSE_LOCALE = 'nb-NO'
 
-  const date = new Date(dateString)
-  return date.toLocaleDateString('en-GB', {
+/** Conference timezone. All dates are anchored/rendered here. */
+const OSLO_TZ = 'Europe/Oslo'
+
+/** Lowercase Norwegian long month names (index = month number - 1). */
+const NB_LONG_MONTHS = [
+  'januar',
+  'februar',
+  'mars',
+  'april',
+  'mai',
+  'juni',
+  'juli',
+  'august',
+  'september',
+  'oktober',
+  'november',
+  'desember',
+] as const
+
+/**
+ * Parses a date string so its calendar day is stable in Europe/Oslo regardless
+ * of the viewer's timezone. Bare YYYY-MM-DD values are pinned to 12:00 UTC
+ * (noon) — far enough from midnight that no real-world offset shifts the day
+ * (the previous `new Date(y, m-1, d)` used LOCAL midnight, so viewers east of
+ * Oslo saw the previous day and it hydration-mismatched). Full ISO timestamps
+ * are parsed as-is since they already carry an offset.
+ */
+function toOsloAnchoredDate(dateString: string): Date {
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString)
+  if (dateOnly) {
+    return new Date(
+      Date.UTC(
+        Number(dateOnly[1]),
+        Number(dateOnly[2]) - 1,
+        Number(dateOnly[3]),
+        12,
+      ),
+    )
+  }
+  return new Date(dateString)
+}
+
+/** Extracts and validates Y/M/D components from a bare YYYY-MM-DD string. */
+function dateOnlyParts(
+  dateString: string,
+): { day: number; monthIndex: number; year: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateString)
+  if (!m) return null
+  const year = Number(m[1])
+  const monthIndex = Number(m[2]) - 1
+  const day = Number(m[3])
+  const probe = new Date(Date.UTC(year, monthIndex, day, 12))
+  if (
+    isNaN(probe.getTime()) ||
+    probe.getUTCFullYear() !== year ||
+    probe.getUTCMonth() !== monthIndex ||
+    probe.getUTCDate() !== day
+  ) {
+    return null
+  }
+  return { day, monthIndex, year }
+}
+
+/**
+ * Formats a date in the given BCP-47 locale (defaults to the nb-NO house
+ * locale). Anchored to Europe/Oslo so the calendar day is stable across
+ * viewer timezones. Use the `locale` override only for documents that must
+ * follow their own language (e.g. English sponsor contracts).
+ */
+export function formatDateLocalized(
+  dateString: string,
+  locale: string = HOUSE_LOCALE,
+): string {
+  if (!dateString) return 'TBD'
+  return toOsloAnchoredDate(dateString).toLocaleDateString(locale, {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
+    timeZone: OSLO_TZ,
   })
 }
 
+/** Formats a date in the house locale (e.g. "27. oktober 2025"). */
+export function formatDate(dateString: string): string {
+  return formatDateLocalized(dateString, HOUSE_LOCALE)
+}
+
+/** Compact date, house locale (e.g. "27. okt. 2025"). Safe for timestamps. */
 export function formatDateSafe(dateString: string): string {
   if (!dateString) return 'TBD'
 
-  try {
-    const date = new Date(dateString)
-    if (isNaN(date.getTime())) return 'Invalid Date'
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return 'Invalid Date'
 
-    const months = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ]
-    const month = months[date.getMonth()]
-    const day = date.getDate()
-    const year = date.getFullYear()
-
-    return `${month} ${day}, ${year}`
-  } catch (error) {
-    console.error('Error formatting date:', error)
-    return 'Invalid Date'
-  }
+  return date.toLocaleDateString(HOUSE_LOCALE, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: OSLO_TZ,
+  })
 }
 
+/**
+ * Formats a date range in the house locale, collapsing shared parts
+ * (e.g. "27.–28. oktober 2025", "27. oktober – 5. november 2025").
+ * Inputs are conference dates in YYYY-MM-DD form.
+ */
 export function formatDatesSafe(
   dateString1: string,
   dateString2: string,
 ): string {
   if (!dateString1 || !dateString2) return 'TBD'
 
-  try {
-    const date1 = new Date(dateString1)
-    const date2 = new Date(dateString2)
+  const p1 = dateOnlyParts(dateString1)
+  const p2 = dateOnlyParts(dateString2)
 
-    if (isNaN(date1.getTime()) || isNaN(date2.getTime())) {
-      if (!isNaN(date1.getTime())) return formatDateSafe(dateString1)
-      if (!isNaN(date2.getTime())) return formatDateSafe(dateString2)
-      return 'Invalid Date Range'
-    }
-
-    const months = [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December',
-    ]
-
-    const day1 = date1.getDate()
-    const month1 = months[date1.getMonth()]
-    const year1 = date1.getFullYear()
-
-    const day2 = date2.getDate()
-    const month2 = months[date2.getMonth()]
-    const year2 = date2.getFullYear()
-
-    if (dateString1 === dateString2) {
-      return `${day1} ${month1} ${year1}`
-    }
-    if (year1 !== year2) {
-      return `${day1} ${month1} ${year1} - ${day2} ${month2} ${year2}`
-    }
-    if (month1 !== month2) {
-      return `${day1} ${month1} - ${day2} ${month2} ${year1}`
-    }
-    return `${day1} - ${day2} ${month1} ${year1}`
-  } catch (error) {
-    console.error('Error formatting date range:', error)
-    const formatted1 = formatDateSafe(dateString1)
-    const formatted2 = formatDateSafe(dateString2)
-    if (formatted1 !== 'TBD' && formatted2 !== 'TBD') {
-      return `${formatted1} - ${formatted2}`
-    }
-    return 'TBD'
+  if (!p1 || !p2) {
+    if (p1) return formatDateSafe(dateString1)
+    if (p2) return formatDateSafe(dateString2)
+    return 'Invalid Date Range'
   }
+
+  const month1 = NB_LONG_MONTHS[p1.monthIndex]
+  const month2 = NB_LONG_MONTHS[p2.monthIndex]
+
+  if (dateString1 === dateString2) {
+    return `${p1.day}. ${month1} ${p1.year}`
+  }
+  if (p1.year !== p2.year) {
+    return `${p1.day}. ${month1} ${p1.year} – ${p2.day}. ${month2} ${p2.year}`
+  }
+  if (p1.monthIndex !== p2.monthIndex) {
+    return `${p1.day}. ${month1} – ${p2.day}. ${month2} ${p1.year}`
+  }
+  return `${p1.day}.–${p2.day}. ${month1} ${p1.year}`
 }
 
+/** Formats a timestamp with time, house locale (e.g. "27. oktober 2025, 14:30"). */
 export function formatDateTimeSafe(dateString: string): string {
   if (!dateString) return 'TBD'
 
-  try {
-    const date = new Date(dateString)
-    if (isNaN(date.getTime())) return 'Invalid Date'
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return 'Invalid Date'
 
-    const months = [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December',
-    ]
-    const month = months[date.getMonth()]
-    const day = date.getDate()
-    const year = date.getFullYear()
-
-    const hours = String(date.getHours()).padStart(2, '0')
-    const minutes = String(date.getMinutes()).padStart(2, '0')
-
-    return `${month} ${day}, ${year} at ${hours}:${minutes}`
-  } catch (error) {
-    console.error('Error formatting date time:', error)
-    return 'Invalid Date'
-  }
+  return date.toLocaleString(HOUSE_LOCALE, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: OSLO_TZ,
+  })
 }
 
 /**
@@ -159,19 +182,16 @@ export function formatConferenceDate(
     day: 'numeric',
   },
 ): string {
-  // Parse the date string (YYYY-MM-DD) components directly
-  // to avoid timezone-related parsing issues
-  const [year, month, day] = dateString.split('-').map(Number)
-  const date = new Date(year, month - 1, day)
-
-  return date.toLocaleDateString('en-US', {
+  // Anchor bare YYYY-MM-DD at 12:00 UTC so the calendar day is stable in every
+  // viewer timezone, then render in the conference timezone (Europe/Oslo).
+  return toOsloAnchoredDate(dateString).toLocaleDateString(HOUSE_LOCALE, {
     ...options,
-    timeZone: 'Europe/Oslo',
+    timeZone: OSLO_TZ,
   })
 }
 
 /**
- * Formats a date string with short format (e.g., "Mon, Oct 27")
+ * Formats a date string with short format (e.g., "man. 27. okt.")
  */
 export function formatConferenceDateShort(dateString: string): string {
   return formatConferenceDate(dateString, {
@@ -182,7 +202,7 @@ export function formatConferenceDateShort(dateString: string): string {
 }
 
 /**
- * Formats a date string with long format (e.g., "Monday, October 27, 2025")
+ * Formats a date string with long format (e.g., "mandag 27. oktober 2025")
  */
 export function formatConferenceDateLong(dateString: string): string {
   return formatConferenceDate(dateString, {
@@ -194,13 +214,46 @@ export function formatConferenceDateLong(dateString: string): string {
 }
 
 /**
- * Formats a date string for badge display (e.g., "October 2025")
+ * Formats a date string for badge display (e.g., "oktober 2025")
  * Shows only month and year without day or weekday
  */
 export function formatConferenceDateForBadge(dateString: string): string {
   return formatConferenceDate(dateString, {
     year: 'numeric',
     month: 'long',
+  })
+}
+
+/**
+ * Compact month label for chart axes/trends (e.g. "okt"), house locale.
+ * Pairs with formatChartDay for two-line labels in narrow chart columns.
+ */
+export function formatChartMonth(dateString: string): string {
+  return toOsloAnchoredDate(dateString).toLocaleDateString(HOUSE_LOCALE, {
+    month: 'short',
+    timeZone: OSLO_TZ,
+  })
+}
+
+/**
+ * Bare day-of-month label for chart axes/trends (e.g. "27"), Oslo-anchored.
+ * Extracted via formatToParts because nb-NO renders a standalone numeric day
+ * with a trailing period ("27.") which reads as noise on a chart axis.
+ */
+export function formatChartDay(dateString: string): string {
+  const parts = new Intl.DateTimeFormat(HOUSE_LOCALE, {
+    day: 'numeric',
+    timeZone: OSLO_TZ,
+  }).formatToParts(toOsloAnchoredDate(dateString))
+  return parts.find((p) => p.type === 'day')?.value ?? ''
+}
+
+/** Single-line compact chart date label (e.g. "27. okt."), house locale. */
+export function formatChartDateShort(dateString: string): string {
+  return toOsloAnchoredDate(dateString).toLocaleDateString(HOUSE_LOCALE, {
+    day: 'numeric',
+    month: 'short',
+    timeZone: OSLO_TZ,
   })
 }
 

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -8,6 +8,20 @@ const HOUSE_LOCALE = 'nb-NO'
 /** Conference timezone. All dates are anchored/rendered here. */
 const OSLO_TZ = 'Europe/Oslo'
 
+/**
+ * Today's calendar date in the conference timezone (Europe/Oslo) as
+ * YYYY-MM-DD. Use for day-equality/ordering comparisons against stored
+ * date-only strings so "today" doesn't shift with the viewer's timezone.
+ */
+export function osloTodayDateString(now: Date = new Date()): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: OSLO_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now)
+}
+
 /** Lowercase Norwegian long month names (index = month number - 1). */
 const NB_LONG_MONTHS = [
   'januar',
@@ -51,7 +65,9 @@ function toOsloAnchoredDate(dateString: string): Date {
 function dateOnlyParts(
   dateString: string,
 ): { day: number; monthIndex: number; year: number } | null {
-  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateString)
+  // Anchored end-to-end: a timestamp like 2025-10-27T23:00:00Z must NOT match
+  // (its calendar day depends on timezone; callers pass it down other paths).
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString)
   if (!m) return null
   const year = Number(m[1])
   const monthIndex = Number(m[2]) - 1

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { formatDate } from '@/lib/time'
 import {
   router,
   publicProcedure,
@@ -459,7 +460,7 @@ export const workshopRouter = router({
         ) {
           throw new TRPCError({
             code: 'PRECONDITION_FAILED',
-            message: `Workshop registration opens on ${new Date(conference.workshopRegistrationStart).toLocaleDateString()}`,
+            message: `Workshop registration opens on ${formatDate(conference.workshopRegistrationStart)}`,
           })
         }
 


### PR DESCRIPTION
## Summary

Fixes a real timezone bug in the canonical date helper and converges the app's date formatting on the **nb-NO** house locale ("27. oktober 2026").

### Fix 1 — TZ bug (the real bug)
`formatConferenceDate` parsed `YYYY-MM-DD` via `new Date(y, m-1, d)` (LOCAL midnight) then formatted with `timeZone: 'Europe/Oslo'`. Viewers **east of Oslo** saw the **previous** calendar day, and because it runs client-side it hydration-mismatched. Now bare date-only strings are anchored at **12:00 UTC** before formatting, so the Oslo calendar day is stable in every viewer timezone. The same local-`getDate()`/`getMonth()` pattern in the sibling safe/range helpers was fixed too.

Regression tests drive the helpers under extreme timezones (UTC+14 Kiritimati, UTC-11 Pago Pago, LA, Tokyo) via runtime `process.env.TZ` and assert the day never shifts; one test also demonstrates the legacy local-midnight parse rendering the wrong day.

### Fix 2 — one house locale (nb-NO)
`time.ts` mixed en-GB, hand-rolled US, and en-US. All UI-facing formatters now use nb-NO (exported names/signatures unchanged). nb-NO renders weekday/month **lowercase** ("27. oktober 2025", "mandag") — correct Norwegian orthography, **accepted as-is** for consistency. Adds `formatDateLocalized` (locale override) and compact chart-label helpers (`formatChartMonth`/`formatChartDay`/`formatChartDateShort`).

### Fix 3 — adopt the lib at raw call sites
Replaced raw `toLocaleDateString`/`Intl.DateTimeFormat` with the helpers across dashboard widgets (CFPHealth, WorkshopCapacity, TicketSalesDashboard, UpcomingDeadlines), GalleryModal, TicketSalesChartDisplay, Badge/CompactBadges, PaymentDetailsModal, tickets chart-adapter/public, admin tickets/proposals pages, the workshop-router error message, NextTalkDisplay, SponsorContractView (5 sites), ExpenseForm and the cospeaker invitation email. Chart axes use the compact helpers. Also fixed the deprecated `no-NO` → `nb-NO` tag in the Slack weekly digest (behaviour-equivalent; digest otherwise unchanged, per scope).

### Judgment calls
- **Legal contract dates** follow the contract's own `language` (nb-NO / en-GB) rather than a fixed locale, so the document is internally consistent. Defaults to Norwegian, matching the existing Norwegian-default VAT suffix.
- **Capitalization**: accepted lowercase nb-NO weekday/month names everywhere (correct Norwegian orthography) instead of sprinkling CSS `capitalize` — consistent and low-risk.

### Excluded (per scope)
`lib/og/*`, `DevTimeControl`, stories/tests, and the Slack digest body (beyond the tag fix).

## QA
- New TZ-stability + nb-NO output unit tests; full suite green (**3886 passed**).
- `mise run check` green (typecheck, lint, knip, format). `mise run build` not run — this machine lacks the keychain secrets (expected).
- Visual (`pnpm shoot`, 393px, light + dark): CFP submissions-trend labels render "jun" over bare day numbers (no double-period, no overflow); UpcomingDeadlines shows "11. aug." inline cleanly; dark theme verified. Norwegian short months are the same length class as English, so tight widget layouts do not overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)