### PR TITLE
feat(admin): in-page editors for sponsorship tiers, formats and sponsor affordances (kill-Studio gaps)

### DIFF
--- a/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
+++ b/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
@@ -21,6 +21,7 @@ import {
 import {
   InfoCard,
   FieldRow,
+  LinkedBadgeList,
   StudioEditLink,
   SectionNav,
   SectionHeading,
@@ -259,7 +260,10 @@ function SettingsIADemo() {
             <InfoCard
               title="Sponsorship Tiers"
               icon={CurrencyDollarIcon}
-              editUrl={EDIT_URL}
+              manageLink={{
+                href: '/admin/sponsors/tiers',
+                label: 'Manage tiers',
+              }}
             >
               <div className="border-b border-gray-200 pb-3 last:border-b-0 last:pb-0 dark:border-gray-700">
                 <div className="mb-2 flex items-center justify-between">
@@ -277,12 +281,22 @@ function SettingsIADemo() {
             <InfoCard
               title="Current Sponsors"
               icon={CurrencyDollarIcon}
-              editUrl={EDIT_URL}
+              manageLink={{ href: '/admin/sponsors/crm', label: 'Open CRM' }}
             >
-              <FieldRow
+              <LinkedBadgeList
                 label="Sponsors"
-                value={['Acme (Gold)', 'Globex (Silver)']}
-                type="array"
+                items={[
+                  {
+                    key: 'acme',
+                    label: 'Acme (Gold)',
+                    href: '/admin/sponsors/crm?sponsor=acme',
+                  },
+                  {
+                    key: 'globex',
+                    label: 'Globex (Silver)',
+                    href: '/admin/sponsors/crm?sponsor=globex',
+                  },
+                ]}
               />
             </InfoCard>
 
@@ -380,9 +394,18 @@ function SettingsIADemo() {
             <InfoCard
               title="Topics & Formats"
               icon={TagIcon}
-              editUrl={EDIT_URL}
-              action={<EditPencil />}
+              action={
+                <>
+                  <EditPencil />
+                  <EditPencil />
+                </>
+              }
             >
+              <FieldRow
+                label="Available Formats"
+                value={['lightning_10', 'presentation_25', 'workshop_120']}
+                type="formats"
+              />
               <FieldRow
                 label="Available Topics"
                 value={['Kubernetes', 'Observability', 'Security']}

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/lib/conference/backgroundPattern'
 import { OrganizersEditor } from '@/components/admin/OrganizersEditor'
 import { TopicsEditor } from '@/components/admin/TopicsEditor'
+import { FormatsEditor } from '@/components/admin/FormatsEditor'
 import { TeamsEditor } from '@/components/admin/TeamsEditor'
 import { HomepageSectionsEditor } from '@/components/admin/HomepageSectionsEditor'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
@@ -33,6 +34,7 @@ import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
 import {
   InfoCard,
   FieldRow,
+  LinkedBadgeList,
   StudioEditLink,
   SectionNav,
   SectionHeading,
@@ -569,7 +571,10 @@ export default async function AdminSettings() {
               <InfoCard
                 title="Sponsorship Tiers"
                 icon={CurrencyDollarIcon}
-                editUrl={editUrl}
+                manageLink={{
+                  href: '/admin/sponsors/tiers',
+                  label: 'Manage tiers',
+                }}
               >
                 {conference.sponsorTiers.map((tier, idx) => (
                   <div
@@ -611,14 +616,26 @@ export default async function AdminSettings() {
               <InfoCard
                 title="Current Sponsors"
                 icon={CurrencyDollarIcon}
-                editUrl={editUrl}
+                manageLink={{ href: '/admin/sponsors/crm', label: 'Open CRM' }}
               >
-                <FieldRow
+                {/* Each sponsor deep-links to its CRM record — the full sponsor
+                    editor lives in /admin/sponsors, so this card surfaces WHO
+                    is signed and jumps you there rather than duplicating the
+                    CRM. Add/remove a sponsor also happens in the CRM. The CRM
+                    matches its `?sponsor=` param against the sponsorForConference
+                    id (`_sfcId`), NOT the sponsor document id; fall back to the
+                    CRM landing page if that id is somehow absent. */}
+                <LinkedBadgeList
                   label="Sponsors"
-                  value={conference.sponsors.map(
-                    (s) => `${s.sponsor.name} (${s.tier?.title ?? 'No Tier'})`,
-                  )}
-                  type="array"
+                  items={conference.sponsors.map((s) => ({
+                    key: s._sfcId ?? s.sponsor._id,
+                    label: `${s.sponsor.name} (${s.tier?.title ?? 'No Tier'})`,
+                    href: s._sfcId
+                      ? `/admin/sponsors/crm?sponsor=${encodeURIComponent(
+                          s._sfcId,
+                        )}`
+                      : '/admin/sponsors/crm',
+                  }))}
                 />
               </InfoCard>
             )}
@@ -830,15 +847,17 @@ export default async function AdminSettings() {
             <InfoCard
               title="Topics & Formats"
               icon={TagIcon}
-              editUrl={editUrl}
               action={
-                <TopicsEditor
-                  selectedTopics={(conference.topics ?? []).map((t) => ({
-                    _id: t._id,
-                    title: t.title,
-                    color: t.color,
-                  }))}
-                />
+                <>
+                  <FormatsEditor selectedFormats={conference.formats ?? []} />
+                  <TopicsEditor
+                    selectedTopics={(conference.topics ?? []).map((t) => ({
+                      _id: t._id,
+                      title: t.title,
+                      color: t.color,
+                    }))}
+                  />
+                </>
               }
             >
               <FieldRow

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -107,7 +107,7 @@ export function ManageLink({ href, label }: ManageLinkTarget) {
       className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
     >
       {label}
-      <ArrowUpRightIcon className="h-4 w-4" />
+      <ArrowUpRightIcon className="h-4 w-4" aria-hidden="true" />
     </Link>
   )
 }
@@ -371,7 +371,10 @@ export function LinkedBadgeList({
                 className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 hover:bg-indigo-50 hover:text-indigo-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-indigo-900/30 dark:hover:text-indigo-300"
               >
                 <span className="min-w-0 break-words">{item.label}</span>
-                <ArrowUpRightIcon className="h-3 w-3 shrink-0" />
+                <ArrowUpRightIcon
+                  className="h-3 w-3 shrink-0"
+                  aria-hidden="true"
+                />
               </Link>
             ))}
           </div>

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType, ReactNode } from 'react'
+import Link from 'next/link'
 import { formatDate, formatDateTimeSafe } from '@/lib/time'
 import { formats, Format } from '@/lib/proposal/types'
 import { StatusBadge } from '@/components/StatusBadge'
@@ -13,6 +14,7 @@ import {
   XCircleIcon,
   LinkIcon,
   EnvelopeIcon,
+  ArrowUpRightIcon,
 } from '@heroicons/react/24/outline'
 
 /**
@@ -34,17 +36,33 @@ function isValidFormat(key: string): key is Format {
   return Object.values(Format).includes(key as Format)
 }
 
+/** A deep-link to a dedicated management page (the in-app editor for this
+ * card's data). Used where a full editor already lives elsewhere in /admin, so
+ * the settings card links to it instead of duplicating the editor (and instead
+ * of a "Edit in Studio" link). */
+export interface ManageLinkTarget {
+  href: string
+  label: string
+}
+
 export function InfoCard({
   title,
   children,
   icon: Icon,
   editUrl,
+  manageLink,
   action,
 }: {
   title: string
   children: ReactNode
   icon: ComponentType<{ className?: string }>
   editUrl?: string | null
+  /**
+   * Optional deep-link to a dedicated /admin management page for this card's
+   * data. Rendered in the header action slot in place of the Studio link (a
+   * card should offer one or the other, not both).
+   */
+  manageLink?: ManageLinkTarget
   /**
    * Optional inline edit affordance (an EditConferenceCard island). When present
    * it sits beside the Studio deep-link; the card body keeps rendering the
@@ -62,12 +80,30 @@ export function InfoCard({
           </h3>
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          {manageLink ? <ManageLink {...manageLink} /> : null}
           <StudioEditLink editUrl={editUrl} />
           {action}
         </div>
       </div>
       <div className="space-y-3">{children}</div>
     </div>
+  )
+}
+
+/**
+ * Deep-link affordance to a dedicated /admin management page. An INTERNAL link
+ * (Next `Link`, no `target=_blank`) — it stays in the admin app, unlike the
+ * Studio deep-link which opens an external CMS.
+ */
+export function ManageLink({ href, label }: ManageLinkTarget) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+    >
+      {label}
+      <ArrowUpRightIcon className="h-4 w-4" />
+    </Link>
   )
 }
 
@@ -290,6 +326,53 @@ export function FieldRow({
           viewport and the page pans horizontally. */}
       <dd className="max-w-xs min-w-0 text-right text-sm text-gray-900 dark:text-white">
         {displayValue}
+      </dd>
+    </div>
+  )
+}
+
+/** One clickable row in a {@link LinkedBadgeList}. */
+export interface LinkedBadgeItem {
+  key: string
+  label: string
+  href: string
+}
+
+/**
+ * A labelled list of clickable badges, each deep-linking into a management page
+ * (e.g. each current sponsor → its CRM record). The read-only settings card
+ * shows WHAT exists; the links are how an organizer jumps to EDIT it, so the
+ * card never has to embed the CRM. `href` is an internal /admin path.
+ */
+export function LinkedBadgeList({
+  label,
+  items,
+}: {
+  label: string
+  items: LinkedBadgeItem[]
+}) {
+  return (
+    <div className="flex justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
+      <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+        {label}
+      </dt>
+      <dd className="max-w-xs min-w-0 text-right text-sm">
+        {items.length > 0 ? (
+          <div className="flex flex-wrap justify-end gap-1">
+            {items.map((item) => (
+              <Link
+                key={item.key}
+                href={item.href}
+                className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 hover:bg-indigo-50 hover:text-indigo-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-indigo-900/30 dark:hover:text-indigo-300"
+              >
+                <span className="min-w-0 break-words">{item.label}</span>
+                <ArrowUpRightIcon className="h-3 w-3 shrink-0" />
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )}
       </dd>
     </div>
   )

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -80,8 +80,13 @@ export function InfoCard({
           </h3>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {manageLink ? <ManageLink {...manageLink} /> : null}
-          <StudioEditLink editUrl={editUrl} />
+          {/* One or the other, per the contract above: an in-app manage
+              link supersedes the Studio deep-link. */}
+          {manageLink ? (
+            <ManageLink {...manageLink} />
+          ) : (
+            <StudioEditLink editUrl={editUrl} />
+          )}
           {action}
         </div>
       </div>

--- a/src/components/admin/FormatsEditor.stories.tsx
+++ b/src/components/admin/FormatsEditor.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { FormatsEditor } from './FormatsEditor'
+import { NotificationProvider } from './NotificationProvider'
+
+const handlers = [
+  http.post('/api/trpc/conference.updateFormats', () =>
+    HttpResponse.json({ result: { data: { success: true, updated: {} } } }),
+  ),
+]
+
+const selectedFormats = ['lightning_10', 'presentation_25', 'workshop_120']
+
+const meta = {
+  title: 'Systems/Settings/Admin/FormatsEditor',
+  component: FormatsEditor,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'The conference Formats editor (kill-Studio gap). Toggle which of the canonical CFP formats this conference offers. Unlike TopicsEditor the set is fixed, so there is no "create new". Saving replaces `conference.formats[]` (min 1).',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-white p-6 dark:bg-gray-950">
+                <Story />
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof FormatsEditor>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { selectedFormats, defaultOpen: true },
+}
+
+export const Dark: Story = {
+  args: { selectedFormats, defaultOpen: true },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}

--- a/src/components/admin/FormatsEditor.tsx
+++ b/src/components/admin/FormatsEditor.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { PencilSquareIcon } from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { api } from '@/lib/trpc/client'
+import { formats, Format } from '@/lib/proposal/types'
+import { useNotification } from './NotificationProvider'
+
+/**
+ * The conference Formats editor island (kill-Studio gap).
+ *
+ * `conference.formats[]` is an array of canonical CFP format KEYS (plain
+ * enum strings — NOT references, unlike `topics[]`). The set of selectable
+ * formats is FIXED (the {@link formats} map), so — unlike {@link TopicsEditor}
+ * — there is no "create new" affordance: the organizer simply toggles which of
+ * the known formats this conference offers. Saving patches
+ * `conference.updateFormats` with the selected keys (non-empty, mirroring the
+ * schema's `min(1)`).
+ */
+export interface FormatsEditorProps {
+  /** The conference's currently-enabled format keys. */
+  selectedFormats: string[]
+  defaultOpen?: boolean
+}
+
+/** The canonical format options, in the map's declared order. */
+const ALL_FORMATS: { key: Format; label: string }[] = Array.from(formats).map(
+  ([key, label]) => ({ key, label }),
+)
+
+export function FormatsEditor({
+  selectedFormats,
+  defaultOpen = false,
+}: FormatsEditorProps) {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+
+  // Only keep keys that are still canonical (a stale/removed key can't be
+  // re-saved, since the schema enum would reject it).
+  const initial = selectedFormats.filter((k): k is Format =>
+    ALL_FORMATS.some((f) => f.key === k),
+  )
+
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const [selectedKeys, setSelectedKeys] = useState<Format[]>(initial)
+  const [error, setError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const baseline = [...initial].sort()
+  const isDirty =
+    JSON.stringify([...selectedKeys].sort()) !== JSON.stringify(baseline)
+
+  const saveMutation = api.conference.updateFormats.useMutation({
+    onSuccess: () => {
+      void utils.invalidate()
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Formats updated',
+        message: 'Conference formats saved.',
+      })
+      setIsOpen(false)
+    },
+    onError: (err) => {
+      setSubmitError(err.message || 'Failed to save formats.')
+      showNotification({
+        type: 'error',
+        title: 'Could not save',
+        message: err.message || 'Failed to save formats.',
+      })
+    },
+  })
+
+  const reset = () => {
+    setSelectedKeys(initial)
+    setError(null)
+    setSubmitError(null)
+  }
+  const openModal = () => {
+    reset()
+    setIsOpen(true)
+  }
+  const closeModal = () => {
+    setIsOpen(false)
+    reset()
+  }
+
+  const toggle = (key: Format) => {
+    setSelectedKeys((prev) =>
+      prev.includes(key) ? prev.filter((x) => x !== key) : [...prev, key],
+    )
+    setError(null)
+  }
+
+  const handleSave = () => {
+    setSubmitError(null)
+    if (selectedKeys.length === 0) {
+      setError('At least one format is required.')
+      return
+    }
+    saveMutation.mutate({ formats: selectedKeys })
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openModal}
+        aria-label="Edit Formats"
+        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-cloud-blue dark:text-gray-400 dark:hover:bg-gray-800"
+      >
+        <PencilSquareIcon className="h-5 w-5" />
+      </button>
+
+      <ModalShell
+        isOpen={isOpen}
+        onClose={closeModal}
+        size="lg"
+        title="Edit Formats"
+        subtitle="Formats available for CFP submissions and the agenda"
+        icon={<PencilSquareIcon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty && !saveMutation.isPending}
+      >
+        <form
+          noValidate
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSave()
+          }}
+          className="space-y-4"
+        >
+          <fieldset>
+            <legend className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+              Select formats
+            </legend>
+            <ul className="space-y-1 rounded-lg border border-gray-200 p-2 dark:border-gray-700">
+              {ALL_FORMATS.map((format) => {
+                const cid = `format-${format.key}`
+                return (
+                  <li key={format.key}>
+                    <label
+                      htmlFor={cid}
+                      className="flex min-h-[44px] cursor-pointer items-center gap-2 rounded-md px-2 text-sm text-gray-800 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800"
+                    >
+                      <input
+                        id={cid}
+                        type="checkbox"
+                        checked={selectedKeys.includes(format.key)}
+                        onChange={() => toggle(format.key)}
+                        className="h-5 w-5 rounded border-gray-300 text-brand-cloud-blue focus:ring-brand-cloud-blue"
+                      />
+                      <span className="truncate">{format.label}</span>
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+          </fieldset>
+
+          {error ? (
+            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+              {error}
+            </p>
+          ) : null}
+          {submitError ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+            <AdminButton
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={closeModal}
+              disabled={saveMutation.isPending}
+              className="min-h-[44px]"
+            >
+              Cancel
+            </AdminButton>
+            <AdminButton
+              type="submit"
+              color="blue"
+              size="md"
+              disabled={saveMutation.isPending || !isDirty}
+              className="min-h-[44px]"
+            >
+              {saveMutation.isPending ? 'Saving…' : 'Save formats'}
+            </AdminButton>
+          </div>
+        </form>
+      </ModalShell>
+    </>
+  )
+}

--- a/src/components/admin/FormatsEditor.tsx
+++ b/src/components/admin/FormatsEditor.tsx
@@ -44,13 +44,17 @@ export function FormatsEditor({
   const initial = selectedFormats.filter((k): k is Format =>
     ALL_FORMATS.some((f) => f.key === k),
   )
-  // Non-canonical stored keys are shown nowhere but MUST count as a pending
-  // change: baselining on the RAW stored list makes the editor open dirty, so
-  // one Save persists the cleaned canonical set.
-  const hasStaleStoredKeys = initial.length !== selectedFormats.length
+  // Non-canonical OR duplicate stored keys are shown nowhere but MUST count
+  // as a pending change: the editor opens dirty so one Save persists the
+  // cleaned, unique canonical set.
+  const hasStaleStoredKeys =
+    initial.length !== selectedFormats.length ||
+    new Set(selectedFormats).size !== selectedFormats.length
 
   const [isOpen, setIsOpen] = useState(defaultOpen)
-  const [selectedKeys, setSelectedKeys] = useState<Format[]>(initial)
+  const [selectedKeys, setSelectedKeys] = useState<Format[]>([
+    ...new Set(initial),
+  ])
   const [error, setError] = useState<string | null>(null)
   const [submitError, setSubmitError] = useState<string | null>(null)
 

--- a/src/components/admin/FormatsEditor.tsx
+++ b/src/components/admin/FormatsEditor.tsx
@@ -44,6 +44,10 @@ export function FormatsEditor({
   const initial = selectedFormats.filter((k): k is Format =>
     ALL_FORMATS.some((f) => f.key === k),
   )
+  // Non-canonical stored keys are shown nowhere but MUST count as a pending
+  // change: baselining on the RAW stored list makes the editor open dirty, so
+  // one Save persists the cleaned canonical set.
+  const hasStaleStoredKeys = initial.length !== selectedFormats.length
 
   const [isOpen, setIsOpen] = useState(defaultOpen)
   const [selectedKeys, setSelectedKeys] = useState<Format[]>(initial)
@@ -52,6 +56,7 @@ export function FormatsEditor({
 
   const baseline = [...initial].sort()
   const isDirty =
+    hasStaleStoredKeys ||
     JSON.stringify([...selectedKeys].sort()) !== JSON.stringify(baseline)
 
   const saveMutation = api.conference.updateFormats.useMutation({
@@ -102,7 +107,12 @@ export function FormatsEditor({
       setError('At least one format is required.')
       return
     }
-    saveMutation.mutate({ formats: selectedKeys })
+    // Persist in CANONICAL order — interaction order must not reorder the
+    // stored list (it drives display order elsewhere).
+    const canonicalOrder = ALL_FORMATS.map((f) => f.key).filter((k) =>
+      selectedKeys.includes(k),
+    )
+    saveMutation.mutate({ formats: canonicalOrder })
   }
 
   return (

--- a/src/server/routers/conference.test.ts
+++ b/src/server/routers/conference.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Context } from '@/server/trpc'
+import { Format } from '@/lib/proposal/types'
 
 // --- next/cache -------------------------------------------------------------
 vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
@@ -603,6 +604,54 @@ describe('conference router — topics', () => {
     await expect(
       makeCaller({ isOrganizer: true }).updateTopics({
         topics: ['topic-a', 'topic-a'],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('conference router — formats', () => {
+  it('replaces the formats array as PLAIN keys (no reference wrapping)', async () => {
+    const result = await makeCaller({ isOrganizer: true }).updateFormats({
+      formats: [Format.lightning_10, Format.presentation_25],
+    })
+    expect(result.success).toBe(true)
+    // Formats are enum strings, not references — stored verbatim, no _key/_ref.
+    expect(lastSet!.formats).toEqual(['lightning_10', 'presentation_25'])
+    // Field-scoped to the resolved conference, never a client-sent id.
+    expect(lastPatchId).toBe(CONFERENCE_ID)
+  })
+
+  it('rejects an empty format list (min 1)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateFormats({ formats: [] }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects duplicate format keys', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateFormats({
+        formats: [Format.lightning_10, Format.lightning_10],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown format key (enum-constrained)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: true }).updateFormats({
+        // @ts-expect-error — deliberately outside the Format enum
+        formats: ['keynote_60'],
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-organizer (adminProcedure)', async () => {
+    await expect(
+      makeCaller({ isOrganizer: false }).updateFormats({
+        formats: [Format.lightning_10],
       }),
     ).rejects.toBeTruthy()
     expect(commitMock).not.toHaveBeenCalled()

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -39,6 +39,7 @@ import {
   UpdateDomainsSchema,
   UpdateOrganizersSchema,
   UpdateTopicsSchema,
+  UpdateFormatsSchema,
   UpdateTeamsSchema,
   UpdateAnnouncementSchema,
   UpdateBrandingLogoSchema,
@@ -322,6 +323,21 @@ export const conferenceRouter = router({
       const conferenceId = await resolveConferenceId()
       return applyConferencePatch(conferenceId, {
         topics: input.topics.map((id) => createReferenceWithKey(id, 'topic')),
+      })
+    }),
+
+  /**
+   * Formats — the conference's `formats[]` CFP/agenda format keys. Unlike
+   * topics these are plain enum STRINGS (no reference/`_key` wrapping), so the
+   * validated array is stored verbatim. Field-scoped full-array replace; the
+   * Zod schema guarantees ≥1, unique, and only canonical {@link Format} keys.
+   */
+  updateFormats: adminProcedure
+    .input(UpdateFormatsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, {
+        formats: input.formats,
       })
     }),
 

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -390,7 +390,6 @@ export const UpdateTopicsSchema = z.object({
  * array may contain. Mirrors the Sanity schema's inline `options.list`
  * (sourced from the same `formats` map), so the editor can never store a key
  * the CFP/agenda code doesn't understand. */
-const FORMAT_VALUES = Object.values(Format) as [Format, ...Format[]]
 
 /**
  * Formats — the conference's `formats[]` array of canonical format KEYS (plain
@@ -400,7 +399,7 @@ const FORMAT_VALUES = Object.values(Format) as [Format, ...Format[]]
  */
 export const UpdateFormatsSchema = z.object({
   formats: z
-    .array(z.enum(FORMAT_VALUES))
+    .array(z.nativeEnum(Format))
     .min(1, 'At least one format is required')
     .refine((keys) => new Set(keys).size === keys.length, {
       message: 'Formats must be unique',

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -386,11 +386,6 @@ export const UpdateTopicsSchema = z.object({
     }),
 })
 
-/** The canonical CFP format keys — the closed set the conference `formats[]`
- * array may contain. Mirrors the Sanity schema's inline `options.list`
- * (sourced from the same `formats` map), so the editor can never store a key
- * the CFP/agenda code doesn't understand. */
-
 /**
  * Formats — the conference's `formats[]` array of canonical format KEYS (plain
  * strings, not references). Mirrors the Sanity schema's `required().min(1)

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { HEX_COLOR_RE } from '@/lib/branding/theme'
+import { Format } from '@/lib/proposal/types'
 import { HEROICON_OPTIONS } from '../../../sanity/schemaTypes/constants'
 import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
 import { isValidTeamKey } from '@/lib/teams/validation'
@@ -382,6 +383,27 @@ export const UpdateTopicsSchema = z.object({
     .min(1, 'At least one topic is required')
     .refine((ids) => new Set(ids).size === ids.length, {
       message: 'Topics must be unique',
+    }),
+})
+
+/** The canonical CFP format keys — the closed set the conference `formats[]`
+ * array may contain. Mirrors the Sanity schema's inline `options.list`
+ * (sourced from the same `formats` map), so the editor can never store a key
+ * the CFP/agenda code doesn't understand. */
+const FORMAT_VALUES = Object.values(Format) as [Format, ...Format[]]
+
+/**
+ * Formats — the conference's `formats[]` array of canonical format KEYS (plain
+ * strings, not references). Mirrors the Sanity schema's `required().min(1)
+ * .unique()` and its enum-constrained `of`: at least one, no duplicates, and
+ * every entry a known {@link Format}. A full-array replace.
+ */
+export const UpdateFormatsSchema = z.object({
+  formats: z
+    .array(z.enum(FORMAT_VALUES))
+    .min(1, 'At least one format is required')
+    .refine((keys) => new Set(keys).size === keys.length, {
+      message: 'Formats must be unique',
     }),
 })
 


### PR DESCRIPTION
Closes three read-only cards on the admin **Settings** page (#654 IA) that still pushed organizers into Sanity Studio. Each gap was verified against current code first — and the verification changed the plan for two of them.

## Gap 1 — Sponsorship Tiers → affordance (not a new editor)
A **full tier CRUD manager already exists** at `/admin/sponsors/tiers` (`SponsorTierManagement` + the ~860-line `SponsorTierEditor`, backed by `sponsor.tiers.{create,update,delete}`). Building a second tier editor inside the settings card would duplicate that CRM logic and invite divergence. So the card now links to the existing manager (**"Manage tiers"**) and the **"Edit in Studio"** link is removed. Studio is already unnecessary for tiers; this just points the settings card at the in-app path.

## Gap 2 — Formats → real new in-page editor
`conference.formats[]` is a plain array of **canonical CFP format keys** (enum strings, not references), `min(1)`, unique. This was the one genuinely missing capability. Added:
- `UpdateFormatsSchema` — enum-constrained to the `Format` keys, `min(1)`, no duplicates (mirrors the Sanity schema).
- `conference.updateFormats` — field-scoped `adminProcedure` mutation, org/conference-scoped via `resolveConferenceId()` like the rest of the house; stores the keys verbatim (no reference/`_key` wrapping).
- `FormatsEditor` island — mirrors `TopicsEditor`, but the format set is fixed so there is **no "create new"**: organizers just toggle which canonical formats this conference offers.
- The **Topics & Formats** card now carries both the Formats and Topics editor pencils, and its **"Edit in Studio"** link is removed (both fields are in-page editable).

## Gap 3 — Current Sponsors → affordance (correct, per the brief)
The full sponsor CRM lives at `/admin/sponsors`, incl. create via `SponsorAddModal`. This card doesn't need an editor — it needs the right jump. Each sponsor row now deep-links to its CRM record (`/admin/sponsors/crm?sponsor=<id>`) and the card links to the CRM (**"Open CRM"**). Studio link removed. **Deep-link correctness:** the CRM matches its `?sponsor=` param against the `sponsorForConference` id — exposed on the settings payload as `_sfcId` — **not** the sponsor document id; the link uses `_sfcId` (with a graceful fallback to the CRM landing page).

## Shared primitives
`settingsLayout` gains an `InfoCard` `manageLink` prop + `ManageLink` (internal deep-link affordance) and `LinkedBadgeList` (labelled row of CRM-linked badges), so the pattern is single-sourced and Storybook-inspectable.

## What Sanity Studio is still needed for (honest list)
Nothing on these three cards. Repo-wide, Studio is already optional for organizer workflows (per the self-sufficiency program). Remaining Studio-only surfaces are unchanged by this PR and out of scope: developer/config-only fields and any document types without an admin editor yet — not touched here.

## QA
- `mise run check` green (lint 0 errors, typecheck 0, format 0, knip 0).
- **Full vitest green: 328 files, 4282 tests.** New `conference.test.ts` cases cover `updateFormats` mapping (plain keys, field-scoped id), `min(1)`, duplicate rejection, unknown-key (enum) rejection, and non-organizer rejection.
- Visual QA via Storybook (`FormatsEditor` + `SettingsIA` harness), inspected at **393px and desktop, light and dark**: FormatsEditor modal (correct pre-selection, Save disabled when clean, 44px targets, no overflow); Sponsorship Tiers "Manage tiers"; Current Sponsors "Open CRM" + clickable sponsor badges; Topics & Formats dual pencils + formatted formats row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
