### PR TITLE
fix(tenancy): remove branded fallbacks, per-host PWA manifest (CaaS #625 part 1)

### DIFF
--- a/src/app/(admin)/admin/marketing/page.tsx
+++ b/src/app/(admin)/admin/marketing/page.tsx
@@ -523,8 +523,13 @@ export default async function MarketingPage() {
                           sponsor={sponsor}
                           tier={tier}
                           variant={variant}
-                          eventName={conference.title || 'Cloud Native Days'}
+                          eventName={conference.title}
                           eventDate={eventDate}
+                          baseUrl={
+                            conference.domains?.[0]
+                              ? `https://${conference.domains[0]}`
+                              : undefined
+                          }
                           showCloudNativePattern={true}
                           className="h-full w-full"
                         />

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -2,6 +2,7 @@ import { BackgroundImage } from '@/components/BackgroundImage'
 import { Container } from '@/components/Container'
 import { ContentCard } from '@/components/ContentCard'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
+import { resolveConferenceContact } from '@/lib/email/from'
 import { ErrorDisplay } from '@/components/admin'
 import {
   ShieldCheckIcon,
@@ -68,7 +69,7 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
   }
 
   const lastUpdated = 'October 31, 2025'
-  const contactEmail = conference.contactEmail || 'contact@cloudnativedays.no'
+  const contactEmail = resolveConferenceContact(conference)
   const organizationName = 'Cloud Native Days Norway'
 
   return (

--- a/src/app/(main)/terms/page.tsx
+++ b/src/app/(main)/terms/page.tsx
@@ -1,6 +1,7 @@
 import { BackgroundImage } from '@/components/BackgroundImage'
 import { Container } from '@/components/Container'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
+import { resolveConferenceContact } from '@/lib/email/from'
 import { ErrorDisplay } from '@/components/admin'
 import {
   DocumentTextIcon,
@@ -48,7 +49,7 @@ async function CachedTermsContent({ domain }: { domain: string }) {
   }
 
   const lastUpdated = 'October 31, 2025'
-  const contactEmail = conference.contactEmail || 'contact@cloudnativedays.no'
+  const contactEmail = resolveConferenceContact(conference)
   const organizationName = conference.organizer || 'Cloud Native Days'
 
   return (

--- a/src/app/(stream)/stream/[room]/page.tsx
+++ b/src/app/(stream)/stream/[room]/page.tsx
@@ -7,7 +7,7 @@ import type { ConferenceSponsor } from '@/lib/sponsor/types'
 import BlueskyAuthorFeedLooping from '@/components/stream/BlueskyAuthorFeedLooping'
 import { AutoRefreshWrapper } from '@/components/stream/AutoRefreshWrapper'
 import { StreamError } from '@/components/stream/StreamError'
-import { STREAM_CONFIG } from '@/lib/stream/config'
+import { STREAM_CONFIG, deriveBlueskyHandle } from '@/lib/stream/config'
 import { findTrackByRoom, getAvailableRooms } from '@/lib/stream/schedule-utils'
 import { DevTimeProvider } from '@/components/program/DevTimeProvider'
 import { DevTimeControl } from '@/components/program/DevTimeControl'
@@ -43,6 +43,8 @@ export default async function StreamRoomPage({ params }: Props) {
       />
     )
   }
+
+  const blueskyHandle = deriveBlueskyHandle(conference.socialLinks)
 
   const matchedTrack = findTrackByRoom(conference.schedules, room)
 
@@ -99,14 +101,16 @@ export default async function StreamRoomPage({ params }: Props) {
                   className={STREAM_CONFIG.nextTalk.className}
                 />
 
-                <BlueskyAuthorFeedLooping
-                  handle={STREAM_CONFIG.blueskyFeed.handle}
-                  compact={STREAM_CONFIG.blueskyFeed.compact}
-                  title={STREAM_CONFIG.blueskyFeed.title}
-                  speed={STREAM_CONFIG.blueskyFeed.speed}
-                  maxHeight={STREAM_CONFIG.blueskyFeed.maxHeight}
-                  className={STREAM_CONFIG.blueskyFeed.className}
-                />
+                {blueskyHandle && (
+                  <BlueskyAuthorFeedLooping
+                    handle={blueskyHandle}
+                    compact={STREAM_CONFIG.blueskyFeed.compact}
+                    title={STREAM_CONFIG.blueskyFeed.title}
+                    speed={STREAM_CONFIG.blueskyFeed.speed}
+                    maxHeight={STREAM_CONFIG.blueskyFeed.maxHeight}
+                    className={STREAM_CONFIG.blueskyFeed.className}
+                  />
+                )}
               </div>
             </div>
           </Container>

--- a/src/app/(workshop)/workshop/page.tsx
+++ b/src/app/(workshop)/workshop/page.tsx
@@ -6,6 +6,7 @@ import { Container } from '@/components/Container'
 import { BackgroundImage } from '@/components/BackgroundImage'
 import { Button } from '@/components/Button'
 import { checkWorkshopEligibility } from '@/lib/workshop/eligibility'
+import { resolveConferenceContact } from '@/lib/email/from'
 import { EnvelopeIcon } from '@heroicons/react/24/outline'
 
 export default async function WorkshopPage() {
@@ -152,7 +153,7 @@ export default async function WorkshopPage() {
 
               <div className="mt-8">
                 <Button
-                  href={`mailto:${conference.contactEmail || 'contact@cloudnativedays.no'}`}
+                  href={`mailto:${resolveConferenceContact(conference)}`}
                   variant="outline"
                 >
                   <EnvelopeIcon className="mr-2 h-5 w-5" />

--- a/src/app/api/badge/issuer/route.ts
+++ b/src/app/api/badge/issuer/route.ts
@@ -17,6 +17,7 @@
 import { NextResponse } from 'next/server'
 import { createPublicKey } from 'crypto'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { resolveConferenceContact } from '@/lib/email/from'
 import { generateErrorResponse, seedToMultikey } from '@/lib/openbadges'
 
 export async function GET(request: Request) {
@@ -111,11 +112,7 @@ export async function GET(request: Request) {
       type: ['Profile'],
       name: conference.organizer,
       url: baseUrl,
-      email:
-        conference.contactEmail ||
-        (conference.domains?.[0]
-          ? `contact@${conference.domains[0]}`
-          : 'contact@cloudnativedays.no'),
+      email: resolveConferenceContact(conference),
       description: conference.description || conference.tagline || '',
       image: {
         id: `${baseUrl}/og/base.png`,

--- a/src/app/api/cron/contract-reminders/route.ts
+++ b/src/app/api/cron/contract-reminders/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { clientWrite } from '@/lib/sanity/client'
 import { getCurrentDateTime } from '@/lib/time'
 import { resend, retryWithBackoff } from '@/lib/email/config'
+import { platformFallbackContact } from '@/lib/email/from'
 import { unstable_noStore as noStore } from 'next/cache'
 
 const MAX_REMINDERS = 2
@@ -77,10 +78,10 @@ export async function GET(request: NextRequest) {
 
         const newCount = (contract.reminderCount || 0) + 1
 
+        const eventName = contract.conferenceName || 'the conference'
         const fromEmail =
-          contract.conferenceSponsorEmail || 'sponsors@cloudnativeday.no'
-        const fromName = contract.conferenceOrganizer || 'Cloud Native Days'
-        const eventName = contract.conferenceName || 'Cloud Native Day'
+          contract.conferenceSponsorEmail || platformFallbackContact()
+        const fromName = contract.conferenceOrganizer || eventName
 
         const { renderContractEmail, CONTRACT_EMAIL_SLUGS } =
           await import('@/lib/email/contract-email')

--- a/src/app/manifest.test.ts
+++ b/src/app/manifest.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const headersMock = vi.fn()
+const getConferenceForDomainMock = vi.fn()
+
+vi.mock('next/headers', () => ({
+  headers: () => headersMock(),
+}))
+
+// `'use cache'` helpers call cacheLife/cacheTag — no-op them under vitest.
+vi.mock('next/cache', () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForDomain: (...args: unknown[]) =>
+    getConferenceForDomainMock(...args),
+}))
+
+import manifest from './manifest'
+
+function withHost(host: string) {
+  headersMock.mockResolvedValue(new Headers({ host }))
+}
+
+describe('manifest — per-host PWA identity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the resolved conference title as the app name', async () => {
+    withHost('2026.cloudnativebergen.dev')
+    getConferenceForDomainMock.mockResolvedValue({
+      conference: {
+        title: 'Cloud Native Day Bergen',
+        description: 'A Bergen conference.',
+      },
+      domain: '2026.cloudnativebergen.dev',
+      error: null,
+    })
+
+    const result = await manifest()
+
+    expect(result.name).toBe('Cloud Native Day Bergen')
+    expect(result.description).toBe('A Bergen conference.')
+    // short_name is truncated on a word boundary within the length budget.
+    expect(result.short_name).toBe('Cloud Native')
+    expect(result.short_name!.length).toBeLessThanOrEqual(12)
+  })
+
+  it('gives different hosts different names', async () => {
+    withHost('a.example.dev')
+    getConferenceForDomainMock.mockResolvedValueOnce({
+      conference: { title: 'Alpha Conf' },
+      domain: 'a.example.dev',
+      error: null,
+    })
+    const a = await manifest()
+
+    withHost('b.example.dev')
+    getConferenceForDomainMock.mockResolvedValueOnce({
+      conference: { title: 'Beta Conf' },
+      domain: 'b.example.dev',
+      error: null,
+    })
+    const b = await manifest()
+
+    expect(a.name).toBe('Alpha Conf')
+    expect(b.name).toBe('Beta Conf')
+  })
+
+  it('falls back to the platform identity when no conference resolves', async () => {
+    withHost('localhost:3000')
+    getConferenceForDomainMock.mockResolvedValue({
+      conference: {},
+      domain: 'localhost:3000',
+      error: new Error('no conference for host'),
+    })
+
+    const result = await manifest()
+
+    expect(result.name).toBe('Cloud Native Days')
+    expect(result.short_name).toBe('CND')
+    expect(result.description).toContain('Community-driven')
+  })
+
+  it('falls back to the platform identity when resolution throws', async () => {
+    withHost('broken.example.dev')
+    getConferenceForDomainMock.mockRejectedValue(new Error('sanity down'))
+
+    const result = await manifest()
+
+    expect(result.name).toBe('Cloud Native Days')
+    expect(result.short_name).toBe('CND')
+  })
+
+  it('keeps id/scope/start_url/theme_color host-invariant', async () => {
+    withHost('2026.cloudnativebergen.dev')
+    getConferenceForDomainMock.mockResolvedValue({
+      conference: { title: 'Whatever Conf' },
+      domain: '2026.cloudnativebergen.dev',
+      error: null,
+    })
+
+    const result = await manifest()
+
+    expect(result.id).toBe('/')
+    expect(result.scope).toBe('/')
+    expect(result.start_url).toBe('/launch')
+    expect(result.theme_color).toBe('#1d4ed8')
+  })
+
+  it('uses a short title verbatim as short_name', async () => {
+    withHost('kcd.example.dev')
+    getConferenceForDomainMock.mockResolvedValue({
+      conference: { title: 'KCD Oslo' },
+      domain: 'kcd.example.dev',
+      error: null,
+    })
+
+    const result = await manifest()
+
+    expect(result.short_name).toBe('KCD Oslo')
+  })
+})

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
+import { normalizeDomain } from '@/lib/conference/domains'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 
 /**
@@ -87,7 +88,10 @@ async function resolveManifestIdentity(host: string): Promise<{
 }
 
 export default async function manifest(): Promise<MetadataRoute.Manifest> {
-  const host = (await headers()).get('host') || ''
+  // Normalize BEFORE the cached resolver: the raw Host header can vary in
+  // case/whitespace, and the cache key + domain:<host> tag must match the
+  // normalized form the rest of the per-host surface (and revalidations) use.
+  const host = normalizeDomain((await headers()).get('host') || '')
   const { name, shortName, description } = await resolveManifestIdentity(host)
 
   return {

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,26 +1,100 @@
 import type { MetadataRoute } from 'next'
+import { headers } from 'next/headers'
+import { cacheLife, cacheTag } from 'next/cache'
+import { getConferenceForDomain } from '@/lib/conference/sanity'
 
 /**
  * Web app manifest (Next.js metadata route → `/manifest.webmanifest`).
  *
- * Next injects `<link rel="manifest">` automatically. The name/id are kept
- * stable across tenants so the installed app identity never changes, while the
- * icons resolve per host via the dynamic `/pwa/icon/*` routes (each conference's
- * own `logomarkBright`, with a static fallback).
+ * Next injects `<link rel="manifest">` automatically. Each tenant domain is its
+ * own PWA origin and the install identity (`id`/`scope`/`start_url`) is
+ * path-based, so per-host `name`/`short_name` are SAFE — a device only ever
+ * sees one host's manifest. `name` therefore reflects the conference resolved
+ * for the request host; when no conference resolves (e.g. localhost) it falls
+ * back to the platform defaults below.
  *
- * `start_url` points at `/launch` (see `src/app/launch/route.ts`): a UI-less
- * Route Handler that resolves the signed-in role server-side and 307-redirects
- * to the right home (organizer → `/admin`, speaker → `/cfp/list`, logged-out
- * attendee → the public `/program`). `id` stays `/` so the installed app
- * identity is unchanged by this start_url move.
+ * `id`/`scope`/`start_url`/`theme_color` are intentionally left host-invariant:
+ * `id`/`scope` anchor the installed app identity and `start_url` points at
+ * `/launch` (a role-aware redirect dispatcher — see `src/app/launch/route.ts`).
+ * `theme_color` stays platform-blue until the design-token wave.
+ *
+ * Icons resolve per host via the dynamic `/pwa/icon/*` routes (each
+ * conference's own `logomarkBright`, with a static fallback).
  */
-export default function manifest(): MetadataRoute.Manifest {
+
+const PLATFORM_NAME = 'Cloud Native Days'
+const PLATFORM_SHORT_NAME = 'CND'
+const PLATFORM_DESCRIPTION =
+  'Community-driven Kubernetes and Cloud Native conferences in the Nordics.'
+
+/** Max length for a PWA `short_name` (kept tight so launchers never truncate). */
+const SHORT_NAME_MAX = 12
+
+/** Derive a `short_name` from a full title by truncating on a word boundary. */
+function toShortName(title: string): string {
+  const trimmed = title.trim()
+  if (trimmed.length <= SHORT_NAME_MAX) return trimmed
+
+  const slice = trimmed.slice(0, SHORT_NAME_MAX)
+  // Only back off to the last word boundary when the budget cuts THROUGH a word
+  // (the next char is not whitespace). A clean fit like "Cloud Native" is kept.
+  if (trimmed[SHORT_NAME_MAX] !== ' ') {
+    const lastSpace = slice.lastIndexOf(' ')
+    if (lastSpace > 0) return slice.slice(0, lastSpace).trim()
+  }
+  return slice.trim()
+}
+
+/**
+ * Resolve the host-specific manifest identity. Cached per host (keyed on the
+ * `domain` argument and tagged `domain:<host>`) so it revalidates with the same
+ * `content:conferences` invalidation as the rest of the per-host surface, while
+ * `manifest()` itself stays a thin dynamic wrapper that only reads the host.
+ */
+async function resolveManifestIdentity(host: string): Promise<{
+  name: string
+  shortName: string
+  description: string
+}> {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('content:conferences')
+  cacheTag(`domain:${host}`)
+
+  try {
+    const { conference, error } = await getConferenceForDomain(host)
+    if (error || !conference?.title) {
+      return {
+        name: PLATFORM_NAME,
+        shortName: PLATFORM_SHORT_NAME,
+        description: PLATFORM_DESCRIPTION,
+      }
+    }
+    return {
+      name: conference.title,
+      shortName: toShortName(conference.title),
+      description: conference.description || PLATFORM_DESCRIPTION,
+    }
+  } catch {
+    // A misconfigured/unreachable Sanity must never break the manifest; fall
+    // back to the platform identity so installs still succeed.
+    return {
+      name: PLATFORM_NAME,
+      shortName: PLATFORM_SHORT_NAME,
+      description: PLATFORM_DESCRIPTION,
+    }
+  }
+}
+
+export default async function manifest(): Promise<MetadataRoute.Manifest> {
+  const host = (await headers()).get('host') || ''
+  const { name, shortName, description } = await resolveManifestIdentity(host)
+
   return {
     id: '/',
-    name: 'Cloud Native Days',
-    short_name: 'CND',
-    description:
-      'Community-driven Kubernetes and Cloud Native conferences in the Nordics.',
+    name,
+    short_name: shortName,
+    description,
     start_url: '/launch',
     scope: '/',
     display: 'standalone',

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,13 +22,18 @@ export function Header({ c }: { c: Conference }) {
   const { data: session } = useSession()
   const isPast = isConferenceOver(c)
 
-  const currentDomain = c.domains?.[0] ?? 'cloudnativedays.no'
-  const currentYear = parseInt(currentDomain.split('.')[0])
+  // The previous-edition link is derived from THIS conference's own domain
+  // (`<year>.<host>`), decrementing the year on the same host — never a
+  // hardcoded brand. When the domain has no leading `<year>.` label the link is
+  // underivable and omitted entirely.
+  const currentDomain = c.domains?.[0]
+  const [firstLabel, ...restLabels] = currentDomain?.split('.') ?? []
+  const currentYear = firstLabel ? parseInt(firstLabel, 10) : NaN
   const previousYear = currentYear - 1
   const previousDomain =
-    currentYear <= 2026
-      ? `${previousYear}.cloudnativebergen.dev`
-      : `${previousYear}.cloudnativedays.no`
+    Number.isFinite(currentYear) && restLabels.length > 0
+      ? `${previousYear}.${restLabels.join('.')}`
+      : null
 
   return (
     <header className="relative z-50 flex-none lg:pt-11">
@@ -95,13 +100,17 @@ export function Header({ c }: { c: Conference }) {
                 Past Event
               </span>
             )}
-            <DiamondIcon className="h-1.5 w-1.5 overflow-visible fill-current stroke-current" />
-            <a
-              href={`https://${previousDomain}`}
-              className="text-brand-cloud-blue hover:text-brand-slate-gray"
-            >
-              {previousYear} Conference
-            </a>
+            {previousDomain && (
+              <>
+                <DiamondIcon className="h-1.5 w-1.5 overflow-visible fill-current stroke-current" />
+                <a
+                  href={`https://${previousDomain}`}
+                  className="text-brand-cloud-blue hover:text-brand-slate-gray"
+                >
+                  {previousYear} Conference
+                </a>
+              </>
+            )}
           </div>
         </div>
         <div className="hidden whitespace-nowrap sm:mt-10 sm:flex lg:mt-0 lg:grow lg:basis-0 lg:justify-end">

--- a/src/components/SponsorThankYou.tsx
+++ b/src/components/SponsorThankYou.tsx
@@ -41,6 +41,9 @@ interface SponsorThankYouProps {
   eventDate?: string
   showCloudNativePattern?: boolean
   ctaUrl?: string
+  /** Conference origin (e.g. `https://2026.example.dev`) used to absolutize a
+   * relative `ctaUrl` for the QR code. Falls back to `NEXT_PUBLIC_BASE_URL`. */
+  baseUrl?: string
 }
 
 interface VariantConfig {
@@ -106,10 +109,18 @@ const variantConfig: Record<SponsorVariant, VariantConfig> = {
   },
 }
 
-async function generateQRCode(url: string, size = 256): Promise<string> {
-  const fullUrl = url.startsWith('http')
-    ? url
-    : `https://cloudnativedays.no${url}`
+async function generateQRCode(
+  url: string,
+  size = 256,
+  baseUrl?: string,
+): Promise<string> {
+  // For a relative CTA, prefix the conference's own origin (passed in) or the
+  // platform base URL — never a hardcoded brand host.
+  const origin = (baseUrl || process.env.NEXT_PUBLIC_BASE_URL || '').replace(
+    /\/$/,
+    '',
+  )
+  const fullUrl = url.startsWith('http') ? url : `${origin}${url}`
   const cacheKey = `${fullUrl}_${size}`
 
   if (qrCodeCache.has(cacheKey)) {
@@ -209,11 +220,12 @@ export async function SponsorThankYou({
   eventDate,
   showCloudNativePattern = false,
   ctaUrl,
+  baseUrl,
 }: SponsorThankYouProps) {
   const config = variantConfig[variant]
   const Icon = config.icon
   const finalCtaUrl = ctaUrl || '/'
-  const qrCodeUrl = await generateQRCode(finalCtaUrl, 512)
+  const qrCodeUrl = await generateQRCode(finalCtaUrl, 512, baseUrl)
   const backgroundStyle = showCloudNativePattern
     ? 'from-slate-900 via-blue-900 to-slate-900'
     : config.gradient

--- a/src/components/SponsorThankYou.tsx
+++ b/src/components/SponsorThankYou.tsx
@@ -120,6 +120,9 @@ async function generateQRCode(
     /\/$/,
     '',
   )
+  // A relative CTA with NO resolvable origin would encode a relative URL —
+  // scanning that QR resolves nowhere. Skip QR generation instead.
+  if (!url.startsWith('http') && !origin) return ''
   const fullUrl = url.startsWith('http') ? url : `${origin}${url}`
   const cacheKey = `${fullUrl}_${size}`
 

--- a/src/components/cfp/CompactConferenceHeader.tsx
+++ b/src/components/cfp/CompactConferenceHeader.tsx
@@ -18,7 +18,7 @@ export function CompactConferenceHeader({
   data,
 }: CompactConferenceHeaderProps) {
   const { conference, proposals, galleryImages, workshopStats, isOver } = data
-  const domain = conference.domains?.[0] || 'cloudnativedays.no'
+  const domain = conference.domains?.[0]
 
   return (
     <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
@@ -69,15 +69,17 @@ export function CompactConferenceHeader({
             <span className="font-medium">{galleryImages.length}</span>
           </div>
         )}
-        <Link
-          href={`https://${domain}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs font-medium text-brand-cloud-blue transition-colors hover:text-brand-cloud-blue/80 dark:text-blue-400 dark:hover:text-blue-300"
-          onClick={(e) => e.stopPropagation()}
-        >
-          View →
-        </Link>
+        {domain && (
+          <Link
+            href={`https://${domain}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-medium text-brand-cloud-blue transition-colors hover:text-brand-cloud-blue/80 dark:text-blue-400 dark:hover:text-blue-300"
+            onClick={(e) => e.stopPropagation()}
+          >
+            View →
+          </Link>
+        )}
       </div>
     </div>
   )

--- a/src/lib/badge/config.ts
+++ b/src/lib/badge/config.ts
@@ -1,5 +1,6 @@
 import type { Conference } from '@/lib/conference/types'
 import { createPublicKey } from 'crypto'
+import { resolveConferenceContact } from '@/lib/email/from'
 
 /**
  * Signing configuration for OpenBadges credentials
@@ -151,11 +152,7 @@ export async function createBadgeConfiguration(
   const baseUrl = domain.startsWith('http') ? domain : `https://${domain}`
 
   // Build issuer configuration
-  const issuerEmail =
-    conference.contactEmail ||
-    (conference.domains?.[0]
-      ? `contact@${conference.domains[0]}`
-      : 'contact@cloudnativedays.no')
+  const issuerEmail = resolveConferenceContact(conference)
 
   const issuerDescription =
     conference.description ||

--- a/src/lib/email/badge.ts
+++ b/src/lib/email/badge.ts
@@ -3,6 +3,7 @@ import { BadgeEmailTemplate } from '@/components/email/BadgeEmailTemplate'
 import { updateBadgeEmailStatus } from '@/lib/badge/sanity'
 import type { BadgeRecord } from '@/lib/badge/types'
 import type { Conference } from '@/lib/conference/types'
+import { resolveConferenceFrom } from '@/lib/email/from'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
@@ -46,12 +47,9 @@ export async function sendBadgeEmail({
       downloadUrl,
     })
 
-    // Determine from email using conference data
-    const fromEmail = conference.contactEmail
-      ? `${conference.organizer} <${conference.contactEmail}>`
-      : conference.domains?.[0]
-        ? `${conference.organizer} <contact@${conference.domains[0]}>`
-        : 'Cloud Native Days <contact@cloudnativedays.org>'
+    // Determine from email using conference data (neutral platform fallback
+    // when the conference has no contactEmail/domain — never a hardcoded brand).
+    const fromEmail = resolveConferenceFrom(conference)
 
     // Send email using Resend
     const { data, error } = await resend.emails.send({

--- a/src/lib/email/contract-email.ts
+++ b/src/lib/email/contract-email.ts
@@ -119,7 +119,7 @@ export async function renderContractEmail(
   }
 
   const titleColor = TITLE_COLORS[slug] || '#334155'
-  const eventUrl = variables.EVENT_URL || 'https://cloudnativeday.no'
+  const eventUrl = variables.EVENT_URL || ''
   const eventDate = variables.EVENT_DATE || ''
   const eventLocation = variables.EVENT_LOCATION || 'Norway'
 

--- a/src/lib/email/from.test.ts
+++ b/src/lib/email/from.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  resolveConferenceFrom,
+  resolveConferenceContact,
+  platformFallbackFrom,
+  platformFallbackContact,
+} from './from'
+
+describe('email from/contact resolution (CaaS #625)', () => {
+  const OLD = process.env.EMAIL_FALLBACK_FROM
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    delete process.env.EMAIL_FALLBACK_FROM
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (OLD === undefined) delete process.env.EMAIL_FALLBACK_FROM
+    else process.env.EMAIL_FALLBACK_FROM = OLD
+  })
+
+  describe('resolveConferenceFrom', () => {
+    it('prefers the explicit field with the organizer name', () => {
+      expect(
+        resolveConferenceFrom({
+          organizer: 'KCD Bergen',
+          contactEmail: 'hi@kcd.dev',
+          domains: ['2026.kcd.dev'],
+        }),
+      ).toBe('KCD Bergen <hi@kcd.dev>')
+    })
+
+    it('honors the field + localPart options for sponsor mail', () => {
+      expect(
+        resolveConferenceFrom(
+          { organizer: 'KCD', sponsorEmail: 'sales@kcd.dev' },
+          { field: 'sponsorEmail', localPart: 'sponsors' },
+        ),
+      ).toBe('KCD <sales@kcd.dev>')
+    })
+
+    it('derives <localPart>@<domain> when the field is absent', () => {
+      expect(
+        resolveConferenceFrom(
+          { organizer: 'KCD', domains: ['2026.kcd.dev'] },
+          { field: 'sponsorEmail', localPart: 'sponsors' },
+        ),
+      ).toBe('KCD <sponsors@2026.kcd.dev>')
+    })
+
+    it('uses the neutral env fallback (never a brand) when nothing resolves', () => {
+      process.env.EMAIL_FALLBACK_FROM = 'Platform <noreply@platform.test>'
+      const warn = vi.spyOn(console, 'warn')
+      const result = resolveConferenceFrom({ title: 'Orphan Conf' })
+      expect(result).toBe('Platform <noreply@platform.test>')
+      expect(warn).toHaveBeenCalled()
+    })
+
+    it('never returns a hardcoded brand address', () => {
+      const result = resolveConferenceFrom({ title: 'Orphan Conf' })
+      expect(result.toLowerCase()).not.toContain('cloudnativeday')
+      expect(result.toLowerCase()).not.toContain('cloudnativebergen')
+    })
+  })
+
+  describe('resolveConferenceContact', () => {
+    it('prefers contactEmail', () => {
+      expect(resolveConferenceContact({ contactEmail: 'hello@kcd.dev' })).toBe(
+        'hello@kcd.dev',
+      )
+    })
+
+    it('derives contact@domain when contactEmail is absent', () => {
+      expect(resolveConferenceContact({ domains: ['2026.kcd.dev'] })).toBe(
+        'contact@2026.kcd.dev',
+      )
+    })
+
+    it('falls back to the neutral platform contact (no brand)', () => {
+      const result = resolveConferenceContact({ title: 'Orphan Conf' })
+      expect(result).toBe(platformFallbackContact())
+      expect(result.toLowerCase()).not.toContain('cloudnative')
+    })
+  })
+
+  describe('platform fallback', () => {
+    it('reads EMAIL_FALLBACK_FROM and extracts the bare address', () => {
+      process.env.EMAIL_FALLBACK_FROM = 'Platform <noreply@platform.test>'
+      expect(platformFallbackFrom()).toBe('Platform <noreply@platform.test>')
+      expect(platformFallbackContact()).toBe('noreply@platform.test')
+    })
+
+    it('uses a brand-free default when the env var is unset', () => {
+      expect(platformFallbackFrom().toLowerCase()).not.toContain('cloudnative')
+    })
+  })
+})

--- a/src/lib/email/from.ts
+++ b/src/lib/email/from.ts
@@ -1,0 +1,108 @@
+import type { Conference } from '@/lib/conference/types'
+
+/**
+ * Non-branded sender/contact resolution for conference emails (CaaS #625).
+ *
+ * The rule: prefer the conference's own field, then derive from its primary
+ * domain, and ONLY as a last resort use a NEUTRAL platform default read from
+ * the environment — never another org's hardcoded brand address. The last
+ * resort is a genuine misconfiguration (a conference with neither an email
+ * field nor a domain), so it is logged loudly rather than silently papered
+ * over.
+ *
+ * `EMAIL_FALLBACK_FROM` (optional) supplies that neutral default as a full
+ * `"Name <address>"` header. When unset a deliberately non-deliverable,
+ * brand-free placeholder is used so a broken config surfaces instead of
+ * masquerading as a real conference.
+ */
+
+const NEUTRAL_FALLBACK_FROM = 'Conference <noreply@localhost>'
+
+/** The neutral, env-driven platform sender (`"Name <address>"`). */
+export function platformFallbackFrom(): string {
+  return process.env.EMAIL_FALLBACK_FROM || NEUTRAL_FALLBACK_FROM
+}
+
+/** Extract the bare `address` from a `"Name <address>"` (or plain) string. */
+function bareAddress(from: string): string {
+  const match = from.match(/<([^>]+)>/)
+  return match ? match[1].trim() : from.trim()
+}
+
+/** The bare address of the neutral platform sender. */
+export function platformFallbackContact(): string {
+  return bareAddress(platformFallbackFrom())
+}
+
+type EmailField = 'contactEmail' | 'sponsorEmail' | 'cfpEmail'
+
+/**
+ * Structurally-typed, null-tolerant view of a conference. Sanity projections
+ * surface these fields as `string | null`, so every field is optional AND
+ * nullable here — callers pass whatever conference-shaped object they hold.
+ */
+type ConferenceFields = keyof Pick<
+  Conference,
+  'title' | 'organizer' | 'contactEmail' | 'sponsorEmail' | 'cfpEmail'
+>
+
+type ConferenceLike =
+  | (Partial<Record<ConferenceFields, string | null | undefined>> & {
+      domains?: string[] | null
+    })
+  | null
+  | undefined
+
+/**
+ * Resolve a `"Name <address>"` From header for a conference email.
+ *
+ * Preference order: the explicit `field` → `<localPart>@<primary-domain>` →
+ * the neutral, logged platform fallback.
+ */
+export function resolveConferenceFrom(
+  conference: ConferenceLike,
+  {
+    field = 'contactEmail',
+    localPart = 'contact',
+  }: { field?: EmailField; localPart?: string } = {},
+): string {
+  const organizer = conference?.organizer?.trim()
+  const explicit = conference?.[field]?.trim()
+  const domain = conference?.domains?.[0]?.trim()
+
+  if (explicit) {
+    return organizer ? `${organizer} <${explicit}>` : explicit
+  }
+  if (domain) {
+    const address = `${localPart}@${domain}`
+    return organizer ? `${organizer} <${address}>` : address
+  }
+
+  console.warn(
+    `[email] conference "${conference?.title ?? 'unknown'}" has no ${field} or domain; ` +
+      'using the neutral platform fallback sender',
+  )
+  const fallback = platformFallbackFrom()
+  return organizer ? `${organizer} <${bareAddress(fallback)}>` : fallback
+}
+
+/**
+ * Resolve a bare contact address for a conference (for `mailto:` links,
+ * "contact us at …" copy, badge issuer profiles, etc.).
+ *
+ * Preference order: `contactEmail` → `contact@<primary-domain>` → the neutral,
+ * logged platform fallback.
+ */
+export function resolveConferenceContact(conference: ConferenceLike): string {
+  const explicit = conference?.contactEmail?.trim()
+  if (explicit) return explicit
+
+  const domain = conference?.domains?.[0]?.trim()
+  if (domain) return `contact@${domain}`
+
+  console.warn(
+    `[email] conference "${conference?.title ?? 'unknown'}" has no contactEmail or domain; ` +
+      'using the neutral platform fallback contact',
+  )
+  return platformFallbackContact()
+}

--- a/src/lib/email/from.ts
+++ b/src/lib/email/from.ts
@@ -66,12 +66,19 @@ export function resolveConferenceFrom(
     localPart = 'contact',
   }: { field?: EmailField; localPart?: string } = {},
 ): string {
-  const organizer = conference?.organizer?.trim()
+  // Header-injection hardening: the display name and address are interpolated
+  // into a "Name <address>" From header — strip CR/LF and angle brackets so a
+  // stored value can never smuggle extra headers or nest brackets.
+  const sanitizeHeaderText = (v: string) => v.replace(/[\r\n<>]/g, '').trim()
+  const organizer = conference?.organizer
+    ? sanitizeHeaderText(conference.organizer)
+    : undefined
   const explicit = conference?.[field]?.trim()
   const domain = conference?.domains?.[0]?.trim()
 
   if (explicit) {
-    return organizer ? `${organizer} <${explicit}>` : explicit
+    const safeExplicit = sanitizeHeaderText(explicit)
+    return organizer ? `${organizer} <${safeExplicit}>` : safeExplicit
   }
   if (domain) {
     const address = `${localPart}@${domain}`

--- a/src/lib/email/gallery.ts
+++ b/src/lib/email/gallery.ts
@@ -100,15 +100,12 @@ export async function sendGalleryTagEmail(
     const galleryUrl = buildGalleryImageUrl(domain, image._id)
     const dashboardUrl = `${eventUrl}/cfp/list`
 
-    // Use conference social links if available, otherwise fall back to defaults
-    const defaultSocialLinks = [
-      'https://twitter.com/cloudnativebergen',
-      'https://www.linkedin.com/company/cloudnativebergen',
-    ]
+    // Use the conference's own social links; omit rather than fall back to
+    // another org's hardcoded handles.
     const socialLinks =
       conference.socialLinks && conference.socialLinks.length > 0
         ? conference.socialLinks
-        : defaultSocialLinks
+        : []
 
     const emailHtml = await render(
       React.createElement(GallerySpeakerTaggedTemplate, {

--- a/src/lib/email/volunteer.ts
+++ b/src/lib/email/volunteer.ts
@@ -54,12 +54,14 @@ export async function sendVolunteerApprovalEmail(
     const eventDate = conference.startDate
       ? formatConferenceDateLong(conference.startDate)
       : 'TBD'
-    const eventUrl = `https://${conference.domains?.[0] || 'cloudnativebergen.no'}`
+    const eventUrl = conference.domains?.[0]
+      ? `https://${conference.domains[0]}`
+      : ''
     const socialLinks = conference.socialLinks?.map((link) => link.url) || []
 
     const result = await retryWithBackoff(async () => {
       const response = await resend.emails.send({
-        from: `${conference.organizer || 'Cloud Native Days'} <${fromEmail}>`,
+        from: `${conference.organizer || conference.title} <${fromEmail}>`,
         to: volunteer.email!,
         subject,
         react: VolunteerApprovalTemplate({

--- a/src/lib/email/workshop.ts
+++ b/src/lib/email/workshop.ts
@@ -174,7 +174,7 @@ export async function sendWorkshopSignupInstructions({
 
                     <p style="margin: 0 0 8px 0; font-size: 16px; font-weight: 600; color: #334155;">How to register for workshops:</p>
                     <ol style="margin: 0 0 24px 0; padding-left: 24px;">
-                      <li style="margin: 0 0 8px 0; font-size: 16px; line-height: 24px; color: #334155;">Visit the workshop signup page: <a href="${workshopUrl}" style="color: #1D4ED8; text-decoration: none;">${workshopUrl}</a></li>
+                      ${workshopUrl ? `<li style="margin: 0 0 8px 0; font-size: 16px; line-height: 24px; color: #334155;">Visit the workshop signup page: <a href="${workshopUrl}" style="color: #1D4ED8; text-decoration: none;">${workshopUrl}</a></li>` : ''}
                       <li style="margin: 0 0 8px 0; font-size: 16px; line-height: 24px; color: #334155;">Sign in with the email address associated with your ticket: <strong>${userEmail}</strong></li>
                       <li style="margin: 0 0 8px 0; font-size: 16px; line-height: 24px; color: #334155;">Browse available workshops and select the ones you&apos;d like to attend</li>
                       <li style="margin: 0 0 8px 0; font-size: 16px; line-height: 24px; color: #334155;">Complete your registration</li>
@@ -187,7 +187,7 @@ export async function sendWorkshopSignupInstructions({
                     <table width="100%" cellpadding="0" cellspacing="0" style="margin: 32px 0;">
                       <tr>
                         <td align="center">
-                          <a href="${workshopUrl}" style="display: inline-block; background-color: #1D4ED8; color: #FFFFFF; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 6px;">Sign Up for Workshops</a>
+                          ${workshopUrl ? `<a href="${workshopUrl}" style="display: inline-block; background-color: #1D4ED8; color: #FFFFFF; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 6px;">Sign Up for Workshops</a>` : ''}
                         </td>
                       </tr>
                     </table>

--- a/src/lib/email/workshop.ts
+++ b/src/lib/email/workshop.ts
@@ -5,6 +5,7 @@ import {
   type EmailResult,
 } from './config'
 import type { Conference } from '@/lib/conference/types'
+import { resolveConferenceFrom, resolveConferenceContact } from './from'
 
 export interface WorkshopConfirmationEmailRequest {
   userEmail: string
@@ -35,14 +36,9 @@ export async function sendBasicWorkshopConfirmation({
   EmailResult<{ emailId: string }>
 > {
   try {
-    const fromEmail = conference?.contactEmail
-      ? `${conference.organizer} <${conference.contactEmail}>`
-      : conference?.domains?.[0]
-        ? `${conference.organizer} <contact@${conference.domains[0]}>`
-        : 'Cloud Native Days <contact@cloudnativedays.org>'
+    const fromEmail = resolveConferenceFrom(conference)
 
-    const contactEmail =
-      conference?.contactEmail || 'contact@cloudnativedays.org'
+    const contactEmail = resolveConferenceContact(conference)
 
     const subject = `Workshop Confirmation: ${workshopTitle}`
 
@@ -145,18 +141,13 @@ export async function sendWorkshopSignupInstructions({
   EmailResult<{ emailId: string }>
 > {
   try {
-    const fromEmail = conference.contactEmail
-      ? `${conference.organizer} <${conference.contactEmail}>`
-      : conference.domains?.[0]
-        ? `${conference.organizer} <contact@${conference.domains[0]}>`
-        : 'Cloud Native Days <contact@cloudnativedays.org>'
+    const fromEmail = resolveConferenceFrom(conference)
 
-    const contactEmail =
-      conference.contactEmail || 'contact@cloudnativedays.org'
+    const contactEmail = resolveConferenceContact(conference)
 
     const workshopUrl = conference.domains?.[0]
       ? `https://${conference.domains[0]}/workshop`
-      : 'https://cloudnativedays.org/workshop'
+      : ''
 
     const subject = `Workshop Signup Available - ${conference.title}`
 
@@ -295,14 +286,9 @@ export async function sendWorkshopAnnouncementEmail({
   EmailResult<{ emailId: string }>
 > {
   try {
-    const fromEmail = conference?.contactEmail
-      ? `${conference.organizer} <${conference.contactEmail}>`
-      : conference?.domains?.[0]
-        ? `${conference.organizer} <contact@${conference.domains[0]}>`
-        : 'Cloud Native Days <contact@cloudnativedays.org>'
+    const fromEmail = resolveConferenceFrom(conference)
 
-    const contactEmail =
-      conference?.contactEmail || 'contact@cloudnativedays.org'
+    const contactEmail = resolveConferenceContact(conference)
 
     const subject = `Workshop Update: ${workshopTitle}`
     const safeBody = escapeHtml(body).replace(/\r?\n/g, '<br>')

--- a/src/lib/push/vapid.test.ts
+++ b/src/lib/push/vapid.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const setVapidDetailsMock = vi.fn()
+
+vi.mock('web-push', () => ({
+  default: {
+    setVapidDetails: (...args: unknown[]) => setVapidDetailsMock(...args),
+  },
+}))
+
+// A valid pair so isPushConfigured() is true and the subject branch is reached.
+const VALID_KEY = 'x'.repeat(87)
+
+function loadFresh() {
+  // The module memoizes config state at module scope; reset between cases.
+  vi.resetModules()
+  return import('./vapid')
+}
+
+describe('VAPID subject de-hardcoding (CaaS #625)', () => {
+  const OLD = {
+    subject: process.env.VAPID_SUBJECT,
+    pub: process.env.VAPID_PUBLIC_KEY,
+    priv: process.env.VAPID_PRIVATE_KEY,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    process.env.VAPID_PUBLIC_KEY = VALID_KEY
+    process.env.VAPID_PRIVATE_KEY = VALID_KEY
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    for (const [k, v] of [
+      ['VAPID_SUBJECT', OLD.subject],
+      ['VAPID_PUBLIC_KEY', OLD.pub],
+      ['VAPID_PRIVATE_KEY', OLD.priv],
+    ] as const) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  it('configures web-push with the env subject when set', async () => {
+    process.env.VAPID_SUBJECT = 'mailto:ops@example.test'
+    const { getConfiguredWebPush, getWebPushConfigError } = await loadFresh()
+
+    expect(getConfiguredWebPush()).not.toBeNull()
+    expect(setVapidDetailsMock).toHaveBeenCalledWith(
+      'mailto:ops@example.test',
+      VALID_KEY,
+      VALID_KEY,
+    )
+    expect(getWebPushConfigError()).toBeNull()
+  })
+
+  it('fails loudly (no branded fallback) when VAPID_SUBJECT is unset', async () => {
+    delete process.env.VAPID_SUBJECT
+    const { getConfiguredWebPush, getWebPushConfigError } = await loadFresh()
+
+    expect(getConfiguredWebPush()).toBeNull()
+    expect(setVapidDetailsMock).not.toHaveBeenCalled()
+    expect(getWebPushConfigError()).toMatch(/VAPID_SUBJECT is not set/)
+  })
+})

--- a/src/lib/push/vapid.ts
+++ b/src/lib/push/vapid.ts
@@ -29,9 +29,12 @@ function getVapidPrivateKey(): string {
 }
 
 function getVapidSubject(): string {
-  // A syntactically valid contact URL is required by the push spec. Fall back to
-  // a mailto so a misconfigured env fails loudly at send time, not at import.
-  return process.env.VAPID_SUBJECT ?? 'mailto:hei@cloudnativedays.no'
+  // A syntactically valid contact URL is required by the push spec. This is
+  // required config (it exists in prod as VAPID_SUBJECT) — there is NO branded
+  // fallback: an unset value is surfaced as a configuration error by
+  // getConfiguredWebPush() rather than silently sending under another org's
+  // contact address.
+  return process.env.VAPID_SUBJECT?.trim() ?? ''
 }
 
 /** True only when a full, usable VAPID key pair is configured. */
@@ -68,9 +71,16 @@ export function getConfiguredWebPush(): typeof webpush | null {
     return null
   }
   if (!configured) {
+    const subject = getVapidSubject()
+    if (!subject) {
+      configError =
+        'VAPID_SUBJECT is not set (a `mailto:` or `https:` contact URL is required)'
+      console.error('[push] VAPID configuration is invalid:', configError)
+      return null
+    }
     try {
       webpush.setVapidDetails(
-        getVapidSubject(),
+        subject,
         getVapidPublicKey(),
         getVapidPrivateKey(),
       )

--- a/src/lib/stream/config.test.ts
+++ b/src/lib/stream/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { deriveBlueskyHandle, STREAM_CONFIG } from './config'
+
+describe('deriveBlueskyHandle (CaaS #625)', () => {
+  it('extracts the handle from a bsky.app profile URL', () => {
+    expect(
+      deriveBlueskyHandle(['https://bsky.app/profile/kcd.bergen.dev']),
+    ).toBe('kcd.bergen.dev')
+  })
+
+  it('ignores non-Bluesky links and finds the Bluesky one', () => {
+    expect(
+      deriveBlueskyHandle([
+        'https://twitter.com/kcd',
+        'https://www.linkedin.com/company/kcd',
+        'https://bsky.app/profile/kcd.dev',
+      ]),
+    ).toBe('kcd.dev')
+  })
+
+  it('strips a leading @ and decodes URL-encoding', () => {
+    expect(deriveBlueskyHandle(['https://bsky.app/profile/@kcd.dev'])).toBe(
+      'kcd.dev',
+    )
+  })
+
+  it('returns null when there is no Bluesky link (feed is omitted)', () => {
+    expect(deriveBlueskyHandle(['https://twitter.com/kcd'])).toBeNull()
+    expect(deriveBlueskyHandle([])).toBeNull()
+    expect(deriveBlueskyHandle(undefined)).toBeNull()
+  })
+
+  it('no longer carries a hardcoded brand handle in the static config', () => {
+    expect('handle' in STREAM_CONFIG.blueskyFeed).toBe(false)
+  })
+})

--- a/src/lib/stream/config.ts
+++ b/src/lib/stream/config.ts
@@ -48,7 +48,22 @@ export function deriveBlueskyHandle(
 
     const profileMatch = link.match(/bsky\.app\/profile\/([^/?#]+)/i)
     if (profileMatch) {
-      return decodeURIComponent(profileMatch[1]).replace(/^@/, '')
+      // decodeURIComponent throws on malformed %-escapes in user-entered
+      // links — treat an undecodable segment as "no handle" rather than
+      // crashing the render.
+      try {
+        return decodeURIComponent(profileMatch[1]).replace(/^@/, '')
+      } catch {
+        continue
+      }
+    }
+
+    // Bare handle entry ("@handle.bsky.social" or "handle.tld"): accept a
+    // non-URL entry that looks like a Bluesky handle (has a dot, no scheme,
+    // no slashes) — matches the doc contract above.
+    if (!link.includes('://') && !link.includes('/')) {
+      const bare = link.replace(/^@/, '')
+      if (/^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$/i.test(bare)) return bare
     }
   }
 

--- a/src/lib/stream/config.ts
+++ b/src/lib/stream/config.ts
@@ -8,7 +8,10 @@ export const STREAM_CONFIG = {
   },
 
   blueskyFeed: {
-    handle: 'cloudnativedays.no',
+    // NOTE: no hardcoded `handle` — it is derived per conference from
+    // `socialLinks` at render time (see `deriveBlueskyHandle`). When a
+    // conference has no Bluesky link the feed is omitted rather than defaulting
+    // to another org's account.
     compact: true,
     title: 'Social Stream',
     speed: 180,
@@ -25,3 +28,29 @@ export const STREAM_CONFIG = {
     contentSpacing: 'space-y-8',
   },
 } as const
+
+/**
+ * Derive the conference's Bluesky handle from its `socialLinks`.
+ *
+ * Accepts a `https://bsky.app/profile/<handle>` URL (or a bare `@handle` /
+ * `handle` entry) and returns the bare handle. Returns `null` when no Bluesky
+ * link is present so callers can OMIT the social feed instead of falling back
+ * to a hardcoded brand account.
+ */
+export function deriveBlueskyHandle(
+  socialLinks: string[] | undefined | null,
+): string | null {
+  if (!socialLinks?.length) return null
+
+  for (const raw of socialLinks) {
+    const link = raw?.trim()
+    if (!link) continue
+
+    const profileMatch = link.match(/bsky\.app\/profile\/([^/?#]+)/i)
+    if (profileMatch) {
+      return decodeURIComponent(profileMatch[1]).replace(/^@/, '')
+    }
+  }
+
+  return null
+}

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -350,6 +350,20 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
         missing: 'conference.cfpEmail is unset',
       },
     ),
+    plainCheck(
+      {
+        id: 'email.platformFallback',
+        group: 'email',
+        label: 'EMAIL_FALLBACK_FROM',
+      },
+      process.env.EMAIL_FALLBACK_FROM,
+      'warn',
+      {
+        present: 'Last-resort sender when a conference has no email config',
+        missing:
+          'Unset — a conference without email config would send from a placeholder address',
+      },
+    ),
   )
 
   // ---- SLACK ----------------------------------------------------------------

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -430,7 +430,7 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
   checks.push(
     plainCheck(
       { id: 'push.vapidSubject', group: 'push', label: 'VAPID_SUBJECT' },
-      process.env.VAPID_SUBJECT ?? 'mailto:hei@cloudnativedays.no',
+      process.env.VAPID_SUBJECT ?? 'not set',
       'warn',
     ),
   )

--- a/src/lib/workshop/eligibility.ts
+++ b/src/lib/workshop/eligibility.ts
@@ -1,5 +1,6 @@
 import { fetchEventTickets } from '@/lib/tickets/api'
 import type { EventTicket } from '@/lib/tickets/types'
+import { platformFallbackContact } from '@/lib/email/from'
 
 const WORKSHOP_ELIGIBLE_CATEGORIES = [
   'Workshop + Conference (2 days)',
@@ -20,7 +21,7 @@ export async function checkWorkshopEligibility(params: {
   eventId: number
   contactEmail?: string
 }): Promise<WorkshopEligibilityResult> {
-  const contactEmail = params.contactEmail || 'contact@cloudnativedays.no'
+  const contactEmail = params.contactEmail || platformFallbackContact()
 
   try {
     const tickets = await fetchEventTickets(params.customerId, params.eventId)

--- a/src/server/routers/registration.ts
+++ b/src/server/routers/registration.ts
@@ -25,6 +25,7 @@ import { clientWrite } from '@/lib/sanity/client'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { notifySponsorRegistrationComplete } from '@/lib/slack/notify'
 import { sanitizeSvgFieldOrThrow, SvgSanitizeError } from '@/lib/svg/upload'
+import { resolveConferenceFrom } from '@/lib/email/from'
 
 export const registrationRouter = router({
   validate: publicProcedure
@@ -266,13 +267,14 @@ export const registrationRouter = router({
         socialLinks: sfc.conference.socialLinks || [],
       })
 
-      const fromEmail =
-        sfc.conference.sponsorEmail || 'sponsors@cloudnativeday.no'
-      const fromName = sfc.conference.organizer || 'Cloud Native Days'
+      const from = resolveConferenceFrom(sfc.conference, {
+        field: 'sponsorEmail',
+        localPart: 'sponsors',
+      })
 
       const result = await retryWithBackoff(async () => {
         return resend.emails.send({
-          from: `${fromName} <${fromEmail}>`,
+          from,
           to: recipients,
           subject: `Sponsor Registration — ${sfc.conference!.title}`,
           react: emailElement,

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -134,6 +134,7 @@ import {
   type SigningProviderType,
 } from '@/lib/contract-signing'
 import { resend, retryWithBackoff } from '@/lib/email/config'
+import { resolveConferenceFrom } from '@/lib/email/from'
 import { sendBroadcastEmail } from '@/lib/email/broadcast'
 import { sendIndividualEmail } from '@/lib/email/broadcast'
 import { syncSponsorAudience, type Contact } from '@/lib/email/audience'
@@ -2199,13 +2200,14 @@ export const sponsorRouter = router({
             if (!result) {
               console.error(`${logCtxFull} Contract email template not found`)
             } else {
-              const fromEmail =
-                sfc.conference.sponsorEmail || 'sponsors@cloudnativeday.no'
-              const fromName = sfc.conference.organizer || 'Cloud Native Days'
+              const from = resolveConferenceFrom(sfc.conference, {
+                field: 'sponsorEmail',
+                localPart: 'sponsors',
+              })
 
               await retryWithBackoff(async () => {
                 return resend.emails.send({
-                  from: `${fromName} <${fromEmail}>`,
+                  from,
                   to: [input.signerEmail!],
                   subject: result.subject,
                   react: result.react,


### PR DESCRIPTION
Closes the closable part of #625 (CaaS T2-13). Per-tenant VAPID keys are **deferred** (needs the secrets store) — out of scope here.

## Part 1 — de-hardcode load-bearing brand fallbacks

Each site now prefers the conference field; where a field is missing the behavior is EXPLICIT (log + neutral platform default, or omit) — never silently another org's brand.

| Site | Before | After |
| --- | --- | --- |
| `lib/push/vapid.ts` | `VAPID_SUBJECT ?? 'mailto:hei@cloudnativedays.no'` | require `VAPID_SUBJECT`; surface a config error when unset (no send). Mirrored in `system-status/checks.ts` display (`'not set'`). |
| `lib/stream/config.ts` + stream page | static `handle: 'cloudnativedays.no'` | `deriveBlueskyHandle(conference.socialLinks)`; feed omitted when absent |
| `components/Header.tsx` | `?? 'cloudnativedays.no'` + hardcoded `.cloudnativebergen.dev`/`.cloudnativedays.no` edition link | previous-edition link derived from this conference's own `domains` (`<year-1>.<host>`); omitted when underivable |
| `components/cfp/CompactConferenceHeader.tsx` | `|| 'cloudnativedays.no'` | `conference.domains?.[0]`; "View" link omitted when absent |
| `lib/email/badge.ts`, `lib/email/workshop.ts` (x3), `server/routers/sponsor.ts`, `server/routers/registration.ts` | `… : 'Cloud Native Days <contact@cloudnativedays.org>'` / `'sponsors@cloudnativeday.no'` | new `resolveConferenceFrom()` (field → `<localPart>@<domain>` → logged neutral `EMAIL_FALLBACK_FROM`) |
| `lib/workshop/eligibility.ts`, `privacy/page.tsx`, `terms/page.tsx`, `workshop/page.tsx`, `api/badge/issuer/route.ts`, `lib/badge/config.ts` | `|| 'contact@cloudnativedays.no'` | new `resolveConferenceContact()` (contactEmail → `contact@<domain>` → logged neutral) |
| `lib/email/volunteer.ts` | `eventUrl … || 'cloudnativebergen.no'`; organizer `|| 'Cloud Native Days'` | eventUrl omitted when no domain; organizer name → `conference.title` |
| `api/cron/contract-reminders/route.ts` | `'sponsors@cloudnativeday.no'` / `'Cloud Native Days'` / `'Cloud Native Day'` | neutral platform contact + `conferenceName`-derived names |
| `lib/email/contract-email.ts` | `EVENT_URL || 'https://cloudnativeday.no'` | `EVENT_URL || ''` |
| `components/SponsorThankYou.tsx` | relative CTA prefixed with `https://cloudnativedays.no` | new `baseUrl` prop (conference origin) → `NEXT_PUBLIC_BASE_URL` |
| `lib/email/gallery.ts` | default social links → `twitter.com/cloudnativebergen` etc. | omit (use only conference's own `socialLinks`) |

New helper: `src/lib/email/from.ts` (`resolveConferenceFrom` / `resolveConferenceContact` / `platformFallbackFrom` / `platformFallbackContact`), env `EMAIL_FALLBACK_FROM`.

### Straggler classification (`grep -rn 'cloudnativeday\|cloudnativebergen' src`, minus tests)

**Load-bearing → fixed:** all rows above.

**Cosmetic / left as-is:**
- `*.stories.tsx`, `__mocks__/sponsor-data.ts`, `__matrix__/fixtures.ts` — test/story fixtures.
- OpenBadges error-message doc links to `github.com/cloudnativebergen/website/blob/main/docs/…` in `api/badge/.well-known/jwks.json/route.ts`, `api/badge/keys/[keyId]/route.ts`, `lib/openbadges/crypto.ts`, `lib/badge/config.ts` — real repo doc URLs, not tenant brand.
- JSDoc `@example` comments in `lib/badge/config.ts`, `lib/seo/eventJsonLd.ts`.
- `components/admin/EditConferenceCard.tsx` form-hint text ("e.g. cloudnativebergen.no").
- `scripts/gen-vapid-keys.ts` example output (dev helper, not scoped by the sweep).

## Part 2 — per-host PWA manifest

`src/app/manifest.ts` is now dynamic: reads `headers()` host → `getConferenceForDomain(host)` and emits `name` = conference title, `short_name` = word-boundary truncation of the title (no schema field added), `description` = conference description. Falls back to the existing platform values (`Cloud Native Days` / `CND`) when no conference resolves (e.g. localhost) or resolution throws — installs never break. `id`/`scope`/`start_url`/`theme_color` stay host-invariant (theme_color stays platform-blue until the design-token wave). Icons remain per-host via `/pwa/icon/*`.

**Caching:** identity resolution is memoized per host via a `'use cache'` helper keyed on the host arg and tagged `content:conferences` + `domain:<host>`, mirroring the `/pwa/icon` route; `manifest()` itself is a thin dynamic wrapper that only reads the host.

## QA
- `mise run check` green (typecheck, lint, knip, format).
- Full vitest suite green: **3919 passed** (286 files). New tests: `manifest.test.ts` (per-host names, unresolvable → platform fallback, host-invariant fields), `email/from.test.ts`, `push/vapid.test.ts` (subject required, no branded fallback), `stream/config.test.ts` (`deriveBlueskyHandle`).
- Build compiles + typechecks; fails only at page-data collection on `RESEND_API_KEY is not set` — the documented acceptable keychain/secret failure on this machine, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)