### PR TITLE
feat(org): per-org feature entitlements — plan, registry, resolver, requireFeature

### DIFF
--- a/sanity/schemaTypes/organization.ts
+++ b/sanity/schemaTypes/organization.ts
@@ -10,8 +10,10 @@ import { defineField, defineType } from 'sanity'
  * `organization` reference back to exactly one of these.
  *
  * SCOPE (T1-1): this document is intentionally LEAN — identity + branding +
- * contact only. Billing/plan fields arrive with the billing issue; do not add
- * them here speculatively.
+ * contact, plus the entitlement pair below (`plan` + `featureOverrides`, the
+ * feature-entitlements foundation). Billing mechanics (invoicing, payment
+ * state) still arrive with the billing issue; do not add them here
+ * speculatively.
  */
 export default defineType({
   name: 'organization',
@@ -72,6 +74,87 @@ export default defineType({
       type: 'inlineSvg',
       description:
         'Optional inline SVG logo for the organization (same mechanism as conference branding).',
+    }),
+    // Feature entitlements: the plan sets the baseline of GA features; the
+    // overrides are explicit per-feature grants/denials that always win over
+    // the plan. Resolution semantics live in `src/lib/features/registry.ts` +
+    // `entitlements.ts`. ABSENT plan resolves to `community`, so legacy orgs
+    // are unaffected without a migration.
+    defineField({
+      name: 'plan',
+      title: 'Plan',
+      type: 'string',
+      description:
+        'Commercial tier of this organization. Determines which generally-available features are enabled by default; leave unset to default to Community.',
+      options: {
+        list: [
+          { title: 'Community', value: 'community' },
+          { title: 'Pro', value: 'pro' },
+          { title: 'Enterprise', value: 'enterprise' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'community',
+    }),
+    defineField({
+      name: 'featureOverrides',
+      title: 'Feature Overrides',
+      type: 'array',
+      description:
+        'Explicit per-feature grants or denials that take precedence over the plan (beta/internal opt-ins, pilot grants, temporary revocations). Feature ids must match the code registry in src/lib/features/registry.ts; overrides past their expiry are ignored.',
+      of: [
+        {
+          type: 'object',
+          name: 'featureOverride',
+          title: 'Feature Override',
+          fields: [
+            defineField({
+              name: 'feature',
+              title: 'Feature',
+              type: 'string',
+              description:
+                'Feature id from the code registry (e.g. "graphql-api").',
+              validation: (Rule) => Rule.required(),
+            }),
+            defineField({
+              name: 'enabled',
+              title: 'Enabled',
+              type: 'boolean',
+              description:
+                'On grants the feature regardless of plan; off revokes it regardless of plan.',
+              initialValue: true,
+              validation: (Rule) => Rule.required(),
+            }),
+            defineField({
+              name: 'note',
+              title: 'Note',
+              type: 'string',
+              description:
+                'Optional audit note — why this override exists (e.g. "beta cohort 2").',
+            }),
+            defineField({
+              name: 'expiresAt',
+              title: 'Expires At',
+              type: 'datetime',
+              description:
+                'Optional expiry; after this instant the override is ignored entirely.',
+            }),
+          ],
+          preview: {
+            select: {
+              title: 'feature',
+              enabled: 'enabled',
+              note: 'note',
+            },
+            prepare({ title, enabled, note }) {
+              return {
+                title: `${title ?? '(unset)'} — ${enabled ? 'enabled' : 'disabled'}`,
+                subtitle: note,
+              }
+            },
+          },
+        },
+      ],
     }),
     // Legal identity (go-live gate G2, #643): drives the tenant's /privacy and
     // /terms pages. ABSENT resolves to Norway + Datatilsynet (the existing

--- a/src/app/(admin)/admin/settings/PlanFeaturesCard.stories.tsx
+++ b/src/app/(admin)/admin/settings/PlanFeaturesCard.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { PlanFeaturesCard } from './PlanFeaturesCard'
+
+/**
+ * Read-only "Plan & Features" settings card: the current org's plan badge plus
+ * its entitled features with readiness chips. Rows mirror what the server page
+ * derives via `listEntitledFeatures` — a community org with no overrides shows
+ * the empty state, a pro org shows its GA entitlements, and override-granted
+ * beta/internal features carry the extra "Override" chip.
+ */
+const meta = {
+  title: 'Systems/Settings/Admin/PlanFeaturesCard',
+  component: PlanFeaturesCard,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-gray-50 p-4 sm:p-6 dark:bg-gray-950">
+        <div className="mx-auto max-w-xl">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof PlanFeaturesCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const CommunityEmpty: Story = {
+  args: {
+    plan: 'community',
+    features: [],
+  },
+}
+
+export const ProPlan: Story = {
+  args: {
+    plan: 'pro',
+    features: [
+      {
+        id: 'dedicated-email',
+        title: 'Dedicated email sending',
+        description:
+          "Outbound email from the organization's own verified sender domain instead of the shared platform sender.",
+        readiness: 'ga',
+        viaOverride: false,
+      },
+    ],
+  },
+}
+
+export const EnterpriseWithOverrides: Story = {
+  args: {
+    plan: 'enterprise',
+    features: [
+      {
+        id: 'dedicated-email',
+        title: 'Dedicated email sending',
+        description:
+          "Outbound email from the organization's own verified sender domain instead of the shared platform sender.",
+        readiness: 'ga',
+        viaOverride: false,
+      },
+      {
+        id: 'graphql-api',
+        title: 'GraphQL API',
+        description:
+          'Programmatic read access to conference content over a public GraphQL endpoint.',
+        readiness: 'internal',
+        viaOverride: true,
+      },
+      {
+        id: 'slack-mirror',
+        title: 'Slack mirroring',
+        description:
+          "Mirror speaker and sponsor conversations into the organization's Slack workspace.",
+        readiness: 'internal',
+        viaOverride: true,
+      },
+    ],
+  },
+}

--- a/src/app/(admin)/admin/settings/PlanFeaturesCard.tsx
+++ b/src/app/(admin)/admin/settings/PlanFeaturesCard.tsx
@@ -1,0 +1,102 @@
+import { SparklesIcon } from '@heroicons/react/24/outline'
+import { StatusBadge, type BadgeColor } from '@/components/StatusBadge'
+import type { OrganizationPlan } from '@/lib/organization/types'
+import type { FeatureReadiness } from '@/lib/features/registry'
+import { InfoCard } from './settingsLayout'
+
+/**
+ * Read-only "Plan & Features" card for the CURRENT organization: the org's
+ * plan as a badge plus the features it is entitled to (title + readiness
+ * chip), per the resolver in `src/lib/features/entitlements.ts`. Presentational
+ * — the server settings page resolves the entitlements and passes rows in, so
+ * the card is renderable in Storybook for visual QA. There is deliberately no
+ * edit affordance: plans and overrides are managed by the platform org (the
+ * `PlatformOrgManager` card / `platform` router), not by the tenant itself.
+ */
+
+export interface PlanFeatureRow {
+  id: string
+  title: string
+  description: string
+  readiness: FeatureReadiness
+  /** Entitled through an explicit override rather than the plan. */
+  viaOverride: boolean
+}
+
+export interface PlanFeaturesCardProps {
+  plan: OrganizationPlan
+  features: PlanFeatureRow[]
+}
+
+const PLAN_BADGES: Record<
+  OrganizationPlan,
+  { label: string; color: BadgeColor }
+> = {
+  community: { label: 'Community', color: 'gray' },
+  pro: { label: 'Pro', color: 'blue' },
+  enterprise: { label: 'Enterprise', color: 'purple' },
+}
+
+const READINESS_BADGES: Record<
+  FeatureReadiness,
+  { label: string; color: BadgeColor }
+> = {
+  ga: { label: 'GA', color: 'green' },
+  beta: { label: 'Beta', color: 'yellow' },
+  internal: { label: 'Internal', color: 'gray' },
+}
+
+export function PlanFeaturesCard({ plan, features }: PlanFeaturesCardProps) {
+  const planBadge = PLAN_BADGES[plan]
+  return (
+    <InfoCard title="Plan & Features" icon={SparklesIcon}>
+      <div
+        id="plan-features"
+        className="flex scroll-mt-24 items-center justify-between gap-3 border-b border-gray-200 py-2 dark:border-gray-700"
+      >
+        <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+          Plan
+        </dt>
+        <dd className="min-w-0 text-right text-sm">
+          <StatusBadge label={planBadge.label} color={planBadge.color} />
+        </dd>
+      </div>
+
+      {features.length === 0 ? (
+        <p className="pt-1 text-sm text-gray-500 dark:text-gray-400">
+          No optional features are enabled for this organization.
+        </p>
+      ) : (
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+          {features.map((feature) => {
+            const readiness = READINESS_BADGES[feature.readiness]
+            return (
+              <li key={feature.id} className="py-2">
+                {/* Badges share the TITLE row only; the description spans the
+                    full card width below so a wide badge stack cannot squeeze
+                    it into a one-word-per-line column. */}
+                <div className="flex items-center justify-between gap-3">
+                  <p className="min-w-0 text-sm font-medium text-gray-900 dark:text-white">
+                    {feature.title}
+                  </p>
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    {feature.viaOverride ? (
+                      <StatusBadge label="Override" color="orange" />
+                    ) : null}
+                    <StatusBadge
+                      label={readiness.label}
+                      color={readiness.color}
+                    />
+                  </div>
+                </div>
+                <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+                  {feature.description}
+                </p>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </InfoCard>
+  )
+}

--- a/src/app/(admin)/admin/settings/PlanFeaturesCard.tsx
+++ b/src/app/(admin)/admin/settings/PlanFeaturesCard.tsx
@@ -54,12 +54,17 @@ export function PlanFeaturesCard({ plan, features }: PlanFeaturesCardProps) {
         id="plan-features"
         className="flex scroll-mt-24 items-center justify-between gap-3 border-b border-gray-200 py-2 dark:border-gray-700"
       >
-        <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+        {/* Plain span/div, not dt/dd (same fix as the shared FieldRow): dt/dd
+            without an enclosing dl is invalid HTML. FieldRow itself is not
+            reusable here — its value prop takes primitives/arrays, not a
+            ReactNode badge, and this row also carries the #plan-features
+            anchor. */}
+        <span className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
           Plan
-        </dt>
-        <dd className="min-w-0 text-right text-sm">
+        </span>
+        <div className="min-w-0 text-right text-sm">
           <StatusBadge label={planBadge.label} color={planBadge.color} />
-        </dd>
+        </div>
       </div>
 
       {features.length === 0 ? (

--- a/src/app/(admin)/admin/settings/PlanFeaturesCard.tsx
+++ b/src/app/(admin)/admin/settings/PlanFeaturesCard.tsx
@@ -1,7 +1,7 @@
 import { SparklesIcon } from '@heroicons/react/24/outline'
 import { StatusBadge, type BadgeColor } from '@/components/StatusBadge'
 import type { OrganizationPlan } from '@/lib/organization/types'
-import type { FeatureReadiness } from '@/lib/features/registry'
+import type { FeatureId, FeatureReadiness } from '@/lib/features/registry'
 import { InfoCard } from './settingsLayout'
 
 /**
@@ -15,7 +15,7 @@ import { InfoCard } from './settingsLayout'
  */
 
 export interface PlanFeatureRow {
-  id: string
+  id: FeatureId
   title: string
   description: string
   readiness: FeatureReadiness

--- a/src/app/(admin)/admin/settings/PlatformOrgManager.stories.tsx
+++ b/src/app/(admin)/admin/settings/PlatformOrgManager.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import { PlatformOrgManager } from './PlatformOrgManager'
+
+/**
+ * The PLATFORM-ONLY organization management card: every org with its plan, and
+ * the per-org editor modal for the plan + feature-override rows. Rendered only
+ * for the platform org (`PLATFORM_ORG_SLUG`); the save mutation is msw-mocked
+ * so a story Save never hits the network unhandled.
+ */
+const handlers = [
+  http.post('/api/trpc/platform.updateEntitlements', () =>
+    HttpResponse.json({ result: { data: { success: true } } }),
+  ),
+]
+
+const ORGANIZATIONS = [
+  {
+    _id: 'org-platform',
+    name: 'Cloud Native Days',
+    slug: 'cloud-native-days',
+    plan: 'enterprise' as const,
+    featureOverrides: [
+      {
+        _key: 'ov-1',
+        feature: 'graphql-api',
+        enabled: true,
+        note: 'Dogfooding the public API',
+      },
+      {
+        _key: 'ov-2',
+        feature: 'slack-mirror',
+        enabled: true,
+        expiresAt: '2027-01-01T00:00:00Z',
+      },
+    ],
+  },
+  {
+    _id: 'org-bergen',
+    name: 'Cloud Native Bergen',
+    slug: 'cloud-native-bergen',
+    plan: 'community' as const,
+    featureOverrides: [],
+  },
+  {
+    _id: 'org-oslo',
+    name: 'Cloud Native Oslo',
+    slug: 'cloud-native-oslo',
+    plan: 'pro' as const,
+  },
+]
+
+const meta = {
+  title: 'Systems/Settings/Admin/PlatformOrgManager',
+  component: PlatformOrgManager,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        // ModalShell reads next-themes and portals to <body>, so the theme is
+        // forced here — a plain `.dark` wrapper would not reach the portal.
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-gray-50 p-4 sm:p-6 dark:bg-gray-950">
+                <div className="mx-auto max-w-xl">
+                  <Story />
+                </div>
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof PlatformOrgManager>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    organizations: ORGANIZATIONS,
+  },
+}
+
+export const EditorOpen: Story = {
+  args: {
+    organizations: ORGANIZATIONS,
+    defaultOpenOrgId: 'org-platform',
+  },
+}
+
+export const EditorOpenNoOverrides: Story = {
+  args: {
+    organizations: ORGANIZATIONS,
+    defaultOpenOrgId: 'org-bergen',
+  },
+}

--- a/src/app/(admin)/admin/settings/PlatformOrgManager.tsx
+++ b/src/app/(admin)/admin/settings/PlatformOrgManager.tsx
@@ -17,6 +17,7 @@ import { instantToOsloLocalInput, osloLocalInputToIso } from '@/lib/time'
 import {
   FEATURE_LIST,
   FEATURES,
+  effectivePlan,
   isFeatureId,
   type FeatureId,
 } from '@/lib/features/registry'
@@ -64,6 +65,14 @@ const PLAN_BADGES: Record<
   community: { label: 'Community', color: 'gray' },
   pro: { label: 'Pro', color: 'blue' },
   enterprise: { label: 'Enterprise', color: 'purple' },
+}
+
+/**
+ * Registry title for a feature id, falling back to the raw id for anything
+ * outside the closed registry — never an unchecked `FEATURES[...]` dereference.
+ */
+function featureTitle(id: string): string {
+  return isFeatureId(id) ? FEATURES[id].title : id
 }
 
 /** Editable override row: keyed for React identity, expiry as Oslo wall-clock. */
@@ -139,7 +148,7 @@ export function PlatformOrgManager({
     defaultOrg ?? null,
   )
   const [plan, setPlan] = useState<OrganizationPlan>(
-    defaultOrg?.plan ?? 'community',
+    effectivePlan(defaultOrg?.plan),
   )
   const [drafts, setDrafts] = useState<DraftOverride[]>(
     toDrafts(defaultOrg?.featureOverrides),
@@ -150,7 +159,7 @@ export function PlatformOrgManager({
     defaultOrg
       ? staleBaseline(
           defaultOrg,
-          defaultOrg.plan ?? 'community',
+          effectivePlan(defaultOrg.plan),
           toDrafts(defaultOrg.featureOverrides),
         )
       : '',
@@ -176,7 +185,9 @@ export function PlatformOrgManager({
   })
 
   const openEditor = (org: PlatformOrganizationRow) => {
-    const initialPlan = org.plan ?? 'community'
+    // effectivePlan, not a plain `?? 'community'` default: a malformed/legacy
+    // stored plan must normalize exactly as the server resolver does.
+    const initialPlan = effectivePlan(org.plan)
     const initialDrafts = toDrafts(org.featureOverrides)
     setPlan(initialPlan)
     setDrafts(initialDrafts)
@@ -242,7 +253,10 @@ export function PlatformOrgManager({
         </p>
         <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {organizations.map((org) => {
-            const badge = PLAN_BADGES[org.plan ?? 'community']
+            // Route through effectivePlan (same normalization as the server
+            // resolver) so a malformed/legacy stored plan renders as Community
+            // instead of crashing the badge lookup.
+            const badge = PLAN_BADGES[effectivePlan(org.plan)]
             const overrideCount = (org.featureOverrides ?? []).length
             return (
               <li
@@ -294,7 +308,11 @@ export function PlatformOrgManager({
         subtitle="Plan and per-feature entitlement overrides"
         icon={<BuildingOffice2Icon className="h-5 w-5" />}
         confirmOnDirtyClose
-        isDirty={isDirty && !saveMutation.isPending}
+        // The guard must stay ARMED while the save is in flight: backdrop /
+        // Escape / header-close then hit ModalShell's discard confirm instead
+        // of silently closing mid-save (Cancel is likewise disabled during
+        // pending). ModalShell has no harder prevent-close affordance.
+        isDirty={isDirty || saveMutation.isPending}
       >
         <form
           noValidate
@@ -358,11 +376,15 @@ export function PlatformOrgManager({
                         Feature
                         <select
                           value={draft.feature}
-                          onChange={(e) =>
-                            updateDraft(draft._key, {
-                              feature: e.target.value as FeatureId,
-                            })
-                          }
+                          onChange={(e) => {
+                            // Guard, not cast: only registry ids may enter the
+                            // draft — anything else (tampered/stale DOM value)
+                            // is ignored.
+                            const value = e.target.value
+                            if (isFeatureId(value)) {
+                              updateDraft(draft._key, { feature: value })
+                            }
+                          }}
                           className="mt-1 block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-base text-gray-900 shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
                         >
                           {FEATURE_LIST.map((feature) => (
@@ -418,7 +440,7 @@ export function PlatformOrgManager({
                       <button
                         type="button"
                         onClick={() => removeDraft(draft._key)}
-                        aria-label={`Remove override for ${FEATURES[draft.feature].title}`}
+                        aria-label={`Remove override for ${featureTitle(draft.feature)}`}
                         className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-red-50 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 dark:text-gray-400 dark:hover:bg-red-900/20 dark:hover:text-red-400"
                       >
                         <TrashIcon className="h-5 w-5" />

--- a/src/app/(admin)/admin/settings/PlatformOrgManager.tsx
+++ b/src/app/(admin)/admin/settings/PlatformOrgManager.tsx
@@ -1,0 +1,477 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  BuildingOffice2Icon,
+  PlusIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline'
+import { ModalShell } from '@/components/ModalShell'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { useNotification } from '@/components/admin/NotificationProvider'
+import { StatusBadge, type BadgeColor } from '@/components/StatusBadge'
+import { api } from '@/lib/trpc/client'
+import { generateKey } from '@/lib/sanity/helpers'
+import { instantToOsloLocalInput, osloLocalInputToIso } from '@/lib/time'
+import {
+  FEATURE_LIST,
+  FEATURES,
+  isFeatureId,
+  type FeatureId,
+} from '@/lib/features/registry'
+import {
+  ORGANIZATION_PLANS,
+  type OrganizationFeatureOverride,
+  type OrganizationPlan,
+} from '@/lib/organization/types'
+import { InfoCard } from './settingsLayout'
+
+/**
+ * PLATFORM-ONLY organization management card (feature entitlements
+ * foundation): every organization with its plan, plus a per-org editor for the
+ * plan and the feature-override rows. The server settings page renders this
+ * card only for the platform org (`PLATFORM_ORG_SLUG` contract — see
+ * `src/lib/features/platform.ts`), and the `platform` tRPC router re-enforces
+ * that same check server-side, so hiding the card is presentation, not
+ * security.
+ *
+ * The org list arrives as props from the server page (uncached read) and a
+ * successful save refreshes the route, so the card always shows what is
+ * stored. The editor follows the house modal conventions: the dirty baseline
+ * is captured ONCE when the modal opens, and cancel/backdrop/Escape are
+ * guarded by ModalShell's dirty-close confirm.
+ */
+
+export interface PlatformOrganizationRow {
+  _id: string
+  name: string
+  slug: string
+  plan?: OrganizationPlan
+  featureOverrides?: OrganizationFeatureOverride[]
+}
+
+export interface PlatformOrgManagerProps {
+  organizations: PlatformOrganizationRow[]
+  /** Storybook/test hook: open the editor for this org id on mount. */
+  defaultOpenOrgId?: string
+}
+
+const PLAN_BADGES: Record<
+  OrganizationPlan,
+  { label: string; color: BadgeColor }
+> = {
+  community: { label: 'Community', color: 'gray' },
+  pro: { label: 'Pro', color: 'blue' },
+  enterprise: { label: 'Enterprise', color: 'purple' },
+}
+
+/** Editable override row: keyed for React identity, expiry as Oslo wall-clock. */
+interface DraftOverride {
+  _key: string
+  feature: FeatureId
+  enabled: boolean
+  note: string
+  expiresAtLocal: string
+}
+
+/**
+ * Stored overrides → editable drafts. Rows whose feature id is no longer in
+ * the registry are dropped (the resolver already ignores them) and counted as
+ * a pending change via {@link staleBaseline}, so the editor opens dirty and
+ * one Save persists the cleaned set — same posture as the FormatsEditor's
+ * stale-key handling.
+ */
+function toDrafts(overrides: OrganizationFeatureOverride[] | undefined) {
+  return (overrides ?? [])
+    .filter((o) => isFeatureId(o.feature))
+    .map((o) => ({
+      _key: o._key || generateKey('override'),
+      feature: o.feature as FeatureId,
+      enabled: o.enabled,
+      note: o.note ?? '',
+      expiresAtLocal: instantToOsloLocalInput(o.expiresAt),
+    }))
+}
+
+/**
+ * Baseline for an org's stored state. When a stored row was dropped as stale
+ * the baseline is prefixed so it can never equal a serialized draft state —
+ * the editor opens dirty and Save is offered.
+ */
+function staleBaseline(
+  org: PlatformOrganizationRow,
+  plan: OrganizationPlan,
+  drafts: DraftOverride[],
+): string {
+  const stored = org.featureOverrides ?? []
+  const hasStale = stored.some((o) => !isFeatureId(o.feature))
+  const serialized = serialize(plan, drafts)
+  return hasStale ? `stale:${serialized}` : serialized
+}
+
+/** Stable serialization of the editor state for dirty comparison. */
+function serialize(plan: OrganizationPlan, drafts: DraftOverride[]): string {
+  return JSON.stringify({
+    plan,
+    overrides: drafts.map((d) => ({
+      feature: d.feature,
+      enabled: d.enabled,
+      note: d.note.trim(),
+      expiresAtLocal: d.expiresAtLocal,
+    })),
+  })
+}
+
+export function PlatformOrgManager({
+  organizations,
+  defaultOpenOrgId,
+}: PlatformOrgManagerProps) {
+  const router = useRouter()
+  const utils = api.useUtils()
+  const { showNotification } = useNotification()
+
+  const defaultOrg = defaultOpenOrgId
+    ? organizations.find((o) => o._id === defaultOpenOrgId)
+    : undefined
+
+  const [editing, setEditing] = useState<PlatformOrganizationRow | null>(
+    defaultOrg ?? null,
+  )
+  const [plan, setPlan] = useState<OrganizationPlan>(
+    defaultOrg?.plan ?? 'community',
+  )
+  const [drafts, setDrafts] = useState<DraftOverride[]>(
+    toDrafts(defaultOrg?.featureOverrides),
+  )
+  // Captured once per open — edits compare against the state the modal opened
+  // with, not against re-rendered props.
+  const [baseline, setBaseline] = useState<string>(
+    defaultOrg
+      ? staleBaseline(
+          defaultOrg,
+          defaultOrg.plan ?? 'community',
+          toDrafts(defaultOrg.featureOverrides),
+        )
+      : '',
+  )
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const isDirty = editing !== null && serialize(plan, drafts) !== baseline
+
+  const saveMutation = api.platform.updateEntitlements.useMutation({
+    onSuccess: () => {
+      void utils.platform.listOrganizations.invalidate()
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Entitlements updated',
+        message: `Saved plan and feature overrides for ${editing?.name ?? 'the organization'}.`,
+      })
+      setEditing(null)
+    },
+    onError: (err) => {
+      setSubmitError(err.message || 'Failed to save entitlements.')
+    },
+  })
+
+  const openEditor = (org: PlatformOrganizationRow) => {
+    const initialPlan = org.plan ?? 'community'
+    const initialDrafts = toDrafts(org.featureOverrides)
+    setPlan(initialPlan)
+    setDrafts(initialDrafts)
+    setBaseline(staleBaseline(org, initialPlan, initialDrafts))
+    setSubmitError(null)
+    setEditing(org)
+  }
+
+  const closeEditor = () => {
+    setEditing(null)
+    setSubmitError(null)
+  }
+
+  const updateDraft = (key: string, patch: Partial<DraftOverride>) => {
+    setDrafts((prev) =>
+      prev.map((d) => (d._key === key ? { ...d, ...patch } : d)),
+    )
+  }
+
+  const addDraft = () => {
+    setDrafts((prev) => [
+      ...prev,
+      {
+        _key: generateKey('override'),
+        feature: FEATURE_LIST[0].id,
+        enabled: true,
+        note: '',
+        expiresAtLocal: '',
+      },
+    ])
+  }
+
+  const removeDraft = (key: string) => {
+    setDrafts((prev) => prev.filter((d) => d._key !== key))
+  }
+
+  const handleSave = () => {
+    if (!editing) return
+    setSubmitError(null)
+    saveMutation.mutate({
+      organizationId: editing._id,
+      plan,
+      overrides: drafts.map((d) => {
+        const note = d.note.trim()
+        const expiresAt = osloLocalInputToIso(d.expiresAtLocal)
+        return {
+          _key: d._key,
+          feature: d.feature,
+          enabled: d.enabled,
+          ...(note ? { note } : {}),
+          ...(expiresAt ? { expiresAt } : {}),
+        }
+      }),
+    })
+  }
+
+  return (
+    <>
+      <InfoCard title="Organizations" icon={BuildingOffice2Icon}>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Platform management: every organization on this deployment, with its
+          plan and feature overrides.
+        </p>
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+          {organizations.map((org) => {
+            const badge = PLAN_BADGES[org.plan ?? 'community']
+            const overrideCount = (org.featureOverrides ?? []).length
+            return (
+              <li
+                key={org._id}
+                className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 py-2.5"
+              >
+                {/* `basis-48` + wrap: on narrow viewports the badge/button
+                    group drops to its own line instead of truncating the org
+                    name to a few characters. */}
+                <div className="min-w-0 flex-1 basis-48">
+                  <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                    {org.name}
+                  </p>
+                  <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                    {org.slug}
+                    {overrideCount > 0
+                      ? ` · ${overrideCount} override${overrideCount === 1 ? '' : 's'}`
+                      : ''}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <StatusBadge label={badge.label} color={badge.color} />
+                  <AdminButton
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => openEditor(org)}
+                    className="min-h-[44px]"
+                  >
+                    Manage
+                  </AdminButton>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+        {organizations.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No organizations found.
+          </p>
+        ) : null}
+      </InfoCard>
+
+      <ModalShell
+        isOpen={editing !== null}
+        onClose={closeEditor}
+        size="2xl"
+        title={editing ? `Manage ${editing.name}` : 'Manage organization'}
+        subtitle="Plan and per-feature entitlement overrides"
+        icon={<BuildingOffice2Icon className="h-5 w-5" />}
+        confirmOnDirtyClose
+        isDirty={isDirty && !saveMutation.isPending}
+      >
+        <form
+          noValidate
+          onSubmit={(e) => {
+            e.preventDefault()
+            handleSave()
+          }}
+          className="space-y-5"
+        >
+          <fieldset>
+            <legend className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+              Plan
+            </legend>
+            <div className="flex flex-col gap-1 sm:flex-row sm:gap-2">
+              {ORGANIZATION_PLANS.map((value) => (
+                <label
+                  key={value}
+                  className={`flex min-h-[44px] flex-1 cursor-pointer items-center gap-2 rounded-lg border px-3 text-sm ${
+                    plan === value
+                      ? 'border-brand-cloud-blue bg-blue-50 text-gray-900 dark:bg-blue-900/20 dark:text-white'
+                      : 'border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="plan"
+                    value={value}
+                    checked={plan === value}
+                    onChange={() => setPlan(value)}
+                    className="h-4 w-4 border-gray-300 text-brand-cloud-blue focus:ring-brand-cloud-blue"
+                  />
+                  <span className="capitalize">{value}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">
+              Feature overrides
+            </legend>
+            <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+              Overrides win over the plan in both directions. Beta and internal
+              features are only ever enabled through an override; expired
+              overrides are ignored.
+            </p>
+            {drafts.length === 0 ? (
+              <p className="rounded-lg border border-dashed border-gray-300 px-3 py-3 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                No overrides — this organization gets exactly its plan&apos;s
+                features.
+              </p>
+            ) : (
+              <ul className="space-y-3">
+                {drafts.map((draft) => (
+                  <li
+                    key={draft._key}
+                    className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+                  >
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                      <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
+                        Feature
+                        <select
+                          value={draft.feature}
+                          onChange={(e) =>
+                            updateDraft(draft._key, {
+                              feature: e.target.value as FeatureId,
+                            })
+                          }
+                          className="mt-1 block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-base text-gray-900 shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                        >
+                          {FEATURE_LIST.map((feature) => (
+                            <option key={feature.id} value={feature.id}>
+                              {feature.title} ({feature.readiness})
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
+                        Expires (optional, Oslo time)
+                        <input
+                          type="datetime-local"
+                          value={draft.expiresAtLocal}
+                          onChange={(e) =>
+                            updateDraft(draft._key, {
+                              expiresAtLocal: e.target.value,
+                            })
+                          }
+                          className="mt-1 block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-base text-gray-900 shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                        />
+                      </label>
+                    </div>
+                    <label className="mt-3 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                      Note (optional)
+                      <input
+                        type="text"
+                        value={draft.note}
+                        maxLength={500}
+                        onChange={(e) =>
+                          updateDraft(draft._key, { note: e.target.value })
+                        }
+                        placeholder="Why this override exists"
+                        className="mt-1 block min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-base text-gray-900 shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                      />
+                    </label>
+                    <div className="mt-3 flex items-center justify-between">
+                      <label className="flex min-h-[44px] cursor-pointer items-center gap-2 text-sm text-gray-800 dark:text-gray-200">
+                        <input
+                          type="checkbox"
+                          checked={draft.enabled}
+                          onChange={(e) =>
+                            updateDraft(draft._key, {
+                              enabled: e.target.checked,
+                            })
+                          }
+                          className="h-5 w-5 rounded border-gray-300 text-brand-cloud-blue focus:ring-brand-cloud-blue"
+                        />
+                        {draft.enabled
+                          ? 'Enabled (grant)'
+                          : 'Disabled (revoke)'}
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => removeDraft(draft._key)}
+                        aria-label={`Remove override for ${FEATURES[draft.feature].title}`}
+                        className="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 hover:bg-red-50 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 dark:text-gray-400 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+                      >
+                        <TrashIcon className="h-5 w-5" />
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <AdminButton
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={addDraft}
+              className="mt-3 min-h-[44px]"
+            >
+              <PlusIcon className="mr-1 h-4 w-4" />
+              Add override
+            </AdminButton>
+          </fieldset>
+
+          {submitError ? (
+            <p
+              role="alert"
+              className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            >
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
+            <AdminButton
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={closeEditor}
+              disabled={saveMutation.isPending}
+              className="min-h-[44px]"
+            >
+              Cancel
+            </AdminButton>
+            <AdminButton
+              type="submit"
+              color="blue"
+              size="md"
+              disabled={saveMutation.isPending || !isDirty}
+              className="min-h-[44px]"
+            >
+              {saveMutation.isPending ? 'Saving…' : 'Save entitlements'}
+            </AdminButton>
+          </div>
+        </form>
+      </ModalShell>
+    </>
+  )
+}

--- a/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
+++ b/src/app/(admin)/admin/settings/SettingsIA.stories.tsx
@@ -27,8 +27,11 @@ import {
   SettingsGroupSection,
 } from './settingsLayout'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
 import { StatusBadge } from '@/components/StatusBadge'
 import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
+import { PlanFeaturesCard } from './PlanFeaturesCard'
+import { PlatformOrgManager } from './PlatformOrgManager'
 
 /**
  * Visual-QA harness for the Settings page information architecture: the sticky
@@ -126,6 +129,42 @@ function SettingsIADemo() {
                 Publicly listed and indexed by search engines.
               </p>
             </InfoCard>
+
+            <PlanFeaturesCard
+              plan="community"
+              features={[
+                {
+                  id: 'graphql-api',
+                  title: 'GraphQL API',
+                  description:
+                    'Programmatic read access to conference content over a public GraphQL endpoint.',
+                  readiness: 'internal',
+                  viaOverride: true,
+                },
+              ]}
+            />
+
+            {/* Platform-only card — in the app it renders ONLY when the
+                current org matches PLATFORM_ORG_SLUG. */}
+            <PlatformOrgManager
+              organizations={[
+                {
+                  _id: 'org-platform',
+                  name: 'Cloud Native Days',
+                  slug: 'cloud-native-days',
+                  plan: 'enterprise',
+                  featureOverrides: [
+                    { _key: 'ov-1', feature: 'graphql-api', enabled: true },
+                  ],
+                },
+                {
+                  _id: 'org-bergen',
+                  name: 'Cloud Native Bergen',
+                  slug: 'cloud-native-bergen',
+                  plan: 'community',
+                },
+              ]}
+            />
 
             <CollapsibleSection
               title="Venue Information"
@@ -358,11 +397,15 @@ const meta = {
   },
   decorators: [
     (Story: React.ComponentType) => (
-      <div className="min-h-screen bg-gray-50 p-4 sm:p-6 dark:bg-gray-950">
-        <div className="mx-auto max-w-5xl">
-          <Story />
+      // NotificationProvider: the PlatformOrgManager island calls
+      // useNotification for its save toast (never fired in this static story).
+      <NotificationProvider>
+        <div className="min-h-screen bg-gray-50 p-4 sm:p-6 dark:bg-gray-950">
+          <div className="mx-auto max-w-5xl">
+            <Story />
+          </div>
         </div>
-      </div>
+      </NotificationProvider>
     ),
   ],
 } satisfies Meta<typeof SettingsIADemo>

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -30,6 +30,17 @@ import { resolveHomepageSections } from '@/lib/homepage'
 import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
 import { buildActivationChecklist } from '@/lib/settings/activation'
 import {
+  getAllOrganizations,
+  getOrganizationById,
+} from '@/lib/organization/sanity'
+import {
+  effectivePlan,
+  listEntitledFeatures,
+} from '@/lib/features/entitlements'
+import { isPlatformOrgRequest } from '@/lib/features/platform'
+import { PlanFeaturesCard } from './PlanFeaturesCard'
+import { PlatformOrgManager } from './PlatformOrgManager'
+import {
   InfoCard,
   FieldRow,
   StudioEditLink,
@@ -118,6 +129,30 @@ export default async function AdminSettings() {
     image: org.image,
     title: org.title,
   }))
+
+  // Plan & feature entitlements for the CURRENT org (read-only card). Skipped
+  // entirely when the conference has no organization ref (pre-backfill data).
+  const orgId = conference.organization?._ref ?? null
+  const organization = orgId ? await getOrganizationById(orgId) : null
+  const entitledFeatureRows = organization
+    ? listEntitledFeatures(
+        organization.plan,
+        organization.featureOverrides,
+        new Date(),
+      ).map(({ feature, viaOverride }) => ({
+        id: feature.id,
+        title: feature.title,
+        description: feature.description,
+        readiness: feature.readiness,
+        viaOverride,
+      }))
+    : []
+
+  // Cross-tenant list, fetched ONLY when this request's org is the platform
+  // org (PLATFORM_ORG_SLUG contract, src/lib/features/platform.ts).
+  const platformOrganizations = (await isPlatformOrgRequest())
+    ? await getAllOrganizations()
+    : null
 
   // Homepage composition (front-page builder F1/F2). When nothing is stored the
   // page renders the phase-aware default; seed the editor with that same default
@@ -288,6 +323,20 @@ export default async function AdminSettings() {
                   : 'Publicly listed and indexed by search engines.'}
               </p>
             </InfoCard>
+
+            {organization ? (
+              <PlanFeaturesCard
+                plan={effectivePlan(organization.plan)}
+                features={entitledFeatureRows}
+              />
+            ) : null}
+
+            {/* Cross-tenant management — rendered ONLY for the platform org
+                (PLATFORM_ORG_SLUG contract); the platform router re-enforces
+                the same gate server-side. */}
+            {platformOrganizations ? (
+              <PlatformOrgManager organizations={platformOrganizations} />
+            ) : null}
 
             {/* Set-once — collapsed by default. */}
             <CollapsibleSection

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -33,10 +33,8 @@ import {
   getAllOrganizations,
   getOrganizationById,
 } from '@/lib/organization/sanity'
-import {
-  effectivePlan,
-  listEntitledFeatures,
-} from '@/lib/features/entitlements'
+import { effectivePlan } from '@/lib/features/registry'
+import { listEntitledFeatures } from '@/lib/features/entitlements'
 import { isPlatformOrgRequest } from '@/lib/features/platform'
 import { PlanFeaturesCard } from './PlanFeaturesCard'
 import { PlatformOrgManager } from './PlatformOrgManager'

--- a/src/app/(main)/privacy/page.tsx
+++ b/src/app/(main)/privacy/page.tsx
@@ -82,7 +82,7 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
     )
   }
 
-  const lastUpdated = 'October 31, 2025'
+  const lastUpdated = 'July 27, 2026'
   const legal = await resolveLegalConfig(conference)
   const contactEmail = legal.contactEmail
   const organizationName = legal.controllerName
@@ -552,6 +552,37 @@ async function CachedPrivacyContent({ domain }: { domain: string }) {
                           profiles
                         </li>
                       </ul>
+                    </div>
+
+                    {/* Organization Account & Plan Data */}
+                    <div className="rounded-lg border border-cyan-200 bg-cyan-50 p-6 dark:border-cyan-800 dark:bg-cyan-900/20">
+                      <h3 className="mb-4 flex items-center text-lg font-semibold text-cyan-800 dark:text-cyan-200">
+                        <BuildingOfficeIcon className="mr-3 h-5 w-5" />
+                        Organization Account & Plan Data
+                      </h3>
+                      <ul className="space-y-2 text-sm text-cyan-700 dark:text-cyan-300">
+                        <li>
+                          • Organization plan tier (community, pro, enterprise)
+                        </li>
+                        <li>
+                          • Feature configuration (per-feature enablement
+                          overrides with optional expiry dates)
+                        </li>
+                        <li>
+                          • Administrative notes recorded by platform operators
+                          about an organization&apos;s plan or feature access
+                        </li>
+                      </ul>
+                      <div className="mt-3 rounded-lg bg-cyan-100 p-2 dark:bg-cyan-800/30">
+                        <p className="text-xs text-cyan-800 dark:text-cyan-200">
+                          <strong>Purpose & Legal Basis:</strong> Platform
+                          administration and service provisioning (contract
+                          performance / legitimate interest). This data
+                          describes the organization&apos;s account, is visible
+                          only to platform operators, and is retained for as
+                          long as the organization uses the platform.
+                        </p>
+                      </div>
                     </div>
                   </div>
                   {/* Volunteer Information */}

--- a/src/lib/cache/tags.ts
+++ b/src/lib/cache/tags.ts
@@ -13,6 +13,10 @@
  *   fetch). This is the tag mutations should revalidate.
  * - `domainTag(domain)` — a per-domain fallback for the rare spot where a
  *   conference id is not available but the host is.
+ * - `organizationTag(orgId)` — the per-ORGANIZATION-document tag, for cached
+ *   reads keyed on the tenant itself rather than one of its conference
+ *   editions (plan/entitlement resolution). Mutations that edit an
+ *   organization document must revalidate this tag.
  */
 
 export function conferenceTag(conferenceId: string): string {
@@ -21,4 +25,8 @@ export function conferenceTag(conferenceId: string): string {
 
 export function domainTag(domain: string): string {
   return `domain:${domain}`
+}
+
+export function organizationTag(orgId: string): string {
+  return `sanity:organization-${orgId}`
 }

--- a/src/lib/features/entitlements.test.ts
+++ b/src/lib/features/entitlements.test.ts
@@ -8,12 +8,8 @@
  * registry facts.
  */
 import { describe, it, expect } from 'vitest'
-import {
-  computeEntitlements,
-  listEntitledFeatures,
-  effectivePlan,
-} from './entitlements'
-import { FEATURES } from './registry'
+import { computeEntitlements, listEntitledFeatures } from './entitlements'
+import { FEATURES, effectivePlan } from './registry'
 import type { OrganizationFeatureOverride } from '@/lib/organization/types'
 
 const NOW = new Date('2026-07-01T12:00:00Z')

--- a/src/lib/features/entitlements.test.ts
+++ b/src/lib/features/entitlements.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for the PURE entitlement resolution (`computeEntitlements` /
+ * `listEntitledFeatures`): the plan ladder for `ga` features, override-only
+ * gating for `beta`/`internal`, override precedence in both directions, and
+ * expiry handling. Uses the real registry seeds — `dedicated-email` is the
+ * `ga`+`minPlan: 'pro'` entry and `graphql-api`/`slack-mirror` are
+ * override-only (`internal`) — so the tests double as a guard on those
+ * registry facts.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  computeEntitlements,
+  listEntitledFeatures,
+  effectivePlan,
+} from './entitlements'
+import { FEATURES } from './registry'
+import type { OrganizationFeatureOverride } from '@/lib/organization/types'
+
+const NOW = new Date('2026-07-01T12:00:00Z')
+const FUTURE = '2026-12-31T00:00:00Z'
+const PAST = '2026-01-01T00:00:00Z'
+
+const grant = (
+  feature: string,
+  extra: Partial<OrganizationFeatureOverride> = {},
+): OrganizationFeatureOverride => ({ feature, enabled: true, ...extra })
+
+const revoke = (
+  feature: string,
+  extra: Partial<OrganizationFeatureOverride> = {},
+): OrganizationFeatureOverride => ({ feature, enabled: false, ...extra })
+
+describe('registry assumptions the tests below rely on', () => {
+  it('dedicated-email is ga/minPlan pro; graphql-api and slack-mirror are internal', () => {
+    expect(FEATURES['dedicated-email']).toMatchObject({
+      readiness: 'ga',
+      minPlan: 'pro',
+    })
+    expect(FEATURES['graphql-api'].readiness).toBe('internal')
+    expect(FEATURES['slack-mirror'].readiness).toBe('internal')
+  })
+})
+
+describe('effectivePlan', () => {
+  it('defaults absent or invalid stored values to community', () => {
+    expect(effectivePlan(undefined)).toBe('community')
+    expect(effectivePlan(null)).toBe('community')
+    expect(effectivePlan('premium')).toBe('community')
+    expect(effectivePlan('enterprise')).toBe('enterprise')
+  })
+})
+
+describe('computeEntitlements — plan ladder for ga features', () => {
+  it('community does not reach a minPlan pro feature', () => {
+    expect(
+      computeEntitlements('community', [], NOW).has('dedicated-email'),
+    ).toBe(false)
+  })
+
+  it('pro and enterprise satisfy minPlan pro', () => {
+    expect(computeEntitlements('pro', [], NOW).has('dedicated-email')).toBe(
+      true,
+    )
+    expect(
+      computeEntitlements('enterprise', [], NOW).has('dedicated-email'),
+    ).toBe(true)
+  })
+
+  it('an absent plan resolves as community', () => {
+    expect(computeEntitlements(undefined, [], NOW).has('dedicated-email')).toBe(
+      false,
+    )
+  })
+})
+
+describe('computeEntitlements — beta/internal require an explicit override', () => {
+  it('no plan enables an internal feature by itself', () => {
+    for (const plan of ['community', 'pro', 'enterprise'] as const) {
+      const enabled = computeEntitlements(plan, [], NOW)
+      expect(enabled.has('graphql-api')).toBe(false)
+      expect(enabled.has('slack-mirror')).toBe(false)
+    }
+  })
+
+  it('an enabled override grants an internal feature regardless of plan', () => {
+    const enabled = computeEntitlements(
+      'community',
+      [grant('graphql-api')],
+      NOW,
+    )
+    expect(enabled.has('graphql-api')).toBe(true)
+  })
+})
+
+describe('computeEntitlements — overrides always win', () => {
+  it('a disable override revokes a plan-granted ga feature', () => {
+    const enabled = computeEntitlements(
+      'enterprise',
+      [revoke('dedicated-email')],
+      NOW,
+    )
+    expect(enabled.has('dedicated-email')).toBe(false)
+  })
+
+  it('a later override for the same feature supersedes an earlier one', () => {
+    const enabled = computeEntitlements(
+      'community',
+      [grant('graphql-api'), revoke('graphql-api')],
+      NOW,
+    )
+    expect(enabled.has('graphql-api')).toBe(false)
+  })
+})
+
+describe('computeEntitlements — expiry', () => {
+  it('an expired grant is ignored', () => {
+    const enabled = computeEntitlements(
+      'community',
+      [grant('graphql-api', { expiresAt: PAST })],
+      NOW,
+    )
+    expect(enabled.has('graphql-api')).toBe(false)
+  })
+
+  it('an expired DISABLE override is also ignored (the plan grant returns)', () => {
+    const enabled = computeEntitlements(
+      'pro',
+      [revoke('dedicated-email', { expiresAt: PAST })],
+      NOW,
+    )
+    expect(enabled.has('dedicated-email')).toBe(true)
+  })
+
+  it('a future-dated override is active', () => {
+    const enabled = computeEntitlements(
+      'community',
+      [grant('slack-mirror', { expiresAt: FUTURE })],
+      NOW,
+    )
+    expect(enabled.has('slack-mirror')).toBe(true)
+  })
+
+  it('an unparsable expiresAt fails closed (treated as expired)', () => {
+    const enabled = computeEntitlements(
+      'community',
+      [grant('graphql-api', { expiresAt: 'not-a-date' })],
+      NOW,
+    )
+    expect(enabled.has('graphql-api')).toBe(false)
+  })
+})
+
+describe('computeEntitlements — unknown feature ids', () => {
+  it('a stale override for a removed feature is inert', () => {
+    const enabled = computeEntitlements(
+      'community',
+      [grant('no-such-feature')],
+      NOW,
+    )
+    expect(enabled.size).toBe(computeEntitlements('community', [], NOW).size)
+  })
+})
+
+describe('listEntitledFeatures', () => {
+  it('flags override-granted features and keeps plan-granted ones unflagged', () => {
+    const rows = listEntitledFeatures('pro', [grant('graphql-api')], NOW)
+    const byId = Object.fromEntries(rows.map((r) => [r.feature.id, r]))
+    expect(byId['dedicated-email'].viaOverride).toBe(false)
+    expect(byId['graphql-api'].viaOverride).toBe(true)
+  })
+
+  it('omits disabled features entirely', () => {
+    const rows = listEntitledFeatures(
+      'enterprise',
+      [revoke('dedicated-email')],
+      NOW,
+    )
+    expect(rows.find((r) => r.feature.id === 'dedicated-email')).toBeUndefined()
+  })
+})

--- a/src/lib/features/entitlements.ts
+++ b/src/lib/features/entitlements.ts
@@ -1,0 +1,126 @@
+import 'server-only'
+import { getOrganizationById } from '@/lib/organization/sanity'
+import type {
+  OrganizationFeatureOverride,
+  OrganizationPlan,
+} from '@/lib/organization/types'
+import { isOrganizationPlan } from '@/lib/organization/types'
+import {
+  FEATURE_LIST,
+  planSatisfies,
+  isFeatureId,
+  type FeatureDefinition,
+  type FeatureId,
+} from './registry'
+
+/**
+ * Entitlement RESOLUTION — turns an organization's `plan` + `featureOverrides`
+ * into the set of enabled {@link FeatureId}s, per the semantics documented in
+ * `./registry.ts`:
+ *
+ * 1. `ga` features whose `minPlan` the plan satisfies start ENABLED; `beta` and
+ *    `internal` features start DISABLED regardless of plan.
+ * 2. Overrides are then applied IN ARRAY ORDER and always win — `enabled: true`
+ *    grants, `enabled: false` revokes — so a later override for the same
+ *    feature supersedes an earlier one.
+ * 3. An override is IGNORED when its `feature` is not a known id (stale entry
+ *    for a removed feature), or when `expiresAt` is set and not strictly in the
+ *    future of `now` — including an unparsable `expiresAt`, which fails closed
+ *    to "expired" rather than granting forever.
+ *
+ * The pure {@link computeEntitlements} carries all of that logic;
+ * {@link getEntitlementsForOrganization} feeds it the org document via the
+ * CACHED, `organizationTag`-tagged read (`getOrganizationById`) and a fresh
+ * `now`, so expiry is evaluated per call while the document read itself is
+ * cached until a plan/override mutation revalidates the tag.
+ */
+
+/** Resolve an org's stored plan to an effective plan (absent/invalid → community). */
+export function effectivePlan(
+  plan: OrganizationPlan | string | null | undefined,
+): OrganizationPlan {
+  return isOrganizationPlan(plan) ? plan : 'community'
+}
+
+/** Whether an override is active at `now` (see the module doc, rule 3). */
+function isOverrideActive(
+  override: OrganizationFeatureOverride,
+  now: Date,
+): boolean {
+  if (!override.expiresAt) return true
+  const expiry = Date.parse(override.expiresAt)
+  if (Number.isNaN(expiry)) return false
+  return expiry > now.getTime()
+}
+
+/**
+ * PURE entitlement computation. See the module doc for the exact semantics;
+ * `plan` may be the raw stored value (absent → community).
+ */
+export function computeEntitlements(
+  plan: OrganizationPlan | string | null | undefined,
+  overrides: readonly OrganizationFeatureOverride[] | null | undefined,
+  now: Date,
+): Set<FeatureId> {
+  const resolvedPlan = effectivePlan(plan)
+  const enabled = new Set<FeatureId>()
+
+  for (const feature of FEATURE_LIST) {
+    if (
+      feature.readiness === 'ga' &&
+      planSatisfies(resolvedPlan, feature.minPlan)
+    ) {
+      enabled.add(feature.id)
+    }
+  }
+
+  for (const override of overrides ?? []) {
+    if (!isFeatureId(override.feature)) continue
+    if (!isOverrideActive(override, now)) continue
+    if (override.enabled) enabled.add(override.feature)
+    else enabled.delete(override.feature)
+  }
+
+  return enabled
+}
+
+/** An entitled feature plus HOW it is entitled (for read-only admin surfaces). */
+export interface EntitledFeature {
+  feature: FeatureDefinition
+  /**
+   * True when the feature is enabled only because of an explicit override
+   * (i.e. the plan alone would not grant it).
+   */
+  viaOverride: boolean
+}
+
+/**
+ * The entitled features as presentational rows (registry order), each flagged
+ * with whether an override — rather than the plan — is what grants it.
+ */
+export function listEntitledFeatures(
+  plan: OrganizationPlan | string | null | undefined,
+  overrides: readonly OrganizationFeatureOverride[] | null | undefined,
+  now: Date,
+): EntitledFeature[] {
+  const enabled = computeEntitlements(plan, overrides, now)
+  const byPlan = computeEntitlements(plan, [], now)
+  return FEATURE_LIST.filter((feature) => enabled.has(feature.id)).map(
+    (feature) => ({ feature, viaOverride: !byPlan.has(feature.id) }),
+  )
+}
+
+/**
+ * The enabled feature set for an organization. The underlying document read is
+ * cached and tagged `organizationTag(orgId)` (see `getOrganizationById`), so a
+ * plan/override mutation that revalidates that tag immediately busts this
+ * resolution. An unknown org resolves to the community baseline (no doc, no
+ * overrides) rather than throwing — callers gating access treat a missing
+ * feature as FORBIDDEN anyway.
+ */
+export async function getEntitlementsForOrganization(
+  orgId: string,
+): Promise<Set<FeatureId>> {
+  const org = await getOrganizationById(orgId)
+  return computeEntitlements(org?.plan, org?.featureOverrides, new Date())
+}

--- a/src/lib/features/entitlements.ts
+++ b/src/lib/features/entitlements.ts
@@ -4,9 +4,9 @@ import type {
   OrganizationFeatureOverride,
   OrganizationPlan,
 } from '@/lib/organization/types'
-import { isOrganizationPlan } from '@/lib/organization/types'
 import {
   FEATURE_LIST,
+  effectivePlan,
   planSatisfies,
   isFeatureId,
   type FeatureDefinition,
@@ -34,13 +34,6 @@ import {
  * `now`, so expiry is evaluated per call while the document read itself is
  * cached until a plan/override mutation revalidates the tag.
  */
-
-/** Resolve an org's stored plan to an effective plan (absent/invalid → community). */
-export function effectivePlan(
-  plan: OrganizationPlan | string | null | undefined,
-): OrganizationPlan {
-  return isOrganizationPlan(plan) ? plan : 'community'
-}
 
 /** Whether an override is active at `now` (see the module doc, rule 3). */
 function isOverrideActive(

--- a/src/lib/features/platform.ts
+++ b/src/lib/features/platform.ts
@@ -1,0 +1,61 @@
+import 'server-only'
+import { getOrganizationById } from '@/lib/organization/sanity'
+import { resolveCurrentOrgId } from '@/lib/authz/organizer'
+
+/**
+ * PLATFORM-organization identification for cross-tenant management surfaces
+ * (the entitlements management card + `platform` tRPC router).
+ *
+ * There is no superadmin role in the codebase — the only "platform" concept is
+ * the brand-fallback `PLATFORM_NAME` label (`src/lib/branding/platform.ts`),
+ * which identifies no tenant. So the CONTRACT is env-based:
+ *
+ * - `PLATFORM_ORG_SLUG` names the slug of the ONE organization whose
+ *   organizers may manage other organizations' plans and feature overrides.
+ * - UNSET (the default) means NO org is the platform org: every platform
+ *   surface stays hidden and every platform procedure fails closed. Deploys
+ *   that never set the variable are therefore unaffected by this module.
+ * - The check compares the REQUEST-resolved org (domain conference → its
+ *   `organization` ref, never client input) against that slug, so it composes
+ *   with the org-scoped organizer waist: platform access = organizer of the
+ *   platform org, on the platform org's own domain.
+ *
+ * Server-side enforcement lives in the platform router's middleware — the
+ * settings page merely also hides the card, which is presentation, not
+ * security.
+ */
+
+/** The configured platform org slug, or `null` when the contract is unset. */
+export function platformOrgSlug(): string | null {
+  const slug = process.env.PLATFORM_ORG_SLUG?.trim()
+  return slug ? slug : null
+}
+
+/** PURE slug comparison against the `PLATFORM_ORG_SLUG` contract. */
+export function isPlatformOrgSlug(slug: string | null | undefined): boolean {
+  const configured = platformOrgSlug()
+  return configured !== null && !!slug && slug === configured
+}
+
+/**
+ * Whether the organization with this id IS the platform org. Uses the cached,
+ * `organizationTag`-tagged org read; `false` for a missing/unknown org or an
+ * unset contract.
+ */
+export async function isPlatformOrganization(
+  orgId: string | null | undefined,
+): Promise<boolean> {
+  if (!orgId || platformOrgSlug() === null) return false
+  const org = await getOrganizationById(orgId)
+  return isPlatformOrgSlug(org?.slug)
+}
+
+/**
+ * Whether the CURRENT request's domain-resolved org is the platform org (the
+ * settings page uses this to decide whether to render the management card).
+ */
+export async function isPlatformOrgRequest(): Promise<boolean> {
+  if (platformOrgSlug() === null) return false
+  const orgId = await resolveCurrentOrgId()
+  return isPlatformOrganization(orgId)
+}

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -1,0 +1,116 @@
+import type { OrganizationPlan } from '@/lib/organization/types'
+
+/**
+ * The CLOSED, typed feature registry — the single source of truth for which
+ * per-organization features exist and how each one becomes available.
+ *
+ * Like the homepage section registry (`src/lib/homepage/sections.ts`) this is
+ * deliberately a fixed union: every feature here maps to vetted house
+ * functionality, and an open/stringly registry would let a typo silently gate
+ * (or un-gate) an endpoint. Add a feature by extending {@link FEATURE_IDS} and
+ * {@link FEATURES}; the types force the two to stay in sync.
+ *
+ * AVAILABILITY SEMANTICS (resolved by `computeEntitlements` in
+ * `./entitlements.ts`):
+ *
+ * - `readiness: 'ga'` — generally available: enabled for every org whose plan
+ *   satisfies `minPlan` (an ABSENT `minPlan` means every plan, including
+ *   community). The plan ladder is community < pro < enterprise.
+ * - `readiness: 'beta'` — enabled ONLY via an explicit `featureOverrides`
+ *   grant on the organization, regardless of plan. Beta features MAY be
+ *   advertised as opt-in in upsell/marketing surfaces; `minPlan` (when set)
+ *   documents the plan the feature is expected to require once it reaches GA.
+ * - `readiness: 'internal'` — same override-only gating as beta, but NEVER
+ *   surfaced in upsell UI: it exists for platform/pilot rollouts and appears
+ *   only where the org is already entitled.
+ * - OVERRIDES ALWAYS WIN, in both directions: an `enabled: true` override
+ *   grants a feature the plan would deny, and an `enabled: false` override
+ *   revokes a feature the plan would grant. An override whose `expiresAt` is
+ *   in the past is ignored entirely.
+ *
+ * The seed set is intentionally SMALL and truthful: none of these features are
+ * enforced anywhere yet (this registry is foundation only), so shipping it
+ * changes no behaviour for any existing organization. Enforcement is wired
+ * per-feature later via the `requireFeature` tRPC middleware.
+ */
+
+export const FEATURE_IDS = [
+  'graphql-api',
+  'dedicated-email',
+  'slack-mirror',
+] as const
+
+export type FeatureId = (typeof FEATURE_IDS)[number]
+
+export type FeatureReadiness = 'ga' | 'beta' | 'internal'
+
+export interface FeatureDefinition {
+  id: FeatureId
+  /** Short human title (entitlement lists, platform override editor). */
+  title: string
+  /** One-line description of what the feature unlocks. */
+  description: string
+  readiness: FeatureReadiness
+  /**
+   * Minimum plan for `ga` availability. Absent = every plan. For `beta` /
+   * `internal` features this is informational only (the expected GA tier) —
+   * availability still requires an explicit override.
+   */
+  minPlan?: OrganizationPlan
+}
+
+export const FEATURES: Record<FeatureId, FeatureDefinition> = {
+  'graphql-api': {
+    id: 'graphql-api',
+    title: 'GraphQL API',
+    description:
+      'Programmatic read access to conference content over a public GraphQL endpoint.',
+    readiness: 'internal',
+  },
+  'dedicated-email': {
+    id: 'dedicated-email',
+    title: 'Dedicated email sending',
+    description:
+      "Outbound email from the organization's own verified sender domain instead of the shared platform sender.",
+    readiness: 'ga',
+    minPlan: 'pro',
+  },
+  'slack-mirror': {
+    id: 'slack-mirror',
+    title: 'Slack mirroring',
+    description:
+      "Mirror speaker and sponsor conversations into the organization's Slack workspace.",
+    readiness: 'internal',
+  },
+}
+
+/** Registry entries in declaration order (stable for lists and editors). */
+export const FEATURE_LIST: readonly FeatureDefinition[] = FEATURE_IDS.map(
+  (id) => FEATURES[id],
+)
+
+export function isFeatureId(value: unknown): value is FeatureId {
+  return (
+    typeof value === 'string' &&
+    (FEATURE_IDS as readonly string[]).includes(value)
+  )
+}
+
+/** The plan ladder: community < pro < enterprise. */
+const PLAN_RANK: Record<OrganizationPlan, number> = {
+  community: 0,
+  pro: 1,
+  enterprise: 2,
+}
+
+/**
+ * Whether `plan` satisfies a feature's `minPlan`. An absent `minPlan` is
+ * satisfied by every plan.
+ */
+export function planSatisfies(
+  plan: OrganizationPlan,
+  minPlan: OrganizationPlan | undefined,
+): boolean {
+  if (!minPlan) return true
+  return PLAN_RANK[plan] >= PLAN_RANK[minPlan]
+}

--- a/src/lib/features/registry.ts
+++ b/src/lib/features/registry.ts
@@ -1,4 +1,7 @@
-import type { OrganizationPlan } from '@/lib/organization/types'
+import {
+  isOrganizationPlan,
+  type OrganizationPlan,
+} from '@/lib/organization/types'
 
 /**
  * The CLOSED, typed feature registry — the single source of truth for which
@@ -94,6 +97,18 @@ export function isFeatureId(value: unknown): value is FeatureId {
     typeof value === 'string' &&
     (FEATURE_IDS as readonly string[]).includes(value)
   )
+}
+
+/**
+ * Resolve an org's stored plan to an effective plan (absent/invalid →
+ * community). Lives in this CLIENT-SAFE module (not the server-only
+ * entitlements resolver) because admin UI (the platform org manager) must apply
+ * the same normalization before badge lookups as the resolver does.
+ */
+export function effectivePlan(
+  plan: OrganizationPlan | string | null | undefined,
+): OrganizationPlan {
+  return isOrganizationPlan(plan) ? plan : 'community'
 }
 
 /** The plan ladder: community < pro < enterprise. */

--- a/src/lib/organization/sanity.ts
+++ b/src/lib/organization/sanity.ts
@@ -1,6 +1,9 @@
 import 'server-only'
+import { cacheLife, cacheTag } from 'next/cache'
 import { clientReadUncached } from '@/lib/sanity/client'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { organizationTag } from '@/lib/cache/tags'
+import type { Organization } from './types'
 
 /**
  * Multi-tenant (CaaS T1-1, #613) organization resolution + stamping helpers.
@@ -80,4 +83,52 @@ export async function getOrganizationRefViaParentConference(
   } catch {
     return null
   }
+}
+
+/**
+ * Projection shared by the organization reads below. `slug` is flattened to a
+ * plain string; `plan`/`featureOverrides` feed the entitlement resolver
+ * (`src/lib/features/entitlements.ts`).
+ */
+const ORGANIZATION_PROJECTION = `{
+  _id,
+  name,
+  "slug": slug.current,
+  contactEmail,
+  plan,
+  featureOverrides
+}`
+
+/**
+ * One organization document by id, CACHED and tagged with the org's own
+ * tenant tag: any mutation that edits the organization (plan or overrides —
+ * see the platform router) revalidates `organizationTag(orgId)` and busts
+ * exactly this read. Returns `null` for an unknown id.
+ */
+export async function getOrganizationById(
+  orgId: string,
+): Promise<Organization | null> {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('content:organizations')
+  cacheTag(organizationTag(orgId))
+  const org = await clientReadUncached.fetch<Organization | null>(
+    // groq-global: the organization document IS the tenant (id-keyed read).
+    `*[_type == "organization" && _id == $orgId][0]${ORGANIZATION_PROJECTION}`,
+    { orgId },
+  )
+  return org ?? null
+}
+
+/**
+ * EVERY organization document, name-ordered — the platform management list.
+ * Deliberately UNCACHED: it is a cross-tenant admin read (platform card only)
+ * and must reflect a just-saved plan/override immediately.
+ */
+export async function getAllOrganizations(): Promise<Organization[]> {
+  const orgs = await clientReadUncached.fetch<Organization[]>(
+    // groq-global: intentionally cross-tenant — the PLATFORM management list, reachable only behind the platform gate (src/lib/features/platform.ts).
+    `*[_type == "organization"] | order(name asc)${ORGANIZATION_PROJECTION}`,
+  )
+  return orgs ?? []
 }

--- a/src/lib/organization/sanity.ts
+++ b/src/lib/organization/sanity.ts
@@ -121,14 +121,34 @@ export async function getOrganizationById(
 }
 
 /**
+ * MINIMAL projection for the platform management list: exactly the fields the
+ * `PlatformOrgManager` card renders/edits and nothing else. Deliberately NOT
+ * {@link ORGANIZATION_PROJECTION} — that one carries `contactEmail`, and a
+ * cross-tenant list must not ship every org's contact email to the client
+ * (data minimization, even for an operator-only surface).
+ */
+const PLATFORM_ORG_LIST_PROJECTION = `{
+  _id,
+  name,
+  "slug": slug.current,
+  plan,
+  featureOverrides
+}`
+
+/** What {@link getAllOrganizations} returns — the org sans contact details. */
+type PlatformOrganizationSummary = Omit<Organization, 'contactEmail'>
+
+/**
  * EVERY organization document, name-ordered — the platform management list.
  * Deliberately UNCACHED: it is a cross-tenant admin read (platform card only)
  * and must reflect a just-saved plan/override immediately.
  */
-export async function getAllOrganizations(): Promise<Organization[]> {
-  const orgs = await clientReadUncached.fetch<Organization[]>(
+export async function getAllOrganizations(): Promise<
+  PlatformOrganizationSummary[]
+> {
+  const orgs = await clientReadUncached.fetch<PlatformOrganizationSummary[]>(
     // groq-global: intentionally cross-tenant — the PLATFORM management list, reachable only behind the platform gate (src/lib/features/platform.ts).
-    `*[_type == "organization"] | order(name asc)${ORGANIZATION_PROJECTION}`,
+    `*[_type == "organization"] | order(name asc)${PLATFORM_ORG_LIST_PROJECTION}`,
   )
   return orgs ?? []
 }

--- a/src/lib/organization/types.ts
+++ b/src/lib/organization/types.ts
@@ -1,0 +1,48 @@
+/**
+ * TypeScript shapes for the multi-tenant `organization` document (CaaS tier 1,
+ * #613) — mirrors `sanity/schemaTypes/organization.ts`.
+ *
+ * PLAN & OVERRIDES (feature entitlements foundation): `plan` is the org's
+ * commercial tier; ABSENT resolves to `'community'` so every legacy org keeps
+ * its current behaviour without a migration. `featureOverrides` are explicit
+ * per-feature grants/denials that always win over the plan — see
+ * `src/lib/features/entitlements.ts` for the resolution semantics.
+ */
+
+export const ORGANIZATION_PLANS = ['community', 'pro', 'enterprise'] as const
+
+export type OrganizationPlan = (typeof ORGANIZATION_PLANS)[number]
+
+export function isOrganizationPlan(value: unknown): value is OrganizationPlan {
+  return (
+    typeof value === 'string' &&
+    (ORGANIZATION_PLANS as readonly string[]).includes(value)
+  )
+}
+
+/**
+ * One explicit entitlement override on an organization. `feature` is stored as
+ * a plain string (the Sanity document cannot enforce the registry's closed
+ * union); the resolver ignores entries whose `feature` is not a known
+ * `FeatureId`, so a stale override for a removed feature is inert rather than
+ * breaking resolution.
+ */
+export interface OrganizationFeatureOverride {
+  _key?: string
+  feature: string
+  enabled: boolean
+  /** Free-text audit note ("granted for pilot", "beta cohort 2", …). */
+  note?: string
+  /** ISO datetime after which the override is ignored (both directions). */
+  expiresAt?: string
+}
+
+/** The organization document as projected by the org queries (`slug` flattened). */
+export interface Organization {
+  _id: string
+  name: string
+  slug: string
+  contactEmail?: string
+  plan?: OrganizationPlan
+  featureOverrides?: OrganizationFeatureOverride[]
+}

--- a/src/server/_app.ts
+++ b/src/server/_app.ts
@@ -21,6 +21,7 @@ import { conferenceRouter } from './routers/conference'
 import { topicRouter } from './routers/topic'
 import { staffRouter } from './routers/staff'
 import { sponsorMessagesRouter } from './routers/sponsorMessages'
+import { platformRouter } from './routers/platform'
 
 export const appRouter = router({
   badge: badgeRouter,
@@ -45,6 +46,7 @@ export const appRouter = router({
   topic: topicRouter,
   staff: staffRouter,
   sponsorMessages: sponsorMessagesRouter,
+  platform: platformRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/src/server/routers/platform.test.ts
+++ b/src/server/routers/platform.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment node
+ *
+ * `platform` router — the cross-tenant management surface. The critical
+ * property is the SERVER-SIDE platform gate: an ordinary tenant organizer
+ * (admin of a non-platform org) gets FORBIDDEN on every procedure, because the
+ * client hiding the card is presentation, not security. Also covers the
+ * updateEntitlements write path: keyed overrides, empty-optional stripping,
+ * and the `organizationTag` revalidation that busts the cached entitlements
+ * read.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+
+const isPlatformOrganizationMock = vi.fn()
+vi.mock('@/lib/features/platform', () => ({
+  isPlatformOrganization: (...args: unknown[]) =>
+    isPlatformOrganizationMock(...args),
+}))
+
+const getAllOrganizationsMock = vi.fn()
+const getOrganizationByIdMock = vi.fn()
+vi.mock('@/lib/organization/sanity', () => ({
+  getAllOrganizations: (...args: unknown[]) => getAllOrganizationsMock(...args),
+  getOrganizationById: (...args: unknown[]) => getOrganizationByIdMock(...args),
+  // Imported by the authz waist's module graph; not exercised here.
+  getOrganizationRefForCurrentConference: vi.fn(),
+  getOrganizationRefViaParentConference: vi.fn(),
+  organizationField: vi.fn(() => ({})),
+  organizationReference: vi.fn(),
+}))
+
+const commitMock = vi.fn()
+const setMock = vi.fn<
+  (patch: Record<string, unknown>) => { commit: typeof commitMock }
+>(() => ({ commit: commitMock }))
+const patchMock = vi.fn<(id: string) => { set: typeof setMock }>(() => ({
+  set: setMock,
+}))
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { patch: (id: string) => patchMock(id) },
+}))
+
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+import { revalidateTag } from 'next/cache'
+import { platformRouter } from './platform'
+import type { Context } from '../trpc'
+
+function callerFor(orgIds: string[]) {
+  const speaker = { _id: 'admin-1', organizerOrgIds: orgIds }
+  const session = { speaker, user: { email: 'admin@x.test' } }
+  return platformRouter.createCaller({
+    session,
+    speaker,
+    user: session.user,
+  } as unknown as Context)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: 'conf-A', organization: { _ref: 'org-A' } },
+    error: null,
+  })
+  getAllOrganizationsMock.mockResolvedValue([
+    {
+      _id: 'org-A',
+      name: 'Platform Org',
+      slug: 'platform',
+      plan: 'enterprise',
+    },
+    { _id: 'org-B', name: 'Tenant Org', slug: 'tenant', plan: 'community' },
+  ])
+  getOrganizationByIdMock.mockResolvedValue({
+    _id: 'org-B',
+    name: 'Tenant Org',
+    slug: 'tenant',
+  })
+  commitMock.mockResolvedValue({})
+})
+
+describe('platform gate', () => {
+  it('FORBIDDEN for an organizer whose request org is not the platform org', async () => {
+    isPlatformOrganizationMock.mockResolvedValue(false)
+    const caller = callerFor(['org-A'])
+    await expect(caller.listOrganizations()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+    expect(getAllOrganizationsMock).not.toHaveBeenCalled()
+  })
+
+  it('lists every organization for the platform org', async () => {
+    isPlatformOrganizationMock.mockResolvedValue(true)
+    const caller = callerFor(['org-A'])
+    const orgs = await caller.listOrganizations()
+    expect(orgs).toHaveLength(2)
+    expect(isPlatformOrganizationMock).toHaveBeenCalledWith('org-A')
+  })
+})
+
+describe('updateEntitlements', () => {
+  it('is gated exactly like the list (no cross-tenant write for tenants)', async () => {
+    isPlatformOrganizationMock.mockResolvedValue(false)
+    const caller = callerFor(['org-A'])
+    await expect(
+      caller.updateEntitlements({
+        organizationId: 'org-B',
+        plan: 'pro',
+        overrides: [],
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(patchMock).not.toHaveBeenCalled()
+  })
+
+  it('NOT_FOUND for an unknown target organization', async () => {
+    isPlatformOrganizationMock.mockResolvedValue(true)
+    getOrganizationByIdMock.mockResolvedValue(null)
+    const caller = callerFor(['org-A'])
+    await expect(
+      caller.updateEntitlements({
+        organizationId: 'org-missing',
+        plan: 'pro',
+        overrides: [],
+      }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(patchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an override for a feature outside the closed registry', async () => {
+    isPlatformOrganizationMock.mockResolvedValue(true)
+    const caller = callerFor(['org-A'])
+    await expect(
+      caller.updateEntitlements({
+        organizationId: 'org-B',
+        plan: 'pro',
+        overrides: [
+          // @ts-expect-error — deliberately outside the FeatureId union
+          { feature: 'no-such-feature', enabled: true },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+  })
+
+  it('patches plan + keyed overrides and revalidates the org tag', async () => {
+    isPlatformOrganizationMock.mockResolvedValue(true)
+    const caller = callerFor(['org-A'])
+    const res = await caller.updateEntitlements({
+      organizationId: 'org-B',
+      plan: 'pro',
+      overrides: [
+        { _key: 'k1', feature: 'graphql-api', enabled: true, note: 'pilot' },
+        { feature: 'slack-mirror', enabled: false },
+      ],
+    })
+    expect(res).toEqual({ success: true })
+    expect(patchMock).toHaveBeenCalledWith('org-B')
+
+    const patched = setMock.mock.calls[0][0] as unknown as {
+      plan: string
+      featureOverrides: Array<Record<string, unknown>>
+    }
+    expect(patched.plan).toBe('pro')
+    expect(patched.featureOverrides).toHaveLength(2)
+    // The supplied key survives; the missing one is backfilled; optionals that
+    // were not provided are absent, not null/empty.
+    expect(patched.featureOverrides[0]).toMatchObject({
+      _key: 'k1',
+      _type: 'featureOverride',
+      feature: 'graphql-api',
+      enabled: true,
+      note: 'pilot',
+    })
+    expect(patched.featureOverrides[0]).not.toHaveProperty('expiresAt')
+    expect(typeof patched.featureOverrides[1]._key).toBe('string')
+    expect(patched.featureOverrides[1]._key).toBeTruthy()
+
+    expect(revalidateTag).toHaveBeenCalledWith(
+      'sanity:organization-org-B',
+      'default',
+    )
+  })
+})

--- a/src/server/routers/platform.test.ts
+++ b/src/server/routers/platform.test.ts
@@ -4,32 +4,47 @@
  * `platform` router — the cross-tenant management surface. The critical
  * property is the SERVER-SIDE platform gate: an ordinary tenant organizer
  * (admin of a non-platform org) gets FORBIDDEN on every procedure, because the
- * client hiding the card is presentation, not security. Also covers the
- * updateEntitlements write path: keyed overrides, empty-optional stripping,
- * and the `organizationTag` revalidation that busts the cached entitlements
- * read.
+ * client hiding the card is presentation, not security. The gate runs FOR REAL
+ * here — `PLATFORM_ORG_SLUG` env + the request org's document slug drive
+ * `isPlatformOrganization`; only the external boundaries (the Sanity client,
+ * Next's cache API, the domain-conference resolution) are mocked. Also covers
+ * the updateEntitlements write path: keyed overrides, empty-optional
+ * stripping, and the `organizationTag` revalidation that busts the cached
+ * entitlements read.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
-
-const isPlatformOrganizationMock = vi.fn()
-vi.mock('@/lib/features/platform', () => ({
-  isPlatformOrganization: (...args: unknown[]) =>
-    isPlatformOrganizationMock(...args),
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
 }))
 
-const getAllOrganizationsMock = vi.fn()
-const getOrganizationByIdMock = vi.fn()
-vi.mock('@/lib/organization/sanity', () => ({
-  getAllOrganizations: (...args: unknown[]) => getAllOrganizationsMock(...args),
-  getOrganizationById: (...args: unknown[]) => getOrganizationByIdMock(...args),
-  // Imported by the authz waist's module graph; not exercised here.
-  getOrganizationRefForCurrentConference: vi.fn(),
-  getOrganizationRefViaParentConference: vi.fn(),
-  organizationField: vi.fn(() => ({})),
-  organizationReference: vi.fn(),
-}))
+// The Sanity CLIENT is the external boundary: reads (org documents) and writes
+// (the entitlements patch) are stubbed here, and everything above it —
+// `getOrganizationById` / `getAllOrganizations`, `isPlatformOrganization`, the
+// platform middleware — runs for real.
+const ORG_DOCS: Record<
+  string,
+  { _id: string; name: string; slug: string; plan?: string }
+> = {
+  'org-A': {
+    _id: 'org-A',
+    name: 'Platform Org',
+    slug: 'platform',
+    plan: 'enterprise',
+  },
+  'org-B': { _id: 'org-B', name: 'Tenant Org', slug: 'tenant' },
+}
+
+const fetchMock = vi.fn(
+  async (_query: string, params?: Record<string, unknown>) => {
+    if (params && typeof params.orgId === 'string') {
+      return ORG_DOCS[params.orgId] ?? null
+    }
+    return Object.values(ORG_DOCS)
+  },
+)
 
 const commitMock = vi.fn()
 const setMock = vi.fn<
@@ -39,6 +54,10 @@ const patchMock = vi.fn<(id: string) => { set: typeof setMock }>(() => ({
   set: setMock,
 }))
 vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: (query: string, params?: Record<string, unknown>) =>
+      fetchMock(query, params),
+  },
   clientWrite: { patch: (id: string) => patchMock(id) },
 }))
 
@@ -62,52 +81,61 @@ function callerFor(orgIds: string[]) {
   } as unknown as Context)
 }
 
-beforeEach(() => {
-  vi.clearAllMocks()
+/** Point the request's domain-resolved conference at `orgId`'s organization. */
+function requestResolvesToOrg(orgId: string) {
   getConferenceMock.mockResolvedValue({
-    conference: { _id: 'conf-A', organization: { _ref: 'org-A' } },
+    conference: { _id: 'conf-1', organization: { _ref: orgId } },
     error: null,
   })
-  getAllOrganizationsMock.mockResolvedValue([
-    {
-      _id: 'org-A',
-      name: 'Platform Org',
-      slug: 'platform',
-      plan: 'enterprise',
-    },
-    { _id: 'org-B', name: 'Tenant Org', slug: 'tenant', plan: 'community' },
-  ])
-  getOrganizationByIdMock.mockResolvedValue({
-    _id: 'org-B',
-    name: 'Tenant Org',
-    slug: 'tenant',
-  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // The env contract: org-A ("platform" slug) IS the platform org.
+  vi.stubEnv('PLATFORM_ORG_SLUG', 'platform')
+  requestResolvesToOrg('org-A')
   commitMock.mockResolvedValue({})
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
 })
 
 describe('platform gate', () => {
   it('FORBIDDEN for an organizer whose request org is not the platform org', async () => {
-    isPlatformOrganizationMock.mockResolvedValue(false)
+    // A real tenant organizer on the tenant's own domain: the request resolves
+    // to org-B, whose stored slug ("tenant") does not match the contract.
+    requestResolvesToOrg('org-B')
+    const caller = callerFor(['org-B'])
+    await expect(caller.listOrganizations()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    })
+  })
+
+  it('fails closed for everyone when PLATFORM_ORG_SLUG is unset', async () => {
+    vi.stubEnv('PLATFORM_ORG_SLUG', '')
     const caller = callerFor(['org-A'])
     await expect(caller.listOrganizations()).rejects.toMatchObject({
       code: 'FORBIDDEN',
     })
-    expect(getAllOrganizationsMock).not.toHaveBeenCalled()
   })
 
   it('lists every organization for the platform org', async () => {
-    isPlatformOrganizationMock.mockResolvedValue(true)
     const caller = callerFor(['org-A'])
     const orgs = await caller.listOrganizations()
     expect(orgs).toHaveLength(2)
-    expect(isPlatformOrganizationMock).toHaveBeenCalledWith('org-A')
+    // The gate resolved the REQUEST org's document (slug check), not client input.
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('_id == $orgId'),
+      { orgId: 'org-A' },
+    )
   })
 })
 
 describe('updateEntitlements', () => {
   it('is gated exactly like the list (no cross-tenant write for tenants)', async () => {
-    isPlatformOrganizationMock.mockResolvedValue(false)
-    const caller = callerFor(['org-A'])
+    requestResolvesToOrg('org-B')
+    const caller = callerFor(['org-B'])
     await expect(
       caller.updateEntitlements({
         organizationId: 'org-B',
@@ -119,8 +147,6 @@ describe('updateEntitlements', () => {
   })
 
   it('NOT_FOUND for an unknown target organization', async () => {
-    isPlatformOrganizationMock.mockResolvedValue(true)
-    getOrganizationByIdMock.mockResolvedValue(null)
     const caller = callerFor(['org-A'])
     await expect(
       caller.updateEntitlements({
@@ -133,7 +159,6 @@ describe('updateEntitlements', () => {
   })
 
   it('rejects an override for a feature outside the closed registry', async () => {
-    isPlatformOrganizationMock.mockResolvedValue(true)
     const caller = callerFor(['org-A'])
     await expect(
       caller.updateEntitlements({
@@ -148,7 +173,6 @@ describe('updateEntitlements', () => {
   })
 
   it('patches plan + keyed overrides and revalidates the org tag', async () => {
-    isPlatformOrganizationMock.mockResolvedValue(true)
     const caller = callerFor(['org-A'])
     const res = await caller.updateEntitlements({
       organizationId: 'org-B',

--- a/src/server/routers/platform.ts
+++ b/src/server/routers/platform.ts
@@ -1,0 +1,92 @@
+import { TRPCError } from '@trpc/server'
+import { revalidateTag } from 'next/cache'
+import { router, adminProcedure } from '../trpc'
+import { clientWrite } from '@/lib/sanity/client'
+import { organizationTag } from '@/lib/cache/tags'
+import { ensureUniqueArrayKeys } from '@/lib/sanity/helpers'
+import { isPlatformOrganization } from '@/lib/features/platform'
+import {
+  getAllOrganizations,
+  getOrganizationById,
+} from '@/lib/organization/sanity'
+import { UpdateEntitlementsSchema } from '../schemas/platform'
+
+/**
+ * PLATFORM-scoped organization management (feature entitlements foundation).
+ *
+ * Every procedure here is CROSS-TENANT — it reads or writes OTHER
+ * organizations' documents — so on top of the org-scoped admin waist
+ * (`adminProcedure`) it is gated by the `PLATFORM_ORG_SLUG` contract
+ * (`src/lib/features/platform.ts`): the request's own domain-resolved org must
+ * BE the platform org. The client-side card being hidden for non-platform
+ * tenants is presentation only; THIS gate is the security boundary. With the
+ * env contract unset the whole router fails closed.
+ */
+const platformProcedure = adminProcedure.use(async ({ ctx, next }) => {
+  // `ctx.orgId` can still be null for a legacy-token bridge admin (see the
+  // waist's bridge (2)); a null org is never the platform org, so the
+  // isPlatformOrganization guard fails closed for those too.
+  if (!(await isPlatformOrganization(ctx.orgId))) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Platform administration is not available for this organization',
+    })
+  }
+  return next()
+})
+
+export const platformRouter = router({
+  /** Every organization (name-ordered) with its plan + overrides — the
+   * management list for the platform card. Uncached so a just-saved change is
+   * visible immediately. */
+  listOrganizations: platformProcedure.query(async () => {
+    return getAllOrganizations()
+  }),
+
+  /**
+   * Replace an organization's plan and feature overrides in one patch. A
+   * whole-array override write (not row-diffing) keeps the mutation idempotent
+   * and the client's dirty-state model simple; the array is small (≤100) and
+   * platform-only. Revalidates the org's tenant tag so the cached
+   * entitlements read (`getOrganizationById`) busts immediately.
+   */
+  updateEntitlements: platformProcedure
+    .input(UpdateEntitlementsSchema)
+    .mutation(async ({ input }) => {
+      const target = await getOrganizationById(input.organizationId)
+      if (!target) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Organization not found',
+        })
+      }
+
+      const featureOverrides = ensureUniqueArrayKeys(
+        input.overrides.map((override) => ({
+          _type: 'featureOverride' as const,
+          ...(override._key ? { _key: override._key } : {}),
+          feature: override.feature,
+          enabled: override.enabled,
+          ...(override.note ? { note: override.note } : {}),
+          ...(override.expiresAt ? { expiresAt: override.expiresAt } : {}),
+        })),
+        'override',
+      )
+
+      try {
+        await clientWrite
+          .patch(input.organizationId)
+          .set({ plan: input.plan, featureOverrides })
+          .commit()
+      } catch (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to update organization entitlements',
+          cause: error,
+        })
+      }
+
+      revalidateTag(organizationTag(input.organizationId), 'default')
+      return { success: true }
+    }),
+})

--- a/src/server/schemas/platform.ts
+++ b/src/server/schemas/platform.ts
@@ -28,4 +28,3 @@ export const UpdateEntitlementsSchema = z.object({
   overrides: z.array(FeatureOverrideInputSchema).max(100),
 })
 
-export type UpdateEntitlementsInput = z.infer<typeof UpdateEntitlementsSchema>

--- a/src/server/schemas/platform.ts
+++ b/src/server/schemas/platform.ts
@@ -27,4 +27,3 @@ export const UpdateEntitlementsSchema = z.object({
   plan: PlanSchema,
   overrides: z.array(FeatureOverrideInputSchema).max(100),
 })
-

--- a/src/server/schemas/platform.ts
+++ b/src/server/schemas/platform.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+import { FEATURE_IDS } from '@/lib/features/registry'
+import { ORGANIZATION_PLANS } from '@/lib/organization/types'
+
+/**
+ * Schemas for the `platform` router (feature entitlements foundation). The
+ * feature id and plan enums are derived from the code registries so a value
+ * outside the closed unions is rejected at the boundary — an override for an
+ * unknown feature can therefore never be STORED via this API (the resolver
+ * additionally ignores unknown ids read from Sanity, for stale data).
+ */
+
+export const PlanSchema = z.enum(ORGANIZATION_PLANS)
+
+export const FeatureOverrideInputSchema = z.object({
+  // Client-supplied keys are kept where possible (stable React identity) and
+  // de-duplicated/backfilled server-side via `ensureUniqueArrayKeys`.
+  _key: z.string().optional(),
+  feature: z.enum(FEATURE_IDS),
+  enabled: z.boolean(),
+  note: z.string().trim().max(500).optional(),
+  expiresAt: z.string().datetime({ offset: true }).optional(),
+})
+
+export const UpdateEntitlementsSchema = z.object({
+  organizationId: z.string().trim().min(1, 'An organization id is required'),
+  plan: PlanSchema,
+  overrides: z.array(FeatureOverrideInputSchema).max(100),
+})
+
+export type UpdateEntitlementsInput = z.infer<typeof UpdateEntitlementsSchema>

--- a/src/server/trpc.requireFeature.test.ts
+++ b/src/server/trpc.requireFeature.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @vitest-environment node
+ *
+ * `requireFeature` — the per-organization feature gate. Composed onto the
+ * org-scoped admin waist exactly as consumers will use it
+ * (`adminProcedure.use(requireFeature(...))`) and driven through a test router
+ * with a fake ctx: an entitled org passes (and keeps `ctx.orgId`), a
+ * non-entitled org gets FORBIDDEN naming the feature, and the entitlement read
+ * is keyed on the REQUEST-resolved org, never client input.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getEntitlementsMock = vi.fn()
+vi.mock('@/lib/features/entitlements', () => ({
+  getEntitlementsForOrganization: (...args: unknown[]) =>
+    getEntitlementsMock(...args),
+}))
+
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+import { router, adminProcedure, requireFeature, type Context } from './trpc'
+
+const testRouter = router({
+  probe: adminProcedure
+    .use(requireFeature('graphql-api'))
+    .query(({ ctx }) => ({ orgId: ctx.orgId })),
+})
+
+function callerFor(speaker: {
+  _id: string
+  isOrganizer?: boolean
+  organizerOrgIds?: string[]
+}) {
+  const session = { speaker, user: { email: 'u@x.test' } }
+  return testRouter.createCaller({
+    session,
+    speaker,
+    user: session.user,
+  } as unknown as Context)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: 'conf-A', organization: { _ref: 'org-A' } },
+    error: null,
+  })
+})
+
+describe('requireFeature', () => {
+  it('passes when the org is entitled and exposes the resolved orgId', async () => {
+    getEntitlementsMock.mockResolvedValue(new Set(['graphql-api']))
+    const caller = callerFor({ _id: 'admin', organizerOrgIds: ['org-A'] })
+    await expect(caller.probe()).resolves.toEqual({ orgId: 'org-A' })
+    expect(getEntitlementsMock).toHaveBeenCalledWith('org-A')
+  })
+
+  it('throws FORBIDDEN naming the feature when the org is not entitled', async () => {
+    getEntitlementsMock.mockResolvedValue(new Set())
+    const caller = callerFor({ _id: 'admin', organizerOrgIds: ['org-A'] })
+    await expect(caller.probe()).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: expect.stringContaining('"graphql-api"'),
+    })
+  })
+
+  it('fails closed before the entitlement read when the org is unresolvable', async () => {
+    // Legacy-token bridge admin (no organizerOrgIds, global flag) passes the
+    // waist even with a null org — the feature gate must still deny.
+    getConferenceMock.mockResolvedValue({
+      conference: { _id: 'conf-A' },
+      error: null,
+    })
+    const caller = callerFor({ _id: 'legacy-admin', isOrganizer: true })
+    await expect(caller.probe()).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(getEntitlementsMock).not.toHaveBeenCalled()
+  })
+
+  it('never reaches the gate for a non-organizer (the waist rejects first)', async () => {
+    const caller = callerFor({ _id: 'speaker', organizerOrgIds: [] })
+    await expect(caller.probe()).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(getEntitlementsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import { getAuthSession } from '@/lib/auth'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { isOrganizerForOrg } from '@/lib/authz/organizer'
+import type { FeatureId } from '@/lib/features/registry'
 import { AppEnvironment } from '@/lib/environment/config'
 import { structuredErrorData, type StructuredErrorData } from './errors'
 
@@ -200,6 +201,44 @@ export const organizerProcedure = t.procedure
   .use(requireAuth)
   .use(withOrgOrganizer)
 export const router = t.router
+
+/**
+ * Per-organization FEATURE gate. Composes onto the org-scoped procedures —
+ * `adminProcedure.use(requireFeature('some-feature'))` — and throws FORBIDDEN
+ * (naming the feature) unless the request org's resolved entitlements include
+ * it. The org is taken from the upstream middleware's `ctx.orgId` when present
+ * (the authz waist already resolved it) and resolved from the domain otherwise;
+ * an unresolvable org FAILS CLOSED, matching the waist's posture. Entitlement
+ * resolution semantics live in `src/lib/features/registry.ts` +
+ * `entitlements.ts` (plan ladder, override-only beta/internal, overrides win,
+ * expiry). Imported lazily so this module keeps zero static dependency on the
+ * cached entitlements read.
+ */
+export function requireFeature(featureId: FeatureId) {
+  return t.middleware(async ({ ctx, next }) => {
+    const upstreamOrgId = (ctx as { orgId?: string | null }).orgId
+    const orgId =
+      upstreamOrgId !== undefined
+        ? upstreamOrgId
+        : await resolveOrganizationId()
+    if (!orgId) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `The "${featureId}" feature requires a resolvable organization`,
+      })
+    }
+    const { getEntitlementsForOrganization } =
+      await import('@/lib/features/entitlements')
+    const entitled = await getEntitlementsForOrganization(orgId)
+    if (!entitled.has(featureId)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `The "${featureId}" feature is not enabled for this organization`,
+      })
+    }
+    return next({ ctx: { ...ctx, orgId } })
+  })
+}
 
 const CLIENT_ERROR_CODES = new Set([
   'NOT_FOUND',


### PR DESCRIPTION
Foundation for per-organization feature entitlements. **No existing code path is gated yet** — the seed features are deliberately ones that are not enforced anywhere, so this ships with zero behaviour change for every current organization. Enforcement is wired per-feature in follow-ups via `requireFeature`.

## The model — readiness × plan

Every feature lives in a **closed, typed registry** (`src/lib/features/registry.ts`): `FeatureId` union + `{ id, title, description, readiness, minPlan? }`.

| readiness | availability |
| --- | --- |
| `ga` | enabled for every org whose `plan` satisfies `minPlan` (absent `minPlan` = every plan); ladder is `community < pro < enterprise` |
| `beta` | enabled **only** via an explicit `featureOverrides` grant, regardless of plan; may be advertised as opt-in |
| `internal` | same override-only gating as beta, but never surfaced in upsell UI |

**Override semantics** (resolved by the pure `computeEntitlements(plan, overrides, now)` in `src/lib/features/entitlements.ts`):

- Overrides **always win, in both directions**: `enabled: true` grants what the plan denies, `enabled: false` revokes what the plan grants.
- Applied in array order — a later override for the same feature supersedes an earlier one.
- An override past its `expiresAt` is ignored entirely (an unparsable `expiresAt` fails closed to "expired"); an override for an unknown feature id is inert.
- An absent/invalid stored `plan` resolves to `community`, so legacy orgs need no migration.

Seed registry (all truthfully un-enforced today): `graphql-api` (internal), `dedicated-email` (ga, minPlan pro — placeholder for the per-org sender tier), `slack-mirror` (internal).

## Pieces

- **Schema** — `organization.plan` (radio, initialValue community) + `organization.featureOverrides[]` (`feature`, `enabled`, `note?`, `expiresAt?`); TS shapes in `src/lib/organization/types.ts`.
- **Resolver** — `getEntitlementsForOrganization(orgId)` reads the org through a cached `getOrganizationById` tagged with the new `organizationTag(orgId)` (plus `content:organizations`), so the plan/override mutation below busts exactly the edited tenant's resolution. Expiry is evaluated with a fresh `now` per call; only the document read is cached.
- **tRPC gate** — `requireFeature(id)` (`src/server/trpc.ts`) composes onto the org-scoped admin waist (`adminProcedure.use(requireFeature('…'))`), throws `FORBIDDEN` naming the feature, and fails closed when the request org is unresolvable (matching the waist's posture). Not attached to any existing procedure in this PR.
- **Platform router** — `platform.listOrganizations` / `platform.updateEntitlements`, gated **server-side** by the `PLATFORM_ORG_SLUG` contract (`src/lib/features/platform.ts`): the env var names the slug of the one org whose organizers may manage other orgs' entitlements; unset (the default) means the whole surface fails closed. The mutation writes keyed overrides (`ensureUniqueArrayKeys`) and revalidates `organizationTag`.
- **Admin settings** (Identity & Brand group):
  - Read-only **Plan & Features** card for the current org — plan badge + entitled features with readiness chips, override-granted ones flagged.
  - Platform-only **Organizations** card — all orgs with plan badges and a per-org ModalShell editor (plan radio + override rows with feature/enabled/note/expiry), stable dirty baseline + guarded cancel. Hidden for non-platform tenants; the router gate is the security boundary.

## Verification

- `pnpm vitest run`: 337 files / 4375 tests green (26 new: resolver semantics, `requireFeature` incl. legacy-token fail-closed, platform gate + write path).
- `tsc --noEmit` clean; eslint clean on changed files (tenancy rule satisfied via annotated reviewed-global org reads); prettier applied.
- `pnpm shoot` on the new card stories and the SettingsIA page harness (both cards in place, mobile 393px, no viewport overflow; description rows restructured after a first capture showed badge-squeezed text).

## Follow-ups

- Wire the registry's `feature` field into the admin destination registry / Cmd+K palette (deferred — #663 owns those files).
- PR #666 (onboarding wizard) creates organizations **without** a `plan` field; once this lands, its create mutation should default `plan: 'community'` explicitly (the resolver already treats absent as community, so this is hygiene, not a bug).
- First real consumer: attach `requireFeature('…')` to an endpoint and grant via override to validate end-to-end in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C
