### PR TITLE
feat(admin): Get started activation checklist (onboarding S4)

### DIFF
--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -28,8 +28,10 @@ import { TopicsEditor } from '@/components/admin/TopicsEditor'
 import { TeamsEditor } from '@/components/admin/TeamsEditor'
 import { HomepageSectionsEditor } from '@/components/admin/HomepageSectionsEditor'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
+import { ActivationChecklist } from '@/components/admin/ActivationChecklist'
 import { resolveHomepageSections } from '@/lib/homepage'
 import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
+import { buildActivationChecklist } from '@/lib/settings/activation'
 import {
   InfoCard,
   FieldRow,
@@ -109,6 +111,10 @@ export default async function AdminSettings() {
   const editUrl = studioEditUrl(conference._id)
   const visibility = resolveConferenceVisibility(conference)
   const systemChecks = await buildSystemChecks(conference)
+  // "Get started" activation checklist — derived purely from the conference and
+  // the checks we already built above (no extra probing). Rendered at the top of
+  // the Configuration tier; auto-collapses once everything required is done.
+  const activation = buildActivationChecklist(conference, systemChecks)
   const session = await getAuthSession()
   const currentUserId = session?.speaker?._id ?? ''
   const organizerRows = (conference.organizers ?? []).map((org) => ({
@@ -167,6 +173,10 @@ export default async function AdminSettings() {
           title="Conference configuration"
           description="Content managed in Sanity for this conference."
         />
+
+        {/* "Get started" — the onboarding checklist. Sits above the grouped
+            configuration cards and deep-links into them. */}
+        <ActivationChecklist checklist={activation} />
 
         <div className="space-y-10">
           {/* ---- Identity & Brand ---- */}

--- a/src/components/admin/ActivationChecklist.stories.tsx
+++ b/src/components/admin/ActivationChecklist.stories.tsx
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { ActivationChecklist } from './ActivationChecklist'
+import {
+  buildActivationChecklist,
+  type ConferenceForActivation,
+} from '@/lib/settings/activation'
+import type { SystemCheck } from '@/lib/system-status/types'
+
+/**
+ * The "Get started" onboarding checklist, rendered from three representative
+ * derivation states. The stories call the REAL `buildActivationChecklist` so the
+ * card and the derivation stay in lockstep.
+ */
+const meta = {
+  title: 'Systems/Admin/Settings/ActivationChecklist',
+  component: ActivationChecklist,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ActivationChecklist>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const emailOk: SystemCheck[] = [
+  {
+    id: 'email.resendKey',
+    group: 'email',
+    label: 'RESEND_API_KEY',
+    status: 'ok',
+  },
+]
+const emailAndSlackOk: SystemCheck[] = [
+  ...emailOk,
+  {
+    id: 'slack.botToken',
+    group: 'slack',
+    label: 'SLACK_BOT_TOKEN',
+    status: 'ok',
+  },
+]
+
+/** A brand-new, unlisted trial conference — almost nothing configured. */
+const FRESH: ConferenceForActivation = {
+  title: 'My New Conference',
+  organizer: 'Acme Events',
+  visibility: 'unlisted',
+}
+
+/** Everything required except the final Go-live switch. */
+const NEARLY_DONE: ConferenceForActivation = {
+  title: 'Cloud Native Day',
+  organizer: 'Cloud Native Bergen',
+  logoBright: 'https://cdn/logo.svg',
+  venueName: 'Grieghallen',
+  startDate: '2026-05-01',
+  endDate: '2026-05-02',
+  cfpStartDate: '2026-01-01',
+  cfpEndDate: '2026-03-01',
+  topics: [{ _id: 't1', title: 'Kubernetes' }],
+  contactEmail: 'hi@example.com',
+  cfpEmail: 'cfp@example.com',
+  sponsorEmail: 'sponsors@example.com',
+  registrationLink: 'https://tickets.example.com',
+  ticketingProvider: 'checkin',
+  checkinCustomerId: 123,
+  checkinEventId: 456,
+  visibility: 'unlisted',
+  domains: ['foo.cloudnativebergen.dev'],
+}
+
+/** Fully configured and live — the card collapses to a compact header. */
+const ALL_DONE: ConferenceForActivation = {
+  ...NEARLY_DONE,
+  visibility: 'live',
+  domains: ['cloudnativeday.example', 'foo.cloudnativebergen.dev'],
+}
+
+function Frame({ children }: { children: React.ReactNode }) {
+  return <div className="mx-auto max-w-3xl p-4">{children}</div>
+}
+
+export const Fresh: Story = {
+  args: { checklist: buildActivationChecklist(FRESH, []) },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-gray-50">
+        <Frame>
+          <Story />
+        </Frame>
+      </div>
+    ),
+  ],
+}
+
+export const NearlyDone: Story = {
+  args: { checklist: buildActivationChecklist(NEARLY_DONE, emailOk) },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-gray-50">
+        <Frame>
+          <Story />
+        </Frame>
+      </div>
+    ),
+  ],
+}
+
+export const AllDone: Story = {
+  args: { checklist: buildActivationChecklist(ALL_DONE, emailAndSlackOk) },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-gray-50">
+        <Frame>
+          <Story />
+        </Frame>
+      </div>
+    ),
+  ],
+}
+
+export const FreshDark: Story = {
+  args: { checklist: buildActivationChecklist(FRESH, []) },
+  decorators: [
+    (Story) => (
+      <div className="dark min-h-screen bg-gray-950">
+        <Frame>
+          <Story />
+        </Frame>
+      </div>
+    ),
+  ],
+}
+
+export const NearlyDoneDark: Story = {
+  args: { checklist: buildActivationChecklist(NEARLY_DONE, emailOk) },
+  decorators: [
+    (Story) => (
+      <div className="dark min-h-screen bg-gray-950">
+        <Frame>
+          <Story />
+        </Frame>
+      </div>
+    ),
+  ],
+}

--- a/src/components/admin/ActivationChecklist.tsx
+++ b/src/components/admin/ActivationChecklist.tsx
@@ -1,0 +1,136 @@
+import { CheckCircleIcon } from '@heroicons/react/24/solid'
+import { RocketLaunchIcon } from '@heroicons/react/24/outline'
+import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
+import { StatusBadge } from '@/components/StatusBadge'
+import type {
+  ActivationChecklist as ActivationChecklistData,
+  ActivationRow,
+} from '@/lib/settings/activation'
+
+/**
+ * "Get started" activation checklist card (onboarding S4).
+ *
+ * A read-only, server-safe presentational surface: it renders an
+ * already-derived {@link ActivationChecklistData} (see
+ * `@/lib/settings/activation`) — it never reads conference data or probes
+ * anything itself. It sits at the TOP of the Settings "Configuration" tier and
+ * answers "what do I still need to configure to launch?".
+ *
+ * The card auto-collapses (`defaultOpen = !allDone`) once every REQUIRED row is
+ * satisfied, so a fully configured conference sees only a compact "Ready to
+ * launch" header. Each row deep-links to the relevant group / card anchor.
+ *
+ * headingLevel={3}: the card sits directly under the Configuration `h2`, so its
+ * disclosure heading is an `h3` (the grouped subsections below are also h3).
+ */
+export function ActivationChecklist({
+  checklist,
+}: {
+  checklist: ActivationChecklistData
+}) {
+  const { rows, done, required, allDone } = checklist
+  const pct = required === 0 ? 100 : Math.round((done / required) * 100)
+
+  return (
+    <CollapsibleSection
+      headingLevel={3}
+      title="Get started"
+      icon={<RocketLaunchIcon />}
+      defaultOpen={!allDone}
+      action={
+        // Compact so the "Get started" title is never squeezed to an ellipsis
+        // on a narrow (393px) viewport, where the disclosure's Hide/Show label
+        // and chevron already consume header width.
+        allDone ? (
+          <StatusBadge label="Ready" color="green" />
+        ) : (
+          <StatusBadge label={`${done}/${required}`} color="gray" />
+        )
+      }
+    >
+      <div className="space-y-4 px-6 py-4">
+        <div>
+          <div className="mb-1 flex items-center justify-between text-sm">
+            <span className="font-medium text-gray-700 dark:text-gray-300">
+              Launch readiness
+            </span>
+            <span className="text-gray-500 dark:text-gray-400">
+              {done}/{required} required steps
+            </span>
+          </div>
+          <div
+            className="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+            role="progressbar"
+            aria-valuenow={done}
+            aria-valuemin={0}
+            aria-valuemax={required}
+            aria-label="Launch readiness"
+          >
+            <div
+              className="h-2 rounded-full bg-indigo-600 transition-all duration-300 dark:bg-indigo-500"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        </div>
+
+        <ul className="space-y-1">
+          {rows.map((row) => (
+            <ActivationRowItem key={row.id} row={row} />
+          ))}
+        </ul>
+      </div>
+    </CollapsibleSection>
+  )
+}
+
+/** One checklist row — an anchor link with a done/pending icon and a hint. */
+function ActivationRowItem({ row }: { row: ActivationRow }) {
+  return (
+    <li>
+      <a
+        href={row.anchor}
+        className="group flex items-start gap-3 rounded-md px-2 py-2 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
+      >
+        <span className="mt-0.5 shrink-0">
+          {row.done ? (
+            <CheckCircleIcon className="h-5 w-5 text-green-500 dark:text-green-400" />
+          ) : (
+            <span
+              aria-hidden="true"
+              className={`block h-5 w-5 rounded-full border-2 ${
+                row.optional
+                  ? 'border-dashed border-gray-300 dark:border-gray-600'
+                  : 'border-gray-300 dark:border-gray-600'
+              }`}
+            />
+          )}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex flex-wrap items-center gap-2">
+            <span
+              className={`text-sm font-medium ${
+                row.done
+                  ? 'text-gray-500 line-through dark:text-gray-500'
+                  : 'text-gray-900 dark:text-white'
+              }`}
+            >
+              {row.label}
+            </span>
+            {row.optional && <StatusBadge label="Optional" color="gray" />}
+          </span>
+          {!row.done && (
+            <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+              {row.hint}
+            </span>
+          )}
+        </span>
+        <span
+          aria-hidden="true"
+          className="mt-0.5 shrink-0 text-xs font-medium text-indigo-600 opacity-0 transition-opacity group-hover:opacity-100 dark:text-indigo-400"
+        >
+          Configure &rarr;
+        </span>
+      </a>
+    </li>
+  )
+}

--- a/src/lib/settings/activation.test.ts
+++ b/src/lib/settings/activation.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildActivationChecklist,
+  hasCustomDomain,
+  hasTicketingBinding,
+  type ConferenceForActivation,
+} from './activation'
+import type { SystemCheck } from '@/lib/system-status/types'
+
+/** A fully configured, live conference — every required row should be done. */
+const FULLY_LIVE: ConferenceForActivation = {
+  title: 'Cloud Native Day',
+  organizer: 'Cloud Native Bergen',
+  logoBright: 'https://cdn/logo-bright.svg',
+  venueName: 'Grieghallen',
+  startDate: '2026-05-01',
+  endDate: '2026-05-02',
+  cfpStartDate: '2026-01-01',
+  cfpEndDate: '2026-03-01',
+  topics: [{ _id: 't1', title: 'Kubernetes' }],
+  contactEmail: 'hi@example.com',
+  cfpEmail: 'cfp@example.com',
+  sponsorEmail: 'sponsors@example.com',
+  registrationLink: 'https://tickets.example.com',
+  ticketingProvider: 'checkin',
+  checkinCustomerId: 123,
+  checkinEventId: 456,
+  visibility: 'live',
+  domains: ['example.com', 'foo.cloudnativebergen.dev'],
+}
+
+/** The two system checks the checklist reads, both satisfied. */
+const CHECKS_OK: SystemCheck[] = [
+  {
+    id: 'email.resendKey',
+    group: 'email',
+    label: 'RESEND_API_KEY',
+    status: 'ok',
+  },
+  {
+    id: 'slack.botToken',
+    group: 'slack',
+    label: 'SLACK_BOT_TOKEN',
+    status: 'ok',
+  },
+]
+
+function rowById(
+  checklist: ReturnType<typeof buildActivationChecklist>,
+  id: string,
+) {
+  const row = checklist.rows.find((r) => r.id === id)
+  if (!row) throw new Error(`no row ${id}`)
+  return row
+}
+
+describe('buildActivationChecklist', () => {
+  it('a fresh conference has only Go-live done and does not collapse', () => {
+    const checklist = buildActivationChecklist({}, [])
+    // Absent visibility resolves to live, so "Go live" is the one already-done
+    // required row on an otherwise-empty document.
+    expect(checklist.done).toBe(1)
+    expect(checklist.allDone).toBe(false)
+    for (const row of checklist.rows) {
+      if (row.id === 'visibility') expect(row.done).toBe(true)
+      else expect(row.done).toBe(false)
+    }
+  })
+
+  it('a fully configured live conference is all done and collapses', () => {
+    const checklist = buildActivationChecklist(FULLY_LIVE, CHECKS_OK)
+    expect(checklist.done).toBe(checklist.required)
+    expect(checklist.allDone).toBe(true)
+    for (const row of checklist.rows) expect(row.done).toBe(true)
+  })
+
+  it('progress counts only required rows (optional rows excluded)', () => {
+    const checklist = buildActivationChecklist(FULLY_LIVE, CHECKS_OK)
+    const optional = checklist.rows.filter((r) => r.optional)
+    expect(optional.map((r) => r.id).sort()).toEqual(['custom-domain', 'slack'])
+    expect(checklist.required).toBe(checklist.rows.length - optional.length)
+  })
+
+  it('a partially configured conference reports partial progress', () => {
+    const partial: ConferenceForActivation = {
+      title: 'Half Set Up',
+      organizer: 'Someone',
+      startDate: '2026-05-01',
+      endDate: '2026-05-02',
+      // no CFP window, no emails, no logo, no venue, no topics, no ticketing
+      visibility: 'unlisted',
+    }
+    const checklist = buildActivationChecklist(partial, [])
+    expect(rowById(checklist, 'basics').done).toBe(true)
+    expect(rowById(checklist, 'dates').done).toBe(true)
+    expect(rowById(checklist, 'cfp-window').done).toBe(false)
+    expect(rowById(checklist, 'emails').done).toBe(false)
+    expect(rowById(checklist, 'visibility').done).toBe(false)
+    expect(checklist.allDone).toBe(false)
+    expect(checklist.done).toBeGreaterThan(0)
+    expect(checklist.done).toBeLessThan(checklist.required)
+  })
+
+  it('the emails row needs all three addresses', () => {
+    const twoOfThree = buildActivationChecklist(
+      { contactEmail: 'a@b.c', cfpEmail: 'c@b.c' },
+      [],
+    )
+    expect(rowById(twoOfThree, 'emails').done).toBe(false)
+    const allThree = buildActivationChecklist(
+      { contactEmail: 'a@b.c', cfpEmail: 'c@b.c', sponsorEmail: 's@b.c' },
+      [],
+    )
+    expect(rowById(allThree, 'emails').done).toBe(true)
+  })
+
+  it('treats blank/whitespace strings as unset', () => {
+    const checklist = buildActivationChecklist(
+      { title: '   ', organizer: '', venueName: '\t' },
+      [],
+    )
+    expect(rowById(checklist, 'basics').done).toBe(false)
+    expect(rowById(checklist, 'venue').done).toBe(false)
+  })
+
+  it('accepts any of the four logo fields for the brand-logo row', () => {
+    expect(
+      rowById(
+        buildActivationChecklist({ logomarkDark: 'https://x/mark.svg' }, []),
+        'branding-logo',
+      ).done,
+    ).toBe(true)
+  })
+
+  describe('the terminal Go-live row', () => {
+    it('is done only for an explicitly live (or absent) visibility', () => {
+      expect(
+        rowById(
+          buildActivationChecklist({ visibility: 'live' }, []),
+          'visibility',
+        ).done,
+      ).toBe(true)
+      // Absent ⇒ live (legacy documents carry no field).
+      expect(rowById(buildActivationChecklist({}, []), 'visibility').done).toBe(
+        true,
+      )
+      expect(
+        rowById(
+          buildActivationChecklist({ visibility: 'unlisted' }, []),
+          'visibility',
+        ).done,
+      ).toBe(false)
+    })
+
+    it('is always the last row', () => {
+      const checklist = buildActivationChecklist(FULLY_LIVE, CHECKS_OK)
+      expect(checklist.rows.at(-1)?.id).toBe('visibility')
+    })
+  })
+
+  describe('provider-aware ticketing row', () => {
+    it('checkin (default) needs both customer and event id', () => {
+      expect(
+        rowById(
+          buildActivationChecklist({ checkinCustomerId: 1 }, []),
+          'ticketing',
+        ).done,
+      ).toBe(false)
+      const row = rowById(
+        buildActivationChecklist(
+          { checkinCustomerId: 1, checkinEventId: 2 },
+          [],
+        ),
+        'ticketing',
+      )
+      expect(row.done).toBe(true)
+      expect(row.hint).toMatch(/checkin/i)
+    })
+
+    it('tito needs both slugs and ignores checkin ids', () => {
+      // Checkin ids present but provider is tito ⇒ not done.
+      expect(
+        rowById(
+          buildActivationChecklist(
+            {
+              ticketingProvider: 'tito',
+              checkinCustomerId: 1,
+              checkinEventId: 2,
+            },
+            [],
+          ),
+          'ticketing',
+        ).done,
+      ).toBe(false)
+      const row = rowById(
+        buildActivationChecklist(
+          {
+            ticketingProvider: 'tito',
+            titoAccountSlug: 'acme',
+            titoEventSlug: '2026',
+          },
+          [],
+        ),
+        'ticketing',
+      )
+      expect(row.done).toBe(true)
+      expect(row.hint).toMatch(/tito/i)
+    })
+  })
+
+  describe('system-check reuse', () => {
+    it('email-delivery follows the email.resendKey check', () => {
+      expect(
+        rowById(buildActivationChecklist({}, []), 'email-delivery').done,
+      ).toBe(false)
+      expect(
+        rowById(
+          buildActivationChecklist({}, [
+            {
+              id: 'email.resendKey',
+              group: 'email',
+              label: 'x',
+              status: 'error',
+            },
+          ]),
+          'email-delivery',
+        ).done,
+      ).toBe(false)
+      expect(
+        rowById(buildActivationChecklist({}, CHECKS_OK), 'email-delivery').done,
+      ).toBe(true)
+    })
+
+    it('the optional Slack row follows the slack.botToken check', () => {
+      expect(rowById(buildActivationChecklist({}, []), 'slack').done).toBe(
+        false,
+      )
+      expect(
+        rowById(buildActivationChecklist({}, CHECKS_OK), 'slack').done,
+      ).toBe(true)
+    })
+  })
+
+  it('every row deep-links to an in-page anchor', () => {
+    for (const row of buildActivationChecklist(FULLY_LIVE, CHECKS_OK).rows) {
+      expect(row.anchor.startsWith('#')).toBe(true)
+      expect(row.anchor.length).toBeGreaterThan(1)
+    }
+  })
+})
+
+describe('hasTicketingBinding', () => {
+  it('defaults an absent provider to checkin', () => {
+    expect(
+      hasTicketingBinding({ checkinCustomerId: 1, checkinEventId: 2 }),
+    ).toBe(true)
+    expect(
+      hasTicketingBinding({ titoAccountSlug: 'a', titoEventSlug: 'b' }),
+    ).toBe(false)
+  })
+})
+
+describe('hasCustomDomain', () => {
+  it('is false with no domains', () => {
+    expect(hasCustomDomain(undefined)).toBe(false)
+    expect(hasCustomDomain([])).toBe(false)
+  })
+
+  it('without a platform suffix, treats >1 domain as custom', () => {
+    expect(hasCustomDomain(['only.example.com'])).toBe(false)
+    expect(hasCustomDomain(['a.example.com', 'b.example.com'])).toBe(true)
+  })
+
+  it('with a platform suffix, ignores that host and its subdomains', () => {
+    const suffix = 'cloudnativebergen.dev'
+    expect(hasCustomDomain(['foo.cloudnativebergen.dev'], suffix)).toBe(false)
+    expect(hasCustomDomain(['cloudnativebergen.dev'], suffix)).toBe(false)
+    expect(
+      hasCustomDomain(['foo.cloudnativebergen.dev', 'myconf.com'], suffix),
+    ).toBe(true)
+  })
+})

