### PR TITLE
feat(admin): settings page IA — grouped sections, jump nav, organizer-friendly naming

### DIFF
--- a/__tests__/lib/time.test.ts
+++ b/__tests__/lib/time.test.ts
@@ -256,6 +256,20 @@ describe('instantToOsloLocalInput / osloLocalInputToIso', () => {
     )
   })
 
+  it('resolves DST transition edge cases to a consistent instant', () => {
+    // Spring forward 2026: 02:00→03:00 Oslo on Mar 29; 02:30 does not exist as
+    // a wall-clock time. Best-effort resolution maps it to a real instant
+    // inside the transition hour (documented behavior, pinned here).
+    const spring = osloLocalInputToIso('2026-03-29T02:30')
+    expect(spring).toBe('2026-03-29T01:30:00.000Z')
+    // Fall back 2026: 03:00→02:00 on Oct 25; 02:30 occurs twice. The helper
+    // resolves deterministically to one of the two instants (CET, post-switch).
+    const fall = osloLocalInputToIso('2026-10-25T02:30')
+    expect(fall).toBe('2026-10-25T01:30:00.000Z')
+    // Both round-trip back to a 02:30 Oslo wall-clock display.
+    expect(instantToOsloLocalInput(fall!)).toBe('2026-10-25T02:30')
+  })
+
   it('degrades malformed values instead of throwing', () => {
     expect(instantToOsloLocalInput('nope')).toBe('')
     expect(instantToOsloLocalInput(undefined)).toBe('')

--- a/__tests__/lib/time.test.ts
+++ b/__tests__/lib/time.test.ts
@@ -14,6 +14,8 @@ import {
   formatChartMonth,
   formatChartDay,
   formatChartDateShort,
+  instantToOsloLocalInput,
+  osloLocalInputToIso,
 } from '@/lib/time'
 
 describe('time.ts', () => {
@@ -231,5 +233,33 @@ describe('time.ts', () => {
       // The fixed helper stays on the 27th.
       expect(formatConferenceDate('2025-10-27', { day: 'numeric' })).toBe('27.')
     })
+  })
+})
+
+describe('instantToOsloLocalInput / osloLocalInputToIso', () => {
+  it('round-trips an instant through Oslo wall-clock (CET, UTC+1)', () => {
+    // 10:00Z in January = 11:00 Oslo (CET)
+    expect(instantToOsloLocalInput('2026-01-15T10:00:00.000Z')).toBe(
+      '2026-01-15T11:00',
+    )
+    expect(osloLocalInputToIso('2026-01-15T11:00')).toBe(
+      '2026-01-15T10:00:00.000Z',
+    )
+  })
+
+  it('is DST-correct in summer (CEST, UTC+2)', () => {
+    expect(instantToOsloLocalInput('2026-07-15T10:00:00.000Z')).toBe(
+      '2026-07-15T12:00',
+    )
+    expect(osloLocalInputToIso('2026-07-15T12:00')).toBe(
+      '2026-07-15T10:00:00.000Z',
+    )
+  })
+
+  it('degrades malformed values instead of throwing', () => {
+    expect(instantToOsloLocalInput('nope')).toBe('')
+    expect(instantToOsloLocalInput(undefined)).toBe('')
+    expect(osloLocalInputToIso('not-a-date')).toBeNull()
+    expect(osloLocalInputToIso('')).toBeNull()
   })
 })

