### PR TITLE
feat(homepage): FAQ, countdown and venue blocks (front-page builder F4)

### DIFF
--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -1392,6 +1392,96 @@ export default defineType({
             validation: (Rule) => Rule.required(),
           }),
         ]),
+        defineHomepageSection('homepageFaq', 'FAQ', [
+          defineField({
+            name: 'heading',
+            title: 'Heading',
+            type: 'string',
+            description:
+              'Optional heading. Defaults to "Frequently asked questions".',
+          }),
+          defineField({
+            name: 'source',
+            title: 'Source',
+            type: 'string',
+            initialValue: 'own',
+            options: {
+              list: [
+                { title: 'This block’s own items', value: 'own' },
+                { title: 'Ticket FAQs (reuse existing)', value: 'ticketFaqs' },
+              ],
+              layout: 'radio',
+            },
+            description:
+              'Reuse the ticket FAQs instead of duplicating them, or curate your own list below.',
+          }),
+          defineField({
+            name: 'items',
+            title: 'FAQ Items',
+            type: 'array',
+            hidden: ({ parent }) =>
+              (parent as { source?: string })?.source === 'ticketFaqs',
+            of: [
+              {
+                type: 'object',
+                name: 'homepageFaqItem',
+                fields: [
+                  defineField({
+                    name: 'question',
+                    title: 'Question',
+                    type: 'string',
+                    validation: (Rule) => Rule.required(),
+                  }),
+                  defineField({
+                    name: 'answer',
+                    title: 'Answer',
+                    type: 'text',
+                    rows: 3,
+                    validation: (Rule) => Rule.required(),
+                  }),
+                ],
+                preview: { select: { title: 'question', subtitle: 'answer' } },
+              },
+            ],
+          }),
+        ]),
+        defineHomepageSection('homepageCountdown', 'Countdown', [
+          defineField({
+            name: 'heading',
+            title: 'Heading',
+            type: 'string',
+            description: 'Optional heading above the countdown.',
+          }),
+          defineField({
+            name: 'targetOverride',
+            title: 'Target Date/Time Override',
+            type: 'datetime',
+            description:
+              'Leave blank to count down to the conference start date.',
+          }),
+          defineField({
+            name: 'liveMessage',
+            title: 'Live Message',
+            type: 'string',
+            description:
+              'Shown once the countdown reaches zero. Leave blank to hide the block afterwards.',
+          }),
+        ]),
+        defineHomepageSection('homepageVenue', 'Venue', [
+          defineField({
+            name: 'heading',
+            title: 'Heading',
+            type: 'string',
+            description: 'Optional heading. Defaults to "Venue".',
+          }),
+          defineField({
+            name: 'description',
+            title: 'Description',
+            type: 'text',
+            rows: 2,
+            description: 'Optional copy shown above the venue card.',
+          }),
+        ]),
       ],
     }),
   ],

--- a/src/app/(main)/tickets/page.tsx
+++ b/src/app/(main)/tickets/page.tsx
@@ -7,6 +7,7 @@ import { TicketPricingGrid } from '@/components/TicketPricingGrid'
 import { Container } from '@/components/Container'
 import { Button } from '@/components/Button'
 import { BackgroundImage } from '@/components/BackgroundImage'
+import { FaqAccordion } from '@/components/FaqAccordion'
 import { formatDatesSafe } from '@/lib/time'
 import {
   MicrophoneIcon,
@@ -32,7 +33,6 @@ import {
   CalendarDaysIcon,
   ClockIcon,
   TicketIcon,
-  ChevronDownIcon,
 } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { headers } from 'next/headers'
@@ -263,26 +263,7 @@ async function CachedTicketsContent({ domain }: { domain: string }) {
                 <h2 className="font-jetbrains mb-6 text-center text-3xl font-medium tracking-tighter text-brand-cloud-blue sm:text-4xl dark:text-blue-400">
                   Frequently Asked Questions
                 </h2>
-                <div className="mx-auto max-w-3xl space-y-3">
-                  {faqs.map((faq) => (
-                    <details
-                      key={faq._key || faq.question}
-                      className="group rounded-xl bg-white/80 shadow-md ring-1 ring-brand-cloud-blue/10 backdrop-blur-sm dark:bg-gray-800/80 dark:ring-gray-700"
-                    >
-                      <summary className="flex cursor-pointer items-center justify-between px-5 py-4">
-                        <span className="font-space-grotesk pr-4 text-sm font-semibold text-brand-slate-gray dark:text-gray-200">
-                          {faq.question}
-                        </span>
-                        <ChevronDownIcon className="h-4 w-4 shrink-0 text-brand-cloud-blue transition-transform group-open:rotate-180 dark:text-blue-400" />
-                      </summary>
-                      <div className="border-t border-gray-100 px-5 py-4 dark:border-gray-700">
-                        <p className="font-inter text-sm leading-relaxed text-brand-slate-gray/80 dark:text-gray-300">
-                          {faq.answer}
-                        </p>
-                      </div>
-                    </details>
-                  ))}
-                </div>
+                <FaqAccordion faqs={faqs} />
               </div>
             )}
 

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -1,0 +1,40 @@
+import { ChevronDownIcon } from '@heroicons/react/24/outline'
+
+/** One FAQ entry. Structurally matches `TicketFaq` and `HomepageFaqItem`. */
+export interface FaqEntry {
+  _key?: string
+  question: string
+  answer: string
+}
+
+/**
+ * Shared FAQ accordion — the native `<details>` disclosure list used on the
+ * tickets page and by the homepage FAQ block, so both render an identical look
+ * from a single source. Plain-text answers (matching how `ticketFaqs` models
+ * them). Renders nothing when there are no entries.
+ */
+export function FaqAccordion({ faqs }: { faqs: FaqEntry[] }) {
+  if (!faqs || faqs.length === 0) return null
+  return (
+    <div className="mx-auto max-w-3xl space-y-3">
+      {faqs.map((faq) => (
+        <details
+          key={faq._key || faq.question}
+          className="group rounded-xl bg-white/80 shadow-md ring-1 ring-brand-cloud-blue/10 backdrop-blur-sm dark:bg-gray-800/80 dark:ring-gray-700"
+        >
+          <summary className="flex min-h-[44px] cursor-pointer items-center justify-between px-5 py-4">
+            <span className="font-space-grotesk pr-4 text-sm font-semibold text-brand-slate-gray dark:text-gray-200">
+              {faq.question}
+            </span>
+            <ChevronDownIcon className="h-4 w-4 shrink-0 text-brand-cloud-blue transition-transform group-open:rotate-180 dark:text-blue-400" />
+          </summary>
+          <div className="border-t border-gray-100 px-5 py-4 dark:border-gray-700">
+            <p className="font-inter text-sm leading-relaxed whitespace-pre-line text-brand-slate-gray/80 dark:text-gray-300">
+              {faq.answer}
+            </p>
+          </div>
+        </details>
+      ))}
+    </div>
+  )
+}

--- a/src/components/admin/HomepageSectionsEditor.stories.tsx
+++ b/src/components/admin/HomepageSectionsEditor.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { screen, userEvent } from 'storybook/test'
 import { http, HttpResponse } from 'msw'
 import { ThemeProvider } from 'next-themes'
 import { HomepageSectionsEditor } from './HomepageSectionsEditor'
