### PR TITLE
fix(edition): new editions are created unlisted

### DIFF
--- a/src/lib/conference/edition.test.ts
+++ b/src/lib/conference/edition.test.ts
@@ -156,6 +156,11 @@ describe('buildEditionDocuments — always-applied invariants', () => {
     expect(conference.registrationEnabled).toBe(false)
   })
 
+  it('creates every new edition unlisted (absent-means-live makes an explicit value mandatory)', () => {
+    const { conference } = build(makeInput())
+    expect(conference.visibility).toBe('unlisted')
+  })
+
   it('always copies identity (city, logos) and normalizes domains', () => {
     const { conference } = build(
       makeInput({ domains: ['2026.CNB.no', 'ALT.example.com'] }),

--- a/src/lib/conference/edition.ts
+++ b/src/lib/conference/edition.ts
@@ -351,6 +351,11 @@ export function buildEditionDocuments(
     domains: input.domains.map(normalizeDomain),
     // A new edition NEVER opens registration on creation.
     registrationEnabled: false,
+    // …and is NEVER publicly discoverable on creation: absent-means-live
+    // (see lib/conference/visibility.ts), so an explicit 'unlisted' is
+    // required or the clone would be indexed/listed the instant its domains
+    // commit. The organizer flips it to 'live' from settings when ready.
+    visibility: 'unlisted',
   }
 
   if (flags.topics && src.topics && src.topics.length > 0) {

--- a/src/lib/conference/visibility.ts
+++ b/src/lib/conference/visibility.ts
@@ -18,7 +18,7 @@
 
 import { cacheLife, cacheTag } from 'next/cache'
 import { clientReadCached } from '@/lib/sanity/client'
-import { domainTag } from '@/lib/cache/tags'
+import { conferenceTag, domainTag } from '@/lib/cache/tags'
 import { normalizeDomain, wildcardFormForHost } from '@/lib/conference/domains'
 
 export type ConferenceVisibility = 'unlisted' | 'live'
@@ -77,6 +77,11 @@ export async function getDiscoveryVisibilityForDomain(
       },
     )
     if (!row?._id) return { discoverable: false }
+    // Tag with the resolved conference so the settings visibility flip —
+    // which revalidates `conferenceTag(id)` via applyConferencePatch — busts
+    // THIS cached discovery read too. Without it, robots/sitemap stayed on
+    // the old visibility for up to the cacheLife window after going live.
+    cacheTag(conferenceTag(row._id))
     return { discoverable: resolveConferenceVisibility(row) === 'live' }
   } catch {
     return { discoverable: false }


### PR DESCRIPTION
The `visibility` field is absent-means-live (M0 groundwork, #641), so a freshly cloned edition arrived publicly discoverable — live in robots/sitemap/discovery — the moment its domains committed, before the organizer had built out anything. This was flagged as the J8 gap in the go-live plan.

The edition wizard's conference document now carries an explicit `visibility: 'unlisted'`; the organizer flips it to live from the settings card when the new edition is ready. Test pins it alongside the existing "never opens registration" invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)