### PR TITLE
feat(onboarding): atomic organization creation + concierge setup wizard (S1-S2)

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,12 @@ NEXT_TELEMETRY_DISABLED=1
 # Development Test Mode (add to .env.local to enable)
 # NEXT_PUBLIC_ENABLE_TEST_MODE=true
 
+# Platform-operator surface (concierge tenant onboarding, RunKonf/platform#4):
+# organizers of the organization with this slug may create NEW organizations at
+# /admin/platform/new-organization. Unset = the surface is DISABLED (fail closed).
+# Set it in .env.local / Vercel, e.g.:
+# PLATFORM_ORG_SLUG="cloud-native-bergen"
+
 NEXT_PUBLIC_SANITY_PROJECT_ID="mvzwvw14"
 NEXT_PUBLIC_SANITY_DATASET="production"
 SANITY_STUDIO_PROJECT_ID="mvzwvw14"

--- a/src/app/(admin)/admin/platform/new-organization/page.tsx
+++ b/src/app/(admin)/admin/platform/new-organization/page.tsx
@@ -19,7 +19,7 @@ export const metadata = {
  * domain's org; on top of that this page — like the tRPC mutation it drives —
  * requires the caller to be an organizer of the CONFIGURED platform org
  * (`PLATFORM_ORG_SLUG`, see `@/lib/authz/platform`). Non-operators get a 404
- * so the surface's existence isn't disclosed. The SERVER mutation re-enforces
+ * so the surface's existence isn't disclosed. The SERVER mutation reinforces
  * the same gate; this page check is UX, not the security boundary.
  */
 export default async function NewOrganizationPage() {

--- a/src/app/(admin)/admin/platform/new-organization/page.tsx
+++ b/src/app/(admin)/admin/platform/new-organization/page.tsx
@@ -1,0 +1,42 @@
+import { notFound } from 'next/navigation'
+import { getAuthSession } from '@/lib/auth'
+import { isPlatformOperator } from '@/lib/authz/platform'
+import { AdminPageHeader } from '@/components/admin'
+import { OnboardingWizard } from '@/components/admin/onboarding'
+import { BuildingOffice2Icon } from '@heroicons/react/24/outline'
+
+export const metadata = {
+  title: 'New organization',
+}
+
+/**
+ * Onboarding S2 (RunKonf/platform#4) — the PLATFORM-OPERATOR concierge wizard
+ * that creates a new tenant: organization + first conference + organizer
+ * membership. This is NOT public signup (no billing/entity exists yet); the
+ * operator runs it on a new customer's behalf.
+ *
+ * GATING: the (admin) layout already requires an organizer of the CURRENT
+ * domain's org; on top of that this page — like the tRPC mutation it drives —
+ * requires the caller to be an organizer of the CONFIGURED platform org
+ * (`PLATFORM_ORG_SLUG`, see `@/lib/authz/platform`). Non-operators get a 404
+ * so the surface's existence isn't disclosed. The SERVER mutation re-enforces
+ * the same gate; this page check is UX, not the security boundary.
+ */
+export default async function NewOrganizationPage() {
+  const session = await getAuthSession()
+  if (!(await isPlatformOperator(session?.speaker))) {
+    notFound()
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <AdminPageHeader
+        icon={<BuildingOffice2Icon />}
+        title="New organization"
+        description="Concierge onboarding: create a tenant organization, its first conference and the founding organizer."
+        backLink={{ href: '/admin', label: 'Back to admin' }}
+      />
+      <OnboardingWizard />
+    </div>
+  )
+}

--- a/src/components/admin/onboarding/OnboardingWizard.stories.tsx
+++ b/src/components/admin/onboarding/OnboardingWizard.stories.tsx
@@ -163,3 +163,42 @@ export const OrganizationValidation: Story = {
     await expect(next).toBeDisabled()
   },
 }
+
+/**
+ * Ambiguity gate — an organizer email matching SEVERAL speaker accounts is a
+ * deterministic server rejection, so the step blocks (not just warns) until
+ * the duplicates are merged.
+ */
+export const OrganizationAmbiguousOrganizer: Story = {
+  args: {
+    initialStep: 'organization',
+    initialState: { organization: filledOrganization },
+    initialOrganizer: organizer,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/trpc/onboarding.validateSetup', () =>
+          HttpResponse.json({
+            result: {
+              data: {
+                slugTaken: false,
+                takenDomains: [],
+                organizer: { matchCount: 2, match: null },
+              },
+            },
+          }),
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText(/matches several speaker accounts/i, undefined, {
+      timeout: 5000,
+    })
+    await expect(
+      await canvas.findByRole('button', { name: /next/i }),
+    ).toBeDisabled()
+  },
+}

--- a/src/components/admin/onboarding/OnboardingWizard.stories.tsx
+++ b/src/components/admin/onboarding/OnboardingWizard.stories.tsx
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { within, userEvent, expect } from 'storybook/test'
+import { OnboardingWizard } from './OnboardingWizard'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import type { OrganizerState, WizardState } from './wizardLogic'
+
+const filledOrganization: WizardState['organization'] = {
+  name: 'Cloud Native Oslo',
+  slug: '',
+  slugTouched: false,
+  contactEmail: 'hello@cloudnativeoslo.no',
+  billingEmail: '',
+}
+
+const filledConference: WizardState['conference'] = {
+  title: 'Cloud Native Days Oslo 2027',
+  city: 'Oslo',
+  country: 'Norway',
+  startDate: '2027-06-01',
+  endDate: '2027-06-02',
+}
+
+const organizer: OrganizerState = {
+  name: 'Kari Nordmann',
+  email: 'kari@cloudnativeoslo.no',
+}
+
+// Happy path: slug/domains free, organizer email matches one existing account.
+const handlers = [
+  http.get('/api/trpc/onboarding.validateSetup', () =>
+    HttpResponse.json({
+      result: {
+        data: {
+          slugTaken: false,
+          takenDomains: [],
+          organizer: { matchCount: 1, match: { name: 'Kari Nordmann' } },
+        },
+      },
+    }),
+  ),
+  http.post('/api/trpc/onboarding.createOrganization', () =>
+    HttpResponse.json({
+      result: {
+        data: {
+          organizationId: 'organization-abc123',
+          conferenceId: 'conference-def456',
+          speakerId: 'speaker-xyz',
+          speakerCreated: false,
+          organizerMatchedName: 'Kari Nordmann',
+        },
+      },
+    }),
+  ),
+]
+
+const meta = {
+  title: 'Systems/Admin/Platform/Onboarding Wizard',
+  component: OnboardingWizard,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+  },
+  decorators: [
+    (Story) => (
+      <NotificationProvider>
+        <div className="mx-auto max-w-3xl p-4">
+          <Story />
+        </div>
+      </NotificationProvider>
+    ),
+  ],
+} satisfies Meta<typeof OnboardingWizard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Step 1 — Organization details + the founding organizer, blank start. */
+export const Organization: Story = {
+  args: { initialStep: 'organization' },
+}
+
+/** Step 1 filled — auto-derived slug and an existing-account match. */
+export const OrganizationFilled: Story = {
+  args: {
+    initialStep: 'organization',
+    initialState: { organization: filledOrganization },
+    initialOrganizer: organizer,
+  },
+  play: async ({ canvas }) => {
+    // The slug derives from the name until hand-edited.
+    const slugInput = canvas.getByPlaceholderText('cloud-native-oslo')
+    await expect(slugInput).toHaveValue('cloud-native-oslo')
+  },
+}
+
+/** Step 2 — First conference basics (dates optional). */
+export const Conference: Story = {
+  args: {
+    initialStep: 'conference',
+    initialState: {
+      organization: filledOrganization,
+      conference: filledConference,
+    },
+    initialOrganizer: organizer,
+  },
+}
+
+/** Step 3 — Domains, explicitly optional (tenants can start on none). */
+export const Domains: Story = {
+  args: {
+    initialStep: 'domains',
+    initialState: {
+      organization: filledOrganization,
+      conference: filledConference,
+      domains: ['oslo.cloudnativedays.no'],
+    },
+    initialOrganizer: organizer,
+  },
+}
+
+/** Step 4 — Review with the Create button armed. */
+export const Review: Story = {
+  args: {
+    initialStep: 'review',
+    initialState: {
+      organization: filledOrganization,
+      conference: filledConference,
+      domains: ['oslo.cloudnativedays.no'],
+    },
+    initialOrganizer: organizer,
+  },
+}
+
+/** Done — the handoff screen after a successful creation (with a domain). */
+export const Done: Story = {
+  args: {
+    initialStep: 'review',
+    initialState: {
+      organization: filledOrganization,
+      conference: filledConference,
+      domains: ['oslo.cloudnativedays.no'],
+    },
+    initialOrganizer: organizer,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /create organization/i }),
+    )
+    await expect(
+      await canvas.findByText(/is on board/i, undefined, { timeout: 5000 }),
+    ).toBeVisible()
+  },
+}
+
+/** Step validation — an empty Organization step cannot advance. */
+export const OrganizationValidation: Story = {
+  args: { initialStep: 'organization' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const next = await canvas.findByRole('button', { name: /next/i })
+    await expect(next).toBeDisabled()
+  },
+}

