### PR TITLE
feat(theming): per-tenant brand token layer (L1)

### DIFF
--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -261,6 +261,20 @@ export default defineType({
       fieldset: 'branding',
       description:
         'Optional per-conference brand colors. Leave unset to use the default Cloud Native Days palette.',
+      // Both-or-neither: the server schema and the ThemeEditor treat the theme
+      // as a complete pair, so a Studio edit must not persist a half-theme.
+      validation: (rule) =>
+        rule.custom(
+          (
+            value: { primaryColor?: string; accentColor?: string } | undefined,
+          ) => {
+            if (!value) return true
+            if (Boolean(value.primaryColor) !== Boolean(value.accentColor)) {
+              return 'Set both the primary and the accent color — or clear both'
+            }
+            return true
+          },
+        ),
       fields: [
         defineField({
           name: 'primaryColor',

--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -248,6 +248,50 @@ export default defineType({
         layout: 'radio',
       },
     }),
+    // Per-tenant brand theme (THEMING L1): an optional design-token override for
+    // the primary interactive colour and the gradient accent. ABSENT resolves to
+    // the house palette (Cloud Native Days blue) — existing tenants unchanged.
+    // Colours are used verbatim; contrast is the editor's responsibility (the
+    // admin settings preview shows the result). Edited through the dedicated
+    // ThemeEditor island via `conference.updateBranding`.
+    defineField({
+      name: 'theme',
+      title: 'Brand Theme (colors)',
+      type: 'object',
+      fieldset: 'branding',
+      description:
+        'Optional per-conference brand colors. Leave unset to use the default Cloud Native Days palette.',
+      fields: [
+        defineField({
+          name: 'primaryColor',
+          title: 'Primary Color',
+          type: 'string',
+          description:
+            'Primary interactive color (buttons, links, focus rings) and gradient start. 6-digit hex, e.g. #1D4ED8.',
+          validation: (rule) =>
+            rule
+              .regex(/^#[0-9a-fA-F]{6}$/, {
+                name: 'hex color',
+                invert: false,
+              })
+              .error('Enter a 6-digit hex color, e.g. #1D4ED8'),
+        }),
+        defineField({
+          name: 'accentColor',
+          title: 'Accent Color',
+          type: 'string',
+          description:
+            'Gradient endpoint / accent color. 6-digit hex, e.g. #06B6D4.',
+          validation: (rule) =>
+            rule
+              .regex(/^#[0-9a-fA-F]{6}$/, {
+                name: 'hex color',
+                invert: false,
+              })
+              .error('Enter a 6-digit hex color, e.g. #06B6D4'),
+        }),
+      ],
+    }),
 
     // === Important Dates ===
     defineField({

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -20,6 +20,7 @@ import {
   BrandingEditor,
   BrandingPreviewGrid,
 } from '@/components/admin/BrandingEditor'
+import { ThemeEditor, ThemeSwatchRow } from '@/components/admin/ThemeEditor'
 import {
   normalizeBackgroundPattern,
   type BackgroundPattern,
@@ -505,6 +506,7 @@ export default async function AdminSettings() {
                     ),
                   }}
                 />
+                <ThemeEditor initialTheme={conference.theme} />
                 <BrandingEditor
                   initialValues={{
                     logoBright: conference.logoBright,
@@ -532,6 +534,12 @@ export default async function AdminSettings() {
                 ]
               }
             />
+            <div className="border-t border-gray-100 pt-4 dark:border-gray-800">
+              <p className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+                Brand Colors
+              </p>
+              <ThemeSwatchRow theme={conference.theme} />
+            </div>
           </InfoCard>
 
           <InfoCard

--- a/src/app/manifest.test.ts
+++ b/src/app/manifest.test.ts
@@ -95,7 +95,7 @@ describe('manifest — per-host PWA identity', () => {
     expect(result.short_name).toBe('CND')
   })
 
-  it('keeps id/scope/start_url/theme_color host-invariant', async () => {
+  it('keeps id/scope/start_url host-invariant', async () => {
     withHost('2026.cloudnativebergen.dev')
     getConferenceForDomainMock.mockResolvedValue({
       conference: { title: 'Whatever Conf' },
@@ -108,7 +108,51 @@ describe('manifest — per-host PWA identity', () => {
     expect(result.id).toBe('/')
     expect(result.scope).toBe('/')
     expect(result.start_url).toBe('/launch')
-    expect(result.theme_color).toBe('#1d4ed8')
+  })
+
+  it('uses the house primary as theme_color when the conference has no theme', async () => {
+    withHost('2026.cloudnativebergen.dev')
+    getConferenceForDomainMock.mockResolvedValue({
+      conference: { title: 'Whatever Conf' },
+      domain: '2026.cloudnativebergen.dev',
+      error: null,
+    })
+
+    const result = await manifest()
+
+    expect(result.theme_color).toBe('#1D4ED8')
+  })
+
+  it('uses the conference theme primary as theme_color (THEMING L1)', async () => {
+    withHost('purple.example.dev')
+    getConferenceForDomainMock.mockResolvedValue({
+      conference: {
+        title: 'Purple Conf',
+        theme: { primaryColor: '#7C3AED', accentColor: '#22D3EE' },
+      },
+      domain: 'purple.example.dev',
+      error: null,
+    })
+
+    const result = await manifest()
+
+    expect(result.theme_color).toBe('#7C3AED')
+  })
+
+  it('ignores a malformed theme primary and falls back to the house blue', async () => {
+    withHost('bad.example.dev')
+    getConferenceForDomainMock.mockResolvedValue({
+      conference: {
+        title: 'Bad Conf',
+        theme: { primaryColor: 'not-a-color' },
+      },
+      domain: 'bad.example.dev',
+      error: null,
+    })
+
+    const result = await manifest()
+
+    expect(result.theme_color).toBe('#1D4ED8')
   })
 
   it('uses a short title verbatim as short_name', async () => {

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -3,6 +3,7 @@ import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
 import { normalizeDomain } from '@/lib/conference/domains'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
+import { DEFAULT_PRIMARY_COLOR, manifestThemeColor } from '@/lib/branding/theme'
 
 /**
  * Web app manifest (Next.js metadata route → `/manifest.webmanifest`).
@@ -14,10 +15,14 @@ import { getConferenceForDomain } from '@/lib/conference/sanity'
  * for the request host; when no conference resolves (e.g. localhost) it falls
  * back to the platform defaults below.
  *
- * `id`/`scope`/`start_url`/`theme_color` are intentionally left host-invariant:
- * `id`/`scope` anchor the installed app identity and `start_url` points at
- * `/launch` (a role-aware redirect dispatcher — see `src/app/launch/route.ts`).
- * `theme_color` stays platform-blue until the design-token wave.
+ * `id`/`scope`/`start_url` are intentionally left host-invariant: `id`/`scope`
+ * anchor the installed app identity and `start_url` points at `/launch` (a
+ * role-aware redirect dispatcher — see `src/app/launch/route.ts`).
+ *
+ * `theme_color` follows the per-tenant brand theme (THEMING L1): the resolved
+ * conference's primary hex, or the house blue when it has no theme (or no
+ * conference resolves). It is safe per-host for the same reason `name` is — a
+ * device only ever sees one host's manifest.
  *
  * Icons resolve per host via the dynamic `/pwa/icon/*` routes (each
  * conference's own `logomarkBright`, with a static fallback).
@@ -56,6 +61,7 @@ async function resolveManifestIdentity(host: string): Promise<{
   name: string
   shortName: string
   description: string
+  themeColor: string
 }> {
   'use cache'
   cacheLife('hours')
@@ -69,12 +75,14 @@ async function resolveManifestIdentity(host: string): Promise<{
         name: PLATFORM_NAME,
         shortName: PLATFORM_SHORT_NAME,
         description: PLATFORM_DESCRIPTION,
+        themeColor: DEFAULT_PRIMARY_COLOR,
       }
     }
     return {
       name: conference.title,
       shortName: toShortName(conference.title),
       description: conference.description || PLATFORM_DESCRIPTION,
+      themeColor: manifestThemeColor(conference.theme),
     }
   } catch {
     // A misconfigured/unreachable Sanity must never break the manifest; fall
@@ -83,6 +91,7 @@ async function resolveManifestIdentity(host: string): Promise<{
       name: PLATFORM_NAME,
       shortName: PLATFORM_SHORT_NAME,
       description: PLATFORM_DESCRIPTION,
+      themeColor: DEFAULT_PRIMARY_COLOR,
     }
   }
 }
@@ -92,7 +101,8 @@ export default async function manifest(): Promise<MetadataRoute.Manifest> {
   // case/whitespace, and the cache key + domain:<host> tag must match the
   // normalized form the rest of the per-host surface (and revalidations) use.
   const host = normalizeDomain((await headers()).get('host') || '')
-  const { name, shortName, description } = await resolveManifestIdentity(host)
+  const { name, shortName, description, themeColor } =
+    await resolveManifestIdentity(host)
 
   return {
     id: '/',
@@ -102,7 +112,7 @@ export default async function manifest(): Promise<MetadataRoute.Manifest> {
     start_url: '/launch',
     scope: '/',
     display: 'standalone',
-    theme_color: '#1d4ed8',
+    theme_color: themeColor,
     background_color: '#0b1220',
     icons: [
       {

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { headers } from 'next/headers'
 import { cacheLife, cacheTag } from 'next/cache'
+import { conferenceTag } from '@/lib/cache/tags'
 import { normalizeDomain } from '@/lib/conference/domains'
 import { getConferenceForDomain } from '@/lib/conference/sanity'
 import { DEFAULT_PRIMARY_COLOR, manifestThemeColor } from '@/lib/branding/theme'
@@ -70,6 +71,12 @@ async function resolveManifestIdentity(host: string): Promise<{
 
   try {
     const { conference, error } = await getConferenceForDomain(host)
+    // Tag with the resolved conference so a branding/theme save — which
+    // revalidates `conferenceTag(id)` — busts this cached manifest too;
+    // without it the theme_color would lag by up to the cacheLife window.
+    if (conference?._id) {
+      cacheTag(conferenceTag(conference._id))
+    }
     if (error || !conference?.title) {
       return {
         name: PLATFORM_NAME,

--- a/src/components/BrandThemeShowcase.stories.tsx
+++ b/src/components/BrandThemeShowcase.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ThemeProvider } from 'next-themes'
+import { Button } from './Button'
+import { ThemeStyle } from './ThemeStyle'
+import { type ConferenceTheme } from '@/lib/branding/theme'
+
+/**
+ * THEMING L1 visual proof. Renders the public brand surfaces that a per-tenant
+ * theme re-skins — the primary/outline Button, brand-text heading and the
+ * `bg-brand-gradient` hero — so a shoot can compare the DEFAULT (house blue) and
+ * a THEMED tenant, in light and dark.
+ *
+ * The themed sample renders the REAL {@link ThemeStyle}, which injects the
+ * `--brand-*` seam variables on `:root` — exactly what the tenant `Layout` does
+ * at runtime. The light brand tokens resolve the seam AT `:root` (an indirection
+ * `--color-brand-*: var(--brand-primary, …)`), so the override MUST live on
+ * `:root`; a descendant wrapper would not re-skin them. One story renders per
+ * capture iframe, so the `:root` injection is isolated per shot.
+ */
+
+function BrandSample({ theme }: { theme?: ConferenceTheme | null }) {
+  return (
+    <div className="mx-auto max-w-md space-y-6 p-6">
+      <ThemeStyle theme={theme} />
+      <p className="text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
+        {theme ? 'Themed tenant' : 'Default (house palette)'}
+      </p>
+
+      <div className="flex h-40 flex-col items-center justify-center rounded-2xl bg-brand-gradient px-6 text-center text-white shadow-lg">
+        <p className="text-2xl font-bold">Cloud Native Day</p>
+        <p className="mt-1 text-sm opacity-90">Bergen · 2026</p>
+      </div>
+
+      <h2 className="text-xl font-bold text-brand-cloud-blue">
+        A brand-coloured heading
+      </h2>
+
+      <div className="flex flex-wrap gap-3">
+        <Button variant="primary" size="md">
+          Register now
+        </Button>
+        <Button variant="outline" size="md">
+          Submit a talk
+        </Button>
+      </div>
+
+      <div className="rounded-xl border-2 border-brand-cloud-blue p-4">
+        <p className="text-sm font-medium text-brand-cloud-blue">
+          Bordered callout using the brand colour.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+const PURPLE: ConferenceTheme = {
+  primaryColor: '#7C3AED',
+  accentColor: '#F59E0B',
+}
+
+// A second tenant to show the seam is not hard-coded to one hue.
+const TEAL: ConferenceTheme = {
+  primaryColor: '#0D9488',
+  accentColor: '#84CC16',
+}
+
+const meta = {
+  title: 'Systems/Branding/BrandThemeShowcase',
+  component: BrandSample,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Public brand surfaces under THEMING L1. Compare Default vs Themed to confirm the token seam re-skins the primary colour, brand gradient and brand text — while the Default stays pixel-identical to the house palette.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <div className={dark ? 'dark' : ''}>
+            <div className="min-h-screen bg-white dark:bg-gray-950">
+              <Story />
+            </div>
+          </div>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof BrandSample>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = { args: { theme: null } }
+export const DefaultDark: Story = {
+  args: { theme: null },
+  parameters: { theme: 'dark' },
+}
+
+export const ThemedPurple: Story = { args: { theme: PURPLE } }
+export const ThemedPurpleDark: Story = {
+  args: { theme: PURPLE },
+  parameters: { theme: 'dark' },
+}
+
+export const ThemedTeal: Story = { args: { theme: TEAL } }
+export const ThemedTealDark: Story = {
+  args: { theme: TEAL },
+  parameters: { theme: 'dark' },
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Footer } from '@/components/Footer'
 import { Header } from '@/components/Header'
 import { BackgroundPatternProvider } from '@/components/BackgroundPatternProvider'
+import { ThemeStyle } from '@/components/ThemeStyle'
 import { normalizeBackgroundPattern } from '@/lib/conference/backgroundPattern'
 import { Conference } from '@/lib/conference/types'
 
@@ -17,6 +18,7 @@ export async function Layout({
     <BackgroundPatternProvider
       pattern={normalizeBackgroundPattern(conference.backgroundPattern)}
     >
+      <ThemeStyle theme={conference.theme} />
       <Header c={conference} />
       <main className="flex-auto">{children}</main>
       {showFooter && <Footer c={conference} />}

--- a/src/components/ThemeStyle.test.tsx
+++ b/src/components/ThemeStyle.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { ThemeStyle } from './ThemeStyle'
+
+afterEach(cleanup)
+
+describe('ThemeStyle injection', () => {
+  it('renders nothing when there is no theme (default output is untouched)', () => {
+    const { container } = render(<ThemeStyle theme={undefined} />)
+    expect(container.querySelector('style')).toBeNull()
+  })
+
+  it('renders nothing when the theme carries only invalid colours', () => {
+    const { container } = render(
+      <ThemeStyle theme={{ primaryColor: 'not-a-hex' }} />,
+    )
+    expect(container.querySelector('style')).toBeNull()
+  })
+
+  it('injects a :root style setting the brand vars when themed', () => {
+    const { container } = render(
+      <ThemeStyle
+        theme={{ primaryColor: '#7C3AED', accentColor: '#22D3EE' }}
+      />,
+    )
+    const style = container.querySelector('style[data-tenant-theme]')
+    expect(style).not.toBeNull()
+    const css = style!.innerHTML
+    expect(css).toContain(':root{')
+    expect(css).toContain('--brand-primary:#7C3AED')
+    expect(css).toContain('--brand-accent:#22D3EE')
+    expect(css).toContain('--brand-primary-hover:color-mix')
+  })
+})

--- a/src/components/ThemeStyle.tsx
+++ b/src/components/ThemeStyle.tsx
@@ -18,8 +18,10 @@ export function ThemeStyle({ theme }: { theme?: ConferenceTheme | null }) {
   const css = conferenceThemeCss(theme)
   if (!css) return null
   return (
-    // The content is machine-generated from validated hex colours (see
-    // `conferenceThemeCss`), never raw user markup.
-    <style data-tenant-theme dangerouslySetInnerHTML={{ __html: css }} />
+    // Rendered as text children (not dangerouslySetInnerHTML): the CSS is
+    // machine-generated from validated hex colours and contains none of the
+    // characters React escapes, so children are equivalent — and keep React's
+    // escaping as a backstop if the generator ever grows beyond hex tokens.
+    <style data-tenant-theme>{css}</style>
   )
 }

--- a/src/components/ThemeStyle.tsx
+++ b/src/components/ThemeStyle.tsx
@@ -1,0 +1,25 @@
+import { conferenceThemeCss, type ConferenceTheme } from '@/lib/branding/theme'
+
+/**
+ * Injects a conference's per-tenant brand theme (THEMING L1) as a single
+ * `<style>` setting the `--brand-*` custom properties on `:root`. Rendered by
+ * the tenant `Layout` (which has already domain-resolved the conference), so it
+ * is per-tenant by construction and cached with the rest of that layout.
+ *
+ * When the conference has no theme (or only invalid colours), `conferenceThemeCss`
+ * returns an empty string and NOTHING is rendered — the default site output
+ * stays byte-identical, which is the L1 no-visual-change guarantee.
+ *
+ * The style tag reads the same `--brand-*` variables that both the light and the
+ * dark brand rules fall back through, so this one `:root` block re-skins both
+ * colour schemes without a `.dark` override.
+ */
+export function ThemeStyle({ theme }: { theme?: ConferenceTheme | null }) {
+  const css = conferenceThemeCss(theme)
+  if (!css) return null
+  return (
+    // The content is machine-generated from validated hex colours (see
+    // `conferenceThemeCss`), never raw user markup.
+    <style data-tenant-theme dangerouslySetInnerHTML={{ __html: css }} />
+  )
+}

--- a/src/components/admin/ThemeEditor.stories.tsx
+++ b/src/components/admin/ThemeEditor.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, screen, userEvent, waitFor } from 'storybook/test'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { ThemeEditor, ThemeSwatchRow } from './ThemeEditor'
+import { NotificationProvider } from './NotificationProvider'
+import type { ConferenceTheme } from '@/lib/branding/theme'
+
+const PURPLE: ConferenceTheme = {
+  primaryColor: '#7C3AED',
+  accentColor: '#22D3EE',
+}
+
+const ok = (data: unknown) => () => HttpResponse.json({ result: { data } })
+
+const handlers = [
+  http.post(
+    '/api/trpc/conference.updateBranding',
+    ok({ success: true, updated: {} }),
+  ),
+]
+
+const meta = {
+  title: 'Systems/Settings/Admin/ThemeEditor',
+  component: ThemeEditor,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'THEMING L1 — the per-conference brand-colour editor. Sets the conference `theme` object (primary + accent) through `conference.updateBranding`. The live preview shows a button, heading and gradient in the chosen colours; colours are applied verbatim (no contrast auto-derivation). "Reset to default" clears the override.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-gray-50 p-6 dark:bg-gray-950">
+                <Story />
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof ThemeEditor>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** The read-only Branding-card body as the settings page renders it. */
+function Card({ theme }: { theme?: ConferenceTheme | null }) {
+  return (
+    <div className="mx-auto max-w-xl rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+      <h3 className="mb-4 text-lg font-medium text-gray-900 dark:text-white">
+        Brand Colors
+      </h3>
+      <ThemeSwatchRow theme={theme} />
+    </div>
+  )
+}
+
+/** Card body: no override → house-palette note. */
+export const CardDefault: Story = {
+  args: {},
+  render: () => <Card theme={undefined} />,
+}
+
+/** Card body: a themed conference shows its two swatches + hex values. */
+export const CardThemed: Story = {
+  args: { initialTheme: PURPLE },
+  render: () => <Card theme={PURPLE} />,
+}
+
+export const CardThemedDark: Story = {
+  ...CardThemed,
+  parameters: { theme: 'dark' },
+}
+
+/** The editor modal, opened, seeded with the house defaults (no override yet). */
+export const ModalDefault: Story = {
+  args: { defaultOpen: true },
+}
+
+export const ModalDefaultDark: Story = {
+  ...ModalDefault,
+  parameters: { theme: 'dark' },
+}
+
+/** The editor modal, opened, seeded with an existing purple/cyan theme. */
+export const ModalThemed: Story = {
+  args: { initialTheme: PURPLE, defaultOpen: true },
+}
+
+export const ModalThemedDark: Story = {
+  ...ModalThemed,
+  parameters: { theme: 'dark' },
+}
+
+/**
+ * Interaction test: typing an invalid hex disables Save and shows the field
+ * error; correcting it re-enables Save and updates the live preview swatch.
+ */
+export const ValidationFlow: Story = {
+  args: { defaultOpen: true },
+  play: async () => {
+    const primary = screen.getByLabelText<HTMLInputElement>('Primary Color', {
+      selector: 'input#theme-primary-hex',
+    })
+    await userEvent.clear(primary)
+    await userEvent.type(primary, '#12345g')
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/6-digit hex color/i).length).toBeGreaterThan(
+        0,
+      ),
+    )
+    const save = screen.getByRole('button', { name: /save colors/i })
+    expect(save).toBeDisabled()
+
+    await userEvent.clear(primary)
+    await userEvent.type(primary, '#10b981')
+    await waitFor(() => expect(save).toBeEnabled())
+  },
+}

--- a/src/components/admin/ThemeEditor.tsx
+++ b/src/components/admin/ThemeEditor.tsx
@@ -1,0 +1,376 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { SwatchIcon, ArrowUturnLeftIcon } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { api } from '@/lib/trpc/client'
+import { useNotification } from './NotificationProvider'
+import {
+  DEFAULT_ACCENT_COLOR,
+  DEFAULT_PRIMARY_COLOR,
+  isHexColor,
+  type ConferenceTheme,
+} from '@/lib/branding/theme'
+
+/**
+ * THEMING L1 — the per-conference brand-colour editor island + read-only swatch
+ * preview. Sits on the settings Branding card alongside the background-pattern
+ * and logo editors, and patches the conference `theme` object through the shared
+ * `conference.updateBranding` mutation (validated by `UpdateBrandingSchema`).
+ *
+ * L1 knobs: `primaryColor` (interactive colour + gradient start) and
+ * `accentColor` (gradient endpoint). Colours are used verbatim — the live
+ * preview shows a Button, heading and gradient in the chosen colours so the
+ * editor can judge contrast themselves (L1 does not auto-derive or clamp).
+ * "Reset to default" clears the override (sends `theme: null`).
+ */
+
+/** Normalise free text into a candidate hex string (adds a leading `#`). */
+function normalizeHexInput(raw: string): string {
+  const trimmed = raw.trim()
+  if (trimmed === '') return ''
+  return trimmed.startsWith('#') ? trimmed : `#${trimmed}`
+}
+
+export interface ThemeEditorProps {
+  initialTheme?: ConferenceTheme | null
+  /** Render the modal open on mount — for stories/tests only. */
+  defaultOpen?: boolean
+}
+
+export function ThemeEditor({
+  initialTheme,
+  defaultOpen = false,
+}: ThemeEditorProps) {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const [primary, setPrimary] = useState(
+    initialTheme?.primaryColor ?? DEFAULT_PRIMARY_COLOR,
+  )
+  const [accent, setAccent] = useState(
+    initialTheme?.accentColor ?? DEFAULT_ACCENT_COLOR,
+  )
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const mutation = api.conference.updateBranding.useMutation({
+    onSuccess: () => {
+      void utils.invalidate()
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Theme updated',
+        message: 'Conference brand colors were saved.',
+      })
+      setIsOpen(false)
+    },
+    onError: (error) => {
+      setSubmitError(error.message || 'Failed to save. Please try again.')
+      showNotification({
+        type: 'error',
+        title: 'Could not save',
+        message: error.message || 'Failed to save brand colors.',
+      })
+    },
+  })
+
+  const reset = () => {
+    setPrimary(initialTheme?.primaryColor ?? DEFAULT_PRIMARY_COLOR)
+    setAccent(initialTheme?.accentColor ?? DEFAULT_ACCENT_COLOR)
+    setSubmitError(null)
+  }
+  const openModal = () => {
+    reset()
+    setIsOpen(true)
+  }
+  const closeModal = () => {
+    setIsOpen(false)
+    reset()
+  }
+
+  const primaryValid = isHexColor(primary)
+  const accentValid = isHexColor(accent)
+  const canSave = primaryValid && accentValid && !mutation.isPending
+
+  const isOverridden = Boolean(
+    initialTheme?.primaryColor || initialTheme?.accentColor,
+  )
+
+  const handleSave = () => {
+    setSubmitError(null)
+    if (!canSave) return
+    mutation.mutate({
+      theme: { primaryColor: primary.trim(), accentColor: accent.trim() },
+    })
+  }
+
+  const handleResetToDefault = () => {
+    setSubmitError(null)
+    // An explicit null unsets the field → the conference reverts to the house
+    // palette. Only meaningful when an override currently exists.
+    mutation.mutate({ theme: null })
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openModal}
+        aria-label="Edit Brand Colors"
+        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+      >
+        <SwatchIcon className="h-5 w-5" />
+      </button>
+
+      <ModalShell
+        isOpen={isOpen}
+        onClose={closeModal}
+        size="lg"
+        title="Edit Brand Colors"
+        subtitle="Primary interactive color and gradient accent for the public site"
+        icon={<SwatchIcon className="h-5 w-5" />}
+      >
+        <form
+          noValidate
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSave()
+          }}
+          className="space-y-5"
+        >
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <ColorField
+              id="theme-primary"
+              label="Primary Color"
+              hint="Buttons, links, focus rings and the gradient start."
+              value={primary}
+              valid={primaryValid}
+              onChange={setPrimary}
+            />
+            <ColorField
+              id="theme-accent"
+              label="Accent Color"
+              hint="The gradient endpoint that pairs with the primary."
+              value={accent}
+              valid={accentValid}
+              onChange={setAccent}
+            />
+          </div>
+
+          <ThemePreview primary={primary} accent={accent} />
+
+          <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+            Colors are applied exactly as entered — the preview above is what
+            visitors see. Check that text stays readable on your primary color;
+            it is not adjusted automatically.
+          </p>
+
+          {submitError ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:items-center sm:justify-between">
+            {isOverridden ? (
+              <AdminButton
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={handleResetToDefault}
+                disabled={mutation.isPending}
+                className="min-h-[44px] sm:mr-auto"
+              >
+                <ArrowUturnLeftIcon className="mr-1.5 h-4 w-4" />
+                Reset to default
+              </AdminButton>
+            ) : (
+              <span className="hidden sm:block" />
+            )}
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <AdminButton
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={closeModal}
+                disabled={mutation.isPending}
+                className="min-h-[44px]"
+              >
+                Cancel
+              </AdminButton>
+              <AdminButton
+                type="submit"
+                color="blue"
+                size="md"
+                disabled={!canSave}
+                className="min-h-[44px]"
+              >
+                {mutation.isPending ? 'Saving…' : 'Save colors'}
+              </AdminButton>
+            </div>
+          </div>
+        </form>
+      </ModalShell>
+    </>
+  )
+}
+
+const inputClass =
+  'block w-full min-h-[44px] rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+
+/** A native colour picker + synced hex text field for one colour. */
+function ColorField({
+  id,
+  label,
+  hint,
+  value,
+  valid,
+  onChange,
+}: {
+  id: string
+  label: string
+  hint: string
+  value: string
+  valid: boolean
+  onChange: (value: string) => void
+}) {
+  // The native <input type="color"> needs a well-formed value; fall back to a
+  // neutral swatch while the text field holds an invalid draft.
+  const swatch = valid ? value : '#000000'
+  return (
+    <div>
+      <label
+        htmlFor={`${id}-hex`}
+        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          aria-label={`${label} picker`}
+          value={swatch}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-11 w-14 shrink-0 cursor-pointer rounded-lg border border-gray-300 bg-white p-1 dark:border-gray-600 dark:bg-gray-700"
+        />
+        <input
+          id={`${id}-hex`}
+          type="text"
+          inputMode="text"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          value={value}
+          aria-invalid={valid ? undefined : true}
+          aria-describedby={valid ? `${id}-hint` : `${id}-error`}
+          onChange={(e) => onChange(normalizeHexInput(e.target.value))}
+          placeholder="#1D4ED8"
+          className={`${inputClass} font-mono`}
+        />
+      </div>
+      {valid ? (
+        <p
+          id={`${id}-hint`}
+          className="mt-1 text-xs text-gray-500 dark:text-gray-400"
+        >
+          {hint}
+        </p>
+      ) : (
+        <p
+          id={`${id}-error`}
+          role="alert"
+          className="mt-1 text-xs text-red-600 dark:text-red-400"
+        >
+          Enter a 6-digit hex color, e.g. #1D4ED8
+        </p>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Live preview swatch row — a Button, a heading and the brand gradient rendered
+ * in the chosen colours (applied inline so the sample is exact regardless of the
+ * surrounding document theme).
+ */
+function ThemePreview({
+  primary,
+  accent,
+}: {
+  primary: string
+  accent: string
+}) {
+  const p = isHexColor(primary) ? primary : DEFAULT_PRIMARY_COLOR
+  const a = isHexColor(accent) ? accent : DEFAULT_ACCENT_COLOR
+  return (
+    <div className="space-y-3 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+      <p className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+        Preview
+      </p>
+      <div className="flex flex-wrap items-center gap-3">
+        <span
+          className="inline-flex min-h-[40px] items-center rounded-full px-5 text-sm font-semibold text-white shadow-sm"
+          style={{ backgroundColor: p }}
+        >
+          Primary button
+        </span>
+        <span className="text-lg font-semibold" style={{ color: p }}>
+          Heading sample
+        </span>
+      </div>
+      <div
+        className="flex h-14 items-center justify-center rounded-lg text-sm font-semibold text-white"
+        style={{ backgroundImage: `linear-gradient(135deg, ${p}, ${a})` }}
+      >
+        Brand gradient
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Read-only theme summary for the settings card body: the two swatches + hex
+ * values when a theme is set, or a "default palette" note when it is not.
+ */
+export function ThemeSwatchRow({ theme }: { theme?: ConferenceTheme | null }) {
+  const overridden = Boolean(theme?.primaryColor || theme?.accentColor)
+  if (!overridden) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        Using the default Cloud Native Days palette.
+      </p>
+    )
+  }
+  const primary = theme?.primaryColor ?? DEFAULT_PRIMARY_COLOR
+  const accent = theme?.accentColor ?? DEFAULT_ACCENT_COLOR
+  return (
+    <div className="flex flex-wrap gap-4">
+      <Swatch label="Primary" value={primary} />
+      <Swatch label="Accent" value={accent} />
+    </div>
+  )
+}
+
+function Swatch({ label, value }: { label: string; value: string }) {
+  const safe = isHexColor(value) ? value : '#000000'
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className="h-8 w-8 shrink-0 rounded-md border border-gray-200 dark:border-gray-700"
+        style={{ backgroundColor: safe }}
+        aria-hidden="true"
+      />
+      <div className="text-xs">
+        <p className="font-medium text-gray-700 dark:text-gray-300">{label}</p>
+        <p className="font-mono text-gray-500 dark:text-gray-400">{value}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/ThemeEditor.tsx
+++ b/src/components/admin/ThemeEditor.tsx
@@ -103,8 +103,16 @@ export function ThemeEditor({
   const handleSave = () => {
     setSubmitError(null)
     if (!canSave) return
+    // Saving the untouched house defaults must NOT persist a theme object:
+    // "no theme" means "follow the evolving house palette" (and no injected
+    // color-mix hover), whereas an explicit theme pins today's values forever.
+    const p = primary.trim()
+    const a = accent.trim()
+    const isHouseDefault =
+      p.toLowerCase() === DEFAULT_PRIMARY_COLOR.toLowerCase() &&
+      a.toLowerCase() === DEFAULT_ACCENT_COLOR.toLowerCase()
     mutation.mutate({
-      theme: { primaryColor: primary.trim(), accentColor: accent.trim() },
+      theme: isHouseDefault ? null : { primaryColor: p, accentColor: a },
     })
   }
 

--- a/src/components/email/BaseEmailTemplate.tsx
+++ b/src/components/email/BaseEmailTemplate.tsx
@@ -1,14 +1,17 @@
 import * as React from 'react'
 import { iconForLink, titleForLink } from '../SocialIcons'
 
+import { DEFAULT_PRIMARY_COLOR } from '@/lib/branding/theme'
+
 /**
- * The default brand accent (Cloud Native Days blue). Overridable per-send via
- * `brandColor` so a tenant's mail can carry its own accent; full design-token
- * theming lands later — this is the neutral-correctness seam (go-live gate G2,
- * E8). The base template's footer already names the sender via `eventName`, so
- * no hardcoded brand name remains here.
+ * The default brand PRIMARY (Cloud Native Days blue) — re-exported from the
+ * theming core so the email default can never drift from the house palette.
+ * Overridable per-send via `brandColor` so a tenant's mail can carry its own
+ * primary; full design-token theming lands later — this is the
+ * neutral-correctness seam (go-live gate G2, E8). The base template's footer
+ * already names the sender via `eventName`, so no hardcoded brand name remains.
  */
-export const DEFAULT_EMAIL_BRAND_COLOR = '#1D4ED8'
+export const DEFAULT_EMAIL_BRAND_COLOR = DEFAULT_PRIMARY_COLOR
 
 interface BaseEmailTemplateProps {
   title?: string

--- a/src/components/email/ProposalAcceptTemplate.tsx
+++ b/src/components/email/ProposalAcceptTemplate.tsx
@@ -18,6 +18,7 @@ export function ProposalAcceptTemplate({
   confirmUrl,
   comment,
   socialLinks = [],
+  brandColor,
 }: ProposalAcceptTemplateProps) {
   const congratsText = (
     <p
@@ -87,6 +88,7 @@ export function ProposalAcceptTemplate({
       eventDate={eventDate}
       eventUrl={eventUrl}
       socialLinks={socialLinks}
+      brandColor={brandColor}
       showMessagesLink
       footer={footer}
     >

--- a/src/components/email/ProposalRejectTemplate.tsx
+++ b/src/components/email/ProposalRejectTemplate.tsx
@@ -12,6 +12,7 @@ export function ProposalRejectTemplate({
   eventUrl,
   comment,
   socialLinks = [],
+  brandColor,
 }: ProposalRejectTemplateProps) {
   const decisionText = (
     <p
@@ -81,6 +82,7 @@ export function ProposalRejectTemplate({
       eventDate={eventDate}
       eventUrl={eventUrl}
       socialLinks={socialLinks}
+      brandColor={brandColor}
       showMessagesLink
       footer={footer}
     >

--- a/src/components/email/ProposalWaitlistTemplate.tsx
+++ b/src/components/email/ProposalWaitlistTemplate.tsx
@@ -12,6 +12,7 @@ export function ProposalWaitlistTemplate({
   eventUrl,
   comment,
   socialLinks = [],
+  brandColor,
 }: BaseEmailTemplateProps) {
   const waitlistText = (
     <p
@@ -84,6 +85,7 @@ export function ProposalWaitlistTemplate({
       eventDate={eventDate}
       eventUrl={eventUrl}
       socialLinks={socialLinks}
+      brandColor={brandColor}
       showMessagesLink
       footer={footer}
     >

--- a/src/lib/branding/theme.test.ts
+++ b/src/lib/branding/theme.test.ts
@@ -59,17 +59,9 @@ describe('conferenceThemeCss — token resolution', () => {
     expect(css.endsWith('}')).toBe(true)
   })
 
-  it('emits only the primary when accent is absent', () => {
-    const css = conferenceThemeCss({ primaryColor: '#7C3AED' })
-    expect(css).toContain('--brand-primary:#7C3AED')
-    expect(css).toContain('--brand-primary-hover:')
-    expect(css).not.toContain('--brand-accent')
-  })
-
-  it('emits only the accent when primary is absent', () => {
-    const css = conferenceThemeCss({ accentColor: '#22D3EE' })
-    expect(css).toContain('--brand-accent:#22D3EE')
-    expect(css).not.toContain('--brand-primary')
+  it('emits nothing for a half-theme (all-or-nothing, matching the write-path pair contract)', () => {
+    expect(conferenceThemeCss({ primaryColor: '#7C3AED' })).toBe('')
+    expect(conferenceThemeCss({ accentColor: '#22D3EE' })).toBe('')
   })
 
   it('ignores malformed colours (defence in depth) and emits nothing', () => {
@@ -80,8 +72,12 @@ describe('conferenceThemeCss — token resolution', () => {
   })
 
   it('trims surrounding whitespace before validating', () => {
-    const css = conferenceThemeCss({ primaryColor: '  #1D4ED8  ' })
+    const css = conferenceThemeCss({
+      primaryColor: '  #1D4ED8  ',
+      accentColor: ' #06B6D4 ',
+    })
     expect(css).toContain('--brand-primary:#1D4ED8')
+    expect(css).toContain('--brand-accent:#06B6D4')
   })
 })
 

--- a/src/lib/branding/theme.test.ts
+++ b/src/lib/branding/theme.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import {
+  conferenceThemeCss,
+  emailBrandColor,
+  manifestThemeColor,
+  isHexColor,
+  DEFAULT_PRIMARY_COLOR,
+  DEFAULT_ACCENT_COLOR,
+} from './theme'
+
+describe('isHexColor', () => {
+  it('accepts 6-digit hex, any case', () => {
+    expect(isHexColor('#1d4ed8')).toBe(true)
+    expect(isHexColor('#1D4ED8')).toBe(true)
+    expect(isHexColor('#ABCDEF')).toBe(true)
+  })
+
+  it('rejects malformed values', () => {
+    expect(isHexColor('1d4ed8')).toBe(false) // missing #
+    expect(isHexColor('#fff')).toBe(false) // 3-digit
+    expect(isHexColor('#1d4ed88')).toBe(false) // 7 digits
+    expect(isHexColor('#12345g')).toBe(false) // non-hex char
+    expect(isHexColor('rebeccapurple')).toBe(false)
+    expect(isHexColor('')).toBe(false)
+    expect(isHexColor(undefined)).toBe(false)
+    expect(isHexColor(null)).toBe(false)
+    expect(isHexColor(123)).toBe(false)
+  })
+})
+
+describe('conferenceThemeCss — token resolution', () => {
+  it('returns an empty string when no theme is present (default = pixel-identical)', () => {
+    expect(conferenceThemeCss(undefined)).toBe('')
+    expect(conferenceThemeCss(null)).toBe('')
+    expect(conferenceThemeCss({})).toBe('')
+  })
+
+  it('emits primary + derived hover + accent for a full theme', () => {
+    const css = conferenceThemeCss({
+      primaryColor: '#7C3AED',
+      accentColor: '#22D3EE',
+    })
+    expect(css).toContain('--brand-primary:#7C3AED')
+    expect(css).toContain('--brand-accent:#22D3EE')
+    // Hover is a darker primary, derived in pure CSS.
+    expect(css).toContain(
+      '--brand-primary-hover:color-mix(in srgb, #7C3AED 85%, #000)',
+    )
+    // A single :root block drives both light and dark.
+    expect(css.startsWith(':root{')).toBe(true)
+    expect(css.endsWith('}')).toBe(true)
+  })
+
+  it('emits only the primary when accent is absent', () => {
+    const css = conferenceThemeCss({ primaryColor: '#7C3AED' })
+    expect(css).toContain('--brand-primary:#7C3AED')
+    expect(css).toContain('--brand-primary-hover:')
+    expect(css).not.toContain('--brand-accent')
+  })
+
+  it('emits only the accent when primary is absent', () => {
+    const css = conferenceThemeCss({ accentColor: '#22D3EE' })
+    expect(css).toContain('--brand-accent:#22D3EE')
+    expect(css).not.toContain('--brand-primary')
+  })
+
+  it('ignores malformed colours (defence in depth) and emits nothing', () => {
+    expect(conferenceThemeCss({ primaryColor: 'purple' })).toBe('')
+    expect(
+      conferenceThemeCss({ primaryColor: '#fff', accentColor: '#zzz' }),
+    ).toBe('')
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    const css = conferenceThemeCss({ primaryColor: '  #1D4ED8  ' })
+    expect(css).toContain('--brand-primary:#1D4ED8')
+  })
+})
+
+describe('emailBrandColor / manifestThemeColor', () => {
+  it('returns the primary hex when themed', () => {
+    expect(emailBrandColor({ primaryColor: '#7C3AED' })).toBe('#7C3AED')
+    expect(manifestThemeColor({ primaryColor: '#7C3AED' })).toBe('#7C3AED')
+  })
+
+  it('falls back to the house blue when unthemed or invalid', () => {
+    expect(emailBrandColor(undefined)).toBe(DEFAULT_PRIMARY_COLOR)
+    expect(emailBrandColor({})).toBe(DEFAULT_PRIMARY_COLOR)
+    expect(emailBrandColor({ primaryColor: 'nope' })).toBe(
+      DEFAULT_PRIMARY_COLOR,
+    )
+    expect(manifestThemeColor(null)).toBe(DEFAULT_PRIMARY_COLOR)
+  })
+})
+
+describe('house defaults', () => {
+  it('match the tailwind.css seam fallbacks', () => {
+    // These MUST equal the fallbacks in src/styles/tailwind.css or the injected
+    // override and the CSS default would disagree.
+    expect(DEFAULT_PRIMARY_COLOR.toLowerCase()).toBe('#1d4ed8')
+    expect(DEFAULT_ACCENT_COLOR.toLowerCase()).toBe('#06b6d4')
+  })
+})

--- a/src/lib/branding/theme.test.ts
+++ b/src/lib/branding/theme.test.ts
@@ -82,9 +82,19 @@ describe('conferenceThemeCss — token resolution', () => {
 })
 
 describe('emailBrandColor / manifestThemeColor', () => {
-  it('returns the primary hex when themed', () => {
-    expect(emailBrandColor({ primaryColor: '#7C3AED' })).toBe('#7C3AED')
-    expect(manifestThemeColor({ primaryColor: '#7C3AED' })).toBe('#7C3AED')
+  it('returns the primary hex when fully themed', () => {
+    const theme = { primaryColor: '#7C3AED', accentColor: '#22D3EE' }
+    expect(emailBrandColor(theme)).toBe('#7C3AED')
+    expect(manifestThemeColor(theme)).toBe('#7C3AED')
+  })
+
+  it('treats a half-theme as unthemed (consistent with the CSS seam)', () => {
+    expect(emailBrandColor({ primaryColor: '#7C3AED' })).toBe(
+      DEFAULT_PRIMARY_COLOR,
+    )
+    expect(manifestThemeColor({ accentColor: '#22D3EE' })).toBe(
+      DEFAULT_PRIMARY_COLOR,
+    )
   })
 
   it('falls back to the house blue when unthemed or invalid', () => {

--- a/src/lib/branding/theme.test.ts
+++ b/src/lib/branding/theme.test.ts
@@ -42,9 +42,17 @@ describe('conferenceThemeCss — token resolution', () => {
     })
     expect(css).toContain('--brand-primary:#7C3AED')
     expect(css).toContain('--brand-accent:#22D3EE')
-    // Hover is a darker primary, derived in pure CSS.
+    // Hover is a darker primary, derived in pure CSS — but the color-mix()
+    // upgrade lives behind @supports, with the primary itself as the base
+    // fallback (an unsupported function in a custom property would otherwise
+    // drop the hover rule entirely at var() substitution time).
+    expect(css).toContain('--brand-primary-hover:#7C3AED')
     expect(css).toContain(
-      '--brand-primary-hover:color-mix(in srgb, #7C3AED 85%, #000)',
+      '@supports (color: color-mix(in srgb, red 50%, blue)){:root{--brand-primary-hover:color-mix(in srgb, #7C3AED 85%, #000)}}',
+    )
+    // The safe fallback precedes the @supports upgrade.
+    expect(css.indexOf('--brand-primary-hover:#7C3AED')).toBeLessThan(
+      css.indexOf('@supports'),
     )
     // A single :root block drives both light and dark.
     expect(css.startsWith(':root{')).toBe(true)

--- a/src/lib/branding/theme.ts
+++ b/src/lib/branding/theme.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-tenant brand theme resolution (THEMING L1).
+ *
+ * A conference may carry an optional `theme` object overriding the site's two
+ * L1 brand knobs:
+ *   - `primaryColor` — the primary interactive colour (buttons, links, focus
+ *     rings, the gradient START). Drives `--brand-primary`.
+ *   - `accentColor`  — the gradient ENDPOINT / accent. Drives `--brand-accent`.
+ *
+ * These map onto the CSS custom-property seam in `src/styles/tailwind.css`
+ * (`--color-brand-cloud-blue`, `--color-brand-cloud-blue-hover`,
+ * `--color-brand-aqua-end` and the brand gradient all resolve through them,
+ * with the house hex as the FALLBACK). With no theme the site renders
+ * pixel-identical; with one, a single `:root` block re-skins light AND dark.
+ *
+ * L1 constraint: colours are used VERBATIM. No contrast auto-derivation and no
+ * clamping — a light primary on a white surface is the admin's call (the
+ * settings preview surfaces the result before they save). The one derived value
+ * is the hover shade, computed in pure CSS via `color-mix` (a darker primary),
+ * which only ever appears in the injected override, never in the default path.
+ */
+
+/** A 6-digit hex colour, e.g. `#1D4ED8`. Case-insensitive; `#` required. */
+export const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
+
+export interface ConferenceTheme {
+  /** Primary interactive colour + gradient start. */
+  primaryColor?: string
+  /** Gradient endpoint / accent colour. */
+  accentColor?: string
+}
+
+/** House defaults — the Cloud Native Days Norway palette (see tailwind.css). */
+export const DEFAULT_PRIMARY_COLOR = '#1D4ED8'
+export const DEFAULT_ACCENT_COLOR = '#06B6D4'
+
+/** True when `value` is a syntactically valid 6-digit hex colour. */
+export function isHexColor(value: unknown): value is string {
+  return typeof value === 'string' && HEX_COLOR_RE.test(value.trim())
+}
+
+/**
+ * Build the `<style>` body that injects a conference's theme onto `:root`.
+ * Returns an EMPTY string when there is nothing to override (no theme, or no
+ * valid colour) — callers render no `<style>` at all in that case, keeping the
+ * default output byte-identical.
+ *
+ * Only well-formed hex values are emitted; a malformed stored value is ignored
+ * (defence in depth — the schema already rejects them on write). The hover
+ * shade is derived from the primary purely in CSS so no colour maths lives here.
+ */
+export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
+  if (!theme) return ''
+
+  const decls: string[] = []
+
+  const primary = theme.primaryColor?.trim()
+  if (primary && isHexColor(primary)) {
+    decls.push(`--brand-primary:${primary}`)
+    // L1 hover = a slightly darker primary, derived in pure CSS (no derivation
+    // logic in TS). color-mix is only ever emitted here, never on the default
+    // path, so it can't affect the no-override pixel-identity guarantee.
+    decls.push(`--brand-primary-hover:color-mix(in srgb, ${primary} 85%, #000)`)
+  }
+
+  const accent = theme.accentColor?.trim()
+  if (accent && isHexColor(accent)) {
+    decls.push(`--brand-accent:${accent}`)
+  }
+
+  if (decls.length === 0) return ''
+  return `:root{${decls.join(';')}}`
+}
+
+/**
+ * The brand accent colour for a conference's outbound email (BaseEmailTemplate
+ * `brandColor`). Email cannot read CSS custom properties, so senders resolve the
+ * primary hex here and pass it explicitly. Falls back to the house blue when no
+ * theme is set — the same default `BaseEmailTemplate` already uses.
+ */
+export function emailBrandColor(theme?: ConferenceTheme | null): string {
+  const primary = theme?.primaryColor?.trim()
+  return primary && isHexColor(primary) ? primary : DEFAULT_PRIMARY_COLOR
+}
+
+/**
+ * The PWA manifest `theme_color` for a conference. Same resolution as email:
+ * the primary hex when themed, else the house blue.
+ */
+export function manifestThemeColor(theme?: ConferenceTheme | null): string {
+  return emailBrandColor(theme)
+}

--- a/src/lib/branding/theme.ts
+++ b/src/lib/branding/theme.ts
@@ -96,8 +96,14 @@ export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
  * theme is set — the same default `BaseEmailTemplate` already uses.
  */
 export function emailBrandColor(theme?: ConferenceTheme | null): string {
+  // Same ALL-OR-NOTHING pair rule as `conferenceThemeCss`: a half-theme
+  // (legacy/malformed data) is unthemed EVERYWHERE — site, email and manifest
+  // must never disagree about whether a tenant is themed.
   const primary = theme?.primaryColor?.trim()
-  return primary && isHexColor(primary) ? primary : DEFAULT_PRIMARY_COLOR
+  const accent = theme?.accentColor?.trim()
+  const isCompletePair =
+    primary && isHexColor(primary) && accent && isHexColor(accent)
+  return isCompletePair ? primary : DEFAULT_PRIMARY_COLOR
 }
 
 /**

--- a/src/lib/branding/theme.ts
+++ b/src/lib/branding/theme.ts
@@ -53,14 +53,21 @@ export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
   if (!theme) return ''
 
   const decls: string[] = []
+  let hoverMix: string | null = null
 
   const primary = theme.primaryColor?.trim()
   if (primary && isHexColor(primary)) {
     decls.push(`--brand-primary:${primary}`)
+    // Hover fallback for engines without color-mix(): the primary itself. An
+    // unsupported function in a custom property is only detected at var()
+    // substitution time (the property computes to invalid → the hover rule is
+    // DROPPED entirely), so the safe value must live in the base block and the
+    // color-mix upgrade behind @supports.
+    decls.push(`--brand-primary-hover:${primary}`)
     // L1 hover = a slightly darker primary, derived in pure CSS (no derivation
     // logic in TS). color-mix is only ever emitted here, never on the default
     // path, so it can't affect the no-override pixel-identity guarantee.
-    decls.push(`--brand-primary-hover:color-mix(in srgb, ${primary} 85%, #000)`)
+    hoverMix = `--brand-primary-hover:color-mix(in srgb, ${primary} 85%, #000)`
   }
 
   const accent = theme.accentColor?.trim()
@@ -69,7 +76,10 @@ export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
   }
 
   if (decls.length === 0) return ''
-  return `:root{${decls.join(';')}}`
+  const base = `:root{${decls.join(';')}}`
+  return hoverMix
+    ? `${base}@supports (color: color-mix(in srgb, red 50%, blue)){:root{${hoverMix}}}`
+    : base
 }
 
 /**

--- a/src/lib/branding/theme.ts
+++ b/src/lib/branding/theme.ts
@@ -52,10 +52,18 @@ export function isHexColor(value: unknown): value is string {
 export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
   if (!theme) return ''
 
+  // ALL-OR-NOTHING, matching the write-path contract (Zod + Studio both
+  // enforce the pair): a half-theme — legacy or malformed data with only one
+  // valid colour — renders NO override at all rather than a half-themed UI.
+  const primary = theme.primaryColor?.trim()
+  const accent = theme.accentColor?.trim()
+  if (!primary || !isHexColor(primary) || !accent || !isHexColor(accent)) {
+    return ''
+  }
+
   const decls: string[] = []
   let hoverMix: string | null = null
 
-  const primary = theme.primaryColor?.trim()
   if (primary && isHexColor(primary)) {
     decls.push(`--brand-primary:${primary}`)
     // Hover fallback for engines without color-mix(): the primary itself. An
@@ -70,7 +78,6 @@ export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
     hoverMix = `--brand-primary-hover:color-mix(in srgb, ${primary} 85%, #000)`
   }
 
-  const accent = theme.accentColor?.trim()
   if (accent && isHexColor(accent)) {
     decls.push(`--brand-accent:${accent}`)
   }

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -139,6 +139,17 @@ export interface Conference {
    * conference projection's `...` spread.
    */
   backgroundPattern?: BackgroundPattern
+  /**
+   * Per-tenant brand theme (THEMING L1). Optional design-token override for the
+   * primary interactive colour and the gradient accent; ABSENT renders the house
+   * palette pixel-identical. Resolved into CSS custom properties by `ThemeStyle`
+   * / `conferenceThemeCss`. Projected by the main conference projection's `...`
+   * spread. See `@/lib/branding/theme`.
+   */
+  theme?: {
+    primaryColor?: string
+    accentColor?: string
+  }
   announcement?: TypedObject[]
   startDate: string
   endDate: string

--- a/src/lib/events/handlers/emailNotification.ts
+++ b/src/lib/events/handlers/emailNotification.ts
@@ -2,6 +2,7 @@ import { ProposalStatusChangeEvent } from '@/lib/events/types'
 import { sendAcceptRejectNotification } from '@/lib/proposal/server'
 import { Action } from '@/lib/proposal/types'
 import { formatDate } from '@/lib/time'
+import { emailBrandColor } from '@/lib/branding/theme'
 
 export async function handleEmailNotification(
   event: ProposalStatusChangeEvent,
@@ -67,6 +68,8 @@ export async function handleEmailNotification(
           url: `https://${event.metadata.domain}`,
           socialLinks: event.conference.socialLinks,
           contactEmail: event.conference.contactEmail,
+          // THEMING L1: carry the tenant's brand primary into the mail accent.
+          brandColor: emailBrandColor(event.conference.theme),
         },
       }),
     ),

--- a/src/lib/proposal/email/types.ts
+++ b/src/lib/proposal/email/types.ts
@@ -9,6 +9,12 @@ export interface BaseEmailTemplateProps {
   eventUrl: string
   comment?: string
   socialLinks?: string[]
+  /**
+   * Per-tenant brand accent (THEMING L1). The conference theme's primary hex,
+   * resolved by the sender via `emailBrandColor`; absent falls back to the house
+   * blue inside `BaseEmailTemplate`.
+   */
+  brandColor?: string
 }
 
 export interface ProposalAcceptTemplateProps extends BaseEmailTemplateProps {
@@ -25,6 +31,8 @@ export interface NotificationEventData {
   organizer: string
   socialLinks?: string[]
   contactEmail?: string
+  /** Conference theme primary hex (THEMING L1); see `emailBrandColor`. */
+  brandColor?: string
 }
 
 export interface NotificationParams {
@@ -54,6 +62,7 @@ export function createTemplateProps(
     eventUrl: params.event.url,
     socialLinks: params.event.socialLinks || [],
     comment: params.comment,
+    ...(params.event.brandColor && { brandColor: params.event.brandColor }),
     ...(confirmUrl && { confirmUrl }),
   }
 }

--- a/src/lib/proposal/email/types.ts
+++ b/src/lib/proposal/email/types.ts
@@ -10,9 +10,9 @@ export interface BaseEmailTemplateProps {
   comment?: string
   socialLinks?: string[]
   /**
-   * Per-tenant brand accent (THEMING L1). The conference theme's primary hex,
-   * resolved by the sender via `emailBrandColor`; absent falls back to the house
-   * blue inside `BaseEmailTemplate`.
+   * Per-tenant brand PRIMARY color (THEMING L1) — the conference theme's
+   * primary hex, resolved by the sender via `emailBrandColor`; absent falls
+   * back to the house blue inside `BaseEmailTemplate`.
    */
   brandColor?: string
 }

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -82,8 +82,9 @@ export const UpdateVenueSchema = z.object({
 // `theme` is a whole-object override: present → set `{ primaryColor, accentColor }`,
 // explicit `null` → unset (revert to the house palette). Both colours must be
 // 6-digit hex — non-hex is REJECTED (validated here, the write-path authority).
-// ONE regex (from the theming core) backs the Zod schema, the runtime guard and
-// the Sanity rule, so the layers cannot drift.
+// The regex is shared with the runtime guard via the theming core's
+// HEX_COLOR_RE; the Sanity rule inlines an intentionally identical pattern
+// (schema files stay import-light) — keep them in sync if it ever changes.
 const hexColor = z
   .string()
   .trim()

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -67,18 +67,41 @@ export const UpdateVenueSchema = z.object({
   venueAddress: z.string().trim().nullable().optional(),
 })
 
-// === Branding (background pattern; go-live gate G2, #643) ===
+// === Branding (background pattern + brand theme) ===
 // The logo slots are edited through the dedicated BrandingEditor/updateBrandingLogo
-// path; this scalar fieldset carries only the decorative background switch.
-// A required enum — the mutation always sets an explicit value; absent is
-// treated as `'cloud-native'` by the renderer (see backgroundPattern.ts).
+// path. This fieldset carries the decorative background switch (go-live gate G2,
+// #643) AND the optional per-tenant brand theme (THEMING L1).
+//
+// `backgroundPattern` is now OPTIONAL so the two editors that share this mutation
+// can each patch just their own field: the generic branding fieldset sends
+// `backgroundPattern` alone, the ThemeEditor sends `theme` alone. `undefined`
+// leaves a field untouched (see UNSET SEMANTICS); the renderer still treats an
+// absent stored pattern as `'cloud-native'`.
+//
+// `theme` is a whole-object override: present → set `{ primaryColor, accentColor }`,
+// explicit `null` → unset (revert to the house palette). Both colours must be
+// 6-digit hex — non-hex is REJECTED (validated here, the write-path authority).
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
+const hexColor = z
+  .string()
+  .trim()
+  .regex(HEX_COLOR_RE, 'Enter a 6-digit hex color, e.g. #1D4ED8')
+
+export const ConferenceThemeSchema = z.object({
+  primaryColor: hexColor,
+  accentColor: hexColor,
+})
+
 export const UpdateBrandingSchema = z.object({
-  backgroundPattern: z.enum(
-    BACKGROUND_PATTERN_VALUES as unknown as [
-      BackgroundPattern,
-      ...BackgroundPattern[],
-    ],
-  ),
+  backgroundPattern: z
+    .enum(
+      BACKGROUND_PATTERN_VALUES as unknown as [
+        BackgroundPattern,
+        ...BackgroundPattern[],
+      ],
+    )
+    .optional(),
+  theme: ConferenceThemeSchema.nullable().optional(),
 })
 
 // === Dates ===

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { HEX_COLOR_RE } from '@/lib/branding/theme'
 import { HEROICON_OPTIONS } from '../../../sanity/schemaTypes/constants'
 import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
 import { isValidTeamKey } from '@/lib/teams/validation'
@@ -81,7 +82,8 @@ export const UpdateVenueSchema = z.object({
 // `theme` is a whole-object override: present → set `{ primaryColor, accentColor }`,
 // explicit `null` → unset (revert to the house palette). Both colours must be
 // 6-digit hex — non-hex is REJECTED (validated here, the write-path authority).
-const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
+// ONE regex (from the theming core) backs the Zod schema, the runtime guard and
+// the Sanity rule, so the layers cannot drift.
 const hexColor = z
   .string()
   .trim()

--- a/src/server/schemas/conferenceBrandingTheme.test.ts
+++ b/src/server/schemas/conferenceBrandingTheme.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { UpdateBrandingSchema, ConferenceThemeSchema } from './conference'
+
+describe('ConferenceThemeSchema', () => {
+  it('accepts a well-formed hex pair', () => {
+    const parsed = ConferenceThemeSchema.parse({
+      primaryColor: '#7C3AED',
+      accentColor: '#22D3EE',
+    })
+    expect(parsed).toEqual({ primaryColor: '#7C3AED', accentColor: '#22D3EE' })
+  })
+
+  it('rejects non-hex colours', () => {
+    expect(
+      ConferenceThemeSchema.safeParse({
+        primaryColor: 'purple',
+        accentColor: '#22D3EE',
+      }).success,
+    ).toBe(false)
+    expect(
+      ConferenceThemeSchema.safeParse({
+        primaryColor: '#fff', // 3-digit not allowed
+        accentColor: '#22D3EE',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('requires both colours', () => {
+    expect(
+      ConferenceThemeSchema.safeParse({ primaryColor: '#7C3AED' }).success,
+    ).toBe(false)
+  })
+})
+
+describe('UpdateBrandingSchema — theme extension', () => {
+  it('accepts a theme-only patch (backgroundPattern optional)', () => {
+    const res = UpdateBrandingSchema.safeParse({
+      theme: { primaryColor: '#7C3AED', accentColor: '#22D3EE' },
+    })
+    expect(res.success).toBe(true)
+  })
+
+  it('accepts a backgroundPattern-only patch (theme untouched)', () => {
+    const res = UpdateBrandingSchema.safeParse({ backgroundPattern: 'subtle' })
+    expect(res.success).toBe(true)
+  })
+
+  it('accepts an explicit null theme (unset → revert to defaults)', () => {
+    const res = UpdateBrandingSchema.safeParse({ theme: null })
+    expect(res.success).toBe(true)
+    if (res.success) expect(res.data.theme).toBeNull()
+  })
+
+  it('rejects a theme with a malformed colour', () => {
+    const res = UpdateBrandingSchema.safeParse({
+      theme: { primaryColor: '#12345g', accentColor: '#22D3EE' },
+    })
+    expect(res.success).toBe(false)
+  })
+
+  it('rejects an invalid backgroundPattern', () => {
+    const res = UpdateBrandingSchema.safeParse({
+      backgroundPattern: 'rainbow',
+    })
+    expect(res.success).toBe(false)
+  })
+})

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -401,7 +401,7 @@
   background-color: var(
     --brand-primary-hover,
     #1e40af
-  ); /* blue-700 equivalent */
+  ); /* blue-800 (same dark house shade as the non-hover rule) */
 }
 
 .hover\:bg-brand-fresh-green-hover:hover {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -158,11 +158,30 @@
   --radius-4xl: 2rem;
   --radius-5xl: 2.5rem;
 
+  /*
+   * Per-tenant theme seam (THEMING L1).
+   *
+   * The three brand tokens a conference may re-skin — the primary interactive
+   * colour, its hover shade and the gradient endpoint (accent) — resolve through
+   * CSS custom properties whose FALLBACK is the current house value. With no
+   * override injected, `var(--brand-primary, #1d4ed8)` computes to exactly
+   * `#1d4ed8`, so the site renders pixel-identical (the L1 hard requirement).
+   *
+   * A per-conference `<style>` (see ThemeStyle / `conferenceThemeCss`) sets
+   * `--brand-primary` / `--brand-primary-hover` / `--brand-accent` on `:root`
+   * when a tenant theme exists. Those variables are ALSO read by the dark-mode
+   * rules below (each with its own darker fallback), so ONE `:root` injection
+   * re-skins both light and dark without a `.dark` redefinition to clobber it.
+   *
+   * L1 does NOT auto-derive contrast: a light primary on white is the admin's
+   * responsibility (the settings preview shows the result). Secondary brand
+   * hues (green/purple/yellow/sky) and per-usage dark tints are NOT L1 knobs.
+   */
   /* Cloud Native Days Norway Brand Colors */
-  --color-brand-cloud-blue: #1d4ed8;
-  --color-brand-cloud-blue-hover: #1e40af;
+  --color-brand-cloud-blue: var(--brand-primary, #1d4ed8);
+  --color-brand-cloud-blue-hover: var(--brand-primary-hover, #1e40af);
   --color-brand-aqua-start: #3b82f6;
-  --color-brand-aqua-end: #06b6d4;
+  --color-brand-aqua-end: var(--brand-accent, #06b6d4);
   --color-brand-sky-mist: #e0f2fe;
   --color-brand-fresh-green: #10b981;
   --color-brand-fresh-green-hover: #059669;
@@ -192,7 +211,11 @@
 
   /* Background Image Utilities */
   --background-image-aqua-gradient: linear-gradient(135deg, #3b82f6, #06b6d4);
-  --background-image-brand-gradient: linear-gradient(135deg, #1d4ed8, #06b6d4);
+  --background-image-brand-gradient: linear-gradient(
+    135deg,
+    var(--brand-primary, #1d4ed8),
+    var(--brand-accent, #06b6d4)
+  );
   --background-image-nordic-gradient: linear-gradient(135deg, #6366f1, #1d4ed8);
   --background-image-cloud-gradient: linear-gradient(135deg, #1d4ed8, #3b82f6);
   --background-image-aqua-gradient-to-r: linear-gradient(
@@ -206,11 +229,11 @@
     #06b6d4
   );
 
-  /* Color System */
-  --color-brand-cloud-blue: #1d4ed8;
-  --color-brand-cloud-blue-hover: #1e40af;
+  /* Color System (duplicate declarations — kept in sync with the seam above) */
+  --color-brand-cloud-blue: var(--brand-primary, #1d4ed8);
+  --color-brand-cloud-blue-hover: var(--brand-primary-hover, #1e40af);
   --color-brand-aqua-start: #3b82f6;
-  --color-brand-aqua-end: #06b6d4;
+  --color-brand-aqua-end: var(--brand-accent, #06b6d4);
   --color-brand-sky-mist: #e0f2fe;
   --color-brand-fresh-green: #10b981;
   --color-brand-fresh-green-hover: #059669;
@@ -316,7 +339,9 @@
 }
 
 .dark .bg-brand-cloud-blue {
-  background-color: #1e40af; /* blue-800 equivalent */
+  /* Reads the tenant override (set once on :root); dark house shade is the
+     fallback, so the default renders identically. */
+  background-color: var(--brand-primary, #1e40af); /* blue-800 equivalent */
 }
 
 .bg-brand-sky-mist {
@@ -373,7 +398,10 @@
 }
 
 .dark .hover\:bg-brand-cloud-blue-hover:hover {
-  background-color: #1e40af; /* blue-700 equivalent */
+  background-color: var(
+    --brand-primary-hover,
+    #1e40af
+  ); /* blue-700 equivalent */
 }
 
 .hover\:bg-brand-fresh-green-hover:hover {
@@ -499,10 +527,11 @@
 }
 
 .dark .bg-brand-gradient {
+  /* Same override vars as light; dark house endpoints are the fallbacks. */
   background-image: linear-gradient(
     135deg,
-    #1e3a8a,
-    #155e75
+    var(--brand-primary, #1e3a8a),
+    var(--brand-accent, #155e75)
   ); /* blue-900 to cyan-800 */
 }
 
@@ -536,7 +565,7 @@
 }
 
 .dark .border-brand-cloud-blue {
-  border-color: #2563eb; /* blue-600 equivalent */
+  border-color: var(--brand-primary, #2563eb); /* blue-600 equivalent */
 }
 
 .border-brand-sky-mist {
@@ -763,7 +792,7 @@
   appearance: none;
   width: 1.25rem;
   height: 1.25rem;
-  background-color: #1d4ed8;
+  background-color: var(--brand-primary, #1d4ed8);
   border-radius: 50%;
   cursor: pointer;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
@@ -776,7 +805,7 @@
 .slider::-moz-range-thumb {
   width: 1.25rem;
   height: 1.25rem;
-  background-color: #1d4ed8;
+  background-color: var(--brand-primary, #1d4ed8);
   border-radius: 50%;
   cursor: pointer;
   border: 0;


### PR DESCRIPTION
## THEMING L1 — per-tenant brand token layer

CaaS groundwork: a conference can override the site's brand colors via a design-token seam, with **zero visual change** for any conference that sets no theme. The current CNB blue is now just the default theme.

### Token inventory

Every `brand-*` token was inventoried in `src/styles/tailwind.css`. The tokens carrying the primary/accent signature now resolve through a CSS custom-property seam (`var(--override, <house hex>)`); the rest stay house-fixed (not L1 knobs).

| Token / surface | Before | After (default resolves identically) | L1 knob |
| --- | --- | --- | --- |
| `--color-brand-cloud-blue` | `#1d4ed8` | `var(--brand-primary, #1d4ed8)` | primary |
| `--color-brand-cloud-blue-hover` | `#1e40af` | `var(--brand-primary-hover, #1e40af)` | primary (hover) |
| `--color-brand-aqua-end` | `#06b6d4` | `var(--brand-accent, #06b6d4)` | accent |
| `--gradient-brand` / `bg-brand-gradient` | blue→cyan | primary→accent (via the two tokens above) | primary+accent |
| `--background-image-brand-gradient` | `#1d4ed8,#06b6d4` | `var(--brand-primary…),var(--brand-accent…)` | primary+accent |
| `.dark .bg-brand-cloud-blue` | `#1e40af` | `var(--brand-primary, #1e40af)` | primary (dark) |
| `.dark .hover:bg-brand-cloud-blue-hover` | `#1e40af` | `var(--brand-primary-hover, #1e40af)` | primary (dark) |
| `.dark .border-brand-cloud-blue` | `#2563eb` | `var(--brand-primary, #2563eb)` | primary (dark) |
| `.dark .bg-brand-gradient` | `#1e3a8a,#155e75` | `var(--brand-primary…),var(--brand-accent…)` | primary+accent (dark) |
| slider thumb fill | `#1d4ed8` | `var(--brand-primary, #1d4ed8)` | primary |
| green / purple / yellow / sky-mist, dark brand **text** tints | — | unchanged (house) | not L1 |

### Override knobs chosen — and why

The smallest set that meaningfully re-skins the public site: **`primaryColor`** (primary interactive color — buttons, links, focus rings, borders, gradient start) and **`accentColor`** (gradient endpoint). The brand gradient decomposes cleanly as primary→accent, so these two knobs also drive it — no separate `gradientFrom/To` needed. Hover is derived in **pure CSS** (`color-mix(... 85%, #000)`) so no color math lives in TS, and it only ever appears in the injected override (never the default path).

### The no-visual-change guarantee — how it's ensured

Every themeable token became `X → var(--override, X)` where the fallback `X` is the exact prior hex. With no `theme` set, no `<style>` is injected and every `var(--override, X)` computes to `X` — byte-identical. `conferenceThemeCss` returns `''` for absent/invalid themes, so `<ThemeStyle>` renders nothing. Verified by shooting default light+dark against the house palette (unchanged) and unit tests asserting the empty-string default. Any Chromatic diff on a default (unthemed) story is therefore a bug.

The seam is injected **once on `:root`** (in the shared `Layout`, which has already domain-resolved the conference). This is deliberate: the light tokens use an indirection (`--color-brand-*: var(--brand-primary, …)`) that resolves at `:root`, so the override must live on `:root` — a descendant wrapper would not re-skin them. Because the dark rules read the same override vars directly, that one `:root` block re-skins both color schemes with no `.dark` redefinition to clobber it.

### Contrast constraint (L1)

L1 applies colors **verbatim** — no contrast auto-derivation, no clamping. A light primary on a white surface is the admin's responsibility; the settings editor shows a live preview (button + heading + gradient) so they judge it before saving. Additionally, dark-mode brand **text** tints (deliberately light, e.g. `#93c5fd`, for readability) are **not** re-skinned in L1 — deriving a readable themed dark tint is contrast derivation, deferred to L2. So a themed conference in dark mode shows re-skinned fills/gradients/borders but house-tinted brand text.

### Scope

- **Schema**: `conference.theme { primaryColor, accentColor }` (Sanity + `ConferenceThemeSchema`, 6-digit hex validated, non-hex rejected). Extended `UpdateBrandingSchema`/`updateBranding` (backgroundPattern made optional so the two editors each patch their own field); `theme: null` unsets.
- **Injection**: `ThemeStyle` server component in `Layout`, per-tenant cached with the layout.
- **Admin**: `ThemeEditor` island on the Branding card (native color picker + hex field + live preview + Reset-to-default) and a read-only swatch row.
- **Email**: `emailBrandColor()` threads the theme primary into the proposal accept/reject/waitlist mail (the canonical conference speaker mail; `BaseEmailTemplate.brandColor`). Other transactional senders keep the house default — they each have `conference` in scope, so adopting the same one-line helper is mechanical L2 follow-up.
- **PWA**: manifest `theme_color` now follows the tenant theme primary (host-safe like `name`).

### QA

- `mise run check` green (knip/lint/format/typecheck all exit 0).
- Full vitest: **4133 passed / 314 files**. New tests cover token resolution (default vs override vs invalid), schema validation (rejects non-hex), the injection component, and manifest theme_color.
- `pnpm shoot` @393px light+dark: default = house palette (pixel-identical), themed re-skins primary/gradient/borders; ThemeEditor modal + card inspected.
- `mise run build`: TypeScript + bundle compile clean; fails only at page-data collection on `RESEND_API_KEY is not set` (expected local secrets/keychain limitation).

Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
