### PR TITLE
feat(homepage): drag-and-drop composition builder (F3)

### DIFF
--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -29,7 +29,7 @@ import { OrganizersEditor } from '@/components/admin/OrganizersEditor'
 import { TopicsEditor } from '@/components/admin/TopicsEditor'
 import { TeamsEditor } from '@/components/admin/TeamsEditor'
 import { HomepageSectionsEditor } from '@/components/admin/HomepageSectionsEditor'
-import { resolveHomepageSections } from '@/lib/homepage/sections'
+import { resolveHomepageSections } from '@/lib/homepage'
 import {
   CalendarIcon,
   GlobeAltIcon,

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -14,7 +14,7 @@ import { headers } from 'next/headers'
 import { EventJsonLd } from '@/components/seo/EventJsonLd'
 import { canonicalUrl } from '@/lib/seo/canonical'
 import { HomepageSectionRenderer } from '@/components/homepage/SectionRenderer'
-import { resolveHomepageSections } from '@/lib/homepage/sections'
+import { resolveHomepageSections } from '@/lib/homepage'
 
 function truncateDescription(text: string, maxLength = 160): string {
   const trimmed = text.trim()

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 import { BackgroundImage } from '@/components/BackgroundImage'
-import type { HeroCtaOverride } from '@/lib/homepage/sections'
+import type { HeroCtaOverride } from '@/lib/homepage'
 import { Button } from '@/components/Button'
 import { CollapsibleDescription } from '@/components/CollapsibleDescription'
 import { Container } from '@/components/Container'

--- a/src/components/admin/HomepageSectionsEditor.stories.tsx
+++ b/src/components/admin/HomepageSectionsEditor.stories.tsx
@@ -11,11 +11,13 @@ const handlers = [
   ),
 ]
 
+// Mirrors getDefaultSections() with a published schedule: the middle slot is the
+// phase-dependent Program Highlights, which the preview badges as auto-swapping.
 const defaultSections: HomepageSection[] = [
-  { _key: 'hero', _type: 'homepageHero' },
-  { _key: 'gallery', _type: 'homepageGallery' },
-  { _key: 'featured', _type: 'homepageFeaturedSpeakers' },
-  { _key: 'sponsors', _type: 'homepageSponsors' },
+  { _key: 'default-hero', _type: 'homepageHero' },
+  { _key: 'default-gallery', _type: 'homepageGallery' },
+  { _key: 'default-program', _type: 'homepageProgramHighlights' },
+  { _key: 'default-sponsors', _type: 'homepageSponsors' },
 ]
 
 const customSections: HomepageSection[] = [
@@ -32,6 +34,7 @@ const customSections: HomepageSection[] = [
     buttonLabel: 'Submit a talk',
     buttonHref: '/cfp',
   },
+  { _key: 'metrics', _type: 'homepageMetrics', heading: 'By the numbers' },
   { _key: 'gallery', _type: 'homepageGallery', hidden: true },
   { _key: 'sponsors', _type: 'homepageSponsors' },
 ]
@@ -45,7 +48,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Front-page builder (F2) admin editor — plain-form editing of the homepage section composition (F3 adds drag-and-drop). Reorder with up/down, toggle per-section visibility, and edit per-type config (hero copy + CTA overrides, CTA banner, rich text, metrics heading). "Reset to default" clears the stored list so the page falls back to the phase-aware default layout.',
+          'Front-page builder (F3) admin editor — a drag-and-drop composition builder with a live structural preview. Drag a card by its grab handle (pointer + keyboard) or use the up/down buttons (mobile + a11y fallback) to reorder; toggle per-section visibility; open per-type config inline as an accordion. The preview panel maps the composition to labeled bands in order (hidden ones ghosted, the default phase-dependent middle slot badged) and updates live while dragging. "Revert to default" (confirmed) clears the stored list so the page falls back to the phase-aware default layout.',
       },
     },
   },
@@ -90,6 +93,27 @@ export const CustomComposition: Story = {
     initialSections: customSections,
     usingDefault: false,
     defaultOpen: true,
+  },
+}
+
+/** The empty state after every section has been removed. */
+export const EmptyComposition: Story = {
+  args: {
+    initialSections: [],
+    usingDefault: false,
+    defaultOpen: true,
+  },
+}
+
+/** Mobile (393px): drag handles fall back to up/down buttons; preview stacks under the list. */
+export const Mobile: Story = {
+  args: {
+    initialSections: customSections,
+    usingDefault: false,
+    defaultOpen: true,
+  },
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
   },
 }
 

--- a/src/components/admin/HomepageSectionsEditor.stories.tsx
+++ b/src/components/admin/HomepageSectionsEditor.stories.tsx
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { ThemeProvider } from 'next-themes'
 import { HomepageSectionsEditor } from './HomepageSectionsEditor'
 import { NotificationProvider } from './NotificationProvider'