--- a/src/lib/settings/activation.ts
+++ b/src/lib/settings/activation.ts
@@ -1,0 +1,293 @@
+/**
+ * "Get started" activation checklist (onboarding S4).
+ *
+ * Pure, server-safe AND client-safe derivation of "what do I still need to
+ * configure to launch?" for the admin Settings page. Every row is computed from
+ * TWO sources:
+ *
+ *   1. Required-field emptiness on the conference document (pure — no I/O).
+ *   2. A SELECTIVE read of the already-built system checks
+ *      (`buildSystemChecks`) where a wiring state overlaps launch-readiness
+ *      (email delivery, Slack). This module NEVER re-probes — it only inspects
+ *      the flat `SystemCheck[]` the caller already assembled.
+ *
+ * The terminal row is `visibility` ("Go live"), the launch switch itself.
+ *
+ * IMPORTANT — this module is imported by a Storybook story, so it must stay free
+ * of any `server-only` / `next/cache` transitive import. Two tiny pure predicates
+ * that would otherwise come from server-only barrels
+ * (`@/lib/tickets/provider`, `@/lib/conference/visibility`) are re-expressed
+ * inline below; the type it does import is erased at compile time.
+ */
+
+import type { SystemCheck } from '@/lib/system-status/types'
+
+/** A single checklist line. */
+export interface ActivationRow {
+  /** Stable id (test + React key). */
+  id: string
+  /** Short imperative label ("Set conference dates"). */
+  label: string
+  /** Whether the requirement is satisfied. */
+  done: boolean
+  /**
+   * Deep-link target: a group anchor (`#schedule`) or a per-card anchor
+   * (`#visibility`) already rendered on the Settings page. Always begins `#`.
+   */
+  anchor: string
+  /** One-line orientation / what to do to satisfy the row. */
+  hint: string
+  /**
+   * Present-but-not-required informational rows (Slack, custom domain). Excluded
+   * from the progress numerator/denominator and rendered in a muted style.
+   */
+  optional?: boolean
+}
+
+/** The derived checklist plus its progress rollup. */
+export interface ActivationChecklist {
+  /** All rows in display order (required first, then optional, `visibility` last). */
+  rows: ActivationRow[]
+  /** Required rows that are done. */
+  done: number
+  /** Total required rows (optional rows excluded). */
+  required: number
+  /** True when every REQUIRED row is done — the card collapses in this state. */
+  allDone: boolean
+}
+
+/**
+ * The narrow slice of the conference document the checklist reads. Deliberately
+ * a structural subset of `Conference` (all fields optional) so the page can pass
+ * the full document and unit tests can pass a tiny fixture.
+ */
+export interface ConferenceForActivation {
+  title?: string
+  organizer?: string
+  startDate?: string
+  endDate?: string
+  cfpStartDate?: string
+  cfpEndDate?: string
+  topics?: unknown[]
+  logoBright?: string
+  logoDark?: string
+  logomarkBright?: string
+  logomarkDark?: string
+  venueName?: string
+  contactEmail?: string
+  cfpEmail?: string
+  sponsorEmail?: string
+  registrationLink?: string
+  visibility?: string | null
+  domains?: string[]
+  // Provider-aware ticketing binding.
+  ticketingProvider?: 'checkin' | 'tito' | null
+  checkinCustomerId?: number | null
+  checkinEventId?: number | null
+  titoAccountSlug?: string | null
+  titoEventSlug?: string | null
+}
+
+export interface ActivationOptions {
+  /**
+   * The platform's shared base host (e.g. `cloudnativebergen.dev`). When known,
+   * the informational "custom domain" row is done once the conference declares a
+   * domain that is neither that host nor a subdomain of it. When absent, the row
+   * falls back to "more than the single auto-provisioned platform subdomain".
+   */
+  platformDomainSuffix?: string
+}
+
+/** Non-empty string / present number. Trims strings; a 0 id counts as absent. */
+function present(value: unknown): boolean {
+  if (typeof value === 'string') return value.trim().length > 0
+  if (typeof value === 'number') return value !== 0 && !Number.isNaN(value)
+  return value != null
+}
+
+/** A system check is satisfied when the caller already resolved it to `ok`. */
+function checkOk(checks: SystemCheck[], id: string): boolean {
+  return checks.find((c) => c.id === id)?.status === 'ok'
+}
+
+/**
+ * Provider-aware ticketing binding. Mirrors `hasTicketingBinding` in
+ * `@/lib/tickets/provider` WITHOUT importing that barrel (it pulls in the
+ * server-only secret store). Absent provider ⇒ Checkin, the historical default.
+ */
+export function hasTicketingBinding(c: ConferenceForActivation): boolean {
+  if ((c.ticketingProvider ?? 'checkin') === 'tito') {
+    return present(c.titoAccountSlug) && present(c.titoEventSlug)
+  }
+  return present(c.checkinCustomerId) && present(c.checkinEventId)
+}
+
+/**
+ * True when the conference has a domain BEYOND the auto-provisioned platform
+ * subdomain — informational, so this never blocks launch. With a known
+ * `platformDomainSuffix`, "custom" = any entry that is neither that host nor a
+ * subdomain of it; without one, the honest fallback is "declares more than one
+ * domain" (the provisioned subdomain plus at least one the tenant added).
+ */
+export function hasCustomDomain(
+  domains: string[] | undefined,
+  platformDomainSuffix?: string,
+): boolean {
+  const list = (domains ?? [])
+    .map((d) => d.trim().toLowerCase())
+    .filter(Boolean)
+  if (list.length === 0) return false
+  const suffix = platformDomainSuffix?.trim().toLowerCase().replace(/^\.+/, '')
+  if (suffix) {
+    return list.some((d) => d !== suffix && !d.endsWith(`.${suffix}`))
+  }
+  return list.length > 1
+}
+
+/**
+ * Build the ordered activation checklist for a conference.
+ *
+ * @param conference required-field source (structural subset of `Conference`)
+ * @param checks     the already-built `SystemCheck[]` (no re-probing here)
+ * @param options    optional platform host for the custom-domain row
+ */
+export function buildActivationChecklist(
+  conference: ConferenceForActivation,
+  checks: SystemCheck[] = [],
+  options: ActivationOptions = {},
+): ActivationChecklist {
+  const hasLogo =
+    present(conference.logoBright) ||
+    present(conference.logoDark) ||
+    present(conference.logomarkBright) ||
+    present(conference.logomarkDark)
+
+  const provider = conference.ticketingProvider ?? 'checkin'
+  const ticketingHint =
+    provider === 'tito'
+      ? 'Add your Tito account and event slugs.'
+      : 'Add your Checkin.no customer and event IDs.'
+
+  // Absent visibility means live (see @/lib/conference/visibility), so a legacy
+  // conference reads as already live; a fresh trial edition is created unlisted
+  // and stays "to do" until an organizer flips the switch.
+  const isLive = conference.visibility !== 'unlisted'
+
+  const rows: ActivationRow[] = [
+    {
+      id: 'basics',
+      label: 'Name & organizer',
+      done: present(conference.title) && present(conference.organizer),
+      anchor: '#identity-brand',
+      hint: 'Set the conference name and the organizing body.',
+    },
+    {
+      id: 'branding-logo',
+      label: 'Brand logo',
+      done: hasLogo,
+      anchor: '#identity-brand',
+      hint: 'Upload a logo so the site and emails carry your brand.',
+    },
+    {
+      id: 'venue',
+      label: 'Venue',
+      done: present(conference.venueName),
+      anchor: '#identity-brand',
+      hint: 'Name the venue so attendees know where to go.',
+    },
+    {
+      id: 'dates',
+      label: 'Conference dates',
+      done: present(conference.startDate) && present(conference.endDate),
+      anchor: '#schedule',
+      hint: 'Set the start and end dates of the event.',
+    },
+    {
+      id: 'cfp-window',
+      label: 'Call-for-papers window',
+      done: present(conference.cfpStartDate) && present(conference.cfpEndDate),
+      anchor: '#schedule',
+      hint: 'Open the CFP by setting its start and end dates.',
+    },
+    {
+      id: 'topics',
+      label: 'At least one topic',
+      done: Array.isArray(conference.topics) && conference.topics.length > 0,
+      anchor: '#team-content',
+      hint: 'Add topics so speakers can categorise their proposals.',
+    },
+    {
+      id: 'emails',
+      label: 'Contact, CFP & sponsor emails',
+      done:
+        present(conference.contactEmail) &&
+        present(conference.cfpEmail) &&
+        present(conference.sponsorEmail),
+      anchor: '#team-content',
+      hint: 'Set the contact, CFP and sponsor email addresses.',
+    },
+    {
+      id: 'registration',
+      label: 'Registration link',
+      done: present(conference.registrationLink),
+      anchor: '#tickets-registration',
+      hint: 'Link out to where attendees buy tickets or register.',
+    },
+    {
+      id: 'ticketing',
+      label: 'Ticketing connected',
+      done: hasTicketingBinding(conference),
+      anchor: '#tickets-registration',
+      hint: ticketingHint,
+    },
+    {
+      // Reused from the system checks — email delivery is a hard launch
+      // requirement (its check reports `error` when unset).
+      id: 'email-delivery',
+      label: 'Email delivery configured',
+      done: checkOk(checks, 'email.resendKey'),
+      anchor: '#system-status',
+      hint: 'Configure the Resend API key so outbound email can send.',
+    },
+    {
+      // Reused from the system checks — Slack is an optional integration (its
+      // check reports `off`, not `error`, when unset).
+      id: 'slack',
+      label: 'Slack notifications',
+      done: checkOk(checks, 'slack.botToken'),
+      anchor: '#system-status',
+      hint: 'Optional: connect Slack to receive CFP and sales notifications.',
+      optional: true,
+    },
+    {
+      id: 'custom-domain',
+      label: 'Custom domain',
+      done: hasCustomDomain(conference.domains, options.platformDomainSuffix),
+      anchor: '#team-content',
+      hint: 'Optional: point your own domain at the site once you are ready.',
+      optional: true,
+    },
+    // TERMINAL ROW — the launch switch, always last so it reads as the finish
+    // line. FUTURE: the paid-activation / billing gate (a "Complete payment"
+    // step) will slot in immediately BEFORE this row once CaaS billing lands.
+    {
+      id: 'visibility',
+      label: 'Go live',
+      done: isLive,
+      anchor: '#visibility',
+      hint: isLive
+        ? 'This edition is publicly listed and indexed.'
+        : 'Flip visibility to Live to publish and index the site.',
+    },
+  ]
+
+  const requiredRows = rows.filter((r) => !r.optional)
+  const done = requiredRows.filter((r) => r.done).length
+
+  return {
+    rows,
+    done,
+    required: requiredRows.length,
+    allDone: done === requiredRows.length,
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **"Get started"** onboarding checklist at the **top of the Settings → Configuration tier** answering *"what do I still need to configure to launch?"* — the key onboarding surface for external tenants (activation S4). It is **purely derived**: no new mutations, no schema changes. The card auto-collapses once every required step is done, so an established conference sees only a compact "Ready" header.

## Row inventory & sources

Rows are computed from two sources — required-field emptiness on the conference document (pure) and a *selective* read of the already-built `buildSystemChecks` output (no re-probing).

| # | Row | Done when | Source | Anchor |
|---|-----|-----------|--------|--------|
| 1 | Name & organizer | `title` && `organizer` set | conference | `#identity-brand` |
| 2 | Brand logo | any of `logoBright/Dark`, `logomarkBright/Dark` set | conference | `#identity-brand` |
| 3 | Venue | `venueName` set | conference | `#identity-brand` |
| 4 | Conference dates | `startDate` && `endDate` | conference | `#schedule` |
| 5 | Call-for-papers window | `cfpStartDate` && `cfpEndDate` | conference | `#schedule` |
| 6 | At least one topic | `topics.length > 0` | conference | `#team-content` |
| 7 | Contact, CFP & sponsor emails | all three emails set | conference | `#team-content` |
| 8 | Registration link | `registrationLink` set | conference | `#tickets-registration` |
| 9 | Ticketing connected | **provider-aware** binding | conference | `#tickets-registration` |
| 10 | Email delivery configured | `email.resendKey` check `ok` | system checks | `#system-status` |
| 11 | Slack notifications *(optional)* | `slack.botToken` check `ok` | system checks | `#system-status` |
| 12 | Custom domain *(optional, informational)* | a domain beyond the platform subdomain | conference | `#team-content` |
| 13 | **Go live** *(terminal)* | `visibility === 'live'` | conference | `#visibility` |

**Provider-aware ticketing (row 9):** mirrors `hasTicketingBinding` — Tito needs both account+event slugs; Checkin (the absent-provider default) needs both customer+event IDs. Re-expressed inline in `activation.ts` rather than imported, because the `@/lib/tickets/provider` barrel pulls in the `server-only` secret store and this module is imported by the Storybook story (must stay client-safe). Same reason `resolveConferenceVisibility` is inlined.

**Optional rows** (Slack, Custom domain) carry `optional: true` and are excluded from the progress numerator/denominator. Progress = done / required.

## The Go-live terminal row

`visibility` is always the **last** row — the launch switch, so it reads as the finish line. A code comment marks it as the seat for the **future paid-activation / billing gate** (a "Complete payment" step slots in immediately *before* Go-live once CaaS billing lands). Note: absent visibility resolves to `live` (legacy docs), consistent with the rest of the app; a fresh trial edition is created `unlisted` and stays "to do" until an organizer flips it.

## Build notes

- `src/lib/settings/activation.ts` — pure `buildActivationChecklist(conference, checks, options?)` → `{ rows, done, required, allDone }`. Fully unit-tested.
- `src/components/admin/ActivationChecklist.tsx` — server-safe card on `CollapsibleSection` (`headingLevel={3}`, sits directly under the Configuration `h2`; `defaultOpen = !allDone`). Progress bar + anchor-linked rows with check/empty icons; optional rows use a dashed circle + "Optional" badge.
- Wired at the top of tier 1 in the settings page. **No new mutations, no schema changes.**

## Verification

- `mise run check` — lint, typecheck, knip, format all green.
- Full vitest suite: **4295 passed** (18 new activation tests: derivation across fresh/partial/live states, provider-aware ticketing, optional-row exclusion, system-check reuse, custom-domain heuristic).
- Visual: shot at 393px + desktop, light + dark — fresh, nearly-done, all-done. No viewport overflow. (Collapsed title truncates to "Get sta…" at 393px — inherent shared-`CollapsibleSection` behavior, consistent with every other collapsible card on the page; full at desktop width.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
