### PR TITLE
fix(auth): static cookie-domain (middleware-safe) + post-build smoke guardrail (re-fixes #462, closes the CI gap)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -203,3 +203,78 @@ jobs:
           VAPID_PUBLIC_KEY: ci_vapid_public_key_not_for_production
           VAPID_PRIVATE_KEY: ci_vapid_private_key_not_for_production
           VAPID_SUBJECT: mailto:ci@example.com
+
+  # POST-BUILD RUNTIME SMOKE TEST (#671). `next build` COMPILES the broken
+  # lazy-auth-config form fine and vitest mocks next-auth, so neither the Build
+  # nor the Tests job can catch a runtime middleware regression like #462
+  # (`nextAuthMiddleware is not a function`, 500 on every authenticated route).
+  # This job boots the REAL production server and curls PROTECTED routes (which
+  # run the middleware — the exact failure surface), failing loudly on any 500
+  # or `is not a function` / `TypeError` signature. Kept a separate, distinctly
+  # NAMED job so it can be added to the required-status ruleset in branch
+  # protection. A protected-route redirect needs no real backend/secrets.
+  smoke:
+    name: Runtime Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # ratchet:pnpm/action-setup@v4
+        with:
+          version: 10.24.0
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build application
+        run: pnpm run build
+        env:
+          # Same placeholder env as the Build job — a `next build` must compile
+          # with these dummy Auth.js v5 secrets (no real backend is contacted).
+          NODE_ENV: production
+          AUTH_SECRET: ci-build-secret-not-for-production
+          AUTH_GITHUB_ID: ci-build-github-id-not-for-production
+          AUTH_GITHUB_SECRET: ci-build-github-secret-not-for-production
+          AUTH_LINKEDIN_ID: ci-build-linkedin-id-not-for-production
+          AUTH_LINKEDIN_SECRET: ci-build-linkedin-secret-not-for-production
+          NEXTAUTH_URL: http://localhost:3000
+          RESEND_API_KEY: re_ci_build_key_not_for_production
+          INVITATION_TOKEN_SECRET: ci_invitation_token_secret_not_for_production
+          VAPID_PUBLIC_KEY: ci_vapid_public_key_not_for_production
+          VAPID_PRIVATE_KEY: ci_vapid_private_key_not_for_production
+          VAPID_SUBJECT: mailto:ci@example.com
+
+      - name: Smoke-test protected routes against a live server
+        run: node scripts/smoke-protected-routes.mjs
+        env:
+          # `next start` runs the production bundle. A protected-route redirect
+          # needs no real secrets; these dummy values just satisfy config reads.
+          NODE_ENV: production
+          AUTH_SECRET: ci-build-secret-not-for-production
+          AUTH_GITHUB_ID: ci-build-github-id-not-for-production
+          AUTH_GITHUB_SECRET: ci-build-github-secret-not-for-production
+          AUTH_LINKEDIN_ID: ci-build-linkedin-id-not-for-production
+          AUTH_LINKEDIN_SECRET: ci-build-linkedin-secret-not-for-production
+          NEXTAUTH_URL: http://localhost:3000

--- a/__tests__/lib/auth/proxy-middleware-contract.test.ts
+++ b/__tests__/lib/auth/proxy-middleware-contract.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment node
+ *
+ * MIDDLEWARE-WRAPPER SHAPE CONTRACT — the unit-level guard for the #462 / #671
+ * incident.
+ *
+ * The incident: PR #462 fed `NextAuth` a CONFIG FUNCTION (Auth.js "lazy" form).
+ * In next-auth v5 that changes the shape of the returned `auth`, so the wrapper
+ * `auth((req) => …)` in `src/proxy.ts` yielded a NON-function and every
+ * authenticated route 500'd (`nextAuthMiddleware is not a function`).
+ *
+ * This test asserts the contract the proxy depends on, WITHOUT mocking
+ * `@/lib/auth` (only next-auth itself is globally mocked in vitest.config, as it
+ * is for every test): the exported `auth` must be callable and, given a request
+ * handler, return a FUNCTION; and the proxy's default middleware export must be
+ * a function that returns a Response for a protected route.
+ *
+ * IMPORTANT LIMITATION (why PART 2's post-build smoke test also exists): the
+ * global next-auth mock's `auth()` returns a function REGARDLESS of whether the
+ * real code passed a static object or a lazy function to `NextAuth`, so this
+ * unit test CANNOT distinguish the two config shapes and would NOT, on its own,
+ * have caught #462. It locks the export/wrapper contract at the source level;
+ * the real regression is caught by the production-bundle smoke test in
+ * `scripts/smoke-protected-routes.mjs` (CI job "Runtime Smoke Test").
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { NextRequest, type NextFetchEvent } from 'next/server'
+
+// The proxy statically imports the WorkOS middleware factory and the app
+// environment; stub both so importing the REAL proxy (and the REAL @/lib/auth)
+// does not require a live WorkOS client or a fixed NODE_ENV. @/lib/auth is
+// deliberately NOT mocked — this test exercises its real wrapper export.
+vi.mock('@workos-inc/authkit-nextjs', () => ({
+  authkitMiddleware: vi.fn(() => vi.fn()),
+}))
+vi.mock('@/lib/environment/config', () => ({
+  AppEnvironment: {
+    isTestMode: false,
+    isDevelopment: false,
+    isProduction: true,
+    createMockAuthContext: () => ({ user: { email: 'mock@test' } }),
+  },
+}))
+
+import { auth } from '@/lib/auth'
+import middleware from '@/proxy'
+
+describe('proxy middleware wrapper shape (#462 regression contract)', () => {
+  it('exports `auth` as a callable that wraps a handler into a function', () => {
+    expect(typeof auth).toBe('function')
+    const wrapped = auth((() => undefined) as never)
+    expect(typeof wrapped).toBe('function')
+  })
+
+  it('exports a middleware function that returns a Response for a protected route', async () => {
+    expect(typeof middleware).toBe('function')
+    const req = new NextRequest('http://localhost:3000/admin')
+    const result = await middleware(req, {} as NextFetchEvent)
+    // Unauthenticated → the wrapped middleware runs and redirects to sign-in.
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBeGreaterThanOrEqual(300)
+    expect((result as Response).status).toBeLessThan(400)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "styled-components": "^6.4.3",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.1",
+    "tldts": "^7.4.0",
     "typescript": "^6.0.3",
     "uuid": "^14.0.1",
     "web-push": "^3.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
+      tldts:
+        specifier: ^7.4.0
+        version: 7.4.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/smoke-protected-routes.mjs
+++ b/scripts/smoke-protected-routes.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * POST-BUILD RUNTIME SMOKE TEST — the guardrail for the #462 incident.
+ *
+ * Context (issue #671): PR #462 fed NextAuth a CONFIG FUNCTION (Auth.js "lazy"
+ * form). In next-auth v5 that changes the shape of the returned `auth`, so the
+ * middleware wrapper `auth((req) => …)` in `src/proxy.ts` produced a
+ * NON-function — every authenticated route (admin + speaker dashboard) 500'd
+ * with `nextAuthMiddleware is not a function`. It passed CI because `next build`
+ * COMPILES the lazy form fine (the failure is runtime-only) and vitest aliases
+ * `next-auth` to a mock whose `auth()` always returns a function — so no unit
+ * test could ever tell the two config shapes apart.
+ *
+ * This script closes that gap by exercising the REAL production bundle: it boots
+ * `next start` against a real `next build`, then hits the exact failure surface —
+ * a PROTECTED route, which runs the middleware — plus a NextAuth route handler,
+ * and FAILS LOUDLY on any 500 or `is not a function` / `TypeError` signature.
+ * Hitting a protected route UNAUTHENTICATED runs the middleware and should
+ * redirect to sign-in (3xx) WITHOUT needing Sanity/WorkOS/any backend.
+ *
+ * Usage: node scripts/smoke-protected-routes.mjs [--port 3123] [--start-cmd "…"]
+ * Assumes a production build already exists in `.next` (run `next build` first).
+ */
+
+import { spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const PORT = Number(
+  process.env.SMOKE_PORT ??
+    (process.argv.includes('--port')
+      ? process.argv[process.argv.indexOf('--port') + 1]
+      : 3123),
+)
+const BASE = `http://127.0.0.1:${PORT}`
+const BOOT_TIMEOUT_MS = 90_000
+const POLL_INTERVAL_MS = 750
+
+// Error signatures that indicate the middleware/config regression (or any
+// unhandled server error) rather than an expected auth redirect.
+const ERROR_SIGNATURES = [
+  'is not a function',
+  'TypeError',
+  'Internal Server Error',
+  'ReferenceError',
+]
+
+/**
+ * Surfaces to probe. `expectRedirect` routes MUST run the middleware
+ * (protected paths) and are the precise crash surface; the API handler proves
+ * the NextAuth route handlers (the other half of the returned `auth`) boot.
+ */
+const SURFACES = [
+  {
+    name: 'admin dashboard (middleware, unauthenticated)',
+    path: '/admin',
+    expect: 'redirect-or-ok',
+  },
+  {
+    name: 'speaker CFP list (middleware, unauthenticated)',
+    path: '/cfp/list',
+    expect: 'redirect-or-ok',
+  },
+  {
+    name: 'NextAuth providers route handler',
+    path: '/api/auth/providers',
+    expect: 'ok',
+  },
+]
+
+function log(msg) {
+  process.stdout.write(`[smoke] ${msg}\n`)
+}
+
+let server
+
+function startServer() {
+  const startArgs = ['next', 'start', '-p', String(PORT)]
+  log(`booting: pnpm exec ${startArgs.join(' ')}`)
+  server = spawn('pnpm', ['exec', ...startArgs], {
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+      // Minimal dummy env — a protected-route redirect never needs real
+      // secrets. Mirrors the CI Build job's placeholder env. Real env wins.
+      AUTH_SECRET:
+        process.env.AUTH_SECRET ?? 'ci-smoke-secret-not-for-production',
+      AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID ?? 'ci-smoke-github-id',
+      AUTH_GITHUB_SECRET:
+        process.env.AUTH_GITHUB_SECRET ?? 'ci-smoke-github-secret',
+      AUTH_LINKEDIN_ID: process.env.AUTH_LINKEDIN_ID ?? 'ci-smoke-linkedin-id',
+      AUTH_LINKEDIN_SECRET:
+        process.env.AUTH_LINKEDIN_SECRET ?? 'ci-smoke-linkedin-secret',
+      // Auth.js v5 refuses to serve its route handlers on an "untrusted" Host
+      // unless trustHost is set — Vercel auto-enables it in prod, but a bare
+      // `next start` (local/CI) does not, so `/api/auth/*` would 500 with
+      // `UntrustedHost` and mask the real signal. Trust the loopback host we
+      // ourselves bind to.
+      AUTH_TRUST_HOST: process.env.AUTH_TRUST_HOST ?? 'true',
+      // A few modules assert their env at import-time (e.g. the contract-
+      // reminders cron route asserts RESEND_API_KEY); provide dummies so an
+      // unrelated route's module-eval cannot throw during boot.
+      RESEND_API_KEY: process.env.RESEND_API_KEY ?? 're_ci_smoke_not_for_prod',
+      INVITATION_TOKEN_SECRET:
+        process.env.INVITATION_TOKEN_SECRET ?? 'ci_smoke_invitation_secret',
+      VAPID_PUBLIC_KEY: process.env.VAPID_PUBLIC_KEY ?? 'ci_smoke_vapid_public',
+      VAPID_PRIVATE_KEY:
+        process.env.VAPID_PRIVATE_KEY ?? 'ci_smoke_vapid_private',
+      VAPID_SUBJECT: process.env.VAPID_SUBJECT ?? 'mailto:ci@example.com',
+    },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  })
+  server.on('exit', (code, signal) => {
+    if (code && code !== 0 && !shuttingDown) {
+      log(`server exited early (code=${code} signal=${signal})`)
+    }
+  })
+}
+
+let shuttingDown = false
+function stopServer() {
+  if (shuttingDown || !server) return
+  shuttingDown = true
+  try {
+    server.kill('SIGTERM')
+  } catch {
+    // already gone
+  }
+}
+
+// Kill the server whatever happens.
+for (const sig of ['exit', 'SIGINT', 'SIGTERM', 'uncaughtException']) {
+  process.on(sig, stopServer)
+}
+
+async function waitForReady() {
+  const deadline = Date.now() + BOOT_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    if (server?.exitCode != null) {
+      throw new Error(
+        `server process exited (code=${server.exitCode}) before ready`,
+      )
+    }
+    try {
+      // Any HTTP response (even non-200) means the server accepts connections.
+      const res = await fetch(`${BASE}/api/auth/providers`, {
+        redirect: 'manual',
+      })
+      if (res.status > 0) {
+        log(`server ready (providers responded ${res.status})`)
+        return
+      }
+    } catch {
+      // not up yet
+    }
+    await sleep(POLL_INTERVAL_MS)
+  }
+  throw new Error(`server not ready within ${BOOT_TIMEOUT_MS}ms`)
+}
+
+function bodySignatureHit(body) {
+  return ERROR_SIGNATURES.find((sig) => body.includes(sig))
+}
+
+async function probe(surface) {
+  const res = await fetch(`${BASE}${surface.path}`, { redirect: 'manual' })
+  const body = await res.text().catch(() => '')
+  const failures = []
+
+  if (res.status >= 500) {
+    failures.push(`HTTP ${res.status} (server error)`)
+  }
+  const sig = bodySignatureHit(body)
+  if (sig) {
+    failures.push(`body contains error signature: "${sig}"`)
+  }
+  if (surface.expect === 'redirect-or-ok') {
+    const ok =
+      (res.status >= 300 && res.status < 400) ||
+      (res.status >= 200 && res.status < 300)
+    if (!ok) {
+      failures.push(
+        `expected a 2xx render or 3xx sign-in redirect, got ${res.status}`,
+      )
+    }
+  } else if (surface.expect === 'ok') {
+    if (res.status >= 400) {
+      failures.push(`expected a 2xx/3xx response, got ${res.status}`)
+    }
+  }
+
+  const loc = res.headers.get('location')
+  const detail = `${res.status}${loc ? ` → ${loc}` : ''}`
+  return { failures, detail }
+}
+
+async function main() {
+  startServer()
+  await waitForReady()
+
+  let failed = false
+  for (const surface of SURFACES) {
+    try {
+      const { failures, detail } = await probe(surface)
+      if (failures.length) {
+        failed = true
+        log(`FAIL  ${surface.name} [${surface.path}] — ${detail}`)
+        for (const f of failures) log(`        ✗ ${f}`)
+      } else {
+        log(`PASS  ${surface.name} [${surface.path}] — ${detail}`)
+      }
+    } catch (err) {
+      failed = true
+      log(`FAIL  ${surface.name} [${surface.path}] — request threw: ${err}`)
+    }
+  }
+
+  if (failed) {
+    log('SMOKE TEST FAILED — a protected route errored or returned 500.')
+    log('This is the exact failure class of the #462 incident (see #671).')
+    process.exitCode = 1
+  } else {
+    log('SMOKE TEST PASSED — all protected routes redirect/render, no 500s.')
+  }
+}
+
+main()
+  .catch((err) => {
+    log(`SMOKE TEST ERRORED: ${err?.stack ?? err}`)
+    process.exitCode = 1
+  })
+  .finally(() => {
+    stopServer()
+  })

--- a/scripts/smoke-protected-routes.mjs
+++ b/scripts/smoke-protected-routes.mjs
@@ -18,19 +18,28 @@
  * Hitting a protected route UNAUTHENTICATED runs the middleware and should
  * redirect to sign-in (3xx) WITHOUT needing Sanity/WorkOS/any backend.
  *
- * Usage: node scripts/smoke-protected-routes.mjs [--port 3123] [--start-cmd "…"]
- * Assumes a production build already exists in `.next` (run `next build` first).
+ * Usage: node scripts/smoke-protected-routes.mjs [--port 3123]
+ *   (or set SMOKE_PORT). Assumes a production build already exists in `.next`
+ *   (run `next build` first).
  */
 
 import { spawn } from 'node:child_process'
 import { setTimeout as sleep } from 'node:timers/promises'
 
-const PORT = Number(
+const RAW_PORT =
   process.env.SMOKE_PORT ??
-    (process.argv.includes('--port')
-      ? process.argv[process.argv.indexOf('--port') + 1]
-      : 3123),
-)
+  (process.argv.includes('--port')
+    ? process.argv[process.argv.indexOf('--port') + 1]
+    : '3123')
+const PORT = Number(RAW_PORT)
+// A bare `--port` with no value, or a non-numeric SMOKE_PORT, yields NaN — fail
+// loudly instead of booting `next start` against an invalid `http://…:NaN` URL.
+if (!Number.isInteger(PORT) || PORT <= 0 || PORT > 65535) {
+  process.stderr.write(
+    `[smoke] invalid port: ${JSON.stringify(RAW_PORT)} — pass a valid --port <1-65535> or SMOKE_PORT.\n`,
+  )
+  process.exit(1)
+}
 const BASE = `http://127.0.0.1:${PORT}`
 const BOOT_TIMEOUT_MS = 90_000
 const POLL_INTERVAL_MS = 750
@@ -127,10 +136,26 @@ function stopServer() {
   }
 }
 
-// Kill the server whatever happens.
-for (const sig of ['exit', 'SIGINT', 'SIGTERM', 'uncaughtException']) {
-  process.on(sig, stopServer)
+// Best-effort cleanup on NORMAL process exit — the 'exit' handler runs
+// synchronously and cannot change the exit code or run async work.
+process.on('exit', stopServer)
+
+// On a SIGNAL or an UNCAUGHT EXCEPTION we must exit EXPLICITLY: installing a
+// handler overrides Node's default behavior of terminating the process, so if
+// we only stopped the child the process would hang (child killed, parent alive
+// with nothing left to do). Stop the child, then exit non-zero.
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => {
+    log(`received ${sig} — stopping server and exiting`)
+    stopServer()
+    process.exit(1)
+  })
 }
+process.on('uncaughtException', (err) => {
+  log(`uncaught exception: ${err?.stack ?? err}`)
+  stopServer()
+  process.exit(1)
+})
 
 async function waitForReady() {
   const deadline = Date.now() + BOOT_TIMEOUT_MS

--- a/scripts/smoke-protected-routes.mjs
+++ b/scripts/smoke-protected-routes.mjs
@@ -89,6 +89,13 @@ function startServer() {
     env: {
       ...process.env,
       NODE_ENV: 'production',
+      // Force the auth base URL to THIS smoke server's port so next-auth's
+      // host/URL construction matches where we actually boot — the ambient
+      // NEXTAUTH_URL/AUTH_URL (CI sets localhost:3000) would mismatch our port
+      // and make the smoke flaky. Self-contained over inherited.
+      NEXTAUTH_URL: `http://localhost:${PORT}`,
+      AUTH_URL: `http://localhost:${PORT}`,
+      AUTH_TRUST_HOST: 'true',
       // Minimal dummy env — a protected-route redirect never needs real
       // secrets. Mirrors the CI Build job's placeholder env. Real env wins.
       AUTH_SECRET:

--- a/src/lib/auth-cookie-domain.test.ts
+++ b/src/lib/auth-cookie-domain.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deriveSessionCookieDomain,
+  SHARED_PARENT_DOMAIN_DENYLIST,
+} from './auth-cookie-domain'
+
+describe('deriveSessionCookieDomain — registrable-domain (eTLD+1) derivation', () => {
+  it('widens a subdomain host to its registrable domain', () => {
+    expect(deriveSessionCookieDomain('admin.cloudnativedays.no')).toBe(
+      '.cloudnativedays.no',
+    )
+    expect(deriveSessionCookieDomain('2026.cloudnativebergen.dev')).toBe(
+      '.cloudnativebergen.dev',
+    )
+    // Deeper nesting still resolves to eTLD+1.
+    expect(deriveSessionCookieDomain('a.b.cloudnativedays.no')).toBe(
+      '.cloudnativedays.no',
+    )
+  })
+
+  it('returns the registrable domain for the apex host itself', () => {
+    // Domain=.cloudnativedays.no on the apex is valid and shares with subdomains.
+    expect(deriveSessionCookieDomain('cloudnativedays.no')).toBe(
+      '.cloudnativedays.no',
+    )
+  })
+
+  it('handles multi-part public suffixes via the PSL, not label counting', () => {
+    // A naive "last two labels" heuristic would derive the PUBLIC suffix
+    // `.co.uk` here — which browsers reject, dropping the whole cookie.
+    expect(deriveSessionCookieDomain('conf.example.co.uk')).toBe(
+      '.example.co.uk',
+    )
+    expect(deriveSessionCookieDomain('www.tickets.example.com.au')).toBe(
+      '.example.com.au',
+    )
+  })
+
+  it('normalizes case, ports, whitespace, and x-forwarded-host chains', () => {
+    expect(deriveSessionCookieDomain('Admin.CloudNativeDays.NO')).toBe(
+      '.cloudnativedays.no',
+    )
+    expect(deriveSessionCookieDomain('admin.cloudnativedays.no:8443')).toBe(
+      '.cloudnativedays.no',
+    )
+    expect(
+      deriveSessionCookieDomain(' admin.cloudnativedays.no , proxy.internal '),
+    ).toBe('.cloudnativedays.no')
+  })
+
+  it('NEVER widens on denylisted platform-shared parents (tenant isolation)', () => {
+    // konf.run: every subdomain is a DIFFERENT tenant — widening would put one
+    // tenant's session cookie in every other tenant's XSS blast radius.
+    expect(deriveSessionCookieDomain('tenant-a.konf.run')).toBeUndefined()
+    expect(deriveSessionCookieDomain('konf.run')).toBeUndefined()
+    expect(
+      deriveSessionCookieDomain('deep.sub.tenant.konf.run'),
+    ).toBeUndefined()
+    // vercel.app previews: subdomains are unrelated projects.
+    expect(deriveSessionCookieDomain('my-app.vercel.app')).toBeUndefined()
+    expect(
+      deriveSessionCookieDomain('website-git-branch-team.vercel.app'),
+    ).toBeUndefined()
+    expect(deriveSessionCookieDomain('vercel.app')).toBeUndefined()
+    // localhost, with and without port.
+    expect(deriveSessionCookieDomain('localhost')).toBeUndefined()
+    expect(deriveSessionCookieDomain('localhost:3000')).toBeUndefined()
+    expect(deriveSessionCookieDomain('app.localhost')).toBeUndefined()
+  })
+
+  it('exports the denylist with the expected shared parents', () => {
+    // Pin the security-critical entries so an accidental removal fails a test.
+    for (const parent of ['konf.run', 'vercel.app', 'localhost']) {
+      expect(SHARED_PARENT_DOMAIN_DENYLIST).toContain(parent)
+    }
+  })
+
+  it('falls back to host-only (undefined) for garbage and non-domains', () => {
+    expect(deriveSessionCookieDomain(undefined)).toBeUndefined()
+    expect(deriveSessionCookieDomain(null)).toBeUndefined()
+    expect(deriveSessionCookieDomain('')).toBeUndefined()
+    expect(deriveSessionCookieDomain('   ')).toBeUndefined()
+    expect(deriveSessionCookieDomain(',')).toBeUndefined()
+    expect(deriveSessionCookieDomain('not a host name')).toBeUndefined()
+    expect(deriveSessionCookieDomain('exa mple.com')).toBeUndefined()
+    // Single-label and bare-suffix hosts have no registrable domain.
+    expect(deriveSessionCookieDomain('intranet')).toBeUndefined()
+    expect(deriveSessionCookieDomain('no')).toBeUndefined()
+    expect(deriveSessionCookieDomain('.no')).toBeUndefined()
+    expect(deriveSessionCookieDomain('co.uk')).toBeUndefined()
+    // IP literals never get a Domain attribute.
+    expect(deriveSessionCookieDomain('127.0.0.1')).toBeUndefined()
+    expect(deriveSessionCookieDomain('127.0.0.1:3000')).toBeUndefined()
+    expect(deriveSessionCookieDomain('[::1]')).toBeUndefined()
+    expect(deriveSessionCookieDomain('[::1]:3000')).toBeUndefined()
+  })
+})

--- a/src/lib/auth-cookie-domain.ts
+++ b/src/lib/auth-cookie-domain.ts
@@ -1,0 +1,93 @@
+import { getDomain } from 'tldts'
+
+/**
+ * Parent domains that are SHARED ACROSS TENANTS — the session cookie must
+ * NEVER be widened to any of these, no matter what eTLD+1 derivation says.
+ *
+ * Rationale (XSS blast radius): a cookie scoped to `Domain=.parent` is sent to
+ * — and can be overwritten from — EVERY subdomain of that parent. On a domain
+ * whose subdomains all belong to ONE tenant (e.g. `cloudnativedays.no`) that is
+ * exactly the point of this feature. But on a platform-shared parent, the
+ * subdomains belong to DIFFERENT tenants: an XSS (or a malicious tenant) on
+ * `evil.konf.run` could read or fixate the session cookie of `victim.konf.run`.
+ * For these hosts we fall back to the default host-only cookie, which the
+ * browser scopes to the exact host that set it.
+ *
+ * Entries are bare registrable/parent domains (no leading dot, lowercase). A
+ * request host matches when it EQUALS an entry or is a subdomain of one.
+ * Extend this list whenever a new shared parent domain enters the platform.
+ */
+export const SHARED_PARENT_DOMAIN_DENYLIST: readonly string[] = [
+  // Future tenant-runtime domain: each subdomain is a DIFFERENT tenant.
+  'konf.run',
+  // Vercel preview/production deploys: subdomains are unrelated projects.
+  // (Also a PSL private-section suffix, but denylisted explicitly — defence in
+  // depth against PSL-data or derivation drift.)
+  'vercel.app',
+  // Local development: host-only cookies, never a Domain attribute.
+  'localhost',
+]
+
+/**
+ * Derive the session-cookie `Domain` attribute for a request host: the host's
+ * REGISTRABLE domain (eTLD+1, per the Public Suffix List via `tldts`) with a
+ * leading dot, so the cookie is shared across all subdomains of the
+ * conference's domain (e.g. host `admin.cloudnativedays.no` →
+ * `.cloudnativedays.no` → apex + www + per-year subdomains). Per-request
+ * derivation means every tenant domain gets the correct scope with ZERO
+ * per-tenant configuration.
+ *
+ * Returns `undefined` — meaning "set no Domain attribute; keep today's
+ * host-only cookie" — for every case where widening is wrong or unsafe:
+ *
+ * - hosts on {@link SHARED_PARENT_DOMAIN_DENYLIST} (see its doc comment),
+ * - IP literals, `localhost`, single-label / unresolvable hosts, and hosts
+ *   that ARE a public suffix (no registrable domain → `getDomain` = null),
+ * - anything unparseable — derivation is FAIL-SAFE: garbage in → host-only
+ *   cookie out, never a malformed `Domain` attribute.
+ *
+ * `allowPrivateDomains: true` matches browser behavior: browsers enforce the
+ * FULL Public Suffix List (private section included), so treating e.g.
+ * `vercel.app` as a suffix here avoids deriving a Domain the browser would
+ * reject (a rejected Set-Cookie drops the ENTIRE cookie, breaking sign-in).
+ */
+export function deriveSessionCookieDomain(
+  host: string | null | undefined,
+): string | undefined {
+  try {
+    if (!host) return undefined
+
+    // `x-forwarded-host` may carry a comma-separated chain — use the first
+    // (client-facing) entry. Strip any port; reject IPv6 literals outright.
+    let hostname = host.split(',')[0].trim().toLowerCase()
+    if (hostname.startsWith('[')) return undefined
+    hostname = hostname.split(':')[0]
+    if (!hostname) return undefined
+
+    if (isDenylistedHost(hostname)) return undefined
+
+    const registrable = getDomain(hostname, { allowPrivateDomains: true })
+    if (!registrable) return undefined
+
+    // Belt and braces: the derived domain must domain-match the request host
+    // (equal or a parent), contain a dot (never a bare TLD), and must not be —
+    // or sit under — a denylisted parent even if PSL data says otherwise.
+    if (registrable !== hostname && !hostname.endsWith(`.${registrable}`)) {
+      return undefined
+    }
+    if (!registrable.includes('.')) return undefined
+    if (isDenylistedHost(registrable)) return undefined
+
+    return `.${registrable}`
+  } catch {
+    // FAIL-SAFE: any unexpected derivation error → host-only cookie.
+    return undefined
+  }
+}
+
+/** True when `hostname` equals or is a subdomain of a denylisted parent. */
+function isDenylistedHost(hostname: string): boolean {
+  return SHARED_PARENT_DOMAIN_DENYLIST.some(
+    (parent) => hostname === parent || hostname.endsWith(`.${parent}`),
+  )
+}

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -12,6 +12,7 @@ process.env.AUTH_SECRET = 'auth-callback-test-secret'
 type Jar = {
   store: Map<string, string>
   get: (name: string) => { value: string } | undefined
+  getAll: () => { name: string; value: string }[]
   set: (name: string, value: string) => void
   delete: ReturnType<typeof vi.fn>
 }
@@ -27,6 +28,8 @@ function createJar(initial: Record<string, string> = {}): Jar {
       const value = store.get(name)
       return value === undefined ? undefined : { value }
     },
+    getAll: () =>
+      Array.from(store.entries(), ([name, value]) => ({ name, value })),
     set: (name: string, value: string) => {
       store.set(name, value)
     },
@@ -63,7 +66,12 @@ vi.mock('@/lib/sanity/client', () => ({
   speakerImageUrl: (src: string) => `img:${src}`,
 }))
 
-import { jwtSignInCallback, signOutHandler, redirectProxyConfig } from './auth'
+import {
+  jwtSignInCallback,
+  signOutHandler,
+  redirectProxyConfig,
+  staticSessionCookieDomain,
+} from './auth'
 import { signLinkIntent, LINK_INTENT_COOKIE } from './auth-link'
 
 const SESSION_COOKIE = 'authjs.session-token'
@@ -360,6 +368,29 @@ describe('signOutHandler — clears link-flow state', () => {
 
     expect(currentJar.delete).toHaveBeenCalledWith(LINK_INTENT_COOKIE)
   })
+
+  it('deletes RESIDUAL host-only session cookies (incl. chunked parts) on sign-out', async () => {
+    // @auth/core's own clear targets the Domain-scoped cookie; a pre-widening
+    // HOST-ONLY cookie of the same name must be deleted separately or the user
+    // stays signed in on that host after sign-out.
+    currentJar = createJar({
+      'authjs.session-token': 'stale',
+      '__Secure-authjs.session-token.0': 'chunk0',
+      '__Secure-authjs.session-token.1': 'chunk1',
+      'unrelated-cookie': 'keep',
+    })
+
+    await signOutHandler()
+
+    expect(currentJar.delete).toHaveBeenCalledWith('authjs.session-token')
+    expect(currentJar.delete).toHaveBeenCalledWith(
+      '__Secure-authjs.session-token.0',
+    )
+    expect(currentJar.delete).toHaveBeenCalledWith(
+      '__Secure-authjs.session-token.1',
+    )
+    expect(currentJar.delete).not.toHaveBeenCalledWith('unrelated-cookie')
+  })
 })
 
 describe('jwtSignInCallback — org-scoped session computation (CaaS T1-2, #614)', () => {
@@ -555,5 +586,83 @@ describe('redirectProxyConfig — centralized OAuth origin wiring (#619)', () =>
       redirectProxyUrl: 'https://auth.example.no/api/auth',
       trustHost: true,
     })
+  })
+})
+
+describe('staticSessionCookieDomain — primary-domain cookie Domain (#462 re-fix)', () => {
+  const env = (vars: Record<string, string>) =>
+    vars as unknown as NodeJS.ProcessEnv
+
+  it('derives the registrable domain from NEXT_PUBLIC_BASE_URL (full URL)', () => {
+    expect(
+      staticSessionCookieDomain(
+        env({ NEXT_PUBLIC_BASE_URL: 'https://cloudnativedays.no' }),
+      ),
+    ).toBe('.cloudnativedays.no')
+    // Subdomain host in the base URL still widens to eTLD+1.
+    expect(
+      staticSessionCookieDomain(
+        env({ NEXT_PUBLIC_BASE_URL: 'https://2026.cloudnativebergen.dev/cfp' }),
+      ),
+    ).toBe('.cloudnativebergen.dev')
+  })
+
+  it('accepts a bare host (no scheme) and strips ports', () => {
+    expect(
+      staticSessionCookieDomain(
+        env({ NEXT_PUBLIC_BASE_URL: 'admin.cloudnativedays.no' }),
+      ),
+    ).toBe('.cloudnativedays.no')
+    expect(
+      staticSessionCookieDomain(
+        env({ NEXT_PUBLIC_BASE_URL: 'cloudnativedays.no:8443' }),
+      ),
+    ).toBe('.cloudnativedays.no')
+  })
+
+  it('falls back to the legacy NEXT_PUBLIC_URL alias', () => {
+    expect(
+      staticSessionCookieDomain(
+        env({ NEXT_PUBLIC_URL: 'https://cloudnativedays.no' }),
+      ),
+    ).toBe('.cloudnativedays.no')
+    // NEXT_PUBLIC_BASE_URL takes precedence when both are set.
+    expect(
+      staticSessionCookieDomain(
+        env({
+          NEXT_PUBLIC_BASE_URL: 'https://cloudnativebergen.dev',
+          NEXT_PUBLIC_URL: 'https://cloudnativedays.no',
+        }),
+      ),
+    ).toBe('.cloudnativebergen.dev')
+  })
+
+  it('returns undefined (host-only) for localhost, previews, unset, and garbage', () => {
+    // Unset / blank → no domain (fail-safe; never throws at module load).
+    expect(staticSessionCookieDomain(env({}))).toBeUndefined()
+    expect(
+      staticSessionCookieDomain(env({ NEXT_PUBLIC_BASE_URL: '   ' })),
+    ).toBeUndefined()
+    // localhost dev origin.
+    expect(
+      staticSessionCookieDomain(
+        env({ NEXT_PUBLIC_BASE_URL: 'http://localhost:3000' }),
+      ),
+    ).toBeUndefined()
+    // Vercel preview + platform-shared parent (tenant isolation).
+    expect(
+      staticSessionCookieDomain(
+        env({ NEXT_PUBLIC_BASE_URL: 'https://website-abc123.vercel.app' }),
+      ),
+    ).toBeUndefined()
+    expect(
+      staticSessionCookieDomain(
+        env({ NEXT_PUBLIC_BASE_URL: 'https://tenant.konf.run' }),
+      ),
+    ).toBeUndefined()
+    // Unparseable.
+    expect(
+      staticSessionCookieDomain(env({ NEXT_PUBLIC_BASE_URL: 'not a url' })),
+    ).toBeUndefined()
   })
 })

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -590,8 +590,10 @@ describe('redirectProxyConfig — centralized OAuth origin wiring (#619)', () =>
 })
 
 describe('staticSessionCookieDomain — primary-domain cookie Domain (#462 re-fix)', () => {
+  // The override is production-only (see below), so the derivation cases default
+  // to a production env; individual tests override NODE_ENV/VERCEL_ENV.
   const env = (vars: Record<string, string>) =>
-    vars as unknown as NodeJS.ProcessEnv
+    ({ NODE_ENV: 'production', ...vars }) as unknown as NodeJS.ProcessEnv
 
   it('derives the registrable domain from NEXT_PUBLIC_BASE_URL (full URL)', () => {
     expect(
@@ -663,6 +665,67 @@ describe('staticSessionCookieDomain — primary-domain cookie Domain (#462 re-fi
     // Unparseable.
     expect(
       staticSessionCookieDomain(env({ NEXT_PUBLIC_BASE_URL: 'not a url' })),
+    ).toBeUndefined()
+  })
+
+  it('applies the Domain ONLY in a genuine production deployment', () => {
+    const raw = (vars: Record<string, string>) =>
+      vars as unknown as NodeJS.ProcessEnv
+
+    // Off-Vercel production (NODE_ENV=production, no VERCEL_ENV) → Domain set.
+    expect(
+      staticSessionCookieDomain(
+        raw({
+          NODE_ENV: 'production',
+          NEXT_PUBLIC_URL: 'https://cloudnativedays.no',
+        }),
+      ),
+    ).toBe('.cloudnativedays.no')
+
+    // Vercel production → Domain set.
+    expect(
+      staticSessionCookieDomain(
+        raw({
+          VERCEL_ENV: 'production',
+          NODE_ENV: 'production',
+          NEXT_PUBLIC_URL: 'https://cloudnativedays.no',
+        }),
+      ),
+    ).toBe('.cloudnativedays.no')
+  })
+
+  it('stays host-only (no Domain) in any NON-production env even when NEXT_PUBLIC_URL is set', () => {
+    const raw = (vars: Record<string, string>) =>
+      vars as unknown as NodeJS.ProcessEnv
+
+    // Local dev.
+    expect(
+      staticSessionCookieDomain(
+        raw({
+          NODE_ENV: 'development',
+          NEXT_PUBLIC_URL: 'https://cloudnativedays.no',
+        }),
+      ),
+    ).toBeUndefined()
+
+    // Vercel PREVIEW — NODE_ENV is 'production' here, so only VERCEL_ENV can
+    // distinguish it; a preview must NOT inherit the production Domain even if
+    // NEXT_PUBLIC_URL leaks into the preview scope (the mismatch the gate guards).
+    expect(
+      staticSessionCookieDomain(
+        raw({
+          VERCEL_ENV: 'preview',
+          NODE_ENV: 'production',
+          NEXT_PUBLIC_URL: 'https://cloudnativedays.no',
+        }),
+      ),
+    ).toBeUndefined()
+
+    // No env markers at all → not production → host-only.
+    expect(
+      staticSessionCookieDomain(
+        raw({ NEXT_PUBLIC_URL: 'https://cloudnativedays.no' }),
+      ),
     ).toBeUndefined()
   })
 })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,6 +5,7 @@ import type { Account, NextAuthConfig, Profile, Session, User } from 'next-auth'
 import { decode } from 'next-auth/jwt'
 import { NextRequest } from 'next/server'
 import { getOrCreateSpeaker } from '@/lib/speaker/sanity'
+import { deriveSessionCookieDomain } from '@/lib/auth-cookie-domain'
 import { speakerImageUrl } from '@/lib/sanity/client'
 import { AppEnvironment } from '@/lib/environment/config'
 import type { Speaker } from '@/lib/speaker/types'
@@ -127,9 +128,31 @@ export async function signOutHandler(): Promise<void> {
   try {
     const { LINK_INTENT_COOKIE } = await import('@/lib/auth-link')
     const { cookies } = await import('next/headers')
-    ;(await cookies()).delete(LINK_INTENT_COOKIE)
+    const jar = await cookies()
+    jar.delete(LINK_INTENT_COOKIE)
+
+    // RESIDUAL HOST-ONLY COOKIE CLEANUP: @auth/core clears the session cookie
+    // using the CURRENT cookie options — with the static `Domain` widening (see
+    // `staticSessionCookieDomain`), that clear targets the Domain-scoped cookie.
+    // A browser can additionally hold a HOST-ONLY cookie of the same name (set
+    // before the widening shipped, or across a config/denylist change); a
+    // Set-Cookie with a Domain attribute can never remove it, so it would
+    // SURVIVE sign-out and keep the user signed in on that host. Delete every
+    // session-token cookie (including chunked `<name>.0`, `.1`, … parts)
+    // host-only as well — the two deletes target different cookies, so both are
+    // needed. This is independent of how the Domain is derived (it just walks
+    // the request's own cookie jar), so it is correct under the static config.
+    for (const { name } of jar.getAll()) {
+      if (
+        SESSION_TOKEN_COOKIE_NAMES.some(
+          (base) => name === base || name.startsWith(`${base}.`),
+        )
+      ) {
+        jar.delete(name)
+      }
+    }
   } catch (err) {
-    console.error('Failed to clear link-intent cookie on sign-out', err)
+    console.error('Failed to clear auth cookies on sign-out', err)
   }
 }
 
@@ -431,6 +454,70 @@ export function redirectProxyConfig(
   return { redirectProxyUrl: url, trustHost: true }
 }
 
+/**
+ * STATIC session-cookie `Domain` for the platform's primary domain, derived
+ * ONCE at module load from the configured platform base URL (the same env the
+ * rest of the app treats as canonical — `NEXT_PUBLIC_BASE_URL`, then the legacy
+ * alias `NEXT_PUBLIC_URL`; see `platformBaseUrl` in `@/lib/branding/platform`).
+ *
+ * The host's registrable domain (eTLD+1, via `deriveSessionCookieDomain`) is
+ * used with a leading dot — host `admin.cloudnativedays.no` →
+ * `Domain=.cloudnativedays.no` — so a signed-in user stays signed in across
+ * apex + www + per-year subdomains of the primary domain instead of being
+ * dropped by the default host-only cookie (the #462 bug this re-fixes).
+ *
+ * WHY STATIC (not the reverted per-request/lazy form): feeding `NextAuth` a
+ * CONFIG FUNCTION changes the shape of the returned `auth` in next-auth v5, so
+ * the middleware wrapper `auth((req) => …)` in `src/proxy.ts` becomes a
+ * NON-function and every authenticated route 500s (`nextAuthMiddleware is not a
+ * function`) — the production incident (#671). A single primary domain today
+ * needs no per-request derivation, so we compute the Domain once from config
+ * and keep `NextAuth(config)` (a plain object), which leaves the middleware
+ * wrapper intact. Per-request / multi-tenant derivation is DELIBERATELY
+ * DEFERRED to when auth goes multi-tenant (central-auth-origin work, #619),
+ * where it must be re-introduced WITHOUT the lazy-config form.
+ *
+ * FAIL-SAFE: `deriveSessionCookieDomain` returns `undefined` for localhost, IP
+ * literals, previews on `vercel.app`, platform-shared parents (`konf.run`),
+ * public suffixes, unset/blank env, and anything unparseable — in which case NO
+ * `cookies` key is emitted and today's host-only cookie is kept. It never
+ * throws (so it cannot break module load / `next build`, unlike calling
+ * `platformBaseUrl` which throws when unconfigured in production).
+ *
+ * Env-parameterised + exported so the derivation is unit-testable under both
+ * outcomes. Referenced in-file by `config`, so not an unused export.
+ */
+export function staticSessionCookieDomain(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const configured =
+    env.NEXT_PUBLIC_BASE_URL?.trim() || env.NEXT_PUBLIC_URL?.trim() || ''
+  if (!configured) return undefined
+
+  // The env may be a full URL (`https://host[:port]/path`) or a bare host.
+  // Extract just the host before deriving; `deriveSessionCookieDomain` itself
+  // strips any port. On a parse failure fall through with the raw value — the
+  // derivation is fail-safe and will decline anything it cannot parse.
+  let host = configured
+  try {
+    const withScheme = /^https?:\/\//i.test(configured)
+      ? configured
+      : `https://${configured}`
+    host = new URL(withScheme).host
+  } catch {
+    // keep `host = configured`; derivation will fail-safe to undefined.
+  }
+
+  return deriveSessionCookieDomain(host)
+}
+
+/**
+ * The primary domain's session-cookie `Domain`, resolved once at module load.
+ * `undefined` (localhost / preview / unset env / unparseable) → no `cookies`
+ * override → default host-only cookie.
+ */
+const sessionCookieDomain = staticSessionCookieDomain()
+
 const config = {
   providers: [
     GitHub({
@@ -469,6 +556,23 @@ const config = {
       return redirectCallback(params)
     },
   },
+
+  // STATIC cross-subdomain session-cookie Domain for the primary domain (see
+  // `staticSessionCookieDomain`). Spread CONDITIONALLY: when derivation declines
+  // (localhost / preview / unset env) no `cookies` key is contributed and the
+  // default HOST-ONLY cookie is kept — byte-for-byte today's behavior. Only the
+  // `domain` option is set; @auth/core DEEP-MERGES it onto the cookie defaults,
+  // so the `__Secure-` name prefix + httpOnly / secure / sameSite=lax / path are
+  // all preserved (that prefix permits a Domain attribute, unlike `__Host-`).
+  ...(sessionCookieDomain
+    ? {
+        cookies: {
+          sessionToken: {
+            options: { domain: sessionCookieDomain },
+          },
+        },
+      }
+    : {}),
 
   // Opt-in centralized OAuth origin (#619). Spread LAST so an absent env
   // contributes no keys and the built config is byte-for-byte today's.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -477,6 +477,23 @@ export function redirectProxyConfig(
  * DEFERRED to when auth goes multi-tenant (central-auth-origin work, #619),
  * where it must be re-introduced WITHOUT the lazy-config form.
  *
+ * PRODUCTION-ONLY: the derived `Domain` is baked into the static config and
+ * therefore applies to EVERY request host. On a single-domain deployment that
+ * is exactly right, but a request for a DIFFERENT registrable domain (a Vercel
+ * preview, or a future tenant on another apex — deferred to #619) would receive
+ * a `Set-Cookie` whose `Domain` the browser rejects, silently dropping auth.
+ * We therefore only emit the override in a real PRODUCTION deployment, where
+ * `NEXT_PUBLIC_URL` is production-scoped and matches the sole production host.
+ * Note Vercel sets `NODE_ENV=production` for BOTH production AND preview builds,
+ * so `NODE_ENV` alone cannot tell them apart — `VERCEL_ENV` does. We treat it as
+ * production when `VERCEL_ENV === 'production'`, or — OFF Vercel (self-hosted /
+ * CI, where `VERCEL_ENV` is unset) — when `NODE_ENV === 'production'`. A Vercel
+ * PREVIEW (`VERCEL_ENV='preview'`, `NODE_ENV='production'`) is thus NOT treated
+ * as production and stays host-only, which is what protects preview/other-host
+ * auth from a mismatched `Domain` even if `NEXT_PUBLIC_URL` is ever set more
+ * broadly than the production scope. True multi-tenant per-request derivation
+ * is DELIBERATELY DEFERRED to #619.
+ *
  * FAIL-SAFE: `deriveSessionCookieDomain` returns `undefined` for localhost, IP
  * literals, previews on `vercel.app`, platform-shared parents (`konf.run`),
  * public suffixes, unset/blank env, and anything unparseable — in which case NO
@@ -490,6 +507,15 @@ export function redirectProxyConfig(
 export function staticSessionCookieDomain(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
+  // Production-only gate (see doc comment): apply the cross-subdomain Domain
+  // ONLY in a genuine production deployment. `VERCEL_ENV` is authoritative on
+  // Vercel (preview also has `NODE_ENV=production`); off Vercel we fall back to
+  // `NODE_ENV`. Any non-production env stays host-only.
+  const isProduction =
+    env.VERCEL_ENV === 'production' ||
+    (!env.VERCEL_ENV && env.NODE_ENV === 'production')
+  if (!isProduction) return undefined
+
   const configured =
     env.NEXT_PUBLIC_BASE_URL?.trim() || env.NEXT_PUBLIC_URL?.trim() || ''
   if (!configured) return undefined

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -341,10 +341,14 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
       { missing: 'JWT signing/verification breaks — no one can sign in' },
     ),
   )
-  // NOTE: AUTH_COOKIE_DOMAIN (the prod subdomain-cookie fix) is NOT read as an
-  // env var anywhere in the codebase today, so there is nothing to surface.
-  // If it is later wired as a `process.env.AUTH_COOKIE_DOMAIN` read, add a plain
-  // check here that warns when unset.
+  // NOTE: the cross-subdomain session cookie needs NO dedicated env check. Its
+  // `Domain` attribute is derived once at module load from the platform's own
+  // base URL (`NEXT_PUBLIC_BASE_URL` / `NEXT_PUBLIC_URL`, already surfaced as
+  // `build.baseUrl`) via `deriveSessionCookieDomain` in
+  // `src/lib/auth-cookie-domain.ts`, so there is no separate configuration to
+  // surface here. (Per-request/multi-tenant derivation is deferred to the
+  // central-auth-origin work; it must NOT re-introduce the lazy-config form
+  // that broke the middleware — see #671.)
   //
   // Centralized OAuth origin (#619). Informational: 'ok' when configured (opt-in
   // multi-domain OAuth), 'off' when absent (today's single-domain default). Not


### PR DESCRIPTION
## Why

PR #462 tried to share the session cookie across subdomains by feeding NextAuth a **config _function_** (Auth.js "lazy initialization"): `NextAuth(requestScopedConfig)`. In next-auth v5 the function form changes the shape of the returned `auth`, so the middleware wrapper `const nextAuthMiddleware = auth((req) => …)` in `src/proxy.ts` became a **non-function** — `nextAuthMiddleware is not a function`, **500ing every authenticated route** (admin + speaker dashboard) in production.

It sailed through CI because:
- `next build` **compiles the lazy form fine** — the failure is runtime-only.
- the test suite **aliases `next-auth` to a mock** whose `auth()` returns a function regardless of the config shape, so no unit test could tell the two apart.

#462 was reverted in #670. This PR re-does the fix the **middleware-safe** way and adds the **CI guardrail** (issue #671) that would have caught the incident.

## Part 1 — static cookie-domain fix (middleware-safe)

- **Keeps `NextAuth(config)` with a STATIC config object** — never a function — so the `auth((req) => …)` wrapper keeps working.
- Recovers the sound derivation from #462 verbatim: `src/lib/auth-cookie-domain.ts` — `deriveSessionCookieDomain` (registrable eTLD+1 via `tldts`, PSL-aware) + `SHARED_PARENT_DOMAIN_DENYLIST` (`konf.run` / `vercel.app` / `localhost`) + fail-safe to `undefined`. Re-adds the `tldts@^7.4.0` dependency.
- Computes the cookie `Domain` **once at module load** from the platform's primary domain (`NEXT_PUBLIC_BASE_URL`, then legacy `NEXT_PUBLIC_URL`) via new `staticSessionCookieDomain()`. When it yields a registrable domain it sets `config.cookies.sessionToken.options.domain` statically; when it declines (localhost / preview / denylist / unset / unparseable) **no `cookies` key is emitted** and today's host-only cookie is kept. Only `domain` is set — @auth/core **deep-merges** it onto the cookie defaults (verified in `@auth/core/lib/utils/merge.js`), so the `__Secure-` name prefix + httpOnly / secure / sameSite=lax / path are all preserved. It never throws, so it can't break `next build` (unlike calling `platformBaseUrl`, which throws when unconfigured in prod).
- **Why static, not lazy:** a single primary domain needs no per-request derivation today. Per-request / multi-tenant derivation is **deliberately deferred** to the central-auth-origin work (#619) — and when it returns it must NOT re-introduce the lazy-config form that broke the middleware.
- Keeps #462's sign-out hardening (clears residual **host-only** session cookies incl. chunked `.0`/`.1` parts) — it only walks the request's own cookie jar, so it's correct under the static config.
- Tests: derivation unit tests (normal / subdomain / apex / multi-part `.co.uk` / denylist / IP / garbage); `staticSessionCookieDomain` shape tests (domain present for a real base URL, absent for localhost / preview / unset); a **proxy middleware-shape contract test** importing the REAL `src/proxy.ts` against the REAL `src/lib/auth` (no mock of `@/lib/auth`) asserting the exported middleware is a function returning a Response — the source-level check that was missing.

## Part 2 — post-build runtime smoke guardrail (the important half, #671)

New CI job **"Runtime Smoke Test"** (`.github/workflows/pr-checks.yml`) + `scripts/smoke-protected-routes.mjs`:

1. `next build` (production) then `next start` on a port then poll readiness.
2. curl **protected** routes unauthenticated — `/admin` and `/cfp/list` (these run the **middleware**, the exact failure surface) — plus the NextAuth route handler `/api/auth/providers`.
3. **Fail loudly** on any HTTP 500 or `is not a function` / `TypeError` / error signature. A protected-route redirect needs no real backend/secrets (`AUTH_TRUST_HOST=true` so Auth.js serves its handlers under a bare `next start`).

Robust: bounded boot timeout, server killed in a trap/`finally`, single boot plus a few hits.

### Proof it catches the regression (run locally against a real `next build`)

| Config | `next build` | `/admin` | `/cfp/list` | `/api/auth/providers` | Smoke result |
| --- | --- | --- | --- | --- | --- |
| **Static fix (this PR)** | compiles | 307 to sign-in | 307 to sign-in | 200 | **PASS** |
| **Broken lazy `NextAuth(() => config)`** | compiles | **500 · `is not a function`** | **500 · `is not a function`** | 500 | **FAIL (caught)** |

The broken form **builds cleanly** yet the smoke test fails on the exact `TypeError: … is not a function` signature — proving the guardrail closes the gap the Build and Tests jobs cannot.

## Branch protection

The `Runtime Smoke Test` check is a **required-status candidate**: please add its name to the branch-protection ruleset (Settings → Rules) so it gates merges.

## Quality

`vitest` green (4583 tests), `tsc` clean, `eslint` 0 errors, `prettier --check` clean, `knip` clean, scoped auth coverage gate green.

> Held for owner review (auth surface) — do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C
