### PR TITLE
feat(budget): spreadsheet-style inline expense/ticket editing + fix section collapse

### DIFF
--- a/src/app/(admin)/admin/budget/config/loading.tsx
+++ b/src/app/(admin)/admin/budget/config/loading.tsx
@@ -1,0 +1,5 @@
+import { AdminPageLoading } from '@/components/admin/PageLoadingSkeleton'
+
+export default function Loading() {
+  return <AdminPageLoading />
+}

--- a/src/app/(admin)/admin/budget/config/page.tsx
+++ b/src/app/(admin)/admin/budget/config/page.tsx
@@ -27,7 +27,25 @@ export default async function AdminBudgetConfigPage() {
     )
   }
 
-  const budget = await getBudgetForConference(conference._id).catch(() => null)
+  // Distinguish a transient read failure from a genuine "no budget yet" state,
+  // matching /admin/budget/page.tsx: a Sanity outage must render a controlled
+  // "unavailable" error (and log), never the "create one first" empty state.
+  const { budget, error: budgetError } = await getBudgetForConference(
+    conference._id,
+  ).then(
+    (budget) => ({ budget, error: null as Error | null }),
+    (error: unknown) => ({ budget: null, error: error as Error }),
+  )
+
+  if (budgetError) {
+    console.error('Budget config: failed to load budget document', budgetError)
+    return (
+      <ErrorDisplay
+        title="Budget Unavailable"
+        message="The budget could not be loaded right now. This is usually transient — reload the page to try again."
+      />
+    )
+  }
 
   if (!budget) {
     return (

--- a/src/app/(admin)/admin/budget/config/page.tsx
+++ b/src/app/(admin)/admin/budget/config/page.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+
+import { getBudgetForConference } from '@/lib/budget'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { ErrorDisplay } from '@/components/admin'
+import { BudgetConfigPageClient } from '@/components/admin/budget'
+
+/**
+ * Budget configuration sub-page (`/admin/budget/config`).
+ *
+ * Org-scoped like every admin page: access is gated by the (admin) layout and
+ * the budget is resolved from the domain-derived conference. This page owns
+ * the SCALAR globals (VAT / fee rates, dinner-participation model) and the
+ * SCENARIOS editor — the complex, non-tabular config that does not belong in
+ * the main page's inline spreadsheet tables.
+ */
+export default async function AdminBudgetConfigPage() {
+  const { conference, error: conferenceError } =
+    await getConferenceForCurrentDomain({})
+
+  if (conferenceError || !conference) {
+    return (
+      <ErrorDisplay
+        title="Error Loading Conference"
+        message={conferenceError?.message ?? 'No conference found'}
+      />
+    )
+  }
+
+  const budget = await getBudgetForConference(conference._id).catch(() => null)
+
+  if (!budget) {
+    return (
+      <div className="space-y-4">
+        <ErrorDisplay
+          title="No budget to configure"
+          message="This conference has no budget yet. Create one first, then configure its rates and scenarios."
+        />
+        <Link
+          href="/admin/budget"
+          className="inline-flex items-center text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+        >
+          ← Back to Budget
+        </Link>
+      </div>
+    )
+  }
+
+  return <BudgetConfigPageClient budget={budget} />
+}

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -58,6 +58,7 @@ import {
   LinkIcon,
   EnvelopeIcon,
   Cog6ToothIcon,
+  CpuChipIcon,
   ServerStackIcon,
   BeakerIcon,
   SwatchIcon,
@@ -806,6 +807,28 @@ export default async function AdminSettings() {
               </ol>
             </InfoCard>
           </SettingsGroupSection>
+        </div>
+      </section>
+
+      {/* ---- Tools ---- */}
+      <section className="space-y-4">
+        <SectionHeading
+          id="tools"
+          icon={CpuChipIcon}
+          title="Tools"
+          description="Standalone admin tools that live on their own pages, kept off the sidebar to keep navigation short."
+        />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <InfoCard
+            title="Agents"
+            icon={CpuChipIcon}
+            manageLink={{ href: '/admin/agents', label: 'Open Agents' }}
+          >
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              AI agents and automations for this conference — moved here from
+              the sidebar to keep the navigation compact.
+            </p>
+          </InfoCard>
         </div>
       </section>
 

--- a/src/components/admin/CollapsibleSection.stories.tsx
+++ b/src/components/admin/CollapsibleSection.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, userEvent, within } from 'storybook/test'
 import { CollapsibleSection } from './CollapsibleSection'
 
 const meta = {
@@ -114,4 +115,35 @@ export const MultipleSections: Story = {
       </CollapsibleSection>
     </div>
   ),
+}
+
+/**
+ * Regression net for the Hide/Show toggle: an open section collapses on click
+ * (body content leaves the DOM, `aria-expanded` flips to false, the label
+ * reads "Show") and re-expands on a second click.
+ */
+export const TogglesOpenAndClosed: Story = {
+  args: {
+    title: 'Collapsible',
+    defaultOpen: true,
+    children: (
+      <div className="p-6">
+        <p className="text-gray-600 dark:text-gray-400">Collapsible body.</p>
+      </div>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const toggle = canvas.getByRole('button', { name: /collapsible/i })
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(canvas.getByText('Collapsible body.')).toBeVisible()
+
+    await userEvent.click(toggle)
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(canvas.queryByText('Collapsible body.')).toBeNull()
+
+    await userEvent.click(toggle)
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(canvas.getByText('Collapsible body.')).toBeVisible()
+  },
 }

--- a/src/components/admin/budget/BudgetConfigPage.stories.tsx
+++ b/src/components/admin/budget/BudgetConfigPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { http, HttpResponse } from 'msw'
 import { ThemeProvider } from 'next-themes'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
 
 import { defaultBudgetSeed } from '@/lib/budget/defaults'
 import type { ConferenceBudgetDocument } from '@/lib/budget/types'
@@ -70,4 +71,74 @@ export const Default: Story = {
 export const Dark: Story = {
   args: { budget },
   parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+/**
+ * Percent inputs are capped: they carry `max=100` and a > 100 entry is
+ * blocked client-side with a clear message (the server only accepts fractions
+ * ≤ 1 after the /100 conversion), instead of surfacing a confusing
+ * "enter as a fraction" error on save.
+ */
+export const PercentCapped: Story = {
+  args: { budget },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const vat = await canvas.findByRole('spinbutton', { name: /VAT rate/i })
+    await expect(vat).toHaveAttribute('max', '100')
+    await expect(
+      canvas.getByRole('spinbutton', { name: /Ticketing fee/i }),
+    ).toHaveAttribute('max', '100')
+
+    await userEvent.clear(vat)
+    await userEvent.type(vat, '150')
+    await userEvent.click(
+      canvas.getByRole('button', { name: /save parameters/i }),
+    )
+    await expect(
+      await canvas.findByText(/VAT rate must be between 0 and 100%/i),
+    ).toBeInTheDocument()
+  },
+}
+
+/**
+ * After saving, the form re-seeds from the persisted document (via
+ * `budgetToGlobals` → `toPercent`), so the dirty flag clears — the Save button
+ * returns to disabled instead of staying stuck on. This is what normalizes
+ * equivalent percent strings ("4.50" ≡ "4.5") that would otherwise leave the
+ * button enabled forever.
+ */
+export const GlobalsDirtyNormalizes: Story = {
+  args: { budget },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const fee = await canvas.findByRole('spinbutton', {
+      name: /Ticketing fee/i,
+    })
+    await userEvent.clear(fee)
+    await userEvent.type(fee, '4.6')
+    const save = canvas.getByRole('button', { name: /save parameters/i })
+    await expect(save).toBeEnabled()
+    await userEvent.click(save)
+    // Once the save resolves, local state re-seeds from the persisted budget
+    // and the dirty flag clears, so the button disables again.
+    await waitFor(() => expect(save).toBeDisabled())
+  },
+}
+
+/**
+ * Saving scenarios re-seeds local state from the persisted document (whose
+ * `_key`s `updateScenarios` may have normalized), so the dirty flag clears and
+ * later edits target the persisted keys — the Save button disables after save.
+ */
+export const ScenarioKeysRefresh: Story = {
+  args: { budget },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const name = await canvas.findByDisplayValue('Conservative')
+    await userEvent.type(name, ' (edited)')
+    const save = canvas.getByRole('button', { name: /save scenarios/i })
+    await expect(save).toBeEnabled()
+    await userEvent.click(save)
+    await waitFor(() => expect(save).toBeDisabled())
+  },
 }

--- a/src/components/admin/budget/BudgetConfigPage.stories.tsx
+++ b/src/components/admin/budget/BudgetConfigPage.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ThemeProvider } from 'next-themes'
+
+import { defaultBudgetSeed } from '@/lib/budget/defaults'
+import type { ConferenceBudgetDocument } from '@/lib/budget/types'
+import { NotificationProvider } from '@/components/admin/NotificationProvider'
+import { BudgetConfigPageClient } from './BudgetConfigPageClient'
+
+const budget: ConferenceBudgetDocument = {
+  ...defaultBudgetSeed(),
+  _id: 'budget-story',
+  conference: { _ref: 'conf-story' },
+}
+
+const handlers = [
+  http.post('/api/trpc/budget.updateConfig', () =>
+    HttpResponse.json({ result: { data: { success: true, budget } } }),
+  ),
+  http.post('/api/trpc/budget.updateScenarios', () =>
+    HttpResponse.json({ result: { data: { success: true, budget } } }),
+  ),
+]
+
+const meta = {
+  title: 'Systems/Budget/Admin/BudgetConfigPage',
+  component: BudgetConfigPageClient,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'Budget configuration sub-page (/admin/budget/config): scalar global parameters (VAT / ticketing-fee rates, dinner-participation model) as a labeled form, plus the per-scenario ticket / tier / add-on quantity editor and optional-cost cut flags. The non-tabular config that does not belong in the main page inline tables.',
+      },
+    },
+  },
+  decorators: [
+    (Story, ctx) => {
+      const dark = ctx.parameters.theme === 'dark'
+      return (
+        <ThemeProvider
+          attribute="class"
+          forcedTheme={dark ? 'dark' : 'light'}
+          enableSystem={false}
+        >
+          <NotificationProvider>
+            <div className={dark ? 'dark' : ''}>
+              <div className="min-h-screen bg-gray-50 p-4 sm:p-6 dark:bg-gray-900">
+                <div className="mx-auto max-w-6xl">
+                  <Story />
+                </div>
+              </div>
+            </div>
+          </NotificationProvider>
+        </ThemeProvider>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof BudgetConfigPageClient>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { budget },
+}
+
+export const Dark: Story = {
+  args: { budget },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}

--- a/src/components/admin/budget/BudgetConfigPageClient.tsx
+++ b/src/components/admin/budget/BudgetConfigPageClient.tsx
@@ -1,0 +1,549 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  AdjustmentsHorizontalIcon,
+  Cog6ToothIcon,
+  PlusIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline'
+
+import {
+  DEFAULT_DINNER_PARTICIPATION,
+  type ConferenceBudgetDocument,
+} from '@/lib/budget'
+import { generateKey } from '@/lib/sanity/helpers'
+import { api } from '@/lib/trpc/client'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
+import { useNotification } from '@/components/admin/NotificationProvider'
+import { inputClass, labelClass, numberOrNull } from './fields'
+import {
+  NumberCell,
+  tableClass,
+  tableWrapClass,
+  tbodyRowClass,
+  tdClass,
+  theadClass,
+  thClass,
+} from './BudgetTableCells'
+
+export interface BudgetConfigPageClientProps {
+  budget: ConferenceBudgetDocument
+}
+
+/** Fraction (0.045) → percent input string ("4.5") without float noise. */
+const toPercent = (fraction: number) =>
+  String(Number((fraction * 100).toFixed(4)))
+const fromPercent = (value: string) => (numberOrNull(value) ?? 0) / 100
+
+interface ScenarioDraft {
+  _key: string
+  name: string
+  description: string
+  ticketCounts: Record<string, number>
+  tierCounts: Record<string, number>
+  addonCounts: Record<string, number>
+  cutCosts: string[]
+}
+
+function toDraft(
+  scenario: NonNullable<ConferenceBudgetDocument['scenarios']>[number],
+): ScenarioDraft {
+  const record = <T,>(
+    items: T[] | undefined,
+    key: (t: T) => string,
+    value: (t: T) => number,
+  ) => Object.fromEntries((items ?? []).map((i) => [key(i), value(i)]))
+  return {
+    _key: scenario._key,
+    name: scenario.name,
+    description: scenario.description ?? '',
+    ticketCounts: record(
+      scenario.ticketCounts,
+      (c) => c.ticketType,
+      (c) => c.quantity ?? 0,
+    ),
+    tierCounts: record(
+      scenario.tierCounts,
+      (c) => c.tier,
+      (c) => c.count ?? 0,
+    ),
+    addonCounts: record(
+      scenario.addonCounts,
+      (c) => c.addon,
+      (c) => c.count ?? 0,
+    ),
+    cutCosts: scenario.cutCosts ?? [],
+  }
+}
+
+export function BudgetConfigPageClient({
+  budget,
+}: BudgetConfigPageClientProps) {
+  const router = useRouter()
+  const { showNotification } = useNotification()
+
+  // Reference lists for the scenario count rows.
+  const ticketTypes = budget.ticketTypes ?? []
+  const tiers = budget.sponsorTierAssumptions ?? []
+  const addons = budget.sponsorAddonAssumptions ?? []
+  const optionalFixed = (budget.fixedCosts ?? []).filter((c) => c.optional)
+
+  // --- Global parameters (percent-facing inputs) ---------------------------
+  const initialGlobals = useMemo(
+    () => ({
+      vat: toPercent(budget.vatRate),
+      fee: toPercent(budget.ticketingFeeRate),
+      floor: toPercent(
+        budget.dinnerParticipation?.floor ?? DEFAULT_DINNER_PARTICIPATION.floor,
+      ),
+      base: toPercent(
+        budget.dinnerParticipation?.base ?? DEFAULT_DINNER_PARTICIPATION.base,
+      ),
+      decay: String(
+        budget.dinnerParticipation?.decay ?? DEFAULT_DINNER_PARTICIPATION.decay,
+      ),
+    }),
+    [budget],
+  )
+  const [globals, setGlobals] = useState(initialGlobals)
+  const [globalsError, setGlobalsError] = useState<string | null>(null)
+  const globalsDirty =
+    JSON.stringify(globals) !== JSON.stringify(initialGlobals)
+
+  const configMutation = api.budget.updateConfig.useMutation({
+    onSuccess: () => {
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Configuration saved',
+        message: 'Global budget parameters updated.',
+      })
+    },
+    onError: (err) =>
+      setGlobalsError(err.message || 'Failed to save configuration.'),
+  })
+
+  const saveGlobals = () => {
+    setGlobalsError(null)
+    const decay = numberOrNull(globals.decay) ?? 0
+    if (decay <= 0) {
+      setGlobalsError('Dinner decay must be greater than 0.')
+      return
+    }
+    configMutation.mutate({
+      vatRate: fromPercent(globals.vat),
+      ticketingFeeRate: fromPercent(globals.fee),
+      dinnerParticipation: {
+        floor: fromPercent(globals.floor),
+        base: fromPercent(globals.base),
+        decay,
+      },
+    })
+  }
+
+  // --- Scenarios -----------------------------------------------------------
+  const initialScenarios = useMemo(
+    () => (budget.scenarios ?? []).map(toDraft),
+    [budget],
+  )
+  const [scenarios, setScenarios] = useState<ScenarioDraft[]>(() =>
+    structuredClone(initialScenarios),
+  )
+  const [scenariosError, setScenariosError] = useState<string | null>(null)
+  const scenariosDirty =
+    JSON.stringify(scenarios) !== JSON.stringify(initialScenarios)
+
+  const scenariosMutation = api.budget.updateScenarios.useMutation({
+    onSuccess: () => {
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Scenarios saved',
+        message: 'Budget scenarios updated.',
+      })
+    },
+    onError: (err) =>
+      setScenariosError(err.message || 'Failed to save scenarios.'),
+  })
+
+  const updateScenario = (key: string, patch: Partial<ScenarioDraft>) =>
+    setScenarios((prev) =>
+      prev.map((s) => (s._key === key ? { ...s, ...patch } : s)),
+    )
+  const setCount = (
+    key: string,
+    field: 'ticketCounts' | 'tierCounts' | 'addonCounts',
+    refKey: string,
+    value: number,
+  ) =>
+    setScenarios((prev) =>
+      prev.map((s) =>
+        s._key === key
+          ? { ...s, [field]: { ...s[field], [refKey]: value } }
+          : s,
+      ),
+    )
+  const toggleCut = (key: string, costKey: string, cut: boolean) =>
+    setScenarios((prev) =>
+      prev.map((s) =>
+        s._key === key
+          ? {
+              ...s,
+              cutCosts: cut
+                ? [...new Set([...s.cutCosts, costKey])]
+                : s.cutCosts.filter((c) => c !== costKey),
+            }
+          : s,
+      ),
+    )
+
+  const addScenario = () =>
+    setScenarios((prev) => [
+      ...prev,
+      {
+        _key: generateKey('scenario'),
+        name: '',
+        description: '',
+        ticketCounts: {},
+        tierCounts: {},
+        addonCounts: {},
+        cutCosts: [],
+      },
+    ])
+
+  const saveScenarios = () => {
+    setScenariosError(null)
+    if (scenarios.some((s) => !s.name.trim())) {
+      setScenariosError('Every scenario needs a name.')
+      return
+    }
+    scenariosMutation.mutate({
+      scenarios: scenarios.map((s) => ({
+        _key: s._key,
+        name: s.name,
+        description: s.description || undefined,
+        ticketCounts: Object.entries(s.ticketCounts).map(
+          ([ticketType, quantity]) => ({ ticketType, quantity }),
+        ),
+        tierCounts: Object.entries(s.tierCounts).map(([tier, count]) => ({
+          tier,
+          count,
+        })),
+        addonCounts: Object.entries(s.addonCounts).map(([addon, count]) => ({
+          addon,
+          count,
+        })),
+        cutCosts: s.cutCosts,
+      })),
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        icon={<Cog6ToothIcon />}
+        title="Budget configuration"
+        description="Global rates and scenario assumptions that drive every projection on the budget page."
+        backLink={{ href: '/admin/budget', label: 'Back to Budget' }}
+      />
+
+      {/* Global parameters */}
+      <section className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-gray-700">
+        <div className="flex items-center gap-2">
+          <AdjustmentsHorizontalIcon className="h-5 w-5 text-gray-400" />
+          <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+            Global parameters
+          </h2>
+        </div>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          VAT and platform-fee rates, plus the dinner-participation decay model
+          (participation = max(floor, base − attendees ÷ decay)).
+        </p>
+
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <label className={labelClass}>
+            VAT rate (%)
+            <input
+              type="number"
+              min={0}
+              step="0.1"
+              className={inputClass}
+              value={globals.vat}
+              onChange={(e) =>
+                setGlobals((g) => ({ ...g, vat: e.target.value }))
+              }
+            />
+          </label>
+          <label className={labelClass}>
+            Ticketing fee (%)
+            <input
+              type="number"
+              min={0}
+              step="0.1"
+              className={inputClass}
+              value={globals.fee}
+              onChange={(e) =>
+                setGlobals((g) => ({ ...g, fee: e.target.value }))
+              }
+            />
+          </label>
+          <div className="hidden lg:block" />
+          <label className={labelClass}>
+            Dinner floor (%)
+            <input
+              type="number"
+              min={0}
+              step="1"
+              className={inputClass}
+              value={globals.floor}
+              onChange={(e) =>
+                setGlobals((g) => ({ ...g, floor: e.target.value }))
+              }
+            />
+          </label>
+          <label className={labelClass}>
+            Dinner base (%)
+            <input
+              type="number"
+              min={0}
+              step="1"
+              className={inputClass}
+              value={globals.base}
+              onChange={(e) =>
+                setGlobals((g) => ({ ...g, base: e.target.value }))
+              }
+            />
+          </label>
+          <label className={labelClass}>
+            Dinner decay (attendees)
+            <input
+              type="number"
+              min={1}
+              step="1"
+              className={inputClass}
+              value={globals.decay}
+              onChange={(e) =>
+                setGlobals((g) => ({ ...g, decay: e.target.value }))
+              }
+            />
+          </label>
+        </div>
+
+        {globalsError ? (
+          <p
+            role="alert"
+            className="mt-3 text-sm text-red-600 dark:text-red-400"
+          >
+            {globalsError}
+          </p>
+        ) : null}
+
+        <div className="mt-4 flex justify-end">
+          <AdminButton
+            color="blue"
+            size="md"
+            onClick={saveGlobals}
+            disabled={configMutation.isPending || !globalsDirty}
+            className="min-h-[44px]"
+          >
+            {configMutation.isPending ? 'Saving…' : 'Save parameters'}
+          </AdminButton>
+        </div>
+      </section>
+
+      {/* Scenarios */}
+      <section className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-gray-700">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+          Scenarios
+        </h2>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Projected ticket, sponsor-tier and add-on quantities per scenario, and
+          which optional fixed costs are cut. Sponsor-included tickets are
+          derived from tier counts, so they have no quantity here.
+        </p>
+
+        <div className="mt-4 space-y-4">
+          {scenarios.map((s) => (
+            <div
+              key={s._key}
+              className="rounded-lg border border-gray-200 p-4 dark:border-gray-700"
+            >
+              <div className="flex flex-wrap items-start gap-3">
+                <label className={`${labelClass} flex-1`}>
+                  Name
+                  <input
+                    type="text"
+                    className={inputClass}
+                    value={s.name}
+                    onChange={(e) =>
+                      updateScenario(s._key, { name: e.target.value })
+                    }
+                  />
+                </label>
+                <label className={`${labelClass} flex-[2]`}>
+                  Description
+                  <input
+                    type="text"
+                    className={inputClass}
+                    value={s.description}
+                    onChange={(e) =>
+                      updateScenario(s._key, { description: e.target.value })
+                    }
+                  />
+                </label>
+                <button
+                  type="button"
+                  aria-label={`Remove scenario ${s.name || 'scenario'}`}
+                  onClick={() =>
+                    setScenarios((prev) =>
+                      prev.filter((x) => x._key !== s._key),
+                    )
+                  }
+                  className="mt-5 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30"
+                >
+                  <TrashIcon className="h-5 w-5" />
+                </button>
+              </div>
+
+              <div className="mt-4 grid gap-4 lg:grid-cols-3">
+                <ScenarioCountTable
+                  heading="Ticket counts"
+                  rows={ticketTypes
+                    .filter((t) => !t.sponsorIncluded)
+                    .map((t) => ({ key: t._key, label: t.name }))}
+                  value={s.ticketCounts}
+                  onChange={(refKey, v) =>
+                    setCount(s._key, 'ticketCounts', refKey, v)
+                  }
+                />
+                <ScenarioCountTable
+                  heading="Sponsor tiers"
+                  rows={tiers.map((t) => ({ key: t._key, label: t.name }))}
+                  value={s.tierCounts}
+                  onChange={(refKey, v) =>
+                    setCount(s._key, 'tierCounts', refKey, v)
+                  }
+                />
+                <ScenarioCountTable
+                  heading="Add-ons"
+                  rows={addons.map((a) => ({ key: a._key, label: a.name }))}
+                  value={s.addonCounts}
+                  onChange={(refKey, v) =>
+                    setCount(s._key, 'addonCounts', refKey, v)
+                  }
+                />
+              </div>
+
+              {optionalFixed.length > 0 ? (
+                <div className="mt-4">
+                  <h4 className="text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                    Optional costs cut in this scenario
+                  </h4>
+                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-2">
+                    {optionalFixed.map((c) => (
+                      <label
+                        key={c._key}
+                        className="flex items-center gap-1.5 text-sm text-gray-700 dark:text-gray-300"
+                      >
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-600 dark:border-gray-600 dark:bg-gray-900"
+                          checked={s.cutCosts.includes(c._key)}
+                          onChange={(e) =>
+                            toggleCut(s._key, c._key, e.target.checked)
+                          }
+                        />
+                        {c.name}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4">
+          <AdminButton variant="secondary" size="sm" onClick={addScenario}>
+            <PlusIcon className="h-4 w-4" /> Add scenario
+          </AdminButton>
+        </div>
+
+        {scenariosError ? (
+          <p
+            role="alert"
+            className="mt-3 text-sm text-red-600 dark:text-red-400"
+          >
+            {scenariosError}
+          </p>
+        ) : null}
+
+        <div className="mt-4 flex justify-end">
+          <AdminButton
+            color="blue"
+            size="md"
+            onClick={saveScenarios}
+            disabled={scenariosMutation.isPending || !scenariosDirty}
+            className="min-h-[44px]"
+          >
+            {scenariosMutation.isPending ? 'Saving…' : 'Save scenarios'}
+          </AdminButton>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function ScenarioCountTable({
+  heading,
+  rows,
+  value,
+  onChange,
+}: {
+  heading: string
+  rows: { key: string; label: string }[]
+  value: Record<string, number>
+  onChange: (refKey: string, value: number) => void
+}) {
+  return (
+    <div>
+      <h4 className="mb-2 text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+        {heading}
+      </h4>
+      {rows.length === 0 ? (
+        <p className="text-sm text-gray-400">None defined.</p>
+      ) : (
+        <div className={tableWrapClass}>
+          <table className={tableClass}>
+            <thead className={theadClass}>
+              <tr>
+                <th className={thClass}>Item</th>
+                <th className={`${thClass} text-right`}>Qty</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.key} className={tbodyRowClass}>
+                  <td className={`${tdClass} text-gray-700 dark:text-gray-300`}>
+                    {row.label}
+                  </td>
+                  <td className={`${tdClass} text-right`}>
+                    <NumberCell
+                      ariaLabel={`${heading} — ${row.label}`}
+                      widthClass="w-20"
+                      value={value[row.key] ?? 0}
+                      onChange={(v) => onChange(row.key, numberOrNull(v) ?? 0)}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/budget/BudgetConfigPageClient.tsx
+++ b/src/components/admin/budget/BudgetConfigPageClient.tsx
@@ -38,6 +38,28 @@ const toPercent = (fraction: number) =>
   String(Number((fraction * 100).toFixed(4)))
 const fromPercent = (value: string) => (numberOrNull(value) ?? 0) / 100
 
+/**
+ * Normalized percent-facing form values for the global parameters, derived
+ * from a budget document. Normalizing through {@link toPercent} means "4.50"
+ * and "4.5" collapse to the same string, so re-deriving this after a save
+ * clears the dirty flag instead of leaving Save stuck enabled.
+ */
+function budgetToGlobals(budget: ConferenceBudgetDocument) {
+  return {
+    vat: toPercent(budget.vatRate),
+    fee: toPercent(budget.ticketingFeeRate),
+    floor: toPercent(
+      budget.dinnerParticipation?.floor ?? DEFAULT_DINNER_PARTICIPATION.floor,
+    ),
+    base: toPercent(
+      budget.dinnerParticipation?.base ?? DEFAULT_DINNER_PARTICIPATION.base,
+    ),
+    decay: String(
+      budget.dinnerParticipation?.decay ?? DEFAULT_DINNER_PARTICIPATION.decay,
+    ),
+  }
+}
+
 interface ScenarioDraft {
   _key: string
   name: string
@@ -51,11 +73,22 @@ interface ScenarioDraft {
 function toDraft(
   scenario: NonNullable<ConferenceBudgetDocument['scenarios']>[number],
 ): ScenarioDraft {
+  // Duplicate references keep the FIRST entry, matching the computation mapper
+  // (`src/lib/budget/mapper.ts`). `Object.fromEntries` would be last-write-wins
+  // and could silently change projections when saving legacy/bypassed docs
+  // that carry duplicate count rows.
   const record = <T,>(
     items: T[] | undefined,
     key: (t: T) => string,
     value: (t: T) => number,
-  ) => Object.fromEntries((items ?? []).map((i) => [key(i), value(i)]))
+  ) => {
+    const out: Record<string, number> = {}
+    for (const item of items ?? []) {
+      const k = key(item)
+      if (!(k in out)) out[k] = value(item)
+    }
+    return out
+  }
   return {
     _key: scenario._key,
     name: scenario.name,
@@ -92,29 +125,17 @@ export function BudgetConfigPageClient({
   const optionalFixed = (budget.fixedCosts ?? []).filter((c) => c.optional)
 
   // --- Global parameters (percent-facing inputs) ---------------------------
-  const initialGlobals = useMemo(
-    () => ({
-      vat: toPercent(budget.vatRate),
-      fee: toPercent(budget.ticketingFeeRate),
-      floor: toPercent(
-        budget.dinnerParticipation?.floor ?? DEFAULT_DINNER_PARTICIPATION.floor,
-      ),
-      base: toPercent(
-        budget.dinnerParticipation?.base ?? DEFAULT_DINNER_PARTICIPATION.base,
-      ),
-      decay: String(
-        budget.dinnerParticipation?.decay ?? DEFAULT_DINNER_PARTICIPATION.decay,
-      ),
-    }),
-    [budget],
-  )
+  const initialGlobals = useMemo(() => budgetToGlobals(budget), [budget])
   const [globals, setGlobals] = useState(initialGlobals)
   const [globalsError, setGlobalsError] = useState<string | null>(null)
   const globalsDirty =
     JSON.stringify(globals) !== JSON.stringify(initialGlobals)
 
   const configMutation = api.budget.updateConfig.useMutation({
-    onSuccess: () => {
+    onSuccess: ({ budget: saved }) => {
+      // Re-seed the form from the persisted document so equivalent percent
+      // strings (e.g. "4.50" → "4.5") normalize and the dirty flag clears.
+      setGlobals(budgetToGlobals(saved))
       router.refresh()
       showNotification({
         type: 'success',
@@ -128,6 +149,21 @@ export function BudgetConfigPageClient({
 
   const saveGlobals = () => {
     setGlobalsError(null)
+    // Percent-facing inputs map to fractions ≤ 1 server-side; block > 100 here
+    // with a clear message instead of surfacing a "fraction" error on save.
+    const percentFields: [label: string, value: string][] = [
+      ['VAT rate', globals.vat],
+      ['Ticketing fee', globals.fee],
+      ['Dinner floor', globals.floor],
+      ['Dinner base', globals.base],
+    ]
+    for (const [label, value] of percentFields) {
+      const pct = numberOrNull(value)
+      if (pct !== null && (pct < 0 || pct > 100)) {
+        setGlobalsError(`${label} must be between 0 and 100%.`)
+        return
+      }
+    }
     const decay = numberOrNull(globals.decay) ?? 0
     if (decay <= 0) {
       setGlobalsError('Dinner decay must be greater than 0.')
@@ -157,7 +193,12 @@ export function BudgetConfigPageClient({
     JSON.stringify(scenarios) !== JSON.stringify(initialScenarios)
 
   const scenariosMutation = api.budget.updateScenarios.useMutation({
-    onSuccess: () => {
+    onSuccess: ({ budget: saved }) => {
+      // `updateScenarios` runs `ensureUniqueArrayKeys`, which can rewrite
+      // scenario (and nested count) `_key`s server-side. Re-seed local state
+      // from the persisted document so later edits target the persisted keys
+      // and the dirty flag reflects the normalized data.
+      setScenarios((saved.scenarios ?? []).map(toDraft))
       router.refresh()
       showNotification({
         type: 'success',
@@ -269,6 +310,7 @@ export function BudgetConfigPageClient({
             <input
               type="number"
               min={0}
+              max={100}
               step="0.1"
               className={inputClass}
               value={globals.vat}
@@ -282,6 +324,7 @@ export function BudgetConfigPageClient({
             <input
               type="number"
               min={0}
+              max={100}
               step="0.1"
               className={inputClass}
               value={globals.fee}
@@ -296,6 +339,7 @@ export function BudgetConfigPageClient({
             <input
               type="number"
               min={0}
+              max={100}
               step="1"
               className={inputClass}
               value={globals.floor}
@@ -309,6 +353,7 @@ export function BudgetConfigPageClient({
             <input
               type="number"
               min={0}
+              max={100}
               step="1"
               className={inputClass}
               value={globals.base}

--- a/src/components/admin/budget/BudgetExpensesEditor.tsx
+++ b/src/components/admin/budget/BudgetExpensesEditor.tsx
@@ -1,12 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
-import {
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-} from '@heroicons/react/24/outline'
+import { PlusIcon } from '@heroicons/react/24/outline'
 
 import type {
   BudgetFixedCostItem,
@@ -16,17 +12,23 @@ import type {
 } from '@/lib/budget'
 import { generateKey } from '@/lib/sanity/helpers'
 import { api } from '@/lib/trpc/client'
-import { ModalShell } from '@/components/ModalShell'
 import { AdminButton } from '@/components/admin/AdminButton'
 import { useNotification } from '@/components/admin/NotificationProvider'
+import { BASIS_OPTIONS, CATEGORY_OPTIONS, numberOrNull } from './fields'
+import { EditableTableCard } from './EditableTableCard'
 import {
-  BASIS_OPTIONS,
-  CATEGORY_OPTIONS,
-  inputClass,
-  labelClass,
-  numberOrNull,
-  removeButtonClass,
-} from './fields'
+  CheckboxCell,
+  DeleteRowButton,
+  NumberCell,
+  SelectCell,
+  TextCell,
+  tableClass,
+  tableWrapClass,
+  tbodyRowClass,
+  tdClass,
+  theadClass,
+  thClass,
+} from './BudgetTableCells'
 
 export interface BudgetExpensesEditorProps {
   variableCosts: BudgetVariableCostItem[]
@@ -37,27 +39,29 @@ export interface BudgetExpensesEditorProps {
    * click.
    */
   scenarioReferencedKeys?: string[]
-  defaultOpen?: boolean
+  /** Read-only summary shown when not editing (expense-by-category rows). */
+  display: ReactNode
+  defaultEditing?: boolean
 }
 
 /**
- * Expense CRUD editor island (house editor idiom: pencil trigger +
- * ModalShell with dirty-close confirm, save via tRPC + router.refresh).
- * Edits BOTH expense arrays of the budget document: per-person variable
- * costs and fixed costs (with optional-cost flag and manual actuals).
+ * Expense editor: edits BOTH expense arrays of the budget document — fixed
+ * costs (with optional-cost flag + manual actuals) and per-person variable
+ * costs. Edits INLINE ON THE PAGE as two full-width spreadsheet tables (one
+ * row per line item) — no modal, no per-row cards.
  */
 export function BudgetExpensesEditor({
   variableCosts,
   fixedCosts,
   scenarioReferencedKeys = [],
-  defaultOpen = false,
+  display,
+  defaultEditing = false,
 }: BudgetExpensesEditorProps) {
   const router = useRouter()
   const { showNotification } = useNotification()
   const referencedKeys = new Set(scenarioReferencedKeys)
 
-  const [isOpen, setIsOpen] = useState(defaultOpen)
-  // Referenced row awaiting delete confirmation (second click removes).
+  const [editing, setEditing] = useState(defaultEditing)
   const [pendingRemoval, setPendingRemoval] = useState<string | null>(null)
   const [variable, setVariable] = useState<BudgetVariableCostItem[]>(() =>
     structuredClone(variableCosts),
@@ -79,7 +83,7 @@ export function BudgetExpensesEditor({
         title: 'Expenses updated',
         message: 'Budget expense lines saved.',
       })
-      setIsOpen(false)
+      setEditing(false)
     },
     onError: (err) => {
       setError(err.message || 'Failed to save expenses.')
@@ -97,27 +101,34 @@ export function BudgetExpensesEditor({
     setError(null)
     setPendingRemoval(null)
   }
-  const openModal = () => {
+  const startEdit = () => {
     reset()
-    setIsOpen(true)
+    setEditing(true)
   }
-  const closeModal = () => {
-    setIsOpen(false)
+  const cancel = () => {
+    setEditing(false)
     reset()
   }
 
   const updateVariable = (
     key: string,
     patch: Partial<BudgetVariableCostItem>,
-  ) => {
+  ) =>
     setVariable((prev) =>
       prev.map((item) => (item._key === key ? { ...item, ...patch } : item)),
     )
-  }
-  const updateFixed = (key: string, patch: Partial<BudgetFixedCostItem>) => {
+  const updateFixed = (key: string, patch: Partial<BudgetFixedCostItem>) =>
     setFixed((prev) =>
       prev.map((item) => (item._key === key ? { ...item, ...patch } : item)),
     )
+
+  const removeFixed = (key: string) => {
+    if (referencedKeys.has(key) && pendingRemoval !== key) {
+      setPendingRemoval(key)
+      return
+    }
+    setPendingRemoval(null)
+    setFixed((prev) => prev.filter((x) => x._key !== key))
   }
 
   const handleSave = () => {
@@ -140,351 +151,242 @@ export function BudgetExpensesEditor({
   }
 
   return (
-    <>
-      <button
-        type="button"
-        aria-label="Edit expenses"
-        onClick={openModal}
-        className="inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-      >
-        <PencilSquareIcon className="h-5 w-5" />
-      </button>
-      <ModalShell
-        isOpen={isOpen}
-        onClose={closeModal}
-        size="xl"
-        title="Edit expenses"
-        subtitle="Fixed costs (with optional-cost flags) and per-person variable costs. Amounts in NOK incl VAT."
-        icon={<PencilSquareIcon className="h-5 w-5" />}
-        confirmOnDirtyClose
-        isDirty={isDirty && !saveMutation.isPending}
-      >
-        <form
-          noValidate
-          onSubmit={(e) => {
-            e.preventDefault()
-            handleSave()
-          }}
-          className="space-y-6"
+    <EditableTableCard
+      editing={editing}
+      onStartEdit={startEdit}
+      onSave={handleSave}
+      onCancel={cancel}
+      isDirty={isDirty}
+      isSaving={saveMutation.isPending}
+      saveLabel="Save expenses"
+      editLabel="Edit expenses"
+      error={error}
+      display={display}
+    >
+      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+        All amounts in NOK, including VAT (what the organization pays).
+      </p>
+
+      {/* Fixed costs */}
+      <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+        Fixed costs
+      </h3>
+      <div className={tableWrapClass}>
+        <table className={tableClass}>
+          <thead className={theadClass}>
+            <tr>
+              <th className={thClass}>Name</th>
+              <th className={thClass}>Category</th>
+              <th className={`${thClass} text-right`}>Budget</th>
+              <th className={`${thClass} text-right`}>Actual</th>
+              <th className={`${thClass} text-center`}>Optional</th>
+              <th className={`${thClass} text-center`}>
+                <span className="sr-only">Delete</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {fixed.map((item) => (
+              <tr key={item._key} className={tbodyRowClass}>
+                <td className={tdClass}>
+                  <TextCell
+                    ariaLabel="Fixed cost name"
+                    value={item.name}
+                    onChange={(v) => updateFixed(item._key, { name: v })}
+                  />
+                </td>
+                <td className={tdClass}>
+                  <SelectCell
+                    ariaLabel={`Category for ${item.name || 'fixed cost'}`}
+                    value={item.category}
+                    options={CATEGORY_OPTIONS}
+                    onChange={(v) =>
+                      updateFixed(item._key, { category: v as ExpenseCategory })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`Budget for ${item.name || 'fixed cost'}`}
+                    value={item.amount}
+                    onChange={(v) =>
+                      updateFixed(item._key, { amount: numberOrNull(v) ?? 0 })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`Actual for ${item.name || 'fixed cost'}`}
+                    value={item.actualAmount ?? ''}
+                    placeholder="—"
+                    onChange={(v) =>
+                      updateFixed(item._key, { actualAmount: numberOrNull(v) })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <CheckboxCell
+                    ariaLabel={`${item.name || 'Fixed cost'} is optional`}
+                    checked={item.optional ?? false}
+                    onChange={(c) => updateFixed(item._key, { optional: c })}
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <DeleteRowButton
+                    ariaLabel={
+                      referencedKeys.has(item._key) &&
+                      pendingRemoval === item._key
+                        ? `Confirm removing ${item.name || 'fixed cost'} (used by scenarios)`
+                        : `Remove ${item.name || 'fixed cost'}`
+                    }
+                    pending={pendingRemoval === item._key}
+                    onClick={() => removeFixed(item._key)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-3 flex items-center gap-3">
+        <AdminButton
+          variant="secondary"
+          size="sm"
+          onClick={() =>
+            setFixed((prev) => [
+              ...prev,
+              {
+                _key: generateKey('fixedcost'),
+                name: '',
+                category: 'other',
+                amount: 0,
+                optional: false,
+                actualAmount: null,
+              },
+            ])
+          }
         >
-          <section>
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-              Fixed costs
-            </h3>
-            <div className="mt-2 space-y-3">
-              {fixed.map((item) => (
-                <div
-                  key={item._key}
-                  className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
-                >
-                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-12">
-                    <div className="col-span-2 sm:col-span-4">
-                      <label className={labelClass}>
-                        Name
-                        <input
-                          type="text"
-                          className={inputClass}
-                          value={item.name}
-                          onChange={(e) =>
-                            updateFixed(item._key, { name: e.target.value })
-                          }
-                        />
-                      </label>
-                    </div>
-                    <div className="sm:col-span-3">
-                      <label className={labelClass}>
-                        Category
-                        <select
-                          className={inputClass}
-                          value={item.category}
-                          onChange={(e) =>
-                            updateFixed(item._key, {
-                              category: e.target.value as ExpenseCategory,
-                            })
-                          }
-                        >
-                          {CATEGORY_OPTIONS.map((opt) => (
-                            <option key={opt.value} value={opt.value}>
-                              {opt.label}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                    </div>
-                    <div className="sm:col-span-2">
-                      <label className={labelClass}>
-                        Budget (NOK)
-                        <input
-                          type="number"
-                          min={0}
-                          className={inputClass}
-                          value={item.amount}
-                          onChange={(e) =>
-                            updateFixed(item._key, {
-                              amount: numberOrNull(e.target.value) ?? 0,
-                            })
-                          }
-                        />
-                      </label>
-                    </div>
-                    <div className="sm:col-span-2">
-                      <label className={labelClass}>
-                        Actual (NOK)
-                        <input
-                          type="number"
-                          min={0}
-                          className={inputClass}
-                          value={item.actualAmount ?? ''}
-                          onChange={(e) =>
-                            updateFixed(item._key, {
-                              actualAmount: numberOrNull(e.target.value),
-                            })
-                          }
-                        />
-                      </label>
-                    </div>
-                    <div className="flex items-end justify-between gap-2 sm:col-span-1">
-                      <label className="flex min-h-[44px] items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300">
-                        <input
-                          type="checkbox"
-                          className="h-4 w-4 rounded border-gray-300"
-                          checked={item.optional ?? false}
-                          onChange={(e) =>
-                            updateFixed(item._key, {
-                              optional: e.target.checked,
-                            })
-                          }
-                        />
-                        Optional
-                      </label>
-                      <button
-                        type="button"
-                        aria-label={
-                          referencedKeys.has(item._key) &&
-                          pendingRemoval === item._key
-                            ? `Confirm removing ${item.name || 'fixed cost'} (used by scenarios)`
-                            : `Remove ${item.name || 'fixed cost'}`
-                        }
-                        onClick={() => {
-                          if (
-                            referencedKeys.has(item._key) &&
-                            pendingRemoval !== item._key
-                          ) {
-                            setPendingRemoval(item._key)
-                            return
-                          }
-                          setPendingRemoval(null)
-                          setFixed((prev) =>
-                            prev.filter((x) => x._key !== item._key),
-                          )
-                        }}
-                        className={removeButtonClass}
-                      >
-                        <TrashIcon className="h-5 w-5" />
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-            <AdminButton
-              type="button"
-              variant="secondary"
-              size="sm"
-              className="mt-3"
-              onClick={() =>
-                setFixed((prev) => [
-                  ...prev,
-                  {
-                    _key: generateKey('fixedcost'),
-                    name: '',
-                    category: 'other',
-                    amount: 0,
-                    optional: false,
-                    actualAmount: null,
-                  },
-                ])
-              }
-            >
-              <PlusIcon className="mr-1 h-4 w-4" /> Add fixed cost
-            </AdminButton>
-          </section>
+          <PlusIcon className="h-4 w-4" /> Add fixed cost
+        </AdminButton>
+        {pendingRemoval ? (
+          <span className="text-xs text-amber-700 dark:text-amber-400">
+            That cost is referenced by a scenario — click delete again to
+            confirm; scenario references will be orphaned.
+          </span>
+        ) : null}
+      </div>
 
-          <section>
-            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
-              Variable costs (per person)
-            </h3>
-            <div className="mt-2 space-y-3">
-              {variable.map((item) => (
-                <div
-                  key={item._key}
-                  className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
-                >
-                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-12">
-                    <div className="col-span-2 sm:col-span-4">
-                      <label className={labelClass}>
-                        Name
-                        <input
-                          type="text"
-                          className={inputClass}
-                          value={item.name}
-                          onChange={(e) =>
-                            updateVariable(item._key, { name: e.target.value })
-                          }
-                        />
-                      </label>
-                    </div>
-                    <div className="sm:col-span-2">
-                      <label className={labelClass}>
-                        Category
-                        <select
-                          className={inputClass}
-                          value={item.category}
-                          onChange={(e) =>
-                            updateVariable(item._key, {
-                              category: e.target.value as ExpenseCategory,
-                            })
-                          }
-                        >
-                          {CATEGORY_OPTIONS.map((opt) => (
-                            <option key={opt.value} value={opt.value}>
-                              {opt.label}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                    </div>
-                    <div className="sm:col-span-2">
-                      <label className={labelClass}>
-                        NOK / person
-                        <input
-                          type="number"
-                          min={0}
-                          className={inputClass}
-                          value={item.amountPerPerson}
-                          onChange={(e) =>
-                            updateVariable(item._key, {
-                              amountPerPerson:
-                                numberOrNull(e.target.value) ?? 0,
-                            })
-                          }
-                        />
-                      </label>
-                    </div>
-                    <div className="sm:col-span-2">
-                      <label className={labelClass}>
-                        Basis
-                        <select
-                          className={inputClass}
-                          value={item.basis}
-                          onChange={(e) =>
-                            updateVariable(item._key, {
-                              basis: e.target.value as VariableCostBasis,
-                            })
-                          }
-                        >
-                          {BASIS_OPTIONS.map((opt) => (
-                            <option key={opt.value} value={opt.value}>
-                              {opt.label}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                    </div>
-                    <div className="flex items-end gap-2 sm:col-span-2">
-                      <label className={`${labelClass} grow`}>
-                        Actual (NOK)
-                        <input
-                          type="number"
-                          min={0}
-                          className={inputClass}
-                          value={item.actualAmount ?? ''}
-                          onChange={(e) =>
-                            updateVariable(item._key, {
-                              actualAmount: numberOrNull(e.target.value),
-                            })
-                          }
-                        />
-                      </label>
-                      <button
-                        type="button"
-                        aria-label={`Remove ${item.name || 'variable cost'}`}
-                        onClick={() =>
-                          setVariable((prev) =>
-                            prev.filter((x) => x._key !== item._key),
-                          )
-                        }
-                        className={`${removeButtonClass} shrink-0`}
-                      >
-                        <TrashIcon className="h-5 w-5" />
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-            <AdminButton
-              type="button"
-              variant="secondary"
-              size="sm"
-              className="mt-3"
-              onClick={() =>
-                setVariable((prev) => [
-                  ...prev,
-                  {
-                    _key: generateKey('varcost'),
-                    name: '',
-                    category: 'catering',
-                    amountPerPerson: 0,
-                    basis: 'conference',
-                    actualAmount: null,
-                  },
-                ])
-              }
-            >
-              <PlusIcon className="mr-1 h-4 w-4" /> Add variable cost
-            </AdminButton>
-          </section>
-
-          {pendingRemoval && (
-            <p
-              role="alert"
-              className="text-sm text-amber-700 dark:text-amber-400"
-            >
-              This cost is referenced by one or more scenarios &mdash; click
-              remove again to confirm. Scenario references to it will be
-              orphaned.
-            </p>
-          )}
-          {error && (
-            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
-              {error}
-            </p>
-          )}
-
-          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
-            <AdminButton
-              type="button"
-              variant="secondary"
-              size="md"
-              onClick={closeModal}
-              disabled={saveMutation.isPending}
-              className="min-h-[44px]"
-            >
-              Cancel
-            </AdminButton>
-            <AdminButton
-              type="submit"
-              color="blue"
-              size="md"
-              disabled={saveMutation.isPending || !isDirty}
-              className="min-h-[44px]"
-            >
-              {saveMutation.isPending ? 'Saving…' : 'Save expenses'}
-            </AdminButton>
-          </div>
-        </form>
-      </ModalShell>
-    </>
+      {/* Variable costs */}
+      <h3 className="mt-6 mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+        Variable costs (per person)
+      </h3>
+      <div className={tableWrapClass}>
+        <table className={tableClass}>
+          <thead className={theadClass}>
+            <tr>
+              <th className={thClass}>Name</th>
+              <th className={thClass}>Category</th>
+              <th className={`${thClass} text-right`}>NOK / person</th>
+              <th className={thClass}>Basis</th>
+              <th className={`${thClass} text-right`}>Actual</th>
+              <th className={`${thClass} text-center`}>
+                <span className="sr-only">Delete</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {variable.map((item) => (
+              <tr key={item._key} className={tbodyRowClass}>
+                <td className={tdClass}>
+                  <TextCell
+                    ariaLabel="Variable cost name"
+                    value={item.name}
+                    onChange={(v) => updateVariable(item._key, { name: v })}
+                  />
+                </td>
+                <td className={tdClass}>
+                  <SelectCell
+                    ariaLabel={`Category for ${item.name || 'variable cost'}`}
+                    value={item.category}
+                    options={CATEGORY_OPTIONS}
+                    onChange={(v) =>
+                      updateVariable(item._key, {
+                        category: v as ExpenseCategory,
+                      })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`NOK per person for ${item.name || 'variable cost'}`}
+                    value={item.amountPerPerson}
+                    onChange={(v) =>
+                      updateVariable(item._key, {
+                        amountPerPerson: numberOrNull(v) ?? 0,
+                      })
+                    }
+                  />
+                </td>
+                <td className={tdClass}>
+                  <SelectCell
+                    ariaLabel={`Basis for ${item.name || 'variable cost'}`}
+                    value={item.basis}
+                    options={BASIS_OPTIONS}
+                    onChange={(v) =>
+                      updateVariable(item._key, {
+                        basis: v as VariableCostBasis,
+                      })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`Actual for ${item.name || 'variable cost'}`}
+                    value={item.actualAmount ?? ''}
+                    placeholder="—"
+                    onChange={(v) =>
+                      updateVariable(item._key, {
+                        actualAmount: numberOrNull(v),
+                      })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <DeleteRowButton
+                    ariaLabel={`Remove ${item.name || 'variable cost'}`}
+                    onClick={() =>
+                      setVariable((prev) =>
+                        prev.filter((x) => x._key !== item._key),
+                      )
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-3">
+        <AdminButton
+          variant="secondary"
+          size="sm"
+          onClick={() =>
+            setVariable((prev) => [
+              ...prev,
+              {
+                _key: generateKey('varcost'),
+                name: '',
+                category: 'catering',
+                amountPerPerson: 0,
+                basis: 'conference',
+                actualAmount: null,
+              },
+            ])
+          }
+        >
+          <PlusIcon className="h-4 w-4" /> Add variable cost
+        </AdminButton>
+      </div>
+    </EditableTableCard>
   )
 }

--- a/src/components/admin/budget/BudgetPage.stories.tsx
+++ b/src/components/admin/budget/BudgetPage.stories.tsx
@@ -223,6 +223,48 @@ export const EditingTables: Story = {
 }
 
 /**
+ * Reference-aware delete guard on the sponsor assumptions editor: the seeded
+ * scenarios reference the "Community Partner" tier, so a first delete click
+ * only arms a confirm (row stays, amber hint shows) — the same two-click guard
+ * the ticket-type and expense editors use — and a second click removes it.
+ */
+export const SponsorDeleteGuard: Story = {
+  args: { budget, sponsorIncome, ticketIncome },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /edit assumptions/i }),
+    )
+    const del = await canvas.findByRole('button', {
+      name: /^Remove Community Partner$/i,
+    })
+    await userEvent.click(del)
+    // First click only arms the confirm: the row is still present and the
+    // guard affordance appears.
+    await expect(
+      await canvas.findByRole('button', {
+        name: /Confirm removing Community Partner/i,
+      }),
+    ).toBeInTheDocument()
+    await expect(
+      canvas.getByText(/referenced by a scenario/i),
+    ).toBeInTheDocument()
+    await expect(
+      canvas.getByDisplayValue('Community Partner'),
+    ).toBeInTheDocument()
+    // Second click confirms the removal.
+    await userEvent.click(
+      canvas.getByRole('button', {
+        name: /Confirm removing Community Partner/i,
+      }),
+    )
+    await expect(
+      canvas.queryByDisplayValue('Community Partner'),
+    ).not.toBeInTheDocument()
+  },
+}
+
+/**
  * Regression net for the section collapse (task 1): clicking the Income
  * section's Hide toggle collapses ONLY that section — its body unmounts and
  * `aria-expanded` flips to false — while Expenses stays open independently.

--- a/src/components/admin/budget/BudgetPage.stories.tsx
+++ b/src/components/admin/budget/BudgetPage.stories.tsx
@@ -217,8 +217,8 @@ export const EditingTables: Story = {
     await userEvent.click(
       await canvas.findByRole('button', { name: /edit expenses/i }),
     )
-    // The spreadsheet inputs are now on the page.
-    await canvas.findByRole('textbox', { name: /ticket type name/i })
+    // The spreadsheet inputs are now on the page (one name field per row).
+    await canvas.findAllByRole('textbox', { name: /ticket type name/i })
   },
 }
 

--- a/src/components/admin/budget/BudgetPage.stories.tsx
+++ b/src/components/admin/budget/BudgetPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { http, HttpResponse } from 'msw'
 import { ThemeProvider } from 'next-themes'
+import { expect, userEvent, within } from 'storybook/test'
 
 import { defaultBudgetSeed } from '@/lib/budget/defaults'
 import type { ConferenceBudgetDocument } from '@/lib/budget/types'
@@ -56,6 +57,21 @@ const handlers = [
     }),
   ),
   http.post('/api/trpc/budget.updateTicketTypes', () =>
+    HttpResponse.json({
+      result: { data: { success: true, budget } },
+    }),
+  ),
+  http.post('/api/trpc/budget.updateSponsorAssumptions', () =>
+    HttpResponse.json({
+      result: { data: { success: true, budget } },
+    }),
+  ),
+  http.post('/api/trpc/budget.updateConfig', () =>
+    HttpResponse.json({
+      result: { data: { success: true, budget } },
+    }),
+  ),
+  http.post('/api/trpc/budget.updateScenarios', () =>
     HttpResponse.json({
       result: { data: { success: true, budget } },
     }),
@@ -183,5 +199,47 @@ export const MixedCurrencySponsorIncome: Story = {
       totalSponsors: 24,
     },
     ticketIncome,
+  },
+}
+
+/**
+ * Editing state: the ticket-type and expense cards toggled into their inline
+ * spreadsheet tables (one row per line item, cells edit in place). Drives the
+ * "Edit" affordance so the wide-table editing surface is captured for review.
+ */
+export const EditingTables: Story = {
+  args: { budget, sponsorIncome, ticketIncome },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /edit ticket types/i }),
+    )
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /edit expenses/i }),
+    )
+    // The spreadsheet inputs are now on the page.
+    await canvas.findByRole('textbox', { name: /ticket type name/i })
+  },
+}
+
+/**
+ * Regression net for the section collapse (task 1): clicking the Income
+ * section's Hide toggle collapses ONLY that section — its body unmounts and
+ * `aria-expanded` flips to false — while Expenses stays open independently.
+ */
+export const CollapseIncome: Story = {
+  args: { budget, sponsorIncome, ticketIncome },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const toggles = await canvas.findAllByRole('button', { expanded: true })
+    const incomeToggle = toggles.find((b) => /Income/.test(b.textContent ?? ''))
+    if (!incomeToggle) throw new Error('Income toggle not found')
+    await userEvent.click(incomeToggle)
+    await expect(incomeToggle).toHaveAttribute('aria-expanded', 'false')
+    // Expenses remains open — the two sections collapse independently.
+    const stillOpen = await canvas.findAllByRole('button', { expanded: true })
+    await expect(
+      stillOpen.some((b) => /Expenses/.test(b.textContent ?? '')),
+    ).toBe(true)
   },
 }

--- a/src/components/admin/budget/BudgetPageClient.tsx
+++ b/src/components/admin/budget/BudgetPageClient.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import {
   BanknotesIcon,
+  Cog6ToothIcon,
   ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline'
 
@@ -23,6 +25,7 @@ import { AdminPageHeader } from '@/components/admin/AdminPageHeader'
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
 import { useNotification } from '@/components/admin/NotificationProvider'
 import { BudgetExpensesEditor } from './BudgetExpensesEditor'
+import { BudgetSponsorAssumptionsEditor } from './BudgetSponsorAssumptionsEditor'
 import { BudgetTicketTypesEditor } from './BudgetTicketTypesEditor'
 
 export interface BudgetPageClientProps {
@@ -278,6 +281,15 @@ export function BudgetPageClient({
       icon={<BanknotesIcon className="h-8 w-8" />}
       title="Budget"
       description="Budget vs actuals: expense plan and scenario projections against live sponsor and ticket income."
+      actions={
+        <Link
+          href="/admin/budget/config"
+          className="inline-flex min-h-[44px] items-center gap-2 rounded-md bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-600 dark:hover:bg-gray-700"
+        >
+          <Cog6ToothIcon className="h-5 w-5" />
+          Configure
+        </Link>
+      }
       stats={
         result
           ? [
@@ -410,177 +422,191 @@ export function BudgetPageClient({
           </div>
 
           {/* Income */}
-          <CollapsibleSection
-            title="Income"
-            defaultOpen
-            action={
-              <BudgetTicketTypesEditor
-                ticketTypes={budget.ticketTypes ?? []}
-                manualActualsInUse={ticketIncome?.source === 'manual'}
-                scenarioReferencedKeys={scenarioTicketKeys}
-              />
-            }
-          >
-            <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-              All amounts in NOK, excluding VAT.
-            </p>
-            <div className="overflow-x-auto">
-              <table className="min-w-full">
-                {TABLE_HEAD}
-                <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
-                  <BudgetVsActualRow
-                    label="Ticket revenue"
-                    sublabel={`${result.headcounts.totalTickets} tickets in scenario`}
-                    budget={result.ticketRevenue}
-                    actual={actualTicketRevenue}
-                    actualNote={
-                      ticketIncome
-                        ? ticketIncome.source === 'live'
-                          ? `live: ${ticketIncome.ticketCount} tickets, ${ticketIncome.orderCount} orders`
-                          : `manual: ${ticketIncome.ticketCount} tickets entered`
-                        : 'no ticketing data'
-                    }
-                  />
-                  <BudgetVsActualRow
-                    label="Sponsorships"
-                    sublabel={`tiers ${nok(result.sponsorTierRevenue)} + add-ons ${nok(result.sponsorAddonRevenue)}`}
-                    budget={result.sponsorRevenue}
-                    actual={
-                      sponsorIncome && sponsorAllNok ? sponsorSignedNok : null
-                    }
-                    actualText={
-                      sponsorIncome && !sponsorAllNok
-                        ? sponsorAmounts('signedRevenue')
-                        : undefined
-                    }
-                    actualNote={
-                      sponsorIncome
-                        ? `${sponsorIncome.signedCount} signed · ${sponsorAmounts('paidRevenue')} paid · ${sponsorAmounts('openPipelineRevenue')} in pipeline${
-                            sponsorAllNok
-                              ? ''
-                              : sponsorByCurrency.length > 1
-                                ? ' · mixed currencies — amounts not combined'
-                                : ' · non-NOK income — not compared to the NOK budget'
-                          }`
-                        : 'sponsor data unavailable'
-                    }
-                  />
-                  <BudgetVsActualRow
-                    label="Total income"
-                    budget={result.totalIncome}
-                    actual={actualIncomeTotal}
-                    actualNote={
-                      incomeActualsComplete ? undefined : 'partial — see rows'
-                    }
-                    emphasize
-                    hideDelta={!incomeActualsComplete}
-                  />
-                </tbody>
-              </table>
-            </div>
+          <CollapsibleSection title="Income" defaultOpen>
+            <BudgetTicketTypesEditor
+              ticketTypes={budget.ticketTypes ?? []}
+              manualActualsInUse={ticketIncome?.source === 'manual'}
+              scenarioReferencedKeys={scenarioTicketKeys}
+              display={
+                <>
+                  <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                    All amounts in NOK, excluding VAT.
+                  </p>
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full">
+                      {TABLE_HEAD}
+                      <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
+                        <BudgetVsActualRow
+                          label="Ticket revenue"
+                          sublabel={`${result.headcounts.totalTickets} tickets in scenario`}
+                          budget={result.ticketRevenue}
+                          actual={actualTicketRevenue}
+                          actualNote={
+                            ticketIncome
+                              ? ticketIncome.source === 'live'
+                                ? `live: ${ticketIncome.ticketCount} tickets, ${ticketIncome.orderCount} orders`
+                                : `manual: ${ticketIncome.ticketCount} tickets entered`
+                              : 'no ticketing data'
+                          }
+                        />
+                        <BudgetVsActualRow
+                          label="Sponsorships"
+                          sublabel={`tiers ${nok(result.sponsorTierRevenue)} + add-ons ${nok(result.sponsorAddonRevenue)}`}
+                          budget={result.sponsorRevenue}
+                          actual={
+                            sponsorIncome && sponsorAllNok
+                              ? sponsorSignedNok
+                              : null
+                          }
+                          actualText={
+                            sponsorIncome && !sponsorAllNok
+                              ? sponsorAmounts('signedRevenue')
+                              : undefined
+                          }
+                          actualNote={
+                            sponsorIncome
+                              ? `${sponsorIncome.signedCount} signed · ${sponsorAmounts('paidRevenue')} paid · ${sponsorAmounts('openPipelineRevenue')} in pipeline${
+                                  sponsorAllNok
+                                    ? ''
+                                    : sponsorByCurrency.length > 1
+                                      ? ' · mixed currencies — amounts not combined'
+                                      : ' · non-NOK income — not compared to the NOK budget'
+                                }`
+                              : 'sponsor data unavailable'
+                          }
+                        />
+                        <BudgetVsActualRow
+                          label="Total income"
+                          budget={result.totalIncome}
+                          actual={actualIncomeTotal}
+                          actualNote={
+                            incomeActualsComplete
+                              ? undefined
+                              : 'partial — see rows'
+                          }
+                          emphasize
+                          hideDelta={!incomeActualsComplete}
+                        />
+                      </tbody>
+                    </table>
+                  </div>
+                </>
+              }
+            />
           </CollapsibleSection>
 
           {/* Expenses */}
-          <CollapsibleSection
-            title="Expenses"
-            defaultOpen
-            action={
-              <BudgetExpensesEditor
-                variableCosts={budget.variableCosts ?? []}
-                fixedCosts={budget.fixedCosts ?? []}
-                scenarioReferencedKeys={scenarioCutCostKeys}
-              />
-            }
-          >
-            <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-              All amounts in NOK, including VAT (what the organization pays).
-            </p>
-            <div className="overflow-x-auto">
-              <table className="min-w-full">
-                {TABLE_HEAD}
-                <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
-                  {categories.map((category) => {
-                    const lines = expenseLines.filter(
-                      (line) => line.category === category,
-                    )
-                    const subtotal = lines.reduce(
-                      (sum, line) => sum + line.amount,
-                      0,
-                    )
-                    const actualSubtotal = lines.reduce(
-                      (sum, line) => sum + (expenseActuals.get(line.key) ?? 0),
-                      0,
-                    )
-                    const hasActuals = lines.some((line) =>
-                      expenseActuals.has(line.key),
-                    )
-                    // A delta against the FULL category budget is only
-                    // honest once every (non-cut) line has a recorded
-                    // actual - otherwise partially-recorded spend reads as
-                    // a big underspend.
-                    const actualsComplete = lines.every(
-                      (line) => line.cut || expenseActuals.has(line.key),
-                    )
-                    return (
-                      <BudgetVsActualRow
-                        key={category}
-                        label={EXPENSE_CATEGORY_LABELS[category]}
-                        sublabel={lines
-                          .map(
-                            (line) => `${line.name}${line.cut ? ' (cut)' : ''}`,
+          <CollapsibleSection title="Expenses" defaultOpen>
+            <BudgetExpensesEditor
+              variableCosts={budget.variableCosts ?? []}
+              fixedCosts={budget.fixedCosts ?? []}
+              scenarioReferencedKeys={scenarioCutCostKeys}
+              display={
+                <>
+                  <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                    All amounts in NOK, including VAT (what the organization
+                    pays).
+                  </p>
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full">
+                      {TABLE_HEAD}
+                      <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
+                        {categories.map((category) => {
+                          const lines = expenseLines.filter(
+                            (line) => line.category === category,
                           )
-                          .join(' · ')}
-                        budget={subtotal}
-                        actual={hasActuals ? actualSubtotal : null}
-                        actualNote={
-                          hasActuals && !actualsComplete
-                            ? 'recorded so far'
-                            : undefined
-                        }
-                        kind="expense"
-                        hideDelta={!actualsComplete}
-                      />
-                    )
-                  })}
-                  <BudgetVsActualRow
-                    label={`Ticketing platform fee (${(model.ticketingFeeRate * 100).toFixed(1)}%)`}
-                    sublabel="computed on gross ticket revenue"
-                    budget={result.ticketingFee}
-                    actual={null}
-                    kind="expense"
-                  />
-                  <BudgetVsActualRow
-                    label="Variable expenses"
-                    sublabel="headcount-driven + ticketing fee"
-                    budget={result.totalVariableExpenses}
-                    actual={null}
-                    kind="expense"
-                  />
-                  <BudgetVsActualRow
-                    label="Fixed expenses"
-                    sublabel={
-                      selectedScenario.cutCostKeys.length > 0
-                        ? `${selectedScenario.cutCostKeys.length} optional cost(s) cut in this scenario`
-                        : undefined
-                    }
-                    budget={result.totalFixedExpenses}
-                    actual={null}
-                    kind="expense"
-                  />
-                  <BudgetVsActualRow
-                    label="Total expenses"
-                    budget={result.totalExpenses}
-                    actual={hasExpenseActuals ? actualExpenseTotal : null}
-                    actualNote={
-                      hasExpenseActuals ? 'recorded so far' : undefined
-                    }
-                    emphasize
-                    kind="expense"
-                    hideDelta
-                  />
-                </tbody>
-              </table>
-            </div>
+                          const subtotal = lines.reduce(
+                            (sum, line) => sum + line.amount,
+                            0,
+                          )
+                          const actualSubtotal = lines.reduce(
+                            (sum, line) =>
+                              sum + (expenseActuals.get(line.key) ?? 0),
+                            0,
+                          )
+                          const hasActuals = lines.some((line) =>
+                            expenseActuals.has(line.key),
+                          )
+                          // A delta against the FULL category budget is only
+                          // honest once every (non-cut) line has a recorded
+                          // actual - otherwise partially-recorded spend reads as
+                          // a big underspend.
+                          const actualsComplete = lines.every(
+                            (line) => line.cut || expenseActuals.has(line.key),
+                          )
+                          return (
+                            <BudgetVsActualRow
+                              key={category}
+                              label={EXPENSE_CATEGORY_LABELS[category]}
+                              sublabel={lines
+                                .map(
+                                  (line) =>
+                                    `${line.name}${line.cut ? ' (cut)' : ''}`,
+                                )
+                                .join(' · ')}
+                              budget={subtotal}
+                              actual={hasActuals ? actualSubtotal : null}
+                              actualNote={
+                                hasActuals && !actualsComplete
+                                  ? 'recorded so far'
+                                  : undefined
+                              }
+                              kind="expense"
+                              hideDelta={!actualsComplete}
+                            />
+                          )
+                        })}
+                        <BudgetVsActualRow
+                          label={`Ticketing platform fee (${(model.ticketingFeeRate * 100).toFixed(1)}%)`}
+                          sublabel="computed on gross ticket revenue"
+                          budget={result.ticketingFee}
+                          actual={null}
+                          kind="expense"
+                        />
+                        <BudgetVsActualRow
+                          label="Variable expenses"
+                          sublabel="headcount-driven + ticketing fee"
+                          budget={result.totalVariableExpenses}
+                          actual={null}
+                          kind="expense"
+                        />
+                        <BudgetVsActualRow
+                          label="Fixed expenses"
+                          sublabel={
+                            selectedScenario.cutCostKeys.length > 0
+                              ? `${selectedScenario.cutCostKeys.length} optional cost(s) cut in this scenario`
+                              : undefined
+                          }
+                          budget={result.totalFixedExpenses}
+                          actual={null}
+                          kind="expense"
+                        />
+                        <BudgetVsActualRow
+                          label="Total expenses"
+                          budget={result.totalExpenses}
+                          actual={hasExpenseActuals ? actualExpenseTotal : null}
+                          actualNote={
+                            hasExpenseActuals ? 'recorded so far' : undefined
+                          }
+                          emphasize
+                          kind="expense"
+                          hideDelta
+                        />
+                      </tbody>
+                    </table>
+                  </div>
+                </>
+              }
+            />
+          </CollapsibleSection>
+
+          {/* Sponsor assumptions — tier & add-on price lists that drive the
+              scenario sponsor-revenue projections. */}
+          <CollapsibleSection title="Sponsor assumptions" defaultOpen>
+            <BudgetSponsorAssumptionsEditor
+              sponsorTierAssumptions={budget.sponsorTierAssumptions ?? []}
+              sponsorAddonAssumptions={budget.sponsorAddonAssumptions ?? []}
+            />
           </CollapsibleSection>
 
           {/* Margin readout */}

--- a/src/components/admin/budget/BudgetPageClient.tsx
+++ b/src/components/admin/budget/BudgetPageClient.tsx
@@ -241,6 +241,26 @@ export function BudgetPageClient({
     ],
     [budget],
   )
+  const scenarioTierKeys = useMemo(
+    () => [
+      ...new Set(
+        (budget?.scenarios ?? []).flatMap((scenario) =>
+          (scenario.tierCounts ?? []).map((count) => count.tier),
+        ),
+      ),
+    ],
+    [budget],
+  )
+  const scenarioAddonKeys = useMemo(
+    () => [
+      ...new Set(
+        (budget?.scenarios ?? []).flatMap((scenario) =>
+          (scenario.addonCounts ?? []).map((count) => count.addon),
+        ),
+      ),
+    ],
+    [budget],
+  )
 
   const actualTicketRevenue = ticketIncome?.revenue ?? null
   // Sponsor income is grouped BY CURRENCY (see deriveSponsorIncome): only
@@ -606,6 +626,8 @@ export function BudgetPageClient({
             <BudgetSponsorAssumptionsEditor
               sponsorTierAssumptions={budget.sponsorTierAssumptions ?? []}
               sponsorAddonAssumptions={budget.sponsorAddonAssumptions ?? []}
+              scenarioReferencedTierKeys={scenarioTierKeys}
+              scenarioReferencedAddonKeys={scenarioAddonKeys}
             />
           </CollapsibleSection>
 

--- a/src/components/admin/budget/BudgetSponsorAssumptionsEditor.tsx
+++ b/src/components/admin/budget/BudgetSponsorAssumptionsEditor.tsx
@@ -1,0 +1,344 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { PlusIcon } from '@heroicons/react/24/outline'
+
+import type {
+  BudgetSponsorAddonItem,
+  BudgetSponsorTierItem,
+} from '@/lib/budget'
+import { formatCurrency } from '@/lib/format'
+import { generateKey } from '@/lib/sanity/helpers'
+import { api } from '@/lib/trpc/client'
+import { AdminButton } from '@/components/admin/AdminButton'
+import { useNotification } from '@/components/admin/NotificationProvider'
+import { numberOrNull } from './fields'
+import { EditableTableCard } from './EditableTableCard'
+import {
+  DeleteRowButton,
+  NumberCell,
+  TextCell,
+  tableClass,
+  tableWrapClass,
+  tbodyRowClass,
+  tdClass,
+  theadClass,
+  thClass,
+} from './BudgetTableCells'
+
+export interface BudgetSponsorAssumptionsEditorProps {
+  sponsorTierAssumptions: BudgetSponsorTierItem[]
+  sponsorAddonAssumptions: BudgetSponsorAddonItem[]
+  defaultEditing?: boolean
+}
+
+const nok = (amount: number) => formatCurrency(Math.round(amount), 'NOK')
+
+/**
+ * Sponsor assumption editor: the tier + a-la-carte add-on price lists that
+ * drive scenario sponsor-revenue projections (prices are ex VAT, sponsor CRM
+ * convention). Edits INLINE ON THE PAGE as two spreadsheet tables — no modal.
+ */
+export function BudgetSponsorAssumptionsEditor({
+  sponsorTierAssumptions,
+  sponsorAddonAssumptions,
+  defaultEditing = false,
+}: BudgetSponsorAssumptionsEditorProps) {
+  const router = useRouter()
+  const { showNotification } = useNotification()
+
+  const [editing, setEditing] = useState(defaultEditing)
+  const [tiers, setTiers] = useState<BudgetSponsorTierItem[]>(() =>
+    structuredClone(sponsorTierAssumptions),
+  )
+  const [addons, setAddons] = useState<BudgetSponsorAddonItem[]>(() =>
+    structuredClone(sponsorAddonAssumptions),
+  )
+  const [error, setError] = useState<string | null>(null)
+
+  const isDirty =
+    JSON.stringify({ tiers, addons }) !==
+    JSON.stringify({
+      tiers: sponsorTierAssumptions,
+      addons: sponsorAddonAssumptions,
+    })
+
+  const saveMutation = api.budget.updateSponsorAssumptions.useMutation({
+    onSuccess: () => {
+      router.refresh()
+      showNotification({
+        type: 'success',
+        title: 'Sponsor assumptions updated',
+        message: 'Tier and add-on price lists saved.',
+      })
+      setEditing(false)
+    },
+    onError: (err) => {
+      setError(err.message || 'Failed to save sponsor assumptions.')
+      showNotification({
+        type: 'error',
+        title: 'Could not save',
+        message: err.message || 'Failed to save sponsor assumptions.',
+      })
+    },
+  })
+
+  const reset = () => {
+    setTiers(structuredClone(sponsorTierAssumptions))
+    setAddons(structuredClone(sponsorAddonAssumptions))
+    setError(null)
+  }
+  const startEdit = () => {
+    reset()
+    setEditing(true)
+  }
+  const cancel = () => {
+    setEditing(false)
+    reset()
+  }
+
+  const updateTier = (key: string, patch: Partial<BudgetSponsorTierItem>) =>
+    setTiers((prev) =>
+      prev.map((t) => (t._key === key ? { ...t, ...patch } : t)),
+    )
+  const updateAddon = (key: string, patch: Partial<BudgetSponsorAddonItem>) =>
+    setAddons((prev) =>
+      prev.map((a) => (a._key === key ? { ...a, ...patch } : a)),
+    )
+
+  const handleSave = () => {
+    setError(null)
+    if ([...tiers, ...addons].some((item) => !item.name.trim())) {
+      setError('Every tier and add-on needs a name.')
+      return
+    }
+    saveMutation.mutate({
+      sponsorTierAssumptions: tiers.map((t) => ({
+        _key: t._key,
+        name: t.name,
+        priceExVat: t.priceExVat ?? 0,
+        includedTickets: t.includedTickets ?? 0,
+      })),
+      sponsorAddonAssumptions: addons.map((a) => ({
+        _key: a._key,
+        name: a.name,
+        priceExVat: a.priceExVat ?? 0,
+      })),
+    })
+  }
+
+  const display = (
+    <div className="grid gap-6 sm:grid-cols-2">
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+          Tiers
+        </h3>
+        {tiers.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No tiers defined.
+          </p>
+        ) : (
+          <dl className="divide-y divide-gray-100 dark:divide-gray-800">
+            {sponsorTierAssumptions.map((t) => (
+              <div key={t._key} className="flex justify-between gap-4 py-1.5">
+                <dt className="text-sm text-gray-700 dark:text-gray-300">
+                  {t.name}
+                  <span className="ml-1 text-xs text-gray-400">
+                    · {t.includedTickets ?? 0} tickets
+                  </span>
+                </dt>
+                <dd className="text-sm whitespace-nowrap text-gray-900 tabular-nums dark:text-white">
+                  {nok(t.priceExVat ?? 0)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </div>
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+          Add-ons
+        </h3>
+        {sponsorAddonAssumptions.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No add-ons defined.
+          </p>
+        ) : (
+          <dl className="divide-y divide-gray-100 dark:divide-gray-800">
+            {sponsorAddonAssumptions.map((a) => (
+              <div key={a._key} className="flex justify-between gap-4 py-1.5">
+                <dt className="text-sm text-gray-700 dark:text-gray-300">
+                  {a.name}
+                </dt>
+                <dd className="text-sm whitespace-nowrap text-gray-900 tabular-nums dark:text-white">
+                  {nok(a.priceExVat ?? 0)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </div>
+    </div>
+  )
+
+  return (
+    <EditableTableCard
+      editing={editing}
+      onStartEdit={startEdit}
+      onSave={handleSave}
+      onCancel={cancel}
+      isDirty={isDirty}
+      isSaving={saveMutation.isPending}
+      saveLabel="Save assumptions"
+      editLabel="Edit assumptions"
+      error={error}
+      display={display}
+    >
+      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+        Prices in NOK, excluding VAT (sponsor CRM convention). Scenario sponsor
+        counts live on the config page.
+      </p>
+
+      <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+        Tiers
+      </h3>
+      <div className={tableWrapClass}>
+        <table className={tableClass}>
+          <thead className={theadClass}>
+            <tr>
+              <th className={thClass}>Name</th>
+              <th className={`${thClass} text-right`}>Price ex VAT</th>
+              <th className={`${thClass} text-right`}>Included tickets</th>
+              <th className={`${thClass} text-center`}>
+                <span className="sr-only">Delete</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {tiers.map((t) => (
+              <tr key={t._key} className={tbodyRowClass}>
+                <td className={tdClass}>
+                  <TextCell
+                    ariaLabel="Tier name"
+                    value={t.name}
+                    onChange={(v) => updateTier(t._key, { name: v })}
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`Price ex VAT for ${t.name || 'tier'}`}
+                    value={t.priceExVat}
+                    onChange={(v) =>
+                      updateTier(t._key, { priceExVat: numberOrNull(v) ?? 0 })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`Included tickets for ${t.name || 'tier'}`}
+                    widthClass="w-24"
+                    value={t.includedTickets ?? 0}
+                    onChange={(v) =>
+                      updateTier(t._key, {
+                        includedTickets: numberOrNull(v) ?? 0,
+                      })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <DeleteRowButton
+                    ariaLabel={`Remove ${t.name || 'tier'}`}
+                    onClick={() =>
+                      setTiers((prev) => prev.filter((x) => x._key !== t._key))
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-3">
+        <AdminButton
+          variant="secondary"
+          size="sm"
+          onClick={() =>
+            setTiers((prev) => [
+              ...prev,
+              {
+                _key: generateKey('sponsortier'),
+                name: '',
+                priceExVat: 0,
+                includedTickets: 0,
+              },
+            ])
+          }
+        >
+          <PlusIcon className="h-4 w-4" /> Add tier
+        </AdminButton>
+      </div>
+
+      <h3 className="mt-6 mb-2 text-sm font-semibold text-gray-900 dark:text-white">
+        Add-ons
+      </h3>
+      <div className={tableWrapClass}>
+        <table className={tableClass}>
+          <thead className={theadClass}>
+            <tr>
+              <th className={thClass}>Name</th>
+              <th className={`${thClass} text-right`}>Price ex VAT</th>
+              <th className={`${thClass} text-center`}>
+                <span className="sr-only">Delete</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {addons.map((a) => (
+              <tr key={a._key} className={tbodyRowClass}>
+                <td className={tdClass}>
+                  <TextCell
+                    ariaLabel="Add-on name"
+                    value={a.name}
+                    onChange={(v) => updateAddon(a._key, { name: v })}
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`Price ex VAT for ${a.name || 'add-on'}`}
+                    value={a.priceExVat}
+                    onChange={(v) =>
+                      updateAddon(a._key, { priceExVat: numberOrNull(v) ?? 0 })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <DeleteRowButton
+                    ariaLabel={`Remove ${a.name || 'add-on'}`}
+                    onClick={() =>
+                      setAddons((prev) => prev.filter((x) => x._key !== a._key))
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-3">
+        <AdminButton
+          variant="secondary"
+          size="sm"
+          onClick={() =>
+            setAddons((prev) => [
+              ...prev,
+              { _key: generateKey('sponsoraddon'), name: '', priceExVat: 0 },
+            ])
+          }
+        >
+          <PlusIcon className="h-4 w-4" /> Add add-on
+        </AdminButton>
+      </div>
+    </EditableTableCard>
+  )
+}

--- a/src/components/admin/budget/BudgetSponsorAssumptionsEditor.tsx
+++ b/src/components/admin/budget/BudgetSponsorAssumptionsEditor.tsx
@@ -30,6 +30,15 @@ import {
 export interface BudgetSponsorAssumptionsEditorProps {
   sponsorTierAssumptions: BudgetSponsorTierItem[]
   sponsorAddonAssumptions: BudgetSponsorAddonItem[]
+  /**
+   * Tier `_key`s referenced by scenario `tierCounts`. Deleting a referenced
+   * tier orphans those scenario counts (its projected sponsor revenue and
+   * included tickets silently drop), so it takes a confirming second click —
+   * the same guard the ticket-type and expense editors use.
+   */
+  scenarioReferencedTierKeys?: string[]
+  /** Add-on `_key`s referenced by scenario `addonCounts` (see above). */
+  scenarioReferencedAddonKeys?: string[]
   defaultEditing?: boolean
 }
 
@@ -43,12 +52,17 @@ const nok = (amount: number) => formatCurrency(Math.round(amount), 'NOK')
 export function BudgetSponsorAssumptionsEditor({
   sponsorTierAssumptions,
   sponsorAddonAssumptions,
+  scenarioReferencedTierKeys = [],
+  scenarioReferencedAddonKeys = [],
   defaultEditing = false,
 }: BudgetSponsorAssumptionsEditorProps) {
   const router = useRouter()
   const { showNotification } = useNotification()
+  const referencedTierKeys = new Set(scenarioReferencedTierKeys)
+  const referencedAddonKeys = new Set(scenarioReferencedAddonKeys)
 
   const [editing, setEditing] = useState(defaultEditing)
+  const [pendingRemoval, setPendingRemoval] = useState<string | null>(null)
   const [tiers, setTiers] = useState<BudgetSponsorTierItem[]>(() =>
     structuredClone(sponsorTierAssumptions),
   )
@@ -88,6 +102,7 @@ export function BudgetSponsorAssumptionsEditor({
     setTiers(structuredClone(sponsorTierAssumptions))
     setAddons(structuredClone(sponsorAddonAssumptions))
     setError(null)
+    setPendingRemoval(null)
   }
   const startEdit = () => {
     reset()
@@ -106,6 +121,23 @@ export function BudgetSponsorAssumptionsEditor({
     setAddons((prev) =>
       prev.map((a) => (a._key === key ? { ...a, ...patch } : a)),
     )
+
+  const removeTier = (key: string) => {
+    if (referencedTierKeys.has(key) && pendingRemoval !== key) {
+      setPendingRemoval(key)
+      return
+    }
+    setPendingRemoval(null)
+    setTiers((prev) => prev.filter((x) => x._key !== key))
+  }
+  const removeAddon = (key: string) => {
+    if (referencedAddonKeys.has(key) && pendingRemoval !== key) {
+      setPendingRemoval(key)
+      return
+    }
+    setPendingRemoval(null)
+    setAddons((prev) => prev.filter((x) => x._key !== key))
+  }
 
   const handleSave = () => {
     setError(null)
@@ -134,7 +166,7 @@ export function BudgetSponsorAssumptionsEditor({
         <h3 className="mb-2 text-sm font-semibold text-gray-900 dark:text-white">
           Tiers
         </h3>
-        {tiers.length === 0 ? (
+        {sponsorTierAssumptions.length === 0 ? (
           <p className="text-sm text-gray-500 dark:text-gray-400">
             No tiers defined.
           </p>
@@ -248,10 +280,14 @@ export function BudgetSponsorAssumptionsEditor({
                 </td>
                 <td className={`${tdClass} text-center`}>
                   <DeleteRowButton
-                    ariaLabel={`Remove ${t.name || 'tier'}`}
-                    onClick={() =>
-                      setTiers((prev) => prev.filter((x) => x._key !== t._key))
+                    ariaLabel={
+                      referencedTierKeys.has(t._key) &&
+                      pendingRemoval === t._key
+                        ? `Confirm removing ${t.name || 'tier'} (used by scenarios)`
+                        : `Remove ${t.name || 'tier'}`
                     }
+                    pending={pendingRemoval === t._key}
+                    onClick={() => removeTier(t._key)}
                   />
                 </td>
               </tr>
@@ -259,7 +295,7 @@ export function BudgetSponsorAssumptionsEditor({
           </tbody>
         </table>
       </div>
-      <div className="mt-3">
+      <div className="mt-3 flex items-center gap-3">
         <AdminButton
           variant="secondary"
           size="sm"
@@ -277,6 +313,12 @@ export function BudgetSponsorAssumptionsEditor({
         >
           <PlusIcon className="h-4 w-4" /> Add tier
         </AdminButton>
+        {pendingRemoval && tiers.some((t) => t._key === pendingRemoval) ? (
+          <span className="text-xs text-amber-700 dark:text-amber-400">
+            That tier is referenced by a scenario — click delete again to
+            confirm; its scenario counts will be dropped.
+          </span>
+        ) : null}
       </div>
 
       <h3 className="mt-6 mb-2 text-sm font-semibold text-gray-900 dark:text-white">
@@ -314,10 +356,14 @@ export function BudgetSponsorAssumptionsEditor({
                 </td>
                 <td className={`${tdClass} text-center`}>
                   <DeleteRowButton
-                    ariaLabel={`Remove ${a.name || 'add-on'}`}
-                    onClick={() =>
-                      setAddons((prev) => prev.filter((x) => x._key !== a._key))
+                    ariaLabel={
+                      referencedAddonKeys.has(a._key) &&
+                      pendingRemoval === a._key
+                        ? `Confirm removing ${a.name || 'add-on'} (used by scenarios)`
+                        : `Remove ${a.name || 'add-on'}`
                     }
+                    pending={pendingRemoval === a._key}
+                    onClick={() => removeAddon(a._key)}
                   />
                 </td>
               </tr>
@@ -325,7 +371,7 @@ export function BudgetSponsorAssumptionsEditor({
           </tbody>
         </table>
       </div>
-      <div className="mt-3">
+      <div className="mt-3 flex items-center gap-3">
         <AdminButton
           variant="secondary"
           size="sm"
@@ -338,6 +384,12 @@ export function BudgetSponsorAssumptionsEditor({
         >
           <PlusIcon className="h-4 w-4" /> Add add-on
         </AdminButton>
+        {pendingRemoval && addons.some((a) => a._key === pendingRemoval) ? (
+          <span className="text-xs text-amber-700 dark:text-amber-400">
+            That add-on is referenced by a scenario — click delete again to
+            confirm; its scenario counts will be dropped.
+          </span>
+        ) : null}
       </div>
     </EditableTableCard>
   )

--- a/src/components/admin/budget/BudgetTableCells.tsx
+++ b/src/components/admin/budget/BudgetTableCells.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { TrashIcon } from '@heroicons/react/24/outline'
+
+/**
+ * Spreadsheet-style inline table primitives for the budget editors.
+ *
+ * The whole editing surface is a real `<table>`: one row per line item, one
+ * column per field, cells that ARE the inputs (text / number / select /
+ * checkbox) — no per-row cards. Numeric cells right-align with `tabular-nums`
+ * so columns of NOK figures line up like a spreadsheet. The parent wraps the
+ * table in an `overflow-x-auto` container so a wide table scrolls sideways
+ * inside its card instead of pushing the page horizontally.
+ */
+
+/** Wrapper class: header row + cells share this for a tight, gridded feel. */
+export const tableWrapClass =
+  'overflow-x-auto rounded-lg ring-1 ring-gray-200 dark:ring-gray-700'
+
+export const tableClass = 'min-w-full border-collapse text-sm'
+
+export const theadClass =
+  'bg-gray-50 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:bg-gray-800 dark:text-gray-400'
+
+/** Base header cell: adds a bottom divider and consistent padding. */
+export const thClass =
+  'border-b border-gray-200 px-3 py-2 font-medium whitespace-nowrap dark:border-gray-700'
+
+export const tbodyRowClass =
+  'border-b border-gray-100 last:border-0 dark:border-gray-800'
+
+/** Base cell padding; numeric columns add `text-right`. */
+export const tdClass = 'px-3 py-1.5 align-middle'
+
+const baseInput =
+  'w-full rounded-md border-0 bg-transparent px-2 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-transparent hover:ring-gray-300 focus:bg-white focus:ring-2 focus:ring-blue-600 focus:outline-none dark:text-white dark:hover:ring-gray-600 dark:focus:bg-gray-900'
+
+export function TextCell({
+  value,
+  onChange,
+  ariaLabel,
+  placeholder,
+}: {
+  value: string
+  onChange: (value: string) => void
+  ariaLabel: string
+  placeholder?: string
+}) {
+  return (
+    <input
+      type="text"
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      className={`${baseInput} min-w-[10rem]`}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  )
+}
+
+export function NumberCell({
+  value,
+  onChange,
+  ariaLabel,
+  min = 0,
+  placeholder,
+  widthClass = 'w-28',
+}: {
+  value: number | string
+  onChange: (value: string) => void
+  ariaLabel: string
+  min?: number
+  placeholder?: string
+  widthClass?: string
+}) {
+  return (
+    <input
+      type="number"
+      inputMode="numeric"
+      min={min}
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      className={`${baseInput} ${widthClass} text-right tabular-nums`}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  )
+}
+
+export function SelectCell<T extends string>({
+  value,
+  onChange,
+  ariaLabel,
+  options,
+}: {
+  value: T
+  onChange: (value: T) => void
+  ariaLabel: string
+  options: { value: T; label: string }[]
+}) {
+  return (
+    <select
+      aria-label={ariaLabel}
+      className={`${baseInput} min-w-[9rem]`}
+      value={value}
+      onChange={(e) => onChange(e.target.value as T)}
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+export function CheckboxCell({
+  checked,
+  onChange,
+  ariaLabel,
+}: {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  ariaLabel: string
+}) {
+  return (
+    <span className="flex justify-center">
+      <input
+        type="checkbox"
+        aria-label={ariaLabel}
+        className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-600 dark:border-gray-600 dark:bg-gray-900"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+    </span>
+  )
+}
+
+export function DeleteRowButton({
+  onClick,
+  ariaLabel,
+  pending = false,
+}: {
+  onClick: () => void
+  ariaLabel: string
+  /** Referenced-row confirm state: tints the button amber before the 2nd click. */
+  pending?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className={`inline-flex h-9 w-9 items-center justify-center rounded-md ${
+        pending
+          ? 'text-amber-600 ring-1 ring-amber-400 dark:text-amber-400'
+          : 'text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30'
+      }`}
+    >
+      <TrashIcon className="h-4 w-4" />
+    </button>
+  )
+}

--- a/src/components/admin/budget/BudgetTicketTypesEditor.tsx
+++ b/src/components/admin/budget/BudgetTicketTypesEditor.tsx
@@ -1,26 +1,28 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
-import {
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-} from '@heroicons/react/24/outline'
+import { PlusIcon } from '@heroicons/react/24/outline'
 
 import type { BudgetTicketTypeItem } from '@/lib/budget'
 import { generateKey } from '@/lib/sanity/helpers'
 import { api } from '@/lib/trpc/client'
-import { ModalShell } from '@/components/ModalShell'
 import { AdminButton } from '@/components/admin/AdminButton'
 import { useNotification } from '@/components/admin/NotificationProvider'
+import { numberOrNull } from './fields'
+import { EditableTableCard } from './EditableTableCard'
 import {
-  checkboxLabelClass,
-  inputClass,
-  labelClass,
-  numberOrNull,
-  removeButtonClass,
-} from './fields'
+  CheckboxCell,
+  DeleteRowButton,
+  NumberCell,
+  TextCell,
+  tableClass,
+  tableWrapClass,
+  tbodyRowClass,
+  tdClass,
+  theadClass,
+  thClass,
+} from './BudgetTableCells'
 
 export interface BudgetTicketTypesEditorProps {
   ticketTypes: BudgetTicketTypeItem[]
@@ -32,27 +34,30 @@ export interface BudgetTicketTypesEditorProps {
    * second click.
    */
   scenarioReferencedKeys?: string[]
-  defaultOpen?: boolean
+  /** Read-only summary shown when not editing (the budget-vs-actual rows). */
+  display: ReactNode
+  /** Force edit mode on mount (Storybook / deep links). */
+  defaultEditing?: boolean
 }
 
 /**
- * Ticket-mix editor island. Edits the budget's ticket-type assumptions
- * (price incl VAT + attendance flags that drive per-person costs) and the
- * manual "actual sold" counts used as the ticket-income fallback when no
- * ticketing provider is connected.
+ * Ticket-mix editor: edits the budget's ticket-type assumptions (price incl
+ * VAT + attendance flags that drive per-person costs) and the manual "actual
+ * sold" counts used as the ticket-income fallback. Edits INLINE ON THE PAGE
+ * as a full-width spreadsheet table (one row per ticket type) — no modal.
  */
 export function BudgetTicketTypesEditor({
   ticketTypes,
   manualActualsInUse = false,
   scenarioReferencedKeys = [],
-  defaultOpen = false,
+  display,
+  defaultEditing = false,
 }: BudgetTicketTypesEditorProps) {
   const router = useRouter()
   const { showNotification } = useNotification()
   const referencedKeys = new Set(scenarioReferencedKeys)
 
-  const [isOpen, setIsOpen] = useState(defaultOpen)
-  // Referenced row awaiting delete confirmation (second click removes).
+  const [editing, setEditing] = useState(defaultEditing)
   const [pendingRemoval, setPendingRemoval] = useState<string | null>(null)
   const [items, setItems] = useState<BudgetTicketTypeItem[]>(() =>
     structuredClone(ticketTypes),
@@ -69,7 +74,7 @@ export function BudgetTicketTypesEditor({
         title: 'Ticket types updated',
         message: 'Budget ticket mix saved.',
       })
-      setIsOpen(false)
+      setEditing(false)
     },
     onError: (err) => {
       setError(err.message || 'Failed to save ticket types.')
@@ -86,12 +91,12 @@ export function BudgetTicketTypesEditor({
     setError(null)
     setPendingRemoval(null)
   }
-  const openModal = () => {
+  const startEdit = () => {
     reset()
-    setIsOpen(true)
+    setEditing(true)
   }
-  const closeModal = () => {
-    setIsOpen(false)
+  const cancel = () => {
+    setEditing(false)
     reset()
   }
 
@@ -100,6 +105,30 @@ export function BudgetTicketTypesEditor({
       prev.map((item) => (item._key === key ? { ...item, ...patch } : item)),
     )
   }
+
+  const removeRow = (key: string) => {
+    if (referencedKeys.has(key) && pendingRemoval !== key) {
+      setPendingRemoval(key)
+      return
+    }
+    setPendingRemoval(null)
+    setItems((prev) => prev.filter((x) => x._key !== key))
+  }
+
+  const addRow = () =>
+    setItems((prev) => [
+      ...prev,
+      {
+        _key: generateKey('tickettype'),
+        name: '',
+        priceInclVat: 0,
+        attendsConference: true,
+        attendsWorkshop: false,
+        workshopCrew: false,
+        sponsorIncluded: false,
+        actualCount: null,
+      },
+    ])
 
   const handleSave = () => {
     setError(null)
@@ -132,233 +161,130 @@ export function BudgetTicketTypesEditor({
   }
 
   return (
-    <>
-      <button
-        type="button"
-        aria-label="Edit ticket types"
-        onClick={openModal}
-        className="inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-      >
-        <PencilSquareIcon className="h-5 w-5" />
-      </button>
-      <ModalShell
-        isOpen={isOpen}
-        onClose={closeModal}
-        size="xl"
-        title="Edit ticket types"
-        subtitle={
-          manualActualsInUse
-            ? 'Prices in NOK incl VAT. "Actual sold" feeds ticket income (no ticketing provider connected).'
-            : 'Prices in NOK incl VAT. Attendance flags drive per-person costs; scenario quantities live on scenarios.'
-        }
-        icon={<PencilSquareIcon className="h-5 w-5" />}
-        confirmOnDirtyClose
-        isDirty={isDirty && !saveMutation.isPending}
-      >
-        <form
-          noValidate
-          onSubmit={(e) => {
-            e.preventDefault()
-            handleSave()
-          }}
-          className="space-y-4"
-        >
-          <div className="space-y-3">
+    <EditableTableCard
+      editing={editing}
+      onStartEdit={startEdit}
+      onSave={handleSave}
+      onCancel={cancel}
+      isDirty={isDirty}
+      isSaving={saveMutation.isPending}
+      saveLabel="Save ticket types"
+      editLabel="Edit ticket types"
+      error={error}
+      display={display}
+    >
+      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+        {manualActualsInUse
+          ? 'Prices in NOK incl VAT. “Actual sold” feeds ticket income (no ticketing provider connected).'
+          : 'Prices in NOK incl VAT. Attendance flags drive per-person costs; scenario quantities live on the config page.'}
+      </p>
+      <div className={tableWrapClass}>
+        <table className={tableClass}>
+          <thead className={theadClass}>
+            <tr>
+              <th className={thClass}>Name</th>
+              <th className={`${thClass} text-right`}>Price incl VAT</th>
+              <th className={`${thClass} text-center`}>Conf</th>
+              <th className={`${thClass} text-center`}>Workshop</th>
+              <th className={`${thClass} text-center`}>Crew</th>
+              <th className={`${thClass} text-center`}>Sponsor-incl</th>
+              <th className={`${thClass} text-right`}>Actual sold</th>
+              <th className={`${thClass} text-center`}>
+                <span className="sr-only">Delete</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
             {items.map((item) => (
-              <div
-                key={item._key}
-                className="rounded-lg border border-gray-200 p-3 dark:border-gray-700"
-              >
-                <div className="grid grid-cols-2 gap-3 sm:grid-cols-12">
-                  <div className="col-span-2 sm:col-span-4">
-                    <label className={labelClass}>
-                      Name
-                      <input
-                        type="text"
-                        className={inputClass}
-                        value={item.name}
-                        onChange={(e) =>
-                          update(item._key, { name: e.target.value })
-                        }
-                      />
-                    </label>
-                  </div>
-                  <div className="sm:col-span-2">
-                    <label className={labelClass}>
-                      Price (incl VAT)
-                      <input
-                        type="number"
-                        min={0}
-                        className={inputClass}
-                        value={item.priceInclVat}
-                        onChange={(e) =>
-                          update(item._key, {
-                            priceInclVat: numberOrNull(e.target.value) ?? 0,
-                          })
-                        }
-                      />
-                    </label>
-                  </div>
-                  <div className="sm:col-span-2">
-                    <label className={labelClass}>
-                      Actual sold
-                      <input
-                        type="number"
-                        min={0}
-                        className={inputClass}
-                        value={item.actualCount ?? ''}
-                        onChange={(e) =>
-                          update(item._key, {
-                            actualCount: numberOrNull(e.target.value),
-                          })
-                        }
-                      />
-                    </label>
-                  </div>
-                  <div className="col-span-2 flex flex-wrap items-end gap-x-4 sm:col-span-4">
-                    <label className={checkboxLabelClass}>
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-gray-300"
-                        checked={item.attendsConference ?? false}
-                        onChange={(e) =>
-                          update(item._key, {
-                            attendsConference: e.target.checked,
-                          })
-                        }
-                      />
-                      Conference
-                    </label>
-                    <label className={checkboxLabelClass}>
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-gray-300"
-                        checked={item.attendsWorkshop ?? false}
-                        onChange={(e) =>
-                          update(item._key, {
-                            attendsWorkshop: e.target.checked,
-                          })
-                        }
-                      />
-                      Workshop
-                    </label>
-                    <label className={checkboxLabelClass}>
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-gray-300"
-                        checked={item.workshopCrew ?? false}
-                        onChange={(e) =>
-                          update(item._key, { workshopCrew: e.target.checked })
-                        }
-                      />
-                      Crew
-                    </label>
-                    <label className={checkboxLabelClass}>
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-gray-300"
-                        checked={item.sponsorIncluded ?? false}
-                        onChange={(e) =>
-                          update(item._key, {
-                            sponsorIncluded: e.target.checked,
-                          })
-                        }
-                      />
-                      Sponsor-incl
-                    </label>
-                    <button
-                      type="button"
-                      aria-label={
-                        referencedKeys.has(item._key) &&
-                        pendingRemoval === item._key
-                          ? `Confirm removing ${item.name || 'ticket type'} (used by scenarios)`
-                          : `Remove ${item.name || 'ticket type'}`
-                      }
-                      onClick={() => {
-                        if (
-                          referencedKeys.has(item._key) &&
-                          pendingRemoval !== item._key
-                        ) {
-                          setPendingRemoval(item._key)
-                          return
-                        }
-                        setPendingRemoval(null)
-                        setItems((prev) =>
-                          prev.filter((x) => x._key !== item._key),
-                        )
-                      }}
-                      className={`ml-auto ${removeButtonClass}`}
-                    >
-                      <TrashIcon className="h-5 w-5" />
-                    </button>
-                  </div>
-                </div>
-              </div>
+              <tr key={item._key} className={tbodyRowClass}>
+                <td className={tdClass}>
+                  <TextCell
+                    ariaLabel="Ticket type name"
+                    value={item.name}
+                    onChange={(v) => update(item._key, { name: v })}
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`Price incl VAT for ${item.name || 'ticket type'}`}
+                    value={item.priceInclVat}
+                    onChange={(v) =>
+                      update(item._key, {
+                        priceInclVat: numberOrNull(v) ?? 0,
+                      })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <CheckboxCell
+                    ariaLabel={`${item.name || 'Ticket type'} attends conference`}
+                    checked={item.attendsConference ?? false}
+                    onChange={(c) =>
+                      update(item._key, { attendsConference: c })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <CheckboxCell
+                    ariaLabel={`${item.name || 'Ticket type'} attends workshop`}
+                    checked={item.attendsWorkshop ?? false}
+                    onChange={(c) => update(item._key, { attendsWorkshop: c })}
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <CheckboxCell
+                    ariaLabel={`${item.name || 'Ticket type'} is workshop-day crew`}
+                    checked={item.workshopCrew ?? false}
+                    onChange={(c) => update(item._key, { workshopCrew: c })}
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <CheckboxCell
+                    ariaLabel={`${item.name || 'Ticket type'} is sponsor-included`}
+                    checked={item.sponsorIncluded ?? false}
+                    onChange={(c) => update(item._key, { sponsorIncluded: c })}
+                  />
+                </td>
+                <td className={`${tdClass} text-right`}>
+                  <NumberCell
+                    ariaLabel={`Actual sold for ${item.name || 'ticket type'}`}
+                    value={item.actualCount ?? ''}
+                    placeholder="—"
+                    widthClass="w-24"
+                    onChange={(v) =>
+                      update(item._key, { actualCount: numberOrNull(v) })
+                    }
+                  />
+                </td>
+                <td className={`${tdClass} text-center`}>
+                  <DeleteRowButton
+                    ariaLabel={
+                      referencedKeys.has(item._key) &&
+                      pendingRemoval === item._key
+                        ? `Confirm removing ${item.name || 'ticket type'} (used by scenarios)`
+                        : `Remove ${item.name || 'ticket type'}`
+                    }
+                    pending={pendingRemoval === item._key}
+                    onClick={() => removeRow(item._key)}
+                  />
+                </td>
+              </tr>
             ))}
-          </div>
+          </tbody>
+        </table>
+      </div>
 
-          <AdminButton
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() =>
-              setItems((prev) => [
-                ...prev,
-                {
-                  _key: generateKey('tickettype'),
-                  name: '',
-                  priceInclVat: 0,
-                  attendsConference: true,
-                  attendsWorkshop: false,
-                  workshopCrew: false,
-                  sponsorIncluded: false,
-                  actualCount: null,
-                },
-              ])
-            }
-          >
-            <PlusIcon className="mr-1 h-4 w-4" /> Add ticket type
-          </AdminButton>
-
-          {pendingRemoval && (
-            <p
-              role="alert"
-              className="text-sm text-amber-700 dark:text-amber-400"
-            >
-              This ticket type is referenced by one or more scenarios &mdash;
-              click remove again to confirm. Its scenario quantities will be
-              dropped.
-            </p>
-          )}
-          {error && (
-            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
-              {error}
-            </p>
-          )}
-
-          <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-end">
-            <AdminButton
-              type="button"
-              variant="secondary"
-              size="md"
-              onClick={closeModal}
-              disabled={saveMutation.isPending}
-              className="min-h-[44px]"
-            >
-              Cancel
-            </AdminButton>
-            <AdminButton
-              type="submit"
-              color="blue"
-              size="md"
-              disabled={saveMutation.isPending || !isDirty}
-              className="min-h-[44px]"
-            >
-              {saveMutation.isPending ? 'Saving…' : 'Save ticket types'}
-            </AdminButton>
-          </div>
-        </form>
-      </ModalShell>
-    </>
+      <div className="mt-3 flex items-center gap-3">
+        <AdminButton variant="secondary" size="sm" onClick={addRow}>
+          <PlusIcon className="h-4 w-4" /> Add ticket type
+        </AdminButton>
+        {pendingRemoval ? (
+          <span className="text-xs text-amber-700 dark:text-amber-400">
+            That ticket type is referenced by a scenario — click delete again to
+            confirm; its scenario quantities will be dropped.
+          </span>
+        ) : null}
+      </div>
+    </EditableTableCard>
   )
 }

--- a/src/components/admin/budget/EditableTableCard.tsx
+++ b/src/components/admin/budget/EditableTableCard.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import { PencilSquareIcon } from '@heroicons/react/24/outline'
+
+import { AdminButton } from '@/components/admin/AdminButton'
+
+/**
+ * Shared Edit → Save / Cancel affordance for the budget's in-place editors.
+ *
+ * A card shows its read-only `display` until "Edit" is pressed, then swaps the
+ * body for the editable spreadsheet table (`children`) with a right-aligned
+ * Save/Cancel toolbar. Cancelling with unsaved changes routes through a
+ * confirm bar (no ModalShell) so edits are never dropped silently — this is
+ * the in-page replacement for the old modal's dirty-close guard.
+ */
+export function EditableTableCard({
+  editing,
+  onStartEdit,
+  onSave,
+  onCancel,
+  isDirty,
+  isSaving,
+  saveLabel = 'Save',
+  editLabel = 'Edit',
+  error,
+  display,
+  children,
+}: {
+  editing: boolean
+  onStartEdit: () => void
+  onSave: () => void
+  onCancel: () => void
+  isDirty: boolean
+  isSaving: boolean
+  saveLabel?: string
+  editLabel?: string
+  error?: string | null
+  display: ReactNode
+  children: ReactNode
+}) {
+  const [confirmingCancel, setConfirmingCancel] = useState(false)
+
+  const requestCancel = () => {
+    if (isDirty && !isSaving) {
+      setConfirmingCancel(true)
+      return
+    }
+    onCancel()
+  }
+  const discard = () => {
+    setConfirmingCancel(false)
+    onCancel()
+  }
+
+  return (
+    <div className="p-4 sm:p-6">
+      <div className="mb-3 flex items-center justify-end gap-2">
+        {editing ? (
+          <>
+            <AdminButton
+              variant="secondary"
+              size="sm"
+              onClick={requestCancel}
+              disabled={isSaving}
+            >
+              Cancel
+            </AdminButton>
+            <AdminButton
+              color="blue"
+              size="sm"
+              onClick={onSave}
+              disabled={isSaving || !isDirty}
+            >
+              {isSaving ? 'Saving…' : saveLabel}
+            </AdminButton>
+          </>
+        ) : (
+          <AdminButton variant="secondary" size="sm" onClick={onStartEdit}>
+            <PencilSquareIcon className="h-4 w-4" />
+            {editLabel}
+          </AdminButton>
+        )}
+      </div>
+
+      {editing && confirmingCancel ? (
+        <div
+          role="alertdialog"
+          aria-label="Discard unsaved changes?"
+          className="mb-3 flex flex-col gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm sm:flex-row sm:items-center sm:justify-between dark:border-amber-500/40 dark:bg-amber-900/20"
+        >
+          <span className="text-amber-900 dark:text-amber-200">
+            Discard unsaved changes?
+          </span>
+          <div className="flex gap-2">
+            <AdminButton
+              variant="secondary"
+              size="xs"
+              onClick={() => setConfirmingCancel(false)}
+            >
+              Keep editing
+            </AdminButton>
+            <AdminButton color="red" size="xs" onClick={discard}>
+              Discard
+            </AdminButton>
+          </div>
+        </div>
+      ) : null}
+
+      {error ? (
+        <p role="alert" className="mb-3 text-sm text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      ) : null}
+
+      {editing ? children : display}
+    </div>
+  )
+}

--- a/src/components/admin/budget/EditableTableCard.tsx
+++ b/src/components/admin/budget/EditableTableCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { PencilSquareIcon } from '@heroicons/react/24/outline'
 
 import { AdminButton } from '@/components/admin/AdminButton'
@@ -40,6 +40,12 @@ export function EditableTableCard({
   children: ReactNode
 }) {
   const [confirmingCancel, setConfirmingCancel] = useState(false)
+
+  // Leaving edit mode (via Save, or any parent-driven toggle) must clear a
+  // pending discard prompt so it can never re-appear in a later edit session.
+  useEffect(() => {
+    if (!editing) setConfirmingCancel(false)
+  }, [editing])
 
   const requestCancel = () => {
     if (isDirty && !isSaving) {
@@ -85,8 +91,7 @@ export function EditableTableCard({
 
       {editing && confirmingCancel ? (
         <div
-          role="alertdialog"
-          aria-label="Discard unsaved changes?"
+          role="alert"
           className="mb-3 flex flex-col gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm sm:flex-row sm:items-center sm:justify-between dark:border-amber-500/40 dark:bg-amber-900/20"
         >
           <span className="text-amber-900 dark:text-amber-200">

--- a/src/components/admin/budget/fields.ts
+++ b/src/components/admin/budget/fields.ts
@@ -13,12 +13,6 @@ export const inputClass =
 export const labelClass =
   'block text-xs font-medium text-gray-600 dark:text-gray-300'
 
-export const checkboxLabelClass =
-  'flex min-h-[44px] items-center gap-1.5 text-xs text-gray-600 dark:text-gray-300'
-
-export const removeButtonClass =
-  'inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30'
-
 export const CATEGORY_OPTIONS: { value: ExpenseCategory; label: string }[] =
   Object.entries(EXPENSE_CATEGORY_LABELS).map(([value, label]) => ({
     value: value as ExpenseCategory,

--- a/src/components/admin/budget/index.ts
+++ b/src/components/admin/budget/index.ts
@@ -1,4 +1,7 @@
 export { BudgetPageClient } from './BudgetPageClient'
 export type { BudgetPageClientProps } from './BudgetPageClient'
+export { BudgetConfigPageClient } from './BudgetConfigPageClient'
+export type { BudgetConfigPageClientProps } from './BudgetConfigPageClient'
 export { BudgetExpensesEditor } from './BudgetExpensesEditor'
 export { BudgetTicketTypesEditor } from './BudgetTicketTypesEditor'
+export { BudgetSponsorAssumptionsEditor } from './BudgetSponsorAssumptionsEditor'

--- a/src/lib/admin/registry.ts
+++ b/src/lib/admin/registry.ts
@@ -161,12 +161,6 @@ export const ADMIN_NAV_SECTIONS: AdminNavSection[] = [
     label: 'System',
     items: [
       {
-        name: 'Agents',
-        href: '/admin/agents',
-        icon: CpuChipIcon,
-        keywords: ['ai', 'automation', 'bots'],
-      },
-      {
         name: 'Settings',
         href: '/admin/settings',
         icon: Cog6ToothIcon,
@@ -178,6 +172,32 @@ export const ADMIN_NAV_SECTIONS: AdminNavSection[] = [
 
 /** Admin pages reachable only from within a section (no sidebar entry). */
 const ADMIN_SUB_PAGES: Omit<AdminDestination, 'kind'>[] = [
+  {
+    // Moved out of the sidebar (the nav had grown tall enough to scroll);
+    // reachable from the Settings page and still ⌘K-searchable here.
+    id: 'agents',
+    title: 'Agents',
+    href: '/admin/agents',
+    group: 'System',
+    keywords: ['ai', 'automation', 'bots', 'agents'],
+    icon: CpuChipIcon,
+  },
+  {
+    id: 'budget-config',
+    title: 'Budget Configuration',
+    href: '/admin/budget/config',
+    group: 'Events & Content',
+    keywords: [
+      'budget config',
+      'vat',
+      'rates',
+      'ticketing fee',
+      'scenarios',
+      'dinner',
+      'assumptions',
+    ],
+    icon: BanknotesIcon,
+  },
   {
     id: 'speakers-badge',
     title: 'Speaker Badges',

--- a/src/server/routers/budget.test.ts
+++ b/src/server/routers/budget.test.ts
@@ -322,4 +322,74 @@ describe('budget router — mutations', () => {
     const tickets = lastSet?.ticketTypes as { actualCount?: number | null }[]
     expect(tickets[0].actualCount).toBe(42)
   })
+
+  it('saves sponsor tier + add-on assumptions with unique keys', async () => {
+    const result = await makeCaller(orgOrganizer).updateSponsorAssumptions({
+      sponsorTierAssumptions: [
+        { _key: 'dup', name: 'Gold', priceExVat: 50000, includedTickets: 4 },
+        { _key: 'dup', name: 'Silver', priceExVat: 25000, includedTickets: 2 },
+      ],
+      sponsorAddonAssumptions: [{ name: 'Streaming', priceExVat: 20000 }],
+    })
+    expect(result?.success).toBe(true)
+    const tiers = lastSet?.sponsorTierAssumptions as { _key: string }[]
+    expect(new Set(tiers.map((t) => t._key)).size).toBe(2)
+    const addons = lastSet?.sponsorAddonAssumptions as { _key: string }[]
+    expect(addons[0]._key).toBeTruthy()
+  })
+
+  it('saves scalar config (rates + dinner participation)', async () => {
+    const result = await makeCaller(orgOrganizer).updateConfig({
+      vatRate: 0.25,
+      ticketingFeeRate: 0.045,
+      dinnerParticipation: { floor: 0.4, base: 0.9, decay: 1000 },
+    })
+    expect(result?.success).toBe(true)
+    expect(lastSet?.vatRate).toBe(0.25)
+    expect(lastSet?.ticketingFeeRate).toBe(0.045)
+    expect(lastSet?.dinnerParticipation).toEqual({
+      floor: 0.4,
+      base: 0.9,
+      decay: 1000,
+    })
+  })
+
+  it('rejects a dinner decay of zero (division guard)', async () => {
+    await expect(
+      makeCaller(orgOrganizer).updateConfig({
+        vatRate: 0.25,
+        ticketingFeeRate: 0.045,
+        dinnerParticipation: { floor: 0.4, base: 0.9, decay: 0 },
+      }),
+    ).rejects.toBeTruthy()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('keys scenarios AND their nested count arrays', async () => {
+    const result = await makeCaller(orgOrganizer).updateScenarios({
+      scenarios: [
+        {
+          name: 'Baseline',
+          description: 'Full costs',
+          ticketCounts: [{ ticketType: 'standard', quantity: 75 }],
+          tierCounts: [{ tier: 'gold', count: 10 }],
+          addonCounts: [{ addon: 'streaming', count: 1 }],
+          cutCosts: ['photography'],
+        },
+      ],
+    })
+    expect(result?.success).toBe(true)
+    const scenarios = lastSet?.scenarios as {
+      _key: string
+      ticketCounts: { _key: string }[]
+      tierCounts: { _key: string }[]
+      addonCounts: { _key: string }[]
+      cutCosts: string[]
+    }[]
+    expect(scenarios[0]._key).toBeTruthy()
+    expect(scenarios[0].ticketCounts[0]._key).toBeTruthy()
+    expect(scenarios[0].tierCounts[0]._key).toBeTruthy()
+    expect(scenarios[0].addonCounts[0]._key).toBeTruthy()
+    expect(scenarios[0].cutCosts).toEqual(['photography'])
+  })
 })

--- a/src/server/routers/budget.ts
+++ b/src/server/routers/budget.ts
@@ -8,7 +8,10 @@ import {
 } from '@/lib/budget/sanity'
 import { ensureUniqueArrayKeys } from '@/lib/sanity/helpers'
 import {
+  UpdateConfigSchema,
   UpdateExpensesSchema,
+  UpdateScenariosSchema,
+  UpdateSponsorAssumptionsSchema,
   UpdateTicketTypesSchema,
 } from '../schemas/budget'
 import { adminProcedure, resolveConferenceId, router } from '../trpc'
@@ -83,6 +86,74 @@ export const budgetRouter = router({
         return { success: true, budget }
       } catch (error) {
         wrapUnknown(error, 'Failed to update ticket types')
+      }
+    }),
+
+  updateSponsorAssumptions: adminProcedure
+    .input(UpdateSponsorAssumptionsSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      try {
+        const budget = await patchBudgetForConference(conferenceId, {
+          sponsorTierAssumptions: ensureUniqueArrayKeys(
+            input.sponsorTierAssumptions,
+            'sponsortier',
+          ),
+          sponsorAddonAssumptions: ensureUniqueArrayKeys(
+            input.sponsorAddonAssumptions,
+            'sponsoraddon',
+          ),
+        })
+        return { success: true, budget }
+      } catch (error) {
+        wrapUnknown(error, 'Failed to update sponsor assumptions')
+      }
+    }),
+
+  updateConfig: adminProcedure
+    .input(UpdateConfigSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      try {
+        const budget = await patchBudgetForConference(conferenceId, {
+          vatRate: input.vatRate,
+          ticketingFeeRate: input.ticketingFeeRate,
+          dinnerParticipation: input.dinnerParticipation,
+        })
+        return { success: true, budget }
+      } catch (error) {
+        wrapUnknown(error, 'Failed to update budget configuration')
+      }
+    }),
+
+  updateScenarios: adminProcedure
+    .input(UpdateScenariosSchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      try {
+        // Each scenario AND its nested count arrays are keyed for Sanity.
+        const scenarios = ensureUniqueArrayKeys(
+          input.scenarios,
+          'scenario',
+        ).map((scenario) => ({
+          ...scenario,
+          ticketCounts: ensureUniqueArrayKeys(
+            scenario.ticketCounts ?? [],
+            'ticket',
+          ),
+          tierCounts: ensureUniqueArrayKeys(scenario.tierCounts ?? [], 'tier'),
+          addonCounts: ensureUniqueArrayKeys(
+            scenario.addonCounts ?? [],
+            'addon',
+          ),
+          cutCosts: scenario.cutCosts ?? [],
+        }))
+        const budget = await patchBudgetForConference(conferenceId, {
+          scenarios,
+        })
+        return { success: true, budget }
+      } catch (error) {
+        wrapUnknown(error, 'Failed to update scenarios')
       }
     }),
 })

--- a/src/server/schemas/budget.ts
+++ b/src/server/schemas/budget.ts
@@ -66,3 +66,82 @@ export const UpdateTicketTypesSchema = z.object({
       }
     }),
 })
+
+export const BudgetSponsorTierSchema = z.object({
+  _key: z.string().optional(),
+  name: z.string().trim().min(1, 'Name is required'),
+  priceExVat: nonNegative('Price'),
+  includedTickets: z
+    .number()
+    .int()
+    .min(0, 'Included tickets cannot be negative'),
+})
+
+export const BudgetSponsorAddonSchema = z.object({
+  _key: z.string().optional(),
+  name: z.string().trim().min(1, 'Name is required'),
+  priceExVat: nonNegative('Price'),
+})
+
+export const UpdateSponsorAssumptionsSchema = z.object({
+  sponsorTierAssumptions: z.array(BudgetSponsorTierSchema),
+  sponsorAddonAssumptions: z.array(BudgetSponsorAddonSchema),
+})
+
+/**
+ * Scalar/global budget parameters. Rates are fractions (0.25 = 25%);
+ * `decay` is an attendee count the model divides by, so it must be > 0.
+ */
+export const UpdateConfigSchema = z.object({
+  vatRate: z
+    .number()
+    .min(0, 'VAT rate cannot be negative')
+    .max(1, 'Enter the VAT rate as a fraction (0.25 = 25%)'),
+  ticketingFeeRate: z
+    .number()
+    .min(0, 'Fee rate cannot be negative')
+    .max(1, 'Enter the fee rate as a fraction (0.045 = 4.5%)'),
+  dinnerParticipation: z.object({
+    floor: z
+      .number()
+      .min(0, 'Floor cannot be negative')
+      .max(1, 'Floor is a fraction (0–1)'),
+    base: z
+      .number()
+      .min(0, 'Base cannot be negative')
+      .max(1, 'Base is a fraction (0–1)'),
+    decay: z.number().gt(0, 'Decay must be greater than 0'),
+  }),
+})
+
+export const BudgetScenarioTicketCountSchema = z.object({
+  _key: z.string().optional(),
+  ticketType: z.string().min(1),
+  quantity: z.number().int().min(0, 'Quantity cannot be negative'),
+})
+
+export const BudgetScenarioTierCountSchema = z.object({
+  _key: z.string().optional(),
+  tier: z.string().min(1),
+  count: z.number().int().min(0, 'Count cannot be negative'),
+})
+
+export const BudgetScenarioAddonCountSchema = z.object({
+  _key: z.string().optional(),
+  addon: z.string().min(1),
+  count: z.number().int().min(0, 'Count cannot be negative'),
+})
+
+export const BudgetScenarioSchema = z.object({
+  _key: z.string().optional(),
+  name: z.string().trim().min(1, 'Name is required'),
+  description: z.string().optional(),
+  ticketCounts: z.array(BudgetScenarioTicketCountSchema).optional(),
+  tierCounts: z.array(BudgetScenarioTierCountSchema).optional(),
+  addonCounts: z.array(BudgetScenarioAddonCountSchema).optional(),
+  cutCosts: z.array(z.string()).optional(),
+})
+
+export const UpdateScenariosSchema = z.object({
+  scenarios: z.array(BudgetScenarioSchema),
+})


### PR DESCRIPTION
## Summary

Reshapes the budget module's editing UX around the shape of each kind of data, and cleans up the section collapse. **No budget editing happens in a ModalShell anymore** — tabular data edits inline in spreadsheet tables on the main page; scalar/scenario config lives on a new sub-page.

## 1. Section collapse (Hide/Show) — root cause + fix

The reported "the toggle does not really work" is **not** a broken toggle: `CollapsibleSection` is functionally correct in isolation — I drove it with a Playwright interaction and Storybook play-test, and clicking Hide sets `aria-expanded=false`, applies the `hidden` attribute (`display:none`), unmounts the body (`childCount 0`), and flips the label to "Show", with the two sections collapsing **independently**.

The real problem was in the **usage**: each section header carried a second interactive control — the edit-pencil `action` — sitting right next to the Hide/Show affordance. Clicking to collapse frequently hit the pencil (which opened a modal) instead of the toggle, so it "didn't really work."

**Fix:** editing moved into the card body, so the header is now a single, unambiguous toggle target. Added regression play-tests at both the component (`CollapsibleSection` → `TogglesOpenAndClosed`) and page (`BudgetPage` → `CollapseIncome`) level.

## 2. Spreadsheet-style inline tables (main page) — inline-vs-modal choice

**Chose inline-on-page over modal.** Budget data is tabular, and the page already had a display card per section, so toggling that card into an editable table in place (Edit → Save/Cancel, guarded cancel when dirty) fit cleanly and removes a layer of indirection.

- One **row per line item**; columns are the fields; cells are the inputs (text / number / select / checkbox) editing directly in the row — no per-row cards.
- Numeric columns right-align with `tabular-nums`; NOK; "Add row" at the bottom; per-row delete (with the referenced-row confirm preserved).
- Each table is wrapped in `overflow-x-auto` so a wide table scrolls **inside its card**; the page never scrolls sideways (shoot's hard overflow check passes on mobile).
- Ticket types, fixed costs, variable costs, **and** a new sponsor tier/add-on assumptions editor — all five tabular arrays are now editable on the page.
- All existing save mutations and validation kept (single sponsor-included, XOR workshop/crew, number coercion, `ensureUniqueArrayKeys`).

## 3. Config sub-page `/admin/budget/config`

Org-scoped page for the config that is **not** tabular:
- **Global parameters** as a labeled form: VAT rate, ticketing-fee rate, dinner-participation `{floor, base, decay}` (rates shown as percentages, stored as fractions).
- **Scenarios editor**: per-scenario name/description, structured ticket / tier / add-on quantity tables, and optional-cost cut checkboxes.
- New tRPC mutations `updateConfig` / `updateSponsorAssumptions` / `updateScenarios` with the same conference-scoping and Sanity-keying discipline as the existing ones (nested scenario count arrays are keyed too).
- A **Configure** link on the main budget page ↔ back-link on the config page. Registered in `src/lib/admin/registry.ts` so ⌘K finds "budget config" / "vat" / "scenarios".

## 4. Nav trim (folded in per owner request)

Moved **Agents** out of the sidebar (the nav had grown tall enough to scroll) onto the Settings page as a manage-link `InfoCard`; kept the registry destination (`kind: 'page'`) so ⌘K still finds it.

## Screenshots (Storybook, verified)

- **Budget main — display (desktop):** Configure link top-right; Income/Expenses each with a Hide toggle + an Edit button in the body; budget-vs-actual summaries unchanged.
- **Budget main — editing (desktop + mobile):** both sections toggled into spreadsheet tables — one row per item, inline cells, right-aligned numbers, Cancel/Save toolbar, Add-row buttons. On mobile the table scrolls horizontally inside its ringed card; page body does not overflow.
- **Collapse:** after clicking Income's Hide, Income shows "Show" with its body gone while Expenses stays open — independent collapse confirmed.
- **Config sub-page (desktop + mobile + dark):** globals form + per-scenario cards with count tables and cut-cost checkboxes; single-column and readable on mobile; dark mode styled.
- **Sidebar:** System group now shows only the Settings gear (Agents removed).

## Quality
- `tsc` clean, ESLint 0 errors (only pre-existing repo-wide warnings), Prettier clean.
- Vitest green — 292 affected tests, including new router tests for the three new mutations (keying, decay>0 guard, scalar round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C