### PR TITLE
fix(security): per-org nudge recipients, resolver-routed public ticketing, org-scoped pickers (go-live gate B4, B7, E3-E10)

### DIFF
--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -422,8 +422,13 @@ describe('send — organizer-initiated general threads (subjectSpeaker)', () => 
   })
 
   it('creates an organizer general thread when the recipient HAS standing (A5)', async () => {
-    // The speaker id comes back → proposal in this conference OR organizer.
-    standingFetch.mockResolvedValue('sp-target')
+    // The standing helper now runs two reads: (1) resolve the conference's
+    // owning org, (2) the standing predicate. First returns the org, second the
+    // speaker id → proposal in this conference OR same-org organizer.
+    standingFetch.mockReset()
+    standingFetch
+      .mockResolvedValueOnce('org-1') // conference.organization._ref
+      .mockResolvedValueOnce('sp-target') // standing predicate
     getById.mockResolvedValue(organizerGeneralConv)
     const caller = createAdminCaller()
 
@@ -433,18 +438,20 @@ describe('send — organizer-initiated general threads (subjectSpeaker)', () => 
       body: 'hi',
     })
 
-    // Standing MUST accept organizers without a talk this edition — the picker
-    // (speaker.admin.search) offers them, and a narrower server check regressed
-    // into "Speaker not found" for autocompleted organizers in prod.
-    const standingQuery = standingFetch.mock.calls[0][0] as string
+    // E9 (go-live gate): the organizer arm is ORG-SCOPED — same-org, cross-edition
+    // organizers (which the picker offers) still qualify without a talk this
+    // edition, but a cross-TENANT organizer no longer does. The predicate is the
+    // SECOND read; the first resolves the conference's org.
+    const standingQuery = standingFetch.mock.calls[1][0] as string
     expect(standingQuery).toContain(
-      '_id in *[_type == "conference"].organizers[]._ref',
+      '*[_type == "conference" && organization._ref == $orgId].organizers[]._ref',
     )
     expect(standingQuery).toContain('conference._ref == $conferenceId')
 
-    expect(standingFetch).toHaveBeenCalledWith(
+    expect(standingFetch).toHaveBeenNthCalledWith(
+      2,
       expect.any(String),
-      { speakerId: 'sp-target', conferenceId: 'conf-1' },
+      { speakerId: 'sp-target', conferenceId: 'conf-1', orgId: 'org-1' },
       expect.anything(),
     )
     expect(createGeneral).toHaveBeenCalledWith(

--- a/__tests__/lib/messaging/nudge.test.ts
+++ b/__tests__/lib/messaging/nudge.test.ts
@@ -81,7 +81,19 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.spyOn(console, 'error').mockImplementation(() => {})
   vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
   vi.mocked(getOrganizerSpeakerIds).mockResolvedValue(['org-1', 'org-2'])
+  // B4: the loop now batch-resolves each conversation's conference → owning org
+  // before scoping recipients. That extra read is the ONLY fetch carrying
+  // `organization._ref`; route it to a stable mapping so conf-1 owns org-1 (the
+  // per-test `mockResolvedValueOnce` still supplies the selection rows first).
+  // Everything else (the selection query, the teams read) falls through to [].
+  readMock.fetch.mockImplementation(async (query: unknown) => {
+    if (typeof query === 'string' && query.includes('organization._ref')) {
+      return [{ _id: 'conf-1', orgId: 'org-1' }]
+    }
+    return []
+  })
 })
 
 describe('staleConversationCutoff', () => {

--- a/src/app/(cfp)/cfp/list/page.tsx
+++ b/src/app/(cfp)/cfp/list/page.tsx
@@ -54,9 +54,21 @@ export default async function SpeakerDashboard() {
   const organizerContactEmail =
     currentConference?.cfpEmail || currentConference?.contactEmail
 
-  // Fetch all conferences where speaker has activity (server-side)
+  // Fetch conferences where the speaker has activity (server-side). Scoped to
+  // the CURRENT tenant's org (E4): the speaker dashboard on a tenant domain
+  // lists that org's editions (cross-conference within the org is intended;
+  // cross-ORG is a leak). Org-less legacy conferences (pre-044 backfill) still
+  // appear via the coalesce fallback, and the per-conference activity filter
+  // below further narrows to editions the speaker actually took part in. When
+  // the org is unresolvable (legacy domain) the query is unscoped — the
+  // migration bridge used across the codebase.
+  const orgRef = currentConference?.organization?._ref ?? null
   const conferencesQuery = groq`
-    *[_type == "conference"] | order(startDate desc) {
+    *[_type == "conference"${
+      orgRef
+        ? ' && (!defined(organization) || organization._ref == $orgId)'
+        : ''
+    }] | order(startDate desc) {
       _id,
       title,
       organizer,
@@ -86,7 +98,7 @@ export default async function SpeakerDashboard() {
 
   const conferences = await clientReadCached.fetch<Conference[]>(
     conferencesQuery,
-    {},
+    orgRef ? { orgId: orgRef } : {},
     { next: { revalidate: 300 } },
   )
 

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -25,6 +25,7 @@ import {
   getLowestTicketPrice,
   type LowestTicketPrice,
 } from '@/lib/tickets/public'
+import { hasTicketingBinding, ticketingBinding } from '@/lib/tickets/provider'
 import { formatDatesSafe } from '@/lib/time'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { cacheLife, cacheTag } from 'next/cache'
@@ -208,9 +209,14 @@ async function CachedHomeContent({ domain }: { domain: string }) {
   // back silently to plain labels — the homepage must never fail because
   // checkin.no is unavailable.
   let lowestTicketPrice: LowestTicketPrice | null = null
-  if (conference.checkinEventId) {
+  // Gate on the FULL binding (customer + event id — what the resolver
+  // requires) and pass only the minimal binding so the 'use cache' key stays
+  // stable across unrelated conference-field changes.
+  if (hasTicketingBinding(conference)) {
     try {
-      const ticketData = await getPublicTicketTypes(conference)
+      const ticketData = await getPublicTicketTypes(
+        ticketingBinding(conference),
+      )
       if (ticketData) {
         lowestTicketPrice = getLowestTicketPrice(ticketData.tickets)
       }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -210,7 +210,7 @@ async function CachedHomeContent({ domain }: { domain: string }) {
   let lowestTicketPrice: LowestTicketPrice | null = null
   if (conference.checkinEventId) {
     try {
-      const ticketData = await getPublicTicketTypes(conference.checkinEventId)
+      const ticketData = await getPublicTicketTypes(conference)
       if (ticketData) {
         lowestTicketPrice = getLowestTicketPrice(ticketData.tickets)
       }

--- a/src/app/(main)/tickets/page.tsx
+++ b/src/app/(main)/tickets/page.tsx
@@ -105,7 +105,7 @@ async function CachedTicketsContent({ domain }: { domain: string }) {
   }
 
   const ticketData = conference.checkinEventId
-    ? await getPublicTicketTypes(conference.checkinEventId)
+    ? await getPublicTicketTypes(conference)
     : null
 
   const hasTicketPricing = ticketData && ticketData.tickets.length > 0

--- a/src/app/(main)/tickets/page.tsx
+++ b/src/app/(main)/tickets/page.tsx
@@ -2,6 +2,7 @@ import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
 import { isRegistrationAvailable } from '@/lib/conference/state'
 import { getPublicTicketTypes } from '@/lib/tickets/public'
+import { hasTicketingBinding, ticketingBinding } from '@/lib/tickets/provider'
 import { TicketPricingGrid } from '@/components/TicketPricingGrid'
 import { Container } from '@/components/Container'
 import { Button } from '@/components/Button'
@@ -104,8 +105,11 @@ async function CachedTicketsContent({ domain }: { domain: string }) {
     return <div>Error loading conference data</div>
   }
 
-  const ticketData = conference.checkinEventId
-    ? await getPublicTicketTypes(conference)
+  // Gate on the FULL binding (customer + event id — what the resolver
+  // requires) and pass only the minimal binding so the 'use cache' key stays
+  // stable across unrelated conference-field changes.
+  const ticketData = hasTicketingBinding(conference)
+    ? await getPublicTicketTypes(ticketingBinding(conference))
     : null
 
   const hasTicketPricing = ticketData && ticketData.tickets.length > 0

--- a/src/app/(workshop)/workshop/page.tsx
+++ b/src/app/(workshop)/workshop/page.tsx
@@ -95,8 +95,7 @@ export default async function WorkshopPage() {
   if (conference.checkinCustomerId && conference.checkinEventId) {
     const eligibility = await checkWorkshopEligibility({
       userEmail: user.email,
-      customerId: conference.checkinCustomerId,
-      eventId: conference.checkinEventId,
+      conference,
       contactEmail: conference.contactEmail,
     })
 

--- a/src/lib/messaging/nudge.test.ts
+++ b/src/lib/messaging/nudge.test.ts
@@ -3,12 +3,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // --- Boundary mocks --------------------------------------------------------
 
 const createNotificationsMock = vi.fn().mockResolvedValue(undefined)
+// Per-org organizer sets: the nudge now passes the resolved org id and must get
+// back ONLY that tenant's organizers (B4). The default returns the legacy trio
+// for every org so the routing-chain test below is unaffected.
 const getOrganizerSpeakerIdsMock = vi
   .fn()
   .mockResolvedValue(['org-1', 'org-2', 'org-3'])
 vi.mock('@/lib/notification/sanity', () => ({
   createNotifications: (...a: unknown[]) => createNotificationsMock(...a),
-  getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
+  getOrganizerSpeakerIds: (orgId?: string | null) =>
+    getOrganizerSpeakerIdsMock(orgId),
 }))
 
 // TEAMS-2 teams SOURCE keyed by conference id, so the REAL
@@ -72,7 +76,7 @@ const ROWS: Row[] = [
     conferenceId: 'conf-spon',
     lastMessageAt: '2026-01-01T00:00:00Z',
   },
-  // 4. Unassigned, no team on its conference → ALL organizers.
+  // 4. Unassigned, no team on its conference → ALL organizers (of its org).
   {
     _id: 'c-all',
     conversationType: 'general',
@@ -82,9 +86,29 @@ const ROWS: Row[] = [
   },
 ]
 
+// The conversation-selection rows and the conference→org rows come through the
+// SAME `clientReadUncached.fetch` mock; route by the GROQ so the batched
+// conference→org lookup (B4) can be controlled independently.
+let conversationRows: Row[] = ROWS
+let conferenceOrgRows: { _id: string; orgId: string | null }[] = []
+function routeFetch(query: unknown) {
+  if (typeof query === 'string' && query.includes('_type == "conference"')) {
+    return Promise.resolve(conferenceOrgRows)
+  }
+  return Promise.resolve(conversationRows)
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
-  fetchMock.mockResolvedValue(ROWS)
+  getOrganizerSpeakerIdsMock.mockResolvedValue(['org-1', 'org-2', 'org-3'])
+  conversationRows = ROWS
+  // Every conference resolves to a tenant so the routing-chain test proceeds.
+  conferenceOrgRows = [
+    { _id: 'conf-cfp', orgId: 'org-A' },
+    { _id: 'conf-spon', orgId: 'org-A' },
+    { _id: 'conf-none', orgId: 'org-A' },
+  ]
+  fetchMock.mockImplementation((query: unknown) => routeFetch(query))
 })
 
 /** The recipient ids of the createNotifications call whose inputs target `id`. */
@@ -110,5 +134,74 @@ describe('nudgeStaleConversations — assignee → team → all chain', () => {
     expect(summary.nudged).toBe(4)
     // 1 (assignee) + 1 (cfp team) + 1 (sponsors team) + 3 (all orgs) = 6.
     expect(summary.notifications).toBe(6)
+  })
+})
+
+describe('nudgeStaleConversations — per-org recipient isolation (B4)', () => {
+  it('nudges only the owning org’s organizers for each conversation', async () => {
+    // Two unassigned, team-less threads in DIFFERENT tenants. Each must reach
+    // only its own org's organizers via the team-else-all fallback.
+    conversationRows = [
+      {
+        _id: 'c-a',
+        conversationType: 'general',
+        subject: 'Org A thread',
+        conferenceId: 'conf-a',
+        lastMessageAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        _id: 'c-b',
+        conversationType: 'general',
+        subject: 'Org B thread',
+        conferenceId: 'conf-b',
+        lastMessageAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+    conferenceOrgRows = [
+      { _id: 'conf-a', orgId: 'org-A' },
+      { _id: 'conf-b', orgId: 'org-B' },
+    ]
+    getOrganizerSpeakerIdsMock.mockImplementation((orgId?: string | null) => {
+      if (orgId === 'org-A') return Promise.resolve(['a1', 'a2'])
+      if (orgId === 'org-B') return Promise.resolve(['b1', 'b2'])
+      return Promise.resolve([])
+    })
+
+    const summary = await nudgeStaleConversations()
+
+    expect(recipientsFor('c-a')).toEqual(['a1', 'a2'])
+    expect(recipientsFor('c-b')).toEqual(['b1', 'b2'])
+    // No cross-tenant bleed: org B's organizers are never told about org A's
+    // thread and vice versa.
+    expect(recipientsFor('c-a')).not.toContain('b1')
+    expect(recipientsFor('c-b')).not.toContain('a1')
+    expect(summary.nudged).toBe(2)
+    expect(summary.notifications).toBe(4)
+    // The GLOBAL organizer set is never requested for recipient resolution.
+    expect(getOrganizerSpeakerIdsMock).not.toHaveBeenCalledWith(undefined)
+  })
+
+  it('skips a conversation whose org is unresolvable — never broadcasts', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    conversationRows = [
+      {
+        _id: 'c-orphan',
+        conversationType: 'general',
+        subject: 'No org',
+        conferenceId: 'conf-orphan',
+        lastMessageAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+    // Conference exists but carries no organization ref (pre-backfill / null).
+    conferenceOrgRows = [{ _id: 'conf-orphan', orgId: null }]
+
+    const summary = await nudgeStaleConversations()
+
+    expect(createNotificationsMock).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+    expect(summary.nudged).toBe(0)
+    expect(summary.notifications).toBe(0)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 })

--- a/src/lib/messaging/nudge.ts
+++ b/src/lib/messaging/nudge.ts
@@ -90,7 +90,13 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
   }
 
   try {
-    const organizerIds = await getOrganizerSpeakerIds()
+    // GLOBAL organizer set — used ONLY as the candidacy filter below (to exclude
+    // threads whose LAST message is from an organizer). It is a conservative
+    // superset for "was the last author an organizer" and is NEVER used as a
+    // recipient list. Recipients are resolved PER-ORG inside the loop (B4): the
+    // prior code reused this global set as the team-else-all fallback, which
+    // push-notified every tenant's organizers about one tenant's threads.
+    const selectionOrganizerIds = await getOrganizerSpeakerIds(null)
     const cutoff = staleConversationCutoff()
 
     // Selection: open (or absent status) AND no activity since the cutoff AND
@@ -118,11 +124,41 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
           "assignedToId": assignedTo._ref,
           lastMessageAt
         }`,
-        { cutoff, organizerIds },
+        { cutoff, organizerIds: selectionOrganizerIds },
         { cache: 'no-store' },
       )) ?? []
 
     summary.scanned = conversations.length
+
+    // Batch-resolve each distinct conference → owning organization once, so the
+    // per-conversation recipient scoping below never re-reads the same
+    // conference. A conference whose organization is unresolvable (pre-backfill
+    // or missing) maps to `null` and its conversations are SKIPPED — never
+    // broadcast to the global organizer set (B4).
+    const conferenceIds = [
+      ...new Set(
+        conversations
+          .map((c) => c.conferenceId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ]
+    const orgByConference = new Map<string, string | null>()
+    if (conferenceIds.length > 0) {
+      const rows =
+        (await clientReadUncached.fetch<
+          { _id: string; orgId: string | null }[]
+        >(
+          `*[_type == "conference" && _id in $conferenceIds]{
+            "_id": _id,
+            "orgId": organization._ref
+          }`,
+          { conferenceIds },
+          { cache: 'no-store' },
+        )) ?? []
+      for (const row of rows) {
+        orgByConference.set(row._id, row.orgId ?? null)
+      }
+    }
 
     for (const conversation of conversations) {
       try {
@@ -130,11 +166,28 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
         // notification requires a conference ref); skip without stamping.
         if (!conversation.conferenceId) continue
 
+        // Resolve THIS conversation's tenant (its conference's organization).
+        // NO global fallback: if the org is unresolvable we must not broadcast
+        // to other tenants' organizers, so skip (without stamping) and warn —
+        // the thread is retried once the conference is backfilled. (B4)
+        const orgId = orgByConference.get(conversation.conferenceId) ?? null
+        if (!orgId) {
+          console.warn(
+            `Stale nudge: conversation ${conversation._id} has no resolvable organization; skipping (never broadcasting to the global organizer set)`,
+          )
+          continue
+        }
+
+        // The organizer set for THIS tenant only — the team-else-all fallback
+        // for an unassigned thread. Cached per-org by getOrganizerSpeakerIds, so
+        // multiple conversations in the same org share one read.
+        const orgOrganizerIds = await getOrganizerSpeakerIds(orgId)
+
         // Route down the TEAMS-2 chain: the assignee when set → else the
         // thread's team (`sponsors` for a sponsor thread, `cfp` otherwise) →
-        // else every organizer (the team-else-all fallback). If nobody can be
-        // notified (no assignee AND no team AND no organizers), skip without
-        // stamping so the thread is retried once organizers exist.
+        // else every organizer OF THIS ORG (the team-else-all fallback). If
+        // nobody can be notified (no assignee AND no team AND no organizers),
+        // skip without stamping so the thread is retried once organizers exist.
         const recipientIds = conversation.assignedToId
           ? [conversation.assignedToId]
           : await resolveRoutedOrganizerIds({
@@ -143,10 +196,7 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
                 conversation.conversationType === 'sponsor'
                   ? 'sponsors'
                   : 'cfp',
-              // Reuse the organizer set fetched once before the loop as the
-              // team-else-all fallback, so each unassigned conversation does not
-              // re-read it.
-              allOrganizerIds: organizerIds,
+              allOrganizerIds: orgOrganizerIds,
             })
         if (recipientIds.length === 0) continue
 

--- a/src/lib/messaging/standing.test.ts
+++ b/src/lib/messaging/standing.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+
+import { speakerHasStandingInConference } from './standing'
+
+beforeEach(() => vi.clearAllMocks())
+
+/** First fetch resolves the conference's org; second runs the standing query. */
+function primeFetches(orgId: string | null, standingId: string | null) {
+  fetchMock
+    .mockResolvedValueOnce(orgId) // conference.organization._ref
+    .mockResolvedValueOnce(standingId) // standing predicate
+}
+
+describe('speakerHasStandingInConference — org scoping (E9)', () => {
+  it('scopes the organizer arm to the conference’s owning org', async () => {
+    primeFetches('org-A', 'spk-1')
+
+    const ok = await speakerHasStandingInConference('spk-1', 'conf-1')
+
+    expect(ok).toBe(true)
+    const [query, params] = fetchMock.mock.calls[1]
+    // The organizer arm is org-scoped, and the org id is bound.
+    expect(query).toContain('organization._ref == $orgId')
+    expect(params).toMatchObject({
+      speakerId: 'spk-1',
+      conferenceId: 'conf-1',
+      orgId: 'org-A',
+    })
+  })
+
+  it('does NOT match cross-tenant organizers (org-scoped predicate returns null)', async () => {
+    // A cross-org organizer fails the org-scoped organizer arm and has no talk
+    // here → the predicate resolves to null → no standing.
+    primeFetches('org-A', null)
+    expect(await speakerHasStandingInConference('spk-b', 'conf-1')).toBe(false)
+  })
+
+  it('falls back to the GLOBAL organizer scope with a warn for an org-less conference', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    primeFetches(null, 'spk-1')
+
+    const ok = await speakerHasStandingInConference('spk-1', 'legacy-conf')
+
+    expect(ok).toBe(true)
+    const [query, params] = fetchMock.mock.calls[1]
+    expect(query).not.toContain('organization._ref == $orgId')
+    expect(query).toContain('*[_type == "conference"].organizers[]._ref')
+    expect(params).not.toHaveProperty('orgId')
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/src/lib/messaging/standing.ts
+++ b/src/lib/messaging/standing.ts
@@ -1,0 +1,56 @@
+import 'server-only'
+import { clientReadUncached } from '@/lib/sanity/client'
+
+/**
+ * Does `speakerId` have STANDING in `conferenceId` — a proposal (talk) in that
+ * conference OR organizer status of the conference's OWNING ORGANIZATION? This
+ * gates who an organizer may name as the subject of a new general thread and
+ * MUST match the population the admin speaker picker offers (confirmed/accepted
+ * speakers ∪ the org's organizers).
+ *
+ * WHY ORG-SCOPED (E9, go-live gate): the organizer arm was previously matched
+ * against `*[_type == "conference"].organizers[]._ref` — an organizer of ANY
+ * edition anywhere. That was justified only while `isOrganizer` was GLOBAL and
+ * `canAccessConversation` short-circuited on it, so a cross-edition organizer
+ * "already" had access. Under the org-scoped authz boundary (#614) that premise
+ * is gone: a cross-TENANT organizer must NOT be grantable standing in another
+ * org's conference. Scoping the organizer arm to the conference's organization
+ * closes that leak while STILL matching same-org, cross-edition organizers
+ * (which the picker legitimately offers) and talk-holding speakers.
+ *
+ * LEGACY BRIDGE: a conference with no resolvable organization (pre-044 backfill)
+ * falls back to the global organizer scope with a warn — the same migration
+ * bridge used by the authz layer and the recipient-selection helpers. Remove it
+ * under the same condition as those bridges.
+ *
+ * This predicate lives in its own module so the E9 fix can be reviewed and
+ * merged independently of the parallel messaging-authz work that owns the
+ * message router's gates.
+ */
+export async function speakerHasStandingInConference(
+  speakerId: string,
+  conferenceId: string,
+): Promise<boolean> {
+  const orgId = await clientReadUncached.fetch<string | null>(
+    `*[_type == "conference" && _id == $conferenceId][0].organization._ref`,
+    { conferenceId },
+    { cache: 'no-store' },
+  )
+
+  if (!orgId) {
+    console.warn(
+      `[authz-bridge] speakerHasStandingInConference: conference ${conferenceId} has no resolvable organization; using the GLOBAL organizer scope (standing-check legacy bridge)`,
+    )
+  }
+
+  const organizerScope = orgId
+    ? `*[_type == "conference" && organization._ref == $orgId].organizers[]._ref`
+    : `*[_type == "conference"].organizers[]._ref`
+
+  const id = await clientReadUncached.fetch<string | null>(
+    `*[_type == "speaker" && _id == $speakerId && (_id in ${organizerScope} || count(*[_type == "talk" && conference._ref == $conferenceId && ^._id in speakers[]._ref]) > 0)][0]._id`,
+    orgId ? { speakerId, conferenceId, orgId } : { speakerId, conferenceId },
+    { cache: 'no-store' },
+  )
+  return Boolean(id)
+}

--- a/src/lib/sponsor/sanity.orgfilter.test.ts
+++ b/src/lib/sponsor/sanity.orgfilter.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// E10: the sponsor company pickers must be tenant-scoped. getAllSponsors /
+// searchSponsors take an optional orgId that adds a coalesce org clause,
+// tolerating org-less legacy sponsors; omitting it preserves the global catalog.
+const fetchMock = vi.fn().mockResolvedValue([])
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: vi.fn(),
+  organizationField: () => ({}),
+}))
+
+import { getAllSponsors, searchSponsors } from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockResolvedValue([])
+})
+
+describe('getAllSponsors — org scoping (E10)', () => {
+  it('adds a coalesce org clause and binds the org when scoped', async () => {
+    await getAllSponsors('org-A')
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).toContain('!defined(organization)')
+    expect(query).toContain('organization._ref == $orgId')
+    expect(params).toEqual({ orgId: 'org-A' })
+  })
+
+  it('is unscoped (global catalog) when no org is provided', async () => {
+    await getAllSponsors()
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).not.toContain('organization._ref')
+    expect(params).toEqual({})
+  })
+})
+
+describe('searchSponsors — org scoping (E10)', () => {
+  it('applies the org clause alongside the name match', async () => {
+    await searchSponsors('acme', 'org-A')
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).toContain('name match $searchQuery')
+    expect(query).toContain('organization._ref == $orgId')
+    expect(params).toEqual({ searchQuery: 'acme*', orgId: 'org-A' })
+  })
+
+  it('omits the org clause when unscoped', async () => {
+    await searchSponsors('acme')
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).not.toContain('organization._ref')
+    expect(params).toEqual({ searchQuery: 'acme*' })
+  })
+})