--- a/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
+++ b/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
@@ -1,0 +1,460 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import {
+  CalendarIcon,
+  GlobeAltIcon,
+  MapPinIcon,
+  UserGroupIcon,
+  DocumentTextIcon,
+  TagIcon,
+  CurrencyDollarIcon,
+  InformationCircleIcon,
+  LinkIcon,
+  EnvelopeIcon,
+  Cog6ToothIcon,
+  ServerStackIcon,
+  BeakerIcon,
+  SwatchIcon,
+  EyeIcon,
+  PencilSquareIcon,
+  ChartPieIcon,
+} from '@heroicons/react/24/outline'
+import {
+  InfoCard,
+  FieldRow,
+  StudioEditLink,
+  SectionNav,
+  SectionHeading,
+  SettingsGroupSection,
+} from './settingsLayout'
+import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
+import { StatusBadge } from '@/components/StatusBadge'
+import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
+
+/**
+ * Visual-QA harness for the Settings page information architecture: the sticky
+ * jump-nav, the six grouped tier-1 subsections, the collapsed-by-default cards
+ * and the three tiers. Rendered with static mock data and non-functional edit
+ * pencils (the real cards use tRPC-backed editor islands) so the whole layout is
+ * inspectable in isolation without providers.
+ */
+
+const GROUP: Record<string, SettingsGroup> = Object.fromEntries(
+  SETTINGS_GROUPS.map((g) => [g.id, g]),
+)
+
+const EDIT_URL =
+  'https://studio.example.com/intent/edit/id=conf;type=conference'
+
+/** Non-functional stand-in for the EditConferenceCard pencil trigger. */
+function EditPencil() {
+  return (
+    <span className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 dark:text-gray-400">
+      <PencilSquareIcon className="h-5 w-5" />
+    </span>
+  )
+}
+
+function SettingsIADemo() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Cog6ToothIcon className="h-8 w-8 text-gray-400" />
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Conference Settings
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Configuration settings for Cloud Native Bergen 2026
+          </p>
+        </div>
+      </div>
+
+      <SectionNav />
+
+      {/* ---- TIER 1 ---- */}
+      <section className="space-y-4">
+        <SectionHeading
+          id="configuration"
+          icon={DocumentTextIcon}
+          title="Conference configuration"
+          description="Content managed in Sanity for this conference."
+        />
+
+        <div className="space-y-10">
+          <SettingsGroupSection
+            group={GROUP['identity-brand']}
+            icon={InformationCircleIcon}
+          >
+            <InfoCard
+              title="Basic Information"
+              icon={InformationCircleIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow label="Title" value="Cloud Native Bergen 2026" />
+              <FieldRow label="Organizer" value="Cloud Native Norway" />
+              <FieldRow label="City" value="Bergen" />
+              <FieldRow label="Country" value="Norway" />
+              <FieldRow label="Tagline" value="Cloud on your terms" />
+            </InfoCard>
+
+            <InfoCard
+              title="Branding"
+              icon={SwatchIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow
+                label="Background Pattern"
+                value="Cloud Native (animated CNCF logos)"
+              />
+            </InfoCard>
+
+            <InfoCard title="Visibility" icon={EyeIcon} action={<EditPencil />}>
+              <div
+                id="visibility"
+                className="flex scroll-mt-24 items-center justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700"
+              >
+                <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Status
+                </dt>
+                <dd className="min-w-0 text-right text-sm">
+                  <StatusBadge label="Live" color="green" />
+                </dd>
+              </div>
+              <p className="pt-1 text-sm text-gray-500 dark:text-gray-400">
+                Publicly listed and indexed by search engines.
+              </p>
+            </InfoCard>
+
+            <CollapsibleSection
+              title="Venue Information"
+              icon={MapPinIcon}
+              action={
+                <>
+                  <StudioEditLink editUrl={EDIT_URL} />
+                  <EditPencil />
+                </>
+              }
+            >
+              <div className="space-y-3 px-6 py-4">
+                <FieldRow label="Venue Name" value="Grieghallen" />
+                <FieldRow label="Venue Address" value="Edvard Griegs plass 1" />
+              </div>
+            </CollapsibleSection>
+          </SettingsGroupSection>
+
+          <SettingsGroupSection group={GROUP['schedule']} icon={CalendarIcon}>
+            <InfoCard
+              title="Dates & Timeline"
+              icon={CalendarIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow label="Start Date" value="2026-06-10" type="date" />
+              <FieldRow label="End Date" value="2026-06-11" type="date" />
+              <FieldRow label="CFP End Date" value="2026-03-01" type="date" />
+              <FieldRow label="Travel Support Budget" value={50000} />
+            </InfoCard>
+
+            <InfoCard
+              title="Announcement"
+              icon={DocumentTextIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow label="Landing-page banner" value="Configured" />
+            </InfoCard>
+          </SettingsGroupSection>
+
+          <SettingsGroupSection
+            group={GROUP['call-for-papers']}
+            icon={DocumentTextIcon}
+          >
+            <InfoCard
+              title="CFP & Revenue Goals"
+              icon={CurrencyDollarIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow label="CFP Submission Goal" value={120} />
+              <FieldRow label="Presentation Goal" value={40} />
+              <FieldRow label="Sponsor Revenue Goal" value={800000} />
+            </InfoCard>
+          </SettingsGroupSection>
+
+          <SettingsGroupSection
+            group={GROUP['tickets-registration']}
+            icon={TagIcon}
+          >
+            <InfoCard
+              title="Registration"
+              icon={DocumentTextIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow label="Registration Enabled" value type="boolean" />
+              <FieldRow
+                label="Registration Link"
+                value="https://checkin.no/event/cloud-native-bergen-2026"
+                type="url"
+              />
+            </InfoCard>
+
+            <InfoCard
+              title="Workshop Registration"
+              icon={CalendarIcon}
+              action={<EditPencil />}
+            >
+              <FieldRow
+                label="Registration Opens"
+                value="2026-04-01T09:00:00Z"
+                type="datetime"
+              />
+              <FieldRow
+                label="Registration Closes"
+                value="2026-05-01T09:00:00Z"
+                type="datetime"
+              />
+              <div className="flex items-center justify-between py-2">
+                <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Status
+                </span>
+                <StatusBadge label="Not yet open" color="yellow" />
+              </div>
+            </InfoCard>
+
+            <InfoCard
+              title="Ticketing"
+              icon={LinkIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow label="Ticketing Provider" value="checkin" />
+              <FieldRow label="Checkin Customer ID" value={12345} />
+              <FieldRow label="Checkin Event ID" value={67890} />
+            </InfoCard>
+
+            <CollapsibleSection
+              title="Homepage Stats"
+              icon={ChartPieIcon}
+              action={
+                <>
+                  <StudioEditLink editUrl={EDIT_URL} />
+                  <EditPencil />
+                </>
+              }
+            >
+              <div className="space-y-3 px-6 py-4">
+                <FieldRow label="Attendees" value="500+" />
+                <FieldRow label="Speakers" value="60" />
+              </div>
+            </CollapsibleSection>
+          </SettingsGroupSection>
+
+          <SettingsGroupSection
+            group={GROUP['sponsors']}
+            icon={CurrencyDollarIcon}
+          >
+            <InfoCard
+              title="Sponsorship Tiers"
+              icon={CurrencyDollarIcon}
+              editUrl={EDIT_URL}
+            >
+              <div className="border-b border-gray-200 pb-3 last:border-b-0 last:pb-0 dark:border-gray-700">
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="font-medium text-gray-900 dark:text-white">
+                    Gold
+                  </span>
+                  <StatusBadge label="Popular" color="green" />
+                </div>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Prime logo placement and 4 tickets.
+                </p>
+              </div>
+            </InfoCard>
+
+            <InfoCard
+              title="Current Sponsors"
+              icon={CurrencyDollarIcon}
+              editUrl={EDIT_URL}
+            >
+              <FieldRow
+                label="Sponsors"
+                value={['Acme (Gold)', 'Globex (Silver)']}
+                type="array"
+              />
+            </InfoCard>
+
+            <CollapsibleSection
+              title="Sponsor Benefits"
+              icon={CurrencyDollarIcon}
+              action={
+                <>
+                  <StudioEditLink editUrl={EDIT_URL} />
+                  <EditPencil />
+                </>
+              }
+            >
+              <div className="space-y-3 px-6 py-4">
+                <FieldRow
+                  label="Reach"
+                  value="Access to 500+ cloud native engineers."
+                />
+              </div>
+            </CollapsibleSection>
+
+            <CollapsibleSection
+              title="Sponsorship Page"
+              icon={DocumentTextIcon}
+              action={
+                <>
+                  <StudioEditLink editUrl={EDIT_URL} />
+                  <EditPencil />
+                </>
+              }
+            >
+              <div className="space-y-3 px-6 py-4">
+                <FieldRow label="Hero Headline" value="Partner with us" />
+                <FieldRow
+                  label="Prospectus Link"
+                  value="https://example.com/prospectus.pdf"
+                  type="url"
+                />
+              </div>
+            </CollapsibleSection>
+          </SettingsGroupSection>
+
+          <SettingsGroupSection
+            group={GROUP['team-content']}
+            icon={UserGroupIcon}
+          >
+            <InfoCard
+              title="Organizers & Teams"
+              icon={UserGroupIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow
+                label="Organizers"
+                value={['Hans Flaatten', 'Jane Doe', 'John Smith']}
+                type="team"
+              />
+            </InfoCard>
+
+            <InfoCard
+              title="Communication"
+              icon={EnvelopeIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow
+                label="Contact Email"
+                value="hello@cloudnativebergen.no"
+                type="email"
+              />
+              <FieldRow
+                label="Sales / Weekly Update Channel"
+                value="#conference-updates"
+              />
+            </InfoCard>
+
+            <InfoCard
+              title="Domains & Social Links"
+              icon={GlobeAltIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow
+                label="Domains"
+                value={['cloudnativebergen.no', '2026.cloudnativebergen.no']}
+                type="array"
+              />
+              <FieldRow
+                label="Social Links"
+                value={['https://bsky.app/profile/cloudnativebergen.no']}
+                type="links"
+              />
+            </InfoCard>
+
+            <InfoCard
+              title="Topics & Formats"
+              icon={TagIcon}
+              editUrl={EDIT_URL}
+              action={<EditPencil />}
+            >
+              <FieldRow
+                label="Available Topics"
+                value={['Kubernetes', 'Observability', 'Security']}
+                type="array"
+              />
+            </InfoCard>
+
+            <InfoCard
+              title="Homepage Composition"
+              icon={DocumentTextIcon}
+              action={<EditPencil />}
+            >
+              <div className="flex items-center justify-between gap-3 border-b border-gray-200 py-2 dark:border-gray-700">
+                <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Layout
+                </dt>
+                <dd className="min-w-0 text-right text-sm">
+                  <StatusBadge label="Default (automatic)" color="gray" />
+                </dd>
+              </div>
+            </InfoCard>
+          </SettingsGroupSection>
+        </div>
+      </section>
+
+      {/* ---- TIER 2 ---- */}
+      <section className="space-y-4">
+        <SectionHeading
+          id="system-status"
+          icon={ServerStackIcon}
+          title="System status"
+          description="Environment configuration and live integration health."
+        />
+        <div className="rounded-lg bg-white p-6 text-sm text-gray-500 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:ring-gray-700">
+          System status checks render here.
+        </div>
+      </section>
+
+      {/* ---- TIER 3 ---- */}
+      <section className="space-y-4">
+        <SectionHeading
+          id="self-check"
+          icon={BeakerIcon}
+          title="Self-check"
+          description="Actively exercise an integration end to end."
+        />
+        <div className="rounded-lg bg-white p-6 text-sm text-gray-500 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:ring-gray-700">
+          Self-check probes render here.
+        </div>
+      </section>
+    </div>
+  )
+}
+
+const meta = {
+  title: 'Systems/Admin/SettingsIA',
+  component: SettingsIADemo,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story: React.ComponentType) => (
+      <div className="min-h-screen bg-gray-50 p-4 sm:p-6 dark:bg-gray-950">
+        <div className="mx-auto max-w-5xl">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof SettingsIADemo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
+++ b/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
@@ -129,7 +129,7 @@ function SettingsIADemo() {
 
             <CollapsibleSection
               title="Venue Information"
-              icon={MapPinIcon}
+              icon={<MapPinIcon />}
               action={
                 <>
                   <StudioEditLink editUrl={EDIT_URL} />
@@ -237,7 +237,7 @@ function SettingsIADemo() {
 
             <CollapsibleSection
               title="Homepage Stats"
-              icon={ChartPieIcon}
+              icon={<ChartPieIcon />}
               action={
                 <>
                   <StudioEditLink editUrl={EDIT_URL} />
@@ -288,7 +288,7 @@ function SettingsIADemo() {
 
             <CollapsibleSection
               title="Sponsor Benefits"
-              icon={CurrencyDollarIcon}
+              icon={<CurrencyDollarIcon />}
               action={
                 <>
                   <StudioEditLink editUrl={EDIT_URL} />
@@ -306,7 +306,7 @@ function SettingsIADemo() {
 
             <CollapsibleSection
               title="Sponsorship Page"
-              icon={DocumentTextIcon}
+              icon={<DocumentTextIcon />}
               action={
                 <>
                   <StudioEditLink editUrl={EDIT_URL} />

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,7 +1,5 @@
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { resolveConferenceVisibility } from '@/lib/conference/visibility'
-import { formatDate } from '@/lib/time'
-import { formats, Format } from '@/lib/proposal/types'
 import { buildSystemChecks } from '@/lib/system-status/checks'
 import { formatTeamSummary } from '@/lib/teams'
 import {
@@ -29,7 +27,17 @@ import { OrganizersEditor } from '@/components/admin/OrganizersEditor'
 import { TopicsEditor } from '@/components/admin/TopicsEditor'
 import { TeamsEditor } from '@/components/admin/TeamsEditor'
 import { HomepageSectionsEditor } from '@/components/admin/HomepageSectionsEditor'
+import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
 import { resolveHomepageSections } from '@/lib/homepage'
+import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
+import {
+  InfoCard,
+  FieldRow,
+  StudioEditLink,
+  SectionNav,
+  SectionHeading,
+  SettingsGroupSection,
+} from './settingsLayout'
 import {
   CalendarIcon,
   GlobeAltIcon,
@@ -38,13 +46,10 @@ import {
   DocumentTextIcon,
   TagIcon,
   CurrencyDollarIcon,
-  CheckCircleIcon,
-  XCircleIcon,
   InformationCircleIcon,
   LinkIcon,
   EnvelopeIcon,
   Cog6ToothIcon,
-  PencilSquareIcon,
   ServerStackIcon,
   BeakerIcon,
   SwatchIcon,
@@ -53,22 +58,16 @@ import {
   EyeSlashIcon,
 } from '@heroicons/react/24/outline'
 
+/** Group id → group metadata, so tier-1 subsections stay single-sourced. */
+const GROUP: Record<string, SettingsGroup> = Object.fromEntries(
+  SETTINGS_GROUPS.map((g) => [g.id, g]),
+)
+
 /** Read-only labels for the branding-card background-pattern row. */
 const BACKGROUND_PATTERN_LABELS: Record<BackgroundPattern, string> = {
   'cloud-native': 'Cloud Native (animated CNCF logos)',
   subtle: 'Subtle (sparse, faint logos)',
   none: 'None (plain gradient)',
-}
-
-interface NamedItem {
-  name?: string
-  title?: string
-}
-
-type ArrayItem = string | NamedItem
-
-function isValidFormat(key: string): key is Format {
-  return Object.values(Format).includes(key as Format)
 }
 
 /**
@@ -80,289 +79,6 @@ function studioEditUrl(conferenceId: string | undefined): string | null {
   const base = process.env.NEXT_PUBLIC_STUDIO_URL
   if (!base || !conferenceId) return null
   return `${base.replace(/\/$/, '')}/intent/edit/id=${conferenceId};type=conference`
-}
-
-function InfoCard({
-  title,
-  children,
-  icon: Icon,
-  editUrl,
-  action,
-}: {
-  title: string
-  children: React.ReactNode
-  icon: React.ComponentType<{ className?: string }>
-  editUrl?: string | null
-  /**
-   * Optional inline edit affordance (an {@link EditConferenceCard} island). When
-   * present it sits beside the Studio deep-link; the card body keeps rendering
-   * the read-only values and refreshes after a save.
-   */
-  action?: React.ReactNode
-}) {
-  return (
-    <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
-      <div className="mb-4 flex items-center justify-between gap-2">
-        <div className="flex items-center">
-          <Icon className="mr-2 h-5 w-5 text-gray-400 dark:text-gray-500" />
-          <h3 className="text-lg font-medium text-gray-900 dark:text-white">
-            {title}
-          </h3>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {editUrl && (
-            <a
-              href={editUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
-            >
-              <PencilSquareIcon className="h-4 w-4" />
-              Edit in Studio
-            </a>
-          )}
-          {action}
-        </div>
-      </div>
-      <div className="space-y-3">{children}</div>
-    </div>
-  )
-}
-
-function FieldRow({
-  label,
-  value,
-  type = 'text',
-}: {
-  label: string
-  value:
-    string | boolean | Array<string | NamedItem> | number | null | undefined
-  type?:
-    | 'text'
-    | 'date'
-    | 'datetime'
-    | 'boolean'
-    | 'array'
-    | 'links'
-    | 'formats'
-    | 'team'
-    | 'url'
-    | 'email'
-}) {
-  let displayValue: React.ReactNode = value as React.ReactNode
-
-  switch (type) {
-    case 'datetime':
-      displayValue = value
-        ? new Date(value as string).toLocaleString('en-US', {
-            dateStyle: 'medium',
-            timeStyle: 'short',
-          })
-        : 'Not set'
-      break
-    case 'date':
-      displayValue = value ? formatDate(value as string) : 'Not set'
-      break
-    case 'boolean':
-      displayValue = (
-        <div className="flex items-center">
-          {value ? (
-            <>
-              <CheckCircleIcon className="mr-1 h-4 w-4 text-green-500 dark:text-green-400" />
-              <span className="text-green-700 dark:text-green-300">Yes</span>
-            </>
-          ) : (
-            <>
-              <XCircleIcon className="mr-1 h-4 w-4 text-red-500 dark:text-red-400" />
-              <span className="text-red-700 dark:text-red-300">No</span>
-            </>
-          )}
-        </div>
-      )
-      break
-    case 'array':
-      displayValue =
-        Array.isArray(value) && value.length > 0 ? (
-          <div className="flex flex-wrap gap-1">
-            {value.map((item: ArrayItem, idx) => {
-              const displayText =
-                typeof item === 'string'
-                  ? item
-                  : (item as NamedItem)?.title ||
-                    (item as NamedItem)?.name ||
-                    JSON.stringify(item)
-              return <StatusBadge key={idx} label={displayText} color="gray" />
-            })}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )
-      break
-    case 'links':
-      displayValue =
-        Array.isArray(value) && value.length > 0 ? (
-          <div className="space-y-2">
-            {value.map((link, idx) => (
-              <div key={idx}>
-                <a
-                  href={link as string}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex max-w-full min-w-0 items-start text-sm text-indigo-600 hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300"
-                >
-                  {/* break-all, not truncate: a URL is an unbreakable token, and
-                      an unconstrained nowrap span dictated the row's intrinsic
-                      width — the whole page scrolled horizontally on mobile. */}
-                  <span className="min-w-0 break-all">{link as string}</span>
-                  <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
-                </a>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )
-      break
-    case 'formats':
-      displayValue =
-        Array.isArray(value) && value.length > 0 ? (
-          <div className="flex flex-wrap gap-1">
-            {value.map((format: ArrayItem, idx) => {
-              const formatKey =
-                typeof format === 'string'
-                  ? format
-                  : (format as NamedItem)?.title || (format as NamedItem)?.name
-              const displayText =
-                formatKey && isValidFormat(formatKey)
-                  ? formats.get(formatKey) || formatKey
-                  : formatKey || 'Unknown Format'
-              return <StatusBadge key={idx} label={displayText} color="gray" />
-            })}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )
-      break
-    case 'team':
-      displayValue =
-        Array.isArray(value) && value.length > 0 ? (
-          <div className="grid grid-cols-2 gap-2">
-            {value.map((member: ArrayItem, idx) => {
-              const memberName =
-                typeof member === 'string'
-                  ? member
-                  : (member as NamedItem)?.name || 'Unknown Member'
-              return (
-                <div
-                  key={idx}
-                  className="py-1 text-sm text-gray-900 dark:text-white"
-                >
-                  {memberName}
-                </div>
-              )
-            })}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )
-      break
-    case 'url':
-      displayValue = value ? (
-        <a
-          href={value as string}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex min-w-0 items-start text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
-        >
-          {/* Same overflow class as the 'links' case: an unbreakable URL must
-              break rather than widen the row past the viewport. */}
-          <span className="min-w-0 break-all">{value as string}</span>
-          <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
-        </a>
-      ) : (
-        'Not set'
-      )
-      break
-    case 'email':
-      displayValue = value ? (
-        <a
-          href={`mailto:${value}`}
-          className="flex items-center text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
-        >
-          {value as string}
-          <EnvelopeIcon className="ml-1 h-3 w-3" />
-        </a>
-      ) : (
-        'Not set'
-      )
-      break
-    default:
-      displayValue = (value as string) || 'Not set'
-  }
-
-  return (
-    <div className="flex justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
-      <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
-        {label}
-      </dt>
-      {/* min-w-0 lets the value column actually shrink inside the flex row —
-          without it, wide unbreakable content (URLs) forces the row past the
-          viewport and the page pans horizontally. */}
-      <dd className="max-w-xs min-w-0 text-right text-sm text-gray-900 dark:text-white">
-        {displayValue}
-      </dd>
-    </div>
-  )
-}
-
-function SectionNav() {
-  const items = [
-    { href: '#configuration', label: 'Configuration' },
-    { href: '#system-status', label: 'System status' },
-    { href: '#self-check', label: 'Self-check' },
-  ]
-  return (
-    <nav className="sticky top-0 z-10 -mx-4 mb-2 border-b border-gray-200 bg-gray-50/90 px-4 py-2 backdrop-blur sm:mx-0 sm:rounded-lg sm:border sm:px-4 dark:border-gray-700 dark:bg-gray-900/90">
-      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
-        {items.map((item) => (
-          <li key={item.href}>
-            <a
-              href={item.href}
-              className="font-medium text-gray-600 hover:text-indigo-600 dark:text-gray-300 dark:hover:text-indigo-400"
-            >
-              {item.label}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </nav>
-  )
-}
-
-function SectionHeading({
-  id,
-  icon: Icon,
-  title,
-  description,
-}: {
-  id: string
-  icon: React.ComponentType<{ className?: string }>
-  title: string
-  description: string
-}) {
-  return (
-    <div id={id} className="scroll-mt-16">
-      <div className="flex items-center gap-2">
-        <Icon className="h-6 w-6 text-gray-400 dark:text-gray-500" />
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-          {title}
-        </h2>
-      </div>
-      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-        {description}
-      </p>
-    </div>
-  )
 }
 
 export default async function AdminSettings() {
@@ -452,654 +168,727 @@ export default async function AdminSettings() {
           description="Content managed in Sanity for this conference."
         />
 
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <InfoCard
-            title="Visibility"
-            icon={visibility === 'unlisted' ? EyeSlashIcon : EyeIcon}
-            action={
-              <EditConferenceCard
-                fieldset="visibility"
-                initialValues={{ visibility }}
-              />
-            }
-          >
-            <div
-              id="visibility"
-              className="flex scroll-mt-16 items-center justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700"
-            >
-              <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
-                Status
-              </dt>
-              <dd className="min-w-0 text-right text-sm">
-                {visibility === 'unlisted' ? (
-                  <StatusBadge label="Unlisted" color="yellow" />
-                ) : (
-                  <StatusBadge label="Live" color="green" />
-                )}
-              </dd>
-            </div>
-            <p className="pt-1 text-sm text-gray-500 dark:text-gray-400">
-              {visibility === 'unlisted'
-                ? 'Reachable by direct link but excluded from sitemaps, robots and search indexing.'
-                : 'Publicly listed and indexed by search engines.'}
-            </p>
-          </InfoCard>
-
-          <InfoCard
-            title="Basic Information"
+        <div className="space-y-10">
+          {/* ---- Identity & Brand ---- */}
+          <SettingsGroupSection
+            group={GROUP['identity-brand']}
             icon={InformationCircleIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="basicInfo"
-                initialValues={{
-                  title: conference.title,
-                  organizer: conference.organizer,
-                  city: conference.city,
-                  country: conference.country,
-                  tagline: conference.tagline,
-                  description: conference.description,
-                }}
-              />
-            }
           >
-            <FieldRow label="Title" value={conference.title} />
-            <FieldRow label="Organizer" value={conference.organizer} />
-            <FieldRow label="City" value={conference.city} />
-            <FieldRow label="Country" value={conference.country} />
-            <FieldRow label="Tagline" value={conference.tagline} />
-            <FieldRow label="Description" value={conference.description} />
-          </InfoCard>
-
-          <InfoCard
-            title="Branding"
-            icon={SwatchIcon}
-            editUrl={editUrl}
-            action={
-              <>
+            <InfoCard
+              title="Basic Information"
+              icon={InformationCircleIcon}
+              editUrl={editUrl}
+              action={
                 <EditConferenceCard
-                  fieldset="branding"
+                  fieldset="basicInfo"
                   initialValues={{
-                    // Normalize (not just null-coalesce) so an invalid stored
-                    // value can't seed an enum-invalid submit.
-                    backgroundPattern: normalizeBackgroundPattern(
-                      conference.backgroundPattern,
-                    ),
+                    title: conference.title,
+                    organizer: conference.organizer,
+                    city: conference.city,
+                    country: conference.country,
+                    tagline: conference.tagline,
+                    description: conference.description,
                   }}
                 />
-                <ThemeEditor initialTheme={conference.theme} />
-                <BrandingEditor
-                  initialValues={{
-                    logoBright: conference.logoBright,
-                    logoDark: conference.logoDark,
-                    logomarkBright: conference.logomarkBright,
-                    logomarkDark: conference.logomarkDark,
-                  }}
-                />
-              </>
-            }
-          >
-            <BrandingPreviewGrid
-              values={{
-                logoBright: conference.logoBright,
-                logoDark: conference.logoDark,
-                logomarkBright: conference.logomarkBright,
-                logomarkDark: conference.logomarkDark,
-              }}
-            />
-            <FieldRow
-              label="Background Pattern"
-              value={
-                BACKGROUND_PATTERN_LABELS[
-                  normalizeBackgroundPattern(conference.backgroundPattern)
-                ]
               }
-            />
-            <div className="border-t border-gray-100 pt-4 dark:border-gray-800">
-              <p className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
-                Brand Colors
-              </p>
-              <ThemeSwatchRow theme={conference.theme} />
-            </div>
-          </InfoCard>
+            >
+              <FieldRow label="Title" value={conference.title} />
+              <FieldRow label="Organizer" value={conference.organizer} />
+              <FieldRow label="City" value={conference.city} />
+              <FieldRow label="Country" value={conference.country} />
+              <FieldRow label="Tagline" value={conference.tagline} />
+              <FieldRow label="Description" value={conference.description} />
+            </InfoCard>
 
-          <InfoCard
-            title="Venue Information"
-            icon={MapPinIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="venue"
-                initialValues={{
-                  venueName: conference.venueName,
-                  venueAddress: conference.venueAddress,
-                }}
-              />
-            }
-          >
-            <FieldRow label="Venue Name" value={conference.venueName} />
-            <FieldRow label="Venue Address" value={conference.venueAddress} />
-          </InfoCard>
-
-          <InfoCard
-            title="Dates & Timeline"
-            icon={CalendarIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="dates"
-                initialValues={{
-                  startDate: conference.startDate,
-                  endDate: conference.endDate,
-                  cfpStartDate: conference.cfpStartDate,
-                  cfpEndDate: conference.cfpEndDate,
-                  cfpNotifyDate: conference.cfpNotifyDate,
-                  programDate: conference.programDate,
-                  travelSupportPaymentDate: conference.travelSupportPaymentDate,
-                  travelSupportBudget: conference.travelSupportBudget,
-                }}
-              />
-            }
-          >
-            <FieldRow
-              label="Start Date"
-              value={conference.startDate}
-              type="date"
-            />
-            <FieldRow label="End Date" value={conference.endDate} type="date" />
-            <FieldRow
-              label="CFP Start Date"
-              value={conference.cfpStartDate}
-              type="date"
-            />
-            <FieldRow
-              label="CFP End Date"
-              value={conference.cfpEndDate}
-              type="date"
-            />
-            <FieldRow
-              label="CFP Notify Date"
-              value={conference.cfpNotifyDate}
-              type="date"
-            />
-            <FieldRow
-              label="Program Release Date"
-              value={conference.programDate}
-              type="date"
-            />
-            <FieldRow
-              label="Travel Support Payment Date"
-              value={conference.travelSupportPaymentDate}
-              type="date"
-            />
-            <FieldRow
-              label="Travel Support Budget"
-              value={conference.travelSupportBudget}
-            />
-          </InfoCard>
-
-          <InfoCard
-            title="Registration"
-            icon={DocumentTextIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="registration"
-                initialValues={{
-                  registrationEnabled: conference.registrationEnabled,
-                  registrationLink: conference.registrationLink,
-                }}
-              />
-            }
-          >
-            <FieldRow
-              label="Registration Enabled"
-              value={conference.registrationEnabled}
-              type="boolean"
-            />
-            <FieldRow
-              label="Registration Link"
-              value={conference.registrationLink}
-              type="url"
-            />
-          </InfoCard>
-
-          <InfoCard
-            title="Communication"
-            icon={EnvelopeIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="communication"
-                initialValues={{
-                  contactEmail: conference.contactEmail,
-                  cfpEmail: conference.cfpEmail,
-                  sponsorEmail: conference.sponsorEmail,
-                  salesNotificationChannel: conference.salesNotificationChannel,
-                  cfpNotificationChannel: conference.cfpNotificationChannel,
-                }}
-              />
-            }
-          >
-            <FieldRow
-              label="Contact Email"
-              value={conference.contactEmail}
-              type="email"
-            />
-            <FieldRow
-              label="CFP Email"
-              value={conference.cfpEmail}
-              type="email"
-            />
-            <FieldRow
-              label="Sponsor Email"
-              value={conference.sponsorEmail}
-              type="email"
-            />
-            <FieldRow
-              label="Sales / Weekly Update Channel"
-              value={conference.salesNotificationChannel}
-            />
-            <FieldRow
-              label="CFP Notification Channel"
-              value={conference.cfpNotificationChannel}
-            />
-          </InfoCard>
-
-          <WorkshopRegistrationSettings
-            workshopRegistrationStart={conference.workshopRegistrationStart}
-            workshopRegistrationEnd={conference.workshopRegistrationEnd}
-          />
-
-          <InfoCard
-            title="Domain Configuration"
-            icon={GlobeAltIcon}
-            editUrl={editUrl}
-            action={
-              <>
-                <EditConferenceCard
-                  fieldset="socialLinks"
-                  initialValues={{ socialLinks: conference.socialLinks }}
-                />
-                <EditConferenceCard
-                  fieldset="domains"
-                  initialValues={{ domains: conference.domains }}
-                  currentDomain={domain}
-                />
-              </>
-            }
-          >
-            <FieldRow label="Domains" value={conference.domains} type="array" />
-            <FieldRow
-              label="Social Links"
-              value={conference.socialLinks}
-              type="links"
-            />
-          </InfoCard>
-
-          <InfoCard
-            title="External Integrations"
-            icon={LinkIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="ticketingIds"
-                initialValues={{
-                  ticketingProvider: conference.ticketingProvider,
-                  checkinCustomerId: conference.checkinCustomerId,
-                  checkinEventId: conference.checkinEventId,
-                  titoAccountSlug: conference.titoAccountSlug,
-                  titoEventSlug: conference.titoEventSlug,
-                }}
-              />
-            }
-          >
-            <FieldRow
-              label="Ticketing Provider"
-              value={conference.ticketingProvider ?? 'checkin'}
-            />
-            {conference.ticketingProvider === 'tito' ? (
-              <>
-                <FieldRow
-                  label="Tito Account Slug"
-                  value={conference.titoAccountSlug}
-                />
-                <FieldRow
-                  label="Tito Event Slug"
-                  value={conference.titoEventSlug}
-                />
-              </>
-            ) : (
-              <>
-                <FieldRow
-                  label="Checkin Customer ID"
-                  value={conference.checkinCustomerId}
-                />
-                <FieldRow
-                  label="Checkin Event ID"
-                  value={conference.checkinEventId}
-                />
-              </>
-            )}
-          </InfoCard>
-
-          <InfoCard
-            title="CFP & Revenue Goals"
-            icon={CurrencyDollarIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="cfpGoals"
-                initialValues={{
-                  cfpSubmissionGoal: conference.cfpSubmissionGoal,
-                  cfpLightningGoal: conference.cfpLightningGoal,
-                  cfpPresentationGoal: conference.cfpPresentationGoal,
-                  cfpWorkshopGoal: conference.cfpWorkshopGoal,
-                  sponsorRevenueGoal: conference.sponsorRevenueGoal,
-                }}
-              />
-            }
-          >
-            <FieldRow
-              label="CFP Submission Goal"
-              value={conference.cfpSubmissionGoal}
-            />
-            <FieldRow
-              label="Lightning Talk Goal"
-              value={conference.cfpLightningGoal}
-            />
-            <FieldRow
-              label="Presentation Goal"
-              value={conference.cfpPresentationGoal}
-            />
-            <FieldRow
-              label="Workshop Goal"
-              value={conference.cfpWorkshopGoal}
-            />
-            <FieldRow
-              label="Sponsor Revenue Goal"
-              value={conference.sponsorRevenueGoal}
-            />
-          </InfoCard>
-
-          <InfoCard
-            title="Content Configuration"
-            icon={TagIcon}
-            editUrl={editUrl}
-            action={
-              <TopicsEditor
-                selectedTopics={(conference.topics ?? []).map((t) => ({
-                  _id: t._id,
-                  title: t.title,
-                  color: t.color,
-                }))}
-              />
-            }
-          >
-            <FieldRow
-              label="Available Formats"
-              value={conference.formats}
-              type="formats"
-            />
-            <FieldRow
-              label="Available Topics"
-              value={conference.topics}
-              type="array"
-            />
-          </InfoCard>
-
-          <InfoCard
-            title="Announcement"
-            icon={DocumentTextIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="announcement"
-                initialValues={{ announcement: conference.announcement }}
-              />
-            }
-          >
-            <FieldRow
-              label="Landing-page banner"
-              value={
-                Array.isArray(conference.announcement) &&
-                conference.announcement.length > 0
-                  ? 'Configured'
-                  : null
+            <InfoCard
+              title="Branding"
+              icon={SwatchIcon}
+              editUrl={editUrl}
+              action={
+                <>
+                  <EditConferenceCard
+                    fieldset="branding"
+                    initialValues={{
+                      // Normalize (not just null-coalesce) so an invalid stored
+                      // value can't seed an enum-invalid submit.
+                      backgroundPattern: normalizeBackgroundPattern(
+                        conference.backgroundPattern,
+                      ),
+                    }}
+                  />
+                  <ThemeEditor initialTheme={conference.theme} />
+                  <BrandingEditor
+                    initialValues={{
+                      logoBright: conference.logoBright,
+                      logoDark: conference.logoDark,
+                      logomarkBright: conference.logomarkBright,
+                      logomarkDark: conference.logomarkDark,
+                    }}
+                  />
+                </>
               }
-            />
-          </InfoCard>
-
-          <InfoCard
-            title="Homepage Composition"
-            icon={DocumentTextIcon}
-            action={
-              <HomepageSectionsEditor
-                initialSections={homepageSectionsForEditor}
-                usingDefault={usingDefaultHomepage}
+            >
+              <BrandingPreviewGrid
+                values={{
+                  logoBright: conference.logoBright,
+                  logoDark: conference.logoDark,
+                  logomarkBright: conference.logomarkBright,
+                  logomarkDark: conference.logomarkDark,
+                }}
               />
-            }
-          >
-            <div className="flex items-center justify-between gap-3 border-b border-gray-200 py-2 dark:border-gray-700">
-              <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
-                Layout
-              </dt>
-              <dd className="min-w-0 text-right text-sm">
-                {usingDefaultHomepage ? (
-                  <StatusBadge label="Default (automatic)" color="gray" />
-                ) : (
-                  <StatusBadge label="Custom composition" color="green" />
-                )}
-              </dd>
-            </div>
-            <ol className="space-y-1 pt-1">
-              {homepageSectionsForEditor.map((section, idx) => (
-                <li
-                  key={section._key}
-                  className="flex items-center justify-between gap-2 text-sm text-gray-900 dark:text-white"
-                >
-                  <span>
-                    {idx + 1}.{' '}
-                    {HOMEPAGE_SECTION_LABELS[section._type] ?? section._type}
-                  </span>
-                  {section.hidden ? (
-                    <StatusBadge label="Hidden" color="yellow" />
-                  ) : null}
-                </li>
-              ))}
-            </ol>
-          </InfoCard>
+              <FieldRow
+                label="Background Pattern"
+                value={
+                  BACKGROUND_PATTERN_LABELS[
+                    normalizeBackgroundPattern(conference.backgroundPattern)
+                  ]
+                }
+              />
+              <div className="border-t border-gray-100 pt-4 dark:border-gray-800">
+                <p className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400">
+                  Brand Colors
+                </p>
+                <ThemeSwatchRow theme={conference.theme} />
+              </div>
+            </InfoCard>
 
-          <InfoCard
-            title="Team"
-            icon={UserGroupIcon}
-            editUrl={editUrl}
-            action={
-              <>
-                <OrganizersEditor
-                  organizers={organizerRows}
-                  currentUserId={currentUserId}
+            <InfoCard
+              title="Visibility"
+              icon={visibility === 'unlisted' ? EyeSlashIcon : EyeIcon}
+              action={
+                <EditConferenceCard
+                  fieldset="visibility"
+                  initialValues={{ visibility }}
                 />
-                <TeamsEditor
-                  teams={(conference.teams ?? []).map((team) => ({
-                    _key: team._key,
-                    key: team.key,
-                    title: team.title,
-                    members: Array.isArray(team.members)
-                      ? (team.members as unknown as string[])
-                      : [],
-                    slackChannel: team.slackChannel,
-                    emailIdentity: team.emailIdentity,
-                  }))}
-                  organizers={organizerRows.map((o) => ({
-                    _id: o._id,
-                    name: o.name,
-                  }))}
-                />
-              </>
-            }
-          >
-            <FieldRow
-              label="Organizers"
-              value={conference.organizers?.map((org) => org.name)}
-              type="team"
-            />
-            {conference.teams && conference.teams.length > 0 && (
-              <div className="border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
-                <dt className="mb-2 text-sm font-medium text-gray-500 dark:text-gray-400">
-                  Teams
+              }
+            >
+              <div
+                id="visibility"
+                className="flex scroll-mt-24 items-center justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700"
+              >
+                <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Status
                 </dt>
-                <dd className="space-y-1">
-                  {conference.teams.map((team) => (
-                    <div
-                      key={team._key ?? team.key}
-                      className="min-w-0 text-sm break-words text-gray-900 dark:text-white"
-                    >
-                      {formatTeamSummary(team)}
-                    </div>
-                  ))}
+                <dd className="min-w-0 text-right text-sm">
+                  {visibility === 'unlisted' ? (
+                    <StatusBadge label="Unlisted" color="yellow" />
+                  ) : (
+                    <StatusBadge label="Live" color="green" />
+                  )}
                 </dd>
               </div>
-            )}
-          </InfoCard>
-
-          {conference.sponsorTiers && conference.sponsorTiers.length > 0 && (
-            <InfoCard
-              title="Sponsorship Tiers"
-              icon={CurrencyDollarIcon}
-              editUrl={editUrl}
-            >
-              {conference.sponsorTiers.map((tier, idx) => (
-                <div
-                  key={idx}
-                  className="border-b border-gray-200 pb-3 last:border-b-0 last:pb-0 dark:border-gray-700"
-                >
-                  <div className="mb-2 flex items-center justify-between">
-                    <span className="font-medium text-gray-900 dark:text-white">
-                      {tier.title}
-                    </span>
-                    <div className="flex items-center space-x-2">
-                      {tier.soldOut && (
-                        <StatusBadge label="Sold Out" color="red" />
-                      )}
-                      {tier.mostPopular && (
-                        <StatusBadge label="Popular" color="green" />
-                      )}
-                    </div>
-                  </div>
-                  <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
-                    {tier.tagline}
-                  </p>
-                  {tier.price && tier.price.length > 0 && (
-                    <div className="text-sm text-gray-500 dark:text-gray-400">
-                      {tier.price.map((price, pidx) => (
-                        <span key={pidx}>
-                          {price.amount} {price.currency}
-                          {pidx < tier.price!.length - 1 && ', '}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              ))}
+              <p className="pt-1 text-sm text-gray-500 dark:text-gray-400">
+                {visibility === 'unlisted'
+                  ? 'Reachable by direct link but excluded from sitemaps, robots and search indexing.'
+                  : 'Publicly listed and indexed by search engines.'}
+              </p>
             </InfoCard>
-          )}
 
-          {conference.sponsors && conference.sponsors.length > 0 && (
+            {/* Set-once — collapsed by default. */}
+            <CollapsibleSection
+              title="Venue Information"
+              icon={MapPinIcon}
+              action={
+                <>
+                  <StudioEditLink editUrl={editUrl} />
+                  <EditConferenceCard
+                    fieldset="venue"
+                    initialValues={{
+                      venueName: conference.venueName,
+                      venueAddress: conference.venueAddress,
+                    }}
+                  />
+                </>
+              }
+            >
+              <div className="space-y-3 px-6 py-4">
+                <FieldRow label="Venue Name" value={conference.venueName} />
+                <FieldRow
+                  label="Venue Address"
+                  value={conference.venueAddress}
+                />
+              </div>
+            </CollapsibleSection>
+          </SettingsGroupSection>
+
+          {/* ---- Schedule ---- */}
+          <SettingsGroupSection group={GROUP['schedule']} icon={CalendarIcon}>
             <InfoCard
-              title="Current Sponsors"
-              icon={CurrencyDollarIcon}
+              title="Dates & Timeline"
+              icon={CalendarIcon}
               editUrl={editUrl}
+              action={
+                <EditConferenceCard
+                  fieldset="dates"
+                  initialValues={{
+                    startDate: conference.startDate,
+                    endDate: conference.endDate,
+                    cfpStartDate: conference.cfpStartDate,
+                    cfpEndDate: conference.cfpEndDate,
+                    cfpNotifyDate: conference.cfpNotifyDate,
+                    programDate: conference.programDate,
+                    travelSupportPaymentDate:
+                      conference.travelSupportPaymentDate,
+                    travelSupportBudget: conference.travelSupportBudget,
+                  }}
+                />
+              }
             >
               <FieldRow
-                label="Sponsors"
-                value={conference.sponsors.map(
-                  (s) => `${s.sponsor.name} (${s.tier?.title ?? 'No Tier'})`,
+                label="Start Date"
+                value={conference.startDate}
+                type="date"
+              />
+              <FieldRow
+                label="End Date"
+                value={conference.endDate}
+                type="date"
+              />
+              <FieldRow
+                label="CFP Start Date"
+                value={conference.cfpStartDate}
+                type="date"
+              />
+              <FieldRow
+                label="CFP End Date"
+                value={conference.cfpEndDate}
+                type="date"
+              />
+              <FieldRow
+                label="CFP Notify Date"
+                value={conference.cfpNotifyDate}
+                type="date"
+              />
+              <FieldRow
+                label="Program Release Date"
+                value={conference.programDate}
+                type="date"
+              />
+              <FieldRow
+                label="Travel Support Payment Date"
+                value={conference.travelSupportPaymentDate}
+                type="date"
+              />
+              <FieldRow
+                label="Travel Support Budget"
+                value={conference.travelSupportBudget}
+              />
+            </InfoCard>
+
+            <InfoCard
+              title="Announcement"
+              icon={DocumentTextIcon}
+              editUrl={editUrl}
+              action={
+                <EditConferenceCard
+                  fieldset="announcement"
+                  initialValues={{ announcement: conference.announcement }}
+                />
+              }
+            >
+              <FieldRow
+                label="Landing-page banner"
+                value={
+                  Array.isArray(conference.announcement) &&
+                  conference.announcement.length > 0
+                    ? 'Configured'
+                    : null
+                }
+              />
+            </InfoCard>
+          </SettingsGroupSection>
+
+          {/* ---- Call for Papers ---- */}
+          <SettingsGroupSection
+            group={GROUP['call-for-papers']}
+            icon={DocumentTextIcon}
+          >
+            <InfoCard
+              title="CFP & Revenue Goals"
+              icon={CurrencyDollarIcon}
+              editUrl={editUrl}
+              action={
+                <EditConferenceCard
+                  fieldset="cfpGoals"
+                  initialValues={{
+                    cfpSubmissionGoal: conference.cfpSubmissionGoal,
+                    cfpLightningGoal: conference.cfpLightningGoal,
+                    cfpPresentationGoal: conference.cfpPresentationGoal,
+                    cfpWorkshopGoal: conference.cfpWorkshopGoal,
+                    sponsorRevenueGoal: conference.sponsorRevenueGoal,
+                  }}
+                />
+              }
+            >
+              <FieldRow
+                label="CFP Submission Goal"
+                value={conference.cfpSubmissionGoal}
+              />
+              <FieldRow
+                label="Lightning Talk Goal"
+                value={conference.cfpLightningGoal}
+              />
+              <FieldRow
+                label="Presentation Goal"
+                value={conference.cfpPresentationGoal}
+              />
+              <FieldRow
+                label="Workshop Goal"
+                value={conference.cfpWorkshopGoal}
+              />
+              <FieldRow
+                label="Sponsor Revenue Goal"
+                value={conference.sponsorRevenueGoal}
+              />
+            </InfoCard>
+          </SettingsGroupSection>
+
+          {/* ---- Tickets & Registration ---- */}
+          <SettingsGroupSection
+            group={GROUP['tickets-registration']}
+            icon={TagIcon}
+          >
+            <InfoCard
+              title="Registration"
+              icon={DocumentTextIcon}
+              editUrl={editUrl}
+              action={
+                <EditConferenceCard
+                  fieldset="registration"
+                  initialValues={{
+                    registrationEnabled: conference.registrationEnabled,
+                    registrationLink: conference.registrationLink,
+                  }}
+                />
+              }
+            >
+              <FieldRow
+                label="Registration Enabled"
+                value={conference.registrationEnabled}
+                type="boolean"
+              />
+              <FieldRow
+                label="Registration Link"
+                value={conference.registrationLink}
+                type="url"
+              />
+            </InfoCard>
+
+            <WorkshopRegistrationSettings
+              workshopRegistrationStart={conference.workshopRegistrationStart}
+              workshopRegistrationEnd={conference.workshopRegistrationEnd}
+            />
+
+            <InfoCard
+              title="Ticketing"
+              icon={LinkIcon}
+              editUrl={editUrl}
+              action={
+                <EditConferenceCard
+                  fieldset="ticketingIds"
+                  initialValues={{
+                    ticketingProvider: conference.ticketingProvider,
+                    checkinCustomerId: conference.checkinCustomerId,
+                    checkinEventId: conference.checkinEventId,
+                    titoAccountSlug: conference.titoAccountSlug,
+                    titoEventSlug: conference.titoEventSlug,
+                  }}
+                />
+              }
+            >
+              <FieldRow
+                label="Ticketing Provider"
+                value={conference.ticketingProvider ?? 'checkin'}
+              />
+              {conference.ticketingProvider === 'tito' ? (
+                <>
+                  <FieldRow
+                    label="Tito Account Slug"
+                    value={conference.titoAccountSlug}
+                  />
+                  <FieldRow
+                    label="Tito Event Slug"
+                    value={conference.titoEventSlug}
+                  />
+                </>
+              ) : (
+                <>
+                  <FieldRow
+                    label="Checkin Customer ID"
+                    value={conference.checkinCustomerId}
+                  />
+                  <FieldRow
+                    label="Checkin Event ID"
+                    value={conference.checkinEventId}
+                  />
+                </>
+              )}
+            </InfoCard>
+
+            {/* Set-once — collapsed by default. */}
+            <CollapsibleSection
+              title="Homepage Stats"
+              icon={ChartPieIcon}
+              action={
+                <>
+                  <StudioEditLink editUrl={editUrl} />
+                  <EditConferenceCard
+                    fieldset="vanityMetrics"
+                    initialValues={{ vanityMetrics: conference.vanityMetrics }}
+                  />
+                </>
+              }
+            >
+              <div className="space-y-3 px-6 py-4">
+                {conference.vanityMetrics &&
+                conference.vanityMetrics.length > 0 ? (
+                  conference.vanityMetrics.map((metric, idx) => (
+                    <FieldRow
+                      key={idx}
+                      label={metric.label}
+                      value={metric.value}
+                    />
+                  ))
+                ) : (
+                  <span className="text-sm text-gray-500 dark:text-gray-400">
+                    None
+                  </span>
                 )}
+              </div>
+            </CollapsibleSection>
+          </SettingsGroupSection>
+
+          {/* ---- Sponsors ---- */}
+          <SettingsGroupSection
+            group={GROUP['sponsors']}
+            icon={CurrencyDollarIcon}
+          >
+            {conference.sponsorTiers && conference.sponsorTiers.length > 0 && (
+              <InfoCard
+                title="Sponsorship Tiers"
+                icon={CurrencyDollarIcon}
+                editUrl={editUrl}
+              >
+                {conference.sponsorTiers.map((tier, idx) => (
+                  <div
+                    key={idx}
+                    className="border-b border-gray-200 pb-3 last:border-b-0 last:pb-0 dark:border-gray-700"
+                  >
+                    <div className="mb-2 flex items-center justify-between">
+                      <span className="font-medium text-gray-900 dark:text-white">
+                        {tier.title}
+                      </span>
+                      <div className="flex items-center space-x-2">
+                        {tier.soldOut && (
+                          <StatusBadge label="Sold Out" color="red" />
+                        )}
+                        {tier.mostPopular && (
+                          <StatusBadge label="Popular" color="green" />
+                        )}
+                      </div>
+                    </div>
+                    <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
+                      {tier.tagline}
+                    </p>
+                    {tier.price && tier.price.length > 0 && (
+                      <div className="text-sm text-gray-500 dark:text-gray-400">
+                        {tier.price.map((price, pidx) => (
+                          <span key={pidx}>
+                            {price.amount} {price.currency}
+                            {pidx < tier.price!.length - 1 && ', '}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </InfoCard>
+            )}
+
+            {conference.sponsors && conference.sponsors.length > 0 && (
+              <InfoCard
+                title="Current Sponsors"
+                icon={CurrencyDollarIcon}
+                editUrl={editUrl}
+              >
+                <FieldRow
+                  label="Sponsors"
+                  value={conference.sponsors.map(
+                    (s) => `${s.sponsor.name} (${s.tier?.title ?? 'No Tier'})`,
+                  )}
+                  type="array"
+                />
+              </InfoCard>
+            )}
+
+            {/* Set-once — collapsed by default. */}
+            <CollapsibleSection
+              title="Sponsor Benefits"
+              icon={CurrencyDollarIcon}
+              action={
+                <>
+                  <StudioEditLink editUrl={editUrl} />
+                  <EditConferenceCard
+                    fieldset="sponsorBenefits"
+                    initialValues={{
+                      sponsorBenefits: conference.sponsorBenefits,
+                    }}
+                  />
+                </>
+              }
+            >
+              <div className="space-y-3 px-6 py-4">
+                {conference.sponsorBenefits &&
+                conference.sponsorBenefits.length > 0 ? (
+                  conference.sponsorBenefits.map((benefit, idx) => (
+                    <FieldRow
+                      key={idx}
+                      label={benefit.title}
+                      value={benefit.description}
+                    />
+                  ))
+                ) : (
+                  <span className="text-sm text-gray-500 dark:text-gray-400">
+                    None
+                  </span>
+                )}
+              </div>
+            </CollapsibleSection>
+
+            {/* Set-once — collapsed by default. */}
+            <CollapsibleSection
+              title="Sponsorship Page"
+              icon={DocumentTextIcon}
+              action={
+                <>
+                  <StudioEditLink editUrl={editUrl} />
+                  <EditConferenceCard
+                    fieldset="sponsorshipCustomization"
+                    initialValues={
+                      (conference.sponsorshipCustomization ?? {}) as Record<
+                        string,
+                        unknown
+                      >
+                    }
+                  />
+                </>
+              }
+            >
+              <div className="space-y-3 px-6 py-4">
+                <FieldRow
+                  label="Hero Headline"
+                  value={conference.sponsorshipCustomization?.heroHeadline}
+                />
+                <FieldRow
+                  label="Philosophy Title"
+                  value={conference.sponsorshipCustomization?.philosophyTitle}
+                />
+                <FieldRow
+                  label="Prospectus Link"
+                  value={conference.sponsorshipCustomization?.prospectusUrl}
+                  type="url"
+                />
+              </div>
+            </CollapsibleSection>
+          </SettingsGroupSection>
+
+          {/* ---- Team & Content ---- */}
+          <SettingsGroupSection
+            group={GROUP['team-content']}
+            icon={UserGroupIcon}
+          >
+            <InfoCard
+              title="Organizers & Teams"
+              icon={UserGroupIcon}
+              editUrl={editUrl}
+              action={
+                <>
+                  <OrganizersEditor
+                    organizers={organizerRows}
+                    currentUserId={currentUserId}
+                  />
+                  <TeamsEditor
+                    teams={(conference.teams ?? []).map((team) => ({
+                      _key: team._key,
+                      key: team.key,
+                      title: team.title,
+                      members: Array.isArray(team.members)
+                        ? (team.members as unknown as string[])
+                        : [],
+                      slackChannel: team.slackChannel,
+                      emailIdentity: team.emailIdentity,
+                    }))}
+                    organizers={organizerRows.map((o) => ({
+                      _id: o._id,
+                      name: o.name,
+                    }))}
+                  />
+                </>
+              }
+            >
+              <FieldRow
+                label="Organizers"
+                value={conference.organizers?.map((org) => org.name)}
+                type="team"
+              />
+              {conference.teams && conference.teams.length > 0 && (
+                <div className="border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
+                  <dt className="mb-2 text-sm font-medium text-gray-500 dark:text-gray-400">
+                    Teams
+                  </dt>
+                  <dd className="space-y-1">
+                    {conference.teams.map((team) => (
+                      <div
+                        key={team._key ?? team.key}
+                        className="min-w-0 text-sm break-words text-gray-900 dark:text-white"
+                      >
+                        {formatTeamSummary(team)}
+                      </div>
+                    ))}
+                  </dd>
+                </div>
+              )}
+            </InfoCard>
+
+            <InfoCard
+              title="Communication"
+              icon={EnvelopeIcon}
+              editUrl={editUrl}
+              action={
+                <EditConferenceCard
+                  fieldset="communication"
+                  initialValues={{
+                    contactEmail: conference.contactEmail,
+                    cfpEmail: conference.cfpEmail,
+                    sponsorEmail: conference.sponsorEmail,
+                    salesNotificationChannel:
+                      conference.salesNotificationChannel,
+                    cfpNotificationChannel: conference.cfpNotificationChannel,
+                  }}
+                />
+              }
+            >
+              <FieldRow
+                label="Contact Email"
+                value={conference.contactEmail}
+                type="email"
+              />
+              <FieldRow
+                label="CFP Email"
+                value={conference.cfpEmail}
+                type="email"
+              />
+              <FieldRow
+                label="Sponsor Email"
+                value={conference.sponsorEmail}
+                type="email"
+              />
+              <FieldRow
+                label="Sales / Weekly Update Channel"
+                value={conference.salesNotificationChannel}
+              />
+              <FieldRow
+                label="CFP Notification Channel"
+                value={conference.cfpNotificationChannel}
+              />
+            </InfoCard>
+
+            <InfoCard
+              title="Domains & Social Links"
+              icon={GlobeAltIcon}
+              editUrl={editUrl}
+              action={
+                <>
+                  <EditConferenceCard
+                    fieldset="socialLinks"
+                    initialValues={{ socialLinks: conference.socialLinks }}
+                  />
+                  <EditConferenceCard
+                    fieldset="domains"
+                    initialValues={{ domains: conference.domains }}
+                    currentDomain={domain}
+                  />
+                </>
+              }
+            >
+              <FieldRow
+                label="Domains"
+                value={conference.domains}
+                type="array"
+              />
+              <FieldRow
+                label="Social Links"
+                value={conference.socialLinks}
+                type="links"
+              />
+            </InfoCard>
+
+            <InfoCard
+              title="Topics & Formats"
+              icon={TagIcon}
+              editUrl={editUrl}
+              action={
+                <TopicsEditor
+                  selectedTopics={(conference.topics ?? []).map((t) => ({
+                    _id: t._id,
+                    title: t.title,
+                    color: t.color,
+                  }))}
+                />
+              }
+            >
+              <FieldRow
+                label="Available Formats"
+                value={conference.formats}
+                type="formats"
+              />
+              <FieldRow
+                label="Available Topics"
+                value={conference.topics}
                 type="array"
               />
             </InfoCard>
-          )}
 
-          <InfoCard
-            title="Sponsor Benefits"
-            icon={CurrencyDollarIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="sponsorBenefits"
-                initialValues={{ sponsorBenefits: conference.sponsorBenefits }}
-              />
-            }
-          >
-            {conference.sponsorBenefits &&
-            conference.sponsorBenefits.length > 0 ? (
-              conference.sponsorBenefits.map((benefit, idx) => (
-                <FieldRow
-                  key={idx}
-                  label={benefit.title}
-                  value={benefit.description}
+            <InfoCard
+              title="Homepage Composition"
+              icon={DocumentTextIcon}
+              action={
+                <HomepageSectionsEditor
+                  initialSections={homepageSectionsForEditor}
+                  usingDefault={usingDefaultHomepage}
                 />
-              ))
-            ) : (
-              <span className="text-sm text-gray-500 dark:text-gray-400">
-                None
-              </span>
-            )}
-          </InfoCard>
-
-          <InfoCard
-            title="Sponsorship Page"
-            icon={DocumentTextIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="sponsorshipCustomization"
-                initialValues={
-                  (conference.sponsorshipCustomization ?? {}) as Record<
-                    string,
-                    unknown
+              }
+            >
+              <div className="flex items-center justify-between gap-3 border-b border-gray-200 py-2 dark:border-gray-700">
+                <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Layout
+                </dt>
+                <dd className="min-w-0 text-right text-sm">
+                  {usingDefaultHomepage ? (
+                    <StatusBadge label="Default (automatic)" color="gray" />
+                  ) : (
+                    <StatusBadge label="Custom composition" color="green" />
+                  )}
+                </dd>
+              </div>
+              <ol className="space-y-1 pt-1">
+                {homepageSectionsForEditor.map((section, idx) => (
+                  <li
+                    key={section._key}
+                    className="flex items-center justify-between gap-2 text-sm text-gray-900 dark:text-white"
                   >
-                }
-              />
-            }
-          >
-            <FieldRow
-              label="Hero Headline"
-              value={conference.sponsorshipCustomization?.heroHeadline}
-            />
-            <FieldRow
-              label="Philosophy Title"
-              value={conference.sponsorshipCustomization?.philosophyTitle}
-            />
-            <FieldRow
-              label="Prospectus Link"
-              value={conference.sponsorshipCustomization?.prospectusUrl}
-              type="url"
-            />
-          </InfoCard>
-
-          <InfoCard
-            title="Vanity Metrics"
-            icon={ChartPieIcon}
-            editUrl={editUrl}
-            action={
-              <EditConferenceCard
-                fieldset="vanityMetrics"
-                initialValues={{ vanityMetrics: conference.vanityMetrics }}
-              />
-            }
-          >
-            {conference.vanityMetrics && conference.vanityMetrics.length > 0 ? (
-              conference.vanityMetrics.map((metric, idx) => (
-                <FieldRow key={idx} label={metric.label} value={metric.value} />
-              ))
-            ) : (
-              <span className="text-sm text-gray-500 dark:text-gray-400">
-                None
-              </span>
-            )}
-          </InfoCard>
+                    <span>
+                      {idx + 1}.{' '}
+                      {HOMEPAGE_SECTION_LABELS[section._type] ?? section._type}
+                    </span>
+                    {section.hidden ? (
+                      <StatusBadge label="Hidden" color="yellow" />
+                    ) : null}
+                  </li>
+                ))}
+              </ol>
+            </InfoCard>
+          </SettingsGroupSection>
         </div>
       </section>
 

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -287,7 +287,7 @@ export default async function AdminSettings() {
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection
               title="Venue Information"
-              icon={MapPinIcon}
+              icon={<MapPinIcon />}
               action={
                 <>
                   <StudioEditLink editUrl={editUrl} />
@@ -528,7 +528,7 @@ export default async function AdminSettings() {
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection
               title="Homepage Stats"
-              icon={ChartPieIcon}
+              icon={<ChartPieIcon />}
               action={
                 <>
                   <StudioEditLink editUrl={editUrl} />
@@ -624,7 +624,7 @@ export default async function AdminSettings() {
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection
               title="Sponsor Benefits"
-              icon={CurrencyDollarIcon}
+              icon={<CurrencyDollarIcon />}
               action={
                 <>
                   <StudioEditLink editUrl={editUrl} />
@@ -658,7 +658,7 @@ export default async function AdminSettings() {
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection
               title="Sponsorship Page"
-              icon={DocumentTextIcon}
+              icon={<DocumentTextIcon />}
               action={
                 <>
                   <StudioEditLink editUrl={editUrl} />

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -286,6 +286,7 @@ export default async function AdminSettings() {
 
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection
+              headingLevel={4}
               title="Venue Information"
               icon={<MapPinIcon />}
               action={
@@ -527,6 +528,7 @@ export default async function AdminSettings() {
 
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection
+              headingLevel={4}
               title="Homepage Stats"
               icon={<ChartPieIcon />}
               action={
@@ -623,6 +625,7 @@ export default async function AdminSettings() {
 
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection
+              headingLevel={4}
               title="Sponsor Benefits"
               icon={<CurrencyDollarIcon />}
               action={
@@ -657,6 +660,7 @@ export default async function AdminSettings() {
 
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection
+              headingLevel={4}
               title="Sponsorship Page"
               icon={<DocumentTextIcon />}
               action={

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, ReactNode } from 'react'
-import { formatDate } from '@/lib/time'
+import { formatDate, formatDateTimeSafe } from '@/lib/time'
 import { formats, Format } from '@/lib/proposal/types'
 import { StatusBadge } from '@/components/StatusBadge'
 import {
@@ -115,12 +115,8 @@ export function FieldRow({
 
   switch (type) {
     case 'datetime':
-      displayValue = value
-        ? new Date(value as string).toLocaleString('en-US', {
-            dateStyle: 'medium',
-            timeStyle: 'short',
-          })
-        : 'Not set'
+      // House formatter — consistent locale/timezone rendering.
+      displayValue = value ? formatDateTimeSafe(value as string) : 'Not set'
       break
     case 'date':
       displayValue = value ? formatDate(value as string) : 'Not set'
@@ -259,7 +255,11 @@ export function FieldRow({
       )
       break
     default:
-      displayValue = (value as string) || 'Not set'
+      // `??`/emptiness check, not `||`: a legitimate 0 must not read as unset.
+      displayValue =
+        value === undefined || value === null || value === ''
+          ? 'Not set'
+          : (value as ReactNode)
   }
 
   return (

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -245,10 +245,10 @@ export function FieldRow({
       displayValue = value ? (
         <a
           href={`mailto:${value}`}
-          className="flex items-center text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          className="flex min-w-0 items-center text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
         >
-          {value as string}
-          <EnvelopeIcon className="ml-1 h-3 w-3" />
+          <span className="break-all">{value as string}</span>
+          <EnvelopeIcon className="ml-1 h-3 w-3 shrink-0" />
         </a>
       ) : (
         'Not set'

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -91,6 +91,22 @@ export function StudioEditLink({ editUrl }: { editUrl?: string | null }) {
   )
 }
 
+/**
+ * Restrict a STORED href to schemes safe to render as a clickable link
+ * (site paths, http(s), mailto) — anything else (javascript:, data:,
+ * scheme-relative) degrades to an inert '#'. Same closed-scheme standard as
+ * the write-path safeLinkHref and the portable-text link guard.
+ */
+function safeDisplayHref(value: unknown): string {
+  if (typeof value !== 'string') return '#'
+  const v = value.trim()
+  if (!v) return '#'
+  if (v.startsWith('/') && !v.startsWith('//')) return v
+  if (/^https?:\/\//i.test(v)) return v
+  if (/^mailto:/i.test(v)) return v
+  return '#'
+}
+
 export function FieldRow({
   label,
   value,
@@ -163,7 +179,7 @@ export function FieldRow({
             {value.map((link, idx) => (
               <div key={idx}>
                 <a
-                  href={link as string}
+                  href={safeDisplayHref(link)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex max-w-full min-w-0 items-start text-sm text-indigo-600 hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300"
@@ -227,7 +243,7 @@ export function FieldRow({
     case 'url':
       displayValue = value ? (
         <a
-          href={value as string}
+          href={safeDisplayHref(value)}
           target="_blank"
           rel="noopener noreferrer"
           className="flex min-w-0 items-start text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -1,0 +1,382 @@
+import type { ComponentType, ReactNode } from 'react'
+import { formatDate } from '@/lib/time'
+import { formats, Format } from '@/lib/proposal/types'
+import { StatusBadge } from '@/components/StatusBadge'
+import {
+  SETTINGS_GROUP_ANCHORS,
+  SETTINGS_TIER_ANCHORS,
+  type SettingsGroup,
+} from '@/lib/settings/groups'
+import {
+  PencilSquareIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  LinkIcon,
+  EnvelopeIcon,
+} from '@heroicons/react/24/outline'
+
+/**
+ * Presentational primitives for the admin Settings page. Extracted from the
+ * server `page.tsx` so the layout (cards, field rows, the jump-nav and the
+ * grouped section headings) is data-agnostic and can be rendered in Storybook
+ * for the mandatory visual QA. None of these read conference data or call tRPC —
+ * callers pass values and action nodes in.
+ */
+
+export interface NamedItem {
+  name?: string
+  title?: string
+}
+
+export type ArrayItem = string | NamedItem
+
+function isValidFormat(key: string): key is Format {
+  return Object.values(Format).includes(key as Format)
+}
+
+export function InfoCard({
+  title,
+  children,
+  icon: Icon,
+  editUrl,
+  action,
+}: {
+  title: string
+  children: ReactNode
+  icon: ComponentType<{ className?: string }>
+  editUrl?: string | null
+  /**
+   * Optional inline edit affordance (an EditConferenceCard island). When present
+   * it sits beside the Studio deep-link; the card body keeps rendering the
+   * read-only values and refreshes after a save.
+   */
+  action?: ReactNode
+}) {
+  return (
+    <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+      <div className="mb-4 flex items-center justify-between gap-2">
+        <div className="flex items-center">
+          <Icon className="mr-2 h-5 w-5 text-gray-400 dark:text-gray-500" />
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+            {title}
+          </h3>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <StudioEditLink editUrl={editUrl} />
+          {action}
+        </div>
+      </div>
+      <div className="space-y-3">{children}</div>
+    </div>
+  )
+}
+
+/**
+ * The "Edit in Studio" deep-link affordance, factored out of {@link InfoCard} so
+ * collapsed cards (which use CollapsibleSection instead of InfoCard) can still
+ * surface it in their header action slot.
+ */
+export function StudioEditLink({ editUrl }: { editUrl?: string | null }) {
+  if (!editUrl) return null
+  return (
+    <a
+      href={editUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+    >
+      <PencilSquareIcon className="h-4 w-4" />
+      Edit in Studio
+    </a>
+  )
+}
+
+export function FieldRow({
+  label,
+  value,
+  type = 'text',
+}: {
+  label: string
+  value:
+    string | boolean | Array<string | NamedItem> | number | null | undefined
+  type?:
+    | 'text'
+    | 'date'
+    | 'datetime'
+    | 'boolean'
+    | 'array'
+    | 'links'
+    | 'formats'
+    | 'team'
+    | 'url'
+    | 'email'
+}) {
+  let displayValue: ReactNode = value as ReactNode
+
+  switch (type) {
+    case 'datetime':
+      displayValue = value
+        ? new Date(value as string).toLocaleString('en-US', {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+          })
+        : 'Not set'
+      break
+    case 'date':
+      displayValue = value ? formatDate(value as string) : 'Not set'
+      break
+    case 'boolean':
+      displayValue = (
+        <div className="flex items-center">
+          {value ? (
+            <>
+              <CheckCircleIcon className="mr-1 h-4 w-4 text-green-500 dark:text-green-400" />
+              <span className="text-green-700 dark:text-green-300">Yes</span>
+            </>
+          ) : (
+            <>
+              <XCircleIcon className="mr-1 h-4 w-4 text-red-500 dark:text-red-400" />
+              <span className="text-red-700 dark:text-red-300">No</span>
+            </>
+          )}
+        </div>
+      )
+      break
+    case 'array':
+      displayValue =
+        Array.isArray(value) && value.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {value.map((item: ArrayItem, idx) => {
+              const displayText =
+                typeof item === 'string'
+                  ? item
+                  : (item as NamedItem)?.title ||
+                    (item as NamedItem)?.name ||
+                    JSON.stringify(item)
+              return <StatusBadge key={idx} label={displayText} color="gray" />
+            })}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )
+      break
+    case 'links':
+      displayValue =
+        Array.isArray(value) && value.length > 0 ? (
+          <div className="space-y-2">
+            {value.map((link, idx) => (
+              <div key={idx}>
+                <a
+                  href={link as string}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex max-w-full min-w-0 items-start text-sm text-indigo-600 hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300"
+                >
+                  {/* break-all, not truncate: a URL is an unbreakable token, and
+                      an unconstrained nowrap span dictated the row's intrinsic
+                      width — the whole page scrolled horizontally on mobile. */}
+                  <span className="min-w-0 break-all">{link as string}</span>
+                  <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
+                </a>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )
+      break
+    case 'formats':
+      displayValue =
+        Array.isArray(value) && value.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {value.map((format: ArrayItem, idx) => {
+              const formatKey =
+                typeof format === 'string'
+                  ? format
+                  : (format as NamedItem)?.title || (format as NamedItem)?.name
+              const displayText =
+                formatKey && isValidFormat(formatKey)
+                  ? formats.get(formatKey) || formatKey
+                  : formatKey || 'Unknown Format'
+              return <StatusBadge key={idx} label={displayText} color="gray" />
+            })}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )
+      break
+    case 'team':
+      displayValue =
+        Array.isArray(value) && value.length > 0 ? (
+          <div className="grid grid-cols-2 gap-2">
+            {value.map((member: ArrayItem, idx) => {
+              const memberName =
+                typeof member === 'string'
+                  ? member
+                  : (member as NamedItem)?.name || 'Unknown Member'
+              return (
+                <div
+                  key={idx}
+                  className="py-1 text-sm text-gray-900 dark:text-white"
+                >
+                  {memberName}
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )
+      break
+    case 'url':
+      displayValue = value ? (
+        <a
+          href={value as string}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex min-w-0 items-start text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+        >
+          {/* Same overflow class as the 'links' case: an unbreakable URL must
+              break rather than widen the row past the viewport. */}
+          <span className="min-w-0 break-all">{value as string}</span>
+          <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
+        </a>
+      ) : (
+        'Not set'
+      )
+      break
+    case 'email':
+      displayValue = value ? (
+        <a
+          href={`mailto:${value}`}
+          className="flex items-center text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+        >
+          {value as string}
+          <EnvelopeIcon className="ml-1 h-3 w-3" />
+        </a>
+      ) : (
+        'Not set'
+      )
+      break
+    default:
+      displayValue = (value as string) || 'Not set'
+  }
+
+  return (
+    <div className="flex justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
+      <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+        {label}
+      </dt>
+      {/* min-w-0 lets the value column actually shrink inside the flex row —
+          without it, wide unbreakable content (URLs) forces the row past the
+          viewport and the page pans horizontally. */}
+      <dd className="max-w-xs min-w-0 text-right text-sm text-gray-900 dark:text-white">
+        {displayValue}
+      </dd>
+    </div>
+  )
+}
+
+export function SectionNav() {
+  return (
+    <nav className="sticky top-0 z-10 -mx-4 mb-2 space-y-2 border-b border-gray-200 bg-gray-50/90 px-4 py-2 backdrop-blur sm:mx-0 sm:rounded-lg sm:border sm:px-4 dark:border-gray-700 dark:bg-gray-900/90">
+      {/* Tier anchors — the three top-level sections. */}
+      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
+        {SETTINGS_TIER_ANCHORS.map((item) => (
+          <li key={item.href}>
+            <a
+              href={item.href}
+              className="font-medium text-gray-600 hover:text-indigo-600 dark:text-gray-300 dark:hover:text-indigo-400"
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+      {/* Group anchors — one click to any tier-1 subsection. Horizontally
+          scrollable chips so they never wrap or overflow on mobile. */}
+      <ul className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-0.5 text-xs">
+        {SETTINGS_GROUP_ANCHORS.map((item) => (
+          <li key={item.href} className="shrink-0">
+            <a
+              href={item.href}
+              className="inline-block rounded-full border border-gray-200 bg-white px-3 py-1 font-medium whitespace-nowrap text-gray-600 hover:border-indigo-300 hover:text-indigo-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:text-indigo-400"
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+export function SectionHeading({
+  id,
+  icon: Icon,
+  title,
+  description,
+  level = 2,
+}: {
+  id: string
+  icon: ComponentType<{ className?: string }>
+  title: string
+  description: string
+  /** 2 = tier heading (default), 3 = subordinate group heading. */
+  level?: 2 | 3
+}) {
+  const Heading = level === 3 ? 'h3' : 'h2'
+  return (
+    <div id={id} className="scroll-mt-24">
+      <div className="flex items-center gap-2">
+        <Icon
+          className={
+            level === 3
+              ? 'h-5 w-5 text-gray-400 dark:text-gray-500'
+              : 'h-6 w-6 text-gray-400 dark:text-gray-500'
+          }
+        />
+        <Heading
+          className={
+            level === 3
+              ? 'text-lg font-semibold text-gray-900 dark:text-white'
+              : 'text-xl font-semibold text-gray-900 dark:text-white'
+          }
+        >
+          {title}
+        </Heading>
+      </div>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {description}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * A tier-1 subsection: a group heading (h3) followed by its own card grid. The
+ * `id` is the additive jump-nav anchor; per-card deep-link anchors live inside
+ * the cards and are preserved independently.
+ */
+export function SettingsGroupSection({
+  group,
+  icon,
+  children,
+}: {
+  group: SettingsGroup
+  icon: ComponentType<{ className?: string }>
+  children: ReactNode
+}) {
+  return (
+    <div className="space-y-4">
+      <SectionHeading
+        id={group.id}
+        icon={icon}
+        title={group.title}
+        description={group.description}
+        level={3}
+      />
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">{children}</div>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -180,8 +180,9 @@ export function FieldRow({
               <div key={idx}>
                 <a
                   href={safeDisplayHref(link)}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  {...(safeDisplayHref(link) !== '#'
+                    ? { target: '_blank', rel: 'noopener noreferrer' }
+                    : {})}
                   className="inline-flex max-w-full min-w-0 items-start text-sm text-indigo-600 hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300"
                 >
                   {/* break-all, not truncate: a URL is an unbreakable token, and
@@ -244,8 +245,9 @@ export function FieldRow({
       displayValue = value ? (
         <a
           href={safeDisplayHref(value)}
-          target="_blank"
-          rel="noopener noreferrer"
+          {...(safeDisplayHref(value) !== '#'
+            ? { target: '_blank', rel: 'noopener noreferrer' }
+            : {})}
           className="flex min-w-0 items-start text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
         >
           {/* Same overflow class as the 'links' case: an unbreakable URL must

--- a/src/components/admin/CollapsibleSection.tsx
+++ b/src/components/admin/CollapsibleSection.tsx
@@ -33,30 +33,35 @@ export function CollapsibleSection({
       className={`overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-gray-700 ${className}`}
     >
       <div className="flex items-center">
-        <button
-          onClick={() => setIsOpen(!isOpen)}
-          aria-expanded={isOpen}
-          className="flex min-w-0 flex-1 items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
-        >
-          <span className="flex min-w-0 items-center">
-            {Icon ? (
-              <Icon className="mr-2 h-5 w-5 shrink-0 text-gray-400 dark:text-gray-500" />
-            ) : null}
-            <h2 className="truncate text-lg font-medium text-gray-900 dark:text-white">
-              {title}
-            </h2>
-          </span>
-          <span className="ml-2 flex shrink-0 items-center gap-2">
-            <span className="text-sm text-gray-500 dark:text-gray-400">
-              {isOpen ? 'Hide' : 'Show'}
+        {/* Accessible-disclosure pattern: the HEADING wraps the toggle button
+            (h2 > button is valid; button/span > h2 is not — a heading is flow
+            content and cannot sit inside phrasing content). */}
+        <h2 className="flex min-w-0 flex-1">
+          <button
+            onClick={() => setIsOpen(!isOpen)}
+            aria-expanded={isOpen}
+            className="flex min-w-0 flex-1 items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
+          >
+            <span className="flex min-w-0 items-center">
+              {Icon ? (
+                <Icon className="mr-2 h-5 w-5 shrink-0 text-gray-400 dark:text-gray-500" />
+              ) : null}
+              <span className="truncate text-lg font-medium text-gray-900 dark:text-white">
+                {title}
+              </span>
             </span>
-            {isOpen ? (
-              <ChevronDownIcon className="h-5 w-5 text-gray-400" />
-            ) : (
-              <ChevronRightIcon className="h-5 w-5 text-gray-400" />
-            )}
-          </span>
-        </button>
+            <span className="ml-2 flex shrink-0 items-center gap-2">
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                {isOpen ? 'Hide' : 'Show'}
+              </span>
+              {isOpen ? (
+                <ChevronDownIcon className="h-5 w-5 text-gray-400" />
+              ) : (
+                <ChevronRightIcon className="h-5 w-5 text-gray-400" />
+              )}
+            </span>
+          </button>
+        </h2>
         {action ? (
           <div className="flex shrink-0 items-center gap-2 pr-4">{action}</div>
         ) : null}

--- a/src/components/admin/CollapsibleSection.tsx
+++ b/src/components/admin/CollapsibleSection.tsx
@@ -42,6 +42,7 @@ export function CollapsibleSection({
             content and cannot sit inside phrasing content). */}
         <h2 className="flex min-w-0 flex-1">
           <button
+            type="button"
             onClick={() => setIsOpen(!isOpen)}
             aria-expanded={isOpen}
             className="flex min-w-0 flex-1 items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"

--- a/src/components/admin/CollapsibleSection.tsx
+++ b/src/components/admin/CollapsibleSection.tsx
@@ -76,14 +76,16 @@ export function CollapsibleSection({
         ) : null}
       </div>
 
-      {isOpen && (
-        <div
-          id={contentId}
-          className="border-t border-gray-200 dark:border-gray-700"
-        >
-          {children}
-        </div>
-      )}
+      {/* The controlled region keeps its id in the DOM while collapsed so the
+          aria-controls relationship always resolves; children stay
+          conditionally rendered (no hidden work for collapsed cards). */}
+      <div
+        id={contentId}
+        hidden={!isOpen}
+        className="border-t border-gray-200 dark:border-gray-700"
+      >
+        {isOpen ? children : null}
+      </div>
     </div>
   )
 }

--- a/src/components/admin/CollapsibleSection.tsx
+++ b/src/components/admin/CollapsibleSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, ReactNode, ComponentType } from 'react'
+import { useState, ReactNode } from 'react'
 import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 
 interface CollapsibleSectionProps {
@@ -8,8 +8,12 @@ interface CollapsibleSectionProps {
   children: ReactNode
   defaultOpen?: boolean
   className?: string
-  /** Optional leading icon shown next to the title (matches InfoCard chrome). */
-  icon?: ComponentType<{ className?: string }>
+  /**
+   * Rendered icon ELEMENT (not a component function): this is a client
+   * component, and server callers can only pass serializable props — a
+   * ReactNode element crosses the RSC boundary; a component function throws.
+   */
+  icon?: ReactNode
   /**
    * Optional header affordance (e.g. an EditConferenceCard pencil) rendered to
    * the right, OUTSIDE the toggle button so it stays valid HTML and clickable
@@ -23,7 +27,7 @@ export function CollapsibleSection({
   children,
   defaultOpen = false,
   className = '',
-  icon: Icon,
+  icon,
   action,
 }: CollapsibleSectionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen)
@@ -43,8 +47,10 @@ export function CollapsibleSection({
             className="flex min-w-0 flex-1 items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
           >
             <span className="flex min-w-0 items-center">
-              {Icon ? (
-                <Icon className="mr-2 h-5 w-5 shrink-0 text-gray-400 dark:text-gray-500" />
+              {icon ? (
+                <span className="mr-2 shrink-0 text-gray-400 dark:text-gray-500 [&>svg]:h-5 [&>svg]:w-5">
+                  {icon}
+                </span>
               ) : null}
               <span className="truncate text-lg font-medium text-gray-900 dark:text-white">
                 {title}

--- a/src/components/admin/CollapsibleSection.tsx
+++ b/src/components/admin/CollapsibleSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, ReactNode } from 'react'
+import { useState, ReactNode, ComponentType } from 'react'
 import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 
 interface CollapsibleSectionProps {
@@ -8,6 +8,14 @@ interface CollapsibleSectionProps {
   children: ReactNode
   defaultOpen?: boolean
   className?: string
+  /** Optional leading icon shown next to the title (matches InfoCard chrome). */
+  icon?: ComponentType<{ className?: string }>
+  /**
+   * Optional header affordance (e.g. an EditConferenceCard pencil) rendered to
+   * the right, OUTSIDE the toggle button so it stays valid HTML and clickable
+   * independently of expanding/collapsing.
+   */
+  action?: ReactNode
 }
 
 export function CollapsibleSection({
@@ -15,6 +23,8 @@ export function CollapsibleSection({
   children,
   defaultOpen = false,
   className = '',
+  icon: Icon,
+  action,
 }: CollapsibleSectionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen)
 
@@ -22,24 +32,35 @@ export function CollapsibleSection({
     <div
       className={`overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-gray-700 ${className}`}
     >
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex w-full items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
-      >
-        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
-          {title}
-        </h2>
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">
-            {isOpen ? 'Hide' : 'Show'}
+      <div className="flex items-center">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          aria-expanded={isOpen}
+          className="flex min-w-0 flex-1 items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          <span className="flex min-w-0 items-center">
+            {Icon ? (
+              <Icon className="mr-2 h-5 w-5 shrink-0 text-gray-400 dark:text-gray-500" />
+            ) : null}
+            <h2 className="truncate text-lg font-medium text-gray-900 dark:text-white">
+              {title}
+            </h2>
           </span>
-          {isOpen ? (
-            <ChevronDownIcon className="h-5 w-5 text-gray-400" />
-          ) : (
-            <ChevronRightIcon className="h-5 w-5 text-gray-400" />
-          )}
-        </div>
-      </button>
+          <span className="ml-2 flex shrink-0 items-center gap-2">
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              {isOpen ? 'Hide' : 'Show'}
+            </span>
+            {isOpen ? (
+              <ChevronDownIcon className="h-5 w-5 text-gray-400" />
+            ) : (
+              <ChevronRightIcon className="h-5 w-5 text-gray-400" />
+            )}
+          </span>
+        </button>
+        {action ? (
+          <div className="flex shrink-0 items-center gap-2 pr-4">{action}</div>
+        ) : null}
+      </div>
 
       {isOpen && (
         <div className="border-t border-gray-200 dark:border-gray-700">

--- a/src/components/admin/CollapsibleSection.tsx
+++ b/src/components/admin/CollapsibleSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, ReactNode } from 'react'
+import { useId, useState, ReactNode } from 'react'
 import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 
 interface CollapsibleSectionProps {
@@ -31,6 +31,7 @@ export function CollapsibleSection({
   action,
 }: CollapsibleSectionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen)
+  const contentId = useId()
 
   return (
     <div
@@ -45,6 +46,7 @@ export function CollapsibleSection({
             type="button"
             onClick={() => setIsOpen(!isOpen)}
             aria-expanded={isOpen}
+            aria-controls={contentId}
             className="flex min-w-0 flex-1 items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
           >
             <span className="flex min-w-0 items-center">
@@ -75,7 +77,10 @@ export function CollapsibleSection({
       </div>
 
       {isOpen && (
-        <div className="border-t border-gray-200 dark:border-gray-700">
+        <div
+          id={contentId}
+          className="border-t border-gray-200 dark:border-gray-700"
+        >
           {children}
         </div>
       )}

--- a/src/components/admin/CollapsibleSection.tsx
+++ b/src/components/admin/CollapsibleSection.tsx
@@ -20,6 +20,11 @@ interface CollapsibleSectionProps {
    * independently of expanding/collapsing.
    */
   action?: ReactNode
+  /**
+   * Heading level for the card title so the document outline stays monotonic
+   * wherever the card is nested (e.g. 4 under the Settings groups' h3s).
+   */
+  headingLevel?: 2 | 3 | 4
 }
 
 export function CollapsibleSection({
@@ -29,7 +34,9 @@ export function CollapsibleSection({
   className = '',
   icon,
   action,
+  headingLevel = 2,
 }: CollapsibleSectionProps) {
+  const Heading = `h${headingLevel}` as const
   const [isOpen, setIsOpen] = useState(defaultOpen)
   const contentId = useId()
 
@@ -41,7 +48,7 @@ export function CollapsibleSection({
         {/* Accessible-disclosure pattern: the HEADING wraps the toggle button
             (h2 > button is valid; button/span > h2 is not — a heading is flow
             content and cannot sit inside phrasing content). */}
-        <h2 className="flex min-w-0 flex-1">
+        <Heading className="flex min-w-0 flex-1">
           <button
             type="button"
             onClick={() => setIsOpen(!isOpen)}
@@ -70,7 +77,7 @@ export function CollapsibleSection({
               )}
             </span>
           </button>
-        </h2>
+        </Heading>
         {action ? (
           <div className="flex shrink-0 items-center gap-2 pr-4">{action}</div>
         ) : null}

--- a/src/components/admin/WorkshopRegistrationSettings.tsx
+++ b/src/components/admin/WorkshopRegistrationSettings.tsx
@@ -94,7 +94,13 @@ export function WorkshopRegistrationSettings({
     // The datetime-local value is a timezone-less LOCAL wall-clock string; the
     // Date constructor interprets it as local time, and we persist the
     // unambiguous ISO instant so storage is timezone-stable.
-    const toIso = (v: string) => (v ? new Date(v).toISOString() : null)
+    const toIso = (v: string) => {
+      if (!v) return null
+      const d = new Date(v)
+      // A malformed input value must degrade to unset, not throw a RangeError
+      // out of toISOString and break the save flow.
+      return Number.isNaN(d.getTime()) ? null : d.toISOString()
+    }
     updateRegistrationTimes.mutate({
       startDate: toIso(startDate),
       endDate: toIso(endDate),

--- a/src/components/admin/WorkshopRegistrationSettings.tsx
+++ b/src/components/admin/WorkshopRegistrationSettings.tsx
@@ -12,6 +12,7 @@ import { AdminButton } from '@/components/admin/AdminButton'
 import { StatusBadge } from '@/components/StatusBadge'
 import { api } from '@/lib/trpc/client'
 import { useNotification } from './NotificationProvider'
+import { formatDateTimeSafe } from '@/lib/time'
 
 interface WorkshopRegistrationSettingsProps {
   workshopRegistrationStart?: string
@@ -34,8 +35,18 @@ export function WorkshopRegistrationSettings({
   const router = useRouter()
   const { showNotification } = useNotification()
 
-  const toLocalInput = (value?: string) =>
-    value ? new Date(value).toISOString().slice(0, 16) : ''
+  /**
+   * Stored ISO (UTC) → the LOCAL wall-clock string a `datetime-local` input
+   * expects. `toISOString().slice(0,16)` would show UTC and shift the time by
+   * the admin's timezone offset on every open/save round-trip.
+   */
+  const toLocalInput = (value?: string) => {
+    if (!value) return ''
+    const d = new Date(value)
+    if (Number.isNaN(d.getTime())) return ''
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  }
 
   const [isOpen, setIsOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -80,18 +91,21 @@ export function WorkshopRegistrationSettings({
 
   const handleSave = () => {
     setError(null)
+    // The datetime-local value is a timezone-less LOCAL wall-clock string; the
+    // Date constructor interprets it as local time, and we persist the
+    // unambiguous ISO instant so storage is timezone-stable.
+    const toIso = (v: string) => (v ? new Date(v).toISOString() : null)
     updateRegistrationTimes.mutate({
-      startDate: startDate || null,
-      endDate: endDate || null,
+      startDate: toIso(startDate),
+      endDate: toIso(endDate),
     })
   }
 
   const formatDateTime = (dateString?: string) => {
     if (!dateString) return 'Not set'
-    return new Date(dateString).toLocaleString('en-US', {
-      dateStyle: 'medium',
-      timeStyle: 'short',
-    })
+    // House formatter: consistent Europe/Oslo rendering regardless of the
+    // admin's locale/timezone.
+    return formatDateTimeSafe(dateString)
   }
 
   const getRegistrationStatus = () => {

--- a/src/components/admin/WorkshopRegistrationSettings.tsx
+++ b/src/components/admin/WorkshopRegistrationSettings.tsx
@@ -12,7 +12,11 @@ import { AdminButton } from '@/components/admin/AdminButton'
 import { StatusBadge } from '@/components/StatusBadge'
 import { api } from '@/lib/trpc/client'
 import { useNotification } from './NotificationProvider'
-import { formatDateTimeSafe } from '@/lib/time'
+import {
+  formatDateTimeSafe,
+  instantToOsloLocalInput,
+  osloLocalInputToIso,
+} from '@/lib/time'
 
 interface WorkshopRegistrationSettingsProps {
   workshopRegistrationStart?: string
@@ -36,17 +40,14 @@ export function WorkshopRegistrationSettings({
   const { showNotification } = useNotification()
 
   /**
-   * Stored ISO (UTC) → the LOCAL wall-clock string a `datetime-local` input
+   * Stored ISO instant → the EUROPE/OSLO wall-clock string the input
    * expects. `toISOString().slice(0,16)` would show UTC and shift the time by
    * the admin's timezone offset on every open/save round-trip.
    */
-  const toLocalInput = (value?: string) => {
-    if (!value) return ''
-    const d = new Date(value)
-    if (Number.isNaN(d.getTime())) return ''
-    const pad = (n: number) => String(n).padStart(2, '0')
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
-  }
+  // Edit fields display and accept EUROPE/OSLO wall-clock — the same zone the
+  // read-only rows format in (formatDateTimeSafe) — so an admin outside Oslo
+  // never sees two different times for one stored instant.
+  const toLocalInput = (value?: string) => instantToOsloLocalInput(value)
 
   const [isOpen, setIsOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -94,16 +95,10 @@ export function WorkshopRegistrationSettings({
 
   const handleSave = () => {
     setError(null)
-    // The datetime-local value is a timezone-less LOCAL wall-clock string; the
-    // Date constructor interprets it as local time, and we persist the
-    // unambiguous ISO instant so storage is timezone-stable.
-    const toIso = (v: string) => {
-      if (!v) return null
-      const d = new Date(v)
-      // A malformed input value must degrade to unset, not throw a RangeError
-      // out of toISOString and break the save flow.
-      return Number.isNaN(d.getTime()) ? null : d.toISOString()
-    }
+    // The datetime-local value is entered as Europe/Oslo wall-clock (matching
+    // the read-only rows); persist the unambiguous ISO instant. Malformed
+    // values degrade to unset rather than throwing.
+    const toIso = (v: string) => osloLocalInputToIso(v)
     updateRegistrationTimes.mutate({
       startDate: toIso(startDate),
       endDate: toIso(endDate),
@@ -207,7 +202,7 @@ export function WorkshopRegistrationSettings({
               htmlFor="workshop-reg-start"
               className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
             >
-              Registration Opens
+              Registration Opens (Europe/Oslo)
             </label>
             <input
               id="workshop-reg-start"
@@ -223,7 +218,7 @@ export function WorkshopRegistrationSettings({
               htmlFor="workshop-reg-end"
               className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
             >
-              Registration Closes
+              Registration Closes (Europe/Oslo)
             </label>
             <input
               id="workshop-reg-end"

--- a/src/components/admin/WorkshopRegistrationSettings.tsx
+++ b/src/components/admin/WorkshopRegistrationSettings.tsx
@@ -68,7 +68,10 @@ export function WorkshopRegistrationSettings({
         router.refresh()
       },
       onError: (err) => {
-        setError(err.message || 'Failed to update')
+        setError(
+          err.message ||
+            'Failed to update the workshop registration window. Please try again.',
+        )
         showNotification({
           type: 'error',
           title: 'Could not save',

--- a/src/components/admin/WorkshopRegistrationSettings.tsx
+++ b/src/components/admin/WorkshopRegistrationSettings.tsx
@@ -1,70 +1,89 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import {
   CalendarIcon,
-  PencilIcon,
-  CheckIcon,
-  XMarkIcon,
+  PencilSquareIcon,
+  CheckCircleIcon,
 } from '@heroicons/react/24/outline'
-import { api } from '@/lib/trpc/client'
+import { ModalShell } from '@/components/ModalShell'
 import { AdminButton } from '@/components/admin/AdminButton'
+import { StatusBadge } from '@/components/StatusBadge'
+import { api } from '@/lib/trpc/client'
+import { useNotification } from './NotificationProvider'
 
 interface WorkshopRegistrationSettingsProps {
   workshopRegistrationStart?: string
   workshopRegistrationEnd?: string
 }
 
+/**
+ * Workshop registration window (open/close datetimes). This is the one settings
+ * island that can't fold into the generic {@link EditConferenceCard} fieldset
+ * table because it is patched through the dedicated `workshop.admin` router
+ * rather than a `conference.*` mutation. So it keeps its own mutation but adopts
+ * the house interaction: a read-only card with a pencil trigger opening a
+ * {@link ModalShell} form, and `router.refresh()` (never a full-page reload)
+ * after a successful save.
+ */
 export function WorkshopRegistrationSettings({
   workshopRegistrationStart,
   workshopRegistrationEnd,
 }: WorkshopRegistrationSettingsProps) {
-  const [isEditing, setIsEditing] = useState(false)
+  const router = useRouter()
+  const { showNotification } = useNotification()
+
+  const toLocalInput = (value?: string) =>
+    value ? new Date(value).toISOString().slice(0, 16) : ''
+
+  const [isOpen, setIsOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [startDate, setStartDate] = useState(
-    workshopRegistrationStart
-      ? new Date(workshopRegistrationStart).toISOString().slice(0, 16)
-      : '',
+    toLocalInput(workshopRegistrationStart),
   )
-  const [endDate, setEndDate] = useState(
-    workshopRegistrationEnd
-      ? new Date(workshopRegistrationEnd).toISOString().slice(0, 16)
-      : '',
-  )
+  const [endDate, setEndDate] = useState(toLocalInput(workshopRegistrationEnd))
 
   const updateRegistrationTimes =
     api.workshop.admin.updateRegistrationTimes.useMutation({
       onSuccess: () => {
-        setIsEditing(false)
+        setIsOpen(false)
         setError(null)
-        window.location.reload()
+        showNotification({
+          type: 'success',
+          title: 'Settings updated',
+          message: 'Workshop Registration saved.',
+        })
+        router.refresh()
       },
-      onError: (error) => {
-        setError(error.message || 'Failed to update')
+      onError: (err) => {
+        setError(err.message || 'Failed to update')
+        showNotification({
+          type: 'error',
+          title: 'Could not save',
+          message: err.message || 'Failed to update workshop registration.',
+        })
       },
     })
 
-  const handleSave = async () => {
+  const openModal = () => {
+    setStartDate(toLocalInput(workshopRegistrationStart))
+    setEndDate(toLocalInput(workshopRegistrationEnd))
+    setError(null)
+    setIsOpen(true)
+  }
+
+  const closeModal = () => {
+    setIsOpen(false)
+    setError(null)
+  }
+
+  const handleSave = () => {
     setError(null)
     updateRegistrationTimes.mutate({
       startDate: startDate || null,
       endDate: endDate || null,
     })
-  }
-
-  const handleCancel = () => {
-    setStartDate(
-      workshopRegistrationStart
-        ? new Date(workshopRegistrationStart).toISOString().slice(0, 16)
-        : '',
-    )
-    setEndDate(
-      workshopRegistrationEnd
-        ? new Date(workshopRegistrationEnd).toISOString().slice(0, 16)
-        : '',
-    )
-    setIsEditing(false)
-    setError(null)
   }
 
   const formatDateTime = (dateString?: string) => {
@@ -77,130 +96,145 @@ export function WorkshopRegistrationSettings({
 
   const getRegistrationStatus = () => {
     if (!workshopRegistrationStart || !workshopRegistrationEnd) {
-      return { text: 'Not configured', color: 'text-gray-500' }
+      return { label: 'Not configured', color: 'gray' as const }
     }
-
     const now = new Date()
     const start = new Date(workshopRegistrationStart)
     const end = new Date(workshopRegistrationEnd)
-
-    if (now < start) {
-      return {
-        text: 'Not yet open',
-        color: 'text-yellow-600 dark:text-yellow-400',
-      }
-    }
-    if (now > end) {
-      return { text: 'Closed', color: 'text-red-600 dark:text-red-400' }
-    }
-    return {
-      text: 'Currently open',
-      color: 'text-green-600 dark:text-green-400',
-    }
+    if (now < start) return { label: 'Not yet open', color: 'yellow' as const }
+    if (now > end) return { label: 'Closed', color: 'red' as const }
+    return { label: 'Currently open', color: 'green' as const }
   }
 
   const status = getRegistrationStatus()
 
   return (
     <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex items-center justify-between gap-2">
         <div className="flex items-center">
           <CalendarIcon className="mr-2 h-5 w-5 text-gray-400 dark:text-gray-500" />
           <h3 className="text-lg font-medium text-gray-900 dark:text-white">
             Workshop Registration
           </h3>
         </div>
-        {!isEditing && (
-          <AdminButton color="blue" onClick={() => setIsEditing(true)}>
-            <PencilIcon className="h-4 w-4" />
-            Edit
-          </AdminButton>
-        )}
+        <button
+          type="button"
+          onClick={openModal}
+          aria-label="Edit Workshop Registration"
+          className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+        >
+          <PencilSquareIcon className="h-5 w-5" />
+        </button>
       </div>
 
-      {error && (
-        <div className="mb-4 rounded-md bg-red-50 p-3 dark:bg-red-900/20">
-          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+      <div className="space-y-3">
+        <div className="flex justify-between border-b border-gray-200 py-2 dark:border-gray-700">
+          <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
+            Registration Opens
+          </span>
+          <span className="text-sm text-gray-900 dark:text-white">
+            {formatDateTime(workshopRegistrationStart)}
+          </span>
         </div>
-      )}
 
-      {isEditing ? (
-        <div className="space-y-4">
+        <div className="flex justify-between border-b border-gray-200 py-2 dark:border-gray-700">
+          <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
+            Registration Closes
+          </span>
+          <span className="text-sm text-gray-900 dark:text-white">
+            {formatDateTime(workshopRegistrationEnd)}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between py-2">
+          <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
+            Status
+          </span>
+          <StatusBadge label={status.label} color={status.color} />
+        </div>
+      </div>
+
+      <ModalShell
+        isOpen={isOpen}
+        onClose={closeModal}
+        size="lg"
+        title="Edit Workshop Registration"
+        subtitle="When workshop sign-ups open and close"
+        icon={<PencilSquareIcon className="h-5 w-5" />}
+      >
+        <form
+          noValidate
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSave()
+          }}
+          className="space-y-4"
+        >
+          {error ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {error}
+            </p>
+          ) : null}
+
           <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label
+              htmlFor="workshop-reg-start"
+              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
               Registration Opens
             </label>
             <input
+              id="workshop-reg-start"
               type="datetime-local"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              className="block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label
+              htmlFor="workshop-reg-end"
+              className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
               Registration Closes
             </label>
             <input
+              id="workshop-reg-end"
               type="datetime-local"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
-              className="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              className="block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
             />
           </div>
 
-          <div className="flex gap-2">
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
             <AdminButton
-              color="green"
-              size="md"
-              onClick={handleSave}
-              disabled={updateRegistrationTimes.isPending}
-            >
-              <CheckIcon className="h-4 w-4" />
-              {updateRegistrationTimes.isPending ? 'Saving...' : 'Save'}
-            </AdminButton>
-            <AdminButton
+              type="button"
               variant="secondary"
               size="md"
-              onClick={handleCancel}
+              onClick={closeModal}
               disabled={updateRegistrationTimes.isPending}
+              className="min-h-[44px]"
             >
-              <XMarkIcon className="h-4 w-4" />
               Cancel
             </AdminButton>
+            <AdminButton
+              type="submit"
+              color="blue"
+              size="md"
+              disabled={updateRegistrationTimes.isPending}
+              className="min-h-[44px]"
+            >
+              <CheckCircleIcon className="h-4 w-4" />
+              {updateRegistrationTimes.isPending ? 'Saving…' : 'Save'}
+            </AdminButton>
           </div>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          <div className="flex justify-between py-2">
-            <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
-              Registration Opens
-            </span>
-            <span className="text-sm text-gray-900 dark:text-white">
-              {formatDateTime(workshopRegistrationStart)}
-            </span>
-          </div>
-
-          <div className="flex justify-between border-t border-gray-200 py-2 dark:border-gray-700">
-            <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
-              Registration Closes
-            </span>
-            <span className="text-sm text-gray-900 dark:text-white">
-              {formatDateTime(workshopRegistrationEnd)}
-            </span>
-          </div>
-
-          <div className="flex justify-between border-t border-gray-200 py-2 dark:border-gray-700">
-            <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
-              Status
-            </span>
-            <span className={`text-sm font-medium ${status.color}`}>
-              {status.text}
-            </span>
-          </div>
-        </div>
-      )}
+        </form>
+      </ModalShell>
     </div>
   )
 }

--- a/src/lib/settings/groups.test.ts
+++ b/src/lib/settings/groups.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SETTINGS_GROUPS,
+  SETTINGS_TIERS,
+  SETTINGS_GROUP_ANCHORS,
+  SETTINGS_TIER_ANCHORS,
+} from './groups'
+
+describe('settings IA groups', () => {
+  it('defines the six organizer-facing groups in order', () => {
+    expect(SETTINGS_GROUPS.map((g) => g.id)).toEqual([
+      'identity-brand',
+      'schedule',
+      'call-for-papers',
+      'tickets-registration',
+      'sponsors',
+      'team-content',
+    ])
+  })
+
+  it('gives every group a title, nav label and description', () => {
+    for (const g of SETTINGS_GROUPS) {
+      expect(g.title.length).toBeGreaterThan(0)
+      expect(g.navLabel.length).toBeGreaterThan(0)
+      expect(g.description.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('has unique group ids that never collide with tier or per-card anchors', () => {
+    const groupIds = SETTINGS_GROUPS.map((g) => g.id)
+    expect(new Set(groupIds).size).toBe(groupIds.length)
+
+    const tierIds = SETTINGS_TIERS.map((t) => t.id)
+    // Preserved per-card deep-link anchors that must not be shadowed by a group.
+    const reserved = new Set([...tierIds, 'visibility'])
+    for (const id of groupIds) {
+      expect(reserved.has(id)).toBe(false)
+    }
+  })
+
+  it('produces well-formed jump-nav anchors for tiers and groups', () => {
+    for (const a of [...SETTINGS_TIER_ANCHORS, ...SETTINGS_GROUP_ANCHORS]) {
+      expect(a.href.startsWith('#')).toBe(true)
+      expect(a.href.length).toBeGreaterThan(1)
+      expect(a.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('derives group anchors 1:1 from the group ids', () => {
+    expect(SETTINGS_GROUP_ANCHORS.map((a) => a.href)).toEqual(
+      SETTINGS_GROUPS.map((g) => `#${g.id}`),
+    )
+  })
+
+  it('keeps the three tiers stable', () => {
+    expect(SETTINGS_TIERS.map((t) => t.id)).toEqual([
+      'configuration',
+      'system-status',
+      'self-check',
+    ])
+  })
+})

--- a/src/lib/settings/groups.ts
+++ b/src/lib/settings/groups.ts
@@ -1,0 +1,95 @@
+/**
+ * Information architecture for the admin Settings page (tier 1: Configuration).
+ *
+ * The ~19 read-only configuration cards are organised into a handful of labelled
+ * subsections, ordered by an organizer's mental model ("where would I look for
+ * X?"). This module is the single source of truth for those group anchors and
+ * their headings so the page body and the sticky jump-nav can never drift apart,
+ * and so the anchor set is unit-testable in isolation.
+ *
+ * These group anchors are ADDITIVE — the per-card deep-link anchors (e.g.
+ * `#visibility`) and the three tier anchors (`#configuration`, `#system-status`,
+ * `#self-check`) are preserved elsewhere and must keep working.
+ */
+
+export interface SettingsGroup {
+  /** Stable anchor id (used as `#id` deep link and `scroll-mt` target). */
+  id: string
+  /** Short label shown in the jump-nav chip. */
+  navLabel: string
+  /** Heading rendered above the group's card grid. */
+  title: string
+  /** One-line orientation text under the group heading. */
+  description: string
+}
+
+/** Tier-level anchors (the three top-level Settings sections). */
+export interface SettingsTier {
+  id: string
+  navLabel: string
+}
+
+export const SETTINGS_TIERS: readonly SettingsTier[] = [
+  { id: 'configuration', navLabel: 'Configuration' },
+  { id: 'system-status', navLabel: 'System status' },
+  { id: 'self-check', navLabel: 'Self-check' },
+]
+
+/**
+ * Tier-1 subsection groups, in display order. Membership (which card lives in
+ * which group) is expressed by JSX placement on the settings page; this table
+ * owns only the group's identity and heading copy.
+ */
+export const SETTINGS_GROUPS: readonly SettingsGroup[] = [
+  {
+    id: 'identity-brand',
+    navLabel: 'Identity & Brand',
+    title: 'Identity & Brand',
+    description:
+      'Name, location, logos, colours and whether this edition is publicly listed.',
+  },
+  {
+    id: 'schedule',
+    navLabel: 'Schedule',
+    title: 'Schedule',
+    description:
+      'Key dates, the CFP timeline and the landing-page announcement.',
+  },
+  {
+    id: 'call-for-papers',
+    navLabel: 'Call for Papers',
+    title: 'Call for Papers',
+    description: 'Submission and revenue targets tracked on the dashboard.',
+  },
+  {
+    id: 'tickets-registration',
+    navLabel: 'Tickets & Registration',
+    title: 'Tickets & Registration',
+    description:
+      'Registration, workshop sign-ups, the ticketing provider and homepage stats.',
+  },
+  {
+    id: 'sponsors',
+    navLabel: 'Sponsors',
+    title: 'Sponsors',
+    description:
+      'Sponsorship tiers, current sponsors, benefits and the public sponsorship page.',
+  },
+  {
+    id: 'team-content',
+    navLabel: 'Team & Content',
+    title: 'Team & Content',
+    description:
+      'Organizers, teams, contact channels, domains, topics/formats and homepage composition.',
+  },
+]
+
+/** Jump-nav anchors for the tier-1 groups (`#id` hrefs + labels). */
+export const SETTINGS_GROUP_ANCHORS: readonly {
+  href: string
+  label: string
+}[] = SETTINGS_GROUPS.map((g) => ({ href: `#${g.id}`, label: g.navLabel }))
+
+/** Jump-nav anchors for the three tiers. */
+export const SETTINGS_TIER_ANCHORS: readonly { href: string; label: string }[] =
+  SETTINGS_TIERS.map((t) => ({ href: `#${t.id}`, label: t.navLabel }))

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -400,3 +400,66 @@ export function formatRelativeTime(isoDate: string): string {
 export function formatLabel(value: string): string {
   return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
+
+/**
+ * Wall-clock parts of an instant in Europe/Oslo (DST-correct, via Intl).
+ * sv-SE formats as "YYYY-MM-DD HH:mm" which splits cleanly.
+ */
+function osloParts(instant: Date): {
+  date: string
+  time: string
+} {
+  const formatted = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: OSLO_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(instant)
+  const [date, time] = formatted.split(' ')
+  return { date, time }
+}
+
+/** Millisecond offset of Europe/Oslo from UTC at the given instant. */
+function osloOffsetMs(instant: Date): number {
+  const { date, time } = osloParts(instant)
+  const asUtc = Date.parse(`${date}T${time}:00Z`)
+  // Truncate the instant to the minute the parts represent before comparing.
+  const truncated = Math.floor(instant.getTime() / 60_000) * 60_000
+  return asUtc - truncated
+}
+
+/**
+ * Stored ISO instant → the Europe/Oslo wall-clock string a `datetime-local`
+ * input should DISPLAY, so edit fields agree with the read-only views (which
+ * format via {@link formatDateTimeSafe} in Oslo time) regardless of the
+ * admin's own timezone.
+ */
+export function instantToOsloLocalInput(value?: string): string {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  const { date, time } = osloParts(d)
+  return `${date}T${time}`
+}
+
+/**
+ * A `datetime-local` string ENTERED AS Europe/Oslo wall-clock → the ISO
+ * instant to persist. DST-correct: the offset is resolved at the target
+ * instant (with one re-check across a transition boundary).
+ */
+export function osloLocalInputToIso(value?: string): string | null {
+  const v = value?.trim()
+  if (!v) return null
+  // Strict datetime-local shape only — engines parse surprising strings
+  // leniently (e.g. bare years), which must not silently become instants.
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(v)) return null
+  const naiveUtc = Date.parse(`${v}:00Z`)
+  if (Number.isNaN(naiveUtc)) return null
+  let instant = naiveUtc - osloOffsetMs(new Date(naiveUtc))
+  const secondPass = naiveUtc - osloOffsetMs(new Date(instant))
+  if (secondPass !== instant) instant = secondPass
+  return new Date(instant).toISOString()
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -409,16 +409,20 @@ function osloParts(instant: Date): {
   date: string
   time: string
 } {
-  const formatted = new Intl.DateTimeFormat('sv-SE', {
+  // formatToParts, not format(): the assembled string's separators are not
+  // guaranteed across engines, but part values are.
+  const parts = new Intl.DateTimeFormat('en-US', {
     timeZone: OSLO_TZ,
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
-    hour12: false,
-  }).format(instant)
-  const [date, time] = formatted.split(' ')
+    hourCycle: 'h23',
+  }).formatToParts(instant)
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  const date = `${get('year')}-${get('month')}-${get('day')}`
+  const time = `${get('hour')}:${get('minute')}`
   return { date, time }
 }
 

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -402,8 +402,8 @@ export function formatLabel(value: string): string {
 }
 
 /**
- * Wall-clock parts of an instant in Europe/Oslo (DST-correct, via Intl).
- * sv-SE formats as "YYYY-MM-DD HH:mm" which splits cleanly.
+ * Wall-clock parts of an instant in Europe/Oslo (DST-correct, via Intl),
+ * assembled from formatToParts values — never from a locale-formatted string.
  */
 function osloParts(instant: Date): {
   date: string


### PR DESCRIPTION
## What & why

Presentation-only restructure of the admin **Settings** page (tier 1) from a flat ~19-card grid into six labelled subsections ordered by an organizer's mental model, plus a jump-nav, collapse-by-default for set-once cards, and organizer-friendly naming. No mutation, schema, or `EditConferenceCard` fieldset contract was touched (the one exception: normalizing the Workshop editor's interaction, below).

The three-tier structure (Configuration / System status / Self-check) stays; the grouping happens **inside** tier 1.

## Group map

| Group (anchor) | Cards |
| --- | --- |
| **Identity & Brand** (`#identity-brand`) | Basic Information, Branding, Visibility, **Venue** (collapsed) |
| **Schedule** (`#schedule`) | Dates & Timeline, Announcement |
| **Call for Papers** (`#call-for-papers`) | CFP & Revenue Goals |
| **Tickets & Registration** (`#tickets-registration`) | Registration, Workshop Registration, Ticketing, **Homepage Stats** (collapsed) |
| **Sponsors** (`#sponsors`) | Sponsorship Tiers, Current Sponsors, **Sponsor Benefits** (collapsed), **Sponsorship Page** (collapsed) |
| **Team & Content** (`#team-content`) | Organizers & Teams, Communication, Domains & Social Links, Topics & Formats, Homepage Composition |

Every existing per-card deep-link anchor (`#visibility`) and the three tier anchors are preserved; the group anchors are **additive**.

## Jump nav

The sticky `SectionNav` now has two rows: the three tier links (unchanged) plus a row of **horizontally-scrollable group-anchor chips**, so every group is one click from the top. On mobile the chips scroll rather than wrap or overflow; on desktop all six fit.

## Renames (display labels/titles only — no fieldset keys changed)

| Before | After | Note |
| --- | --- | --- |
| External Integrations | **Ticketing** | now clearly the provider selector + Checkin/Tito binding |
| Content Configuration | **Topics & Formats** | says what it drives |
| Vanity Metrics | **Homepage Stats** | these numbers drive the homepage metrics section |
| Domain Configuration | **Domains & Social Links** | surfaces Social Links out of the domain card's title shadow |
| Team | **Organizers & Teams** | |

## Collapse-by-default

The set-once/rarely-touched cards — **Venue, Homepage Stats, Sponsor Benefits, Sponsorship Page** — now use `CollapsibleSection` (collapsed by default; everything else stays expanded). `CollapsibleSection` gained optional `icon` and `action` props (backward-compatible) so a collapsed card still shows its title, its "Edit in Studio" link and its edit pencil in the header.

## Workshop editor normalization

`WorkshopRegistrationSettings` is the one settings island that can't fold into the generic `EditConferenceCard` fieldset table — it is patched through the dedicated `workshop.admin.updateRegistrationTimes` router, not a `conference.*` mutation. So it **keeps its own mutation** but adopts the house interaction: a read-only card with a pencil trigger opening a `ModalShell` form, success/error surfaced via the toast `useNotification()`, and **`router.refresh()`** instead of the old `window.location.reload()` full-page reload.

## Refactor for testability

- Presentational primitives (`InfoCard`, `FieldRow`, `SectionNav`, `SectionHeading`, `SettingsGroupSection`, `StudioEditLink`) extracted from the server `page.tsx` into `settingsLayout.tsx`.
- Group + anchor definitions extracted to `src/lib/settings/groups.ts`, unit-tested in `groups.test.ts` (single source for the nav and the section headings).
- Added a provider-free Storybook harness (`SettingsIA.stories.tsx`) reproducing the grouped page for visual QA.

## Shoot findings

`SettingsIA` story shot full-page at **393px** and **1280px**, **light + dark**:
- Group headers render with icons + descriptions.
- Nav chips scroll horizontally on mobile (no wrap/overflow) and all six fit on desktop.
- Collapsed cards show their titles + Show toggle + edit affordances.
- No horizontal page overflow; dark mode consistent across cards, chips and headings.
- No layout regressions. (Pre-existing InfoCard header wrapping of long titles on narrow mobile is unchanged.)

## Tests

- New unit test for the group/anchor definitions (6 cases) — green.
- Full vitest suite: **4207 passed**. `mise run check` (typecheck, format, knip, lint): exit 0 (only pre-existing tenancy warnings in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)