### PR TITLE
chore: post-merge review follow-ups (#644/#646/#647 bot threads)

### DIFF
--- a/docs/SPONSOR_SYSTEM.md
+++ b/docs/SPONSOR_SYSTEM.md
@@ -567,6 +567,8 @@ The contract lifecycle is tracked across several fields on the `sponsorForConfer
 
 **Synchronous status updates.** The self-hosted provider records status transitions directly in Sanity when the sponsor submits their signature — no external webhooks or polling. Legacy provider values stored on older conference documents fall back to self-hosted gracefully.
 
+**Self-hosted is the only supported provider.** `CONTRACT_SIGNING_PROVIDER` is optional and does not need to be set to enable signing — self-hosted is the default. The env var exists only as a legacy knob: any value other than `self-hosted` falls back to self-hosted with a warning, and the system-status page flags it as stale configuration to delete.
+
 **Single source of storage.** The contract PDF is stored in Sanity (permanent, accessible via CMS). When the signed version is submitted, it replaces the original in Sanity.
 
 **Unified send function.** `generateAndSendContract()` is the single entry point for both manual admin sends and automated registration-triggered sends, ensuring consistent behavior and logging.

--- a/src/components/BackgroundImage.tsx
+++ b/src/components/BackgroundImage.tsx
@@ -33,6 +33,13 @@ export function BackgroundImage({
 
   const settings = pattern === 'none' ? null : PATTERN_SETTINGS[pattern]
 
+  // Daily-rotating pattern seed as the UTC day number. The previous
+  // `new Date().setHours(0, 0, 0, 0)` was LOCAL-timezone midnight, which
+  // differs between the SSR server and the visitor's browser — a hydration
+  // mismatch whenever their timezones disagree. The UTC day is identical on
+  // both (except in the instant of UTC midnight between render and hydration).
+  const dailySeed = Math.floor(Date.now() / 86_400_000)
+
   return (
     <div className={clsx('absolute inset-0 overflow-hidden', className)}>
       <div className="absolute inset-0 bg-brand-gradient opacity-20" />
@@ -48,7 +55,7 @@ export function BackgroundImage({
               baseSize={100}
               iconCount={settings.iconCount}
               className="size-full"
-              seed={new Date().setHours(0, 0, 0, 0)}
+              seed={dailySeed}
             />
           </div>
 
@@ -60,7 +67,7 @@ export function BackgroundImage({
               baseSize={100}
               iconCount={settings.iconCount}
               className="size-full"
-              seed={new Date().setHours(0, 0, 0, 0)}
+              seed={dailySeed}
             />
           </div>
         </div>

--- a/src/docs/SponsorSystem.stories.tsx
+++ b/src/docs/SponsorSystem.stories.tsx
@@ -564,6 +564,8 @@ Self-service portal
 │  cancelAgreement()  sendReminder()              │
 │  getConnectionStatus()  disconnect()            │
 │  getAuthorizeUrl()  registerWebhook()           │
+│  (both no-ops for self-hosted — no OAuth or    │
+│   webhook setup step exists)                    │
 └──────────────────────┬──────────────────────────┘
                        │ SelfHostedSigningProvider
                        ▼

--- a/src/lib/messaging/nudge.ts
+++ b/src/lib/messaging/nudge.ts
@@ -178,16 +178,14 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
           continue
         }
 
-        // The organizer set for THIS tenant only — the team-else-all fallback
-        // for an unassigned thread. Cached per-org by getOrganizerSpeakerIds, so
-        // multiple conversations in the same org share one read.
-        const orgOrganizerIds = await getOrganizerSpeakerIds(orgId)
-
         // Route down the TEAMS-2 chain: the assignee when set → else the
         // thread's team (`sponsors` for a sponsor thread, `cfp` otherwise) →
         // else every organizer OF THIS ORG (the team-else-all fallback). If
         // nobody can be notified (no assignee AND no team AND no organizers),
         // skip without stamping so the thread is retried once organizers exist.
+        // The per-org organizer read happens only on the unassigned branch
+        // (assigned threads never need it) and is cached per-org by
+        // getOrganizerSpeakerIds, so same-org conversations share one read.
         const recipientIds = conversation.assignedToId
           ? [conversation.assignedToId]
           : await resolveRoutedOrganizerIds({
@@ -196,7 +194,7 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
                 conversation.conversationType === 'sponsor'
                   ? 'sponsors'
                   : 'cfp',
-              allOrganizerIds: orgOrganizerIds,
+              allOrganizerIds: await getOrganizerSpeakerIds(orgId),
             })
         if (recipientIds.length === 0) continue
 

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -707,11 +707,13 @@ const organizerCache = new Map<string, { ids: string[]; expiresAt: number }>()
  *    sends don't depend on request domain).
  *  - `orgId` explicitly `null` → the GLOBAL set (every conference's organizers).
  *
- * LEGACY BRIDGE: a `null` resolved org (pre-044-backfill conference / no domain)
- * yields the GLOBAL organizer set with a `console.warn`, mirroring the auth
- * bridge in `src/lib/authz/organizer.ts`. This historical behaviour ("organizer
- * of one edition = organizer everywhere") is retained ONLY as the migration
- * bridge; remove it under the same condition as the auth bridge.
+ * LEGACY BRIDGE: an `undefined` orgId that RESOLVES to null (pre-044-backfill
+ * conference / no domain) yields the GLOBAL organizer set with a
+ * `console.warn`, mirroring the auth bridge in `src/lib/authz/organizer.ts`.
+ * This historical behaviour ("organizer of one edition = organizer everywhere")
+ * is retained ONLY as the migration bridge; remove it under the same condition
+ * as the auth bridge. An EXPLICIT `null` is an intentional global read (e.g.
+ * the nudge candidacy superset) and does NOT log the bridge warning.
  *
  * Cached per instance for {@link ORGANIZER_CACHE_TTL_MS}, keyed by resolved org.
  * The returned array is treated as read-only by callers (they wrap it in a Set).
@@ -743,7 +745,9 @@ export async function getOrganizerSpeakerIds(
     ? `*[_type == "conference" && organization._ref == $orgId].organizers[]._ref`
     : `*[_type == "conference"].organizers[]._ref`
 
-  if (!resolvedOrgId) {
+  // Warn only when the org was supposed to resolve and didn't — an explicit
+  // `null` is an intentional global read, not a bridge event.
+  if (!resolvedOrgId && orgId === undefined) {
     console.warn(
       '[authz-bridge] getOrganizerSpeakerIds: org unresolvable; using the GLOBAL organizer set (recipient-selection legacy bridge)',
     )

--- a/src/lib/system-status/checks.test.ts
+++ b/src/lib/system-status/checks.test.ts
@@ -155,6 +155,21 @@ describe('collectStaticChecks — contract provider', () => {
     const checks = collectStaticChecks(CONFERENCE)
     expect(byId(checks, 'contracts.provider').value).toBe('self-hosted')
   })
+
+  it('warns on an unsupported legacy provider value instead of reporting ok', () => {
+    vi.stubEnv('CONTRACT_SIGNING_PROVIDER', 'adobe-sign')
+    const checks = collectStaticChecks(CONFERENCE)
+    const check = byId(checks, 'contracts.provider')
+    expect(check.status).toBe('warn')
+    expect(check.value).toBe('adobe-sign')
+    expect(check.detail).toContain('falling back to self-hosted')
+  })
+
+  it('reports ok for the supported self-hosted value', () => {
+    vi.stubEnv('CONTRACT_SIGNING_PROVIDER', 'self-hosted')
+    const checks = collectStaticChecks(CONFERENCE)
+    expect(byId(checks, 'contracts.provider').status).toBe('ok')
+  })
 })
 
 describe('buildSystemChecks — live probes', () => {


### PR DESCRIPTION
Closes out the accepted-but-deferred bot findings from the three merged go-live PRs, batched here so the security-gated changes stayed scoped:

**From #644 (nudge/scoping):**
- The per-org organizer read in the stale-conversation cron now happens only on the unassigned branch — assigned threads never needed it. Still cached per-org, so same-org conversations share one read.
- \`getOrganizerSpeakerIds\`: the \`[authz-bridge]\` warning now fires only when an \`undefined\` orgId fails to resolve (a genuine bridge event). An explicit \`null\` — the nudge candidacy superset — is an intentional global read and no longer logs a misleading warning every cron run.

**From #646 (Adobe removal):**
- Tests pin the \`contracts.provider\` system-status behavior: \`warn\` + operator hint on an unsupported legacy value, \`ok\` on self-hosted.
- Docs now state self-hosted is the only supported signing provider and \`CONTRACT_SIGNING_PROVIDER\` is optional; the architecture diagram notes \`getAuthorizeUrl\`/\`registerWebhook\` are no-ops (no OAuth/webhook setup step).

**From #647 (G2), pre-existing:**
- The background pattern's daily seed was local-timezone midnight — an SSR/CSR hydration mismatch whenever server and visitor timezones disagree. Now the UTC day number, identical on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)