### PR TITLE
fix(conference): judge new-edition domain claims by routing overlap, not string equality

### DIFF
--- a/src/server/routers/conference.createEdition.test.ts
+++ b/src/server/routers/conference.createEdition.test.ts
@@ -126,9 +126,42 @@ describe('createEdition — domain global uniqueness', () => {
     expect(createSpy).not.toHaveBeenCalled()
   })
 
+  it('rejects a domain an existing WILDCARD entry already routes (overlap, not equality)', async () => {
+    claimedDomains = ['*.cnb.no']
+    const err = await makeCaller({ isOrganizer: true })
+      .createEdition(input({ domains: ['2026.cnb.no'] }))
+      .catch((e) => e)
+    expect(err.code).toBe('BAD_REQUEST')
+    expect(err.message).toContain(DOMAIN_ALREADY_CLAIMED)
+    expect(err.message).toContain('2026.cnb.no')
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a WILDCARD that would capture an existing exact host (reverse overlap)', async () => {
+    claimedDomains = ['2025.cnb.no']
+    const err = await makeCaller({ isOrganizer: true })
+      .createEdition(input({ domains: ['*.cnb.no'] }))
+      .catch((e) => e)
+    expect(err.code).toBe('BAD_REQUEST')
+    expect(err.message).toContain(DOMAIN_ALREADY_CLAIMED)
+    expect(err.message).toContain('*.cnb.no')
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
   it('accepts a domain not claimed by anyone', async () => {
     const res = await makeCaller({ isOrganizer: true }).createEdition(input())
     expect(res.conferenceId).toBeTruthy()
+  })
+
+  it('accepts a host under a DIFFERENT apex than an existing wildcard (no overlap)', async () => {
+    claimedDomains = ['*.cnb.no']
+    const res = await makeCaller({ isOrganizer: true }).createEdition(
+      input({ domains: ['2026.cndn.no'] }),
+    )
+    expect(res.conferenceId).toBeTruthy()
+    expect(commitMock).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -189,5 +222,13 @@ describe('validateNewDomains', () => {
       domains: ['2025.cnb.no', 'fresh.example.com'],
     })
     expect(res.taken).toEqual(['2025.cnb.no'])
+  })
+
+  it('reports a host an existing wildcard routes, and a wildcard capturing an existing host', async () => {
+    claimedDomains = ['*.cnb.no', '2025.cndn.no']
+    const res = await makeCaller({ isOrganizer: true }).validateNewDomains({
+      domains: ['2026.cnb.no', '*.cndn.no', 'fresh.example.com'],
+    })
+    expect(res.taken).toEqual(['2026.cnb.no', '*.cndn.no'])
   })
 })

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -13,6 +13,7 @@ import {
 import { clearConferenceTeamsCache } from '@/lib/teams'
 import {
   CANNOT_REMOVE_CURRENT_DOMAIN,
+  domainEntriesOverlap,
   domainsWouldStrandHost,
   normalizeDomain,
 } from '@/lib/conference/domains'
@@ -67,11 +68,30 @@ export const DOMAIN_ALREADY_CLAIMED = 'Already used by another conference'
  * edition's routing (`getConferenceForDomain` picks the FIRST conference whose
  * `domains[]` matches the host — a duplicate would silently steal traffic).
  */
