### PR TITLE
fix(conference): enforce global domain uniqueness on updateDomains (#680)

### DIFF
--- a/__tests__/components/admin/EditConferenceCard.test.tsx
+++ b/__tests__/components/admin/EditConferenceCard.test.tsx
@@ -15,7 +15,12 @@ const mutateMocks = vi.hoisted(() => ({
   updateCommunication: vi.fn(),
   updateTicketingIds: vi.fn(),
   updateCfpGoals: vi.fn(),
+  updateDomains: vi.fn(),
 }))
+
+// What the Domains availability probe (#680) reports back as claimed by ANOTHER
+// conference. The real query self-excludes this conference server-side.
+const probeState = vi.hoisted(() => ({ taken: [] as string[] }))
 
 vi.mock('@/lib/trpc/client', () => {
   const make = (mutate: (input: unknown) => void) => ({
@@ -31,6 +36,13 @@ vi.mock('@/lib/trpc/client', () => {
         updateCommunication: make(mutateMocks.updateCommunication),
         updateTicketingIds: make(mutateMocks.updateTicketingIds),
         updateCfpGoals: make(mutateMocks.updateCfpGoals),
+        updateDomains: make(mutateMocks.updateDomains),
+        validateUpdatedDomains: {
+          useQuery: () => ({
+            data: { taken: probeState.taken },
+            isFetching: false,
+          }),
+        },
       },
       useUtils: () => ({ invalidate: vi.fn() }),
     },
@@ -51,6 +63,7 @@ function renderCard(props: Parameters<typeof EditConferenceCard>[0]) {
 
 beforeEach(() => {
   Object.values(mutateMocks).forEach((m) => m.mockReset())
+  probeState.taken = []
 })
 afterEach(() => cleanup())
 
@@ -160,5 +173,58 @@ describe('EditConferenceCard', () => {
     // Closing a dirty modal reveals the in-dialog discard confirm.
     fireEvent.click(screen.getByRole('button', { name: 'Close dialog' }))
     expect(screen.getByText('Discard unsaved changes?')).toBeInTheDocument()
+  })
+})
+
+/**
+ * The editor-side mirror of `updateDomains`' global-uniqueness guard (#680).
+ * The server is the authority; this only has to surface the conflict inline and
+ * refuse to submit a payload the mutation would reject anyway.
+ */
+describe('EditConferenceCard — Domains availability probe (#680)', () => {
+  const CURRENT = 'cloudnativebergen.no'
+
+  function openDomainsEditor() {
+    renderCard({
+      fieldset: 'domains',
+      initialValues: { domains: [CURRENT] },
+      currentDomain: CURRENT,
+      defaultOpen: true,
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add domain' }))
+    fireEvent.change(screen.getByLabelText('domain 2'), {
+      target: { value: '2026.cnb.no' },
+    })
+    // Satisfy the dangerous-fieldset type-to-confirm gate so the probe is the
+    // only thing that can still block Save.
+    fireEvent.change(screen.getByLabelText(`Type ${CURRENT} to confirm`), {
+      target: { value: CURRENT },
+    })
+  }
+
+  it('flags a row the probe reports as claimed elsewhere and blocks Save', () => {
+    probeState.taken = ['2026.cnb.no']
+    openDomainsEditor()
+    expect(
+      screen.getByText('Already used by another conference'),
+    ).toBeInTheDocument()
+    const save = screen.getByRole('button', { name: 'Save domains' })
+    expect(save).toBeDisabled()
+    fireEvent.click(save)
+    expect(mutateMocks.updateDomains).not.toHaveBeenCalled()
+  })
+
+  it('leaves an available domain submittable', () => {
+    probeState.taken = []
+    openDomainsEditor()
+    expect(
+      screen.queryByText('Already used by another conference'),
+    ).not.toBeInTheDocument()
+    const save = screen.getByRole('button', { name: 'Save domains' })
+    expect(save).toBeEnabled()
+    fireEvent.click(save)
+    expect(mutateMocks.updateDomains).toHaveBeenCalledWith({
+      domains: [CURRENT, '2026.cnb.no'],
+    })
   })
 })

--- a/src/components/admin/EditConferenceCard.stories.tsx
+++ b/src/components/admin/EditConferenceCard.stories.tsx
@@ -25,6 +25,17 @@ const handlers = [
   http.post('/api/trpc/conference.updateAnnouncement', ok),
 ]
 
+/**
+ * The Domains availability probe (#680) with a canned `taken` list. Default: no
+ * hostname is claimed elsewhere, so the Domains stories behave as before.
+ */
+const handlersWithProbe = (taken: string[] = []) => [
+  ...handlers,
+  http.get('/api/trpc/conference.validateUpdatedDomains', () =>
+    HttpResponse.json({ result: { data: { taken } } }),
+  ),
+]
+
 const announcementInitial = {
   announcement: [
     {
@@ -49,7 +60,7 @@ const meta = {
   component: EditConferenceCard,
   parameters: {
     layout: 'fullscreen',
-    msw: { handlers },
+    msw: { handlers: handlersWithProbe() },
     docs: {
       description: {
         component:
@@ -290,6 +301,48 @@ export const DomainsDangerousDark: Story = {
     defaultOpen: true,
   },
   parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+}
+
+/**
+ * #680 — the organizer types a hostname ANOTHER conference already routes. The
+ * availability probe reports it, the row carries the inline conflict message and
+ * the red Save stays disabled even with the confirm token typed, because
+ * `updateDomains` would refuse the payload anyway.
+ */
+export const DomainsTakenElsewhere: Story = {
+  args: {
+    fieldset: 'domains',
+    initialValues: { domains: ['cloudnativebergen.no'] },
+    currentDomain: 'cloudnativebergen.no',
+    defaultOpen: true,
+  },
+  parameters: {
+    msw: { handlers: handlersWithProbe(['2026.cloudnativeday.no']) },
+  },
+  play: async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Add domain' }))
+    await userEvent.type(
+      screen.getByLabelText('domain 2'),
+      '2026.cloudnativeday.no',
+    )
+    await userEvent.type(
+      screen.getByLabelText(/Type cloudnativebergen\.no to confirm/),
+      'cloudnativebergen.no',
+    )
+    expect(
+      await screen.findByText('Already used by another conference'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save domains' })).toBeDisabled()
+  },
+}
+
+export const DomainsTakenElsewhereDark: Story = {
+  ...DomainsTakenElsewhere,
+  parameters: {
+    msw: { handlers: handlersWithProbe(['2026.cloudnativeday.no']) },
+    theme: 'dark',
+    backgrounds: { default: 'dark' },
+  },
 }
 
 /** The rich-text Announcement fieldset — the portable-text editor + toolbar. */

--- a/src/components/admin/EditConferenceCard.tsx
+++ b/src/components/admin/EditConferenceCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {
   PencilSquareIcon,
@@ -17,7 +17,11 @@ import { PortableTextEditor } from '@/components/PortableTextEditor'
 import type { PortableTextBlock } from '@portabletext/editor'
 import { api } from '@/lib/trpc/client'
 import { HEROICON_OPTIONS } from '../../../sanity/schemaTypes/constants'
-import { domainServesHost } from '@/lib/conference/domains'
+import {
+  DOMAIN_ALREADY_CLAIMED,
+  domainServesHost,
+  normalizeDomain,
+} from '@/lib/conference/domains'
 import {
   type ListRow,
   TEMP_KEY_PREFIX,
@@ -745,6 +749,44 @@ export function EditConferenceCard({
   const confirmSatisfied =
     !dangerous || (confirmToken !== '' && confirmInput.trim() === confirmToken)
 
+  // --- Domains: global-uniqueness availability probe (#680) ----------------
+  // Mirrors `updateDomains`' cross-tenant guard so a domain another conference
+  // already routes is flagged inline instead of blowing up on save. The server
+  // stays the authority (and self-excludes THIS conference, so the rows already
+  // stored here never report as taken). Hooks run for every fieldset — the
+  // query is simply disabled outside `domains` — so hook order stays stable.
+  const isDomains = fieldset === 'domains'
+  const probeDomains = useMemo(() => {
+    if (!isDomains) return [] as string[]
+    const list = Array.isArray(values.domains)
+      ? (values.domains as string[])
+      : []
+    return Array.from(
+      new Set(list.map((d) => normalizeDomain(String(d))).filter((d) => d)),
+    )
+  }, [isDomains, values.domains])
+  // Debounced so keystrokes don't spam the server (same 400ms as the wizard).
+  const [domainCheckList, setDomainCheckList] = useState<string[]>([])
+  const probeKey = probeDomains.join('\n')
+  useEffect(() => {
+    const t = setTimeout(
+      () => setDomainCheckList(probeKey === '' ? [] : probeKey.split('\n')),
+      400,
+    )
+    return () => clearTimeout(t)
+  }, [probeKey])
+  const domainAvailability = api.conference.validateUpdatedDomains.useQuery(
+    { domains: domainCheckList },
+    { enabled: isDomains && isOpen && domainCheckList.length > 0 },
+  )
+  const takenDomains = useMemo(
+    () => (isDomains ? (domainAvailability.data?.taken ?? []) : []),
+    [isDomains, domainAvailability.data],
+  )
+  // Only block on entries still present in the CURRENT list — a stale probe
+  // result must never wedge the Save button after the row was edited away.
+  const liveTakenDomains = takenDomains.filter((d) => probeDomains.includes(d))
+
   // `api.conference[procName]` narrows to a union of procedures; select the
   // proc first (plain property access, not a hook) then call `.useMutation`
   // exactly once so the hook order is stable regardless of `fieldset`.
@@ -896,6 +938,7 @@ export function EditConferenceCard({
   const handleSave = () => {
     setSubmitError(null)
     if (!confirmSatisfied) return
+    if (liveTakenDomains.length > 0) return
     const errs = validate()
     setErrors(errs)
     if (Object.keys(errs).length > 0) return
@@ -952,9 +995,16 @@ export function EditConferenceCard({
               error={errors[f.name]}
               rowErrors={errors}
               currentDomain={currentDomain}
+              unavailableValues={liveTakenDomains}
               onChange={(v) => setValue(f.name, v)}
             />
           ))}
+
+          {isDomains && domainAvailability.isFetching ? (
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Checking availability…
+            </p>
+          ) : null}
 
           {dangerous ? (
             <DangerousConfirm
@@ -988,7 +1038,12 @@ export function EditConferenceCard({
               type="submit"
               color={dangerous ? 'red' : 'blue'}
               size="md"
-              disabled={mutation.isPending || !isDirty || !confirmSatisfied}
+              disabled={
+                mutation.isPending ||
+                !isDirty ||
+                !confirmSatisfied ||
+                liveTakenDomains.length > 0
+              }
               className="min-h-[44px]"
             >
               {mutation.isPending
@@ -1013,6 +1068,7 @@ function EditField({
   error,
   rowErrors,
   currentDomain,
+  unavailableValues,
   onChange,
 }: {
   field: EditFieldDef
@@ -1021,6 +1077,8 @@ function EditField({
   /** The full error map, so list editors can pull their `<name>.<row>` keys. */
   rowErrors?: Record<string, string>
   currentDomain?: string
+  /** Normalized `string-list` values a server probe reported as unavailable. */
+  unavailableValues?: readonly string[]
   onChange: (value: FormValue) => void
 }) {
   const id = `conf-field-${field.name}`
@@ -1037,6 +1095,7 @@ function EditField({
         rows={(value as string[]) ?? []}
         errors={rowErrors ?? {}}
         currentDomain={currentDomain}
+        unavailableValues={unavailableValues}
         onChange={(rows) => onChange(rows)}
       />
     )
@@ -1308,16 +1367,20 @@ function StringListEditor({
   rows,
   errors,
   currentDomain,
+  unavailableValues,
   onChange,
 }: {
   field: EditFieldDef
   rows: string[]
   errors: Record<string, string>
   currentDomain?: string
+  /** Normalized values a server probe reported as claimed elsewhere (#680). */
+  unavailableValues?: readonly string[]
   onChange: (rows: string[]) => void
 }) {
   const noun = field.itemLabel ?? 'entry'
   const listErr = errors[field.name]
+  const unavailable = new Set(unavailableValues ?? [])
   const knownValues = field.knownValues ?? []
   const knownSet = new Set(knownValues.map((k) => k.value))
   // Rows shown as editable text inputs — known values are represented by the
@@ -1381,7 +1444,14 @@ function StringListEditor({
 
       <ul className="space-y-2">
         {visible.map(({ value, index }, pos) => {
-          const rowErr = errors[`${field.name}.${index}`]
+          // A probe hit renders as a row error too. The local shape error wins
+          // when both apply — it explains the value itself, and a malformed
+          // hostname could never have been claimed by anyone.
+          const rowErr =
+            errors[`${field.name}.${index}`] ??
+            (unavailable.has(normalizeDomain(value))
+              ? DOMAIN_ALREADY_CLAIMED
+              : undefined)
           const locked = Boolean(
             field.lockCurrent &&
             currentDomain &&

--- a/src/components/admin/new-edition/NewEditionWizard.tsx
+++ b/src/components/admin/new-edition/NewEditionWizard.tsx
@@ -13,6 +13,7 @@ import {
 import { api } from '@/lib/trpc/client'
 import { AdminButton } from '@/components/admin/AdminButton'
 import { useNotificationSafe } from '@/components/admin/NotificationProvider'
+import { DOMAIN_ALREADY_CLAIMED } from '@/lib/conference/domains'
 import {
   CLONE_FAMILIES,
   CLONE_FAMILY_META,
@@ -355,7 +356,7 @@ export function NewEditionWizard({
                     </div>
                     {(localErr || isTaken) && (
                       <p className="mt-1 text-xs text-red-600 dark:text-red-400">
-                        {localErr ?? 'Already used by another conference'}
+                        {localErr ?? DOMAIN_ALREADY_CLAIMED}
                       </p>
                     )}
                   </div>

--- a/src/lib/conference/domains.ts
+++ b/src/lib/conference/domains.ts
@@ -16,6 +16,15 @@
 export const CANNOT_REMOVE_CURRENT_DOMAIN =
   'You cannot remove the domain you are currently using'
 
+/**
+ * Prefix for the BAD_REQUEST thrown when a requested domain overlaps a claim
+ * some OTHER conference already holds. Lives here, next to the matcher, because
+ * both sides render it: the server mutations (`createEdition`, `updateDomains`,
+ * onboarding) throw it, and the client editors show it inline next to the
+ * offending row.
+ */
+export const DOMAIN_ALREADY_CLAIMED = 'Already used by another conference'
+
 // A bare hostname, lowercase, optionally with a `:port` (dev entries such as
 // `localhost:3000`) or a leading `*.` wildcard label (the routing matches a
 // request's `*.<rest>` subdomain form against such entries). No scheme, no path,

--- a/src/server/routers/conference.createEdition.test.ts
+++ b/src/server/routers/conference.createEdition.test.ts
@@ -72,7 +72,8 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }))
 
-import { conferenceRouter, DOMAIN_ALREADY_CLAIMED } from './conference'
+import { conferenceRouter } from './conference'
+import { DOMAIN_ALREADY_CLAIMED } from '@/lib/conference/domains'
 
 function makeCaller(opts: { isOrganizer?: boolean } | null) {
   const speaker = opts

--- a/src/server/routers/conference.test.ts
+++ b/src/server/routers/conference.test.ts
@@ -22,8 +22,18 @@ vi.mock('@/lib/conference/sanity', () => ({
 
 // --- Sanity write client: capture the patch shape ---------------------------
 const commitMock = vi.fn()
-// Drives clientReadUncached.fetch — updateTeams reads the current organizer ids.
+// Drives clientReadUncached.fetch — updateTeams reads the current organizer ids
+// and updateDomains reads the domains claimed by OTHER conferences.
 const uncachedFetchMock = vi.fn()
+/**
+ * Stand-in datastore for the claimed-domains GROQ: every conference document's
+ * `domains[]`, keyed by `_id` (drafts included, under their `drafts.` id). The
+ * mock APPLIES the query's `$excludeIds` itself rather than returning a canned
+ * list, so a router that forgets to self-exclude really does see its OWN
+ * domains come back — which is what makes the self-exclusion tests bite.
+ */
+let domainsByConference: Record<string, string[]> = {}
+let lastClaimedParams: Record<string, unknown> | undefined
 let lastPatchId: string | undefined
 let lastSet: Record<string, unknown> | undefined
 let lastUnset: string[] | undefined
@@ -64,6 +74,7 @@ vi.mock('@/lib/teams', () => ({
 
 import { revalidateTag } from 'next/cache'
 import { conferenceRouter } from './conference'
+import { DOMAIN_ALREADY_CLAIMED } from '@/lib/conference/domains'
 
 const revalidateTagMock = revalidateTag as unknown as ReturnType<typeof vi.fn>
 
@@ -88,8 +99,24 @@ beforeEach(() => {
   lastSetIfMissing = undefined
   hostMock.mockReturnValue('cloudnativebergen.no')
   commitMock.mockResolvedValue({ _id: CONFERENCE_ID })
+  // This conference already owns the host every test is served on.
+  domainsByConference = { [CONFERENCE_ID]: ['cloudnativebergen.no'] }
+  lastClaimedParams = undefined
   // Default organizer set for the teams subset check: the caller (sp-1) + sp-2.
-  uncachedFetchMock.mockResolvedValue(['sp-1', 'sp-2'])
+  // The domains claimed-set query is answered from `domainsByConference`, with
+  // the query's own `$excludeIds` applied.
+  uncachedFetchMock.mockImplementation(
+    async (query: string, params?: Record<string, unknown>) => {
+      if (query.includes('.domains[]')) {
+        lastClaimedParams = params
+        const excluded = new Set((params?.excludeIds as string[]) ?? [])
+        return Object.entries(domainsByConference)
+          .filter(([id]) => !excluded.has(id))
+          .flatMap(([, domains]) => domains)
+      }
+      return ['sp-1', 'sp-2']
+    },
+  )
   getConferenceMock.mockResolvedValue({
     conference: { _id: CONFERENCE_ID },
     error: null,
@@ -535,6 +562,119 @@ describe('conference router — domains (safeguarded)', () => {
       domains: [`${CURRENT.toUpperCase()}`, 'Other.Example.COM'],
     })
     expect(lastSet).toEqual({ domains: [CURRENT, 'other.example.com'] })
+  })
+})
+
+describe('conference router — domains global uniqueness (#680)', () => {
+  const CURRENT = 'cloudnativebergen.no'
+  const OTHER_CONFERENCE = 'other-conf'
+
+  it('rejects an exact host another conference already routes via a WILDCARD', async () => {
+    domainsByConference[OTHER_CONFERENCE] = ['*.cnb.no']
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({
+        domains: [CURRENT, '2026.cnb.no'],
+      }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: `${DOMAIN_ALREADY_CLAIMED}: 2026.cnb.no`,
+    })
+    // Fail CLOSED: no patch is opened when the claim is refused.
+    expect(commitMock).not.toHaveBeenCalled()
+    expect(lastSet).toBeUndefined()
+  })
+
+  it('rejects a WILDCARD that would capture the exact host of another conference', async () => {
+    domainsByConference[OTHER_CONFERENCE] = ['2025.cnb.no']
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({
+        domains: [CURRENT, '*.cnb.no'],
+      }),
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: `${DOMAIN_ALREADY_CLAIMED}: *.cnb.no`,
+    })
+    expect(commitMock).not.toHaveBeenCalled()
+    expect(lastSet).toBeUndefined()
+  })
+
+  it('rejects an exact host another conference claims exactly', async () => {
+    domainsByConference[OTHER_CONFERENCE] = ['2025.cnb.no']
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({
+        domains: [CURRENT, '2025.cnb.no'],
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  // --- SELF-EXCLUSION: the false-positive guard ----------------------------
+
+  it('SELF-EXCLUSION: re-saving its OWN unchanged domains succeeds', async () => {
+    // A wildcard + the hosts it covers, all owned by THIS conference — every
+    // pair overlaps, so a claimed set that failed to drop the document under
+    // edit would reject this no-op save and brick all domain editing.
+    const own = [CURRENT, '*.cnb.no', '2025.cnb.no']
+    domainsByConference[CONFERENCE_ID] = own
+    const result = await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: own,
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toEqual({ domains: own })
+  })
+
+  it('SELF-EXCLUSION: excludes BOTH the published and the draft id', async () => {
+    const own = [CURRENT, '*.cnb.no']
+    domainsByConference[CONFERENCE_ID] = own
+    // An unpublished draft carries its own copy of the same list.
+    domainsByConference[`drafts.${CONFERENCE_ID}`] = own
+    const result = await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: own,
+    })
+    expect(result.success).toBe(true)
+    expect(lastClaimedParams?.excludeIds).toEqual([
+      CONFERENCE_ID,
+      `drafts.${CONFERENCE_ID}`,
+    ])
+  })
+
+  it('SELF-EXCLUSION: reordering its own domains succeeds', async () => {
+    const own = [CURRENT, '*.cnb.no', '2025.cnb.no']
+    domainsByConference[CONFERENCE_ID] = own
+    const reordered = ['2025.cnb.no', CURRENT, '*.cnb.no']
+    const result = await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: reordered,
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toEqual({ domains: reordered })
+  })
+
+  it('SELF-EXCLUSION: removing one of its own domains succeeds', async () => {
+    domainsByConference[CONFERENCE_ID] = [CURRENT, '*.cnb.no', '2025.cnb.no']
+    const result = await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: [CURRENT, '*.cnb.no'],
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toEqual({ domains: [CURRENT, '*.cnb.no'] })
+  })
+
+  it('accepts a legitimate, non-overlapping addition', async () => {
+    domainsByConference[OTHER_CONFERENCE] = ['*.cnb.no', '2025.cndn.no']
+    const result = await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: [CURRENT, '2027.example.com'],
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toEqual({ domains: [CURRENT, '2027.example.com'] })
+  })
+
+  it('validateUpdatedDomains mirrors the rule and self-excludes', async () => {
+    domainsByConference[CONFERENCE_ID] = [CURRENT, '2025.cnb.no']
+    domainsByConference[OTHER_CONFERENCE] = ['*.cndn.no']
+    const res = await makeCaller({ isOrganizer: true }).validateUpdatedDomains({
+      domains: ['2025.cnb.no', '2026.cndn.no', 'fresh.example.com'],
+    })
+    // Own entry is NOT reported; the other tenant's wildcard match is.
+    expect(res.taken).toEqual(['2026.cndn.no'])
   })
 })
 

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -13,6 +13,7 @@ import {
 import { clearConferenceTeamsCache } from '@/lib/teams'
 import {
   CANNOT_REMOVE_CURRENT_DOMAIN,
+  DOMAIN_ALREADY_CLAIMED,
   domainEntriesOverlap,
   domainsWouldStrandHost,
   normalizeDomain,
@@ -59,8 +60,16 @@ import {
 export const CANNOT_REMOVE_SELF_ORGANIZER =
   'You cannot remove yourself from the organizer team'
 
-/** Prefix for the BAD_REQUEST thrown when a new-edition domain is already taken. */
-export const DOMAIN_ALREADY_CLAIMED = 'Already used by another conference'
+/**
+ * Both id forms a Sanity conference document can appear under — the published id
+ * and its `drafts.` counterpart. Self-exclusion must drop BOTH, otherwise a
+ * conference that also has a draft would collide with its own draft's copy of
+ * the same `domains[]` and every domain edit would be rejected.
+ */
+function conferenceIdVariants(conferenceId: string): string[] {
+  const published = conferenceId.replace(/^drafts\./, '')
+  return [published, `drafts.${published}`]
+}
 
 /**
  * Every domain claimed by ANY conference document, normalized and deduped (two
@@ -68,12 +77,32 @@ export const DOMAIN_ALREADY_CLAIMED = 'Already used by another conference'
  * wizard's GLOBAL-uniqueness rule: a new edition must never shadow an existing
  * edition's routing (`getConferenceForDomain` picks the FIRST conference whose
  * `domains[]` matches the host — a duplicate would silently steal traffic).
+ *
+ * SELF-EXCLUSION: `excludeConferenceId` drops the document under edit (and its
+ * draft) from the claimed set. The create paths claim domains no document owns
+ * yet and pass nothing; `updateDomains` MUST pass its own id, or re-saving a
+ * conference's unchanged `domains[]` would collide with itself and brick every
+ * domain edit.
  */
-async function fetchClaimedDomains(): Promise<string[]> {
-  const all = await clientReadUncached.fetch<string[] | null>(
-    // groq-global: domain uniqueness is a GLOBAL routing invariant across every tenant's conferences (same rule as onboarding's createOrganization).
-    `*[_type == "conference" && defined(domains)].domains[]`,
-  )
+async function fetchClaimedDomains(
+  excludeConferenceId?: string,
+): Promise<string[]> {
+  const excludeIds = excludeConferenceId
+    ? conferenceIdVariants(excludeConferenceId)
+    : []
+  // The exclusion predicate is appended ONLY when there is something to
+  // exclude, so the create paths keep running the exact query they always have
+  // — an `_id in []` term is never introduced where it could only ever widen
+  // the risk of the claimed set coming back empty (which would fail OPEN).
+  const query =
+    excludeIds.length > 0
+      ? // groq-global: domain uniqueness is a GLOBAL routing invariant across every tenant's conferences (same rule as onboarding's createOrganization).
+        `*[_type == "conference" && defined(domains) && !(_id in $excludeIds)].domains[]`
+      : // groq-global: domain uniqueness is a GLOBAL routing invariant across every tenant's conferences (same rule as onboarding's createOrganization).
+        `*[_type == "conference" && defined(domains)].domains[]`
+  const all = await clientReadUncached.fetch<string[] | null>(query, {
+    excludeIds,
+  })
   return Array.from(new Set((all ?? []).map(normalizeDomain)))
 }
 
@@ -293,6 +322,20 @@ export const conferenceRouter = router({
    * payload that would strand it (BAD_REQUEST). The client mirrors this with a
    * locked, non-removable row + a type-to-confirm gate, but the server is the
    * authority — a crafted request cannot bypass the guard.
+   *
+   * GLOBAL UNIQUENESS (#680): editing `domains[]` claims routing exactly like
+   * creating an edition does, so the same overlap rule applies here — an entry
+   * that ROUTING-OVERLAPS another conference's claim (exact, or a single-label
+   * wildcard in either direction, see {@link findClaimedOverlaps}) is rejected
+   * BAD_REQUEST naming it. Without this an organizer could add another tenant's
+   * host — or a `*.` wildcard capturing it — to their own list and steal that
+   * tenant's traffic (`getConferenceForDomain` serves the FIRST match).
+   *
+   * SELF-EXCLUSION: THIS conference's own entries are excluded from the claimed
+   * set, so re-saving unchanged domains, reordering them, or removing one all
+   * still succeed — only OTHER conferences' claims can collide.
+   *
+   * Both guards run BEFORE any write: a rejection patches nothing.
    */
   updateDomains: adminProcedure
     .input(UpdateDomainsSchema)
@@ -303,6 +346,14 @@ export const conferenceRouter = router({
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: CANNOT_REMOVE_CURRENT_DOMAIN,
+        })
+      }
+      const claimedElsewhere = await fetchClaimedDomains(conferenceId)
+      const taken = findClaimedOverlaps(input.domains, claimedElsewhere)
+      if (taken.length > 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `${DOMAIN_ALREADY_CLAIMED}: ${taken.join(', ')}`,
         })
       }
       return applyConferencePatch(conferenceId, { domains: input.domains })
@@ -601,6 +652,31 @@ export const conferenceRouter = router({
     .input(ValidateNewDomainsSchema)
     .query(async ({ input }) => {
       const claimed = await fetchClaimedDomains()
+      const normalized = input.domains.map(normalizeDomain).filter((d) => d)
+      const taken = findClaimedOverlaps(
+        Array.from(new Set(normalized)),
+        claimed,
+      )
+      return { taken }
+    }),
+
+  /**
+   * Availability probe for the SETTINGS Domains editor — the mirror of
+   * {@link conferenceRouter.updateDomains} exactly as `validateNewDomains`
+   * mirrors `createEdition`, so a cross-tenant conflict surfaces inline instead
+   * of failing on save. Same `{ taken }` shape and same routing-overlap rule.
+   *
+   * Differs from `validateNewDomains` in ONE way, and it is the whole point:
+   * the CURRENT conference (resolved from the request domain, never from
+   * client input) is excluded from the claimed set — its own entries are not
+   * conflicts with itself. Read-only, and only a mirror: the mutation is the
+   * authority.
+   */
+  validateUpdatedDomains: adminProcedure
+    .input(ValidateNewDomainsSchema)
+    .query(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      const claimed = await fetchClaimedDomains(conferenceId)
       const normalized = input.domains.map(normalizeDomain).filter((d) => d)
       const taken = findClaimedOverlaps(
         Array.from(new Set(normalized)),

--- a/src/server/routers/onboarding.test.ts
+++ b/src/server/routers/onboarding.test.ts
@@ -85,7 +85,7 @@ import {
   ORG_SLUG_ALREADY_TAKEN,
   AMBIGUOUS_ORGANIZER_EMAIL,
 } from './onboarding'
-import { DOMAIN_ALREADY_CLAIMED } from './conference'
+import { DOMAIN_ALREADY_CLAIMED } from '@/lib/conference/domains'
 
 type CallerSpeaker = {
   _id: string

--- a/src/server/routers/onboarding.ts
+++ b/src/server/routers/onboarding.ts
@@ -8,6 +8,7 @@ import {
   isPlatformOperatorForOrg,
 } from '@/lib/authz/platform'
 import {
+  DOMAIN_ALREADY_CLAIMED,
   normalizeDomain,
   wildcardFormForHost,
   domainEntriesOverlap,
@@ -17,7 +18,6 @@ import {
   CreateOrganizationSchema,
   ValidateOnboardingSchema,
 } from '../schemas/onboarding'
-import { DOMAIN_ALREADY_CLAIMED } from './conference'
 
 /** Message prefix when the organization slug is already taken. */
 export const ORG_SLUG_ALREADY_TAKEN = 'Already used by another organization'


### PR DESCRIPTION
Fixes #680

## The gap

`conference.updateDomains` (SE-1b — editing an existing conference's `domains[]`) performed **no global uniqueness check at all** — not even string equality. Its only guard prevented the organizer from stranding the *current request host*.

Concretely, before this PR: an organizer of conference **A** (served on `a.example`) opens Settings → Domains and adds `2026.cnb.no` — a hostname conference **B** already owns. The save succeeds. `getConferenceForDomain` resolves a host by picking the **first** conference whose `domains[]` matches, so from that moment traffic for `2026.cnb.no` can land on A's site: A's branding, A's CFP, A's tickets. The wildcard form is worse — adding `*.cnb.no` to A captures *every* subdomain B holds in one edit. Same blast radius as #667, but reachable from an ordinary settings edit rather than edition creation.

#679 fixed the *create* path and #666 the onboarding path; the *update* path was never covered.

## The fix

`updateDomains` now judges a claim by the same routing-overlap predicate as the create paths — `domainEntriesOverlap()` from `src/lib/conference/domains.ts`, reused via the existing `fetchClaimedDomains()` / `findClaimedOverlaps()` helpers, **not** new matcher logic. An entry that overlaps another conference's claim (exact, or a single-label wildcard in **either** direction) is rejected `BAD_REQUEST` naming the offending domain, with the same `DOMAIN_ALREADY_CLAIMED` prefix the other paths use.

Fails **closed**: both guards run before `applyConferencePatch`, so a rejection opens no patch and commits nothing.

## Self-exclusion

This is what made the update path shaped differently from the create paths, and the main risk: **a conference must not collide with its own existing entries.** A conference typically stores a wildcard *and* hosts it covers (`*.cnb.no` + `2025.cnb.no`), which overlap each other — so a naive global claimed-set would reject every save, including a no-op one, and brick all domain editing.

`fetchClaimedDomains()` takes an optional `excludeConferenceId` and drops the document under edit from the claimed set via `!(_id in $excludeIds)`. The exclusion covers **both id forms**, `<id>` and `drafts.<id>`, so an unpublished draft's copy of the same list can't collide with its published parent. The predicate is appended **only** when there is something to exclude, so `createEdition` / `validateNewDomains` / onboarding keep running the exact query they always have.

Result: re-saving unchanged domains, reordering them, and removing one all still succeed — only *other* conferences' claims can collide.

## Editor-side mirror

As `validateNewDomains` mirrors `createEdition`, the new `validateUpdatedDomains` query mirrors `updateDomains`: same `{ taken: string[] }` shape and same overlap rule, self-excluding the current conference (resolved from the request domain, never from client input). The settings Domains editor debounces the typed list (400 ms, same as the wizard) and surfaces a conflict inline — `Already used by another conference` under the offending row — with the red Save disabled even once the type-to-confirm token is entered. The server remains the authority.

`DOMAIN_ALREADY_CLAIMED` moved from the conference router to the client-safe `src/lib/conference/domains.ts` (next to the matcher, alongside `CANNOT_REMOVE_CURRENT_DOMAIN`) so the server throw and both client editors render one string instead of a duplicated literal.

## Tests

New `conference router — domains global uniqueness (#680)` suite. The claimed-domains fetch is mocked as a **stand-in datastore keyed by document id that applies the query's own `$excludeIds`**, rather than a canned list — that is what lets the self-exclusion tests actually bite.

- exact host colliding with another conference's existing wildcard
- wildcard capturing another conference's existing exact host
- exact-vs-exact collision
- **self-exclusion: re-saving own unchanged domains succeeds** (wildcard + covered hosts, i.e. maximally self-overlapping)
- self-exclusion covers the `drafts.` id too (asserts `$excludeIds`)
- reordering own domains succeeds; removing one succeeds
- a legitimate non-overlapping addition succeeds
- `validateUpdatedDomains` mirrors the rule and self-excludes

Plus editor tests (inline message + Save blocked / available domain submittable) and a `DomainsTakenElsewhere` story (light + dark).

### Bite verification

| Sabotage | Result |
| --- | --- |
| Guard removed from `updateDomains` | 4 tests FAIL — all three collision tests plus the `$excludeIds` assertion |
| `fetchClaimedDomains()` called without the conference id (self-exclusion broken) | 7 tests FAIL — **all four self-exclusion tests**, plus the non-overlapping-change test and two collision tests |

Both restored; full suite green (4629 tests).

## Verification

`tsc --noEmit`, eslint (no new warnings — both GROQ literals carry the existing `groq-global` annotation), `prettier --check`, knip, full vitest suite. UI change inspected via `pnpm shoot` in light/desktop and dark/mobile.