### PR TITLE
feat(authz): org-scoped organizer authorization with legacy bridge (CaaS T1-2, #614)

### DIFF
--- a/__tests__/api/trpc/authz-org-scoped.test.ts
+++ b/__tests__/api/trpc/authz-org-scoped.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment node
+ *
+ * The org-scoped authorization WAIST (CaaS T1-2, #614). Exercises the real
+ * `adminProcedure` middleware (`requireAdmin` in src/server/trpc.ts) end to end:
+ * the request org comes from the domain conference, and access requires the
+ * caller's `organizerOrgIds` to include it. Proves the cross-org 403, the fail-
+ * closed (resolvable org, non-member) path, and the legacy bridge (org
+ * unresolvable → deprecated global `isOrganizer`, with a warn).
+ *
+ * `getConferenceForCurrentDomain` is mocked to control the request's org; callers
+ * are built with explicit session shapes so `organizerOrgIds` can be varied.
+ */
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/events/registry', () => ({}))
+
+const h = vi.hoisted(() => ({ getConference: vi.fn() }))
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: h.getConference,
+}))
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { initTRPC } from '@trpc/server'
+import type { Context } from '@/server/trpc'
+import { appRouter } from '@/server/_app'
+
+const t = initTRPC.context<Context>().create()
+const createCaller = t.createCallerFactory(appRouter)
+
+function callerFor(speaker: {
+  _id: string
+  isOrganizer?: boolean
+  organizerOrgIds?: string[]
+}) {
+  const user = { email: 'org@example.com', name: 'Org', picture: '' }
+  return createCaller({
+    req: {
+      headers: new Headers(),
+      url: 'http://localhost:3000',
+    } as unknown as Context['req'],
+    session: {
+      expires: new Date(Date.now() + 86_400_000).toISOString(),
+      user,
+      speaker,
+    } as unknown as Context['session'],
+    speaker: speaker as unknown as Context['speaker'],
+    user,
+    workosUser: null,
+    ipAddress: '127.0.0.1',
+  })
+}
+
+function resolveOrg(orgId: string | null) {
+  h.getConference.mockResolvedValue({
+    conference: orgId
+      ? { _id: 'conf-1', organization: { _ref: orgId } }
+      : { _id: 'conf-1' },
+    domain: 'localhost',
+    error: null,
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+// `speaker.admin.list` is an adminProcedure — the FIRST thing it hits is the
+// org-scoped `requireAdmin` waist. A rejection with FORBIDDEN means the waist
+// denied; any OTHER outcome (resolves, or throws a non-FORBIDDEN code from the
+// endpoint body) means the waist ALLOWED the call through.
+async function wasAllowed(
+  caller: ReturnType<typeof callerFor>,
+): Promise<boolean> {
+  try {
+    await caller.speaker.admin.list()
+    return true
+  } catch (err) {
+    return (err as { code?: string }).code !== 'FORBIDDEN'
+  }
+}
+
+describe('adminProcedure waist — org-scoped organizer authorization', () => {
+  it('ALLOWS an organizer of the request org', async () => {
+    resolveOrg('org-A')
+    const allowed = await wasAllowed(
+      callerFor({ _id: 'sp-1', organizerOrgIds: ['org-A'] }),
+    )
+    expect(allowed).toBe(true)
+  })
+
+  it('DENIES an organizer of ANOTHER org (cross-org 403)', async () => {
+    resolveOrg('org-A')
+    await expect(
+      callerFor({
+        _id: 'sp-2',
+        isOrganizer: true,
+        organizerOrgIds: ['org-B'],
+      }).speaker.admin.list(),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+
+  it('FAILS CLOSED for a resolvable org when the caller is not a member', async () => {
+    resolveOrg('org-A')
+    // Globally flagged organizer, but NOT a member of the resolved org.
+    await expect(
+      callerFor({
+        _id: 'sp-3',
+        isOrganizer: true,
+        organizerOrgIds: [],
+      }).speaker.admin.list(),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+
+  describe('legacy bridge — org unresolvable', () => {
+    it('ALLOWS via the deprecated global isOrganizer and warns', async () => {
+      resolveOrg(null) // conference has no organization (pre-backfill)
+      const caller = callerFor({
+        _id: 'sp-4',
+        isOrganizer: true,
+        organizerOrgIds: [],
+      })
+      expect(await wasAllowed(caller)).toBe(true)
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[authz-bridge]'),
+      )
+    })
+
+    it('DENIES a non-organizer even when the org is unresolvable', async () => {
+      resolveOrg(null)
+      await expect(
+        callerFor({
+          _id: 'sp-5',
+          isOrganizer: false,
+          organizerOrgIds: [],
+        }).speaker.admin.list(),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    })
+
+    it('bridges when domain resolution THROWS (fail-closed to bridge, not error)', async () => {
+      h.getConference.mockRejectedValue(new Error('no domain'))
+      const caller = callerFor({
+        _id: 'sp-6',
+        isOrganizer: true,
+        organizerOrgIds: [],
+      })
+      expect(await wasAllowed(caller)).toBe(true)
+    })
+  })
+})

--- a/__tests__/lib/auth/impersonation.test.ts
+++ b/__tests__/lib/auth/impersonation.test.ts
@@ -23,6 +23,16 @@ const h = vi.hoisted(() => ({
   env: { isTestMode: false, isDevelopment: true, isProduction: false },
   mockAuth: vi.fn(),
   mockGetSpeaker: vi.fn(),
+  // The current-domain org resolver, consumed by the org-scoped impersonation
+  // gate (CaaS T1-2, #614) via `@/lib/authz/organizer`. Defaults per-test.
+  mockResolveOrg: vi.fn<() => Promise<string | null>>(),
+}))
+
+// The impersonation gate is now ORG-SCOPED: the real admin must be an organizer
+// of the CURRENT domain's org. `isOrganizerForCurrentOrg` resolves that org via
+// this module, so control it here.
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: h.mockResolveOrg,
 }))
 
 // Control what `_auth()` resolves to (the browser cookie session).
@@ -62,6 +72,8 @@ import { getAuthSession } from '@/lib/auth'
 const ADMIN_ID = 'org-admin-1'
 const TARGET_SPEAKER_ID = 'speaker-2'
 const OTHER_ORGANIZER_ID = 'org-admin-2'
+const CURRENT_ORG_ID = 'org-current'
+const OTHER_ORG_ID = 'org-other'
 
 function organizerSession(): Session {
   return {
@@ -76,6 +88,9 @@ function organizerSession(): Session {
       _id: ADMIN_ID,
       email: 'admin@cloudnativedays.no',
       isOrganizer: true,
+      // Organizer of the current org (CURRENT_ORG_ID) — the org-scoped gate keys
+      // on this, not on the deprecated global flag.
+      organizerOrgIds: [CURRENT_ORG_ID],
     },
     account: { provider: 'github', providerAccountId: '1', type: 'oauth' },
   } as unknown as Session
@@ -83,8 +98,10 @@ function organizerSession(): Session {
 
 function nonOrganizerSession(): Session {
   const s = organizerSession()
-  ;(s.speaker as { _id: string; isOrganizer: boolean })._id = TARGET_SPEAKER_ID
+  ;(s.speaker as { _id: string })._id = TARGET_SPEAKER_ID
   ;(s.speaker as { isOrganizer: boolean }).isOrganizer = false
+  // Not an organizer of ANY org — clear the inherited org membership.
+  ;(s.speaker as { organizerOrgIds: string[] }).organizerOrgIds = []
   return s
 }
 
@@ -101,6 +118,9 @@ beforeEach(() => {
   h.env.isTestMode = false
   h.env.isDevelopment = true
   h.env.isProduction = false
+  // The current domain resolves to CURRENT_ORG_ID by default; the organizer
+  // session is an organizer of exactly that org, so the gate passes.
+  h.mockResolveOrg.mockResolvedValue(CURRENT_ORG_ID)
   // Silence audit/security console output the code emits.
   vi.spyOn(console, 'log').mockImplementation(() => {})
   vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -151,6 +171,23 @@ describe('getAuthSession impersonation — dev/organizer gating', () => {
 
     expect(result?.isImpersonating).toBeUndefined()
     expect(result?.speaker?._id).toBe(TARGET_SPEAKER_ID)
+    expect(h.mockGetSpeaker).not.toHaveBeenCalled()
+  })
+
+  it('ORG-SCOPED: an organizer of ANOTHER org cannot impersonate on this domain', async () => {
+    // Admin organizes org-other, but the current domain resolves to org-current.
+    const session = organizerSession()
+    ;(
+      session.speaker as { organizerOrgIds: string[]; isOrganizer: boolean }
+    ).organizerOrgIds = [OTHER_ORG_ID]
+    h.mockAuth.mockResolvedValue(session)
+    h.mockResolveOrg.mockResolvedValue(CURRENT_ORG_ID)
+
+    const result = await getAuthSession(reqWithImpersonate(TARGET_SPEAKER_ID))
+
+    // Gate denied → session unchanged, no speaker lookup, no impersonation.
+    expect(result?.isImpersonating).toBeUndefined()
+    expect(result?.speaker?._id).toBe(ADMIN_ID)
     expect(h.mockGetSpeaker).not.toHaveBeenCalled()
   })
 

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -35,6 +35,14 @@ vi.mock('@/lib/push/send', () => ({
   sendPushForNotifications: vi.fn(async () => {}),
 }))
 
+// getOrganizerSpeakerIds resolves the CURRENT org (CaaS T1-2, #614) when called
+// without an explicit id. Control that resolver; the default (null) keeps the
+// pre-existing GLOBAL-set assertions valid via the legacy bridge.
+const resolveOrgMock = vi.fn<() => Promise<string | null>>()
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: resolveOrgMock,
+}))
+
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import { sendPushForNotifications } from '@/lib/push/send'
 import {
@@ -92,7 +100,11 @@ beforeEach(() => {
   // The organizer id set is cached in module scope; clear it so cache-sensitive
   // tests (and the fresh-fetch assumptions of others) don't leak across tests.
   clearOrganizerSpeakerIdsCache()
+  // Default: current org unresolvable → GLOBAL set (legacy bridge). Individual
+  // org-scoping tests override this.
+  resolveOrgMock.mockResolvedValue(null)
   vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
 })
 
 afterEach(() => {
@@ -935,8 +947,61 @@ describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () 
     // Cached: only one underlying read despite two calls.
     expect(readMock.fetch).toHaveBeenCalledTimes(1)
     const [query] = readMock.fetch.mock.calls[0]
+    // Org unresolvable (default) → the GLOBAL organizer query (legacy bridge).
     expect(query).toContain('_id in *[_type == "conference"].organizers[]._ref')
     expect(query).toContain('[0...200]')
+  })
+
+  it('ORG-SCOPED: scopes the query to the resolved current org and passes $orgId', async () => {
+    resolveOrgMock.mockResolvedValue('org-A')
+    readMock.fetch.mockResolvedValue(['org-1'])
+
+    const ids = await getOrganizerSpeakerIds()
+
+    expect(ids).toEqual(['org-1'])
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain(
+      '_id in *[_type == "conference" && organization._ref == $orgId].organizers[]._ref',
+    )
+    expect(params).toEqual({ orgId: 'org-A' })
+  })
+
+  it('scopes to an EXPLICIT orgId argument without resolving the domain', async () => {
+    readMock.fetch.mockResolvedValue(['org-9'])
+
+    const ids = await getOrganizerSpeakerIds('org-Z')
+
+    expect(ids).toEqual(['org-9'])
+    // Explicit id → no domain resolution.
+    expect(resolveOrgMock).not.toHaveBeenCalled()
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('organization._ref == $orgId')
+    expect(params).toEqual({ orgId: 'org-Z' })
+  })
+
+  it('caches PER ORG — different orgs do not share a cache entry', async () => {
+    readMock.fetch.mockResolvedValueOnce(['a']).mockResolvedValueOnce(['b'])
+
+    const a = await getOrganizerSpeakerIds('org-A')
+    const b = await getOrganizerSpeakerIds('org-B')
+    const aAgain = await getOrganizerSpeakerIds('org-A')
+
+    expect(a).toEqual(['a'])
+    expect(b).toEqual(['b'])
+    expect(aAgain).toEqual(['a']) // served from org-A's cache
+    // Two distinct orgs → two reads; the third call hit org-A's cache.
+    expect(readMock.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('LEGACY BRIDGE: warns and uses the GLOBAL set when the org is null', async () => {
+    resolveOrgMock.mockResolvedValue(null)
+    readMock.fetch.mockResolvedValue(['org-1'])
+
+    await getOrganizerSpeakerIds()
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[authz-bridge]'),
+    )
   })
 
   it('re-fetches after the cache is cleared', async () => {

--- a/docs/ORGANIZATION_TIER.md
+++ b/docs/ORGANIZATION_TIER.md
@@ -136,3 +136,41 @@ dry run before applying with `--no-dry-run --no-confirm`.
 - **Wave 3 (#616) — query scoping.** Application GROQ projections start
   filtering by `organization`, so a request only ever sees its own tenant's
   documents.
+
+## Org-scoped authorization (CaaS T1-2, #614)
+
+With the tenant key on every conference and speaker, **authorization** becomes
+org-scoped rather than a single global boolean.
+
+- **Before.** `isOrganizer` was one global flag: membership in **any**
+  conference's `organizers[]`, baked into the session token and checked by the
+  tRPC `requireAdmin` waist and ~13 handler/layout gates.
+- **Now.** A user is an organizer **of an organization** iff they are in the
+  `organizers[]` of any of **that org's** conferences — derivable, so no new
+  schema. Login computes `speaker.organizerOrgIds` (the deduped set of
+  `organization._ref`s of the conferences whose `organizers[]` contain the
+  speaker) and stores it in the token. The request's org comes from the
+  **domain-resolved conference** (`conference.organization._ref`), never from
+  client input, and access requires that org id to be in `organizerOrgIds`.
+
+The old `isOrganizer` boolean is **kept in the token, marked deprecated**, purely
+as a **legacy bridge**: the middleware and gates fall back to it (with a
+`console.warn('[authz-bridge] …')`) **only** when the request's org cannot be
+resolved (a pre-`044`-backfill conference, or an unknown domain). Because the
+`044` backfill has run, this bridge is rarely exercised in production; it exists
+so any residual org-less data or an old token cannot lock organizers out during
+rollout.
+
+**Removal condition** (shared with `src/lib/authz/organizer.ts` and
+`docs/TRPC_SERVER_ARCHITECTURE.md`): once every live conference has an
+`organization` and every issued token carries `organizerOrgIds`, delete the
+bridge so an unresolvable org **denies**, and drop the deprecated `isOrganizer`
+field and its remaining UI reads.
+
+Key modules: `src/lib/authz/organizer.ts` (the shared `isOrganizerForOrg` /
+`isOrganizerForCurrentOrg` helpers + bridge), `src/server/trpc.ts`
+(`requireAdmin` waist + `resolveOrganizationId`), `src/lib/speaker/sanity.ts`
+(`ORGANIZER_ORG_IDS_FIELD` projection). Recipient-selection helpers
+(`getOrganizerSpeakerIds`, `getOrganizers`) are **org-scoped too** — they select
+message recipients, not access, but must agree with this boundary so a cross-org
+organizer is neither notified about nor able to own another tenant's threads.

--- a/docs/TRPC_SERVER_ARCHITECTURE.md
+++ b/docs/TRPC_SERVER_ARCHITECTURE.md
@@ -283,13 +283,56 @@ publicProcedure
 // Requires session.speaker._id — any authenticated user
 protectedProcedure
 
-// Requires session.speaker.isOrganizer — organizer-only
+// Requires org-scoped organizer of the request's org — organizer-only
 adminProcedure
 ```
 
 The context is created in `createTRPCContext()` which calls `getAuthSession()`, supporting both cookie-based sessions (browser) and Bearer tokens (CLI). After `requireAuth` middleware, `ctx.speaker` and `ctx.user` are guaranteed non-null. Access `ctx.session!` when you need the full session (e.g., `session.account`).
 
 **Rule:** All admin operations use `adminProcedure`. There is no separate REST middleware — tRPC handles auth entirely.
+
+### Org-scoped organizer authorization (CaaS T1-2, #614)
+
+`adminProcedure` is **the authorization waist**: every admin endpoint inherits a
+single org-scoped organizer check from the `requireAdmin` middleware — **do not
+re-gate individual endpoints.**
+
+**The model.** A user is an organizer _of an organization_ iff they are in the
+`organizers[]` of any of **that org's** conferences. This is computed at login
+and baked into the session token as `speaker.organizerOrgIds` (the deduped set of
+`organization._ref`s of the conferences whose `organizers[]` contain the
+speaker — see `ORGANIZER_ORG_IDS_FIELD` in `src/lib/speaker/sanity.ts` and
+`applySpeakerToToken` in `src/lib/auth.ts`).
+
+**The request's org** is always resolved server-side from the **domain
+conference** via `resolveOrganizationId()` (mirrors `resolveConferenceId()` but
+returns `null` instead of throwing) — **never** from client input. The waist then
+requires `organizerOrgIds` to include that org id (`isOrganizerForOrg` in
+`src/lib/authz/organizer.ts`). It **fails closed**: a resolvable org whose id is
+not in the caller's set is denied (`FORBIDDEN`), including a cross-org organizer.
+
+**The legacy bridge.** When the request's org **cannot** be resolved
+(pre-`044`-backfill conference without an `organization`, or an unknown domain),
+the check falls back to the **deprecated global** `speaker.isOrganizer` boolean
+(organizer of _any_ conference) and emits a `console.warn('[authz-bridge] …')`.
+This is a deliberate, temporary migration bridge so the org tier can roll out
+without locking legitimate organizers out; a resolution _throw_ also maps to the
+bridge rather than erroring the waist.
+
+**Removal condition.** Delete the bridge (make an unresolvable org **deny**) once
+every live conference has an `organization` **and** every issued token carries
+`organizerOrgIds` (all pre-#614 tokens expired / all users re-logged-in). At that
+point `resolveOrganizationId() === null` should produce `FORBIDDEN`, and the
+deprecated `isOrganizer` field (plus its UI reads) can be removed.
+
+**Shared gates.** Handler/layout/route-handler gates that previously read
+`session.speaker.isOrganizer` (the `(admin)` layout, admin server actions'
+`requireOrganizer`, the `/launch` dispatcher, the `speaker-image` / `gallery` /
+`adobe-sign` / upload API routes, the `(cfp)` organizer-view pages, and the
+dev-only impersonation gate in `src/lib/auth.ts`) all go through the **same**
+`isOrganizerForOrg` / `isOrganizerForCurrentOrg` helpers with the **same** bridge.
+UI components still read the deprecated `isOrganizer` boolean this wave (a
+follow-up rewrites them).
 
 ## Performance Considerations
 

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -24,6 +24,7 @@ import { getConversationViewCounts } from '@/lib/messaging/sanity'
 import { getVolunteersByConference } from '@/lib/volunteer/sanity'
 import { VolunteerStatus } from '@/lib/volunteer/types'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import {
   clientWrite,
   clientReadUncached as clientRead,
@@ -58,7 +59,9 @@ import { resolveConferenceId } from '@/server/trpc'
 
 async function requireOrganizer(): Promise<void> {
   const session = await getAuthSession()
-  if (!session?.speaker?.isOrganizer) {
+  // ORG-SCOPED (CaaS T1-2, #614): organizer of the CURRENT domain's org, with the
+  // authz legacy bridge for unresolvable orgs.
+  if (!(await isOrganizerForCurrentOrg(session?.speaker))) {
     throw new Error('Unauthorized: organizer access required')
   }
 }
@@ -97,7 +100,12 @@ async function resolveConference(
  */
 async function requireOrganizerSession(): Promise<{ speakerId: string }> {
   const session = await getAuthSession()
-  if (!session?.speaker?.isOrganizer || !session.speaker._id) {
+  // ORG-SCOPED (CaaS T1-2, #614): same org gate as requireOrganizer, but also
+  // returns the caller's server-derived speaker id for per-organizer scoping.
+  if (
+    !session?.speaker?._id ||
+    !(await isOrganizerForCurrentOrg(session.speaker))
+  ) {
     throw new Error('Unauthorized: organizer access required')
   }
   return { speakerId: session.speaker._id }

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { AdminLayout } from '@/components/admin'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 
 export const metadata: Metadata = {
@@ -13,7 +14,9 @@ export default async function AdminRootLayout({
   children: React.ReactNode
 }) {
   const session = await getAuthSession()
-  if (!session || !session.speaker || !session.speaker.isOrganizer) {
+  // ORG-SCOPED admin gate (CaaS T1-2, #614): organizer of the CURRENT domain's
+  // org (legacy-bridged to the deprecated global flag when the org is unresolvable).
+  if (!(await isOrganizerForCurrentOrg(session?.speaker))) {
     return (
       <div className="flex h-screen items-center justify-center">
         <p className="text-lg text-gray-500">Access Denied</p>

--- a/src/app/(admin)/admin/marketing/page.tsx
+++ b/src/app/(admin)/admin/marketing/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { getProposals } from '@/lib/proposal/server'
 import { formatConferenceDateLong } from '@/lib/time'
@@ -124,7 +125,8 @@ const ErrorDisplay = ({ message }: { message: string }) => (
 export default async function MarketingPage() {
   const session = await getAuthSession()
 
-  if (!session?.speaker?.isOrganizer) {
+  // ORG-SCOPED admin gate (CaaS T1-2, #614), matching the (admin) layout.
+  if (!(await isOrganizerForCurrentOrg(session?.speaker))) {
     return (
       <div className="flex h-screen items-center justify-center">
         <p className="text-lg text-gray-500 dark:text-gray-400">

--- a/src/app/(admin)/admin/messages/[id]/page.tsx
+++ b/src/app/(admin)/admin/messages/[id]/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { BackLink } from '@/components/BackButton'
 import { ConversationThread } from '@/components/messaging'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 
 export const metadata: Metadata = {
   title: 'Conversation',
@@ -22,7 +23,7 @@ export default async function AdminConversationPage({
   // who reaches this route to their own labelled surface rather than the bare
   // "Access Denied" wall (audience-correct deep link, admin mirror of /cfp).
   const session = await getAuthSession()
-  if (session?.speaker && !session.speaker.isOrganizer) {
+  if (session?.speaker && !(await isOrganizerForCurrentOrg(session.speaker))) {
     redirect(`/cfp/messages/${id}`)
   }
 

--- a/src/app/(cfp)/cfp/messages/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/messages/[id]/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { BackLink } from '@/components/BackButton'
 import { ConversationThread } from '@/components/messaging'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 
 export const metadata: Metadata = {
   title: 'Conversation',
@@ -21,7 +22,10 @@ export default async function CfpConversationPage({
   // Audience-correct deep link: an organizer following a handed /cfp link would
   // otherwise land on a speaker-labelled surface. Send them to the admin thread.
   const session = await getAuthSession()
-  if (session?.speaker?.isOrganizer && !session.isImpersonating) {
+  if (
+    !session?.isImpersonating &&
+    (await isOrganizerForCurrentOrg(session?.speaker))
+  ) {
     redirect(`/admin/messages/${id}`)
   }
 

--- a/src/app/(cfp)/cfp/proposal/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/proposal/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { getProposalSanity as getProposal } from '@/lib/proposal/server'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { ProposalReadOnlyView } from '@/components/cfp/ProposalReadOnlyView'
@@ -40,8 +41,11 @@ export default async function ProposalViewPage({
     return redirect('/api/auth/signin?callbackUrl=/cfp/proposal/' + id)
   }
 
+  // ORG-SCOPED (CaaS T1-2, #614): during dev impersonation, grant organizer-level
+  // proposal access only when the REAL admin is an organizer of the current org.
   const isImpersonatingAsOrganizer =
-    session.isImpersonating && !!session.realAdmin?.isOrganizer
+    !!session.isImpersonating &&
+    (await isOrganizerForCurrentOrg(session.realAdmin))
 
   const { proposal, proposalError } = await getProposal({
     id,

--- a/src/app/(cfp)/cfp/workshop/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/workshop/[id]/page.tsx
@@ -2,6 +2,7 @@ import { connection } from 'next/server'
 import { redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import { clientReadUncached } from '@/lib/sanity/client'
 import { groq } from 'next-sanity'
@@ -130,8 +131,11 @@ export default async function WorkshopDetailsPage({
       typeof s === 'object' && s !== null && s._id === currentSpeaker._id,
   )
 
+  // ORG-SCOPED (CaaS T1-2, #614): during dev impersonation, treat the viewer as an
+  // organizer only when the REAL admin is an organizer of the current org.
   const isImpersonatingAsOrganizer =
-    session.isImpersonating && session.realAdmin?.isOrganizer
+    !!session.isImpersonating &&
+    (await isOrganizerForCurrentOrg(session.realAdmin))
 
   if (!isSpeaker && !isImpersonatingAsOrganizer) {
     return (

--- a/src/app/api/admin/gallery/upload/route.ts
+++ b/src/app/api/admin/gallery/upload/route.ts
@@ -4,6 +4,7 @@ import { createGalleryImage } from '@/lib/gallery/sanity'
 import { getSpeakerByEmail } from '@/lib/sanity/speaker'
 import { galleryImageCreateSchema } from '@/server/schemas/gallery'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import { getCurrentDateTime } from '@/lib/time'
 
@@ -21,8 +22,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
+    // ORG-SCOPED (CaaS T1-2, #614): organizer of the current domain's org.
+    // `getSpeakerByEmail` now projects `organizerOrgIds` for this check.
     const speaker = await getSpeakerByEmail(session.user.email)
-    if (!speaker?.isOrganizer) {
+    if (!(await isOrganizerForCurrentOrg(speaker))) {
       return NextResponse.json(
         { error: 'Admin access required' },
         { status: 403 },

--- a/src/app/api/admin/speaker-image/route.ts
+++ b/src/app/api/admin/speaker-image/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { clientWrite } from '@/lib/sanity/client'
 
 export async function POST(request: Request) {
   try {
     const session = await getAuthSession()
-    if (!session?.speaker?.isOrganizer) {
+    // ORG-SCOPED (CaaS T1-2, #614): organizer of the current domain's org.
+    if (!(await isOrganizerForCurrentOrg(session?.speaker))) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 

--- a/src/app/api/adobe-sign/authorize/route.ts
+++ b/src/app/api/adobe-sign/authorize/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getAuthorizeUrl, setStateCookie } from '@/lib/adobe-sign/auth'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 
 export async function GET() {
   const session = await getAuthSession()
-  if (!session?.speaker?.isOrganizer) {
+  // ORG-SCOPED (CaaS T1-2, #614): organizer of the current domain's org.
+  if (!(await isOrganizerForCurrentOrg(session?.speaker))) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/src/app/api/adobe-sign/callback/route.ts
+++ b/src/app/api/adobe-sign/callback/route.ts
@@ -7,10 +7,12 @@ import {
   setAdobeSignSessionCookie,
 } from '@/lib/adobe-sign/auth'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 
 export async function GET(request: Request) {
   const session = await getAuthSession()
-  if (!session?.speaker?.isOrganizer) {
+  // ORG-SCOPED (CaaS T1-2, #614): organizer of the current domain's org.
+  if (!(await isOrganizerForCurrentOrg(session?.speaker))) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/src/app/api/upload/proposal-attachment/route.ts
+++ b/src/app/api/upload/proposal-attachment/route.ts
@@ -1,6 +1,7 @@
 import { handleUpload, type HandleUploadBody } from '@vercel/blob/client'
 import { NextResponse } from 'next/server'
 import { NextAuthRequest, auth } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getProposal } from '@/lib/proposal/data/sanity'
 
 /**
@@ -87,7 +88,9 @@ export const POST = auth(async (req: NextAuthRequest) => {
         const proposalId = match[1]
 
         const speakerId = req.auth?.speaker?._id
-        const isOrganizer = req.auth?.speaker?.isOrganizer === true
+        // ORG-SCOPED (CaaS T1-2, #614): organizer-level proposal access is granted
+        // only to organizers of the current domain's org (legacy-bridged).
+        const isOrganizer = await isOrganizerForCurrentOrg(req.auth?.speaker)
 
         if (!speakerId) {
           throw new Error('Speaker ID not found in session')

--- a/src/app/api/upload/speaker-image/route.ts
+++ b/src/app/api/upload/speaker-image/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { clientWrite } from '@/lib/sanity/client'
 
 export async function POST(request: Request) {
@@ -49,9 +50,10 @@ export async function POST(request: Request) {
       )
     }
 
-    // Verify authorization: user must be uploading their own image OR be an organizer
+    // Verify authorization: user must be uploading their own image OR be an
+    // organizer of the current domain's org (CaaS T1-2, #614; legacy-bridged).
     const isOwnProfile = !speakerId || speakerId === session.speaker._id
-    const isOrganizer = session.speaker.isOrganizer === true
+    const isOrganizer = await isOrganizerForCurrentOrg(session.speaker)
 
     if (!isOwnProfile && !isOrganizer) {
       return NextResponse.json(

--- a/src/app/launch/route.ts
+++ b/src/app/launch/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
+import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 
 /**
  * PWA launcher — role-aware start page (`start_url` in `src/app/manifest.ts`).
@@ -42,8 +43,11 @@ export async function GET(request: Request): Promise<NextResponse> {
     headers: request.headers,
   })
 
+  // ORG-SCOPED (CaaS T1-2, #614): send to /admin only when the caller is an
+  // organizer of the CURRENT domain's organization (falls back to the deprecated
+  // global flag via the authz legacy bridge when the org can't be resolved).
   let target: string
-  if (session?.speaker?.isOrganizer) {
+  if (await isOrganizerForCurrentOrg(session?.speaker)) {
     target = '/admin'
   } else if (session?.speaker) {
     target = '/cfp/list'

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -361,3 +361,50 @@ describe('signOutHandler — clears link-flow state', () => {
     expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
   })
 })
+
+describe('jwtSignInCallback — org-scoped session computation (CaaS T1-2, #614)', () => {
+  it('bakes a DEDUPED organizerOrgIds set into the token on normal sign-in', async () => {
+    // A speaker who organizes several conferences of the SAME org yields
+    // duplicate org refs from the projection; the token must carry each org once.
+    getOrCreateSpeaker.mockResolvedValue({
+      speaker: {
+        _id: 'spk-org',
+        slug: 'spk-org',
+        name: 'Org Person',
+        email: 'org@example.com',
+        isOrganizer: true,
+        organizerOrgIds: ['org-A', 'org-A', 'org-B'],
+      },
+      err: null,
+    })
+
+    const token = (await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })) as JWT & { speaker?: { organizerOrgIds?: string[] } }
+
+    expect(token.speaker?.organizerOrgIds).toEqual(['org-A', 'org-B'])
+  })
+
+  it('bakes an EMPTY organizerOrgIds set for a non-organizer / pre-backfill speaker', async () => {
+    getOrCreateSpeaker.mockResolvedValue({
+      speaker: {
+        _id: 'spk-plain',
+        slug: 'spk-plain',
+        name: 'Plain Person',
+        email: 'plain@example.com',
+        // No organizerOrgIds key at all (legacy doc / not an organizer).
+      },
+      err: null,
+    })
+
+    const token = (await jwtSignInCallback({
+      token: freshSignInToken(),
+      account: GITHUB,
+      trigger: 'signIn',
+    })) as JWT & { speaker?: { organizerOrgIds?: string[] } }
+
+    expect(token.speaker?.organizerOrgIds).toEqual([])
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -39,7 +39,14 @@ function applySpeakerToToken(
     name: speaker.name,
     email: speaker.email,
     image: speaker.image,
+    // Deprecated GLOBAL flag — kept as the org-scoped authz migration bridge.
     isOrganizer: speaker.isOrganizer,
+    // Org-SCOPED organizer capability (CaaS T1-2, #614). Deduped + falsy-filtered
+    // so a speaker organizing several conferences of one org contributes its org
+    // id once, and pre-backfill conferences (no org) contribute nothing.
+    organizerOrgIds: Array.from(
+      new Set((speaker.organizerOrgIds ?? []).filter(Boolean)),
+    ),
     flags: speaker.flags,
   }
 }
@@ -513,8 +520,13 @@ export async function getAuthSession(req?: {
     return session
   }
 
-  // SECURITY: Only organizers can impersonate
-  if (!session?.speaker?.isOrganizer) {
+  // SECURITY: Only organizers can impersonate — ORG-SCOPED (CaaS T1-2, #614): the
+  // impersonator must be an organizer of the CURRENT domain's org (legacy-bridged
+  // to the deprecated global flag when the org can't be resolved). Dynamically
+  // imported to keep the org/conference read out of the edge middleware bundle,
+  // mirroring the `getSpeaker` import below.
+  const { isOrganizerForCurrentOrg } = await import('@/lib/authz/organizer')
+  if (!(await isOrganizerForCurrentOrg(session?.speaker))) {
     return session
   }
 

--- a/src/lib/authz/organizer.test.ts
+++ b/src/lib/authz/organizer.test.ts
@@ -72,6 +72,37 @@ describe('isOrganizerForOrg — pure org-scoped decision', () => {
     expect(isOrganizerForOrg(undefined, null)).toBe(false)
   })
 
+  describe('legacy-token bridge (organizerOrgIds absent)', () => {
+    it('GRANTS a pre-#614 token (no organizerOrgIds field) via the global flag and WARNS', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      expect(
+        isOrganizerForOrg({ _id: 'sp-1', isOrganizer: true } as never, 'org-a'),
+      ).toBe(true)
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('legacy token without organizerOrgIds'),
+      )
+      warn.mockRestore()
+    })
+
+    it('DENIES a present-but-EMPTY organizerOrgIds (organizer of no org)', () => {
+      expect(
+        isOrganizerForOrg(
+          { _id: 'sp-1', isOrganizer: true, organizerOrgIds: [] } as never,
+          'org-a',
+        ),
+      ).toBe(false)
+    })
+
+    it('DENIES a legacy token whose global flag is false', () => {
+      expect(
+        isOrganizerForOrg(
+          { _id: 'sp-1', isOrganizer: false } as never,
+          'org-a',
+        ),
+      ).toBe(false)
+    })
+  })
+
   describe('legacy bridge (orgId === null)', () => {
     it('GRANTS via the deprecated global isOrganizer and WARNS', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/lib/authz/organizer.test.ts
+++ b/src/lib/authz/organizer.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the org-scoped organizer authorization helpers (CaaS T1-2,
+ * #614). This is THE security boundary the middleware waist and every gate share,
+ * so we pin: an org member passes; an organizer of ANOTHER org is denied;
+ * fail-closed when the org resolves but the caller is not a member; and the
+ * deliberate LEGACY BRIDGE (org unresolvable → deprecated global `isOrganizer`,
+ * with a warn) both grants and denies correctly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  resolveOrg: vi.fn<() => Promise<string | null>>(),
+}))
+
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: h.resolveOrg,
+}))
+
+import {
+  isOrganizerForOrg,
+  isOrganizerForCurrentOrg,
+  resolveCurrentOrgId,
+} from './organizer'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const speaker = (over: Record<string, unknown> = {}) => ({
+  _id: 'sp-1',
+  isOrganizer: false,
+  organizerOrgIds: [] as string[],
+  ...over,
+})
+
+describe('isOrganizerForOrg — pure org-scoped decision', () => {
+  it('grants when the request org is in organizerOrgIds', () => {
+    expect(
+      isOrganizerForOrg(speaker({ organizerOrgIds: ['org-A'] }), 'org-A'),
+    ).toBe(true)
+  })
+
+  it('DENIES an organizer of ANOTHER org (cross-org 403)', () => {
+    expect(
+      isOrganizerForOrg(
+        speaker({ organizerOrgIds: ['org-B'], isOrganizer: true }),
+        'org-A',
+      ),
+    ).toBe(false)
+  })
+
+  it('FAILS CLOSED when the org resolves but the speaker is not a member', () => {
+    // A globally-flagged organizer with NO org membership is still denied for a
+    // resolvable org — the bridge only applies when the org is unresolvable.
+    expect(
+      isOrganizerForOrg(
+        speaker({ organizerOrgIds: [], isOrganizer: true }),
+        'org-A',
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false for a missing/anonymous speaker', () => {
+    expect(isOrganizerForOrg(null, 'org-A')).toBe(false)
+    expect(isOrganizerForOrg(undefined, null)).toBe(false)
+  })
+
+  describe('legacy bridge (orgId === null)', () => {
+    it('GRANTS via the deprecated global isOrganizer and WARNS', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      expect(isOrganizerForOrg(speaker({ isOrganizer: true }), null)).toBe(true)
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('[authz-bridge]'),
+      )
+    })
+
+    it('DENIES a non-organizer even when the org is unresolvable (no warn)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      expect(isOrganizerForOrg(speaker({ isOrganizer: false }), null)).toBe(
+        false,
+      )
+      expect(warn).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('resolveCurrentOrgId', () => {
+  it('delegates to the current-conference org resolver', async () => {
+    h.resolveOrg.mockResolvedValue('org-A')
+    expect(await resolveCurrentOrgId()).toBe('org-A')
+  })
+
+  it('passes through a null (unresolvable) org', async () => {
+    h.resolveOrg.mockResolvedValue(null)
+    expect(await resolveCurrentOrgId()).toBeNull()
+  })
+})
+
+describe('isOrganizerForCurrentOrg — resolve + decide', () => {
+  it('grants an organizer of the resolved current org', async () => {
+    h.resolveOrg.mockResolvedValue('org-A')
+    expect(
+      await isOrganizerForCurrentOrg(speaker({ organizerOrgIds: ['org-A'] })),
+    ).toBe(true)
+  })
+
+  it('denies an organizer of a different org (cross-org)', async () => {
+    h.resolveOrg.mockResolvedValue('org-A')
+    expect(
+      await isOrganizerForCurrentOrg(
+        speaker({ organizerOrgIds: ['org-B'], isOrganizer: true }),
+      ),
+    ).toBe(false)
+  })
+
+  it('bridges to the global flag when the org is unresolvable', async () => {
+    h.resolveOrg.mockResolvedValue(null)
+    expect(await isOrganizerForCurrentOrg(speaker({ isOrganizer: true }))).toBe(
+      true,
+    )
+  })
+
+  it('short-circuits (no resolve) for an anonymous speaker', async () => {
+    expect(await isOrganizerForCurrentOrg(null)).toBe(false)
+    expect(h.resolveOrg).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/authz/organizer.ts
+++ b/src/lib/authz/organizer.ts
@@ -1,0 +1,85 @@
+import 'server-only'
+import type { Speaker } from '@/lib/speaker/types'
+import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanity'
+
+/**
+ * Org-scoped organizer authorization (CaaS T1-2, #614).
+ *
+ * THE MODEL. A user is an organizer OF AN ORGANIZATION iff they are in the
+ * `organizers[]` of any of THAT org's conferences. This is baked into the session
+ * token at login as `speaker.organizerOrgIds` (see `applySpeakerToToken` /
+ * `ORGANIZER_ORG_IDS_FIELD`). Authorization for a request keys on whether the
+ * REQUEST's organization is in that set. The request's org is ALWAYS derived from
+ * the domain-resolved conference — never from client input.
+ *
+ * THE LEGACY BRIDGE. Production still carries pre-044-backfill data (conferences
+ * without an `organization`) and requests can hit domains that don't resolve to a
+ * conference. When the request's org cannot be resolved we FAIL OPEN TO THE
+ * LEGACY GLOBAL CHECK: the deprecated `speaker.isOrganizer` boolean (organizer of
+ * ANY conference). This is a DELIBERATE, TEMPORARY migration bridge so the org
+ * tier can roll out without locking legitimate organizers out. Every bridged
+ * grant emits a `console.warn('[authz-bridge] …')` so the gap is observable.
+ *
+ * REMOVAL CONDITION. Delete the bridge (make an unresolvable org deny) once every
+ * live conference has an `organization` AND every issued session token carries
+ * `organizerOrgIds` (i.e. after all pre-#614 tokens have expired / all users have
+ * re-logged-in). At that point `orgId === null` should return `false`.
+ */
+
+/** The minimum shape these checks read off a speaker/session token. */
+type OrganizerSpeaker = Pick<Speaker, '_id' | 'isOrganizer' | 'organizerOrgIds'>
+
+/**
+ * PURE, synchronous org-scoped organizer check. Given a speaker and the already-
+ * resolved request org id, decide organizer access. `orgId === null` engages the
+ * LEGACY BRIDGE (see module docs): fall back to the global `isOrganizer` flag and
+ * warn when that grants. Extracted so the decision is unit-testable without a
+ * request context.
+ */
+export function isOrganizerForOrg(
+  speaker: OrganizerSpeaker | null | undefined,
+  orgId: string | null,
+): boolean {
+  if (!speaker?._id) return false
+
+  if (!orgId) {
+    // LEGACY BRIDGE: org unresolvable → defer to the deprecated global flag.
+    if (speaker.isOrganizer === true) {
+      console.warn(
+        `[authz-bridge] organizer org unresolvable; granting via deprecated global isOrganizer for speaker ${speaker._id}`,
+      )
+      return true
+    }
+    return false
+  }
+
+  return (
+    Array.isArray(speaker.organizerOrgIds) &&
+    speaker.organizerOrgIds.includes(orgId)
+  )
+}
+
+/**
+ * Resolve the CURRENT request's organization id from the domain conference, or
+ * `null` when it cannot be resolved (pre-backfill / unknown domain). Thin wrapper
+ * over {@link getOrganizationRefForCurrentConference} named to mirror
+ * `resolveConferenceId`; the underlying conference read is request-cached.
+ */
+export async function resolveCurrentOrgId(): Promise<string | null> {
+  return getOrganizationRefForCurrentConference()
+}
+
+/**
+ * Async org-scoped organizer check for the CURRENT request: resolves the request
+ * org from the domain conference, then applies {@link isOrganizerForOrg} (with the
+ * legacy bridge). This is the SHARED gate used by every handler/layout/route that
+ * previously read `session.speaker.isOrganizer`. Pass the speaker to check —
+ * usually `session?.speaker`, or `session.realAdmin` for impersonation gates.
+ */
+export async function isOrganizerForCurrentOrg(
+  speaker: OrganizerSpeaker | null | undefined,
+): Promise<boolean> {
+  if (!speaker?._id) return false
+  const orgId = await resolveCurrentOrgId()
+  return isOrganizerForOrg(speaker, orgId)
+}

--- a/src/lib/authz/organizer.ts
+++ b/src/lib/authz/organizer.ts
@@ -53,6 +53,20 @@ export function isOrganizerForOrg(
     return false
   }
 
+  // LEGACY-TOKEN BRIDGE: a pre-#614 JWT has NO organizerOrgIds field at all
+  // (undefined). Denying those would 403 every logged-in organizer at deploy
+  // time until re-login — bridge via the deprecated flag instead. A PRESENT
+  // but empty array is the real signal "organizer of no org" and is denied.
+  if (speaker.organizerOrgIds === undefined) {
+    if (speaker.isOrganizer === true) {
+      console.warn(
+        `[authz-bridge] legacy token without organizerOrgIds; granting via deprecated global isOrganizer for speaker ${speaker._id}`,
+      )
+      return true
+    }
+    return false
+  }
+
   return (
     Array.isArray(speaker.organizerOrgIds) &&
     speaker.organizerOrgIds.includes(orgId)

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -106,11 +106,16 @@ export async function notifyNewMessage({
 }): Promise<void> {
   try {
     // ACCESS vs ROUTING split (TEAMS-2). `organizerSet` is the FULL organizer
-    // set and is used ONLY to CLASSIFY identities — whether the author is an
-    // organizer, whether a recipient is an organizer (audience-dependent email
-    // default + link variant), whether any recipient is a speaker. That is an
-    // access/participant question and MUST stay the whole organizer set.
-    const organizerIds = await getOrganizerSpeakerIds()
+    // set for THIS conference's org and is used ONLY to CLASSIFY identities —
+    // whether the author is an organizer, whether a recipient is an organizer
+    // (audience-dependent email default + link variant), whether any recipient is
+    // a speaker. That is an access/participant question. ORG-SCOPED (CaaS T1-2,
+    // #614): pass the conference's own org so a background send does not depend on
+    // request domain; a pre-backfill conference (no org) falls back to the global
+    // set via the recipient-selection legacy bridge.
+    const organizerIds = await getOrganizerSpeakerIds(
+      conference.organization?._ref ?? null,
+    )
     const organizerSet = new Set(organizerIds)
     const authorIsOrganizer = organizerSet.has(authorId)
     // ROUTING: the `organizers` group party is expanded for NOTIFICATION

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -733,6 +733,11 @@ export async function getOrganizerSpeakerIds(
   if (cached && cached.expiresAt > now) {
     return cached.ids
   }
+  // Prune this key's expired entry (and any other expired keys) so a
+  // long-lived warm instance seeing many orgs never grows the map unboundedly.
+  for (const [key, entry] of organizerCache) {
+    if (entry.expiresAt <= now) organizerCache.delete(key)
+  }
 
   const organizerScope = resolvedOrgId
     ? `*[_type == "conference" && organization._ref == $orgId].organizers[]._ref`

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -680,47 +680,93 @@ const ORGANIZER_CACHE_TTL_MS = 60_000
 /** Upper bound on the organizer fetch; the organizer set is tiny in practice. */
 const ORGANIZER_FETCH_LIMIT = 200
 
-let organizerCache: { ids: string[]; expiresAt: number } | null = null
+/** Cache-map key for the GLOBAL (legacy-bridge) organizer set. */
+const GLOBAL_ORGANIZER_CACHE_KEY = '__global__'
+
+// Per-org (and global) organizer-id cache, keyed by resolved org id. Keying by
+// org keeps two tenants sharing a warm instance from cross-contaminating each
+// other's recipient sets.
+const organizerCache = new Map<string, { ids: string[]; expiresAt: number }>()
 
 /**
- * The `_id`s of every organizer speaker (bounded to
- * [0...{@link ORGANIZER_FETCH_LIMIT}]). THE CANONICAL ORGANIZER DEFINITION is
- * membership in ANY conference's `organizers[]` array — the same rule the auth
- * session and the admin speaker picker derive `isOrganizer` from
- * (src/lib/speaker/sanity.ts). The speaker schema has NO stored `isOrganizer`
- * field: an earlier version of this query tested `isOrganizer == true`, which
- * matched NOTHING in production — silently emptying the messaging fan-out's
- * organizer recipients, needs-reply, standing checks, and assignee validation
- * while organizers could still browse /admin via the session's DERIVED flag.
- * Organizer-of-one-edition = organizer everywhere (matches auth). Conference
- * scoping happens implicitly because the created notification carries the
- * conference ref. Cached per instance for {@link ORGANIZER_CACHE_TTL_MS}. The
- * returned array is treated as read-only by callers (they wrap it in a Set).
+ * The `_id`s of the organizer speakers for a TENANT (bounded to
+ * [0...{@link ORGANIZER_FETCH_LIMIT}]). An organizer is a speaker in the
+ * `organizers[]` of one of the org's conferences — the org-SCOPED reading of the
+ * canonical organizer definition (CaaS T1-2, #614). This selects MESSAGE
+ * RECIPIENTS (fan-out targets, needs-reply, assignee validation, participant
+ * classification), NOT access — but it must agree with the org-scoped auth
+ * boundary so a cross-org organizer is neither notified about nor allowed to own
+ * another tenant's threads.
+ *
+ * ORG RESOLUTION:
+ *  - `orgId` omitted (default) → resolve the CURRENT domain's org. In a request
+ *    this scopes to that tenant; in a context without a domain (e.g. the stale-
+ *    thread cron) it resolves to `null` and falls through to the GLOBAL set.
+ *  - `orgId` a string → scope to that org (callers with a conference in hand,
+ *    e.g. the message fan-out, pass `conference.organization._ref` so background
+ *    sends don't depend on request domain).
+ *  - `orgId` explicitly `null` → the GLOBAL set (every conference's organizers).
+ *
+ * LEGACY BRIDGE: a `null` resolved org (pre-044-backfill conference / no domain)
+ * yields the GLOBAL organizer set with a `console.warn`, mirroring the auth
+ * bridge in `src/lib/authz/organizer.ts`. This historical behaviour ("organizer
+ * of one edition = organizer everywhere") is retained ONLY as the migration
+ * bridge; remove it under the same condition as the auth bridge.
+ *
+ * Cached per instance for {@link ORGANIZER_CACHE_TTL_MS}, keyed by resolved org.
+ * The returned array is treated as read-only by callers (they wrap it in a Set).
  */
-export async function getOrganizerSpeakerIds(): Promise<string[]> {
+export async function getOrganizerSpeakerIds(
+  orgId?: string | null,
+): Promise<string[]> {
+  const resolvedOrgId =
+    orgId === undefined
+      ? await (
+          await import('@/lib/organization/sanity')
+        ).getOrganizationRefForCurrentConference()
+      : orgId
+
+  const cacheKey = resolvedOrgId ?? GLOBAL_ORGANIZER_CACHE_KEY
+
   const now = Date.now()
-  if (organizerCache && organizerCache.expiresAt > now) {
-    return organizerCache.ids
+  const cached = organizerCache.get(cacheKey)
+  if (cached && cached.expiresAt > now) {
+    return cached.ids
   }
+
+  const organizerScope = resolvedOrgId
+    ? `*[_type == "conference" && organization._ref == $orgId].organizers[]._ref`
+    : `*[_type == "conference"].organizers[]._ref`
+
+  if (!resolvedOrgId) {
+    console.warn(
+      '[authz-bridge] getOrganizerSpeakerIds: org unresolvable; using the GLOBAL organizer set (recipient-selection legacy bridge)',
+    )
+  }
+
   // ONLY successes are cached (R2): the `await` throws on a failed read BEFORE
   // the cache assignment below, so a transient Sanity failure is never poisoned
   // into the cache as an empty organizer set (which would, e.g., vacuously empty
   // the needs-reply view or misroute stale nudges for a full TTL). A genuinely
-  // empty result (`null`/`[]` — a conference with no organizers yet) IS a
-  // success and is cached normally.
+  // empty result (`null`/`[]` — a tenant with no organizers yet) IS a success
+  // and is cached normally.
   const ids = await clientReadUncached.fetch<string[]>(
-    `*[_type == "speaker" && _id in *[_type == "conference"].organizers[]._ref][0...${ORGANIZER_FETCH_LIMIT}]._id`,
+    `*[_type == "speaker" && _id in ${organizerScope}][0...${ORGANIZER_FETCH_LIMIT}]._id`,
+    resolvedOrgId ? { orgId: resolvedOrgId } : {},
   )
   const resolved = ids || []
-  organizerCache = { ids: resolved, expiresAt: now + ORGANIZER_CACHE_TTL_MS }
+  organizerCache.set(cacheKey, {
+    ids: resolved,
+    expiresAt: now + ORGANIZER_CACHE_TTL_MS,
+  })
   return resolved
 }
 
 /**
- * Clear the per-instance organizer cache. Exposed for tests (which assert fresh
- * reads) and as a hook if a future admin flow wants to invalidate eagerly after
- * changing organizer membership.
+ * Clear the per-instance organizer cache (all org keys). Exposed for tests (which
+ * assert fresh reads) and as a hook if a future admin flow wants to invalidate
+ * eagerly after changing organizer membership.
  */
 export function clearOrganizerSpeakerIdsCache(): void {
-  organizerCache = null
+  organizerCache.clear()
 }

--- a/src/lib/sanity/speaker.ts
+++ b/src/lib/sanity/speaker.ts
@@ -12,6 +12,7 @@ export async function getSpeakerByEmail(
         name,
         email,
         "isOrganizer": _id in *[_type == "conference"].organizers[]._ref,
+        "organizerOrgIds": *[_type == "conference" && ^._id in organizers[]._ref && defined(organization._ref)].organization._ref,
         "image": coalesce(image.asset->url, imageURL),
         "slug": slug.current
       }

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -20,6 +20,15 @@ import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanit
 const IS_ORGANIZER_FIELD =
   '"isOrganizer": _id in *[_type == "conference"].organizers[]._ref'
 
+// Computed field (CaaS T1-2, #614): the ORG-SCOPED organizer capability — the
+// `organization._ref`s of the conferences whose `organizers[]` contain this
+// speaker. Conferences with no `organization` (pre-044-backfill) are filtered
+// out; duplicate refs (a speaker organizing several conferences of one org) are
+// deduped in `applySpeakerToToken`. This is the source of the session token's
+// `organizerOrgIds`, which the authorization middleware/gates key on.
+const ORGANIZER_ORG_IDS_FIELD =
+  '"organizerOrgIds": *[_type == "conference" && ^._id in organizers[]._ref && defined(organization._ref)].organization._ref'
+
 /**
  * MINIMAL projection for the two hot login queries (`findSpeakerByProvider`,
  * `findSpeakersByEmails`). These run on EVERY login and cannot be indexed
@@ -43,7 +52,8 @@ const LOGIN_SPEAKER_PROJECTION = `{
     "organizations": organizations[]._ref,
     "slug": slug.current,
     "image": coalesce(image.asset->url, imageURL),
-    ${IS_ORGANIZER_FIELD}
+    ${IS_ORGANIZER_FIELD},
+    ${ORGANIZER_ORG_IDS_FIELD}
   }`
 
 /**
@@ -622,7 +632,8 @@ export async function getSpeaker(
       ${EXCLUDE_PUSH_FIELDS},
       "slug": slug.current,
       "image": coalesce(image.asset->url, imageURL),
-      ${IS_ORGANIZER_FIELD}
+      ${IS_ORGANIZER_FIELD},
+      ${ORGANIZER_ORG_IDS_FIELD}
     }`,
       { speakerId },
       { cache: 'no-store' },

--- a/src/lib/speaker/types.ts
+++ b/src/lib/speaker/types.ts
@@ -124,7 +124,28 @@ export interface Speaker extends SpeakerBase {
    * above.
    */
   imageURL?: string
+  /**
+   * @deprecated GLOBAL organizer flag — true iff this speaker is in ANY
+   * conference's `organizers[]`. Superseded by {@link organizerOrgIds} for
+   * authorization (CaaS T1-2, #614): access is now org-SCOPED. Retained in the
+   * token as a backward-compat/migration bridge — the org-scoped middleware and
+   * gates fall back to this ONLY when the request's organization cannot be
+   * resolved (pre-044-backfill data / unknown domain). Prefer
+   * `isOrganizerForOrg`/`isOrganizerForCurrentOrg` (src/lib/authz/organizer.ts).
+   * UI still reads it this wave; a follow-up removes both the reads and the bridge.
+   */
   isOrganizer?: boolean
+  /**
+   * Org-scoped organizer capability (CaaS T1-2, #614): the organization ids where
+   * this speaker is an organizer — derived at login as the (deduped) set of
+   * `organization._ref`s of the conferences whose `organizers[]` contain this
+   * speaker. The authorization boundary keys on membership of the REQUEST's org
+   * in this set; the request's org always comes from the domain-resolved
+   * conference, never from client input. A handful of ids at most, so it is safe
+   * to bake into the JWT. Additive/optional; a legacy token without it degrades
+   * to the {@link isOrganizer} bridge.
+   */
+  organizerOrgIds?: string[]
   /**
    * Opt-in web push subscriptions for this speaker (#444). Additive/optional —
    * legacy documents without it remain valid. Managed exclusively by the tRPC

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -2,6 +2,7 @@ import { initTRPC, TRPCError } from '@trpc/server'
 import { NextRequest } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { isOrganizerForOrg } from '@/lib/authz/organizer'
 import { AppEnvironment } from '@/lib/environment/config'
 import { structuredErrorData, type StructuredErrorData } from './errors'
 
@@ -132,8 +133,20 @@ const requireAuth = t.middleware(({ ctx, next }) => {
   })
 })
 
-const requireAdmin = t.middleware(({ ctx, next }) => {
-  if (!ctx.session?.speaker?.isOrganizer) {
+/**
+ * THE AUTHORIZATION WAIST (CaaS T1-2, #614). Every `adminProcedure` inherits this
+ * single org-scoped organizer check — do NOT re-gate individual endpoints. The
+ * request's organization is resolved from the domain conference (never from
+ * client input) and the caller must be an organizer OF THAT org
+ * (`speaker.organizerOrgIds` includes it). FAIL CLOSED when the org resolves but
+ * the caller is not a member; when the org CANNOT be resolved (pre-044-backfill
+ * data / unknown domain) {@link isOrganizerForOrg} engages the documented LEGACY
+ * BRIDGE (deprecated global `isOrganizer`, with a `console.warn`). See
+ * `src/lib/authz/organizer.ts` for the bridge's removal condition.
+ */
+const requireAdmin = t.middleware(async ({ ctx, next }) => {
+  const orgId = await resolveOrganizationId()
+  if (!isOrganizerForOrg(ctx.session?.speaker, orgId)) {
     throw new TRPCError({
       code: 'FORBIDDEN',
       message: 'Admin privileges required',
@@ -143,8 +156,8 @@ const requireAdmin = t.middleware(({ ctx, next }) => {
   return next({
     ctx: {
       ...ctx,
-      speaker: ctx.session.speaker,
-      user: ctx.session.user!,
+      speaker: ctx.session!.speaker!,
+      user: ctx.session!.user!,
     },
   })
 })
@@ -175,4 +188,26 @@ export async function resolveConferenceId(): Promise<string> {
     })
   }
   return conference._id
+}
+
+/**
+ * The REQUEST's organization id, resolved from the domain conference (the tenant
+ * key the org-scoped authz waist gates on). Mirrors {@link resolveConferenceId}
+ * but returns `null` rather than throwing when the org cannot be resolved
+ * (pre-044-backfill conference / unknown domain), because the authorization
+ * middleware maps that `null` onto the deliberate LEGACY BRIDGE rather than a hard
+ * failure. The underlying conference read is request-cached, so calling this in
+ * the waist does not add a fetch for endpoints that also call
+ * `resolveConferenceId`.
+ */
+export async function resolveOrganizationId(): Promise<string | null> {
+  try {
+    const { conference, error } = await getConferenceForCurrentDomain()
+    if (error || !conference?._id) return null
+    return conference.organization?._ref ?? null
+  } catch {
+    // A thrown resolution (no request domain, transient read) must not error the
+    // authz waist — it maps to `null`, i.e. the deliberate legacy bridge.
+    return null
+  }
 }


### PR DESCRIPTION
## What & why (CaaS T1-2, #614)

Replaces the single **global** organizer boolean with **org-scoped** authorization. Builds on the organization tier (#631, `044` backfill has run) and org-aware identity + scoped-query invariant (#632).

### The model
A user is an organizer **of an organization** iff they are in the `organizers[]` of any of **that org's** conferences — derivable, no new schema. Login computes `speaker.organizerOrgIds` (deduped `organization._ref`s of the conferences whose `organizers[]` contain them) and bakes it into the JWT. The request's org always comes from the **domain-resolved conference** (`conference.organization._ref`), never from client input; access requires that org id to be in `organizerOrgIds`.

`isOrganizer` stays in the token, **marked deprecated**, as a migration bridge (UI still reads it this wave — a follow-up rewrites it).

### The middleware waist
`adminProcedure`'s `requireAdmin` resolves the request org (`resolveOrganizationId()`, mirrors `resolveConferenceId()` but returns `null` instead of throwing) and requires `organizerOrgIds` to include it (`isOrganizerForOrg`, `src/lib/authz/organizer.ts`). All ~192 admin endpoints inherit this — **no per-endpoint changes**.

### The legacy bridge (+ removal condition)
When the request org **can't be resolved** (pre-`044` conference without an `organization`, unknown domain, or a resolution throw), the check falls back to the deprecated global `isOrganizer` with a `console.warn('[authz-bridge] …')`. **Fails closed** when the org *is* resolvable but the caller isn't a member (including cross-org organizers).

**Remove the bridge** (make an unresolvable org **deny**, drop `isOrganizer` + its UI reads) once every live conference has an `organization` **and** all pre-#614 tokens have expired.

### Gates converted (shared `isOrganizerForCurrentOrg` / `isOrganizerForOrg`, same bridge)
- tRPC `requireAdmin` waist (`src/server/trpc.ts`)
- Dev-only impersonation gate (`src/lib/auth.ts` `getAuthSession`)
- `(admin)` layout; admin actions `requireOrganizer` + `requireOrganizerSession`; marketing page; `(admin)`/`(cfp)` messages redirect pages; `(cfp)` proposal + workshop organizer-view (impersonation) pages
- API routes: `admin/speaker-image`, `admin/gallery/upload`, `adobe-sign/authorize`, `adobe-sign/callback`, `upload/speaker-image`, `upload/proposal-attachment`
- `/launch` dispatcher

### Recipient selection (not access, but must agree)
`getOrganizerSpeakerIds` is now org-scoped (per-org cache; explicit `orgId` or current-domain default; global fallback + warn). The message fan-out (`notify.ts`) passes the conference's own org so background sends don't depend on request domain. `getOrganizers` was already org-scoped in #632.

## Tests
Full vitest green (**4006 passed**). New/updated security coverage:
- `src/lib/authz/organizer.test.ts` — pure decision, cross-org denial, fail-closed, bridge grant/deny.
- `__tests__/api/trpc/authz-org-scoped.test.ts` — real `adminProcedure` waist: **cross-org 403**, resolvable-non-member 403, bridge allow+warn, bridge deny, resolution-throw → bridge.
- `impersonation.test.ts` — org-scoped gate + cross-org denial.
- `auth.test.ts` — token computation dedupes multi-conference orgs.
- `notification/sanity.test.ts` — org-scoped query + per-org cache + bridge.

`mise run check` (typecheck / lint / format / knip) clean.

## Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