@@ -37,6 +38,42 @@ const customSections: HomepageSection[] = [
   { _key: 'metrics', _type: 'homepageMetrics', heading: 'By the numbers' },
   { _key: 'gallery', _type: 'homepageGallery', hidden: true },
   { _key: 'sponsors', _type: 'homepageSponsors' },
+]
+
+// The three F4 blocks (FAQ / Countdown / Venue), each carrying inline config.
+const f4Sections: HomepageSection[] = [
+  { _key: 'hero', _type: 'homepageHero' },
+  {
+    _key: 'faq',
+    _type: 'homepageFaq',
+    heading: 'Frequently asked questions',
+    source: 'own',
+    items: [
+      {
+        _key: 'q1',
+        question: 'Where is the venue?',
+        answer: 'At Grieghallen in central Bergen.',
+      },
+      {
+        _key: 'q2',
+        question: 'Is lunch included?',
+        answer: 'Yes — lunch and coffee are included with every ticket.',
+      },
+    ],
+  },
+  {
+    _key: 'countdown',
+    _type: 'homepageCountdown',
+    heading: 'Doors open in',
+    targetOverride: '2099-09-15T09:00:00.000Z',
+    liveMessage: 'We are live — welcome!',
+  },
+  {
+    _key: 'venue',
+    _type: 'homepageVenue',
+    heading: 'The venue',
+    description: 'A landmark concert hall in the heart of Bergen.',
+  },
 ]
 
 const meta = {
@@ -124,4 +161,33 @@ export const Dark: Story = {
     defaultOpen: true,
   },
   parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+/**
+ * The three F4 blocks (FAQ / Countdown / Venue) with the FAQ block's inline
+ * config accordion expanded — verifies the new per-type config forms render.
+ */
+export const F4ConfigForms: Story = {
+  args: {
+    initialSections: f4Sections,
+    usingDefault: false,
+    defaultOpen: true,
+  },
+  play: async () => {
+    const configureFaq = await screen.findByRole('button', {
+      name: 'Configure FAQ',
+    })
+    await userEvent.click(configureFaq)
+  },
+}
+
+/** F4 config forms in dark mode, FAQ accordion expanded. */
+export const F4ConfigFormsDark: Story = {
+  args: {
+    initialSections: f4Sections,
+    usingDefault: false,
+    defaultOpen: true,
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  play: F4ConfigForms.play,
 }

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -879,7 +879,7 @@ function SectionConfig({
           aria-label="FAQ source"
           className={inputClass}
         >
-          <option value="own">Use this block’s own items</option>
+          <option value="own">Use this block&rsquo;s own items</option>
           <option value="ticketFaqs">Reuse the ticket FAQs</option>
         </select>
         {source === 'ticketFaqs' ? (

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -858,5 +858,164 @@ function SectionConfig({
     )
   }
 
+  if (row._type === 'homepageFaq') {
+    const source = row.source ?? 'own'
+    const items = row.faqItems ?? []
+    return (
+      <div className="space-y-2">
+        <input
+          type="text"
+          value={row.heading ?? ''}
+          onChange={(e) => onChange({ heading: e.target.value })}
+          placeholder="Heading (optional — default “Frequently asked questions”)"
+          aria-label="FAQ heading"
+          className={inputClass}
+        />
+        <select
+          value={source}
+          onChange={(e) =>
+            onChange({ source: e.target.value as 'own' | 'ticketFaqs' })
+          }
+          aria-label="FAQ source"
+          className={inputClass}
+        >
+          <option value="own">Use this block’s own items</option>
+          <option value="ticketFaqs">Reuse the ticket FAQs</option>
+        </select>
+        {source === 'ticketFaqs' ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Renders the FAQs configured on the tickets page — nothing to edit
+            here.
+          </p>
+        ) : (
+          <>
+            {items.map((item, i) => (
+              <div
+                key={item._key}
+                className="space-y-1 rounded-lg border border-gray-200 p-2 dark:border-gray-700"
+              >
+                <div className="flex items-start gap-1">
+                  <input
+                    type="text"
+                    value={item.question}
+                    onChange={(e) =>
+                      onChange({
+                        faqItems: items.map((it, j) =>
+                          j === i ? { ...it, question: e.target.value } : it,
+                        ),
+                      })
+                    }
+                    placeholder="Question"
+                    aria-label={`FAQ ${i + 1} question`}
+                    className={inputClass}
+                  />
+                  <button
+                    type="button"
+                    className={`${rowBtnClass} hover:text-red-600`}
+                    onClick={() =>
+                      onChange({ faqItems: items.filter((_, j) => j !== i) })
+                    }
+                    aria-label={`Remove FAQ ${i + 1}`}
+                  >
+                    <TrashIcon className="h-5 w-5" />
+                  </button>
+                </div>
+                <textarea
+                  value={item.answer}
+                  onChange={(e) =>
+                    onChange({
+                      faqItems: items.map((it, j) =>
+                        j === i ? { ...it, answer: e.target.value } : it,
+                      ),
+                    })
+                  }
+                  placeholder="Answer"
+                  aria-label={`FAQ ${i + 1} answer`}
+                  rows={2}
+                  className={inputClass}
+                />
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() =>
+                onChange({
+                  faqItems: [
+                    ...items,
+                    { _key: nextKey(), question: '', answer: '' },
+                  ],
+                })
+              }
+              className="inline-flex min-h-[44px] items-center gap-1.5 text-sm font-medium text-brand-cloud-blue"
+            >
+              <PlusIcon className="h-4 w-4" /> Add FAQ item
+            </button>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  if (row._type === 'homepageCountdown') {
+    return (
+      <div className="space-y-2">
+        <input
+          type="text"
+          value={row.heading ?? ''}
+          onChange={(e) => onChange({ heading: e.target.value })}
+          placeholder="Heading (optional)"
+          aria-label="Countdown heading"
+          className={inputClass}
+        />
+        <label className="block text-xs text-gray-500 dark:text-gray-400">
+          Target date/time override (optional — defaults to the conference
+          start)
+          <input
+            type="datetime-local"
+            value={row.targetOverride ?? ''}
+            onChange={(e) => onChange({ targetOverride: e.target.value })}
+            aria-label="Countdown target override"
+            className={`${inputClass} mt-1`}
+          />
+        </label>
+        <input
+          type="text"
+          value={row.liveMessage ?? ''}
+          onChange={(e) => onChange({ liveMessage: e.target.value })}
+          placeholder="Live message after the target (blank to hide)"
+          aria-label="Countdown live message"
+          className={inputClass}
+        />
+      </div>
+    )
+  }
+
+  if (row._type === 'homepageVenue') {
+    return (
+      <div className="space-y-2">
+        <input
+          type="text"
+          value={row.heading ?? ''}
+          onChange={(e) => onChange({ heading: e.target.value })}
+          placeholder="Heading (optional — default “Venue”)"
+          aria-label="Venue heading"
+          className={inputClass}
+        />
+        <textarea
+          value={row.description ?? ''}
+          onChange={(e) => onChange({ description: e.target.value })}
+          placeholder="Description (optional)"
+          aria-label="Venue description"
+          rows={2}
+          className={inputClass}
+        />
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Venue name and address come from the conference configuration. “Get
+          directions” links to a map built from the address.
+        </p>
+      </div>
+    )
+  }
+
   return null
 }

--- a/src/components/homepage/Countdown.stories.tsx
+++ b/src/components/homepage/Countdown.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { Countdown } from './Countdown'
+
+const meta = {
+  title: 'Systems/Homepage/Public/Countdown',
+  component: Countdown,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Front-page builder (F4) countdown. SSR-safe: the target arrives as a plain `targetMs` prop; the first render (server + first client) shows an em-dash placeholder, then the effect ticks once a second after hydration. After the target passes it shows `liveMessage`, or hides when that is blank.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Countdown>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** ~90 days out. */
+export const Default: Story = {
+  args: {
+    heading: 'Cloud Native Days Norway starts in',
+    targetMs: Date.now() + 90 * 86_400_000 + 5 * 3_600_000,
+  },
+}
+
+export const NoHeading: Story = {
+  args: {
+    targetMs: Date.now() + 3 * 86_400_000,
+  },
+}
+
+/** Edge case: target already passed, with a live message. */
+export const PastWithLiveMessage: Story = {
+  args: {
+    heading: 'Countdown',
+    targetMs: Date.now() - 3_600_000,
+    liveMessage: 'We are live — welcome to the conference!',
+  },
+}
+
+export const Dark: Story = {
+  args: Default.args,
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-gray-950">
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/components/homepage/Countdown.stories.tsx
+++ b/src/components/homepage/Countdown.stories.tsx
@@ -1,7 +1,35 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { Countdown } from './Countdown'
 
+const FIXED_NOW = new Date('2026-03-01T12:00:00Z').getTime()
+
 const meta = {
+  beforeEach: () => {
+    // Pin the clock (house pattern — see PaymentDetailsModal.stories): the
+    // Countdown reads Date.now() every tick, so an unpinned clock would
+    // drift Chromatic snapshots.
+    const OriginalDate = globalThis.Date
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const MockDate: any = function (...args: any[]) {
+      if (args.length === 0) return new OriginalDate(FIXED_NOW)
+      return new (
+        Function.prototype.bind.apply(OriginalDate, [
+          null,
+          ...args,
+        ]) as typeof OriginalDate
+      )()
+    }
+    Object.setPrototypeOf(MockDate, OriginalDate)
+    MockDate.prototype = Object.create(OriginalDate.prototype)
+    MockDate.now = () => FIXED_NOW
+    MockDate.parse = OriginalDate.parse.bind(OriginalDate)
+    MockDate.UTC = OriginalDate.UTC.bind(OriginalDate)
+    globalThis.Date = MockDate
+    return () => {
+      globalThis.Date = OriginalDate
+    }
+  },
+
   title: 'Systems/Homepage/Public/Countdown',
   component: Countdown,
   parameters: {
@@ -23,13 +51,13 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     heading: 'Cloud Native Days Norway starts in',
-    targetMs: Date.now() + 90 * 86_400_000 + 5 * 3_600_000,
+    targetMs: FIXED_NOW + 90 * 86_400_000 + 5 * 3_600_000,
   },
 }
 
 export const NoHeading: Story = {
   args: {
-    targetMs: Date.now() + 3 * 86_400_000,
+    targetMs: FIXED_NOW + 3 * 86_400_000,
   },
 }
 
@@ -37,7 +65,7 @@ export const NoHeading: Story = {
 export const PastWithLiveMessage: Story = {
   args: {
     heading: 'Countdown',
-    targetMs: Date.now() - 3_600_000,
+    targetMs: FIXED_NOW - 3_600_000,
     liveMessage: 'We are live — welcome to the conference!',
   },
 }

--- a/src/components/homepage/Countdown.tsx
+++ b/src/components/homepage/Countdown.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Container } from '@/components/Container'
+
+/**
+ * Countdown block (front-page builder F4). SSR-SAFE by construction: the target
+ * is resolved server-side (see `resolveCountdownTarget`) and passed in as a plain
+ * `targetMs` timestamp. The FIRST render — server and first client render alike —
+ * shows a stable placeholder (em-dashes), so there is no `Date.now()` on any
+ * server render path and therefore no hydration mismatch. Only after hydration
+ * does the effect start reading the clock and ticking once a second.
+ *
+ * Once the target passes, `liveMessage` is shown if configured; otherwise the
+ * block hides itself (the config knob is "leave the message blank to hide").
+ */
+
+const MS_PER_DAY = 86_400_000
+const MS_PER_HOUR = 3_600_000
+const MS_PER_MINUTE = 60_000
+const MS_PER_SECOND = 1_000
+
+interface Breakdown {
+  days: number
+  hours: number
+  minutes: number
+  seconds: number
+}
+
+/** Split a non-negative millisecond remainder into d/h/m/s. */
+export function countdownBreakdown(remainingMs: number): Breakdown {
+  const total = Math.max(0, remainingMs)
+  return {
+    days: Math.floor(total / MS_PER_DAY),
+    hours: Math.floor((total % MS_PER_DAY) / MS_PER_HOUR),
+    minutes: Math.floor((total % MS_PER_HOUR) / MS_PER_MINUTE),
+    seconds: Math.floor((total % MS_PER_MINUTE) / MS_PER_SECOND),
+  }
+}
+
+const headingClass =
+  'font-space-grotesk mb-10 text-center text-4xl font-medium tracking-tighter text-brand-cloud-blue sm:text-5xl dark:text-blue-400'
+
+function Unit({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="flex flex-col items-center">
+      <span
+        className="font-space-grotesk text-4xl font-bold text-brand-slate-gray tabular-nums sm:text-6xl dark:text-gray-100"
+        aria-hidden={value === '--'}
+      >
+        {value}
+      </span>
+      <span className="font-inter mt-1 text-xs font-medium tracking-wide text-brand-slate-gray/60 uppercase sm:text-sm dark:text-gray-400">
+        {label}
+      </span>
+    </div>
+  )
+}
+
+export function Countdown({
+  targetMs,
+  heading,
+  liveMessage,
+}: {
+  targetMs: number
+  heading?: string
+  liveMessage?: string
+}) {
+  // `null` = not yet measured on the client. Server render and the first client
+  // render both see `null`, guaranteeing identical markup (the placeholder).
+  const [remaining, setRemaining] = useState<number | null>(null)
+
+  useEffect(() => {
+    const tick = () => setRemaining(Math.max(0, targetMs - Date.now()))
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [targetMs])
+
+  // Post-hydration, once the target has passed.
+  if (remaining !== null && remaining <= 0) {
+    if (!liveMessage) return null
+    return (
+      <section className="py-20 sm:py-32">
+        <Container>
+          <p className={headingClass}>{liveMessage}</p>
+        </Container>
+      </section>
+    )
+  }
+
+  const parts = remaining === null ? null : countdownBreakdown(remaining)
+  const units: { label: string; value: string }[] = [
+    {
+      label: 'Days',
+      value: parts ? String(parts.days) : '--',
+    },
+    {
+      label: 'Hours',
+      value: parts ? String(parts.hours).padStart(2, '0') : '--',
+    },
+    {
+      label: 'Minutes',
+      value: parts ? String(parts.minutes).padStart(2, '0') : '--',
+    },
+    {
+      label: 'Seconds',
+      value: parts ? String(parts.seconds).padStart(2, '0') : '--',
+    },
+  ]
+
+  return (
+    <section className="py-20 sm:py-32">
+      <Container>
+        {heading ? <h2 className={headingClass}>{heading}</h2> : null}
+        <div
+          className="mx-auto grid max-w-2xl grid-cols-4 gap-4 sm:gap-8"
+          role="timer"
+          aria-live="off"
+        >
+          {units.map((u) => (
+            <Unit key={u.label} value={u.value} label={u.label} />
+          ))}
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/src/components/homepage/Countdown.tsx
+++ b/src/components/homepage/Countdown.tsx
@@ -71,9 +71,15 @@ export function Countdown({
   const [remaining, setRemaining] = useState<number | null>(null)
 
   useEffect(() => {
-    const tick = () => setRemaining(Math.max(0, targetMs - Date.now()))
-    tick()
+    const tick = () => {
+      const next = Math.max(0, targetMs - Date.now())
+      setRemaining(next)
+      // Once the target has passed the display is static — stop ticking
+      // instead of holding a 1s interval for the rest of the page's life.
+      if (next <= 0) clearInterval(id)
+    }
     const id = setInterval(tick, 1000)
+    tick()
     return () => clearInterval(id)
   }, [targetMs])
 

--- a/src/components/homepage/FaqBlock.stories.tsx
+++ b/src/components/homepage/FaqBlock.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { FaqBlock } from './FaqBlock'
+import type { Conference } from '@/lib/conference/types'
+
+const conference = {
+  _id: 'conf-1',
+  title: 'Cloud Native Days Norway 2026',
+  ticketFaqs: [
+    {
+      _key: 't1',
+      question: 'Can I get a refund?',
+      answer: 'Tickets are refundable up to 14 days before the event.',
+    },
+    {
+      _key: 't2',
+      question: 'Is lunch included?',
+      answer: 'Yes — lunch and coffee are included with every ticket.',
+    },
+  ],
+} as unknown as Conference
+
+const meta = {
+  title: 'Systems/Homepage/Public/FaqBlock',
+  component: FaqBlock,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Front-page builder (F4) FAQ accordion. Renders EITHER its own items or, via `source: "ticketFaqs"`, the existing ticket FAQs (no duplication). Uses the shared FaqAccordion so it matches the tickets page. Renders nothing when empty.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof FaqBlock>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const OwnItems: Story = {
+  args: {
+    conference,
+    section: {
+      _key: 'faq-1',
+      _type: 'homepageFaq',
+      heading: 'Frequently asked questions',
+      source: 'own',
+      items: [
+        {
+          _key: 'i1',
+          question: 'Where is the conference held?',
+          answer: 'At Grieghallen in the centre of Bergen, Norway.',
+        },
+        {
+          _key: 'i2',
+          question: 'Will talks be recorded?',
+          answer:
+            'Yes, all talks are recorded and published on our YouTube channel afterwards.',
+        },
+      ],
+    },
+  },
+}
+
+export const FromTicketFaqs: Story = {
+  args: {
+    conference,
+    section: {
+      _key: 'faq-2',
+      _type: 'homepageFaq',
+      source: 'ticketFaqs',
+    },
+  },
+}
+
+/** Edge case: no items and own source → the block renders nothing. */
+export const EmptyItems: Story = {
+  args: {
+    conference,
+    section: {
+      _key: 'faq-3',
+      _type: 'homepageFaq',
+      source: 'own',
+      items: [],
+    },
+  },
+}
+
+export const Dark: Story = {
+  args: OwnItems.args,
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-gray-950">
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/components/homepage/FaqBlock.tsx
+++ b/src/components/homepage/FaqBlock.tsx
@@ -1,0 +1,35 @@
+import { Container } from '@/components/Container'
+import { FaqAccordion } from '@/components/FaqAccordion'
+import { DEFAULT_FAQ_HEADING, type FaqSection } from '@/lib/homepage/sections'
+import type { Conference } from '@/lib/conference/types'
+
+/**
+ * FAQ accordion block (front-page builder F4). Renders EITHER this block's own
+ * items or — when `source === 'ticketFaqs'` — the existing `conference.ticketFaqs`,
+ * so ticket FAQs are not duplicated. Uses the shared {@link FaqAccordion} so the
+ * look matches the tickets page. Renders nothing when there are no entries.
+ */
+export function FaqBlock({
+  section,
+  conference,
+}: {
+  section: FaqSection
+  conference: Conference
+}) {
+  const faqs =
+    section.source === 'ticketFaqs'
+      ? (conference.ticketFaqs ?? [])
+      : (section.items ?? [])
+  if (faqs.length === 0) return null
+  const heading = section.heading?.trim() || DEFAULT_FAQ_HEADING
+  return (
+    <section className="py-20 sm:py-32">
+      <Container>
+        <h2 className="font-space-grotesk mb-10 text-center text-4xl font-medium tracking-tighter text-brand-cloud-blue sm:text-5xl dark:text-blue-400">
+          {heading}
+        </h2>
+        <FaqAccordion faqs={faqs} />
+      </Container>
+    </section>
+  )
+}

--- a/src/components/homepage/HomepageComposition.stories.tsx
+++ b/src/components/homepage/HomepageComposition.stories.tsx
@@ -21,8 +21,16 @@ const baseConference = {
   city: 'Bergen',
   country: 'Norway',
   venueName: 'Grieghallen',
+  venueAddress: 'Edvard Griegs plass 1\n5015 Bergen\nNorway',
   startDate: '2099-09-15',
   endDate: '2099-09-15',
+  ticketFaqs: [
+    {
+      _key: 't1',
+      question: 'Can I get a refund?',
+      answer: 'Tickets are refundable up to 14 days before the event.',
+    },
+  ],
   cfpStartDate: '2020-01-01',
   cfpEndDate: '2020-06-01',
   cfpNotifyDate: '2020-07-01',
@@ -88,6 +96,35 @@ const customSections: HomepageSection[] = [
     content: richContent,
   },
   { _key: 'metrics', _type: 'homepageMetrics', heading: 'By the numbers' },
+  {
+    _key: 'countdown',
+    _type: 'homepageCountdown',
+    heading: 'The doors open in',
+  },
+  {
+    _key: 'faq',
+    _type: 'homepageFaq',
+    heading: 'Frequently asked questions',
+    source: 'own',
+    items: [
+      {
+        _key: 'q1',
+        question: 'Where is the conference held?',
+        answer: 'At Grieghallen in the centre of Bergen, Norway.',
+      },
+      {
+        _key: 'q2',
+        question: 'Will talks be recorded?',
+        answer: 'Yes — every talk is recorded and published afterwards.',
+      },
+    ],
+  },
+  {
+    _key: 'venue',
+    _type: 'homepageVenue',
+    heading: 'Where to find us',
+    description: 'A short walk from Bergen train station.',
+  },
   { _key: 'sponsors', _type: 'homepageSponsors' },
 ]
 

--- a/src/components/homepage/SectionRenderer.test.tsx
+++ b/src/components/homepage/SectionRenderer.test.tsx
@@ -37,6 +37,17 @@ vi.mock('@/components/homepage/RichTextBlock', () => ({
 vi.mock('@/components/homepage/MetricsBlock', () => ({
   MetricsBlock: () => <div data-testid="metrics" />,
 }))
+vi.mock('@/components/homepage/FaqBlock', () => ({
+  FaqBlock: () => <div data-testid="faq" />,
+}))
+vi.mock('@/components/homepage/Countdown', () => ({
+  Countdown: ({ targetMs }: { targetMs: number }) => (
+    <div data-testid="countdown" data-target={targetMs} />
+  ),
+}))
+vi.mock('@/components/homepage/VenueBlock', () => ({
+  VenueBlock: () => <div data-testid="venue" />,
+}))
 
 import { HomepageSectionRenderer } from './SectionRenderer'
 import { getDefaultSections, type HomepageSection } from '@/lib/homepage'
@@ -130,5 +141,36 @@ describe('HomepageSectionRenderer — visibility & forward compat', () => {
       expect.stringContaining('homepageFromTheFuture'),
     )
     warn.mockRestore()
+  })
+})
+
+describe('HomepageSectionRenderer — F4 blocks', () => {
+  it('renders FAQ, countdown (resolved target) and venue in order', () => {
+    const conference = makeConference({ startDate: '2099-09-15' })
+    const sections = [
+      { _key: '1', _type: 'homepageFaq', source: 'ticketFaqs' },
+      { _key: '2', _type: 'homepageCountdown' },
+      { _key: '3', _type: 'homepageVenue' },
+    ] as unknown as HomepageSection[]
+    const { container } = render(
+      <HomepageSectionRenderer sections={sections} conference={conference} />,
+    )
+    expect(testIdsInOrder(container)).toEqual(['faq', 'countdown', 'venue'])
+    expect(
+      container
+        .querySelector('[data-testid="countdown"]')
+        ?.getAttribute('data-target'),
+    ).toBe(String(Date.UTC(2099, 8, 15, 12)))
+  })
+
+  it('renders nothing for a countdown with no resolvable target', () => {
+    const conference = makeConference({ startDate: undefined })
+    const sections = [
+      { _key: '1', _type: 'homepageCountdown' },
+    ] as unknown as HomepageSection[]
+    const { container } = render(
+      <HomepageSectionRenderer sections={sections} conference={conference} />,
+    )
+    expect(container.querySelector('[data-testid="countdown"]')).toBeNull()
   })
 })

--- a/src/components/homepage/SectionRenderer.tsx
+++ b/src/components/homepage/SectionRenderer.tsx
@@ -10,6 +10,10 @@ import { FeaturedSpeakersShelf } from '@/components/FeaturedSpeakersShelf'
 import { CtaBanner } from '@/components/homepage/CtaBanner'
 import { RichTextBlock } from '@/components/homepage/RichTextBlock'
 import { MetricsBlock } from '@/components/homepage/MetricsBlock'
+import { FaqBlock } from '@/components/homepage/FaqBlock'
+import { Countdown } from '@/components/homepage/Countdown'
+import { VenueBlock } from '@/components/homepage/VenueBlock'
+import { resolveCountdownTarget } from '@/lib/homepage/countdown'
 import {
   InformationCircleIcon,
   MicrophoneIcon,
@@ -289,6 +293,23 @@ function renderSection(
       return <CtaBanner section={section} />
     case 'homepageRichText':
       return <RichTextBlock section={section} />
+    case 'homepageFaq':
+      return <FaqBlock section={section} conference={conference} />
+    case 'homepageCountdown': {
+      // SSR-safe: resolve the target to a stable timestamp server-side; the
+      // client component ticks after hydration. Null target → nothing to show.
+      const targetMs = resolveCountdownTarget(conference, section)
+      if (targetMs === null) return null
+      return (
+        <Countdown
+          targetMs={targetMs}
+          heading={section.heading}
+          liveMessage={section.liveMessage}
+        />
+      )
+    }
+    case 'homepageVenue':
+      return <VenueBlock section={section} conference={conference} />
     default: {
       // Forward compat: an unknown `_type` (data written by a newer schema
       // during deploy skew) is skipped at runtime, never fatal. Warned once per

--- a/src/components/homepage/VenueBlock.stories.tsx
+++ b/src/components/homepage/VenueBlock.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { VenueBlock } from './VenueBlock'
+import type { Conference } from '@/lib/conference/types'
+
+const withVenue = {
+  _id: 'conf-1',
+  title: 'Cloud Native Days Norway 2026',
+  venueName: 'Grieghallen',
+  venueAddress: 'Edvard Griegs plass 1\n5015 Bergen\nNorway',
+} as unknown as Conference
+
+const nameOnly = {
+  _id: 'conf-1',
+  title: 'Cloud Native Days Norway 2026',
+  venueName: 'Grieghallen',
+} as unknown as Conference
+
+const meta = {
+  title: 'Systems/Homepage/Public/VenueBlock',
+  component: VenueBlock,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Front-page builder (F4) venue block. Name/address come from the conference; the "Get directions" link is constructed from the address at render (no map tiles/embeds, no stored URL). Renders nothing without a venue name or address.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof VenueBlock>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    conference: withVenue,
+    section: {
+      _key: 'venue-1',
+      _type: 'homepageVenue',
+      heading: 'Where to find us',
+      description:
+        'In the heart of Bergen, a short walk from the train station.',
+    },
+  },
+}
+
+/** Edge case: venue name but no address → no "Get directions" for the address. */
+export const NameOnly: Story = {
+  args: {
+    conference: nameOnly,
+    section: {
+      _key: 'venue-2',
+      _type: 'homepageVenue',
+    },
+  },
+}
+
+export const Dark: Story = {
+  args: Default.args,
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-gray-950">
+        <Story />
+      </div>
+    ),
+  ],
+}

--- a/src/components/homepage/VenueBlock.stories.tsx
+++ b/src/components/homepage/VenueBlock.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Front-page builder (F4) venue block. Name/address come from the conference; the "Get directions" link is constructed from the address at render (no map tiles/embeds, no stored URL). Renders nothing without a venue name or address.',
+          'Front-page builder (F4) venue block. Name/address come from the conference; the "Get directions" link is constructed from the venue name and address (either alone suffices) at render (no map tiles/embeds, no stored URL). Renders nothing without a venue name or address.',
       },
     },
   },

--- a/src/components/homepage/VenueBlock.tsx
+++ b/src/components/homepage/VenueBlock.tsx
@@ -1,0 +1,71 @@
+import { Container } from '@/components/Container'
+import { Button } from '@/components/Button'
+import { MapPinIcon } from '@heroicons/react/24/outline'
+import type { VenueSection } from '@/lib/homepage/sections'
+import type { Conference } from '@/lib/conference/types'
+import { buildDirectionsUrl } from '@/lib/homepage/venue'
+
+/**
+ * Venue block (front-page builder F4). Name + address come from the conference
+ * fields; the block carries only an optional heading/description. A "Get
+ * directions" house Button links to a constructed maps URL. Renders nothing when
+ * the conference has neither a venue name nor address.
+ */
+export function VenueBlock({
+  section,
+  conference,
+}: {
+  section: VenueSection
+  conference: Conference
+}) {
+  const name = conference.venueName?.trim()
+  const address = conference.venueAddress?.trim()
+  if (!name && !address) return null
+
+  const heading = section.heading?.trim() || 'Venue'
+  const description = section.description?.trim()
+  const directionsUrl = buildDirectionsUrl(name, address)
+
+  return (
+    <section className="py-20 sm:py-32">
+      <Container>
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="font-space-grotesk text-4xl font-medium tracking-tighter text-brand-cloud-blue sm:text-5xl dark:text-blue-400">
+            {heading}
+          </h2>
+          {description ? (
+            <p className="font-inter mt-4 text-xl tracking-tight text-brand-slate-gray dark:text-gray-300">
+              {description}
+            </p>
+          ) : null}
+          <div className="mt-8 rounded-2xl bg-white/80 p-6 shadow-md ring-1 ring-brand-cloud-blue/10 backdrop-blur-sm dark:bg-gray-800/80 dark:ring-gray-700">
+            {name ? (
+              <p className="font-space-grotesk text-2xl font-semibold text-brand-slate-gray dark:text-gray-100">
+                {name}
+              </p>
+            ) : null}
+            {address ? (
+              <p className="font-inter mt-1 whitespace-pre-line text-brand-slate-gray/80 dark:text-gray-300">
+                {address}
+              </p>
+            ) : null}
+            {directionsUrl ? (
+              <div className="mt-6 flex justify-center">
+                <Button
+                  href={directionsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="primary"
+                  className="inline-flex items-center space-x-2 px-6 py-3 font-semibold"
+                >
+                  <MapPinIcon className="h-5 w-5" aria-hidden="true" />
+                  <span>Get directions</span>
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}

--- a/src/lib/homepage/countdown.test.ts
+++ b/src/lib/homepage/countdown.test.ts
@@ -6,7 +6,7 @@ const conf = (startDate?: string) =>
   ({ startDate }) as unknown as Pick<Conference, 'startDate'>
 
 describe('resolveCountdownTarget', () => {
-  it('anchors the conference start date at Oslo noon (12:00 UTC)', () => {
+  it('anchors the conference start date at 12:00 UTC (house anchoring)', () => {
     const ms = resolveCountdownTarget(conf('2099-09-15'), {})
     expect(ms).toBe(Date.UTC(2099, 8, 15, 12))
   })

--- a/src/lib/homepage/countdown.test.ts
+++ b/src/lib/homepage/countdown.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCountdownTarget } from './countdown'
+import type { Conference } from '@/lib/conference/types'
+
+const conf = (startDate?: string) =>
+  ({ startDate }) as unknown as Pick<Conference, 'startDate'>
+
+describe('resolveCountdownTarget', () => {
+  it('anchors the conference start date at Oslo noon (12:00 UTC)', () => {
+    const ms = resolveCountdownTarget(conf('2099-09-15'), {})
+    expect(ms).toBe(Date.UTC(2099, 8, 15, 12))
+  })
+
+  it('prefers targetOverride over the start date', () => {
+    const ms = resolveCountdownTarget(conf('2099-09-15'), {
+      targetOverride: '2099-01-01',
+    })
+    expect(ms).toBe(Date.UTC(2099, 0, 1, 12))
+  })
+
+  it('uses a full ISO override as-is (not date-anchored)', () => {
+    const iso = '2099-09-15T09:30:00Z'
+    const ms = resolveCountdownTarget(conf('2099-09-15'), {
+      targetOverride: iso,
+    })
+    expect(ms).toBe(new Date(iso).getTime())
+  })
+
+  it('returns null when there is no start date and no override', () => {
+    expect(resolveCountdownTarget(conf(undefined), {})).toBeNull()
+  })
+
+  it('returns null for an unparseable override', () => {
+    expect(
+      resolveCountdownTarget(conf('2099-09-15'), {
+        targetOverride: 'not-a-date',
+      }),
+    ).toBeNull()
+  })
+
+  it('ignores a blank override and falls back to the start date', () => {
+    const ms = resolveCountdownTarget(conf('2099-09-15'), {
+      targetOverride: '   ',
+    })
+    expect(ms).toBe(Date.UTC(2099, 8, 15, 12))
+  })
+})

--- a/src/lib/homepage/countdown.ts
+++ b/src/lib/homepage/countdown.ts
@@ -1,0 +1,25 @@
+import type { Conference } from '@/lib/conference/types'
+import { toOsloAnchoredDate } from '@/lib/time'
+import type { CountdownSection } from './sections'
+
+/**
+ * Resolve the countdown target as an epoch-millisecond timestamp, or `null` when
+ * there is nothing to count down to. `targetOverride` wins over the conference
+ * start date. Bare `YYYY-MM-DD` values are anchored at 12:00 Europe/Oslo (house
+ * convention — see {@link toOsloAnchoredDate}) so the target does not drift with
+ * the viewer's timezone; full ISO timestamps are used as-is. An unparseable
+ * value resolves to `null` (the block then renders nothing).
+ *
+ * Pure and server-safe: the renderer calls this to pass a stable timestamp prop
+ * into the client `Countdown`, keeping the countdown SSR-safe (no `Date.now()`
+ * on the server render path).
+ */
+export function resolveCountdownTarget(
+  conference: Pick<Conference, 'startDate'>,
+  section: Pick<CountdownSection, 'targetOverride'>,
+): number | null {
+  const raw = section.targetOverride?.trim() || conference.startDate?.trim()
+  if (!raw) return null
+  const ms = toOsloAnchoredDate(raw).getTime()
+  return Number.isNaN(ms) ? null : ms
+}

--- a/src/lib/homepage/countdown.ts
+++ b/src/lib/homepage/countdown.ts
@@ -5,9 +5,10 @@ import type { CountdownSection } from './sections'
 /**
  * Resolve the countdown target as an epoch-millisecond timestamp, or `null` when
  * there is nothing to count down to. `targetOverride` wins over the conference
- * start date. Bare `YYYY-MM-DD` values are anchored at 12:00 Europe/Oslo (house
- * convention — see {@link toOsloAnchoredDate}) so the target does not drift with
- * the viewer's timezone; full ISO timestamps are used as-is. An unparseable
+ * start date. Bare `YYYY-MM-DD` values are anchored at 12:00 UTC (the house
+ * anchoring convention — see {@link toOsloAnchoredDate}, whose name predates
+ * the UTC-noon implementation) so the target does not drift with the viewer's
+ * timezone; full ISO timestamps are used as-is. An unparseable
  * value resolves to `null` (the block then renders nothing).
  *
  * Pure and server-safe: the renderer calls this to pass a stable timestamp prop

--- a/src/lib/homepage/editor.test.ts
+++ b/src/lib/homepage/editor.test.ts
@@ -235,3 +235,113 @@ describe('toPayload — mapping semantics', () => {
     })
   })
 })
+
+describe('toEditorRows — new F4 blocks', () => {
+  it('maps a FAQ block with own items (source defaults to own)', () => {
+    const sections: HomepageSection[] = [
+      {
+        _key: 'faq',
+        _type: 'homepageFaq',
+        heading: 'Questions',
+        items: [{ _key: 'i1', question: 'Q1', answer: 'A1' }],
+      },
+    ]
+    const [row] = toEditorRows(sections)
+    expect(row.source).toBe('own')
+    expect(row.faqItems).toEqual([{ _key: 'i1', question: 'Q1', answer: 'A1' }])
+  })
+
+  it('preserves the ticketFaqs source toggle', () => {
+    const [row] = toEditorRows([
+      { _key: 'faq', _type: 'homepageFaq', source: 'ticketFaqs' },
+    ])
+    expect(row.source).toBe('ticketFaqs')
+    expect(row.faqItems).toEqual([])
+  })
+
+  it('maps countdown and venue fields', () => {
+    const rows = toEditorRows([
+      {
+        _key: 'cd',
+        _type: 'homepageCountdown',
+        heading: 'Starts in',
+        targetOverride: '2099-09-15',
+        liveMessage: 'We are live!',
+      },
+      {
+        _key: 'v',
+        _type: 'homepageVenue',
+        heading: 'Where',
+        description: 'Downtown',
+      },
+    ])
+    expect(rows[0]).toMatchObject({
+      targetOverride: '2099-09-15',
+      liveMessage: 'We are live!',
+    })
+    expect(rows[1]).toMatchObject({ heading: 'Where', description: 'Downtown' })
+  })
+})
+
+describe('toPayload — trimming, omission and item filtering', () => {
+  it('stores own FAQ items (trimmed) and drops blank ones', () => {
+    const rows: EditorRow[] = [
+      {
+        _key: 'faq',
+        _type: 'homepageFaq',
+        heading: '  Questions  ',
+        source: 'own',
+        faqItems: [
+          { _key: 'i1', question: '  Q1  ', answer: '  A1  ' },
+          { _key: 'i2', question: '', answer: 'orphan' },
+        ],
+      },
+    ]
+    const [out] = toPayload(rows)
+    expect(out.heading).toBe('Questions')
+    expect(out.items).toEqual([{ _key: 'i1', question: 'Q1', answer: 'A1' }])
+    expect(out.source).toBeUndefined() // 'own' is implicit
+  })
+
+  it('stores the ticketFaqs source and omits items entirely', () => {
+    const [out] = toPayload([
+      {
+        _key: 'faq',
+        _type: 'homepageFaq',
+        source: 'ticketFaqs',
+        faqItems: [{ _key: 'i1', question: 'ignored', answer: 'ignored' }],
+      },
+    ])
+    expect(out.source).toBe('ticketFaqs')
+    expect(out.items).toBeUndefined()
+  })
+
+  it('omits blank countdown/venue optionals but keeps set ones', () => {
+    const [cd, venue] = toPayload([
+      {
+        _key: 'cd',
+        _type: 'homepageCountdown',
+        heading: '   ',
+        targetOverride: '2099-09-15',
+        liveMessage: '  ',
+      },
+      { _key: 'v', _type: 'homepageVenue', description: 'Grieghallen' },
+    ])
+    expect(cd.heading).toBeUndefined()
+    expect(cd.liveMessage).toBeUndefined()
+    expect(cd.targetOverride).toBe('2099-09-15')
+    expect(venue.heading).toBeUndefined()
+    expect(venue.description).toBe('Grieghallen')
+  })
+
+  it('always carries _type and _key, plus hidden when set', () => {
+    const [out] = toPayload([
+      { _key: 'v', _type: 'homepageVenue', hidden: true },
+    ])
+    expect(out).toMatchObject({
+      _type: 'homepageVenue',
+      _key: 'v',
+      hidden: true,
+    })
+  })
+})

--- a/src/lib/homepage/editor.test.ts
+++ b/src/lib/homepage/editor.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   EditorRow,
   isConfigurable,
+  isoToLocalInput,
+  localInputToIso,
   moveByIndex,
   reorderByKey,
   serializeRows,
@@ -265,7 +267,7 @@ describe('toEditorRows — new F4 blocks', () => {
         _key: 'cd',
         _type: 'homepageCountdown',
         heading: 'Starts in',
-        targetOverride: '2099-09-15',
+        targetOverride: '2099-09-15T10:00:00.000Z',
         liveMessage: 'We are live!',
       },
       {
@@ -276,7 +278,9 @@ describe('toEditorRows — new F4 blocks', () => {
       },
     ])
     expect(rows[0]).toMatchObject({
-      targetOverride: '2099-09-15',
+      // Stored ISO instants surface as LOCAL wall-clock datetime-local values
+      // (round-tripped back to ISO by toPayload below).
+      targetOverride: isoToLocalInput('2099-09-15T10:00:00.000Z'),
       liveMessage: 'We are live!',
     })
     expect(rows[1]).toMatchObject({ heading: 'Where', description: 'Downtown' })
@@ -322,14 +326,16 @@ describe('toPayload — trimming, omission and item filtering', () => {
         _key: 'cd',
         _type: 'homepageCountdown',
         heading: '   ',
-        targetOverride: '2099-09-15',
+        targetOverride: '2099-09-15T10:00:00.000Z',
         liveMessage: '  ',
       },
       { _key: 'v', _type: 'homepageVenue', description: 'Grieghallen' },
     ])
     expect(cd.heading).toBeUndefined()
     expect(cd.liveMessage).toBeUndefined()
-    expect(cd.targetOverride).toBe('2099-09-15')
+    expect(cd.targetOverride).toBe(
+      localInputToIso(isoToLocalInput('2099-09-15T10:00:00.000Z')),
+    )
     expect(venue.heading).toBeUndefined()
     expect(venue.description).toBe('Grieghallen')
   })

--- a/src/lib/homepage/editor.ts
+++ b/src/lib/homepage/editor.ts
@@ -20,6 +20,9 @@ export const SECTION_LABELS: Record<HomepageSectionType, string> = {
   homepageMetrics: 'Vanity Metrics',
   homepageCtaBanner: 'Call-to-action Banner',
   homepageRichText: 'Rich Text',
+  homepageFaq: 'FAQ',
+  homepageCountdown: 'Countdown',
+  homepageVenue: 'Venue',
 }
 
 /**
@@ -33,6 +36,9 @@ const CONFIGURABLE_TYPES: ReadonlySet<HomepageSectionType> = new Set([
   'homepageCtaBanner',
   'homepageRichText',
   'homepageMetrics',
+  'homepageFaq',
+  'homepageCountdown',
+  'homepageVenue',
 ])
 
 export function isConfigurable(type: HomepageSectionType): boolean {
@@ -65,6 +71,14 @@ export interface EditorRow {
   buttonLabel?: string
   buttonHref?: string
   content?: PortableTextBlock[]
+  // FAQ block
+  source?: 'own' | 'ticketFaqs'
+  faqItems?: { _key: string; question: string; answer: string }[]
+  // Countdown block
+  targetOverride?: string
+  liveMessage?: string
+  // Venue block
+  description?: string
 }
 
 let keyCounter = 0
@@ -95,6 +109,21 @@ export function toEditorRows(sections: HomepageSection[]): EditorRow[] {
       row.content = (s.content as PortableTextBlock[]) ?? []
     } else if (s._type === 'homepageMetrics') {
       row.heading = s.heading
+    } else if (s._type === 'homepageFaq') {
+      row.heading = s.heading
+      row.source = s.source ?? 'own'
+      row.faqItems = (s.items ?? []).map((i) => ({
+        _key: i._key || nextKey(),
+        question: i.question,
+        answer: i.answer,
+      }))
+    } else if (s._type === 'homepageCountdown') {
+      row.heading = s.heading
+      row.targetOverride = s.targetOverride
+      row.liveMessage = s.liveMessage
+    } else if (s._type === 'homepageVenue') {
+      row.heading = s.heading
+      row.description = s.description
     }
     return row
   })
@@ -137,6 +166,34 @@ export function toPayload(rows: EditorRow[]): Record<string, unknown>[] {
         break
       case 'homepageMetrics':
         if (row.heading?.trim()) out.heading = row.heading.trim()
+        break
+      case 'homepageFaq': {
+        if (row.heading?.trim()) out.heading = row.heading.trim()
+        const source = row.source ?? 'own'
+        if (source === 'ticketFaqs') {
+          out.source = 'ticketFaqs'
+        } else {
+          // 'own' is the default; only store items (source stays implicit).
+          const items = (row.faqItems ?? [])
+            .filter((i) => i.question.trim() && i.answer.trim())
+            .map((i) => ({
+              _key: i._key,
+              question: i.question.trim(),
+              answer: i.answer.trim(),
+            }))
+          if (items.length > 0) out.items = items
+        }
+        break
+      }
+      case 'homepageCountdown':
+        if (row.heading?.trim()) out.heading = row.heading.trim()
+        if (row.targetOverride?.trim())
+          out.targetOverride = row.targetOverride.trim()
+        if (row.liveMessage?.trim()) out.liveMessage = row.liveMessage.trim()
+        break
+      case 'homepageVenue':
+        if (row.heading?.trim()) out.heading = row.heading.trim()
+        if (row.description?.trim()) out.description = row.description.trim()
         break
       default:
         break

--- a/src/lib/homepage/editor.ts
+++ b/src/lib/homepage/editor.ts
@@ -82,6 +82,26 @@ export interface EditorRow {
 }
 
 let keyCounter = 0
+/**
+ * Stored ISO instant → the LOCAL wall-clock string a `datetime-local` input
+ * expects (and back, below). Same round-trip discipline as the workshop
+ * registration editor: local into the input, ISO instant into storage.
+ */
+export function isoToLocalInput(value?: string): string | undefined {
+  if (!value) return undefined
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return undefined
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+export function localInputToIso(value?: string): string | undefined {
+  const v = value?.trim()
+  if (!v) return undefined
+  const d = new Date(v)
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString()
+}
+
 export const nextKey = () => `hp-${Date.now()}-${++keyCounter}`
 
 export function toEditorRows(sections: HomepageSection[]): EditorRow[] {
@@ -119,7 +139,7 @@ export function toEditorRows(sections: HomepageSection[]): EditorRow[] {
       }))
     } else if (s._type === 'homepageCountdown') {
       row.heading = s.heading
-      row.targetOverride = s.targetOverride
+      row.targetOverride = isoToLocalInput(s.targetOverride)
       row.liveMessage = s.liveMessage
     } else if (s._type === 'homepageVenue') {
       row.heading = s.heading
@@ -187,8 +207,13 @@ export function toPayload(rows: EditorRow[]): Record<string, unknown>[] {
       }
       case 'homepageCountdown':
         if (row.heading?.trim()) out.heading = row.heading.trim()
-        if (row.targetOverride?.trim())
-          out.targetOverride = row.targetOverride.trim()
+        {
+          // The datetime-local value is a timezone-less LOCAL wall-clock
+          // string; persist the unambiguous ISO instant so the server-side
+          // target resolution can never re-interpret it in the server's zone.
+          const iso = localInputToIso(row.targetOverride)
+          if (iso) out.targetOverride = iso
+        }
         if (row.liveMessage?.trim()) out.liveMessage = row.liveMessage.trim()
         break
       case 'homepageVenue':

--- a/src/lib/homepage/sections.ts
+++ b/src/lib/homepage/sections.ts
@@ -34,7 +34,13 @@ export const HOMEPAGE_SECTION_TYPES = [
   'homepageMetrics',
   'homepageCtaBanner',
   'homepageRichText',
+  'homepageFaq',
+  'homepageCountdown',
+  'homepageVenue',
 ] as const
+
+/** Default heading for the FAQ block when none is configured. */
+export const DEFAULT_FAQ_HEADING = 'Frequently asked questions'
 
 export type HomepageSectionType = (typeof HOMEPAGE_SECTION_TYPES)[number]
 
@@ -116,6 +122,57 @@ export interface RichTextSection extends BaseSection {
   content: TypedObject[]
 }
 
+/**
+ * A single FAQ entry for the block's OWN item source. The answer is plain text,
+ * mirroring how `conference.ticketFaqs` models answers (see `TicketFaq`) so the
+ * `source: 'ticketFaqs'` toggle can render the exact same shape.
+ */
+export interface HomepageFaqItem {
+  _key?: string
+  question: string
+  answer: string
+}
+
+/**
+ * FAQ accordion block. To avoid duplicating content, `source: 'ticketFaqs'`
+ * renders the existing `conference.ticketFaqs`; the default `'own'` renders this
+ * block's own {@link HomepageFaqItem} list.
+ */
+export interface FaqSection extends BaseSection {
+  _type: 'homepageFaq'
+  heading?: string
+  /** `'own'` (default) renders `items`; `'ticketFaqs'` renders the ticket FAQs. */
+  source?: 'own' | 'ticketFaqs'
+  items?: HomepageFaqItem[]
+}
+
+/**
+ * Countdown to the conference start. The target is `conference.startDate` unless
+ * `targetOverride` is set. The renderer resolves the target server-side and the
+ * client component ticks after hydration (SSR-safe — see {@link resolveCountdownTarget}
+ * and the `Countdown` component).
+ */
+export interface CountdownSection extends BaseSection {
+  _type: 'homepageCountdown'
+  heading?: string
+  /** ISO date/timestamp that overrides `conference.startDate` as the target. */
+  targetOverride?: string
+  /** Shown once the target passes. Blank hides the block after the target. */
+  liveMessage?: string
+}
+
+/**
+ * Venue block. Name and address come from `conference.venueName` /
+ * `venueAddress`; the block carries only presentation copy. The "Get directions"
+ * link is CONSTRUCTED from the address at render (no map tiles/embeds, and no
+ * tenant-entered URL is stored).
+ */
+export interface VenueSection extends BaseSection {
+  _type: 'homepageVenue'
+  heading?: string
+  description?: string
+}
+
 export type HomepageSection =
   | HeroSection
   | FeaturedSpeakersSection
@@ -126,6 +183,9 @@ export type HomepageSection =
   | MetricsSection
   | CtaBannerSection
   | RichTextSection
+  | FaqSection
+  | CountdownSection
+  | VenueSection
 
 /** True when the program is published AND at least one schedule day exists. */
 export function hasPublishedSchedule(conference: Conference): boolean {

--- a/src/lib/homepage/venue.test.ts
+++ b/src/lib/homepage/venue.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { buildDirectionsUrl } from './venue'
+
+describe('buildDirectionsUrl', () => {
+  it('constructs a maps search URL from name + address, URL-encoded', () => {
+    const url = buildDirectionsUrl('Grieghallen', 'Edvard Griegs plass 1')
+    expect(url).toBe(
+      'https://www.google.com/maps/search/?api=1&query=' +
+        encodeURIComponent('Grieghallen, Edvard Griegs plass 1'),
+    )
+  })
+
+  it('works with only a name or only an address', () => {
+    expect(buildDirectionsUrl('Grieghallen', undefined)).toContain(
+      encodeURIComponent('Grieghallen'),
+    )
+    expect(buildDirectionsUrl(undefined, 'Somewhere 1')).toContain(
+      encodeURIComponent('Somewhere 1'),
+    )
+  })
+
+  it('trims parts and skips blank ones', () => {
+    const url = buildDirectionsUrl('  Grieghallen  ', '   ')
+    expect(url).toBe(
+      'https://www.google.com/maps/search/?api=1&query=' +
+        encodeURIComponent('Grieghallen'),
+    )
+  })
+
+  it('returns null when there is nothing to search for', () => {
+    expect(buildDirectionsUrl(undefined, undefined)).toBeNull()
+    expect(buildDirectionsUrl('  ', '')).toBeNull()
+  })
+
+  it('only ever produces a plain https maps URL (no tenant-entered scheme)', () => {
+    const url = buildDirectionsUrl('javascript:alert(1)', 'x')
+    expect(url?.startsWith('https://www.google.com/maps/search/')).toBe(true)
+  })
+})

--- a/src/lib/homepage/venue.ts
+++ b/src/lib/homepage/venue.ts
@@ -1,0 +1,17 @@
+/**
+ * Build a Google Maps "search" directions link from the venue name/address. The
+ * URL is CONSTRUCTED from the conference fields at render — no tenant-entered URL
+ * is stored, and there are no map tiles/embeds (CSP + privacy, closed-registry
+ * rule). Returns `null` when there is nothing to search for.
+ */
+export function buildDirectionsUrl(
+  name?: string,
+  address?: string,
+): string | null {
+  const query = [name, address]
+    .map((p) => p?.trim())
+    .filter(Boolean)
+    .join(', ')
+  if (!query) return null
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -46,7 +46,7 @@ const NB_LONG_MONTHS = [
  * Oslo saw the previous day and it hydration-mismatched). Full ISO timestamps
  * are parsed as-is since they already carry an offset.
  */
-function toOsloAnchoredDate(dateString: string): Date {
+export function toOsloAnchoredDate(dateString: string): Date {
   const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString)
   if (dateOnly) {
     return new Date(

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -457,6 +457,33 @@ export const conferenceRouter = router({
               base.content = ensureUniqueArrayKeys(section.content, 'block')
               break
             }
+            case 'homepageFaq': {
+              if (section.heading) base.heading = section.heading
+              if (section.source) base.source = section.source
+              if (section.items && section.items.length > 0) {
+                base.items = ensureUniqueArrayKeys(
+                  section.items.map((item) => ({
+                    question: item.question,
+                    answer: item.answer,
+                    ...(item._key ? { _key: item._key } : {}),
+                  })),
+                  'faq',
+                )
+              }
+              break
+            }
+            case 'homepageCountdown': {
+              if (section.heading) base.heading = section.heading
+              if (section.targetOverride)
+                base.targetOverride = section.targetOverride
+              if (section.liveMessage) base.liveMessage = section.liveMessage
+              break
+            }
+            case 'homepageVenue': {
+              if (section.heading) base.heading = section.heading
+              if (section.description) base.description = section.description
+              break
+            }
             default:
               // The content-free blocks (featured speakers, program, organizers,
               // sponsors, gallery) carry only `_type`/`_key`/`hidden`.

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -459,8 +459,17 @@ export const conferenceRouter = router({
             }
             case 'homepageFaq': {
               if (section.heading) base.heading = section.heading
-              if (section.source) base.source = section.source
-              if (section.items && section.items.length > 0) {
+              // Persist only the EFFECTIVE config: `source` only when it's the
+              // non-default 'ticketFaqs', and `items` only when they're what
+              // renders ('own') — a block in ticketFaqs mode must not store
+              // dead item drafts.
+              const usesTicketFaqs = section.source === 'ticketFaqs'
+              if (usesTicketFaqs) base.source = 'ticketFaqs'
+              if (
+                !usesTicketFaqs &&
+                section.items &&
+                section.items.length > 0
+              ) {
                 base.items = ensureUniqueArrayKeys(
                   section.items.map((item) => ({
                     question: item.question,

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -626,6 +626,28 @@ const HeroCtaOverrideSchema = z.object({
   href: safeLinkHref,
 })
 
+/**
+ * A tenant-entered date for the countdown target. Accepts a bare `YYYY-MM-DD`
+ * (anchored at Oslo noon downstream) or any timestamp `Date.parse` understands
+ * (e.g. the datetime-local editor value); anything unparseable is rejected so
+ * the stored value always resolves.
+ */
+const countdownTargetString = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((v) => !Number.isNaN(Date.parse(v)), {
+    message: 'Enter a valid date',
+  })
+  .nullable()
+  .optional()
+
+const HomepageFaqItemSchema = z.object({
+  _key: sectionKey,
+  question: z.string().trim().min(1, 'Question is required'),
+  answer: z.string().trim().min(1, 'Answer is required'),
+})
+
 const HomepageSectionSchema = z.discriminatedUnion('_type', [
   z.object({
     _type: z.literal('homepageHero'),
@@ -683,6 +705,30 @@ const HomepageSectionSchema = z.discriminatedUnion('_type', [
     content: z
       .array(PortableTextBlockSchema)
       .min(1, 'Rich text needs at least one block'),
+  }),
+  z.object({
+    _type: z.literal('homepageFaq'),
+    _key: sectionKey,
+    hidden: sectionHidden,
+    heading: z.string().trim().min(1).nullable().optional(),
+    // 'own' (default) renders `items`; 'ticketFaqs' renders conference.ticketFaqs.
+    source: z.enum(['own', 'ticketFaqs']).optional(),
+    items: z.array(HomepageFaqItemSchema).optional(),
+  }),
+  z.object({
+    _type: z.literal('homepageCountdown'),
+    _key: sectionKey,
+    hidden: sectionHidden,
+    heading: z.string().trim().min(1).nullable().optional(),
+    targetOverride: countdownTargetString,
+    liveMessage: z.string().trim().min(1).nullable().optional(),
+  }),
+  z.object({
+    _type: z.literal('homepageVenue'),
+    _key: sectionKey,
+    hidden: sectionHidden,
+    heading: z.string().trim().min(1).nullable().optional(),
+    description: z.string().trim().min(1).nullable().optional(),
   }),
 ])
 

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -628,7 +628,7 @@ const HeroCtaOverrideSchema = z.object({
 
 /**
  * A tenant-entered date for the countdown target. Accepts a bare `YYYY-MM-DD`
- * (anchored at Oslo noon downstream) or any timestamp `Date.parse` understands
+ * (anchored at 12:00 UTC (the house date-anchoring convention) downstream) or any timestamp `Date.parse` understands
  * (e.g. the datetime-local editor value); anything unparseable is rejected so
  * the stored value always resolves.
  */

--- a/src/server/schemas/homepageSections.test.ts
+++ b/src/server/schemas/homepageSections.test.ts
@@ -115,4 +115,94 @@ describe('UpdateHomepageSectionsSchema', () => {
       }),
     ).toThrow()
   })
+
+  it('round-trips an FAQ block with own items', () => {
+    const parsed = UpdateHomepageSectionsSchema.parse({
+      homepageSections: [
+        {
+          _type: 'homepageFaq',
+          _key: 'faq',
+          heading: 'FAQ',
+          source: 'own',
+          items: [{ _key: 'i1', question: 'Q?', answer: 'A.' }],
+        },
+      ],
+    })
+    expect(parsed.homepageSections[0]).toMatchObject({
+      _type: 'homepageFaq',
+      source: 'own',
+    })
+  })
+
+  it('accepts the FAQ ticketFaqs source toggle without items', () => {
+    expect(() =>
+      UpdateHomepageSectionsSchema.parse({
+        homepageSections: [
+          { _type: 'homepageFaq', _key: 'faq', source: 'ticketFaqs' },
+        ],
+      }),
+    ).not.toThrow()
+  })
+
+  it('rejects an unknown FAQ source and a blank FAQ item', () => {
+    expect(
+      UpdateHomepageSectionsSchema.safeParse({
+        homepageSections: [
+          { _type: 'homepageFaq', _key: 'faq', source: 'somewhereElse' },
+        ],
+      }).success,
+    ).toBe(false)
+    expect(
+      UpdateHomepageSectionsSchema.safeParse({
+        homepageSections: [
+          {
+            _type: 'homepageFaq',
+            _key: 'faq',
+            items: [{ _key: 'i1', question: '', answer: 'A' }],
+          },
+        ],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('validates the countdown target override as a real date', () => {
+    const withTarget = (targetOverride: string) =>
+      UpdateHomepageSectionsSchema.safeParse({
+        homepageSections: [
+          { _type: 'homepageCountdown', _key: 'cd', targetOverride },
+        ],
+      }).success
+    expect(withTarget('2099-09-15')).toBe(true)
+    expect(withTarget('2099-09-15T09:00:00Z')).toBe(true)
+    expect(withTarget('not-a-date')).toBe(false)
+  })
+
+  it('accepts a countdown with just a heading and live message', () => {
+    expect(() =>
+      UpdateHomepageSectionsSchema.parse({
+        homepageSections: [
+          {
+            _type: 'homepageCountdown',
+            _key: 'cd',
+            heading: 'Starts in',
+            liveMessage: 'We are live!',
+          },
+        ],
+      }),
+    ).not.toThrow()
+  })
+
+  it('round-trips a venue block (name/address come from the conference)', () => {
+    const parsed = UpdateHomepageSectionsSchema.parse({
+      homepageSections: [
+        {
+          _type: 'homepageVenue',
+          _key: 'v',
+          heading: 'Venue',
+          description: 'In the heart of Bergen.',
+        },
+      ],
+    })
+    expect(parsed.homepageSections[0]).toMatchObject({ _type: 'homepageVenue' })
+  })
 })


### PR DESCRIPTION
## Front-page builder F4 — three new homepage blocks

Adds three blocks to the **closed** homepage section registry, each wired end-to-end (`sections.ts` type + zod + Sanity type + renderer case + component + editor config form + `SECTION_LABELS` + tests + stories).

### 1. `homepageFaq` — FAQ accordion
- Renders **either** its own `items[]` (default `source: 'own'`) **or**, via a `source: 'ticketFaqs'` toggle, the existing `conference.ticketFaqs` — so ticket FAQs are never duplicated.
- Answers are plain text, mirroring how `ticketFaqs` models them.
- The tickets-page accordion markup was extracted into a shared `FaqAccordion` component now used by **both** the tickets page and this block, so the look stays in one place.

**ticketFaqs-source decision:** rather than copy content, the block defaults to its own curated items but can point at the canonical ticket FAQs. In the Sanity editor the items list is hidden when the source is `ticketFaqs`.

### 2. `homepageCountdown` — SSR-safe countdown
- Counts down to `conference.startDate` (UTC-noon anchored per house convention) unless a `targetOverride` is set.
- **SSR-safety design:** the target is resolved server-side (`resolveCountdownTarget`) to a plain `targetMs` timestamp prop. The first render — server and first client render alike — shows a stable em-dash placeholder (no `Date.now()` on any server render path, so no hydration mismatch). Only after hydration does an effect read the clock and tick once a second.
- After the target passes it shows a configurable `liveMessage`, or hides when that is blank (the config knob).

### 3. `homepageVenue` — venue + directions
- Name/address come from `conference.venueName` / `venueAddress`; the block carries only an optional heading/description.
- **No map tiles/embeds** (CSP + privacy). A "Get directions" house Button links to a Google Maps *search* URL **constructed at render** from the address — no tenant-entered URL is ever stored.

## Safety / review notes
- Any stored href goes through `safeLinkHref` (zod) + `safeLinkRule` (Sanity). This F4 **stores no URLs at all** — the directions URL is constructed at render.
- FAQ items get unique `_key`s via `ensureUniqueArrayKeys` in the mutation mapping.
- Editor mapping logic (`toEditorRows`/`toPayload`) was extracted to `src/lib/homepage/editor.ts` (deep import, **not** re-exported from the server-safe `sections.ts` barrel) and unit-tested.
- Renderer forward-compat (unknown `_type` → warn-once + skip) is unchanged; the three new cases are exhaustive.

## Out of scope
- **Email-capture block:** evidence-backed but requires a data destination (list storage/provider) that does not exist yet. It needs an owner decision — *where do captured emails land?* — before it can be built, so it is deferred.

## QA
- Unit tests: registry/zod round-trips for the three blocks (incl. FAQ source toggle, countdown target resolution incl. anchoring/override/unparseable, venue directions-URL construction), editor `toEditorRows`/`toPayload` mapping, and renderer cases. Full vitest suite green (4227 passed).
- `pnpm run check` green (typecheck, lint 0 errors, knip, format).
- `shoot` visual inspection at 393px + desktop, light + dark, for a composition containing all three blocks plus each block's stories (default + edge: empty FAQ items, past-date countdown, venue without address). No viewport overflow; all blocks render correctly in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
