### PR TITLE
fix(badge): dereferenceable verification-method endpoint for embedded proofs

### DIFF
--- a/__tests__/api/badge/issuer-profile.test.ts
+++ b/__tests__/api/badge/issuer-profile.test.ts
@@ -19,6 +19,8 @@ const mockedGetConference = vi.mocked(getConferenceForCurrentDomain)
 
 const DOMAIN = 'example.com'
 const ISSUER_ID = `https://${DOMAIN}/api/badge/issuer`
+const KEY_DOC_ID = `https://${DOMAIN}/api/badge/keys/key-ed25519`
+const LEGACY_VM_ID = `${ISSUER_ID}#key-ed25519`
 
 async function callIssuerRoute() {
   const { GET } = await import('@/app/api/badge/issuer/route')
@@ -74,14 +76,20 @@ describe('GET /api/badge/issuer - Ed25519 verification method', () => {
     expect(response.status).toBe(200)
     const data = await response.json()
 
-    expect(data.verificationMethod).toHaveLength(1)
-    const vm = data.verificationMethod[0]
-    expect(vm.id).toBe(`${ISSUER_ID}#key-ed25519`)
-    expect(vm.type).toBe('Multikey')
-    expect(vm.controller).toBe(ISSUER_ID)
+    // Two ids for the SAME key: the dereferenceable keys-endpoint URL that new
+    // credentials pin, and the legacy issuer-profile fragment older baked SVGs
+    // pin. Both list controller = issuer id.
+    expect(data.verificationMethod).toHaveLength(2)
+    const [keyDocVm, legacyVm] = data.verificationMethod
+    expect(keyDocVm.id).toBe(KEY_DOC_ID)
+    expect(keyDocVm.type).toBe('Multikey')
+    expect(keyDocVm.controller).toBe(ISSUER_ID)
     // The published public key IS the publicKeyMultibase — no seed needed.
-    expect(vm.publicKeyMultibase).toBe(publicKey)
-    expect(data.assertionMethod).toEqual([`${ISSUER_ID}#key-ed25519`])
+    expect(keyDocVm.publicKeyMultibase).toBe(publicKey)
+    expect(legacyVm.id).toBe(LEGACY_VM_ID)
+    expect(legacyVm.controller).toBe(ISSUER_ID)
+    expect(legacyVm.publicKeyMultibase).toBe(publicKey)
+    expect(data.assertionMethod).toEqual([KEY_DOC_ID, LEGACY_VM_ID])
 
     // RSA JWT key is still served alongside.
     expect(data.publicKey[0].type).toBe('JsonWebKey')

--- a/__tests__/api/badge/keys-endpoint.test.ts
+++ b/__tests__/api/badge/keys-endpoint.test.ts
@@ -1,0 +1,115 @@
+/**
+ * GET /api/badge/keys/[keyId] — dereferenceable public-key documents
+ *
+ * - key-ed25519 returns the BARE Multikey document the 1EdTech
+ *   EmbeddedProofProbe dereferences (controller + publicKeyMultibase at the
+ *   response root); this is what fixes the "Invalid verification key URL" NPE.
+ * - key-1 still returns the bare RSA JWK for the JWT ExternalProofProbe.
+ */
+
+import { seedToMultikey } from '@/lib/openbadges'
+
+vi.mock('next/headers', () => ({
+  headers: async () => new Headers({ host: 'example.com' }),
+}))
+
+const DOMAIN = 'example.com'
+const ISSUER_ID = `https://${DOMAIN}/api/badge/issuer`
+const KEY_DOC_ID = `https://${DOMAIN}/api/badge/keys/key-ed25519`
+
+async function callKeysRoute(keyId: string) {
+  const { GET } = await import('@/app/api/badge/keys/[keyId]/route')
+  const request = new Request(`https://${DOMAIN}/api/badge/keys/${keyId}`)
+  return GET(request, { params: Promise.resolve({ keyId }) })
+}
+
+describe('GET /api/badge/keys/[keyId]', () => {
+  let savedSeed: string | undefined
+  let savedPublicKey: string | undefined
+
+  beforeAll(() => {
+    savedSeed = process.env.BADGE_ISSUER_ED25519_SEED
+    savedPublicKey = process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
+  })
+
+  afterEach(() => {
+    if (savedSeed !== undefined)
+      process.env.BADGE_ISSUER_ED25519_SEED = savedSeed
+    else delete process.env.BADGE_ISSUER_ED25519_SEED
+    if (savedPublicKey !== undefined)
+      process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY = savedPublicKey
+    else delete process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
+  })
+
+  it('serves key-ed25519 as a bare Multikey document (public key path)', async () => {
+    const publicKey = savedPublicKey
+    expect(publicKey?.startsWith('z')).toBe(true)
+
+    delete process.env.BADGE_ISSUER_ED25519_SEED
+    process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY = publicKey
+
+    const response = await callKeysRoute('key-ed25519')
+    expect(response.status).toBe(200)
+    // JSON-LD content type so the validator's document loader accepts it.
+    expect(response.headers.get('content-type')).toContain(
+      'application/ld+json',
+    )
+
+    const doc = await response.json()
+    expect(doc).toEqual({
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/multikey/v1',
+      ],
+      id: KEY_DOC_ID,
+      type: 'Multikey',
+      controller: ISSUER_ID,
+      publicKeyMultibase: publicKey,
+    })
+    // The probe reads these off the root — a fragment→issuer-profile response
+    // has no top-level controller and NPEs. Assert they are present here.
+    expect(doc.controller).toBe(ISSUER_ID)
+    expect(typeof doc.publicKeyMultibase).toBe('string')
+  })
+
+  it('derives key-ed25519 from the seed when no public key env is set', async () => {
+    const seed = savedSeed
+    expect(seed).toBeTruthy()
+
+    delete process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
+    process.env.BADGE_ISSUER_ED25519_SEED = seed
+
+    const response = await callKeysRoute('key-ed25519')
+    expect(response.status).toBe(200)
+    const doc = await response.json()
+
+    const { publicKeyMultibase } = await seedToMultikey(seed!)
+    expect(doc.publicKeyMultibase).toBe(publicKeyMultibase)
+    expect(doc.type).toBe('Multikey')
+  })
+
+  it('500s for key-ed25519 when no Ed25519 material is configured', async () => {
+    delete process.env.BADGE_ISSUER_ED25519_SEED
+    delete process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
+
+    const response = await callKeysRoute('key-ed25519')
+    expect(response.status).toBe(500)
+  })
+
+  it('still serves key-1 as a bare RSA JWK', async () => {
+    const response = await callKeysRoute('key-1')
+    expect(response.status).toBe(200)
+    const jwk = await response.json()
+    expect(jwk.kty).toBe('RSA')
+    expect(jwk).toHaveProperty('n')
+    expect(jwk).toHaveProperty('e')
+    // Bare JWK — never wrapped in an issuer profile.
+    expect(jwk).not.toHaveProperty('publicKey')
+    expect(jwk).not.toHaveProperty('verificationMethod')
+  })
+
+  it('404s for an unknown key id', async () => {
+    const response = await callKeysRoute('key-unknown')
+    expect(response.status).toBe(404)
+  })
+})

--- a/__tests__/lib/badge/generator-credential.test.ts
+++ b/__tests__/lib/badge/generator-credential.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment node
+ *
+ * generateBadgeCredential — embedded-proof credential shape.
+ *
+ * Two consumer-reported bugs are pinned here:
+ * 1. proof.verificationMethod must be the dereferenceable keys URL (not an
+ *    issuer-profile fragment) so the 1EdTech EmbeddedProofProbe can read the
+ *    key document off the response root.
+ * 2. credentialSubject.identifier[] must carry an emailAddress IdentityObject
+ *    so displayers (Credly) can match badge ownership to a verified email.
+ *
+ * The generated credential is also validated against the official OB 3.0 JSON
+ * schema (vendored, no network) and round-tripped through verifyCredential.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { generateBadgeCredential } from '@/lib/badge/generator'
+import { createTestConfiguration } from '@/lib/badge/config'
+import { validateCredential, verifyCredential } from '@/lib/openbadges'
+import type { SignedCredential } from '@/lib/openbadges'
+import { ed25519VerificationMethodUrl } from '@/lib/badge/verification-method'
+
+const BASE = 'https://test.cloudnativedays.no'
+
+describe('generateBadgeCredential - embedded proof', () => {
+  let credential: SignedCredential
+
+  beforeAll(async () => {
+    const config = createTestConfiguration()
+    const generated = await generateBadgeCredential(
+      {
+        speakerId: 'speaker-1',
+        speakerName: 'Jane Doe',
+        speakerEmail: 'Jane.Doe@Example.COM',
+        speakerSlug: 'jane-doe',
+        conferenceId: 'conference-1',
+        conferenceTitle: 'Test Conference 2026',
+        conferenceYear: '2026',
+        conferenceDate: 'June 15, 2026',
+        badgeType: 'speaker',
+        talkId: 'talk-1',
+        talkTitle: 'Kubernetes at Scale',
+      },
+      config,
+    )
+    credential = generated.credentialJson
+  })
+
+  it('pins proof.verificationMethod to the dereferenceable keys URL (no fragment)', () => {
+    const vm = credential.proof[0].verificationMethod
+    expect(vm).toBe(ed25519VerificationMethodUrl(BASE))
+    expect(vm).toBe(`${BASE}/api/badge/keys/key-ed25519`)
+    expect(vm).not.toContain('#')
+  })
+
+  it('emits an emailAddress IdentityObject in credentialSubject.identifier', () => {
+    const identifier = credential.credentialSubject.identifier
+    expect(Array.isArray(identifier)).toBe(true)
+    expect(identifier).toHaveLength(1)
+    expect(identifier![0]).toEqual({
+      // type is the plain STRING "IdentityObject" per the OB 3.0 schema.
+      type: 'IdentityObject',
+      hashed: false,
+      // plaintext, lowercased to match the normalized mailto: subject id.
+      identityHash: 'jane.doe@example.com',
+      identityType: 'emailAddress',
+    })
+  })
+
+  it('keeps credentialSubject.id as the (normalized) mailto: URI', () => {
+    expect(credential.credentialSubject.id).toBe('mailto:jane.doe@example.com')
+  })
+
+  it('validates against the official OpenBadges 3.0 JSON schema', () => {
+    const result = validateCredential(credential)
+    expect(result.errors ?? []).toEqual([])
+    expect(result.valid).toBe(true)
+  })
+
+  it('round-trips through verifyCredential with the issuer public key', async () => {
+    const publicKey = process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
+    expect(publicKey?.startsWith('z')).toBe(true)
+    const ok = await verifyCredential(credential, publicKey!)
+    expect(ok).toBe(true)
+  })
+})

--- a/__tests__/lib/badge/verification-method.test.ts
+++ b/__tests__/lib/badge/verification-method.test.ts
@@ -76,3 +76,11 @@ describe('verification-method helpers', () => {
     expect(typeof doc.publicKeyMultibase).toBe('string')
   })
 })
