### PR TITLE
fix(security): scope staff + sponsor-template queries to the tenant (cross-org leak + write)

### DIFF
--- a/src/app/(main)/staff/[role]/page.tsx
+++ b/src/app/(main)/staff/[role]/page.tsx
@@ -1,7 +1,10 @@
 import Image from 'next/image'
 import { cacheLife, cacheTag } from 'next/cache'
+import { headers } from 'next/headers'
 import type { Metadata } from 'next'
 import { getStaffMembers } from '@/lib/staff/sanity'
+import { getConferenceForDomain } from '@/lib/conference/sanity'
+import { conferenceTag, organizationTag } from '@/lib/cache/tags'
 import { Container } from '@/components/Container'
 import { canonicalAlternates } from '@/lib/seo/canonical'
 
@@ -16,12 +19,29 @@ export async function generateMetadata({
   }
 }
 
-async function CachedStaffContent({ role }: { role: string }) {
+async function CachedStaffContent({
+  domain,
+  role,
+}: {
+  domain: string
+  role: string
+}) {
   'use cache'
   cacheLife('hours')
   cacheTag('content:staff')
 
-  const staff = await getStaffMembers(role)
+  // Resolve the tenant FROM the domain argument (part of the cache key) — never
+  // via request-time `headers()`, which is unavailable inside `'use cache'` and
+  // would not participate in the key. This keeps org A's staff from ever being
+  // served on org B: the read below is tenant-scoped by `orgId`, and the cache
+  // entry is keyed by `domain` and tagged per-tenant so a mutation busts only
+  // this tenant's page.
+  const { conference } = await getConferenceForDomain(domain)
+  const orgId = conference?.organization?._ref ?? null
+  if (conference?._id) cacheTag(conferenceTag(conference._id))
+  if (orgId) cacheTag(organizationTag(orgId))
+
+  const staff = await getStaffMembers(role, orgId)
 
   return (
     <>
@@ -69,5 +89,9 @@ export default async function StaffPage({
   params: Promise<{ role: string }>
 }) {
   const { role } = await params
-  return <CachedStaffContent role={role} />
+  // Read the host OUTSIDE the cached component and pass it in, so the tenant is
+  // part of the cache key (the wrapper pattern — see AGENTS.md / homepage).
+  const headersList = await headers()
+  const domain = headersList.get('host') || ''
+  return <CachedStaffContent domain={domain} role={role} />
 }

--- a/src/lib/sponsor/sanity.templatescope.test.ts
+++ b/src/lib/sponsor/sanity.templatescope.test.ts
@@ -74,6 +74,8 @@ const txPatchIds: string[] = []
 const txCommitMock = vi.fn().mockResolvedValue({})
 
 vi.mock('@/lib/sanity/client', () => ({
+  // Imported (unused in these paths) by the real @/lib/organization/sanity.
+  clientReadUncached: { fetch: vi.fn() },
   clientWrite: {
     fetch: (q: string, p?: Record<string, unknown>) => fetchMock(q, p),
     delete: (id: string) => deleteMock(id),
@@ -100,10 +102,14 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }))
 
-const getOrgMock = vi.fn<() => Promise<string | null>>()
-vi.mock('@/lib/organization/sanity', () => ({
-  getOrganizationRefForCurrentConference: () => getOrgMock(),
-  organizationField: () => ({}),
+// External boundary: the current-domain conference resolution reads headers() +
+// Sanity. We mock THAT (not the internal `@/lib/organization/sanity`) and let
+// the real `getOrganizationRefForCurrentConference` run on top of it — it reads
+// `.organization._ref` off whatever conference this returns.
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
 }))
 
 import {
@@ -115,10 +121,21 @@ import {
   reorderSponsorEmailTemplates,
 } from './sanity'
 
+// Resolve the current tenant to `orgId`, or to no organization (null) to
+// exercise the fail-closed paths.
+function setCurrentOrg(orgId: string | null) {
+  getConferenceMock.mockResolvedValue({
+    conference: orgId
+      ? { organization: { _ref: orgId } }
+      : { organization: null },
+    error: null,
+  })
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   txPatchIds.length = 0
-  getOrgMock.mockResolvedValue('org-A') // current tenant = org A
+  setCurrentOrg('org-A') // current tenant = org A
 })
 
 describe('sponsor email templates — read scoping (#19)', () => {
@@ -139,7 +156,7 @@ describe('sponsor email templates — read scoping (#19)', () => {
   })
 
   it('scopes the other direction too (org B cannot read org A)', async () => {
-    getOrgMock.mockResolvedValue('org-B')
+    setCurrentOrg('org-B')
     expect((await getSponsorEmailTemplate('t-A')).template).toBeUndefined()
     expect((await getSponsorEmailTemplate('t-B')).template).toBeTruthy()
   })
@@ -191,5 +208,53 @@ describe('sponsor email templates — mutation deny (#19)', () => {
     const { error } = await deleteSponsorEmailTemplate('t-A')
     expect(error).toBeUndefined()
     expect(deleteMock).toHaveBeenCalledWith('t-A')
+  })
+})
+
+describe('sponsor email templates — fail closed when tenant is unresolvable (#19)', () => {
+  beforeEach(() => {
+    setCurrentOrg(null) // tenant cannot be resolved → must NOT read/write globally
+  })
+
+  it('list returns empty and issues NO query', async () => {
+    const { templates } = await getSponsorEmailTemplates()
+    expect(templates).toEqual([])
+    // The guard must bite: reverting it would issue an unscoped read of both orgs.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('read by id returns undefined and issues NO query', async () => {
+    const { template } = await getSponsorEmailTemplate('t-A')
+    expect(template).toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('update is rejected with no read and no write', async () => {
+    const { error } = await updateSponsorEmailTemplate('t-A', { title: 'x' })
+    expect(error).toBeTruthy()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(patchSetMock).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('delete is rejected with no read and no delete', async () => {
+    const { error } = await deleteSponsorEmailTemplate('t-A')
+    expect(error).toBeTruthy()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
+
+  it('set-default is rejected with no read and no write', async () => {
+    const { error } = await setDefaultSponsorEmailTemplate('t-A')
+    expect(error).toBeTruthy()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(txCommitMock).not.toHaveBeenCalled()
+  })
+
+  it('reorder is rejected with no read and no write', async () => {
+    const { error } = await reorderSponsorEmailTemplates(['t-A', 't-B'])
+    expect(error).toBeTruthy()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(txCommitMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/sponsor/sanity.templatescope.test.ts
+++ b/src/lib/sponsor/sanity.templatescope.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * Cross-tenant deny tests for sponsor email templates (#616/#19).
+ *
+ * `sponsorEmailTemplate` carries an `organization` ref. Before the scoping fix
+ * the reads were unscoped and the set-default / reorder / update / delete
+ * mutations operated on any id — a tenant organizer could READ and, worse,
+ * MUTATE another org's templates. These tests exercise a two-org store through
+ * a fetch mock that honours the injected `organization._ref == $orgId`
+ * predicate, and assert BOTH directions: a foreign template is never returned by
+ * a read, and a mutation targeting a foreign template is rejected with no write.
+ */
+
+interface Tpl {
+  _id: string
+  organization: { _ref: string }
+  category: string
+  isDefault: boolean
+  title: string
+}
+
+const STORE: Tpl[] = [
+  {
+    _id: 't-A',
+    organization: { _ref: 'org-A' },
+    category: 'welcome',
+    isDefault: false,
+    title: 'A welcome',
+  },
+  {
+    _id: 't-B',
+    organization: { _ref: 'org-B' },
+    category: 'welcome',
+    isDefault: true,
+    title: 'B welcome',
+  },
+]
+
+// A minimal GROQ-aware evaluator: applies the org predicate (only when the
+// scoped query injected it) plus the id / ids / category / isDefault filters
+// the template queries use, then returns a single doc (`[0]`) or an array.
+function evalFetch(query: string, params: Record<string, unknown> = {}) {
+  const scoped = query.includes('organization._ref == $orgId')
+  let rows = STORE.filter((t) =>
+    scoped ? t.organization._ref === params.orgId : true,
+  )
+  if (query.includes('_id == $id'))
+    rows = rows.filter((t) => t._id === params.id)
+  if (query.includes('_id != $id'))
+    rows = rows.filter((t) => t._id !== params.id)
+  if (query.includes('_id in $ids'))
+    rows = rows.filter((t) => (params.ids as string[]).includes(t._id))
+  if (query.includes('category == $category'))
+    rows = rows.filter((t) => t.category === params.category)
+  if (query.includes('isDefault == true'))
+    rows = rows.filter((t) => t.isDefault === true)
+  if (query.includes('[0]')) {
+    const row = rows[0]
+    if (!row) return null
+    if (query.includes('._id')) return row._id
+    return row
+  }
+  return rows
+}
+
+const fetchMock = vi.fn((query: string, params?: Record<string, unknown>) =>
+  Promise.resolve(evalFetch(query, params)),
+)
+const deleteMock = vi.fn().mockResolvedValue({})
+const commitMock = vi.fn().mockResolvedValue({})
+const patchSetMock = vi.fn()
+const txPatchIds: string[] = []
+const txCommitMock = vi.fn().mockResolvedValue({})
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: {
+    fetch: (q: string, p?: Record<string, unknown>) => fetchMock(q, p),
+    delete: (id: string) => deleteMock(id),
+    patch: (id: string) => {
+      const builder = {
+        set: (obj: Record<string, unknown>) => {
+          patchSetMock(id, obj)
+          return builder
+        },
+        commit: () => commitMock(),
+      }
+      return builder
+    },
+    transaction: () => {
+      const tx = {
+        patch: (id: string) => {
+          txPatchIds.push(id)
+          return tx
+        },
+        commit: () => txCommitMock(),
+      }
+      return tx
+    },
+  },
+}))
+
+const getOrgMock = vi.fn<() => Promise<string | null>>()
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: () => getOrgMock(),
+  organizationField: () => ({}),
+}))
+
+import {
+  getSponsorEmailTemplates,
+  getSponsorEmailTemplate,
+  updateSponsorEmailTemplate,
+  deleteSponsorEmailTemplate,
+  setDefaultSponsorEmailTemplate,
+  reorderSponsorEmailTemplates,
+} from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  txPatchIds.length = 0
+  getOrgMock.mockResolvedValue('org-A') // current tenant = org A
+})
+
+describe('sponsor email templates — read scoping (#19)', () => {
+  it('lists only the current org’s templates', async () => {
+    const { templates } = await getSponsorEmailTemplates()
+    expect(templates?.map((t) => t._id)).toEqual(['t-A'])
+    expect(templates?.some((t) => t._id === 't-B')).toBe(false)
+  })
+
+  it('returns undefined for a foreign org’s template by id', async () => {
+    const { template } = await getSponsorEmailTemplate('t-B')
+    expect(template).toBeUndefined()
+  })
+
+  it('returns the own org’s template by id', async () => {
+    const { template } = await getSponsorEmailTemplate('t-A')
+    expect(template).toBeTruthy()
+  })
+
+  it('scopes the other direction too (org B cannot read org A)', async () => {
+    getOrgMock.mockResolvedValue('org-B')
+    expect((await getSponsorEmailTemplate('t-A')).template).toBeUndefined()
+    expect((await getSponsorEmailTemplate('t-B')).template).toBeTruthy()
+  })
+})
+
+describe('sponsor email templates — mutation deny (#19)', () => {
+  it('set-default on a foreign template is rejected with no write', async () => {
+    const { error } = await setDefaultSponsorEmailTemplate('t-B')
+    expect(error).toBeTruthy()
+    expect(txCommitMock).not.toHaveBeenCalled()
+  })
+
+  it('set-default on the own template commits', async () => {
+    const { error } = await setDefaultSponsorEmailTemplate('t-A')
+    expect(error).toBeUndefined()
+    expect(txCommitMock).toHaveBeenCalledTimes(1)
+    expect(txPatchIds).toContain('t-A')
+  })
+
+  it('reorder including a foreign template is rejected with no write', async () => {
+    const { error } = await reorderSponsorEmailTemplates(['t-A', 't-B'])
+    expect(error).toBeTruthy()
+    expect(txCommitMock).not.toHaveBeenCalled()
+  })
+
+  it('update of a foreign template is rejected with no patch', async () => {
+    const { error } = await updateSponsorEmailTemplate('t-B', {
+      title: 'hijack',
+    })
+    expect(error).toBeTruthy()
+    expect(patchSetMock).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('update of the own template patches and commits', async () => {
+    const { error } = await updateSponsorEmailTemplate('t-A', { title: 'ok' })
+    expect(error).toBeUndefined()
+    expect(patchSetMock).toHaveBeenCalledWith('t-A', { title: 'ok' })
+    expect(commitMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('delete of a foreign template is rejected with no delete', async () => {
+    const { error } = await deleteSponsorEmailTemplate('t-B')
+    expect(error).toBeTruthy()
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
+
+  it('delete of the own template deletes', async () => {
+    const { error } = await deleteSponsorEmailTemplate('t-A')
+    expect(error).toBeUndefined()
+    expect(deleteMock).toHaveBeenCalledWith('t-A')
+  })
+})

--- a/src/lib/sponsor/sanity.ts
+++ b/src/lib/sponsor/sanity.ts
@@ -7,6 +7,7 @@ import {
   SponsorEmailTemplate,
 } from './types'
 import { prepareArrayWithKeys, createReference } from '@/lib/sanity/helpers'
+import { scopedFetch } from '@/lib/sanity/scoped'
 import {
   getOrganizationRefForCurrentConference,
   organizationField,
@@ -405,12 +406,22 @@ const EMAIL_TEMPLATE_PROJECTION = `{
   sortOrder
 }`
 
+/**
+ * Sponsor email templates carry an `organization` ref (CaaS T1-1). Every read
+ * and mutation below is TENANT-SCOPED (#616/#19) to the current-domain org so an
+ * organizer can only see and modify their OWN org's templates — a cross-tenant
+ * read OR write (the worse half) is denied. Resolved once per call; a null org
+ * (unresolvable tenant / pre-044 backfill) degrades to the prior global read.
+ */
 export async function getSponsorEmailTemplates(): Promise<{
   templates?: SponsorEmailTemplate[]
   error?: Error
 }> {
   try {
-    const templates = await clientWrite.fetch(
+    const orgId = await getOrganizationRefForCurrentConference()
+    const templates = await scopedFetch<SponsorEmailTemplate[]>(
+      clientWrite,
+      { orgId },
       `*[_type == "sponsorEmailTemplate"] | order(category asc, sortOrder asc) ${EMAIL_TEMPLATE_PROJECTION}`,
     )
     return { templates }
@@ -423,7 +434,10 @@ export async function getSponsorEmailTemplate(
   id: string,
 ): Promise<{ template?: SponsorEmailTemplate; error?: Error }> {
   try {
-    const template = await clientWrite.fetch(
+    const orgId = await getOrganizationRefForCurrentConference()
+    const template = await scopedFetch<SponsorEmailTemplate | null>(
+      clientWrite,
+      { orgId },
       `*[_type == "sponsorEmailTemplate" && _id == $id][0] ${EMAIL_TEMPLATE_PROJECTION}`,
       { id },
     )
@@ -437,7 +451,10 @@ export async function getSponsorEmailTemplateBySlug(
   slug: string,
 ): Promise<{ template?: SponsorEmailTemplate; error?: Error }> {
   try {
-    const template = await clientWrite.fetch(
+    const orgId = await getOrganizationRefForCurrentConference()
+    const template = await scopedFetch<SponsorEmailTemplate | null>(
+      clientWrite,
+      { orgId },
       `*[_type == "sponsorEmailTemplate" && slug.current == $slug][0] ${EMAIL_TEMPLATE_PROJECTION}`,
       { slug },
     )
@@ -445,6 +462,23 @@ export async function getSponsorEmailTemplateBySlug(
   } catch (error) {
     return { error: error as Error }
   }
+}
+
+/**
+ * True when `id` names a sponsorEmailTemplate owned by the current-domain org.
+ * The mutation guard (#19): a scoped existence probe that returns false for a
+ * FOREIGN org's template, so update/delete/set-default reject rather than
+ * silently mutating another tenant's data. A null org degrades to existence-only.
+ */
+async function isTemplateInCurrentOrg(id: string): Promise<boolean> {
+  const orgId = await getOrganizationRefForCurrentConference()
+  const found = await scopedFetch<string | null>(
+    clientWrite,
+    { orgId },
+    `*[_type == "sponsorEmailTemplate" && _id == $id][0]._id`,
+    { id },
+  )
+  return Boolean(found)
 }
 
 export async function createSponsorEmailTemplate(data: {
@@ -496,6 +530,10 @@ export async function updateSponsorEmailTemplate(
   },
 ): Promise<{ template?: SponsorEmailTemplate; error?: Error }> {
   try {
+    // Tenant guard (#19): reject a write to another org's template.
+    if (!(await isTemplateInCurrentOrg(id))) {
+      return { error: new Error('Sponsor email template not found') }
+    }
     const patch: Record<string, unknown> = {}
     if (data.title !== undefined) patch.title = data.title
     if (data.slug !== undefined)
@@ -519,6 +557,10 @@ export async function deleteSponsorEmailTemplate(
   id: string,
 ): Promise<{ error?: Error }> {
   try {
+    // Tenant guard (#19): reject a delete of another org's template.
+    if (!(await isTemplateInCurrentOrg(id))) {
+      return { error: new Error('Sponsor email template not found') }
+    }
     await clientWrite.delete(id)
     return {}
   } catch (error) {
@@ -530,11 +572,16 @@ export async function setDefaultSponsorEmailTemplate(
   id: string,
 ): Promise<{ error?: Error }> {
   try {
-    // Fetch template to derive category server-side (don't trust client)
-    const current = await clientWrite.fetch<{
+    // Fetch template to derive category server-side (don't trust client).
+    // Tenant-scoped (#19): a foreign org's template reads as not-found, so
+    // set-default can never toggle another tenant's template.
+    const orgId = await getOrganizationRefForCurrentConference()
+    const current = await scopedFetch<{
       isDefault?: boolean
       category?: string
-    }>(
+    } | null>(
+      clientWrite,
+      { orgId },
       `*[_type == "sponsorEmailTemplate" && _id == $id][0]{ isDefault, category }`,
       { id },
     )
@@ -545,8 +592,11 @@ export async function setDefaultSponsorEmailTemplate(
       return { error: new Error('Sponsor email template has no category') }
     }
 
-    // Unset is_default for all other templates in the same category
-    const others = await clientWrite.fetch<{ _id: string }[]>(
+    // Unset is_default for all OTHER templates in the same category — scoped to
+    // this org so a shared category name across tenants can't cross-clear.
+    const others = await scopedFetch<{ _id: string }[]>(
+      clientWrite,
+      { orgId },
       `*[_type == "sponsorEmailTemplate" && category == $category && _id != $id && isDefault == true]{ _id }`,
       { category: current.category, id },
     )
@@ -567,8 +617,13 @@ export async function reorderSponsorEmailTemplates(
   orderedIds: string[],
 ): Promise<{ error?: Error }> {
   try {
-    // Validate all IDs belong to sponsorEmailTemplate documents
-    const valid = await clientWrite.fetch<{ _id: string }[]>(
+    // Validate all IDs belong to sponsorEmailTemplate documents OWNED BY this
+    // org (#19): a foreign template id is not in `valid`, so reorder rejects it
+    // and never re-sorts another tenant's templates.
+    const orgId = await getOrganizationRefForCurrentConference()
+    const valid = await scopedFetch<{ _id: string }[]>(
+      clientWrite,
+      { orgId },
       `*[_type == "sponsorEmailTemplate" && _id in $ids]{ _id }`,
       { ids: orderedIds },
     )

--- a/src/lib/sponsor/sanity.ts
+++ b/src/lib/sponsor/sanity.ts
@@ -410,8 +410,13 @@ const EMAIL_TEMPLATE_PROJECTION = `{
  * Sponsor email templates carry an `organization` ref (CaaS T1-1). Every read
  * and mutation below is TENANT-SCOPED (#616/#19) to the current-domain org so an
  * organizer can only see and modify their OWN org's templates — a cross-tenant
- * read OR write (the worse half) is denied. Resolved once per call; a null org
- * (unresolvable tenant / pre-044 backfill) degrades to the prior global read.
+ * read OR write (the worse half) is denied.
+ *
+ * These paths FAIL CLOSED: `scopedFetch` injects no predicate when `orgId` is
+ * null and would degrade to an UNSCOPED global query, re-enabling cross-tenant
+ * reads and (via the existence-only mutation guard) foreign-id writes. So an
+ * unresolvable tenant returns an EMPTY read result and REJECTS every mutation
+ * rather than falling through to a global query.
  */
 export async function getSponsorEmailTemplates(): Promise<{
   templates?: SponsorEmailTemplate[]
@@ -419,6 +424,8 @@ export async function getSponsorEmailTemplates(): Promise<{
 }> {
   try {
     const orgId = await getOrganizationRefForCurrentConference()
+    // FAIL CLOSED (#616/#19): no tenant → empty list, never a global read.
+    if (!orgId) return { templates: [] }
     const templates = await scopedFetch<SponsorEmailTemplate[]>(
       clientWrite,
       { orgId },
@@ -435,6 +442,8 @@ export async function getSponsorEmailTemplate(
 ): Promise<{ template?: SponsorEmailTemplate; error?: Error }> {
   try {
     const orgId = await getOrganizationRefForCurrentConference()
+    // FAIL CLOSED (#616/#19): no tenant → not found, never a global read.
+    if (!orgId) return { template: undefined }
     const template = await scopedFetch<SponsorEmailTemplate | null>(
       clientWrite,
       { orgId },
@@ -452,6 +461,8 @@ export async function getSponsorEmailTemplateBySlug(
 ): Promise<{ template?: SponsorEmailTemplate; error?: Error }> {
   try {
     const orgId = await getOrganizationRefForCurrentConference()
+    // FAIL CLOSED (#616/#19): no tenant → not found, never a global read.
+    if (!orgId) return { template: undefined }
     const template = await scopedFetch<SponsorEmailTemplate | null>(
       clientWrite,
       { orgId },
@@ -468,10 +479,14 @@ export async function getSponsorEmailTemplateBySlug(
  * True when `id` names a sponsorEmailTemplate owned by the current-domain org.
  * The mutation guard (#19): a scoped existence probe that returns false for a
  * FOREIGN org's template, so update/delete/set-default reject rather than
- * silently mutating another tenant's data. A null org degrades to existence-only.
+ * silently mutating another tenant's data. FAILS CLOSED: an unresolvable tenant
+ * returns `false` (treated as not-owned) so the mutation is rejected — it never
+ * degrades to an unscoped existence-only probe that would pass any foreign id.
  */
 async function isTemplateInCurrentOrg(id: string): Promise<boolean> {
   const orgId = await getOrganizationRefForCurrentConference()
+  // FAIL CLOSED (#616/#19): no tenant → not-owned, so the caller rejects.
+  if (!orgId) return false
   const found = await scopedFetch<string | null>(
     clientWrite,
     { orgId },
@@ -576,6 +591,10 @@ export async function setDefaultSponsorEmailTemplate(
     // Tenant-scoped (#19): a foreign org's template reads as not-found, so
     // set-default can never toggle another tenant's template.
     const orgId = await getOrganizationRefForCurrentConference()
+    // FAIL CLOSED (#616/#19): no tenant → reject, never an unscoped read/write.
+    if (!orgId) {
+      return { error: new Error('Sponsor email template not found') }
+    }
     const current = await scopedFetch<{
       isDefault?: boolean
       category?: string
@@ -621,6 +640,11 @@ export async function reorderSponsorEmailTemplates(
     // org (#19): a foreign template id is not in `valid`, so reorder rejects it
     // and never re-sorts another tenant's templates.
     const orgId = await getOrganizationRefForCurrentConference()
+    // FAIL CLOSED (#616/#19): no tenant → reject, never an unscoped validation
+    // that would treat every supplied id as valid and re-sort foreign templates.
+    if (!orgId) {
+      return { error: new Error('Tenant could not be resolved') }
+    }
     const valid = await scopedFetch<{ _id: string }[]>(
       clientWrite,
       { orgId },

--- a/src/lib/staff/sanity.test.ts
+++ b/src/lib/staff/sanity.test.ts
@@ -1,13 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 /**
- * Cross-tenant deny test for staff (#616/#18).
+ * Cross-tenant deny + fail-closed tests for staff (#616/#18).
  *
  * `staff` carries an `organization` ref and renders on the PUBLIC `/staff/[role]`
  * pages. Before the scoping fix the query was unscoped, so every org's staff
  * leaked onto every tenant's public site. The fetch mock below honours the
  * injected `organization._ref == $orgId` predicate over a two-org store and
- * asserts a foreign org's staff is NOT returned.
+ * asserts a foreign org's staff is NOT returned — in BOTH directions.
+ *
+ * Boundary discipline (mock only external boundaries): the Sanity CLIENT and the
+ * current-domain conference resolution (`getConferenceForCurrentDomain`, which
+ * reads `headers()` + Sanity) are the boundaries mocked here. The real
+ * `getOrganizationRefForCurrentConference` runs on top of the conference mock —
+ * it is the unit under test for `getAllStaffMembers`. `getStaffMembers` now
+ * takes a resolved `orgId` argument (resolved by the cached page from the
+ * domain), so it is driven directly.
+ *
+ * Fail-closed (the critical property): when the tenant cannot be resolved
+ * (`orgId` null), reads must return EMPTY and issue NO unscoped query — never
+ * degrade to a global read.
  */
 
 interface Doc {
@@ -15,6 +27,7 @@ interface Doc {
   organization: { _ref: string }
   role: string
   name: string
+  link: string
 }
 
 const STORE: Doc[] = [
@@ -23,12 +36,14 @@ const STORE: Doc[] = [
     organization: { _ref: 'org-A' },
     role: 'photographer',
     name: 'A Shooter',
+    link: 'https://a.example/portfolio',
   },
   {
     _id: 's-B',
     organization: { _ref: 'org-B' },
     role: 'photographer',
     name: 'B Shooter',
+    link: 'https://b.example/portfolio',
   },
 ]
 
@@ -44,6 +59,7 @@ function evalFetch(query: string, params: Record<string, unknown> = {}) {
     _id: d._id,
     name: d.name,
     role: d.role,
+    link: d.link,
   }))
 }
 
@@ -56,33 +72,84 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }))
 
-const getOrgMock = vi.fn<() => Promise<string | null>>()
-vi.mock('@/lib/organization/sanity', () => ({
-  getOrganizationRefForCurrentConference: () => getOrgMock(),
+// External boundary: current-domain resolution reads headers() + Sanity. Mock
+// it; the real getOrganizationRefForCurrentConference reads `.organization._ref`
+// off whatever conference this returns.
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
 }))
 
 import { getStaffMembers, getAllStaffMembers } from './sanity'
 
 beforeEach(() => {
   vi.clearAllMocks()
-  getOrgMock.mockResolvedValue('org-A') // current tenant = org A
+  // Current tenant = org A.
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: 'conf-A', organization: { _ref: 'org-A' } },
+    error: null,
+  })
 })
 
 describe('staff — public read scoping (#18)', () => {
   it('does not return a foreign org’s staff for a role', async () => {
-    const { data } = await getStaffMembers('photographer')
+    const { data } = await getStaffMembers('photographer', 'org-A')
     expect(data.map((m) => m.name)).toEqual(['A Shooter'])
     expect(data.some((m) => m.name === 'B Shooter')).toBe(false)
   })
 
-  it('admin list is scoped to the current org too', async () => {
+  it('scopes the other direction (org B sees only its own)', async () => {
+    const { data } = await getStaffMembers('photographer', 'org-B')
+    expect(data.map((m) => m.name)).toEqual(['B Shooter'])
+  })
+
+  it('admin list is scoped to the current org', async () => {
     const all = await getAllStaffMembers()
     expect(all.map((m) => m._id)).toEqual(['s-A'])
   })
 
-  it('scopes the other direction (org B sees only its own)', async () => {
-    getOrgMock.mockResolvedValue('org-B')
-    const { data } = await getStaffMembers('photographer')
-    expect(data.map((m) => m.name)).toEqual(['B Shooter'])
+  it('admin list scopes the other direction too', async () => {
+    getConferenceMock.mockResolvedValue({
+      conference: { _id: 'conf-B', organization: { _ref: 'org-B' } },
+      error: null,
+    })
+    const all = await getAllStaffMembers()
+    expect(all.map((m) => m._id)).toEqual(['s-B'])
+  })
+
+  it('admin list projects `link` (regression: StaffManager edit form needs it)', async () => {
+    const all = await getAllStaffMembers()
+    expect(all[0].link).toBe('https://a.example/portfolio')
+  })
+})
+
+describe('staff — fail closed when tenant is unresolvable (#18)', () => {
+  it('getStaffMembers returns empty and issues NO query for a null org', async () => {
+    const { data } = await getStaffMembers('photographer', null)
+    expect(data).toEqual([])
+    // The guard must bite: no unscoped global read may reach the client.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('getAllStaffMembers returns empty and issues NO query for a null org', async () => {
+    // Conference has no resolvable organization → org ref is null.
+    getConferenceMock.mockResolvedValue({
+      conference: { _id: 'conf-X', organization: null },
+      error: null,
+    })
+    const all = await getAllStaffMembers()
+    expect(all).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('getAllStaffMembers fails closed when the conference lookup errors', async () => {
+    getConferenceMock.mockResolvedValue({
+      conference: null,
+      error: new Error('no host'),
+    })
+    const all = await getAllStaffMembers()
+    expect(all).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/staff/sanity.test.ts
+++ b/src/lib/staff/sanity.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * Cross-tenant deny test for staff (#616/#18).
+ *
+ * `staff` carries an `organization` ref and renders on the PUBLIC `/staff/[role]`
+ * pages. Before the scoping fix the query was unscoped, so every org's staff
+ * leaked onto every tenant's public site. The fetch mock below honours the
+ * injected `organization._ref == $orgId` predicate over a two-org store and
+ * asserts a foreign org's staff is NOT returned.
+ */
+
+interface Doc {
+  _id: string
+  organization: { _ref: string }
+  role: string
+  name: string
+}
+
+const STORE: Doc[] = [
+  {
+    _id: 's-A',
+    organization: { _ref: 'org-A' },
+    role: 'photographer',
+    name: 'A Shooter',
+  },
+  {
+    _id: 's-B',
+    organization: { _ref: 'org-B' },
+    role: 'photographer',
+    name: 'B Shooter',
+  },
+]
+
+function evalFetch(query: string, params: Record<string, unknown> = {}) {
+  const scoped = query.includes('organization._ref == $orgId')
+  let rows = STORE.filter((d) =>
+    scoped ? d.organization._ref === params.orgId : true,
+  )
+  if (query.includes('role == $role'))
+    rows = rows.filter((d) => d.role === params.role)
+  return rows.map((d) => ({
+    id: d._id,
+    _id: d._id,
+    name: d.name,
+    role: d.role,
+  }))
+}
+
+const fetchMock = vi.fn((query: string, params?: Record<string, unknown>) =>
+  Promise.resolve(evalFetch(query, params)),
+)
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: {
+    fetch: (q: string, p?: Record<string, unknown>) => fetchMock(q, p),
+  },
+}))
+
+const getOrgMock = vi.fn<() => Promise<string | null>>()
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefForCurrentConference: () => getOrgMock(),
+}))
+
+import { getStaffMembers, getAllStaffMembers } from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getOrgMock.mockResolvedValue('org-A') // current tenant = org A
+})
+
+describe('staff — public read scoping (#18)', () => {
+  it('does not return a foreign org’s staff for a role', async () => {
+    const { data } = await getStaffMembers('photographer')
+    expect(data.map((m) => m.name)).toEqual(['A Shooter'])
+    expect(data.some((m) => m.name === 'B Shooter')).toBe(false)
+  })
+
+  it('admin list is scoped to the current org too', async () => {
+    const all = await getAllStaffMembers()
+    expect(all.map((m) => m._id)).toEqual(['s-A'])
+  })
+
+  it('scopes the other direction (org B sees only its own)', async () => {
+    getOrgMock.mockResolvedValue('org-B')
+    const { data } = await getStaffMembers('photographer')
+    expect(data.map((m) => m.name)).toEqual(['B Shooter'])
+  })
+})

--- a/src/lib/staff/sanity.ts
+++ b/src/lib/staff/sanity.ts
@@ -10,10 +10,15 @@ import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanit
  *
  * TENANT-SCOPED (#616/#18): `staff` carries an `organization` ref, so the read
  * is constrained to the current-domain tenant — an organizer only ever sees
- * their own org's staff.
+ * their own org's staff. FAILS CLOSED: if the tenant cannot be resolved we
+ * return an EMPTY list rather than letting `scopedFetch` degrade to an unscoped
+ * global read (which would leak every org's staff).
  */
 export async function getAllStaffMembers(): Promise<StaffAdmin[]> {
   const orgId = await getOrganizationRefForCurrentConference()
+  // FAIL CLOSED (#616/#18): `scopedFetch` drops the predicate on a null orgId
+  // and would read GLOBALLY. An unresolvable tenant must never cross-read.
+  if (!orgId) return []
   return await scopedFetch<StaffAdmin[]>(
     clientRead,
     { orgId },
@@ -24,6 +29,7 @@ export async function getAllStaffMembers(): Promise<StaffAdmin[]> {
       role,
       email,
       company,
+      link,
       "imageAssetId": image.asset._ref,
       "imageURL": image.asset->url
     }`,
@@ -34,12 +40,19 @@ export async function getAllStaffMembers(): Promise<StaffAdmin[]> {
  * Public staff listing for a role (rendered on `/staff/[role]`). TENANT-SCOPED
  * (#616/#18): `staff` carries an `organization` ref, so only the current
  * tenant's staff surface — one org's people never leak onto another's site.
+ *
+ * The caller resolves the tenant (`orgId`) OUTSIDE any `'use cache'` boundary
+ * and passes it in, so the cached page can key/tag on the tenant (see
+ * `/staff/[role]/page.tsx`). FAILS CLOSED: a null/undefined `orgId` returns an
+ * EMPTY list — never an unscoped global read.
  */
 export async function getStaffMembers(
   role: string,
+  orgId: string | null,
 ): Promise<{ data: Staff[]; err?: Error }> {
   try {
-    const orgId = await getOrganizationRefForCurrentConference()
+    // FAIL CLOSED (#616/#18): unresolvable tenant → empty, never a global read.
+    if (!orgId) return { data: [] }
     const queryResult = await scopedFetch<Staff[]>(
       clientRead,
       { orgId },

--- a/src/lib/staff/sanity.ts
+++ b/src/lib/staff/sanity.ts
@@ -1,35 +1,49 @@
 import { Staff, StaffAdmin } from '@/lib/staff/types'
 import { clientReadUncached as clientRead } from '@/lib/sanity/client'
-import { defineQuery } from 'next-sanity'
+import { scopedFetch } from '@/lib/sanity/scoped'
+import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanity'
 
 /**
  * Every staff member across all roles, ordered for the admin table (SE-4).
  * Projects the raw image asset id alongside the resolved URL so the editor can
  * both preview the image and re-submit it unchanged.
+ *
+ * TENANT-SCOPED (#616/#18): `staff` carries an `organization` ref, so the read
+ * is constrained to the current-domain tenant — an organizer only ever sees
+ * their own org's staff.
  */
 export async function getAllStaffMembers(): Promise<StaffAdmin[]> {
-  const query = defineQuery(`
-    * [_type == "staff"] | order(role asc, name asc)
+  const orgId = await getOrganizationRefForCurrentConference()
+  return await scopedFetch<StaffAdmin[]>(
+    clientRead,
+    { orgId },
+    `*[_type == "staff"] | order(role asc, name asc)
     {
       "_id": _id,
       name,
       role,
       email,
       company,
-      link,
       "imageAssetId": image.asset._ref,
       "imageURL": image.asset->url
-    }
-  `)
-
-  return await clientRead.fetch<StaffAdmin[]>(query)
+    }`,
+  )
 }
 
+/**
+ * Public staff listing for a role (rendered on `/staff/[role]`). TENANT-SCOPED
+ * (#616/#18): `staff` carries an `organization` ref, so only the current
+ * tenant's staff surface — one org's people never leak onto another's site.
+ */
 export async function getStaffMembers(
   role: string,
 ): Promise<{ data: Staff[]; err?: Error }> {
-  const query = defineQuery(`
-    * [_type == "staff" && role == $role]
+  try {
+    const orgId = await getOrganizationRefForCurrentConference()
+    const queryResult = await scopedFetch<Staff[]>(
+      clientRead,
+      { orgId },
+      `*[_type == "staff" && role == $role]
     {
       "id": _id,
       name,
@@ -38,11 +52,9 @@ export async function getStaffMembers(
       company,
       "imageURL": image.asset->url,
       link
-    }
-  `)
-
-  try {
-    const queryResult = await clientRead.fetch<Staff[]>(query, { role: role })
+    }`,
+      { role },
+    )
     return { data: queryResult }
   } catch (error) {
     return { data: [], err: error as Error }


### PR DESCRIPTION
## Two cross-tenant data-exposure fixes (G1-class tenant isolation)

Both `staff` and `sponsorEmailTemplate` carry an `organization` ref (CaaS T1-1) but their reads were unscoped, so one tenant's data surfaced on another's — and for templates, one tenant's *writes* could hit another's documents. Scoped per the tenancy discipline in `docs/TENANT_SCOPING.md` (`scopedFetch` + `getOrganizationRefForCurrentConference` → `ORG_FILTER`); no new mechanism.

### BUG platform#18 — public staff leak
`src/lib/staff/sanity.ts` fetched `*[_type == "staff"]` **unscoped** and renders on the **public** `/staff/[role]` pages, so every organization's staff (names, photos, roles) appeared on every tenant's public site.

- **Fix:** `getStaffMembers` (public) and `getAllStaffMembers` (admin) resolve the current-domain org and read via `scopedFetch({ orgId }, …)`, applying `organization._ref == $orgId`. (The old queries used `* [` with a space, which even slipped past the `no-unscoped-groq` lint rule — part of why this lurked.)

### BUG platform#19 — sponsor email template cross-org read + WRITE
`src/lib/sponsor/sanity.ts` read templates unscoped, and `setDefault` / `reorder` / `update` / `delete` operated on a raw id with **no tenant check** — a tenant organizer could read *and mutate* (the worse half) another org's templates.

- **Reads** (`getSponsorEmailTemplates`, `getSponsorEmailTemplate`, `getSponsorEmailTemplateBySlug`) are now org-scoped.
- **Mutations** are guarded:
  - `setDefault`: the `current` and same-category `others` lookups are org-scoped, so a foreign template reads as not-found (no toggle) and a shared category name across tenants can't cross-clear.
  - `reorder`: the id-validation read is org-scoped, so a foreign id is not "valid" and the whole reorder is rejected.
  - `update` / `delete`: guarded by `isTemplateInCurrentOrg` (a scoped existence probe) — a foreign target is a no-op rejection.

### Deny tests (fail before, pass after — verified)
- `src/lib/staff/sanity.test.ts` — a foreign org's staff is NOT returned by the role query or the admin list; scoping holds in both directions.
- `src/lib/sponsor/sanity.templatescope.test.ts` — reads return only the caller's own org (both directions); set-default / reorder / update / delete against a foreign template are rejected with **no write** (tx/patch/delete never invoked). The two source files carried 14 `tenancy/no-unscoped-groq` warnings; the 6 template-query warnings clear (8 unrelated pre-existing remain).

`tsc` clean, affected vitest green (86 tests), lint/prettier clean.

Closes RunKonf/platform#18, closes RunKonf/platform#19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQYa6gorBTSEYvxT7Vq98C
