### PR TITLE
fix(badge): consumer compatibility — rebake-aware caching, credential-id endpoint, PNG download

### DIFF
--- a/__tests__/api/badge/badge-endpoints.test.ts
+++ b/__tests__/api/badge/badge-endpoints.test.ts
@@ -111,6 +111,71 @@ describe('Badge endpoints - dual format', () => {
     })
   })
 
+  describe('GET /api/badge/[badgeId] (credential id / hosted verification)', () => {
+    it('serves the same credential bytes as /json (application/ld+json)', async () => {
+      mockedGetBadgeById.mockResolvedValue({
+        badge: badgeRecord({
+          badgeJson: credentialJsonString,
+          badgeJwt: credentialJwt,
+        }),
+      })
+      const { GET: JSON_GET } =
+        await import('@/app/api/badge/[badgeId]/json/route')
+      const jsonBytes = await (await JSON_GET(request, routeParams())).text()
+
+      mockedGetBadgeById.mockResolvedValue({
+        badge: badgeRecord({
+          badgeJson: credentialJsonString,
+          badgeJwt: credentialJwt,
+        }),
+      })
+      const { GET } = await import('@/app/api/badge/[badgeId]/route')
+      const res = await GET(request, routeParams())
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Content-Type')).toContain('application/ld+json')
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+      expect(await res.text()).toBe(jsonBytes)
+    })
+
+    it('uses rebake-aware caching (revalidate + ETag, not immutable)', async () => {
+      mockedGetBadgeById.mockResolvedValue({
+        badge: badgeRecord({ badgeJson: credentialJsonString }),
+      })
+      const { GET } = await import('@/app/api/badge/[badgeId]/route')
+      const res = await GET(request, routeParams())
+
+      expect(res.headers.get('Cache-Control')).toBe(
+        'public, max-age=0, must-revalidate',
+      )
+      expect(res.headers.get('Cache-Control')).not.toContain('immutable')
+      expect(res.headers.get('ETag')).toBeTruthy()
+    })
+
+    it('redirects browsers (Accept: text/html) to the human badge page', async () => {
+      const { GET } = await import('@/app/api/badge/[badgeId]/route')
+      const htmlReq = {
+        headers: {
+          get: (n: string) =>
+            n.toLowerCase() === 'accept' ? 'text/html' : null,
+        },
+        url: 'https://conf.test/api/badge/test-badge-id',
+      } as unknown as NextRequest
+      const res = await GET(htmlReq, routeParams())
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toContain('/badge/test-badge-id')
+    })
+
+    it('404s an unknown badge', async () => {
+      mockedGetBadgeById.mockResolvedValue({ badge: null, error: null })
+      const { GET } = await import('@/app/api/badge/[badgeId]/route')
+      const res = await GET(request, routeParams('nope'))
+
+      expect(res.status).toBe(404)
+    })
+  })
+
   describe('GET /api/badge/[badgeId]/jwt', () => {
     it('serves the JWT from badgeJwt for new badges', async () => {
       mockedGetBadgeById.mockResolvedValue({

--- a/__tests__/api/badge/badge-endpoints.test.ts
+++ b/__tests__/api/badge/badge-endpoints.test.ts
@@ -168,7 +168,9 @@ describe('Badge endpoints - dual format', () => {
     })
 
     it('404s an unknown badge', async () => {
-      mockedGetBadgeById.mockResolvedValue({ badge: null, error: null })
+      mockedGetBadgeById.mockResolvedValue({
+        error: new Error('Badge not found'),
+      })
       const { GET } = await import('@/app/api/badge/[badgeId]/route')
       const res = await GET(request, routeParams('nope'))
 

--- a/__tests__/api/badge/download-png.test.ts
+++ b/__tests__/api/badge/download-png.test.ts
@@ -100,10 +100,12 @@ describe('GET /api/badge/[badgeId]/download?format=png', () => {
     })
     const etag = first.headers.get('ETag')!
 
+    // The 304 path returns before rasterization: fonts must NOT be loaded.
+    vi.mocked(loadBadgeFontFiles).mockClear()
     const res = await GET(pngRequest(etag), {
       params: Promise.resolve({ badgeId: 'test-badge-id' }),
     })
     expect(res.status).toBe(304)
-    expect(vi.mocked(loadBadgeFontFiles)).toHaveBeenCalled()
+    expect(vi.mocked(loadBadgeFontFiles)).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/api/badge/download-png.test.ts
+++ b/__tests__/api/badge/download-png.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment node
+ *
+ * Endpoint-level coverage for GET /api/badge/[badgeId]/download?format=png:
+ * the route must return image/png with the rebake-aware cache headers and a
+ * credential actually baked into the PNG bytes.
+ */
+import type { NextRequest } from 'next/server'
+import { extractCredentialFromPng } from '@/lib/badge/png'
+import type { BadgeRecord } from '@/lib/badge/types'
+
+vi.mock('@/lib/badge/sanity', () => ({
+  getBadgeById: vi.fn(),
+  getBadgeSVGUrl: vi.fn(),
+}))
+vi.mock('@/lib/badge/fonts', () => ({
+  loadBadgeFontFiles: vi.fn().mockResolvedValue([]),
+}))
+
+import { getBadgeById, getBadgeSVGUrl } from '@/lib/badge/sanity'
+import { loadBadgeFontFiles } from '@/lib/badge/fonts'
+
+const CREDENTIAL = JSON.stringify({
+  '@context': ['https://www.w3.org/ns/credentials/v2'],
+  id: 'https://example.com/api/badge/test-badge-id',
+  type: ['VerifiableCredential', 'OpenBadgeCredential'],
+})
+
+const SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" xmlns:openbadges="https://purl.imsglobal.org/ob/v3p0" viewBox="0 0 100 100">' +
+  '<openbadges:credential><![CDATA[ ' +
+  CREDENTIAL +
+  ' ]]></openbadges:credential>' +
+  '<rect width="100" height="100" fill="#123"/></svg>'
+
+function badgeRecord(): BadgeRecord {
+  return {
+    _id: 'badge-doc-1',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-06-01T12:00:00Z',
+    badgeId: 'test-badge-id',
+    speaker: { _ref: 'speaker-1', _type: 'reference' },
+    conference: { _ref: 'conference-1', _type: 'reference' },
+    badgeType: 'speaker',
+    issuedAt: '2026-01-01T00:00:00Z',
+    badgeJson: CREDENTIAL,
+    generatorVersion: 2,
+    emailSent: false,
+  } as unknown as BadgeRecord
+}
+
+function pngRequest(ifNoneMatch?: string): NextRequest {
+  return {
+    nextUrl: new URL(
+      'https://conf.example/api/badge/test-badge-id/download?format=png',
+    ),
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'if-none-match' ? (ifNoneMatch ?? null) : null,
+    },
+  } as unknown as NextRequest
+}
+
+describe('GET /api/badge/[badgeId]/download?format=png', () => {
+  beforeEach(() => {
+    vi.mocked(getBadgeById).mockResolvedValue({ badge: badgeRecord() })
+    vi.mocked(getBadgeSVGUrl).mockReturnValue('https://cdn.example/badge.svg')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(SVG) }),
+    )
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns a baked PNG with rebake-aware caching headers', async () => {
+    const { GET } = await import('@/app/api/badge/[badgeId]/download/route')
+    const res = await GET(pngRequest(), {
+      params: Promise.resolve({ badgeId: 'test-badge-id' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('image/png')
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, max-age=0, must-revalidate',
+    )
+    const etag = res.headers.get('ETag')
+    expect(etag).toMatch(/^W\/"badge-download-png-v2-/)
+    expect(res.headers.get('Content-Disposition')).toContain('.png')
+
+    const bytes = new Uint8Array(await res.arrayBuffer())
+    expect(Array.from(bytes.subarray(0, 4))).toEqual([137, 80, 78, 71])
+    // The credential must be baked into the PNG bytes, byte-for-byte.
+    expect(extractCredentialFromPng(bytes)).toBe(CREDENTIAL)
+  })
+
+  it('revalidates to a 304 on a matching ETag without rendering', async () => {
+    const { GET } = await import('@/app/api/badge/[badgeId]/download/route')
+    const first = await GET(pngRequest(), {
+      params: Promise.resolve({ badgeId: 'test-badge-id' }),
+    })
+    const etag = first.headers.get('ETag')!
+
+    const res = await GET(pngRequest(etag), {
+      params: Promise.resolve({ badgeId: 'test-badge-id' }),
+    })
+    expect(res.status).toBe(304)
+    expect(vi.mocked(loadBadgeFontFiles)).toHaveBeenCalled()
+  })
+})

--- a/__tests__/lib/badge/fonts.test.ts
+++ b/__tests__/lib/badge/fonts.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment node
+ *
+ * Badge rasterization font provisioning: fetched once per warm function from
+ * the deployment's own /fonts/ path, persisted to tmpdir for resvg's
+ * file-path-only font API. A failed fetch must NOT be cached.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import {
+  loadBadgeFontFiles,
+  resetBadgeFontCacheForTests,
+} from '@/lib/badge/fonts'
+
+const FONT_BYTES = new Uint8Array([1, 2, 3, 4]).buffer
+
+describe('loadBadgeFontFiles', () => {
+  beforeEach(() => {
+    resetBadgeFontCacheForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches the self-hosted font once and returns a readable tmp path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(FONT_BYTES),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const [first] = await loadBadgeFontFiles('https://example.com')
+    const [second] = await loadBadgeFontFiles('https://example.com')
+
+    expect(second).toBe(first)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      'https://example.com/fonts/Inter-SemiBold.ttf',
+    )
+    const written = await fs.readFile(first)
+    expect(Array.from(written)).toEqual([1, 2, 3, 4])
+  })
+
+  it('does not cache a failed fetch — the next call retries', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 502 })
+      .mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(FONT_BYTES),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(loadBadgeFontFiles('https://example.com')).rejects.toThrow(
+      /502/,
+    )
+    const [recovered] = await loadBadgeFontFiles('https://example.com')
+    expect(recovered).toMatch(/badge-font-inter-semibold\.ttf$/)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/__tests__/lib/badge/http.test.ts
+++ b/__tests__/lib/badge/http.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment node
+ *
+ * Rebake-aware caching for baked badge artifacts. These replaced a
+ * `max-age=1yr, immutable` policy that stranded rebakes in browser/CDN cache —
+ * the root cause of "the validator still fails after rebaking" (the recipient
+ * re-validated the immutable pre-rebake file).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  BADGE_ARTIFACT_CACHE_CONTROL,
+  badgeArtifactETag,
+  badgeNotModifiedResponse,
+} from '@/lib/badge/http'
+
+const base = { _updatedAt: '2026-07-01T10:00:00Z', generatorVersion: 2 }
+
+function req(ifNoneMatch?: string) {
+  return {
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'if-none-match' ? (ifNoneMatch ?? null) : null,
+    },
+  }
+}
+
+describe('badge artifact caching', () => {
+  it('is a revalidating, non-immutable policy', () => {
+    expect(BADGE_ARTIFACT_CACHE_CONTROL).toBe(
+      'public, max-age=0, must-revalidate',
+    )
+    expect(BADGE_ARTIFACT_CACHE_CONTROL).not.toContain('immutable')
+  })
+
+  it('ETag changes when the doc is rebaked (_updatedAt moves)', () => {
+    const before = badgeArtifactETag(base, 'download')
+    const after = badgeArtifactETag(
+      { ...base, _updatedAt: '2026-07-02T09:00:00Z' },
+      'download',
+    )
+    expect(before).not.toBe(after)
+  })
+
+  it('ETag is stable for the same doc + variant', () => {
+    expect(badgeArtifactETag(base, 'json')).toBe(
+      badgeArtifactETag(base, 'json'),
+    )
+  })
+
+  it('ETag differs per artifact variant and per generatorVersion', () => {
+    expect(badgeArtifactETag(base, 'download')).not.toBe(
+      badgeArtifactETag(base, 'download-png'),
+    )
+    expect(badgeArtifactETag(base, 'download')).not.toBe(
+      badgeArtifactETag({ ...base, generatorVersion: 3 }, 'download'),
+    )
+  })
+
+  it('treats an absent generatorVersion as v1', () => {
+    expect(
+      badgeArtifactETag({ _updatedAt: base._updatedAt }, 'json'),
+    ).toContain('-v1-')
+  })
+
+  it('returns a 304 when If-None-Match matches (weak-prefix tolerant)', () => {
+    const etag = badgeArtifactETag(base, 'download')
+    const res = badgeNotModifiedResponse(req(etag), etag)
+    expect(res?.status).toBe(304)
+    // Strong-form client value still matches our weak validator.
+    const strong = etag.replace(/^W\//, '')
+    expect(badgeNotModifiedResponse(req(strong), etag)?.status).toBe(304)
+  })
+
+  it('returns null (serve fresh) when If-None-Match is absent or stale', () => {
+    const etag = badgeArtifactETag(base, 'download')
+    expect(badgeNotModifiedResponse(req(), etag)).toBeNull()
+    expect(
+      badgeNotModifiedResponse(req('W/"badge-download-v2-stale"'), etag),
+    ).toBeNull()
+  })
+})

--- a/__tests__/lib/badge/http.test.ts
+++ b/__tests__/lib/badge/http.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   BADGE_ARTIFACT_CACHE_CONTROL,
+  BADGE_CORS_HEADERS,
   badgeArtifactETag,
   badgeNotModifiedResponse,
 } from '@/lib/badge/http'
@@ -77,5 +78,16 @@ describe('badge artifact caching', () => {
     expect(
       badgeNotModifiedResponse(req('W/"badge-download-v2-stale"'), etag),
     ).toBeNull()
+  })
+
+  it('mirrors extra headers (CORS, Vary) onto the 304', () => {
+    const etag = badgeArtifactETag(base, 'credential')
+    const res = badgeNotModifiedResponse(req(etag), etag, {
+      ...BADGE_CORS_HEADERS,
+      Vary: 'Accept',
+    })
+    expect(res?.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    expect(res?.headers.get('Access-Control-Allow-Methods')).toBe('GET')
+    expect(res?.headers.get('Vary')).toBe('Accept')
   })
 })

--- a/__tests__/lib/badge/png.test.ts
+++ b/__tests__/lib/badge/png.test.ts
@@ -6,6 +6,7 @@
  * bake→extract untouched (a signed credential cannot tolerate mutation).
  */
 import { describe, it, expect } from 'vitest'
+import path from 'path'
 import {
   OB_PNG_KEYWORD,
   bakeCredentialIntoPng,
@@ -16,7 +17,7 @@ import {
 // A real, multi-chunk PNG produced by the same rasterizer the route uses.
 const TINY_PNG = renderBadgeSvgToPng(
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><rect width="8" height="8" fill="#111"/></svg>',
-  8,
+  { width: 8 },
 )
 
 const CREDENTIAL = JSON.stringify({
@@ -64,12 +65,28 @@ describe('PNG baking', () => {
     ).toThrow(/PNG/)
   })
 
+  it('renders <text> only when a font file is provided (serverless has no system fonts)', () => {
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">' +
+      '<rect width="200" height="100" fill="#111"/>' +
+      '<text x="20" y="60" font-family="Arial, sans-serif" font-size="40" fill="#fff">Jane Doe</text>' +
+      '</svg>'
+    const fontFile = path.join(process.cwd(), 'public/fonts/Inter-SemiBold.ttf')
+    const withoutFont = renderBadgeSvgToPng(svg, { width: 200 })
+    const withFont = renderBadgeSvgToPng(svg, {
+      width: 200,
+      fontFiles: [fontFile],
+    })
+    // Text glyphs add real pixel data; a fontless render silently drops them.
+    expect(withFont.length).toBeGreaterThan(withoutFont.length)
+  })
+
   it('rasterizes a badge SVG (strips the credential node) then bakes', () => {
     const svg =
       '<svg xmlns="http://www.w3.org/2000/svg" xmlns:openbadges="https://purl.imsglobal.org/ob/v3p0" viewBox="0 0 100 100">' +
       '<openbadges:credential><![CDATA[ {"stale":true} ]]></openbadges:credential>' +
       '<rect width="100" height="100" fill="#3b82f6"/></svg>'
-    const png = renderBadgeSvgToPng(svg, 256)
+    const png = renderBadgeSvgToPng(svg, { width: 256 })
     // Valid PNG, and the drawable-only render carries no credential yet.
     expect(Array.from(png.subarray(0, 4))).toEqual([137, 80, 78, 71])
     expect(extractCredentialFromPng(png)).toBeNull()

--- a/__tests__/lib/badge/png.test.ts
+++ b/__tests__/lib/badge/png.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment node
+ *
+ * OB 3.0 PNG baking: an `openbadgecredential` iTXt chunk carrying the raw
+ * credential, rasterized from the badge SVG. The credential bytes must survive
+ * bake→extract untouched (a signed credential cannot tolerate mutation).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  OB_PNG_KEYWORD,
+  bakeCredentialIntoPng,
+  extractCredentialFromPng,
+  renderBadgeSvgToPng,
+} from '@/lib/badge/png'
+
+// A real, multi-chunk PNG produced by the same rasterizer the route uses.
+const TINY_PNG = renderBadgeSvgToPng(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><rect width="8" height="8" fill="#111"/></svg>',
+  8,
+)
+
+const CREDENTIAL = JSON.stringify({
+  '@context': ['https://www.w3.org/ns/credentials/v2'],
+  id: 'https://example.com/api/badge/abc',
+  type: ['VerifiableCredential', 'OpenBadgeCredential'],
+  proof: [{ type: 'DataIntegrityProof', proofValue: 'z3Abc]]>weird' }],
+})
+
+describe('PNG baking', () => {
+  it('uses the spec keyword openbadgecredential', () => {
+    expect(OB_PNG_KEYWORD).toBe('openbadgecredential')
+  })
+
+  it('round-trips the credential byte-for-byte through bake → extract', () => {
+    const baked = bakeCredentialIntoPng(TINY_PNG, CREDENTIAL)
+    expect(extractCredentialFromPng(baked)).toBe(CREDENTIAL)
+  })
+
+  it('keeps the PNG valid (signature + IEND preserved)', () => {
+    const baked = bakeCredentialIntoPng(TINY_PNG, CREDENTIAL)
+    expect(Array.from(baked.subarray(0, 8))).toEqual([
+      137, 80, 78, 71, 13, 10, 26, 10,
+    ])
+    const tail = Buffer.from(baked.subarray(baked.length - 8)).toString(
+      'latin1',
+    )
+    expect(tail).toContain('IEND')
+  })
+
+  it('re-bakes idempotently (single credential chunk, not two)', () => {
+    const once = bakeCredentialIntoPng(TINY_PNG, CREDENTIAL)
+    const twice = bakeCredentialIntoPng(once, CREDENTIAL)
+    expect(twice.length).toBe(once.length)
+    expect(extractCredentialFromPng(twice)).toBe(CREDENTIAL)
+  })
+
+  it('returns null when no credential is baked in', () => {
+    expect(extractCredentialFromPng(TINY_PNG)).toBeNull()
+  })
+
+  it('throws on non-PNG input', () => {
+    expect(() =>
+      bakeCredentialIntoPng(new Uint8Array([1, 2, 3]), CREDENTIAL),
+    ).toThrow(/PNG/)
+  })
+
+  it('rasterizes a badge SVG (strips the credential node) then bakes', () => {
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:openbadges="https://purl.imsglobal.org/ob/v3p0" viewBox="0 0 100 100">' +
+      '<openbadges:credential><![CDATA[ {"stale":true} ]]></openbadges:credential>' +
+      '<rect width="100" height="100" fill="#3b82f6"/></svg>'
+    const png = renderBadgeSvgToPng(svg, 256)
+    // Valid PNG, and the drawable-only render carries no credential yet.
+    expect(Array.from(png.subarray(0, 4))).toEqual([137, 80, 78, 71])
+    expect(extractCredentialFromPng(png)).toBeNull()
+    // Baking the real credential in makes it extractable.
+    const baked = bakeCredentialIntoPng(png, CREDENTIAL)
+    expect(extractCredentialFromPng(baked)).toBe(CREDENTIAL)
+  })
+})

--- a/__tests__/lib/badge/png.test.ts
+++ b/__tests__/lib/badge/png.test.ts
@@ -59,6 +59,19 @@ describe('PNG baking', () => {
     expect(extractCredentialFromPng(TINY_PNG)).toBeNull()
   })
 
+  it('rejects a compressed iTXt credential chunk instead of returning zlib bytes', () => {
+    const baked = bakeCredentialIntoPng(TINY_PNG, CREDENTIAL)
+    // Locate the credential chunk and flip its compression flag to 1.
+    const marker = new TextEncoder().encode(OB_PNG_KEYWORD)
+    const idx = baked.findIndex((_, i) =>
+      marker.every((b, j) => baked[i + j] === b),
+    )
+    expect(idx).toBeGreaterThan(0)
+    const tampered = baked.slice()
+    tampered[idx + marker.length + 1] = 1 // keyword NUL, then compression flag
+    expect(extractCredentialFromPng(tampered)).toBeNull()
+  })
+
   it('throws on non-PNG input', () => {
     expect(() =>
       bakeCredentialIntoPng(new Uint8Array([1, 2, 3]), CREDENTIAL),

--- a/src/app/api/badge/[badgeId]/achievement/route.ts
+++ b/src/app/api/badge/[badgeId]/achievement/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getBadgeById } from '@/lib/badge/sanity'
 import {
+  BADGE_ARTIFACT_CACHE_CONTROL,
+  badgeArtifactETag,
+  badgeNotModifiedResponse,
+} from '@/lib/badge/http'
+import {
   generateAchievementResponse,
   generateErrorResponse,
   verifyCredentialJWT,
@@ -32,6 +37,10 @@ export async function GET(
         status: 404,
       })
     }
+
+    const etag = badgeArtifactETag(badge, 'achievement')
+    const notModified = badgeNotModifiedResponse(request, etag)
+    if (notModified) return notModified
 
     let badgeAssertion
     if (isJWTFormat(badge.badgeJson)) {
@@ -76,7 +85,8 @@ export async function GET(
       status: 200,
       headers: {
         'Content-Type': 'application/ld+json',
-        'Cache-Control': 'public, max-age=31536000, immutable',
+        'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
+        ETag: etag,
       },
     })
   } catch (error) {

--- a/src/app/api/badge/[badgeId]/download/route.ts
+++ b/src/app/api/badge/[badgeId]/download/route.ts
@@ -6,6 +6,7 @@ import {
   badgeNotModifiedResponse,
 } from '@/lib/badge/http'
 import { renderBadgeSvgToPng, bakeCredentialIntoPng } from '@/lib/badge/png'
+import { loadBadgeFontFiles } from '@/lib/badge/fonts'
 
 /**
  * GET /api/badge/[badgeId]/download
@@ -73,7 +74,10 @@ export async function GET(
 
     if (wantPng) {
       try {
-        const png = renderBadgeSvgToPng(svgContent)
+        // The badge SVG renders the speaker name via <text>; the serverless
+        // runtime has no system fonts, so provide the self-hosted brand font.
+        const fontFiles = await loadBadgeFontFiles(request.nextUrl.origin)
+        const png = renderBadgeSvgToPng(svgContent, { fontFiles })
         const bakedPng = bakeCredentialIntoPng(png, badge.badgeJson)
         return new NextResponse(Buffer.from(bakedPng), {
           status: 200,

--- a/src/app/api/badge/[badgeId]/download/route.ts
+++ b/src/app/api/badge/[badgeId]/download/route.ts
@@ -65,12 +65,20 @@ export async function GET(
 
     const svgContent = await svgResponse.text()
 
-    const speakerName =
+    // Header-safe filename token: names can hold quotes/unicode/punctuation
+    // that would break the Content-Disposition filename parameter.
+    const rawName =
       badge.speaker &&
       typeof badge.speaker === 'object' &&
       'name' in badge.speaker
-        ? badge.speaker.name.replace(/\s+/g, '-').toLowerCase()
+        ? badge.speaker.name
         : 'speaker'
+    const speakerName =
+      rawName
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^[-.]+|[-.]+$/g, '') || 'speaker'
 
     if (wantPng) {
       try {

--- a/src/app/api/badge/[badgeId]/download/route.ts
+++ b/src/app/api/badge/[badgeId]/download/route.ts
@@ -1,6 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getBadgeById, getBadgeSVGUrl } from '@/lib/badge/sanity'
+import {
+  BADGE_ARTIFACT_CACHE_CONTROL,
+  badgeArtifactETag,
+  badgeNotModifiedResponse,
+} from '@/lib/badge/http'
+import { renderBadgeSvgToPng, bakeCredentialIntoPng } from '@/lib/badge/png'
 
+/**
+ * GET /api/badge/[badgeId]/download
+ *
+ * Downloads the baked badge. Default is the OpenBadges 3.0 baked SVG
+ * (`<openbadges:credential>` CDATA). `?format=png` returns a rasterized PNG with
+ * the same credential baked into an `openbadgecredential` iTXt chunk — a second
+ * container for displayers/tools that prefer PNG.
+ *
+ * Both formats are REBAKE-MUTABLE, so they carry a revalidating cache + an ETag
+ * that changes when the badge is rebaked (see lib/badge/http.ts). This replaces
+ * the previous `immutable, max-age=1yr` policy that stranded rebakes in cache.
+ */
 export async function GET(
   request: NextRequest,
   segmentData: { params: Promise<{ badgeId: string }> },
@@ -20,6 +38,12 @@ export async function GET(
     if (error || !badge) {
       return NextResponse.json({ error: 'Badge not found' }, { status: 404 })
     }
+
+    const wantPng = request.nextUrl?.searchParams?.get('format') === 'png'
+
+    const etag = badgeArtifactETag(badge, wantPng ? 'download-png' : 'download')
+    const notModified = badgeNotModifiedResponse(request, etag)
+    if (notModified) return notModified
 
     const svgUrl = getBadgeSVGUrl(badge)
 
@@ -47,12 +71,35 @@ export async function GET(
         ? badge.speaker.name.replace(/\s+/g, '-').toLowerCase()
         : 'speaker'
 
+    if (wantPng) {
+      try {
+        const png = renderBadgeSvgToPng(svgContent)
+        const bakedPng = bakeCredentialIntoPng(png, badge.badgeJson)
+        return new NextResponse(Buffer.from(bakedPng), {
+          status: 200,
+          headers: {
+            'Content-Type': 'image/png',
+            'Content-Disposition': `attachment; filename="badge-${speakerName}-${badgeId}.png"`,
+            'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
+            ETag: etag,
+          },
+        })
+      } catch (pngError) {
+        console.error('Error rendering badge PNG:', pngError)
+        return NextResponse.json(
+          { error: 'Failed to render badge PNG' },
+          { status: 500 },
+        )
+      }
+    }
+
     return new NextResponse(svgContent, {
       status: 200,
       headers: {
         'Content-Type': 'image/svg+xml',
         'Content-Disposition': `attachment; filename="badge-${speakerName}-${badgeId}.svg"`,
-        'Cache-Control': 'public, max-age=31536000, immutable',
+        'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
+        ETag: etag,
       },
     })
   } catch (error) {

--- a/src/app/api/badge/[badgeId]/image/route.ts
+++ b/src/app/api/badge/[badgeId]/image/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getBadgeById, getBadgeSVGUrl } from '@/lib/badge/sanity'
+import {
+  BADGE_ARTIFACT_CACHE_CONTROL,
+  badgeArtifactETag,
+  badgeNotModifiedResponse,
+} from '@/lib/badge/http'
 
 export async function GET(
   request: NextRequest,
@@ -20,6 +25,10 @@ export async function GET(
     if (error || !badge) {
       return NextResponse.json({ error: 'Badge not found' }, { status: 404 })
     }
+
+    const etag = badgeArtifactETag(badge, 'image')
+    const notModified = badgeNotModifiedResponse(request, etag)
+    if (notModified) return notModified
 
     const svgUrl = getBadgeSVGUrl(badge)
 
@@ -44,7 +53,8 @@ export async function GET(
       status: 200,
       headers: {
         'Content-Type': 'image/svg+xml',
-        'Cache-Control': 'public, max-age=31536000, immutable',
+        'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
+        ETag: etag,
       },
     })
   } catch (error) {

--- a/src/app/api/badge/[badgeId]/json/route.ts
+++ b/src/app/api/badge/[badgeId]/json/route.ts
@@ -39,6 +39,7 @@ export async function GET(
     if (error || !badge) {
       return NextResponse.json(generateErrorResponse('Badge not found', 404), {
         status: 404,
+        headers: { ...BADGE_CORS_HEADERS },
       })
     }
 
@@ -55,7 +56,7 @@ export async function GET(
     } catch {
       return NextResponse.json(
         generateErrorResponse('Invalid badge JSON', 500),
-        { status: 500 },
+        { status: 500, headers: { ...BADGE_CORS_HEADERS } },
       )
     }
 

--- a/src/app/api/badge/[badgeId]/json/route.ts
+++ b/src/app/api/badge/[badgeId]/json/route.ts
@@ -75,7 +75,7 @@ export async function GET(
 
     return NextResponse.json(
       generateErrorResponse('Internal server error', 500),
-      { status: 500 },
+      { status: 500, headers: { ...BADGE_CORS_HEADERS } },
     )
   }
 }

--- a/src/app/api/badge/[badgeId]/json/route.ts
+++ b/src/app/api/badge/[badgeId]/json/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getBadgeById } from '@/lib/badge/sanity'
 import {
   BADGE_ARTIFACT_CACHE_CONTROL,
+  BADGE_CORS_HEADERS,
   badgeArtifactETag,
   badgeNotModifiedResponse,
 } from '@/lib/badge/http'
@@ -42,7 +43,9 @@ export async function GET(
     }
 
     const etag = badgeArtifactETag(badge, 'json')
-    const notModified = badgeNotModifiedResponse(request, etag)
+    const notModified = badgeNotModifiedResponse(request, etag, {
+      ...BADGE_CORS_HEADERS,
+    })
     if (notModified) return notModified
 
     let payload: { body: string; isJwt: boolean }
@@ -60,8 +63,7 @@ export async function GET(
       status: 200,
       headers: {
         'Content-Type': payload.isJwt ? 'text/plain' : 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET',
+        ...BADGE_CORS_HEADERS,
         'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
         ETag: etag,
       },

--- a/src/app/api/badge/[badgeId]/jwt/route.ts
+++ b/src/app/api/badge/[badgeId]/jwt/route.ts
@@ -73,7 +73,7 @@ export async function GET(
 
     return NextResponse.json(
       generateErrorResponse('Internal server error', 500),
-      { status: 500 },
+      { status: 500, headers: { ...BADGE_CORS_HEADERS } },
     )
   }
 }

--- a/src/app/api/badge/[badgeId]/jwt/route.ts
+++ b/src/app/api/badge/[badgeId]/jwt/route.ts
@@ -35,6 +35,7 @@ export async function GET(
     if (error || !badge) {
       return NextResponse.json(generateErrorResponse('Badge not found', 404), {
         status: 404,
+        headers: { ...BADGE_CORS_HEADERS },
       })
     }
 
@@ -53,7 +54,7 @@ export async function GET(
           'No JWT credential available for this badge',
           404,
         ),
-        { status: 404 },
+        { status: 404, headers: { ...BADGE_CORS_HEADERS } },
       )
     }
 

--- a/src/app/api/badge/[badgeId]/jwt/route.ts
+++ b/src/app/api/badge/[badgeId]/jwt/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getBadgeById } from '@/lib/badge/sanity'
+import {
+  BADGE_ARTIFACT_CACHE_CONTROL,
+  badgeArtifactETag,
+  badgeNotModifiedResponse,
+} from '@/lib/badge/http'
 import { generateErrorResponse, isJWTFormat } from '@/lib/openbadges'
 
 /**
@@ -32,6 +37,10 @@ export async function GET(
       })
     }
 
+    const etag = badgeArtifactETag(badge, 'jwt')
+    const notModified = badgeNotModifiedResponse(request, etag)
+    if (notModified) return notModified
+
     const jwt =
       badge.badgeJwt ?? (isJWTFormat(badge.badgeJson) ? badge.badgeJson : null)
 
@@ -51,7 +60,8 @@ export async function GET(
         'Content-Type': 'text/plain',
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET',
-        'Cache-Control': 'public, max-age=31536000, immutable',
+        'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
+        ETag: etag,
       },
     })
   } catch (error) {

--- a/src/app/api/badge/[badgeId]/jwt/route.ts
+++ b/src/app/api/badge/[badgeId]/jwt/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getBadgeById } from '@/lib/badge/sanity'
 import {
   BADGE_ARTIFACT_CACHE_CONTROL,
+  BADGE_CORS_HEADERS,
   badgeArtifactETag,
   badgeNotModifiedResponse,
 } from '@/lib/badge/http'
@@ -38,7 +39,9 @@ export async function GET(
     }
 
     const etag = badgeArtifactETag(badge, 'jwt')
-    const notModified = badgeNotModifiedResponse(request, etag)
+    const notModified = badgeNotModifiedResponse(request, etag, {
+      ...BADGE_CORS_HEADERS,
+    })
     if (notModified) return notModified
 
     const jwt =
@@ -58,8 +61,7 @@ export async function GET(
       status: 200,
       headers: {
         'Content-Type': 'text/plain',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET',
+        ...BADGE_CORS_HEADERS,
         'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
         ETag: etag,
       },

--- a/src/app/api/badge/[badgeId]/route.ts
+++ b/src/app/api/badge/[badgeId]/route.ts
@@ -57,8 +57,11 @@ export async function GET(
     const { badge, error } = await getBadgeById(badgeId)
 
     if (error || !badge) {
+      // CORS on errors too: a cross-origin verifier should see a readable
+      // 404, not an opaque CORS failure.
       return NextResponse.json(generateErrorResponse('Badge not found', 404), {
         status: 404,
+        headers: { ...BADGE_CORS_HEADERS, Vary: 'Accept' },
       })
     }
 
@@ -75,7 +78,7 @@ export async function GET(
     } catch {
       return NextResponse.json(
         generateErrorResponse('Invalid badge JSON', 500),
-        { status: 500 },
+        { status: 500, headers: { ...BADGE_CORS_HEADERS, Vary: 'Accept' } },
       )
     }
 

--- a/src/app/api/badge/[badgeId]/route.ts
+++ b/src/app/api/badge/[badgeId]/route.ts
@@ -3,6 +3,7 @@ import { getBadgeById } from '@/lib/badge/sanity'
 import { generateErrorResponse } from '@/lib/openbadges'
 import {
   BADGE_ARTIFACT_CACHE_CONTROL,
+  BADGE_CORS_HEADERS,
   badgeArtifactETag,
   badgeNotModifiedResponse,
 } from '@/lib/badge/http'
@@ -38,13 +39,19 @@ export async function GET(
       )
     }
 
-    // Humans get the rendered badge page; verifiers get the credential.
+    // Humans get the rendered badge page; verifiers get the credential. Every
+    // response of this route content-negotiates on Accept, so all of them
+    // carry `Vary: Accept`; the redirect is additionally no-store so a shared
+    // cache can never replay it to a machine client.
     const accept = request.headers?.get?.('accept') ?? ''
     if (accept.includes('text/html')) {
-      return NextResponse.redirect(
+      const redirect = NextResponse.redirect(
         new URL(`/badge/${badgeId}`, request.url),
         302,
       )
+      redirect.headers.set('Vary', 'Accept')
+      redirect.headers.set('Cache-Control', 'no-store')
+      return redirect
     }
 
     const { badge, error } = await getBadgeById(badgeId)
@@ -56,7 +63,10 @@ export async function GET(
     }
 
     const etag = badgeArtifactETag(badge, 'credential')
-    const notModified = badgeNotModifiedResponse(request, etag)
+    const notModified = badgeNotModifiedResponse(request, etag, {
+      ...BADGE_CORS_HEADERS,
+      Vary: 'Accept',
+    })
     if (notModified) return notModified
 
     let payload: { body: string; isJwt: boolean }
@@ -73,8 +83,8 @@ export async function GET(
       status: 200,
       headers: {
         'Content-Type': payload.isJwt ? 'text/plain' : 'application/ld+json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET',
+        ...BADGE_CORS_HEADERS,
+        Vary: 'Accept',
         'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
         ETag: etag,
       },

--- a/src/app/api/badge/[badgeId]/route.ts
+++ b/src/app/api/badge/[badgeId]/route.ts
@@ -96,7 +96,7 @@ export async function GET(
     console.error('Error serving badge credential:', error)
     return NextResponse.json(
       generateErrorResponse('Internal server error', 500),
-      { status: 500 },
+      { status: 500, headers: { ...BADGE_CORS_HEADERS, Vary: 'Accept' } },
     )
   }
 }

--- a/src/app/api/badge/[badgeId]/route.ts
+++ b/src/app/api/badge/[badgeId]/route.ts
@@ -42,9 +42,12 @@ export async function GET(
     // Humans get the rendered badge page; verifiers get the credential. Every
     // response of this route content-negotiates on Accept, so all of them
     // carry `Vary: Accept`; the redirect is additionally no-store so a shared
-    // cache can never replay it to a machine client.
+    // cache can never replay it to a machine client. Only a client whose
+    // FIRST media range is text/html (how browsers send it) is redirected — a
+    // verifier listing html as a low-q fallback still gets the credential.
     const accept = request.headers?.get?.('accept') ?? ''
-    if (accept.includes('text/html')) {
+    const primaryType = accept.split(',')[0]?.trim().toLowerCase() ?? ''
+    if (primaryType.startsWith('text/html')) {
       const redirect = NextResponse.redirect(
         new URL(`/badge/${badgeId}`, request.url),
         302,

--- a/src/app/api/badge/[badgeId]/route.ts
+++ b/src/app/api/badge/[badgeId]/route.ts
@@ -1,23 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getBadgeById } from '@/lib/badge/sanity'
+import { generateErrorResponse } from '@/lib/openbadges'
 import {
   BADGE_ARTIFACT_CACHE_CONTROL,
   badgeArtifactETag,
   badgeNotModifiedResponse,
 } from '@/lib/badge/http'
-import { generateErrorResponse } from '@/lib/openbadges'
 import { badgeCredentialBody } from '@/lib/badge/credential-response'
 
 /**
- * GET /api/badge/[badgeId]/json
+ * GET /api/badge/[badgeId]
  *
- * Returns the OpenBadges 3.0 credential.
+ * The credential's OWN `id` URL (`${baseUrl}/api/badge/{badgeId}`). OB 3.0
+ * displayers dereference the credential id to confirm the badge's authenticity
+ * against hosted data — Credly marks an imported badge "Unverified" when this id
+ * does not resolve. It previously 404'd (only the `/json`, `/jwt`, `/achievement`
+ * sub-paths existed), so this serves the SAME credential bytes as
+ * `/api/badge/[badgeId]/json` (shared via badgeCredentialBody) as
+ * application/ld+json with open CORS.
  *
- * New badges: JSON-LD credential with embedded Data Integrity Proof — this
- * is the .json file recipients can upload directly to Credly and other
- * certified OB 3.0 displayers.
- * Legacy badges (badgeJson holds a JWT string): the JWT as text/plain.
- * The JWT for new badges is served from /api/badge/[badgeId]/jwt.
+ * Content negotiation: a browser (Accept: text/html) is redirected to the human
+ * badge page at `/badge/[badgeId]`; machine clients get the credential.
+ *
+ * @see https://www.imsglobal.org/spec/ob/v3p0/#data-integrity-proof-verification
  */
 export async function GET(
   request: NextRequest,
@@ -33,6 +38,15 @@ export async function GET(
       )
     }
 
+    // Humans get the rendered badge page; verifiers get the credential.
+    const accept = request.headers?.get?.('accept') ?? ''
+    if (accept.includes('text/html')) {
+      return NextResponse.redirect(
+        new URL(`/badge/${badgeId}`, request.url),
+        302,
+      )
+    }
+
     const { badge, error } = await getBadgeById(badgeId)
 
     if (error || !badge) {
@@ -41,13 +55,12 @@ export async function GET(
       })
     }
 
-    const etag = badgeArtifactETag(badge, 'json')
+    const etag = badgeArtifactETag(badge, 'credential')
     const notModified = badgeNotModifiedResponse(request, etag)
     if (notModified) return notModified
 
     let payload: { body: string; isJwt: boolean }
     try {
-      // Shared with the credential-id route so both emit identical bytes.
       payload = badgeCredentialBody(badge)
     } catch {
       return NextResponse.json(
@@ -59,7 +72,7 @@ export async function GET(
     return new NextResponse(payload.body, {
       status: 200,
       headers: {
-        'Content-Type': payload.isJwt ? 'text/plain' : 'application/json',
+        'Content-Type': payload.isJwt ? 'text/plain' : 'application/ld+json',
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET',
         'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
@@ -67,9 +80,7 @@ export async function GET(
       },
     })
   } catch (error) {
-    // Log detail server-side; return a generic message to the client.
-    console.error('Error fetching badge JSON:', error)
-
+    console.error('Error serving badge credential:', error)
     return NextResponse.json(
       generateErrorResponse('Internal server error', 500),
       { status: 500 },

--- a/src/components/admin/BadgeManagementClient.tsx
+++ b/src/components/admin/BadgeManagementClient.tsx
@@ -533,7 +533,15 @@ export function BadgeManagementClient({
               href={`/api/badge/${badge.badgeId}/download`}
               download
             >
-              Download
+              Download SVG
+            </ActionMenuItem>
+            <ActionMenuItem
+              onClick={() => {}}
+              icon={ArrowDownTrayIcon}
+              href={`/api/badge/${badge.badgeId}/download?format=png`}
+              download
+            >
+              Download PNG
             </ActionMenuItem>
             <ActionMenuItem
               onClick={() => handleRebakeBadge(badge.badgeId, speaker.name)}

--- a/src/lib/badge/credential-response.ts
+++ b/src/lib/badge/credential-response.ts
@@ -1,0 +1,22 @@
+import { isJWTFormat } from '@/lib/openbadges'
+import type { BadgeRecord } from './types'
+
+/**
+ * Serialize a badge's stored credential for HTTP delivery. New badges store the
+ * embedded-proof JSON-LD credential (pretty-printed here); legacy badges store a
+ * Compact JWS string. Shared by the /json route and the credential-`id` route so
+ * both emit byte-identical payloads.
+ *
+ * Throws (SyntaxError) when a non-JWT `badgeJson` is not valid JSON — callers
+ * translate that into a 500.
+ */
+export function badgeCredentialBody(badge: Pick<BadgeRecord, 'badgeJson'>): {
+  body: string
+  isJwt: boolean
+} {
+  if (isJWTFormat(badge.badgeJson)) {
+    return { body: badge.badgeJson, isJwt: true }
+  }
+  const assertion = JSON.parse(badge.badgeJson)
+  return { body: JSON.stringify(assertion, null, 2), isJwt: false }
+}

--- a/src/lib/badge/fonts.ts
+++ b/src/lib/badge/fonts.ts
@@ -1,0 +1,52 @@
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+
+/**
+ * Font provisioning for server-side badge rasterization.
+ *
+ * resvg loads no fonts of its own in serverless (there ARE no system fonts on
+ * Vercel's runtime — a PNG rendered there would silently drop every `<text>`
+ * node, i.e. the speaker name). Same pattern as `loadBrandFonts` in lib/og:
+ * fetch the self-hosted font over HTTP (fs on `public/` is not reliable in
+ * serverless), then persist it to the function's tmpdir because resvg-js only
+ * accepts font FILE PATHS (`fontFiles`), not buffers.
+ *
+ * The promise is module-cached so a warm function fetches/writes once.
+ */
+const BADGE_FONT_PUBLIC_PATH = '/fonts/Inter-SemiBold.ttf'
+const BADGE_FONT_TMP_NAME = 'badge-font-inter-semibold.ttf'
+
+let cachedFontFile: Promise<string> | null = null
+
+export async function loadBadgeFontFiles(origin: string): Promise<string[]> {
+  if (!cachedFontFile) {
+    cachedFontFile = fetchFontToTmp(origin).catch((error) => {
+      // Do not cache a failure — the next request retries the fetch.
+      cachedFontFile = null
+      throw error
+    })
+  }
+  return [await cachedFontFile]
+}
+
+async function fetchFontToTmp(origin: string): Promise<string> {
+  const response = await fetch(new URL(BADGE_FONT_PUBLIC_PATH, origin))
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch badge font ${BADGE_FONT_PUBLIC_PATH}: ${response.status}`,
+    )
+  }
+  const bytes = Buffer.from(await response.arrayBuffer())
+  const filePath = path.join(os.tmpdir(), BADGE_FONT_TMP_NAME)
+  // Write-then-rename so a concurrent reader never sees a partial file.
+  const tmpPath = `${filePath}.${process.pid}.partial`
+  await fs.writeFile(tmpPath, bytes)
+  await fs.rename(tmpPath, filePath)
+  return filePath
+}
+
+/** Test hook: clear the module cache so fetch behavior can be re-exercised. */
+export function resetBadgeFontCacheForTests(): void {
+  cachedFontFile = null
+}

--- a/src/lib/badge/http.ts
+++ b/src/lib/badge/http.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import type { BadgeRecord } from './types'
+
+/**
+ * Cache policy for baked badge artifacts (SVG / PNG / JSON / JWT / achievement).
+ *
+ * These artifacts are REBAKE-MUTABLE: an admin rebake patches the Sanity doc in
+ * place — same `badgeId`, same URL, NEW bytes. The routes previously served
+ * `Cache-Control: public, max-age=31536000, immutable`, which stranded every
+ * rebake behind up to a YEAR of browser/CDN cache. That was the root cause of
+ * the "official validator still fails after rebaking" incident: the recipient
+ * re-downloaded the immutable, pre-rebake (pre-#655) file and validated stale
+ * bytes.
+ *
+ * We now force revalidation and key a WEAK ETag on the doc's `_updatedAt` (moves
+ * on every Sanity patch, so a rebake changes it) plus `generatorVersion` and the
+ * artifact variant. An UNCHANGED artifact still gets a cheap 304; a rebake is
+ * picked up on the next request. Keys/issuer endpoints are NOT covered here —
+ * signing keys do not rotate, so their immutable caching is correct.
+ */
+export const BADGE_ARTIFACT_CACHE_CONTROL = 'public, max-age=0, must-revalidate'
+
+/** Weak ETag that changes whenever the badge doc is (re)baked. */
+export function badgeArtifactETag(
+  badge: Pick<BadgeRecord, '_updatedAt' | 'generatorVersion'>,
+  variant: string,
+): string {
+  const version = badge.generatorVersion ?? 1
+  const updatedMs = Date.parse(badge._updatedAt)
+  const stamp = Number.isNaN(updatedMs) ? badge._updatedAt : String(updatedMs)
+  return `W/"badge-${variant}-v${version}-${stamp}"`
+}
+
+/**
+ * A 304 Not Modified response when the client's `If-None-Match` already holds
+ * this exact artifact version, otherwise null. Comparison is lenient over a
+ * comma-separated list and tolerates the optional weak-validator prefix.
+ */
+export function badgeNotModifiedResponse(
+  request: { headers?: { get(name: string): string | null } } | undefined,
+  etag: string,
+): NextResponse | null {
+  const inm = request?.headers?.get?.('if-none-match') ?? null
+  if (!inm) return null
+  const normalize = (t: string) => t.trim().replace(/^W\//, '')
+  const target = normalize(etag)
+  const matches = inm.split(',').some((t) => normalize(t) === target)
+  if (!matches) return null
+  return new NextResponse(null, {
+    status: 304,
+    headers: { ETag: etag, 'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL },
+  })
+}

--- a/src/lib/badge/http.ts
+++ b/src/lib/badge/http.ts
@@ -20,6 +20,16 @@ import type { BadgeRecord } from './types'
  */
 export const BADGE_ARTIFACT_CACHE_CONTROL = 'public, max-age=0, must-revalidate'
 
+/**
+ * CORS headers for the publicly-verifiable credential routes. Shared between
+ * the 200 and 304 paths — a 304 without Access-Control-Allow-Origin fails the
+ * browser CORS check on revalidation even though the cached 200 was usable.
+ */
+export const BADGE_CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET',
+} as const
+
 /** Weak ETag that changes whenever the badge doc is (re)baked. */
 export function badgeArtifactETag(
   badge: Pick<BadgeRecord, '_updatedAt' | 'generatorVersion'>,
@@ -35,10 +45,14 @@ export function badgeArtifactETag(
  * A 304 Not Modified response when the client's `If-None-Match` already holds
  * this exact artifact version, otherwise null. Comparison is lenient over a
  * comma-separated list and tolerates the optional weak-validator prefix.
+ *
+ * `extraHeaders` must mirror any header the route's 200 response needs on
+ * revalidation too (CORS headers, `Vary`).
  */
 export function badgeNotModifiedResponse(
   request: { headers?: { get(name: string): string | null } } | undefined,
   etag: string,
+  extraHeaders?: Record<string, string>,
 ): NextResponse | null {
   const inm = request?.headers?.get?.('if-none-match') ?? null
   if (!inm) return null
@@ -48,6 +62,10 @@ export function badgeNotModifiedResponse(
   if (!matches) return null
   return new NextResponse(null, {
     status: 304,
-    headers: { ETag: etag, 'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL },
+    headers: {
+      ETag: etag,
+      'Cache-Control': BADGE_ARTIFACT_CACHE_CONTROL,
+      ...extraHeaders,
+    },
   })
 }

--- a/src/lib/badge/png.ts
+++ b/src/lib/badge/png.ts
@@ -178,14 +178,28 @@ export function extractCredentialFromPng(png: Uint8Array): string | null {
  * `<openbadges:credential>` node (and its CDATA) is stripped first so the
  * rasterizer only sees drawable markup; the credential is re-baked into the PNG
  * separately via {@link bakeCredentialIntoPng}.
+ *
+ * System fonts are never consulted (there are none on the serverless runtime,
+ * and depending on them makes output differ between environments) — callers
+ * whose SVG contains `<text>` MUST pass `fontFiles` (see lib/badge/fonts.ts)
+ * or the text silently disappears from the render.
  */
-export function renderBadgeSvgToPng(svg: string, width = 1024): Uint8Array {
+export function renderBadgeSvgToPng(
+  svg: string,
+  options: { width?: number; fontFiles?: string[] } = {},
+): Uint8Array {
+  const { width = 1024, fontFiles = [] } = options
   const drawable = svg.replace(
     /<openbadges:credential[\s\S]*?<\/openbadges:credential>\s*/g,
     '',
   )
   const resvg = new Resvg(drawable, {
     fitTo: { mode: 'width', value: width },
+    font: {
+      loadSystemFonts: false,
+      fontFiles,
+      defaultFontFamily: 'Inter',
+    },
   })
   return resvg.render().asPng()
 }

--- a/src/lib/badge/png.ts
+++ b/src/lib/badge/png.ts
@@ -1,0 +1,191 @@
+import { Resvg } from '@resvg/resvg-js'
+
+/**
+ * OpenBadges 3.0 PNG baking.
+ *
+ * Per the OB 3.0 baking spec (§ PNG), a baked credential lives in an `iTXt`
+ * chunk whose keyword is `openbadgecredential`; the text is the raw credential
+ * (the JSON-LD credential for embedded-proof badges, or the Compact JWS for
+ * JWT badges — the 1EdTech PngParser accepts either). This mirrors the SVG
+ * baking (`<openbadges:credential>`), giving recipients a PNG they can upload to
+ * OB 3.0 displayers such as Credly.
+ */
+export const OB_PNG_KEYWORD = 'openbadgecredential'
+
+const PNG_SIGNATURE = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10])
+
+// CRC-32 (IEEE) table, computed once.
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256)
+  for (let n = 0; n < 256; n++) {
+    let c = n
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    }
+    table[n] = c >>> 0
+  }
+  return table
+})()
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff
+  for (let i = 0; i < bytes.length; i++) {
+    crc = CRC_TABLE[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+/** Serialize a PNG chunk: length(4) | type(4) | data | crc(4). */
+function encodeChunk(type: string, data: Uint8Array): Uint8Array {
+  const typeBytes = new TextEncoder().encode(type)
+  const typeAndData = new Uint8Array(typeBytes.length + data.length)
+  typeAndData.set(typeBytes, 0)
+  typeAndData.set(data, typeBytes.length)
+
+  const out = new Uint8Array(4 + typeAndData.length + 4)
+  const view = new DataView(out.buffer)
+  view.setUint32(0, data.length)
+  out.set(typeAndData, 4)
+  view.setUint32(4 + typeAndData.length, crc32(typeAndData))
+  return out
+}
+
+/**
+ * iTXt data payload (uncompressed): keyword \0 compFlag(0) compMethod(0)
+ * langTag \0 translatedKeyword \0 text.
+ */
+function encodeITXtData(keyword: string, text: string): Uint8Array {
+  const enc = new TextEncoder()
+  const kw = enc.encode(keyword)
+  const txt = enc.encode(text)
+  // kw + NUL + compFlag + compMethod + langTag(NUL) + transKw(NUL) + text
+  const out = new Uint8Array(kw.length + 5 + txt.length)
+  let o = 0
+  out.set(kw, o)
+  o += kw.length
+  out[o++] = 0 // null separator after keyword
+  out[o++] = 0 // compression flag (0 = uncompressed)
+  out[o++] = 0 // compression method
+  out[o++] = 0 // empty language tag + null
+  out[o++] = 0 // empty translated keyword + null
+  out.set(txt, o)
+  return out
+}
+
+function isPng(bytes: Uint8Array): boolean {
+  if (bytes.length < 8) return false
+  for (let i = 0; i < 8; i++) if (bytes[i] !== PNG_SIGNATURE[i]) return false
+  return true
+}
+
+/**
+ * Insert an `openbadgecredential` iTXt chunk immediately before the IEND chunk.
+ * Any pre-existing `openbadgecredential` iTXt chunk is dropped first so baking
+ * is idempotent.
+ */
+export function bakeCredentialIntoPng(
+  png: Uint8Array,
+  credentialText: string,
+): Uint8Array {
+  if (!isPng(png)) {
+    throw new Error('Not a PNG: bad signature')
+  }
+
+  const chunks: Uint8Array[] = []
+  let offset = 8
+  let iendChunk: Uint8Array | null = null
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength)
+
+  while (offset + 8 <= png.length) {
+    const length = view.getUint32(offset)
+    const type = new TextDecoder().decode(png.subarray(offset + 4, offset + 8))
+    const total = 12 + length
+    const chunk = png.subarray(offset, offset + total)
+
+    if (type === 'IEND') {
+      iendChunk = chunk
+      break
+    }
+    // Drop any prior baked credential chunk (idempotent re-bake).
+    if (!(type === 'iTXt' && chunkKeyword(png, offset) === OB_PNG_KEYWORD)) {
+      chunks.push(chunk)
+    }
+    offset += total
+  }
+
+  if (!iendChunk) {
+    throw new Error('Invalid PNG: missing IEND chunk')
+  }
+
+  const credentialChunk = encodeChunk(
+    'iTXt',
+    encodeITXtData(OB_PNG_KEYWORD, credentialText),
+  )
+
+  const parts = [PNG_SIGNATURE, ...chunks, credentialChunk, iendChunk]
+  const totalLength = parts.reduce((n, p) => n + p.length, 0)
+  const result = new Uint8Array(totalLength)
+  let o = 0
+  for (const p of parts) {
+    result.set(p, o)
+    o += p.length
+  }
+  return result
+}
+
+/** Read the iTXt keyword at a chunk offset (up to its first NUL). */
+function chunkKeyword(png: Uint8Array, offset: number): string {
+  const dataStart = offset + 8
+  let end = dataStart
+  while (end < png.length && png[end] !== 0) end++
+  return new TextDecoder().decode(png.subarray(dataStart, end))
+}
+
+/**
+ * Extract the `openbadgecredential` text from a baked PNG, or null when absent.
+ * Only the uncompressed iTXt form this module writes is supported.
+ */
+export function extractCredentialFromPng(png: Uint8Array): string | null {
+  if (!isPng(png)) return null
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength)
+  let offset = 8
+  while (offset + 8 <= png.length) {
+    const length = view.getUint32(offset)
+    const type = new TextDecoder().decode(png.subarray(offset + 4, offset + 8))
+    if (type === 'iTXt' && chunkKeyword(png, offset) === OB_PNG_KEYWORD) {
+      const dataStart = offset + 8
+      const data = png.subarray(dataStart, dataStart + length)
+      // keyword \0 compFlag compMethod langTag \0 transKw \0 text
+      let p = 0
+      while (p < data.length && data[p] !== 0) p++ // keyword
+      p++ // NUL
+      p++ // compression flag
+      p++ // compression method
+      while (p < data.length && data[p] !== 0) p++ // language tag
+      p++ // NUL
+      while (p < data.length && data[p] !== 0) p++ // translated keyword
+      p++ // NUL
+      return new TextDecoder().decode(data.subarray(p))
+    }
+    if (type === 'IEND') break
+    offset += 12 + length
+  }
+  return null
+}
+
+/**
+ * Rasterize a badge SVG to a square PNG. The non-rendering
+ * `<openbadges:credential>` node (and its CDATA) is stripped first so the
+ * rasterizer only sees drawable markup; the credential is re-baked into the PNG
+ * separately via {@link bakeCredentialIntoPng}.
+ */
+export function renderBadgeSvgToPng(svg: string, width = 1024): Uint8Array {
+  const drawable = svg.replace(
+    /<openbadges:credential[\s\S]*?<\/openbadges:credential>\s*/g,
+    '',
+  )
+  const resvg = new Resvg(drawable, {
+    fitTo: { mode: 'width', value: width },
+  })
+  return resvg.render().asPng()
+}

--- a/src/lib/badge/png.ts
+++ b/src/lib/badge/png.ts
@@ -107,7 +107,9 @@ export function bakeCredentialIntoPng(
       break
     }
     // Drop any prior baked credential chunk (idempotent re-bake).
-    if (!(type === 'iTXt' && chunkKeyword(png, offset) === OB_PNG_KEYWORD)) {
+    if (!(
+      type === 'iTXt' && chunkKeyword(png, offset, length) === OB_PNG_KEYWORD
+    )) {
       chunks.push(chunk)
     }
     offset += total
@@ -133,11 +135,20 @@ export function bakeCredentialIntoPng(
   return result
 }
 
-/** Read the iTXt keyword at a chunk offset (up to its first NUL). */
-function chunkKeyword(png: Uint8Array, offset: number): string {
+/**
+ * Read the iTXt keyword at a chunk offset (up to its first NUL), never scanning
+ * past the chunk's declared data length — a malformed chunk without a NUL must
+ * not bleed into subsequent chunks.
+ */
+function chunkKeyword(
+  png: Uint8Array,
+  offset: number,
+  dataLength: number,
+): string {
   const dataStart = offset + 8
+  const dataEnd = Math.min(dataStart + dataLength, png.length)
   let end = dataStart
-  while (end < png.length && png[end] !== 0) end++
+  while (end < dataEnd && png[end] !== 0) end++
   return new TextDecoder().decode(png.subarray(dataStart, end))
 }
 
@@ -152,13 +163,19 @@ export function extractCredentialFromPng(png: Uint8Array): string | null {
   while (offset + 8 <= png.length) {
     const length = view.getUint32(offset)
     const type = new TextDecoder().decode(png.subarray(offset + 4, offset + 8))
-    if (type === 'iTXt' && chunkKeyword(png, offset) === OB_PNG_KEYWORD) {
+    if (
+      type === 'iTXt' &&
+      chunkKeyword(png, offset, length) === OB_PNG_KEYWORD
+    ) {
       const dataStart = offset + 8
       const data = png.subarray(dataStart, dataStart + length)
       // keyword \0 compFlag compMethod langTag \0 transKw \0 text
       let p = 0
       while (p < data.length && data[p] !== 0) p++ // keyword
       p++ // NUL
+      // Only the uncompressed form this module writes is supported — a
+      // compressed chunk's payload would be zlib bytes, not the credential.
+      if (data[p] !== 0) return null
       p++ // compression flag
       p++ // compression method
       while (p < data.length && data[p] !== 0) p++ // language tag
@@ -174,7 +191,8 @@ export function extractCredentialFromPng(png: Uint8Array): string | null {
 }
 
 /**
- * Rasterize a badge SVG to a square PNG. The non-rendering
+ * Rasterize a badge SVG to a PNG at the given width (aspect ratio is
+ * preserved; badge SVGs are square so output is too). The non-rendering
  * `<openbadges:credential>` node (and its CDATA) is stripped first so the
  * rasterizer only sees drawable markup; the credential is re-baked into the PNG
  * separately via {@link bakeCredentialIntoPng}.


### PR DESCRIPTION
Root cause of the "official validator still fails after rebaking" and Credly "Unverified" reports was NOT a credential defect — the #655 credential/key design is field-proven correct (verifybadge.org OB30 Inspector confirms VALID on fresh bytes). Two real defects remained:

## 1. Stale immutable cache (the actual "persistent failure")

`/download`, `/image`, `/json`, `/jwt` and `/achievement` served `Cache-Control: public, max-age=31536000, immutable`. A rebake patches the Sanity doc in place (same badgeId/URL, new bytes), so every rebake was stranded behind up to a year of browser/CDN cache — the re-validated file was a cached pre-#655 copy. These routes now use a revalidating policy (`public, max-age=0, must-revalidate`) with a weak ETag keyed on the doc's `_updatedAt` (moves on every rebake) + `generatorVersion` + variant, so unchanged artifacts still get a cheap 304 while rebakes appear immediately. Keys/issuer stay immutable (signing keys do not rotate).

## 2. Credential `id` 404 (Credly "Unverified" suspect)

The credential's own `id` (`${baseUrl}/api/badge/{id}`) had no route and 404'd, while every other id in the credential dereferences. Hosted-data verification is the most likely reason Credly marked imported badges "Unverified" (their FAQ: they can't confirm authenticity). Added `GET /api/badge/[badgeId]` serving the SAME credential bytes as `/json` (shared via `badgeCredentialBody`) as `application/ld+json` with open CORS; browsers (`Accept: text/html`) redirect to the human page `/badge/[badgeId]`.

## 3. Baked PNG download

`/download?format=png`: resvg rasterizes the badge SVG and the **raw credential JSON** is baked into an `openbadgecredential` iTXt chunk per the OB 3.0 PNG baking spec — a second, non-JWT container (Credly rejects JWT-baked badges per their support). Admin badge menu gains "Download PNG".

No generator version bump: baked SVG bytes are unchanged (CDATA-JSON is the spec-canonical form, matching the 1EdTech `simple-json.svg` fixture).

**Tests:** PNG bake→extract byte-parity + idempotent re-bake + rasterize; ETag/304 + cache-policy; credential-id ↔ `/json` byte parity, ld+json, CORS, HTML redirect. Full suite green: 333 files / 4332 tests.

**Post-deploy verification:** re-download the badge SVG (hard refresh), re-test fresh SVG + JSON on Credly, confirm whether "Unverified" clears now that the credential id resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C