--- a/src/components/admin/onboarding/OnboardingWizard.tsx
+++ b/src/components/admin/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,732 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  CheckCircleIcon,
+  PlusIcon,
+  TrashIcon,
+  ExclamationTriangleIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  UserCircleIcon,
+} from '@heroicons/react/24/outline'
+import { api } from '@/lib/trpc/client'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { useNotificationSafe } from '@/components/admin/NotificationProvider'
+import {
+  WIZARD_STEPS,
+  WIZARD_STEP_TITLES,
+  type WizardStepId,
+  type WizardState,
+  type OrganizerState,
+  stepIndex,
+  derivedSlug,
+  validateOrganization,
+  validateOrganizer,
+  validateConference,
+  domainsLocalErrors,
+  cleanDomains,
+  canProceed,
+  canCreate,
+} from './wizardLogic'
+
+export interface OnboardingWizardProps {
+  /** Storybook/deep-link seam: which step to render first. */
+  initialStep?: WizardStepId
+  /** Storybook seam: seed the wizard state. */
+  initialState?: Partial<WizardState>
+  /** Storybook seam: seed the organizer identity. */
+  initialOrganizer?: OrganizerState
+}
+
+interface FieldProps {
+  label: string
+  children: React.ReactNode
+  error?: string
+  hint?: string
+}
+
+function Field({ label, children, error, hint }: FieldProps) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-200">
+        {label}
+      </span>
+      {children}
+      {hint && !error && (
+        <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+          {hint}
+        </span>
+      )}
+      {error && (
+        <span className="mt-1 block text-xs text-red-600 dark:text-red-400">
+          {error}
+        </span>
+      )}
+    </label>
+  )
+}
+
+const inputClass =
+  'w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+
+function StepIndicator({ current }: { current: WizardStepId }) {
+  const currentIdx = stepIndex(current)
+  return (
+    <ol className="flex flex-wrap items-center gap-2">
+      {WIZARD_STEPS.map((id, i) => {
+        const done = i < currentIdx
+        const active = i === currentIdx
+        return (
+          <li key={id} className="flex items-center gap-2">
+            <span
+              className={[
+                'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
+                active
+                  ? 'bg-indigo-600 text-white'
+                  : done
+                    ? 'bg-green-600 text-white'
+                    : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400',
+              ].join(' ')}
+            >
+              {done ? <CheckCircleIcon className="h-4 w-4" /> : i + 1}
+            </span>
+            <span
+              className={[
+                'text-sm',
+                active
+                  ? 'font-semibold text-gray-900 dark:text-white'
+                  : 'text-gray-500 dark:text-gray-400',
+              ].join(' ')}
+            >
+              {WIZARD_STEP_TITLES[id]}
+            </span>
+            {i < WIZARD_STEPS.length - 1 && (
+              <span className="mx-1 h-px w-4 bg-gray-300 dark:bg-gray-600" />
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export function OnboardingWizard({
+  initialStep = 'organization',
+  initialState,
+  initialOrganizer,
+}: OnboardingWizardProps) {
+  const notify = useNotificationSafe()
+  const [step, setStep] = useState<WizardStepId>(initialStep)
+  const [state, setState] = useState<WizardState>(() => ({
+    organization: {
+      name: '',
+      slug: '',
+      slugTouched: false,
+      contactEmail: '',
+      billingEmail: '',
+      ...initialState?.organization,
+    },
+    conference: {
+      title: '',
+      city: '',
+      country: '',
+      startDate: '',
+      endDate: '',
+      ...initialState?.conference,
+    },
+    domains: initialState?.domains ?? [''],
+  }))
+  const [organizer, setOrganizer] = useState<OrganizerState>(
+    () => initialOrganizer ?? { name: '', email: '' },
+  )
+
+  const [result, setResult] = useState<{
+    organizationId: string
+    conferenceId: string
+    speakerCreated: boolean
+    organizerMatchedName: string | null
+  } | null>(null)
+
+  // Debounce the availability probe inputs so keystrokes don't spam the server.
+  const slug = derivedSlug(state.organization)
+  const cleanedDomains = useMemo(
+    () => cleanDomains(state.domains),
+    [state.domains],
+  )
+  const organizerEmail = organizer.email.trim().toLowerCase()
+  const [probe, setProbe] = useState<{
+    slug?: string
+    domains?: string[]
+    organizerEmail?: string
+  }>({})
+  useEffect(() => {
+    const t = setTimeout(
+      () =>
+        setProbe({
+          slug: slug || undefined,
+          domains: cleanedDomains.length > 0 ? cleanedDomains : undefined,
+          organizerEmail: EMAIL_RE.test(organizerEmail)
+            ? organizerEmail
+            : undefined,
+        }),
+      400,
+    )
+    return () => clearTimeout(t)
+  }, [slug, cleanedDomains, organizerEmail])
+
+  const availability = api.onboarding.validateSetup.useQuery(probe, {
+    enabled: Boolean(probe.slug || probe.domains || probe.organizerEmail),
+  })
+  // Only trust the probe verdicts for the CURRENTLY typed values — a stale
+  // response for an old slug/domain list must not gate (or ungate) this one.
+  const slugTaken = availability.data?.slugTaken === true && probe.slug === slug
+  const takenDomains =
+    probe.domains &&
+    probe.domains.length === cleanedDomains.length &&
+    probe.domains.every((d, i) => d === cleanedDomains[i])
+      ? (availability.data?.takenDomains ?? [])
+      : []
+  const organizerProbe =
+    probe.organizerEmail === organizerEmail && EMAIL_RE.test(organizerEmail)
+      ? availability.data?.organizer
+      : undefined
+
+  const createMutation = api.onboarding.createOrganization.useMutation({
+    onSuccess: (data) => {
+      setResult({
+        organizationId: data.organizationId,
+        conferenceId: data.conferenceId,
+        speakerCreated: data.speakerCreated,
+        organizerMatchedName: data.organizerMatchedName,
+      })
+    },
+    onError: (err) => {
+      notify?.showNotification({
+        type: 'error',
+        title: 'Could not create the organization',
+        message: err.message,
+      })
+    },
+  })
+
+  const orgErrors = validateOrganization(state.organization, slugTaken)
+  const organizerErrors = validateOrganizer(organizer)
+  const conferenceErrors = validateConference(state.conference)
+  const domainErrors = domainsLocalErrors(state.domains)
+
+  function patchOrg(patch: Partial<WizardState['organization']>) {
+    setState((s) => ({
+      ...s,
+      organization: { ...s.organization, ...patch },
+    }))
+  }
+  function patchConference(patch: Partial<WizardState['conference']>) {
+    setState((s) => ({ ...s, conference: { ...s.conference, ...patch } }))
+  }
+  function setDomain(i: number, value: string) {
+    setState((s) => {
+      const domains = [...s.domains]
+      domains[i] = value
+      return { ...s, domains }
+    })
+  }
+  function addDomain() {
+    setState((s) => ({ ...s, domains: [...s.domains, ''] }))
+  }
+  function removeDomain(i: number) {
+    setState((s) => ({
+      ...s,
+      domains:
+        s.domains.length > 1 ? s.domains.filter((_, j) => j !== i) : [''],
+    }))
+  }
+
+  function submit() {
+    if (!canCreate(state, organizer, slugTaken, takenDomains)) return
+    createMutation.mutate({
+      organization: {
+        name: state.organization.name.trim(),
+        slug,
+        contactEmail: state.organization.contactEmail.trim(),
+        billingEmail: state.organization.billingEmail.trim() || null,
+      },
+      conference: {
+        title: state.conference.title.trim(),
+        city: state.conference.city.trim(),
+        country: state.conference.country.trim(),
+        startDate: state.conference.startDate || null,
+        endDate: state.conference.endDate || null,
+      },
+      organizer: {
+        name: organizer.name.trim(),
+        email: organizerEmail,
+      },
+      domains: cleanedDomains,
+    })
+  }
+
+  if (result) {
+    return (
+      <SuccessPanel
+        result={result}
+        organizationName={state.organization.name}
+        conferenceTitle={state.conference.title}
+        organizerEmail={organizerEmail}
+        domains={cleanedDomains}
+      />
+    )
+  }
+
+  const idx = stepIndex(step)
+  const canGoNext = canProceed(step, state, organizer, slugTaken, takenDomains)
+
+  return (
+    <div className="space-y-6">
+      <StepIndicator current={step} />
+
+      <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+        {step === 'organization' && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              The organization is the tenant that will own this conference and
+              every future edition.
+            </p>
+            <Field label="Organization name" error={orgErrors.name}>
+              <input
+                className={inputClass}
+                placeholder="Cloud Native Oslo"
+                value={state.organization.name}
+                onChange={(e) => patchOrg({ name: e.target.value })}
+              />
+            </Field>
+            <Field
+              label="Slug"
+              error={orgErrors.slug}
+              hint="Stable identifier for the organization. Derived from the name — edit to override."
+            >
+              <input
+                className={inputClass}
+                placeholder="cloud-native-oslo"
+                value={slug}
+                onChange={(e) =>
+                  patchOrg({ slug: e.target.value, slugTouched: true })
+                }
+              />
+            </Field>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Field label="Contact email" error={orgErrors.contactEmail}>
+                <input
+                  type="email"
+                  className={inputClass}
+                  placeholder="hello@example.org"
+                  value={state.organization.contactEmail}
+                  onChange={(e) => patchOrg({ contactEmail: e.target.value })}
+                />
+              </Field>
+              <Field
+                label="Billing email (optional)"
+                error={orgErrors.billingEmail}
+                hint="Falls back to the contact email when unset."
+              >
+                <input
+                  type="email"
+                  className={inputClass}
+                  value={state.organization.billingEmail}
+                  onChange={(e) => patchOrg({ billingEmail: e.target.value })}
+                />
+              </Field>
+            </div>
+
+            <div className="border-t border-gray-100 pt-4 dark:border-gray-800">
+              <h3 className="mb-1 flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
+                <UserCircleIcon className="h-5 w-5" /> First organizer
+              </h3>
+              <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
+                The person who will run this tenant. They get admin access on
+                their next sign-in with this email.
+              </p>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <Field label="Name" error={organizerErrors.organizerName}>
+                  <input
+                    className={inputClass}
+                    value={organizer.name}
+                    onChange={(e) =>
+                      setOrganizer((o) => ({ ...o, name: e.target.value }))
+                    }
+                  />
+                </Field>
+                <Field label="Email" error={organizerErrors.organizerEmail}>
+                  <input
+                    type="email"
+                    className={inputClass}
+                    value={organizer.email}
+                    onChange={(e) =>
+                      setOrganizer((o) => ({ ...o, email: e.target.value }))
+                    }
+                  />
+                </Field>
+              </div>
+              {organizerProbe && organizerProbe.matchCount === 1 && (
+                <p className="mt-2 text-xs text-green-700 dark:text-green-400">
+                  Matches the existing account{' '}
+                  <span className="font-semibold">
+                    {organizerProbe.match?.name ?? 'unnamed'}
+                  </span>{' '}
+                  — it will be made an organizer.
+                </p>
+              )}
+              {organizerProbe && organizerProbe.matchCount === 0 && (
+                <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                  No existing account — one will be created and linked when they
+                  first sign in with this email.
+                </p>
+              )}
+              {organizerProbe && organizerProbe.matchCount > 1 && (
+                <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+                  This email matches several speaker accounts. Merge the
+                  duplicates before onboarding this organizer.
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {step === 'conference' && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              The organization&apos;s first conference. Only the basics are
+              needed now — everything else is configured from the new
+              tenant&apos;s settings.
+            </p>
+            <Field label="Title" error={conferenceErrors.title}>
+              <input
+                className={inputClass}
+                placeholder="Cloud Native Days Oslo 2027"
+                value={state.conference.title}
+                onChange={(e) => patchConference({ title: e.target.value })}
+              />
+            </Field>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Field label="City" error={conferenceErrors.city}>
+                <input
+                  className={inputClass}
+                  value={state.conference.city}
+                  onChange={(e) => patchConference({ city: e.target.value })}
+                />
+              </Field>
+              <Field label="Country" error={conferenceErrors.country}>
+                <input
+                  className={inputClass}
+                  value={state.conference.country}
+                  onChange={(e) => patchConference({ country: e.target.value })}
+                />
+              </Field>
+              <Field
+                label="Start date (optional)"
+                error={conferenceErrors.startDate}
+              >
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={state.conference.startDate}
+                  onChange={(e) =>
+                    patchConference({ startDate: e.target.value })
+                  }
+                />
+              </Field>
+              <Field
+                label="End date (optional)"
+                error={conferenceErrors.endDate}
+                hint="Dates can be set later — the activation checklist will prompt for them."
+              >
+                <input
+                  type="date"
+                  className={inputClass}
+                  value={state.conference.endDate}
+                  onChange={(e) => patchConference({ endDate: e.target.value })}
+                />
+              </Field>
+            </div>
+          </div>
+        )}
+
+        {step === 'domains' && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Optional. A tenant can start on no domain at all — the conference
+              stays unreachable until a hostname is attached from settings and
+              DNS points here. Each entry must be a bare hostname not used by
+              another conference.
+            </p>
+            <div className="space-y-2">
+              {state.domains.map((domain, i) => {
+                const localErr = domainErrors[`domains.${i}`]
+                const trimmed = domain.trim().toLowerCase()
+                const isTaken = trimmed !== '' && takenDomains.includes(trimmed)
+                return (
+                  <div key={i}>
+                    <div className="flex items-center gap-2">
+                      <input
+                        className={inputClass}
+                        placeholder="conference.example.com"
+                        value={domain}
+                        aria-label={`Domain ${i + 1}`}
+                        onChange={(e) => setDomain(i, e.target.value)}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeDomain(i)}
+                        aria-label={`Remove domain ${i + 1}`}
+                        className="shrink-0 rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-red-600 dark:hover:bg-gray-800"
+                      >
+                        <TrashIcon className="h-4 w-4" />
+                      </button>
+                    </div>
+                    {(localErr || isTaken) && (
+                      <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                        {localErr ?? 'Already used by another conference'}
+                      </p>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+            <button
+              type="button"
+              onClick={addDomain}
+              className="inline-flex items-center gap-1 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+            >
+              <PlusIcon className="h-4 w-4" /> Add domain
+            </button>
+            {availability.isFetching && cleanedDomains.length > 0 && (
+              <p className="text-xs text-gray-400">Checking availability…</p>
+            )}
+          </div>
+        )}
+
+        {step === 'review' && (
+          <div className="space-y-4">
+            <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <ReviewRow
+                label="Organization"
+                value={`${state.organization.name} (${slug})`}
+              />
+              <ReviewRow
+                label="Contact email"
+                value={state.organization.contactEmail}
+              />
+              <ReviewRow
+                label="Billing email"
+                value={state.organization.billingEmail || '— (contact email)'}
+              />
+              <ReviewRow
+                label="First organizer"
+                value={`${organizer.name} <${organizerEmail}>`}
+              />
+              <ReviewRow label="Conference" value={state.conference.title} />
+              <ReviewRow
+                label="Location"
+                value={`${state.conference.city}, ${state.conference.country}`}
+              />
+              <ReviewRow
+                label="Dates"
+                value={
+                  state.conference.startDate
+                    ? `${state.conference.startDate} → ${state.conference.endDate}`
+                    : 'Not set yet'
+                }
+              />
+              <ReviewRow
+                label="Domains"
+                value={cleanedDomains.join(', ') || 'None yet'}
+              />
+            </dl>
+
+            <div className="rounded-md border border-blue-300 bg-blue-50 p-3 text-sm text-blue-800 dark:border-blue-700/60 dark:bg-blue-900/20 dark:text-blue-200">
+              The new conference starts <strong>unlisted</strong> with
+              registration closed and an empty CFP setup. The organizer
+              completes it from the activation checklist in their admin
+              settings.
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div>
+          {idx > 0 ? (
+            <AdminButton
+              variant="secondary"
+              onClick={() => setStep(WIZARD_STEPS[idx - 1])}
+            >
+              <ArrowLeftIcon className="mr-1 h-4 w-4" /> Back
+            </AdminButton>
+          ) : (
+            <Link
+              href="/admin"
+              className="text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            >
+              Cancel
+            </Link>
+          )}
+        </div>
+        <div>
+          {step !== 'review' ? (
+            <AdminButton
+              disabled={!canGoNext}
+              onClick={() => setStep(WIZARD_STEPS[idx + 1])}
+            >
+              Next <ArrowRightIcon className="ml-1 h-4 w-4" />
+            </AdminButton>
+          ) : (
+            <AdminButton
+              disabled={
+                !canCreate(state, organizer, slugTaken, takenDomains) ||
+                createMutation.isPending
+              }
+              onClick={submit}
+            >
+              {createMutation.isPending ? 'Creating…' : 'Create organization'}
+            </AdminButton>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ReviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-gray-50 px-3 py-2 dark:bg-gray-800/50">
+      <dt className="text-xs font-medium text-gray-500 dark:text-gray-400">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-sm break-words text-gray-900 dark:text-white">
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+function SuccessPanel({
+  result,
+  organizationName,
+  conferenceTitle,
+  organizerEmail,
+  domains,
+}: {
+  result: {
+    organizationId: string
+    conferenceId: string
+    speakerCreated: boolean
+    organizerMatchedName: string | null
+  }
+  organizationName: string
+  conferenceTitle: string
+  organizerEmail: string
+  domains: string[]
+}) {
+  const firstDomain = domains[0]
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-green-300 bg-green-50 p-6 dark:border-green-700/60 dark:bg-green-900/20">
+        <div className="flex items-start gap-3">
+          <CheckCircleIcon className="mt-0.5 h-6 w-6 shrink-0 text-green-600 dark:text-green-400" />
+          <div>
+            <h3 className="text-lg font-semibold text-green-900 dark:text-green-100">
+              {organizationName} is on board
+            </h3>
+            <p className="mt-1 text-sm text-green-800 dark:text-green-200">
+              Created the organization (
+              <code className="rounded bg-green-100 px-1 dark:bg-green-800/40">
+                {result.organizationId}
+              </code>
+              ) and its first conference{' '}
+              <span className="font-medium">{conferenceTitle}</span> (
+              <code className="rounded bg-green-100 px-1 dark:bg-green-800/40">
+                {result.conferenceId}
+              </code>
+              ), unlisted and with registration closed.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+        <h4 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+          Organizer access
+        </h4>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          {result.speakerCreated ? (
+            <>
+              A new account was prepared for{' '}
+              <span className="font-medium">{organizerEmail}</span>. It links
+              automatically the first time they sign in with that email, and
+              admin access follows on that sign-in.
+            </>
+          ) : (
+            <>
+              The existing account{' '}
+              <span className="font-medium">
+                {result.organizerMatchedName ?? organizerEmail}
+              </span>{' '}
+              was made an organizer. Admin access lights up on their next
+              sign-in.
+            </>
+          )}
+        </p>
+      </div>
+
+      {firstDomain ? (
+        <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:ring-gray-700">
+          <h4 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+            Next: the activation checklist
+          </h4>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Once DNS and Vercel domain setup for{' '}
+            <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">
+              {firstDomain}
+            </code>{' '}
+            point at this platform, the tenant&apos;s admin lives at{' '}
+            <a
+              href={`https://${firstDomain}/admin/settings`}
+              className="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+            >
+              {firstDomain}/admin/settings
+            </a>{' '}
+            — the Get-started checklist there walks the organizer through dates,
+            CFP formats, topics and going live.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-200">
+          <div className="flex items-start gap-2">
+            <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <p className="font-semibold">No domain attached yet.</p>
+              <p className="mt-1">
+                That&apos;s fine — the tenant exists, but it cannot be opened
+                until a hostname is attached and DNS points here. When one is
+                ready, its admin settings and activation checklist live at{' '}
+                <code>&lt;domain&gt;/admin/settings</code>.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div>
+        <Link
+          href="/admin"
+          className="text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+        >
+          ← Back to admin
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/onboarding/OnboardingWizard.tsx
+++ b/src/components/admin/onboarding/OnboardingWizard.tsx
@@ -14,6 +14,8 @@ import {
 import { api } from '@/lib/trpc/client'
 import { AdminButton } from '@/components/admin/AdminButton'
 import { useNotificationSafe } from '@/components/admin/NotificationProvider'
+import { formatDatesSafe } from '@/lib/time'
+import { ORG_SLUG_RE } from '@/lib/onboarding/create'
 import {
   WIZARD_STEPS,
   WIZARD_STEP_TITLES,
@@ -151,10 +153,17 @@ export function OnboardingWizard({
     organizerMatchedName: string | null
   } | null>(null)
 
-  // Debounce the availability probe inputs so keystrokes don't spam the server.
+  // Debounce the availability probe inputs so keystrokes don't spam the
+  // server — and only probe values that already pass the server schema's SHAPE
+  // rules (slug regex/length, valid hostnames, well-formed email): a partially
+  // typed value would only bounce off input validation as BAD_REQUEST noise.
   const slug = derivedSlug(state.organization)
   const cleanedDomains = useMemo(
     () => cleanDomains(state.domains),
+    [state.domains],
+  )
+  const domainsShapeValid = useMemo(
+    () => Object.keys(domainsLocalErrors(state.domains)).length === 0,
     [state.domains],
   )
   const organizerEmail = organizer.email.trim().toLowerCase()
@@ -167,8 +176,11 @@ export function OnboardingWizard({
     const t = setTimeout(
       () =>
         setProbe({
-          slug: slug || undefined,
-          domains: cleanedDomains.length > 0 ? cleanedDomains : undefined,
+          slug: ORG_SLUG_RE.test(slug) && slug.length <= 96 ? slug : undefined,
+          domains:
+            domainsShapeValid && cleanedDomains.length > 0
+              ? cleanedDomains
+              : undefined,
           organizerEmail: EMAIL_RE.test(organizerEmail)
             ? organizerEmail
             : undefined,
@@ -176,7 +188,7 @@ export function OnboardingWizard({
       400,
     )
     return () => clearTimeout(t)
-  }, [slug, cleanedDomains, organizerEmail])
+  }, [slug, cleanedDomains, domainsShapeValid, organizerEmail])
 
   const availability = api.onboarding.validateSetup.useQuery(probe, {
     enabled: Boolean(probe.slug || probe.domains || probe.organizerEmail),
@@ -194,6 +206,9 @@ export function OnboardingWizard({
     probe.organizerEmail === organizerEmail && EMAIL_RE.test(organizerEmail)
       ? availability.data?.organizer
       : undefined
+  // An ambiguous email (several speaker accounts) is a DETERMINISTIC server
+  // rejection — gate progression/creation on it, don't just warn.
+  const organizerAmbiguous = (organizerProbe?.matchCount ?? 0) > 1
 
   const createMutation = api.onboarding.createOrganization.useMutation({
     onSuccess: (data) => {
@@ -246,7 +261,10 @@ export function OnboardingWizard({
   }
 
   function submit() {
-    if (!canCreate(state, organizer, slugTaken, takenDomains)) return
+    if (
+      !canCreate(state, organizer, slugTaken, takenDomains, organizerAmbiguous)
+    )
+      return
     createMutation.mutate({
       organization: {
         name: state.organization.name.trim(),
@@ -282,7 +300,14 @@ export function OnboardingWizard({
   }
 
   const idx = stepIndex(step)
-  const canGoNext = canProceed(step, state, organizer, slugTaken, takenDomains)
+  const canGoNext = canProceed(
+    step,
+    state,
+    organizer,
+    slugTaken,
+    takenDomains,
+    organizerAmbiguous,
+  )
 
   return (
     <div className="space-y-6">
@@ -535,8 +560,11 @@ export function OnboardingWizard({
               <ReviewRow
                 label="Dates"
                 value={
-                  state.conference.startDate
-                    ? `${state.conference.startDate} → ${state.conference.endDate}`
+                  state.conference.startDate && state.conference.endDate
+                    ? formatDatesSafe(
+                        state.conference.startDate,
+                        state.conference.endDate,
+                      )
                     : 'Not set yet'
                 }
               />
@@ -585,8 +613,13 @@ export function OnboardingWizard({
           ) : (
             <AdminButton
               disabled={
-                !canCreate(state, organizer, slugTaken, takenDomains) ||
-                createMutation.isPending
+                !canCreate(
+                  state,
+                  organizer,
+                  slugTaken,
+                  takenDomains,
+                  organizerAmbiguous,
+                ) || createMutation.isPending
               }
               onClick={submit}
             >

--- a/src/components/admin/onboarding/index.ts
+++ b/src/components/admin/onboarding/index.ts
@@ -1,0 +1,2 @@
+export { OnboardingWizard } from './OnboardingWizard'
+export type { OnboardingWizardProps } from './OnboardingWizard'

--- a/src/components/admin/onboarding/wizardLogic.test.ts
+++ b/src/components/admin/onboarding/wizardLogic.test.ts
@@ -156,7 +156,9 @@ describe('step gating', () => {
   })
 
   it('gates each step on its own validation', () => {
-    expect(canProceed('organization', state, organizer, false, [])).toBe(true)
+    expect(canProceed('organization', state, organizer, false, [], false)).toBe(
+      true,
+    )
     expect(
       canProceed(
         'organization',
@@ -164,29 +166,52 @@ describe('step gating', () => {
         organizer,
         false,
         [],
+        false,
       ),
     ).toBe(false)
     expect(
-      canProceed('organization', state, { name: '', email: '' }, false, []),
+      canProceed(
+        'organization',
+        state,
+        { name: '', email: '' },
+        false,
+        [],
+        false,
+      ),
     ).toBe(false)
-    expect(canProceed('conference', state, organizer, false, [])).toBe(true)
-    expect(canProceed('domains', state, organizer, false, [])).toBe(true)
-    expect(canProceed('review', state, organizer, false, [])).toBe(false)
+    expect(canProceed('conference', state, organizer, false, [], false)).toBe(
+      true,
+    )
+    expect(canProceed('domains', state, organizer, false, [], false)).toBe(true)
+    expect(canProceed('review', state, organizer, false, [], false)).toBe(false)
   })
 
   it('a slug-taken verdict blocks the organization step', () => {
-    expect(canProceed('organization', state, organizer, true, [])).toBe(false)
+    expect(canProceed('organization', state, organizer, true, [], false)).toBe(
+      false,
+    )
+  })
+
+  it('an AMBIGUOUS organizer email blocks the organization step (server would deterministically reject)', () => {
+    expect(canProceed('organization', state, organizer, false, [], true)).toBe(
+      false,
+    )
+    // The ambiguity gate only bites on the step that owns the organizer.
+    expect(canProceed('conference', state, organizer, false, [], true)).toBe(
+      true,
+    )
   })
 
   it('canCreate requires every step to be complete', () => {
-    expect(canCreate(state, organizer, false, [])).toBe(true)
-    expect(canCreate(state, organizer, true, [])).toBe(false)
+    expect(canCreate(state, organizer, false, [], false)).toBe(true)
+    expect(canCreate(state, organizer, true, [], false)).toBe(false)
     expect(
       canCreate(
         { ...state, conference: { ...conference, title: '' } },
         organizer,
         false,
         [],
+        false,
       ),
     ).toBe(false)
     expect(
@@ -195,7 +220,12 @@ describe('step gating', () => {
         organizer,
         false,
         ['taken.example.com'],
+        false,
       ),
     ).toBe(false)
+  })
+
+  it('canCreate is blocked by an ambiguous organizer email', () => {
+    expect(canCreate(state, organizer, false, [], true)).toBe(false)
   })
 })

--- a/src/components/admin/onboarding/wizardLogic.test.ts
+++ b/src/components/admin/onboarding/wizardLogic.test.ts
@@ -85,6 +85,19 @@ describe('validateOrganization', () => {
   it('layers the server slug-taken verdict on top', () => {
     expect(validateOrganization(org, true).slug).toContain('Already used')
   })
+  it('caps a hand-edited slug at 96 characters (matches the server schema)', () => {
+    const errs = validateOrganization(
+      {
+        name: 'X',
+        slug: 'a'.repeat(97),
+        slugTouched: true,
+        contactEmail: 'x@example.com',
+        billingEmail: '',
+      },
+      false,
+    )
+    expect(errs.slug).toMatch(/96/)
+  })
 })
 
 describe('validateOrganizer', () => {

--- a/src/components/admin/onboarding/wizardLogic.test.ts
+++ b/src/components/admin/onboarding/wizardLogic.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the onboarding wizard's pure step logic (S2). Pins the gates
+ * the UI renders from: per-step validation, the OPTIONAL domains contract
+ * (empty list is valid), slug auto-derivation, and the final Create gate.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  WIZARD_STEPS,
+  derivedSlug,
+  validateOrganization,
+  validateOrganizer,
+  validateConference,
+  domainsLocalErrors,
+  domainsComplete,
+  cleanDomains,
+  canProceed,
+  canCreate,
+  type WizardState,
+  type OrganizerState,
+  type OrganizationState,
+  type ConferenceState,
+} from './wizardLogic'
+
+const org: OrganizationState = {
+  name: 'Cloud Native Oslo',
+  slug: '',
+  slugTouched: false,
+  contactEmail: 'hello@cno.no',
+  billingEmail: '',
+}
+
+const conference: ConferenceState = {
+  title: 'Cloud Native Days Oslo 2027',
+  city: 'Oslo',
+  country: 'Norway',
+  startDate: '2027-06-01',
+  endDate: '2027-06-02',
+}
+
+const organizer: OrganizerState = { name: 'Kari', email: 'kari@cno.no' }
+
+const state: WizardState = { organization: org, conference, domains: [''] }
+
+describe('derivedSlug', () => {
+  it('derives from the name until hand-edited', () => {
+    expect(derivedSlug(org)).toBe('cloud-native-oslo')
+    expect(derivedSlug({ ...org, slugTouched: true, slug: 'custom' })).toBe(
+      'custom',
+    )
+  })
+})
+
+describe('validateOrganization', () => {
+  it('passes a complete org', () => {
+    expect(validateOrganization(org, false)).toEqual({})
+  })
+
+  it('requires name, slug and contact email', () => {
+    const errs = validateOrganization(
+      { ...org, name: '', contactEmail: '' },
+      false,
+    )
+    expect(errs.name).toBeTruthy()
+    expect(errs.slug).toBeTruthy() // empty name → empty derived slug
+    expect(errs.contactEmail).toBeTruthy()
+  })
+
+  it('rejects malformed slugs and emails', () => {
+    expect(
+      validateOrganization(
+        { ...org, slugTouched: true, slug: '-Bad Slug-' },
+        false,
+      ).slug,
+    ).toBeTruthy()
+    expect(
+      validateOrganization({ ...org, contactEmail: 'nope' }, false)
+        .contactEmail,
+    ).toBeTruthy()
+    expect(
+      validateOrganization({ ...org, billingEmail: 'nope' }, false)
+        .billingEmail,
+    ).toBeTruthy()
+  })
+
+  it('layers the server slug-taken verdict on top', () => {
+    expect(validateOrganization(org, true).slug).toContain('Already used')
+  })
+})
+
+describe('validateOrganizer', () => {
+  it('requires name and a well-formed email', () => {
+    expect(validateOrganizer(organizer)).toEqual({})
+    expect(validateOrganizer({ name: '', email: 'x' })).toMatchObject({
+      organizerName: expect.any(String),
+      organizerEmail: expect.any(String),
+    })
+  })
+})
+
+describe('validateConference — dates optional but paired and ordered', () => {
+  it('passes with both dates or neither', () => {
+    expect(validateConference(conference)).toEqual({})
+    expect(
+      validateConference({ ...conference, startDate: '', endDate: '' }),
+    ).toEqual({})
+  })
+
+  it('requires title, city and country', () => {
+    const errs = validateConference({
+      ...conference,
+      title: '',
+      city: '',
+      country: '',
+    })
+    expect(Object.keys(errs).sort()).toEqual(['city', 'country', 'title'])
+  })
+
+  it('rejects a lone date and a reversed range', () => {
+    expect(
+      validateConference({ ...conference, endDate: '' }).endDate,
+    ).toBeTruthy()
+    expect(
+      validateConference({ ...conference, startDate: '' }).startDate,
+    ).toBeTruthy()
+    expect(
+      validateConference({ ...conference, endDate: '2027-05-31' }).endDate,
+    ).toBeTruthy()
+  })
+})
+
+describe('domains — optional list', () => {
+  it('accepts an entirely empty list (tenants can start on none)', () => {
+    expect(domainsLocalErrors([''])).toEqual({})
+    expect(domainsComplete([''], [])).toBe(true)
+    expect(cleanDomains([''])).toEqual([])
+  })
+
+  it('still validates and dedupes typed entries', () => {
+    expect(
+      Object.keys(domainsLocalErrors(['not a hostname'])).length,
+    ).toBeGreaterThan(0)
+    expect(domainsComplete(['taken.example.com'], ['taken.example.com'])).toBe(
+      false,
+    )
+  })
+})
+
+describe('step gating', () => {
+  it('walks the four steps in order', () => {
+    expect(WIZARD_STEPS).toEqual([
+      'organization',
+      'conference',
+      'domains',
+      'review',
+    ])
+  })
+
+  it('gates each step on its own validation', () => {
+    expect(canProceed('organization', state, organizer, false, [])).toBe(true)
+    expect(
+      canProceed(
+        'organization',
+        { ...state, organization: { ...org, name: '' } },
+        organizer,
+        false,
+        [],
+      ),
+    ).toBe(false)
+    expect(
+      canProceed('organization', state, { name: '', email: '' }, false, []),
+    ).toBe(false)
+    expect(canProceed('conference', state, organizer, false, [])).toBe(true)
+    expect(canProceed('domains', state, organizer, false, [])).toBe(true)
+    expect(canProceed('review', state, organizer, false, [])).toBe(false)
+  })
+
+  it('a slug-taken verdict blocks the organization step', () => {
+    expect(canProceed('organization', state, organizer, true, [])).toBe(false)
+  })
+
+  it('canCreate requires every step to be complete', () => {
+    expect(canCreate(state, organizer, false, [])).toBe(true)
+    expect(canCreate(state, organizer, true, [])).toBe(false)
+    expect(
+      canCreate(
+        { ...state, conference: { ...conference, title: '' } },
+        organizer,
+        false,
+        [],
+      ),
+    ).toBe(false)
+    expect(
+      canCreate(
+        { ...state, domains: ['taken.example.com'] },
+        organizer,
+        false,
+        ['taken.example.com'],
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/components/admin/onboarding/wizardLogic.ts
+++ b/src/components/admin/onboarding/wizardLogic.ts
@@ -175,19 +175,28 @@ export function organizerComplete(o: OrganizerState): boolean {
   return Object.keys(validateOrganizer(o)).length === 0
 }
 
-/** Whether the wizard may advance FROM `step`. Review has no "next". */
+/**
+ * Whether the wizard may advance FROM `step`. Review has no "next".
+ *
+ * `organizerAmbiguous` mirrors the server's AMBIGUOUS_ORGANIZER_EMAIL rule
+ * (the probe's `matchCount > 1`): createOrganization deterministically rejects
+ * such an email, so the Organization step must not let the operator walk into
+ * a guaranteed failure — the duplicates have to be merged first.
+ */
 export function canProceed(
   step: WizardStepId,
   state: WizardState,
   organizer: OrganizerState,
   slugTaken: boolean,
   takenDomains: readonly string[],
+  organizerAmbiguous: boolean,
 ): boolean {
   switch (step) {
     case 'organization':
       return (
         organizationComplete(state.organization, slugTaken) &&
-        organizerComplete(organizer)
+        organizerComplete(organizer) &&
+        !organizerAmbiguous
       )
     case 'conference':
       return conferenceComplete(state.conference)
@@ -198,16 +207,18 @@ export function canProceed(
   }
 }
 
-/** The final gate on the Create button. */
+/** The final gate on the Create button (same ambiguity rule as `canProceed`). */
 export function canCreate(
   state: WizardState,
   organizer: OrganizerState,
   slugTaken: boolean,
   takenDomains: readonly string[],
+  organizerAmbiguous: boolean,
 ): boolean {
   return (
     organizationComplete(state.organization, slugTaken) &&
     organizerComplete(organizer) &&
+    !organizerAmbiguous &&
     conferenceComplete(state.conference) &&
     domainsComplete(state.domains, takenDomains)
   )

--- a/src/components/admin/onboarding/wizardLogic.ts
+++ b/src/components/admin/onboarding/wizardLogic.ts
@@ -1,0 +1,214 @@
+/**
+ * Pure, React-free step logic for the onboarding S2 "New organization"
+ * concierge wizard (RunKonf/platform#4). Kept separate from the component —
+ * mirroring the SE-5 new-edition wizard — so gating/validation is unit-testable
+ * without rendering internals.
+ */
+
+import {
+  validateStringList,
+  buildStringListPayload,
+} from '@/components/admin/editConferenceLists'
+import { ORG_SLUG_RE, slugifyOrganizationName } from '@/lib/onboarding/create'
+
+/** The four wizard steps, in order. The done screen replaces the wizard. */
+export const WIZARD_STEPS = [
+  'organization',
+  'conference',
+  'domains',
+  'review',
+] as const
+export type WizardStepId = (typeof WIZARD_STEPS)[number]
+
+export const WIZARD_STEP_TITLES: Record<WizardStepId, string> = {
+  organization: 'Organization',
+  conference: 'First conference',
+  domains: 'Domains',
+  review: 'Review & create',
+}
+
+export function stepIndex(id: WizardStepId): number {
+  return WIZARD_STEPS.indexOf(id)
+}
+
+export interface OrganizationState {
+  name: string
+  slug: string
+  /** Whether the operator has hand-edited the slug (stops auto-derivation). */
+  slugTouched: boolean
+  contactEmail: string
+  billingEmail: string
+}
+
+export interface ConferenceState {
+  title: string
+  city: string
+  country: string
+  startDate: string
+  endDate: string
+}
+
+export interface WizardState {
+  organization: OrganizationState
+  conference: ConferenceState
+  domains: string[]
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/** The slug shown for the current name until the operator edits it by hand. */
+export function derivedSlug(org: OrganizationState): string {
+  return org.slugTouched ? org.slug : slugifyOrganizationName(org.name)
+}
+
+/**
+ * Validate the Organization step. Name, slug and contact email are required;
+ * billing email is optional but must be well-formed when present. Server-side
+ * slug availability is layered on top via `slugTaken`.
+ */
+export function validateOrganization(
+  org: OrganizationState,
+  slugTaken: boolean,
+): Record<string, string> {
+  const errs: Record<string, string> = {}
+  const slug = derivedSlug(org)
+  if (org.name.trim() === '') errs.name = 'Organization name is required'
+  if (slug === '') errs.slug = 'Slug is required'
+  else if (!ORG_SLUG_RE.test(slug))
+    errs.slug =
+      'Use lowercase letters, digits and single dashes (no leading/trailing dash)'
+  else if (slugTaken) errs.slug = 'Already used by another organization'
+  if (org.contactEmail.trim() === '')
+    errs.contactEmail = 'Contact email is required'
+  else if (!EMAIL_RE.test(org.contactEmail.trim()))
+    errs.contactEmail = 'Enter a valid email address'
+  if (org.billingEmail.trim() !== '' && !EMAIL_RE.test(org.billingEmail.trim()))
+    errs.billingEmail = 'Enter a valid email address'
+  return errs
+}
+
+/**
+ * Validate the First-conference step. Title, city and country are required;
+ * dates are OPTIONAL but travel as an ordered pair (a single-day event sets
+ * both to the same date).
+ */
+export function validateConference(c: ConferenceState): Record<string, string> {
+  const errs: Record<string, string> = {}
+  if (c.title.trim() === '') errs.title = 'Conference title is required'
+  if (c.city.trim() === '') errs.city = 'City is required'
+  if (c.country.trim() === '') errs.country = 'Country is required'
+  if (c.startDate !== '' && !DATE_RE.test(c.startDate))
+    errs.startDate = 'Invalid date'
+  if (c.endDate !== '' && !DATE_RE.test(c.endDate))
+    errs.endDate = 'Invalid date'
+  if (!errs.startDate && !errs.endDate) {
+    if (Boolean(c.startDate) !== Boolean(c.endDate)) {
+      errs[c.startDate ? 'endDate' : 'startDate'] =
+        'Provide both dates, or neither'
+    } else if (c.startDate && c.endDate && c.endDate < c.startDate) {
+      errs.endDate = 'End date must be on or after the start date'
+    }
+  }
+  return errs
+}
+
+/**
+ * Local (shape) validation for the OPTIONAL domain list: blank rows are
+ * ignored and an entirely empty list is VALID (a tenant can start on no domain
+ * and attach one later). Global uniqueness is a server concern layered on via
+ * `takenDomains`.
+ */
+export function domainsLocalErrors(domains: string[]): Record<string, string> {
+  return validateStringList(
+    {
+      name: 'domains',
+      itemType: 'hostname',
+      itemLabel: 'domain',
+      allowEmptyList: true,
+    },
+    domains,
+  )
+}
+
+/** The cleaned, deduped domain payload sent to the server (may be empty). */
+export function cleanDomains(domains: string[]): string[] {
+  return buildStringListPayload(domains).map((d) => d.trim().toLowerCase())
+}
+
+export function organizationComplete(
+  org: OrganizationState,
+  slugTaken: boolean,
+): boolean {
+  return Object.keys(validateOrganization(org, slugTaken)).length === 0
+}
+
+export function conferenceComplete(c: ConferenceState): boolean {
+  return Object.keys(validateConference(c)).length === 0
+}
+
+export function domainsComplete(
+  domains: string[],
+  takenDomains: readonly string[],
+): boolean {
+  if (Object.keys(domainsLocalErrors(domains)).length > 0) return false
+  const taken = new Set(takenDomains.map((d) => d.trim().toLowerCase()))
+  return cleanDomains(domains).every((d) => !taken.has(d))
+}
+
+/** Organizer identity (asked on the Organization step alongside the org). */
+export interface OrganizerState {
+  name: string
+  email: string
+}
+
+export function validateOrganizer(o: OrganizerState): Record<string, string> {
+  const errs: Record<string, string> = {}
+  if (o.name.trim() === '') errs.organizerName = 'Organizer name is required'
+  if (o.email.trim() === '') errs.organizerEmail = 'Organizer email is required'
+  else if (!EMAIL_RE.test(o.email.trim()))
+    errs.organizerEmail = 'Enter a valid email address'
+  return errs
+}
+
+export function organizerComplete(o: OrganizerState): boolean {
+  return Object.keys(validateOrganizer(o)).length === 0
+}
+
+/** Whether the wizard may advance FROM `step`. Review has no "next". */
+export function canProceed(
+  step: WizardStepId,
+  state: WizardState,
+  organizer: OrganizerState,
+  slugTaken: boolean,
+  takenDomains: readonly string[],
+): boolean {
+  switch (step) {
+    case 'organization':
+      return (
+        organizationComplete(state.organization, slugTaken) &&
+        organizerComplete(organizer)
+      )
+    case 'conference':
+      return conferenceComplete(state.conference)
+    case 'domains':
+      return domainsComplete(state.domains, takenDomains)
+    case 'review':
+      return false
+  }
+}
+
+/** The final gate on the Create button. */
+export function canCreate(
+  state: WizardState,
+  organizer: OrganizerState,
+  slugTaken: boolean,
+  takenDomains: readonly string[],
+): boolean {
+  return (
+    organizationComplete(state.organization, slugTaken) &&
+    organizerComplete(organizer) &&
+    conferenceComplete(state.conference) &&
+    domainsComplete(state.domains, takenDomains)
+  )
+}

--- a/src/components/admin/onboarding/wizardLogic.ts
+++ b/src/components/admin/onboarding/wizardLogic.ts
@@ -78,6 +78,8 @@ export function validateOrganization(
   else if (!ORG_SLUG_RE.test(slug))
     errs.slug =
       'Use lowercase letters, digits and single dashes (no leading/trailing dash)'
+  else if (slug.length > 96)
+    errs.slug = 'Keep the slug at 96 characters or fewer'
   else if (slugTaken) errs.slug = 'Already used by another organization'
   if (org.contactEmail.trim() === '')
     errs.contactEmail = 'Contact email is required'

--- a/src/lib/authz/platform.test.ts
+++ b/src/lib/authz/platform.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the PLATFORM-OPERATOR gate (onboarding S1). This guards
+ * cross-tenant creation, so it is deliberately STRICTER than the tenant waist:
+ * no legacy-token bridge (the deprecated global `isOrganizer` never grants),
+ * and fail-closed on every unresolvable input (env unset, unknown slug,
+ * transient read failure).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  fetch: vi.fn<(query: string, params?: unknown) => Promise<unknown>>(),
+}))
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: h.fetch },
+}))
+
+import {
+  resolvePlatformOrgSlug,
+  getPlatformOrgId,
+  isPlatformOperatorForOrg,
+  isPlatformOperator,
+} from './platform'
+
+const PLATFORM_ORG_ID = 'org-platform'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.PLATFORM_ORG_SLUG = 'runkonf'
+  h.fetch.mockResolvedValue(PLATFORM_ORG_ID)
+})
+
+afterEach(() => {
+  delete process.env.PLATFORM_ORG_SLUG
+})
+
+describe('resolvePlatformOrgSlug', () => {
+  it('returns the trimmed slug, or null when unset/blank', () => {
+    expect(resolvePlatformOrgSlug()).toBe('runkonf')
+    process.env.PLATFORM_ORG_SLUG = '  '
+    expect(resolvePlatformOrgSlug()).toBeNull()
+    delete process.env.PLATFORM_ORG_SLUG
+    expect(resolvePlatformOrgSlug()).toBeNull()
+  })
+})
+
+describe('getPlatformOrgId', () => {
+  it('resolves the org id by slug', async () => {
+    await expect(getPlatformOrgId()).resolves.toBe(PLATFORM_ORG_ID)
+    expect(h.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('slug.current'),
+      {
+        slug: 'runkonf',
+      },
+    )
+  })
+
+  it('returns null without querying when the env is unset', async () => {
+    delete process.env.PLATFORM_ORG_SLUG
+    await expect(getPlatformOrgId()).resolves.toBeNull()
+    expect(h.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns null on an unknown slug or a transient read failure', async () => {
+    h.fetch.mockResolvedValueOnce(null)
+    await expect(getPlatformOrgId()).resolves.toBeNull()
+    h.fetch.mockRejectedValueOnce(new Error('boom'))
+    await expect(getPlatformOrgId()).resolves.toBeNull()
+  })
+})
+
+describe('isPlatformOperatorForOrg — the pure decision', () => {
+  it('grants a modern token whose organizerOrgIds contains the platform org', () => {
+    expect(
+      isPlatformOperatorForOrg(
+        { _id: 'sp-1', organizerOrgIds: ['org-other', PLATFORM_ORG_ID] },
+        PLATFORM_ORG_ID,
+      ),
+    ).toBe(true)
+  })
+
+  it('denies an organizer of only OTHER orgs', () => {
+    expect(
+      isPlatformOperatorForOrg(
+        { _id: 'sp-1', organizerOrgIds: ['org-other'] },
+        PLATFORM_ORG_ID,
+      ),
+    ).toBe(false)
+  })
+
+  it('denies a LEGACY token even with the deprecated global flag set (no bridge)', () => {
+    expect(
+      isPlatformOperatorForOrg(
+        { _id: 'sp-1', isOrganizer: true } as never,
+        PLATFORM_ORG_ID,
+      ),
+    ).toBe(false)
+  })
+
+  it('fails closed on a null platform org or missing speaker', () => {
+    expect(
+      isPlatformOperatorForOrg(
+        { _id: 'sp-1', organizerOrgIds: [PLATFORM_ORG_ID] },
+        null,
+      ),
+    ).toBe(false)
+    expect(isPlatformOperatorForOrg(null, PLATFORM_ORG_ID)).toBe(false)
+    expect(isPlatformOperatorForOrg(undefined, PLATFORM_ORG_ID)).toBe(false)
+  })
+})
+
+describe('isPlatformOperator — the request-level check', () => {
+  it('grants a platform-org organizer', async () => {
+    await expect(
+      isPlatformOperator({ _id: 'sp-1', organizerOrgIds: [PLATFORM_ORG_ID] }),
+    ).resolves.toBe(true)
+  })
+
+  it('denies when the env is not configured (surface disabled)', async () => {
+    delete process.env.PLATFORM_ORG_SLUG
+    await expect(
+      isPlatformOperator({ _id: 'sp-1', organizerOrgIds: [PLATFORM_ORG_ID] }),
+    ).resolves.toBe(false)
+  })
+})

--- a/src/lib/authz/platform.ts
+++ b/src/lib/authz/platform.ts
@@ -1,0 +1,84 @@
+import 'server-only'
+import type { Speaker } from '@/lib/speaker/types'
+import { clientReadUncached } from '@/lib/sanity/client'
+
+/**
+ * PLATFORM-OPERATOR authorization (onboarding S1/S2, RunKonf/platform#4).
+ *
+ * Tenant creation is a CONCIERGE, platform-operator-only surface: there is no
+ * public signup and no billing entity yet, so the operator creates tenants on
+ * behalf of new organizations. Until a first-class platform-org concept lands
+ * (with the entitlements work), the platform org is designated by ENV:
+ * `PLATFORM_ORG_SLUG` names the organization whose organizers ARE the platform
+ * operators.
+ *
+ * THE MODEL. A caller is a platform operator iff their session token's
+ * `organizerOrgIds` contains the id of the org whose `slug.current` equals
+ * `PLATFORM_ORG_SLUG`. This is deliberately STRICTER than the tenant-admin
+ * waist (`isOrganizerForOrg`):
+ *
+ *   - NO legacy-token bridge: a pre-#635 token (no `organizerOrgIds`) is DENIED
+ *     even when the deprecated global `isOrganizer` flag is set — that flag is
+ *     true for an organizer of ANY org and must never mint cross-tenant
+ *     creation powers. Operators on legacy tokens simply re-login once.
+ *   - FAIL CLOSED on every unresolvable input: env unset, org slug not found,
+ *     transient read failure → deny.
+ */
+
+/** The minimum shape the platform check reads off a session speaker. */
+type PlatformSpeaker = Pick<Speaker, '_id' | 'organizerOrgIds'>
+
+/** The configured platform-org slug, or `null` when the surface is disabled. */
+export function resolvePlatformOrgSlug(): string | null {
+  const slug = process.env.PLATFORM_ORG_SLUG?.trim()
+  return slug ? slug : null
+}
+
+/**
+ * Resolve the platform organization's document id from `PLATFORM_ORG_SLUG`, or
+ * `null` (env unset / unknown slug / transient failure — all deny downstream).
+ * Uncached read: this guards a rare, high-privilege surface, so staleness is a
+ * worse trade than a fetch per call.
+ */
+export async function getPlatformOrgId(): Promise<string | null> {
+  const slug = resolvePlatformOrgSlug()
+  if (!slug) return null
+  try {
+    const id = await clientReadUncached.fetch<string | null>(
+      // groq-global: the platform org is resolved by its configured slug, not from the request domain — the operator may be on any admin host.
+      `*[_type == "organization" && slug.current == $slug][0]._id`,
+      { slug },
+    )
+    return id ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * PURE platform-operator decision for an already-resolved platform org id.
+ * STRICT membership only — no legacy-token bridge, fail closed on `null`.
+ */
+export function isPlatformOperatorForOrg(
+  speaker: PlatformSpeaker | null | undefined,
+  platformOrgId: string | null,
+): boolean {
+  if (!speaker?._id || !platformOrgId) return false
+  return (
+    Array.isArray(speaker.organizerOrgIds) &&
+    speaker.organizerOrgIds.includes(platformOrgId)
+  )
+}
+
+/**
+ * Async platform-operator check for the CURRENT request: resolves the platform
+ * org from `PLATFORM_ORG_SLUG` and applies {@link isPlatformOperatorForOrg}.
+ * Shared by the tRPC onboarding gate and the /admin/platform page gate.
+ */
+export async function isPlatformOperator(
+  speaker: PlatformSpeaker | null | undefined,
+): Promise<boolean> {
+  if (!speaker?._id) return false
+  const platformOrgId = await getPlatformOrgId()
+  return isPlatformOperatorForOrg(speaker, platformOrgId)
+}

--- a/src/lib/conference/domains.test.ts
+++ b/src/lib/conference/domains.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the shared domain-routing predicates (SE-1b). Pins the ONE rule
+ * both the routing GROQ and every claim/strand guard must agree on: an entry
+ * serves a host exactly, or via its single-label wildcard form — and the
+ * claim-uniqueness predicate `domainEntriesOverlap` applies that rule in BOTH
+ * directions so no two tenants can ever route the same host.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  domainServesHost,
+  domainEntriesOverlap,
+  wildcardFormForHost,
+} from './domains'
+
+describe('wildcardFormForHost', () => {
+  it('wildcards the first label of a 3+-label host', () => {
+    expect(wildcardFormForHost('foo.example.com')).toBe('*.example.com')
+    expect(wildcardFormForHost('a.b.example.com')).toBe('*.b.example.com')
+  })
+
+  it('returns null for hosts with nothing to wildcard', () => {
+    expect(wildcardFormForHost('example.com')).toBeNull()
+    expect(wildcardFormForHost('localhost:3000')).toBeNull()
+  })
+})
+
+describe('domainServesHost', () => {
+  it('matches exactly and via the single-label wildcard', () => {
+    expect(domainServesHost('example.com', 'example.com')).toBe(true)
+    expect(domainServesHost('*.example.com', 'foo.example.com')).toBe(true)
+    expect(domainServesHost('*.example.com', 'bar.example.com')).toBe(true)
+  })
+
+  it('does NOT match deeper subdomains or the apex through a wildcard', () => {
+    expect(domainServesHost('*.example.com', 'a.b.example.com')).toBe(false)
+    expect(domainServesHost('*.example.com', 'example.com')).toBe(false)
+    expect(domainServesHost('other.com', 'example.com')).toBe(false)
+  })
+})
+
+describe('domainEntriesOverlap — the claim-uniqueness predicate', () => {
+  it('overlaps on equality (exact and wildcard entries alike)', () => {
+    expect(domainEntriesOverlap('example.com', 'example.com')).toBe(true)
+    expect(domainEntriesOverlap('*.example.com', '*.example.com')).toBe(true)
+  })
+
+  it('an existing wildcard overlaps a new host under it (direction 1)', () => {
+    expect(domainEntriesOverlap('*.example.com', 'sub.example.com')).toBe(true)
+  })
+
+  it('a new wildcard overlaps an existing host it would capture (direction 2)', () => {
+    expect(domainEntriesOverlap('sub.example.com', '*.example.com')).toBe(true)
+  })
+
+  it('distinct wildcards and unrelated hosts do not overlap', () => {
+    expect(domainEntriesOverlap('*.example.com', '*.example.org')).toBe(false)
+    // Single-label semantics: *.example.com never serves a.b.example.com.
+    expect(domainEntriesOverlap('*.example.com', '*.b.example.com')).toBe(false)
+    expect(domainEntriesOverlap('a.example.com', 'b.example.com')).toBe(false)
+    // The apex is NOT covered by its wildcard (≤2 labels have no wildcard form).
+    expect(domainEntriesOverlap('*.example.com', 'example.com')).toBe(false)
+  })
+
+  it('is normalization-tolerant like the routing matcher', () => {
+    expect(domainEntriesOverlap('*.Example.com ', 'sub.example.COM')).toBe(true)
+  })
+})

--- a/src/lib/conference/domains.ts
+++ b/src/lib/conference/domains.ts
@@ -64,6 +64,18 @@ export function domainServesHost(entry: string, host: string): boolean {
 }
 
 /**
+ * True when two `domains[]` entries could ever route the SAME request host —
+ * they are equal, or one is the single-label wildcard that covers the other
+ * (`*.example.com` overlaps `sub.example.com`, in BOTH directions). This is the
+ * claim-uniqueness predicate: a new entry may only be claimed when it overlaps
+ * NO existing entry, otherwise `getConferenceForDomain` (exact-or-wildcard, see
+ * {@link domainServesHost}) could resolve a host to the wrong tenant.
+ */
+export function domainEntriesOverlap(a: string, b: string): boolean {
+  return domainServesHost(a, b) || domainServesHost(b, a)
+}
+
+/**
  * True when NONE of the entries would serve `host` — i.e. saving this list would
  * strand the current request. The server guard rejects such a payload and the
  * client disables removing the last serving row.

--- a/src/lib/onboarding/create.test.ts
+++ b/src/lib/onboarding/create.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the onboarding S1 pure document builder — the blank-start
+ * tenant defaults are contractual: unlisted, registration closed, empty
+ * formats/topics, comms funneled to the org contact address, and NO
+ * plan/billing fields (the org schema excludes them until billing lands).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildOnboardingDocuments,
+  slugifyOrganizationName,
+  ORG_SLUG_RE,
+  type OnboardingInput,
+} from './create'
+
+function input(overrides: Partial<OnboardingInput> = {}): OnboardingInput {
+  return {
+    organization: {
+      name: 'Cloud Native Oslo',
+      slug: 'cloud-native-oslo',
+      contactEmail: 'hello@cno.no',
+    },
+    conference: {
+      title: 'Cloud Native Days Oslo 2027',
+      city: 'Oslo',
+      country: 'Norway',
+      startDate: '2027-06-01',
+      endDate: '2027-06-02',
+    },
+    organizer: { name: 'Kari Nordmann', email: 'kari@cno.no' },
+    domains: ['oslo.cloudnativedays.no'],
+    ...overrides,
+  }
+}
+
+let keyCounter = 0
+const ids = () => ({
+  organizationId: 'organization-1',
+  conferenceId: 'conference-1',
+  speakerId: 'speaker-1',
+  mintKey: () => `key-${++keyCounter}`,
+})
+
+describe('slugifyOrganizationName', () => {
+  it('normalizes punctuation, case and edge dashes', () => {
+    expect(slugifyOrganizationName('  Cloud Native Oslo!  ')).toBe(
+      'cloud-native-oslo',
+    )
+    expect(slugifyOrganizationName('--Æøå x--')).toBe('x')
+    expect(ORG_SLUG_RE.test(slugifyOrganizationName('A  B__C'))).toBe(true)
+  })
+})
+
+describe('buildOnboardingDocuments — organization', () => {
+  it('builds the org doc with slug object and no billing email when unset', () => {
+    const { organization } = buildOnboardingDocuments(input(), ids(), null)
+    expect(organization).toMatchObject({
+      _id: 'organization-1',
+      _type: 'organization',
+      name: 'Cloud Native Oslo',
+      slug: { _type: 'slug', current: 'cloud-native-oslo' },
+      contactEmail: 'hello@cno.no',
+    })
+    expect(organization).not.toHaveProperty('billingEmail')
+    // NO plan/entitlement fields until the billing issue lands.
+    expect(organization).not.toHaveProperty('plan')
+  })
+
+  it('carries the billing email when provided', () => {
+    const { organization } = buildOnboardingDocuments(
+      input({
+        organization: {
+          name: 'X',
+          slug: 'x',
+          contactEmail: 'a@b.co',
+          billingEmail: 'billing@b.co',
+        },
+      }),
+      ids(),
+      null,
+    )
+    expect(organization.billingEmail).toBe('billing@b.co')
+  })
+})
+
+describe('buildOnboardingDocuments — conference defaults', () => {
+  it('is born unlisted, registration closed, org-owned, with comms defaulted', () => {
+    const { conference } = buildOnboardingDocuments(input(), ids(), null)
+    expect(conference).toMatchObject({
+      _type: 'conference',
+      title: 'Cloud Native Days Oslo 2027',
+      organization: { _type: 'reference', _ref: 'organization-1' },
+      organizer: 'Cloud Native Oslo',
+      city: 'Oslo',
+      country: 'Norway',
+      startDate: '2027-06-01',
+      endDate: '2027-06-02',
+      contactEmail: 'hello@cno.no',
+      cfpEmail: 'hello@cno.no',
+      sponsorEmail: 'hello@cno.no',
+      registrationEnabled: false,
+      visibility: 'unlisted',
+      domains: ['oslo.cloudnativedays.no'],
+    })
+    // Empty-safe CFP config: the activation checklist fills these later.
+    expect(conference).not.toHaveProperty('formats')
+    expect(conference).not.toHaveProperty('topics')
+  })
+
+  it('omits dates and domains entirely when not provided', () => {
+    const { conference } = buildOnboardingDocuments(
+      input({
+        conference: { title: 'T', city: 'C', country: 'N' },
+        domains: [],
+      }),
+      ids(),
+      null,
+    )
+    expect(conference).not.toHaveProperty('startDate')
+    expect(conference).not.toHaveProperty('endDate')
+    expect(conference).not.toHaveProperty('domains')
+  })
+
+  it('normalizes and drops blank domains', () => {
+    const { conference } = buildOnboardingDocuments(
+      input({ domains: [' Oslo.Example.COM ', ''] }),
+      ids(),
+      null,
+    )
+    expect(conference.domains).toEqual(['oslo.example.com'])
+  })
+})
+
+describe('buildOnboardingDocuments — organizer membership', () => {
+  it('creates a speaker carrying the org membership when none exists', () => {
+    const { conference, speaker } = buildOnboardingDocuments(
+      input(),
+      ids(),
+      null,
+    )
+    expect(speaker).toMatchObject({
+      _id: 'speaker-1',
+      _type: 'speaker',
+      name: 'Kari Nordmann',
+      email: 'kari@cno.no',
+      organizations: [
+        {
+          _type: 'reference',
+          _ref: 'organization-1',
+          _key: 'organization-1',
+        },
+      ],
+    })
+    const organizers = conference.organizers as Array<{ _ref: string }>
+    expect(organizers).toHaveLength(1)
+    expect(organizers[0]._ref).toBe('speaker-1')
+  })
+
+  it('references the EXISTING speaker and creates no new one when matched', () => {
+    const { conference, speaker } = buildOnboardingDocuments(
+      input(),
+      ids(),
+      'speaker-existing',
+    )
+    expect(speaker).toBeNull()
+    const organizers = conference.organizers as Array<{
+      _ref: string
+      _key: string
+    }>
+    expect(organizers[0]._ref).toBe('speaker-existing')
+    expect(organizers[0]._key).toBeTruthy()
+  })
+})

--- a/src/lib/onboarding/create.ts
+++ b/src/lib/onboarding/create.ts
@@ -1,0 +1,174 @@
+/**
+ * Onboarding S1 — pure, dependency-light building blocks for the CONCIERGE
+ * organization-creation flow (RunKonf/platform#4, first slice).
+ *
+ * WHAT THIS IS: the platform operator (not public signup — no billing entity
+ * exists yet) creates a brand-new TENANT: one `organization` document, that
+ * org's FIRST `conference` document, and the organizer membership for a named
+ * user — all in ONE Sanity transaction (see `onboarding.createOrganization`).
+ *
+ * These builders are React-free and Sanity-client-free so they can be
+ * unit-tested directly and reused by the server mutation AND the wizard UI.
+ * They mirror the SE-5 edition builder (`@/lib/conference/edition`) — but where
+ * the edition wizard CLONES an existing edition's structure, this one starts
+ * from BLANK with sane defaults:
+ *
+ *   - `visibility: 'unlisted'` — a new tenant is NEVER publicly discoverable
+ *     on creation (absent-means-live, see `@/lib/conference/visibility`).
+ *   - `registrationEnabled: false` — registration never opens on creation.
+ *   - `formats` / `topics` are LEFT EMPTY (the admin surfaces are empty-safe);
+ *     the activation checklist walks the new organizer through filling them.
+ *   - conference contact/CFP/sponsor emails default to the org contact email.
+ *   - NO plan/billing fields: the organization schema deliberately excludes
+ *     them until the billing issue lands (see `sanity/schemaTypes/organization.ts`).
+ */
+
+import { normalizeDomain } from '@/lib/conference/domains'
+
+/** Same normalization as the organization schema's `slugify` (and the 044
+ * backfill migration) — strip punctuation and edge dashes, not just whitespace. */
+export function slugifyOrganizationName(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 96)
+}
+
+/** A valid stored org slug: kebab-case alphanumeric, no edge/double dashes. */
+export const ORG_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+export interface OnboardingOrganizationInput {
+  name: string
+  slug: string
+  contactEmail: string
+  billingEmail?: string | null
+}
+
+export interface OnboardingConferenceInput {
+  title: string
+  city: string
+  country: string
+  /** Optional — a concierge tenant may not have dates yet; the activation
+   * checklist prompts for them later. */
+  startDate?: string | null
+  endDate?: string | null
+}
+
+export interface OnboardingOrganizerInput {
+  name: string
+  /** Normalized (lowercased/trimmed) by the caller. */
+  email: string
+}
+
+export interface OnboardingInput {
+  organization: OnboardingOrganizationInput
+  conference: OnboardingConferenceInput
+  organizer: OnboardingOrganizerInput
+  /** Optional at creation — a tenant can start on NO domain and attach one
+   * later from settings; until then the conference simply doesn't route. */
+  domains: string[]
+}
+
+/** A brand-new Sanity document stub (always carries an `_id` + `_type`). */
+export type NewDocument = Record<string, unknown> & {
+  _id: string
+  _type: string
+}
+
+export interface BuildOnboardingResult {
+  organization: NewDocument
+  conference: NewDocument
+  /**
+   * The speaker document to CREATE for the named organizer — `null` when an
+   * existing speaker was matched (the mutation then PATCHES that speaker's org
+   * membership in the same transaction instead).
+   */
+  speaker: NewDocument | null
+}
+
+/**
+ * Build the tenant's documents. PURE: takes pre-minted ids and a key minter so
+ * tests are deterministic and the server passes real generators. When
+ * `existingSpeakerId` is set, the organizer membership references THAT speaker
+ * and no new speaker document is produced.
+ */
+export function buildOnboardingDocuments(
+  input: OnboardingInput,
+  ids: {
+    organizationId: string
+    conferenceId: string
+    /** Used only when no existing speaker matched. */
+    speakerId: string
+    mintKey: () => string
+  },
+  existingSpeakerId: string | null,
+): BuildOnboardingResult {
+  const { organizationId, conferenceId, speakerId, mintKey } = ids
+  const org = input.organization
+  const conf = input.conference
+
+  const organization: NewDocument = {
+    _id: organizationId,
+    _type: 'organization',
+    name: org.name,
+    slug: { _type: 'slug', current: org.slug },
+    contactEmail: org.contactEmail,
+    ...(org.billingEmail ? { billingEmail: org.billingEmail } : {}),
+    // NO plan/entitlement fields: the org schema is intentionally lean until
+    // the billing issue lands — do not add them here speculatively.
+  }
+
+  const organizerSpeakerId = existingSpeakerId ?? speakerId
+
+  const speaker: NewDocument | null = existingSpeakerId
+    ? null
+    : {
+        _id: speakerId,
+        _type: 'speaker',
+        name: input.organizer.name,
+        // The login flow auto-links this account on the new organizer's FIRST
+        // sign-in via verified-email intersection (`lower(email) in $emails`,
+        // see getOrCreateSpeaker) and backfills the slug then.
+        email: input.organizer.email,
+        organizations: [
+          { _type: 'reference', _ref: organizationId, _key: organizationId },
+        ],
+      }
+
+  const domains = input.domains.map(normalizeDomain).filter((d) => d !== '')
+
+  const conference: NewDocument = {
+    _id: conferenceId,
+    _type: 'conference',
+    title: conf.title,
+    // Tenant ownership (CaaS T1-1): the first edition belongs to the new org.
+    organization: { _type: 'reference', _ref: organizationId },
+    // The organizing body defaults to the organization's display name.
+    organizer: org.name,
+    city: conf.city,
+    country: conf.country,
+    ...(conf.startDate ? { startDate: conf.startDate } : {}),
+    ...(conf.endDate ? { endDate: conf.endDate } : {}),
+    // Sane comms defaults: everything funnels to the org contact address until
+    // the tenant configures real ones from settings.
+    contactEmail: org.contactEmail,
+    cfpEmail: org.contactEmail,
+    sponsorEmail: org.contactEmail,
+    // The named user is the FIRST organizer — this membership is what makes
+    // `organizerOrgIds` (and thus /admin access) light up at their next login.
+    organizers: [
+      { _type: 'reference', _ref: organizerSpeakerId, _key: mintKey() },
+    ],
+    ...(domains.length > 0 ? { domains } : {}),
+    // A new tenant NEVER opens registration or gets discovered on creation:
+    // absent-means-live, so the explicit 'unlisted' is required.
+    registrationEnabled: false,
+    visibility: 'unlisted',
+    // formats/topics are deliberately ABSENT (empty-safe): the activation
+    // checklist walks the organizer through CFP configuration.
+  }
+
+  return { organization, conference, speaker }
+}

--- a/src/server/_app.ts
+++ b/src/server/_app.ts
@@ -18,6 +18,7 @@ import { notificationRouter } from './routers/notification'
 import { pushRouter } from './routers/push'
 import { messageRouter } from './routers/message'
 import { conferenceRouter } from './routers/conference'
+import { onboardingRouter } from './routers/onboarding'
 import { topicRouter } from './routers/topic'
 import { staffRouter } from './routers/staff'
 import { sponsorMessagesRouter } from './routers/sponsorMessages'
@@ -42,6 +43,7 @@ export const appRouter = router({
   push: pushRouter,
   message: messageRouter,
   conference: conferenceRouter,
+  onboarding: onboardingRouter,
   topic: topicRouter,
   staff: staffRouter,
   sponsorMessages: sponsorMessagesRouter,

--- a/src/server/routers/onboarding.test.ts
+++ b/src/server/routers/onboarding.test.ts
@@ -215,6 +215,37 @@ describe('createOrganization — server-side uniqueness authority', () => {
     expect(commitMock).not.toHaveBeenCalled()
   })
 
+  it('rejects a domain that an existing WILDCARD entry would capture (routing overlap, not just equality)', async () => {
+    claimedDomains = ['*.cloudnativedays.no']
+    const err = await makeCaller(operator)
+      .createOrganization(input({ domains: ['oslo.cloudnativedays.no'] }))
+      .catch((e) => e)
+    expect(err).toMatchObject({ code: 'BAD_REQUEST' })
+    expect(err.message).toContain(DOMAIN_ALREADY_CLAIMED)
+    expect(err.message).toContain('oslo.cloudnativedays.no')
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a WILDCARD that would capture an existing exact host (reverse overlap)', async () => {
+    claimedDomains = ['oslo.cloudnativedays.no']
+    const err = await makeCaller(operator)
+      .createOrganization(input({ domains: ['*.cloudnativedays.no'] }))
+      .catch((e) => e)
+    expect(err).toMatchObject({ code: 'BAD_REQUEST' })
+    expect(err.message).toContain(DOMAIN_ALREADY_CLAIMED)
+    expect(err.message).toContain('*.cloudnativedays.no')
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('skips the claimed-domains read entirely for a domainless tenant', async () => {
+    await makeCaller(operator).createOrganization(input({ domains: [] }))
+    expect(commitMock).toHaveBeenCalledTimes(1)
+    const domainQueries = fetchMock.mock.calls.filter(([q]) =>
+      (q as string).includes('.domains[]'),
+    )
+    expect(domainQueries).toEqual([])
+  })
+
   it('refuses an organizer email matching SEVERAL accounts (duplicates first)', async () => {
     speakerMatches = [{ _id: 'sp-a' }, { _id: 'sp-b' }]
     const err = await makeCaller(operator)
@@ -352,6 +383,24 @@ describe('validateSetup — preflight probe', () => {
       takenDomains: ['taken.example.com'],
       organizer: { matchCount: 1, match: { name: 'Kari' } },
     })
+  })
+
+  it('flags wildcard-overlapping domains as taken (same matcher as routing)', async () => {
+    claimedDomains = ['*.example.com', 'bergen.cloudnative.no']
+    const result = await makeCaller(operator).validateSetup({
+      domains: ['sub.example.com', '*.cloudnative.no', 'free.example.org'],
+    })
+    // sub.example.com is captured by the existing *.example.com; the requested
+    // *.cloudnative.no would capture the existing bergen.cloudnative.no.
+    expect(result.takenDomains).toEqual(['sub.example.com', '*.cloudnative.no'])
+  })
+
+  it('skips the claimed-domains read when no domains are probed', async () => {
+    await makeCaller(operator).validateSetup({ slug: 'some-slug' })
+    const domainQueries = fetchMock.mock.calls.filter(([q]) =>
+      (q as string).includes('.domains[]'),
+    )
+    expect(domainQueries).toEqual([])
   })
 
   it('hides names on an ambiguous match', async () => {

--- a/src/server/routers/onboarding.test.ts
+++ b/src/server/routers/onboarding.test.ts
@@ -1,0 +1,367 @@
+/**
+ * @vitest-environment node
+ *
+ * Router tests for onboarding S1 (`onboarding.createOrganization` +
+ * `onboarding.validateSetup`). Pins the three contracts the concierge flow
+ * lives by:
+ *
+ *   1. AUTHZ — platform-operator only: strict membership in the configured
+ *      platform org; tenant organizers, legacy tokens and unconfigured envs
+ *      are all DENIED before any read/write happens.
+ *   2. ATOMICITY — org + conference + speaker(create/patch) ride ONE Sanity
+ *      transaction; a commit failure surfaces INTERNAL_SERVER_ERROR and no
+ *      document is written outside the transaction.
+ *   3. GLOBAL uniqueness — org slug and domains are validated server-side
+ *      (BAD_REQUEST, nothing written), and an ambiguous organizer email
+ *      (duplicate accounts) is refused rather than silently picked from.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+const PLATFORM_ORG_ID = 'org-platform'
+
+// Sanity read fan-out, routed by query shape.
+let orgSlugCount = 0
+let claimedDomains: string[] = ['cloudnativebergen.no']
+let speakerMatches: Array<{ _id: string; name?: string }> = []
+let platformOrgId: string | null = PLATFORM_ORG_ID
+
+const fetchMock = vi.fn(async (query: string) => {
+  if (query.includes('_type == "organization"') && query.includes('count('))
+    return orgSlugCount
+  if (query.includes('_type == "organization"')) return platformOrgId
+  if (query.includes('.domains[]')) return claimedDomains
+  if (query.includes('_type == "speaker"')) return speakerMatches
+  throw new Error(`Unexpected query: ${query}`)
+})
+
+const createSpy = vi.fn()
+const patchSpy = vi.fn()
+const commitMock = vi.fn().mockResolvedValue({})
+
+function makePatchRecorder(id: string) {
+  const ops: Array<{ op: string; args: unknown[] }> = []
+  const p = {
+    setIfMissing: (...args: unknown[]) => {
+      ops.push({ op: 'setIfMissing', args })
+      return p
+    },
+    insert: (...args: unknown[]) => {
+      ops.push({ op: 'insert', args })
+      return p
+    },
+  }
+  return { p, done: () => patchSpy(id, ops) }
+}
+
+function makeTransaction() {
+  const tx = {
+    create: (doc: unknown) => {
+      createSpy(doc)
+      return tx
+    },
+    patch: (id: string, fn: (p: unknown) => unknown) => {
+      const rec = makePatchRecorder(id)
+      fn(rec.p)
+      rec.done()
+      return tx
+    },
+    commit: () => commitMock(),
+  }
+  return tx
+}
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { transaction: () => makeTransaction() },
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => fetchMock(args[0] as string),
+  },
+}))
+
+import {
+  onboardingRouter,
+  ORG_SLUG_ALREADY_TAKEN,
+  AMBIGUOUS_ORGANIZER_EMAIL,
+} from './onboarding'
+import { DOMAIN_ALREADY_CLAIMED } from './conference'
+
+type CallerSpeaker = {
+  _id: string
+  organizerOrgIds?: string[]
+  isOrganizer?: boolean
+} | null
+
+function makeCaller(speaker: CallerSpeaker) {
+  const ctx = {
+    session: speaker ? { speaker, user: { name: 'U' } } : null,
+    speaker: speaker ?? undefined,
+  } as unknown as Context
+  return onboardingRouter.createCaller(ctx)
+}
+
+const operator: CallerSpeaker = {
+  _id: 'sp-op',
+  organizerOrgIds: [PLATFORM_ORG_ID],
+}
+
+function input(overrides: Record<string, unknown> = {}) {
+  return {
+    organization: {
+      name: 'Cloud Native Oslo',
+      slug: 'cloud-native-oslo',
+      contactEmail: 'hello@cno.no',
+    },
+    conference: {
+      title: 'Cloud Native Days Oslo 2027',
+      city: 'Oslo',
+      country: 'Norway',
+      startDate: '2027-06-01',
+      endDate: '2027-06-02',
+    },
+    organizer: { name: 'Kari Nordmann', email: 'Kari@CNO.no' },
+    domains: ['oslo.cloudnativedays.no'],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.PLATFORM_ORG_SLUG = 'runkonf'
+  orgSlugCount = 0
+  claimedDomains = ['cloudnativebergen.no']
+  speakerMatches = []
+  platformOrgId = PLATFORM_ORG_ID
+  commitMock.mockResolvedValue({})
+})
+
+afterEach(() => {
+  delete process.env.PLATFORM_ORG_SLUG
+})
+
+describe('createOrganization — authorization (platform waist)', () => {
+  it('denies an unauthenticated caller (UNAUTHORIZED)', async () => {
+    await expect(
+      makeCaller(null).createOrganization(input()),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
+  it("denies another tenant's organizer (FORBIDDEN)", async () => {
+    await expect(
+      makeCaller({
+        _id: 'sp-tenant',
+        organizerOrgIds: ['org-other'],
+      }).createOrganization(input()),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('denies a LEGACY token even with the deprecated global organizer flag', async () => {
+    await expect(
+      makeCaller({ _id: 'sp-legacy', isOrganizer: true }).createOrganization(
+        input(),
+      ),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+
+  it('denies everyone when PLATFORM_ORG_SLUG is not configured', async () => {
+    delete process.env.PLATFORM_ORG_SLUG
+    await expect(
+      makeCaller(operator).createOrganization(input()),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+
+  it('denies when the configured slug resolves to no organization', async () => {
+    platformOrgId = null
+    await expect(
+      makeCaller(operator).createOrganization(input()),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+
+  it('gates validateSetup behind the same waist', async () => {
+    await expect(
+      makeCaller({
+        _id: 'sp-tenant',
+        organizerOrgIds: ['org-other'],
+      }).validateSetup({ slug: 'x' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+})
+
+describe('createOrganization — server-side uniqueness authority', () => {
+  it('rejects a taken org slug (BAD_REQUEST, named) and writes nothing', async () => {
+    orgSlugCount = 1
+    const err = await makeCaller(operator)
+      .createOrganization(input())
+      .catch((e) => e)
+    expect(err).toMatchObject({ code: 'BAD_REQUEST' })
+    expect(err.message).toContain(ORG_SLUG_ALREADY_TAKEN)
+    expect(err.message).toContain('cloud-native-oslo')
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a domain claimed by ANY conference (BAD_REQUEST, named)', async () => {
+    claimedDomains = ['oslo.cloudnativedays.no']
+    const err = await makeCaller(operator)
+      .createOrganization(input())
+      .catch((e) => e)
+    expect(err).toMatchObject({ code: 'BAD_REQUEST' })
+    expect(err.message).toContain(DOMAIN_ALREADY_CLAIMED)
+    expect(err.message).toContain('oslo.cloudnativedays.no')
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses an organizer email matching SEVERAL accounts (duplicates first)', async () => {
+    speakerMatches = [{ _id: 'sp-a' }, { _id: 'sp-b' }]
+    const err = await makeCaller(operator)
+      .createOrganization(input())
+      .catch((e) => e)
+    expect(err).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: AMBIGUOUS_ORGANIZER_EMAIL,
+    })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('createOrganization — atomic transaction', () => {
+  it('creates org + conference + NEW speaker in one committed transaction', async () => {
+    const result = await makeCaller(operator).createOrganization(input())
+
+    expect(commitMock).toHaveBeenCalledTimes(1)
+    expect(createSpy).toHaveBeenCalledTimes(3)
+    expect(patchSpy).not.toHaveBeenCalled()
+
+    const docs = createSpy.mock.calls.map((c) => c[0])
+    const org = docs.find((d) => d._type === 'organization')
+    const conf = docs.find((d) => d._type === 'conference')
+    const speaker = docs.find((d) => d._type === 'speaker')
+
+    expect(org).toMatchObject({
+      name: 'Cloud Native Oslo',
+      slug: { current: 'cloud-native-oslo' },
+    })
+    expect(org).not.toHaveProperty('plan')
+    expect(conf).toMatchObject({
+      visibility: 'unlisted',
+      registrationEnabled: false,
+      organization: { _ref: org._id },
+      domains: ['oslo.cloudnativedays.no'],
+    })
+    // The normalized (lowercased) email is stored for verified-email linking.
+    expect(speaker).toMatchObject({ email: 'kari@cno.no' })
+    expect(conf.organizers).toEqual([
+      expect.objectContaining({ _ref: speaker._id }),
+    ])
+
+    expect(result).toMatchObject({
+      organizationId: org._id,
+      conferenceId: conf._id,
+      speakerId: speaker._id,
+      speakerCreated: true,
+      organizerMatchedName: null,
+    })
+  })
+
+  it('PATCHES the matched existing speaker instead of creating one', async () => {
+    speakerMatches = [{ _id: 'sp-existing', name: 'Kari Nordmann' }]
+    const result = await makeCaller(operator).createOrganization(input())
+
+    expect(commitMock).toHaveBeenCalledTimes(1)
+    expect(createSpy).toHaveBeenCalledTimes(2) // org + conference only
+    expect(patchSpy).toHaveBeenCalledTimes(1)
+
+    const [patchedId, ops] = patchSpy.mock.calls[0]
+    expect(patchedId).toBe('sp-existing')
+    expect(ops).toEqual([
+      { op: 'setIfMissing', args: [{ organizations: [] }] },
+      {
+        op: 'insert',
+        args: [
+          'after',
+          'organizations[-1]',
+          [expect.objectContaining({ _type: 'reference' })],
+        ],
+      },
+    ])
+
+    const conf = createSpy.mock.calls
+      .map((c) => c[0])
+      .find((d) => d._type === 'conference')
+    expect(conf.organizers).toEqual([
+      expect.objectContaining({ _ref: 'sp-existing' }),
+    ])
+    expect(result).toMatchObject({
+      speakerId: 'sp-existing',
+      speakerCreated: false,
+      organizerMatchedName: 'Kari Nordmann',
+    })
+  })
+
+  it('maps a commit failure to INTERNAL_SERVER_ERROR (all-or-nothing rollback)', async () => {
+    commitMock.mockRejectedValueOnce(new Error('sanity down'))
+    await expect(
+      makeCaller(operator).createOrganization(input()),
+    ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' })
+    // Everything rode the ONE transaction — no writes happen outside it, so a
+    // failed commit means nothing was persisted.
+    expect(commitMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts a tenant with NO domains and omits the field', async () => {
+    await makeCaller(operator).createOrganization(input({ domains: [] }))
+    const conf = createSpy.mock.calls
+      .map((c) => c[0])
+      .find((d) => d._type === 'conference')
+    expect(conf).not.toHaveProperty('domains')
+  })
+
+  it('rejects a lone start date (dates travel as a pair) before any read', async () => {
+    await expect(
+      makeCaller(operator).createOrganization(
+        input({
+          conference: {
+            title: 'T',
+            city: 'C',
+            country: 'N',
+            startDate: '2027-06-01',
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('validateSetup — preflight probe', () => {
+  it('reports slug availability, taken domains and the organizer match', async () => {
+    orgSlugCount = 1
+    claimedDomains = ['taken.example.com']
+    speakerMatches = [{ _id: 'sp-1', name: 'Kari' }]
+    const result = await makeCaller(operator).validateSetup({
+      slug: 'cloud-native-oslo',
+      domains: ['taken.example.com', 'free.example.com'],
+      organizerEmail: 'kari@cno.no',
+    })
+    expect(result).toEqual({
+      slugTaken: true,
+      takenDomains: ['taken.example.com'],
+      organizer: { matchCount: 1, match: { name: 'Kari' } },
+    })
+  })
+
+  it('hides names on an ambiguous match', async () => {
+    speakerMatches = [
+      { _id: 'sp-1', name: 'A' },
+      { _id: 'sp-2', name: 'B' },
+    ]
+    const result = await makeCaller(operator).validateSetup({
+      organizerEmail: 'kari@cno.no',
+    })
+    expect(result.organizer).toEqual({ matchCount: 2, match: null })
+  })
+})

--- a/src/server/routers/onboarding.ts
+++ b/src/server/routers/onboarding.ts
@@ -1,0 +1,233 @@
+import { TRPCError } from '@trpc/server'
+import { revalidateTag } from 'next/cache'
+import { router, protectedProcedure } from '../trpc'
+import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
+import { generateKey } from '@/lib/sanity/helpers'
+import {
+  getPlatformOrgId,
+  isPlatformOperatorForOrg,
+} from '@/lib/authz/platform'
+import { normalizeDomain } from '@/lib/conference/domains'
+import { buildOnboardingDocuments } from '@/lib/onboarding/create'
+import {
+  CreateOrganizationSchema,
+  ValidateOnboardingSchema,
+} from '../schemas/onboarding'
+import { DOMAIN_ALREADY_CLAIMED } from './conference'
+
+/** Message prefix when the organization slug is already taken. */
+export const ORG_SLUG_ALREADY_TAKEN = 'Already used by another organization'
+
+/** Message when the organizer email matches SEVERAL speaker accounts. */
+export const AMBIGUOUS_ORGANIZER_EMAIL =
+  'That email matches multiple speaker accounts — resolve the duplicates before onboarding this organizer'
+
+/**
+ * PLATFORM-OPERATOR gate (onboarding S1). Layered on `protectedProcedure`
+ * (authentication) exactly like `requireAdmin` layers the tenant waist — but
+ * the org checked is the CONFIGURED platform org (`PLATFORM_ORG_SLUG`), never
+ * the request domain's: tenant creation is cross-tenant by nature and must not
+ * be reachable by an arbitrary tenant's organizers. STRICT check, fail closed
+ * (see `@/lib/authz/platform`).
+ */
+const platformProcedure = protectedProcedure.use(async ({ ctx, next }) => {
+  const platformOrgId = await getPlatformOrgId()
+  if (!isPlatformOperatorForOrg(ctx.session?.speaker, platformOrgId)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Platform operator privileges required',
+    })
+  }
+  return next({ ctx: { ...ctx, platformOrgId: platformOrgId! } })
+})
+
+/** Every domain claimed by ANY conference, normalized (global uniqueness). */
+async function fetchClaimedDomains(): Promise<Set<string>> {
+  const all = await clientReadUncached.fetch<string[] | null>(
+    // groq-global: domain uniqueness is a GLOBAL routing invariant across every tenant's conferences (same rule as SE-5 createEdition).
+    `*[_type == "conference" && defined(domains)].domains[]`,
+    {},
+  )
+  return new Set((all ?? []).map(normalizeDomain))
+}
+
+/** Whether an organization already claims this slug. */
+async function isOrgSlugTaken(slug: string): Promise<boolean> {
+  const count = await clientReadUncached.fetch<number>(
+    // groq-global: org slugs are a GLOBAL namespace (they identify tenants).
+    `count(*[_type == "organization" && slug.current == $slug])`,
+    { slug },
+  )
+  return (count ?? 0) > 0
+}
+
+interface SpeakerMatch {
+  _id: string
+  name?: string
+}
+
+/**
+ * Speakers whose stored VERIFIED match-set (display `email` or `knownEmails`,
+ * both verified-owned — see `getOrCreateSpeaker`'s stored-side-verified
+ * invariant) contains the given normalized email. Oldest-first, bounded, so the
+ * caller can deterministically pick a single match and detect duplicates.
+ */
+async function findSpeakersByEmail(email: string): Promise<SpeakerMatch[]> {
+  const speakers = await clientReadUncached.fetch<SpeakerMatch[] | null>(
+    // groq-global: identity is a global person — the named organizer may already exist as a speaker of any tenant's conference (#615).
+    `*[_type == "speaker" && (lower(email) == $email || count((knownEmails[])[lower(@) == $email]) > 0)] | order(_createdAt asc) [0...5] { _id, name }`,
+    { email },
+  )
+  return speakers ?? []
+}
+
+/**
+ * Onboarding S1 (RunKonf/platform#4) — the CONCIERGE tenant-creation API.
+ * Platform-operator only; there is no public signup surface.
+ */
+export const onboardingRouter = router({
+  /**
+   * Preflight probe for the wizard's inline feedback: org-slug availability,
+   * globally-claimed domains among the typed ones, and whether the organizer
+   * email resolves to an existing speaker account (or ambiguously to several).
+   * Read-only.
+   */
+  validateSetup: platformProcedure
+    .input(ValidateOnboardingSchema)
+    .query(async ({ input }) => {
+      const [slugTaken, claimed, matches] = await Promise.all([
+        input.slug ? isOrgSlugTaken(input.slug) : Promise.resolve(false),
+        input.domains && input.domains.length > 0
+          ? fetchClaimedDomains()
+          : Promise.resolve(new Set<string>()),
+        input.organizerEmail
+          ? findSpeakersByEmail(input.organizerEmail)
+          : Promise.resolve([] as SpeakerMatch[]),
+      ])
+
+      const taken = (input.domains ?? []).filter((d) => claimed.has(d))
+
+      return {
+        slugTaken,
+        takenDomains: taken,
+        organizer: {
+          matchCount: matches.length,
+          // Only the unambiguous single match is surfaced by name.
+          match:
+            matches.length === 1 ? { name: matches[0].name ?? null } : null,
+        },
+      }
+    }),
+
+  /**
+   * Create a NEW TENANT: organization + first conference + organizer
+   * membership for the named user — ALL-OR-NOTHING in one Sanity transaction
+   * (a failure writes NOTHING; the wizard is simply re-runnable).
+   *
+   * SERVER-SIDE AUTHORITY (the wizard only mirrors these):
+   *   - org slug must be globally unique among organizations;
+   *   - every domain must be globally unclaimed (same rule as SE-5 — a
+   *     duplicate would silently steal another tenant's routing);
+   *   - the organizer email must resolve to AT MOST one existing speaker; on
+   *     several matches the duplicate accounts must be merged first
+   *     (BAD_REQUEST) — silently picking one risks binding the tenant to the
+   *     wrong person.
+   *
+   * MEMBERSHIP MECHANICS: an existing speaker is PATCHED (org membership
+   * appended) in the same transaction; a brand-new speaker document is created
+   * carrying the membership, and the login flow auto-links the person's first
+   * sign-in to it via verified-email intersection, then `organizerOrgIds`
+   * (derived from `conference.organizers[]`) grants them /admin.
+   *
+   * DEFAULTS: visibility 'unlisted', registration closed, empty formats/
+   * topics, comms emails funneled to the org contact address — see
+   * `buildOnboardingDocuments`. NO plan/entitlement fields are set (the org
+   * schema deliberately excludes billing until that issue lands).
+   */
+  createOrganization: platformProcedure
+    .input(CreateOrganizationSchema)
+    .mutation(async ({ input }) => {
+      const [slugTaken, claimedDomains, speakerMatches] = await Promise.all([
+        isOrgSlugTaken(input.organization.slug),
+        fetchClaimedDomains(),
+        findSpeakersByEmail(input.organizer.email),
+      ])
+
+      if (slugTaken) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `${ORG_SLUG_ALREADY_TAKEN}: ${input.organization.slug}`,
+        })
+      }
+
+      const taken = input.domains.filter((d) => claimedDomains.has(d))
+      if (taken.length > 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `${DOMAIN_ALREADY_CLAIMED}: ${taken.join(', ')}`,
+        })
+      }
+
+      if (speakerMatches.length > 1) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: AMBIGUOUS_ORGANIZER_EMAIL,
+        })
+      }
+      const existingSpeaker = speakerMatches[0] ?? null
+
+      const { organization, conference, speaker } = buildOnboardingDocuments(
+        input,
+        {
+          organizationId: generateKey('organization'),
+          conferenceId: generateKey('conference'),
+          speakerId: generateKey('speaker'),
+          mintKey: () => generateKey('key'),
+        },
+        existingSpeaker?._id ?? null,
+      )
+
+      try {
+        let tx = clientWrite
+          .transaction()
+          .create(organization)
+          .create(conference)
+        if (speaker) {
+          tx = tx.create(speaker)
+        } else if (existingSpeaker) {
+          // The org is brand-new, so the membership cannot already exist —
+          // an unconditional append is safe and stays inside the transaction.
+          tx = tx.patch(existingSpeaker._id, (p) =>
+            p
+              .setIfMissing({ organizations: [] })
+              .insert('after', 'organizations[-1]', [
+                {
+                  _type: 'reference',
+                  _ref: organization._id,
+                  _key: organization._id,
+                },
+              ]),
+          )
+        }
+        await tx.commit()
+      } catch (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to create the organization',
+          cause: error,
+        })
+      }
+
+      // A new conference document exists; bust the shared conferences tag so
+      // domain resolution can see it once its domain actually routes here.
+      revalidateTag('content:conferences', 'default')
+
+      return {
+        organizationId: organization._id,
+        conferenceId: conference._id,
+        speakerId: speaker?._id ?? existingSpeaker!._id,
+        speakerCreated: speaker !== null,
+        organizerMatchedName: existingSpeaker?.name ?? null,
+      }
+    }),
+})

--- a/src/server/routers/onboarding.ts
+++ b/src/server/routers/onboarding.ts
@@ -7,7 +7,11 @@ import {
   getPlatformOrgId,
   isPlatformOperatorForOrg,
 } from '@/lib/authz/platform'
-import { normalizeDomain } from '@/lib/conference/domains'
+import {
+  normalizeDomain,
+  wildcardFormForHost,
+  domainEntriesOverlap,
+} from '@/lib/conference/domains'
 import { buildOnboardingDocuments } from '@/lib/onboarding/create'
 import {
   CreateOrganizationSchema,
@@ -41,14 +45,53 @@ const platformProcedure = protectedProcedure.use(async ({ ctx, next }) => {
   return next({ ctx: { ...ctx, platformOrgId: platformOrgId! } })
 })
 
-/** Every domain claimed by ANY conference, normalized (global uniqueness). */
-async function fetchClaimedDomains(): Promise<Set<string>> {
-  const all = await clientReadUncached.fetch<string[] | null>(
+/**
+ * The subset of `requested` domains that would collide with an entry some
+ * conference already claims — under the ROUTING matcher's semantics (exact OR
+ * single-label wildcard, {@link domainEntriesOverlap}), NOT mere string
+ * equality: requesting `sub.example.com` collides with an existing
+ * `*.example.com` (the wildcard already serves that host), and requesting
+ * `*.example.com` collides with an existing `sub.example.com` (the new
+ * wildcard would capture the existing host). Either direction misroutes
+ * traffic across tenants, so both are refused.
+ *
+ * BOUNDED: only conferences whose entries could possibly overlap are read
+ * (the wizard's 400ms-debounced validateSetup calls this repeatedly) —
+ *   - `$probes` catches entries EQUAL to a requested domain or to its wildcard
+ *     form (an existing wildcard covering a requested host);
+ *   - the `match` clauses PRUNE for existing hosts under a requested wildcard
+ *     by suffix tokens (`*.example.com` → entries containing `example.com`'s
+ *     tokens — a superset of the true conflicts, never a miss, since a
+ *     conflicting `<label>.example.com` always carries every suffix token).
+ * The GROQ only narrows; the shared JS predicate is the authority.
+ */
+async function findConflictingDomains(requested: string[]): Promise<string[]> {
+  if (requested.length === 0) return []
+
+  const probes = new Set<string>()
+  const params: Record<string, unknown> = {}
+  const clauses = ['@ in $probes']
+  for (const domain of requested) {
+    probes.add(domain)
+    const wildcard = wildcardFormForHost(domain)
+    if (wildcard) probes.add(wildcard)
+    if (domain.startsWith('*.')) {
+      const param = `base${clauses.length - 1}`
+      params[param] = domain.slice(2)
+      clauses.push(`@ match $${param}`)
+    }
+  }
+  params.probes = [...probes]
+
+  const candidates = await clientReadUncached.fetch<string[] | null>(
     // groq-global: domain uniqueness is a GLOBAL routing invariant across every tenant's conferences (same rule as SE-5 createEdition).
-    `*[_type == "conference" && defined(domains)].domains[]`,
-    {},
+    `*[_type == "conference" && count(domains[${clauses.join(' || ')}]) > 0].domains[]`,
+    params,
   )
-  return new Set((all ?? []).map(normalizeDomain))
+  const claimed = (candidates ?? []).map(normalizeDomain)
+  return requested.filter((r) =>
+    claimed.some((entry) => domainEntriesOverlap(entry, r)),
+  )
 }
 
 /** Whether an organization already claims this slug. */
@@ -95,17 +138,14 @@ export const onboardingRouter = router({
   validateSetup: platformProcedure
     .input(ValidateOnboardingSchema)
     .query(async ({ input }) => {
-      const [slugTaken, claimed, matches] = await Promise.all([
+      const [slugTaken, taken, matches] = await Promise.all([
         input.slug ? isOrgSlugTaken(input.slug) : Promise.resolve(false),
-        input.domains && input.domains.length > 0
-          ? fetchClaimedDomains()
-          : Promise.resolve(new Set<string>()),
+        // Skips the read entirely for an empty list (returns []).
+        findConflictingDomains(input.domains ?? []),
         input.organizerEmail
           ? findSpeakersByEmail(input.organizerEmail)
           : Promise.resolve([] as SpeakerMatch[]),
       ])
-
-      const taken = (input.domains ?? []).filter((d) => claimed.has(d))
 
       return {
         slugTaken,
@@ -126,8 +166,10 @@ export const onboardingRouter = router({
    *
    * SERVER-SIDE AUTHORITY (the wizard only mirrors these):
    *   - org slug must be globally unique among organizations;
-   *   - every domain must be globally unclaimed (same rule as SE-5 — a
-   *     duplicate would silently steal another tenant's routing);
+   *   - every domain must be globally unclaimed under the ROUTING matcher's
+   *     semantics — exact OR single-label wildcard, in both directions
+   *     ({@link findConflictingDomains}) — an overlap would silently steal
+   *     another tenant's routing;
    *   - the organizer email must resolve to AT MOST one existing speaker; on
    *     several matches the duplicate accounts must be merged first
    *     (BAD_REQUEST) — silently picking one risks binding the tenant to the
@@ -147,9 +189,12 @@ export const onboardingRouter = router({
   createOrganization: platformProcedure
     .input(CreateOrganizationSchema)
     .mutation(async ({ input }) => {
-      const [slugTaken, claimedDomains, speakerMatches] = await Promise.all([
+      const [slugTaken, taken, speakerMatches] = await Promise.all([
         isOrgSlugTaken(input.organization.slug),
-        fetchClaimedDomains(),
+        // Overlap-aware (exact OR wildcard, both directions) and SKIPPED
+        // outright for a domainless tenant — that path must not depend on a
+        // global read it doesn't need.
+        findConflictingDomains(input.domains),
         findSpeakersByEmail(input.organizer.email),
       ])
 
@@ -160,7 +205,6 @@ export const onboardingRouter = router({
         })
       }
 
-      const taken = input.domains.filter((d) => claimedDomains.has(d))
       if (taken.length > 0) {
         throw new TRPCError({
           code: 'BAD_REQUEST',

--- a/src/server/schemas/onboarding.ts
+++ b/src/server/schemas/onboarding.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod'
+import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
+import { ORG_SLUG_RE } from '@/lib/onboarding/create'
+
+/**
+ * Onboarding S1 — input schemas for the platform-operator concierge flow
+ * (`src/server/routers/onboarding.ts`). Mirrors the SE-5 `CreateEditionSchema`
+ * conventions; the ONE deliberate divergence is that `domains` may be EMPTY —
+ * a new tenant can start on no domain and attach one later from settings.
+ */
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+const dateString = z
+  .string()
+  .regex(DATE_RE, 'Date must be in YYYY-MM-DD format')
+const optionalDateString = dateString.nullable().optional()
+
+const emailString = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .email('Enter a valid email address')
+
+/** Kebab-case org slug, matching the organization schema's slugify output. */
+const orgSlug = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .min(1, 'Slug is required')
+  .max(96, 'Slug must be at most 96 characters')
+  .regex(
+    ORG_SLUG_RE,
+    'Use lowercase letters, digits and single dashes (no leading/trailing dash)',
+  )
+
+/**
+ * OPTIONAL domain list (may be empty, unlike `NewEditionDomains`): entries are
+ * normalized, must be valid bare hostnames and unique within the payload.
+ * GLOBAL uniqueness (claimed by another conference) is enforced in the router.
+ */
+const OptionalDomains = z
+  .array(z.string())
+  .transform((list) => list.map(normalizeDomain))
+  .superRefine((list, ctx) => {
+    const seen = new Set<string>()
+    list.forEach((entry, i) => {
+      if (entry === '') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Domain cannot be empty',
+          path: [i],
+        })
+        return
+      }
+      if (!isValidDomainEntry(entry)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Enter a bare hostname, e.g. conference.example.com',
+          path: [i],
+        })
+        return
+      }
+      if (seen.has(entry)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Duplicate domain',
+          path: [i],
+        })
+        return
+      }
+      seen.add(entry)
+    })
+  })
+
+export const CreateOrganizationSchema = z
+  .object({
+    organization: z.object({
+      name: z.string().trim().min(1, 'Organization name is required'),
+      slug: orgSlug,
+      contactEmail: emailString,
+      billingEmail: emailString.nullable().optional(),
+    }),
+    conference: z.object({
+      title: z.string().trim().min(1, 'Conference title is required'),
+      city: z.string().trim().min(1, 'City is required'),
+      country: z.string().trim().min(1, 'Country is required'),
+      startDate: optionalDateString,
+      endDate: optionalDateString,
+    }),
+    organizer: z.object({
+      name: z.string().trim().min(1, 'Organizer name is required'),
+      email: emailString,
+    }),
+    domains: OptionalDomains,
+  })
+  .refine(
+    (d) =>
+      !d.conference.startDate ||
+      !d.conference.endDate ||
+      d.conference.endDate >= d.conference.startDate,
+    {
+      message: 'End date must be on or after the start date',
+      path: ['conference', 'endDate'],
+    },
+  )
+  // Dates travel as a pair: one without the other is almost certainly a slip
+  // (a single-day event should set both to the same date).
+  .refine(
+    (d) => Boolean(d.conference.startDate) === Boolean(d.conference.endDate),
+    {
+      message: 'Provide both start and end dates, or neither',
+      path: ['conference', 'endDate'],
+    },
+  )
+
+/** Preflight probe for the wizard's inline availability feedback. */
+export const ValidateOnboardingSchema = z.object({
+  slug: orgSlug.optional(),
+  domains: OptionalDomains.optional(),
+  organizerEmail: emailString.optional(),
+})


### PR DESCRIPTION
First slice of RunKonf/platform#4 — the CONCIERGE onboarding path (deliberately not public signup; that waits for the legal-entity/billing gates).

## S1 — atomic organization creation

- `createOrganization` tRPC mutation: ONE Sanity transaction creating the organization + first conference + organizer membership (or patching membership onto a verified-email-matched existing speaker). Commit failure → nothing written.
- `validateSetup` preflight: org-slug global uniqueness, globally-claimed domain detection, organizer-email matching — with BAD_REQUEST on an email matching more than one speaker (dedup-first, per the speaker-identity discipline).
- Defaults: `visibility: 'unlisted'`, registration disabled, contact/cfp/sponsor emails funneled to the org contact email. Domains may be empty at creation (tenants can start domainless).

## S2 — the wizard

- `/admin/platform/new-organization`: platform-operator-only page flow — Organization → First conference → Domains (optional) → Review → Done, handing off to the new conference's activation checklist.
- Gate: `PLATFORM_ORG_SLUG` env names the platform org; strict `organizerOrgIds` membership, fail-closed (surface is disabled until the env var is set — **set `PLATFORM_ORG_SLUG` in Vercel to enable**). No legacy-token bridge on this surface.
- Slug auto-derives from the name until touched; debounced preflight with stale-response guards; inline account-match feedback.

## Notes

- TODO for the entitlements PR: set `plan: 'community'` + empty `featureOverrides` in the creation defaults once that schema lands (it wasn't merged when this branched).
- 49 new tests (atomicity, authz denial matrix incl. env-unset fail-closed, uniqueness/ambiguity with zero writes, wizard step validation); full suite 335 files / 4368 tests green; tsc/eslint/prettier/knip clean; all five wizard screens visually inspected at mobile viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C