### PR TITLE
fix(cache): tenant-scoped invalidation — conference publishes no longer bust every tenant

### DIFF
--- a/docs/CONFERENCE_SETTINGS_EDITING.md
+++ b/docs/CONFERENCE_SETTINGS_EDITING.md
@@ -31,20 +31,31 @@ input, opts?)`. Two invariants make it safe:
   `pathPrefix` so the patch writes dot paths under the parent and `setIfMissing`s
   it first — a save never clobbers sibling subfields it doesn't render.
 
-### Cache-tag revalidation
+### Cache-tag revalidation (tenant-scoped)
 
 After a successful commit, `applyConferencePatch` busts the cached conference
-read with **two** revalidations:
+read with a **single, tenant-scoped** revalidation:
 
 ```ts
-revalidateTag('content:conferences', 'default')
-revalidateTag(`sanity:conference-${conferenceId}`, 'default')
+import { conferenceTag } from '@/lib/cache/tags'
+
+revalidateTag(conferenceTag(conferenceId), 'default') // sanity:conference-<id>
 ```
 
-`content:conferences` is the broad tag every `getConferenceForCurrentDomain`
-consumer shares (so the server-rendered settings page and public pages reflect
-the change); `sanity:conference-<id>` is the per-document tag. Both are needed so
-the edit is visible on the next render without waiting out the cache TTL.
+One deploy serves every conference domain, so settings are multi-tenant. Editing
+one conference must not bust another tenant's cache. Every public page that
+renders a conference's content — and the shared `fetchConferenceData` read in
+`src/lib/conference/sanity.ts` — now tags its cache entry with
+`sanity:conference-<id>` (via `conferenceTag`). Revalidating that one scoped tag
+therefore invalidates **only** the edited conference's pages and reads, and the
+edit is visible on the next render without waiting out the cache TTL.
+
+The broad `content:conferences` / `content:*` tags are still present on those
+cache entries for **platform-wide** invalidation (a deploy or a cross-tenant
+content change), but conference-scoped mutations deliberately do **not**
+revalidate them — that would bust every tenant at once (issue #618). Build the
+tag names only through the helpers in `src/lib/cache/tags.ts`
+(`conferenceTag(id)`, `domainTag(domain)`), never as inline strings.
 
 ## The shared fieldset editor (`EditConferenceCard`)
 

--- a/docs/TICKET_SYSTEM.md
+++ b/docs/TICKET_SYSTEM.md
@@ -122,8 +122,14 @@ Complimentary tickets are identified using **name-pattern filtering** (e.g., tic
 ### Caching Strategy
 
 - `getPublicTicketTypes()` uses `'use cache'` + `cacheLife('hours')` + `cacheTag('content:tickets')`
-- The page component `CachedTicketsContent` has its own `'use cache'` layer
-- Cache can be invalidated via `revalidateTag('content:tickets')`
+- The page component `CachedTicketsContent` has its own `'use cache'` layer, and
+  additionally tags itself with the tenant-scoped `conferenceTag(conference._id)`
+  (`sanity:conference-<id>`) once the conference resolves
+- Editing ticket page content (`tickets.updatePageContent`) revalidates the
+  **tenant-scoped** tag only — `revalidateTag(conferenceTag(conferenceId))` — so
+  one conference's edit does not bust every other tenant's tickets page (#618).
+  The generic `content:tickets` tag stays on the cache entries for platform-wide
+  invalidation. Build tag names via `src/lib/cache/tags.ts`, never inline strings.
 
 ---
 

--- a/src/app/(main)/cfp/page.tsx
+++ b/src/app/(main)/cfp/page.tsx
@@ -12,6 +12,7 @@ import { formats } from '@/lib/proposal/types'
 import clsx from 'clsx'
 import Link from 'next/link'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
@@ -33,6 +34,10 @@ async function CachedCFPContent({ domain }: { domain: string }) {
   cacheLife('days')
   cacheTag('content:cfp')
   const { conference } = await getConferenceForDomain(domain, { topics: true })
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
   const talkFormats = conference.formats
     .filter((formatId) => !formatId.startsWith('workshop_'))
     .map((formatId) => formats.get(formatId))

--- a/src/app/(main)/conduct/page.tsx
+++ b/src/app/(main)/conduct/page.tsx
@@ -3,6 +3,7 @@ import { Container } from '@/components/Container'
 import { ContentCard } from '@/components/ContentCard'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
@@ -22,6 +23,11 @@ async function CachedConductContent({ domain }: { domain: string }) {
   cacheTag('content:conduct')
 
   const { conference } = await getConferenceForDomain(domain)
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
+
   const organizerName = conference?.organizer || 'Cloud Native Days Norway'
 
   return (

--- a/src/app/(main)/info/page.tsx
+++ b/src/app/(main)/info/page.tsx
@@ -5,6 +5,7 @@ import { Container } from '@/components/Container'
 import { InfoContent } from '@/components/info/InfoContent'
 import type { ConferenceSchedule } from '@/lib/conference/types'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
@@ -79,6 +80,10 @@ async function CachedInfoContent({ domain }: { domain: string }) {
   const { conference } = await getConferenceForDomain(domain, {
     schedule: true,
   })
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (!conference) {
     return null

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -27,6 +27,7 @@ import {
 import { formatDatesSafe } from '@/lib/time'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import { EventJsonLd } from '@/components/seo/EventJsonLd'
 import { canonicalUrl } from '@/lib/seo/canonical'
@@ -189,6 +190,13 @@ async function CachedHomeContent({ domain }: { domain: string }) {
     schedule: true,
     gallery: { featuredOnly: true },
   })
+
+  // Tenant-scoped tag: a mutation on THIS conference busts this page without
+  // busting every other tenant's homepage (the generic tag above stays for
+  // platform-wide invalidation).
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (error) {
     console.error('Error fetching conference data:', error)

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -37,6 +37,7 @@ import {
   UserMinusIcon,
 } from '@heroicons/react/24/outline'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
@@ -57,6 +58,10 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
 
   const { conference, error: conferenceError } =
     await getConferenceForDomain(domain)
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (conferenceError) {
     return (

--- a/src/app/(main)/program/page.tsx
+++ b/src/app/(main)/program/page.tsx
@@ -7,6 +7,7 @@ import { Sponsors } from '@/components/Sponsors'
 import { DevTimeProvider } from '@/components/program/DevTimeProvider'
 import { DevTimeControl } from '@/components/program/DevTimeControl'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import { EventJsonLd } from '@/components/seo/EventJsonLd'
 import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd'
@@ -38,6 +39,10 @@ async function CachedProgramContent({ domain }: { domain: string }) {
     sponsorTiers: true,
     confirmedTalksOnly: false,
   })
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (error || !conference) {
     return (

--- a/src/app/(main)/speaker/[slug]/page.tsx
+++ b/src/app/(main)/speaker/[slug]/page.tsx
@@ -30,6 +30,7 @@ import { PhotoGallerySection } from '@/components/PhotoGallerySection'
 import { AttachmentDisplay } from '@/components/proposal/AttachmentDisplay'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { PersonJsonLd } from '@/components/seo/PersonJsonLd'
 import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd'
 import { canonicalUrl } from '@/lib/seo/canonical'
@@ -119,6 +120,11 @@ async function CachedSpeakerContent({
   cacheTag('content:speaker-detail')
 
   const { conference } = await getConferenceForDomain(domain)
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
+
   const { speaker, talks, err } = await getPublicSpeaker(conference._id, slug)
 
   if (err) {

--- a/src/app/(main)/speaker/page.tsx
+++ b/src/app/(main)/speaker/page.tsx
@@ -5,6 +5,7 @@ import { getSpeakers } from '@/lib/speaker/sanity'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { SpeakerWithTalks } from '@/lib/speaker/types'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd'
@@ -27,6 +28,10 @@ async function CachedSpeakersContent({ domain }: { domain: string }) {
   cacheTag('content:speakers')
 
   const { conference } = await getConferenceForDomain(domain)
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   const { speakers, err } = await getSpeakers(conference._id)
   if (err) {

--- a/src/app/(main)/sponsor/page.tsx
+++ b/src/app/(main)/sponsor/page.tsx
@@ -4,6 +4,7 @@ import { Container } from '@/components/Container'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { SponsorTier, ConferenceSponsor } from '@/lib/sponsor/types'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import { SponsorProspectus } from '@/components/sponsor/SponsorProspectus'
 import type { Metadata } from 'next'
@@ -31,6 +32,10 @@ async function CachedSponsorContent({ domain }: { domain: string }) {
     sponsors: true,
     gallery: { featuredLimit: 8, featuredOnly: true },
   })
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (error || !conference) {
     console.error('Failed to load conference data:', error)

--- a/src/app/(main)/sponsor/terms/page.tsx
+++ b/src/app/(main)/sponsor/terms/page.tsx
@@ -5,6 +5,7 @@ import { getTermsForConference } from '@/lib/sponsor-crm/contract-templates'
 import { PortableText } from '@portabletext/react'
 import { portableTextComponents } from '@/lib/portabletext/components'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
@@ -24,6 +25,10 @@ async function CachedTermsContent({ domain }: { domain: string }) {
   cacheTag('content:sponsor-terms')
 
   const { conference, error: confError } = await getConferenceForDomain(domain)
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (confError || !conference) {
     return (

--- a/src/app/(main)/terms/page.tsx
+++ b/src/app/(main)/terms/page.tsx
@@ -17,6 +17,7 @@ import {
 import Link from 'next/link'
 import { ContentCard } from '@/components/ContentCard'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
@@ -37,6 +38,10 @@ async function CachedTermsContent({ domain }: { domain: string }) {
 
   const { conference, error: conferenceError } =
     await getConferenceForDomain(domain)
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (conferenceError) {
     return (

--- a/src/app/(main)/tickets/page.tsx
+++ b/src/app/(main)/tickets/page.tsx
@@ -36,6 +36,7 @@ import Link from 'next/link'
 import { headers } from 'next/headers'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import type { ElementType } from 'react'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
@@ -92,6 +93,10 @@ async function CachedTicketsContent({ domain }: { domain: string }) {
   cacheTag('content:tickets')
 
   const { conference, error } = await getConferenceForDomain(domain)
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (error) {
     console.error('Error fetching conference data:', error)

--- a/src/app/(main)/volunteer/page.tsx
+++ b/src/app/(main)/volunteer/page.tsx
@@ -6,6 +6,7 @@ import { UserGroupIcon, SparklesIcon } from '@heroicons/react/24/outline'
 import { Container } from '@/components/Container'
 import { BackgroundImage } from '@/components/BackgroundImage'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import { canonicalAlternates } from '@/lib/seo/canonical'
 
@@ -24,6 +25,10 @@ async function CachedVolunteerContent({ domain }: { domain: string }) {
   cacheTag('content:volunteer')
 
   const { conference, error } = await getConferenceForDomain(domain)
+
+  if (conference?._id) {
+    cacheTag(conferenceTag(conference._id))
+  }
 
   if (error || !conference?._id) {
     return (

--- a/src/app/pwa/icon/[spec]/route.ts
+++ b/src/app/pwa/icon/[spec]/route.ts
@@ -23,6 +23,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
+import { domainTag } from '@/lib/cache/tags'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { ICON_SPECS, renderConferenceIconPng } from '@/lib/pwa/icons'
 
@@ -41,7 +42,7 @@ async function renderCachedIconBase64(
   'use cache'
   cacheLife('max')
   cacheTag('pwa-icons')
-  cacheTag(`domain:${host}`)
+  cacheTag(domainTag(host))
 
   const spec = ICON_SPECS[specKey]
   const { conference } = await getConferenceForDomain(host)

--- a/src/lib/cache/tags.ts
+++ b/src/lib/cache/tags.ts
@@ -1,0 +1,24 @@
+/**
+ * Cache-tag builders — the single source of truth for tenant-scoped
+ * `cacheTag`/`revalidateTag` names.
+ *
+ * Content is served per-conference (multi-tenant, one deploy serves every
+ * conference domain). A tenant-scoped tag lets a mutation on one conference
+ * invalidate ONLY that conference's cached pages/reads, instead of the broad
+ * `content:*` tags that bust every tenant at once.
+ *
+ * - `conferenceTag(id)` — the per-conference-document tag. Prefer this whenever
+ *   the conference `_id` is available (mutations resolve it; page/data
+ *   functions resolve the conference from the domain and can tag after the
+ *   fetch). This is the tag mutations should revalidate.
+ * - `domainTag(domain)` — a per-domain fallback for the rare spot where a
+ *   conference id is not available but the host is.
+ */
+
+export function conferenceTag(conferenceId: string): string {
+  return `sanity:conference-${conferenceId}`
+}
+
+export function domainTag(domain: string): string {
+  return `domain:${domain}`
+}

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -4,6 +4,7 @@ import { normalizeDomain } from './domains'
 import { isConferenceOver } from './state'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag, domainTag } from '@/lib/cache/tags'
 import {
   getFeaturedGalleryImages,
   getGalleryImages,
@@ -18,8 +19,16 @@ async function fetchConferenceData(
   'use cache'
   cacheLife('hours')
   cacheTag('content:conferences')
-  cacheTag(`domain:${domain}`)
-  return clientWrite.fetch(query, { domain, wildcardSubdomain })
+  cacheTag(domainTag(domain))
+  const result = await clientWrite.fetch(query, { domain, wildcardSubdomain })
+  // Tag this cached read with the resolved conference id so a conference-scoped
+  // mutation (which revalidates `sanity:conference-<id>`) busts THIS tenant's
+  // conference read — and only this tenant's — without the broad
+  // `content:conferences` hammer that busts every tenant.
+  if (result?._id) {
+    cacheTag(conferenceTag(result._id))
+  }
+  return result
 }
 
 export async function getConferenceForCurrentDomain({

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -9,6 +9,7 @@ import { v4 as randomUUID } from 'uuid'
 import { Account, Profile, User } from 'next-auth'
 import { ProposalExisting, Status } from '../proposal/types'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { generateUniqueSpeakerSlug } from './slug'
 import { normalizeEmail, uniqueEmails } from './email'
 import { verifiedEmails as fetchGithubVerifiedEmails } from '@/lib/profile/github'
@@ -655,7 +656,7 @@ export async function getSpeakers(
   cacheLife('hours')
   cacheTag('content:speakers')
   if (conferenceId) {
-    cacheTag(`sanity:conference-${conferenceId}`)
+    cacheTag(conferenceTag(conferenceId))
   }
 
   let speakers: (Speaker & { proposals: ProposalExisting[] })[] = []

--- a/src/server/routers/conference.test.ts
+++ b/src/server/routers/conference.test.ts
@@ -61,7 +61,10 @@ vi.mock('@/lib/teams', () => ({
   clearConferenceTeamsCache: () => clearTeamsCacheMock(),
 }))
 
+import { revalidateTag } from 'next/cache'
 import { conferenceRouter } from './conference'
+
+const revalidateTagMock = revalidateTag as unknown as ReturnType<typeof vi.fn>
 
 const CONFERENCE_ID = 'conf-1'
 
@@ -117,6 +120,24 @@ describe('conference router — authorization', () => {
     })
     expect(result.success).toBe(true)
     expect(lastPatchId).toBe(CONFERENCE_ID)
+  })
+})
+
+describe('conference router — tenant-scoped cache invalidation (#618)', () => {
+  it('revalidates only the edited conference by its scoped tag', async () => {
+    await makeCaller({ isOrganizer: true }).updateBasicInfo({
+      title: 'DevOpsDays',
+      organizer: 'CNB',
+    })
+    expect(revalidateTagMock).toHaveBeenCalledWith(
+      `sanity:conference-${CONFERENCE_ID}`,
+      'default',
+    )
+    // The broad tag would bust every other tenant's cached conference read.
+    expect(revalidateTagMock).not.toHaveBeenCalledWith(
+      'content:conferences',
+      expect.anything(),
+    )
   })
 })
 

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server'
 import { revalidateTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import { router, adminProcedure, resolveConferenceId } from '../trpc'
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
@@ -124,8 +125,10 @@ async function applyConferencePatch(
 
     // Bust the cached conference read so the server-rendered settings page (and
     // every other `getConferenceForCurrentDomain` consumer) reflects the change.
-    revalidateTag('content:conferences', 'default')
-    revalidateTag(`sanity:conference-${conferenceId}`, 'default')
+    // Settings belong to ONE conference, so revalidate the tenant-scoped tag
+    // only — `fetchConferenceData` and every public page tag this conference's
+    // cached reads with `sanity:conference-<id>`, so other tenants stay warm.
+    revalidateTag(conferenceTag(conferenceId), 'default')
 
     return { success: true, updated: result }
   } catch (error) {

--- a/src/server/routers/featured.ts
+++ b/src/server/routers/featured.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server'
 import { revalidateTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { router, adminProcedure } from '../trpc'
 import {
   FeaturedSpeakerInputSchema,
@@ -114,9 +115,9 @@ export const featuredRouter = router({
             })
           }
 
-          revalidateTag('content:featured', 'default')
-          revalidateTag('content:conferences', 'default')
-          revalidateTag(`sanity:conference-${conference._id}`, 'default')
+          // Featured speakers surface on this conference's homepage — bust only
+          // this tenant (its pages carry `sanity:conference-<id>`).
+          revalidateTag(conferenceTag(conference._id), 'default')
 
           return { success: true }
         } catch (error) {
@@ -156,9 +157,9 @@ export const featuredRouter = router({
             })
           }
 
-          revalidateTag('content:featured', 'default')
-          revalidateTag('content:conferences', 'default')
-          revalidateTag(`sanity:conference-${conference._id}`, 'default')
+          // Featured speakers surface on this conference's homepage — bust only
+          // this tenant (its pages carry `sanity:conference-<id>`).
+          revalidateTag(conferenceTag(conference._id), 'default')
 
           return { success: true }
         } catch (error) {
@@ -198,10 +199,9 @@ export const featuredRouter = router({
             })
           }
 
-          revalidateTag('content:featured', 'default')
-          revalidateTag('content:conferences', 'default')
-          revalidateTag('content:program', 'default')
-          revalidateTag(`sanity:conference-${conference._id}`, 'default')
+          // Featured talks surface on this conference's home/program pages —
+          // bust only this tenant (all those pages carry `sanity:conference-<id>`).
+          revalidateTag(conferenceTag(conference._id), 'default')
 
           return { success: true }
         } catch (error) {
@@ -241,10 +241,9 @@ export const featuredRouter = router({
             })
           }
 
-          revalidateTag('content:featured', 'default')
-          revalidateTag('content:conferences', 'default')
-          revalidateTag('content:program', 'default')
-          revalidateTag(`sanity:conference-${conference._id}`, 'default')
+          // Featured talks surface on this conference's home/program pages —
+          // bust only this tenant (all those pages carry `sanity:conference-<id>`).
+          revalidateTag(conferenceTag(conference._id), 'default')
 
           return { success: true }
         } catch (error) {

--- a/src/server/routers/schedule.test.ts
+++ b/src/server/routers/schedule.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+// --- next/cache: capture every revalidateTag call ---------------------------
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+// --- Conference resolution --------------------------------------------------
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+// --- Schedule persistence layer (stubbed — we assert the router, not Sanity) -
+const saveScheduleMock = vi.fn()
+const getValidTalkIdsMock = vi.fn()
+vi.mock('@/lib/schedule/sanity', () => ({
+  saveScheduleToSanity: (...args: unknown[]) => saveScheduleMock(...args),
+  getValidTalkIds: (...args: unknown[]) => getValidTalkIdsMock(...args),
+}))
+
+const validateMock = vi.fn()
+vi.mock('@/lib/schedule/validation', () => ({
+  validateSchedulePayload: (...args: unknown[]) => validateMock(...args),
+}))
+
+import { revalidateTag } from 'next/cache'
+import { scheduleRouter } from './schedule'
+
+const revalidateTagMock = revalidateTag as unknown as Mock
+
+const CONFERENCE_ID = 'conf-bergen'
+const OTHER_CONFERENCE_ID = 'conf-oslo'
+
+function makeCaller() {
+  const speaker = { _id: 'sp-1', name: 'Org', isOrganizer: true }
+  const ctx = {
+    session: { speaker, user: { name: 'Org' } },
+    speaker,
+  } as unknown as Context
+  return scheduleRouter.createCaller(ctx)
+}
+
+const validPayload = { _id: '', date: '2026-10-10', tracks: [] }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: CONFERENCE_ID },
+    error: null,
+  })
+  getValidTalkIdsMock.mockResolvedValue(new Set<string>())
+  validateMock.mockReturnValue(null)
+  saveScheduleMock.mockResolvedValue({
+    schedule: { _id: 'sched-1' },
+    error: null,
+    conflict: false,
+  })
+})
+
+describe('schedule router — tenant-scoped cache invalidation (#618)', () => {
+  it('revalidates the publishing conference by its scoped tag', async () => {
+    await makeCaller().save(validPayload)
+    expect(revalidateTagMock).toHaveBeenCalledWith(
+      `sanity:conference-${CONFERENCE_ID}`,
+      'default',
+    )
+  })
+
+  it('does NOT bust other tenants via the generic content tags', async () => {
+    await makeCaller().save(validPayload)
+    // The old behavior busted EVERY conference's /program via these broad tags.
+    expect(revalidateTagMock).not.toHaveBeenCalledWith(
+      'content:program',
+      expect.anything(),
+    )
+    expect(revalidateTagMock).not.toHaveBeenCalledWith(
+      'content:conferences',
+      expect.anything(),
+    )
+  })
+
+  it('never revalidates a different conference than the one saved', async () => {
+    await makeCaller().save(validPayload)
+    expect(revalidateTagMock).not.toHaveBeenCalledWith(
+      `sanity:conference-${OTHER_CONFERENCE_ID}`,
+      expect.anything(),
+    )
+  })
+
+  it('revalidates exactly once — the scoped tag only', async () => {
+    await makeCaller().save(validPayload)
+    expect(revalidateTagMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not revalidate anything when the save fails', async () => {
+    saveScheduleMock.mockResolvedValueOnce({
+      schedule: null,
+      error: 'boom',
+      conflict: false,
+    })
+    await expect(makeCaller().save(validPayload)).rejects.toBeTruthy()
+    expect(revalidateTagMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/routers/schedule.ts
+++ b/src/server/routers/schedule.ts
@@ -5,6 +5,7 @@ import { saveScheduleToSanity, getValidTalkIds } from '@/lib/schedule/sanity'
 import { validateSchedulePayload } from '@/lib/schedule/validation'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { revalidateTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import type { ConferenceSchedule } from '@/lib/conference/types'
 
 export const scheduleRouter = router({
@@ -56,9 +57,13 @@ export const scheduleRouter = router({
         })
       }
 
-      revalidateTag('content:program', 'default')
-      revalidateTag('content:conferences', 'default')
-      revalidateTag(`sanity:conference-${conference._id}`, 'default')
+      // A schedule save changes exactly ONE conference's program. Revalidate the
+      // tenant-scoped tag ONLY — the generic `content:program`/`content:conferences`
+      // tags would bust every other conference's cached pages. Every page that
+      // renders this conference's content (and the shared conference read in
+      // `fetchConferenceData`) now carries `sanity:conference-<id>`, so the
+      // scoped tag alone fully invalidates this tenant.
+      revalidateTag(conferenceTag(conference._id), 'default')
 
       return { schedule }
     }),

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { revalidateTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { router, adminProcedure, resolveConferenceId } from '../trpc'
 import {
   SponsorInputSchema,
@@ -560,8 +561,8 @@ export const sponsorRouter = router({
           })
         }
 
-        revalidateTag('content:sponsor', 'default')
-        revalidateTag('content:conferences', 'default')
+        // Sponsor tiers belong to one conference — bust only this tenant.
+        revalidateTag(conferenceTag(conference._id), 'default')
 
         return sponsorTier
       }),
@@ -616,8 +617,8 @@ export const sponsorRouter = router({
             })
           }
 
-          revalidateTag('content:sponsor', 'default')
-          revalidateTag('content:conferences', 'default')
+          // Sponsor tiers belong to one conference — bust only this tenant.
+          revalidateTag(conferenceTag(await resolveConferenceId()), 'default')
 
           return sponsorTier
         } else {
@@ -643,8 +644,8 @@ export const sponsorRouter = router({
         })
       }
 
-      revalidateTag('content:sponsor', 'default')
-      revalidateTag('content:conferences', 'default')
+      // Sponsor tiers belong to one conference — bust only this tenant.
+      revalidateTag(conferenceTag(await resolveConferenceId()), 'default')
 
       return { success: true }
     }),

--- a/src/server/routers/tickets.ts
+++ b/src/server/routers/tickets.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server'
 import { revalidateTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { router, adminProcedure, resolveConferenceId } from '../trpc'
 import {
   TicketSettingsUpdateSchema,
@@ -497,7 +498,8 @@ export const ticketsRouter = router({
             .set(updates)
             .commit()
 
-          revalidateTag('content:tickets', 'default')
+          // Ticket page content belongs to one conference — bust only this tenant.
+          revalidateTag(conferenceTag(conferenceId), 'default')
 
           return {
             success: true,

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -11,6 +11,7 @@ import {
 } from '@/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { revalidateTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { clientWrite } from '@/lib/sanity/client'
 import {
   workshopListInputSchema,
@@ -1057,7 +1058,7 @@ export const workshopRouter = router({
             .commit()
 
           revalidateTag('admin:settings', 'default')
-          revalidateTag(`sanity:conference-${conferenceId}`, 'default')
+          revalidateTag(conferenceTag(conferenceId), 'default')
 
           return {
             success: true,


### PR DESCRIPTION
## Problem (QA-verified)

One deploy serves every conference domain, so page and content caches are
multi-tenant. But `'use cache'` pages tagged their entries by content-type only
(e.g. `cacheTag('content:program')`), and conference-scoped mutations
revalidated those generic tags globally (`revalidateTag('content:program')`).
Result: **conference A publishing its schedule busted every conference's
`/program` cache** (and the same for homepage, speakers, sponsors, tickets, …).

Per-conference tags (`sanity:conference-<id>`) already existed in the data layer
but were never applied at the page-render layer, so scoped revalidation had
nothing to hit.

## Fix

- **One tag-builder source** — `src/lib/cache/tags.ts`: `conferenceTag(id)` →
  `sanity:conference-<id>`, `domainTag(domain)` → `domain:<domain>`. Every call
  site now builds tags through these (removed the last inline literals in
  `workshop.ts` and the PWA icon route).
- **Pages / data reads** carry the scoped tag alongside the generic one. The
  generic `content:*` tag stays for platform-wide invalidation (deploy-time /
  cross-tenant); the scoped tag is what conference mutations bust.
- **`fetchConferenceData`** (the shared conference read every page funnels
  through) now tags the resolved conference id after the fetch — so a scoped
  revalidation busts the inner read too, not just the page shell.
- **Mutations** that change one conference's content revalidate the scoped tag
  **only**.

### Page → cache tags (after)

| Page / cached read | Generic tag (kept) | Scoped tag (added) |
| --- | --- | --- |
| `/` homepage | `content:homepage` | `sanity:conference-<id>` |
| `/program` | `content:program` | `sanity:conference-<id>` |
| `/speaker` + `getSpeakers` | `content:speakers` | `sanity:conference-<id>` |
| `/speaker/[slug]` | `content:speaker-detail` | `sanity:conference-<id>` |
| `/sponsor` | `content:sponsor` | `sanity:conference-<id>` |
| `/sponsor/terms` | `content:sponsor-terms` | `sanity:conference-<id>` |
| `/tickets` | `content:tickets` | `sanity:conference-<id>` |
| `/cfp` | `content:cfp` | `sanity:conference-<id>` |
| `/info` | `content:info` | `sanity:conference-<id>` |
| `/volunteer` | `content:volunteer` | `sanity:conference-<id>` |
| `/privacy` `/terms` `/conduct` | `content:{privacy,terms,conduct}` | `sanity:conference-<id>` |
| `fetchConferenceData` | `content:conferences`, `domain:<domain>` | `sanity:conference-<id>` |
| `/staff/[role]` | `content:staff` | — (global, not conference-scoped) |

### Mutation → revalidations (before → after)

| Mutation | Before | After |
| --- | --- | --- |
| `schedule.save` | `content:program` + `content:conferences` + scoped | **scoped only** |
| conference settings (`applyConferencePatch`) | `content:conferences` + scoped | **scoped only** |
| `sponsor.tiers.{create,update,delete}` | `content:sponsor` + `content:conferences` | **scoped only** |
| `tickets.updatePageContent` | `content:tickets` | **scoped only** |
| `featured.{add,remove}{Speaker,Talk}` | `content:featured` (+`content:program`) + `content:conferences` + scoped | **scoped only** |
| `workshop` settings | `admin:settings` + scoped (inline) | `admin:settings` + scoped (helper) |
| `topic.{create,update,delete}` | `content:conferences` | **unchanged** — topics are global shared docs referenced across conferences |
| `conference.createEdition` | `content:conferences` | **unchanged** — creates a new conference document (genuinely global) |
| `staff.*` | `content:staff` | **unchanged** — staff (photographers) are global |

### Where generic tags were deliberately kept

- **`topic.*`** — a `topic` is a shared document referenced by talks/conferences
  across tenants; a topic edit legitimately affects multiple conferences.
- **`conference.createEdition`** — adds a new conference document; nothing is
  cached under its id yet and the broad tag is what lets domain resolution see
  the new edition.
- **`staff.*` / `content:staff`** — staff are queried by role globally, not per
  conference.
- **`admin:*` and `content:workshops`** — admin dashboards are org-scoped by
  auth and `content:workshops` has no public page consumer, so they do not
  cross-bust public tenant pages; left as-is.

## Verify

- New `src/server/routers/schedule.test.ts`: a publish revalidates
  `sanity:conference-<id>`, and asserts it does **not** revalidate
  `content:program`, `content:conferences`, or any other conference's tag
  (revalidates exactly once).
- Extended `conference.test.ts`: settings edit revalidates the scoped tag and
  not `content:conferences`.
- `mise run check` (format + typecheck + lint + knip) green; full vitest suite
  green (283 files / 3902 tests). `mise run build` compiles + typechecks clean;
  it fails only at page-data collection on a missing `RESEND_API_KEY` keychain
  secret (local-machine limitation, unrelated to this change).

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)
