### PR TITLE
feat(badge): generator versioning, outdated detection and in-place rebake

### DIFF
--- a/docs/OPENBADGES_IMPLEMENTATION.md
+++ b/docs/OPENBADGES_IMPLEMENTATION.md
@@ -324,6 +324,89 @@ Every badge is signed with both methods:
 - **Baking (legacy badges only):** JWT embedded in SVG using
   `<openbadges:credential verify="{jwt}">`
 
+#### Why the RSA keys stay REQUIRED
+
+`BADGE_ISSUER_RSA_PRIVATE_KEY` and `BADGE_ISSUER_RSA_PUBLIC_KEY` are **not
+optional**, even though the primary (Ed25519 embedded) proof does not use them —
+`createBadgeConfiguration()` throws at issuance if either is unset. They are
+required for two durable reasons:
+
+1. **Dual-format issuance.** Every badge is signed in _both_ formats: the
+   embedded Ed25519 proof (baked into the SVG, stored in `badgeJson`) **and** the
+   RS256 JWT (stored in `badgeJwt`, served from `/api/badge/[id]/jwt`). The JWT
+   is what the 1EdTech OB30Inspector validator consumes. Dropping RSA would
+   silently stop minting the JWT half of every new badge.
+2. **Verifying already-issued JWT badges.** The public RSA key is published as a
+   JWK from the keys endpoint and the issuer profile, and the `badge.verify`
+   path uses `BADGE_ISSUER_RSA_PUBLIC_KEY` to verify **legacy badges whose
+   `badgeJson` is a raw JWT** (`isJWTFormat`). Rotating away the RSA public key
+   would make those historical badges fail verification.
+
+---
+
+## Generator Versioning & Rebaking
+
+Baked badges are **immutable artifacts**: the download route serves the stored
+`bakedSvg` as-is and does not re-prove on download, so a badge issued under an
+older credential format keeps that format forever unless it is explicitly
+re-baked.
+
+### The version constant and bump rule
+
+`src/lib/badge/version.ts` exports `BADGE_GENERATOR_VERSION`. Every
+`speakerBadge` document is stamped with `generatorVersion` at issuance. A stored
+doc with **no** `generatorVersion` is treated as **v1**.
+
+**Bump the constant whenever the credential format changes such that
+already-baked badges become stale** — i.e. a fresh re-issue would produce a
+materially different, more correct credential/proof/SVG. Do **not** bump for
+changes that leave existing baked artifacts valid (copy tweaks on new issuance,
+output-identical refactors). The version is a re-bake trigger, not a build
+number.
+
+Version history:
+
+- **v1** — pre-#655. The embedded proof `verificationMethod` was the
+  issuer-profile _fragment_ (not dereferenceable by the 1EdTech
+  `EmbeddedProofProbe`), and the credential carried no
+  `credentialSubject.identifier[]` block for displayer ownership matching.
+- **v2** — #655. The embedded proof `verificationMethod` is the dereferenceable
+  keys URL (`/api/badge/keys/key-ed25519`) returning a bare Multikey document,
+  and the credential includes a `credentialSubject.identifier[]` IdentityObject
+  (email, unhashed).
+
+### Rebake semantics
+
+The `badge.admin.rebake` mutation (org-scoped, admin-only) regenerates
+`badgeJson`, `badgeJwt` and `bakedSvg` with the **current** generator and
+patches the document in place. It is **idempotent** and refuses nothing except a
+missing or cross-tenant badge.
+
+Stable across a rebake (the badge's public identity):
+
+- **`badgeId`** — so the verification URL and any shared / Credly links keep
+  resolving.
+- **`verificationUrl`** — derived from the preserved `badgeId`.
+- **`issuedAt` / `validFrom`** — the achievement date must not shift.
+
+Re-minted by a rebake:
+
+- **The proof** — a fresh signature; the proof's `created` timestamp is _now_.
+- **`badgeJson` + `badgeJwt`** — regenerated in the current format.
+- **`bakedSvg`** — re-baked; the previous SVG asset is deleted so a rebake does
+  not orphan blobs.
+- **`generatorVersion`** — stamped to `BADGE_GENERATOR_VERSION`.
+
+### Outdated detection
+
+- **Admin badge page** (`/admin/speakers/badge`): a badge whose stored version
+  is below the current one shows an **"Outdated format"** marker with a per-row
+  **Rebake** action, plus a **"Rebake N outdated"** button that re-bakes the
+  conference's outdated badges sequentially and reports the count.
+- **System status** (`/admin/settings`): the `badges.outdated` check counts this
+  conference's outdated badges — `ok` at zero, `warn` with the count and a
+  pointer to the admin action otherwise.
+
 ---
 
 ## Multi-Tenant Support

--- a/docs/OPENBADGES_IMPLEMENTATION.md
+++ b/docs/OPENBADGES_IMPLEMENTATION.md
@@ -202,8 +202,9 @@ The badges are:
 - **Subject ID:** `mailto:speaker@example.com` (email-based recipient
   identity, always lowercased — Credly matches recipients by a
   case-sensitive email hash)
-- **Verification Method:** `{baseUrl}/api/badge/issuer#key-ed25519`
-  (embedded proof) and `{baseUrl}/api/badge/keys/key-1` (JWT `kid`)
+- **Verification Method:** `{baseUrl}/api/badge/keys/key-ed25519`
+  (embedded proof — a dereferenceable bare Multikey document, since #655) and
+  `{baseUrl}/api/badge/keys/key-1` (JWT `kid`)
 
 **URLs:**
 
@@ -220,9 +221,12 @@ The badges are:
 - **Type:** `DataIntegrityProof`
 - **Cryptosuite:** `eddsa-rdfc-2022` (Ed25519 signatures)
 - **Proof Purpose:** `assertionMethod`
-- **Verification Method:** `{baseUrl}/api/badge/issuer#key-ed25519` —
-  verifiers strip the fragment and fetch the issuer profile, which lists the
-  key in its `verificationMethod` array with `controller` = issuer id
+- **Verification Method:** `{baseUrl}/api/badge/keys/key-ed25519` — a
+  dereferenceable endpoint returning the bare Multikey document (the 1EdTech
+  EmbeddedProofProbe reads `controller`/`publicKeyMultibase` off the response
+  root; the pre-#655 issuer-profile fragment NPE'd it). The issuer profile
+  lists BOTH the new keys-URL id and the legacy `#key-ed25519` fragment so
+  badges baked before #655 keep verifying against our own routes until rebaked
 
 **JWT Proof (RS256 - Secondary):**
 
@@ -306,8 +310,9 @@ Every badge is signed with both methods:
 - **Document loader:** fully offline — Digital Bazaar's `securityLoader`
   extended with the vendored OB 3.0 context (`/lib/openbadges/data/`); our
   own signing/verification never fetches contexts over the network
-- **Verification Method:** `{baseUrl}/api/badge/issuer#key-ed25519`, listed
-  as a Multikey in the issuer profile with `controller` = issuer id
+- **Verification Method:** `{baseUrl}/api/badge/keys/key-ed25519` (bare
+  Multikey document; also listed in the issuer profile with `controller` =
+  issuer id, alongside the legacy fragment id for pre-#655 badges)
 - **Baking:** Credential embedded in SVG as
   `<openbadges:credential><![CDATA[{json}]]></openbadges:credential>`
   (no `verify` attribute)

--- a/sanity/schemaTypes/speakerBadge.ts
+++ b/sanity/schemaTypes/speakerBadge.ts
@@ -73,6 +73,15 @@ export default defineType({
       readOnly: true,
     }),
     defineField({
+      name: 'centerGraphicSvg',
+      title: 'Center Graphic SVG (issuance input)',
+      type: 'text',
+      description:
+        'The optional custom center graphic supplied at issuance, stored so an ' +
+        'in-place rebake can reproduce the visual identity. Absent for badges ' +
+        'issued before this field existed — those rebake with the default graphic.',
+    }),
+    defineField({
       name: 'bakedSvg',
       title: 'Baked SVG',
       type: 'file',

--- a/sanity/schemaTypes/speakerBadge.ts
+++ b/sanity/schemaTypes/speakerBadge.ts
@@ -48,6 +48,14 @@ export default defineType({
       readOnly: true,
     }),
     defineField({
+      name: 'generatorVersion',
+      title: 'Generator Version',
+      type: 'number',
+      description:
+        'Badge generator format version this artifact was baked with (see src/lib/badge/version.ts). Absent ⇒ v1 (pre-#655). Drives outdated-format detection and in-place rebake.',
+      readOnly: true,
+    }),
+    defineField({
       name: 'badgeJson',
       title: 'Badge JSON',
       type: 'text',

--- a/sanity/schemaTypes/speakerBadge.ts
+++ b/sanity/schemaTypes/speakerBadge.ts
@@ -76,6 +76,7 @@ export default defineType({
       name: 'centerGraphicSvg',
       title: 'Center Graphic SVG (issuance input)',
       type: 'text',
+      readOnly: true,
       description:
         'The optional custom center graphic supplied at issuance, stored so an ' +
         'in-place rebake can reproduce the visual identity. Absent for badges ' +

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -202,16 +202,21 @@ export function BadgeManagementClient({
     let succeeded = 0
     let failed = 0
     // Sequential — one Sanity write + asset upload each; keep the load bounded.
-    for (const badge of outdated) {
-      try {
-        await rebakeMutation.mutateAsync({ badgeId: badge.badgeId })
-        succeeded += 1
-      } catch {
-        failed += 1
+    try {
+      for (const badge of outdated) {
+        try {
+          await rebakeMutation.mutateAsync({ badgeId: badge.badgeId })
+          succeeded += 1
+        } catch {
+          failed += 1
+        }
       }
+      // A failed refetch must not strand the button in its disabled state or
+      // swallow the completion toast.
+      await refetchBadges().catch(() => undefined)
+    } finally {
+      setIsRebakingAll(false)
     }
-    await refetchBadges()
-    setIsRebakingAll(false)
     showNotification({
       type: failed > 0 ? (succeeded > 0 ? 'warning' : 'error') : 'success',
       title: 'Rebake Complete',

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -17,6 +17,7 @@ import {
   TrashIcon,
   ClipboardDocumentIcon,
   ArrowDownTrayIcon,
+  ArrowPathIcon,
   IdentificationIcon,
 } from '@heroicons/react/24/outline'
 import { ModalShell } from '@/components/ModalShell'
@@ -25,6 +26,8 @@ import { ConfirmationModal } from '@/components/admin/ConfirmationModal'
 import BadgeValidator from '@/components/admin/BadgeValidator'
 import { SearchInput } from '@/components/SearchInput'
 import { StatusBadge } from '@/components/StatusBadge'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { isBadgeOutdated } from '@/lib/badge/version'
 import type { BadgeRecord } from '@/lib/badge/types'
 import { createLocalhostWarning } from '@/lib/localhost-warning'
 import { useNotification } from './NotificationProvider'
@@ -162,6 +165,62 @@ export function BadgeManagementClient({
     },
   })
 
+  const [rebakingBadgeId, setRebakingBadgeId] = useState<string | null>(null)
+  const [isRebakingAll, setIsRebakingAll] = useState(false)
+
+  const rebakeMutation = api.badge.admin.rebake.useMutation()
+
+  const handleRebakeBadge = async (badgeId: string, speakerName: string) => {
+    setRebakingBadgeId(badgeId)
+    try {
+      await rebakeMutation.mutateAsync({ badgeId })
+      await refetchBadges()
+      showNotification({
+        type: 'success',
+        title: 'Badge Rebaked',
+        message: `Badge for ${speakerName} rebaked to the current format`,
+      })
+    } catch (error) {
+      showNotification({
+        type: 'error',
+        title: 'Rebake Failed',
+        message:
+          error instanceof Error ? error.message : 'Failed to rebake badge',
+      })
+    } finally {
+      setRebakingBadgeId(null)
+    }
+  }
+
+  const handleRebakeAllOutdated = async () => {
+    const outdated = (existingBadges || []).filter((b) =>
+      isBadgeOutdated(b.generatorVersion),
+    )
+    if (outdated.length === 0) return
+
+    setIsRebakingAll(true)
+    let succeeded = 0
+    let failed = 0
+    // Sequential — one Sanity write + asset upload each; keep the load bounded.
+    for (const badge of outdated) {
+      try {
+        await rebakeMutation.mutateAsync({ badgeId: badge.badgeId })
+        succeeded += 1
+      } catch {
+        failed += 1
+      }
+    }
+    await refetchBadges()
+    setIsRebakingAll(false)
+    showNotification({
+      type: failed > 0 ? (succeeded > 0 ? 'warning' : 'error') : 'success',
+      title: 'Rebake Complete',
+      message: `Rebaked ${succeeded} badge${succeeded === 1 ? '' : 's'}${
+        failed > 0 ? `, ${failed} failed` : ''
+      }`,
+    })
+  }
+
   const handleSelectSpeaker = (speakerId: string) => {
     const newSelection = new Set(selectedSpeakers)
     if (newSelection.has(speakerId)) {
@@ -237,6 +296,9 @@ export function BadgeManagementClient({
   }
 
   const badges = existingBadges || []
+  const outdatedCount = badges.filter((b) =>
+    isBadgeOutdated(b.generatorVersion),
+  ).length
   const localhostWarning = createLocalhostWarning(domain, 'badge recipients')
 
   const hasExistingBadge = (speakerId: string): boolean => {
@@ -418,6 +480,13 @@ export function BadgeManagementClient({
             <div className="text-xs text-gray-500 dark:text-gray-400">
               {formatDateSafe(badge.issuedAt)}
             </div>
+            {isBadgeOutdated(badge.generatorVersion) && (
+              <StatusBadge
+                label="Outdated format"
+                color="yellow"
+                icon={ExclamationTriangleIcon}
+              />
+            )}
             {hasEmailError && badge.emailError && (
               <div className="text-xs text-red-600 dark:text-red-400">
                 {badge.emailError}
@@ -458,6 +527,15 @@ export function BadgeManagementClient({
               download
             >
               Download
+            </ActionMenuItem>
+            <ActionMenuItem
+              onClick={() => handleRebakeBadge(badge.badgeId, speaker.name)}
+              icon={ArrowPathIcon}
+              disabled={rebakingBadgeId === badge.badgeId || isRebakingAll}
+            >
+              {isBadgeOutdated(badge.generatorVersion)
+                ? 'Rebake (outdated)'
+                : 'Rebake'}
             </ActionMenuItem>
             {isDevelopment && (
               <>
@@ -649,6 +727,22 @@ export function BadgeManagementClient({
                   </div>
                 </div>
               </FilterDropdown>
+              {outdatedCount > 0 && (
+                <AdminButton
+                  color="yellow"
+                  size="md"
+                  onClick={handleRebakeAllOutdated}
+                  disabled={isRebakingAll || rebakingBadgeId !== null}
+                  title="Re-bake every badge on an older credential format with the current generator"
+                >
+                  <ArrowPathIcon
+                    className={`h-4 w-4 ${isRebakingAll ? 'animate-spin' : ''}`}
+                  />
+                  {isRebakingAll
+                    ? 'Rebaking...'
+                    : `Rebake ${outdatedCount} outdated`}
+                </AdminButton>
+              )}
               <button
                 onClick={handlePreview}
                 className="flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -174,7 +174,9 @@ export function BadgeManagementClient({
     setRebakingBadgeId(badgeId)
     try {
       await rebakeMutation.mutateAsync({ badgeId })
-      await refetchBadges()
+      // Best-effort like the bulk path: a refetch hiccup after a SUCCESSFUL
+      // rebake must not masquerade as a rebake failure.
+      await refetchBadges().catch(() => undefined)
       showNotification({
         type: 'success',
         title: 'Badge Rebaked',
@@ -536,7 +538,7 @@ export function BadgeManagementClient({
             <ActionMenuItem
               onClick={() => handleRebakeBadge(badge.badgeId, speaker.name)}
               icon={ArrowPathIcon}
-              disabled={rebakingBadgeId === badge.badgeId || isRebakingAll}
+              disabled={rebakingBadgeId !== null || isRebakingAll}
             >
               {isBadgeOutdated(badge.generatorVersion)
                 ? 'Rebake (outdated)'

--- a/src/lib/badge/artifacts.ts
+++ b/src/lib/badge/artifacts.ts
@@ -1,0 +1,52 @@
+import { generateBadgeCredential } from './generator'
+import { generateBadgeSVG } from './svg'
+import { bakeBadge } from '@/lib/openbadges'
+import type { SignedCredential } from '@/lib/openbadges'
+import type { BadgeGenerationParams, BadgeConfiguration } from './types'
+
+/**
+ * Shared badge GENERATION internals — the code path both issuance and rebake
+ * run. It signs the credential (both formats), renders the SVG, and bakes the
+ * embedded-proof credential into it.
+ *
+ * The two callers differ only in bookkeeping, not generation:
+ *   - issuance  = build params from source data + generate + CREATE the doc
+ *   - rebake    = load the doc + generate (fixed id/date) + PATCH the doc
+ *
+ * so the generation lives here once. Pass `options.badgeId` /
+ * `options.validFrom` on a rebake to hold the badge id (and thus the
+ * verification URL) and the achievement date stable while the proof and format
+ * are re-minted; omit both on a fresh issuance to mint new ones.
+ */
+export async function generateBadgeArtifacts(
+  params: BadgeGenerationParams,
+  config: BadgeConfiguration,
+  options?: { badgeId?: string; validFrom?: string },
+): Promise<{
+  credentialJson: SignedCredential
+  credentialJwt: string
+  badgeId: string
+  bakedSvg: string
+  verificationUrl: string
+}> {
+  const { credentialJson, credentialJwt, badgeId } =
+    await generateBadgeCredential(params, config, options)
+
+  const svgContent = generateBadgeSVG({
+    conferenceTitle: params.conferenceTitle,
+    conferenceYear: params.conferenceYear,
+    conferenceDate: params.conferenceDate,
+    badgeType: params.badgeType,
+    centerGraphicSvg: params.centerGraphicSvg,
+  })
+
+  // The verification URL is derived purely from the (preserved-on-rebake)
+  // badgeId, so a rebake reproduces the exact same URL.
+  const verificationUrl = `${config.baseUrl}/badge/${badgeId}`
+
+  // Bake the embedded-proof credential into the SVG — this is the artifact
+  // recipients download and upload to OB 3.0 displayers such as Credly.
+  const bakedSvg = bakeBadge(svgContent, credentialJson)
+
+  return { credentialJson, credentialJwt, badgeId, bakedSvg, verificationUrl }
+}

--- a/src/lib/badge/artifacts.ts
+++ b/src/lib/badge/artifacts.ts
@@ -3,6 +3,7 @@ import { generateBadgeSVG } from './svg'
 import { bakeBadge } from '@/lib/openbadges'
 import type { SignedCredential } from '@/lib/openbadges'
 import type { BadgeGenerationParams, BadgeConfiguration } from './types'
+import { formatConferenceDateForBadge } from '@/lib/time'
 
 /**
  * Shared badge GENERATION internals — the code path both issuance and rebake
@@ -18,6 +19,23 @@ import type { BadgeGenerationParams, BadgeConfiguration } from './types'
  * verification URL) and the achievement date stable while the proof and format
  * are re-minted; omit both on a fresh issuance to mint new ones.
  */
+/**
+ * Conference display fields for badge generation — ONE derivation shared by
+ * issuance and rebake so the two paths can never disagree.
+ */
+export function deriveBadgeConferenceFields(conference: {
+  startDate?: string
+}): { conferenceYear: string; conferenceDate: string } {
+  return {
+    conferenceYear: conference.startDate
+      ? new Date(conference.startDate).getFullYear().toString()
+      : new Date().getFullYear().toString(),
+    conferenceDate: conference.startDate
+      ? formatConferenceDateForBadge(conference.startDate)
+      : 'TBD',
+  }
+}
+
 export async function generateBadgeArtifacts(
   params: BadgeGenerationParams,
   config: BadgeConfiguration,

--- a/src/lib/badge/artifacts.ts
+++ b/src/lib/badge/artifacts.ts
@@ -27,9 +27,13 @@ export function deriveBadgeConferenceFields(conference: {
   startDate?: string
 }): { conferenceYear: string; conferenceDate: string } {
   return {
+    // Year straight from the date string when it's ISO-shaped: bare
+    // YYYY-MM-DD parses as UTC midnight, and getFullYear() reads the LOCAL
+    // zone — off by one west of UTC on Jan 1. getUTCFullYear as the fallback.
     conferenceYear: conference.startDate
-      ? new Date(conference.startDate).getFullYear().toString()
-      : new Date().getFullYear().toString(),
+      ? (/^\d{4}/.exec(conference.startDate)?.[0] ??
+        new Date(conference.startDate).getUTCFullYear().toString())
+      : new Date().getUTCFullYear().toString(),
     conferenceDate: conference.startDate
       ? formatConferenceDateForBadge(conference.startDate)
       : 'TBD',

--- a/src/lib/badge/generator.ts
+++ b/src/lib/badge/generator.ts
@@ -21,6 +21,12 @@ import type { BadgeGenerationParams, BadgeConfiguration } from './types'
  *
  * @param params - Badge generation parameters (speaker info, talk info, etc.)
  * @param config - Badge configuration (keys, URLs, issuer info)
+ * @param options - Optional identity overrides. On a fresh issuance both are
+ *   omitted and a new `badgeId`/`validFrom` (now) are minted. On a REBAKE the
+ *   caller passes the STORED `badgeId` (so the verification URL and any shared /
+ *   Credly links keep resolving) and the STORED `validFrom` (so the achievement
+ *   date does not shift). The proof's `created` timestamp is always minted now
+ *   by the signing layer — a rebake re-mints the proof but preserves the claim.
  * @returns Promise resolving to both signed formats and the badge ID
  *
  * @example
@@ -35,6 +41,7 @@ import type { BadgeGenerationParams, BadgeConfiguration } from './types'
 export async function generateBadgeCredential(
   params: BadgeGenerationParams,
   config: BadgeConfiguration,
+  options?: { badgeId?: string; validFrom?: string },
 ): Promise<{
   credentialJson: SignedCredential
   credentialJwt: string
@@ -50,8 +57,10 @@ export async function generateBadgeCredential(
     talkTitle,
   } = params
 
-  const badgeId = crypto.randomUUID()
-  const issuedAt = getCurrentDateTime()
+  const badgeId = options?.badgeId ?? crypto.randomUUID()
+  // validFrom is the achievement date. Preserve it verbatim on a rebake; mint
+  // now on a fresh issuance.
+  const issuedAt = options?.validFrom ?? getCurrentDateTime()
 
   const evidence: Array<{
     id: string

--- a/src/lib/badge/issuance.ts
+++ b/src/lib/badge/issuance.ts
@@ -4,7 +4,7 @@ import {
   generateBadgeArtifacts,
 } from './artifacts'
 import { createBadgeConfiguration } from './config'
-import { formatConferenceDateForBadge, getCurrentDateTime } from '@/lib/time'
+import { getCurrentDateTime } from '@/lib/time'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import { createBadge, uploadBadgeSVGAsset, checkBadgeExists } from './sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'

--- a/src/lib/badge/issuance.ts
+++ b/src/lib/badge/issuance.ts
@@ -1,12 +1,38 @@
 import type { BadgeType } from './types'
-import { generateBadgeCredential } from './generator'
+import { generateBadgeArtifacts } from './artifacts'
 import { createBadgeConfiguration } from './config'
-import { generateBadgeSVG } from './svg'
-import { bakeBadge } from '@/lib/openbadges'
 import { formatConferenceDateForBadge, getCurrentDateTime } from '@/lib/time'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import { createBadge, uploadBadgeSVGAsset, checkBadgeExists } from './sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { BADGE_GENERATOR_VERSION } from './version'
+
+/**
+ * The accepted/confirmed talk that seeds a SPEAKER badge's talk evidence.
+ * Shared by issuance and rebake so both derive the same evidence from the same
+ * source of truth. Returns empty fields for organizer badges (no talk) or when
+ * the speaker has no qualifying talk.
+ */
+export async function resolveAcceptedTalk(
+  speakerId: string,
+  conferenceId: string,
+): Promise<{ talkId?: string; talkTitle?: string }> {
+  const { clientReadUncached } = await import('@/lib/sanity/client')
+  const acceptedTalk = await clientReadUncached.fetch<{
+    _id: string
+    title: string
+  } | null>(
+    `*[_type == "talk" &&
+      references($speakerId) &&
+      references($conferenceId) &&
+      status in ["accepted", "confirmed"]
+    ][0]{_id, title}`,
+    { speakerId, conferenceId },
+  )
+  return acceptedTalk
+    ? { talkId: acceptedTalk._id, talkTitle: acceptedTalk.title }
+    : {}
+}
 
 interface IssueBadgeParams {
   speakerId: string
@@ -120,29 +146,13 @@ export async function issueBadgeForSpeaker(
 
   const config = await createBadgeConfiguration(conference, domain)
 
-  let talkId: string | undefined
-  let talkTitle: string | undefined
-  if (badgeType === 'speaker') {
-    const { clientReadUncached } = await import('@/lib/sanity/client')
-    const acceptedTalk = await clientReadUncached.fetch<{
-      _id: string
-      title: string
-    } | null>(
-      `*[_type == "talk" &&
-        references($speakerId) &&
-        references($conferenceId) &&
-        status in ["accepted", "confirmed"]
-      ][0]{_id, title}`,
-      { speakerId: speaker._id, conferenceId },
-    )
-    if (acceptedTalk) {
-      talkId = acceptedTalk._id
-      talkTitle = acceptedTalk.title
-    }
-  }
+  const { talkId, talkTitle } =
+    badgeType === 'speaker'
+      ? await resolveAcceptedTalk(speaker._id, conferenceId)
+      : {}
 
-  const { credentialJson, credentialJwt, badgeId } =
-    await generateBadgeCredential(
+  const { credentialJson, credentialJwt, badgeId, bakedSvg, verificationUrl } =
+    await generateBadgeArtifacts(
       {
         speakerId: speaker._id,
         speakerName: speaker.name,
@@ -159,19 +169,6 @@ export async function issueBadgeForSpeaker(
       },
       config,
     )
-
-  const svgContent = generateBadgeSVG({
-    conferenceTitle: conference.title,
-    conferenceYear,
-    conferenceDate,
-    badgeType,
-    centerGraphicSvg,
-  })
-
-  const verificationUrl = `${config.baseUrl}/badge/${badgeId}`
-  // Bake the embedded-proof credential into the SVG — this is the artifact
-  // recipients download and upload to OB 3.0 displayers such as Credly
-  const bakedSvg = bakeBadge(svgContent, credentialJson)
 
   const { assetId, error: uploadError } = await uploadBadgeSVGAsset(
     bakedSvg,
@@ -192,6 +189,7 @@ export async function issueBadgeForSpeaker(
     badgeJwt: credentialJwt,
     bakedSvgAssetId: assetId,
     verificationUrl,
+    generatorVersion: BADGE_GENERATOR_VERSION,
   })
 
   if (createError || !badge) {

--- a/src/lib/badge/issuance.ts
+++ b/src/lib/badge/issuance.ts
@@ -1,5 +1,8 @@
 import type { BadgeType } from './types'
-import { generateBadgeArtifacts } from './artifacts'
+import {
+  deriveBadgeConferenceFields,
+  generateBadgeArtifacts,
+} from './artifacts'
 import { createBadgeConfiguration } from './config'
 import { formatConferenceDateForBadge, getCurrentDateTime } from '@/lib/time'
 import { getSpeaker } from '@/lib/speaker/sanity'
@@ -136,13 +139,8 @@ export async function issueBadgeForSpeaker(
     return { success: false, error: 'Conference not found' }
   }
 
-  const conferenceYear = conference.startDate
-    ? new Date(conference.startDate).getFullYear().toString()
-    : new Date().getFullYear().toString()
-
-  const conferenceDate = conference.startDate
-    ? formatConferenceDateForBadge(conference.startDate)
-    : 'TBD'
+  const { conferenceYear, conferenceDate } =
+    deriveBadgeConferenceFields(conference)
 
   const config = await createBadgeConfiguration(conference, domain)
 
@@ -190,6 +188,8 @@ export async function issueBadgeForSpeaker(
     conferenceId: conference._id,
     badgeType,
     issuedAt,
+    // Stored so an in-place rebake reproduces the visual identity.
+    ...(centerGraphicSvg ? { centerGraphicSvg } : {}),
     badgeJson: JSON.stringify(credentialJson),
     badgeJwt: credentialJwt,
     bakedSvgAssetId: assetId,

--- a/src/lib/badge/issuance.ts
+++ b/src/lib/badge/issuance.ts
@@ -151,6 +151,10 @@ export async function issueBadgeForSpeaker(
       ? await resolveAcceptedTalk(speaker._id, conferenceId)
       : {}
 
+  // ONE timestamp: the credential's validFrom and the stored issuedAt must be
+  // the same instant (a rebake later reuses issuedAt as validFrom).
+  const issuedAt = getCurrentDateTime()
+
   const { credentialJson, credentialJwt, badgeId, bakedSvg, verificationUrl } =
     await generateBadgeArtifacts(
       {
@@ -168,6 +172,7 @@ export async function issueBadgeForSpeaker(
         talkTitle,
       },
       config,
+      { validFrom: issuedAt },
     )
 
   const { assetId, error: uploadError } = await uploadBadgeSVGAsset(
@@ -184,7 +189,7 @@ export async function issueBadgeForSpeaker(
     speakerId: speaker._id,
     conferenceId: conference._id,
     badgeType,
-    issuedAt: getCurrentDateTime(),
+    issuedAt,
     badgeJson: JSON.stringify(credentialJson),
     badgeJwt: credentialJwt,
     bakedSvgAssetId: assetId,

--- a/src/lib/badge/rebake.test.ts
+++ b/src/lib/badge/rebake.test.ts
@@ -167,11 +167,22 @@ describe('rebakeBadge — tenant scoping', () => {
   })
 
   it('reports not_found for a missing badge', async () => {
-    getBadgeByIdMock.mockResolvedValue({ error: new Error('Badge not found') })
+    // Absent badge WITHOUT a read error — a failed read is 'error', not
+    // 'not_found' (a transient Sanity failure must never read as missing).
+    getBadgeByIdMock.mockResolvedValue({ badge: undefined })
 
     const res = await rebakeBadge({ badgeId: 'nope', conferenceId: 'conf-A' })
 
     expect(res).toMatchObject({ success: false, reason: 'not_found' })
+    expect(generateBadgeArtifactsMock).not.toHaveBeenCalled()
+  })
+
+  it('reports error (not not_found) for a failed badge read', async () => {
+    getBadgeByIdMock.mockResolvedValue({ error: new Error('sanity down') })
+
+    const res = await rebakeBadge({ badgeId: 'b-1', conferenceId: 'conf-A' })
+
+    expect(res).toMatchObject({ success: false, reason: 'error' })
     expect(generateBadgeArtifactsMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/badge/rebake.test.ts
+++ b/src/lib/badge/rebake.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @vitest-environment node
+ *
+ * Rebake round-trip + tenant scoping. Sanity and generation are mocked so the
+ * test pins BEHAVIOUR, not I/O:
+ *   - the badge is patched IN PLACE (same badgeId / verificationUrl / issuedAt),
+ *   - the current generatorVersion is stamped,
+ *   - the regenerated artifacts differ from the stored ones,
+ *   - a cross-tenant badge is denied without generating or patching anything.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BADGE_GENERATOR_VERSION } from './version'
+
+const getBadgeByIdMock = vi.fn()
+const patchBadgeArtifactsMock = vi.fn()
+const uploadBadgeSVGAssetMock = vi.fn()
+const generateBadgeArtifactsMock = vi.fn()
+const createBadgeConfigurationMock = vi.fn()
+const resolveAcceptedTalkMock = vi.fn()
+const getConferenceMock = vi.fn()
+
+vi.mock('./sanity', () => ({
+  getBadgeById: (...a: unknown[]) => getBadgeByIdMock(...a),
+  patchBadgeArtifacts: (...a: unknown[]) => patchBadgeArtifactsMock(...a),
+  uploadBadgeSVGAsset: (...a: unknown[]) => uploadBadgeSVGAssetMock(...a),
+}))
+vi.mock('./artifacts', () => ({
+  generateBadgeArtifacts: (...a: unknown[]) => generateBadgeArtifactsMock(...a),
+}))
+vi.mock('./config', () => ({
+  createBadgeConfiguration: (...a: unknown[]) =>
+    createBadgeConfigurationMock(...a),
+}))
+vi.mock('./issuance', () => ({
+  resolveAcceptedTalk: (...a: unknown[]) => resolveAcceptedTalkMock(...a),
+}))
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...a: unknown[]) => getConferenceMock(...a),
+}))
+vi.mock('@/lib/time', () => ({
+  formatConferenceDateForBadge: () => 'JAN 1, 2025',
+}))
+
+import { rebakeBadge } from './rebake'
+
+const ISSUED_AT = '2024-01-15T10:00:00.000Z'
+const OLD_JSON = JSON.stringify({ proof: [{ verificationMethod: 'old#frag' }] })
+const NEW_CREDENTIAL = {
+  proof: [{ verificationMethod: 'https://x/api/badge/keys/key-ed25519' }],
+}
+
+function storedBadge(overrides?: Record<string, unknown>) {
+  return {
+    _id: 'doc-1',
+    badgeId: 'bid-1',
+    badgeType: 'speaker',
+    issuedAt: ISSUED_AT,
+    verificationUrl: 'https://x/badge/bid-1',
+    // absent generatorVersion ⇒ v1 (the pre-#655 target)
+    badgeJson: OLD_JSON,
+    speaker: {
+      _id: 'sp-1',
+      name: 'Ada Lovelace',
+      email: 'ada@x.test',
+      slug: 'ada',
+    },
+    conference: { _id: 'conf-A', title: 'X Conf', startDate: '2025-01-01' },
+    emailSent: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  createBadgeConfigurationMock.mockResolvedValue({ baseUrl: 'https://x' })
+  resolveAcceptedTalkMock.mockResolvedValue({
+    talkId: 't-1',
+    talkTitle: 'Analytical Engine',
+  })
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: 'conf-A', title: 'X Conf', startDate: '2025-01-01' },
+    domain: 'x',
+    error: null,
+  })
+  generateBadgeArtifactsMock.mockResolvedValue({
+    credentialJson: NEW_CREDENTIAL,
+    credentialJwt: 'new.jwt.value',
+    badgeId: 'bid-1',
+    bakedSvg: '<svg>new</svg>',
+    verificationUrl: 'https://x/badge/bid-1',
+  })
+  uploadBadgeSVGAssetMock.mockResolvedValue({ assetId: 'asset-new' })
+  patchBadgeArtifactsMock.mockImplementation(async (_badgeId, patch) => ({
+    badge: {
+      ...storedBadge(),
+      badgeJson: patch.badgeJson,
+      badgeJwt: patch.badgeJwt,
+      generatorVersion: patch.generatorVersion,
+    },
+  }))
+})
+
+describe('rebakeBadge — round trip', () => {
+  it('preserves badgeId + issuedAt while re-minting the credential', async () => {
+    getBadgeByIdMock.mockResolvedValue({ badge: storedBadge() })
+
+    const res = await rebakeBadge({ badgeId: 'bid-1', conferenceId: 'conf-A' })
+
+    expect(res.success).toBe(true)
+
+    // Generation was asked to PRESERVE the identity: same badgeId + the stored
+    // issuedAt as validFrom (so the achievement date does not shift).
+    const [, , options] = generateBadgeArtifactsMock.mock.calls[0]
+    expect(options).toEqual({ badgeId: 'bid-1', validFrom: ISSUED_AT })
+
+    // The doc is patched IN PLACE (same badgeId) with the current version and
+    // the NEW artifacts.
+    const [patchedBadgeId, patch] = patchBadgeArtifactsMock.mock.calls[0]
+    expect(patchedBadgeId).toBe('bid-1')
+    expect(patch.generatorVersion).toBe(BADGE_GENERATOR_VERSION)
+    expect(patch.badgeJson).toBe(JSON.stringify(NEW_CREDENTIAL))
+    expect(patch.badgeJwt).toBe('new.jwt.value')
+    expect(patch.bakedSvgAssetId).toBe('asset-new')
+
+    // The regenerated artifacts differ from what was stored.
+    expect(patch.badgeJson).not.toBe(OLD_JSON)
+  })
+
+  it('returns the updated badge stamped at the current version, URL unchanged', async () => {
+    getBadgeByIdMock.mockResolvedValue({ badge: storedBadge() })
+
+    const res = await rebakeBadge({ badgeId: 'bid-1', conferenceId: 'conf-A' })
+
+    expect(res.success).toBe(true)
+    if (!res.success) return
+    expect(res.badge.generatorVersion).toBe(BADGE_GENERATOR_VERSION)
+    expect(res.badge.badgeId).toBe('bid-1')
+    expect(res.badge.verificationUrl).toBe('https://x/badge/bid-1')
+    expect(res.badge.issuedAt).toBe(ISSUED_AT)
+  })
+
+  it('skips the talk query for organizer badges', async () => {
+    getBadgeByIdMock.mockResolvedValue({
+      badge: storedBadge({ badgeType: 'organizer' }),
+    })
+
+    await rebakeBadge({ badgeId: 'bid-1', conferenceId: 'conf-A' })
+
+    expect(resolveAcceptedTalkMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('rebakeBadge — tenant scoping', () => {
+  it('DENIES a badge that belongs to another conference (cross-tenant)', async () => {
+    getBadgeByIdMock.mockResolvedValue({
+      badge: storedBadge({
+        conference: { _id: 'conf-B', title: 'Other', startDate: '2025-01-01' },
+      }),
+    })
+
+    const res = await rebakeBadge({ badgeId: 'bid-1', conferenceId: 'conf-A' })
+
+    expect(res).toMatchObject({ success: false, reason: 'forbidden' })
+    // Nothing was generated or written for a cross-tenant badge.
+    expect(generateBadgeArtifactsMock).not.toHaveBeenCalled()
+    expect(patchBadgeArtifactsMock).not.toHaveBeenCalled()
+  })
+
+  it('reports not_found for a missing badge', async () => {
+    getBadgeByIdMock.mockResolvedValue({ error: new Error('Badge not found') })
+
+    const res = await rebakeBadge({ badgeId: 'nope', conferenceId: 'conf-A' })
+
+    expect(res).toMatchObject({ success: false, reason: 'not_found' })
+    expect(generateBadgeArtifactsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/badge/rebake.test.ts
+++ b/src/lib/badge/rebake.test.ts
@@ -24,7 +24,9 @@ vi.mock('./sanity', () => ({
   patchBadgeArtifacts: (...a: unknown[]) => patchBadgeArtifactsMock(...a),
   uploadBadgeSVGAsset: (...a: unknown[]) => uploadBadgeSVGAssetMock(...a),
 }))
-vi.mock('./artifacts', () => ({
+vi.mock('./artifacts', async (importOriginal) => ({
+  // Keep the REAL pure derivation; mock only the generation I/O boundary.
+  ...(await importOriginal<typeof import('./artifacts')>()),
   generateBadgeArtifacts: (...a: unknown[]) => generateBadgeArtifactsMock(...a),
 }))
 vi.mock('./config', () => ({

--- a/src/lib/badge/rebake.ts
+++ b/src/lib/badge/rebake.ts
@@ -1,6 +1,7 @@
 import { generateBadgeArtifacts } from './artifacts'
 import { createBadgeConfiguration } from './config'
 import {
+  deleteBadgeSVGAsset,
   getBadgeById,
   patchBadgeArtifacts,
   uploadBadgeSVGAsset,
@@ -57,7 +58,12 @@ export async function rebakeBadge(
   params: RebakeBadgeParams,
 ): Promise<RebakeBadgeResult> {
   const { badge, error } = await getBadgeById(params.badgeId)
-  if (error || !badge) {
+  if (error) {
+    // A failed READ is not "not found" — surface it as an error so a
+    // transient Sanity failure never reads as a missing badge.
+    return { success: false, reason: 'error', error: 'Failed to load badge' }
+  }
+  if (!badge) {
     return { success: false, reason: 'not_found', error: 'Badge not found' }
   }
 
@@ -84,14 +90,27 @@ export async function rebakeBadge(
   }
 
   // Speaker is dereferenced on the badge record (name/email/slug). Guard the
-  // shape defensively — a bare reference cannot seed the credential.
-  const speaker = badge.speaker
-  if (!speaker || typeof speaker !== 'object' || !('email' in speaker)) {
+  // shape defensively — everything generation touches must be present; a bare
+  // reference or partial dereference cannot seed the credential or filename.
+  const rawSpeaker = badge.speaker as Record<string, unknown> | undefined
+  const isUsableSpeaker =
+    !!rawSpeaker &&
+    typeof rawSpeaker === 'object' &&
+    typeof rawSpeaker._id === 'string' &&
+    typeof rawSpeaker.name === 'string' &&
+    typeof rawSpeaker.email === 'string'
+  if (!isUsableSpeaker) {
     return {
       success: false,
       reason: 'error',
       error: 'Badge speaker data unavailable',
     }
+  }
+  const speaker = rawSpeaker as {
+    _id: string
+    name: string
+    email: string
+    slug?: string
   }
 
   const conferenceYear = conference.startDate
@@ -108,55 +127,74 @@ export async function rebakeBadge(
       ? await resolveAcceptedTalk(speaker._id, conference._id)
       : {}
 
-  const { credentialJson, credentialJwt, bakedSvg } =
-    await generateBadgeArtifacts(
-      {
-        speakerId: speaker._id,
-        speakerName: speaker.name,
-        speakerEmail: speaker.email,
-        speakerSlug: speaker.slug,
-        conferenceId: conference._id,
-        conferenceTitle: conference.title,
-        conferenceYear,
-        conferenceDate,
-        badgeType: badge.badgeType,
-        talkId,
-        talkTitle,
-      },
-      config,
-      // Preserve the identity: same badgeId (⇒ same verificationUrl) and the
-      // original achievement date. The proof's `created` is minted now.
-      { badgeId: badge.badgeId, validFrom: badge.issuedAt },
+  try {
+    return await regenerateAndPatch()
+  } catch (err) {
+    // generateBadgeArtifacts/createBadgeConfiguration can throw (signing key
+    // material, canvas failures); the mutation contract is a STRUCTURED
+    // result, never an unexpected tRPC internal error.
+    console.error('rebakeBadge failed:', err)
+    return {
+      success: false,
+      reason: 'error',
+      error: err instanceof Error ? err.message : 'Rebake failed',
+    }
+  }
+
+  async function regenerateAndPatch(): Promise<RebakeBadgeResult> {
+    const { credentialJson, credentialJwt, bakedSvg } =
+      await generateBadgeArtifacts(
+        {
+          speakerId: speaker._id,
+          speakerName: speaker.name,
+          speakerEmail: speaker.email,
+          speakerSlug: speaker.slug,
+          conferenceId: conference._id,
+          conferenceTitle: conference.title,
+          conferenceYear,
+          conferenceDate,
+          badgeType: badge!.badgeType,
+          talkId,
+          talkTitle,
+        },
+        config,
+        // Preserve the identity: same badgeId (⇒ same verificationUrl) and the
+        // original achievement date. The proof's `created` is minted now.
+        { badgeId: badge!.badgeId, validFrom: badge!.issuedAt },
+      )
+
+    const { assetId, error: uploadError } = await uploadBadgeSVGAsset(
+      bakedSvg,
+      `badge-${speaker!.name.replace(/\s+/g, '-').toLowerCase()}-${badge!.badgeId}.svg`,
     )
-
-  const { assetId, error: uploadError } = await uploadBadgeSVGAsset(
-    bakedSvg,
-    `badge-${speaker.name.replace(/\s+/g, '-').toLowerCase()}-${badge.badgeId}.svg`,
-  )
-  if (uploadError || !assetId) {
-    return {
-      success: false,
-      reason: 'error',
-      error: 'Failed to upload badge SVG',
+    if (uploadError || !assetId) {
+      return {
+        success: false,
+        reason: 'error',
+        error: 'Failed to upload badge SVG',
+      }
     }
-  }
 
-  const { badge: updated, error: patchError } = await patchBadgeArtifacts(
-    badge.badgeId,
-    {
-      badgeJson: JSON.stringify(credentialJson),
-      badgeJwt: credentialJwt,
-      bakedSvgAssetId: assetId,
-      generatorVersion: BADGE_GENERATOR_VERSION,
-    },
-  )
-  if (patchError || !updated) {
-    return {
-      success: false,
-      reason: 'error',
-      error: 'Failed to update badge record',
+    const { badge: updated, error: patchError } = await patchBadgeArtifacts(
+      badge!.badgeId,
+      {
+        badgeJson: JSON.stringify(credentialJson),
+        badgeJwt: credentialJwt,
+        bakedSvgAssetId: assetId,
+        generatorVersion: BADGE_GENERATOR_VERSION,
+      },
+    )
+    if (patchError || !updated) {
+      // The new asset is referenced by nothing — best-effort cleanup so a
+      // failed patch doesn't orphan it in the dataset.
+      await deleteBadgeSVGAsset(assetId).catch(() => undefined)
+      return {
+        success: false,
+        reason: 'error',
+        error: 'Failed to update badge record',
+      }
     }
-  }
 
-  return { success: true, badge: updated }
+    return { success: true, badge: updated }
+  }
 }

--- a/src/lib/badge/rebake.ts
+++ b/src/lib/badge/rebake.ts
@@ -1,4 +1,7 @@
-import { generateBadgeArtifacts } from './artifacts'
+import {
+  deriveBadgeConferenceFields,
+  generateBadgeArtifacts,
+} from './artifacts'
 import { createBadgeConfiguration } from './config'
 import {
   deleteBadgeSVGAsset,
@@ -8,7 +11,6 @@ import {
 } from './sanity'
 import { resolveAcceptedTalk } from './issuance'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
-import { formatConferenceDateForBadge } from '@/lib/time'
 import { BADGE_GENERATOR_VERSION } from './version'
 import type { BadgeRecord } from './types'
 
@@ -54,6 +56,17 @@ function refId(
  * badgeJwt, the baked SVG and the proof are re-minted, and generatorVersion is
  * stamped to the current version.
  */
+/** The signed credential's own validFrom, when the stored JSON parses. */
+function storedValidFrom(badgeJson?: string): string | undefined {
+  if (!badgeJson) return undefined
+  try {
+    const parsed = JSON.parse(badgeJson) as { validFrom?: unknown }
+    return typeof parsed.validFrom === 'string' ? parsed.validFrom : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export async function rebakeBadge(
   params: RebakeBadgeParams,
 ): Promise<RebakeBadgeResult> {
@@ -113,12 +126,8 @@ export async function rebakeBadge(
     slug?: string
   }
 
-  const conferenceYear = conference.startDate
-    ? new Date(conference.startDate).getFullYear().toString()
-    : new Date().getFullYear().toString()
-  const conferenceDate = conference.startDate
-    ? formatConferenceDateForBadge(conference.startDate)
-    : 'TBD'
+  const { conferenceYear, conferenceDate } =
+    deriveBadgeConferenceFields(conference)
 
   const config = await createBadgeConfiguration(conference, domain)
 
@@ -154,13 +163,22 @@ export async function rebakeBadge(
           conferenceYear,
           conferenceDate,
           badgeType: badge!.badgeType,
+          // Custom center graphic stored at issuance (absent on badges issued
+          // before the field existed — those rebake with the default).
+          centerGraphicSvg: badge!.centerGraphicSvg,
           talkId,
           talkTitle,
         },
         config,
-        // Preserve the identity: same badgeId (⇒ same verificationUrl) and the
-        // original achievement date. The proof's `created` is minted now.
-        { badgeId: badge!.badgeId, validFrom: badge!.issuedAt },
+        // Preserve the identity: same badgeId (⇒ same verificationUrl) and
+        // the ORIGINAL achievement date — preferring the previously SIGNED
+        // credential's own validFrom (pre-unification badges can have
+        // issuedAt drift from it by milliseconds; the signed value is the
+        // source of truth). The proof's `created` is minted now.
+        {
+          badgeId: badge!.badgeId,
+          validFrom: storedValidFrom(badge!.badgeJson) ?? badge!.issuedAt,
+        },
       )
 
     const { assetId, error: uploadError } = await uploadBadgeSVGAsset(

--- a/src/lib/badge/rebake.ts
+++ b/src/lib/badge/rebake.ts
@@ -1,0 +1,162 @@
+import { generateBadgeArtifacts } from './artifacts'
+import { createBadgeConfiguration } from './config'
+import {
+  getBadgeById,
+  patchBadgeArtifacts,
+  uploadBadgeSVGAsset,
+} from './sanity'
+import { resolveAcceptedTalk } from './issuance'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { formatConferenceDateForBadge } from '@/lib/time'
+import { BADGE_GENERATOR_VERSION } from './version'
+import type { BadgeRecord } from './types'
+
+interface RebakeBadgeParams {
+  badgeId: string
+  /**
+   * The request's authoritative (domain-derived) conference id. The badge is
+   * rebaked ONLY if it belongs to this conference — the tenant scope. This is
+   * the tightest form of the E11 org gate: the admin badge surface is
+   * per-conference, so a badge from another conference (and therefore possibly
+   * another org) is denied outright.
+   */
+  conferenceId: string
+}
+
+type RebakeFailureReason = 'not_found' | 'forbidden' | 'error'
+
+interface RebakeSuccess {
+  success: true
+  badge: BadgeRecord
+}
+
+interface RebakeFailure {
+  success: false
+  reason: RebakeFailureReason
+  error: string
+}
+
+export type RebakeBadgeResult = RebakeSuccess | RebakeFailure
+
+function refId(
+  ref: { _id?: string; _ref?: string } | string | undefined,
+): string | undefined {
+  if (!ref) return undefined
+  if (typeof ref === 'string') return ref
+  return ref._id ?? ref._ref
+}
+
+/**
+ * Re-bake a single badge in place with the CURRENT generator. Idempotent: it
+ * refuses nothing except a missing badge or a cross-tenant badge. The badgeId,
+ * verificationUrl and issuedAt (achievement date) are preserved; badgeJson,
+ * badgeJwt, the baked SVG and the proof are re-minted, and generatorVersion is
+ * stamped to the current version.
+ */
+export async function rebakeBadge(
+  params: RebakeBadgeParams,
+): Promise<RebakeBadgeResult> {
+  const { badge, error } = await getBadgeById(params.badgeId)
+  if (error || !badge) {
+    return { success: false, reason: 'not_found', error: 'Badge not found' }
+  }
+
+  // TENANT SCOPE (fail closed): the badge must belong to the request's
+  // conference. A badge for a different conference/org is denied.
+  const badgeConferenceId = refId(
+    badge.conference as { _id?: string; _ref?: string } | string | undefined,
+  )
+  if (!badgeConferenceId || badgeConferenceId !== params.conferenceId) {
+    return {
+      success: false,
+      reason: 'forbidden',
+      error: 'Badge does not belong to this conference',
+    }
+  }
+
+  const {
+    conference,
+    domain,
+    error: conferenceError,
+  } = await getConferenceForCurrentDomain()
+  if (conferenceError || !conference) {
+    return { success: false, reason: 'error', error: 'Conference not found' }
+  }
+
+  // Speaker is dereferenced on the badge record (name/email/slug). Guard the
+  // shape defensively — a bare reference cannot seed the credential.
+  const speaker = badge.speaker
+  if (!speaker || typeof speaker !== 'object' || !('email' in speaker)) {
+    return {
+      success: false,
+      reason: 'error',
+      error: 'Badge speaker data unavailable',
+    }
+  }
+
+  const conferenceYear = conference.startDate
+    ? new Date(conference.startDate).getFullYear().toString()
+    : new Date().getFullYear().toString()
+  const conferenceDate = conference.startDate
+    ? formatConferenceDateForBadge(conference.startDate)
+    : 'TBD'
+
+  const config = await createBadgeConfiguration(conference, domain)
+
+  const { talkId, talkTitle } =
+    badge.badgeType === 'speaker'
+      ? await resolveAcceptedTalk(speaker._id, conference._id)
+      : {}
+
+  const { credentialJson, credentialJwt, bakedSvg } =
+    await generateBadgeArtifacts(
+      {
+        speakerId: speaker._id,
+        speakerName: speaker.name,
+        speakerEmail: speaker.email,
+        speakerSlug: speaker.slug,
+        conferenceId: conference._id,
+        conferenceTitle: conference.title,
+        conferenceYear,
+        conferenceDate,
+        badgeType: badge.badgeType,
+        talkId,
+        talkTitle,
+      },
+      config,
+      // Preserve the identity: same badgeId (⇒ same verificationUrl) and the
+      // original achievement date. The proof's `created` is minted now.
+      { badgeId: badge.badgeId, validFrom: badge.issuedAt },
+    )
+
+  const { assetId, error: uploadError } = await uploadBadgeSVGAsset(
+    bakedSvg,
+    `badge-${speaker.name.replace(/\s+/g, '-').toLowerCase()}-${badge.badgeId}.svg`,
+  )
+  if (uploadError || !assetId) {
+    return {
+      success: false,
+      reason: 'error',
+      error: 'Failed to upload badge SVG',
+    }
+  }
+
+  const { badge: updated, error: patchError } = await patchBadgeArtifacts(
+    badge.badgeId,
+    {
+      badgeJson: JSON.stringify(credentialJson),
+      badgeJwt: credentialJwt,
+      bakedSvgAssetId: assetId,
+      generatorVersion: BADGE_GENERATOR_VERSION,
+    },
+  )
+  if (patchError || !updated) {
+    return {
+      success: false,
+      reason: 'error',
+      error: 'Failed to update badge record',
+    }
+  }
+
+  return { success: true, badge: updated }
+}

--- a/src/lib/badge/sanity.ts
+++ b/src/lib/badge/sanity.ts
@@ -371,6 +371,15 @@ export async function getBadgeStats(conferenceId: string): Promise<{
   }
 }
 
+/**
+ * Delete a badge SVG asset document. Used for best-effort cleanup when a
+ * rebake uploads a new asset but fails before the badge document references
+ * it (an unreferenced asset would otherwise be orphaned in the dataset).
+ */
+export async function deleteBadgeSVGAsset(assetId: string): Promise<void> {
+  await clientWrite.delete(assetId)
+}
+
 export async function deleteBadge(
   badgeId: string,
 ): Promise<{ success: boolean; error?: Error }> {

--- a/src/lib/badge/sanity.ts
+++ b/src/lib/badge/sanity.ts
@@ -33,6 +33,7 @@ const BADGE_FIELDS = `
   },
   badgeType,
   issuedAt,
+  generatorVersion,
   badgeJson,
   badgeJwt,
   bakedSvg{
@@ -82,11 +83,14 @@ export async function createBadge(params: {
   badgeJwt?: string
   bakedSvgAssetId: string
   verificationUrl: string
+  /** Generator format version stamped at issuance (see lib/badge/version.ts) */
+  generatorVersion: number
 }): Promise<{ badge?: BadgeRecord; error?: Error }> {
   try {
     const doc = {
       _type: 'speakerBadge',
       badgeId: params.badgeId,
+      generatorVersion: params.generatorVersion,
       speaker: {
         _type: 'reference',
         _ref: params.speakerId,
@@ -124,6 +128,77 @@ export async function createBadge(params: {
     return { badge }
   } catch (error) {
     console.error('Failed to create badge:', error)
+    return { error: error as Error }
+  }
+}
+
+/**
+ * Re-bake an existing badge IN PLACE: swap the regenerated artifacts onto the
+ * same document (same `_id`, same `badgeId`, same `verificationUrl`, same
+ * `issuedAt`) and stamp the current `generatorVersion`. The previous baked-SVG
+ * asset is deleted after the patch so a rebake does not orphan blobs. Used by
+ * the rebake flow; issuance uses {@link createBadge}.
+ */
+export async function patchBadgeArtifacts(
+  badgeId: string,
+  params: {
+    badgeJson: string
+    badgeJwt?: string
+    bakedSvgAssetId: string
+    generatorVersion: number
+  },
+): Promise<{ badge?: BadgeRecord; error?: Error }> {
+  try {
+    const existing = await clientRead.fetch<{
+      _id: string
+      bakedSvg?: { asset?: { _ref?: string } }
+    }>(
+      `*[_type == "speakerBadge" && badgeId == $badgeId][0]{ _id, bakedSvg }`,
+      { badgeId },
+    )
+
+    if (!existing) {
+      return { error: new Error('Badge not found') }
+    }
+
+    const oldAssetId = existing.bakedSvg?.asset?._ref
+
+    const patch: Record<string, unknown> = {
+      badgeJson: params.badgeJson,
+      generatorVersion: params.generatorVersion,
+      bakedSvg: {
+        _type: 'file',
+        asset: { _type: 'reference', _ref: params.bakedSvgAssetId },
+      },
+    }
+    if (params.badgeJwt) {
+      patch.badgeJwt = params.badgeJwt
+    }
+
+    const updated = await clientWrite.patch(existing._id).set(patch).commit()
+
+    // Best-effort cleanup of the superseded SVG asset (never fail the rebake on
+    // this — the doc already points at the new asset).
+    if (oldAssetId && oldAssetId !== params.bakedSvgAssetId) {
+      try {
+        await clientWrite.delete(oldAssetId)
+      } catch (assetError) {
+        console.warn('Failed to delete superseded badge SVG asset:', assetError)
+      }
+    }
+
+    const badge = await clientRead.fetch<BadgeRecord>(
+      `*[_type == "speakerBadge" && _id == $id][0]{${BADGE_FIELDS}}`,
+      { id: updated._id },
+    )
+
+    if (!badge) {
+      return { error: new Error('Failed to fetch rebaked badge') }
+    }
+
+    return { badge }
+  } catch (error) {
+    console.error('Failed to patch badge artifacts:', error)
     return { error: error as Error }
   }
 }

--- a/src/lib/badge/sanity.ts
+++ b/src/lib/badge/sanity.ts
@@ -9,6 +9,7 @@ const BADGE_FIELDS = `
   _createdAt,
   _updatedAt,
   badgeId,
+  centerGraphicSvg,
   speaker->{
     _id,
     name,

--- a/src/lib/badge/types.ts
+++ b/src/lib/badge/types.ts
@@ -86,6 +86,11 @@ export interface BadgeRecord {
   badgeType: BadgeType
   issuedAt: string
   /**
+   * Generator format version this badge was baked with. Absent on docs baked
+   * before the field existed ⇒ treated as v1. See lib/badge/version.ts.
+   */
+  generatorVersion?: number
+  /**
    * OpenBadges 3.0 credential. New badges store the embedded-proof JSON-LD
    * credential (stringified). Legacy badges store the raw JWT string —
    * use isJWTFormat() to distinguish.

--- a/src/lib/badge/types.ts
+++ b/src/lib/badge/types.ts
@@ -85,6 +85,8 @@ export interface BadgeRecord {
   conference: Conference | { _ref: string; _type: 'reference' }
   badgeType: BadgeType
   issuedAt: string
+  /** Custom center graphic captured at issuance (reused by rebake). */
+  centerGraphicSvg?: string
   /**
    * Generator format version this badge was baked with. Absent on docs baked
    * before the field existed ⇒ treated as v1. See lib/badge/version.ts.

--- a/src/lib/badge/version.test.ts
+++ b/src/lib/badge/version.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BADGE_GENERATOR_VERSION,
+  badgeGeneratorVersion,
+  isBadgeOutdated,
+} from './version'
+
+describe('badge generator versioning', () => {
+  it('current version is at least 2 (the #655 keys-URL + identifier format)', () => {
+    expect(BADGE_GENERATOR_VERSION).toBeGreaterThanOrEqual(2)
+  })
+
+  describe('badgeGeneratorVersion — absent field defaults to v1', () => {
+    it('treats undefined as v1 (docs baked before the field existed)', () => {
+      expect(badgeGeneratorVersion(undefined)).toBe(1)
+    })
+
+    it('treats null as v1', () => {
+      expect(badgeGeneratorVersion(null)).toBe(1)
+    })
+
+    it('passes a stored version through unchanged', () => {
+      expect(badgeGeneratorVersion(2)).toBe(2)
+      expect(badgeGeneratorVersion(5)).toBe(5)
+    })
+  })
+
+  describe('isBadgeOutdated', () => {
+    it('flags a v1 (absent) badge as outdated while current is > 1', () => {
+      expect(isBadgeOutdated(undefined)).toBe(true)
+      expect(isBadgeOutdated(null)).toBe(true)
+      expect(isBadgeOutdated(1)).toBe(true)
+    })
+
+    it('does NOT flag a badge stamped at the current version', () => {
+      expect(isBadgeOutdated(BADGE_GENERATOR_VERSION)).toBe(false)
+    })
+
+    it('does NOT flag a badge from a hypothetical future version', () => {
+      expect(isBadgeOutdated(BADGE_GENERATOR_VERSION + 1)).toBe(false)
+    })
+
+    it('flags any version strictly below the current one', () => {
+      for (let v = 1; v < BADGE_GENERATOR_VERSION; v++) {
+        expect(isBadgeOutdated(v)).toBe(true)
+      }
+    })
+  })
+})

--- a/src/lib/badge/version.ts
+++ b/src/lib/badge/version.ts
@@ -1,0 +1,53 @@
+/**
+ * Badge generator format version.
+ *
+ * This is a CLIENT-SAFE module (no server-only / crypto imports) so both the
+ * admin UI and the server can read the constant and the outdated predicate.
+ *
+ * BUMP RULE
+ * ---------
+ * Increment {@link BADGE_GENERATOR_VERSION} whenever the credential format
+ * changes such that badges ALREADY BAKED with an older generator become STALE —
+ * i.e. a fresh re-issue would produce a materially different (more correct)
+ * credential/proof/SVG. A bump makes every doc stamped with a lower
+ * `generatorVersion` (and every doc with the field ABSENT, treated as v1) render
+ * as "Outdated format" in the admin badge list and countable by the
+ * `badges.outdated` system-status check, and eligible for in-place `rebake`.
+ *
+ * Do NOT bump for changes that leave existing baked artifacts valid (e.g. a
+ * copy tweak in a NEW issuance, a refactor with identical output). The version
+ * is a re-bake trigger, not a build number.
+ *
+ * VERSION HISTORY
+ * ---------------
+ *   v1 — pre-#655 format. The embedded Data Integrity Proof's
+ *        `verificationMethod` was the issuer-profile FRAGMENT
+ *        (`…/api/badge/issuer#key-…`), which the 1EdTech EmbeddedProofProbe
+ *        cannot dereference, and the credential carried NO
+ *        `credentialSubject.identifier[]` block, so displayers such as Credly
+ *        could not match a badge to a signed-in user. Stored docs from this era
+ *        have no `generatorVersion` field ⇒ treated as v1.
+ *   v2 — #655. The embedded proof `verificationMethod` is now the
+ *        dereferenceable keys URL (`…/api/badge/keys/key-ed25519`) returning a
+ *        bare Multikey document, and the credential includes a
+ *        `credentialSubject.identifier[]` IdentityObject (email, unhashed) for
+ *        displayer ownership matching on import.
+ */
+export const BADGE_GENERATOR_VERSION = 2
+
+/**
+ * The effective generator version of a stored badge. Docs baked before the
+ * field existed have no `generatorVersion` ⇒ they are the original (v1) format.
+ */
+export function badgeGeneratorVersion(stored?: number | null): number {
+  return stored ?? 1
+}
+
+/**
+ * True when a stored badge was baked by an OLDER generator than the current one
+ * and should be re-baked. Absent version ⇒ v1 ⇒ outdated whenever the current
+ * version is > 1.
+ */
+export function isBadgeOutdated(stored?: number | null): boolean {
+  return badgeGeneratorVersion(stored) < BADGE_GENERATOR_VERSION
+}

--- a/src/lib/system-status/checks.test.ts
+++ b/src/lib/system-status/checks.test.ts
@@ -204,6 +204,66 @@ describe('buildSystemChecks — live probes', () => {
   })
 })
 
+describe('buildSystemChecks — badges.outdated', () => {
+  beforeEach(() => {
+    vi.stubEnv('RESEND_API_KEY', 'x')
+  })
+
+  // Route each async probe's fetch by query shape so the outdated-badge count is
+  // controllable independently of the other live probes.
+  function mockFetch(outdated: number | Error) {
+    fetchMock.mockImplementation((query: string) => {
+      if (query.includes('speakerBadge')) {
+        return outdated instanceof Error
+          ? Promise.reject(outdated)
+          : Promise.resolve(outdated)
+      }
+      if (query.includes('"total"'))
+        return Promise.resolve({ total: 0, speakers: 0 })
+      return Promise.resolve('conf-1')
+    })
+  }
+
+  it('is ok when no badge is on an older format', async () => {
+    mockFetch(0)
+    const check = byId(await buildSystemChecks(CONFERENCE), 'badges.outdated')
+    expect(check.status).toBe('ok')
+    expect(check.value).toBe('none')
+  })
+
+  it('warns with the count when badges are outdated', async () => {
+    mockFetch(3)
+    const check = byId(await buildSystemChecks(CONFERENCE), 'badges.outdated')
+    expect(check.status).toBe('warn')
+    expect(check.value).toBe('3 badges')
+    expect(check.detail).toContain('Rebake all outdated')
+  })
+
+  it('singularizes a single outdated badge', async () => {
+    mockFetch(1)
+    const check = byId(await buildSystemChecks(CONFERENCE), 'badges.outdated')
+    expect(check.value).toBe('1 badge')
+  })
+
+  it('scopes the count to the conference (conference._ref bound)', async () => {
+    mockFetch(0)
+    await buildSystemChecks(CONFERENCE)
+    const call = fetchMock.mock.calls.find((c) =>
+      String(c[0]).includes('speakerBadge'),
+    )
+    expect(call).toBeDefined()
+    expect(String(call![0])).toContain('conference._ref == $conferenceId')
+    expect(call![1]).toMatchObject({ conferenceId: 'conf-1' })
+  })
+
+  it('degrades to warn/unknown when the count query throws', async () => {
+    mockFetch(new Error('boom'))
+    const check = byId(await buildSystemChecks(CONFERENCE), 'badges.outdated')
+    expect(check.status).toBe('warn')
+    expect(check.value).toBe('unknown')
+  })
+})
+
 describe('types helpers', () => {
   const sample: SystemCheck[] = [
     { id: 'a', group: 'sanity', label: 'A', status: 'ok' },

--- a/src/lib/system-status/checks.test.ts
+++ b/src/lib/system-status/checks.test.ts
@@ -236,7 +236,7 @@ describe('buildSystemChecks — badges.outdated', () => {
     const check = byId(await buildSystemChecks(CONFERENCE), 'badges.outdated')
     expect(check.status).toBe('warn')
     expect(check.value).toBe('3 badges')
-    expect(check.detail).toContain('Rebake all outdated')
+    expect(check.detail).toContain('Rebake N outdated')
   })
 
   it('singularizes a single outdated badge', async () => {

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -14,6 +14,7 @@ import {
   platformCheckinCredentials,
 } from '@/lib/tickets/provider'
 import { providerMap } from '@/lib/auth'
+import { BADGE_GENERATOR_VERSION } from '@/lib/badge/version'
 import type {
   CheckGroup,
   CheckStatus,
@@ -744,6 +745,55 @@ async function pushSubscriptionCount(): Promise<SystemCheck> {
 }
 
 /**
+ * Count of this conference's badges baked by an OLDER generator than the current
+ * one (absent generatorVersion ⇒ v1). >0 ⇒ warn with a pointer to the admin
+ * page's "Rebake all outdated" action. TENANT-SCOPED to the conference — this is
+ * a per-conference admin read.
+ */
+async function badgesOutdatedProbe(
+  conferenceId: string | undefined,
+): Promise<SystemCheck> {
+  const meta = {
+    id: 'badges.outdated',
+    group: 'badges' as const,
+    label: 'Outdated-format badges',
+  }
+  if (!conferenceId) {
+    return {
+      ...meta,
+      status: 'off',
+      value: 'unknown',
+      detail: 'No conference resolved to scope the badge count',
+    }
+  }
+  try {
+    const outdated = await clientReadUncached.fetch<number>(
+      `count(*[_type == "speakerBadge" && conference._ref == $conferenceId && coalesce(generatorVersion, 1) < $current])`,
+      { conferenceId, current: BADGE_GENERATOR_VERSION },
+    )
+    const count = outdated ?? 0
+    return count > 0
+      ? {
+          ...meta,
+          status: 'warn',
+          value: `${count} badge${count === 1 ? '' : 's'}`,
+          detail:
+            'Baked before the current credential format (v' +
+            BADGE_GENERATOR_VERSION +
+            '). Re-bake them from /admin/speakers/badge → "Rebake all outdated".',
+        }
+      : {
+          ...meta,
+          status: 'ok',
+          value: 'none',
+          detail: `All badges are on the current format (v${BADGE_GENERATOR_VERSION})`,
+        }
+  } catch (err) {
+    return { ...meta, status: 'warn', value: 'unknown', detail: errMsg(err) }
+  }
+}
+
+/**
  * Full registry: synchronous env/file/conference checks PLUS the live Sanity
  * read probe and the push-subscription count. The live probes are appended into
  * their groups so the UI renders them alongside the static rows.
@@ -752,11 +802,12 @@ export async function buildSystemChecks(
   conference: ConferenceForSystemChecks,
 ): Promise<SystemCheck[]> {
   const staticChecks = buildChecks(conference)
-  const [readProbe, pushCount] = await Promise.all([
+  const [readProbe, pushCount, badgesOutdated] = await Promise.all([
     sanityReadProbe(),
     pushSubscriptionCount(),
+    badgesOutdatedProbe(conference._id),
   ])
-  return [...staticChecks, readProbe, pushCount]
+  return [...staticChecks, readProbe, pushCount, badgesOutdated]
 }
 
 /** Exposed for unit tests: the synchronous, side-effect-light checks only. */

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -780,7 +780,7 @@ async function badgesOutdatedProbe(
           detail:
             'Baked before the current credential format (v' +
             BADGE_GENERATOR_VERSION +
-            '). Re-bake them from /admin/speakers/badge → "Rebake all outdated".',
+            '). Re-bake them from /admin/speakers/badge → the "Rebake N outdated" action.',
         }
       : {
           ...meta,

--- a/src/server/routers/badge.ts
+++ b/src/server/routers/badge.ts
@@ -24,6 +24,7 @@ import {
   ValidateBadgeInputSchema,
 } from '@/server/schemas/badge'
 import { issueBadgeForSpeaker } from '@/lib/badge/issuance'
+import { rebakeBadge } from '@/lib/badge/rebake'
 import { isJWTFormat } from '@/lib/openbadges'
 import { getSpeaker } from '@/lib/speaker/sanity'
 import {
@@ -237,6 +238,35 @@ export const badgeRouter = router({
             successful: successCount,
             failed: failureCount,
           },
+        }
+      }),
+
+    rebake: adminProcedure
+      .input(BadgeIdInputSchema)
+      .mutation(async ({ input }) => {
+        // Org/tenant scope: resolveConferenceId() is the domain-authoritative
+        // conference; rebakeBadge denies any badge that is not this conference's
+        // (fail closed, mirrors the E11 badge gate).
+        const conferenceId = await resolveConferenceId()
+        const result = await rebakeBadge({
+          badgeId: input.badgeId,
+          conferenceId,
+        })
+
+        if (!result.success) {
+          const code =
+            result.reason === 'not_found'
+              ? 'NOT_FOUND'
+              : result.reason === 'forbidden'
+                ? 'FORBIDDEN'
+                : 'INTERNAL_SERVER_ERROR'
+          throw new TRPCError({ code, message: result.error })
+        }
+
+        return {
+          success: true,
+          badge: result.badge,
+          message: 'Badge rebaked with the current generator',
         }
       }),
 

--- a/src/server/routers/badge.ts
+++ b/src/server/routers/badge.ts
@@ -263,9 +263,12 @@ export const badgeRouter = router({
           throw new TRPCError({ code, message: result.error })
         }
 
+        // Minimal payload: the client refetches the list; per-badge full
+        // records would just add bulk-rebake bandwidth.
         return {
           success: true,
-          badge: result.badge,
+          badgeId: result.badge.badgeId,
+          generatorVersion: result.badge.generatorVersion,
           message: 'Badge rebaked with the current generator',
         }
       }),


### PR DESCRIPTION
## Why

Baked badges are **immutable artifacts** — the download route serves the stored `bakedSvg` and does not re-prove on download. So every badge issued before #655 permanently carries the broken fragment `verificationMethod` and no `credentialSubject.identifier` block. Deleting + re-issuing is destructive (a new `badgeId` kills the old verification URL and any shared / Credly links). This adds a non-destructive upgrade path.

## Versioning rule

`src/lib/badge/version.ts` exports `BADGE_GENERATOR_VERSION` (starts at **2**). Every `speakerBadge` doc is stamped with `generatorVersion` at issuance; a doc with the field **absent ⇒ v1**. **Bump the constant whenever the credential format changes such that already-baked badges become stale** (a fresh re-issue would produce a materially different, more correct artifact). Do not bump for output-identical refactors or copy tweaks on new issuance — it is a re-bake trigger, not a build number.

- **v1** — pre-#655: embedded proof `verificationMethod` was the issuer-profile fragment (not dereferenceable by the 1EdTech `EmbeddedProofProbe`); no `credentialSubject.identifier[]`.
- **v2** — #655: dereferenceable `/api/badge/keys/key-ed25519` `verificationMethod` + `credentialSubject.identifier[]` IdentityObject for displayer ownership matching.

## Rebake semantics

`badge.admin.rebake` (adminProcedure, conference-scoped, fail-closed) loads the doc, regenerates `badgeJson` + `badgeJwt` + `bakedSvg` with the **current** generator, and patches in place. Idempotent; refuses only a missing or cross-tenant badge.

- **Stable:** `badgeId`, `verificationUrl` (derived from the preserved id), `issuedAt` / `validFrom` (the achievement date must not shift).
- **Re-minted:** the proof (its `created` is _now_), `badgeJson`/`badgeJwt`, the baked SVG (old asset deleted so rebakes don't orphan blobs), and `generatorVersion`.

Issuance and rebake share one generation helper (`generateBadgeArtifacts` = credential + SVG + bake) rather than duplicating; `generateBadgeCredential` gained an optional `{ badgeId, validFrom }` for identity preservation.

## Surfaces

- **Admin badge page:** "Outdated format" marker on stale rows, per-row **Rebake**, and a **"Rebake N outdated"** button (sequential, reports count).
- **System status:** `badges.outdated` check — tenant-scoped count of this conference's outdated badges; `ok` at zero, `warn` with the count + pointer otherwise.

## Why the RSA keys stay required

`BADGE_ISSUER_RSA_PRIVATE_KEY` / `BADGE_ISSUER_RSA_PUBLIC_KEY` remain **required** (`createBadgeConfiguration()` throws without them) even though the primary embedded proof is Ed25519: (1) every badge is signed in **both** formats and the RS256 `badgeJwt` is what the 1EdTech OB30Inspector consumes; (2) the public RSA key is the published JWK used to **verify legacy badges whose `badgeJson` is a raw JWT**. Documented durably in `docs/OPENBADGES_IMPLEMENTATION.md`.

## Owner post-deploy step

After deploy, open **/admin/speakers/badge**, click **"Rebake N outdated"** to re-bake the existing (pre-#655) badges in place, then **re-validate / re-import** them into the displayer (Credly etc.). `/admin/settings → badges.outdated` should then read `ok`.

## Tests

`mise run check` + full vitest green (4259 passed). New: version predicate / outdated detection, rebake round-trip (badgeId/verificationUrl/issuedAt preserved, `generatorVersion` stamped, artifacts differ) + cross-tenant deny, and `badges.outdated` check states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)