-async function fetchClaimedDomains(): Promise<Set<string>> {
+async function fetchClaimedDomains(): Promise<string[]> {
   const all = await clientReadUncached.fetch<string[] | null>(
+    // groq-global: domain uniqueness is a GLOBAL routing invariant across every tenant's conferences (same rule as onboarding's createOrganization).
     `*[_type == "conference" && defined(domains)].domains[]`,
   )
-  return new Set((all ?? []).map(normalizeDomain))
+  return (all ?? []).map(normalizeDomain)
+}
+
+/**
+ * The subset of `requested` entries that collide with an already-claimed one
+ * under the ROUTING matcher's semantics (exact OR single-label wildcard, see
+ * {@link domainEntriesOverlap}) — NOT mere string equality, which would let a
+ * new edition claim `2026.cnb.no` while another tenant's `*.cnb.no` already
+ * routes that host (or claim `*.cnb.no` and capture that tenant's existing
+ * exact hosts). Either direction misroutes traffic across tenants, so both are
+ * refused. Same predicate the onboarding path uses, so the two agree.
+ */
+function findClaimedOverlaps(
+  requested: readonly string[],
+  claimed: readonly string[],
+): string[] {
+  return requested.filter((r) =>
+    claimed.some((entry) => domainEntriesOverlap(entry, r)),
+  )
 }
 
 /**
@@ -569,17 +589,19 @@ export const conferenceRouter = router({
 
   /**
    * Availability probe for the wizard's Domains step. Given the typed hostnames,
-   * returns which are ALREADY claimed by some conference (global uniqueness) and
-   * which are not valid bare hostnames — so the editor can flag them inline
-   * before the maintainer reaches the confirm step. Read-only.
+   * returns which are ALREADY claimed by some conference (global uniqueness,
+   * routing-overlap semantics) and which are not valid bare hostnames — so the
+   * editor can flag them inline before the maintainer reaches the confirm step.
+   * Read-only, and only a mirror: `createEdition` is the authority.
    */
   validateNewDomains: adminProcedure
     .input(ValidateNewDomainsSchema)
     .query(async ({ input }) => {
       const claimed = await fetchClaimedDomains()
       const normalized = input.domains.map(normalizeDomain).filter((d) => d)
-      const taken = Array.from(new Set(normalized)).filter((d) =>
-        claimed.has(d),
+      const taken = findClaimedOverlaps(
+        Array.from(new Set(normalized)),
+        claimed,
       )
       return { taken }
     }),
@@ -591,7 +613,8 @@ export const conferenceRouter = router({
    * SOURCE and is NEVER modified (no patch/set touches its id).
    *
    * DOMAIN VALIDATION: shape/duplicate/hostname come from the schema; here we
-   * add the GLOBAL-uniqueness rule (a domain claimed by any conference is
+   * add the GLOBAL-uniqueness rule (a domain that ROUTING-OVERLAPS any
+   * conference's claim — exact or single-label wildcard, either direction — is
    * rejected, BAD_REQUEST naming it) — the server is the authority, the wizard
    * only mirrors it.
    *
@@ -632,8 +655,9 @@ export const conferenceRouter = router({
       }
 
       // GLOBAL domain uniqueness — the authority. `input.domains` is already
-      // normalized/validated for shape by the schema.
-      const taken = input.domains.filter((d) => claimedDomains.has(d))
+      // normalized/validated for shape by the schema. Uniqueness is judged by
+      // ROUTING overlap, not string equality (see {@link findClaimedOverlaps}).
+      const taken = findClaimedOverlaps(input.domains, claimedDomains)
       if (taken.length > 0) {
         throw new TRPCError({
           code: 'BAD_REQUEST',

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -63,7 +63,8 @@ export const CANNOT_REMOVE_SELF_ORGANIZER =
 export const DOMAIN_ALREADY_CLAIMED = 'Already used by another conference'
 
 /**
- * Every domain claimed by ANY conference document, normalized. Drives the
+ * Every domain claimed by ANY conference document, normalized and deduped (two
+ * conferences may spell the same host differently, or one may repeat it). Drives the
  * wizard's GLOBAL-uniqueness rule: a new edition must never shadow an existing
  * edition's routing (`getConferenceForDomain` picks the FIRST conference whose
  * `domains[]` matches the host — a duplicate would silently steal traffic).
@@ -73,7 +74,7 @@ async function fetchClaimedDomains(): Promise<string[]> {
     // groq-global: domain uniqueness is a GLOBAL routing invariant across every tenant's conferences (same rule as onboarding's createOrganization).
     `*[_type == "conference" && defined(domains)].domains[]`,
   )
-  return (all ?? []).map(normalizeDomain)
+  return Array.from(new Set((all ?? []).map(normalizeDomain)))
 }
 
 /**
@@ -589,10 +590,12 @@ export const conferenceRouter = router({
 
   /**
    * Availability probe for the wizard's Domains step. Given the typed hostnames,
-   * returns which are ALREADY claimed by some conference (global uniqueness,
-   * routing-overlap semantics) and which are not valid bare hostnames — so the
-   * editor can flag them inline before the maintainer reaches the confirm step.
-   * Read-only, and only a mirror: `createEdition` is the authority.
+   * returns which are ALREADY `taken` — claimed by some conference under the
+   * same routing-overlap rule the mutation enforces — so the editor can flag
+   * them inline before the maintainer reaches the confirm step. Hostname SHAPE
+   * is validated client-side (`domainsLocalErrors`) and by the mutation's
+   * schema, not here. Read-only, and only a mirror: `createEdition` is the
+   * authority.
    */
   validateNewDomains: adminProcedure
     .input(ValidateNewDomainsSchema)


### PR DESCRIPTION
Fixes #667.

## The hole

`createEdition` (SE-5) and its `validateNewDomains` probe enforced GLOBAL domain uniqueness with **exact string equality** (`claimedDomains.has(d)`). But `getConferenceForDomain` resolves a request `Host` by **exact match OR single-label wildcard**. The two disagreed, so a new edition could claim a domain that already routes somewhere else:

- **Forward:** tenant A holds `*.cnb.no`. Tenant B creates an edition claiming `2026.cnb.no`. No exact string match → allowed. Now two conference documents match a request for `2026.cnb.no`, and routing picks the FIRST — whichever that is, one tenant is silently serving the other's host.
- **Reverse:** tenant A holds `2025.cnb.no`. Tenant B claims `*.cnb.no`. Again no exact match → allowed, and B's wildcard now captures A's existing host.

Either direction is **cross-tenant misrouting**, from a mutation any organizer can reach.

## The fix

Both call sites now judge uniqueness with `domainEntriesOverlap()` from `src/lib/conference/domains.ts` — the both-directions routing predicate extracted in #666 when the identical gap was closed on the **onboarding** path (`createOrganization`). Same helper, same semantics, so the two tenant-creation paths can no longer disagree about what "already claimed" means.

- `fetchClaimedDomains()` returns the normalized claimed list (was a `Set`, which only supported equality lookups) and carries the `groq-global:` annotation the tenancy lint wants.
- New `findClaimedOverlaps(requested, claimed)` — one predicate, used by the `createEdition` mutation (the authority) and the `validateNewDomains` query (the wizard's inline mirror), so the wizard flags exactly what the server will refuse.
- **Fails closed:** any overlap → `BAD_REQUEST` naming the offending domain, and the create transaction is never opened (tests assert no `create` and no `commit`).
- It returns the *requested* entry (not the claimed one), so the wizard's existing client-side `takenDomains` matching is unaffected.

## Why this matters more than when it was filed

Konf's newly-locked pricing bundles a **custom domain into the base paid tier** — so every paying tenant exercises the domain-claim path, not just the occasional multi-edition organizer. A misroute here serves one customer's site on another customer's host.

## Tests (verified to bite)

Three new router tests plus the extended probe test:

- new exact host colliding with an existing `*.` wildcard → rejected;
- new wildcard capturing an existing exact host → rejected;
- host under a *different* apex than an existing wildcard → still created (no false positive);
- `validateNewDomains` reports both overlap directions and leaves the clean domain alone.

**Bite verification:** with `findClaimedOverlaps` temporarily reverted to `entry === r`, 3 of the new tests FAIL (the two rejection cases pass through and the probe returns `[]`); restored, all 13 in the file pass. Full suite: 359 files / 4618 tests green. `tsc --noEmit`, eslint, prettier, knip clean.

## Follow-up spotted (not in this PR)

`conference.updateDomains` (SE-1b, editing an *existing* conference's `domains[]`) has **no global-uniqueness check at all** — neither equality nor overlap. It only guards against stranding the current host. An organizer can therefore add another tenant's domain, or a wildcard covering it, to their own conference. That is a wider fix than this one (it needs self-exclusion of the conference's own entries plus an editor-side mirror), so it deserves its own issue rather than being bolted on here.