+
+describe('acceptedEd25519VerificationMethods — malformed issuer ids', () => {
+  it('returns an empty accept-list (untrusted, not a throw) for missing/non-string ids', () => {
+    expect(acceptedEd25519VerificationMethods(undefined)).toEqual([])
+    expect(acceptedEd25519VerificationMethods(null)).toEqual([])
+    expect(acceptedEd25519VerificationMethods('')).toEqual([])
+  })
+})

--- a/__tests__/lib/badge/verification-method.test.ts
+++ b/__tests__/lib/badge/verification-method.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment node
+ *
+ * Embedded-proof verification-method helpers. The 1EdTech EmbeddedProofProbe
+ * dereferences proof.verificationMethod and reads controller/publicKeyMultibase
+ * off the RESPONSE ROOT, so the proof must point at a dereferenceable keys URL
+ * that returns a bare Multikey — not an issuer-profile fragment. These pin the
+ * URL shape, the bare Multikey document, and the back-compat accept-list.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  ED25519_KEY_ID,
+  ed25519VerificationMethodUrl,
+  legacyEd25519VerificationMethod,
+  baseUrlFromIssuerId,
+  acceptedEd25519VerificationMethods,
+  buildEd25519MultikeyDocument,
+} from '@/lib/badge/verification-method'
+
+const BASE = 'https://cloudnativedays.no'
+const ISSUER_ID = `${BASE}/api/badge/issuer`
+const KEY_DOC_URL = `${BASE}/api/badge/keys/key-ed25519`
+const PUBLIC_KEY_MULTIBASE = 'z6MkfExampleExampleExampleExampleExampleExample'
+
+describe('verification-method helpers', () => {
+  it('exposes the key id and dereferenceable URL (no fragment)', () => {
+    expect(ED25519_KEY_ID).toBe('key-ed25519')
+    expect(ed25519VerificationMethodUrl(BASE)).toBe(KEY_DOC_URL)
+    expect(ed25519VerificationMethodUrl(BASE)).not.toContain('#')
+  })
+
+  it('tolerates a trailing slash on the base URL', () => {
+    expect(ed25519VerificationMethodUrl(`${BASE}/`)).toBe(KEY_DOC_URL)
+  })
+
+  it('builds the legacy issuer-profile fragment and recovers the base URL', () => {
+    expect(legacyEd25519VerificationMethod(ISSUER_ID)).toBe(
+      `${ISSUER_ID}#key-ed25519`,
+    )
+    expect(baseUrlFromIssuerId(ISSUER_ID)).toBe(BASE)
+  })
+
+  it('accepts BOTH the current URL and the legacy fragment for a given issuer', () => {
+    expect(acceptedEd25519VerificationMethods(ISSUER_ID)).toEqual([
+      KEY_DOC_URL,
+      `${ISSUER_ID}#key-ed25519`,
+    ])
+  })
+
+  it('does NOT accept a foreign / did:key verification method', () => {
+    const accepted = acceptedEd25519VerificationMethods(ISSUER_ID)
+    expect(accepted).not.toContain(
+      'did:key:z6MkvRQ7bnwBVzwozkkbasYzntpfnWJBsHfB1EfWFeFErgoy#z6MkvRQ7bnwBVzwozkkbasYzntpfnWJBsHfB1EfWFeFErgoy',
+    )
+    expect(accepted).not.toContain(
+      'https://evil.example/api/badge/keys/key-ed25519',
+    )
+  })
+
+  it('builds a bare Multikey document with controller + publicKeyMultibase at the root', () => {
+    const doc = buildEd25519MultikeyDocument(BASE, PUBLIC_KEY_MULTIBASE)
+    // Exactly the members the EmbeddedProofProbe reads off the root.
+    expect(doc).toEqual({
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/multikey/v1',
+      ],
+      id: KEY_DOC_URL,
+      type: 'Multikey',
+      controller: ISSUER_ID,
+      publicKeyMultibase: PUBLIC_KEY_MULTIBASE,
+    })
+    // The probe does getString("controller") / getString("publicKeyMultibase")
+    // on the response root — both MUST be present there (the NPE otherwise).
+    expect(typeof doc.controller).toBe('string')
+    expect(typeof doc.publicKeyMultibase).toBe('string')
+  })
+})

