### PR TITLE
fix: tenant-derived base URLs — eliminate localhost fallbacks in outbound content

### DIFF
--- a/src/app/(admin)/admin/marketing/page.tsx
+++ b/src/app/(admin)/admin/marketing/page.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { getAuthSession } from '@/lib/auth'
 import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { getProposals } from '@/lib/proposal/server'
 import { formatConferenceDateLong } from '@/lib/time'
 import { Status } from '@/lib/proposal/types'
@@ -529,7 +530,7 @@ export default async function MarketingPage() {
                           eventDate={eventDate}
                           baseUrl={
                             conference.domains?.[0]
-                              ? `https://${conference.domains[0]}`
+                              ? conferenceBaseUrl(conference)
                               : undefined
                           }
                           showCloudNativePattern={true}

--- a/src/app/(admin)/admin/marketing/page.tsx
+++ b/src/app/(admin)/admin/marketing/page.tsx
@@ -2,7 +2,10 @@ import React from 'react'
 import { getAuthSession } from '@/lib/auth'
 import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
-import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
+import {
+  conferenceBaseUrl,
+  hasConferenceDomain,
+} from '@/lib/conference/baseUrl'
 import { getProposals } from '@/lib/proposal/server'
 import { formatConferenceDateLong } from '@/lib/time'
 import { Status } from '@/lib/proposal/types'
@@ -529,7 +532,7 @@ export default async function MarketingPage() {
                           eventName={conference.title}
                           eventDate={eventDate}
                           baseUrl={
-                            conference.domains?.[0]
+                            hasConferenceDomain(conference)
                               ? conferenceBaseUrl(conference)
                               : undefined
                           }

--- a/src/components/admin/SpeakerActions.tsx
+++ b/src/components/admin/SpeakerActions.tsx
@@ -5,6 +5,7 @@ import { useNotification } from './NotificationProvider'
 import { api } from '@/lib/trpc/client'
 
 import { Conference } from '@/lib/conference/types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { formatConferenceDateLong } from '@/lib/time'
 
 interface SpeakerActionsProps {
@@ -63,7 +64,7 @@ export function SpeakerActions({
       eventName={conference.title}
       eventLocation={`${conference.city}, ${conference.country}`}
       eventDate={formatConferenceDateLong(conference.startDate)}
-      eventUrl={`https://${conference.domains[0]}`}
+      eventUrl={conferenceBaseUrl(conference)}
       socialLinks={conference.socialLinks || []}
     />
   )

--- a/src/components/admin/sponsor/SponsorContactActions.tsx
+++ b/src/components/admin/sponsor/SponsorContactActions.tsx
@@ -6,6 +6,7 @@ import {
   DocumentArrowDownIcon,
 } from '@heroicons/react/24/outline'
 import { Conference } from '@/lib/conference/types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { formatConferenceDateLong } from '@/lib/time'
 import { GeneralBroadcastModal } from '@/components/admin'
 import { AdminHeaderActions } from '@/components/admin/AdminHeaderActions'
@@ -77,7 +78,7 @@ export function SponsorContactActions({
         eventName={conference.title}
         eventLocation={`${conference.city}, ${conference.country}`}
         eventDate={formatConferenceDateLong(conference.startDate)}
-        eventUrl={`https://${conference.domains[0]}`}
+        eventUrl={conferenceBaseUrl(conference)}
         socialLinks={conference.socialLinks || []}
       />
     </>

--- a/src/components/admin/sponsor/SponsorDiscountEmailModal.tsx
+++ b/src/components/admin/sponsor/SponsorDiscountEmailModal.tsx
@@ -8,6 +8,7 @@ import { convertStringToPortableTextBlocks } from '@/lib/proposal'
 import { PortableTextBlock } from '@portabletext/editor'
 import { PortableTextBlock as PortableTextBlockForHTML } from '@portabletext/types'
 import { createLocalhostWarning } from '@/lib/localhost-warning'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { api } from '@/lib/trpc/client'
 
 interface SponsorWithTierInfo {
@@ -71,7 +72,7 @@ As a {{{SPONSOR_TIER}}} sponsor, you're entitled to {{{TICKET_COUNT}}} complimen
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Initialize email template on modal open
       setInitialMessage(portableTextBlocks)
 
-      const defaultTicketUrl = `https://${conference.domains[0]}/tickets`
+      const defaultTicketUrl = `${conferenceBaseUrl(conference)}/tickets`
 
       setTicketUrl(defaultTicketUrl)
       setAdditionalFields({ ticketUrl: defaultTicketUrl })
@@ -227,7 +228,7 @@ As a {{{SPONSOR_TIER}}} sponsor, you're entitled to {{{TICKET_COUNT}}} complimen
         eventName={conference.title}
         eventLocation={`${conference.city}, ${conference.country}`}
         eventDate={formatConferenceDateLong(conference.startDate)}
-        eventUrl={`https://${conference.domains[0]}`}
+        eventUrl={conferenceBaseUrl(conference)}
         socialLinks={conference.socialLinks || []}
         content={<div dangerouslySetInnerHTML={{ __html: fullContent }} />}
       />

--- a/src/components/admin/sponsor/SponsorIndividualEmailModal.tsx
+++ b/src/components/admin/sponsor/SponsorIndividualEmailModal.tsx
@@ -8,6 +8,7 @@ import { convertStringToPortableTextBlocks } from '@/lib/proposal'
 import { PortableTextBlock } from '@portabletext/editor'
 import { PortableTextBlock as PortableTextBlockForHTML } from '@portabletext/types'
 import { formatConferenceDateLong } from '@/lib/time'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { createLocalhostWarning } from '@/lib/localhost-warning'
 import { SponsorTemplatePicker } from './SponsorTemplatePicker'
 import { api } from '@/lib/trpc/client'
@@ -126,7 +127,7 @@ export function SponsorIndividualEmailModal({
         eventName={conference.title}
         eventLocation={`${conference.city}, ${conference.country}`}
         eventDate={formatConferenceDateLong(conference.startDate)}
-        eventUrl={`https://${conference.domains[0]}`}
+        eventUrl={conferenceBaseUrl(conference)}
         socialLinks={conference.socialLinks || []}
         content={<div dangerouslySetInnerHTML={{ __html: messageHTML }} />}
       />

--- a/src/components/admin/sponsor/SponsorTiersPageClient.tsx
+++ b/src/components/admin/sponsor/SponsorTiersPageClient.tsx
@@ -13,6 +13,7 @@ import { TicketIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { ConferenceSponsor } from '@/lib/sponsor/types'
 import { Conference } from '@/lib/conference/types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { SponsorTier } from '@/lib/sponsor/types'
 import { formatConferenceDateLong } from '@/lib/time'
 import { useSponsorBroadcast } from '@/hooks/useSponsorBroadcast'
@@ -139,7 +140,7 @@ export function SponsorTiersPageClient({
         eventName={conference.title}
         eventLocation={`${conference.city}, ${conference.country}`}
         eventDate={formatConferenceDateLong(conference.startDate)}
-        eventUrl={`https://${conference.domains[0]}`}
+        eventUrl={conferenceBaseUrl(conference)}
         socialLinks={conference.socialLinks || []}
       />
     </>

--- a/src/components/admin/system-status/fixtures.ts
+++ b/src/components/admin/system-status/fixtures.ts
@@ -32,10 +32,11 @@ export const fixtureChecks: SystemCheck[] = [
   {
     id: 'build.baseUrl',
     group: 'build',
-    label: 'NEXT_PUBLIC_BASE_URL',
+    label: 'Platform base URL',
     status: 'warn',
     value: 'not set',
-    detail: 'Absolute links fall back to http://localhost:3000',
+    detail:
+      'None of NEXT_PUBLIC_BASE_URL / NEXT_PUBLIC_URL / VERCEL_URL are set — platform-level outbound links fail in production',
   },
   {
     id: 'build.nodeEnv',

--- a/src/lib/branding/platform.ts
+++ b/src/lib/branding/platform.ts
@@ -1,3 +1,5 @@
+import { isLocalhostDomain } from '@/lib/environment/localhost'
+
 /**
  * The neutral, brand-free PLATFORM name (CaaS de-branding, go-live gate G2).
  *
@@ -38,10 +40,18 @@ export function platformBaseUrl(): string {
     ''
   ).trim()
   if (configured) {
+    // Enforce the origin contract: strip any configured path, and give a
+    // scheme-less value the right scheme (`http` for a localhost dev origin).
     const withScheme = /^https?:\/\//i.test(configured)
       ? configured
-      : `https://${configured}`
-    return withScheme.replace(/\/+$/, '')
+      : `${isLocalhostDomain(configured) ? 'http' : 'https'}://${configured}`
+    try {
+      return new URL(withScheme).origin
+    } catch {
+      console.error(
+        `[baseUrl] Configured platform base URL is not a valid URL: "${configured}"`,
+      )
+    }
   }
 
   const vercel = process.env.VERCEL_URL?.trim()

--- a/src/lib/branding/platform.ts
+++ b/src/lib/branding/platform.ts
@@ -34,11 +34,12 @@ export const PLATFORM_NAME = 'Cloud Native Days'
  * dev URL into a real email/notification.
  */
 export function platformBaseUrl(): string {
-  const configured = (
-    process.env.NEXT_PUBLIC_BASE_URL ||
-    process.env.NEXT_PUBLIC_URL ||
+  // Trim BEFORE precedence: a whitespace-only primary must not shadow a
+  // configured fallback.
+  const configured =
+    process.env.NEXT_PUBLIC_BASE_URL?.trim() ||
+    process.env.NEXT_PUBLIC_URL?.trim() ||
     ''
-  ).trim()
   if (configured) {
     // Enforce the origin contract: strip any configured path, and give a
     // scheme-less value the right scheme (`http` for a localhost dev origin).

--- a/src/lib/branding/platform.ts
+++ b/src/lib/branding/platform.ts
@@ -11,3 +11,53 @@
  * metadata and OpenGraph alt text all agree on the platform label.
  */
 export const PLATFORM_NAME = 'Cloud Native Days'
+
+/**
+ * The PLATFORM-level base URL (origin, no trailing slash) for genuinely
+ * non-tenant outbound/stored links — surfaces that do NOT belong to a single
+ * conference and therefore cannot use {@link import('@/lib/conference/baseUrl').conferenceBaseUrl}.
+ *
+ * Env contract (in precedence order):
+ *   1. `NEXT_PUBLIC_BASE_URL` — the canonical, monitored platform origin
+ *      (see `src/lib/system-status/checks.ts` → `build.baseUrl`).
+ *   2. `NEXT_PUBLIC_URL` — legacy alias still set in `.env.production`.
+ *   3. `VERCEL_URL` — the deploy's own hostname (brand-neutral, always set on
+ *      Vercel), used so a preview/misconfigured deploy still resolves.
+ *
+ * Failure behaviour is deliberately LOUD and never leaks `localhost` in
+ * production: outside production a missing config degrades to
+ * `http://localhost:3000` for local link previews; IN production a total
+ * absence of all three env vars is an unrecoverable misconfiguration that is
+ * logged via `console.error` and then thrown, rather than silently emitting a
+ * dev URL into a real email/notification.
+ */
+export function platformBaseUrl(): string {
+  const configured = (
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.NEXT_PUBLIC_URL ||
+    ''
+  ).trim()
+  if (configured) {
+    const withScheme = /^https?:\/\//i.test(configured)
+      ? configured
+      : `https://${configured}`
+    return withScheme.replace(/\/+$/, '')
+  }
+
+  const vercel = process.env.VERCEL_URL?.trim()
+  if (vercel) return `https://${vercel.replace(/\/+$/, '')}`
+
+  const isProduction =
+    process.env.VERCEL_ENV === 'production' ||
+    process.env.NODE_ENV === 'production'
+  if (!isProduction) return 'http://localhost:3000'
+
+  console.error(
+    '[baseUrl] No platform base URL is configured in production. Set ' +
+      'NEXT_PUBLIC_BASE_URL to the platform origin — outbound platform-level ' +
+      'links cannot be built without it.',
+  )
+  throw new Error(
+    'Platform base URL is not configured (set NEXT_PUBLIC_BASE_URL)',
+  )
+}

--- a/src/lib/conference/baseUrl.test.ts
+++ b/src/lib/conference/baseUrl.test.ts
@@ -15,6 +15,18 @@ describe('conferenceBaseUrl', () => {
     )
   })
 
+  it('sheds a scheme even with surrounding whitespace and casing', () => {
+    expect(conferenceBaseUrl({ domains: ['  HTTPS://Example.com/ '] })).toBe(
+      'https://example.com',
+    )
+  })
+
+  it('skips an unparseable entry and uses the next usable one', () => {
+    expect(
+      conferenceBaseUrl({ domains: ['not a domain!!', 'example.com'] }),
+    ).toBe('https://example.com')
+  })
+
   it('strips a defensively-stored scheme and trailing slash', () => {
     expect(conferenceBaseUrl({ domains: ['https://example.com/'] })).toBe(
       'https://example.com',
@@ -74,6 +86,13 @@ describe('hasConferenceDomain', () => {
     expect(hasConferenceDomain({ domains: ['', '*.x.com'] })).toBe(false)
     expect(hasConferenceDomain({ domains: [] })).toBe(false)
     expect(hasConferenceDomain(undefined)).toBe(false)
+  })
+
+  it('rejects entries the derivation cannot parse — guard and URL builder agree', () => {
+    expect(hasConferenceDomain({ domains: ['not a domain!!'] })).toBe(false)
+    expect(hasConferenceDomain({ domains: ['  HTTPS://Example.com/ '] })).toBe(
+      true,
+    )
   })
 })
 

--- a/src/lib/conference/baseUrl.test.ts
+++ b/src/lib/conference/baseUrl.test.ts
@@ -27,6 +27,12 @@ describe('conferenceBaseUrl', () => {
     )
   })
 
+  it('returns the origin only when an entry is mis-stored with a path', () => {
+    expect(conferenceBaseUrl({ domains: ['example.com/foo'] })).toBe(
+      'https://example.com',
+    )
+  })
+
   it('skips wildcard routing entries — outbound links need a concrete host', () => {
     expect(
       conferenceBaseUrl({ domains: ['*.example.com', 'example.com'] }),
@@ -92,6 +98,12 @@ describe('platformBaseUrl', () => {
   it('uses http for a scheme-less localhost value', () => {
     vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'localhost:3000')
     expect(platformBaseUrl()).toBe('http://localhost:3000')
+  })
+
+  it('a whitespace-only primary does not shadow the fallback var', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', '   ')
+    vi.stubEnv('NEXT_PUBLIC_URL', 'https://legacy.example')
+    expect(platformBaseUrl()).toBe('https://legacy.example')
   })
 
   it('falls back to the legacy NEXT_PUBLIC_URL', () => {

--- a/src/lib/conference/baseUrl.test.ts
+++ b/src/lib/conference/baseUrl.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { conferenceBaseUrl } from './baseUrl'
+import { platformBaseUrl } from '@/lib/branding/platform'
+
+describe('conferenceBaseUrl', () => {
+  it('derives an https origin from the primary domain', () => {
+    expect(conferenceBaseUrl({ domains: ['cloudnativebergen.no'] })).toBe(
+      'https://cloudnativebergen.no',
+    )
+  })
+
+  it('normalizes casing and surrounding whitespace', () => {
+    expect(conferenceBaseUrl({ domains: ['  CloudNativeBergen.NO  '] })).toBe(
+      'https://cloudnativebergen.no',
+    )
+  })
+
+  it('strips a defensively-stored scheme and trailing slash', () => {
+    expect(conferenceBaseUrl({ domains: ['https://example.com/'] })).toBe(
+      'https://example.com',
+    )
+  })
+
+  it('uses the first non-empty domain, skipping blanks', () => {
+    expect(conferenceBaseUrl({ domains: ['', '   ', 'second.example'] })).toBe(
+      'https://second.example',
+    )
+  })
+
+  it('uses http for an actual localhost dev domain (with port)', () => {
+    expect(conferenceBaseUrl({ domains: ['localhost:3000'] })).toBe(
+      'http://localhost:3000',
+    )
+  })
+
+  it('never yields a localhost URL when a real domain is present', () => {
+    expect(
+      conferenceBaseUrl({ domains: ['cloudnativebergen.no'] }),
+    ).not.toContain('localhost')
+  })
+
+  it('falls back LOUDLY to the platform base URL when the conference has no domain', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://platform.example')
+    try {
+      expect(conferenceBaseUrl({ title: 'No Domain Conf', domains: [] })).toBe(
+        'https://platform.example',
+      )
+      expect(errSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.unstubAllEnvs()
+      errSpy.mockRestore()
+    }
+  })
+})
+
+describe('platformBaseUrl', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('prefers NEXT_PUBLIC_BASE_URL, stripping a trailing slash', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://platform.example/')
+    expect(platformBaseUrl()).toBe('https://platform.example')
+  })
+
+  it('adds an https scheme when the configured value has none', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'platform.example')
+    expect(platformBaseUrl()).toBe('https://platform.example')
+  })
+
+  it('falls back to the legacy NEXT_PUBLIC_URL', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', '')
+    vi.stubEnv('NEXT_PUBLIC_URL', 'https://legacy.example')
+    expect(platformBaseUrl()).toBe('https://legacy.example')
+  })
+
+  it('falls back to the brand-neutral Vercel deploy URL', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', '')
+    vi.stubEnv('NEXT_PUBLIC_URL', '')
+    vi.stubEnv('VERCEL_URL', 'my-deploy.vercel.app')
+    expect(platformBaseUrl()).toBe('https://my-deploy.vercel.app')
+  })
+
+  it('degrades to localhost ONLY outside production', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', '')
+    vi.stubEnv('NEXT_PUBLIC_URL', '')
+    vi.stubEnv('VERCEL_URL', '')
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('VERCEL_ENV', '')
+    expect(platformBaseUrl()).toBe('http://localhost:3000')
+  })
+
+  it('throws loudly in production when nothing is configured (never localhost)', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', '')
+    vi.stubEnv('NEXT_PUBLIC_URL', '')
+    vi.stubEnv('VERCEL_URL', '')
+    vi.stubEnv('VERCEL_ENV', 'production')
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => platformBaseUrl()).toThrow(/not configured/i)
+    expect(errSpy).toHaveBeenCalledTimes(1)
+    errSpy.mockRestore()
+  })
+})

--- a/src/lib/conference/baseUrl.test.ts
+++ b/src/lib/conference/baseUrl.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { conferenceBaseUrl } from './baseUrl'
+import { conferenceBaseUrl, hasConferenceDomain } from './baseUrl'
 import { platformBaseUrl } from '@/lib/branding/platform'
 
 describe('conferenceBaseUrl', () => {
@@ -25,6 +25,12 @@ describe('conferenceBaseUrl', () => {
     expect(conferenceBaseUrl({ domains: ['', '   ', 'second.example'] })).toBe(
       'https://second.example',
     )
+  })
+
+  it('skips wildcard routing entries — outbound links need a concrete host', () => {
+    expect(
+      conferenceBaseUrl({ domains: ['*.example.com', 'example.com'] }),
+    ).toBe('https://example.com')
   })
 
   it('uses http for an actual localhost dev domain (with port)', () => {
@@ -54,6 +60,17 @@ describe('conferenceBaseUrl', () => {
   })
 })
 
+describe('hasConferenceDomain', () => {
+  it('agrees with conferenceBaseUrl on blanks and wildcards', () => {
+    expect(hasConferenceDomain({ domains: ['', '*.x.com', 'x.com'] })).toBe(
+      true,
+    )
+    expect(hasConferenceDomain({ domains: ['', '*.x.com'] })).toBe(false)
+    expect(hasConferenceDomain({ domains: [] })).toBe(false)
+    expect(hasConferenceDomain(undefined)).toBe(false)
+  })
+})
+
 describe('platformBaseUrl', () => {
   afterEach(() => vi.unstubAllEnvs())
 
@@ -65,6 +82,16 @@ describe('platformBaseUrl', () => {
   it('adds an https scheme when the configured value has none', () => {
     vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'platform.example')
     expect(platformBaseUrl()).toBe('https://platform.example')
+  })
+
+  it('returns the ORIGIN only when a path is misconfigured', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://platform.example/app/')
+    expect(platformBaseUrl()).toBe('https://platform.example')
+  })
+
+  it('uses http for a scheme-less localhost value', () => {
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'localhost:3000')
+    expect(platformBaseUrl()).toBe('http://localhost:3000')
   })
 
   it('falls back to the legacy NEXT_PUBLIC_URL', () => {

--- a/src/lib/conference/baseUrl.ts
+++ b/src/lib/conference/baseUrl.ts
@@ -50,7 +50,16 @@ export function conferenceBaseUrl(
     const protocol = isLocalhostDomain(domain)
       ? 'http'
       : protocolForDomain(domain)
-    return `${protocol}://${domain}`
+    // Enforce the origin contract like platformBaseUrl(): a mis-stored path
+    // segment ("example.com/foo") must not leak into joined outbound URLs.
+    try {
+      return new URL(`${protocol}://${domain}`).origin
+    } catch {
+      console.error(
+        `[baseUrl] conference "${conference?.title ?? 'unknown'}" has an invalid domains[] entry "${entry}"; falling back to the platform base URL.`,
+      )
+      return platformBaseUrl()
+    }
   }
 
   console.error(

--- a/src/lib/conference/baseUrl.ts
+++ b/src/lib/conference/baseUrl.ts
@@ -1,0 +1,64 @@
+import { normalizeDomain } from './domains'
+import {
+  isLocalhostDomain,
+  protocolForDomain,
+} from '@/lib/environment/localhost'
+import { platformBaseUrl } from '@/lib/branding/platform'
+
+/**
+ * Canonical base-URL derivation for TENANT-scoped outbound / stored content
+ * (emails, notification click targets, QR codes, credential URLs, …).
+ *
+ * This is a MULTI-TENANT platform: the correct origin for a conference's own
+ * links is that conference's OWN primary domain — never a single global env var
+ * (which would be wrong for every tenant but one) and never a `localhost`
+ * fallback (which leaks into production email when an env var is absent in the
+ * send context). The rule mirrors `resolveConferenceFrom` in
+ * `src/lib/email/from.ts`: prefer the conference's own field, and degrade only
+ * to a LOUD, brand-neutral platform default.
+ *
+ * Behaviour:
+ *   - Uses the first non-empty `conference.domains[]` entry, normalized
+ *     ({@link normalizeDomain}) and given the right scheme
+ *     ({@link protocolForDomain} → `http` only for an actual `localhost`/dev
+ *     domain, `https` for every real host).
+ *   - When the conference has NO domain (a genuine misconfiguration — routing
+ *     requires one), logs via `console.error` and falls back to the
+ *     {@link platformBaseUrl}, which itself never yields `localhost` in
+ *     production.
+ *
+ * Returns an origin with NO trailing slash; callers append their own path.
+ *
+ * Kept pure and client-safe (no server-only imports) so component and server
+ * code can share it.
+ */
+export function conferenceBaseUrl(
+  conference:
+    | { title?: string | null; domains?: readonly string[] | null }
+    | null
+    | undefined,
+): string {
+  const entry = conference?.domains?.find(
+    (d): d is string => typeof d === 'string' && d.trim().length > 0,
+  )
+
+  if (entry) {
+    // domains[] stores bare hostnames, but strip a defensive scheme so a
+    // mis-stored `https://x` can never become `https://https://x`.
+    const domain = normalizeDomain(entry.replace(/^https?:\/\//i, '')).replace(
+      /\/+$/,
+      '',
+    )
+    const protocol = isLocalhostDomain(domain)
+      ? 'http'
+      : protocolForDomain(domain)
+    return `${protocol}://${domain}`
+  }
+
+  console.error(
+    `[baseUrl] conference "${conference?.title ?? 'unknown'}" has no domains[]; ` +
+      'falling back to the platform base URL for outbound links. This is a ' +
+      'misconfiguration — add a primary domain to this conference.',
+  )
+  return platformBaseUrl()
+}

--- a/src/lib/conference/baseUrl.ts
+++ b/src/lib/conference/baseUrl.ts
@@ -38,9 +38,7 @@ export function conferenceBaseUrl(
     | null
     | undefined,
 ): string {
-  const entry = conference?.domains?.find(
-    (d): d is string => typeof d === 'string' && d.trim().length > 0,
-  )
+  const entry = findOutboundDomain(conference)
 
   if (entry) {
     // domains[] stores bare hostnames, but strip a defensive scheme so a
@@ -56,9 +54,36 @@ export function conferenceBaseUrl(
   }
 
   console.error(
-    `[baseUrl] conference "${conference?.title ?? 'unknown'}" has no domains[]; ` +
+    `[baseUrl] conference "${conference?.title ?? 'unknown'}" has no usable domains[]; ` +
       'falling back to the platform base URL for outbound links. This is a ' +
       'misconfiguration — add a primary domain to this conference.',
   )
   return platformBaseUrl()
+}
+
+/**
+ * First `domains[]` entry usable for OUTBOUND links: non-empty and not a
+ * wildcard routing entry (`*.example.com` matches inbound hosts but is not a
+ * concrete host an email link can point at).
+ */
+function findOutboundDomain(
+  conference: { domains?: readonly string[] | null } | null | undefined,
+): string | undefined {
+  return conference?.domains?.find(
+    (d): d is string =>
+      typeof d === 'string' && d.trim().length > 0 && !d.includes('*'),
+  )
+}
+
+/**
+ * Whether {@link conferenceBaseUrl} would derive a TENANT origin (vs falling
+ * back to the platform). Call sites that deliberately want `undefined`/`''`
+ * instead of a platform fallback must use THIS guard — checking
+ * `domains?.[0]` disagrees with the helper when the first entry is blank or a
+ * wildcard and a later entry is usable.
+ */
+export function hasConferenceDomain(
+  conference: { domains?: readonly string[] | null } | null | undefined,
+): boolean {
+  return findOutboundDomain(conference) !== undefined
 }

--- a/src/lib/conference/baseUrl.ts
+++ b/src/lib/conference/baseUrl.ts
@@ -38,29 +38,8 @@ export function conferenceBaseUrl(
     | null
     | undefined,
 ): string {
-  const entry = findOutboundDomain(conference)
-
-  if (entry) {
-    // domains[] stores bare hostnames, but strip a defensive scheme so a
-    // mis-stored `https://x` can never become `https://https://x`.
-    const domain = normalizeDomain(entry.replace(/^https?:\/\//i, '')).replace(
-      /\/+$/,
-      '',
-    )
-    const protocol = isLocalhostDomain(domain)
-      ? 'http'
-      : protocolForDomain(domain)
-    // Enforce the origin contract like platformBaseUrl(): a mis-stored path
-    // segment ("example.com/foo") must not leak into joined outbound URLs.
-    try {
-      return new URL(`${protocol}://${domain}`).origin
-    } catch {
-      console.error(
-        `[baseUrl] conference "${conference?.title ?? 'unknown'}" has an invalid domains[] entry "${entry}"; falling back to the platform base URL.`,
-      )
-      return platformBaseUrl()
-    }
-  }
+  const origin = findOutboundOrigin(conference)
+  if (origin) return origin
 
   console.error(
     `[baseUrl] conference "${conference?.title ?? 'unknown'}" has no usable domains[]; ` +
@@ -71,28 +50,49 @@ export function conferenceBaseUrl(
 }
 
 /**
- * First `domains[]` entry usable for OUTBOUND links: non-empty and not a
- * wildcard routing entry (`*.example.com` matches inbound hosts but is not a
- * concrete host an email link can point at).
+ * Derive the outbound ORIGIN for one `domains[]` entry, or null when the entry
+ * cannot yield one: blank, a wildcard routing entry (`*.example.com` matches
+ * inbound hosts but is not a concrete host an email link can point at), or
+ * unparseable after normalization. Normalizes BEFORE stripping the defensive
+ * scheme so a mis-stored `"  HTTPS://X.com "` still sheds it, and returns
+ * `URL.origin` so a mis-stored path can never leak into joined outbound URLs.
  */
-function findOutboundDomain(
+function deriveOrigin(entry: string): string | null {
+  if (entry.includes('*')) return null
+  const domain = normalizeDomain(entry)
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/+$/, '')
+  if (!domain) return null
+  const protocol = isLocalhostDomain(domain)
+    ? 'http'
+    : protocolForDomain(domain)
+  try {
+    return new URL(`${protocol}://${domain}`).origin
+  } catch {
+    return null
+  }
+}
+
+/** First `domains[]` entry that derives a usable outbound origin. */
+function findOutboundOrigin(
   conference: { domains?: readonly string[] | null } | null | undefined,
-): string | undefined {
-  return conference?.domains?.find(
-    (d): d is string =>
-      typeof d === 'string' && d.trim().length > 0 && !d.includes('*'),
-  )
+): string | null {
+  for (const d of conference?.domains ?? []) {
+    if (typeof d !== 'string') continue
+    const origin = deriveOrigin(d)
+    if (origin) return origin
+  }
+  return null
 }
 
 /**
  * Whether {@link conferenceBaseUrl} would derive a TENANT origin (vs falling
- * back to the platform). Call sites that deliberately want `undefined`/`''`
- * instead of a platform fallback must use THIS guard — checking
- * `domains?.[0]` disagrees with the helper when the first entry is blank or a
- * wildcard and a later entry is usable.
+ * back to the platform). Shares the exact derivation with conferenceBaseUrl()
+ * — including parseability — so a guard that intends to suppress the platform
+ * fallback can never be satisfied by an entry the derivation would reject.
  */
 export function hasConferenceDomain(
   conference: { domains?: readonly string[] | null } | null | undefined,
 ): boolean {
-  return findOutboundDomain(conference) !== undefined
+  return findOutboundOrigin(conference) !== null
 }

--- a/src/lib/cospeaker/server.ts
+++ b/src/lib/cospeaker/server.ts
@@ -14,6 +14,7 @@ import { CoSpeakerInvitationTemplate } from '@/components/email/CoSpeakerInvitat
 import { CoSpeakerResponseTemplate } from '@/components/email/CoSpeakerResponseTemplate'
 import { AppEnvironment } from '@/lib/environment'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { formatDate } from '@/lib/time'
 
 const TOKEN_SECRET = process.env.INVITATION_TOKEN_SECRET
@@ -119,9 +120,9 @@ function buildEmailEventContext(
       ? `${conference.city}, ${conference.country || 'Norway'}`
       : 'Location TBA',
     eventDate: conference.startDate ? formatDate(conference.startDate) : 'TBD',
-    eventUrl: conference.domains?.[0]
-      ? `https://${conference.domains[0]}`
-      : process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000',
+    // Tenant-derived origin: the conference's own domain, never a global env
+    // var that silently degraded to http://localhost:3000 in the send context.
+    eventUrl: conferenceBaseUrl(conference),
   }
 }
 

--- a/src/lib/email/badge.test.ts
+++ b/src/lib/email/badge.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The badge sender constructs `new Resend(...)` at module load, so mock the
+// package itself and capture the send payload.
+const sendMock = vi.fn()
+vi.mock('resend', () => ({
+  Resend: class {
+    emails = { send: (...args: unknown[]) => sendMock(...args) }
+  },
+}))
+
+const updateStatusMock = vi.fn()
+vi.mock('@/lib/badge/sanity', () => ({
+  updateBadgeEmailStatus: (...args: unknown[]) => updateStatusMock(...args),
+}))
+
+import { sendBadgeEmail } from './badge'
+
+const badge = {
+  badgeId: 'BADGE123',
+  badgeType: 'speaker',
+} as never
+
+const baseParams = {
+  badge,
+  speakerEmail: 'speaker@example.com',
+  speakerName: 'Ada Lovelace',
+  conferenceName: 'Cloud Native Bergen',
+  conferenceYear: '2099',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sendMock.mockResolvedValue({ data: { id: 'email-1' }, error: null })
+  updateStatusMock.mockResolvedValue(undefined)
+})
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('sendBadgeEmail download URL', () => {
+  it('builds the download link from the conference OWN domain', async () => {
+    const result = await sendBadgeEmail({
+      ...baseParams,
+      conference: { domains: ['cloudnativebergen.no'] } as never,
+    })
+
+    expect(result.success).toBe(true)
+    const html = sendMock.mock.calls[0][0].html as string
+    expect(html).toContain(
+      'https://cloudnativebergen.no/api/badge/BADGE123/download',
+    )
+  })
+
+  it('never emits a localhost link, even in production with no global base URL', async () => {
+    // Reproduces the reported bug's environment: production, NEXT_PUBLIC_BASE_URL
+    // absent in the send context. The old code degraded to http://localhost:3000.
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('VERCEL_ENV', 'production')
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', '')
+
+    await sendBadgeEmail({
+      ...baseParams,
+      conference: { domains: ['2099.cloudnativedays.no'] } as never,
+    })
+
+    const html = sendMock.mock.calls[0][0].html as string
+    expect(html).not.toContain('localhost')
+    expect(html).toContain(
+      'https://2099.cloudnativedays.no/api/badge/BADGE123/download',
+    )
+  })
+})

--- a/src/lib/email/badge.ts
+++ b/src/lib/email/badge.ts
@@ -4,6 +4,7 @@ import { updateBadgeEmailStatus } from '@/lib/badge/sanity'
 import type { BadgeRecord } from '@/lib/badge/types'
 import type { Conference } from '@/lib/conference/types'
 import { resolveConferenceFrom } from '@/lib/email/from'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
@@ -34,8 +35,11 @@ export async function sendBadgeEmail({
   conference,
 }: SendBadgeEmailParams): Promise<SendBadgeEmailResult> {
   try {
-    // Generate download URL
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
+    // Generate download URL from the CONFERENCE'S OWN domain — not a global
+    // NEXT_PUBLIC_BASE_URL, which is (a) wrong for every tenant but one and
+    // (b) absent in the Resend send context on production, where it silently
+    // degraded to http://localhost:3000 and shipped dead links to speakers.
+    const baseUrl = conferenceBaseUrl(conference)
     const downloadUrl = `${baseUrl}/api/badge/${badge.badgeId}/download`
 
     // Generate email HTML

--- a/src/lib/email/contract-email.ts
+++ b/src/lib/email/contract-email.ts
@@ -6,6 +6,7 @@ import {
   processPortableTextVariables,
 } from '@/lib/sponsor/templates'
 import { portableTextToHTML } from '@/lib/email/portableTextToHTML'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { PortableTextBlock } from '@portabletext/types'
 import { formatConferenceDateLong } from '@/lib/time'
 
@@ -73,7 +74,7 @@ function buildVariables(vars: ContractEmailVariables): Record<string, string> {
   }
 
   if (vars.conference.domains?.[0]) {
-    v.EVENT_URL = `https://${vars.conference.domains[0]}`
+    v.EVENT_URL = conferenceBaseUrl(vars.conference)
     v.CONFERENCE_URL = v.EVENT_URL
     v.SPONSOR_PAGE_URL = `${v.EVENT_URL}/sponsor`
   }

--- a/src/lib/email/contract-email.ts
+++ b/src/lib/email/contract-email.ts
@@ -6,7 +6,10 @@ import {
   processPortableTextVariables,
 } from '@/lib/sponsor/templates'
 import { portableTextToHTML } from '@/lib/email/portableTextToHTML'
-import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
+import {
+  conferenceBaseUrl,
+  hasConferenceDomain,
+} from '@/lib/conference/baseUrl'
 import { PortableTextBlock } from '@portabletext/types'
 import { formatConferenceDateLong } from '@/lib/time'
 
@@ -73,7 +76,7 @@ function buildVariables(vars: ContractEmailVariables): Record<string, string> {
     if (year) v.CONFERENCE_YEAR = year
   }
 
-  if (vars.conference.domains?.[0]) {
+  if (hasConferenceDomain(vars.conference)) {
     v.EVENT_URL = conferenceBaseUrl(vars.conference)
     v.CONFERENCE_URL = v.EVENT_URL
     v.SPONSOR_PAGE_URL = `${v.EVENT_URL}/sponsor`

--- a/src/lib/email/route-helpers.ts
+++ b/src/lib/email/route-helpers.ts
@@ -3,6 +3,7 @@ import { portableTextToHTML } from '@/lib/email/portableTextToHTML'
 import React from 'react'
 import { PortableTextBlock } from '@portabletext/types'
 import { Conference } from '@/lib/conference/types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { formatConferenceDateLong } from '@/lib/time'
 
 export interface EmailTemplateOptions {
@@ -25,7 +26,7 @@ export function renderEmailTemplate({
     eventName: conference.title,
     eventLocation: `${conference.city}, ${conference.country}`,
     eventDate: formatConferenceDateLong(conference.startDate),
-    eventUrl: `https://${conference.domains[0]}`,
+    eventUrl: conferenceBaseUrl(conference),
     socialLinks: conference.socialLinks || [],
     unsubscribeUrl,
     content: React.createElement('div', {

--- a/src/lib/email/speaker.ts
+++ b/src/lib/email/speaker.ts
@@ -1,4 +1,5 @@
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { getProposalSanity as getProposal } from '@/lib/proposal/server'
 import { SpeakerEmailTemplate } from '@/components/email/SpeakerEmailTemplate'
 import { Conference } from '@/lib/conference/types'
@@ -163,7 +164,8 @@ export async function sendFormattedMultiSpeakerEmail({
   senderName: string
 }): Promise<EmailResult<{ emailId: string }>> {
   try {
-    const proposalUrl = `https://${conference.domains[0]}/admin/proposals/${proposal._id}`
+    const eventUrl = conferenceBaseUrl(conference)
+    const proposalUrl = `${eventUrl}/admin/proposals/${proposal._id}`
 
     const emailTemplate = SpeakerEmailTemplate({
       speakers: speakers.map((s) => ({ name: s.name, email: s.email })),
@@ -172,7 +174,7 @@ export async function sendFormattedMultiSpeakerEmail({
       eventName: conference.title,
       eventLocation: `${conference.city}, ${conference.country}`,
       eventDate: conference.startDate || '',
-      eventUrl: `https://${conference.domains[0]}`,
+      eventUrl,
       subject: subject,
       message: message,
       senderName: senderName,

--- a/src/lib/email/volunteer.ts
+++ b/src/lib/email/volunteer.ts
@@ -5,6 +5,7 @@ import {
   createEmailError,
 } from './config'
 import { VolunteerWithConference } from '@/lib/volunteer/types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { formatConferenceDateLong } from '@/lib/time'
 import { VolunteerApprovalTemplate } from '@/components/email/VolunteerApprovalTemplate'
 
@@ -54,9 +55,7 @@ export async function sendVolunteerApprovalEmail(
     const eventDate = conference.startDate
       ? formatConferenceDateLong(conference.startDate)
       : 'TBD'
-    const eventUrl = conference.domains?.[0]
-      ? `https://${conference.domains[0]}`
-      : ''
+    const eventUrl = conferenceBaseUrl(conference)
     const socialLinks = conference.socialLinks?.map((link) => link.url) || []
 
     const result = await retryWithBackoff(async () => {

--- a/src/lib/email/workshop.ts
+++ b/src/lib/email/workshop.ts
@@ -6,6 +6,7 @@ import {
   type EmailResult,
 } from './config'
 import type { Conference } from '@/lib/conference/types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { resolveConferenceFrom, resolveConferenceContact } from './from'
 
 export interface WorkshopConfirmationEmailRequest {
@@ -147,7 +148,7 @@ export async function sendWorkshopSignupInstructions({
     const contactEmail = resolveConferenceContact(conference)
 
     const workshopUrl = conference.domains?.[0]
-      ? `https://${conference.domains[0]}/workshop`
+      ? `${conferenceBaseUrl(conference)}/workshop`
       : ''
 
     const subject = `Workshop Signup Available - ${conference.title}`

--- a/src/lib/email/workshop.ts
+++ b/src/lib/email/workshop.ts
@@ -6,7 +6,10 @@ import {
   type EmailResult,
 } from './config'
 import type { Conference } from '@/lib/conference/types'
-import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
+import {
+  conferenceBaseUrl,
+  hasConferenceDomain,
+} from '@/lib/conference/baseUrl'
 import { resolveConferenceFrom, resolveConferenceContact } from './from'
 
 export interface WorkshopConfirmationEmailRequest {
@@ -147,7 +150,7 @@ export async function sendWorkshopSignupInstructions({
 
     const contactEmail = resolveConferenceContact(conference)
 
-    const workshopUrl = conference.domains?.[0]
+    const workshopUrl = hasConferenceDomain(conference)
       ? `${conferenceBaseUrl(conference)}/workshop`
       : ''
 

--- a/src/lib/messaging/email.ts
+++ b/src/lib/messaging/email.ts
@@ -3,7 +3,10 @@ import React from 'react'
 import { resend, retryWithBackoff } from '@/lib/email/config'
 import { MessageNotificationTemplate } from '@/components/email/MessageNotificationTemplate'
 import type { Conference } from '@/lib/conference/types'
-import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
+import {
+  conferenceBaseUrl,
+  hasConferenceDomain,
+} from '@/lib/conference/baseUrl'
 import { formatDate } from '@/lib/time'
 
 /** One email recipient for a new-message notification. */
@@ -68,7 +71,7 @@ async function sendOne(
           firstContact: recipient.firstContact ?? false,
           // Settings live on the cfp profile for BOTH audiences; anchor at the
           // notification section so the link matches the in-app gear (A9).
-          preferencesUrl: conference.domains?.[0]
+          preferencesUrl: hasConferenceDomain(conference)
             ? `${conferenceBaseUrl(conference)}/cfp/profile#notification-settings`
             : undefined,
           eventName: conference.title,
@@ -76,7 +79,7 @@ async function sendOne(
           eventDate: conference.startDate
             ? formatDate(conference.startDate)
             : '',
-          eventUrl: conference.domains?.[0]
+          eventUrl: hasConferenceDomain(conference)
             ? conferenceBaseUrl(conference)
             : '',
           socialLinks: conference.socialLinks || [],

--- a/src/lib/messaging/email.ts
+++ b/src/lib/messaging/email.ts
@@ -3,6 +3,7 @@ import React from 'react'
 import { resend, retryWithBackoff } from '@/lib/email/config'
 import { MessageNotificationTemplate } from '@/components/email/MessageNotificationTemplate'
 import type { Conference } from '@/lib/conference/types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { formatDate } from '@/lib/time'
 
 /** One email recipient for a new-message notification. */
@@ -68,7 +69,7 @@ async function sendOne(
           // Settings live on the cfp profile for BOTH audiences; anchor at the
           // notification section so the link matches the in-app gear (A9).
           preferencesUrl: conference.domains?.[0]
-            ? `https://${conference.domains[0]}/cfp/profile#notification-settings`
+            ? `${conferenceBaseUrl(conference)}/cfp/profile#notification-settings`
             : undefined,
           eventName: conference.title,
           eventLocation: `${conference.city}, ${conference.country}`,
@@ -76,7 +77,7 @@ async function sendOne(
             ? formatDate(conference.startDate)
             : '',
           eventUrl: conference.domains?.[0]
-            ? `https://${conference.domains[0]}`
+            ? conferenceBaseUrl(conference)
             : '',
           socialLinks: conference.socialLinks || [],
         }),

--- a/src/lib/messaging/sponsorEmail.ts
+++ b/src/lib/messaging/sponsorEmail.ts
@@ -3,6 +3,7 @@ import React from 'react'
 import { resend, retryWithBackoff } from '@/lib/email/config'
 import { SponsorMessageNotificationTemplate } from '@/components/email/SponsorMessageNotificationTemplate'
 import type { Conference } from '@/lib/conference/types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { formatConferenceDateLong } from '@/lib/time'
 
 /** One contact-person recipient of an organizer→sponsor message email. */
@@ -55,7 +56,7 @@ async function sendOne(
             ? formatConferenceDateLong(conference.startDate)
             : '',
           eventUrl: conference.domains?.[0]
-            ? `https://${conference.domains[0]}`
+            ? conferenceBaseUrl(conference)
             : '',
           socialLinks: conference.socialLinks || [],
         }),

--- a/src/lib/messaging/sponsorEmail.ts
+++ b/src/lib/messaging/sponsorEmail.ts
@@ -3,7 +3,10 @@ import React from 'react'
 import { resend, retryWithBackoff } from '@/lib/email/config'
 import { SponsorMessageNotificationTemplate } from '@/components/email/SponsorMessageNotificationTemplate'
 import type { Conference } from '@/lib/conference/types'
-import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
+import {
+  conferenceBaseUrl,
+  hasConferenceDomain,
+} from '@/lib/conference/baseUrl'
 import { formatConferenceDateLong } from '@/lib/time'
 
 /** One contact-person recipient of an organizer→sponsor message email. */
@@ -55,7 +58,7 @@ async function sendOne(
           eventDate: conference.startDate
             ? formatConferenceDateLong(conference.startDate)
             : '',
-          eventUrl: conference.domains?.[0]
+          eventUrl: hasConferenceDomain(conference)
             ? conferenceBaseUrl(conference)
             : '',
           socialLinks: conference.socialLinks || [],

--- a/src/lib/sponsor/templates.ts
+++ b/src/lib/sponsor/templates.ts
@@ -4,6 +4,7 @@ import type {
   TemplateLanguage,
   SponsorEmailTemplate,
 } from './types'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 
 export const CATEGORY_LABELS: Record<string, string> = {
   'cold-outreach': 'Cold Outreach',
@@ -243,8 +244,8 @@ export function buildTemplateVariables(opts: {
   }
 
   if (conference.domains?.[0]) {
-    vars.CONFERENCE_URL = `https://${conference.domains[0]}`
-    vars.SPONSOR_PAGE_URL = `https://${conference.domains[0]}/sponsor`
+    vars.CONFERENCE_URL = conferenceBaseUrl(conference)
+    vars.SPONSOR_PAGE_URL = `${vars.CONFERENCE_URL}/sponsor`
   }
 
   if (conference.prospectusUrl) {

--- a/src/lib/sponsor/templates.ts
+++ b/src/lib/sponsor/templates.ts
@@ -4,7 +4,10 @@ import type {
   TemplateLanguage,
   SponsorEmailTemplate,
 } from './types'
-import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
+import {
+  conferenceBaseUrl,
+  hasConferenceDomain,
+} from '@/lib/conference/baseUrl'
 
 export const CATEGORY_LABELS: Record<string, string> = {
   'cold-outreach': 'Cold Outreach',
@@ -243,7 +246,7 @@ export function buildTemplateVariables(opts: {
     vars.CONFERENCE_CITY = conference.city
   }
 
-  if (conference.domains?.[0]) {
+  if (hasConferenceDomain(conference)) {
     vars.CONFERENCE_URL = conferenceBaseUrl(conference)
     vars.SPONSOR_PAGE_URL = `${vars.CONFERENCE_URL}/sponsor`
   }

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -204,11 +204,12 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
   checks.push(
     plainCheck(
       { id: 'build.baseUrl', group: 'build', label: 'Platform base URL' },
-      // Mirrors the platformBaseUrl() env chain; in production, none set
-      // means platform-level outbound links THROW rather than degrade.
-      process.env.NEXT_PUBLIC_BASE_URL ||
-        process.env.NEXT_PUBLIC_URL ||
-        process.env.VERCEL_URL,
+      // Mirrors the platformBaseUrl() env chain (which trims each value —
+      // whitespace-only must read as missing here too); in production, none
+      // set means platform-level outbound links THROW rather than degrade.
+      process.env.NEXT_PUBLIC_BASE_URL?.trim() ||
+        process.env.NEXT_PUBLIC_URL?.trim() ||
+        process.env.VERCEL_URL?.trim(),
       'warn',
       {
         missing:

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -203,10 +203,17 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
 
   checks.push(
     plainCheck(
-      { id: 'build.baseUrl', group: 'build', label: 'NEXT_PUBLIC_BASE_URL' },
-      process.env.NEXT_PUBLIC_BASE_URL,
+      { id: 'build.baseUrl', group: 'build', label: 'Platform base URL' },
+      // Mirrors the platformBaseUrl() env chain; in production, none set
+      // means platform-level outbound links THROW rather than degrade.
+      process.env.NEXT_PUBLIC_BASE_URL ||
+        process.env.NEXT_PUBLIC_URL ||
+        process.env.VERCEL_URL,
       'warn',
-      { missing: 'Absolute links fall back to http://localhost:3000' },
+      {
+        missing:
+          'None of NEXT_PUBLIC_BASE_URL / NEXT_PUBLIC_URL / VERCEL_URL are set — platform-level outbound links fail in production',
+      },
     ),
   )
 

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -42,7 +42,10 @@ import {
   suggestTemplateLanguage,
 } from '@/lib/sponsor/templates'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
-import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
+import {
+  conferenceBaseUrl,
+  hasConferenceDomain,
+} from '@/lib/conference/baseUrl'
 import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanity'
 import type { Conference } from '@/lib/conference/types'
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
@@ -2083,7 +2086,7 @@ export const sponsorRouter = router({
               message: `Please sign the sponsorship agreement for ${sfc.conference.title}.`,
               // Tenant-derived signing origin; the provider still applies its
               // own env fallback if a conference somehow has no domain.
-              baseUrl: sfc.conference.domains?.[0]
+              baseUrl: hasConferenceDomain(sfc.conference)
                 ? conferenceBaseUrl(sfc.conference)
                 : undefined,
             })

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -42,6 +42,7 @@ import {
   suggestTemplateLanguage,
 } from '@/lib/sponsor/templates'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
 import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanity'
 import type { Conference } from '@/lib/conference/types'
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
@@ -2074,15 +2075,16 @@ export const sponsorRouter = router({
         if (input.signerEmail) {
           try {
             const provider = getSigningProvider(sfc.conference.signingProvider)
-            const conferenceDomain = sfc.conference.domains?.[0]
             const signingResult = await provider.sendForSigning({
               pdf: pdfBuffer,
               filename,
               signerEmail: input.signerEmail,
               agreementName: `Sponsorship Agreement - ${sfc.sponsor.name}`,
               message: `Please sign the sponsorship agreement for ${sfc.conference.title}.`,
-              baseUrl: conferenceDomain
-                ? `https://${conferenceDomain}`
+              // Tenant-derived signing origin; the provider still applies its
+              // own env fallback if a conference somehow has no domain.
+              baseUrl: sfc.conference.domains?.[0]
+                ? conferenceBaseUrl(sfc.conference)
                 : undefined,
             })
 


### PR DESCRIPTION
## Root cause

The badge-issuance email (`src/lib/email/badge.ts` → `sendBadgeEmail`, invoked from `src/server/routers/badge.ts` after `issueBadgeForSpeaker`) built its download link as:

```ts
const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
const downloadUrl = `${baseUrl}/api/badge/${badge.badgeId}/download`
```

`NEXT_PUBLIC_BASE_URL` is not set in the production Resend send context, so the fallback fired and speakers received badge emails whose download link pointed at `http://localhost:3000`. Notably, the badge *credential* itself was already correct — `src/lib/badge/config.ts` derives `https://${domain}` from the conference — only the *email* used the global env fallback.

A global base-URL env var is also the wrong altitude for a multi-tenant platform: it is correct for at most one tenant.

## The fix — one canonical helper

`conferenceBaseUrl(conference)` — `src/lib/conference/baseUrl.ts` (pure, client-safe):
- Returns `https://<primary domains[] entry>`, normalized via `normalizeDomain` (lowercase/trim, defensive scheme + trailing-slash strip); `http` only for a genuine `localhost`/dev domain via `protocolForDomain`.
- When a conference has NO domain: `console.error` + falls back to `platformBaseUrl()` — never localhost in production.

`platformBaseUrl()` — `src/lib/branding/platform.ts` (platform-level, explicit env contract):
- Precedence `NEXT_PUBLIC_BASE_URL` → `NEXT_PUBLIC_URL` (legacy, in `.env.production`) → `VERCEL_URL` (brand-neutral deploy host).
- Outside production: degrades to `http://localhost:3000`. In production with none set: `console.error` + throws (fails loudly, never a silent dev URL).

## Sweep — every hit classified

| File → line | What it built | Class | Action |
|---|---|---|---|
| `src/lib/email/badge.ts:38` | `NEXT_PUBLIC_BASE_URL \|\| localhost:3000` download link | **(b) LEAK** | FIX → `conferenceBaseUrl` |
| `src/lib/cospeaker/server.ts:124` | invite `eventUrl`: `domains[0] ? https : NEXT_PUBLIC_BASE_URL \|\| localhost:3000` | **(b) LEAK** (fallback) | FIX → `conferenceBaseUrl` |
| `src/lib/email/route-helpers.ts:28` | broadcast `eventUrl` `https://${domains[0]}` (unguarded) | (c) fragile (`https://undefined`) | harden → helper |
| `src/lib/email/speaker.ts:167,176` | `proposalUrl` + `eventUrl` unguarded | (c) fragile | harden → helper |
| `src/lib/email/volunteer.ts:57` | `eventUrl` guarded, else `''` | (c) fragile | harden → helper |
| `src/lib/email/workshop.ts:149` | `workshopUrl` guarded, else `''` | (c) fragile | harden → helper (guard kept) |
| `src/lib/email/contract-email.ts:76` | `EVENT_URL`/`SPONSOR_PAGE_URL` guarded | (c) fragile | harden → helper |
| `src/lib/sponsor/templates.ts:246` | `CONFERENCE_URL`/`SPONSOR_PAGE_URL` guarded | (c) fragile | harden → helper |
| `src/lib/messaging/email.ts:71,79` | `preferencesUrl`/`eventUrl` guarded | (c) fragile | harden → helper |
| `src/lib/messaging/sponsorEmail.ts:58` | `eventUrl` guarded | (c) fragile | harden → helper |
| `src/server/routers/sponsor.ts:2076` | self-hosted signing `baseUrl` | (c) fragile | harden → helper |
| `src/app/(admin)/admin/marketing/page.tsx:530` | `SponsorThankYou baseUrl` prop | (c) fragile | harden → helper |
| `src/components/admin/SpeakerActions.tsx:66` | modal `eventUrl` prop | (c) fragile | harden → helper |
| `src/components/admin/sponsor/SponsorIndividualEmailModal.tsx:129` | modal `eventUrl` prop | (c) fragile | harden → helper |
| `src/components/admin/sponsor/SponsorContactActions.tsx:80` | modal `eventUrl` prop | (c) fragile | harden → helper |
| `src/components/admin/sponsor/SponsorTiersPageClient.tsx:142` | modal `eventUrl` prop | (c) fragile | harden → helper |
| `src/components/admin/sponsor/SponsorDiscountEmailModal.tsx:74,230` | `ticketUrl` + `eventUrl` | (c) fragile | harden → helper |

### Left as-is (cannot leak localhost in practice — honesty)

| File | Why not touched |
|---|---|
| `src/lib/seo/canonical.ts`, `robots.ts`, `sitemap.ts`, `app/layout.tsx`, `app/manifest.ts`, `lib/seo/eventJsonLd.ts` | Request-host-derived, tenant-preferred (`domains[0]` skipping wildcards). The `\|\| 'localhost:3000'` only fires when there is NO `Host` header — impossible on a real request. Correct per spec. |
| `src/lib/email/gallery.ts:99` | Uses the explicit request `domain` from the emitted event metadata (request-derived tenant host), not a global fallback. |
| `src/lib/push/send.ts` (`item.link ?? '/notifications'`) | Relative link; the service worker resolves it against the tenant PWA origin. No base URL to leak. |
| `src/lib/contract-signing/self-hosted.ts:45` | Env chain that THROWS if unresolved (no localhost fallback); tenant `baseUrl` is now passed via `conferenceBaseUrl` from the caller. |
| `src/lib/environment/config.ts:28` (`buildApiUrl`) | No non-test callers; server-internal API URL, not outbound content. |
| `src/lib/environment/localhost.ts:25` | Env *detection* helper, not URL construction. |
| `src/lib/system-status/checks.ts`, `components/admin/system-status/fixtures.ts` | Diagnostic copy describing the fallback, not a live URL. |

## QA

- New `src/lib/conference/baseUrl.test.ts` (13 tests): domain present / normalization / scheme+slash strip / first-non-empty / localhost dev domain / loud no-domain fallback; `platformBaseUrl` env precedence + dev-localhost + production-throw.
- New `src/lib/email/badge.test.ts` (2 tests): download link derived from the conference's own domain; asserts NO localhost even under `NODE_ENV=production` + `VERCEL_ENV=production` with `NEXT_PUBLIC_BASE_URL` unset (reproduces the reported bug's environment).
- `mise run check` → exit 0 (lint 0 errors, format, knip, typecheck). Full `vitest run` → 333 files, 4329 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
