### PR TITLE
refactor(admin): slim settings — dedupe sponsor cards, relocate sponsor/workshop config

### DIFF
--- a/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
+++ b/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
@@ -21,7 +21,6 @@ import {
 import {
   InfoCard,
   FieldRow,
-  LinkedBadgeList,
   StudioEditLink,
   SectionNav,
   SectionHeading,
@@ -33,7 +32,7 @@ import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
 
 /**
  * Visual-QA harness for the Settings page information architecture: the sticky
- * jump-nav, the six grouped tier-1 subsections, the collapsed-by-default cards
+ * jump-nav, the five grouped tier-1 subsections, the collapsed-by-default cards
  * and the three tiers. Rendered with static mock data and non-functional edit
  * pencils (the real cards use tRPC-backed editor islands) so the whole layout is
  * inspectable in isolation without providers.
@@ -203,29 +202,6 @@ function SettingsIADemo() {
             </InfoCard>
 
             <InfoCard
-              title="Workshop Registration"
-              icon={CalendarIcon}
-              action={<EditPencil />}
-            >
-              <FieldRow
-                label="Registration Opens"
-                value="2026-04-01T09:00:00Z"
-                type="datetime"
-              />
-              <FieldRow
-                label="Registration Closes"
-                value="2026-05-01T09:00:00Z"
-                type="datetime"
-              />
-              <div className="flex items-center justify-between py-2">
-                <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                  Status
-                </span>
-                <StatusBadge label="Not yet open" color="yellow" />
-              </div>
-            </InfoCard>
-
-            <InfoCard
               title="Ticketing"
               icon={LinkIcon}
               editUrl={EDIT_URL}
@@ -249,92 +225,6 @@ function SettingsIADemo() {
               <div className="space-y-3 px-6 py-4">
                 <FieldRow label="Attendees" value="500+" />
                 <FieldRow label="Speakers" value="60" />
-              </div>
-            </CollapsibleSection>
-          </SettingsGroupSection>
-
-          <SettingsGroupSection
-            group={GROUP['sponsors']}
-            icon={CurrencyDollarIcon}
-          >
-            <InfoCard
-              title="Sponsorship Tiers"
-              icon={CurrencyDollarIcon}
-              manageLink={{
-                href: '/admin/sponsors/tiers',
-                label: 'Manage tiers',
-              }}
-            >
-              <div className="border-b border-gray-200 pb-3 last:border-b-0 last:pb-0 dark:border-gray-700">
-                <div className="mb-2 flex items-center justify-between">
-                  <span className="font-medium text-gray-900 dark:text-white">
-                    Gold
-                  </span>
-                  <StatusBadge label="Popular" color="green" />
-                </div>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  Prime logo placement and 4 tickets.
-                </p>
-              </div>
-            </InfoCard>
-
-            <InfoCard
-              title="Current Sponsors"
-              icon={CurrencyDollarIcon}
-              manageLink={{ href: '/admin/sponsors/crm', label: 'Open CRM' }}
-            >
-              <LinkedBadgeList
-                label="Sponsors"
-                items={[
-                  {
-                    key: 'acme',
-                    label: 'Acme (Gold)',
-                    href: '/admin/sponsors/crm?sponsor=acme',
-                  },
-                  {
-                    key: 'globex',
-                    label: 'Globex (Silver)',
-                    href: '/admin/sponsors/crm?sponsor=globex',
-                  },
-                ]}
-              />
-            </InfoCard>
-
-            <CollapsibleSection
-              title="Sponsor Benefits"
-              icon={<CurrencyDollarIcon />}
-              action={
-                <>
-                  <StudioEditLink editUrl={EDIT_URL} />
-                  <EditPencil />
-                </>
-              }
-            >
-              <div className="space-y-3 px-6 py-4">
-                <FieldRow
-                  label="Reach"
-                  value="Access to 500+ cloud native engineers."
-                />
-              </div>
-            </CollapsibleSection>
-
-            <CollapsibleSection
-              title="Sponsorship Page"
-              icon={<DocumentTextIcon />}
-              action={
-                <>
-                  <StudioEditLink editUrl={EDIT_URL} />
-                  <EditPencil />
-                </>
-              }
-            >
-              <div className="space-y-3 px-6 py-4">
-                <FieldRow label="Hero Headline" value="Partner with us" />
-                <FieldRow
-                  label="Prospectus Link"
-                  value="https://example.com/prospectus.pdf"
-                  type="url"
-                />
               </div>
             </CollapsibleSection>
           </SettingsGroupSection>

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -2,11 +2,7 @@ import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { resolveConferenceVisibility } from '@/lib/conference/visibility'
 import { buildSystemChecks } from '@/lib/system-status/checks'
 import { formatTeamSummary } from '@/lib/teams'
-import {
-  ErrorDisplay,
-  WorkshopRegistrationSettings,
-  AdminPageHeader,
-} from '@/components/admin'
+import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
 import {
   SystemStatusSection,
   SelfCheckPanel,
@@ -36,7 +32,6 @@ import { buildActivationChecklist } from '@/lib/settings/activation'
 import {
   InfoCard,
   FieldRow,
-  LinkedBadgeList,
   StudioEditLink,
   SectionNav,
   SectionHeading,
@@ -89,8 +84,6 @@ export default async function AdminSettings() {
   const { conference, domain, error } = await getConferenceForCurrentDomain({
     organizers: true,
     schedule: true,
-    sponsors: true,
-    sponsorTiers: true,
     topics: true,
     featuredSpeakers: true,
   })
@@ -487,11 +480,6 @@ export default async function AdminSettings() {
               />
             </InfoCard>
 
-            <WorkshopRegistrationSettings
-              workshopRegistrationStart={conference.workshopRegistrationStart}
-              workshopRegistrationEnd={conference.workshopRegistrationEnd}
-            />
-
             <InfoCard
               title="Ticketing"
               icon={LinkIcon}
@@ -568,157 +556,6 @@ export default async function AdminSettings() {
                     None
                   </span>
                 )}
-              </div>
-            </CollapsibleSection>
-          </SettingsGroupSection>
-
-          {/* ---- Sponsors ---- */}
-          <SettingsGroupSection
-            group={GROUP['sponsors']}
-            icon={CurrencyDollarIcon}
-          >
-            {conference.sponsorTiers && conference.sponsorTiers.length > 0 && (
-              <InfoCard
-                title="Sponsorship Tiers"
-                icon={CurrencyDollarIcon}
-                manageLink={{
-                  href: '/admin/sponsors/tiers',
-                  label: 'Manage tiers',
-                }}
-              >
-                {conference.sponsorTiers.map((tier, idx) => (
-                  <div
-                    key={idx}
-                    className="border-b border-gray-200 pb-3 last:border-b-0 last:pb-0 dark:border-gray-700"
-                  >
-                    <div className="mb-2 flex items-center justify-between">
-                      <span className="font-medium text-gray-900 dark:text-white">
-                        {tier.title}
-                      </span>
-                      <div className="flex items-center space-x-2">
-                        {tier.soldOut && (
-                          <StatusBadge label="Sold Out" color="red" />
-                        )}
-                        {tier.mostPopular && (
-                          <StatusBadge label="Popular" color="green" />
-                        )}
-                      </div>
-                    </div>
-                    <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
-                      {tier.tagline}
-                    </p>
-                    {tier.price && tier.price.length > 0 && (
-                      <div className="text-sm text-gray-500 dark:text-gray-400">
-                        {tier.price.map((price, pidx) => (
-                          <span key={pidx}>
-                            {price.amount} {price.currency}
-                            {pidx < tier.price!.length - 1 && ', '}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </InfoCard>
-            )}
-
-            {conference.sponsors && conference.sponsors.length > 0 && (
-              <InfoCard
-                title="Current Sponsors"
-                icon={CurrencyDollarIcon}
-                manageLink={{ href: '/admin/sponsors/crm', label: 'Open CRM' }}
-              >
-                {/* Each sponsor deep-links to its CRM record — the full sponsor
-                    editor lives in /admin/sponsors, so this card surfaces WHO
-                    is signed and jumps you there rather than duplicating the
-                    CRM. Add/remove a sponsor also happens in the CRM. The CRM
-                    matches its `?sponsor=` param against the sponsorForConference
-                    id (`_sfcId`), NOT the sponsor document id; fall back to the
-                    CRM landing page if that id is somehow absent. */}
-                <LinkedBadgeList
-                  label="Sponsors"
-                  items={conference.sponsors.map((s) => ({
-                    key: s._sfcId ?? s.sponsor._id,
-                    label: `${s.sponsor.name} (${s.tier?.title ?? 'No Tier'})`,
-                    href: s._sfcId
-                      ? `/admin/sponsors/crm?sponsor=${encodeURIComponent(
-                          s._sfcId,
-                        )}`
-                      : '/admin/sponsors/crm',
-                  }))}
-                />
-              </InfoCard>
-            )}
-
-            {/* Set-once — collapsed by default. */}
-            <CollapsibleSection
-              headingLevel={4}
-              title="Sponsor Benefits"
-              icon={<CurrencyDollarIcon />}
-              action={
-                <>
-                  <StudioEditLink editUrl={editUrl} />
-                  <EditConferenceCard
-                    fieldset="sponsorBenefits"
-                    initialValues={{
-                      sponsorBenefits: conference.sponsorBenefits,
-                    }}
-                  />
-                </>
-              }
-            >
-              <div className="space-y-3 px-6 py-4">
-                {conference.sponsorBenefits &&
-                conference.sponsorBenefits.length > 0 ? (
-                  conference.sponsorBenefits.map((benefit, idx) => (
-                    <FieldRow
-                      key={idx}
-                      label={benefit.title}
-                      value={benefit.description}
-                    />
-                  ))
-                ) : (
-                  <span className="text-sm text-gray-500 dark:text-gray-400">
-                    None
-                  </span>
-                )}
-              </div>
-            </CollapsibleSection>
-
-            {/* Set-once — collapsed by default. */}
-            <CollapsibleSection
-              headingLevel={4}
-              title="Sponsorship Page"
-              icon={<DocumentTextIcon />}
-              action={
-                <>
-                  <StudioEditLink editUrl={editUrl} />
-                  <EditConferenceCard
-                    fieldset="sponsorshipCustomization"
-                    initialValues={
-                      (conference.sponsorshipCustomization ?? {}) as Record<
-                        string,
-                        unknown
-                      >
-                    }
-                  />
-                </>
-              }
-            >
-              <div className="space-y-3 px-6 py-4">
-                <FieldRow
-                  label="Hero Headline"
-                  value={conference.sponsorshipCustomization?.heroHeadline}
-                />
-                <FieldRow
-                  label="Philosophy Title"
-                  value={conference.sponsorshipCustomization?.philosophyTitle}
-                />
-                <FieldRow
-                  label="Prospectus Link"
-                  value={conference.sponsorshipCustomization?.prospectusUrl}
-                  type="url"
-                />
               </div>
             </CollapsibleSection>
           </SettingsGroupSection>

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -336,56 +336,6 @@ export function FieldRow({
   )
 }
 
-/** One clickable row in a {@link LinkedBadgeList}. */
-export interface LinkedBadgeItem {
-  key: string
-  label: string
-  href: string
-}
-
-/**
- * A labelled list of clickable badges, each deep-linking into a management page
- * (e.g. each current sponsor → its CRM record). The read-only settings card
- * shows WHAT exists; the links are how an organizer jumps to EDIT it, so the
- * card never has to embed the CRM. `href` is an internal /admin path.
- */
-export function LinkedBadgeList({
-  label,
-  items,
-}: {
-  label: string
-  items: LinkedBadgeItem[]
-}) {
-  return (
-    <div className="flex justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
-      <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
-        {label}
-      </dt>
-      <dd className="max-w-xs min-w-0 text-right text-sm">
-        {items.length > 0 ? (
-          <div className="flex flex-wrap justify-end gap-1">
-            {items.map((item) => (
-              <Link
-                key={item.key}
-                href={item.href}
-                className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 hover:bg-indigo-50 hover:text-indigo-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-indigo-900/30 dark:hover:text-indigo-300"
-              >
-                <span className="min-w-0 break-words">{item.label}</span>
-                <ArrowUpRightIcon
-                  className="h-3 w-3 shrink-0"
-                  aria-hidden="true"
-                />
-              </Link>
-            ))}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )}
-      </dd>
-    </div>
-  )
-}
-
 export function SectionNav() {
   return (
     <nav className="sticky top-0 z-10 -mx-4 mb-2 space-y-2 border-b border-gray-200 bg-gray-50/90 px-4 py-2 backdrop-blur sm:mx-0 sm:rounded-lg sm:border sm:px-4 dark:border-gray-700 dark:bg-gray-900/90">

--- a/src/app/(admin)/admin/settings/settingsLayout.tsx
+++ b/src/app/(admin)/admin/settings/settingsLayout.tsx
@@ -1,40 +1,26 @@
 import type { ComponentType, ReactNode } from 'react'
 import Link from 'next/link'
-import { formatDate, formatDateTimeSafe } from '@/lib/time'
-import { formats, Format } from '@/lib/proposal/types'
-import { StatusBadge } from '@/components/StatusBadge'
 import {
   SETTINGS_GROUP_ANCHORS,
   SETTINGS_TIER_ANCHORS,
   type SettingsGroup,
 } from '@/lib/settings/groups'
-import {
-  PencilSquareIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-  LinkIcon,
-  EnvelopeIcon,
-  ArrowUpRightIcon,
-} from '@heroicons/react/24/outline'
+import { PencilSquareIcon, ArrowUpRightIcon } from '@heroicons/react/24/outline'
 
 /**
  * Presentational primitives for the admin Settings page. Extracted from the
  * server `page.tsx` so the layout (cards, field rows, the jump-nav and the
  * grouped section headings) is data-agnostic and can be rendered in Storybook
  * for the mandatory visual QA. None of these read conference data or call tRPC —
- * callers pass values and action nodes in.
+ * callers pass values and action nodes in. The field row itself is the shared
+ * `@/components/admin/FieldRow`, re-exported here for the settings callers.
  */
 
-export interface NamedItem {
-  name?: string
-  title?: string
-}
-
-export type ArrayItem = string | NamedItem
-
-function isValidFormat(key: string): key is Format {
-  return Object.values(Format).includes(key as Format)
-}
+export {
+  FieldRow,
+  type NamedItem,
+  type ArrayItem,
+} from '@/components/admin/FieldRow'
 
 /** A deep-link to a dedicated management page (the in-app editor for this
  * card's data). Used where a full editor already lives elsewhere in /admin, so
@@ -129,210 +115,6 @@ export function StudioEditLink({ editUrl }: { editUrl?: string | null }) {
       <PencilSquareIcon className="h-4 w-4" />
       Edit in Studio
     </a>
-  )
-}
-
-/**
- * Restrict a STORED href to schemes safe to render as a clickable link
- * (site paths, http(s), mailto) — anything else (javascript:, data:,
- * scheme-relative) degrades to an inert '#'. Same closed-scheme standard as
- * the write-path safeLinkHref and the portable-text link guard.
- */
-function safeDisplayHref(value: unknown): string {
-  if (typeof value !== 'string') return '#'
-  const v = value.trim()
-  if (!v) return '#'
-  if (v.startsWith('/') && !v.startsWith('//')) return v
-  if (/^https?:\/\//i.test(v)) return v
-  if (/^mailto:/i.test(v)) return v
-  return '#'
-}
-
-export function FieldRow({
-  label,
-  value,
-  type = 'text',
-}: {
-  label: string
-  value:
-    string | boolean | Array<string | NamedItem> | number | null | undefined
-  type?:
-    | 'text'
-    | 'date'
-    | 'datetime'
-    | 'boolean'
-    | 'array'
-    | 'links'
-    | 'formats'
-    | 'team'
-    | 'url'
-    | 'email'
-}) {
-  let displayValue: ReactNode = value as ReactNode
-
-  switch (type) {
-    case 'datetime':
-      // House formatter — consistent locale/timezone rendering.
-      displayValue = value ? formatDateTimeSafe(value as string) : 'Not set'
-      break
-    case 'date':
-      displayValue = value ? formatDate(value as string) : 'Not set'
-      break
-    case 'boolean':
-      displayValue = (
-        <div className="flex items-center">
-          {value ? (
-            <>
-              <CheckCircleIcon className="mr-1 h-4 w-4 text-green-500 dark:text-green-400" />
-              <span className="text-green-700 dark:text-green-300">Yes</span>
-            </>
-          ) : (
-            <>
-              <XCircleIcon className="mr-1 h-4 w-4 text-red-500 dark:text-red-400" />
-              <span className="text-red-700 dark:text-red-300">No</span>
-            </>
-          )}
-        </div>
-      )
-      break
-    case 'array':
-      displayValue =
-        Array.isArray(value) && value.length > 0 ? (
-          <div className="flex flex-wrap gap-1">
-            {value.map((item: ArrayItem, idx) => {
-              const displayText =
-                typeof item === 'string'
-                  ? item
-                  : (item as NamedItem)?.title ||
-                    (item as NamedItem)?.name ||
-                    JSON.stringify(item)
-              return <StatusBadge key={idx} label={displayText} color="gray" />
-            })}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )
-      break
-    case 'links':
-      displayValue =
-        Array.isArray(value) && value.length > 0 ? (
-          <div className="space-y-2">
-            {value.map((link, idx) => (
-              <div key={idx}>
-                <a
-                  href={safeDisplayHref(link)}
-                  {...(safeDisplayHref(link) !== '#'
-                    ? { target: '_blank', rel: 'noopener noreferrer' }
-                    : {})}
-                  className="inline-flex max-w-full min-w-0 items-start text-sm text-indigo-600 hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300"
-                >
-                  {/* break-all, not truncate: a URL is an unbreakable token, and
-                      an unconstrained nowrap span dictated the row's intrinsic
-                      width — the whole page scrolled horizontally on mobile. */}
-                  <span className="min-w-0 break-all">{link as string}</span>
-                  <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
-                </a>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )
-      break
-    case 'formats':
-      displayValue =
-        Array.isArray(value) && value.length > 0 ? (
-          <div className="flex flex-wrap gap-1">
-            {value.map((format: ArrayItem, idx) => {
-              const formatKey =
-                typeof format === 'string'
-                  ? format
-                  : (format as NamedItem)?.title || (format as NamedItem)?.name
-              const displayText =
-                formatKey && isValidFormat(formatKey)
-                  ? formats.get(formatKey) || formatKey
-                  : formatKey || 'Unknown Format'
-              return <StatusBadge key={idx} label={displayText} color="gray" />
-            })}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )
-      break
-    case 'team':
-      displayValue =
-        Array.isArray(value) && value.length > 0 ? (
-          <div className="grid grid-cols-2 gap-2">
-            {value.map((member: ArrayItem, idx) => {
-              const memberName =
-                typeof member === 'string'
-                  ? member
-                  : (member as NamedItem)?.name || 'Unknown Member'
-              return (
-                <div
-                  key={idx}
-                  className="py-1 text-sm text-gray-900 dark:text-white"
-                >
-                  {memberName}
-                </div>
-              )
-            })}
-          </div>
-        ) : (
-          <span className="text-gray-500 dark:text-gray-400">None</span>
-        )
-      break
-    case 'url':
-      displayValue = value ? (
-        <a
-          href={safeDisplayHref(value)}
-          {...(safeDisplayHref(value) !== '#'
-            ? { target: '_blank', rel: 'noopener noreferrer' }
-            : {})}
-          className="flex min-w-0 items-start text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
-        >
-          {/* Same overflow class as the 'links' case: an unbreakable URL must
-              break rather than widen the row past the viewport. */}
-          <span className="min-w-0 break-all">{value as string}</span>
-          <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
-        </a>
-      ) : (
-        'Not set'
-      )
-      break
-    case 'email':
-      displayValue = value ? (
-        <a
-          href={`mailto:${value}`}
-          className="flex min-w-0 items-center text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
-        >
-          <span className="break-all">{value as string}</span>
-          <EnvelopeIcon className="ml-1 h-3 w-3 shrink-0" />
-        </a>
-      ) : (
-        'Not set'
-      )
-      break
-    default:
-      // `??`/emptiness check, not `||`: a legitimate 0 must not read as unset.
-      displayValue =
-        value === undefined || value === null || value === ''
-          ? 'Not set'
-          : (value as ReactNode)
-  }
-
-  return (
-    <div className="flex justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
-      <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
-        {label}
-      </dt>
-      {/* min-w-0 lets the value column actually shrink inside the flex row —
-          without it, wide unbreakable content (URLs) forces the row past the
-          viewport and the page pans horizontally. */}
-      <dd className="max-w-xs min-w-0 text-right text-sm text-gray-900 dark:text-white">
-        {displayValue}
-      </dd>
-    </div>
   )
 }
 

--- a/src/app/(admin)/admin/workshops/page.tsx
+++ b/src/app/(admin)/admin/workshops/page.tsx
@@ -22,8 +22,10 @@ export default async function WorkshopAdminPage() {
     <WorkshopsClientPage
       conferenceId={conference._id}
       initialWorkshops={workshops}
-      workshopRegistrationStart={conference.workshopRegistrationStart}
-      workshopRegistrationEnd={conference.workshopRegistrationEnd}
+      workshopRegistrationStart={
+        conference.workshopRegistrationStart ?? undefined
+      }
+      workshopRegistrationEnd={conference.workshopRegistrationEnd ?? undefined}
     />
   )
 }

--- a/src/app/(admin)/admin/workshops/page.tsx
+++ b/src/app/(admin)/admin/workshops/page.tsx
@@ -22,6 +22,8 @@ export default async function WorkshopAdminPage() {
     <WorkshopsClientPage
       conferenceId={conference._id}
       initialWorkshops={workshops}
+      workshopRegistrationStart={conference.workshopRegistrationStart}
+      workshopRegistrationEnd={conference.workshopRegistrationEnd}
     />
   )
 }

--- a/src/components/admin/FieldRow.tsx
+++ b/src/components/admin/FieldRow.tsx
@@ -1,0 +1,232 @@
+import type { ReactNode } from 'react'
+import { formatDate, formatDateTimeSafe } from '@/lib/time'
+import { formats, Format } from '@/lib/proposal/types'
+import { StatusBadge } from '@/components/StatusBadge'
+import {
+  CheckCircleIcon,
+  XCircleIcon,
+  LinkIcon,
+  EnvelopeIcon,
+} from '@heroicons/react/24/outline'
+
+/**
+ * Read-only label/value row used by the admin settings cards and the management
+ * pages that reuse the settings-card idiom. Presentational and client-safe —
+ * no data fetching, no server-only imports — so both server pages and client
+ * islands can render it.
+ */
+
+export interface NamedItem {
+  name?: string
+  title?: string
+}
+
+export type ArrayItem = string | NamedItem
+
+function isValidFormat(key: string): key is Format {
+  return Object.values(Format).includes(key as Format)
+}
+
+/**
+ * Restrict a STORED href to schemes safe to render as a clickable link
+ * (site paths, http(s), mailto) — anything else (javascript:, data:,
+ * scheme-relative) degrades to an inert '#'. Same closed-scheme standard as
+ * the write-path safeLinkHref and the portable-text link guard.
+ */
+function safeDisplayHref(value: unknown): string {
+  if (typeof value !== 'string') return '#'
+  const v = value.trim()
+  if (!v) return '#'
+  if (v.startsWith('/') && !v.startsWith('//')) return v
+  if (/^https?:\/\//i.test(v)) return v
+  if (/^mailto:/i.test(v)) return v
+  return '#'
+}
+
+export function FieldRow({
+  label,
+  value,
+  type = 'text',
+}: {
+  label: string
+  value:
+    string | boolean | Array<string | NamedItem> | number | null | undefined
+  type?:
+    | 'text'
+    | 'date'
+    | 'datetime'
+    | 'boolean'
+    | 'array'
+    | 'links'
+    | 'formats'
+    | 'team'
+    | 'url'
+    | 'email'
+}) {
+  let displayValue: ReactNode = value as ReactNode
+
+  switch (type) {
+    case 'datetime':
+      // House formatter — consistent locale/timezone rendering.
+      displayValue = value ? formatDateTimeSafe(value as string) : 'Not set'
+      break
+    case 'date':
+      displayValue = value ? formatDate(value as string) : 'Not set'
+      break
+    case 'boolean':
+      displayValue = (
+        <div className="flex items-center">
+          {value ? (
+            <>
+              <CheckCircleIcon className="mr-1 h-4 w-4 text-green-500 dark:text-green-400" />
+              <span className="text-green-700 dark:text-green-300">Yes</span>
+            </>
+          ) : (
+            <>
+              <XCircleIcon className="mr-1 h-4 w-4 text-red-500 dark:text-red-400" />
+              <span className="text-red-700 dark:text-red-300">No</span>
+            </>
+          )}
+        </div>
+      )
+      break
+    case 'array':
+      displayValue =
+        Array.isArray(value) && value.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {value.map((item: ArrayItem, idx) => {
+              const displayText =
+                typeof item === 'string'
+                  ? item
+                  : (item as NamedItem)?.title ||
+                    (item as NamedItem)?.name ||
+                    JSON.stringify(item)
+              return <StatusBadge key={idx} label={displayText} color="gray" />
+            })}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )
+      break
+    case 'links':
+      displayValue =
+        Array.isArray(value) && value.length > 0 ? (
+          <div className="space-y-2">
+            {value.map((link, idx) => (
+              <div key={idx}>
+                <a
+                  href={safeDisplayHref(link)}
+                  {...(safeDisplayHref(link) !== '#'
+                    ? { target: '_blank', rel: 'noopener noreferrer' }
+                    : {})}
+                  className="inline-flex max-w-full min-w-0 items-start text-sm text-indigo-600 hover:text-indigo-500 hover:underline dark:text-indigo-400 dark:hover:text-indigo-300"
+                >
+                  {/* break-all, not truncate: a URL is an unbreakable token, and
+                      an unconstrained nowrap span dictated the row's intrinsic
+                      width — the whole page scrolled horizontally on mobile. */}
+                  <span className="min-w-0 break-all">{link as string}</span>
+                  <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
+                </a>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )
+      break
+    case 'formats':
+      displayValue =
+        Array.isArray(value) && value.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {value.map((format: ArrayItem, idx) => {
+              const formatKey =
+                typeof format === 'string'
+                  ? format
+                  : (format as NamedItem)?.title || (format as NamedItem)?.name
+              const displayText =
+                formatKey && isValidFormat(formatKey)
+                  ? formats.get(formatKey) || formatKey
+                  : formatKey || 'Unknown Format'
+              return <StatusBadge key={idx} label={displayText} color="gray" />
+            })}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )
+      break
+    case 'team':
+      displayValue =
+        Array.isArray(value) && value.length > 0 ? (
+          <div className="grid grid-cols-2 gap-2">
+            {value.map((member: ArrayItem, idx) => {
+              const memberName =
+                typeof member === 'string'
+                  ? member
+                  : (member as NamedItem)?.name || 'Unknown Member'
+              return (
+                <div
+                  key={idx}
+                  className="py-1 text-sm text-gray-900 dark:text-white"
+                >
+                  {memberName}
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <span className="text-gray-500 dark:text-gray-400">None</span>
+        )
+      break
+    case 'url':
+      displayValue = value ? (
+        <a
+          href={safeDisplayHref(value)}
+          {...(safeDisplayHref(value) !== '#'
+            ? { target: '_blank', rel: 'noopener noreferrer' }
+            : {})}
+          className="flex min-w-0 items-start text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+        >
+          {/* Same overflow class as the 'links' case: an unbreakable URL must
+              break rather than widen the row past the viewport. */}
+          <span className="min-w-0 break-all">{value as string}</span>
+          <LinkIcon className="mt-1 ml-1 h-3 w-3 shrink-0" />
+        </a>
+      ) : (
+        'Not set'
+      )
+      break
+    case 'email':
+      displayValue = value ? (
+        <a
+          href={`mailto:${value}`}
+          className="flex min-w-0 items-center text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+        >
+          <span className="break-all">{value as string}</span>
+          <EnvelopeIcon className="ml-1 h-3 w-3 shrink-0" />
+        </a>
+      ) : (
+        'Not set'
+      )
+      break
+    default:
+      // `??`/emptiness check, not `||`: a legitimate 0 must not read as unset.
+      displayValue =
+        value === undefined || value === null || value === ''
+          ? 'Not set'
+          : (value as ReactNode)
+  }
+
+  return (
+    <div className="flex justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
+      <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+        {label}
+      </dt>
+      {/* min-w-0 lets the value column actually shrink inside the flex row —
+          without it, wide unbreakable content (URLs) forces the row past the
+          viewport and the page pans horizontally. */}
+      <dd className="max-w-xs min-w-0 text-right text-sm text-gray-900 dark:text-white">
+        {displayValue}
+      </dd>
+    </div>
+  )
+}

--- a/src/components/admin/FieldRow.tsx
+++ b/src/components/admin/FieldRow.tsx
@@ -218,15 +218,17 @@ export function FieldRow({
 
   return (
     <div className="flex justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700">
-      <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+      {/* Plain span/div, not dt/dd: rows render inside arbitrary containers,
+          and dt/dd without an enclosing dl is invalid HTML. */}
+      <span className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
         {label}
-      </dt>
+      </span>
       {/* min-w-0 lets the value column actually shrink inside the flex row —
           without it, wide unbreakable content (URLs) forces the row past the
           viewport and the page pans horizontally. */}
-      <dd className="max-w-xs min-w-0 text-right text-sm text-gray-900 dark:text-white">
+      <div className="max-w-xs min-w-0 text-right text-sm text-gray-900 dark:text-white">
         {displayValue}
-      </dd>
+      </div>
     </div>
   )
 }

--- a/src/components/admin/WorkshopRegistrationSettings.stories.tsx
+++ b/src/components/admin/WorkshopRegistrationSettings.stories.tsx
@@ -4,6 +4,8 @@ import { ThemeProvider } from 'next-themes'
 import { WorkshopRegistrationSettings } from './WorkshopRegistrationSettings'
 import { NotificationProvider } from './NotificationProvider'
 
+const FIXED_NOW = new Date('2026-04-15T12:00:00Z')
+
 const handlers = [
   http.post('/api/trpc/workshop.admin.updateRegistrationTimes', () =>
     HttpResponse.json({ result: { data: { success: true } } }),
@@ -13,13 +15,41 @@ const handlers = [
 const meta = {
   title: 'Systems/Workshops/Admin/WorkshopRegistrationSettings',
   component: WorkshopRegistrationSettings,
+  // Pin the clock: the status badge is derived from `new Date()` vs the window
+  // bounds, so an unpinned clock would flip stories over time and thrash
+  // visual diffs.
+  beforeEach: () => {
+    const OriginalDate = globalThis.Date
+    const fixedTime = FIXED_NOW.getTime()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const MockDate: any = function (...args: any[]) {
+      if (args.length === 0) return new OriginalDate(fixedTime)
+      return new (
+        Function.prototype.bind.apply(OriginalDate, [
+          null,
+          ...args,
+        ]) as typeof OriginalDate
+      )()
+    }
+    Object.setPrototypeOf(MockDate, OriginalDate)
+    MockDate.prototype = Object.create(OriginalDate.prototype)
+    MockDate.now = () => fixedTime
+    MockDate.parse = OriginalDate.parse.bind(OriginalDate)
+    MockDate.UTC = OriginalDate.UTC.bind(OriginalDate)
+    globalThis.Date = MockDate
+
+    return () => {
+      globalThis.Date = OriginalDate
+    }
+  },
   parameters: {
     layout: 'fullscreen',
     msw: { handlers },
     docs: {
       description: {
         component:
-          'The workshop registration window card on /admin/workshops: a read-only card showing the open/close instants and the derived status, with a pencil opening a ModalShell form that patches the window via the workshop.admin router.',
+          'The workshop registration window card on /admin/workshops: a read-only card showing the open/close instants and the derived status, with a pencil opening a ModalShell form that patches the window via the workshop.admin router. A half-set window surfaces as "Partially configured" with a note mirroring the enforcement semantics (each bound is checked independently by the signup path).',
       },
     },
   },
@@ -48,10 +78,24 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Configured: Story = {
+export const Scheduled: Story = {
   args: {
-    workshopRegistrationStart: '2099-04-01T07:00:00.000Z',
-    workshopRegistrationEnd: '2099-05-01T07:00:00.000Z',
+    workshopRegistrationStart: '2026-05-01T07:00:00.000Z',
+    workshopRegistrationEnd: '2026-06-01T07:00:00.000Z',
+  },
+}
+
+export const CurrentlyOpen: Story = {
+  args: {
+    workshopRegistrationStart: '2026-04-01T07:00:00.000Z',
+    workshopRegistrationEnd: '2026-05-01T07:00:00.000Z',
+  },
+}
+
+export const Closed: Story = {
+  args: {
+    workshopRegistrationStart: '2026-03-01T07:00:00.000Z',
+    workshopRegistrationEnd: '2026-04-01T07:00:00.000Z',
   },
 }
 
@@ -59,7 +103,19 @@ export const NotConfigured: Story = {
   args: {},
 }
 
+export const OnlyStartSet: Story = {
+  args: {
+    workshopRegistrationStart: '2026-05-01T07:00:00.000Z',
+  },
+}
+
+export const OnlyEndSet: Story = {
+  args: {
+    workshopRegistrationEnd: '2026-05-01T07:00:00.000Z',
+  },
+}
+
 export const Dark: Story = {
-  args: Configured.args,
+  args: OnlyStartSet.args,
   parameters: { theme: 'dark' },
 }

--- a/src/components/admin/WorkshopRegistrationSettings.stories.tsx
+++ b/src/components/admin/WorkshopRegistrationSettings.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { WorkshopRegistrationSettings } from './WorkshopRegistrationSettings'
+import { NotificationProvider } from './NotificationProvider'
+
+const handlers = [
+  http.post('/api/trpc/workshop.admin.updateRegistrationTimes', () =>
+    HttpResponse.json({ result: { data: { success: true } } }),
+  ),
+]
+
+const meta = {
+  title: 'Systems/Workshops/Admin/WorkshopRegistrationSettings',
+  component: WorkshopRegistrationSettings,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'The workshop registration window card on /admin/workshops: a read-only card showing the open/close instants and the derived status, with a pencil opening a ModalShell form that patches the window via the workshop.admin router.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-gray-50 p-6 dark:bg-gray-950">
+                <Story />
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+} satisfies Meta<typeof WorkshopRegistrationSettings>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Configured: Story = {
+  args: {
+    workshopRegistrationStart: '2099-04-01T07:00:00.000Z',
+    workshopRegistrationEnd: '2099-05-01T07:00:00.000Z',
+  },
+}
+
+export const NotConfigured: Story = {
+  args: {},
+}
+
+export const Dark: Story = {
+  args: Configured.args,
+  parameters: { theme: 'dark' },
+}

--- a/src/components/admin/WorkshopRegistrationSettings.tsx
+++ b/src/components/admin/WorkshopRegistrationSettings.tsx
@@ -112,16 +112,51 @@ export function WorkshopRegistrationSettings({
     return formatDateTimeSafe(dateString)
   }
 
-  const getRegistrationStatus = () => {
-    if (!workshopRegistrationStart || !workshopRegistrationEnd) {
-      return { label: 'Not configured', color: 'gray' as const }
-    }
+  const getRegistrationStatus = (): {
+    label: string
+    color: 'gray' | 'yellow' | 'red' | 'green'
+    note?: string
+  } => {
     const now = new Date()
-    const start = new Date(workshopRegistrationStart)
-    const end = new Date(workshopRegistrationEnd)
-    if (now < start) return { label: 'Not yet open', color: 'yellow' as const }
-    if (now > end) return { label: 'Closed', color: 'red' as const }
-    return { label: 'Currently open', color: 'green' as const }
+    const start = workshopRegistrationStart
+      ? new Date(workshopRegistrationStart)
+      : null
+    const end = workshopRegistrationEnd
+      ? new Date(workshopRegistrationEnd)
+      : null
+
+    if (start && end) {
+      if (now < start) return { label: 'Not yet open', color: 'yellow' }
+      if (now > end) return { label: 'Closed', color: 'red' }
+      return { label: 'Currently open', color: 'green' }
+    }
+
+    if (!start && !end) {
+      return { label: 'Not configured', color: 'gray' }
+    }
+
+    // Partial window. Enforcement (the workshop signup mutation and the public
+    // workshop list) checks each bound independently — a missing bound is
+    // simply not enforced — so a half-set window still gates signups and must
+    // not read as "Not configured".
+    if (start) {
+      return {
+        label: 'Partially configured',
+        color: 'yellow',
+        note:
+          now < start
+            ? `Signups open ${formatDateTimeSafe(workshopRegistrationStart!)}. No close date is set, so once open they never close.`
+            : 'Signups are open. No close date is set, so they never close.',
+      }
+    }
+    return {
+      label: 'Partially configured',
+      color: 'yellow',
+      note:
+        now > end!
+          ? `Signups closed ${formatDateTimeSafe(workshopRegistrationEnd!)}. No open date is set, so they were open until then.`
+          : `Signups are open now (no open date is set) and close ${formatDateTimeSafe(workshopRegistrationEnd!)}.`,
+    }
   }
 
   const status = getRegistrationStatus()
@@ -170,6 +205,12 @@ export function WorkshopRegistrationSettings({
           </span>
           <StatusBadge label={status.label} color={status.color} />
         </div>
+
+        {status.note ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {status.note}
+          </p>
+        ) : null}
       </div>
 
       <ModalShell

--- a/src/components/admin/sponsor/SponsorTiersPage.stories.tsx
+++ b/src/components/admin/sponsor/SponsorTiersPage.stories.tsx
@@ -1,17 +1,31 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
+import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
+import { FieldRow } from '@/app/(admin)/admin/settings/settingsLayout'
 import {
   ChartBarIcon,
   PlusIcon,
   PencilIcon,
+  PencilSquareIcon,
   TrashIcon,
   ArrowDownTrayIcon,
   GlobeAltIcon,
   TagIcon,
   UserGroupIcon,
   TicketIcon,
+  CurrencyDollarIcon,
+  DocumentTextIcon,
 } from '@heroicons/react/24/outline'
 import { StarIcon } from '@heroicons/react/20/solid'
+
+/** Non-functional stand-in for the EditConferenceCard pencil trigger. */
+function EditPencil() {
+  return (
+    <span className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 dark:text-gray-400">
+      <PencilSquareIcon className="h-5 w-5" />
+    </span>
+  )
+}
 
 const meta = {
   title: 'Systems/Sponsors/Admin/Tiers/SponsorTiersPage',
@@ -22,7 +36,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Integration example showing the full /admin/sponsors/tiers page layout. Combines AdminPageHeader, SponsorTierEditor (tier configuration cards), SponsorTierManagement (sponsors grouped by tier), and Quick Actions links.',
+          'Integration example showing the full /admin/sponsors/tiers page layout. Combines AdminPageHeader, SponsorTierEditor (tier configuration cards), SponsorTierManagement (sponsors grouped by tier), Quick Actions links, and the collapsed Sponsor Benefits / Sponsorship Page editors.',
       },
     },
   },
@@ -369,6 +383,37 @@ export const Default: Story = {
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Sponsor content configuration */}
+        <div className="mt-12 space-y-6">
+          <CollapsibleSection
+            title="Sponsor Benefits"
+            icon={<CurrencyDollarIcon />}
+            action={<EditPencil />}
+          >
+            <div className="space-y-3 px-6 py-4">
+              <FieldRow
+                label="Reach"
+                value="Access to 500+ cloud native engineers."
+              />
+            </div>
+          </CollapsibleSection>
+
+          <CollapsibleSection
+            title="Sponsorship Page"
+            icon={<DocumentTextIcon />}
+            action={<EditPencil />}
+          >
+            <div className="space-y-3 px-6 py-4">
+              <FieldRow label="Hero Headline" value="Partner with us" />
+              <FieldRow
+                label="Prospectus Link"
+                value="https://example.com/prospectus.pdf"
+                type="url"
+              />
+            </div>
+          </CollapsibleSection>
         </div>
       </div>
     </div>

--- a/src/components/admin/sponsor/SponsorTiersPage.stories.tsx
+++ b/src/components/admin/sponsor/SponsorTiersPage.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
-import { FieldRow } from '@/app/(admin)/admin/settings/settingsLayout'
+import { FieldRow } from '@/components/admin/FieldRow'
 import {
   ChartBarIcon,
   PlusIcon,

--- a/src/components/admin/sponsor/SponsorTiersPageClient.tsx
+++ b/src/components/admin/sponsor/SponsorTiersPageClient.tsx
@@ -4,10 +4,15 @@ import { AdminPageHeader } from '@/components/admin'
 import { GeneralBroadcastModal } from '@/components/admin'
 import { SponsorTierEditor } from './SponsorTierEditor'
 import { SponsorTierManagement } from './SponsorTierManagement'
+import { EditConferenceCard } from '@/components/admin/EditConferenceCard'
+import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
+import { FieldRow } from '@/app/(admin)/admin/settings/settingsLayout'
 import {
   GlobeAltIcon,
   UserGroupIcon,
   ChartBarIcon,
+  CurrencyDollarIcon,
+  DocumentTextIcon,
 } from '@heroicons/react/24/outline'
 import { TicketIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
@@ -125,6 +130,70 @@ export function SponsorTiersPageClient({
               </div>
             </Link>
           </div>
+        </div>
+
+        <div className="mt-12 space-y-6">
+          <CollapsibleSection
+            title="Sponsor Benefits"
+            icon={<CurrencyDollarIcon />}
+            action={
+              <EditConferenceCard
+                fieldset="sponsorBenefits"
+                initialValues={{
+                  sponsorBenefits: conference.sponsorBenefits,
+                }}
+              />
+            }
+          >
+            <div className="space-y-3 px-6 py-4">
+              {conference.sponsorBenefits &&
+              conference.sponsorBenefits.length > 0 ? (
+                conference.sponsorBenefits.map((benefit, idx) => (
+                  <FieldRow
+                    key={idx}
+                    label={benefit.title}
+                    value={benefit.description}
+                  />
+                ))
+              ) : (
+                <span className="text-sm text-gray-500 dark:text-gray-400">
+                  None
+                </span>
+              )}
+            </div>
+          </CollapsibleSection>
+
+          <CollapsibleSection
+            title="Sponsorship Page"
+            icon={<DocumentTextIcon />}
+            action={
+              <EditConferenceCard
+                fieldset="sponsorshipCustomization"
+                initialValues={
+                  (conference.sponsorshipCustomization ?? {}) as Record<
+                    string,
+                    unknown
+                  >
+                }
+              />
+            }
+          >
+            <div className="space-y-3 px-6 py-4">
+              <FieldRow
+                label="Hero Headline"
+                value={conference.sponsorshipCustomization?.heroHeadline}
+              />
+              <FieldRow
+                label="Philosophy Title"
+                value={conference.sponsorshipCustomization?.philosophyTitle}
+              />
+              <FieldRow
+                label="Prospectus Link"
+                value={conference.sponsorshipCustomization?.prospectusUrl}
+                type="url"
+              />
+            </div>
+          </CollapsibleSection>
         </div>
       </div>
 

--- a/src/components/admin/sponsor/SponsorTiersPageClient.tsx
+++ b/src/components/admin/sponsor/SponsorTiersPageClient.tsx
@@ -6,7 +6,7 @@ import { SponsorTierEditor } from './SponsorTierEditor'
 import { SponsorTierManagement } from './SponsorTierManagement'
 import { EditConferenceCard } from '@/components/admin/EditConferenceCard'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
-import { FieldRow } from '@/app/(admin)/admin/settings/settingsLayout'
+import { FieldRow } from '@/components/admin/FieldRow'
 import {
   GlobeAltIcon,
   UserGroupIcon,

--- a/src/components/admin/sponsor/SponsorTiersPageClient.tsx
+++ b/src/components/admin/sponsor/SponsorTiersPageClient.tsx
@@ -150,7 +150,7 @@ export function SponsorTiersPageClient({
               conference.sponsorBenefits.length > 0 ? (
                 conference.sponsorBenefits.map((benefit, idx) => (
                   <FieldRow
-                    key={idx}
+                    key={benefit._key ?? `${benefit.title}-${idx}`}
                     label={benefit.title}
                     value={benefit.description}
                   />

--- a/src/components/admin/workshop/WorkshopsClientPage.tsx
+++ b/src/components/admin/workshop/WorkshopsClientPage.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useMemo } from 'react'
 import { AcademicCapIcon } from '@heroicons/react/24/outline'
-import { AdminPageHeader } from '@/components/admin'
+import {
+  AdminPageHeader,
+  WorkshopRegistrationSettings,
+} from '@/components/admin'
 import {
   WorkshopCard,
   SignupDetailsModal,
@@ -53,11 +56,15 @@ interface AnnounceModalState {
 interface WorkshopsClientPageProps {
   conferenceId: string
   initialWorkshops: ProposalWithWorkshopData[]
+  workshopRegistrationStart?: string
+  workshopRegistrationEnd?: string
 }
 
 export function WorkshopsClientPage({
   conferenceId,
   initialWorkshops,
+  workshopRegistrationStart,
+  workshopRegistrationEnd,
 }: WorkshopsClientPageProps) {
   const queryClient = useQueryClient()
   const utils = api.useUtils()
@@ -352,6 +359,11 @@ export function WorkshopsClientPage({
               ]
             : []
         }
+      />
+
+      <WorkshopRegistrationSettings
+        workshopRegistrationStart={workshopRegistrationStart}
+        workshopRegistrationEnd={workshopRegistrationEnd}
       />
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -56,6 +56,7 @@ export interface ConferenceVanityMetric {
 }
 
 export interface SponsorBenefit {
+  _key?: string
   title: string
   description: string
   icon?: string

--- a/src/lib/settings/groups.test.ts
+++ b/src/lib/settings/groups.test.ts
@@ -7,13 +7,12 @@ import {
 } from './groups'
 
 describe('settings IA groups', () => {
-  it('defines the six organizer-facing groups in order', () => {
+  it('defines the five organizer-facing groups in order', () => {
     expect(SETTINGS_GROUPS.map((g) => g.id)).toEqual([
       'identity-brand',
       'schedule',
       'call-for-papers',
       'tickets-registration',
-      'sponsors',
       'team-content',
     ])
   })

--- a/src/lib/settings/groups.ts
+++ b/src/lib/settings/groups.ts
@@ -65,15 +65,7 @@ export const SETTINGS_GROUPS: readonly SettingsGroup[] = [
     id: 'tickets-registration',
     navLabel: 'Tickets & Registration',
     title: 'Tickets & Registration',
-    description:
-      'Registration, workshop sign-ups, the ticketing provider and homepage stats.',
-  },
-  {
-    id: 'sponsors',
-    navLabel: 'Sponsors',
-    title: 'Sponsors',
-    description:
-      'Sponsorship tiers, current sponsors, benefits and the public sponsorship page.',
+    description: 'Registration, the ticketing provider and homepage stats.',
   },
   {
     id: 'team-content',


### PR DESCRIPTION
Slims the admin Settings page down to configuration that has no better home, per the settings slim-down decisions.

## Moves

| What | Was | Now |
| --- | --- | --- |
| Sponsorship Tiers card (read-only) | Settings › Sponsors | **removed** — duplicated `/admin/sponsors/tiers` |
| Current Sponsors card (read-only) | Settings › Sponsors | **removed** — duplicated `/admin/sponsors/crm` |
| Sponsor Benefits editor (`EditConferenceCard fieldset="sponsorBenefits"`) | Settings › Sponsors | bottom of `/admin/sponsors/tiers` (collapsed section) |
| Sponsorship Page editor (`EditConferenceCard fieldset="sponsorshipCustomization"`) | Settings › Sponsors | bottom of `/admin/sponsors/tiers` (collapsed section) |
| Workshop Registration window card (`WorkshopRegistrationSettings`) | Settings › Tickets & Registration | top of `/admin/workshops`, under the page header |

## Fallout

- `SETTINGS_GROUPS` goes 6 → 5: the Sponsors group is deleted and the Tickets & Registration description drops "workshop sign-ups"; `groups.test.ts` updated. No activation-checklist rows or deep links pointed at `#sponsors`, so nothing to repoint.
- `LinkedBadgeList` (+ `LinkedBadgeItem`) in `settingsLayout.tsx` became unused and is deleted. `ManageLink`/`manageLink` on `InfoCard` is kept as a generic affordance.
- Settings no longer fetches `sponsors`/`sponsorTiers`.
- Stories: `SettingsIA` reflects the five-group IA, `SponsorTiersPage` shows the two new collapsed sections, and a new `WorkshopRegistrationSettings` story covers the relocated card (msw-mocked mutation).

## QA

- `vitest run`: 331 files / 4319 tests green; eslint + prettier + `tsc --noEmit` clean on the branch.
- `pnpm shoot` visual passes: Settings IA (mobile + desktop — five nav chips, no sponsor cards, no overflow), Sponsor Tiers page (sections render collapsed with pencil affordances), Workshop Registration card (Oslo-formatted window + status badge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C