-import type { HomepageSection } from '@/lib/homepage/sections'
+import type { HomepageSection } from '@/lib/homepage'
 
 const handlers = [
   http.post('/api/trpc/conference.updateHomepageSections', () =>

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -188,9 +188,11 @@ export function HomepageSectionsEditor({
     reset()
   }
   /**
-   * The in-modal Cancel button honors the same dirty guard as the shell's
-   * backdrop/Escape/X close paths — unsaved changes are never discarded
-   * without an explicit choice.
+   * The ONE dirty guard for every close path: the Cancel button AND the
+   * shell's backdrop/Escape/X all route here (the shell's built-in
+   * confirm-on-dirty overlay is intentionally NOT enabled — two mechanisms
+   * would stack confirmations). Unsaved changes are never discarded without
+   * an explicit choice.
    */
   const cancel = () => {
     if (isDirty) {
@@ -318,13 +320,11 @@ export function HomepageSectionsEditor({
 
       <ModalShell
         isOpen={isOpen}
-        onClose={close}
+        onClose={cancel}
         size="4xl"
         title="Edit Homepage Sections"
         subtitle="Compose, reorder and preview the front-page blocks"
         icon={<PencilSquareIcon className="h-5 w-5" />}
-        confirmOnDirtyClose
-        isDirty={isDirty}
       >
         <div className="space-y-4">
           {usingDefault ? (

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -1,20 +1,42 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-  ChevronUpIcon,
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import {
+  Bars3Icon,
   ChevronDownIcon,
+  ChevronUpIcon,
+  Cog6ToothIcon,
   EyeIcon,
   EyeSlashIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  Squares2X2Icon,
+  TrashIcon,
 } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
 import { AdminButton } from '@/components/admin/AdminButton'
+import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import { PortableTextEditor } from '@/components/PortableTextEditor'
-import type { PortableTextBlock } from '@portabletext/editor'
 import { api } from '@/lib/trpc/client'
 import { useNotification } from './NotificationProvider'
 import {
@@ -22,119 +44,34 @@ import {
   type HomepageSection,
   type HomepageSectionType,
 } from '@/lib/homepage/sections'
+import {
+  SECTION_LABELS,
+  isConfigurable,
+  moveByIndex,
+  nextKey,
+  reorderByKey,
+  serializeRows,
+  toEditorRows,
+  toPayload,
+  toPreviewBands,
+  type EditorRow,
+  type PreviewBand,
+} from '@/lib/homepage/editor'
 
 /**
- * Front-page builder (F2) admin editor — PLAIN form editing of the homepage
- * section composition. F3 will add drag-and-drop; for now sections reorder with
- * up/down buttons, toggle visibility, and expose per-type config (hero copy +
- * CTA overrides, CTA banner, rich text, metrics heading). Content-free blocks
- * (featured speakers, program, organizers, sponsors, gallery) carry only their
- * visibility flag — their content still comes from the existing conference
- * sources. Saves via `conference.updateHomepageSections` and refreshes the card.
+ * Front-page builder (F3) admin editor — a drag-and-drop composition builder
+ * with a live structural preview.
  *
- * "Reset to default" clears the stored list, so the page falls back to the
- * phase-aware default layout.
+ * Interaction: section cards reorder by dragging their grab handle (pointer +
+ * keyboard via dnd-kit's SortableContext), with the up/down buttons retained as
+ * the mobile + a11y fallback. Per-type config opens inline as an accordion on
+ * the card, so add → configure → reorder stays on one surface. A compact preview
+ * panel maps the composition to labeled bands in order (hidden ones ghosted, the
+ * default phase-dependent middle slot badged) and updates live as you drag.
+ *
+ * Saves via `conference.updateHomepageSections`. "Revert to default" (confirmed)
+ * clears the stored list so the page falls back to the phase-aware default.
  */
-
-const SECTION_LABELS: Record<HomepageSectionType, string> = {
-  homepageHero: 'Hero',
-  homepageFeaturedSpeakers: 'Featured Speakers',
-  homepageProgramHighlights: 'Program Highlights',
-  homepageOrganizers: 'Organizers',
-  homepageSponsors: 'Sponsors',
-  homepageGallery: 'Photo Gallery',
-  homepageMetrics: 'Vanity Metrics',
-  homepageCtaBanner: 'Call-to-action Banner',
-  homepageRichText: 'Rich Text',
-}
-
-/** Working row shape — a superset of every block's fields, keyed for the list. */
-interface EditorRow {
-  _key: string
-  _type: HomepageSectionType
-  hidden?: boolean
-  heroHeadline?: string
-  heroSubheadline?: string
-  ctaOverrides?: { _key: string; label: string; href: string }[]
-  heading?: string
-  body?: string
-  buttonLabel?: string
-  buttonHref?: string
-  content?: PortableTextBlock[]
-}
-
-let keyCounter = 0
-const nextKey = () => `hp-${Date.now()}-${++keyCounter}`
-
-function toEditorRows(sections: HomepageSection[]): EditorRow[] {
-  return sections.map((s) => {
-    const row: EditorRow = {
-      _key: s._key || nextKey(),
-      _type: s._type,
-      hidden: s.hidden,
-    }
-    if (s._type === 'homepageHero') {
-      row.heroHeadline = s.heroHeadline
-      row.heroSubheadline = s.heroSubheadline
-      row.ctaOverrides = (s.ctaOverrides ?? []).map((c) => ({
-        _key: c._key || nextKey(),
-        label: c.label,
-        href: c.href,
-      }))
-    } else if (s._type === 'homepageCtaBanner') {
-      row.heading = s.heading
-      row.body = s.body
-      row.buttonLabel = s.buttonLabel
-      row.buttonHref = s.buttonHref
-    } else if (s._type === 'homepageRichText') {
-      row.heading = s.heading
-      row.content = (s.content as PortableTextBlock[]) ?? []
-    } else if (s._type === 'homepageMetrics') {
-      row.heading = s.heading
-    }
-    return row
-  })
-}
-
-/** Build the mutation payload; empty strings are dropped by the server. */
-function toPayload(rows: EditorRow[]): Record<string, unknown>[] {
-  return rows.map((row) => {
-    const out: Record<string, unknown> = { _type: row._type, _key: row._key }
-    if (row.hidden) out.hidden = true
-    switch (row._type) {
-      case 'homepageHero':
-        if (row.heroHeadline?.trim()) out.heroHeadline = row.heroHeadline.trim()
-        if (row.heroSubheadline?.trim())
-          out.heroSubheadline = row.heroSubheadline.trim()
-        if (row.ctaOverrides && row.ctaOverrides.length > 0) {
-          out.ctaOverrides = row.ctaOverrides
-            .filter((c) => c.label.trim() && c.href.trim())
-            .map((c) => ({
-              _key: c._key,
-              label: c.label.trim(),
-              href: c.href.trim(),
-            }))
-        }
-        break
-      case 'homepageCtaBanner':
-        out.heading = row.heading?.trim() ?? ''
-        if (row.body?.trim()) out.body = row.body.trim()
-        out.buttonLabel = row.buttonLabel?.trim() ?? ''
-        out.buttonHref = row.buttonHref?.trim() ?? ''
-        break
-      case 'homepageRichText':
-        if (row.heading?.trim()) out.heading = row.heading.trim()
-        out.content = row.content ?? []
-        break
-      case 'homepageMetrics':
-        if (row.heading?.trim()) out.heading = row.heading.trim()
-        break
-      default:
-        break
-    }
-    return out
-  })
-}
 
 const inputClass =
   'block w-full min-h-[44px] rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white'
@@ -165,6 +102,28 @@ export function HomepageSectionsEditor({
   const [addType, setAddType] =
     useState<HomepageSectionType>('homepageCtaBanner')
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [confirmingRevert, setConfirmingRevert] = useState(false)
+  // Live drag state: the id being dragged and the id it is currently over, used
+  // to PROJECT the in-progress order into the preview without disturbing the
+  // sortable list (which animates itself via transforms).
+  const [activeKey, setActiveKey] = useState<string | null>(null)
+  const [overKey, setOverKey] = useState<string | null>(null)
+
+  // The composition serialized at open time; the unsaved-changes guard compares
+  // the live rows against it. Recomputed whenever the stored props change.
+  const initialSignature = useMemo(
+    () => serializeRows(toEditorRows(initialSections)),
+    [initialSections],
+  )
+  const isDirty = serializeRows(rows) !== initialSignature
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
 
   const mutation = api.conference.updateHomepageSections.useMutation({
     onSuccess: () => {
@@ -190,6 +149,9 @@ export function HomepageSectionsEditor({
   const reset = () => {
     setRows(toEditorRows(initialSections))
     setSubmitError(null)
+    setExpanded(new Set())
+    setActiveKey(null)
+    setOverKey(null)
   }
   const open = () => {
     reset()
@@ -200,23 +162,57 @@ export function HomepageSectionsEditor({
     reset()
   }
 
+  const toggleExpanded = (key: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+
   const patchRow = (key: string, patch: Partial<EditorRow>) =>
     setRows((prev) =>
       prev.map((r) => (r._key === key ? { ...r, ...patch } : r)),
     )
-  const move = (from: number, to: number) => {
-    if (to < 0 || to >= rows.length) return
-    setRows((prev) => {
-      const next = prev.slice()
-      const [item] = next.splice(from, 1)
-      next.splice(to, 0, item)
+  const move = (from: number, to: number) =>
+    setRows((prev) => moveByIndex(prev, from, to))
+  const remove = (key: string) => {
+    setRows((prev) => prev.filter((r) => r._key !== key))
+    setExpanded((prev) => {
+      if (!prev.has(key)) return prev
+      const next = new Set(prev)
+      next.delete(key)
       return next
     })
   }
-  const remove = (key: string) =>
-    setRows((prev) => prev.filter((r) => r._key !== key))
-  const add = () =>
-    setRows((prev) => [...prev, { _key: nextKey(), _type: addType }])
+  const add = () => {
+    const key = nextKey()
+    setRows((prev) => [...prev, { _key: key, _type: addType }])
+    // Auto-expand a freshly added configurable block so add → configure flows
+    // without a second click.
+    if (isConfigurable(addType)) {
+      setExpanded((prev) => new Set(prev).add(key))
+    }
+  }
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveKey(String(event.active.id))
+    setOverKey(String(event.active.id))
+  }
+  const handleDragOver = (event: DragOverEvent) => {
+    setOverKey(event.over ? String(event.over.id) : null)
+  }
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    setActiveKey(null)
+    setOverKey(null)
+    if (!over || active.id === over.id) return
+    setRows((prev) => reorderByKey(prev, String(active.id), String(over.id)))
+  }
+  const handleDragCancel = () => {
+    setActiveKey(null)
+    setOverKey(null)
+  }
 
   const validate = (): string | null => {
     for (const r of rows) {
@@ -240,15 +236,29 @@ export function HomepageSectionsEditor({
       setSubmitError(err)
       return
     }
-    mutation.mutate({
-      homepageSections: toPayload(rows) as never,
-    })
+    mutation.mutate({ homepageSections: toPayload(rows) as never })
   }
 
-  const resetToDefault = () => {
+  const revertToDefault = () => {
+    setConfirmingRevert(false)
     setSubmitError(null)
     mutation.mutate({ homepageSections: [] })
   }
+
+  // The preview reflects the in-progress order while dragging (projected from
+  // active/over) and the committed order otherwise. Cheap: a labeled-box map.
+  const previewRows = useMemo(
+    () => (activeKey ? reorderByKey(rows, activeKey, overKey) : rows),
+    [rows, activeKey, overKey],
+  )
+  const previewBands = useMemo(
+    () => toPreviewBands(previewRows, usingDefault),
+    [previewRows, usingDefault],
+  )
+
+  const activeRow = activeKey
+    ? rows.find((r) => r._key === activeKey)
+    : undefined
 
   return (
     <>
@@ -264,110 +274,111 @@ export function HomepageSectionsEditor({
       <ModalShell
         isOpen={isOpen}
         onClose={close}
-        size="3xl"
+        size="4xl"
         title="Edit Homepage Sections"
-        subtitle="Compose and order the front-page blocks"
+        subtitle="Compose, reorder and preview the front-page blocks"
         icon={<PencilSquareIcon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty}
       >
         <div className="space-y-4">
           {usingDefault ? (
             <p className="rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
-              This conference uses the default layout. Saving a composition
-              below overrides it; “Reset to default” restores the automatic
-              layout.
+              Using the default layout — customize below to override it. “Revert
+              to default” restores the automatic phase-aware layout at any time.
             </p>
           ) : null}
 
-          <ul className="space-y-3">
-            {rows.map((row, index) => (
-              <li
-                key={row._key}
-                className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-sm font-semibold text-gray-900 dark:text-white">
-                    {index + 1}. {SECTION_LABELS[row._type]}
-                  </span>
-                  <div className="flex items-center gap-1">
-                    <button
-                      type="button"
-                      className={rowBtnClass}
-                      onClick={() =>
-                        patchRow(row._key, { hidden: !row.hidden })
-                      }
-                      aria-label={
-                        row.hidden
-                          ? `Show ${SECTION_LABELS[row._type]}`
-                          : `Hide ${SECTION_LABELS[row._type]}`
-                      }
-                      title={row.hidden ? 'Hidden — click to show' : 'Visible'}
-                    >
-                      {row.hidden ? (
-                        <EyeSlashIcon className="h-5 w-5" />
-                      ) : (
-                        <EyeIcon className="h-5 w-5" />
-                      )}
-                    </button>
-                    <button
-                      type="button"
-                      className={rowBtnClass}
-                      onClick={() => move(index, index - 1)}
-                      disabled={index === 0}
-                      aria-label={`Move ${SECTION_LABELS[row._type]} up`}
-                    >
-                      <ChevronUpIcon className="h-5 w-5" />
-                    </button>
-                    <button
-                      type="button"
-                      className={rowBtnClass}
-                      onClick={() => move(index, index + 1)}
-                      disabled={index === rows.length - 1}
-                      aria-label={`Move ${SECTION_LABELS[row._type]} down`}
-                    >
-                      <ChevronDownIcon className="h-5 w-5" />
-                    </button>
-                    <button
-                      type="button"
-                      className={`${rowBtnClass} hover:text-red-600`}
-                      onClick={() => remove(row._key)}
-                      aria-label={`Remove ${SECTION_LABELS[row._type]}`}
-                    >
-                      <TrashIcon className="h-5 w-5" />
-                    </button>
-                  </div>
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_15rem]">
+            {/* Section list (drag + fallback controls) */}
+            <div className="min-w-0">
+              {rows.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-gray-300 p-8 text-center dark:border-gray-600">
+                  <Squares2X2Icon className="mx-auto h-10 w-10 text-gray-400" />
+                  <p className="mt-2 text-sm font-semibold text-gray-900 dark:text-white">
+                    No sections yet
+                  </p>
+                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    Add a section below, or revert to the default layout.
+                  </p>
                 </div>
+              ) : (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragStart={handleDragStart}
+                  onDragOver={handleDragOver}
+                  onDragEnd={handleDragEnd}
+                  onDragCancel={handleDragCancel}
+                >
+                  <SortableContext
+                    items={rows.map((r) => r._key)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <ul className="space-y-3">
+                      {rows.map((row, index) => (
+                        <SortableSectionCard
+                          key={row._key}
+                          row={row}
+                          index={index}
+                          total={rows.length}
+                          expanded={expanded.has(row._key)}
+                          onToggleExpanded={() => toggleExpanded(row._key)}
+                          onPatch={(p) => patchRow(row._key, p)}
+                          onToggleHidden={() =>
+                            patchRow(row._key, { hidden: !row.hidden })
+                          }
+                          onMoveUp={() => move(index, index - 1)}
+                          onMoveDown={() => move(index, index + 1)}
+                          onRemove={() => remove(row._key)}
+                        />
+                      ))}
+                    </ul>
+                  </SortableContext>
+                  <DragOverlay>
+                    {activeRow ? (
+                      <div className="flex items-center gap-2 rounded-lg border border-brand-cloud-blue bg-white px-3 py-3 shadow-lg ring-2 ring-brand-cloud-blue/30 dark:bg-gray-800">
+                        <Bars3Icon className="h-5 w-5 text-gray-400" />
+                        <span className="text-sm font-semibold text-gray-900 dark:text-white">
+                          {SECTION_LABELS[activeRow._type]}
+                        </span>
+                      </div>
+                    ) : null}
+                  </DragOverlay>
+                </DndContext>
+              )}
 
-                <SectionConfig
-                  row={row}
-                  onChange={(p) => patchRow(row._key, p)}
-                />
-              </li>
-            ))}
-          </ul>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <select
+                  value={addType}
+                  onChange={(e) =>
+                    setAddType(e.target.value as HomepageSectionType)
+                  }
+                  aria-label="Section type to add"
+                  className={`${inputClass} w-auto`}
+                >
+                  {HOMEPAGE_SECTION_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {SECTION_LABELS[t]}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={add}
+                  className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 hover:border-brand-cloud-blue hover:text-brand-cloud-blue dark:border-gray-600 dark:text-gray-300"
+                >
+                  <PlusIcon className="h-5 w-5" />
+                  Add section
+                </button>
+              </div>
+            </div>
 
-          <div className="flex flex-wrap items-center gap-2">
-            <select
-              value={addType}
-              onChange={(e) =>
-                setAddType(e.target.value as HomepageSectionType)
-              }
-              aria-label="Section type to add"
-              className={`${inputClass} w-auto`}
-            >
-              {HOMEPAGE_SECTION_TYPES.map((t) => (
-                <option key={t} value={t}>
-                  {SECTION_LABELS[t]}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              onClick={add}
-              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 hover:border-brand-cloud-blue hover:text-brand-cloud-blue dark:border-gray-600 dark:text-gray-300"
-            >
-              <PlusIcon className="h-5 w-5" />
-              Add section
-            </button>
+            {/* Live structural preview */}
+            <CompositionPreview
+              bands={previewBands}
+              usingDefault={usingDefault}
+            />
           </div>
 
           {submitError ? (
@@ -384,11 +395,11 @@ export function HomepageSectionsEditor({
               type="button"
               variant="secondary"
               size="md"
-              onClick={resetToDefault}
+              onClick={() => setConfirmingRevert(true)}
               disabled={mutation.isPending}
               className="min-h-[44px]"
             >
-              Reset to default
+              Revert to default
             </AdminButton>
             <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
               <AdminButton
@@ -415,11 +426,216 @@ export function HomepageSectionsEditor({
           </div>
         </div>
       </ModalShell>
+
+      <ConfirmationModal
+        isOpen={confirmingRevert}
+        onClose={() => setConfirmingRevert(false)}
+        onConfirm={revertToDefault}
+        title="Revert to default layout?"
+        message="This clears your saved composition and restores the automatic, phase-aware homepage. This cannot be undone."
+        confirmButtonText="Revert to default"
+        variant="warning"
+        isLoading={mutation.isPending}
+      />
     </>
   )
 }
 
-/** Per-type config editor. Content-free blocks render an explanatory line only. */
+/** One draggable/sortable section card, with inline accordion config. */
+function SortableSectionCard({
+  row,
+  index,
+  total,
+  expanded,
+  onToggleExpanded,
+  onPatch,
+  onToggleHidden,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+}: {
+  row: EditorRow
+  index: number
+  total: number
+  expanded: boolean
+  onToggleExpanded: () => void
+  onPatch: (patch: Partial<EditorRow>) => void
+  onToggleHidden: () => void
+  onMoveUp: () => void
+  onMoveDown: () => void
+  onRemove: () => void
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: row._key })
+
+  const label = SECTION_LABELS[row._type]
+  const configurable = isConfigurable(row._type)
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={`rounded-lg border bg-white dark:bg-gray-800/40 ${
+        isDragging
+          ? 'z-10 border-brand-cloud-blue opacity-50'
+          : 'border-gray-200 dark:border-gray-700'
+      } ${row.hidden ? 'opacity-60' : ''}`}
+    >
+      <div className="flex items-center gap-1 p-2 sm:gap-2 sm:p-3">
+        {/* Grab handle: dnd-kit attributes + listeners on the focusable button so
+            Enter/Space starts a keyboard drag; up/down buttons remain the mobile
+            + a11y fallback. */}
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          aria-label={`Drag ${label} to reorder`}
+          className="hidden h-11 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue active:cursor-grabbing sm:inline-flex dark:hover:bg-gray-800 dark:hover:text-gray-300"
+        >
+          <Bars3Icon className="h-5 w-5" />
+        </button>
+
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="min-w-0 truncate text-sm font-semibold text-gray-900 dark:text-white">
+            <span className="text-gray-400 tabular-nums">{index + 1}.</span>{' '}
+            {label}
+          </span>
+          {row.hidden ? (
+            <span className="shrink-0 rounded bg-gray-200 px-1.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              Hidden
+            </span>
+          ) : null}
+        </div>
+
+        <div className="flex items-center">
+          {configurable ? (
+            <button
+              type="button"
+              className={rowBtnClass}
+              onClick={onToggleExpanded}
+              aria-expanded={expanded}
+              aria-label={`${expanded ? 'Collapse' : 'Configure'} ${label}`}
+              title="Configure"
+            >
+              <Cog6ToothIcon className="h-5 w-5" />
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className={rowBtnClass}
+            onClick={onToggleHidden}
+            aria-label={row.hidden ? `Show ${label}` : `Hide ${label}`}
+            title={row.hidden ? 'Hidden — click to show' : 'Visible'}
+          >
+            {row.hidden ? (
+              <EyeSlashIcon className="h-5 w-5" />
+            ) : (
+              <EyeIcon className="h-5 w-5" />
+            )}
+          </button>
+          <button
+            type="button"
+            className={rowBtnClass}
+            onClick={onMoveUp}
+            disabled={index === 0}
+            aria-label={`Move ${label} up`}
+          >
+            <ChevronUpIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            className={rowBtnClass}
+            onClick={onMoveDown}
+            disabled={index === total - 1}
+            aria-label={`Move ${label} down`}
+          >
+            <ChevronDownIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            className={`${rowBtnClass} hover:text-red-600`}
+            onClick={onRemove}
+            aria-label={`Remove ${label}`}
+          >
+            <TrashIcon className="h-5 w-5" />
+          </button>
+        </div>
+      </div>
+
+      {configurable && expanded ? (
+        <div className="border-t border-gray-200 px-3 pt-2 pb-3 dark:border-gray-700">
+          <SectionConfig row={row} onChange={onPatch} />
+        </div>
+      ) : null}
+    </li>
+  )
+}
+
+/** Compact structural preview — labeled bands in order, hidden ones ghosted. */
+function CompositionPreview({
+  bands,
+  usingDefault,
+}: {
+  bands: PreviewBand[]
+  usingDefault: boolean
+}) {
+  const visibleCount = bands.filter((b) => !b.hidden).length
+  return (
+    <aside
+      aria-label="Homepage structure preview"
+      className="rounded-lg border border-gray-200 bg-gray-50 p-3 lg:sticky lg:top-0 lg:self-start dark:border-gray-700 dark:bg-gray-900/40"
+    >
+      <p className="mb-2 text-xs font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-400">
+        Page structure
+      </p>
+      {bands.length === 0 ? (
+        <p className="text-xs text-gray-400 dark:text-gray-500">
+          Nothing to preview.
+        </p>
+      ) : (
+        <ol className="space-y-1.5">
+          {bands.map((band, i) => (
+            <li
+              key={band.key}
+              className={`rounded-md border px-2.5 py-2 text-xs font-medium ${
+                band.hidden
+                  ? 'border-dashed border-gray-300 bg-transparent text-gray-400 dark:border-gray-600 dark:text-gray-500'
+                  : 'border-transparent bg-white text-gray-800 shadow-sm dark:bg-gray-800 dark:text-gray-100'
+              }`}
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="text-gray-400 tabular-nums">{i + 1}</span>
+                <span className="min-w-0 flex-1 truncate">{band.label}</span>
+                {band.hidden ? (
+                  <span className="shrink-0 text-[10px] tracking-wide uppercase">
+                    hidden
+                  </span>
+                ) : null}
+              </div>
+              {band.isPhaseSlot ? (
+                <p className="mt-1 text-[10px] leading-tight text-brand-cloud-blue dark:text-blue-400">
+                  Auto-swaps with the conference phase
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      )}
+      <p className="mt-2 text-[11px] leading-tight text-gray-400 dark:text-gray-500">
+        {visibleCount} visible section{visibleCount === 1 ? '' : 's'}
+        {usingDefault ? ' · default layout' : ''}
+      </p>
+    </aside>
+  )
+}
+
+/** Per-type config editor. Only reached for configurable blocks (accordion). */
 function SectionConfig({
   row,
   onChange,
@@ -430,7 +646,7 @@ function SectionConfig({
   if (row._type === 'homepageHero') {
     const ctas = row.ctaOverrides ?? []
     return (
-      <div className="mt-3 space-y-2">
+      <div className="space-y-2">
         <input
           type="text"
           value={row.heroHeadline ?? ''}
@@ -509,7 +725,7 @@ function SectionConfig({
 
   if (row._type === 'homepageCtaBanner') {
     return (
-      <div className="mt-3 space-y-2">
+      <div className="space-y-2">
         <input
           type="text"
           value={row.heading ?? ''}
@@ -526,7 +742,7 @@ function SectionConfig({
           rows={2}
           className={inputClass}
         />
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
           <input
             type="text"
             value={row.buttonLabel ?? ''}
@@ -550,7 +766,7 @@ function SectionConfig({
 
   if (row._type === 'homepageRichText') {
     return (
-      <div className="mt-3 space-y-2">
+      <div className="space-y-2">
         <input
           type="text"
           value={row.heading ?? ''}
@@ -571,7 +787,7 @@ function SectionConfig({
 
   if (row._type === 'homepageMetrics') {
     return (
-      <div className="mt-3">
+      <div>
         <input
           type="text"
           value={row.heading ?? ''}
@@ -587,9 +803,5 @@ function SectionConfig({
     )
   }
 
-  return (
-    <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-      Content comes from the existing conference configuration.
-    </p>
-  )
+  return null
 }

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -173,6 +173,8 @@ export function HomepageSectionsEditor({
     const fresh = toEditorRows(initialSections)
     setInitialRows(fresh)
     setRows(fresh)
+    setConfirmingCancel(false)
+    setConfirmingRevert(false)
     setSubmitError(null)
     setExpanded(new Set())
     setActiveKey(null)
@@ -182,6 +184,7 @@ export function HomepageSectionsEditor({
   const close = () => {
     setIsOpen(false)
     setConfirmingCancel(false)
+    setConfirmingRevert(false)
     reset()
   }
   /**

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -56,7 +56,7 @@ import {
   toPreviewBands,
   type EditorRow,
   type PreviewBand,
-} from '@/lib/homepage'
+} from '@/lib/homepage/editor'
 
 /**
  * Front-page builder (F3) admin editor — a drag-and-drop composition builder
@@ -100,7 +100,7 @@ export function HomepageSectionsEditor({
   // stored sections, so a second call would mint DIFFERENT keys — the dirty
   // baseline below must be derived from this same array or the form would
   // read as dirty the moment it opens.
-  const [initialRows] = useState<EditorRow[]>(() =>
+  const [initialRows, setInitialRows] = useState<EditorRow[]>(() =>
     toEditorRows(initialSections),
   )
   const [rows, setRows] = useState<EditorRow[]>(initialRows)
@@ -109,6 +109,7 @@ export function HomepageSectionsEditor({
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [confirmingRevert, setConfirmingRevert] = useState(false)
+  const [confirmingCancel, setConfirmingCancel] = useState(false)
   // Live drag state: the id being dragged and the id it is currently over, used
   // to PROJECT the in-progress order into the preview without disturbing the
   // sortable list (which animates itself via transforms).
@@ -166,12 +167,34 @@ export function HomepageSectionsEditor({
     setOverKey(null)
   }
   const open = () => {
-    reset()
+    // Re-materialize from the CURRENT props: after a save, router.refresh()
+    // delivers the updated composition, and reopening must show and baseline
+    // against that — not the rows captured at first mount.
+    const fresh = toEditorRows(initialSections)
+    setInitialRows(fresh)
+    setRows(fresh)
+    setSubmitError(null)
+    setExpanded(new Set())
+    setActiveKey(null)
+    setOverKey(null)
     setIsOpen(true)
   }
   const close = () => {
     setIsOpen(false)
+    setConfirmingCancel(false)
     reset()
+  }
+  /**
+   * The in-modal Cancel button honors the same dirty guard as the shell's
+   * backdrop/Escape/X close paths — unsaved changes are never discarded
+   * without an explicit choice.
+   */
+  const cancel = () => {
+    if (isDirty) {
+      setConfirmingCancel(true)
+      return
+    }
+    close()
   }
 
   const toggleExpanded = (key: string) =>
@@ -425,7 +448,7 @@ export function HomepageSectionsEditor({
                 type="button"
                 variant="secondary"
                 size="md"
-                onClick={close}
+                onClick={cancel}
                 disabled={mutation.isPending}
                 className="min-h-[44px]"
               >
@@ -455,6 +478,16 @@ export function HomepageSectionsEditor({
         confirmButtonText="Revert to default"
         variant="warning"
         isLoading={mutation.isPending}
+      />
+
+      <ConfirmationModal
+        isOpen={confirmingCancel}
+        onClose={() => setConfirmingCancel(false)}
+        onConfirm={close}
+        title="Discard unsaved changes?"
+        message="Your homepage composition changes have not been saved."
+        confirmButtonText="Discard changes"
+        variant="warning"
       />
     </>
   )

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -43,7 +43,7 @@ import {
   HOMEPAGE_SECTION_TYPES,
   type HomepageSection,
   type HomepageSectionType,
-} from '@/lib/homepage/sections'
+} from '@/lib/homepage'
 import {
   SECTION_LABELS,
   isConfigurable,
@@ -56,7 +56,7 @@ import {
   toPreviewBands,
   type EditorRow,
   type PreviewBand,
-} from '@/lib/homepage/editor'
+} from '@/lib/homepage'
 
 /**
  * Front-page builder (F3) admin editor — a drag-and-drop composition builder
@@ -96,9 +96,14 @@ export function HomepageSectionsEditor({
   const { showNotification } = useNotification()
 
   const [isOpen, setIsOpen] = useState(defaultOpen)
-  const [rows, setRows] = useState<EditorRow[]>(() =>
+  // Rows are materialized ONCE: `toEditorRows` generates keys for keyless
+  // stored sections, so a second call would mint DIFFERENT keys — the dirty
+  // baseline below must be derived from this same array or the form would
+  // read as dirty the moment it opens.
+  const [initialRows] = useState<EditorRow[]>(() =>
     toEditorRows(initialSections),
   )
+  const [rows, setRows] = useState<EditorRow[]>(initialRows)
   const [addType, setAddType] =
     useState<HomepageSectionType>('homepageCtaBanner')
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -111,12 +116,17 @@ export function HomepageSectionsEditor({
   const [overKey, setOverKey] = useState<string | null>(null)
 
   // The composition serialized at open time; the unsaved-changes guard compares
-  // the live rows against it. Recomputed whenever the stored props change.
+  // the live rows against it. Derived from the SAME materialized rows (stable
+  // generated keys) and memoized — serialization must not rerun on the
+  // high-frequency renders dnd emits while dragging.
   const initialSignature = useMemo(
-    () => serializeRows(toEditorRows(initialSections)),
-    [initialSections],
+    () => serializeRows(initialRows),
+    [initialRows],
   )
-  const isDirty = serializeRows(rows) !== initialSignature
+  const isDirty = useMemo(
+    () => serializeRows(rows) !== initialSignature,
+    [rows, initialSignature],
+  )
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -147,7 +157,9 @@ export function HomepageSectionsEditor({
   })
 
   const reset = () => {
-    setRows(toEditorRows(initialSections))
+    // Restore the SAME materialized rows (not a fresh toEditorRows call, which
+    // would mint new keys and desync the dirty baseline).
+    setRows(initialRows)
     setSubmitError(null)
     setExpanded(new Set())
     setActiveKey(null)
@@ -234,6 +246,13 @@ export function HomepageSectionsEditor({
     const err = validate()
     if (err) {
       setSubmitError(err)
+      return
+    }
+    // Saving an EMPTY composition is server-side "unset → revert to default" —
+    // route it through the same confirmation as the explicit Revert button
+    // rather than silently discarding the stored composition.
+    if (rows.length === 0) {
+      setConfirmingRevert(true)
       return
     }
     mutation.mutate({ homepageSections: toPayload(rows) as never })
@@ -496,7 +515,7 @@ function SortableSectionCard({
           {...attributes}
           {...listeners}
           aria-label={`Drag ${label} to reorder`}
-          className="hidden h-11 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue active:cursor-grabbing sm:inline-flex dark:hover:bg-gray-800 dark:hover:text-gray-300"
+          className="hidden h-11 w-11 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue active:cursor-grabbing sm:inline-flex dark:hover:bg-gray-800 dark:hover:text-gray-300"
         >
           <Bars3Icon className="h-5 w-5" />
         </button>

--- a/src/components/homepage/CtaBanner.tsx
+++ b/src/components/homepage/CtaBanner.tsx
@@ -1,6 +1,6 @@
 import { Container } from '@/components/Container'
 import { Button } from '@/components/Button'
-import type { CtaBannerSection } from '@/lib/homepage/sections'
+import type { CtaBannerSection } from '@/lib/homepage'
 
 /**
  * Generic call-to-action banner block (front-page builder F2). A closed-registry

--- a/src/components/homepage/HomepageComposition.stories.tsx
+++ b/src/components/homepage/HomepageComposition.stories.tsx
@@ -1,9 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { HomepageSectionRenderer } from './SectionRenderer'
-import {
-  getDefaultSections,
-  type HomepageSection,
-} from '@/lib/homepage'
+import { getDefaultSections, type HomepageSection } from '@/lib/homepage'
 import type { Conference } from '@/lib/conference/types'
 import type { TypedObject } from 'sanity'
 

--- a/src/components/homepage/HomepageComposition.stories.tsx
+++ b/src/components/homepage/HomepageComposition.stories.tsx
@@ -3,7 +3,7 @@ import { HomepageSectionRenderer } from './SectionRenderer'
 import {
   getDefaultSections,
   type HomepageSection,
-} from '@/lib/homepage/sections'
+} from '@/lib/homepage'
 import type { Conference } from '@/lib/conference/types'
 import type { TypedObject } from 'sanity'
 

--- a/src/components/homepage/MetricsBlock.tsx
+++ b/src/components/homepage/MetricsBlock.tsx
@@ -1,6 +1,6 @@
 import { Container } from '@/components/Container'
 import type { Conference } from '@/lib/conference/types'
-import type { MetricsSection } from '@/lib/homepage/sections'
+import type { MetricsSection } from '@/lib/homepage'
 
 /**
  * Standalone vanity-metrics band (front-page builder F2). Content comes from the

--- a/src/components/homepage/RichTextBlock.tsx
+++ b/src/components/homepage/RichTextBlock.tsx
@@ -1,7 +1,7 @@
 import { PortableText } from '@portabletext/react'
 import { Container } from '@/components/Container'
 import { portableTextComponents } from '@/lib/portabletext/components'
-import type { RichTextSection } from '@/lib/homepage/sections'
+import type { RichTextSection } from '@/lib/homepage'
 
 /**
  * Generic portable-text block (front-page builder F2), rendered with the shared

--- a/src/components/homepage/SectionRenderer.test.tsx
+++ b/src/components/homepage/SectionRenderer.test.tsx
@@ -39,10 +39,7 @@ vi.mock('@/components/homepage/MetricsBlock', () => ({
 }))
 
 import { HomepageSectionRenderer } from './SectionRenderer'
-import {
-  getDefaultSections,
-  type HomepageSection,
-} from '@/lib/homepage'
+import { getDefaultSections, type HomepageSection } from '@/lib/homepage'
 import type { Conference } from '@/lib/conference/types'
 
 function makeConference(overrides: Partial<Conference> = {}): Conference {

--- a/src/components/homepage/SectionRenderer.test.tsx
+++ b/src/components/homepage/SectionRenderer.test.tsx
@@ -42,7 +42,7 @@ import { HomepageSectionRenderer } from './SectionRenderer'
 import {
   getDefaultSections,
   type HomepageSection,
-} from '@/lib/homepage/sections'
+} from '@/lib/homepage'
 import type { Conference } from '@/lib/conference/types'
 
 function makeConference(overrides: Partial<Conference> = {}): Conference {

--- a/src/components/homepage/SectionRenderer.tsx
+++ b/src/components/homepage/SectionRenderer.tsx
@@ -18,10 +18,7 @@ import {
 import type { Conference } from '@/lib/conference/types'
 import { isCfpOpen, isRegistrationAvailable } from '@/lib/conference/state'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
-import {
-  hasPublishedSchedule,
-  type HomepageSection,
-} from '@/lib/homepage'
+import { hasPublishedSchedule, type HomepageSection } from '@/lib/homepage'
 
 /** Unknown section `_type`s already warned about (once per process). */
 const warnedUnknownSectionTypes = new Set<string>()

--- a/src/components/homepage/SectionRenderer.tsx
+++ b/src/components/homepage/SectionRenderer.tsx
@@ -21,7 +21,7 @@ import { PIRSCH_EVENTS } from '@/lib/analytics'
 import {
   hasPublishedSchedule,
   type HomepageSection,
-} from '@/lib/homepage/sections'
+} from '@/lib/homepage'
 
 /** Unknown section `_type`s already warned about (once per process). */
 const warnedUnknownSectionTypes = new Set<string>()

--- a/src/lib/homepage/editor.test.ts
+++ b/src/lib/homepage/editor.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EditorRow,
+  isConfigurable,
+  moveByIndex,
+  reorderByKey,
+  serializeRows,
+  toEditorRows,
+  toPreviewBands,
+} from './editor'
+import type { HomepageSection } from './sections'
+
+const rows: EditorRow[] = [
+  { _key: 'a', _type: 'homepageHero' },
+  { _key: 'b', _type: 'homepageGallery' },
+  { _key: 'c', _type: 'homepageSponsors' },
+]
+
+describe('moveByIndex', () => {
+  it('moves an item up', () => {
+    expect(moveByIndex(rows, 1, 0).map((r) => r._key)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('moves an item down', () => {
+    expect(moveByIndex(rows, 0, 1).map((r) => r._key)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('is a no-op past the top edge', () => {
+    expect(moveByIndex(rows, 0, -1)).toBe(rows)
+  })
+
+  it('is a no-op past the bottom edge', () => {
+    expect(moveByIndex(rows, 2, 3)).toBe(rows)
+  })
+
+  it('does not mutate the input', () => {
+    const copy = rows.slice()
+    moveByIndex(rows, 0, 2)
+    expect(rows).toEqual(copy)
+  })
+})
+
+describe('reorderByKey', () => {
+  it('reorders by key', () => {
+    expect(reorderByKey(rows, 'a', 'c').map((r) => r._key)).toEqual([
+      'b',
+      'c',
+      'a',
+    ])
+  })
+
+  it('is a no-op when active equals over', () => {
+    expect(reorderByKey(rows, 'b', 'b')).toBe(rows)
+  })
+
+  it('is a no-op with a null active or over (mid-drag, no target yet)', () => {
+    expect(reorderByKey(rows, 'a', null)).toBe(rows)
+    expect(reorderByKey(rows, null, 'a')).toBe(rows)
+  })
+
+  it('is a no-op for unknown keys', () => {
+    expect(reorderByKey(rows, 'a', 'zzz')).toBe(rows)
+  })
+})
+
+describe('isConfigurable', () => {
+  it('is true for blocks with a config form', () => {
+    expect(isConfigurable('homepageHero')).toBe(true)
+    expect(isConfigurable('homepageCtaBanner')).toBe(true)
+    expect(isConfigurable('homepageRichText')).toBe(true)
+    expect(isConfigurable('homepageMetrics')).toBe(true)
+  })
+
+  it('is false for content-free blocks', () => {
+    expect(isConfigurable('homepageGallery')).toBe(false)
+    expect(isConfigurable('homepageSponsors')).toBe(false)
+    expect(isConfigurable('homepageFeaturedSpeakers')).toBe(false)
+    expect(isConfigurable('homepageProgramHighlights')).toBe(false)
+    expect(isConfigurable('homepageOrganizers')).toBe(false)
+  })
+})
+
+describe('serializeRows', () => {
+  it('is stable regardless of transient field values that are trimmed away', () => {
+    const a: EditorRow[] = [{ _key: 'a', _type: 'homepageHero' }]
+    const b: EditorRow[] = [
+      { _key: 'a', _type: 'homepageHero', heroHeadline: '   ' },
+    ]
+    expect(serializeRows(a)).toBe(serializeRows(b))
+  })
+
+  it('differs once a section is reordered', () => {
+    expect(serializeRows(rows)).not.toBe(
+      serializeRows(reorderByKey(rows, 'a', 'c')),
+    )
+  })
+
+  it('differs once a section is hidden', () => {
+    const hidden = rows.map((r) =>
+      r._key === 'b' ? { ...r, hidden: true } : r,
+    )
+    expect(serializeRows(rows)).not.toBe(serializeRows(hidden))
+  })
+})
+
+describe('toPreviewBands', () => {
+  const defaultSections: HomepageSection[] = [
+    { _key: 'default-hero', _type: 'homepageHero' },
+    { _key: 'default-gallery', _type: 'homepageGallery' },
+    { _key: 'default-program', _type: 'homepageProgramHighlights' },
+    { _key: 'default-sponsors', _type: 'homepageSponsors' },
+  ]
+
+  it('maps rows to labeled bands in order', () => {
+    const bands = toPreviewBands(toEditorRows(defaultSections), true)
+    expect(bands.map((b) => b.label)).toEqual([
+      'Hero',
+      'Photo Gallery',
+      'Program Highlights',
+      'Sponsors',
+    ])
+  })
+
+  it('marks the phase-dependent middle slot only when using the default layout', () => {
+    const editorRows = toEditorRows(defaultSections)
+    const asDefault = toPreviewBands(editorRows, true)
+    expect(
+      asDefault.find((b) => b.key === 'default-program')?.isPhaseSlot,
+    ).toBe(true)
+    expect(asDefault.find((b) => b.key === 'default-hero')?.isPhaseSlot).toBe(
+      false,
+    )
+
+    const asCustom = toPreviewBands(editorRows, false)
+    expect(asCustom.every((b) => !b.isPhaseSlot)).toBe(true)
+  })
+
+  it('marks the featured-speakers and organizers fallbacks as the phase slot', () => {
+    const featured = toEditorRows([
+      { _key: 'default-featured-speakers', _type: 'homepageFeaturedSpeakers' },
+    ])
+    expect(toPreviewBands(featured, true)[0].isPhaseSlot).toBe(true)
+
+    const organizers = toEditorRows([
+      { _key: 'default-organizers', _type: 'homepageOrganizers' },
+    ])
+    expect(toPreviewBands(organizers, true)[0].isPhaseSlot).toBe(true)
+  })
+
+  it('does not mark a manually added featured-speakers block as the phase slot', () => {
+    const manual = toEditorRows([
+      { _key: 'hp-manual-1', _type: 'homepageFeaturedSpeakers' },
+    ])
+    expect(toPreviewBands(manual, true)[0].isPhaseSlot).toBe(false)
+  })
+
+  it('ghosts hidden sections', () => {
+    const withHidden: HomepageSection[] = [
+      { _key: 'hero', _type: 'homepageHero' },
+      { _key: 'gallery', _type: 'homepageGallery', hidden: true },
+    ]
+    const bands = toPreviewBands(toEditorRows(withHidden), false)
+    expect(bands[0].hidden).toBe(false)
+    expect(bands[1].hidden).toBe(true)
+  })
+})

--- a/src/lib/homepage/editor.test.ts
+++ b/src/lib/homepage/editor.test.ts
@@ -6,6 +6,7 @@ import {
   reorderByKey,
   serializeRows,
   toEditorRows,
+  toPayload,
   toPreviewBands,
 } from './editor'
 import type { HomepageSection } from './sections'
@@ -162,5 +163,75 @@ describe('toPreviewBands', () => {
     const bands = toPreviewBands(toEditorRows(withHidden), false)
     expect(bands[0].hidden).toBe(false)
     expect(bands[1].hidden).toBe(true)
+  })
+})
+
+describe('toPayload — mapping semantics', () => {
+  it('trims hero copy, omits blank optionals, and filters incomplete CTA overrides', () => {
+    const [hero] = toPayload([
+      {
+        _key: 'h',
+        _type: 'homepageHero',
+        heroHeadline: '  Hello  ',
+        heroSubheadline: '   ',
+        ctaOverrides: [
+          { _key: 'c1', label: ' Tickets ', href: ' /tickets ' },
+          { _key: 'c2', label: '  ', href: '/cfp' },
+          { _key: 'c3', label: 'CFP', href: '  ' },
+        ],
+      },
+    ])
+    expect(hero.heroHeadline).toBe('Hello')
+    // Blank subheadline is OMITTED, not sent as ''.
+    expect('heroSubheadline' in hero).toBe(false)
+    // Only the complete override survives, trimmed.
+    expect(hero.ctaOverrides).toEqual([
+      { _key: 'c1', label: 'Tickets', href: '/tickets' },
+    ])
+  })
+
+  it('keeps CTA-banner required fields present (server rejects empties with its own messages)', () => {
+    const [banner] = toPayload([
+      {
+        _key: 'b',
+        _type: 'homepageCtaBanner',
+        heading: ' Go ',
+        body: '   ',
+        buttonLabel: 'Now',
+        buttonHref: '/x',
+      },
+    ])
+    expect(banner.heading).toBe('Go')
+    expect('body' in banner).toBe(false)
+    expect(banner.buttonLabel).toBe('Now')
+    expect(banner.buttonHref).toBe('/x')
+  })
+
+  it('maps rich-text content through verbatim and defaults to an empty array', () => {
+    const block = { _type: 'block', _key: 'p1', children: [] }
+    const [withContent, without] = toPayload([
+      { _key: 'r1', _type: 'homepageRichText', content: [block] as never },
+      { _key: 'r2', _type: 'homepageRichText' },
+    ])
+    expect(withContent.content).toEqual([block])
+    expect(without.content).toEqual([])
+  })
+
+  it('round-trips toEditorRows → toPayload for a stored composition (keys and flags preserved)', () => {
+    const stored = [
+      { _key: 's1', _type: 'homepageHero' as const, heroHeadline: 'Hi' },
+      { _key: 's2', _type: 'homepageSponsors' as const, hidden: true },
+    ]
+    const payload = toPayload(toEditorRows(stored as never))
+    expect(payload[0]).toMatchObject({
+      _key: 's1',
+      _type: 'homepageHero',
+      heroHeadline: 'Hi',
+    })
+    expect(payload[1]).toEqual({
+      _key: 's2',
+      _type: 'homepageSponsors',
+      hidden: true,
+    })
   })
 })

--- a/src/lib/homepage/editor.ts
+++ b/src/lib/homepage/editor.ts
@@ -100,7 +100,12 @@ export function toEditorRows(sections: HomepageSection[]): EditorRow[] {
   })
 }
 
-/** Build the mutation payload; empty strings are dropped by the server. */
+/**
+ * Build the mutation payload. Empty/blank optional fields are omitted HERE
+ * (the server schema trims and REJECTS empty strings via `.min(1)`, it does
+ * not drop them) — the editor's own `validate()` catches required-field gaps
+ * with friendlier messages before the payload is built.
+ */
 export function toPayload(rows: EditorRow[]): Record<string, unknown>[] {
   return rows.map((row) => {
     const out: Record<string, unknown> = { _type: row._type, _key: row._key }

--- a/src/lib/homepage/editor.ts
+++ b/src/lib/homepage/editor.ts
@@ -26,7 +26,7 @@ export const SECTION_LABELS: Record<HomepageSectionType, string> = {
  * The block types that carry per-section config worth an inline accordion. The
  * content-free blocks (featured speakers, program, organizers, sponsors,
  * gallery) only source their content from the conference, so they need no form
- * and render a compact one-line note instead of an expandable panel.
+ * — their cards render without an expandable config panel.
  */
 const CONFIGURABLE_TYPES: ReadonlySet<HomepageSectionType> = new Set([
   'homepageHero',

--- a/src/lib/homepage/editor.ts
+++ b/src/lib/homepage/editor.ts
@@ -1,0 +1,208 @@
+import { arrayMove } from '@dnd-kit/sortable'
+import type { PortableTextBlock } from '@portabletext/editor'
+import { type HomepageSection, type HomepageSectionType } from './sections'
+
+/**
+ * Front-page builder (F3): the PURE editor logic behind the drag-and-drop
+ * composition builder. Kept framework-free (no React) so the reorder handlers,
+ * payload mapping, dirty check and structural-preview mapping are unit-testable
+ * in isolation from the modal surface that drives them.
+ */
+
+/** Human labels for each block type — shared by the list rows and the preview. */
+export const SECTION_LABELS: Record<HomepageSectionType, string> = {
+  homepageHero: 'Hero',
+  homepageFeaturedSpeakers: 'Featured Speakers',
+  homepageProgramHighlights: 'Program Highlights',
+  homepageOrganizers: 'Organizers',
+  homepageSponsors: 'Sponsors',
+  homepageGallery: 'Photo Gallery',
+  homepageMetrics: 'Vanity Metrics',
+  homepageCtaBanner: 'Call-to-action Banner',
+  homepageRichText: 'Rich Text',
+}
+
+/**
+ * The block types that carry per-section config worth an inline accordion. The
+ * content-free blocks (featured speakers, program, organizers, sponsors,
+ * gallery) only source their content from the conference, so they need no form
+ * and render a compact one-line note instead of an expandable panel.
+ */
+const CONFIGURABLE_TYPES: ReadonlySet<HomepageSectionType> = new Set([
+  'homepageHero',
+  'homepageCtaBanner',
+  'homepageRichText',
+  'homepageMetrics',
+])
+
+export function isConfigurable(type: HomepageSectionType): boolean {
+  return CONFIGURABLE_TYPES.has(type)
+}
+
+/**
+ * The `_key`s {@link getDefaultSections} assigns to the phase-dependent MIDDLE
+ * slot (program highlights → featured speakers → organizers, mutually
+ * exclusive). While a conference is still on the default layout, the preview
+ * badges whichever of these is present as the auto-swapping slot so an organizer
+ * understands it changes with the conference phase rather than being fixed.
+ */
+const PHASE_SLOT_DEFAULT_KEYS: ReadonlySet<string> = new Set([
+  'default-program',
+  'default-featured-speakers',
+  'default-organizers',
+])
+
+/** Working row shape — a superset of every block's fields, keyed for the list. */
+export interface EditorRow {
+  _key: string
+  _type: HomepageSectionType
+  hidden?: boolean
+  heroHeadline?: string
+  heroSubheadline?: string
+  ctaOverrides?: { _key: string; label: string; href: string }[]
+  heading?: string
+  body?: string
+  buttonLabel?: string
+  buttonHref?: string
+  content?: PortableTextBlock[]
+}
+
+let keyCounter = 0
+export const nextKey = () => `hp-${Date.now()}-${++keyCounter}`
+
+export function toEditorRows(sections: HomepageSection[]): EditorRow[] {
+  return sections.map((s) => {
+    const row: EditorRow = {
+      _key: s._key || nextKey(),
+      _type: s._type,
+      hidden: s.hidden,
+    }
+    if (s._type === 'homepageHero') {
+      row.heroHeadline = s.heroHeadline
+      row.heroSubheadline = s.heroSubheadline
+      row.ctaOverrides = (s.ctaOverrides ?? []).map((c) => ({
+        _key: c._key || nextKey(),
+        label: c.label,
+        href: c.href,
+      }))
+    } else if (s._type === 'homepageCtaBanner') {
+      row.heading = s.heading
+      row.body = s.body
+      row.buttonLabel = s.buttonLabel
+      row.buttonHref = s.buttonHref
+    } else if (s._type === 'homepageRichText') {
+      row.heading = s.heading
+      row.content = (s.content as PortableTextBlock[]) ?? []
+    } else if (s._type === 'homepageMetrics') {
+      row.heading = s.heading
+    }
+    return row
+  })
+}
+
+/** Build the mutation payload; empty strings are dropped by the server. */
+export function toPayload(rows: EditorRow[]): Record<string, unknown>[] {
+  return rows.map((row) => {
+    const out: Record<string, unknown> = { _type: row._type, _key: row._key }
+    if (row.hidden) out.hidden = true
+    switch (row._type) {
+      case 'homepageHero':
+        if (row.heroHeadline?.trim()) out.heroHeadline = row.heroHeadline.trim()
+        if (row.heroSubheadline?.trim())
+          out.heroSubheadline = row.heroSubheadline.trim()
+        if (row.ctaOverrides && row.ctaOverrides.length > 0) {
+          out.ctaOverrides = row.ctaOverrides
+            .filter((c) => c.label.trim() && c.href.trim())
+            .map((c) => ({
+              _key: c._key,
+              label: c.label.trim(),
+              href: c.href.trim(),
+            }))
+        }
+        break
+      case 'homepageCtaBanner':
+        out.heading = row.heading?.trim() ?? ''
+        if (row.body?.trim()) out.body = row.body.trim()
+        out.buttonLabel = row.buttonLabel?.trim() ?? ''
+        out.buttonHref = row.buttonHref?.trim() ?? ''
+        break
+      case 'homepageRichText':
+        if (row.heading?.trim()) out.heading = row.heading.trim()
+        out.content = row.content ?? []
+        break
+      case 'homepageMetrics':
+        if (row.heading?.trim()) out.heading = row.heading.trim()
+        break
+      default:
+        break
+    }
+    return out
+  })
+}
+
+/** Stable serialization of the composition, used for the unsaved-changes guard. */
+export function serializeRows(rows: EditorRow[]): string {
+  return JSON.stringify(toPayload(rows))
+}
+
+/**
+ * Reorder by array position — backs the up/down buttons (the mobile + a11y
+ * fallback). Out-of-range targets are a no-op so the caller can pass
+ * `index ± 1` blindly at the ends.
+ */
+export function moveByIndex(
+  rows: EditorRow[],
+  from: number,
+  to: number,
+): EditorRow[] {
+  if (to < 0 || to >= rows.length || from < 0 || from >= rows.length)
+    return rows
+  return arrayMove(rows, from, to)
+}
+
+/**
+ * Reorder by `_key` — backs both the committed drag drop and the live preview
+ * projection during a drag. Tolerant of nulls and unknown keys (returns the
+ * input unchanged) so it can be called mid-drag with a not-yet-over target.
+ */
+export function reorderByKey(
+  rows: EditorRow[],
+  activeKey: string | null,
+  overKey: string | null,
+): EditorRow[] {
+  if (!activeKey || !overKey || activeKey === overKey) return rows
+  const oldIndex = rows.findIndex((r) => r._key === activeKey)
+  const newIndex = rows.findIndex((r) => r._key === overKey)
+  if (oldIndex === -1 || newIndex === -1) return rows
+  return arrayMove(rows, oldIndex, newIndex)
+}
+
+/** A single labeled band in the structural preview panel. */
+export interface PreviewBand {
+  key: string
+  type: HomepageSectionType
+  label: string
+  /** Hidden sections are ghosted in the preview (rendered, but skipped at build). */
+  hidden: boolean
+  /** True for the default layout's auto-swapping phase-dependent middle slot. */
+  isPhaseSlot: boolean
+}
+
+/**
+ * Map the working rows to structural preview bands — labeled boxes in order,
+ * NOT a page render. Hidden sections stay in the list but are flagged so the
+ * panel can ghost them; the phase-dependent default middle slot is flagged only
+ * while the conference is still on the default layout.
+ */
+export function toPreviewBands(
+  rows: EditorRow[],
+  usingDefault: boolean,
+): PreviewBand[] {
+  return rows.map((r) => ({
+    key: r._key,
+    type: r._type,
+    label: SECTION_LABELS[r._type],
+    hidden: !!r.hidden,
+    isPhaseSlot: usingDefault && PHASE_SLOT_DEFAULT_KEYS.has(r._key),
+  }))
+}

--- a/src/lib/homepage/index.ts
+++ b/src/lib/homepage/index.ts
@@ -1,2 +1,6 @@
+// Server-safe barrel: ONLY the registry/model module. The editor logic
+// (./editor) deliberately stays a deep import — it pulls in @dnd-kit, a
+// client-only dependency, and this barrel is imported by server components
+// (page.tsx), so re-exporting it here would drag drag-and-drop code into the
+// RSC module graph and break the build.
 export * from './sections'
-export * from './editor'

--- a/src/lib/homepage/index.ts
+++ b/src/lib/homepage/index.ts
@@ -1,0 +1,2 @@
+export * from './sections'
+export * from './editor'

--- a/src/lib/homepage/index.ts
+++ b/src/lib/homepage/index.ts
@@ -1,6 +1,6 @@
 // Server-safe barrel: ONLY the registry/model module. The editor logic
 // (./editor) deliberately stays a deep import — it pulls in @dnd-kit, a
 // client-only dependency, and this barrel is imported by server components
-// (page.tsx), so re-exporting it here would drag drag-and-drop code into the
+// (page.tsx), so re-exporting it here would drag-and-drop code into the
 // RSC module graph and break the build.
 export * from './sections'


### PR DESCRIPTION
## F3 — Drag-and-drop composition builder

Upgrades the F2 plain-form homepage section editor (#652) into a drag-and-drop builder with a live structural preview. Client-surface only — **no schema or server changes**; it reuses the existing `conference.updateHomepageSections` mutation and the closed F2 section registry.

### Interaction design (drag + fallback + a11y)
- **Reuses the house dnd library `@dnd-kit`** (`@dnd-kit/sortable`) — the same dependency the sponsor email-templates list and schedule editor use; no new dnd library added.
- Cards reorder by dragging a **grab handle** (`Bars3Icon`) — `PointerSensor` (5px activation) for pointer, `KeyboardSensor` + `sortableKeyboardCoordinates` for keyboard (Space/Enter to lift, arrows to move). `verticalListSortingStrategy` animates the list; a `DragOverlay` renders the lifted card with elevation + brand ring.
- The **up/down buttons stay** as the mobile + a11y fallback (the grab handle is `sm:`-only, hidden on mobile per the schedule editor's tap-first pattern). Every control keeps its 44×44 touch target.
- Dragging elevation: the source row dims to `opacity-50` with a brand-blue border; the overlay carries the shadow/ring.

### Preview design
- A compact **"Page structure"** panel (beside the list on desktop, stacked under it on mobile) maps the composition to labeled bands **in order** — structural boxes, not a page render.
- **Live**: while dragging, the panel reflects the *projected* order (computed from active/over ids via `reorderByKey`) without disturbing the sortable list, so it updates as you drag for both pointer and keyboard.
- **Hidden sections are ghosted** (dashed border, muted, `HIDDEN` tag) in both the card and the preview.
- The default layout's **phase-dependent middle slot** (program → featured speakers → organizers) is badged *"Auto-swaps with the conference phase"*, but only while the conference is still on the default layout (matched by the `default-*` keys `getDefaultSections` assigns).

### Config + edge states
- Per-block config now opens **inline as an accordion** (gear toggle) instead of always-expanded, keeping cards compact for reordering; a freshly **added** configurable block auto-expands so add → configure → reorder is one fluid surface. Content-free blocks carry no form.
- Default-composition banner reworded to *"Using the default layout — customize below to override it."*
- **Revert to default** now goes through a `ConfirmationModal` (warning variant) instead of firing immediately.
- **Unsaved-changes guard** on close via ModalShell's built-in `confirmOnDirtyClose` + `isDirty` (dirty = live rows differ from the opened composition's serialized payload).
- Empty state (all sections removed) shows a friendly prompt.

### Where the logic lives
Pure, framework-free logic extracted to `src/lib/homepage/editor.ts` (reorder by index/key, payload + dirty serialization, `toPreviewBands` incl. hidden ghosting + phase-slot marking, `isConfigurable`) with full unit coverage in `editor.test.ts`.

### Shoot findings
`pnpm shoot` on the editor modal at **393px and 1280px, light + dark**, all inspected:
- No horizontal overflow at either width (0 cards exceed the viewport).
- Grab handles correctly hidden on mobile; up/down fallback present.
- Preview panel wraps under the list on mobile, sits sticky beside it on desktop.
- Fixed one finding: the `Hidden` badge was truncating to "Hi…" on 393px (it sat inside the card's truncating label span) — moved it to a `shrink-0` sibling so the label truncates but the badge stays whole.

### QA
- `mise run check` (typecheck / lint / knip / format) green; only pre-existing warnings.
- Full vitest suite green (4220 tests); 33 in `src/lib/homepage` (editor + sections).
- Stories: default layout, custom composition, empty, mobile (393), dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
