### PR TITLE
fix(security): org-scope organizer checks across protectedProcedure surfaces (go-live gate B1-B3, E11)

### DIFF
--- a/src/app/(admin)/admin/proposals/[id]/page.tsx
+++ b/src/app/(admin)/admin/proposals/[id]/page.tsx
@@ -32,10 +32,14 @@ export default async function ProposalDetailPage({
     const { conference, domain } = await getConferenceForCurrentDomain({
       topics: true,
     })
+    // ORG-SCOPE the organizer read to this tenant (B1, #642): a proposal from
+    // another organization's conference must not be reachable by URL id even for a
+    // signed-in organizer. A null org fails closed (proposal → notFound below).
     const { proposal, proposalError } = await getProposalSanity({
       id,
       speakerId: '',
       isOrganizer: true,
+      organizerOrgId: conference?.organization?._ref ?? null,
       includeReviews: true,
       includePreviousAcceptedTalks: true,
       includeSubmittedTalks: true,

--- a/src/app/(cfp)/cfp/proposal/[id]/page.tsx
+++ b/src/app/(cfp)/cfp/proposal/[id]/page.tsx
@@ -3,7 +3,10 @@ import { notFound, redirect } from 'next/navigation'
 import { headers } from 'next/headers'
 import { getProposalSanity as getProposal } from '@/lib/proposal/server'
 import { getAuthSession } from '@/lib/auth'
-import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
+import {
+  isOrganizerForCurrentOrg,
+  resolveCurrentOrgId,
+} from '@/lib/authz/organizer'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { ProposalReadOnlyView } from '@/components/cfp/ProposalReadOnlyView'
@@ -51,6 +54,10 @@ export default async function ProposalViewPage({
     id,
     speakerId: session.speaker._id,
     isOrganizer: isImpersonatingAsOrganizer,
+    // B1 (#642): org-scope the impersonated organizer read to the current org.
+    organizerOrgId: isImpersonatingAsOrganizer
+      ? await resolveCurrentOrgId()
+      : null,
   })
 
   if (proposalError) {

--- a/src/app/api/upload/proposal-attachment/route.ts
+++ b/src/app/api/upload/proposal-attachment/route.ts
@@ -1,7 +1,10 @@
 import { handleUpload, type HandleUploadBody } from '@vercel/blob/client'
 import { NextResponse } from 'next/server'
 import { NextAuthRequest, auth } from '@/lib/auth'
-import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
+import {
+  isOrganizerForCurrentOrg,
+  resolveCurrentOrgId,
+} from '@/lib/authz/organizer'
 import { getProposal } from '@/lib/proposal/data/sanity'
 
 /**
@@ -100,6 +103,10 @@ export const POST = auth(async (req: NextAuthRequest) => {
           id: proposalId,
           speakerId,
           isOrganizer,
+          // B1 (#642): the organizer branch is org-scoped — pass the current org
+          // so a legitimate current-org organizer resolves (and cross-tenant ids
+          // do not). Non-organizer reads ignore this (speaker-scoped).
+          organizerOrgId: isOrganizer ? await resolveCurrentOrgId() : null,
         })
 
         if (proposalError || !proposal) {

--- a/src/lib/badge/issuance.orgscope.test.ts
+++ b/src/lib/badge/issuance.orgscope.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment node
+ *
+ * E11 (#642) — an ORGANIZER badge must only be issuable to someone who organizes
+ * a conference IN THIS conference's org. Before the fix the eligibility gate read
+ * the DEPRECATED GLOBAL `speaker.isOrganizer` (true for an organizer of ANY org),
+ * so an org-A admin could mint an org-A organizer badge for an org-B-only
+ * organizer. These pin: cross-tenant recipient rejected; same-org recipient
+ * passes the eligibility gate.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchMock = vi.fn()
+const getSpeakerMock = vi.fn()
+const checkBadgeExistsMock = vi.fn()
+const getConferenceMock = vi.fn()
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+vi.mock('@/lib/speaker/sanity', () => ({
+  getSpeaker: (...a: unknown[]) => getSpeakerMock(...a),
+}))
+vi.mock('./sanity', () => ({
+  checkBadgeExists: (...a: unknown[]) => checkBadgeExistsMock(...a),
+  createBadge: vi.fn(),
+  uploadBadgeSVGAsset: vi.fn(),
+}))
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...a: unknown[]) => getConferenceMock(...a),
+}))
+// Unused-before-return generation deps — inert stubs.
+vi.mock('./generator', () => ({ generateBadgeCredential: vi.fn() }))
+vi.mock('./config', () => ({ createBadgeConfiguration: vi.fn() }))
+vi.mock('./svg', () => ({ generateBadgeSVG: vi.fn() }))
+vi.mock('@/lib/openbadges', () => ({ bakeBadge: vi.fn() }))
+vi.mock('@/lib/time', () => ({
+  formatConferenceDateForBadge: vi.fn(),
+  getCurrentDateTime: vi.fn(),
+}))
+
+import { issueBadgeForSpeaker } from './issuance'
+
+// fetch is called twice for the org check: (1) orgRef of the conference,
+// (2) count of the recipient's org-scoped organizer membership.
+function mockOrgCheck({
+  orgRef,
+  isMember,
+}: {
+  orgRef: string | null
+  isMember: boolean
+}) {
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValueOnce(orgRef) // conference → organization._ref
+  fetchMock.mockResolvedValueOnce(isMember) // count(...) > 0
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkBadgeExistsMock.mockResolvedValue({ exists: false })
+  getSpeakerMock.mockResolvedValue({
+    speaker: { _id: 'sp-x', name: 'Pat', email: 'pat@x.test', slug: 'pat' },
+    err: null,
+  })
+  // Force a distinct later failure so a recipient who PASSES the org-scoped
+  // eligibility gate is provable without mocking the whole issuance pipeline.
+  getConferenceMock.mockResolvedValue({
+    error: new Error('boom'),
+    conference: null,
+  })
+})
+
+describe('issueBadgeForSpeaker — organizer badge org scoping (E11)', () => {
+  it('REJECTS a recipient who does not organize this conference’s org', async () => {
+    mockOrgCheck({ orgRef: 'org-A', isMember: false })
+    const res = await issueBadgeForSpeaker({
+      speakerId: 'sp-x',
+      badgeType: 'organizer',
+      conferenceId: 'conf-A',
+      isDevelopment: false,
+    })
+    expect(res).toEqual({
+      success: false,
+      error: 'Not eligible: Pat is not an organizer',
+    })
+  })
+
+  it('FAILS CLOSED when the conference has no resolvable org', async () => {
+    mockOrgCheck({ orgRef: null, isMember: true })
+    const res = await issueBadgeForSpeaker({
+      speakerId: 'sp-x',
+      badgeType: 'organizer',
+      conferenceId: 'conf-A',
+      isDevelopment: false,
+    })
+    expect(res).toMatchObject({
+      success: false,
+      error: expect.stringContaining('not an organizer'),
+    })
+  })
+
+  it('PASSES the eligibility gate for a same-org organizer (fails later, not on eligibility)', async () => {
+    mockOrgCheck({ orgRef: 'org-A', isMember: true })
+    const res = await issueBadgeForSpeaker({
+      speakerId: 'sp-x',
+      badgeType: 'organizer',
+      conferenceId: 'conf-A',
+      isDevelopment: false,
+    })
+    // Got past the organizer gate → the next step (conference load) is where it
+    // stops, NOT the eligibility check.
+    expect(res).toEqual({ success: false, error: 'Conference not found' })
+  })
+})

--- a/src/lib/badge/issuance.ts
+++ b/src/lib/badge/issuance.ts
@@ -60,10 +60,29 @@ export async function issueBadgeForSpeaker(
     }
   }
 
-  if (badgeType === 'organizer' && !speaker.isOrganizer) {
-    return {
-      success: false,
-      error: `Not eligible: ${speaker.name} is not an organizer`,
+  if (badgeType === 'organizer') {
+    // ORG-SCOPED eligibility (E11, #642): an organizer badge may only be issued
+    // to someone who organizes a conference IN THIS conference's org — not the
+    // deprecated GLOBAL `speaker.isOrganizer` (true for an organizer of ANY org),
+    // which let an org-A admin mint an org-A organizer badge for an org-B-only
+    // organizer. Resolve the org from the (authoritative, domain-derived)
+    // conferenceId; a null org denies (fail closed).
+    const { clientReadUncached } = await import('@/lib/sanity/client')
+    const orgRef = await clientReadUncached.fetch<string | null>(
+      `*[_type == "conference" && _id == $conferenceId][0].organization._ref`,
+      { conferenceId },
+    )
+    const isOrgOrganizer = orgRef
+      ? await clientReadUncached.fetch<boolean>(
+          `count(*[_type == "conference" && organization._ref == $orgRef && $speakerId in organizers[]._ref]) > 0`,
+          { orgRef, speakerId: speaker._id },
+        )
+      : false
+    if (!isOrgOrganizer) {
+      return {
+        success: false,
+        error: `Not eligible: ${speaker.name} is not an organizer`,
+      }
     }
   }
 

--- a/src/lib/email/speaker.ts
+++ b/src/lib/email/speaker.ts
@@ -51,6 +51,9 @@ export async function sendMultiSpeakerEmail({
       id: proposalId,
       speakerId: '',
       isOrganizer: true,
+      // B1 (#642): org-scope the organizer read to this conference's tenant so a
+      // cross-tenant proposal id cannot be loaded into another org's email.
+      organizerOrgId: conference.organization?._ref ?? null,
       includeReviews: false,
       includePreviousAcceptedTalks: false,
       includeSubmittedTalks: false,

--- a/src/lib/messaging/canAccess.orgscope.test.ts
+++ b/src/lib/messaging/canAccess.orgscope.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment node
+ *
+ * B2 (#642) — canAccessConversation's ORGANIZER branch must be ORG-SCOPED. Before
+ * the fix it short-circuited on the DEPRECATED GLOBAL `speaker.isOrganizer`, so an
+ * organizer of ANY org could read/write another tenant's thread by id. It now
+ * keys on the conversation's OWN org (`conferenceOrgId`) via `isOrganizerForOrg`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { canAccessConversation } from './sanity'
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+// A proposal thread owned by org-A, with speaker sp-owner on the proposal.
+const orgAThread = () => ({
+  conversationType: 'proposal' as const,
+  conferenceOrgId: 'org-A',
+  proposalSpeakerIds: ['sp-owner'],
+  createdById: 'sp-owner',
+  subjectSpeakerId: undefined,
+  participants: [{ partyType: 'speaker' as const, speakerId: 'sp-owner' }],
+})
+
+describe('canAccessConversation — org-scoped organizer (B2)', () => {
+  it('GRANTS a same-org organizer', () => {
+    expect(
+      canAccessConversation(orgAThread(), {
+        _id: 'org-a-admin',
+        organizerOrgIds: ['org-A'],
+      }),
+    ).toBe(true)
+  })
+
+  it('DENIES a cross-tenant organizer (org-B) reaching an org-A thread', () => {
+    expect(
+      canAccessConversation(orgAThread(), {
+        _id: 'org-b-admin',
+        isOrganizer: true,
+        organizerOrgIds: ['org-B'],
+      }),
+    ).toBe(false)
+  })
+
+  it('still GRANTS the speaker who is a party on the thread (unaffected)', () => {
+    expect(
+      canAccessConversation(orgAThread(), {
+        _id: 'sp-owner',
+        organizerOrgIds: [],
+      }),
+    ).toBe(true)
+  })
+
+  it('DENIES an unrelated speaker (not a party, not an organizer)', () => {
+    expect(
+      canAccessConversation(orgAThread(), {
+        _id: 'sp-other',
+        organizerOrgIds: [],
+      }),
+    ).toBe(false)
+  })
+
+  it('legacy-token bridge: an org-less global-flag organizer still passes (parity, sunset)', () => {
+    // No organizerOrgIds field → pre-#635 token → isOrganizerForOrg bridges via
+    // the global flag regardless of the thread org (matches #639 semantics).
+    expect(
+      canAccessConversation(orgAThread(), {
+        _id: 'legacy-admin',
+        isOrganizer: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('a null thread org denies an org organizer (fail closed)', () => {
+    expect(
+      canAccessConversation(
+        { ...orgAThread(), conferenceOrgId: null },
+        { _id: 'org-a-admin', isOrganizer: true, organizerOrgIds: ['org-A'] },
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -8,6 +8,7 @@ import {
   organizationField,
 } from '@/lib/organization/sanity'
 import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import { isOrganizerForOrg } from '@/lib/authz/organizer'
 import { getViewerTeamKeys } from '@/lib/teams'
 import type {
   AccessSpeaker,
@@ -63,6 +64,7 @@ const PAGE_SIZE = 20
 const CONVERSATION_PROJECTION = `{
   "_id": _id,
   "conferenceId": conference._ref,
+  "conferenceOrgId": conference->organization._ref,
   conversationType,
   "proposalId": proposal._ref,
   "proposalTitle": proposal->title,
@@ -522,14 +524,22 @@ export function resolveRecipients(
  * `participants[]` preferred, legacy derive fallback) rather than a direct read
  * of the legacy fields. For a proposal thread the speaker parties ARE the
  * proposal speakers; for a general thread they are the creator (+ subject
- * speaker) — the same set the legacy field checks expressed. Organizer access
- * still short-circuits on the server-derived `isOrganizer` flag (the
- * `organizers` group party is never expanded here).
+ * speaker) — the same set the legacy field checks expressed.
+ *
+ * ORG-SCOPED ORGANIZER (B2, #642): organizer access no longer short-circuits on
+ * the DEPRECATED GLOBAL `isOrganizer` flag (true for an organizer of ANY org,
+ * which let a CNB organizer read an external tenant's thread by id). It now keys
+ * on {@link isOrganizerForOrg} against the CONVERSATION'S OWN org
+ * (`conferenceOrgId`, projected from `conference->organization`) — the same
+ * org-scoped decision (with legacy-token bridge) the middleware waist uses. A
+ * conversation whose org the caller does not organize falls through to the
+ * speaker-party check, so a cross-tenant organizer is denied.
  */
 export function canAccessConversation(
   conversation: Pick<
     ConversationWithContext,
     | 'conversationType'
+    | 'conferenceOrgId'
     | 'proposalSpeakerIds'
     | 'createdById'
     | 'subjectSpeakerId'
@@ -537,7 +547,9 @@ export function canAccessConversation(
   >,
   speaker: AccessSpeaker,
 ): boolean {
-  if (speaker.isOrganizer) return true
+  if (isOrganizerForOrg(speaker, conversation.conferenceOrgId ?? null)) {
+    return true
+  }
   return resolveParticipants(conversation).some(
     (party) => party.partyType === 'speaker' && party.speakerId === speaker._id,
   )

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -138,7 +138,12 @@ export function validateConversationParticipant(
 /** A speaker as needed for authorization decisions (server-derived). */
 export interface AccessSpeaker {
   _id: string
+  /** DEPRECATED GLOBAL flag — retained only for the legacy-token bridge inside
+   * {@link isOrganizerForOrg}; do NOT branch access on it directly (B2, #642). */
   isOrganizer?: boolean
+  /** ORG-SCOPED organizer capability: the org ids this speaker organizes. The
+   * conversation-access check keys on this against the thread's own org. */
+  organizerOrgIds?: string[]
 }
 
 /**
@@ -155,6 +160,13 @@ export interface AccessSpeaker {
 export interface ConversationWithContext {
   _id: string
   conferenceId: string
+  /**
+   * The org that owns this conversation's conference (projected from
+   * `conference->organization`). The tenant key the org-scoped organizer access
+   * check ({@link canAccessConversation}) gates on (B2, #642). May be null for a
+   * pre-044-backfill conference; a null org denies organizer access (fail closed).
+   */
+  conferenceOrgId?: string | null
   conversationType: ConversationType
   proposalId?: string
   proposalTitle?: string

--- a/src/lib/proposal/data/getProposal.orgscope.test.ts
+++ b/src/lib/proposal/data/getProposal.orgscope.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @vitest-environment node
+ *
+ * B1 (#642) — getProposal's ORGANIZER branch must be ORG-SCOPED. Before the fix
+ * the organizer branch dropped ALL scoping (`speakerFilter = ''` →
+ * `*[_type=="talk" && _id==$id]`), so an organizer of ANY org could read another
+ * tenant's proposal by exact id. These pin the GROQ the organizer branch now
+ * emits: it constrains the proposal to the conferences of the passed org, and
+ * FAILS CLOSED (matches nothing) when no org is supplied.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientWrite: {},
+}))
+
+import { getProposal } from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockResolvedValue({ _id: 'talk-1' })
+})
+
+const lastCall = () => {
+  const [query, params] = fetchMock.mock.calls.at(-1) as [
+    string,
+    Record<string, unknown>,
+  ]
+  return { query, params }
+}
+
+describe('getProposal — organizer branch org scoping (B1)', () => {
+  it('scopes the organizer read to the org’s conferences (never an unscoped id read)', async () => {
+    await getProposal({
+      id: 'talk-A',
+      speakerId: 'org-user',
+      isOrganizer: true,
+      organizerOrgId: 'org-A',
+    })
+    const { query, params } = lastCall()
+    expect(query).toContain(
+      'conference._ref in *[_type == "conference" && organization._ref == $organizerOrgId]._id',
+    )
+    // The pre-fix unscoped organizer query had NO extra predicate after _id==$id.
+    expect(query).not.toMatch(/_id==\$id\s*\]\{/)
+    expect(params.organizerOrgId).toBe('org-A')
+  })
+
+  it('FAILS CLOSED when the organizer branch has no resolvable org (matches nothing)', async () => {
+    await getProposal({
+      id: 'talk-A',
+      speakerId: 'org-user',
+      isOrganizer: true,
+      organizerOrgId: null,
+    })
+    const { query } = lastCall()
+    expect(query).toContain('&& false')
+    expect(query).not.toContain('organization._ref == $organizerOrgId')
+  })
+
+  it('non-organizer (owner) branch stays speaker-scoped, ignoring org', async () => {
+    await getProposal({
+      id: 'talk-A',
+      speakerId: 'sp-1',
+      isOrganizer: false,
+      organizerOrgId: 'org-A',
+    })
+    const { query } = lastCall()
+    expect(query).toContain('"sp-1" in speakers[]._ref')
+    expect(query).not.toContain('organization._ref == $organizerOrgId')
+  })
+})

--- a/src/lib/proposal/data/sanity.ts
+++ b/src/lib/proposal/data/sanity.ts
@@ -20,6 +20,7 @@ export async function getProposal({
   id,
   speakerId,
   isOrganizer = false,
+  organizerOrgId,
   includeReviews = false,
   includeSubmittedTalks = false,
   includePreviousAcceptedTalks = false,
@@ -27,6 +28,16 @@ export async function getProposal({
   id: string
   speakerId: string
   isOrganizer?: boolean
+  /**
+   * ORG-SCOPE for the organizer branch (go-live B1, #642). When `isOrganizer`,
+   * the proposal is constrained to the conferences of THIS organization — a
+   * proposal from another tenant's conference is invisible even by exact id, so
+   * a CNB organizer cannot reach an external tenant's proposal. Prior to #642
+   * the organizer branch dropped ALL scoping (`speakerFilter = ''`). A null/absent
+   * org here FAILS CLOSED (the organizer branch matches nothing) rather than
+   * reverting to the unscoped query. Ignored for the non-organizer (owner) branch.
+   */
+  organizerOrgId?: string | null
   includeReviews?: boolean
   includeSubmittedTalks?: boolean
   includePreviousAcceptedTalks?: boolean
@@ -39,7 +50,9 @@ export async function getProposal({
   let proposal: ProposalExisting = {} as ProposalExisting
 
   const speakerFilter = isOrganizer
-    ? ''
+    ? organizerOrgId
+      ? `&& conference._ref in *[_type == "conference" && organization._ref == $organizerOrgId]._id`
+      : `&& false`
     : `&& "${speakerId}" in speakers[]._ref`
 
   try {
@@ -112,7 +125,7 @@ export async function getProposal({
 
     proposal = await clientRead.fetch(
       query,
-      { id, speakerId },
+      { id, speakerId, organizerOrgId: organizerOrgId ?? null },
       { cache: 'no-store' },
     )
   } catch (error) {

--- a/src/lib/travel-support/auth.orgscope.test.ts
+++ b/src/lib/travel-support/auth.orgscope.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment node
+ *
+ * B3 (#642) — travel-support authorization (which guards BANKING PII) must scope
+ * the organizer grant to the request's OWN org, not the deprecated global
+ * `isOrganizer` flag. Before the fix `hasAccess = isOrganizer || owner` trusted
+ * the global flag, so an organizer of ANY org could read/modify another tenant's
+ * banking details. These pin: cross-tenant organizer denied, same-org granted,
+ * owner unaffected, and self-approval still blocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getByIdMock = vi.fn()
+vi.mock('./sanity', () => ({
+  getTravelSupportById: (...a: unknown[]) => getByIdMock(...a),
+}))
+vi.mock('@/lib/speaker/sanity', () => ({ getSpeaker: vi.fn() }))
+vi.mock('@/lib/environment/config', () => ({
+  AppEnvironment: { isTestMode: false },
+}))
+
+import {
+  verifyTravelSupportOwnership,
+  authorizeTravelSupportOperation,
+} from './auth'
+
+// An org-A request owned by speaker sp-owner.
+const orgADoc = () => ({
+  _id: 'ts-A',
+  status: 'submitted',
+  speaker: { _id: 'sp-owner', name: 'Owner', email: 'o@x.test' },
+  conference: { _id: 'conf-A', name: 'Conf A' },
+  conferenceOrgId: 'org-A',
+  expenses: [],
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  getByIdMock.mockResolvedValue({ travelSupport: orgADoc(), error: null })
+})
+
+const orgA = { _id: 'a-admin', name: 'A Admin', organizerOrgIds: ['org-A'] }
+const orgB = {
+  _id: 'b-admin',
+  name: 'B Admin',
+  isOrganizer: true,
+  organizerOrgIds: ['org-B'],
+}
+const owner = { _id: 'sp-owner', name: 'Owner', organizerOrgIds: [] }
+
+describe('verifyTravelSupportOwnership — org-scoped (B3)', () => {
+  it('GRANTS a same-org organizer', async () => {
+    const r = await verifyTravelSupportOwnership('ts-A', orgA)
+    expect(r.hasAccess).toBe(true)
+    expect(r.isOrganizer).toBe(true)
+  })
+
+  it('DENIES a cross-tenant organizer (org-B) reaching org-A banking PII', async () => {
+    const r = await verifyTravelSupportOwnership('ts-A', orgB)
+    expect(r.hasAccess).toBe(false)
+    expect(r.isOrganizer).toBe(false)
+  })
+
+  it('GRANTS the owner regardless of org membership', async () => {
+    const r = await verifyTravelSupportOwnership('ts-A', owner)
+    expect(r.hasAccess).toBe(true)
+    expect(r.isOrganizer).toBe(false)
+  })
+})
+
+describe('authorizeTravelSupportOperation — approve (B3)', () => {
+  it('DENIES a cross-tenant organizer approving (NOT_FOUND/FORBIDDEN, never authorized)', async () => {
+    const r = await authorizeTravelSupportOperation('ts-A', orgB, 'approve')
+    expect(r.authorized).toBe(false)
+  })
+
+  it('lets a same-org organizer approve another speaker’s request', async () => {
+    const r = await authorizeTravelSupportOperation('ts-A', orgA, 'approve')
+    expect(r.authorized).toBe(true)
+  })
+
+  it('blocks a same-org organizer approving their OWN request', async () => {
+    getByIdMock.mockResolvedValueOnce({
+      travelSupport: {
+        ...orgADoc(),
+        speaker: { _id: 'a-admin', name: 'A Admin', email: 'a@x.test' },
+      },
+      error: null,
+    })
+    const r = await authorizeTravelSupportOperation('ts-A', orgA, 'approve')
+    expect(r.authorized).toBe(false)
+  })
+
+  it('legacy-token bridge: an org-less global-flag organizer still authorizes (parity, sunset)', async () => {
+    const legacy = { _id: 'legacy', name: 'Legacy', isOrganizer: true }
+    const r = await authorizeTravelSupportOperation('ts-A', legacy, 'approve')
+    expect(r.authorized).toBe(true)
+  })
+})

--- a/src/lib/travel-support/auth.ts
+++ b/src/lib/travel-support/auth.ts
@@ -8,6 +8,23 @@ import {
   TravelExpense,
 } from './types'
 import { AppEnvironment } from '@/lib/environment/config'
+import { isOrganizerForOrg } from '@/lib/authz/organizer'
+
+/**
+ * The minimum speaker shape the travel-support authz needs: identity plus the
+ * ORG-SCOPED organizer capability (`organizerOrgIds`, with `isOrganizer` kept
+ * only for the legacy-token bridge inside {@link isOrganizerForOrg}). Callers pass
+ * `ctx.speaker` (the session speaker). B3 (#642): the organizer grant is decided
+ * against the REQUEST'S OWN org (the travel support's conference org), never the
+ * deprecated global flag — so a cross-tenant organizer cannot reach another
+ * tenant's banking PII.
+ */
+export interface TravelSupportAuthSpeaker {
+  _id: string
+  name?: string
+  isOrganizer?: boolean
+  organizerOrgIds?: string[]
+}
 
 export async function checkSpeakerEligibility(speakerId: string): Promise<{
   isEligible: boolean
@@ -47,12 +64,17 @@ export function canAddExpenses(status: TravelSupportStatus): boolean {
 
 export async function verifyTravelSupportOwnership(
   travelSupportId: string,
-  speakerId: string,
-  isOrganizer: boolean = false,
+  speaker: TravelSupportAuthSpeaker,
 ): Promise<{
   travelSupport:
     (TravelSupportWithSpeaker & { expenses: TravelExpense[] }) | null
   hasAccess: boolean
+  /**
+   * The ORG-SCOPED organizer decision for THIS request (the caller organizes the
+   * travel support's own org). Surfaced so callers (e.g. the `approve` gate) reuse
+   * the same resource-scoped grant rather than the deprecated global flag.
+   */
+  isOrganizer: boolean
   error?: Error
 }> {
   try {
@@ -62,15 +84,28 @@ export async function verifyTravelSupportOwnership(
       return {
         travelSupport: null,
         hasAccess: false,
+        isOrganizer: false,
         error: error || new Error('Travel support request not found'),
       }
     }
 
-    const hasAccess = isOrganizer || travelSupport.speaker._id === speakerId
+    // ORG-SCOPE the organizer grant to the request's OWN org (B3, #642): an
+    // organizer of another tenant is not an organizer HERE and falls back to the
+    // owner check, so cross-tenant banking PII stays inaccessible.
+    const isOrganizer = isOrganizerForOrg(
+      speaker,
+      travelSupport.conferenceOrgId ?? null,
+    )
+    const hasAccess = isOrganizer || travelSupport.speaker._id === speaker._id
 
-    return { travelSupport, hasAccess }
+    return { travelSupport, hasAccess, isOrganizer }
   } catch (error) {
-    return { travelSupport: null, hasAccess: false, error: error as Error }
+    return {
+      travelSupport: null,
+      hasAccess: false,
+      isOrganizer: false,
+      error: error as Error,
+    }
   }
 }
 
@@ -139,8 +174,7 @@ export function auditLog(
 
 export async function authorizeTravelSupportOperation(
   travelSupportId: string,
-  speakerId: string,
-  isOrganizer: boolean,
+  speaker: TravelSupportAuthSpeaker,
   operation: 'read' | 'modify' | 'submit' | 'approve',
 ): Promise<{
   authorized: boolean
@@ -148,12 +182,8 @@ export async function authorizeTravelSupportOperation(
   error?: TRPCError
 }> {
   try {
-    const { travelSupport, hasAccess, error } =
-      await verifyTravelSupportOwnership(
-        travelSupportId,
-        speakerId,
-        isOrganizer,
-      )
+    const { travelSupport, hasAccess, isOrganizer, error } =
+      await verifyTravelSupportOwnership(travelSupportId, speaker)
 
     if (error || !travelSupport) {
       return {
@@ -215,7 +245,7 @@ export async function authorizeTravelSupportOperation(
           }
         }
 
-        if (travelSupport.speaker._id === speakerId) {
+        if (travelSupport.speaker._id === speaker._id) {
           return {
             authorized: false,
             error: createAuthError(

--- a/src/lib/travel-support/auth.ts
+++ b/src/lib/travel-support/auth.ts
@@ -179,6 +179,13 @@ export async function authorizeTravelSupportOperation(
 ): Promise<{
   authorized: boolean
   travelSupport?: TravelSupportWithSpeaker & { expenses: TravelExpense[] }
+  /**
+   * The ORG-SCOPED organizer decision for this request (see
+   * {@link verifyTravelSupportOwnership}), surfaced on success so callers (e.g.
+   * audit logging) record the grant that was actually enforced — not the
+   * deprecated global flag.
+   */
+  isOrganizer?: boolean
   error?: TRPCError
 }> {
   try {
@@ -266,6 +273,7 @@ export async function authorizeTravelSupportOperation(
     return {
       authorized: true,
       travelSupport,
+      isOrganizer,
     }
   } catch (error) {
     return {

--- a/src/lib/travel-support/sanity.ts
+++ b/src/lib/travel-support/sanity.ts
@@ -71,6 +71,7 @@ export async function getTravelSupportById(id: string): Promise<{
           _id,
           name
         },
+        "conferenceOrgId": conference->organization._ref,
         "expenses": *[_type == "travelExpense" && travelSupport._ref == ^._id] | order(_createdAt desc) {
           ...,
           receipts[] {

--- a/src/lib/travel-support/types.ts
+++ b/src/lib/travel-support/types.ts
@@ -121,4 +121,11 @@ export interface TravelSupportWithSpeaker extends Omit<
     _id: string
     name: string
   }
+  /**
+   * The org that owns this request's conference (projected from
+   * `conference->organization`). The tenant key the org-scoped organizer authz
+   * gates on (B3, #642). Null for a pre-044-backfill conference → organizer
+   * access denied (fail closed).
+   */
+  conferenceOrgId?: string | null
 }

--- a/src/server/routers/message.orgscope.test.ts
+++ b/src/server/routers/message.orgscope.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment node
+ *
+ * B2 (#642) — ROUTER gate. An organizer-only management mutation
+ * (`message.setStatus`, via `loadManageableConversation`) must be ORG-SCOPED: an
+ * organizer of ANOTHER org gets NOT_FOUND (no existence oracle) for an org-A
+ * thread, while a same-org organizer succeeds. The gate keys on the thread's own
+ * `conferenceOrgId`, not the deprecated global `isOrganizer` flag.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+const getConversationMock = vi.fn()
+const setStatusMock = vi.fn()
+
+vi.mock('@/lib/messaging/sanity', () => ({
+  listConversationsForSpeaker: vi.fn(),
+  getConversationById: (...a: unknown[]) => getConversationMock(...a),
+  getConversationParticipants: vi.fn(),
+  getConversationPreference: vi.fn(),
+  listMessages: vi.fn(),
+  addMessage: vi.fn(),
+  ensureProposalConversation: vi.fn(),
+  ensureSponsorConversation: vi.fn(),
+  createGeneralConversation: vi.fn(),
+  getProposalForConversation: vi.fn(),
+  setConversationPreference: vi.fn(),
+  setConversationStatus: (...a: unknown[]) => setStatusMock(...a),
+  setConversationAssignee: vi.fn(),
+  setConversationArchived: vi.fn(),
+  getConversationViewCounts: vi.fn(),
+  getUnreadCountsByProposalIds: vi.fn(),
+  // Real access check is bypassed here — the ORG gate under test is the
+  // isOrganizerForOrg(conferenceOrgId) check in loadManageableConversation.
+  canAccessConversation: () => true,
+}))
+vi.mock('@/lib/messaging/sponsor', () => ({ getSponsorFanoutContext: vi.fn() }))
+vi.mock('@/lib/notification/sanity', () => ({
+  getOrganizerSpeakerIds: vi.fn(),
+  createNotifications: vi.fn(),
+}))
+vi.mock('@/lib/messaging/notify', () => ({
+  notifyNewMessage: vi.fn(),
+  notifySponsorMessage: vi.fn(),
+}))
+vi.mock('@/lib/teams', () => ({ getViewerTeamLens: vi.fn() }))
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: vi.fn(),
+}))
+vi.mock('@/server/runAfterResponse', () => ({ runAfterResponse: vi.fn() }))
+
+import { messageRouter } from './message'
+
+function callerFor(speaker: {
+  _id: string
+  isOrganizer?: boolean
+  organizerOrgIds?: string[]
+}) {
+  const session = { speaker, user: { email: 'u@x.test' } }
+  return messageRouter.createCaller({
+    session,
+    speaker,
+    user: session.user,
+  } as unknown as Context)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  getConversationMock.mockResolvedValue({
+    _id: 'c1',
+    conferenceId: 'conf-A',
+    conferenceOrgId: 'org-A',
+    conversationType: 'proposal',
+    proposalSpeakerIds: [],
+    createdById: 'sp-owner',
+    participants: [],
+  })
+})
+
+describe('message.setStatus — org-scoped organizer gate (B2)', () => {
+  it('NOT_FOUND for a cross-tenant organizer (org-B) managing an org-A thread', async () => {
+    const caller = callerFor({
+      _id: 'org-b-admin',
+      isOrganizer: true,
+      organizerOrgIds: ['org-B'],
+    })
+    await expect(
+      caller.setStatus({ conversationId: 'c1', status: 'resolved' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(setStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('succeeds for a same-org organizer (org-A)', async () => {
+    const caller = callerFor({
+      _id: 'org-a-admin',
+      isOrganizer: true,
+      organizerOrgIds: ['org-A'],
+    })
+    const res = await caller.setStatus({
+      conversationId: 'c1',
+      status: 'resolved',
+    })
+    expect(res).toMatchObject({ conversationId: 'c1', status: 'resolved' })
+    expect(setStatusMock).toHaveBeenCalledWith('c1', 'resolved')
+  })
+})

--- a/src/server/routers/message.ts
+++ b/src/server/routers/message.ts
@@ -1,5 +1,11 @@
 import { TRPCError } from '@trpc/server'
-import { router, protectedProcedure, resolveConferenceId } from '@/server/trpc'
+import {
+  router,
+  protectedProcedure,
+  organizerProcedure,
+  resolveConferenceId,
+} from '@/server/trpc'
+import { isOrganizerForOrg } from '@/lib/authz/organizer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { clientReadUncached } from '@/lib/sanity/client'
 import { runAfterResponse } from '@/server/runAfterResponse'
@@ -112,15 +118,16 @@ function claimSendSlot(speakerId: string): boolean {
  * Cross-conference targeting stays blocked: a talk-less non-organizer from
  * another edition has no standing here.
  *
- * ANY-CONFERENCE ORGANIZER MATCH IS INTENTIONAL (QR-M6, verified not a leak):
- * the organizer clause matches an organizer of ANY edition on purpose because
- * `isOrganizer` is GLOBAL in this app — it is derived as `_id in
- * *[_type == "conference"].organizers[]._ref` (see `lib/speaker/sanity.ts`), and
- * `canAccessConversation` short-circuits `if (speaker.isOrganizer) return true`.
- * So a global organizer can ALREADY read/write every thread; naming them the
- * subjectSpeaker of a new general thread grants no access they lack. Scoping this
- * clause to `$conferenceId` would instead REJECT a legitimate organizer the admin
- * picker offers. Not a cross-tenant leak; do not narrow it.
+ * ANY-CONFERENCE ORGANIZER MATCH — NOT AN ACCESS GRANT (B2, #642). This clause
+ * decides only who the admin picker may NAME as a general-thread subject speaker;
+ * it does NOT grant thread access. Access is enforced separately by
+ * `canAccessConversation`, which post-#642 is ORG-SCOPED (keys on
+ * {@link isOrganizerForOrg} against the thread's own org, no longer the global
+ * `isOrganizer` short-circuit). So naming an organizer of another edition as a
+ * subject speaker confers no cross-tenant read/write — a cross-tenant organizer
+ * is still denied by the access check. The clause stays any-conference to keep
+ * matching the population the picker offers; narrowing it would reject a
+ * legitimate same-org organizer without closing any hole.
  */
 async function speakerHasStandingInConference(
   speakerId: string,
@@ -138,8 +145,13 @@ async function speakerHasStandingInConference(
  * Load a conversation for an ORGANIZER-ONLY management mutation (status /
  * assignee / archive). Collapses absent, non-organizer, and inaccessible into a
  * single NOT_FOUND — no existence oracle, and the ticketing capability itself is
- * not revealed to a non-organizer participant (A3 semantics). `isOrganizer`
- * already implies `canAccessConversation`, but both are asserted per the design.
+ * not revealed to a non-organizer participant (A3 semantics).
+ *
+ * ORG-SCOPED (B2, #642): the organizer gate keys on {@link isOrganizerForOrg}
+ * against the CONVERSATION'S OWN org (`conferenceOrgId`), not the deprecated
+ * global `speaker.isOrganizer` — so a cross-tenant organizer gets NOT_FOUND. This
+ * already implies `canAccessConversation` (which uses the same org-scoped check),
+ * but both are asserted per the design.
  */
 async function loadManageableConversation(
   conversationId: string,
@@ -148,7 +160,7 @@ async function loadManageableConversation(
   const conversation = await getConversationById(conversationId)
   if (
     !conversation ||
-    speaker.isOrganizer !== true ||
+    !isOrganizerForOrg(speaker, conversation.conferenceOrgId ?? null) ||
     !canAccessConversation(conversation, speaker)
   ) {
     throw new TRPCError({
@@ -167,11 +179,13 @@ async function loadManageableConversation(
  */
 export const messageRouter = router({
   /** The caller's conversation inbox (organizers see all; speakers see theirs). */
-  listConversations: protectedProcedure
+  listConversations: organizerProcedure
     .input(ListConversationsSchema)
     .query(async ({ ctx, input }) => {
       const conferenceId = await resolveConferenceId()
-      const isOrganizer = ctx.speaker.isOrganizer === true
+      // ORG-SCOPED (B2, #642): only an organizer OF THIS domain's org gets the
+      // all-conversations inbox; a cross-tenant organizer sees only their own.
+      const isOrganizer = ctx.isOrgOrganizer
       const view = input.view ?? 'active'
       // A non-organizer may only use the speaker-appropriate views; the
       // organizer-only views (needs-reply / mine / resolved) carry organizer
@@ -202,11 +216,11 @@ export const messageRouter = router({
    * conversation set, reusing the same predicates the list views apply — meant to
    * accompany the first inbox page, not to be polled hot.
    */
-  viewCounts: protectedProcedure.query(async ({ ctx }) => {
+  viewCounts: organizerProcedure.query(async ({ ctx }) => {
     const conferenceId = await resolveConferenceId()
     return getConversationViewCounts({
       speakerId: ctx.speaker._id,
-      isOrganizer: ctx.speaker.isOrganizer === true,
+      isOrganizer: ctx.isOrgOrganizer,
       conferenceId,
     })
   }),
@@ -295,7 +309,7 @@ export const messageRouter = router({
    * general thread: it is FORBIDDEN for a non-organizer, and REQUIRED (and must
    * resolve to a real speaker) when an organizer starts a general thread.
    */
-  send: protectedProcedure
+  send: organizerProcedure
     .input(SendMessageSchema)
     .mutation(async ({ ctx, input }) => {
       const { conference, error } = await getConferenceForCurrentDomain()
@@ -307,7 +321,10 @@ export const messageRouter = router({
       }
       const conferenceId = conference._id
       const actorId = ctx.speaker._id
-      const isOrganizer = ctx.speaker.isOrganizer === true
+      // ORG-SCOPED (B2, #642): organizer capabilities (naming a subject speaker,
+      // opening any proposal thread, not reopening on reply) require organizer
+      // standing IN THIS domain's org, not the deprecated global flag.
+      const isOrganizer = ctx.isOrgOrganizer
 
       // `recipientSpeakerId` is an organizer-only capability: a non-organizer
       // must never be able to name the subject speaker of a thread.
@@ -487,10 +504,12 @@ export const messageRouter = router({
    * deterministic id. The sfc MUST belong to the current-domain conference
    * (multi-tenant isolation).
    */
-  ensureSponsorThread: protectedProcedure
+  ensureSponsorThread: organizerProcedure
     .input(z.object({ sponsorForConferenceId: z.string().min(1).max(200) }))
     .mutation(async ({ ctx, input }) => {
-      if (ctx.speaker.isOrganizer !== true) {
+      // ORG-SCOPED (B2, #642): sponsor threads are organizer-only, gated on
+      // organizer standing IN THIS domain's org (not the deprecated global flag).
+      if (!ctx.isOrgOrganizer) {
         throw new TRPCError({ code: 'FORBIDDEN', message: 'Access denied' })
       }
       const conferenceId = await resolveConferenceId()

--- a/src/server/routers/proposal.orgscope.test.ts
+++ b/src/server/routers/proposal.orgscope.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment node
+ *
+ * B1 (#642) — ROUTER gate. `proposal.getById` is an `organizerProcedure`: the
+ * middleware resolves the request org from the domain conference and exposes an
+ * ORG-SCOPED `ctx.isOrgOrganizer`. An organizer of ANOTHER org (on this domain)
+ * therefore gets `isOrgOrganizer === false` and is treated as a plain speaker —
+ * so an org-A proposal is invisible to an org-B organizer, while a same-org
+ * organizer reads it. We drive the caller and assert the getProposal invocation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+const getProposalMock = vi.fn()
+const getConfMock = vi.fn()
+
+vi.mock('@/lib/proposal/data/sanity', () => ({
+  getProposal: (...a: unknown[]) => getProposalMock(...a),
+  getProposals: vi.fn(),
+  createProposal: vi.fn(),
+  updateProposal: vi.fn(),
+  deleteProposal: vi.fn(),
+  ProposalDeletionBlockedError: class extends Error {},
+}))
+vi.mock('@/lib/proposal/server', () => ({
+  getProposalSanity: (...a: unknown[]) => getProposalMock(...a),
+  getProposals: vi.fn(),
+  updateProposalStatus: vi.fn(),
+  fetchNextUnreviewedProposal: vi.fn(),
+  searchProposals: vi.fn(),
+}))
+// resolveOrganizationId (trpc waist) resolves the request org from the domain.
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...a: unknown[]) => getConfMock(...a),
+}))
+
+import { proposalRouter } from './proposal'
+
+function callerFor(speaker: {
+  _id: string
+  isOrganizer?: boolean
+  organizerOrgIds?: string[]
+}) {
+  const session = { speaker, user: { email: 'u@x.test' } }
+  return proposalRouter.createCaller({
+    session,
+    speaker,
+    user: session.user,
+  } as unknown as Context)
+}
+
+const ORG_A_PROPOSAL = {
+  _id: 'talk-A',
+  speakers: [{ _id: 'sp-owner' }],
+  conference: { _id: 'conf-A' },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  // Current domain resolves to org-A.
+  getConfMock.mockResolvedValue({
+    conference: { _id: 'conf-A', organization: { _ref: 'org-A' } },
+    error: null,
+  })
+})
+
+describe('proposal.getById — org-scoped organizer gate (B1)', () => {
+  it('DENIES a cross-tenant organizer (org-B) an org-A proposal by id', async () => {
+    // The org-scoped read yields the proposal only via the ownership branch;
+    // a non-owner org-B caller is treated as a speaker → getProposal returns the
+    // (non-owned) doc and the handler enforces ownership → FORBIDDEN.
+    getProposalMock.mockResolvedValue({
+      proposal: ORG_A_PROPOSAL,
+      proposalError: null,
+    })
+    const caller = callerFor({
+      _id: 'org-b-admin',
+      isOrganizer: true,
+      organizerOrgIds: ['org-B'],
+    })
+    await expect(caller.getById({ id: 'talk-A' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+    // Proven org-scoped: the router passed isOrganizer=false for the org-B caller.
+    expect(getProposalMock).toHaveBeenCalledWith(
+      expect.objectContaining({ isOrganizer: false, organizerOrgId: 'org-A' }),
+    )
+  })
+
+  it('GRANTS a same-org organizer (org-A) the org-A proposal', async () => {
+    getProposalMock.mockResolvedValue({
+      proposal: ORG_A_PROPOSAL,
+      proposalError: null,
+    })
+    const caller = callerFor({
+      _id: 'org-a-admin',
+      isOrganizer: true,
+      organizerOrgIds: ['org-A'],
+    })
+    const res = await caller.getById({ id: 'talk-A' })
+    expect(res._id).toBe('talk-A')
+    expect(getProposalMock).toHaveBeenCalledWith(
+      expect.objectContaining({ isOrganizer: true, organizerOrgId: 'org-A' }),
+    )
+  })
+})

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import {
   router,
   protectedProcedure,
+  organizerProcedure,
   adminProcedure,
   resolveConferenceId,
 } from '@/server/trpc'
@@ -203,15 +204,16 @@ export const proposalRouter = router({
   }),
 
   // Get proposal by ID
-  getById: protectedProcedure
+  getById: organizerProcedure
     .input(IdParamSchema)
     .query(async ({ input, ctx }) => {
       try {
-        const isOrganizer = ctx.speaker.isOrganizer === true
+        const isOrganizer = ctx.isOrgOrganizer
         const { proposal, proposalError } = await getProposal({
           id: input.id,
           speakerId: ctx.speaker._id,
           isOrganizer,
+          organizerOrgId: ctx.orgId,
           includeReviews: isOrganizer,
         })
 
@@ -387,7 +389,7 @@ export const proposalRouter = router({
     }),
 
   // Update proposal
-  update: protectedProcedure
+  update: organizerProcedure
     .input(IdParamSchema.extend({ data: ProposalUpdateSchema }))
     .mutation(async ({ input, ctx }) => {
       try {
@@ -413,7 +415,7 @@ export const proposalRouter = router({
           })
         }
 
-        if (!ctx.speaker.isOrganizer && existing.conference) {
+        if (!ctx.isOrgOrganizer && existing.conference) {
           const conferenceId =
             typeof existing.conference === 'object' &&
             '_id' in existing.conference
@@ -496,11 +498,11 @@ export const proposalRouter = router({
 
   // Remove a co-speaker from a proposal. Speakers on the proposal can
   // remove other speakers (not themselves); organizers can remove anyone.
-  removeCoSpeaker: protectedProcedure
+  removeCoSpeaker: organizerProcedure
     .input(RemoveCoSpeakerSchema)
     .mutation(async ({ input, ctx }) => {
       try {
-        const isOrganizer = ctx.speaker.isOrganizer === true
+        const isOrganizer = ctx.isOrgOrganizer
 
         // getProposal scopes the query to the caller's speaker id unless
         // they are an organizer, so this doubles as the ownership check
@@ -508,6 +510,7 @@ export const proposalRouter = router({
           id: input.proposalId,
           speakerId: ctx.speaker._id,
           isOrganizer,
+          organizerOrgId: ctx.orgId,
         })
 
         if (proposalError) {
@@ -621,7 +624,7 @@ export const proposalRouter = router({
     }),
 
   // Execute proposal action (submit, withdraw, etc.)
-  action: protectedProcedure
+  action: organizerProcedure
     .input(
       IdParamSchema.extend(ProposalActionSchema.shape).superRefine(
         requireWithdrawalReason,
@@ -650,7 +653,8 @@ export const proposalRouter = router({
         const { proposal, proposalError } = await getProposalSanity({
           id,
           speakerId: ctx.speaker._id,
-          isOrganizer: ctx.speaker.isOrganizer,
+          isOrganizer: ctx.isOrgOrganizer,
+          organizerOrgId: ctx.orgId,
         })
 
         if (proposalError || !proposal || proposal._id !== id) {
@@ -664,7 +668,7 @@ export const proposalRouter = router({
         const { status, isValidAction } = actionStateMachine(
           proposal.status,
           action,
-          ctx.speaker.isOrganizer,
+          ctx.isOrgOrganizer,
         )
 
         if (!isValidAction) {
@@ -675,7 +679,7 @@ export const proposalRouter = router({
         }
 
         // Block unsubmit after CFP closes — speakers should withdraw instead
-        if (action === Action.unsubmit && !ctx.speaker.isOrganizer) {
+        if (action === Action.unsubmit && !ctx.isOrgOrganizer) {
           const { isCfpOpen } = await import('@/lib/conference/state')
           if (!isCfpOpen(conference)) {
             throw new TRPCError({
@@ -689,7 +693,7 @@ export const proposalRouter = router({
         // Block speaker self-withdrawal within the pre-conference cutoff window.
         // Organizers keep the ability to act on behalf of speakers this close
         // to the event; only self-service withdrawal is closed (#251).
-        if (action === Action.withdraw && !ctx.speaker.isOrganizer) {
+        if (action === Action.withdraw && !ctx.isOrgOrganizer) {
           const { isWithdrawalCutoffActive } =
             await import('@/lib/conference/state')
           if (isWithdrawalCutoffActive(conference)) {
@@ -705,7 +709,7 @@ export const proposalRouter = router({
         if (
           proposal.status === Status.draft &&
           status === Status.submitted &&
-          !ctx.speaker.isOrganizer
+          !ctx.isOrgOrganizer
         ) {
           const { proposals: existingProposals } = await getProposals({
             speakerId: ctx.speaker._id,
@@ -771,7 +775,7 @@ export const proposalRouter = router({
           metadata: {
             triggeredBy: {
               speakerId: ctx.speaker._id,
-              isOrganizer: ctx.speaker.isOrganizer,
+              isOrganizer: ctx.isOrgOrganizer,
             },
             shouldNotify: notify,
             comment,
@@ -798,7 +802,7 @@ export const proposalRouter = router({
         // committed, so a messaging failure must not fail the action.
         const trimmedComment = comment?.trim()
         if (
-          ctx.speaker.isOrganizer &&
+          ctx.isOrgOrganizer &&
           trimmedComment &&
           COMMENT_RELAY_ACTIONS.includes(action)
         ) {
@@ -882,6 +886,7 @@ export const proposalRouter = router({
             id: input.id,
             speakerId: ctx.speaker._id,
             isOrganizer: true,
+            organizerOrgId: ctx.orgId,
             includeReviews: true,
             includeSubmittedTalks: true,
             includePreviousAcceptedTalks: true,
@@ -1168,6 +1173,7 @@ export const proposalRouter = router({
             id: input.id,
             speakerId: ctx.speaker._id,
             isOrganizer: true,
+            organizerOrgId: ctx.orgId,
             includeReviews: true,
           })
 
@@ -1363,7 +1369,7 @@ export const proposalRouter = router({
   }),
 
   // Speaker attachment operations
-  uploadAttachment: protectedProcedure
+  uploadAttachment: organizerProcedure
     .input(
       IdParamSchema.extend({
         blobUrl: z.string().url(),
@@ -1378,7 +1384,8 @@ export const proposalRouter = router({
         const { proposal, proposalError } = await getProposal({
           id: input.id,
           speakerId: ctx.speaker._id,
-          isOrganizer: ctx.speaker.isOrganizer === true,
+          isOrganizer: ctx.isOrgOrganizer,
+          organizerOrgId: ctx.orgId,
         })
 
         if (proposalError || !proposal) {
@@ -1466,7 +1473,7 @@ export const proposalRouter = router({
       }
     }),
 
-  updateAttachments: protectedProcedure
+  updateAttachments: organizerProcedure
     .input(
       IdParamSchema.extend({
         attachments: z.array(AttachmentSchema),
@@ -1478,7 +1485,8 @@ export const proposalRouter = router({
         const { proposal, proposalError } = await getProposal({
           id: input.id,
           speakerId: ctx.speaker._id,
-          isOrganizer: ctx.speaker.isOrganizer === true,
+          isOrganizer: ctx.isOrgOrganizer,
+          organizerOrgId: ctx.orgId,
         })
 
         if (proposalError || !proposal) {
@@ -1520,7 +1528,7 @@ export const proposalRouter = router({
     }),
 
   // Delete attachment (speaker)
-  deleteAttachment: protectedProcedure
+  deleteAttachment: organizerProcedure
     .input(
       IdParamSchema.extend({
         attachmentKey: z.string(),
@@ -1532,7 +1540,8 @@ export const proposalRouter = router({
         const { proposal, proposalError } = await getProposal({
           id: input.id,
           speakerId: ctx.speaker._id,
-          isOrganizer: ctx.speaker.isOrganizer === true,
+          isOrganizer: ctx.isOrgOrganizer,
+          organizerOrgId: ctx.orgId,
         })
 
         if (proposalError || !proposal) {
@@ -1557,7 +1566,7 @@ export const proposalRouter = router({
         // Speakers cannot delete recording attachments
         if (
           attachmentToCheck.attachmentType === 'recording' &&
-          !ctx.speaker.isOrganizer
+          !ctx.isOrgOrganizer
         ) {
           throw new TRPCError({
             code: 'FORBIDDEN',
@@ -1586,7 +1595,7 @@ export const proposalRouter = router({
   // Co-speaker invitation operations
   invitation: router({
     // Send invitation
-    send: protectedProcedure
+    send: organizerProcedure
       .input(InvitationCreateSchema)
       .mutation(async ({ input, ctx }) => {
         try {
@@ -1594,7 +1603,8 @@ export const proposalRouter = router({
           const { proposal, proposalError } = await getProposal({
             id: input.proposalId,
             speakerId: ctx.speaker._id,
-            isOrganizer: ctx.speaker.isOrganizer === true,
+            isOrganizer: ctx.isOrgOrganizer,
+            organizerOrgId: ctx.orgId,
           })
 
           if (proposalError || !proposal || !proposal._id) {
@@ -1732,7 +1742,7 @@ export const proposalRouter = router({
       }),
 
     // Respond to invitation
-    respond: protectedProcedure
+    respond: organizerProcedure
       .input(InvitationResponseSchema)
       .mutation(async ({ input, ctx }) => {
         try {
@@ -1807,10 +1817,16 @@ export const proposalRouter = router({
               })
             }
 
+            // The invitee is not yet a speaker on the proposal, so bypass the
+            // owner filter (isOrganizer branch) — but STILL org-scope the read to
+            // the current tenant (B1): the respond endpoint is always hit on the
+            // proposal's own conference domain, so `ctx.orgId` matches the
+            // proposal's org; a cross-tenant id cannot be loaded here.
             const { proposal } = await getProposal({
               id: proposalId,
               speakerId: ctx.speaker._id,
               isOrganizer: true,
+              organizerOrgId: ctx.orgId,
             })
 
             if (!proposal || !proposal._id) {
@@ -1956,7 +1972,7 @@ export const proposalRouter = router({
       }),
 
     // List invitations for a proposal
-    list: protectedProcedure
+    list: organizerProcedure
       .input(IdParamSchema)
       .query(async ({ input, ctx }) => {
         try {
@@ -1964,7 +1980,8 @@ export const proposalRouter = router({
           const { proposal, proposalError } = await getProposal({
             id: input.id,
             speakerId: ctx.speaker._id,
-            isOrganizer: ctx.speaker.isOrganizer === true,
+            isOrganizer: ctx.isOrgOrganizer,
+            organizerOrgId: ctx.orgId,
           })
 
           if (proposalError || !proposal || !proposal._id) {
@@ -1987,7 +2004,7 @@ export const proposalRouter = router({
       }),
 
     // Cancel invitation
-    cancel: protectedProcedure
+    cancel: organizerProcedure
       .input(InvitationCancelSchema)
       .mutation(async ({ input, ctx }) => {
         try {
@@ -2014,7 +2031,8 @@ export const proposalRouter = router({
           const { proposal, proposalError } = await getProposal({
             id: proposalRef._ref,
             speakerId: ctx.speaker._id,
-            isOrganizer: ctx.speaker.isOrganizer === true,
+            isOrganizer: ctx.isOrgOrganizer,
+            organizerOrgId: ctx.orgId,
           })
 
           if (proposalError || !proposal || !proposal._id) {

--- a/src/server/routers/proposal.ts
+++ b/src/server/routers/proposal.ts
@@ -1819,9 +1819,9 @@ export const proposalRouter = router({
 
             // The invitee is not yet a speaker on the proposal, so bypass the
             // owner filter (isOrganizer branch) — but STILL org-scope the read to
-            // the current tenant (B1): the respond endpoint is always hit on the
-            // proposal's own conference domain, so `ctx.orgId` matches the
-            // proposal's org; a cross-tenant id cannot be loaded here.
+            // the current tenant (B1): the read is constrained to the REQUEST
+            // org (`ctx.orgId`), so a proposal id from another tenant does not
+            // resolve regardless of which domain the request arrives on.
             const { proposal } = await getProposal({
               id: proposalId,
               speakerId: ctx.speaker._id,

--- a/src/server/routers/travelSupport.ts
+++ b/src/server/routers/travelSupport.ts
@@ -181,12 +181,15 @@ export const travelSupportRouter = router({
     .input(UpdateBankingDetailsSchema)
     .mutation(async ({ input, ctx }) => {
       try {
-        const { authorized, error: authError } =
-          await authorizeTravelSupportOperation(
-            input.travelSupportId,
-            ctx.speaker,
-            'modify',
-          )
+        const {
+          authorized,
+          isOrganizer,
+          error: authError,
+        } = await authorizeTravelSupportOperation(
+          input.travelSupportId,
+          ctx.speaker,
+          'modify',
+        )
 
         if (!authorized || authError) {
           throw authError || createAuthError('FORBIDDEN', 'Access denied')
@@ -198,7 +201,9 @@ export const travelSupportRouter = router({
           ctx.speaker.name,
           {
             travelSupportId: input.travelSupportId,
-            isAdmin: ctx.speaker.isOrganizer,
+            // The ORG-SCOPED grant that was actually enforced — not the
+            // deprecated global flag (B3, #642).
+            isAdmin: isOrganizer === true,
           },
           'info',
         )

--- a/src/server/routers/travelSupport.ts
+++ b/src/server/routers/travelSupport.ts
@@ -184,8 +184,7 @@ export const travelSupportRouter = router({
         const { authorized, error: authError } =
           await authorizeTravelSupportOperation(
             input.travelSupportId,
-            ctx.speaker._id,
-            ctx.speaker.isOrganizer,
+            ctx.speaker,
             'modify',
           )
 
@@ -239,8 +238,7 @@ export const travelSupportRouter = router({
           error: authError,
         } = await authorizeTravelSupportOperation(
           input.travelSupportId,
-          ctx.speaker._id,
-          ctx.speaker.isOrganizer,
+          ctx.speaker,
           'submit',
         )
 
@@ -342,8 +340,7 @@ export const travelSupportRouter = router({
           error: accessError,
         } = await verifyTravelSupportOwnership(
           input.travelSupportId,
-          ctx.speaker._id,
-          ctx.speaker.isOrganizer,
+          ctx.speaker,
         )
 
         if (accessError || !hasAccess || !travelSupport) {
@@ -413,8 +410,7 @@ export const travelSupportRouter = router({
           error: accessError,
         } = await verifyTravelSupportOwnership(
           existingExpense.travelSupport._ref,
-          ctx.speaker._id,
-          ctx.speaker.isOrganizer,
+          ctx.speaker,
         )
 
         if (accessError || !hasAccess || !travelSupport) {
@@ -476,8 +472,7 @@ export const travelSupportRouter = router({
           error: accessError,
         } = await verifyTravelSupportOwnership(
           expense.travelSupport._ref,
-          ctx.speaker._id,
-          ctx.speaker.isOrganizer,
+          ctx.speaker,
         )
 
         if (accessError || !hasAccess || !travelSupport) {
@@ -544,8 +539,7 @@ export const travelSupportRouter = router({
           error: accessError,
         } = await verifyTravelSupportOwnership(
           existingExpense.travelSupport._ref,
-          ctx.speaker._id,
-          ctx.speaker.isOrganizer,
+          ctx.speaker,
         )
 
         if (accessError || !hasAccess || !travelSupport) {
@@ -679,8 +673,7 @@ export const travelSupportRouter = router({
           const { authorized, error: authError } =
             await authorizeTravelSupportOperation(
               input.travelSupportId,
-              ctx.speaker._id,
-              ctx.speaker.isOrganizer,
+              ctx.speaker,
               'approve',
             )
 

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -157,6 +157,36 @@ const requireAdmin = t.middleware(async ({ ctx, next }) => {
   return next({
     ctx: {
       ...ctx,
+      // The resolved request org (the tenant the waist gated on) is stashed so
+      // admin handlers can scope resource reads to it (e.g. getProposal's
+      // organizer branch) without re-resolving the domain conference.
+      orgId,
+      speaker: ctx.session!.speaker!,
+      user: ctx.session!.user!,
+    },
+  })
+})
+
+/**
+ * DUAL-ROLE org-scoped organizer resolution (go-live B1-B3/E11, #642). Unlike
+ * {@link requireAdmin} this does NOT reject — it resolves the request org from the
+ * domain conference and exposes an ORG-SCOPED organizer decision as
+ * `ctx.isOrgOrganizer` (plus the resolved `ctx.orgId`) for endpoints that serve
+ * BOTH speakers and organizers (a speaker acts on their own resource; an organizer
+ * acts on any of the ORG's). It replaces the DEPRECATED GLOBAL `ctx.speaker.isOrganizer`
+ * (true for an organizer of ANY org) that dual-role endpoints used to branch on,
+ * which let a CNB organizer reach an external tenant's data. The decision reuses
+ * {@link isOrganizerForOrg} so the legacy-token bridge semantics match the waist
+ * (#635/#639) exactly. Pure-organizer endpoints should use {@link adminProcedure}
+ * (which fails closed); this is for the dual-role surfaces only.
+ */
+const withOrgOrganizer = t.middleware(async ({ ctx, next }) => {
+  const orgId = await resolveOrganizationId()
+  return next({
+    ctx: {
+      ...ctx,
+      orgId,
+      isOrgOrganizer: isOrganizerForOrg(ctx.session?.speaker, orgId),
       speaker: ctx.session!.speaker!,
       user: ctx.session!.user!,
     },
@@ -166,6 +196,9 @@ const requireAdmin = t.middleware(async ({ ctx, next }) => {
 export const publicProcedure = t.procedure
 export const protectedProcedure = t.procedure.use(requireAuth)
 export const adminProcedure = t.procedure.use(requireAuth).use(requireAdmin)
+export const organizerProcedure = t.procedure
+  .use(requireAuth)
+  .use(withOrgOrganizer)
 export const router = t.router
 
 const CLIENT_ERROR_CODES = new Set([


### PR DESCRIPTION
Closes go-live gates **B1, B2, B3, E11** of the readiness audit (#642).

## The hole
The `adminProcedure` waist is org-scoped (#635), but `protectedProcedure` endpoints and shared access primitives still trusted the **deprecated GLOBAL** `ctx.speaker.isOrganizer` (true for an organizer of ANY org). With a second org onboarded, a CNB organizer could reach an external tenant's data by exact id:

- **B1 proposals** — `getProposal`'s organizer branch dropped ALL scoping (`speakerFilter = ''` → `*[_type=="talk" && _id==$id]`), reachable via router passthroughs and the `/admin/proposals/[id]` page by URL id.
- **B2 messaging** — `canAccessConversation` short-circuited on the global flag; router gates read `ctx.speaker.isOrganizer`.
- **B3 travel-support** — `authorize/verify` granted on `isOrganizer || owner` using the global flag, over **banking PII** (incl. payout approval).
- **E11 badges** — organizer-badge eligibility gated on the global flag.

## The fix (right altitude)
1. **`organizerProcedure`** (new, `src/server/trpc.ts`): `protectedProcedure` + org resolution, exposing an org-scoped `ctx.isOrgOrganizer` + `ctx.orgId` **without rejecting** — for dual-role endpoints (a speaker acts on their own resource; an organizer on any of the ORG's). Reuses `isOrganizerForOrg`, so legacy-token bridge semantics match #635/#639 exactly. `adminProcedure` also stashes `ctx.orgId`. Pure-organizer endpoints keep failing closed (`adminProcedure`, or an org-scoped `if` on the resource's own org).
2. **Scoped the primitives to the RESOURCE's own org** (the authoritative tenant, independent of domain):
   - `getProposal` organizer branch constrains `conference._ref` to the org's conferences; fail-closed with no org.
   - `canAccessConversation` keys on the conversation's `conferenceOrgId` (projected from `conference->organization`).
   - travel-support authz computes the organizer grant against `travelSupport.conferenceOrgId`.
   - badge issuance checks org-scoped organizer membership of the recipient in this conference's org.
3. Dual-role UI passthroughs (`isOrganizer:` fields) now carry the org-scoped value.

### Endpoints converted to `organizerProcedure` (dual-role)
- **proposal**: `getById`, `update`, `removeCoSpeaker`, `action`, `uploadAttachment`, `updateAttachments`, `deleteAttachment`, `invitation.send/respond/list/cancel`
- **message**: `listConversations`, `viewCounts`, `send`, `ensureSponsorThread` (and `setStatus/setAssignee/setArchived` org-scoped inside `loadManageableConversation`)
- **admin** proposal `getById`/`submitReview` and non-router organizer reads (`/admin/proposals/[id]`, `/cfp/proposal/[id]` impersonation, attachment-upload route, speaker-email builder) pass the resolved org so legitimate organizers still resolve while cross-tenant ids fail closed.
- **travel-support** router call sites pass `ctx.speaker`; **badge** issuance resolves the org internally.

## Cross-tenant deny proofs (new tests)
- `getProposal` unit: org-scoped GROQ + fail-closed; `proposal.getById` router: org-B organizer → FORBIDDEN, same-org → granted.
- `canAccessConversation` unit + `message.setStatus` router: org-B organizer → NOT_FOUND, same-org → succeeds.
- travel-support `verify`/`authorize` unit: org-B organizer denied (incl. `approve`), owner unaffected, self-approval blocked.
- badge issuance unit: cross-tenant recipient rejected, same-org passes.
- Same-org organizer still passes and speakers are unaffected (own-resource paths) throughout; legacy-token bridge parity asserted.

## Verification
`mise run check` green (typecheck / lint / knip / format); full vitest **4102 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
