### PR TITLE
feat(tickets): Tito as second ticketing provider — adapter generalization proof

### DIFF
--- a/docs/INTEGRATION_ADAPTERS.md
+++ b/docs/INTEGRATION_ADAPTERS.md
@@ -7,9 +7,14 @@ registering it in a factory — no call site changes.
 
 Two integrations use this pattern today:
 
-- **Ticketing** — `src/lib/tickets/provider/` (`TicketingProvider`, Checkin.no)
+- **Ticketing** — `src/lib/tickets/provider/` (`TicketingProvider`; two vendors,
+  Checkin.no and Tito, selected per conference)
 - **Contract signing** — `src/lib/contract-signing/` (`ContractSigningProvider`,
   self-hosted)
+
+Ticketing is the reference case for a **second provider**: Tito (ti.to, REST
+Admin API v3) validated that the adapter generalizes past Checkin. See
+[Ticketing providers: Checkin + Tito](#ticketing-providers-checkin--tito).
 
 ## The house pattern
 
@@ -80,7 +85,10 @@ interface TicketingProvider {
   parseOrderCreated(payload): CheckinOrderCreatedData | null
 }
 
-type EventRef = { customerId: number; eventId: number }
+// EventRef is now a provider-discriminated union (see the Tito section):
+type EventRef =
+  | { provider?: 'checkin'; customerId: number; eventId: number }
+  | { provider: 'tito'; accountSlug: string; eventSlug: string }
 ```
 
 ### The request-boundary resolver
@@ -121,9 +129,12 @@ still **Checkin-shaped**. A second ticketing provider (a separate PR) will need
 these generalized — they are flagged in the source with a `SECOND-PROVIDER
 DEBT` comment:
 
-- **`EventRef`** (`{ customerId, eventId }`) — Checkin binds an event with a
-  customer (tenant) id + event id. A provider that keys events differently
-  (single opaque slug, per-tenant API base) will force this to generalize.
+- **`EventRef`** — ✅ GENERALIZED by the Tito work into a provider-discriminated
+  union (`{ provider?: 'checkin'; customerId; eventId } | { provider: 'tito';
+accountSlug; eventSlug }`). `provider` is optional on the Checkin variant so
+  every legacy `{ customerId, eventId }` literal still type-checks; each provider
+  narrows to its own shape. The rest of the list below is still Checkin-shaped
+  debt.
 - **`EventTicket` / `EventTicketWithoutDate` / `CheckinPayOrder`**
   (`src/lib/tickets/types.ts`) — Checkin field names (`order_id`, `sum_left`,
   `crm`, `findCheckinPayOrderByID` shape).
@@ -141,15 +152,112 @@ mapping layer (the extraction deliberately did **not** remap — zero behavior
 change was the bar). `parseOrderCreated` and `fetchPublicTicketTypes` are the
 natural seams where that mapping will live.
 
-## Adding a ticketing provider (the follow-up PR)
+## Ticketing providers: Checkin + Tito
 
-1. Add the vendor to the `TicketingProviderType` union in
-   `src/lib/tickets/provider/index.ts`.
-2. Write `src/lib/tickets/provider/<vendor>.ts` implementing `TicketingProvider`
-   — credentials injected via the constructor, no `process.env`.
-3. Register it in the `getTicketingProvider` factory `switch`.
-4. Where the new vendor's payloads don't fit the Checkin-shaped neutral types,
-   introduce the neutral shape + a mapping layer (see the debt list above).
-5. Select the provider per conference (a `conference.ticketingProvider` field,
-   mirroring `conference.signingProvider`) and assemble its credentials at the
-   request boundary.
+Tito (ti.to) is the second ticketing provider, proving the adapter generalizes.
+Tito's **Admin API v3** is REST (`https://api.tito.io/v3`), authenticated with
+`Authorization: Token token=<API token>` — a different shape from Checkin's
+GraphQL + `Basic` auth, which is exactly the point.
+
+### Binding design (how a conference selects its provider)
+
+- A conference carries an optional **`ticketingProvider: 'checkin' | 'tito'`**
+  field. **Absent ⇒ `'checkin'`** — every legacy conference behaves identically
+  with zero migration (`conferenceProviderType()` centralizes that default).
+- Each provider reads only **its own** binding fields on the conference:
+  - Checkin: `checkinCustomerId` + `checkinEventId` (numbers)
+  - Tito: `titoAccountSlug` + `titoEventSlug` (the two URL slugs of
+    `ti.to/:account/:event`)
+- **`EventRef`** became a discriminated union (see above). The Checkin variant's
+  `provider` key is **optional**, so the resolver still emits a bare
+  `{ customerId, eventId }` for Checkin — no consumer that reads `.eventId`
+  changed, and the regression is pinned by a test.
+- **`resolveTicketingProvider(conference)`** branches on the provider type and
+  requires that provider's full binding (both fields); a partial binding returns
+  the same `configured: false` soft-fail as before.
+- **`hasTicketingBinding` / `ticketingBinding`** are provider-aware: the gate and
+  the cache-key projection both include the provider + its fields.
+
+### Credentials & secrets
+
+Tito authenticates with a single API token and signs webhooks with the
+endpoint's security token. Credentials are injected (constructor only):
+
+- **Platform fallback:** `platformTitoCredentials()` reads `TITO_API_KEY` and
+  `TITO_WEBHOOK_SECRET` (mirrors `platformCheckinCredentials`).
+- **Per-org secret:** the `ticketing` family is a provider-agnostic opaque
+  record. A Tito org sets
+  `TENANT_SECRETS_JSON = {"<orgId>":{"ticketing":{"apiKey":"tito_secret_…"}}}`.
+- ⚠️ The env-backed `ticketing` family in `EnvSecretsStore` is **Checkin-shaped**
+  (it reads `CHECKIN_*`). A single `(orgId, 'ticketing')` lookup can't know which
+  vendor a conference picked, so the **Tito resolver branch skips that env store**
+  — it resolves per-org Tito secrets through the JSON store only and falls back to
+  `platformTitoCredentials()`. The provider that knows its vendor (the resolver)
+  is the right layer for the vendor-specific env fallback.
+
+### The Tito ↔ `TicketingProvider` mapping
+
+| Interface member           | Tito support         | Mapping / reason                                                                                                                                                                                                                                                  |
+| -------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `isConfigured`             | ✅                   | `!!apiKey`                                                                                                                                                                                                                                                        |
+| `fetchPublicTicketTypes`   | ✅                   | `GET /:a/:e` + `GET /:a/:e/releases`; release `title→name`, `description`, `price→price[0]`, `quantity→available`, `secret→requiresInvitation`, `start_at/end_at→visibleStartsAt/EndsAt`, `position`. Accepts the ref form; **unsupported** on a bare numeric id. |
+| `fetchEventTickets`        | ✅                   | `GET /:a/:e/tickets` (paginated via `meta.next_page`); `email/first_name/last_name`, `release_title→category`, `state→order.paid` (`complete`⇒paid), `registration_id→order_id`.                                                                                  |
+| `verifyWebhook`            | ✅                   | HMAC-SHA256 over the raw body, keyed by the endpoint security token, **base64**-encoded in the **`Tito-Signature`** header (vs Checkin's hex `checkin-signature` over only `data`).                                                                               |
+| `fetchOrderPaymentDetails` | ⛔ typed-unsupported | Tito has no Checkin-shaped per-order payment document; the numeric order id can't address a Tito registration. Throws `ProviderUnsupportedError`.                                                                                                                 |
+| `listDiscounts`            | ⛔ typed-unsupported | Input is a bare numeric `eventId` — can't address a Tito event (needs slugs).                                                                                                                                                                                     |
+| `createDiscount`           | ⛔ typed-unsupported | Tito _does_ expose `POST /:a/:e/discount_codes`, but `CreateEventDiscountInput.eventId` is a Checkin-shaped number with no slugs. Generalizing the discount input to carry an `EventRef` is the unlock (tracked debt).                                            |
+| `deleteDiscount`           | ⛔ typed-unsupported | Same numeric-`eventId` limitation.                                                                                                                                                                                                                                |
+| `parseOrderCreated`        | ⛔ returns `null`    | Typed against the Checkin webhook envelope; Tito's envelope differs. Returning `null` ("not an order-created event") is interface-consistent. The live webhook route is Checkin-namespaced, so this is never invoked today.                                       |
+
+**Unsupported model:** members with a bare domain-object return type throw a
+**named, typed** `ProviderUnsupportedError` (never a generic `Error`), so callers
+can `instanceof`-distinguish "not implemented for this vendor" from a transport
+failure. Members with a result-typed error channel use it (`verifyWebhook` →
+`{ verified: false, reason }`; `parseOrderCreated` → `null`).
+
+**VAT / price semantics (honest note):** Tito prices are **tax-INCLUSIVE** (the
+gross a buyer pays). Checkin's `TicketPrice.price` is **net** (excl. VAT) with a
+separate `vat` percent that downstream `formatTicketPrice` adds back on
+`includeVat`. To avoid double-counting, Tito surfaces the gross as `price` with
+`vat: '0'`, so the incl/excl display math is a no-op and the shown number always
+equals what the buyer pays. A future generalization would add a tax-inclusive
+flag to `TicketPrice`.
+
+## Adding a ticketing provider N+1 (checklist validated by Tito)
+
+These are the files the Tito work actually touched — the concrete "add provider
+N+1" checklist:
+
+1. **Provider class** — `src/lib/tickets/provider/<vendor>.ts` implementing
+   `TicketingProvider`; credentials injected via the constructor, no
+   `process.env`. Throw `ProviderUnsupportedError` for members with no faithful
+   analogue.
+2. **Factory + union** — add the vendor to `TicketingProviderType` and the
+   `getTicketingProvider` `switch` in `provider/index.ts`.
+3. **EventRef** — if the vendor keys events differently, add a variant to the
+   `EventRef` union in `provider/types.ts` and narrow it inside the provider
+   (keep the Checkin variant's `provider` optional so old literals still compile).
+4. **Resolver + binding** — branch `resolveTicketingProvider`, and extend
+   `ConferenceTicketingBinding` / `ticketingBinding` / `hasTicketingBinding` /
+   `conferenceProviderType` with the vendor's binding fields in `provider/index.ts`.
+5. **Platform credentials** — add `platform<Vendor>Credentials()` reading the
+   vendor's env vars; note whether the env-backed secret family covers it (for
+   Tito it does not — see the secrets note above).
+6. **Conference schema** — `sanity/schemaTypes/conference.ts` (the provider
+   selector + the vendor's binding fields, hidden by the selector), the Zod
+   `UpdateTicketingIdsSchema` in `src/server/schemas/conference.ts`, and the
+   `Conference` type in `src/lib/conference/types.ts`.
+7. **Admin edit surface** — the `ticketingIds` fieldset in
+   `src/components/admin/EditConferenceCard.tsx` + the card's `initialValues` /
+   read-only rows in `src/app/(admin)/admin/settings/page.tsx`.
+8. **Consumers passing an event ref** — audit `fetchPublicTicketTypes` /
+   `fetchEventTickets` call sites; pass the whole `eventRef` (not `.eventId`) so
+   slug-keyed providers route correctly (`src/lib/tickets/public.ts`).
+9. **Docs + tests** — this file, plus provider contract tests (mocked `fetch`:
+   happy path, auth failure, mapping edges) and resolver routing/regression tests.
+
+**Not needed for the proof (left as debt):** generalizing the Checkin-shaped
+neutral types (`EventTicket`, `CheckinPayOrder`, the webhook envelope, the
+discount input). Those force `parseOrderCreated` / the discount methods to be
+unsupported for Tito; unlocking them is the next generalization, and the mapping
+seams (`parseOrderCreated`, `fetchPublicTicketTypes`) are where it lands.

--- a/docs/INTEGRATION_ADAPTERS.md
+++ b/docs/INTEGRATION_ADAPTERS.md
@@ -261,3 +261,12 @@ neutral types (`EventTicket`, `CheckinPayOrder`, the webhook envelope, the
 discount input). Those force `parseOrderCreated` / the discount methods to be
 unsupported for Tito; unlocking them is the next generalization, and the mapping
 seams (`parseOrderCreated`, `fetchPublicTicketTypes`) are where it lands.
+
+**Also debt — provider-namespaced per-org secrets:** the per-org `ticketing`
+secret family is a single opaque credential bag with no provider discriminator,
+so an org's Checkin-shaped secret would be handed to a Tito-bound conference
+(and fail loudly at auth time — a 401, not a silent cross-use). Today an org has
+one ticketing provider so the bag is unambiguous in practice; the planned
+layered secrets architecture (per-integration encapsulation) namespaces the
+family per provider (`ticketing.checkin` / `ticketing.tito`) and is where this
+resolves properly.

--- a/docs/TENANT_SECRETS.md
+++ b/docs/TENANT_SECRETS.md
@@ -30,13 +30,13 @@ for every tenant that has not been provisioned with its own.
 `src/lib/secrets/types.ts` defines one typed credential bag per integration,
 unioned as `SecretFamily`:
 
-| Family      | Type                      | Backing env (platform default)                                                                                      |
-| ----------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `ticketing` | `TicketingCredentials`    | `CHECKIN_API_KEY`, `CHECKIN_API_SECRET`, `CHECKIN_WEBHOOK_SECRET`                                                   |
-| `email`     | `EmailCredentials`        | `RESEND_API_KEY` (+ optional per-org `fallbackFrom`)                                                                |
-| `slack`     | `SlackCredentials`        | `SLACK_BOT_TOKEN`                                                                                                   |
-| `push`      | `PushCredentials`         | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`                                                            |
-| `badge`     | `BadgeSigningCredentials` | `BADGE_ISSUER_RSA_PRIVATE_KEY`, `BADGE_ISSUER_RSA_PUBLIC_KEY`, `BADGE_ISSUER_ED25519_SEED`, `BADGE_ISSUER_RSA_ONLY` |
+| Family      | Type                      | Backing env (platform default)                                                                                                                                               |
+| ----------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ticketing` | `TicketingCredentials`    | Checkin: `CHECKIN_API_KEY`, `CHECKIN_API_SECRET`, `CHECKIN_WEBHOOK_SECRET`. Tito: `TITO_API_KEY`, `TITO_WEBHOOK_SECRET` (via `platformTitoCredentials()`, not the env store) |
+| `email`     | `EmailCredentials`        | `RESEND_API_KEY` (+ optional per-org `fallbackFrom`)                                                                                                                         |
+| `slack`     | `SlackCredentials`        | `SLACK_BOT_TOKEN`                                                                                                                                                            |
+| `push`      | `PushCredentials`         | `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`                                                                                                                     |
+| `badge`     | `BadgeSigningCredentials` | `BADGE_ISSUER_RSA_PRIVATE_KEY`, `BADGE_ISSUER_RSA_PUBLIC_KEY`, `BADGE_ISSUER_ED25519_SEED`, `BADGE_ISSUER_RSA_ONLY`                                                          |
 
 `TicketingCredentials` is imported from the provider layer (#634), never
 re-declared, so the secret layer and the provider layer cannot drift apart.
@@ -74,7 +74,11 @@ Reads an optional `TENANT_SECRETS_JSON` env var: a JSON map
 ```jsonc
 {
   "<organization-doc-id>": {
+    // Checkin-backed org:
     "ticketing": { "apiKey": "…", "apiSecret": "…", "webhookSecret": "…" },
+    // A Tito-backed org instead sets just the token (opaque record; the provider
+    // is selected by conference.ticketingProvider, not by the secret shape):
+    //   "ticketing": { "apiKey": "tito_secret_…", "webhookSecret": "…" },
     "email": { "apiKey": "re_…", "fallbackFrom": "hello@tenant.example" },
     "slack": { "botToken": "xoxb-…" },
   },
@@ -110,13 +114,13 @@ family, stores)`) for tests and alternate compositions.
 
 ## Wired consumers
 
-| Family    | Boundary                                                                     | Status                                                                                        |
-| --------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| ticketing | `resolveTicketingProvider` (`src/lib/tickets/provider/index.ts`)             | **Wired.** Resolves per-org creds, falls back to `platformCheckinCredentials()`.              |
-| email     | `resolveEmailSender(orgId)` (`src/lib/email/config.ts`)                      | **Wired (seam).** Lazily-constructed per-credentials client factory + cached default.         |
-| slack     | `resolveConferenceSlackToken(conference)` → `postSlackMessage({ botToken })` | **Wired.** Notify paths, weekly-update cron, and the status probe inject the org token.       |
-| push      | `resolveTenantSecrets(orgId, 'push')`                                        | **Seam only.** Env-only; VAPID config is process-global (see the TODO in `push/vapid.ts`).    |
-| badge     | `resolveTenantSecrets(orgId, 'badge')`                                       | **Seam only.** Env-only; signing keys thread through pure config (TODO in `badge/config.ts`). |
+| Family    | Boundary                                                                     | Status                                                                                                                                                                                               |
+| --------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ticketing | `resolveTicketingProvider` (`src/lib/tickets/provider/index.ts`)             | **Wired (Checkin + Tito).** Branches on `conference.ticketingProvider`; Checkin falls back to `platformCheckinCredentials()`, Tito to `platformTitoCredentials()` (per-org via the JSON store only). |
+| email     | `resolveEmailSender(orgId)` (`src/lib/email/config.ts`)                      | **Wired (seam).** Lazily-constructed per-credentials client factory + cached default.                                                                                                                |
+| slack     | `resolveConferenceSlackToken(conference)` → `postSlackMessage({ botToken })` | **Wired.** Notify paths, weekly-update cron, and the status probe inject the org token.                                                                                                              |
+| push      | `resolveTenantSecrets(orgId, 'push')`                                        | **Seam only.** Env-only; VAPID config is process-global (see the TODO in `push/vapid.ts`).                                                                                                           |
+| badge     | `resolveTenantSecrets(orgId, 'badge')`                                       | **Seam only.** Env-only; signing keys thread through pure config (TODO in `badge/config.ts`).                                                                                                        |
 
 Direct `platformCheckinCredentials()` callers that operate **outside** an org
 context (the Checkin webhook, the public event lookup, cross-tenant admin ticket

--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -344,12 +344,32 @@ export default defineType({
     }),
 
     // === Ticketing & Integrations ===
+    // Provider selector (CaaS, Tito second-provider proof): which ticketing
+    // vendor backs this conference. ABSENT is treated as 'checkin' by server
+    // code (every legacy conference), so this is intentionally NOT required and
+    // has no initialValue that would change existing documents.
+    defineField({
+      name: 'ticketingProvider',
+      title: 'Ticketing Provider',
+      type: 'string',
+      fieldset: 'ticketing',
+      description:
+        'Which ticketing vendor backs this conference. Leave blank for Checkin.no (the default). Choose Tito to use the Tito account/event slugs below.',
+      options: {
+        list: [
+          { title: 'Checkin.no (default)', value: 'checkin' },
+          { title: 'Tito (ti.to)', value: 'tito' },
+        ],
+        layout: 'radio',
+      },
+    }),
     defineField({
       name: 'checkinCustomerId',
       title: 'Checkin.no Customer ID',
       type: 'number',
       fieldset: 'ticketing',
       description: 'Customer ID for Checkin.no API integration',
+      hidden: ({ parent }) => parent?.ticketingProvider === 'tito',
     }),
     defineField({
       name: 'checkinEventId',
@@ -357,6 +377,28 @@ export default defineType({
       type: 'number',
       fieldset: 'ticketing',
       description: 'Event ID for Checkin.no API integration',
+      hidden: ({ parent }) => parent?.ticketingProvider === 'tito',
+    }),
+    // Tito binding: the two URL slugs of the event on ti.to. For an event at
+    // `https://ti.to/ultimateconf/2026`, account slug = "ultimateconf",
+    // event slug = "2026". The API token itself is NOT stored here — it is a
+    // tenant secret (TITO_API_KEY / per-org ticketing secret).
+    defineField({
+      name: 'titoAccountSlug',
+      title: 'Tito Account Slug',
+      type: 'string',
+      fieldset: 'ticketing',
+      description:
+        'Tito account slug (e.g. "ultimateconf" in ti.to/ultimateconf/2026).',
+      hidden: ({ parent }) => parent?.ticketingProvider !== 'tito',
+    }),
+    defineField({
+      name: 'titoEventSlug',
+      title: 'Tito Event Slug',
+      type: 'string',
+      fieldset: 'ticketing',
+      description: 'Tito event slug (e.g. "2026" in ti.to/ultimateconf/2026).',
+      hidden: ({ parent }) => parent?.ticketingProvider !== 'tito',
     }),
     defineField({
       name: 'ticketCapacity',

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -716,20 +716,42 @@ export default async function AdminSettings() {
               <EditConferenceCard
                 fieldset="ticketingIds"
                 initialValues={{
+                  ticketingProvider: conference.ticketingProvider,
                   checkinCustomerId: conference.checkinCustomerId,
                   checkinEventId: conference.checkinEventId,
+                  titoAccountSlug: conference.titoAccountSlug,
+                  titoEventSlug: conference.titoEventSlug,
                 }}
               />
             }
           >
             <FieldRow
-              label="Checkin Customer ID"
-              value={conference.checkinCustomerId}
+              label="Ticketing Provider"
+              value={conference.ticketingProvider ?? 'checkin'}
             />
-            <FieldRow
-              label="Checkin Event ID"
-              value={conference.checkinEventId}
-            />
+            {conference.ticketingProvider === 'tito' ? (
+              <>
+                <FieldRow
+                  label="Tito Account Slug"
+                  value={conference.titoAccountSlug}
+                />
+                <FieldRow
+                  label="Tito Event Slug"
+                  value={conference.titoEventSlug}
+                />
+              </>
+            ) : (
+              <>
+                <FieldRow
+                  label="Checkin Customer ID"
+                  value={conference.checkinCustomerId}
+                />
+                <FieldRow
+                  label="Checkin Event ID"
+                  value={conference.checkinEventId}
+                />
+              </>
+            )}
           </InfoCard>
 
           <InfoCard

--- a/src/components/admin/EditConferenceCard.tsx
+++ b/src/components/admin/EditConferenceCard.tsx
@@ -337,8 +337,20 @@ export const FIELDSET_DEFS: Record<ConferenceFieldsetKey, FieldsetDef> = {
   },
   ticketingIds: {
     title: 'External Integrations',
-    subtitle: 'Checkin.no API identifiers',
+    subtitle: 'Ticketing provider & identifiers',
     fields: [
+      {
+        name: 'ticketingProvider',
+        label: 'Ticketing Provider',
+        type: 'select',
+        nullableWhenEmpty: true,
+        description:
+          'Which ticketing vendor backs this conference. Leave blank for Checkin.no (the default).',
+        options: [
+          { value: 'checkin', title: 'Checkin.no (default)' },
+          { value: 'tito', title: 'Tito (ti.to)' },
+        ],
+      },
       {
         name: 'checkinCustomerId',
         label: 'Checkin Customer ID',
@@ -354,6 +366,20 @@ export const FIELDSET_DEFS: Record<ConferenceFieldsetKey, FieldsetDef> = {
         integer: true,
         positive: true,
         nullableWhenEmpty: true,
+      },
+      {
+        name: 'titoAccountSlug',
+        label: 'Tito Account Slug',
+        type: 'text',
+        nullableWhenEmpty: true,
+        description: 'e.g. "ultimateconf" in ti.to/ultimateconf/2026',
+      },
+      {
+        name: 'titoEventSlug',
+        label: 'Tito Event Slug',
+        type: 'text',
+        nullableWhenEmpty: true,
+        description: 'e.g. "2026" in ti.to/ultimateconf/2026',
       },
     ],
   },

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -153,8 +153,18 @@ export interface Conference {
   workshopRegistrationStart?: string
   workshopRegistrationEnd?: string
   contactEmail: string
+  /**
+   * Ticketing vendor selector. ABSENT ⇒ 'checkin' (every legacy conference);
+   * 'tito' routes to the Tito account/event slugs below. Server code must treat
+   * absence as Checkin — see `conferenceProviderType`.
+   */
+  ticketingProvider?: 'checkin' | 'tito'
   checkinCustomerId?: number
   checkinEventId?: number
+  /** Tito account slug (e.g. "ultimateconf" in ti.to/ultimateconf/2026). */
+  titoAccountSlug?: string
+  /** Tito event slug (e.g. "2026" in ti.to/ultimateconf/2026). */
+  titoEventSlug?: string
   ticketCapacity?: number
   ticketTargets?: SalesTargetConfig
   travelSupportPaymentDate?: string

--- a/src/lib/secrets/store.ts
+++ b/src/lib/secrets/store.ts
@@ -64,6 +64,12 @@ export class EnvSecretsStore implements TenantSecretsStore {
     const env = process.env
     switch (family) {
       case 'ticketing': {
+        // The env-backed ticketing family is CHECKIN-SHAPED. Tito's platform
+        // fallback is NOT here — it lives in `platformTitoCredentials()`
+        // (TITO_API_KEY / TITO_WEBHOOK_SECRET) and the Tito resolver branch
+        // skips this env store, because a single (orgId, 'ticketing') lookup
+        // can't know which vendor a conference selected. Per-org Tito secrets
+        // still flow through the provider-agnostic JSON store below.
         const bag: TicketingCredentials = {
           apiKey: env.CHECKIN_API_KEY,
           apiSecret: env.CHECKIN_API_SECRET,

--- a/src/lib/secrets/types.ts
+++ b/src/lib/secrets/types.ts
@@ -20,6 +20,17 @@ import type { TicketingProviderCredentials } from '@/lib/tickets/provider'
  * Ticketing provider credentials. This is the SAME shape #634 injects into a
  * `TicketingProvider` at construction — imported (not duplicated) so the secret
  * layer and the provider layer can never drift apart.
+ *
+ * PROVIDER-AGNOSTIC (opaque record): a single family carries whichever fields a
+ * conference's selected vendor needs.
+ *   - Checkin.no: `{ apiKey, apiSecret, webhookSecret }`
+ *   - Tito:       `{ apiKey, webhookSecret? }`  (apiKey = the Tito API token;
+ *                 webhookSecret = the endpoint's security token)
+ * A per-org Tito secret in TENANT_SECRETS_JSON is thus
+ * `{"<orgId>":{"ticketing":{"apiKey":"tito_secret_..."}}}`. The Tito resolver
+ * branch reads per-org secrets from the JSON store only and falls back to
+ * `TITO_API_KEY` (see `platformTitoCredentials`), because the ENV-backed
+ * ticketing family below is Checkin-shaped.
  */
 export type TicketingCredentials = TicketingProviderCredentials
 

--- a/src/lib/tickets/provider/checkin.ts
+++ b/src/lib/tickets/provider/checkin.ts
@@ -30,6 +30,21 @@ import type {
 /** Default Checkin.no GraphQL endpoint. Overridable via injected credentials. */
 export const CHECKIN_API_URL = 'https://api.checkin.no/graphql'
 
+/**
+ * Narrow a (possibly Tito-shaped) {@link EventRef} to Checkin's customer+event
+ * pair. A ref without `provider`, or `provider: 'checkin'`, is Checkin; a Tito
+ * ref reaching this provider is a wiring bug (the resolver picks the provider
+ * from the same field), so it throws loudly.
+ */
+function checkinRef(ref: EventRef): { customerId: number; eventId: number } {
+  if (ref.provider === 'tito') {
+    throw new Error(
+      'CheckinProvider received a Tito event reference — check the resolver wiring',
+    )
+  }
+  return { customerId: ref.customerId, eventId: ref.eventId }
+}
+
 interface GraphQLError {
   message: string
 }
@@ -201,10 +216,8 @@ export class CheckinProvider implements TicketingProvider {
 
   // ── Tickets & orders ──────────────────────────────────────────────
 
-  async fetchEventTickets({
-    customerId,
-    eventId,
-  }: EventRef): Promise<EventTicket[]> {
+  async fetchEventTickets(eventRef: EventRef): Promise<EventTicket[]> {
+    const { customerId, eventId } = checkinRef(eventRef)
     if (!customerId || customerId <= 0) {
       throw new Error('Valid customer ID is required')
     }
@@ -483,8 +496,12 @@ export class CheckinProvider implements TicketingProvider {
   // ── Public ticket types ───────────────────────────────────────────
 
   async fetchPublicTicketTypes(
-    eventId: number,
+    event: EventRef | number,
   ): Promise<{ event: PublicEventInfo; tickets: PublicTicketType[] }> {
+    // Accept the historical bare-number form or a provider-shaped ref; Checkin's
+    // public lookup only needs the event id.
+    const eventId =
+      typeof event === 'number' ? event : checkinRef(event).eventId
     const query = `
   query FindEvent($id: Int!) {
     findEventById(id: $id) {

--- a/src/lib/tickets/provider/index.ts
+++ b/src/lib/tickets/provider/index.ts
@@ -1,12 +1,20 @@
 import { CheckinProvider } from './checkin'
-import { resolveTenantSecrets } from '@/lib/secrets/store'
+import { TitoProvider } from './tito'
+import { resolveTenantSecrets, perOrgSecretsStore } from '@/lib/secrets/store'
 import type {
   EventRef,
   TicketingProvider,
   TicketingProviderCredentials,
 } from './types'
 
-export type { TicketingProvider, TicketingProviderCredentials, EventRef }
+export type {
+  TicketingProvider,
+  TicketingProviderCredentials,
+  EventRef,
+  CheckinEventRef,
+  TitoEventRef,
+}
+export { ProviderUnsupportedError } from './types'
 export type {
   PublicEventInfo,
   PublicTicketType,
@@ -16,10 +24,11 @@ export type {
   CheckinOrderCreatedData,
   CheckinWebhookUser,
 } from './types'
+import type { CheckinEventRef, TitoEventRef } from './types'
 
-/** Provider discriminator. Only Checkin.no exists today; the second provider
- * (a separate PR) extends this union. */
-export type TicketingProviderType = 'checkin'
+/** Provider discriminator. Checkin.no is the default; Tito (this PR) is the
+ * second provider — the proof the adapter generalizes. */
+export type TicketingProviderType = 'checkin' | 'tito'
 
 /**
  * Returns a ticketing provider bound to the given credentials.
@@ -33,6 +42,8 @@ export function getTicketingProvider(
   credentials: TicketingProviderCredentials,
 ): TicketingProvider {
   switch (providerType) {
+    case 'tito':
+      return new TitoProvider(credentials)
     case 'checkin':
     default:
       return new CheckinProvider(credentials)
@@ -56,12 +67,49 @@ export function platformCheckinCredentials(): TicketingProviderCredentials {
   }
 }
 
-/** Just the conference fields the ticketing resolver needs. */
+/**
+ * Platform-default TITO credentials, assembled from environment variables —
+ * the Tito mirror of {@link platformCheckinCredentials}. Tito authenticates with
+ * a single API token (`TITO_API_KEY`) and signs webhooks with the endpoint
+ * security token (`TITO_WEBHOOK_SECRET`).
+ *
+ * NOTE on the resolver: the env-backed `ticketing` family in
+ * {@link EnvSecretsStore} is Checkin-shaped (it reads `CHECKIN_*`), so the Tito
+ * branch of {@link resolveTicketingProvider} does NOT use that env store as its
+ * fallback — it resolves per-org Tito secrets through the provider-agnostic
+ * JSON store and falls back to THIS function.
+ */
+export function platformTitoCredentials(): TicketingProviderCredentials {
+  return {
+    apiKey: process.env.TITO_API_KEY,
+    webhookSecret: process.env.TITO_WEBHOOK_SECRET,
+  }
+}
+
+/**
+ * Just the conference fields the ticketing resolver needs.
+ *
+ * PROVIDER-DISCRIMINATED (Tito, this PR): `ticketingProvider` selects the vendor
+ * (ABSENT ⇒ 'checkin', preserving every legacy conference's behavior). Each
+ * provider reads only its own binding fields — Checkin the numeric
+ * customer/event ids, Tito the account/event slugs.
+ */
 export type ConferenceTicketingBinding = {
+  /** Selected vendor. Absent ⇒ 'checkin' (zero behavior change for legacy docs). */
+  ticketingProvider?: TicketingProviderType | null
   checkinCustomerId?: number
   checkinEventId?: number
+  titoAccountSlug?: string | null
+  titoEventSlug?: string | null
   /** The owning organization (tenant), used to resolve per-org credentials. */
   organization?: { _ref?: string } | null
+}
+
+/** The vendor a conference is bound to (absent ⇒ Checkin, the historical default). */
+export function conferenceProviderType(
+  conference: ConferenceTicketingBinding,
+): TicketingProviderType {
+  return conference.ticketingProvider === 'tito' ? 'tito' : 'checkin'
 }
 
 /**
@@ -76,8 +124,11 @@ export function ticketingBinding(
   conference: ConferenceTicketingBinding,
 ): ConferenceTicketingBinding {
   return {
+    ticketingProvider: conference.ticketingProvider ?? undefined,
     checkinCustomerId: conference.checkinCustomerId,
     checkinEventId: conference.checkinEventId,
+    titoAccountSlug: conference.titoAccountSlug ?? undefined,
+    titoEventSlug: conference.titoEventSlug ?? undefined,
     organization: conference.organization?._ref
       ? { _ref: conference.organization._ref }
       : null,
@@ -85,15 +136,18 @@ export function ticketingBinding(
 }
 
 /**
- * True when the conference carries the FULL ticketing binding
- * ({@link resolveTicketingProvider} requires both the customer and event id —
- * an event id alone is a configuration error, not a supported state). Callers
- * should gate on this before invoking cached ticketing reads so an
+ * True when the conference carries the FULL ticketing binding for its selected
+ * provider ({@link resolveTicketingProvider} requires BOTH of a provider's
+ * binding fields — one alone is a configuration error, not a supported state).
+ * Callers should gate on this before invoking cached ticketing reads so an
  * unconfigured conference skips the fetch instead of soft-failing inside it.
  */
 export function hasTicketingBinding(
   conference: ConferenceTicketingBinding,
 ): boolean {
+  if (conferenceProviderType(conference) === 'tito') {
+    return Boolean(conference.titoAccountSlug && conference.titoEventSlug)
+  }
   return Boolean(conference.checkinCustomerId && conference.checkinEventId)
 }
 
@@ -118,22 +172,50 @@ export function hasTicketingBinding(
 export async function resolveTicketingProvider(
   conference: ConferenceTicketingBinding,
 ): Promise<ResolvedTicketing> {
+  const orgId = conference.organization?._ref
+  const providerType = conferenceProviderType(conference)
+
+  if (providerType === 'tito') {
+    if (!conference.titoAccountSlug || !conference.titoEventSlug) {
+      return { configured: false, provider: null, eventRef: null }
+    }
+    // The env-backed `ticketing` family is Checkin-shaped, so the Tito branch
+    // resolves per-org secrets through the provider-agnostic JSON store ONLY,
+    // then falls back to the platform Tito env creds. A per-org Tito ticketing
+    // secret is an opaque `{ apiKey, webhookSecret? }` record.
+    const credentials =
+      (await resolveTenantSecrets(orgId, 'ticketing', [perOrgSecretsStore])) ??
+      platformTitoCredentials()
+
+    const eventRef: TitoEventRef = {
+      provider: 'tito',
+      accountSlug: conference.titoAccountSlug,
+      eventSlug: conference.titoEventSlug,
+    }
+    return {
+      configured: true,
+      provider: getTicketingProvider('tito', credentials),
+      eventRef,
+    }
+  }
+
+  // Checkin (default) — unchanged behavior: requires customer + event id.
   if (!conference.checkinCustomerId || !conference.checkinEventId) {
     return { configured: false, provider: null, eventRef: null }
   }
 
-  const orgId = conference.organization?._ref
   const credentials =
     (await resolveTenantSecrets(orgId, 'ticketing')) ??
     platformCheckinCredentials()
 
+  const eventRef: CheckinEventRef = {
+    customerId: conference.checkinCustomerId,
+    eventId: conference.checkinEventId,
+  }
   return {
     configured: true,
     provider: getTicketingProvider('checkin', credentials),
-    eventRef: {
-      customerId: conference.checkinCustomerId,
-      eventId: conference.checkinEventId,
-    },
+    eventRef,
   }
 }
 

--- a/src/lib/tickets/provider/provider.test.ts
+++ b/src/lib/tickets/provider/provider.test.ts
@@ -3,9 +3,12 @@ import { createHmac } from 'node:crypto'
 import {
   getTicketingProvider,
   platformCheckinCredentials,
+  platformTitoCredentials,
   resolveTicketingProvider,
+  hasTicketingBinding,
 } from './index'
 import { CheckinProvider, CHECKIN_API_URL } from './checkin'
+import { TitoProvider } from './tito'
 import type { CheckinWebhookPayload } from './types'
 
 const CREDS = {
@@ -206,6 +209,129 @@ describe('resolveTicketingProvider', () => {
         eventRef: null,
       })
     }
+  })
+
+  it('REGRESSION PIN: an absent ticketingProvider routes to Checkin unchanged', async () => {
+    const resolved = await resolveTicketingProvider({
+      // No `ticketingProvider` field at all — the legacy shape.
+      checkinCustomerId: 42,
+      checkinEventId: 7,
+    })
+    expect(resolved.configured).toBe(true)
+    if (resolved.configured) {
+      expect(resolved.provider).toBeInstanceOf(CheckinProvider)
+      // The eventRef stays the bare Checkin pair (no `provider` key added), so
+      // every existing consumer reading `.eventId` is unaffected.
+      expect(resolved.eventRef).toEqual({ customerId: 42, eventId: 7 })
+    }
+  })
+
+  it('routes a tito-bound conference to a TitoProvider with a slug eventRef', async () => {
+    vi.stubEnv('TITO_API_KEY', 'env-tito-token')
+    const resolved = await resolveTicketingProvider({
+      ticketingProvider: 'tito',
+      titoAccountSlug: 'acme',
+      titoEventSlug: '2026',
+    })
+    expect(resolved.configured).toBe(true)
+    if (resolved.configured) {
+      expect(resolved.provider).toBeInstanceOf(TitoProvider)
+      expect(resolved.provider.isConfigured()).toBe(true)
+      expect(resolved.eventRef).toEqual({
+        provider: 'tito',
+        accountSlug: 'acme',
+        eventSlug: '2026',
+      })
+    }
+  })
+
+  it('prefers a per-org Tito ticketing secret over the env token', async () => {
+    vi.stubEnv('TITO_API_KEY', 'env-tito-token')
+    vi.stubEnv(
+      'TENANT_SECRETS_JSON',
+      JSON.stringify({
+        'org-tito': { ticketing: { apiKey: 'org-tito-token' } },
+      }),
+    )
+    // Prove the org secret won by observing the Authorization header it sends.
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ tickets: [], meta: { next_page: null } }),
+      text: async () => '',
+    }))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const resolved = await resolveTicketingProvider({
+      ticketingProvider: 'tito',
+      titoAccountSlug: 'acme',
+      titoEventSlug: '2026',
+      organization: { _ref: 'org-tito' },
+    })
+    expect(resolved.configured).toBe(true)
+    if (resolved.configured) {
+      await resolved.provider.fetchEventTickets(resolved.eventRef)
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Token token=org-tito-token',
+          }),
+        }),
+      )
+    }
+  })
+
+  it('returns unconfigured when a tito conference is missing its slugs', async () => {
+    for (const conf of [
+      { ticketingProvider: 'tito' as const },
+      { ticketingProvider: 'tito' as const, titoAccountSlug: 'acme' },
+      { ticketingProvider: 'tito' as const, titoEventSlug: '2026' },
+    ]) {
+      expect(await resolveTicketingProvider(conf)).toEqual({
+        configured: false,
+        provider: null,
+        eventRef: null,
+      })
+    }
+  })
+})
+
+describe('platformTitoCredentials', () => {
+  it('assembles the Tito token + webhook secret from the environment', () => {
+    vi.stubEnv('TITO_API_KEY', 'tito-token')
+    vi.stubEnv('TITO_WEBHOOK_SECRET', 'tito-webhook')
+    expect(platformTitoCredentials()).toEqual({
+      apiKey: 'tito-token',
+      webhookSecret: 'tito-webhook',
+    })
+  })
+})
+
+describe('hasTicketingBinding — provider-discriminated', () => {
+  it('checks Checkin ids when the provider is absent/checkin', () => {
+    expect(
+      hasTicketingBinding({ checkinCustomerId: 1, checkinEventId: 2 }),
+    ).toBe(true)
+    expect(hasTicketingBinding({ checkinCustomerId: 1 })).toBe(false)
+  })
+  it('checks Tito slugs when the provider is tito', () => {
+    expect(
+      hasTicketingBinding({
+        ticketingProvider: 'tito',
+        titoAccountSlug: 'acme',
+        titoEventSlug: '2026',
+      }),
+    ).toBe(true)
+    // Checkin ids do NOT satisfy a tito-bound conference.
+    expect(
+      hasTicketingBinding({
+        ticketingProvider: 'tito',
+        checkinCustomerId: 1,
+        checkinEventId: 2,
+      }),
+    ).toBe(false)
   })
 })
 

--- a/src/lib/tickets/provider/tito.test.ts
+++ b/src/lib/tickets/provider/tito.test.ts
@@ -123,6 +123,7 @@ describe('TitoProvider — fetchPublicTicketTypes', () => {
           description: 'Cheap seats',
           price: '100.0',
           quantity: 50,
+          tickets_count: 12,
           position: 0,
           start_at: '2026-01-01T00:00:00Z',
           end_at: '2026-02-01T00:00:00Z',
@@ -146,7 +147,9 @@ describe('TitoProvider — fetchPublicTicketTypes', () => {
     expect(result.tickets).toHaveLength(1)
     const t = result.tickets[0]
     expect(t.name).toBe('Early Bird')
-    expect(t.available).toBe(50)
+    // Remaining = cap (50) - issued (12); the raw cap alone would mislead the
+    // UI's low-stock messaging.
+    expect(t.available).toBe(38)
     expect(t.requiresInvitation).toBe(false)
     expect(t.visibleStartsAt).toBe('2026-01-01T00:00:00Z')
     // VAT-inclusive bridge: gross price surfaced with vat '0' so incl/excl math
@@ -244,9 +247,33 @@ describe('TitoProvider — fetchEventTickets', () => {
     expect(tickets[0].category).toBe('Speaker ticket')
     expect(tickets[0].order_id).toBe(500)
     expect(tickets[0].order?.paid).toBe(true)
+    // A paid registration owes nothing; an incomplete one still owes its price.
+    expect(tickets[0].sum_left).toBe('0')
     expect(tickets[1].order?.paid).toBe(false)
+    expect(tickets[1].sum_left).toBe(tickets[1].sum)
+    // A missing registration_id gets a per-ticket negative fallback, never a
+    // shared sentinel that would merge unrelated tickets into one order.
+    expect(tickets[1].order_id).toBe(-2)
     // Page 1 then page 2 were both fetched.
     expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws instead of returning partial data when pagination never ends', async () => {
+    // Every page reports another next_page — a looping/pathological cursor.
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            tickets: [{ id: 1, email: 'a@example.com' }],
+            meta: { next_page: 2 },
+          }),
+          { status: 200 },
+        ),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+    await expect(
+      getTicketingProvider('tito', CREDS).fetchEventTickets(TITO_REF),
+    ).rejects.toThrow(/refusing to return partial data/)
   })
 
   it('throws a wiring error when handed a Checkin-shaped ref', async () => {

--- a/src/lib/tickets/provider/tito.test.ts
+++ b/src/lib/tickets/provider/tito.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createHmac } from 'node:crypto'
+import { getTicketingProvider } from './index'
+import { TitoProvider, TITO_API_URL } from './tito'
+import { ProviderUnsupportedError, type EventRef } from './types'
+
+const CREDS = {
+  apiKey: 'tito-token',
+  webhookSecret: 'tito-webhook-secret',
+}
+
+const TITO_REF: EventRef = {
+  provider: 'tito',
+  accountSlug: 'acme',
+  eventSlug: '2026',
+}
+
+interface JsonResponse {
+  ok: boolean
+  status: number
+  statusText: string
+  json: () => Promise<unknown>
+  text: () => Promise<string>
+}
+
+function ok(body: unknown): JsonResponse {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }
+}
+
+function err(status: number, body = ''): JsonResponse {
+  return {
+    ok: false,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'Error',
+    json: async () => ({}),
+    text: async () => body,
+  }
+}
+
+/**
+ * A fetch stub that routes on the Tito REST path. `releases`/`event`/`tickets`
+ * are the per-endpoint response bodies; a numeric `authStatus` forces an error.
+ */
+function stubTitoFetch(handlers: {
+  event?: unknown
+  releases?: unknown[]
+  ticketPages?: Array<{ tickets: unknown[]; nextPage: number | null }>
+  authStatus?: number
+}) {
+  let ticketCall = 0
+  return vi.fn(async (url: string) => {
+    if (handlers.authStatus) return err(handlers.authStatus, 'denied')
+    if (url.includes('/releases')) {
+      return ok({ releases: handlers.releases ?? [] })
+    }
+    if (url.includes('/tickets')) {
+      const page = handlers.ticketPages?.[ticketCall] ?? {
+        tickets: [],
+        nextPage: null,
+      }
+      ticketCall++
+      return ok({ tickets: page.tickets, meta: { next_page: page.nextPage } })
+    }
+    // Otherwise the single-event metadata GET (`/:account/:event`).
+    return ok({ event: handlers.event ?? {} })
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+})
+
+describe('getTicketingProvider factory — tito', () => {
+  it('returns a TitoProvider for the "tito" type', () => {
+    const provider = getTicketingProvider('tito', CREDS)
+    expect(provider).toBeInstanceOf(TitoProvider)
+    expect(provider.name).toBe('Tito')
+  })
+
+  it('reports isConfigured from the injected API token, never from env', () => {
+    expect(getTicketingProvider('tito', CREDS).isConfigured()).toBe(true)
+    expect(getTicketingProvider('tito', {}).isConfigured()).toBe(false)
+  })
+
+  it('defaults the base URL to the platform constant but honors an override', async () => {
+    const fetchSpy = stubTitoFetch({ event: { id: 1, title: 'X' } })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    await getTicketingProvider('tito', {
+      ...CREDS,
+      apiUrl: 'https://tito.example.test/v3',
+    }).fetchPublicTicketTypes(TITO_REF)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('https://tito.example.test/v3/acme/2026'),
+      expect.anything(),
+    )
+
+    fetchSpy.mockClear()
+    await getTicketingProvider('tito', CREDS).fetchPublicTicketTypes(TITO_REF)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`${TITO_API_URL}/acme/2026`),
+      expect.anything(),
+    )
+  })
+})
+
+describe('TitoProvider — fetchPublicTicketTypes', () => {
+  it('maps event + releases (title/price/quantity/position)', async () => {
+    const fetchSpy = stubTitoFetch({
+      event: { id: 99, title: 'Acme 2026', currency: 'EUR' },
+      releases: [
+        {
+          id: 1,
+          slug: 'early-bird',
+          title: 'Early Bird',
+          description: 'Cheap seats',
+          price: '100.0',
+          quantity: 50,
+          position: 0,
+          start_at: '2026-01-01T00:00:00Z',
+          end_at: '2026-02-01T00:00:00Z',
+        },
+      ],
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await getTicketingProvider(
+      'tito',
+      CREDS,
+    ).fetchPublicTicketTypes(TITO_REF)
+
+    expect(result.event).toEqual({
+      id: 99,
+      name: 'Acme 2026',
+      registrationOpensAt: null,
+      registrationClosesAt: null,
+      currencies: ['EUR'],
+    })
+    expect(result.tickets).toHaveLength(1)
+    const t = result.tickets[0]
+    expect(t.name).toBe('Early Bird')
+    expect(t.available).toBe(50)
+    expect(t.requiresInvitation).toBe(false)
+    expect(t.visibleStartsAt).toBe('2026-01-01T00:00:00Z')
+    // VAT-inclusive bridge: gross price surfaced with vat '0' so incl/excl math
+    // is a no-op downstream.
+    expect(t.price).toEqual([
+      { price: '100.0', vat: '0', description: null, key: null },
+    ])
+  })
+
+  it('maps a FREE release (price 0, unlimited quantity)', async () => {
+    const fetchSpy = stubTitoFetch({
+      event: { id: 1, title: 'X' },
+      releases: [{ id: 7, title: 'Community', price: '0.0', quantity: null }],
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { tickets } = await getTicketingProvider(
+      'tito',
+      CREDS,
+    ).fetchPublicTicketTypes(TITO_REF)
+    expect(tickets[0].price[0].price).toBe('0.0')
+    // null quantity ⇒ unlimited ⇒ available null.
+    expect(tickets[0].available).toBeNull()
+  })
+
+  it('maps a HIDDEN/secret release to requiresInvitation', async () => {
+    const fetchSpy = stubTitoFetch({
+      event: { id: 1, title: 'X' },
+      releases: [{ id: 3, title: 'Speaker', price: '0.0', secret: true }],
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { tickets } = await getTicketingProvider(
+      'tito',
+      CREDS,
+    ).fetchPublicTicketTypes(TITO_REF)
+    expect(tickets[0].requiresInvitation).toBe(true)
+  })
+
+  it('throws an access-denied error on a 401 (auth failure)', async () => {
+    vi.stubGlobal('fetch', stubTitoFetch({ authStatus: 401 }))
+    await expect(
+      getTicketingProvider('tito', CREDS).fetchPublicTicketTypes(TITO_REF),
+    ).rejects.toThrow(/access denied/i)
+  })
+
+  it('unsupported-errors on a bare numeric event id (Checkin-shaped)', async () => {
+    await expect(
+      getTicketingProvider('tito', CREDS).fetchPublicTicketTypes(7),
+    ).rejects.toBeInstanceOf(ProviderUnsupportedError)
+  })
+})
+
+describe('TitoProvider — fetchEventTickets', () => {
+  it('maps email/name/release/state and follows pagination', async () => {
+    const fetchSpy = stubTitoFetch({
+      ticketPages: [
+        {
+          tickets: [
+            {
+              id: 1,
+              registration_id: 500,
+              first_name: 'Ada',
+              last_name: 'Lovelace',
+              email: 'ada@example.com',
+              release_title: 'Speaker ticket',
+              state: 'complete',
+              price: '0.0',
+              created_at: '2026-03-01',
+            },
+          ],
+          nextPage: 2,
+        },
+        {
+          tickets: [
+            {
+              id: 2,
+              email: 'grace@example.com',
+              release_title: 'Conference',
+              state: 'incomplete',
+            },
+          ],
+          nextPage: null,
+        },
+      ],
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const tickets = await getTicketingProvider('tito', CREDS).fetchEventTickets(
+      TITO_REF,
+    )
+
+    expect(tickets).toHaveLength(2)
+    expect(tickets[0].crm.email).toBe('ada@example.com')
+    expect(tickets[0].category).toBe('Speaker ticket')
+    expect(tickets[0].order_id).toBe(500)
+    expect(tickets[0].order?.paid).toBe(true)
+    expect(tickets[1].order?.paid).toBe(false)
+    // Page 1 then page 2 were both fetched.
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws a wiring error when handed a Checkin-shaped ref', async () => {
+    await expect(
+      getTicketingProvider('tito', CREDS).fetchEventTickets({
+        customerId: 1,
+        eventId: 2,
+      }),
+    ).rejects.toThrow(/non-Tito event reference/i)
+  })
+})
+
+describe('TitoProvider — unsupported members (typed, not generic)', () => {
+  const provider = getTicketingProvider('tito', CREDS)
+
+  it('fetchOrderPaymentDetails is ProviderUnsupportedError', async () => {
+    await expect(provider.fetchOrderPaymentDetails(1)).rejects.toBeInstanceOf(
+      ProviderUnsupportedError,
+    )
+  })
+  it('listDiscounts is ProviderUnsupportedError', async () => {
+    await expect(provider.listDiscounts(1)).rejects.toBeInstanceOf(
+      ProviderUnsupportedError,
+    )
+  })
+  it('createDiscount is ProviderUnsupportedError', async () => {
+    await expect(
+      provider.createDiscount({
+        eventId: 1,
+        discountCode: 'X',
+        numberOfTickets: 1,
+        ticketTypes: [],
+      }),
+    ).rejects.toBeInstanceOf(ProviderUnsupportedError)
+  })
+  it('deleteDiscount is ProviderUnsupportedError', async () => {
+    await expect(provider.deleteDiscount(1, 'X')).rejects.toBeInstanceOf(
+      ProviderUnsupportedError,
+    )
+  })
+})
+
+describe('TitoProvider — verifyWebhook', () => {
+  const rawBody = JSON.stringify({ hello: 'world' })
+  const sign = (secret: string) =>
+    createHmac('sha256', secret).update(rawBody, 'utf8').digest('base64')
+
+  it('accepts a valid base64 HMAC-SHA256 over the raw body', () => {
+    const provider = getTicketingProvider('tito', CREDS)
+    const headers = new Headers({
+      'tito-signature': sign(CREDS.webhookSecret),
+    })
+    expect(provider.verifyWebhook(rawBody, headers)).toEqual({ verified: true })
+  })
+
+  it('rejects an invalid signature', () => {
+    const provider = getTicketingProvider('tito', CREDS)
+    const headers = new Headers({ 'tito-signature': sign('wrong') })
+    expect(provider.verifyWebhook(rawBody, headers)).toEqual({
+      verified: false,
+      reason: 'invalid-signature',
+    })
+  })
+
+  it('rejects a missing signature header', () => {
+    const provider = getTicketingProvider('tito', CREDS)
+    expect(provider.verifyWebhook(rawBody, new Headers())).toEqual({
+      verified: false,
+      reason: 'invalid-signature',
+    })
+  })
+
+  it('reports not-configured when no webhook secret was injected', () => {
+    const provider = getTicketingProvider('tito', { apiKey: 'k' })
+    const headers = new Headers({ 'tito-signature': 'anything' })
+    expect(provider.verifyWebhook(rawBody, headers)).toEqual({
+      verified: false,
+      reason: 'not-configured',
+    })
+  })
+
+  it('parseOrderCreated returns null (Checkin-shaped payload has no Tito analogue)', () => {
+    const provider = getTicketingProvider('tito', CREDS)
+    expect(
+      provider.parseOrderCreated({
+        payloadId: 'p',
+        event: 'event-order-created',
+        dataType: 'order',
+        data: {
+          id: 1,
+          eventId: 1,
+          users: [],
+          orderContact: {
+            crm: {
+              id: 1,
+              firstName: 'A',
+              lastName: 'B',
+              email: { email: 'a@b' },
+            },
+          },
+        },
+      }),
+    ).toBeNull()
+  })
+})

--- a/src/lib/tickets/provider/tito.ts
+++ b/src/lib/tickets/provider/tito.ts
@@ -37,6 +37,8 @@ interface TitoRelease {
   price?: string | number | null
   /** Allocation cap; null/absent ⇒ unlimited. */
   quantity?: number | null
+  /** Tickets already issued against this release (when the API surfaces it). */
+  tickets_count?: number | null
   /** A secret release is reachable only by a direct link/access code. */
   secret?: boolean
   state?: string
@@ -186,7 +188,16 @@ export class TitoProvider implements TicketingProvider {
     let page: number | undefined = 1
     // Follow Tito's cursor (`meta.next_page`) with a hard page cap so a
     // pathological response can never loop forever.
-    for (let guard = 0; page && guard < 100; guard++) {
+    const PAGE_CAP = 100
+    for (let guard = 0; page; guard++) {
+      if (guard >= PAGE_CAP) {
+        // Never silently return a truncated attendee list: partial data would
+        // corrupt eligibility checks and order groupings downstream. A real
+        // event needing >100 pages should raise the cap deliberately.
+        throw new Error(
+          `Tito ticket pagination exceeded ${PAGE_CAP} pages for ${accountSlug}/${eventSlug} — refusing to return partial data`,
+        )
+      }
       const data: { tickets?: TitoTicket[]; meta?: TitoMeta } = await this.get(
         `/${accountSlug}/${eventSlug}/tickets?page[number]=${page}`,
       )
@@ -207,12 +218,18 @@ export class TitoProvider implements TicketingProvider {
     return {
       id: t.id,
       // Tito groups tickets under a "registration" (the order equivalent).
-      order_id: t.registration_id ?? 0,
+      // A missing registration id must NOT collapse to a shared sentinel (0)
+      // or unrelated tickets would merge into one synthetic order — negate the
+      // ticket id so each orphan stays its own group and can never collide
+      // with a real (positive) registration id.
+      order_id: t.registration_id ?? -t.id,
       category,
       customer_name: name || null,
       sum: String(t.price ?? '0'),
-      // Tito settles at purchase; there is no running balance like Checkin's.
-      sum_left: '0',
+      // Checkin semantics: `sum_left` is the outstanding balance. A completed
+      // Tito registration is settled (0); anything else still owes its price
+      // so downstream paid/unpaid logic doesn't treat it as paid.
+      sum_left: paid ? '0' : String(t.price ?? '0'),
       coupon: t.discount_code ?? undefined,
       fields: [],
       crm: {
@@ -309,9 +326,14 @@ export class TitoProvider implements TicketingProvider {
           key: null,
         },
       ],
-      // Tito's `quantity` is the allocation CAP (null ⇒ unlimited); it is not a
-      // live remaining count the way Checkin's `available` is.
-      available: typeof r.quantity === 'number' ? r.quantity : null,
+      // `available` is surfaced as a LIVE remaining count by the UI (low-stock
+      // messaging), and Tito's `quantity` is only the allocation CAP — so
+      // compute remaining (cap minus issued) when the API surfaces both, and
+      // report null (unknown/unlimited) otherwise rather than a misleading cap.
+      available:
+        typeof r.quantity === 'number' && typeof r.tickets_count === 'number'
+          ? Math.max(0, r.quantity - r.tickets_count)
+          : null,
       // A secret/hidden release is effectively invite-only on the public page.
       requiresInvitation: Boolean(r.secret),
       visibleStartsAt: r.start_at ?? null,

--- a/src/lib/tickets/provider/tito.ts
+++ b/src/lib/tickets/provider/tito.ts
@@ -1,0 +1,416 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import type { EventTicket, CheckinPayOrder } from '@/lib/tickets/types'
+import type {
+  EventDiscount,
+  TicketType,
+  CreateEventDiscountInput,
+} from '@/lib/discounts/types'
+import {
+  ProviderUnsupportedError,
+  type EventRef,
+  type TitoEventRef,
+  type PublicEventInfo,
+  type PublicTicketType,
+  type TicketingProvider,
+  type TicketingProviderCredentials,
+  type WebhookVerifyResult,
+  type CheckinWebhookPayload,
+  type CheckinOrderCreatedData,
+} from './types'
+
+/** Default Tito Admin API v3 base URL. Overridable via injected credentials. */
+export const TITO_API_URL = 'https://api.tito.io/v3'
+
+const PROVIDER_NAME = 'Tito'
+
+// ── Tito wire shapes (only the fields we map) ────────────────────────────────
+//
+// Tito v3 wraps collections under a plural root key with a `meta` block, e.g.
+// `{ releases: [...], meta: { next_page } }`.
+
+interface TitoRelease {
+  id: number
+  slug?: string
+  title?: string
+  description?: string | null
+  /** Decimal string, INCLUSIVE of tax (see the VAT note in fetchPublicTicketTypes). */
+  price?: string | number | null
+  /** Allocation cap; null/absent ⇒ unlimited. */
+  quantity?: number | null
+  /** A secret release is reachable only by a direct link/access code. */
+  secret?: boolean
+  state?: string
+  position?: number
+  start_at?: string | null
+  end_at?: string | null
+}
+
+interface TitoTicket {
+  id: number
+  registration_id?: number | null
+  first_name?: string | null
+  last_name?: string | null
+  name?: string | null
+  email?: string | null
+  release_id?: number | null
+  release_title?: string | null
+  release?: { title?: string | null } | null
+  state?: string | null
+  price?: string | number | null
+  discount_code?: string | null
+  created_at?: string | null
+}
+
+interface TitoEvent {
+  id?: number
+  title?: string
+  slug?: string
+  currency?: string | null
+  start_date?: string | null
+  end_date?: string | null
+}
+
+interface TitoMeta {
+  next_page?: number | null
+}
+
+/**
+ * Narrow a (possibly Checkin-shaped) {@link EventRef} to Tito's account+event
+ * slug pair. A Checkin ref reaching this provider is a wiring bug (the resolver
+ * picks the provider from the same `ticketingProvider` field).
+ */
+function titoRef(ref: EventRef): TitoEventRef {
+  if (ref.provider !== 'tito') {
+    throw new Error(
+      'TitoProvider received a non-Tito event reference — check the resolver wiring',
+    )
+  }
+  return ref
+}
+
+/**
+ * Tito.io implementation of {@link TicketingProvider} (Admin API v3).
+ *
+ * The SECOND provider — its purpose is to prove the adapter generalizes past
+ * Checkin. Credentials are injected (constructor only, never `process.env`);
+ * `apiKey` is the Tito API token, `webhookSecret` is the endpoint's security
+ * token. Where a Checkin-shaped interface member has no faithful Tito analogue
+ * (the numeric-`eventId` discount/order methods), the provider throws a typed
+ * {@link ProviderUnsupportedError} rather than a bare Error.
+ */
+export class TitoProvider implements TicketingProvider {
+  readonly name = PROVIDER_NAME
+
+  private readonly apiUrl: string
+  private readonly apiKey: string | undefined
+  private readonly webhookSecret: string | undefined
+
+  constructor(credentials: TicketingProviderCredentials) {
+    this.apiUrl = (credentials.apiUrl ?? TITO_API_URL).replace(/\/+$/, '')
+    this.apiKey = credentials.apiKey
+    this.webhookSecret = credentials.webhookSecret
+  }
+
+  isConfigured(): boolean {
+    return !!this.apiKey
+  }
+
+  // ── Transport ─────────────────────────────────────────────────────
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    }
+    // Tito v3 auth: `Authorization: Token token=<secret API token>`.
+    if (this.apiKey) {
+      headers.Authorization = `Token token=${this.apiKey}`
+    }
+    return headers
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    if (!this.isConfigured()) {
+      throw new Error(
+        'Tito API is not configured. Please check the TITO_API_KEY environment variable (or the per-org ticketing secret).',
+      )
+    }
+
+    let response: Response
+    try {
+      response = await fetch(`${this.apiUrl}${path}`, {
+        method: 'GET',
+        headers: this.headers(),
+        // A stalled upstream must never hang server rendering indefinitely;
+        // callers handle the rejection via their existing error paths.
+        signal: AbortSignal.timeout(10_000),
+      })
+    } catch (error) {
+      if (error instanceof TypeError && error.message.includes('fetch')) {
+        throw new Error(
+          `Network error connecting to Tito API: ${error.message}`,
+        )
+      }
+      throw error
+    }
+
+    if (!response.ok) {
+      // 401/403 are the auth-failure signal (bad/absent token or no access to
+      // this account/event) — surfaced explicitly so callers can distinguish it.
+      let body = ''
+      try {
+        body = await response.text()
+      } catch {}
+      if (response.status === 401 || response.status === 403) {
+        throw new Error(
+          `Tito API access denied (${response.status}): verify the API token has access to this account/event.${body ? ` - ${body}` : ''}`,
+        )
+      }
+      throw new Error(
+        `Tito API request failed: ${response.status} ${response.statusText}${body ? ` - ${body}` : ''}`,
+      )
+    }
+
+    return (await response.json()) as T
+  }
+
+  // ── Tickets & orders ──────────────────────────────────────────────
+
+  async fetchEventTickets(eventRef: EventRef): Promise<EventTicket[]> {
+    const { accountSlug, eventSlug } = titoRef(eventRef)
+    if (!accountSlug || !eventSlug) {
+      throw new Error('Valid Tito account and event slugs are required')
+    }
+
+    const tickets: EventTicket[] = []
+    let page: number | undefined = 1
+    // Follow Tito's cursor (`meta.next_page`) with a hard page cap so a
+    // pathological response can never loop forever.
+    for (let guard = 0; page && guard < 100; guard++) {
+      const data: { tickets?: TitoTicket[]; meta?: TitoMeta } = await this.get(
+        `/${accountSlug}/${eventSlug}/tickets?page[number]=${page}`,
+      )
+      for (const t of data.tickets ?? []) {
+        tickets.push(this.mapTicket(t))
+      }
+      page = data.meta?.next_page ?? undefined
+    }
+    return tickets
+  }
+
+  private mapTicket(t: TitoTicket): EventTicket {
+    const category = t.release_title ?? t.release?.title ?? ''
+    const first = t.first_name ?? ''
+    const last = t.last_name ?? ''
+    const name = t.name ?? `${first} ${last}`.trim()
+    const paid = t.state === 'complete'
+    return {
+      id: t.id,
+      // Tito groups tickets under a "registration" (the order equivalent).
+      order_id: t.registration_id ?? 0,
+      category,
+      customer_name: name || null,
+      sum: String(t.price ?? '0'),
+      // Tito settles at purchase; there is no running balance like Checkin's.
+      sum_left: '0',
+      coupon: t.discount_code ?? undefined,
+      fields: [],
+      crm: {
+        first_name: first,
+        last_name: last,
+        email: t.email ?? '',
+      },
+      order: {
+        createdAt: t.created_at ?? '',
+        paymentStatus: t.state ?? 'unknown',
+        paid,
+      },
+      order_date: t.created_at ?? '',
+    }
+  }
+
+  /**
+   * UNSUPPORTED: Tito has no Checkin-shaped per-order payment document, and this
+   * method receives only a numeric Checkin order id — it cannot address a Tito
+   * registration. Typed so callers can distinguish "not implemented for this
+   * vendor" from a transport error.
+   */
+  async fetchOrderPaymentDetails(orderId: number): Promise<CheckinPayOrder> {
+    throw new ProviderUnsupportedError(
+      PROVIDER_NAME,
+      'fetchOrderPaymentDetails',
+      `Tito has no Checkin-shaped order payment document; the numeric order id (${orderId}) cannot address a Tito registration`,
+    )
+  }
+
+  // ── Public ticket types ───────────────────────────────────────────
+
+  async fetchPublicTicketTypes(
+    event: EventRef | number,
+  ): Promise<{ event: PublicEventInfo; tickets: PublicTicketType[] }> {
+    if (typeof event === 'number') {
+      // A bare numeric event id is a Checkin concept and cannot address a Tito
+      // event (which needs account + event slugs).
+      throw new ProviderUnsupportedError(
+        PROVIDER_NAME,
+        'fetchPublicTicketTypes',
+        'Tito requires an account/event-slug EventRef, not a bare numeric event id',
+      )
+    }
+    const { accountSlug, eventSlug } = titoRef(event)
+
+    const [eventData, releaseData] = await Promise.all([
+      this.get<{ event?: TitoEvent } & TitoEvent>(
+        `/${accountSlug}/${eventSlug}`,
+      ),
+      this.get<{ releases?: TitoRelease[] }>(
+        `/${accountSlug}/${eventSlug}/releases`,
+      ),
+    ])
+
+    const ev: TitoEvent = eventData.event ?? eventData
+    const info: PublicEventInfo = {
+      // Tito event ids are numeric but not part of the slug-based ref; fall back
+      // to 0 when the event endpoint doesn't surface one.
+      id: ev.id ?? 0,
+      name: ev.title ?? eventSlug,
+      // Tito has no separate registration-window fields on the event resource;
+      // per-release start/end windows carry that instead (see below).
+      registrationOpensAt: null,
+      registrationClosesAt: null,
+      currencies: ev.currency ? [ev.currency] : [],
+    }
+
+    const tickets = (releaseData.releases ?? []).map((r, i) =>
+      this.mapRelease(r, i),
+    )
+    return { event: info, tickets }
+  }
+
+  private mapRelease(r: TitoRelease, index: number): PublicTicketType {
+    return {
+      id: r.id,
+      name: r.title ?? r.slug ?? `Release ${r.id}`,
+      // Tito has no ticket "type" taxonomy; reuse the slug as a stable key.
+      type: r.slug ?? 'release',
+      description: r.description ?? null,
+      // VAT SEMANTICS (deliberate bridge): Tito prices are TAX-INCLUSIVE (the
+      // gross a buyer pays), whereas Checkin's TicketPrice.price is NET (excl.
+      // VAT) with a separate `vat` percent that downstream `formatTicketPrice`
+      // adds back when `includeVat` is set. To avoid double-counting we surface
+      // the Tito gross as `price` with `vat: '0'`, so the excl/incl display math
+      // is a no-op and the shown number always equals what the buyer pays. A
+      // future generalization would carry a tax-inclusive flag on TicketPrice.
+      price: [
+        {
+          price: String(r.price ?? '0'),
+          vat: '0',
+          description: null,
+          key: null,
+        },
+      ],
+      // Tito's `quantity` is the allocation CAP (null ⇒ unlimited); it is not a
+      // live remaining count the way Checkin's `available` is.
+      available: typeof r.quantity === 'number' ? r.quantity : null,
+      // A secret/hidden release is effectively invite-only on the public page.
+      requiresInvitation: Boolean(r.secret),
+      visibleStartsAt: r.start_at ?? null,
+      visibleEndsAt: r.end_at ?? null,
+      position: typeof r.position === 'number' ? r.position : index,
+    }
+  }
+
+  // ── Discounts ─────────────────────────────────────────────────────
+  //
+  // UNSUPPORTED for Tito: the interface's discount methods carry a Checkin-shaped
+  // numeric `eventId` (or `CreateEventDiscountInput.eventId: number`) that cannot
+  // address a Tito event (which needs account + event slugs). Tito DOES expose
+  // `POST /:account/:event/discount_codes`, so wiring these up is a matter of
+  // generalizing the discount input to carry an EventRef — tracked as debt in
+  // docs/INTEGRATION_ADAPTERS.md. Until then they fail with a typed error.
+
+  async listDiscounts(
+    eventId: number,
+  ): Promise<{ discounts: EventDiscount[]; ticketTypes: TicketType[] }> {
+    throw new ProviderUnsupportedError(
+      PROVIDER_NAME,
+      'listDiscounts',
+      `the numeric eventId (${eventId}) cannot address a Tito event (needs account/event slugs)`,
+    )
+  }
+
+  async createDiscount(
+    input: CreateEventDiscountInput,
+  ): Promise<EventDiscount> {
+    throw new ProviderUnsupportedError(
+      PROVIDER_NAME,
+      'createDiscount',
+      `CreateEventDiscountInput.eventId (${input.eventId}) is a Checkin-shaped number; a Tito discount needs account/event slugs`,
+    )
+  }
+
+  async deleteDiscount(
+    eventId: number,
+    discountCode: string,
+  ): Promise<boolean> {
+    throw new ProviderUnsupportedError(
+      PROVIDER_NAME,
+      'deleteDiscount',
+      `the numeric eventId (${eventId}) cannot address a Tito event to delete code "${discountCode}" (needs account/event slugs)`,
+    )
+  }
+
+  // ── Webhooks ──────────────────────────────────────────────────────
+
+  /**
+   * Verify a Tito webhook. Tito signs the raw request body with HMAC-SHA256
+   * keyed by the endpoint's security token and sends the digest BASE64-encoded
+   * in the `Tito-Signature` header (cf. Checkin's hex `checkin-signature` over
+   * only the `data` field). The injected `webhookSecret` is that security token.
+   */
+  verifyWebhook(rawBody: string, headers: Headers): WebhookVerifyResult {
+    if (!this.webhookSecret) {
+      return { verified: false, reason: 'not-configured' }
+    }
+    const signature = headers.get('tito-signature')
+    if (!signature) {
+      return { verified: false, reason: 'invalid-signature' }
+    }
+    try {
+      const expected = createHmac('sha256', this.webhookSecret)
+        .update(rawBody, 'utf8')
+        .digest('base64')
+      const provided = signature.trim()
+      // Length guard before timingSafeEqual (it throws on unequal-length bufs).
+      if (provided.length !== expected.length) {
+        return { verified: false, reason: 'invalid-signature' }
+      }
+      const ok = timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
+      return ok
+        ? { verified: true }
+        : { verified: false, reason: 'invalid-signature' }
+    } catch (error) {
+      console.error('Tito webhook signature verification failed:', error)
+      return { verified: false, reason: 'invalid-signature' }
+    }
+  }
+
+  /**
+   * UNSUPPORTED SHAPE: `parseOrderCreated` is typed against the Checkin webhook
+   * envelope ({@link CheckinWebhookPayload} → {@link CheckinOrderCreatedData}).
+   * Tito's envelope (e.g. `ticket.completed`, identified by the `X-Webhook-Name`
+   * header) is different, so there is nothing faithful to extract from a
+   * Checkin-shaped payload — it always returns `null` ("not an order-created
+   * event"). Generalizing this requires a neutral order-created shape + a
+   * per-provider mapping layer, flagged as debt in docs/INTEGRATION_ADAPTERS.md.
+   * (The live webhook route is Checkin-namespaced, so this is never invoked in
+   * today's wiring.)
+   */
+  parseOrderCreated(
+    payload: CheckinWebhookPayload,
+  ): CheckinOrderCreatedData | null {
+    // Intentionally ignores the Checkin-shaped payload — see the doc above.
+    void payload
+    return null
+  }
+}

--- a/src/lib/tickets/provider/tito.ts
+++ b/src/lib/tickets/provider/tito.ts
@@ -91,6 +91,21 @@ function titoRef(ref: EventRef): TitoEventRef {
 }
 
 /**
+ * URL-path-encode the account/event slugs before interpolation. Slugs are
+ * operator-entered strings; a reserved character must not be able to reshape
+ * the request path into a different Tito API endpoint.
+ */
+function encodedSlugs(ref: TitoEventRef): {
+  accountSlug: string
+  eventSlug: string
+} {
+  return {
+    accountSlug: encodeURIComponent(ref.accountSlug),
+    eventSlug: encodeURIComponent(ref.eventSlug),
+  }
+}
+
+/**
  * Tito.io implementation of {@link TicketingProvider} (Admin API v3).
  *
  * The SECOND provider — its purpose is to prove the adapter generalizes past
@@ -179,7 +194,7 @@ export class TitoProvider implements TicketingProvider {
   // ── Tickets & orders ──────────────────────────────────────────────
 
   async fetchEventTickets(eventRef: EventRef): Promise<EventTicket[]> {
-    const { accountSlug, eventSlug } = titoRef(eventRef)
+    const { accountSlug, eventSlug } = encodedSlugs(titoRef(eventRef))
     if (!accountSlug || !eventSlug) {
       throw new Error('Valid Tito account and event slugs are required')
     }
@@ -274,7 +289,7 @@ export class TitoProvider implements TicketingProvider {
         'Tito requires an account/event-slug EventRef, not a bare numeric event id',
       )
     }
-    const { accountSlug, eventSlug } = titoRef(event)
+    const { accountSlug, eventSlug } = encodedSlugs(titoRef(event))
 
     const [eventData, releaseData] = await Promise.all([
       this.get<{ event?: TitoEvent } & TitoEvent>(

--- a/src/lib/tickets/provider/types.ts
+++ b/src/lib/tickets/provider/types.ts
@@ -6,18 +6,58 @@ import type {
 } from '@/lib/discounts/types'
 
 /**
- * Neutral reference to an event within a ticketing provider.
+ * Provider-shaped reference to an event.
  *
- * For Checkin.no this is a customer (tenant) id plus an event id, both stored
- * per-conference as `conference.checkinCustomerId` / `conference.checkinEventId`.
+ * GENERALIZED FOR THE SECOND PROVIDER (Tito): `EventRef` is now a discriminated
+ * union keyed by `provider`. Each provider narrows to its own binding shape and
+ * throws (or unsupported-errors) if handed another provider's ref.
  *
- * SECOND-PROVIDER DEBT: the two-number shape is Checkin's. A provider that keys
- * events differently (e.g. a single opaque event slug) will need this
- * generalized — see docs/INTEGRATION_ADAPTERS.md.
+ * BACKWARD COMPATIBILITY: `provider` is OPTIONAL on the Checkin variant and
+ * absent means Checkin, so every pre-existing `{ customerId, eventId }` literal
+ * (admin pages, tRPC router, resolver output) is still a valid `EventRef` with
+ * zero edits — the discriminant `'tito'` appears only on the Tito variant, so
+ * narrowing with `ref.provider === 'tito'` is exhaustive.
  */
-export interface EventRef {
+export interface CheckinEventRef {
+  /** Optional discriminant; absent ⇒ Checkin (the historical default). */
+  provider?: 'checkin'
+  /** Checkin customer (tenant) id — `conference.checkinCustomerId`. */
   customerId: number
+  /** Checkin event id — `conference.checkinEventId`. */
   eventId: number
+}
+
+/** Tito keys an event by two URL slugs: `/:account/:event`. */
+export interface TitoEventRef {
+  provider: 'tito'
+  /** Tito account slug — `conference.titoAccountSlug`. */
+  accountSlug: string
+  /** Tito event slug — `conference.titoEventSlug`. */
+  eventSlug: string
+}
+
+export type EventRef = CheckinEventRef | TitoEventRef
+
+/**
+ * Thrown by a provider for an interface member that has NO faithful equivalent
+ * on that vendor (e.g. Tito has no Checkin-shaped `fetchOrderPaymentDetails`, and
+ * the discount methods carry a Checkin-shaped numeric `eventId` input that can't
+ * address a Tito event). It is a NAMED, typed error — callers can `instanceof`
+ * it — so a provider never fails with a bare/opaque `Error` for an operation it
+ * deliberately does not implement.
+ */
+export class ProviderUnsupportedError extends Error {
+  readonly code = 'provider-unsupported'
+  constructor(
+    readonly providerName: string,
+    readonly operation: string,
+    detail?: string,
+  ) {
+    super(
+      `${providerName} does not support "${operation}"${detail ? `: ${detail}` : ''}`,
+    )
+    this.name = 'ProviderUnsupportedError'
+  }
 }
 
 /**
@@ -141,12 +181,19 @@ export interface TicketingProvider {
   fetchOrderPaymentDetails(orderId: number): Promise<CheckinPayOrder>
 
   /**
-   * Public ticket types for an event. Only the event id is required (the public
-   * event lookup is not tenant-scoped). Throws on transport/not-found; callers
-   * that want soft-fail wrap this (see `getPublicTicketTypes`).
+   * Public ticket types for an event.
+   *
+   * Accepts either a bare numeric event id (the historical Checkin-only form —
+   * Checkin's public lookup is not tenant-scoped, so an id alone suffices) OR a
+   * provider-shaped {@link EventRef}. A provider whose public lookup needs more
+   * than a number (Tito needs `account/event` slugs) requires the ref form and
+   * unsupported-errors on a bare number. The resolver path always passes the
+   * ref; direct Checkin callers may still pass the number. Throws on
+   * transport/not-found; callers that want soft-fail wrap this (see
+   * `getPublicTicketTypes`).
    */
   fetchPublicTicketTypes(
-    eventId: number,
+    event: EventRef | number,
   ): Promise<{ event: PublicEventInfo; tickets: PublicTicketType[] }>
 
   // ── Discounts (same vendor + event id) ────────────────────────────

--- a/src/lib/tickets/public.test.ts
+++ b/src/lib/tickets/public.test.ts
@@ -37,7 +37,7 @@ function pubTicket(over: Record<string, unknown>) {
 beforeEach(() => vi.clearAllMocks())
 
 describe('getPublicTicketTypes — resolver routing (B7)', () => {
-  it('resolves from the conference and fetches with the resolved eventId', async () => {
+  it('resolves from the conference and fetches with the resolved eventRef', async () => {
     const fetchPublicTicketTypes = vi.fn().mockResolvedValue({
       event: { id: 7, name: 'Event' },
       tickets: [pubTicket({})],
@@ -51,7 +51,12 @@ describe('getPublicTicketTypes — resolver routing (B7)', () => {
     const result = await getPublicTicketTypes(CONF)
 
     expect(resolveTicketingProviderMock).toHaveBeenCalledWith(CONF)
-    expect(fetchPublicTicketTypes).toHaveBeenCalledWith(7)
+    // Now passes the provider-shaped eventRef (not a bare id) so a Tito-bound
+    // conference can route to its account/event slugs.
+    expect(fetchPublicTicketTypes).toHaveBeenCalledWith({
+      customerId: 42,
+      eventId: 7,
+    })
     expect(result?.tickets).toHaveLength(1)
   })
 

--- a/src/lib/tickets/public.ts
+++ b/src/lib/tickets/public.ts
@@ -48,8 +48,11 @@ export async function getPublicTicketTypes(
     // than resolved-and-refused.
     const ticketing = await resolveTicketingProvider(conference)
     if (!ticketing.configured) return null
+    // Pass the provider-shaped eventRef (not a bare event id) so a Tito-bound
+    // conference routes to its account/event slugs; Checkin ignores the extra
+    // customerId and uses the event id.
     const data = await ticketing.provider.fetchPublicTicketTypes(
-      ticketing.eventRef.eventId,
+      ticketing.eventRef,
     )
 
     // Filter to only public tickets: not invite-only, has at least one price > 0

--- a/src/server/schemas/conference.test.ts
+++ b/src/server/schemas/conference.test.ts
@@ -41,6 +41,26 @@ describe('UpdateTicketingIdsSchema — Tito cross-field validation', () => {
     }
   })
 
+  it('rejects complete Tito slugs while the provider is absent (would be silently ignored)', () => {
+    const r = UpdateTicketingIdsSchema.safeParse({
+      titoAccountSlug: 'acme',
+      titoEventSlug: 'acme-2026',
+    })
+    expect(r.success).toBe(false)
+    if (!r.success) {
+      expect(r.error.issues[0].path).toEqual(['ticketingProvider'])
+    }
+  })
+
+  it('rejects complete Tito slugs while the provider is explicitly checkin', () => {
+    const r = UpdateTicketingIdsSchema.safeParse({
+      ticketingProvider: 'checkin',
+      titoAccountSlug: 'acme',
+      titoEventSlug: 'acme-2026',
+    })
+    expect(r.success).toBe(false)
+  })
+
   it('leaves the Checkin path unconstrained by the Tito rule', () => {
     const r = UpdateTicketingIdsSchema.safeParse({
       checkinCustomerId: 1,

--- a/src/server/schemas/conference.test.ts
+++ b/src/server/schemas/conference.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { UpdateTicketingIdsSchema } from './conference'
+
+describe('UpdateTicketingIdsSchema — Tito cross-field validation', () => {
+  it('accepts a full Tito binding', () => {
+    const r = UpdateTicketingIdsSchema.safeParse({
+      ticketingProvider: 'tito',
+      titoAccountSlug: 'acme',
+      titoEventSlug: 'acme-2026',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts clearing both slugs', () => {
+    const r = UpdateTicketingIdsSchema.safeParse({
+      ticketingProvider: 'tito',
+      titoAccountSlug: null,
+      titoEventSlug: null,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects a Tito provider with only one slug (both-or-neither)', () => {
+    const r = UpdateTicketingIdsSchema.safeParse({
+      ticketingProvider: 'tito',
+      titoAccountSlug: 'acme',
+    })
+    expect(r.success).toBe(false)
+    if (!r.success) {
+      expect(r.error.issues[0].path).toEqual(['titoEventSlug'])
+    }
+  })
+
+  it('rejects a lone slug even without the provider field (half-configured state)', () => {
+    const r = UpdateTicketingIdsSchema.safeParse({
+      titoEventSlug: 'acme-2026',
+    })
+    expect(r.success).toBe(false)
+    if (!r.success) {
+      expect(r.error.issues[0].path).toEqual(['titoAccountSlug'])
+    }
+  })
+
+  it('leaves the Checkin path unconstrained by the Tito rule', () => {
+    const r = UpdateTicketingIdsSchema.safeParse({
+      checkinCustomerId: 1,
+      checkinEventId: 2,
+    })
+    expect(r.success).toBe(true)
+  })
+})

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -148,7 +148,10 @@ export const UpdateCommunicationSchema = z.object({
 
 // === Ticketing IDs ===
 // Positive integers; clearing is allowed by sending `null` (unset).
+// Provider-discriminated: `ticketingProvider` selects the vendor (absent/null ⇒
+// Checkin). Checkin uses the numeric ids; Tito uses the two account/event slugs.
 export const UpdateTicketingIdsSchema = z.object({
+  ticketingProvider: z.enum(['checkin', 'tito']).nullable().optional(),
   checkinCustomerId: z
     .number()
     .int('Must be a whole number')
@@ -161,6 +164,8 @@ export const UpdateTicketingIdsSchema = z.object({
     .positive('Must be a positive number')
     .nullable()
     .optional(),
+  titoAccountSlug: z.string().trim().nullable().optional(),
+  titoEventSlug: z.string().trim().nullable().optional(),
 })
 
 // === CFP & Revenue Goals ===

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -150,23 +150,45 @@ export const UpdateCommunicationSchema = z.object({
 // Positive integers; clearing is allowed by sending `null` (unset).
 // Provider-discriminated: `ticketingProvider` selects the vendor (absent/null ⇒
 // Checkin). Checkin uses the numeric ids; Tito uses the two account/event slugs.
-export const UpdateTicketingIdsSchema = z.object({
-  ticketingProvider: z.enum(['checkin', 'tito']).nullable().optional(),
-  checkinCustomerId: z
-    .number()
-    .int('Must be a whole number')
-    .positive('Must be a positive number')
-    .nullable()
-    .optional(),
-  checkinEventId: z
-    .number()
-    .int('Must be a whole number')
-    .positive('Must be a positive number')
-    .nullable()
-    .optional(),
-  titoAccountSlug: z.string().trim().nullable().optional(),
-  titoEventSlug: z.string().trim().nullable().optional(),
-})
+export const UpdateTicketingIdsSchema = z
+  .object({
+    ticketingProvider: z.enum(['checkin', 'tito']).nullable().optional(),
+    checkinCustomerId: z
+      .number()
+      .int('Must be a whole number')
+      .positive('Must be a positive number')
+      .nullable()
+      .optional(),
+    checkinEventId: z
+      .number()
+      .int('Must be a whole number')
+      .positive('Must be a positive number')
+      .nullable()
+      .optional(),
+    titoAccountSlug: z.string().trim().nullable().optional(),
+    titoEventSlug: z.string().trim().nullable().optional(),
+  })
+  .superRefine((value, ctx) => {
+    // A Tito binding is both-or-neither: the resolver requires account AND event
+    // slug, so persisting one alone would strand the conference in a
+    // half-configured state that silently resolves as "unconfigured".
+    const wantsTito =
+      value.ticketingProvider === 'tito' ||
+      Boolean(value.titoAccountSlug) ||
+      Boolean(value.titoEventSlug)
+    if (!wantsTito) return
+    if (Boolean(value.titoAccountSlug) !== Boolean(value.titoEventSlug)) {
+      const missing = value.titoAccountSlug
+        ? 'titoEventSlug'
+        : 'titoAccountSlug'
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [missing],
+        message:
+          'Tito needs both the account slug and the event slug — set both or clear both',
+      })
+    }
+  })
 
 // === CFP & Revenue Goals ===
 // Non-negative numbers; every field is optional and unsettable via `null`.

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -172,11 +172,9 @@ export const UpdateTicketingIdsSchema = z
     // A Tito binding is both-or-neither: the resolver requires account AND event
     // slug, so persisting one alone would strand the conference in a
     // half-configured state that silently resolves as "unconfigured".
-    const wantsTito =
-      value.ticketingProvider === 'tito' ||
-      Boolean(value.titoAccountSlug) ||
-      Boolean(value.titoEventSlug)
-    if (!wantsTito) return
+    const hasAnySlug =
+      Boolean(value.titoAccountSlug) || Boolean(value.titoEventSlug)
+    if (value.ticketingProvider !== 'tito' && !hasAnySlug) return
     if (Boolean(value.titoAccountSlug) !== Boolean(value.titoEventSlug)) {
       const missing = value.titoAccountSlug
         ? 'titoEventSlug'
@@ -186,6 +184,18 @@ export const UpdateTicketingIdsSchema = z
         path: [missing],
         message:
           'Tito needs both the account slug and the event slug — set both or clear both',
+      })
+    }
+    // Slugs saved while the provider is (or defaults to) Checkin would be
+    // silently ignored by the resolver (absence ⇒ 'checkin') — a stored-but-dead
+    // binding. The fieldset is full-replace, so requiring the provider here is
+    // safe for every caller.
+    if (hasAnySlug && value.ticketingProvider !== 'tito') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['ticketingProvider'],
+        message:
+          'Select Tito as the ticketing provider to use these slugs — or clear them',
       })
     }
   })


### PR DESCRIPTION
## What & why

The `TicketingProvider` adapter (merged in #634, resolver hardened in #644) was built to generalize past Checkin.no but had only one implementation. This PR adds **Tito** (ti.to, REST **Admin API v3** — `https://api.tito.io/v3`, `Authorization: Token token=…`) as the **second provider**, proving the adapter actually generalizes. Providers are selected **per conference**. Part of the CaaS integration-adapters line (#612 / #634 / #644).

**No UI beyond the config surface** — this is an adapter-level proof, not full Tito ticketing UX.

## Binding design

- **`EventRef` → provider-discriminated union.** The Checkin variant's `provider` key is **optional** (`{ provider?: 'checkin'; customerId; eventId } | { provider: 'tito'; accountSlug; eventSlug }`), so every legacy `{ customerId, eventId }` literal still type-checks and the resolver emits the **bare** Checkin ref unchanged — pinned by a regression test.
- **`conference.ticketingProvider: 'checkin' | 'tito'`** (absent ⇒ `'checkin'`, zero behavior change). Each provider reads only its own binding fields: Checkin `checkinCustomerId`/`checkinEventId`; Tito `titoAccountSlug`/`titoEventSlug`.
- `resolveTicketingProvider` / `hasTicketingBinding` / `ticketingBinding` branch on the provider type and require that provider's full binding.
- `fetchPublicTicketTypes` now accepts `EventRef | number` (backward-compatible — the numeric Checkin form still works; the resolver path passes the ref so Tito can route to its slugs).

## Tito ↔ interface mapping

| Member | Tito | Notes |
| --- | --- | --- |
| `isConfigured` | ✅ | `!!apiKey` |
| `fetchPublicTicketTypes` | ✅ | `GET /:a/:e` + `/releases`; unsupported on a bare numeric id |
| `fetchEventTickets` | ✅ | `GET /:a/:e/tickets`, paginated via `meta.next_page` |
| `verifyWebhook` | ✅ | HMAC-SHA256 over raw body, **base64**, `Tito-Signature` header |
| `fetchOrderPaymentDetails` | ⛔ typed-unsupported | no Checkin-shaped order doc; numeric id can't address a Tito registration |
| `listDiscounts` / `createDiscount` / `deleteDiscount` | ⛔ typed-unsupported | inputs carry a Checkin-shaped numeric `eventId` with no slugs (Tito *has* `POST …/discount_codes`; unlock = generalize the discount input to carry an `EventRef`) |
| `parseOrderCreated` | ⛔ returns `null` | typed against the Checkin envelope; Tito's differs (route is Checkin-namespaced, never invoked today) |

Unsupported members with a bare domain-object return type throw a **named, typed `ProviderUnsupportedError`** (never a generic `Error`), so callers can `instanceof`-distinguish "not implemented for this vendor" from a transport failure.

**VAT note (honest):** Tito prices are **tax-inclusive** (gross). Checkin's `TicketPrice.price` is net + a separate `vat` percent that downstream `formatTicketPrice` adds back on `includeVat`. To avoid double-counting, Tito surfaces the gross as `price` with `vat: '0'` so the incl/excl math is a no-op and the shown number equals what the buyer pays. Future generalization: a tax-inclusive flag on `TicketPrice`.

## Env / secret shapes

- **Platform fallback:** `platformTitoCredentials()` reads `TITO_API_KEY` + `TITO_WEBHOOK_SECRET` (mirrors `platformCheckinCredentials`).
- **Per-org:** the `ticketing` family is a provider-agnostic opaque record; a Tito org sets `TENANT_SECRETS_JSON = {"<orgId>":{"ticketing":{"apiKey":"tito_secret_…"}}}`.
- The env-backed `ticketing` family in `EnvSecretsStore` is **Checkin-shaped** (`CHECKIN_*`); a single `(orgId, 'ticketing')` lookup can't know the vendor, so the **Tito resolver branch skips it** — per-org via the JSON store only, then `platformTitoCredentials()`.

## Config surface

Extended the existing admin ticketing card (`EditConferenceCard` `ticketingIds` fieldset) with a provider selector + Tito slug fields, plus Sanity schema, Zod `UpdateTicketingIdsSchema`, `Conference` type, and the settings page card.

## Files touched (the validated "add provider N+1" checklist)

provider `types.ts` (union + `ProviderUnsupportedError`) · `checkin.ts` (union narrowing) · **`tito.ts` (new)** · `index.ts` (factory/union/resolver/binding/`platformTitoCredentials`) · `public.ts` (pass ref) · secrets `types.ts`/`store.ts` (Tito shape docs) · Sanity `conference.ts` · Zod `conference.ts` · `conference/types.ts` · `EditConferenceCard.tsx` · settings `page.tsx` · docs (`INTEGRATION_ADAPTERS.md` Tito section + mapping table + N+1 checklist, `TENANT_SECRETS.md`).

## Tests

`mise run check` green (lint / knip / format / typecheck). Full vitest **4134 passed** (312 files), incl. new TitoProvider contract tests (happy path, 401 auth failure, free/hidden-release mapping edges, webhook verify, typed-unsupported members) and resolver routing + Checkin regression pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)