--- a/src/app/api/badge/[badgeId]/verify/route.ts
+++ b/src/app/api/badge/[badgeId]/verify/route.ts
@@ -8,6 +8,7 @@ import {
   generateErrorResponse,
   isJWTFormat,
 } from '@/lib/openbadges'
+import { acceptedEd25519VerificationMethods } from '@/lib/badge/verification-method'
 
 /**
  * GET /api/badge/[badgeId]/verify
@@ -18,8 +19,10 @@ import {
  * key; embedded-proof badges are verified with the published Ed25519 public
  * key (BADGE_ISSUER_ED25519_PUBLIC_KEY). Verification never needs the secret
  * seed. The proof's verificationMethod is pinned to OUR issuer's embedded VM
- * (`${issuer.id}#key-ed25519`), so a badge presented with a foreign or
- * did:key verification method is reported as not-issued-by-us.
+ * (the dereferenceable `${baseUrl}/api/badge/keys/key-ed25519` URL, or the
+ * legacy `${issuer.id}#key-ed25519` fragment for previously baked badges), so
+ * a badge presented with a foreign or did:key method is reported as
+ * not-issued-by-us.
  */
 export async function GET(
   request: NextRequest,
@@ -122,15 +125,16 @@ export async function GET(
     try {
       // Pin the verification method to OUR issuer's embedded VM. A badge
       // presented with a foreign / did:key VM must never earn a green check
-      // from this endpoint, even if it is internally self-consistent.
+      // from this endpoint, even if it is internally self-consistent. Both the
+      // current dereferenceable keys URL and the legacy issuer-profile fragment
+      // are accepted so previously baked SVGs still verify.
       const issuerId =
         typeof assertion.issuer === 'object'
           ? assertion.issuer?.id
           : assertion.issuer
-      const expectedVm = `${issuerId}#key-ed25519`
       const proofVm = assertion.proof?.[0]?.verificationMethod
 
-      if (proofVm !== expectedVm) {
+      if (!acceptedEd25519VerificationMethods(issuerId).includes(proofVm)) {
         signatureValid = false
       } else {
         signatureValid = await verifyCredential(

--- a/src/app/api/badge/issuer/route.ts
+++ b/src/app/api/badge/issuer/route.ts
@@ -6,10 +6,13 @@
  *
  * Exposes two keys:
  * - RSA JWK (publicKey, #key-1 fragment) for RS256 JWT verification
- * - Ed25519 Multikey (verificationMethod/assertionMethod, #key-ed25519
- *   fragment) for embedded Data Integrity Proof verification — verifiers
- *   strip the fragment from proof.verificationMethod and dereference this
- *   profile, whose controller must equal the credential's issuer.id
+ * - Ed25519 Multikey (verificationMethod/assertionMethod) for embedded Data
+ *   Integrity Proof verification. Two ids point at the same key: the
+ *   dereferenceable /api/badge/keys/key-ed25519 URL that new credentials pin,
+ *   and the legacy #key-ed25519 fragment that older baked SVGs pin. The bare
+ *   Multikey document itself is served by /api/badge/keys/key-ed25519 (the
+ *   1EdTech EmbeddedProofProbe dereferences proof.verificationMethod and reads
+ *   the key off the response root, so it never consults this profile array).
  *
  * Reference: https://www.imsglobal.org/spec/ob/v3p0/impl/
  */
@@ -18,7 +21,12 @@ import { NextResponse } from 'next/server'
 import { createPublicKey } from 'crypto'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { resolveConferenceContact } from '@/lib/email/from'
-import { generateErrorResponse, seedToMultikey } from '@/lib/openbadges'
+import { generateErrorResponse } from '@/lib/openbadges'
+import {
+  ed25519VerificationMethodUrl,
+  legacyEd25519VerificationMethod,
+  resolveEd25519PublicKeyMultibase,
+} from '@/lib/badge/verification-method'
 
 export async function GET(request: Request) {
   try {
@@ -62,39 +70,34 @@ export async function GET(request: Request) {
     //
     // External verifiers (Credly, verifybadge.org) dereference this profile to
     // resolve the proof key, so verify-only / preview deployments that hold
-    // only the PUBLIC key must still publish it. Prefer the published public
-    // key directly (it IS the publicKeyMultibase); fall back to deriving the
-    // key from the secret seed when only the seed is present.
+    // only the PUBLIC key must still publish it.
+    //
+    // TWO ids are listed for the SAME key:
+    // - the dereferenceable keys-endpoint URL (`/api/badge/keys/key-ed25519`),
+    //   which new credentials pin in proof.verificationMethod, and
+    // - the legacy issuer-profile fragment (`#key-ed25519`), which older baked
+    //   SVGs pinned. Our own verify paths look the method up by id in this
+    //   array, so keeping both lets previously downloaded badges still resolve.
     const issuerId = `${baseUrl}/api/badge/issuer`
-    const ed25519PublicKey = process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
-    const ed25519Seed = process.env.BADGE_ISSUER_ED25519_SEED
-    let publicKeyMultibase: string | undefined
-    if (ed25519PublicKey && ed25519PublicKey.startsWith('z')) {
-      // The published public key is already a multibase Ed25519 Multikey.
-      publicKeyMultibase = ed25519PublicKey
-    } else if (ed25519Seed) {
-      try {
-        publicKeyMultibase = (await seedToMultikey(ed25519Seed))
-          .publicKeyMultibase
-      } catch (seedError) {
-        console.error(
-          'Invalid BADGE_ISSUER_ED25519_SEED; omitting Ed25519 verification method:',
-          seedError,
-        )
-      }
-    } else if (ed25519PublicKey) {
-      console.error(
-        'BADGE_ISSUER_ED25519_PUBLIC_KEY is not a multibase Ed25519 key (expected "z" prefix); omitting Ed25519 verification method',
-      )
-    }
+    const publicKeyMultibase = await resolveEd25519PublicKeyMultibase()
 
-    const ed25519VerificationMethod = publicKeyMultibase
-      ? {
-          id: `${issuerId}#key-ed25519`,
-          type: 'Multikey' as const,
-          controller: issuerId,
-          publicKeyMultibase,
-        }
+    const ed25519KeyDocUrl = ed25519VerificationMethodUrl(baseUrl)
+    const ed25519LegacyId = legacyEd25519VerificationMethod(issuerId)
+    const ed25519VerificationMethods = publicKeyMultibase
+      ? [
+          {
+            id: ed25519KeyDocUrl,
+            type: 'Multikey' as const,
+            controller: issuerId,
+            publicKeyMultibase,
+          },
+          {
+            id: ed25519LegacyId,
+            type: 'Multikey' as const,
+            controller: issuerId,
+            publicKeyMultibase,
+          },
+        ]
       : undefined
 
     // Return issuer profile
@@ -125,9 +128,9 @@ export async function GET(request: Request) {
           publicKeyJwk: jwk,
         },
       ],
-      ...(ed25519VerificationMethod && {
-        verificationMethod: [ed25519VerificationMethod],
-        assertionMethod: [ed25519VerificationMethod.id],
+      ...(ed25519VerificationMethods && {
+        verificationMethod: ed25519VerificationMethods,
+        assertionMethod: ed25519VerificationMethods.map((vm) => vm.id),
       }),
     }
 

--- a/src/app/api/badge/keys/[keyId]/route.ts
+++ b/src/app/api/badge/keys/[keyId]/route.ts
@@ -1,20 +1,41 @@
 /**
  * GET /api/badge/keys/[keyId]
  *
- * Returns a bare JWK (JSON Web Key) object for the specified key ID.
- * This endpoint is used by the OpenBadges 3.0 JWT `kid` (key ID) field
- * to dereference the public key used for signature verification.
+ * Dereferenceable public-key endpoint for OpenBadges 3.0 proof verification.
+ * Two keys are served, each as a BARE key document (never wrapped in an issuer
+ * profile) so external validators can read the key material off the response
+ * root:
  *
- * CRITICAL: This endpoint MUST return a bare JWK object, not an issuer profile.
- * The 1EdTech OB30Inspector validator expects the response to be a JWK with
- * `kty`, `n`, and `e` fields at the top level.
+ * - `key-1`        → bare RSA JWK (`{kty, n, e}`) for the RS256 JWT `kid`.
+ *   The 1EdTech ExternalProofProbe reads `jwk.get("kty")` off the top level.
+ * - `key-ed25519`  → bare Multikey (`{id, type, controller, publicKeyMultibase}`)
+ *   for the embedded eddsa-rdfc-2022 `proof.verificationMethod`. The 1EdTech
+ *   EmbeddedProofProbe reads `controller`/`publicKeyMultibase` off the top
+ *   level — pointing the proof at the issuer profile (no top-level controller)
+ *   NPEs the validator, which is exactly the bug this endpoint fixes.
  *
  * @see https://www.imsglobal.org/spec/ob/v3p0/impl/#external-proof-jwt-proof
  * @see https://github.com/1EdTech/digital-credentials-public-validator/blob/main/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/ExternalProofProbe.java#L63
+ * @see https://github.com/1EdTech/digital-credentials-public-validator/blob/main/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/EmbeddedProofProbe.java
  */
 
 import { NextResponse } from 'next/server'
+import { headers } from 'next/headers'
 import { createPublicKey } from 'crypto'
+import {
+  ED25519_KEY_ID,
+  buildEd25519MultikeyDocument,
+  resolveEd25519PublicKeyMultibase,
+} from '@/lib/badge/verification-method'
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Accept',
+} as const
+
+const DOCS_URL =
+  'https://github.com/cloudnativebergen/website/blob/main/docs/OPENBADGES_IMPLEMENTATION.md#key-management'
 
 export async function GET(
   request: Request,
@@ -23,71 +44,105 @@ export async function GET(
   try {
     const { keyId } = await params
 
-    // Validate key ID - only support 'key-1' for now
-    if (keyId !== 'key-1') {
-      return NextResponse.json(
-        {
-          error: 'Key not found',
-          message: `Key ID &apos;${keyId}&apos; not found. Currently only &apos;key-1&apos; is supported.`,
-          documentation:
-            'https://github.com/cloudnativebergen/website/blob/main/docs/OPENBADGES_IMPLEMENTATION.md#key-management',
-        },
-        { status: 404 },
-      )
+    if (keyId === 'key-1') {
+      return serveRsaJwk()
     }
 
-    // Load RSA public key from environment
-    const publicKey = process.env.BADGE_ISSUER_RSA_PUBLIC_KEY
-
-    if (!publicKey) {
-      return NextResponse.json(
-        {
-          error: 'Public key not configured',
-          message:
-            'BADGE_ISSUER_RSA_PUBLIC_KEY environment variable is not set.',
-          documentation:
-            'https://github.com/cloudnativebergen/website/blob/main/docs/OPENBADGES_IMPLEMENTATION.md#key-generation',
-        },
-        { status: 500 },
-      )
+    if (keyId === ED25519_KEY_ID) {
+      return await serveEd25519Multikey()
     }
 
-    // Convert PEM public key to JWK format
-    const publicKeyObj = createPublicKey(publicKey)
-    const jwk = publicKeyObj.export({ format: 'jwk' })
-
-    // CRITICAL: Return BARE JWK object only (no wrapper, no additional fields)
-    // The Java validator expects: { "kty": "RSA", "e": "AQAB", "n": "..." }
-    //
-    // The validator code does:
-    //   String kty = jwk.get("kty").asText();
-    //
-    // If we return anything other than a JWK at the top level, this will fail
-    // with a NullPointerException.
-    return NextResponse.json(jwk, {
-      headers: {
-        'Content-Type': 'application/json',
-        // Enable CORS for external validators
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        // Cache public key for 24 hours (immutable since we don&apos;t rotate keys)
-        'Cache-Control': 'public, max-age=86400, immutable',
+    return NextResponse.json(
+      {
+        error: 'Key not found',
+        message: `Key ID '${keyId}' not found. Supported keys: 'key-1', '${ED25519_KEY_ID}'.`,
+        documentation: DOCS_URL,
       },
-    })
+      { status: 404, headers: { ...CORS_HEADERS } },
+    )
   } catch (error) {
-    console.error('Error serving JWK:', error)
+    console.error('Error serving key document:', error)
     return NextResponse.json(
       {
         error: 'Internal server error',
-        message: 'Failed to generate JWK from public key',
+        message: 'Failed to generate key document',
         details: error instanceof Error ? error.message : String(error),
-        documentation:
-          'https://github.com/cloudnativebergen/website/blob/main/docs/OPENBADGES_IMPLEMENTATION.md#troubleshooting',
+        documentation: DOCS_URL,
       },
-      { status: 500 },
+      { status: 500, headers: { ...CORS_HEADERS } },
     )
   }
+}
+
+/**
+ * Serve the RSA public key as a bare JWK for the RS256 JWT external proof.
+ * CRITICAL: the validator does `String kty = jwk.get("kty").asText();`, so the
+ * response MUST be a bare JWK object with no wrapper fields.
+ */
+function serveRsaJwk(): NextResponse {
+  const publicKey = process.env.BADGE_ISSUER_RSA_PUBLIC_KEY
+
+  if (!publicKey) {
+    return NextResponse.json(
+      {
+        error: 'Public key not configured',
+        message: 'BADGE_ISSUER_RSA_PUBLIC_KEY environment variable is not set.',
+        documentation: DOCS_URL,
+      },
+      { status: 500, headers: { ...CORS_HEADERS } },
+    )
+  }
+
+  const jwk = createPublicKey(publicKey).export({ format: 'jwk' })
+
+  return NextResponse.json(jwk, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...CORS_HEADERS,
+      // Cache public key for 24 hours (immutable since we don't rotate keys)
+      'Cache-Control': 'public, max-age=86400, immutable',
+    },
+  })
+}
+
+/**
+ * Serve the Ed25519 public key as a bare Multikey document for the embedded
+ * Data Integrity Proof. This is the URL that `proof.verificationMethod` points
+ * at; the EmbeddedProofProbe reads `controller`/`publicKeyMultibase` off the
+ * response root.
+ */
+async function serveEd25519Multikey(): Promise<NextResponse> {
+  const publicKeyMultibase = await resolveEd25519PublicKeyMultibase()
+
+  if (!publicKeyMultibase) {
+    return NextResponse.json(
+      {
+        error: 'Ed25519 public key not configured',
+        message:
+          'Set BADGE_ISSUER_ED25519_PUBLIC_KEY (multibase "z…") or ' +
+          'BADGE_ISSUER_ED25519_SEED to publish the embedded-proof key.',
+        documentation: DOCS_URL,
+      },
+      { status: 500, headers: { ...CORS_HEADERS } },
+    )
+  }
+
+  // Derive the tenant base URL from the request host, matching the issuer
+  // profile endpoint (getConferenceForCurrentDomain uses the same header).
+  const host = (await headers()).get('host') || ''
+  const baseUrl = `https://${host}`
+
+  const keyDocument = buildEd25519MultikeyDocument(baseUrl, publicKeyMultibase)
+
+  return NextResponse.json(keyDocument, {
+    headers: {
+      // A Multikey document is JSON-LD; serve ld+json so JSON-LD document
+      // loaders (Titanium, used by the validator) accept it directly.
+      'Content-Type': 'application/ld+json',
+      ...CORS_HEADERS,
+      'Cache-Control': 'public, max-age=86400, immutable',
+    },
+  })
 }
 
 /**
@@ -99,9 +154,7 @@ export async function OPTIONS(): Promise<NextResponse> {
   return new NextResponse(null, {
     status: 204,
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      ...CORS_HEADERS,
       'Access-Control-Max-Age': '86400',
     },
   })

--- a/src/app/api/badge/keys/[keyId]/route.ts
+++ b/src/app/api/badge/keys/[keyId]/route.ts
@@ -22,6 +22,7 @@
 import { NextResponse } from 'next/server'
 import { headers } from 'next/headers'
 import { createPublicKey } from 'crypto'
+import { normalizeDomain } from '@/lib/conference/domains'
 import {
   ED25519_KEY_ID,
   buildEd25519MultikeyDocument,
@@ -128,8 +129,11 @@ async function serveEd25519Multikey(): Promise<NextResponse> {
   }
 
   // Derive the tenant base URL from the request host, matching the issuer
-  // profile endpoint (getConferenceForCurrentDomain uses the same header).
-  const host = (await headers()).get('host') || ''
+  // profile endpoint (getConferenceForCurrentDomain uses the same header) —
+  // normalized with the house helper so the key document's id/controller
+  // byte-match the ids minted into credentials (which derive from the stored,
+  // normalized conference domains).
+  const host = normalizeDomain((await headers()).get('host') || '')
   const baseUrl = `https://${host}`
 
   const keyDocument = buildEd25519MultikeyDocument(baseUrl, publicKeyMultibase)

--- a/src/app/api/badge/keys/[keyId]/route.ts
+++ b/src/app/api/badge/keys/[keyId]/route.ts
@@ -134,6 +134,14 @@ async function serveEd25519Multikey(): Promise<NextResponse> {
   // byte-match the ids minted into credentials (which derive from the stored,
   // normalized conference domains).
   const host = normalizeDomain((await headers()).get('host') || '')
+  if (!host) {
+    // A missing Host header is a server misconfiguration; a key document with
+    // a malformed id would poison verifier caches, so fail loudly instead.
+    return NextResponse.json(
+      { error: 'Cannot resolve request host for the key document' },
+      { status: 500, headers: { ...CORS_HEADERS } },
+    )
+  }
   const baseUrl = `https://${host}`
 
   const keyDocument = buildEd25519MultikeyDocument(baseUrl, publicKeyMultibase)

--- a/src/lib/badge/config.ts
+++ b/src/lib/badge/config.ts
@@ -1,6 +1,7 @@
 import type { Conference } from '@/lib/conference/types'
 import { createPublicKey } from 'crypto'
 import { resolveConferenceContact } from '@/lib/email/from'
+import { ed25519VerificationMethodUrl } from './verification-method'
 
 /**
  * Signing configuration for OpenBadges credentials
@@ -29,11 +30,15 @@ export interface SigningConfiguration {
    */
   ed25519Seed: string
   /**
-   * Verification method id for embedded Data Integrity Proofs. Verifiers
-   * strip the fragment and fetch the issuer profile, which lists this id
-   * in its verificationMethod/assertionMethod arrays.
+   * Verification method URL for embedded Data Integrity Proofs — must be a
+   * dereferenceable HTTP URL that returns the bare Multikey document, NOT an
+   * issuer-profile fragment. The 1EdTech EmbeddedProofProbe dereferences this
+   * URL and reads `controller`/`publicKeyMultibase` off the response root; a
+   * fragment URL resolves to the issuer Profile (no top-level `controller`)
+   * and NPEs the validator. Mirrors the JWT `verificationMethod` /keys pattern.
    *
-   * @example "https://cloudnativedays.no/api/badge/issuer#key-ed25519"
+   * @example "https://cloudnativedays.no/api/badge/keys/key-ed25519"
+   * @see src/lib/badge/verification-method.ts
    */
   embeddedVerificationMethod: string
 }
@@ -184,9 +189,10 @@ export async function createBadgeConfiguration(
       // See: https://github.com/1EdTech/digital-credentials-public-validator/blob/main/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/ExternalProofProbe.java#L63
       verificationMethod: `${baseUrl}/api/badge/keys/key-1`,
       ed25519Seed: ed25519Seed.trim(),
-      // For embedded proofs, verifiers strip the fragment and dereference
-      // the issuer profile, which lists this verification method
-      embeddedVerificationMethod: `${baseUrl}/api/badge/issuer#key-ed25519`,
+      // For embedded proofs, verifiers dereference this URL and expect the bare
+      // Multikey key document back (NOT the issuer profile). See ExternalProof
+      // note above — the embedded path needs the same dereferenceable endpoint.
+      embeddedVerificationMethod: ed25519VerificationMethodUrl(baseUrl),
     },
   }
 }
@@ -251,7 +257,7 @@ export function createTestConfiguration(
       algorithm: 'RS256',
       verificationMethod: `${baseUrl}/api/badge/keys/key-1`,
       ed25519Seed,
-      embeddedVerificationMethod: `${baseUrl}/api/badge/issuer#key-ed25519`,
+      embeddedVerificationMethod: ed25519VerificationMethodUrl(baseUrl),
     },
   }
 

--- a/src/lib/badge/config.ts
+++ b/src/lib/badge/config.ts
@@ -1,7 +1,7 @@
 import type { Conference } from '@/lib/conference/types'
 import { createPublicKey } from 'crypto'
 import { resolveConferenceContact } from '@/lib/email/from'
-import { ed25519VerificationMethodUrl } from './verification-method'
+import { ed25519VerificationMethodUrl } from '@/lib/badge/verification-method'
 
 /**
  * Signing configuration for OpenBadges credentials

--- a/src/lib/badge/generator.ts
+++ b/src/lib/badge/generator.ts
@@ -84,6 +84,21 @@ export async function generateBadgeCredential(
     subject: {
       id: `mailto:${speakerEmail}`,
       type: ['AchievementSubject'],
+      // Recipient identity for ownership matching on import. Displayers such as
+      // Credly match a badge to a signed-in user via credentialSubject
+      // .identifier[] (IdentityObject), not by parsing the mailto: subject id.
+      // The email is lowercased to match the normalized mailto: id and the
+      // case-sensitive comparison some displayers perform. hashed:false keeps
+      // the plaintext value — no new PII exposure since the mailto: id already
+      // carries the email; a salted sha256 hash is the future privacy option.
+      identifier: [
+        {
+          type: 'IdentityObject',
+          hashed: false,
+          identityHash: speakerEmail.toLowerCase(),
+          identityType: 'emailAddress',
+        },
+      ],
     },
     achievement: {
       id: `${config.baseUrl}/api/badge/${badgeId}/achievement`,

--- a/src/lib/badge/generator.ts
+++ b/src/lib/badge/generator.ts
@@ -78,24 +78,28 @@ export async function generateBadgeCredential(
     })
   }
 
+  // One normalization for every email-derived member (mailto id + identifier).
+  const normalizedEmail = speakerEmail.trim().toLowerCase()
+
   const credential = createCredential({
     credentialId: `${config.baseUrl}/api/badge/${badgeId}`,
     name: `${badgeType === 'speaker' ? 'Speaker' : 'Organizer'} Badge for ${conferenceTitle}`,
     subject: {
-      id: `mailto:${speakerEmail}`,
+      id: `mailto:${normalizedEmail}`,
       type: ['AchievementSubject'],
       // Recipient identity for ownership matching on import. Displayers such as
       // Credly match a badge to a signed-in user via credentialSubject
       // .identifier[] (IdentityObject), not by parsing the mailto: subject id.
-      // The email is lowercased to match the normalized mailto: id and the
-      // case-sensitive comparison some displayers perform. hashed:false keeps
+      // ONE normalization (trim+lowercase) feeds BOTH the mailto: id and this
+      // identifier, so a case-sensitive comparison by a displayer can never
+      // see two spellings of the same address. hashed:false keeps
       // the plaintext value — no new PII exposure since the mailto: id already
       // carries the email; a salted sha256 hash is the future privacy option.
       identifier: [
         {
           type: 'IdentityObject',
           hashed: false,
-          identityHash: speakerEmail.toLowerCase(),
+          identityHash: normalizedEmail,
           identityType: 'emailAddress',
         },
       ],

--- a/src/lib/badge/verification-method.ts
+++ b/src/lib/badge/verification-method.ts
@@ -1,0 +1,138 @@
+import { seedToMultikey } from '@/lib/openbadges'
+import type { MultikeyDocument } from '@/lib/openbadges'
+
+/**
+ * Ed25519 embedded-proof verification method (eddsa-rdfc-2022)
+ *
+ * The 1EdTech digital-credentials-public-validator (inspect-vc
+ * EmbeddedProofProbe) dereferences `proof.verificationMethod` and expects the
+ * response to BE a verification-method document — it reads `controller` and
+ * `publicKeyMultibase` off the TOP LEVEL of the returned JSON:
+ *
+ *   controller = keyStructure.get().asJsonObject().getString("controller");
+ *   ...
+ *   publicKeyMultibase = keyStructure.get().asJsonObject().getString("publicKeyMultibase");
+ *
+ * (jakarta JSON-P `getString(name)` is `getJsonString(name).getString()`, which
+ * NPEs when the member is absent — the reported
+ * "Cannot invoke JsonString.getString() because getJsonString(String) is null".)
+ *
+ * A fragment URL such as `${issuer.id}#key-ed25519` cannot satisfy this: the
+ * HTTP loader strips the fragment and GETs the issuer Profile, whose root has
+ * no top-level `controller` — the very first `getString("controller")` NPEs.
+ *
+ * So the proof must point at a dereferenceable endpoint that returns the bare
+ * Multikey document (this is the same lesson the JWT/ExternalProofProbe path
+ * already learned — see `verificationMethod: .../api/badge/keys/key-1`).
+ *
+ * @see https://github.com/1EdTech/digital-credentials-public-validator/blob/main/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/EmbeddedProofProbe.java
+ */
+export const ED25519_KEY_ID = 'key-ed25519'
+
+/** Strip a trailing slash so URLs join cleanly. */
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '')
+}
+
+/**
+ * Dereferenceable verification-method URL for embedded Data Integrity Proofs.
+ * This is what new credentials pin in `proof.verificationMethod`; GETting it
+ * returns the bare Multikey document below.
+ *
+ * @example "https://cloudnativedays.no/api/badge/keys/key-ed25519"
+ */
+export function ed25519VerificationMethodUrl(baseUrl: string): string {
+  return `${stripTrailingSlash(baseUrl)}/api/badge/keys/${ED25519_KEY_ID}`
+}
+
+/**
+ * Legacy embedded verification method: an issuer-profile fragment. Credentials
+ * baked before the dereferenceable endpoint existed pinned this value, and the
+ * bytes are frozen inside already-downloaded SVGs (the download route serves a
+ * stored asset and never re-proofs). Kept only for back-compat recognition.
+ *
+ * @example "https://cloudnativedays.no/api/badge/issuer#key-ed25519"
+ */
+export function legacyEd25519VerificationMethod(issuerId: string): string {
+  return `${issuerId}#${ED25519_KEY_ID}`
+}
+
+/** Recover the tenant base URL from an issuer profile id. */
+export function baseUrlFromIssuerId(issuerId: string): string {
+  return issuerId.replace(/\/api\/badge\/issuer$/, '')
+}
+
+/**
+ * Every `proof.verificationMethod` value we recognise as OUR issuer's embedded
+ * Ed25519 method: the current dereferenceable URL plus the legacy fragment.
+ * Used by the verify paths so freshly minted and previously baked badges both
+ * verify, while foreign / did:key methods still do not.
+ */
+export function acceptedEd25519VerificationMethods(issuerId: string): string[] {
+  return [
+    ed25519VerificationMethodUrl(baseUrlFromIssuerId(issuerId)),
+    legacyEd25519VerificationMethod(issuerId),
+  ]
+}
+
+/**
+ * Resolve the issuer's Ed25519 public key as a multibase Multikey ("z6Mk…").
+ *
+ * Prefers the published public key (`BADGE_ISSUER_ED25519_PUBLIC_KEY`, which IS
+ * the multibase) so verify-only deployments that hold no secret still publish a
+ * key; falls back to deriving it from the secret seed. Returns undefined when
+ * no usable Ed25519 material is configured.
+ */
+export async function resolveEd25519PublicKeyMultibase(): Promise<
+  string | undefined
+> {
+  const ed25519PublicKey = process.env.BADGE_ISSUER_ED25519_PUBLIC_KEY
+  const ed25519Seed = process.env.BADGE_ISSUER_ED25519_SEED
+
+  if (ed25519PublicKey && ed25519PublicKey.startsWith('z')) {
+    // The published public key is already a multibase Ed25519 Multikey.
+    return ed25519PublicKey
+  }
+
+  if (ed25519Seed) {
+    try {
+      return (await seedToMultikey(ed25519Seed)).publicKeyMultibase
+    } catch (error) {
+      console.error(
+        'Invalid BADGE_ISSUER_ED25519_SEED; cannot derive Ed25519 public key:',
+        error,
+      )
+      return undefined
+    }
+  }
+
+  if (ed25519PublicKey) {
+    console.error(
+      'BADGE_ISSUER_ED25519_PUBLIC_KEY is not a multibase Ed25519 key (expected "z" prefix)',
+    )
+  }
+
+  return undefined
+}
+
+/**
+ * Build the bare Multikey verification-method document served at
+ * `/api/badge/keys/key-ed25519`. Its top-level `controller` and
+ * `publicKeyMultibase` are exactly what the 1EdTech EmbeddedProofProbe reads.
+ */
+export function buildEd25519MultikeyDocument(
+  baseUrl: string,
+  publicKeyMultibase: string,
+): MultikeyDocument {
+  const base = stripTrailingSlash(baseUrl)
+  return {
+    '@context': [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/multikey/v1',
+    ],
+    id: ed25519VerificationMethodUrl(base),
+    type: 'Multikey',
+    controller: `${base}/api/badge/issuer`,
+    publicKeyMultibase,
+  }
+}

--- a/src/lib/badge/verification-method.ts
+++ b/src/lib/badge/verification-method.ts
@@ -68,7 +68,13 @@ export function baseUrlFromIssuerId(issuerId: string): string {
  * Used by the verify paths so freshly minted and previously baked badges both
  * verify, while foreign / did:key methods still do not.
  */
-export function acceptedEd25519VerificationMethods(issuerId: string): string[] {
+export function acceptedEd25519VerificationMethods(
+  issuerId: string | null | undefined,
+): string[] {
+  // A malformed assertion can carry a missing/non-string issuer id; that's an
+  // UNTRUSTED badge (empty accept-list → signature invalid), never a throw
+  // that would shove valid/invalid handling through the exception path.
+  if (typeof issuerId !== 'string' || !issuerId) return []
   return [
     ed25519VerificationMethodUrl(baseUrlFromIssuerId(issuerId)),
     legacyEd25519VerificationMethod(issuerId),

--- a/src/lib/openbadges/credential.ts
+++ b/src/lib/openbadges/credential.ts
@@ -328,6 +328,12 @@ export function createCredential(config: CredentialConfig): Credential {
   const credentialSubject: AchievementSubject = {
     id: normalizeSubjectId(config.subject.id),
     type: config.subject.type,
+    // Recipient identifiers (IdentityObject[]) let displayers match the badge
+    // to a signed-in user's verified identity; passed through from the caller.
+    ...(config.subject.identifier &&
+      config.subject.identifier.length > 0 && {
+        identifier: config.subject.identifier,
+      }),
     achievement,
   }
 

--- a/src/lib/openbadges/types.ts
+++ b/src/lib/openbadges/types.ts
@@ -45,9 +45,32 @@ export interface Achievement {
   creator: IssuerProfile // Per OpenBadges 3.0 spec: Achievement uses "creator" property
 }
 
+/**
+ * OB 3.0 IdentityObject — a recipient identifier used by displayers (Credly,
+ * Badgr, …) to match a badge to a signed-in user's verified identity. The
+ * `type` member is the plain string "IdentityObject" (NOT an array) per the
+ * normative schema. `identityHash` carries the plaintext value when
+ * `hashed: false`; a salted hash (sha256$…) is the privacy-preserving variant.
+ *
+ * @see https://www.imsglobal.org/spec/ob/v3p0/#identityobject
+ */
+export interface IdentityObject {
+  type: 'IdentityObject'
+  hashed: boolean
+  identityHash: string
+  identityType: 'emailAddress' | string
+  salt?: string
+}
+
 export interface AchievementSubject {
   id: string
   type: string[]
+  /**
+   * Recipient identifiers. Emitted as an array with a single emailAddress
+   * IdentityObject so ownership matching works on import; either `id` or at
+   * least one `identifier` is required by OB 3.0.
+   */
+  identifier?: IdentityObject[]
   achievement: Achievement
 }
 
@@ -96,6 +119,7 @@ export interface AchievementConfig {
 export interface SubjectProfile {
   id: string
   type: string[]
+  identifier?: IdentityObject[]
 }
 
 export interface IssuerProfileConfig {

--- a/src/lib/openbadges/types.ts
+++ b/src/lib/openbadges/types.ts
@@ -58,7 +58,9 @@ export interface IdentityObject {
   type: 'IdentityObject'
   hashed: boolean
   identityHash: string
-  identityType: 'emailAddress' | string
+  // `(string & {})` keeps the 'emailAddress' literal in autocomplete while
+  // still admitting the spec's other enum values and ext: extensions.
+  identityType: 'emailAddress' | (string & {})
   salt?: string
 }
 

--- a/src/server/routers/badge.ts
+++ b/src/server/routers/badge.ts
@@ -13,6 +13,7 @@ import {
 } from '@/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { isLocalhostEnvironment } from '@/lib/environment/localhost'
+import { acceptedEd25519VerificationMethods } from '@/lib/badge/verification-method'
 import {
   IssueBadgeInputSchema,
   BulkIssueBadgeInputSchema,
@@ -103,14 +104,17 @@ export const badgeRouter = router({
           if (badgeAssertion.proof && badgeAssertion.proof.length > 0) {
             // Pin the verification method to OUR issuer's embedded VM: a badge
             // with a foreign / did:key VM must not report as signature-valid.
+            // Both the current dereferenceable keys URL and the legacy
+            // issuer-profile fragment are accepted (previously baked SVGs).
             const issuerId =
               typeof badgeAssertion.issuer === 'object'
                 ? badgeAssertion.issuer?.id
                 : badgeAssertion.issuer
-            const expectedVm = `${issuerId}#key-ed25519`
             const proofVm = badgeAssertion.proof[0]?.verificationMethod
 
-            if (proofVm === expectedVm) {
+            if (
+              acceptedEd25519VerificationMethods(issuerId).includes(proofVm)
+            ) {
               signatureValid = await verifyCredential(badgeAssertion, publicKey)
             }
           }


### PR DESCRIPTION
## Root cause

Two consumer-reported bugs from the same badge generator, both about how external platforms resolve our credential.

### 1. Official 1EdTech validator: `Invalid verification key URL … getJsonString(String) is null`

Our embedded `DataIntegrityProof` (eddsa-rdfc-2022) pinned:

```
proof.verificationMethod = "<baseUrl>/api/badge/issuer#key-ed25519"
```

The validator (1EdTech/digital-credentials-public-validator, `inspect-vc` **EmbeddedProofProbe**) dereferences that URL and expects the response to **be** a verification-method document — it reads `controller`/`publicKeyMultibase` off the **response root**. Verbatim from [`EmbeddedProofProbe.java`](https://github.com/1EdTech/digital-credentials-public-validator/blob/main/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/EmbeddedProofProbe.java):

```java
Document keyDocument = credentialHolder.getCredential()
    .getDocumentLoader().loadDocument(method, new DocumentLoaderOptions());
Optional<JsonStructure> keyStructure = keyDocument.getJsonContent();
...
// First look for a Ed25519VerificationKey2020 document
controller = keyStructure.get().asJsonObject().getString("controller");
if (StringUtils.isBlank(controller)) {
  ... // else branch: read verificationMethod[] array
} else {
  publicKeyMultibase = keyStructure.get().asJsonObject().getString("publicKeyMultibase");
}
} catch (Exception e) {
  return error("Invalid verification key URL: " + e.getMessage(), ctx);
}
```

The HTTP document loader strips the `#key-ed25519` fragment and GETs `/api/badge/issuer`, which returns our issuer **Profile**. The Profile has no top-level `controller` (it's nested inside the `verificationMethod[]` entries). jakarta JSON-P's `JsonObject.getString(name)` is `getJsonString(name).getString()`, and `getJsonString(name)` returns `null` when the member is absent — so the **very first** `getString("controller")` throws exactly the reported NPE, caught as `Invalid verification key URL: …`. A fragment URL can therefore never satisfy this probe; it needs a URL that returns the bare key document.

The codebase already learned this lesson for the JWT path (`ExternalProofProbe`): `verificationMethod: <baseUrl>/api/badge/keys/key-1`. The embedded path never got the same treatment.

### 2. Credly ownership mismatch

Credly matches badge ownership via `credentialSubject.identifier[]` (OB 3.0 `IdentityObject`), not by parsing the `mailto:` subject id. Our credential emitted no `identifier`, so an imported badge didn't match the owner's verified email.

## The fix

- **New bare key document** at `GET /api/badge/keys/key-ed25519` returning `{ "@context": [did/v1, multikey/v1], id, type: "Multikey", controller: <issuer>, publicKeyMultibase }` as `application/ld+json` (JSON-LD so the validator's Titanium document loader accepts it). Extends the existing `keys/[keyId]` route family alongside `key-1`.
- **Proof points at it**: `embeddedVerificationMethod → <baseUrl>/api/badge/keys/key-ed25519` (no fragment).
- **Issuer profile lists BOTH ids** for the same key — the new keys-URL id and the legacy `#key-ed25519` fragment — so our own verify paths still resolve previously baked badges.
- **Verify route + tRPC** accept both methods (foreign / `did:key` still rejected).
- Shared helpers extracted to `src/lib/badge/verification-method.ts` (URL builders, accept-list, `publicKeyMultibase` resolver reused by the issuer route).
- **`credentialSubject.identifier[]`**: emit one `{ type: "IdentityObject", hashed: false, identityHash: <lowercased email>, identityType: "emailAddress" }`. Verified against the vendored normative OB 3.0 JSON schema — `type` is the plain **string** `"IdentityObject"` (an array fails schema validation); all four members are required; `emailAddress` is in the enum. `credentialSubject.id` stays the `mailto:` URI.

## Back-compat (important)

The download route serves the **stored** baked SVG and never re-proofs (`issuance.ts` bakes once at mint time). So already-downloaded SVGs keep the old `#key-ed25519` fragment in their frozen proof and will **not** self-heal — only newly issued badges get the dereferenceable URL. Keeping the legacy id in the issuer profile + accept-lists means our own verification still recognizes old badges; the 1EdTech validator, however, will still fail old SVGs (they'd need re-issuance). New issuances are correct immediately.

## Privacy note

The `identifier` email is unhashed plaintext — but the email is **already** plaintext in the credential via the `mailto:` subject id, so this is no new exposure. If the subject id ever stops embedding the email, the privacy-preserving follow-up is a salted `sha256$…` `identityHash` (`hashed: true` + `salt`), which the schema and our `IdentityObject` type already allow.

## Tests

- `verification-method.test.ts`: URL/fragment/accept-list helpers + exact bare Multikey shape.
- `keys-endpoint.test.ts`: `key-ed25519` returns the exact Multikey (public-key and seed-derived paths), `ld+json` content type, 500 when unconfigured; `key-1` still a bare JWK; 404 unknown.
- `generator-credential.test.ts`: proof pins the keys URL (no `#`); `identifier[]` block exact; validates against the official OB 3.0 schema; round-trips through `verifyCredential`.
- `issuer-profile.test.ts` updated: profile now lists both ids in `verificationMethod`/`assertionMethod`.
- Full suite green: **4217 tests / 324 files**. `mise run check` clean (typecheck, lint 0 errors, format, knip).

## Manual validation (owner) — could not run the real validator from this sandbox

1. Deploy; issue a fresh badge and download the SVG.
2. Upload it to the official 1EdTech validator (https://validator.imsglobal.org / digital-credentials-public-validator) — the embedded-proof check should now pass instead of the `Invalid verification key URL` NPE.
3. Re-import the fresh badge into Credly — ownership should match the verified email.
4. Sanity check the endpoint directly: `GET https://<domain>/api/badge/keys/key-ed25519` returns the bare Multikey with top-level `controller` + `publicKeyMultibase`.

**Do not merge** — hold for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C