--- a/src/lib/sponsor/sanity.ts
+++ b/src/lib/sponsor/sanity.ts
@@ -313,13 +313,40 @@ export async function getSponsor(id: string): Promise<{
   }
 }
 
-export async function searchSponsors(query: string): Promise<{
+/**
+ * Optional tenant filter for the sponsor company pickers (E10). Sponsor entities
+ * are currently global (a shared company catalog), so this is the CONSERVATIVE
+ * scoping: when an org is provided, restrict to that org's sponsors, tolerating
+ * org-less legacy sponsors (pre-044 backfill) via the coalesce fallback. When no
+ * org is provided, behavior is unchanged (every sponsor).
+ *
+ * NOTE (flagged design question): whether sponsor companies should be shared
+ * across tenants or partitioned per-org is an owner decision still pending. This
+ * filter is written so the shared model can be restored by simply passing no
+ * org, and the partitioned model tightened by dropping the coalesce clause.
+ */
+function sponsorOrgFilter(orgId?: string | null): {
+  clause: string
+  params: Record<string, string>
+} {
+  if (!orgId) return { clause: '', params: {} }
+  return {
+    clause: ' && (!defined(organization) || organization._ref == $orgId)',
+    params: { orgId },
+  }
+}
+
+export async function searchSponsors(
+  query: string,
+  orgId?: string | null,
+): Promise<{
   sponsors?: SponsorExisting[]
   error?: Error
 }> {
   try {
+    const { clause, params } = sponsorOrgFilter(orgId)
     const sponsors = await clientWrite.fetch(
-      `*[_type == "sponsor" && name match $searchQuery]{
+      `*[_type == "sponsor" && name match $searchQuery${clause}]{
         _id,
         _createdAt,
         _updatedAt,
@@ -328,7 +355,7 @@ export async function searchSponsors(query: string): Promise<{
         logo,
         logoBright
       }`,
-      { searchQuery: `${query}*` },
+      { searchQuery: `${query}*`, ...params },
     )
 
     return { sponsors }
@@ -337,13 +364,14 @@ export async function searchSponsors(query: string): Promise<{
   }
 }
 
-export async function getAllSponsors(): Promise<{
+export async function getAllSponsors(orgId?: string | null): Promise<{
   sponsors?: SponsorExisting[]
   error?: Error
 }> {
   try {
+    const { clause, params } = sponsorOrgFilter(orgId)
     const sponsors = await clientWrite.fetch(
-      `*[_type == "sponsor"] | order(name asc){
+      `*[_type == "sponsor"${clause}] | order(name asc){
         _id,
         _createdAt,
         _updatedAt,
@@ -353,6 +381,7 @@ export async function getAllSponsors(): Promise<{
         logoBright,
         linkedinUrl
       }`,
+      params,
     )
 
     return { sponsors }

--- a/src/lib/tickets/provider/index.ts
+++ b/src/lib/tickets/provider/index.ts
@@ -57,7 +57,7 @@ export function platformCheckinCredentials(): TicketingProviderCredentials {
 }
 
 /** Just the conference fields the ticketing resolver needs. */
-type ConferenceTicketingBinding = {
+export type ConferenceTicketingBinding = {
   checkinCustomerId?: number
   checkinEventId?: number
   /** The owning organization (tenant), used to resolve per-org credentials. */

--- a/src/lib/tickets/provider/index.ts
+++ b/src/lib/tickets/provider/index.ts
@@ -65,6 +65,39 @@ export type ConferenceTicketingBinding = {
 }
 
 /**
+ * Extract the minimal {@link ConferenceTicketingBinding} from a (potentially
+ * huge) conference object. Callers of CACHED ticketing reads (e.g.
+ * `getPublicTicketTypes`, a `'use cache'` function) must pass THIS rather than
+ * the whole conference: `'use cache'` keys on the serialized arguments, so a
+ * full conference payload (schedules, featured content, …) would fragment the
+ * cache on every unrelated field change.
+ */
+export function ticketingBinding(
+  conference: ConferenceTicketingBinding,
+): ConferenceTicketingBinding {
+  return {
+    checkinCustomerId: conference.checkinCustomerId,
+    checkinEventId: conference.checkinEventId,
+    organization: conference.organization?._ref
+      ? { _ref: conference.organization._ref }
+      : null,
+  }
+}
+
+/**
+ * True when the conference carries the FULL ticketing binding
+ * ({@link resolveTicketingProvider} requires both the customer and event id —
+ * an event id alone is a configuration error, not a supported state). Callers
+ * should gate on this before invoking cached ticketing reads so an
+ * unconfigured conference skips the fetch instead of soft-failing inside it.
+ */
+export function hasTicketingBinding(
+  conference: ConferenceTicketingBinding,
+): boolean {
+  return Boolean(conference.checkinCustomerId && conference.checkinEventId)
+}
+
+/**
  * Request-boundary resolution of a ticketing provider for an already
  * domain-resolved conference.
  *

--- a/src/lib/tickets/public.test.ts
+++ b/src/lib/tickets/public.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// B7: getPublicTicketTypes must route through the request-boundary resolver so a
+// tenant's per-org Checkin key is honored, and must preserve the prior soft-fail
+// (null on unconfigured/error). The `'use cache'` directive is inert in vitest;
+// the next/cache helpers are stubbed to no-ops.
+vi.mock('next/cache', () => ({
+  cacheLife: () => {},
+  cacheTag: () => {},
+}))
+const resolveTicketingProviderMock = vi.fn()
+vi.mock('./provider', () => ({
+  resolveTicketingProvider: (...a: unknown[]) =>
+    resolveTicketingProviderMock(...a),
+}))
+
+import { getPublicTicketTypes } from './public'
+
+const CONF = {
+  checkinCustomerId: 42,
+  checkinEventId: 7,
+  organization: { _ref: 'org-xyz' },
+}
+
+function pubTicket(over: Record<string, unknown>) {
+  return {
+    id: 1,
+    name: 'General',
+    description: '',
+    requiresInvitation: false,
+    position: 0,
+    price: [{ price: '1000', vat: '25' }],
+    ...over,
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('getPublicTicketTypes — resolver routing (B7)', () => {
+  it('resolves from the conference and fetches with the resolved eventId', async () => {
+    const fetchPublicTicketTypes = vi.fn().mockResolvedValue({
+      event: { id: 7, name: 'Event' },
+      tickets: [pubTicket({})],
+    })
+    resolveTicketingProviderMock.mockResolvedValue({
+      configured: true,
+      provider: { fetchPublicTicketTypes },
+      eventRef: { customerId: 42, eventId: 7 },
+    })
+
+    const result = await getPublicTicketTypes(CONF)
+
+    expect(resolveTicketingProviderMock).toHaveBeenCalledWith(CONF)
+    expect(fetchPublicTicketTypes).toHaveBeenCalledWith(7)
+    expect(result?.tickets).toHaveLength(1)
+  })
+
+  it('soft-fails to null when the conference is unconfigured', async () => {
+    resolveTicketingProviderMock.mockResolvedValue({
+      configured: false,
+      provider: null,
+      eventRef: null,
+    })
+    expect(await getPublicTicketTypes({})).toBeNull()
+  })
+
+  it('soft-fails to null (never throws) when the provider fetch errors', async () => {
+    resolveTicketingProviderMock.mockResolvedValue({
+      configured: true,
+      provider: {
+        fetchPublicTicketTypes: vi
+          .fn()
+          .mockRejectedValue(new Error('checkin down')),
+      },
+      eventRef: { customerId: 42, eventId: 7 },
+    })
+    expect(await getPublicTicketTypes(CONF)).toBeNull()
+  })
+})

--- a/src/lib/tickets/public.ts
+++ b/src/lib/tickets/public.ts
@@ -1,5 +1,8 @@
 import { formatDateSafe } from '@/lib/time'
-import { getTicketingProvider, platformCheckinCredentials } from './provider'
+import {
+  resolveTicketingProvider,
+  type ConferenceTicketingBinding,
+} from './provider'
 import { cacheLife, cacheTag } from 'next/cache'
 
 // Public ticket-type shapes now live with the provider contract (they are
@@ -23,7 +26,9 @@ export interface ComplimentaryTicketInfo {
   link: string | null
 }
 
-export async function getPublicTicketTypes(eventId: number): Promise<{
+export async function getPublicTicketTypes(
+  conference: ConferenceTicketingBinding,
+): Promise<{
   event: PublicEventInfo
   tickets: PublicTicketType[]
   complimentaryTickets: ComplimentaryTicketInfo[]
@@ -33,11 +38,15 @@ export async function getPublicTicketTypes(eventId: number): Promise<{
   cacheTag('content:tickets')
 
   try {
-    const provider = getTicketingProvider(
-      'checkin',
-      platformCheckinCredentials(),
+    // Route through the request-boundary resolver (B7) so a tenant's per-org
+    // Checkin key is honored end-to-end instead of the platform env creds. An
+    // unconfigured conference (missing customer/event id) soft-fails to null,
+    // matching the prior `checkinEventId ? … : null` behavior at call sites.
+    const ticketing = await resolveTicketingProvider(conference)
+    if (!ticketing.configured) return null
+    const data = await ticketing.provider.fetchPublicTicketTypes(
+      ticketing.eventRef.eventId,
     )
-    const data = await provider.fetchPublicTicketTypes(eventId)
 
     // Filter to only public tickets: not invite-only, has at least one price > 0
     const publicTickets = data.tickets

--- a/src/lib/tickets/public.ts
+++ b/src/lib/tickets/public.ts
@@ -39,9 +39,13 @@ export async function getPublicTicketTypes(
 
   try {
     // Route through the request-boundary resolver (B7) so a tenant's per-org
-    // Checkin key is honored end-to-end instead of the platform env creds. An
-    // unconfigured conference (missing customer/event id) soft-fails to null,
-    // matching the prior `checkinEventId ? … : null` behavior at call sites.
+    // Checkin key is honored end-to-end instead of the platform env creds.
+    // The resolver requires the FULL binding (customer + event id) — an event
+    // id alone is a configuration error, not a supported state — and an
+    // unconfigured conference soft-fails to null. Callers gate on
+    // `hasTicketingBinding` (and pass `ticketingBinding(conference)`, keeping
+    // this function's 'use cache' key minimal) so the fetch is skipped rather
+    // than resolved-and-refused.
     const ticketing = await resolveTicketingProvider(conference)
     if (!ticketing.configured) return null
     const data = await ticketing.provider.fetchPublicTicketTypes(

--- a/src/lib/workshop/eligibility.test.ts
+++ b/src/lib/workshop/eligibility.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { EventTicket } from '@/lib/tickets/types'
+
+// B7: eligibility must route through the request-boundary resolver (so a
+// tenant's per-org Checkin key is honored) instead of the platform env creds.
+const resolveTicketingProviderMock = vi.fn()
+vi.mock('@/lib/tickets/provider', () => ({
+  resolveTicketingProvider: (...a: unknown[]) =>
+    resolveTicketingProviderMock(...a),
+}))
+vi.mock('@/lib/email/from', () => ({
+  platformFallbackContact: () => 'fallback@example.test',
+}))
+
+import { checkWorkshopEligibility } from './eligibility'
+
+function ticket(email: string, category: string): EventTicket {
+  return {
+    category,
+    crm: { email },
+  } as unknown as EventTicket
+}
+
+const CONF = {
+  checkinCustomerId: 42,
+  checkinEventId: 7,
+  organization: { _ref: 'org-xyz' },
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('checkWorkshopEligibility — resolver routing (B7)', () => {
+  it('resolves the provider from the conference (per-org creds seam) and honors eligible tickets', async () => {
+    const fetchEventTickets = vi
+      .fn()
+      .mockResolvedValue([ticket('SpeakeR@x.test', 'Speaker ticket')])
+    resolveTicketingProviderMock.mockResolvedValue({
+      configured: true,
+      provider: { fetchEventTickets },
+      eventRef: { customerId: 42, eventId: 7 },
+    })
+
+    const result = await checkWorkshopEligibility({
+      userEmail: 'speaker@x.test',
+      conference: CONF,
+    })
+
+    // The whole conference (with its org ref) is handed to the resolver.
+    expect(resolveTicketingProviderMock).toHaveBeenCalledWith(CONF)
+    // And the resolved eventRef — not raw params — drives the fetch.
+    expect(fetchEventTickets).toHaveBeenCalledWith({
+      customerId: 42,
+      eventId: 7,
+    })
+    expect(result.isEligible).toBe(true)
+    expect(result.eligibleTickets).toHaveLength(1)
+  })
+
+  it('soft-fails to “unable to verify” when the conference is unconfigured', async () => {
+    resolveTicketingProviderMock.mockResolvedValue({
+      configured: false,
+      provider: null,
+      eventRef: null,
+    })
+
+    const result = await checkWorkshopEligibility({
+      userEmail: 'speaker@x.test',
+      conference: {},
+      contactEmail: 'help@x.test',
+    })
+
+    expect(result.isEligible).toBe(false)
+    expect(result.reason).toContain('help@x.test')
+    expect(result.tickets).toEqual([])
+  })
+
+  it('soft-fails (never throws) when the provider fetch errors', async () => {
+    resolveTicketingProviderMock.mockResolvedValue({
+      configured: true,
+      provider: {
+        fetchEventTickets: vi.fn().mockRejectedValue(new Error('checkin down')),
+      },
+      eventRef: { customerId: 42, eventId: 7 },
+    })
+
+    const result = await checkWorkshopEligibility({
+      userEmail: 'speaker@x.test',
+      conference: CONF,
+    })
+
+    expect(result.isEligible).toBe(false)
+    expect(result.reason).toContain('Unable to verify')
+  })
+})

--- a/src/lib/workshop/eligibility.ts
+++ b/src/lib/workshop/eligibility.ts
@@ -1,6 +1,6 @@
 import {
-  getTicketingProvider,
-  platformCheckinCredentials,
+  resolveTicketingProvider,
+  type ConferenceTicketingBinding,
 } from '@/lib/tickets/provider'
 import type { EventTicket } from '@/lib/tickets/types'
 import { platformFallbackContact } from '@/lib/email/from'
@@ -20,21 +20,28 @@ export interface WorkshopEligibilityResult {
 
 export async function checkWorkshopEligibility(params: {
   userEmail: string
-  customerId: number
-  eventId: number
+  /** The domain-resolved conference; carries the checkin binding + tenant org. */
+  conference: ConferenceTicketingBinding
   contactEmail?: string
 }): Promise<WorkshopEligibilityResult> {
   const contactEmail = params.contactEmail || platformFallbackContact()
 
   try {
-    const provider = getTicketingProvider(
-      'checkin',
-      platformCheckinCredentials(),
+    // Route through the resolver (B7) so this tenant's per-org Checkin key is
+    // honored instead of the platform env creds. An unconfigured conference
+    // soft-fails to the same "unable to verify" result as a provider error.
+    const ticketing = await resolveTicketingProvider(params.conference)
+    if (!ticketing.configured) {
+      return {
+        isEligible: false,
+        tickets: [],
+        eligibleTickets: [],
+        reason: `Unable to verify workshop ticket at this time. Please try again later or contact us at ${contactEmail} for assistance.`,
+      }
+    }
+    const tickets = await ticketing.provider.fetchEventTickets(
+      ticketing.eventRef,
     )
-    const tickets = await provider.fetchEventTickets({
-      customerId: params.customerId,
-      eventId: params.eventId,
-    })
 
     const userTickets = tickets.filter(
       (ticket) =>

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -7,7 +7,6 @@ import {
 } from '@/server/trpc'
 import { isOrganizerForOrg } from '@/lib/authz/organizer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
-import { clientReadUncached } from '@/lib/sanity/client'
 import { runAfterResponse } from '@/server/runAfterResponse'
 import {
   ListConversationsSchema,
@@ -44,6 +43,7 @@ import {
   getSponsorFanoutContext,
   type SponsorFanoutContext,
 } from '@/lib/messaging/sponsor'
+import { speakerHasStandingInConference } from '@/lib/messaging/standing'
 import { z } from 'zod'
 import {
   getOrganizerSpeakerIds,
@@ -105,41 +105,14 @@ function claimSendSlot(speakerId: string): boolean {
   return true
 }
 
-/**
- * Does `speakerId` have standing in `conferenceId` — a proposal (talk) in that
- * conference OR organizer status? This MUST match the population the admin
- * speaker picker offers (`speaker.admin.search` = confirmed/accepted speakers ∪
- * organizers): a stricter server check rejects recipients the UI legitimately
- * suggests. THE ORGANIZER CLAUSE USES THE CANONICAL DEFINITION — membership in
- * a conference's `organizers[]` array, the same rule the session and the picker
- * derive from. (The speaker schema has NO stored `isOrganizer` field: a prior
- * version tested `isOrganizer == true`, which matches nothing in production and
- * kept rejecting picker-offered organizers with "Speaker not found".)
- * Cross-conference targeting stays blocked: a talk-less non-organizer from
- * another edition has no standing here.
- *
- * ANY-CONFERENCE ORGANIZER MATCH — NOT AN ACCESS GRANT (B2, #642). This clause
- * decides only who the admin picker may NAME as a general-thread subject speaker;
- * it does NOT grant thread access. Access is enforced separately by
- * `canAccessConversation`, which post-#642 is ORG-SCOPED (keys on
- * {@link isOrganizerForOrg} against the thread's own org, no longer the global
- * `isOrganizer` short-circuit). So naming an organizer of another edition as a
- * subject speaker confers no cross-tenant read/write — a cross-tenant organizer
- * is still denied by the access check. The clause stays any-conference to keep
- * matching the population the picker offers; narrowing it would reject a
- * legitimate same-org organizer without closing any hole.
- */
-async function speakerHasStandingInConference(
-  speakerId: string,
-  conferenceId: string,
-): Promise<boolean> {
-  const id = await clientReadUncached.fetch<string | null>(
-    `*[_type == "speaker" && _id == $speakerId && (_id in *[_type == "conference"].organizers[]._ref || count(*[_type == "talk" && conference._ref == $conferenceId && ^._id in speakers[]._ref]) > 0)][0]._id`,
-    { speakerId, conferenceId },
-    { cache: 'no-store' },
-  )
-  return Boolean(id)
-}
+// E9 (go-live gate): the recipient standing check now lives in
+// `@/lib/messaging/standing` and is ORG-SCOPED — an organizer of another
+// TENANT's edition no longer counts as standing here (the pre-#614 "organizer of
+// any edition = global access" premise no longer holds). Same-org cross-edition
+// organizers and talk-holders still qualify. Extracted to its own module so this
+// fix merges cleanly with the parallel messaging-authz work that owns this
+// router's gates. See `speakerHasStandingInConference` there for the full
+// rationale and the legacy (org-less conference) bridge.
 
 /**
  * Load a conversation for an ORGANIZER-ONLY management mutation (status /

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -43,6 +43,7 @@ import {
   suggestTemplateLanguage,
 } from '@/lib/sponsor/templates'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanity'
 import type { Conference } from '@/lib/conference/types'
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import { getCurrentDateTime } from '@/lib/time'
@@ -315,11 +316,17 @@ export const sponsorRouter = router({
     .input(z.object({ query: z.string().optional() }).optional())
     .query(async ({ input }) => {
       try {
+        // Scope the sponsor company picker to the current tenant (E10). Both
+        // branches (search + full list) are filtered so neither leaks other
+        // tenants' sponsors; org-less legacy sponsors still surface. Passing the
+        // org here (not deeper) keeps the shared-catalog fallback trivial to
+        // restore if the owner decides sponsors stay global.
+        const orgRef = await getOrganizationRefForCurrentConference()
         let result
         if (input?.query) {
-          result = await searchSponsors(input.query)
+          result = await searchSponsors(input.query, orgRef)
         } else {
-          result = await getAllSponsors()
+          result = await getAllSponsors(orgRef)
         }
 
         const { sponsors, error } = result
@@ -480,7 +487,10 @@ export const sponsorRouter = router({
 
   tiers: router({
     list: adminProcedure.query(async () => {
-      const { sponsorTiers, error } = await getAllSponsorTiers()
+      // Scope to the current conference (E5): sponsorTier carries conference._ref
+      // (the tenant boundary), so an unscoped read leaked every tenant's tiers.
+      const conferenceId = await resolveConferenceId()
+      const { sponsorTiers, error } = await getAllSponsorTiers(conferenceId)
 
       if (error) {
         throw new TRPCError({

--- a/src/server/routers/topic.test.ts
+++ b/src/server/routers/topic.test.ts
@@ -38,6 +38,15 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }))
 
+// E3: topic.list scopes to the current org. Mock the org resolver (and keep
+// organizationField behaving like the real helper for create).
+const getOrgRefMock = vi.fn()
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: () => getOrgRefMock(),
+  organizationField: (orgId: string | null | undefined) =>
+    orgId ? { organization: { _type: 'reference', _ref: orgId } } : {},
+}))
+
 import { topicRouter } from './topic'
 
 function makeCaller(isOrganizer = true) {
@@ -57,6 +66,7 @@ beforeEach(() => {
   commitMock.mockResolvedValue({ _id: 'topic-1' })
   createMock.mockResolvedValue({ _id: 'topic-new', color: '#2563EB' })
   deleteMock.mockResolvedValue({})
+  getOrgRefMock.mockResolvedValue(null)
   // Default reads: no slug clash, and no references (counts = 0).
   fetchMock.mockImplementation((query: string) => {
     if (query.includes('slug.current')) return Promise.resolve(null)
@@ -71,6 +81,51 @@ describe('topic router — authorization', () => {
       makeCaller(false).create({ title: 'X' }),
     ).rejects.toMatchObject({ code: 'FORBIDDEN' })
     expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('topic router — list (org scoping, E3)', () => {
+  it('scopes to the current org, tolerating org-less legacy topics', async () => {
+    getOrgRefMock.mockResolvedValue('org-A')
+    let listQuery = ''
+    let listParams: Record<string, unknown> | undefined
+    fetchMock.mockImplementation(
+      (query: string, params?: Record<string, unknown>) => {
+        if (query.includes('order(title asc)')) {
+          listQuery = query
+          listParams = params
+          return Promise.resolve([])
+        }
+        return Promise.resolve([])
+      },
+    )
+
+    await makeCaller().list()
+
+    expect(listQuery).toContain('!defined(organization)')
+    expect(listQuery).toContain('organization._ref == $orgId')
+    expect(listParams).toEqual({ orgId: 'org-A' })
+  })
+
+  it('is unscoped when the org is unresolvable (legacy-domain bridge)', async () => {
+    getOrgRefMock.mockResolvedValue(null)
+    let listQuery = ''
+    let listParams: Record<string, unknown> | undefined
+    fetchMock.mockImplementation(
+      (query: string, params?: Record<string, unknown>) => {
+        if (query.includes('order(title asc)')) {
+          listQuery = query
+          listParams = params
+          return Promise.resolve([])
+        }
+        return Promise.resolve([])
+      },
+    )
+
+    await makeCaller().list()
+
+    expect(listQuery).not.toContain('organization._ref == $orgId')
+    expect(listParams).toEqual({})
   })
 })
 

--- a/src/server/routers/topic.ts
+++ b/src/server/routers/topic.ts
@@ -41,10 +41,18 @@ async function uniqueTopicSlug(title: string): Promise<string> {
 }
 
 export const topicRouter = router({
-  /** Every topic, ordered by title — the pick-list source for the editor. */
+  /** This tenant's topics, ordered by title — the pick-list source for the
+   * editor. Scoped to the current org (E3); org-less legacy topics (pre-044
+   * backfill) still appear via the coalesce fallback so nothing vanishes before
+   * the backfill. When the org is unresolvable (legacy domain), all topics show
+   * — the same migration bridge used elsewhere. */
   list: adminProcedure.query(async () => {
+    const orgRef = await getOrganizationRefForCurrentConference()
+    const filter = orgRef
+      ? `_type == "topic" && (!defined(organization) || organization._ref == $orgId)`
+      : `_type == "topic"`
     const topics = await clientReadUncached.fetch<Topic[]>(
-      `*[_type == "topic"] | order(title asc){
+      `*[${filter}] | order(title asc){
         _id,
         _type,
         title,
@@ -52,6 +60,7 @@ export const topicRouter = router({
         color,
         slug
       }`,
+      orgRef ? { orgId: orgRef } : {},
     )
     return topics ?? []
   }),


### PR DESCRIPTION
Closes go-live cross-tenant leaks from the readiness audit (issue #642): findings **B4**, **B7**, and quick scopings **E3/E4/E5/E9/E10**. No merge — held for review.

## Fixes
- **B4 — nudge cron push-leak** (`src/lib/messaging/nudge.ts`): the stale-thread cron ran with no domain context, so `getOrganizerSpeakerIds()` resolved to the GLOBAL organizer set and reused it as the team-else-all fallback, web-pushing every tenant's organizers about one tenant's threads. Now each conversation's conference → owning org is resolved (batched, once per distinct conference) and recipients are scoped to that org's organizers. Unresolvable-org conversations are **skipped with a warn, never broadcast** (no global fallback on the recipient path). The global set is kept only as the candidacy filter that excludes organizer-authored last messages.
- **B7 — public ticketing bypass** (`src/lib/tickets/public.ts`, `src/lib/workshop/eligibility.ts`): both constructed the Checkin client directly with global env creds, bypassing `resolveTicketingProvider`. Rerouted through the resolver (per-org secret store in front of the env default), preserving exact soft-fail semantics (null / "unable to verify" on unconfigured/error). Call sites thread the already-resolved conference.
- **E3 — topics unscoped** (`src/server/routers/topic.ts`): `topic.list` scoped to the current org, coalesce-tolerating org-less legacy topics.
- **E4 — CFP list enumerated all conferences** (`src/app/(cfp)/cfp/list/page.tsx`): scoped to the current tenant's org (cross-edition within the org intended; cross-ORG is not). The activity filter narrows further.
- **E5 — sponsor tiers unscoped** (`src/server/routers/sponsor.ts`): `tiers.list` now uses the conference-scoped read (no client used the unscoped variant).
- **E9 — message standing check** (`src/server/routers/message.ts` → new `src/lib/messaging/standing.ts`): the organizer arm matched an organizer of ANY edition — safe only under the pre-#614 global-`isOrganizer` model. Now org-scoped (same-org cross-edition organizers still qualify; org-less conferences fall back to the global scope with a warn). Extracted to its own module with a one-line import change so it merges cleanly with the parallel messaging-authz branch that owns this router's gates.
- **E10 — sponsor picker** (`src/lib/sponsor/sanity.ts`, `src/server/routers/sponsor.ts`): `getAllSponsors`/`searchSponsors` gain an optional `orgId` filter; the admin picker passes the current org, tolerating org-less legacy sponsors.

## Design notes / flags
- **Sponsor entity sharing (E10)** is a **flagged owner decision**: whether sponsor companies are shared across tenants or partitioned per-org. This ships the conservative version (optional org filter + coalesce fallback) — the shared model is restored by passing no org; the partitioned model tightened by dropping the coalesce clause.
- **message.ts coordination (E9)**: the parallel branch owns this router's authz gates, so the fixed predicate lives in a new file (`src/lib/messaging/standing.ts`) and message.ts only swaps a local function for an import — trivial to reconcile.
- Legacy (pre-044-backfill) tolerance everywhere follows the established coalesce/`!defined(organization)` + org-unresolvable bridge pattern, matching the authz layer.

## Verification
- `mise run check` green (typecheck, lint, knip, format). Build's keychain secret-resolution failure is environmental and expected.
- Full vitest suite green: **4096 passed**. New/updated tests: per-org nudge isolation + unresolvable-org skip; resolver routing + soft-fail for public types & eligibility; org-scoped standing (incl. legacy bridge); org-scoped topics & sponsor pickers; updated the two existing nudge suites and the message-router standing assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
