### PR TITLE
fix(tenancy): tenant-driven legal pages, background-pattern switch, metadata de-branding (go-live gate G2)

### DIFF
--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -225,6 +225,29 @@ export default defineType({
         'Icon-only logo mark for dark backgrounds. Falls back to Logo Mark (Light Mode) if not set.',
       fieldset: 'branding',
     }),
+    // Background pattern (go-live gate G2, #643): the decorative page background.
+    // ABSENT resolves to 'cloud-native' — the animated CNCF ecosystem logos —
+    // so existing tenants are unchanged. Tenants outside the CNCF ecosystem can
+    // dial it down ('subtle') or off ('none', a plain gradient).
+    defineField({
+      name: 'backgroundPattern',
+      title: 'Background Pattern',
+      type: 'string',
+      fieldset: 'branding',
+      description:
+        'The decorative page background. "Cloud Native" shows the animated CNCF project logos. "Subtle" shows the same logos at a much lower density and opacity. "None" shows a plain gradient with no logos. Leave blank for "Cloud Native".',
+      options: {
+        list: [
+          {
+            title: 'Cloud Native — animated CNCF logos',
+            value: 'cloud-native',
+          },
+          { title: 'Subtle — sparse, faint logos', value: 'subtle' },
+          { title: 'None — plain gradient, no logos', value: 'none' },
+        ],
+        layout: 'radio',
+      },
+    }),
 
     // === Important Dates ===
     defineField({

--- a/sanity/schemaTypes/organization.ts
+++ b/sanity/schemaTypes/organization.ts
@@ -73,6 +73,42 @@ export default defineType({
       description:
         'Optional inline SVG logo for the organization (same mechanism as conference branding).',
     }),
+    // Legal identity (go-live gate G2, #643): drives the tenant's /privacy and
+    // /terms pages. ABSENT resolves to Norway + Datatilsynet (the existing
+    // tenant's values), so legacy orgs are unaffected. Set these for tenants
+    // governed by another country's law.
+    defineField({
+      name: 'legalJurisdiction',
+      title: 'Legal Jurisdiction (Country)',
+      type: 'string',
+      description:
+        'Country whose law governs your Terms of Service and whose accounting/tax law is referenced on the Privacy page (e.g. "Norway", "Germany"). Leave blank to default to the conference country, then Norway. When this is not Norway, the Privacy page renders neutral, non-Norway-specific legal prose.',
+    }),
+    defineField({
+      name: 'supervisoryAuthority',
+      title: 'Data Protection Supervisory Authority',
+      type: 'object',
+      description:
+        'The data protection authority a complaint can be lodged with. Leave blank to default to the Norwegian Data Protection Authority (Datatilsynet) for Norway, or a neutral "your national data protection authority" pointer elsewhere.',
+      fields: [
+        defineField({
+          name: 'name',
+          title: 'Authority Name',
+          type: 'string',
+        }),
+        defineField({
+          name: 'url',
+          title: 'Website',
+          type: 'url',
+        }),
+        defineField({
+          name: 'email',
+          title: 'Contact Email',
+          type: 'string',
+          validation: (Rule) => Rule.email(),
+        }),
+      ],
+    }),
   ],
   preview: {
     select: {

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -20,6 +20,7 @@ import {
   BrandingEditor,
   BrandingPreviewGrid,
 } from '@/components/admin/BrandingEditor'
+import type { BackgroundPattern } from '@/lib/conference/backgroundPattern'
 import { OrganizersEditor } from '@/components/admin/OrganizersEditor'
 import { TopicsEditor } from '@/components/admin/TopicsEditor'
 import { TeamsEditor } from '@/components/admin/TeamsEditor'
@@ -45,6 +46,13 @@ import {
   EyeIcon,
   EyeSlashIcon,
 } from '@heroicons/react/24/outline'
+
+/** Read-only labels for the branding-card background-pattern row. */
+const BACKGROUND_PATTERN_LABELS: Record<BackgroundPattern, string> = {
+  'cloud-native': 'Cloud Native (animated CNCF logos)',
+  subtle: 'Subtle (sparse, faint logos)',
+  none: 'None (plain gradient)',
+}
 
 interface NamedItem {
   name?: string
@@ -483,14 +491,23 @@ export default async function AdminSettings() {
             icon={SwatchIcon}
             editUrl={editUrl}
             action={
-              <BrandingEditor
-                initialValues={{
-                  logoBright: conference.logoBright,
-                  logoDark: conference.logoDark,
-                  logomarkBright: conference.logomarkBright,
-                  logomarkDark: conference.logomarkDark,
-                }}
-              />
+              <>
+                <EditConferenceCard
+                  fieldset="branding"
+                  initialValues={{
+                    backgroundPattern:
+                      conference.backgroundPattern ?? 'cloud-native',
+                  }}
+                />
+                <BrandingEditor
+                  initialValues={{
+                    logoBright: conference.logoBright,
+                    logoDark: conference.logoDark,
+                    logomarkBright: conference.logomarkBright,
+                    logomarkDark: conference.logomarkDark,
+                  }}
+                />
+              </>
             }
           >
             <BrandingPreviewGrid
@@ -500,6 +517,14 @@ export default async function AdminSettings() {
                 logomarkBright: conference.logomarkBright,
                 logomarkDark: conference.logomarkDark,
               }}
+            />
+            <FieldRow
+              label="Background Pattern"
+              value={
+                BACKGROUND_PATTERN_LABELS[
+                  conference.backgroundPattern ?? 'cloud-native'
+                ]
+              }
             />
           </InfoCard>
 

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -20,7 +20,10 @@ import {
   BrandingEditor,
   BrandingPreviewGrid,
 } from '@/components/admin/BrandingEditor'
-import type { BackgroundPattern } from '@/lib/conference/backgroundPattern'
+import {
+  normalizeBackgroundPattern,
+  type BackgroundPattern,
+} from '@/lib/conference/backgroundPattern'
 import { OrganizersEditor } from '@/components/admin/OrganizersEditor'
 import { TopicsEditor } from '@/components/admin/TopicsEditor'
 import { TeamsEditor } from '@/components/admin/TeamsEditor'
@@ -495,8 +498,11 @@ export default async function AdminSettings() {
                 <EditConferenceCard
                   fieldset="branding"
                   initialValues={{
-                    backgroundPattern:
-                      conference.backgroundPattern ?? 'cloud-native',
+                    // Normalize (not just null-coalesce) so an invalid stored
+                    // value can't seed an enum-invalid submit.
+                    backgroundPattern: normalizeBackgroundPattern(
+                      conference.backgroundPattern,
+                    ),
                   }}
                 />
                 <BrandingEditor
@@ -522,7 +528,7 @@ export default async function AdminSettings() {
               label="Background Pattern"
               value={
                 BACKGROUND_PATTERN_LABELS[
-                  conference.backgroundPattern ?? 'cloud-native'
+                  normalizeBackgroundPattern(conference.backgroundPattern)
                 ]
               }
             />

--- a/src/app/(main)/cfp/opengraph-image.tsx
+++ b/src/app/(main)/cfp/opengraph-image.tsx
@@ -1,10 +1,11 @@
 import { generateOGImage } from '@/lib/og/template'
-import { OG_IMAGE_SIZE } from '@/lib/og/styles'
+import { ogImageMetadata } from '@/lib/og/metadata'
 
 export const dynamic = 'force-dynamic'
-export const alt = 'Call for Papers - Cloud Native Days Norway'
-export const size = OG_IMAGE_SIZE
-export const contentType = 'image/png'
+
+export function generateImageMetadata() {
+  return ogImageMetadata((brand) => `Call for Papers - ${brand}`)
+}
 
 export default async function Image() {
   return generateOGImage({

--- a/src/app/(main)/cfp/page.tsx
+++ b/src/app/(main)/cfp/page.tsx
@@ -17,12 +17,13 @@ import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Call for Presentations - Cloud Native Days Norway',
-    description:
-      'Submit your talk proposal for Cloud Native Days Norway conference',
+    title: { absolute: `Call for Presentations - ${brand}` },
+    description: `Submit your talk proposal for ${brand} conference`,
     alternates: await canonicalAlternates('/cfp'),
     twitter: {
       card: 'summary_large_image',

--- a/src/app/(main)/conduct/page.tsx
+++ b/src/app/(main)/conduct/page.tsx
@@ -8,12 +8,14 @@ import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Code of Conduct - Cloud Native Days Norway',
-    description:
-      'Community Code of Conduct for Cloud Native Days Norway events and activities.',
+    title: { absolute: `Code of Conduct - ${brand}` },
+    description: `Community Code of Conduct for ${brand} events and activities.`,
     alternates: await canonicalAlternates('/conduct'),
   }
 }
@@ -35,7 +37,7 @@ async function CachedConductContent({ domain }: { domain: string }) {
     return null
   }
 
-  const organizerName = conference?.organizer || 'Cloud Native Days Norway'
+  const organizerName = conference?.organizer || PLATFORM_NAME
 
   return (
     <>

--- a/src/app/(main)/info/page.tsx
+++ b/src/app/(main)/info/page.tsx
@@ -10,12 +10,13 @@ import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Practical Information - Cloud Native Days Norway',
-    description:
-      'Essential details for attending Cloud Native Days Norway conference',
+    title: { absolute: `Practical Information - ${brand}` },
+    description: `Essential details for attending ${brand} conference`,
     alternates: await canonicalAlternates('/info'),
   }
 }

--- a/src/app/(main)/install/page.tsx
+++ b/src/app/(main)/install/page.tsx
@@ -1,19 +1,27 @@
 import type { Metadata } from 'next'
+import { headers } from 'next/headers'
 import { BackgroundImage } from '@/components/BackgroundImage'
 import { Container } from '@/components/Container'
 import { InstallGuide } from '@/components/pwa/InstallGuide'
 import { canonicalAlternates } from '@/lib/seo/canonical'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
+import { getConferenceForDomain } from '@/lib/conference/sanity'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Install the app - Cloud Native Days Norway',
-    description:
-      'Install Cloud Native Days on your phone or computer for fast, full-screen, offline-ready access to the schedule — with step-by-step instructions for your device.',
+    title: { absolute: `Install the app - ${brand}` },
+    description: `Install ${brand} on your phone or computer for fast, full-screen, offline-ready access to the schedule — with step-by-step instructions for your device.`,
     alternates: await canonicalAlternates('/install'),
   }
 }
 
-export default function InstallPage() {
+export default async function InstallPage() {
+  const host = (await headers()).get('host') || ''
+  const { conference } = await getConferenceForDomain(host)
+  const productName = conference?.title?.trim() || PLATFORM_NAME
+
   return (
     <div className="relative py-20 sm:pt-36 sm:pb-24">
       <BackgroundImage className="-top-36 -bottom-14" />
@@ -23,12 +31,12 @@ export default function InstallPage() {
             Get the app
           </h1>
           <p className="font-inter mt-6 text-lg text-brand-slate-gray dark:text-gray-300">
-            Add Cloud Native Days to your device for a faster, full-screen,
+            Add {productName} to your device for a faster, full-screen,
             offline-ready experience. Follow the steps for your browser below.
           </p>
         </div>
         <div className="mt-12">
-          <InstallGuide />
+          <InstallGuide productName={productName} />
         </div>
       </Container>
     </div>

--- a/src/app/(main)/opengraph-image.tsx
+++ b/src/app/(main)/opengraph-image.tsx
@@ -1,10 +1,11 @@
 import { generateOGImage } from '@/lib/og/template'
-import { OG_IMAGE_SIZE } from '@/lib/og/styles'
+import { ogImageMetadata } from '@/lib/og/metadata'
 
 export const dynamic = 'force-dynamic'
-export const alt = 'Cloud Native Days Norway'
-export const size = OG_IMAGE_SIZE
-export const contentType = 'image/png'
+
+export function generateImageMetadata() {
+  return ogImageMetadata((brand) => brand)
+}
 
 export default async function Image() {
   return generateOGImage({

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -3,7 +3,8 @@ import { Container } from '@/components/Container'
 import { ContentCard } from '@/components/ContentCard'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
-import { resolveConferenceContact } from '@/lib/email/from'
+import { resolveLegalConfig } from '@/lib/legal'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 import { ErrorDisplay } from '@/components/admin'
 import {
   ShieldCheckIcon,
@@ -45,10 +46,10 @@ import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Privacy Policy - Cloud Native Days Norway',
-    description:
-      'Privacy policy and data protection information for Cloud Native Days Norway conference',
+    title: { absolute: `Privacy Policy - ${brand}` },
+    description: `Privacy policy and data protection information for ${brand}`,
     alternates: await canonicalAlternates('/privacy'),
   }
 }
@@ -78,8 +79,9 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
   }
 
   const lastUpdated = 'October 31, 2025'
-  const contactEmail = resolveConferenceContact(conference)
-  const organizationName = 'Cloud Native Days Norway'
+  const legal = await resolveLegalConfig(conference)
+  const contactEmail = legal.contactEmail
+  const organizationName = legal.controllerName
 
   return (
     <>
@@ -126,7 +128,7 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                   <div className="space-y-4 print:space-y-3">
                     <p className="text-base leading-7 text-gray-700 dark:text-gray-300 print:leading-relaxed print:text-black">
                       {organizationName} is a technology conference organizer
-                      based in Bergen, Norway. We organize events focused on
+                      based in {legal.location}. We organize events focused on
                       cloud native technologies and related topics.
                     </p>
 
@@ -153,7 +155,7 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                             Location:
                           </span>{' '}
                           <span className="text-gray-700 dark:text-gray-300">
-                            Bergen, Norway
+                            {legal.location}
                           </span>
                         </div>
                       </div>
@@ -1183,8 +1185,9 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                               <span className="font-medium text-purple-600 dark:text-purple-400">
                                 Legal Obligation:
                               </span>{' '}
-                              Norwegian accounting and tax law requirements for
-                              financial records
+                              {legal.isNorway
+                                ? 'Norwegian accounting and tax law requirements for financial records'
+                                : 'Applicable accounting and tax law requirements for financial records'}
                             </td>
                           </tr>
                           <tr>
@@ -1814,24 +1817,35 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                       <div className="rounded-lg border border-red-300 bg-red-100 p-3 dark:border-red-700 dark:bg-red-800/30">
                         <p className="mb-2 flex items-center font-semibold text-red-800 dark:text-red-200">
                           <FlagIcon className="mr-2 h-4 w-4" />
-                          Norwegian Data Protection Authority (Datatilsynet)
+                          {legal.supervisoryAuthority.name}
                         </p>
-                        <div className="space-y-1 text-sm text-red-700 dark:text-red-300">
-                          <p>
-                            <strong>Website:</strong>{' '}
-                            <a
-                              href="https://www.datatilsynet.no"
-                              className="text-red-600 underline hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              www.datatilsynet.no
-                            </a>
-                          </p>
-                          <p>
-                            <strong>Email:</strong> postkasse@datatilsynet.no
-                          </p>
-                        </div>
+                        {(legal.supervisoryAuthority.url ||
+                          legal.supervisoryAuthority.email) && (
+                          <div className="space-y-1 text-sm text-red-700 dark:text-red-300">
+                            {legal.supervisoryAuthority.url && (
+                              <p>
+                                <strong>Website:</strong>{' '}
+                                <a
+                                  href={legal.supervisoryAuthority.url}
+                                  className="text-red-600 underline hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  {legal.supervisoryAuthority.url.replace(
+                                    /^https?:\/\//,
+                                    '',
+                                  )}
+                                </a>
+                              </p>
+                            )}
+                            {legal.supervisoryAuthority.email && (
+                              <p>
+                                <strong>Email:</strong>{' '}
+                                {legal.supervisoryAuthority.email}
+                              </p>
+                            )}
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -1841,8 +1855,10 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
 
                 <p className="text-sm text-gray-600 dark:text-gray-400 print:mt-4 print:text-base print:leading-relaxed print:text-black">
                   This privacy policy complies with the EU General Data
-                  Protection Regulation (GDPR) and Norwegian data protection
-                  laws.
+                  Protection Regulation (GDPR)
+                  {legal.isNorway
+                    ? ' and Norwegian data protection laws.'
+                    : ' and applicable local data protection laws.'}
                 </p>
               </div>
             </div>

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -56,7 +56,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
 async function CachedPrivacyContent({ domain }: { domain: string }) {
   'use cache'
-  cacheLife('max')
+  // 'hours', not 'max': the page now renders org-derived legal identity
+  // (controller, jurisdiction, supervisory authority) and organization edits
+  // are Studio-side with no revalidation hook — bounded staleness instead of
+  // serving outdated legal data indefinitely.
+  cacheLife('hours')
   cacheTag('content:privacy')
 
   const { conference, error: conferenceError } =

--- a/src/app/(main)/program/opengraph-image.tsx
+++ b/src/app/(main)/program/opengraph-image.tsx
@@ -1,10 +1,11 @@
 import { generateOGImage } from '@/lib/og/template'
-import { OG_IMAGE_SIZE } from '@/lib/og/styles'
+import { ogImageMetadata } from '@/lib/og/metadata'
 
 export const dynamic = 'force-dynamic'
-export const alt = 'Conference Program - Cloud Native Days Norway'
-export const size = OG_IMAGE_SIZE
-export const contentType = 'image/png'
+
+export function generateImageMetadata() {
+  return ogImageMetadata((brand) => `Conference Program - ${brand}`)
+}
 
 export default async function Image() {
   return generateOGImage({

--- a/src/app/(main)/speaker/[slug]/opengraph-image.tsx
+++ b/src/app/(main)/speaker/[slug]/opengraph-image.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { ImageResponse } from 'next/og'
 import { speakerImageUrl } from '@/lib/sanity/client'
 import { STYLES, OG_IMAGE_SIZE } from '@/lib/og/styles'
+import { ogImageMetadata } from '@/lib/og/metadata'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
 import {
   createSvgDataUrl,
   formatDateRange,
@@ -73,9 +75,13 @@ const renderSponsorLogo = (
   size: 'small' | 'large' = 'small',
 ) => createSponsorLogo(logoSvg, logoBrightSvg, sponsorName, size === 'large')
 
-export const alt = 'Cloud Native Days Norway Speaker Profile'
-export const size = OG_IMAGE_SIZE
-export const contentType = 'image/png'
+export function generateImageMetadata() {
+  return ogImageMetadata((brand) => `${brand} Speaker Profile`)
+}
+
+// Internal (non-exported) size for the ImageResponse below; the exported image
+// metadata (alt/size/contentType) now comes from `generateImageMetadata`.
+const size = OG_IMAGE_SIZE
 
 const SpeakerImage = ({
   imageUrl,
@@ -244,7 +250,7 @@ export default async function Image({
   }
 
   const conferenceData = {
-    title: conference?.title || 'Cloud Native Days Norway',
+    title: conference?.title || PLATFORM_NAME,
     startDate: conference?.startDate,
     endDate: conference?.endDate,
     city: conference?.city,

--- a/src/app/(main)/sponsor/opengraph-image.tsx
+++ b/src/app/(main)/sponsor/opengraph-image.tsx
@@ -1,10 +1,11 @@
 import { generateOGImage } from '@/lib/og/template'
-import { OG_IMAGE_SIZE } from '@/lib/og/styles'
+import { ogImageMetadata } from '@/lib/og/metadata'
 
 export const dynamic = 'force-dynamic'
-export const alt = 'Become a Sponsor - Cloud Native Days Norway'
-export const size = OG_IMAGE_SIZE
-export const contentType = 'image/png'
+
+export function generateImageMetadata() {
+  return ogImageMetadata((brand) => `Become a Sponsor - ${brand}`)
+}
 
 export default async function Image() {
   return generateOGImage({

--- a/src/app/(main)/sponsor/page.tsx
+++ b/src/app/(main)/sponsor/page.tsx
@@ -10,12 +10,13 @@ import { headers } from 'next/headers'
 import { SponsorProspectus } from '@/components/sponsor/SponsorProspectus'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Become a Sponsor - Cloud Native Days Norway',
-    description:
-      'Sponsorship opportunities for Cloud Native Days Norway conference',
+    title: { absolute: `Become a Sponsor - ${brand}` },
+    description: `Sponsorship opportunities for ${brand} conference`,
     alternates: await canonicalAlternates('/sponsor'),
     twitter: {
       card: 'summary_large_image',

--- a/src/app/(main)/sponsor/terms/page.tsx
+++ b/src/app/(main)/sponsor/terms/page.tsx
@@ -10,12 +10,13 @@ import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Sponsorship Terms & Conditions - Cloud Native Days Norway',
-    description:
-      'General terms and conditions for sponsorship of Cloud Native Days Norway',
+    title: { absolute: `Sponsorship Terms & Conditions - ${brand}` },
+    description: `General terms and conditions for sponsorship of ${brand}`,
     alternates: await canonicalAlternates('/sponsor/terms'),
   }
 }

--- a/src/app/(main)/terms/page.tsx
+++ b/src/app/(main)/terms/page.tsx
@@ -36,7 +36,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
 async function CachedTermsContent({ domain }: { domain: string }) {
   'use cache'
-  cacheLife('max')
+  // 'hours', not 'max': the page now renders org-derived legal identity
+  // (governing law, controller) and organization edits are Studio-side with no
+  // revalidation hook — bounded staleness instead of serving outdated legal
+  // data indefinitely.
+  cacheLife('hours')
   cacheTag('content:terms')
 
   const { conference, error: conferenceError } =

--- a/src/app/(main)/terms/page.tsx
+++ b/src/app/(main)/terms/page.tsx
@@ -2,7 +2,8 @@ import { BackgroundImage } from '@/components/BackgroundImage'
 import { Container } from '@/components/Container'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isUnknownHost } from '@/lib/conference/guard'
-import { resolveConferenceContact } from '@/lib/email/from'
+import { resolveLegalConfig } from '@/lib/legal'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 import { ErrorDisplay } from '@/components/admin'
 import {
   DocumentTextIcon,
@@ -25,10 +26,10 @@ import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Terms of Service - Cloud Native Days',
-    description:
-      'Terms of Service for Cloud Native Days conference and workshop services',
+    title: { absolute: `Terms of Service - ${brand}` },
+    description: `Terms of Service for ${brand} conference and workshop services`,
     alternates: await canonicalAlternates('/terms'),
   }
 }
@@ -61,8 +62,9 @@ async function CachedTermsContent({ domain }: { domain: string }) {
   }
 
   const lastUpdated = 'October 31, 2025'
-  const contactEmail = resolveConferenceContact(conference)
-  const organizationName = conference.organizer || 'Cloud Native Days'
+  const legal = await resolveLegalConfig(conference)
+  const contactEmail = legal.contactEmail
+  const organizationName = legal.controllerName
 
   return (
     <>
@@ -474,10 +476,10 @@ async function CachedTermsContent({ domain }: { domain: string }) {
                   <div className="space-y-4">
                     <p className="text-base leading-7 text-gray-700 dark:text-gray-300">
                       These Terms of Service are governed by and construed in
-                      accordance with the laws of Norway. Any disputes arising
-                      from these terms or your use of our services shall be
-                      subject to the exclusive jurisdiction of the courts of
-                      Norway.
+                      accordance with the laws of {legal.jurisdiction}. Any
+                      disputes arising from these terms or your use of our
+                      services shall be subject to the exclusive jurisdiction of
+                      the courts of {legal.jurisdiction}.
                     </p>
                     <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
                       <p className="text-sm text-blue-700 dark:text-blue-300">

--- a/src/app/(main)/tickets/opengraph-image.tsx
+++ b/src/app/(main)/tickets/opengraph-image.tsx
@@ -1,10 +1,11 @@
 import { generateOGImage } from '@/lib/og/template'
-import { OG_IMAGE_SIZE } from '@/lib/og/styles'
+import { ogImageMetadata } from '@/lib/og/metadata'
 
 export const dynamic = 'force-dynamic'
-export const alt = 'Get Your Ticket - Cloud Native Days Norway'
-export const size = OG_IMAGE_SIZE
-export const contentType = 'image/png'
+
+export function generateImageMetadata() {
+  return ogImageMetadata((brand) => `Get Your Ticket - ${brand}`)
+}
 
 export default async function Image() {
   return generateOGImage({

--- a/src/app/(main)/tickets/page.tsx
+++ b/src/app/(main)/tickets/page.tsx
@@ -41,6 +41,7 @@ import { conferenceTag } from '@/lib/cache/tags'
 import type { ElementType } from 'react'
 import type { Metadata } from 'next'
 import { canonicalAlternates } from '@/lib/seo/canonical'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 
 const INCLUSION_ICONS: Record<string, ElementType> = {
   MicrophoneIcon,
@@ -66,9 +67,10 @@ const INCLUSION_ICONS: Record<string, ElementType> = {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Tickets - Cloud Native Days Norway',
-    description: 'Get your tickets for Cloud Native Days Norway conference',
+    title: { absolute: `Tickets - ${brand}` },
+    description: `Get your tickets for ${brand} conference`,
     alternates: await canonicalAlternates('/tickets'),
     twitter: {
       card: 'summary_large_image',

--- a/src/app/(main)/volunteer/page.tsx
+++ b/src/app/(main)/volunteer/page.tsx
@@ -10,10 +10,12 @@ import { cacheLife, cacheTag } from 'next/cache'
 import { conferenceTag } from '@/lib/cache/tags'
 import { headers } from 'next/headers'
 import { canonicalAlternates } from '@/lib/seo/canonical'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
   return {
-    title: 'Volunteer | Cloud Native Days Norway',
+    title: { absolute: `Volunteer | ${brand}` },
     description:
       'Join our volunteer team and help make the conference a success',
     alternates: await canonicalAlternates('/volunteer'),

--- a/src/app/(public)/badge/[badgeId]/opengraph-image.tsx
+++ b/src/app/(public)/badge/[badgeId]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ImageResponse } from 'next/og'
 import { getBadgeById, getBadgeSVGUrl } from '@/lib/badge/sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
 import { notFound } from 'next/navigation'
 
 export const runtime = 'edge'
@@ -107,7 +108,7 @@ export default async function Image({
       : null
 
   const speakerName = speaker?.name || 'Speaker'
-  const conferenceName = conference?.title || 'Cloud Native Days'
+  const conferenceName = conference?.title || PLATFORM_NAME
   const conferenceLocation =
     conference && 'city' in conference && 'country' in conference
       ? `${conference.city}, ${conference.country}`

--- a/src/app/(stream)/layout.tsx
+++ b/src/app/(stream)/layout.tsx
@@ -1,14 +1,27 @@
 import type { Metadata } from 'next'
+import { BackgroundPatternProvider } from '@/components/BackgroundPatternProvider'
+import { normalizeBackgroundPattern } from '@/lib/conference/backgroundPattern'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 }
 
-export default function StreamLayout({
+export default async function StreamLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  // No layout wrapper - stream pages render directly without navigation
-  return <>{children}</>
+  // Stream pages render without the shared Layout (no navigation), so resolve
+  // the tenant's background pattern here — otherwise the venue-screen overlays
+  // would fall back to the cloud-native logo pattern regardless of the
+  // conference's configured branding (E1, #643).
+  const { conference } = await getConferenceForCurrentDomain()
+  return (
+    <BackgroundPatternProvider
+      pattern={normalizeBackgroundPattern(conference?.backgroundPattern)}
+    >
+      {children}
+    </BackgroundPatternProvider>
+  )
 }

--- a/src/app/invitation/respond/page.tsx
+++ b/src/app/invitation/respond/page.tsx
@@ -10,11 +10,15 @@ import {
 import InvitationResponseClient from '@/components/InvitationResponseClient'
 import { AppEnvironment } from '@/lib/environment'
 import { DevBanner } from '@/components/DevBanner'
+import { resolveMetadataBrand } from '@/lib/seo/brand'
 
-export const metadata: Metadata = {
-  title: 'Co-Speaker Invitation | Cloud Native Days Norway',
-  description: 'Respond to your co-speaker invitation',
-  robots: { index: false, follow: false },
+export async function generateMetadata(): Promise<Metadata> {
+  const brand = await resolveMetadataBrand()
+  return {
+    title: { absolute: `Co-Speaker Invitation | ${brand}` },
+    description: 'Respond to your co-speaker invitation',
+    robots: { index: false, follow: false },
+  }
 }
 
 interface PageProps {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import { Suspense } from 'react'
 import '@/styles/tailwind.css'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { isConferenceUnlisted } from '@/lib/conference/visibility'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
 import { canonicalOrigin } from '@/lib/seo/canonical'
 import { DevBanner } from '@/components/DevBanner'
 import {
@@ -77,6 +78,7 @@ export async function generateMetadata(): Promise<Metadata> {
   // request host, keeping local development correct.
   const { conference } = await getConferenceForDomain(host)
   const metadataBase = new URL(canonicalOrigin(conference, host))
+  const brand = conference?.title?.trim() || PLATFORM_NAME
 
   return {
     metadataBase,
@@ -89,11 +91,13 @@ export async function generateMetadata(): Promise<Metadata> {
       ? { robots: { index: false, follow: false } }
       : {}),
     title: {
-      template: '%s - Cloud Native Days',
-      default:
-        'Cloud Native Days - A community-driven Kubernetes and Cloud conference',
+      template: `%s - ${brand}`,
+      default: conference?.tagline
+        ? `${brand} - ${conference.tagline}`
+        : `${brand} - A community-driven Kubernetes and Cloud conference`,
     },
     description:
+      conference?.description ||
       'We bring together the community to share knowledge and experience on Kubernetes, Cloud Native, and related technologies.',
     // PWA / installability. Next injects the manifest link automatically from
     // `app/manifest.ts`; here we add the iOS web-app meta and the icon links.
@@ -103,7 +107,7 @@ export async function generateMetadata(): Promise<Metadata> {
     appleWebApp: {
       capable: true,
       statusBarStyle: 'black-translucent',
-      title: 'Cloud Native Days',
+      title: brand,
     },
     icons: {
       icon: [

--- a/src/components/BackgroundImage.stories.tsx
+++ b/src/components/BackgroundImage.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { BackgroundImage } from './BackgroundImage'
+import type { BackgroundPattern } from '@/lib/conference/backgroundPattern'
+
+/**
+ * The per-conference background-pattern switch (go-live gate G2, E1). Each story
+ * renders {@link BackgroundImage} filling a hero-sized frame with a heading on
+ * top, so the three states are directly comparable at 393px in light and dark.
+ */
+const meta = {
+  title: 'Components/BackgroundImage',
+  component: BackgroundImage,
+  parameters: {
+    layout: 'fullscreen',
+    options: { showPanel: false },
+  },
+} satisfies Meta<typeof BackgroundImage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Frame({ pattern }: { pattern: BackgroundPattern }) {
+  return (
+    <div className="relative h-[600px] w-full overflow-hidden bg-white dark:bg-gray-950">
+      <BackgroundImage className="inset-0" pattern={pattern} />
+      <div className="relative flex h-full flex-col items-center justify-center px-6 text-center">
+        <h1 className="font-jetbrains text-3xl font-bold tracking-tighter text-brand-cloud-blue sm:text-5xl dark:text-blue-400">
+          {pattern}
+        </h1>
+        <p className="font-inter mt-4 max-w-md text-base text-brand-slate-gray dark:text-gray-300">
+          Background pattern set to <code>{pattern}</code>.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export const CloudNative: Story = {
+  render: () => <Frame pattern="cloud-native" />,
+}
+
+export const Subtle: Story = {
+  render: () => <Frame pattern="subtle" />,
+}
+
+export const None: Story = {
+  render: () => <Frame pattern="none" />,
+}

--- a/src/components/BackgroundImage.test.tsx
+++ b/src/components/BackgroundImage.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { BackgroundImage } from './BackgroundImage'
+import { BackgroundPatternProvider } from './BackgroundPatternProvider'
+
+// Stub the heavy, SVG-importing pattern with a marker that records its props, so
+// we can assert the switch's density/opacity decisions without a real render.
+const patternCalls: Array<{ opacity?: number; iconCount?: number }> = []
+vi.mock('./CloudNativePattern', () => ({
+  CloudNativePattern: (props: { opacity?: number; iconCount?: number }) => {
+    patternCalls.push({ opacity: props.opacity, iconCount: props.iconCount })
+    return <div data-testid="cnp" />
+  },
+}))
+
+afterEach(() => {
+  cleanup()
+  patternCalls.length = 0
+})
+
+describe('BackgroundImage pattern switch', () => {
+  it("renders the full CNCF pattern for 'cloud-native' (two color-scheme copies)", () => {
+    const { queryAllByTestId } = render(
+      <BackgroundImage pattern="cloud-native" />,
+    )
+    expect(queryAllByTestId('cnp')).toHaveLength(2)
+    expect(patternCalls.every((c) => c.iconCount === 50)).toBe(true)
+    expect(patternCalls.every((c) => c.opacity === 0.1)).toBe(true)
+  })
+
+  it("renders a sparse, faint pattern for 'subtle'", () => {
+    render(<BackgroundImage pattern="subtle" />)
+    expect(patternCalls.every((c) => c.iconCount === 14)).toBe(true)
+    expect(patternCalls.every((c) => c.opacity === 0.04)).toBe(true)
+  })
+
+  it("renders NO logo layer for 'none'", () => {
+    const { queryAllByTestId } = render(<BackgroundImage pattern="none" />)
+    expect(queryAllByTestId('cnp')).toHaveLength(0)
+    expect(patternCalls).toHaveLength(0)
+  })
+
+  it('reads the pattern from context when no prop is given', () => {
+    const { queryAllByTestId } = render(
+      <BackgroundPatternProvider pattern="none">
+        <BackgroundImage />
+      </BackgroundPatternProvider>,
+    )
+    expect(queryAllByTestId('cnp')).toHaveLength(0)
+  })
+
+  it("defaults to 'cloud-native' outside any provider", () => {
+    const { queryAllByTestId } = render(<BackgroundImage />)
+    expect(queryAllByTestId('cnp')).toHaveLength(2)
+  })
+})

--- a/src/components/BackgroundImage.tsx
+++ b/src/components/BackgroundImage.tsx
@@ -47,7 +47,7 @@ export function BackgroundImage({
               animated={true}
               baseSize={100}
               iconCount={settings.iconCount}
-              className="h-full w-full"
+              className="size-full"
               seed={new Date().setHours(0, 0, 0, 0)}
             />
           </div>
@@ -59,7 +59,7 @@ export function BackgroundImage({
               animated={true}
               baseSize={100}
               iconCount={settings.iconCount}
-              className="h-full w-full"
+              className="size-full"
               seed={new Date().setHours(0, 0, 0, 0)}
             />
           </div>

--- a/src/components/BackgroundImage.tsx
+++ b/src/components/BackgroundImage.tsx
@@ -2,38 +2,69 @@
 
 import clsx from 'clsx'
 import { CloudNativePattern } from './CloudNativePattern'
+import { useBackgroundPattern } from './BackgroundPatternProvider'
+import type { BackgroundPattern } from '@/lib/conference/backgroundPattern'
 
-export function BackgroundImage({ className }: { className?: string }) {
+/**
+ * Per-pattern density/opacity for the CNCF logo layer. `'cloud-native'` is the
+ * historical look; `'subtle'` keeps the same logo-based pattern but far sparser
+ * and fainter (the component is inherently logo-based, so "subtle" is low
+ * density + low opacity rather than a different, logo-free texture); `'none'`
+ * omits the logo layer entirely, leaving just the gradient wash.
+ */
+const PATTERN_SETTINGS: Record<
+  Exclude<BackgroundPattern, 'none'>,
+  { opacity: number; iconCount: number }
+> = {
+  'cloud-native': { opacity: 0.1, iconCount: 50 },
+  subtle: { opacity: 0.04, iconCount: 14 },
+}
+
+export function BackgroundImage({
+  className,
+  pattern: patternProp,
+}: {
+  className?: string
+  /** Override the context-provided pattern (stories / isolated previews). */
+  pattern?: BackgroundPattern
+}) {
+  const contextPattern = useBackgroundPattern()
+  const pattern = patternProp ?? contextPattern
+
+  const settings = pattern === 'none' ? null : PATTERN_SETTINGS[pattern]
+
   return (
     <div className={clsx('absolute inset-0 overflow-hidden', className)}>
       <div className="absolute inset-0 bg-brand-gradient opacity-20" />
       <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-white dark:to-gray-950" />
 
-      <div className="absolute inset-0">
-        <div className="block dark:hidden">
-          <CloudNativePattern
-            variant="light"
-            opacity={0.1}
-            animated={true}
-            baseSize={100}
-            iconCount={50}
-            className="h-full w-full"
-            seed={new Date().setHours(0, 0, 0, 0)}
-          />
-        </div>
+      {settings && (
+        <div className="absolute inset-0">
+          <div className="block dark:hidden">
+            <CloudNativePattern
+              variant="light"
+              opacity={settings.opacity}
+              animated={true}
+              baseSize={100}
+              iconCount={settings.iconCount}
+              className="h-full w-full"
+              seed={new Date().setHours(0, 0, 0, 0)}
+            />
+          </div>
 
-        <div className="hidden dark:block">
-          <CloudNativePattern
-            variant="dark"
-            opacity={0.1}
-            animated={true}
-            baseSize={100}
-            iconCount={50}
-            className="h-full w-full"
-            seed={new Date().setHours(0, 0, 0, 0)}
-          />
+          <div className="hidden dark:block">
+            <CloudNativePattern
+              variant="dark"
+              opacity={settings.opacity}
+              animated={true}
+              baseSize={100}
+              iconCount={settings.iconCount}
+              className="h-full w-full"
+              seed={new Date().setHours(0, 0, 0, 0)}
+            />
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-white dark:from-gray-950" />
       <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-white dark:from-gray-950" />

--- a/src/components/BackgroundPatternProvider.tsx
+++ b/src/components/BackgroundPatternProvider.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import {
+  DEFAULT_BACKGROUND_PATTERN,
+  type BackgroundPattern,
+} from '@/lib/conference/backgroundPattern'
+
+/**
+ * Supplies the resolved per-conference {@link BackgroundPattern} to every
+ * {@link import('./BackgroundImage').BackgroundImage} beneath it, without
+ * threading a prop through the ~30 call sites that render one.
+ *
+ * A server layout that has resolved the conference wraps its subtree once with
+ * `<BackgroundPatternProvider pattern={…}>`. Outside any provider (route groups
+ * that never resolve a tenant, isolated stories) the context defaults to
+ * `'cloud-native'`, i.e. the historical behaviour — so nothing regresses.
+ */
+const BackgroundPatternContext = createContext<BackgroundPattern>(
+  DEFAULT_BACKGROUND_PATTERN,
+)
+
+export function BackgroundPatternProvider({
+  pattern,
+  children,
+}: {
+  pattern: BackgroundPattern
+  children: React.ReactNode
+}) {
+  return (
+    <BackgroundPatternContext.Provider value={pattern}>
+      {children}
+    </BackgroundPatternContext.Provider>
+  )
+}
+
+/** The active background pattern for the current subtree. */
+export function useBackgroundPattern(): BackgroundPattern {
+  return useContext(BackgroundPatternContext)
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,7 @@
 import { Footer } from '@/components/Footer'
 import { Header } from '@/components/Header'
+import { BackgroundPatternProvider } from '@/components/BackgroundPatternProvider'
+import { normalizeBackgroundPattern } from '@/lib/conference/backgroundPattern'
 import { Conference } from '@/lib/conference/types'
 
 export async function Layout({
@@ -12,10 +14,12 @@ export async function Layout({
   showFooter?: boolean
 }) {
   return (
-    <>
+    <BackgroundPatternProvider
+      pattern={normalizeBackgroundPattern(conference.backgroundPattern)}
+    >
       <Header c={conference} />
       <main className="flex-auto">{children}</main>
       {showFooter && <Footer c={conference} />}
-    </>
+    </BackgroundPatternProvider>
   )
 }

--- a/src/components/admin/EditConferenceCard.tsx
+++ b/src/components/admin/EditConferenceCard.tsx
@@ -58,6 +58,7 @@ export type ConferenceFieldsetKey =
   | 'basicInfo'
   | 'visibility'
   | 'venue'
+  | 'branding'
   | 'dates'
   | 'registration'
   | 'communication'
@@ -214,6 +215,28 @@ export const FIELDSET_DEFS: Record<ConferenceFieldsetKey, FieldsetDef> = {
         label: 'Venue Address',
         type: 'text',
         nullableWhenEmpty: true,
+      },
+    ],
+  },
+  branding: {
+    title: 'Background Pattern',
+    subtitle: 'The decorative page background',
+    fields: [
+      {
+        name: 'backgroundPattern',
+        label: 'Background Pattern',
+        type: 'select',
+        required: true,
+        options: [
+          {
+            value: 'cloud-native',
+            title: 'Cloud Native — animated CNCF logos',
+          },
+          { value: 'subtle', title: 'Subtle — sparse, faint logos' },
+          { value: 'none', title: 'None — plain gradient, no logos' },
+        ],
+        description:
+          'Cloud Native shows the animated CNCF project logos. Subtle shows the same logos far sparser and fainter. None shows a plain gradient with no logos.',
       },
     ],
   },
@@ -535,6 +558,7 @@ const MUTATION_BY_FIELDSET: Record<
   basicInfo: 'updateBasicInfo',
   visibility: 'updateVisibility',
   venue: 'updateVenue',
+  branding: 'updateBranding',
   dates: 'updateDates',
   registration: 'updateRegistration',
   communication: 'updateCommunication',

--- a/src/components/email/BadgeEmailTemplate.tsx
+++ b/src/components/email/BadgeEmailTemplate.tsx
@@ -1,9 +1,17 @@
+import { PLATFORM_NAME } from '@/lib/branding/platform'
+
 interface BadgeEmailTemplateProps {
   speakerName: string
   conferenceName: string
   conferenceYear: string
   badgeType: 'speaker' | 'organizer'
   downloadUrl: string
+  /**
+   * The issuing organizer shown in the footer. Defaults to the neutral platform
+   * name; callers thread the conference organizer/title so the footer names the
+   * actual tenant (go-live gate G2, E8).
+   */
+  organizerName?: string
 }
 
 export const BadgeEmailTemplate = ({
@@ -12,6 +20,7 @@ export const BadgeEmailTemplate = ({
   conferenceYear,
   badgeType,
   downloadUrl,
+  organizerName = PLATFORM_NAME,
 }: BadgeEmailTemplateProps) => {
   return `
 <!DOCTYPE html>
@@ -54,7 +63,7 @@ export const BadgeEmailTemplate = ({
     </p>
 
     <p style="color: #8898aa; font-size: 12px; line-height: 16px; padding: 0 48px; margin-top: 32px;">
-      Cloud Native Days<br>
+      ${organizerName}<br>
       Building the cloud native community
     </p>
   </div>

--- a/src/components/email/BadgeEmailTemplate.tsx
+++ b/src/components/email/BadgeEmailTemplate.tsx
@@ -1,4 +1,5 @@
 import { PLATFORM_NAME } from '@/lib/branding/platform'
+import { escapeHtml } from '@/lib/email/escape'
 
 interface BadgeEmailTemplateProps {
   speakerName: string
@@ -22,22 +23,34 @@ export const BadgeEmailTemplate = ({
   downloadUrl,
   organizerName = PLATFORM_NAME,
 }: BadgeEmailTemplateProps) => {
+  // Raw template string — every tenant-derived value must be escaped before
+  // interpolation (a conference/organizer/speaker name containing < or & must
+  // not break or inject into the outgoing email). `badgeType` is a closed
+  // union, `downloadUrl` is app-generated; both escaped anyway for depth.
+  const safe = {
+    speakerName: escapeHtml(speakerName),
+    conferenceName: escapeHtml(conferenceName),
+    conferenceYear: escapeHtml(conferenceYear),
+    badgeType: escapeHtml(badgeType),
+    downloadUrl: escapeHtml(downloadUrl),
+    organizerName: escapeHtml(organizerName),
+  }
   return `
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Your ${badgeType} badge for ${conferenceName} ${conferenceYear}</title>
+  <title>Your ${safe.badgeType} badge for ${safe.conferenceName} ${safe.conferenceYear}</title>
 </head>
 <body style="background-color: #f6f9fc; font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Ubuntu,sans-serif; margin: 0; padding: 0;">
   <div style="background-color: #ffffff; margin: 0 auto 64px; padding: 20px 0 48px; max-width: 600px;">
     <h1 style="color: #1D4ED8; font-size: 32px; font-weight: bold; margin: 40px 0; padding: 0 48px;">
-      🎉 Congratulations, ${speakerName}!
+      🎉 Congratulations, ${safe.speakerName}!
     </h1>
 
     <p style="color: #032B45; font-size: 16px; line-height: 26px; padding: 0 48px;">
-      Thank you for being a ${badgeType} at ${conferenceName} ${conferenceYear}. Your contribution to our community is invaluable!
+      Thank you for being a ${safe.badgeType} at ${safe.conferenceName} ${safe.conferenceYear}. Your contribution to our community is invaluable!
     </p>
 
     <p style="color: #032B45; font-size: 16px; line-height: 26px; padding: 0 48px;">
@@ -45,7 +58,7 @@ export const BadgeEmailTemplate = ({
     </p>
 
     <div style="padding: 27px 48px;">
-      <a href="${downloadUrl}" style="background-color: #06B6D4; border-radius: 5px; color: #fff; font-size: 16px; font-weight: bold; text-decoration: none; text-align: center; display: block; padding: 12px 20px;">
+      <a href="${safe.downloadUrl}" style="background-color: #06B6D4; border-radius: 5px; color: #fff; font-size: 16px; font-weight: bold; text-decoration: none; text-align: center; display: block; padding: 12px 20px;">
         Download Your Badge
       </a>
     </div>
@@ -63,7 +76,7 @@ export const BadgeEmailTemplate = ({
     </p>
 
     <p style="color: #8898aa; font-size: 12px; line-height: 16px; padding: 0 48px; margin-top: 32px;">
-      ${organizerName}<br>
+      ${safe.organizerName}<br>
       Building the cloud native community
     </p>
   </div>

--- a/src/components/email/BaseEmailTemplate.tsx
+++ b/src/components/email/BaseEmailTemplate.tsx
@@ -1,9 +1,20 @@
 import * as React from 'react'
 import { iconForLink, titleForLink } from '../SocialIcons'
 
+/**
+ * The default brand accent (Cloud Native Days blue). Overridable per-send via
+ * `brandColor` so a tenant's mail can carry its own accent; full design-token
+ * theming lands later — this is the neutral-correctness seam (go-live gate G2,
+ * E8). The base template's footer already names the sender via `eventName`, so
+ * no hardcoded brand name remains here.
+ */
+export const DEFAULT_EMAIL_BRAND_COLOR = '#1D4ED8'
+
 interface BaseEmailTemplateProps {
   title?: string
   titleColor?: string
+  /** Accent colour for links, the event-details header and footer emphasis. */
+  brandColor?: string
   speakerName?: string
   proposalTitle?: string
   eventName: string
@@ -50,6 +61,7 @@ function messagesUrlFromEventUrl(eventUrl: string): string {
 export function BaseEmailTemplate({
   title,
   titleColor = '#334155',
+  brandColor = DEFAULT_EMAIL_BRAND_COLOR,
   speakerName,
   proposalTitle,
   eventName,
@@ -63,6 +75,7 @@ export function BaseEmailTemplate({
   showMessagesLink,
   customContent,
 }: BaseEmailTemplateProps) {
+  const accent = brandColor
   if (!speakerName && !customContent) {
     throw new Error(
       `BaseEmailTemplate requires either speakerName or customContent to be provided. ` +
@@ -109,7 +122,7 @@ export function BaseEmailTemplate({
   }
 
   const eventDetailsHeaderStyle: React.CSSProperties = {
-    color: '#1D4ED8',
+    color: accent,
     marginTop: '0',
     marginBottom: '16px',
     fontFamily:
@@ -131,7 +144,7 @@ export function BaseEmailTemplate({
   }
 
   const linkStyle: React.CSSProperties = {
-    color: '#1D4ED8',
+    color: accent,
     textDecoration: 'none',
     fontWeight: '500',
   }
@@ -158,7 +171,7 @@ export function BaseEmailTemplate({
   }
 
   const socialLinkStyle: React.CSSProperties = {
-    color: '#1D4ED8',
+    color: accent,
     textDecoration: 'none',
     fontSize: '0',
     marginRight: '12px',
@@ -193,7 +206,7 @@ export function BaseEmailTemplate({
                   {proposalTitle && (
                     <p style={paragraphStyle}>
                       Thank you for submitting your proposal{' '}
-                      <strong style={{ color: '#1D4ED8' }}>
+                      <strong style={{ color: accent }}>
                         &quot;{proposalTitle}&quot;
                       </strong>{' '}
                       for {eventName}.
@@ -278,13 +291,13 @@ export function BaseEmailTemplate({
                   <div style={footerStyle}>
                     <p style={footerTextStyle}>
                       This email was sent by{' '}
-                      <strong style={{ color: '#1D4ED8' }}>{eventName}</strong>
+                      <strong style={{ color: accent }}>{eventName}</strong>
                       .<br />
                       {unsubscribeUrl ? (
                         <a
                           href={unsubscribeUrl}
                           style={{
-                            color: '#1D4ED8',
+                            color: accent,
                             textDecoration: 'underline',
                           }}
                         >

--- a/src/components/email/EmailComponents.tsx
+++ b/src/components/email/EmailComponents.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { DEFAULT_EMAIL_BRAND_COLOR } from './BaseEmailTemplate'
 
 interface EmailSectionProps {
   backgroundColor?: string
@@ -35,7 +36,7 @@ interface EmailSectionHeaderProps {
 
 export function EmailSectionHeader({
   children,
-  color = '#1D4ED8',
+  color = DEFAULT_EMAIL_BRAND_COLOR,
 }: EmailSectionHeaderProps) {
   const headerStyle: React.CSSProperties = {
     color,
@@ -81,15 +82,18 @@ interface EmailButtonProps {
   href: string
   children: React.ReactNode
   variant?: 'primary' | 'secondary'
+  /** Primary-variant accent; defaults to the Cloud Native Days brand blue. */
+  color?: string
 }
 
 export function EmailButton({
   href,
   children,
   variant = 'primary',
+  color = DEFAULT_EMAIL_BRAND_COLOR,
 }: EmailButtonProps) {
   const buttonStyle: React.CSSProperties = {
-    backgroundColor: variant === 'primary' ? '#1D4ED8' : '#6366F1',
+    backgroundColor: variant === 'primary' ? color : '#6366F1',
     color: 'white',
     padding: '16px 32px',
     textDecoration: 'none',

--- a/src/components/pwa/InstallBanner.tsx
+++ b/src/components/pwa/InstallBanner.tsx
@@ -43,7 +43,7 @@ export function InstallBanner({
 
         <div className="flex-1 text-sm text-gray-700 dark:text-gray-200">
           {mode === 'chromium' ? (
-            <span>Install Cloud Native Days for quick, app-like access.</span>
+            <span>Install this app for quick, app-like access.</span>
           ) : (
             <span>
               Add to your Home Screen: tap Share, then{' '}

--- a/src/components/pwa/InstallGuide.tsx
+++ b/src/components/pwa/InstallGuide.tsx
@@ -16,6 +16,7 @@ import {
   resolveInstallView,
   type InstallView,
 } from './installView'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
 
 /** Why someone would install — shown above the manual/actionable flows. */
 function Benefits() {
@@ -68,6 +69,12 @@ export interface InstallGuidePanelProps {
   view: InstallView
   /** Invoked by the Chromium Install button. */
   onInstall?: () => void
+  /**
+   * The installable app's display name, shown in the copy. Defaults to the
+   * neutral platform name; the `/install` page passes the tenant conference
+   * title so the guidance names the actual app.
+   */
+  productName?: string
 }
 
 /**
@@ -75,7 +82,11 @@ export interface InstallGuidePanelProps {
  * any browser-event or context access so every state can be rendered directly
  * (Storybook, tests). The container {@link InstallGuide} picks the view.
  */
-export function InstallGuidePanel({ view, onInstall }: InstallGuidePanelProps) {
+export function InstallGuidePanel({
+  view,
+  onInstall,
+  productName = PLATFORM_NAME,
+}: InstallGuidePanelProps) {
   if (view === 'installed') {
     return (
       <div className="text-center">
@@ -87,7 +98,7 @@ export function InstallGuidePanel({ view, onInstall }: InstallGuidePanelProps) {
           You&rsquo;re all set
         </h2>
         <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-          Cloud Native Days is installed. Launch it from your home screen or app
+          {productName} is installed. Launch it from your home screen or app
           launcher any time.
         </p>
       </div>
@@ -104,7 +115,7 @@ export function InstallGuidePanel({ view, onInstall }: InstallGuidePanelProps) {
           Install the app
         </h2>
         <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-          One tap adds Cloud Native Days to your device.
+          One tap adds {productName} to your device.
         </p>
         <button
           type="button"
@@ -112,7 +123,7 @@ export function InstallGuidePanel({ view, onInstall }: InstallGuidePanelProps) {
           className="mt-6 inline-flex items-center gap-2 rounded-xl bg-brand-cloud-blue px-6 py-3 text-base font-semibold text-white transition hover:bg-brand-cloud-blue-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
         >
           <ArrowDownTrayIcon className="size-5" aria-hidden="true" />
-          Install Cloud Native Days
+          Install {productName}
         </button>
         <Benefits />
       </div>
@@ -195,8 +206,8 @@ export function InstallGuidePanel({ view, onInstall }: InstallGuidePanelProps) {
       <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
         Look for an <span className="font-semibold">install icon</span> in the
         address bar, or open your browser menu and choose{' '}
-        <span className="font-semibold">Install Cloud Native Days</span>.
-        Available in Chrome, Edge, and other Chromium browsers.
+        <span className="font-semibold">Install {productName}</span>. Available
+        in Chrome, Edge, and other Chromium browsers.
       </p>
       <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
         Firefox and desktop Safari don&rsquo;t support installing this app — you
@@ -215,7 +226,7 @@ export function InstallGuidePanel({ view, onInstall }: InstallGuidePanelProps) {
  * prompt; `appinstalled` flips the provider to standalone and this re-renders
  * into the success state automatically.
  */
-export function InstallGuide() {
+export function InstallGuide({ productName }: { productName?: string }) {
   const { platform, isStandalone, promptInstall } = usePwaInstall()
   const [browser, setBrowser] = useState({ isIOS: false, isSafari: false })
 
@@ -235,7 +246,11 @@ export function InstallGuide() {
 
   return (
     <div className="mx-auto max-w-md rounded-2xl bg-white p-6 shadow-lg ring-1 ring-gray-900/5 sm:p-8 dark:bg-gray-800 dark:ring-white/10">
-      <InstallGuidePanel view={view} onInstall={() => void promptInstall()} />
+      <InstallGuidePanel
+        view={view}
+        onInstall={() => void promptInstall()}
+        productName={productName}
+      />
     </div>
   )
 }

--- a/src/lib/branding/platform.ts
+++ b/src/lib/branding/platform.ts
@@ -1,0 +1,13 @@
+/**
+ * The neutral, brand-free PLATFORM name (CaaS de-branding, go-live gate G2).
+ *
+ * This is the last-resort fallback used ONLY when no tenant conference resolves
+ * for the current request (e.g. the apex/platform host, localhost, a preview
+ * deploy with no matching `domains[]`). Tenant-facing surfaces MUST prefer the
+ * resolved `conference.title` / `conference.organizer`; this constant is the
+ * platform default they degrade to, never a substitute for a tenant's own name.
+ *
+ * Kept as ONE source of truth so the manifest, root metadata, per-page
+ * metadata and OpenGraph alt text all agree on the platform label.
+ */
+export const PLATFORM_NAME = 'Cloud Native Days'

--- a/src/lib/conference/backgroundPattern.test.ts
+++ b/src/lib/conference/backgroundPattern.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeBackgroundPattern,
+  DEFAULT_BACKGROUND_PATTERN,
+  BACKGROUND_PATTERN_VALUES,
+} from './backgroundPattern'
+
+describe('normalizeBackgroundPattern', () => {
+  it('passes through each known value unchanged', () => {
+    for (const value of BACKGROUND_PATTERN_VALUES) {
+      expect(normalizeBackgroundPattern(value)).toBe(value)
+    }
+  })
+
+  it('treats absent (undefined/null) as the default cloud-native pattern', () => {
+    expect(normalizeBackgroundPattern(undefined)).toBe('cloud-native')
+    expect(normalizeBackgroundPattern(null)).toBe('cloud-native')
+    expect(DEFAULT_BACKGROUND_PATTERN).toBe('cloud-native')
+  })
+
+  it('coerces an unknown/legacy value to the default', () => {
+    expect(normalizeBackgroundPattern('rainbow')).toBe('cloud-native')
+    expect(normalizeBackgroundPattern('')).toBe('cloud-native')
+  })
+})

--- a/src/lib/conference/backgroundPattern.ts
+++ b/src/lib/conference/backgroundPattern.ts
@@ -1,0 +1,26 @@
+/**
+ * The decorative page-background pattern switch (go-live gate G2, #643, E1).
+ *
+ * The default `'cloud-native'` renders the animated CNCF ecosystem logos (the
+ * historical behaviour). `'subtle'` renders the same pattern far sparser and
+ * fainter; `'none'` renders only the plain gradient with no logos. ABSENT is
+ * normalized to `'cloud-native'`, so legacy conferences are unaffected.
+ */
+export const BACKGROUND_PATTERN_VALUES = [
+  'cloud-native',
+  'subtle',
+  'none',
+] as const
+
+export type BackgroundPattern = (typeof BACKGROUND_PATTERN_VALUES)[number]
+
+export const DEFAULT_BACKGROUND_PATTERN: BackgroundPattern = 'cloud-native'
+
+/** Coerce any stored/absent value to a known pattern (absent → default). */
+export function normalizeBackgroundPattern(
+  value: string | null | undefined,
+): BackgroundPattern {
+  return BACKGROUND_PATTERN_VALUES.includes(value as BackgroundPattern)
+    ? (value as BackgroundPattern)
+    : DEFAULT_BACKGROUND_PATTERN
+}

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -7,6 +7,7 @@ import type { SalesTargetConfig } from '@/lib/tickets/types'
 import { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import type { OrganizerTeam } from '@/lib/teams/types'
 import type { ConferenceVisibility } from './visibility'
+import type { BackgroundPattern } from './backgroundPattern'
 
 export interface CrmActivityThreshold {
   _key?: string
@@ -130,6 +131,14 @@ export interface Conference {
   logoDark?: string
   logomarkBright?: string
   logomarkDark?: string
+  /**
+   * Decorative page background (go-live gate G2, #643). ABSENT is treated as
+   * `'cloud-native'` — the animated CNCF ecosystem logos — so legacy documents
+   * are unaffected. `'subtle'` renders the same pattern far sparser/fainter;
+   * `'none'` renders a plain gradient with no logos. Projected by the main
+   * conference projection's `...` spread.
+   */
+  backgroundPattern?: BackgroundPattern
   announcement?: TypedObject[]
   startDate: string
   endDate: string

--- a/src/lib/email/badge.ts
+++ b/src/lib/email/badge.ts
@@ -45,6 +45,9 @@ export async function sendBadgeEmail({
       conferenceYear,
       badgeType: badge.badgeType,
       downloadUrl,
+      // Footer issuer: the conference organizer, then its title, then the
+      // neutral platform default (never another tenant's hardcoded brand).
+      organizerName: conference?.organizer || conference?.title || undefined,
     })
 
     // Determine from email using conference data (neutral platform fallback

--- a/src/lib/email/escape.ts
+++ b/src/lib/email/escape.ts
@@ -1,0 +1,15 @@
+/**
+ * HTML-escape a value interpolated into a RAW email template string. Email
+ * templates in this codebase are plain template literals (no JSX auto-escaping),
+ * so every tenant- or user-derived value MUST pass through here before
+ * insertion — a conference or organizer name containing `<`, `&` or quotes must
+ * not break markup or inject content into outgoing mail.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/src/lib/email/workshop.ts
+++ b/src/lib/email/workshop.ts
@@ -1,3 +1,4 @@
+import { escapeHtml } from '@/lib/email/escape'
 import {
   resend,
   retryWithBackoff,
@@ -251,20 +252,6 @@ export interface WorkshopAnnouncementEmailRequest {
   authorName: string
   /** Raw announcement text (owner-authored). MUST be HTML-escaped before embed. */
   body: string
-}
-
-/**
- * Escape HTML-significant characters so an announcement's free-text body cannot
- * inject markup into the email. Newlines are converted to <br> AFTER escaping so
- * the participant sees the same line breaks the author typed.
- */
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
 }
 
 /**

--- a/src/lib/legal/config.test.ts
+++ b/src/lib/legal/config.test.ts
@@ -119,9 +119,25 @@ describe('buildLegalConfig — location assembly', () => {
     expect(legal.location).toBe('Germany')
   })
 
-  it('keeps the venue city when the org jurisdiction override matches the conference country', () => {
+  it('keeps the venue city and canonicalizes casing when the org jurisdiction override matches the conference country', () => {
     const legal = buildLegalConfig(conf(), { legalJurisdiction: 'norway' })
-    expect(legal.location).toBe('Bergen, norway')
+    expect(legal.location).toBe('Bergen, Norway')
+    expect(legal.jurisdiction).toBe('Norway')
     expect(legal.isNorway).toBe(true)
+  })
+})
+
+describe('buildLegalConfig — supervisory-authority URL safety', () => {
+  it('keeps http(s) URLs and drops unsafe schemes', () => {
+    const withUrl = (url: string) =>
+      buildLegalConfig(conf(), {
+        supervisoryAuthority: { name: 'Some DPA', url },
+      }).supervisoryAuthority.url
+    expect(withUrl('https://dpa.example')).toBe('https://dpa.example')
+    expect(withUrl('http://dpa.example')).toBe('http://dpa.example')
+    // eslint-disable-next-line no-script-url
+    expect(withUrl('javascript:alert(1)')).toBeUndefined()
+    expect(withUrl('data:text/html,x')).toBeUndefined()
+    expect(withUrl('not a url')).toBeUndefined()
   })
 })

--- a/src/lib/legal/config.test.ts
+++ b/src/lib/legal/config.test.ts
@@ -109,4 +109,19 @@ describe('buildLegalConfig — location assembly', () => {
     )
     expect(legal.location).toBe('Norway')
   })
+
+  it('drops the venue city when an org jurisdiction override disagrees with the conference country', () => {
+    // The location line describes the CONTROLLER's seat: a German legal entity
+    // running a conference in Bergen must not read "Bergen, Germany" — nor keep
+    // "Bergen, Norway" next to a German governing-law clause.
+    const legal = buildLegalConfig(conf(), { legalJurisdiction: 'Germany' })
+    expect(legal.jurisdiction).toBe('Germany')
+    expect(legal.location).toBe('Germany')
+  })
+
+  it('keeps the venue city when the org jurisdiction override matches the conference country', () => {
+    const legal = buildLegalConfig(conf(), { legalJurisdiction: 'norway' })
+    expect(legal.location).toBe('Bergen, norway')
+    expect(legal.isNorway).toBe(true)
+  })
 })

--- a/src/lib/legal/config.test.ts
+++ b/src/lib/legal/config.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildLegalConfig,
+  NORWAY_SUPERVISORY_AUTHORITY,
+  GENERIC_SUPERVISORY_AUTHORITY,
+  type OrganizationLegalFields,
+} from './config'
+import type { Conference } from '@/lib/conference/types'
+
+// A minimal conference; only the fields buildLegalConfig reads matter.
+function conf(overrides: Partial<Conference> = {}): Conference {
+  return {
+    organizer: 'Cloud Native Days Norway',
+    city: 'Bergen',
+    country: 'Norway',
+    contactEmail: 'contact@cloudnativebergen.dev',
+    domains: ['cloudnativebergen.dev'],
+    ...overrides,
+  } as Conference
+}
+
+describe('buildLegalConfig — defaults (existing tenant, no org fields)', () => {
+  it('preserves the Cloud Native Days Norway / Bergen / Datatilsynet values', () => {
+    const legal = buildLegalConfig(conf(), null)
+    expect(legal.controllerName).toBe('Cloud Native Days Norway')
+    expect(legal.contactEmail).toBe('contact@cloudnativebergen.dev')
+    expect(legal.location).toBe('Bergen, Norway')
+    expect(legal.jurisdiction).toBe('Norway')
+    expect(legal.isNorway).toBe(true)
+    expect(legal.supervisoryAuthority).toEqual(NORWAY_SUPERVISORY_AUTHORITY)
+  })
+
+  it('falls back to the conference organizer when the org has no name', () => {
+    const legal = buildLegalConfig(conf(), { name: '  ' })
+    expect(legal.controllerName).toBe('Cloud Native Days Norway')
+  })
+
+  it('uses the neutral platform name when neither org nor organizer is set', () => {
+    const legal = buildLegalConfig(
+      conf({ organizer: '' as unknown as string }),
+      null,
+    )
+    expect(legal.controllerName).toBe('Cloud Native Days')
+  })
+})
+
+describe('buildLegalConfig — org overrides', () => {
+  it('prefers the organization name and contact email', () => {
+    const org: OrganizationLegalFields = {
+      name: 'Cloud Native Bergen',
+      contactEmail: 'legal@cnb.example',
+    }
+    const legal = buildLegalConfig(conf(), org)
+    expect(legal.controllerName).toBe('Cloud Native Bergen')
+    expect(legal.contactEmail).toBe('legal@cnb.example')
+  })
+
+  it('honors an explicit non-Norway jurisdiction and renders neutral prose', () => {
+    const legal = buildLegalConfig(
+      conf({ city: 'Berlin', country: 'Germany' }),
+      { legalJurisdiction: 'Germany' },
+    )
+    expect(legal.jurisdiction).toBe('Germany')
+    expect(legal.isNorway).toBe(false)
+    expect(legal.location).toBe('Berlin, Germany')
+    // No org-configured authority + non-Norway → the generic pointer.
+    expect(legal.supervisoryAuthority).toEqual(GENERIC_SUPERVISORY_AUTHORITY)
+  })
+
+  it('derives a non-Norway jurisdiction from the conference country', () => {
+    const legal = buildLegalConfig(
+      conf({ city: 'Amsterdam', country: 'Netherlands' }),
+      null,
+    )
+    expect(legal.jurisdiction).toBe('Netherlands')
+    expect(legal.isNorway).toBe(false)
+    expect(legal.supervisoryAuthority).toEqual(GENERIC_SUPERVISORY_AUTHORITY)
+  })
+
+  it('uses a fully custom supervisory authority when provided', () => {
+    const org: OrganizationLegalFields = {
+      legalJurisdiction: 'Germany',
+      supervisoryAuthority: {
+        name: 'Der Bundesbeauftragte für den Datenschutz (BfDI)',
+        url: 'https://www.bfdi.bund.de',
+        email: 'poststelle@bfdi.bund.de',
+      },
+    }
+    const legal = buildLegalConfig(conf(), org)
+    expect(legal.supervisoryAuthority).toEqual({
+      name: 'Der Bundesbeauftragte für den Datenschutz (BfDI)',
+      url: 'https://www.bfdi.bund.de',
+      email: 'poststelle@bfdi.bund.de',
+    })
+  })
+
+  it('is case-insensitive when detecting Norway', () => {
+    const legal = buildLegalConfig(conf(), { legalJurisdiction: 'norway' })
+    expect(legal.isNorway).toBe(true)
+    expect(legal.supervisoryAuthority).toEqual(NORWAY_SUPERVISORY_AUTHORITY)
+  })
+})
+
+describe('buildLegalConfig — location assembly', () => {
+  it('omits the city when absent', () => {
+    const legal = buildLegalConfig(
+      conf({ city: undefined, country: 'Norway' }),
+      null,
+    )
+    expect(legal.location).toBe('Norway')
+  })
+})

--- a/src/lib/legal/config.ts
+++ b/src/lib/legal/config.ts
@@ -43,6 +43,25 @@ export const GENERIC_SUPERVISORY_AUTHORITY: SupervisoryAuthority = {
 
 const DEFAULT_JURISDICTION = 'Norway'
 
+/**
+ * Restrict an org-managed URL to http(s) before it is rendered as a link.
+ * The Sanity field is typed `url`, but the client renders whatever is stored —
+ * a `javascript:` (or other scheme) value must never become an executable
+ * anchor on the privacy page. Invalid/unsafe values degrade to no link.
+ */
+function safeHttpUrl(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) return undefined
+  try {
+    const parsed = new URL(trimmed)
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+      ? trimmed
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export interface LegalConfig {
   /** The data controller / legal entity name shown throughout the pages. */
   controllerName: string
@@ -86,12 +105,17 @@ export function buildLegalConfig(
 
   // Legal jurisdiction: an explicit org override wins; otherwise fall back to
   // the conference country, then Norway (the existing tenant's value).
-  const jurisdiction =
+  const rawJurisdiction =
     org?.legalJurisdiction?.trim() ||
     conference?.country?.trim() ||
     DEFAULT_JURISDICTION
 
-  const isNorway = jurisdiction.toLowerCase() === 'norway'
+  const isNorway = rawJurisdiction.toLowerCase() === 'norway'
+  // Canonicalize the casing when it IS Norway so a stored "norway" cannot
+  // render "Bergen, norway" or a lowercase governing-law clause; other
+  // jurisdictions keep the org's own casing (we can't title-case arbitrary
+  // country names correctly).
+  const jurisdiction = isNorway ? DEFAULT_JURISDICTION : rawJurisdiction
 
   // Controller location line ("based in …"): it describes the CONTROLLER's
   // seat, so it follows the resolved jurisdiction. The venue city is included
@@ -112,7 +136,7 @@ export function buildLegalConfig(
   const supervisoryAuthority: SupervisoryAuthority = orgAuthorityName
     ? {
         name: orgAuthorityName,
-        url: org?.supervisoryAuthority?.url?.trim() || undefined,
+        url: safeHttpUrl(org?.supervisoryAuthority?.url),
         email: org?.supervisoryAuthority?.email?.trim() || undefined,
       }
     : isNorway

--- a/src/lib/legal/config.ts
+++ b/src/lib/legal/config.ts
@@ -1,0 +1,121 @@
+import { resolveConferenceContact } from '@/lib/email/from'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
+import type { Conference } from '@/lib/conference/types'
+
+/**
+ * Tenant-driven LEGAL identity for the /privacy and /terms pages (go-live gate
+ * G2, findings B5/B6). These pages previously hardcoded the Cloud Native Days
+ * Norway controller, a Bergen/Norway location, Norwegian tax-law references and
+ * Datatilsynet as the supervisory authority — all WRONG for any other tenant.
+ *
+ * This module resolves ONE `LegalConfig` object from the tenant's organization
+ * (preferred) and conference (fallback). It is deliberately variable
+ * substitution, NOT a legal-blocks CMS: the page structure and prose stay put,
+ * only the org-identity variables and the jurisdiction-specific clauses vary.
+ *
+ * DEFAULTS preserve the existing tenant exactly: absent org legal fields resolve
+ * to Norway + Datatilsynet, and the Norway-specific prose (tax law, "Norwegian
+ * data protection laws") renders only when the jurisdiction is Norway.
+ */
+
+/** A data-protection supervisory authority a complaint can be lodged with. */
+export interface SupervisoryAuthority {
+  name: string
+  url?: string
+  email?: string
+}
+
+/** The Norwegian DPA — the default for the existing tenant and any Norway org. */
+export const NORWAY_SUPERVISORY_AUTHORITY: SupervisoryAuthority = {
+  name: 'Norwegian Data Protection Authority (Datatilsynet)',
+  url: 'https://www.datatilsynet.no',
+  email: 'postkasse@datatilsynet.no',
+}
+
+/**
+ * A jurisdiction-neutral authority pointer for non-Norway tenants that have not
+ * configured their own DPA. It carries no URL/email — a generic sentence, not a
+ * fabricated contact for the wrong country.
+ */
+export const GENERIC_SUPERVISORY_AUTHORITY: SupervisoryAuthority = {
+  name: 'your national or EU/EEA data protection authority',
+}
+
+const DEFAULT_JURISDICTION = 'Norway'
+
+export interface LegalConfig {
+  /** The data controller / legal entity name shown throughout the pages. */
+  controllerName: string
+  /** The controller's contact address for privacy / terms enquiries. */
+  contactEmail: string
+  /** Human location line for the controller, e.g. "Bergen, Norway". */
+  location: string
+  /** Country whose law governs (terms) and whose tax law is referenced. */
+  jurisdiction: string
+  /** True when the jurisdiction is Norway → render Norway-specific prose. */
+  isNorway: boolean
+  /** The DPA a data-subject complaint is lodged with. */
+  supervisoryAuthority: SupervisoryAuthority
+}
+
+/** The org legal fields projected from the `organization` document. */
+export interface OrganizationLegalFields {
+  name?: string | null
+  contactEmail?: string | null
+  legalJurisdiction?: string | null
+  supervisoryAuthority?: {
+    name?: string | null
+    url?: string | null
+    email?: string | null
+  } | null
+}
+
+/**
+ * Build the legal config from a conference and its (optional) organization.
+ * PURE — no I/O — so the resolution rules are unit-testable in isolation.
+ */
+export function buildLegalConfig(
+  conference: Conference | null | undefined,
+  org: OrganizationLegalFields | null | undefined,
+): LegalConfig {
+  const controllerName =
+    org?.name?.trim() || conference?.organizer?.trim() || PLATFORM_NAME
+
+  const contactEmail =
+    org?.contactEmail?.trim() || resolveConferenceContact(conference)
+
+  // Legal jurisdiction: an explicit org override wins; otherwise fall back to
+  // the conference country, then Norway (the existing tenant's value).
+  const jurisdiction =
+    org?.legalJurisdiction?.trim() ||
+    conference?.country?.trim() ||
+    DEFAULT_JURISDICTION
+
+  const isNorway = jurisdiction.toLowerCase() === 'norway'
+
+  // Controller location line: city + country when both are known, else whatever
+  // single part we have, else the jurisdiction.
+  const city = conference?.city?.trim()
+  const country = conference?.country?.trim() || jurisdiction
+  const location = city ? `${city}, ${country}` : country
+
+  const orgAuthorityName = org?.supervisoryAuthority?.name?.trim()
+  const supervisoryAuthority: SupervisoryAuthority = orgAuthorityName
+    ? {
+        name: orgAuthorityName,
+        url: org?.supervisoryAuthority?.url?.trim() || undefined,
+        email: org?.supervisoryAuthority?.email?.trim() || undefined,
+      }
+    : isNorway
+      ? NORWAY_SUPERVISORY_AUTHORITY
+      : GENERIC_SUPERVISORY_AUTHORITY
+
+  return {
+    controllerName,
+    contactEmail,
+    location,
+    jurisdiction,
+    isNorway,
+    supervisoryAuthority,
+  }
+}

--- a/src/lib/legal/config.ts
+++ b/src/lib/legal/config.ts
@@ -93,11 +93,20 @@ export function buildLegalConfig(
 
   const isNorway = jurisdiction.toLowerCase() === 'norway'
 
-  // Controller location line: city + country when both are known, else whatever
-  // single part we have, else the jurisdiction.
+  // Controller location line ("based in …"): it describes the CONTROLLER's
+  // seat, so it follows the resolved jurisdiction. The venue city is included
+  // only when the conference country agrees with that jurisdiction — an org
+  // legal override (e.g. Germany) must not render "Bergen, Germany", nor keep
+  // "Bergen, Norway" next to a German governing-law clause.
   const city = conference?.city?.trim()
-  const country = conference?.country?.trim() || jurisdiction
-  const location = city ? `${city}, ${country}` : country
+  const conferenceCountry = conference?.country?.trim()
+  const cityMatchesJurisdiction =
+    Boolean(city) &&
+    (!conferenceCountry ||
+      conferenceCountry.toLowerCase() === jurisdiction.toLowerCase())
+  const location = cityMatchesJurisdiction
+    ? `${city}, ${jurisdiction}`
+    : jurisdiction
 
   const orgAuthorityName = org?.supervisoryAuthority?.name?.trim()
   const supervisoryAuthority: SupervisoryAuthority = orgAuthorityName

--- a/src/lib/legal/index.ts
+++ b/src/lib/legal/index.ts
@@ -1,0 +1,9 @@
+export {
+  buildLegalConfig,
+  NORWAY_SUPERVISORY_AUTHORITY,
+  GENERIC_SUPERVISORY_AUTHORITY,
+  type LegalConfig,
+  type SupervisoryAuthority,
+  type OrganizationLegalFields,
+} from './config'
+export { resolveLegalConfig } from './resolve'

--- a/src/lib/legal/resolve.ts
+++ b/src/lib/legal/resolve.ts
@@ -1,0 +1,46 @@
+import 'server-only'
+import { clientReadUncached } from '@/lib/sanity/client'
+import type { Conference } from '@/lib/conference/types'
+import {
+  buildLegalConfig,
+  type LegalConfig,
+  type OrganizationLegalFields,
+} from './config'
+
+/**
+ * Best-effort fetch of the legal-identity fields from the tenant's organization
+ * document. Non-throwing: a legacy conference lacking an `organization` ref, or
+ * any transient error, resolves to `null` so `buildLegalConfig` falls back to
+ * the conference/Norway defaults. The pages are `'use cache'`-wrapped, so this
+ * runs inside the cached content function and is tagged with the conference.
+ */
+async function fetchOrganizationLegal(
+  orgRef: string | null | undefined,
+): Promise<OrganizationLegalFields | null> {
+  if (!orgRef) return null
+  try {
+    return await clientReadUncached.fetch<OrganizationLegalFields | null>(
+      `*[_id == $id][0]{
+        name,
+        contactEmail,
+        legalJurisdiction,
+        supervisoryAuthority
+      }`,
+      { id: orgRef },
+    )
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve the tenant-driven {@link LegalConfig} for a conference: dereference
+ * its organization for the legal-identity overrides, then merge with the
+ * conference/Norway defaults.
+ */
+export async function resolveLegalConfig(
+  conference: Conference | null | undefined,
+): Promise<LegalConfig> {
+  const org = await fetchOrganizationLegal(conference?.organization?._ref)
+  return buildLegalConfig(conference, org)
+}

--- a/src/lib/og/metadata.test.ts
+++ b/src/lib/og/metadata.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getConferenceForCurrentDomainMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceForCurrentDomainMock(...args),
+}))
+
+import { ogImageMetadata } from './metadata'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ogImageMetadata', () => {
+  it('templates the alt around the resolved conference title', async () => {
+    getConferenceForCurrentDomainMock.mockResolvedValue({
+      conference: { title: 'Cloud Native Days Norway 2026' },
+    })
+    const [meta] = await ogImageMetadata(
+      (brand) => `Get Your Ticket - ${brand}`,
+    )
+    expect(meta.alt).toBe('Get Your Ticket - Cloud Native Days Norway 2026')
+    expect(meta.contentType).toBe('image/png')
+    expect(meta.id).toBe('og')
+  })
+
+  it('uses the neutral platform name when no conference resolves', async () => {
+    getConferenceForCurrentDomainMock.mockResolvedValue({ conference: null })
+    const [meta] = await ogImageMetadata((brand) => `Program - ${brand}`)
+    expect(meta.alt).toBe('Program - Cloud Native Days')
+  })
+
+  it('falls back to the platform name on error', async () => {
+    getConferenceForCurrentDomainMock.mockRejectedValue(new Error('boom'))
+    const [meta] = await ogImageMetadata((brand) => brand)
+    expect(meta.alt).toBe('Cloud Native Days')
+  })
+})

--- a/src/lib/og/metadata.ts
+++ b/src/lib/og/metadata.ts
@@ -1,0 +1,30 @@
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { OG_IMAGE_SIZE } from '@/lib/og/styles'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
+
+/**
+ * Conference-driven `generateImageMetadata` for an OpenGraph image route
+ * (go-live gate G2, E2). The `alt` text previously hardcoded a single tenant's
+ * brand; this resolves the current-domain conference title (neutral platform
+ * fallback) and lets each route template its own alt around it.
+ *
+ * Returns the single-entry array Next.js expects; the route's default `Image`
+ * export renders the pixels and may ignore the passed `id`.
+ */
+export async function ogImageMetadata(buildAlt: (brand: string) => string) {
+  let brand = PLATFORM_NAME
+  try {
+    const { conference } = await getConferenceForCurrentDomain()
+    brand = conference?.title?.trim() || PLATFORM_NAME
+  } catch {
+    // Keep the neutral fallback on any resolution error.
+  }
+  return [
+    {
+      id: 'og',
+      alt: buildAlt(brand),
+      size: OG_IMAGE_SIZE,
+      contentType: 'image/png',
+    },
+  ]
+}

--- a/src/lib/seo/brand.test.ts
+++ b/src/lib/seo/brand.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const headersMock = vi.fn()
+vi.mock('next/headers', () => ({
+  headers: () => headersMock(),
+}))
+
+const getConferenceForDomainMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForDomain: (...args: unknown[]) =>
+    getConferenceForDomainMock(...args),
+}))
+
+import { resolveMetadataBrand } from './brand'
+
+function headersWithHost(host: string | null) {
+  return { get: (name: string) => (name === 'host' ? host : null) }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('resolveMetadataBrand', () => {
+  it('returns the resolved conference title', async () => {
+    headersMock.mockResolvedValue(headersWithHost('cloudnativebergen.dev'))
+    getConferenceForDomainMock.mockResolvedValue({
+      conference: { title: 'Cloud Native Days Norway 2026' },
+    })
+    expect(await resolveMetadataBrand()).toBe('Cloud Native Days Norway 2026')
+  })
+
+  it('falls back to the neutral platform name when no conference resolves', async () => {
+    headersMock.mockResolvedValue(headersWithHost('localhost:3000'))
+    getConferenceForDomainMock.mockResolvedValue({ conference: null })
+    expect(await resolveMetadataBrand()).toBe('Cloud Native Days')
+  })
+
+  it('falls back to the platform name on a resolution error', async () => {
+    headersMock.mockResolvedValue(headersWithHost('x.example'))
+    getConferenceForDomainMock.mockRejectedValue(new Error('sanity down'))
+    expect(await resolveMetadataBrand()).toBe('Cloud Native Days')
+  })
+})

--- a/src/lib/seo/brand.ts
+++ b/src/lib/seo/brand.ts
@@ -1,0 +1,21 @@
+import { headers } from 'next/headers'
+import { getConferenceForDomain } from '@/lib/conference/sanity'
+import { PLATFORM_NAME } from '@/lib/branding/platform'
+
+/**
+ * The tenant brand name for per-page `generateMetadata` (go-live gate G2, E2).
+ *
+ * Resolves the current-domain conference title, falling back to the neutral
+ * {@link PLATFORM_NAME} when no tenant resolves (apex/platform host, localhost,
+ * a preview with no matching domain) or on any error. Use it to build page
+ * titles / descriptions instead of hardcoding a single tenant's brand.
+ */
+export async function resolveMetadataBrand(): Promise<string> {
+  try {
+    const host = (await headers()).get('host') || ''
+    const { conference } = await getConferenceForDomain(host)
+    return conference?.title?.trim() || PLATFORM_NAME
+  } catch {
+    return PLATFORM_NAME
+  }
+}

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -25,6 +25,7 @@ import {
   UpdateBasicInfoSchema,
   UpdateVisibilitySchema,
   UpdateVenueSchema,
+  UpdateBrandingSchema,
   UpdateDatesSchema,
   UpdateRegistrationSchema,
   UpdateCommunicationSchema,
@@ -166,6 +167,13 @@ export const conferenceRouter = router({
 
   updateVenue: adminProcedure
     .input(UpdateVenueSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+
+  updateBranding: adminProcedure
+    .input(UpdateBrandingSchema)
     .mutation(async ({ input }) => {
       const conferenceId = await resolveConferenceId()
       return applyConferencePatch(conferenceId, input)

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -7,6 +7,10 @@ import {
   CONFERENCE_VISIBILITY_VALUES,
   type ConferenceVisibility,
 } from '@/lib/conference/visibility'
+import {
+  BACKGROUND_PATTERN_VALUES,
+  type BackgroundPattern,
+} from '@/lib/conference/backgroundPattern'
 
 /**
  * Field-scoped conference settings schemas (SE-1a + SE-1b). Each schema mirrors
@@ -61,6 +65,20 @@ export const UpdateVisibilitySchema = z.object({
 export const UpdateVenueSchema = z.object({
   venueName: z.string().trim().nullable().optional(),
   venueAddress: z.string().trim().nullable().optional(),
+})
+
+// === Branding (background pattern; go-live gate G2, #643) ===
+// The logo slots are edited through the dedicated BrandingEditor/updateBrandingLogo
+// path; this scalar fieldset carries only the decorative background switch.
+// A required enum — the mutation always sets an explicit value; absent is
+// treated as `'cloud-native'` by the renderer (see backgroundPattern.ts).
+export const UpdateBrandingSchema = z.object({
+  backgroundPattern: z.enum(
+    BACKGROUND_PATTERN_VALUES as unknown as [
+      BackgroundPattern,
+      ...BackgroundPattern[],
+    ],
+  ),
 })
 
 // === Dates ===


### PR DESCRIPTION
Go-live gate **G2** — issue #643, readiness-audit findings **B5/B6/E1/E2/E8**. Removes the last hardcoded Cloud Native Days Norway identity from tenant-facing surfaces so a second tenant can go live without leaking the wrong org, jurisdiction, or brand.

## B5/B6 — tenant-driven /privacy and /terms
- New `src/lib/legal/` resolves a single `LegalConfig` (controller name, contact, location, jurisdiction, supervisory authority) from the organization (preferred) then conference. Pure `buildLegalConfig` + best-effort async `resolveLegalConfig` (org fetch).
- Every hardcoded occurrence substituted: controller/legal name, "based in Bergen, Norway", the Data Controller/Location block, the Norwegian tax-law retention row, the Datatilsynet complaint block, and the closing GDPR clause.
- New optional organization schema fields `legalJurisdiction` + `supervisoryAuthority` (name/url/email). **Absent resolves to Norway + Datatilsynet**, so the existing tenant is byte-for-byte unchanged. Non-Norway jurisdictions render neutral generic prose (governing law, tax law, "your national/EU DPA").
- `/terms` governing-law + venue and both pages' metadata are conference-driven. Page structure untouched (variable substitution, not a legal-blocks CMS — that's Tier-2).

## E1 — per-conference background pattern
- Schema field `backgroundPattern: 'cloud-native' | 'subtle' | 'none'`; **absent = 'cloud-native'** (existing tenants unchanged).
- Threaded to `BackgroundImage` via a `BackgroundPatternProvider` context set once in the shared `Layout`, so the ~30 call sites need no prop change. `'subtle'` = same logo pattern at much lower density (14 icons) + opacity (0.04); `'none'` = plain gradient, no logos.
- Exposed in the admin **Branding** settings card (new scalar fieldset + `updateBranding` mutation).

## E2 — metadata / PWA / OG de-branding
- Root title template/default/description + `appleWebApp` title → conference-driven with neutral `PLATFORM_NAME` fallback.
- Per-page `generateMetadata` literals → conference title; full-title pages marked `title.absolute` (also fixes a pre-existing double-suffix from the root template).
- OpenGraph-image `alt` → conference-driven via `generateImageMetadata`.
- `InstallGuide` takes the conference title; global `InstallBanner` uses brand-neutral copy; conduct page org name templated (CNCF CoC acknowledgement kept — the text genuinely adapts it; no per-conference CoC-source field exists yet).

## E8 — email base brand (neutral-correctness pass)
- `BaseEmailTemplate` accepts an optional `brandColor` (default `#1D4ED8`) threaded into accent elements; `EmailButton`/`EmailSectionHeader` take the same overridable accent.
- `BadgeEmailTemplate` footer no longer hardcodes "Cloud Native Days" — takes `organizerName` (default neutral platform name), wired from the conference organizer/title. Full token theming lands later.

## QA
- `mise run check` green (typecheck/lint 0 errors, format clean). Full vitest green (**4102 passed**), including new tests for legal-config resolution (defaults vs org overrides), background-pattern normalization, the BackgroundImage switch render states, and metadata/OG-alt generation.
- `mise run build`: compiles + passes TypeScript; fails only at page-data collection on a missing `RESEND_API_KEY` secret (local keychain), unrelated to this change.
- Storybook shoot of the three pattern states at 393px: renders cleanly, no overflow. The CNCF logo `<img>`s don't paint under Storybook's vite (SVG-import interop differs from Next — the pre-existing Patterns story also uses placeholders); the DOM check confirms `'none'` omits the pattern while `'cloud-native'`/`'subtle'` include it, and the unit tests cover the icon-count/opacity difference.

Refs #643. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
