### PR TITLE
fix(auth): session update-trigger refresh; authz bridge fails closed on unresolvable org

### DIFF
--- a/__tests__/api/trpc/authz-org-scoped.test.ts
+++ b/__tests__/api/trpc/authz-org-scoped.test.ts
@@ -5,8 +5,9 @@
  * `adminProcedure` middleware (`requireAdmin` in src/server/trpc.ts) end to end:
  * the request org comes from the domain conference, and access requires the
  * caller's `organizerOrgIds` to include it. Proves the cross-org 403, the fail-
- * closed (resolvable org, non-member) path, and the legacy bridge (org
- * unresolvable → deprecated global `isOrganizer`, with a warn).
+ * closed (resolvable org, non-member) path, and that an UNRESOLVABLE org now FAILS
+ * CLOSED (bridge (1) removed post-044-backfill — deny, with a warn on a would-be
+ * organizer's denial).
  *
  * `getConferenceForCurrentDomain` is mocked to control the request's org; callers
  * are built with explicit session shapes so `organizerOrgIds` can be varied.
@@ -114,15 +115,16 @@ describe('adminProcedure waist — org-scoped organizer authorization', () => {
     ).rejects.toMatchObject({ code: 'FORBIDDEN' })
   })
 
-  describe('legacy bridge — org unresolvable', () => {
-    it('ALLOWS via the deprecated global isOrganizer and warns', async () => {
-      resolveOrg(null) // conference has no organization (pre-backfill)
-      const caller = callerFor({
-        _id: 'sp-4',
-        isOrganizer: true,
-        organizerOrgIds: [],
-      })
-      expect(await wasAllowed(caller)).toBe(true)
+  describe('org unresolvable — bridge (1) removed, FAILS CLOSED', () => {
+    it('DENIES a would-be organizer (global flag set) and warns on the denial', async () => {
+      resolveOrg(null) // conference has no organization (unknown domain)
+      await expect(
+        callerFor({
+          _id: 'sp-4',
+          isOrganizer: true,
+          organizerOrgIds: [],
+        }).speaker.admin.list(),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('[authz-bridge]'),
       )
@@ -139,14 +141,15 @@ describe('adminProcedure waist — org-scoped organizer authorization', () => {
       ).rejects.toMatchObject({ code: 'FORBIDDEN' })
     })
 
-    it('bridges when domain resolution THROWS (fail-closed to bridge, not error)', async () => {
+    it('DENIES (fail-closed) when domain resolution THROWS (maps to null, not error)', async () => {
       h.getConference.mockRejectedValue(new Error('no domain'))
-      const caller = callerFor({
-        _id: 'sp-6',
-        isOrganizer: true,
-        organizerOrgIds: [],
-      })
-      expect(await wasAllowed(caller)).toBe(true)
+      await expect(
+        callerFor({
+          _id: 'sp-6',
+          isOrganizer: true,
+          organizerOrgIds: [],
+        }).speaker.admin.list(),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' })
     })
   })
 })

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -55,6 +55,46 @@ Browser                     Site                        OAuth Provider
    - Stores speaker profile and account info on the JWT token
 5. NextAuth sets an encrypted HttpOnly cookie containing the JWT
 
+### Session Refresh (`trigger === 'update'`)
+
+The speaker claims baked into the JWT (`organizerOrgIds`, `isOrganizer`,
+`name`/`image`) are captured at sign-in. Without a refresh path they would only
+change on a full re-login — which would, for example, lock the creator of a
+brand-new organization out of it until they signed out and back in, and let stale
+organizer grants persist for the token's life.
+
+The `jwt` callback therefore handles `trigger === 'update'`: it re-fetches the
+speaker (`getSpeaker`, the same `organizerOrgIds` + `isOrganizer` read used at
+sign-in) and re-applies the claims via `applySpeakerToToken`, preserving the
+authenticated `account`. A transient read failure (or a vanished document) returns
+the existing token unchanged — a refresh never invalidates a live session. This
+path is kept strictly separate from sign-in and never runs the link-intent logic.
+
+**How to trigger it**
+
+- **Client (browser).** Call the updater from next-auth's session hook:
+
+  ```typescript
+  'use client'
+  import { useSession } from 'next-auth/react'
+
+  const { update } = useSession()
+  // After an action that changes the speaker's grants (e.g. creating an org):
+  await update() // re-invokes the jwt callback with trigger 'update'
+  ```
+
+  The payload is ignored (the callback re-reads from Sanity), so `update()` with
+  no argument is sufficient. This works out of the box because `callbacks.jwt` is
+  registered — no extra wiring is needed. The app wraps the client tree in
+  next-auth's `SessionProvider` (via `SessionProviderWrapper` in the root layout),
+  which `useSession()` requires. The wiring is already exercised in production by
+  `SessionRefreshOnRestore` (`src/components/providers/SessionRefreshOnRestore.tsx`),
+  which calls `update()` on bfcache restore; with the update path implemented, that
+  refresh now also re-reads the speaker's grants from Sanity.
+
+- **Server.** next-auth's `unstable_update` (returned from `NextAuth(config)`) can
+  drive the same refresh from a server action if a client round-trip is undesired.
+
 ### Multi-Domain OAuth (Centralized Auth Origin, #619)
 
 **Opt-in, config-driven, off by default.** Wired in `src/lib/auth.ts` via
@@ -162,7 +202,11 @@ The encrypted JWT contains:
     name: string
     email: string
     image: string       // Sanity image reference
-    isOrganizer: boolean  // Computed via GROQ from conference.organizers[]
+    isOrganizer: boolean  // DEPRECATED global flag; kept only as the authz
+                          // legacy-TOKEN bridge (see "Authorization bridge" below)
+    organizerOrgIds: string[] // Org-SCOPED organizer capability (#614/#635):
+                          // deduped organization refs the speaker organizes.
+                          // The org-scoped authz waist gates on this.
     flags: Flags[]      // e.g., ["local", "first-time"]
   }
   account: {
@@ -220,13 +264,38 @@ Three procedure tiers:
 
 - `publicProcedure` &mdash; no auth required
 - `protectedProcedure` &mdash; requires `session.speaker._id` (401 otherwise)
-- `adminProcedure` &mdash; requires `session.speaker.isOrganizer` (403 otherwise)
+- `adminProcedure` &mdash; org-scoped organizer check (403 otherwise): the request's
+  org is resolved from the domain conference and the caller's `organizerOrgIds`
+  must include it (see `src/lib/authz/organizer.ts`)
 
 Session is obtained via `getAuthSession({ url, headers })` in `createTRPCContext()`,
 which supports both cookie-based and Bearer token authentication.
 
 All admin operations previously protected by REST middleware are now handled by
 `adminProcedure` in tRPC routers.
+
+#### Authorization bridge (org-scoped, sunset)
+
+Org-scoped organizer authz (`isOrganizerForOrg`, #614/#635) gates on the JWT's
+`organizerOrgIds`. Two migration bridges to the deprecated global `isOrganizer`
+flag once softened it; their status now:
+
+- **Org UNRESOLVABLE (`orgId === null`) &mdash; FAILS CLOSED.** The 044 backfill has
+  run (every live conference has an `organization`), so an unresolvable org is now
+  an unknown domain / transient failure rather than pre-backfill data. It **denies**
+  (a `console.warn('[authz-bridge] …')` records a would-be organizer's denial).
+- **Legacy TOKEN (no `organizerOrgIds` field) &mdash; KEPT, SUNSET.** Tokens minted
+  before #635 lack the field; denying them would 403 every logged-in organizer
+  until their token expires (**session `maxAge` = 30 days**, the next-auth default —
+  no explicit `maxAge` is set) or they re-login. This bridge still grants via the
+  global flag. It is dated for removal: `TODO(sunset 2026-08-26)` (30 days after
+  #635).
+
+**Bridge-removal condition.** Once every pre-#635 token has expired, delete the
+legacy-token bridge so a missing `organizerOrgIds` denies. The
+`trigger === 'update'` session refresh (above) is the mechanism by which any active
+session re-mints a modern token carrying `organizerOrgIds` before then; the two
+changes together complete the removal.
 
 ### Test Mode
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -409,6 +409,121 @@ describe('jwtSignInCallback — org-scoped session computation (CaaS T1-2, #614)
   })
 })
 
+describe("jwtSignInCallback — session refresh via trigger 'update' (M0)", () => {
+  // A token that already carries a signed-in speaker + account, as decoded on an
+  // `update()` call. organizerOrgIds starts with just org-A.
+  function updateToken(over: Partial<JWT> = {}): JWT {
+    return {
+      sub: 'sub-upd',
+      email: 'x@example.com',
+      name: 'X User',
+      picture: undefined,
+      account: {
+        provider: 'github',
+        providerAccountId: 'gh-1',
+        type: 'oidc',
+      },
+      speaker: {
+        _id: 'spk-1',
+        slug: 'x-user',
+        name: 'X User',
+        email: 'x@example.com',
+        isOrganizer: false,
+        organizerOrgIds: ['org-A'],
+      },
+      ...over,
+    } as unknown as JWT
+  }
+
+  it('re-fetches the speaker and refreshes organizerOrgIds (new org appears)', async () => {
+    getSpeaker.mockResolvedValue({
+      speaker: {
+        _id: 'spk-1',
+        slug: 'x-user',
+        name: 'X User',
+        email: 'x@example.com',
+        isOrganizer: true,
+        // A freshly-created org (org-B) now grants — must land WITHOUT re-login.
+        organizerOrgIds: ['org-A', 'org-B'],
+      },
+      err: null,
+    })
+
+    const token = (await jwtSignInCallback({
+      token: updateToken(),
+      trigger: 'update',
+    })) as JWT & {
+      speaker?: { organizerOrgIds?: string[]; isOrganizer?: boolean }
+    }
+
+    expect(getSpeaker).toHaveBeenCalledWith('spk-1')
+    expect(token.speaker?.organizerOrgIds).toEqual(['org-A', 'org-B'])
+    expect(token.speaker?.isOrganizer).toBe(true)
+    // The update path must NEVER run sign-in-only logic.
+    expect(getOrCreateSpeaker).not.toHaveBeenCalled()
+    expect(attachProviderToSpeaker).not.toHaveBeenCalled()
+  })
+
+  it('keeps the EXISTING token untouched on a transient re-fetch failure', async () => {
+    getSpeaker.mockResolvedValue({
+      speaker: {} as never,
+      err: new Error('sanity read failed'),
+    })
+
+    const token = (await jwtSignInCallback({
+      token: updateToken(),
+      trigger: 'update',
+    })) as JWT & { speaker?: { _id?: string; organizerOrgIds?: string[] } }
+
+    // Session is NOT invalidated: the prior claims survive verbatim.
+    expect(token.speaker?._id).toBe('spk-1')
+    expect(token.speaker?.organizerOrgIds).toEqual(['org-A'])
+  })
+
+  it('keeps the existing token when the speaker document has vanished', async () => {
+    getSpeaker.mockResolvedValue({ speaker: {} as never, err: null })
+
+    const token = (await jwtSignInCallback({
+      token: updateToken(),
+      trigger: 'update',
+    })) as JWT & { speaker?: { _id?: string } }
+
+    expect(token.speaker?._id).toBe('spk-1')
+  })
+
+  it('does NOT run link-intent handling on update (link cookie is ignored, not consumed)', async () => {
+    const intent = signLinkIntent({
+      speakerId: 'spk-1',
+      provider: 'github',
+      initiatorSub: 'sess-1',
+    })
+    currentJar = createJar({
+      [LINK_INTENT_COOKIE]: intent,
+      [SESSION_COOKIE]: 'PRIOR_1',
+    })
+    decodeMap.set('PRIOR_1', priorSession('spk-1', 'sess-1'))
+    getSpeaker.mockResolvedValue({
+      speaker: {
+        _id: 'spk-1',
+        slug: 'x-user',
+        name: 'X User',
+        email: 'x@example.com',
+        isOrganizer: false,
+        organizerOrgIds: ['org-A'],
+      },
+      err: null,
+    })
+
+    await jwtSignInCallback({ token: updateToken(), trigger: 'update' })
+
+    // Sign-in-only link machinery must not run: no attach, no create, and the
+    // single-use intent cookie is left intact (not deleted) by the update path.
+    expect(attachProviderToSpeaker).not.toHaveBeenCalled()
+    expect(getOrCreateSpeaker).not.toHaveBeenCalled()
+    expect(currentJar.delete).not.toHaveBeenCalled()
+  })
+})
+
 describe('redirectProxyConfig — centralized OAuth origin wiring (#619)', () => {
   it('contributes NO config keys when AUTH_REDIRECT_PROXY_URL is absent', () => {
     expect(redirectProxyConfig({} as NodeJS.ProcessEnv)).toEqual({})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -157,6 +157,37 @@ export async function jwtSignInCallback({
     return {}
   }
 
+  // --- Session refresh via trigger 'update' (M0) -----------------------------
+  // A client calling next-auth's `useSession().update()` — or POSTing to the
+  // session endpoint — re-invokes this callback with `trigger === 'update'` and
+  // NO account/profile. Re-fetch the speaker with the SAME login-shaped read as
+  // sign-in (`getSpeaker` → `organizerOrgIds` + `isOrganizer` + name/image) and
+  // re-apply its claims via `applySpeakerToToken`, so a fresh grant (e.g. a just-
+  // created org from the org-creation wizard) or a profile change lands WITHOUT a
+  // full re-login. This path is deliberately kept SEPARATE from the sign-in path
+  // and NEVER runs the sign-in-only link-intent handling below.
+  if (trigger === 'update') {
+    const existing = token.speaker as Session['speaker'] | undefined
+    if (existing?._id && token.account) {
+      const { getSpeaker } = await import('@/lib/speaker/sanity')
+      const { speaker, err } = await getSpeaker(existing._id)
+      // A transient read failure or a vanished document must NEVER invalidate a
+      // live session — return the existing token untouched on any read problem.
+      if (err || !speaker?._id) {
+        if (err) {
+          console.error(
+            'Session update: speaker re-fetch failed; keeping existing token',
+            err,
+          )
+        }
+        return token
+      }
+      // Preserve the authenticated account; re-apply only the speaker claims.
+      applySpeakerToToken(token, speaker, token.account as Account)
+    }
+    return token
+  }
+
   if (trigger === 'signIn') {
     if (!token || !token.email || !token.name) {
       console.error('Invalid auth token', token)

--- a/src/lib/authz/organizer.test.ts
+++ b/src/lib/authz/organizer.test.ts
@@ -4,9 +4,10 @@
  * Unit tests for the org-scoped organizer authorization helpers (CaaS T1-2,
  * #614). This is THE security boundary the middleware waist and every gate share,
  * so we pin: an org member passes; an organizer of ANOTHER org is denied;
- * fail-closed when the org resolves but the caller is not a member; and the
- * deliberate LEGACY BRIDGE (org unresolvable → deprecated global `isOrganizer`,
- * with a warn) both grants and denies correctly.
+ * fail-closed when the org resolves but the caller is not a member; org
+ * UNRESOLVABLE now FAILS CLOSED (bridge (1) removed post-044-backfill, with a warn
+ * on a would-be organizer's denial); and the remaining legacy-TOKEN bridge
+ * (bridge (2), no `organizerOrgIds` field → deprecated global flag) still grants.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
@@ -103,12 +104,17 @@ describe('isOrganizerForOrg — pure org-scoped decision', () => {
     })
   })
 
-  describe('legacy bridge (orgId === null)', () => {
-    it('GRANTS via the deprecated global isOrganizer and WARNS', () => {
+  describe('org unresolvable (orgId === null) — bridge (1) removed, FAILS CLOSED', () => {
+    it('DENIES a would-be organizer (global flag set) and WARNS on the denial', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      expect(isOrganizerForOrg(speaker({ isOrganizer: true }), null)).toBe(true)
+      expect(isOrganizerForOrg(speaker({ isOrganizer: true }), null)).toBe(
+        false,
+      )
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('[authz-bridge]'),
+      )
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('DENYING (fail-closed'),
       )
     })
 
@@ -151,10 +157,10 @@ describe('isOrganizerForCurrentOrg — resolve + decide', () => {
     ).toBe(false)
   })
 
-  it('bridges to the global flag when the org is unresolvable', async () => {
+  it('DENIES (fail-closed) when the org is unresolvable — bridge (1) removed', async () => {
     h.resolveOrg.mockResolvedValue(null)
     expect(await isOrganizerForCurrentOrg(speaker({ isOrganizer: true }))).toBe(
-      true,
+      false,
     )
   })
 

--- a/src/lib/authz/organizer.ts
+++ b/src/lib/authz/organizer.ts
@@ -12,18 +12,24 @@ import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanit
  * REQUEST's organization is in that set. The request's org is ALWAYS derived from
  * the domain-resolved conference — never from client input.
  *
- * THE LEGACY BRIDGE. Production still carries pre-044-backfill data (conferences
- * without an `organization`) and requests can hit domains that don't resolve to a
- * conference. When the request's org cannot be resolved we FAIL OPEN TO THE
- * LEGACY GLOBAL CHECK: the deprecated `speaker.isOrganizer` boolean (organizer of
- * ANY conference). This is a DELIBERATE, TEMPORARY migration bridge so the org
- * tier can roll out without locking legitimate organizers out. Every bridged
- * grant emits a `console.warn('[authz-bridge] …')` so the gap is observable.
+ * BRIDGE (1) — org UNRESOLVABLE — NOW FAILS CLOSED. The 044 backfill has run, so
+ * every live conference has an `organization`; an unresolvable org id therefore no
+ * longer means "pre-backfill data" but an unknown domain or a transient
+ * resolution failure. Granting organizer access there via the deprecated global
+ * `speaker.isOrganizer` was unnecessary permissiveness, so `orgId === null` now
+ * DENIES. A `console.warn('[authz-bridge] …')` is still emitted when a would-be
+ * organizer (global flag set) is denied, so the denial is observable.
  *
- * REMOVAL CONDITION. Delete the bridge (make an unresolvable org deny) once every
- * live conference has an `organization` AND every issued session token carries
- * `organizerOrgIds` (i.e. after all pre-#614 tokens have expired / all users have
- * re-logged-in). At that point `orgId === null` should return `false`.
+ * BRIDGE (2) — LEGACY TOKEN — KEPT (SUNSET). A JWT minted before #635 has NO
+ * `organizerOrgIds` field at all; denying those would 403 every logged-in
+ * organizer until their token expires (session maxAge = 30d default) or they re-
+ * login. We still bridge those via the deprecated global flag. This is the LAST
+ * remaining bridge and is dated for removal — see the `TODO(sunset …)` below.
+ *
+ * REMOVAL CONDITION. Delete bridge (2) — and with it Fix A's `trigger: 'update'`
+ * session refresh becomes the mechanism by which any straggler re-mints a modern
+ * token — once every pre-#635 token has expired (30d after #635). At that point a
+ * present-but-absent `organizerOrgIds` should return `false`. See docs/AUTH.md.
  */
 
 /** The minimum shape these checks read off a speaker/session token. */
@@ -31,10 +37,11 @@ type OrganizerSpeaker = Pick<Speaker, '_id' | 'isOrganizer' | 'organizerOrgIds'>
 
 /**
  * PURE, synchronous org-scoped organizer check. Given a speaker and the already-
- * resolved request org id, decide organizer access. `orgId === null` engages the
- * LEGACY BRIDGE (see module docs): fall back to the global `isOrganizer` flag and
- * warn when that grants. Extracted so the decision is unit-testable without a
- * request context.
+ * resolved request org id, decide organizer access. Order matters: a legacy TOKEN
+ * (no `organizerOrgIds` field) defers wholesale to the deprecated global flag
+ * (bridge (2), sunset) BEFORE org resolution is considered; a MODERN token with an
+ * unresolvable `orgId === null` now FAILS CLOSED post-044-backfill (bridge (1)
+ * removed). Extracted so the decision is unit-testable without a request context.
  */
 export function isOrganizerForOrg(
   speaker: OrganizerSpeaker | null | undefined,
@@ -42,27 +49,39 @@ export function isOrganizerForOrg(
 ): boolean {
   if (!speaker?._id) return false
 
-  if (!orgId) {
-    // LEGACY BRIDGE: org unresolvable → defer to the deprecated global flag.
-    if (speaker.isOrganizer === true) {
-      console.warn(
-        `[authz-bridge] organizer org unresolvable; granting via deprecated global isOrganizer for speaker ${speaker._id}`,
-      )
-      return true
-    }
-    return false
-  }
-
-  // LEGACY-TOKEN BRIDGE: a pre-#614 JWT has NO organizerOrgIds field at all
-  // (undefined). Denying those would 403 every logged-in organizer at deploy
-  // time until re-login — bridge via the deprecated flag instead. A PRESENT
-  // but empty array is the real signal "organizer of no org" and is denied.
+  // BRIDGE (2) — LEGACY-TOKEN (SUNSET): checked FIRST because a pre-#635 JWT
+  // carries NO org-scoped info at all (organizerOrgIds absent), so neither the
+  // membership check nor bridge (1)'s fail-closed posture can meaningfully apply
+  // to it — we defer wholesale to the deprecated global flag REGARDLESS of whether
+  // the request org resolved. Denying these would 403 every logged-in organizer
+  // until their token expires or they re-login. A PRESENT but empty array is a
+  // MODERN token ("organizer of no org") and does NOT take this path — it falls
+  // through to the org-scoped logic below.
+  // TODO(sunset 2026-08-26): remove this block — 30d after #635, by when all
+  // pre-#635 tokens (session maxAge = 30d default) have expired. Removing it,
+  // together with Fix A's `trigger: 'update'` refresh, completes the bridge
+  // removal condition (see the module docs and docs/AUTH.md).
   if (speaker.organizerOrgIds === undefined) {
     if (speaker.isOrganizer === true) {
       console.warn(
         `[authz-bridge] legacy token without organizerOrgIds; granting via deprecated global isOrganizer for speaker ${speaker._id}`,
       )
       return true
+    }
+    return false
+  }
+
+  // From here the token is MODERN (organizerOrgIds present).
+  if (!orgId) {
+    // BRIDGE (1) REMOVED — FAIL CLOSED. Post-044-backfill an unresolvable org is
+    // an unknown domain / transient failure, not pre-backfill data, so a modern
+    // token is denied here rather than bridged via the deprecated global flag.
+    // Warn only when a would-be organizer (global flag set) is denied, so the
+    // denial is observable without spamming on ordinary non-organizer traffic.
+    if (speaker.isOrganizer === true) {
+      console.warn(
+        `[authz-bridge] organizer org unresolvable; DENYING (fail-closed, post-044-backfill) for speaker ${speaker._id}`,
+      )
     }
     return false
   }

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -139,9 +139,10 @@ const requireAuth = t.middleware(({ ctx, next }) => {
  * request's organization is resolved from the domain conference (never from
  * client input) and the caller must be an organizer OF THAT org
  * (`speaker.organizerOrgIds` includes it). FAIL CLOSED when the org resolves but
- * the caller is not a member; when the org CANNOT be resolved (pre-044-backfill
- * data / unknown domain) {@link isOrganizerForOrg} engages the documented LEGACY
- * BRIDGE (deprecated global `isOrganizer`, with a `console.warn`). See
+ * the caller is not a member AND when the org CANNOT be resolved (unknown domain /
+ * transient failure) — post-044-backfill {@link isOrganizerForOrg} denies an
+ * unresolvable org (the org-unresolvable bridge is gone). The one remaining bridge
+ * is legacy TOKENS without `organizerOrgIds` (sunset). See
  * `src/lib/authz/organizer.ts` for the bridge's removal condition.
  */
 const requireAdmin = t.middleware(async ({ ctx, next }) => {
@@ -194,9 +195,10 @@ export async function resolveConferenceId(): Promise<string> {
  * The REQUEST's organization id, resolved from the domain conference (the tenant
  * key the org-scoped authz waist gates on). Mirrors {@link resolveConferenceId}
  * but returns `null` rather than throwing when the org cannot be resolved
- * (pre-044-backfill conference / unknown domain), because the authorization
- * middleware maps that `null` onto the deliberate LEGACY BRIDGE rather than a hard
- * failure. The underlying conference read is request-cached, so calling this in
+ * (unknown domain / transient read), because the authorization middleware maps
+ * that `null` onto a FAIL-CLOSED denial (the org-unresolvable bridge is gone;
+ * see `src/lib/authz/organizer.ts`). The underlying conference read is
+ * request-cached, so calling this in
  * the waist does not add a fetch for endpoints that also call
  * `resolveConferenceId`.
  */
@@ -207,7 +209,8 @@ export async function resolveOrganizationId(): Promise<string | null> {
     return conference.organization?._ref ?? null
   } catch {
     // A thrown resolution (no request domain, transient read) must not error the
-    // authz waist — it maps to `null`, i.e. the deliberate legacy bridge.
+    // authz waist — it maps to `null`, which the waist now treats as FAIL CLOSED
+    // (deny) rather than the removed org-unresolvable bridge.
     return null
   }
 }


### PR DESCRIPTION
## Summary

Two related auth hardening changes (M0 session-refresh fix + authz-bridge tightening).

### Problem A — `trigger: 'update'` was a no-op
`jwtSignInCallback` only handled `trigger === 'signIn'`; any other trigger returned the token unchanged. A session could therefore never refresh its speaker claims (`organizerOrgIds`, `isOrganizer`, `name`/`image`) without a full re-login — locking a future org-creation wizard's creator out of their new org and letting stale organizer grants persist for the token's life.

**Fix A.** Implement the `trigger === 'update'` path: re-fetch the speaker (`getSpeaker`, the same `organizerOrgIds` + `isOrganizer` read used at sign-in) and re-apply claims via `applySpeakerToToken`, preserving the authenticated `account`. A transient read failure or a vanished document returns the existing token **unchanged** — a refresh never invalidates a live session. The path is kept strictly separate from sign-in and never runs the sign-in-only link-intent handling.

The client wiring already exists and reaches the callback: `SessionRefreshOnRestore` calls `useSession().update()` on bfcache restore. Documented the trigger patterns (client `update()` / server `unstable_update`) in `docs/AUTH.md`.

### Problem B — the authz legacy bridge was looser than necessary
`isOrganizerForOrg` had two bridges to the deprecated global `isOrganizer` flag. Post-044-backfill (every conference has an `organization`), bridge (1)'s only remaining trigger is an unknown domain / transient failure, where granting is unnecessary permissiveness.

**Fix B.**
- **Bridge (1) — org unresolvable — FAILS CLOSED** for modern tokens (deny; `console.warn` on a would-be organizer's denial for observability).
- **Bridge (2) — legacy TOKEN (no `organizerOrgIds` field) — KEPT**, and checked **first** (a pre-#635 token carries no org-scoped info, so it defers wholesale to the global flag regardless of org resolution — otherwise every logged-in organizer would 403 until their token expired). Added a `TODO(sunset 2026-08-26)` marker (30d post-#635; session `maxAge` = 30d default, no explicit value set) and a `docs/AUTH.md` removal-condition note: removing bridge (2) + Fix A's update trigger together complete the bridge removal.

### Tests
- Update path: refresh surfaces a new org id; transient failure and vanished-doc keep the token; link-intent not run on update.
- Bridge: org-unresolvable modern token now denies (warn logged); legacy-token still bridges; updated the #635 assertions accordingly (`organizer.test.ts`, `authz-org-scoped.test.ts`).
- `mise run check` green (lint 0 errors, typecheck, format, knip). Full vitest green (4051 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
