### PR TITLE
chore(auth): drop legacy isOrganizer bridge, bump next-auth to beta.32

### DIFF
--- a/__tests__/api/trpc/authz-org-scoped.test.ts
+++ b/__tests__/api/trpc/authz-org-scoped.test.ts
@@ -147,7 +147,7 @@ describe('adminProcedure waist — org-scoped organizer authorization', () => {
         }).speaker.admin.list(),
       ).rejects.toMatchObject({ code: 'FORBIDDEN' })
       expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('[authz-bridge]'),
+        expect.stringContaining('[authz-deny]'),
       )
     })
 

--- a/__tests__/api/trpc/authz-org-scoped.test.ts
+++ b/__tests__/api/trpc/authz-org-scoped.test.ts
@@ -4,10 +4,19 @@
  * The org-scoped authorization WAIST (CaaS T1-2, #614). Exercises the real
  * `adminProcedure` middleware (`requireAdmin` in src/server/trpc.ts) end to end:
  * the request org comes from the domain conference, and access requires the
- * caller's `organizerOrgIds` to include it. Proves the cross-org 403, the fail-
- * closed (resolvable org, non-member) path, and that an UNRESOLVABLE org now FAILS
- * CLOSED (bridge (1) removed post-044-backfill — deny, with a warn on a would-be
- * organizer's denial).
+ * caller's `organizerOrgIds` to include it — `organizerOrgIds` and NOTHING else.
+ * BOTH migration bridges to the deprecated GLOBAL `isOrganizer` flag are gone, so
+ * this pins the whole contract:
+ *
+ *   - an organizer of the request org is ALLOWED; an organizer of another org is
+ *     DENIED (the cross-org 403), as is a member of no org at all;
+ *   - an UNRESOLVABLE org FAILS CLOSED (deny, with a warn when the denied caller
+ *     organizes at least one org, so the failure mode stays observable);
+ *   - a LEGACY TOKEN minted before #635 — the global flag set but NO
+ *     `organizerOrgIds` — is DENIED ON EVERY HOST. Bridging it granted organizer
+ *     rights on ANY host, because the global flag is true for an organizer of ANY
+ *     org: a cross-tenant grant. Such a holder is an ordinary non-organizer until
+ *     they sign in again.
  *
  * `getConferenceForCurrentDomain` is mocked to control the request's org; callers
  * are built with explicit session shapes so `organizerOrgIds` can be varied.
@@ -115,14 +124,26 @@ describe('adminProcedure waist — org-scoped organizer authorization', () => {
     ).rejects.toMatchObject({ code: 'FORBIDDEN' })
   })
 
-  describe('org unresolvable — bridge (1) removed, FAILS CLOSED', () => {
-    it('DENIES a would-be organizer (global flag set) and warns on the denial', async () => {
+  it('DENIES a LEGACY token (global flag, no organizerOrgIds) on a resolvable org', async () => {
+    resolveOrg('org-A')
+    // Pre-#635 token: `organizerOrgIds` absent ENTIRELY. The bridge that let the
+    // global flag stand in is gone — it granted on ANY host, so it was a
+    // cross-tenant grant.
+    await expect(
+      callerFor({ _id: 'sp-legacy', isOrganizer: true }).speaker.admin.list(),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+  })
+
+  describe('org unresolvable — FAILS CLOSED', () => {
+    it('DENIES a would-be organizer (organizes some org) and warns on the denial', async () => {
       resolveOrg(null) // conference has no organization (unknown domain)
+      // The warn fires only for a caller who organizes AT LEAST ONE org, so the
+      // denial stays observable without spamming on ordinary traffic.
       await expect(
         callerFor({
           _id: 'sp-4',
           isOrganizer: true,
-          organizerOrgIds: [],
+          organizerOrgIds: ['org-A'],
         }).speaker.admin.list(),
       ).rejects.toMatchObject({ code: 'FORBIDDEN' })
       expect(console.warn).toHaveBeenCalledWith(

--- a/__tests__/api/trpc/message-ticketing.test.ts
+++ b/__tests__/api/trpc/message-ticketing.test.ts
@@ -20,9 +20,16 @@ import {
 } from '../../helpers/trpc'
 import type { ConversationWithContext } from '@/lib/messaging/types'
 
+// The domain conference carries the `organization` ref the org-scoped authz waist
+// resolves the request org from; it must match the organizer fixture's
+// `organizerOrgIds` (TEST_ORG_ID) or every organizer call is FORBIDDEN.
 vi.mock('@/lib/conference/sanity', () => ({
   getConferenceForCurrentDomain: vi.fn(async () => ({
-    conference: { _id: 'conf-1', domains: ['cndn.no'] },
+    conference: {
+      _id: 'conf-1',
+      domains: ['cndn.no'],
+      organization: { _type: 'reference', _ref: 'org-test' },
+    },
     domain: 'cndn.no',
     error: null,
   })),
@@ -94,6 +101,9 @@ const organizerId = speakers.find((s) => s.isOrganizer)!._id
 const proposalConv: ConversationWithContext = {
   _id: 'conversation.proposal.prop-1',
   conferenceId: 'conf-1',
+  // `canAccessConversation` scopes organizer access to the conversation's OWN
+  // org, so the thread must belong to the org the organizer fixture organizes.
+  conferenceOrgId: 'org-test',
   conversationType: 'proposal',
   proposalId: 'prop-1',
   proposalTitle: 'T',

--- a/__tests__/api/trpc/message.test.ts
+++ b/__tests__/api/trpc/message.test.ts
@@ -18,9 +18,16 @@ import {
 } from '../../helpers/trpc'
 import type { ConversationWithContext } from '@/lib/messaging/types'
 
+// The domain conference carries the `organization` ref the org-scoped authz waist
+// resolves the request org from; it must match the organizer fixture's
+// `organizerOrgIds` (TEST_ORG_ID) or every organizer call is FORBIDDEN.
 vi.mock('@/lib/conference/sanity', () => ({
   getConferenceForCurrentDomain: vi.fn(async () => ({
-    conference: { _id: 'conf-1', domains: ['cndn.no'] },
+    conference: {
+      _id: 'conf-1',
+      domains: ['cndn.no'],
+      organization: { _type: 'reference', _ref: 'org-test' },
+    },
     domain: 'cndn.no',
     error: null,
   })),
@@ -96,6 +103,9 @@ const organizerId = speakers.find((s) => s.isOrganizer)!._id
 const strangerProposalConv: ConversationWithContext = {
   _id: 'conversation.proposal.prop-1',
   conferenceId: 'conf-1',
+  // `canAccessConversation` scopes organizer access to the conversation's OWN
+  // org, so the thread must belong to the org the organizer fixture organizes.
+  conferenceOrgId: 'org-test',
   conversationType: 'proposal',
   proposalId: 'prop-1',
   proposalTitle: 'T',

--- a/__tests__/api/trpc/middleware.test.ts
+++ b/__tests__/api/trpc/middleware.test.ts
@@ -4,6 +4,22 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@/lib/events/registry', () => ({}))
 
+// The authz waist derives the request's org from the DOMAIN conference, and a
+// test process has no request domain — so resolve it explicitly onto the org the
+// organizer fixture's `organizerOrgIds` names (`TEST_ORG_ID`, duplicated as a
+// literal because `vi.mock` factories are hoisted above imports).
+vi.mock('@/lib/conference/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getConferenceForCurrentDomain: async () => ({
+    conference: {
+      _id: 'conf-1',
+      organization: { _type: 'reference', _ref: 'org-test' },
+    },
+    domain: 'localhost',
+    error: null,
+  }),
+}))
+
 import { describe, it, expect, vi } from 'vitest'
 import { TRPCError } from '@trpc/server'
 import {

--- a/__tests__/api/trpc/proposal-remove-cospeaker.test.ts
+++ b/__tests__/api/trpc/proposal-remove-cospeaker.test.ts
@@ -42,8 +42,13 @@ vi.mock('@/lib/conference/sanity', () => ({
       title: 'Test Conf',
       organizer: 'Test Org',
       cfpEmail: 'cfp@test.com',
+      // The organizer branch is org-scoped: the REQUEST's org comes from this
+      // conference and only a caller whose `organizerOrgIds` contains it counts
+      // as an organizer, so it must be the fixture organizer's org (TEST_ORG_ID).
+      organization: { _type: 'reference', _ref: 'org-test' },
     },
     domain: 'test.com',
+    error: null,
   }),
 }))
 

--- a/__tests__/api/trpc/proposal.test.ts
+++ b/__tests__/api/trpc/proposal.test.ts
@@ -67,6 +67,7 @@ import {
   createAuthenticatedCaller,
   createAdminCaller,
   speakers,
+  TEST_ORG_ID,
 } from '../../helpers/trpc'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import {
@@ -101,6 +102,10 @@ const mockConference = {
   cfpStartDate: '2026-01-01',
   cfpEndDate: '2026-05-01',
   domains: ['localhost'],
+  // Org-scoped authz derives the REQUEST's org from this conference and grants
+  // only when the caller's `organizerOrgIds` contains it, so the domain
+  // conference must belong to the fixture organizer's org.
+  organization: { _type: 'reference', _ref: TEST_ORG_ID },
 }
 
 const validProposalData = {

--- a/__tests__/api/trpc/schedule.test.ts
+++ b/__tests__/api/trpc/schedule.test.ts
@@ -58,7 +58,13 @@ function createAdminCaller() {
     session: {
       expires: new Date(Date.now() + 86400000).toISOString(),
       user: { email: 'admin@example.com', name: 'Admin' },
-      speaker: { _id: 'admin-1', isOrganizer: true },
+      // Org-scoped authz: the waist grants only when `organizerOrgIds` contains
+      // the org the request's domain conference resolves to (see `conference`).
+      speaker: {
+        _id: 'admin-1',
+        isOrganizer: true,
+        organizerOrgIds: ['org-test'],
+      },
     } as unknown as Context['session'],
   })
 }
@@ -74,7 +80,11 @@ function createAuthenticatedCaller() {
   })
 }
 
-const conference = { _id: 'conf-1', title: 'CND 2026' }
+const conference = {
+  _id: 'conf-1',
+  title: 'CND 2026',
+  organization: { _type: 'reference', _ref: 'org-test' },
+}
 
 const validDay = {
   _id: 'sched-1',

--- a/__tests__/api/trpc/sponsor-activity.test.ts
+++ b/__tests__/api/trpc/sponsor-activity.test.ts
@@ -20,11 +20,15 @@ vi.mock('@/lib/auth', () => ({
   getAuthSession: vi.fn(),
 }))
 
+// Org-scoped organizer: `organizerOrgIds` must contain the org the request
+// resolves to (mockConference.organization), since that membership is the whole
+// authz decision — the non-organizer below organizes no org at all.
 const mockOrganizer = {
   _id: 'org-1',
   name: 'Test Organizer',
   email: 'org@test.com',
   isOrganizer: true,
+  organizerOrgIds: ['org-test'],
 }
 
 const mockNonOrganizer = {
@@ -32,11 +36,13 @@ const mockNonOrganizer = {
   name: 'Test Speaker',
   email: 'speaker@test.com',
   isOrganizer: false,
+  organizerOrgIds: [],
 }
 
 const mockConference = {
   _id: 'conf-1',
   title: 'Test Conference',
+  organization: { _type: 'reference', _ref: 'org-test' },
 }
 
 describe('Sponsor CRM Activities & Assignments', () => {

--- a/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-contract-signature-guards.test.ts
@@ -27,13 +27,20 @@ vi.mock('@/lib/sanity/client', () => ({
   clientRead: { fetch: vi.fn() },
 }))
 
+// Org-scoped organizer: `organizerOrgIds` must contain the org the request
+// resolves to (below), since that membership is the whole authz decision.
 const mockOrganizer = {
   _id: 'org-1',
   name: 'Org',
   email: 'org@test.com',
   isOrganizer: true,
+  organizerOrgIds: ['org-test'],
 }
-const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+const mockConference = {
+  _id: 'conf-1',
+  title: 'Test Conf',
+  organization: { _type: 'reference', _ref: 'org-test' },
+}
 
 const tier: SponsorForConferenceExpanded['tier'] = {
   _id: 'tier-gold',

--- a/__tests__/api/trpc/sponsor-health.test.ts
+++ b/__tests__/api/trpc/sponsor-health.test.ts
@@ -15,13 +15,20 @@ vi.mock('@/lib/sanity/client', () => ({
   clientRead: { fetch: vi.fn() },
 }))
 
+// Org-scoped organizer: `organizerOrgIds` must contain the org the request
+// resolves to (below), since that membership is the whole authz decision.
 const mockOrganizer = {
   _id: 'org-1',
   name: 'Org',
   email: 'org@test.com',
   isOrganizer: true,
+  organizerOrgIds: ['org-test'],
 }
-const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+const mockConference = {
+  _id: 'conf-1',
+  title: 'Test Conf',
+  organization: { _type: 'reference', _ref: 'org-test' },
+}
 
 const tier: SponsorForConferenceExpanded['tier'] = {
   _id: 'tier-gold',

--- a/__tests__/api/trpc/sponsor-invoice-status.test.ts
+++ b/__tests__/api/trpc/sponsor-invoice-status.test.ts
@@ -18,11 +18,15 @@ vi.mock('@/lib/sanity/client', () => ({
   clientRead: { fetch: vi.fn() },
 }))
 
+// Org-scoped organizer: `organizerOrgIds` must contain the org the request
+// resolves to (the domain conference's organization), since that membership is
+// the whole authz decision.
 const mockOrganizer = {
   _id: 'org-1',
   name: 'Org',
   email: 'org@test.com',
   isOrganizer: true,
+  organizerOrgIds: ['org-test'],
 }
 
 function makeSfc(
@@ -53,7 +57,10 @@ describe('updateInvoiceStatus mutation', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
-      conference: { _id: 'conf-1' } as any,
+      conference: {
+        _id: 'conf-1',
+        organization: { _type: 'reference', _ref: 'org-test' },
+      } as any,
       domain: 'test.com',
       error: null,
     })

--- a/__tests__/api/trpc/sponsor-move-stage.test.ts
+++ b/__tests__/api/trpc/sponsor-move-stage.test.ts
@@ -17,13 +17,20 @@ vi.mock('@/lib/sponsor-crm/sanity')
 vi.mock('@/lib/sponsor-crm/activity')
 vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
 
+// Org-scoped organizer: `organizerOrgIds` must contain the org the request
+// resolves to (below), since that membership is the whole authz decision.
 const mockOrganizer = {
   _id: 'org-1',
   name: 'Org',
   email: 'org@test.com',
   isOrganizer: true,
+  organizerOrgIds: ['org-test'],
 }
-const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+const mockConference = {
+  _id: 'conf-1',
+  title: 'Test Conf',
+  organization: { _type: 'reference', _ref: 'org-test' },
+}
 
 const tier: SponsorForConferenceExpanded['tier'] = {
   _id: 'tier-gold',

--- a/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
@@ -24,13 +24,20 @@ vi.mock('@/lib/sanity/client', () => ({
   clientRead: { fetch: vi.fn() },
 }))
 
+// Org-scoped organizer: `organizerOrgIds` must contain the org the request
+// resolves to (below), since that membership is the whole authz decision.
 const mockOrganizer = {
   _id: 'org-1',
   name: 'Org',
   email: 'org@test.com',
   isOrganizer: true,
+  organizerOrgIds: ['org-test'],
 }
-const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+const mockConference = {
+  _id: 'conf-1',
+  title: 'Test Conf',
+  organization: { _type: 'reference', _ref: 'org-test' },
+}
 
 const tier: SponsorForConferenceExpanded['tier'] = {
   _id: 'tier-gold',

--- a/__tests__/api/trpc/sponsor-stage-notification.test.ts
+++ b/__tests__/api/trpc/sponsor-stage-notification.test.ts
@@ -27,13 +27,20 @@ vi.mock('@/lib/sponsor-crm/activity')
 vi.mock('@/lib/notification/sanity')
 vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
 
+// Org-scoped organizer: `organizerOrgIds` must contain the org the request
+// resolves to (below), since that membership is the whole authz decision.
 const mockOrganizer = {
   _id: 'actor-1',
   name: 'Acting Organizer',
   email: 'org@test.com',
   isOrganizer: true,
+  organizerOrgIds: ['org-test'],
 }
-const mockConference = { _id: 'conf-1', title: 'Test Conf' }
+const mockConference = {
+  _id: 'conf-1',
+  title: 'Test Conf',
+  organization: { _type: 'reference', _ref: 'org-test' },
+}
 
 function makeSfc(
   overrides: Partial<SponsorForConferenceExpanded> = {},

--- a/__tests__/api/trpc/travel-support-notification.test.ts
+++ b/__tests__/api/trpc/travel-support-notification.test.ts
@@ -30,12 +30,26 @@ vi.mock('@/lib/travel-support/sanity')
 vi.mock('@/lib/travel-support/auth')
 vi.mock('@/lib/notification/sanity')
 vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
+// The admin procedures resolve the request's org from the domain conference and
+// only grant organizer when the session speaker organizes THAT org.
+vi.mock('@/lib/conference/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getConferenceForCurrentDomain: async () => ({
+    conference: {
+      _id: 'conf-1',
+      organization: { _type: 'reference', _ref: 'org-test' },
+    },
+    domain: 'localhost',
+    error: null,
+  }),
+}))
 
 const actor = {
   _id: 'actor-1',
   name: 'Acting Organizer',
   email: 'org@test.com',
   isOrganizer: true,
+  organizerOrgIds: ['org-test'],
 }
 
 const bankingDetails = {

--- a/__tests__/api/trpc/volunteer.test.ts
+++ b/__tests__/api/trpc/volunteer.test.ts
@@ -40,6 +40,7 @@ import {
   createAuthenticatedCaller,
   createAdminCaller,
   speakers,
+  TEST_ORG_ID,
 } from '../../helpers/trpc'
 import { createVolunteer, getVolunteerById } from '@/lib/volunteer/sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
@@ -54,6 +55,10 @@ const mockConference = {
   title: 'Cloud Native Day 2026',
   domains: ['localhost'],
   contactEmail: 'info@test.com',
+  // Org-scoped authz derives the REQUEST's org from this conference and grants
+  // only when the caller's `organizerOrgIds` contains it, so the domain
+  // conference must belong to the fixture organizer's org.
+  organization: { _type: 'reference', _ref: TEST_ORG_ID },
 }
 
 const validVolunteerInput = {

--- a/__tests__/api/trpc/workshop.test.ts
+++ b/__tests__/api/trpc/workshop.test.ts
@@ -31,6 +31,10 @@ vi.mock('@/lib/conference/sanity', () => ({
     conference: {
       _id: 'conf-1',
       title: 'CNDN',
+      // The admin waist derives the REQUEST's org from this conference and grants
+      // only when the caller's `organizerOrgIds` contains it — so the domain
+      // conference must point at the fixture organizer's org (TEST_ORG_ID).
+      organization: { _type: 'reference', _ref: 'org-test' },
       workshopRegistrationStart: null,
       workshopRegistrationEnd: null,
     },

--- a/__tests__/app/admin/myAreas.test.ts
+++ b/__tests__/app/admin/myAreas.test.ts
@@ -5,6 +5,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const getAuthSession = vi.fn()
 vi.mock('@/lib/auth', () => ({ getAuthSession: () => getAuthSession() }))
 
+// `requireOrganizer` is ORG-SCOPED: it derives the REQUEST's org from the domain
+// conference and requires the viewer's `organizerOrgIds` to contain it.
+vi.mock('@/lib/organization/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getOrganizationRefForCurrentConference: async () => 'org-test',
+}))
+
 const getConferenceTeams = vi.fn()
 vi.mock('@/lib/teams', () => ({
   getConferenceTeams: (id: string) => getConferenceTeams(id),
@@ -39,7 +46,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   resolveConferenceId.mockResolvedValue('conf-1')
   getAuthSession.mockResolvedValue({
-    speaker: { _id: 'org-1', isOrganizer: true },
+    speaker: { _id: 'org-1', isOrganizer: true, organizerOrgIds: ['org-test'] },
   })
   getConversationViewCounts.mockResolvedValue({
     active: 0,

--- a/__tests__/helpers/trpc.ts
+++ b/__tests__/helpers/trpc.ts
@@ -1,7 +1,12 @@
 import { initTRPC } from '@trpc/server'
 import type { Context } from '@/server/trpc'
 import { appRouter } from '@/server/_app'
-import speakers from '../testdata/speakers'
+import allSpeakers, { TEST_ORG_ID } from '../testdata/speakers'
+
+/** Re-exported as an OWN binding: a bare `export { … }` of a default import
+ * resolves to `undefined` in test files that mock a module with
+ * `importOriginal`, which re-enters this graph. */
+export const speakers = allSpeakers
 
 const t = initTRPC.context<Context>().create()
 const createCaller = t.createCallerFactory(appRouter)
@@ -47,6 +52,21 @@ export function createWorkshopCaller(
   })
 }
 
+/**
+ * The session-speaker claims the org-scoped authz waist reads. `organizerOrgIds`
+ * is what actually decides access — it must be carried, and the test file must
+ * make the request's org resolve to {@link TEST_ORG_ID} by mocking
+ * `getConferenceForCurrentDomain`. `isOrganizer` is the deprecated global flag,
+ * kept only because non-authz code still reads it.
+ */
+function sessionSpeakerFor(speaker: (typeof speakers)[number]) {
+  return {
+    _id: speaker._id!,
+    isOrganizer: speaker.isOrganizer === true,
+    organizerOrgIds: speaker.organizerOrgIds ?? [],
+  }
+}
+
 export function createAuthenticatedCaller(speakerId?: string) {
   const speaker = speakers.find((s) => s._id === speakerId) ?? speakers[0]
   return createCaller({
@@ -58,15 +78,9 @@ export function createAuthenticatedCaller(speakerId?: string) {
         name: speaker.name!,
         picture: 'https://example.com/avatar.jpg',
       },
-      speaker: {
-        _id: speaker._id!,
-        isOrganizer: speaker.isOrganizer === true,
-      },
+      speaker: sessionSpeakerFor(speaker),
     },
-    speaker: {
-      _id: speaker._id!,
-      isOrganizer: speaker.isOrganizer === true,
-    },
+    speaker: sessionSpeakerFor(speaker),
     user: {
       email: speaker.email!,
       name: speaker.name!,
@@ -82,4 +96,4 @@ export function createAdminCaller() {
   return createAuthenticatedCaller(admin._id)
 }
 
-export { speakers }
+export { TEST_ORG_ID }

--- a/__tests__/lib/dashboard/actions.test.ts
+++ b/__tests__/lib/dashboard/actions.test.ts
@@ -149,6 +149,15 @@ vi.mock('@/lib/conference/sanity', () => ({
     mockGetConferenceForCurrentDomain(...args),
 }))
 
+// Org resolution — `requireOrganizer` is ORG-SCOPED: it grants only when the
+// session speaker's `organizerOrgIds` contains the org the REQUEST resolves to
+// (`isOrganizerForCurrentOrg` → `getOrganizationRefForCurrentConference`), so
+// the request org has to be pinned to the one the session below carries.
+vi.mock('@/lib/organization/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getOrganizationRefForCurrentConference: async () => 'org-test',
+}))
+
 // Time utilities
 vi.mock('@/lib/time', () => ({
   formatRelativeTime: vi.fn((d: string) => d || 'unknown'),
@@ -268,7 +277,13 @@ describe('Dashboard Server Actions', () => {
     mockGetAuthSession.mockResolvedValue({
       user: { name: 'Admin', email: 'admin@test.com' },
       expires: '2099-01-01T00:00:00Z',
-      speaker: { _id: 'speaker-1', isOrganizer: true },
+      // `organizerOrgIds` — not the deprecated global `isOrganizer` flag — is
+      // what grants; it must contain the request's resolved org.
+      speaker: {
+        _id: 'speaker-1',
+        isOrganizer: true,
+        organizerOrgIds: ['org-test'],
+      },
     })
   })
 
@@ -1113,7 +1128,12 @@ describe('Dashboard Server Actions', () => {
         mockGetAuthSession.mockResolvedValue({
           user: { name: 'User', email: 'user@test.com' },
           expires: '2099-01-01T00:00:00Z',
-          speaker: { _id: 'speaker-1', isOrganizer: false },
+          // Organizes no org at all, so the request's org is not in the set.
+          speaker: {
+            _id: 'speaker-1',
+            isOrganizer: false,
+            organizerOrgIds: [],
+          },
         })
 
         await expect(loadDashboardConfig()).rejects.toThrow(/Unauthorized/)
@@ -1283,7 +1303,12 @@ describe('Dashboard Server Actions', () => {
         mockGetAuthSession.mockResolvedValue({
           user: { name: 'User', email: 'user@test.com' },
           expires: '2099-01-01T00:00:00Z',
-          speaker: { _id: 'speaker-1', isOrganizer: false },
+          // Organizes no org at all, so the request's org is not in the set.
+          speaker: {
+            _id: 'speaker-1',
+            isOrganizer: false,
+            organizerOrgIds: [],
+          },
         })
 
         await expect(saveDashboardConfig([validWidget()])).rejects.toThrow(

--- a/__tests__/lib/messaging/party-model.test.ts
+++ b/__tests__/lib/messaging/party-model.test.ts
@@ -259,9 +259,15 @@ describe('READ FLIP (G2a): resolveParticipantIds / resolveRecipients / canAccess
             canAccessConversation(shape.legacy, speaker),
           )
         }
-        // An organizer always has access (short-circuits before party membership).
+        // An organizer OF THE THREAD'S OWN ORG always has access (short-circuits
+        // before party membership). Organizer access is ORG-SCOPED (#642): it
+        // keys on the conversation's `conferenceOrgId` against the caller's
+        // `organizerOrgIds`, so both sides need the owning org.
         expect(
-          canAccessConversation(dualWritten, { _id: 'o-x', isOrganizer: true }),
+          canAccessConversation(
+            { ...dualWritten, conferenceOrgId: 'org-test' },
+            { _id: 'o-x', organizerOrgIds: ['org-test'] },
+          ),
         ).toBe(true)
       })
     })

--- a/__tests__/lib/messaging/sanity.test.ts
+++ b/__tests__/lib/messaging/sanity.test.ts
@@ -70,6 +70,8 @@ function installTransaction(commit: () => Promise<unknown> = async () => ({})) {
 const proposalConv: ConversationWithContext = {
   _id: 'conversation.proposal.prop-1',
   conferenceId: 'conf-1',
+  // Organizer access is ORG-SCOPED: it keys on the thread's OWN org.
+  conferenceOrgId: 'org-test',
   conversationType: 'proposal',
   proposalId: 'prop-1',
   proposalTitle: 'My Talk',
@@ -83,6 +85,7 @@ const proposalConv: ConversationWithContext = {
 const generalConv: ConversationWithContext = {
   _id: 'conversation.gen-1',
   conferenceId: 'conf-1',
+  conferenceOrgId: 'org-test',
   conversationType: 'general',
   proposalSpeakerIds: [],
   createdById: 'sp-9',
@@ -170,13 +173,10 @@ describe('resolveRecipients — excludes the actor', () => {
 })
 
 describe('canAccessConversation — authz matrix', () => {
-  it('any organizer can access any conversation', () => {
-    expect(
-      canAccessConversation(proposalConv, { _id: 'x', isOrganizer: true }),
-    ).toBe(true)
-    expect(
-      canAccessConversation(generalConv, { _id: 'x', isOrganizer: true }),
-    ).toBe(true)
+  it('an organizer of the owning org can access that org conversations', () => {
+    const orgAdmin = { _id: 'x', organizerOrgIds: ['org-test'] }
+    expect(canAccessConversation(proposalConv, orgAdmin)).toBe(true)
+    expect(canAccessConversation(generalConv, orgAdmin)).toBe(true)
   })
   it('a proposal-speaker can access their proposal thread; a stranger cannot', () => {
     expect(canAccessConversation(proposalConv, { _id: 'sp-2' })).toBe(true)

--- a/__tests__/testdata/speakers.ts
+++ b/__tests__/testdata/speakers.ts
@@ -1,5 +1,14 @@
 import { Flags, Speaker } from '@/lib/speaker/types'
 
+/**
+ * The organization every shared fixture belongs to. Org-scoped authz keys on
+ * `organizerOrgIds` ALONE — both bridges to the deprecated global `isOrganizer`
+ * flag are gone — so an organizer fixture must carry this id AND the test's
+ * domain-resolved conference must resolve to it (see `__tests__/helpers/trpc.ts`,
+ * which mocks the domain conference onto this org).
+ */
+export const TEST_ORG_ID = 'org-test'
+
 const speakers: Speaker[] = [
   {
     _id: '92a2ad7c-d831-48e2-aff1-ff81f9561388',
@@ -27,6 +36,10 @@ const speakers: Speaker[] = [
     slug: 'jane-doe',
     flags: [Flags.diverseSpeaker, Flags.requiresTravelFunding],
     isOrganizer: true,
+    // The org-scoped capability the authz waist actually reads. `isOrganizer`
+    // above is the deprecated global flag, kept for the non-authz code (badge
+    // sorting, recipient selection) that still reads it.
+    organizerOrgIds: [TEST_ORG_ID],
     // No image field - should use MissingAvatar
   },
 ] as Speaker[]

--- a/__tests__/testdata/speakers.ts
+++ b/__tests__/testdata/speakers.ts
@@ -3,9 +3,12 @@ import { Flags, Speaker } from '@/lib/speaker/types'
 /**
  * The organization every shared fixture belongs to. Org-scoped authz keys on
  * `organizerOrgIds` ALONE — both bridges to the deprecated global `isOrganizer`
- * flag are gone — so an organizer fixture must carry this id AND the test's
- * domain-resolved conference must resolve to it (see `__tests__/helpers/trpc.ts`,
- * which mocks the domain conference onto this org).
+ * flag are gone — so an organizer fixture must carry this id AND the test file
+ * must make the request's DOMAIN CONFERENCE resolve to it, by mocking
+ * `getConferenceForCurrentDomain` (`@/lib/conference/sanity`, the tRPC waist) or
+ * `getOrganizationRefForCurrentConference` (`@/lib/organization/sanity`, the
+ * handler/server-action gates). `vi.mock` factories are hoisted above imports, so
+ * inline the literal there rather than referencing this constant.
  */
 export const TEST_ORG_ID = 'org-test'
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -283,7 +283,7 @@ global `isOrganizer` flag once softened it; both are now gone:
 - **Org UNRESOLVABLE (`orgId === null`) &mdash; FAILS CLOSED.** The 044 backfill has
   run (every live conference has an `organization`), so an unresolvable org is now
   an unknown domain / transient failure rather than pre-backfill data. It **denies**
-  (a `console.warn('[authz-bridge] …')` records the denial of a caller who
+  (a `console.warn('[authz-deny] …')` records the denial of a caller who
   organizes at least one org, so the failure mode stays observable).
 - **Legacy TOKEN (no `organizerOrgIds` field) &mdash; REMOVED.** Tokens minted before
   #635 lack the field, and the bridge deferred wholesale to the global flag. That

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -202,8 +202,8 @@ The encrypted JWT contains:
     name: string
     email: string
     image: string       // Sanity image reference
-    isOrganizer: boolean  // DEPRECATED global flag; kept only as the authz
-                          // legacy-TOKEN bridge (see "Authorization bridge" below)
+    isOrganizer: boolean  // DEPRECATED global flag; NO LONGER used for authz
+                          // (see "Authorization bridges" below) — UI reads only
     organizerOrgIds: string[] // Org-SCOPED organizer capability (#614/#635):
                           // deduped organization refs the speaker organizes.
                           // The org-scoped authz waist gates on this.
@@ -274,34 +274,37 @@ which supports both cookie-based and Bearer token authentication.
 All admin operations previously protected by REST middleware are now handled by
 `adminProcedure` in tRPC routers.
 
-#### Authorization bridge (org-scoped, sunset)
+#### Authorization bridges (org-scoped) &mdash; both REMOVED
 
 Org-scoped organizer authz (`isOrganizerForOrg`, #614/#635) gates on the JWT's
-`organizerOrgIds`. Two migration bridges to the deprecated global `isOrganizer`
-flag once softened it; their status now:
+`organizerOrgIds` and **nothing else**. Two migration bridges to the deprecated
+global `isOrganizer` flag once softened it; both are now gone:
 
 - **Org UNRESOLVABLE (`orgId === null`) &mdash; FAILS CLOSED.** The 044 backfill has
   run (every live conference has an `organization`), so an unresolvable org is now
   an unknown domain / transient failure rather than pre-backfill data. It **denies**
-  (a `console.warn('[authz-bridge] …')` records a would-be organizer's denial).
-- **Legacy TOKEN (no `organizerOrgIds` field) &mdash; KEPT, SUNSET.** Tokens minted
-  before #635 lack the field; denying them would 403 every logged-in organizer
-  until their token expires (**session `maxAge` = 30 days**, the next-auth default —
-  no explicit `maxAge` is set) or they re-login. This bridge still grants via the
-  global flag. It is dated for removal: `TODO(sunset 2026-08-26)` (30 days after
-  #635).
+  (a `console.warn('[authz-bridge] …')` records the denial of a caller who
+  organizes at least one org, so the failure mode stays observable).
+- **Legacy TOKEN (no `organizerOrgIds` field) &mdash; REMOVED.** Tokens minted before
+  #635 lack the field, and the bridge deferred wholesale to the global flag. That
+  flag is true for an organizer of **any** org, so a legacy token granted organizer
+  on **any host** &mdash; a cross-tenant grant. It now **denies**: a holder of a
+  pre-#635 token is an ordinary non-organizer until they sign in again, or until
+  the `trigger === 'update'` session refresh (above) re-mints a modern token
+  carrying `organizerOrgIds`.
 
-**Bridge-removal condition.** Once every pre-#635 token has expired, delete the
-legacy-token bridge so a missing `organizerOrgIds` denies. The
-`trigger === 'update'` session refresh (above) is the mechanism by which any active
-session re-mints a modern token carrying `organizerOrgIds` before then; the two
-changes together complete the removal.
+The deprecated `isOrganizer` claim is still minted into the token and read by UI
+and by non-authz code (badge sorting, messaging recipient selection), but it no
+longer participates in any authorization decision.
 
 ### Test Mode
 
 When `NODE_ENV === 'development'` and `NEXT_PUBLIC_ENABLE_TEST_MODE === 'true'`,
 `getAuthSession()` returns a mock session via `AppEnvironment.createMockAuthContext()`.
-The mock session has `isOrganizer: true` for full access during development.
+The mock session has `isOrganizer: true`, and `getAuthSession()` additionally
+stamps its `organizerOrgIds` with the **current domain's** org so it gets
+organizer access under the org-scoped model. If that org cannot be resolved the
+mock session is denied organizer access like any other caller (fail closed).
 
 Test mode can also be activated per-request with `?test=true` on protected routes.
 

--- a/docs/ORGANIZATION_TIER.md
+++ b/docs/ORGANIZATION_TIER.md
@@ -153,22 +153,21 @@ org-scoped rather than a single global boolean.
   **domain-resolved conference** (`conference.organization._ref`), never from
   client input, and access requires that org id to be in `organizerOrgIds`.
 
-The old `isOrganizer` boolean is **kept in the token, marked deprecated**, purely
-as a **legacy bridge**: the middleware and gates fall back to it (with a
-`console.warn('[authz-bridge] …')`) **only** when the request's org cannot be
-resolved (a pre-`044`-backfill conference, or an unknown domain). Because the
-`044` backfill has run, this bridge is rarely exercised in production; it exists
-so any residual org-less data or an old token cannot lock organizers out during
-rollout.
+The old `isOrganizer` boolean is **kept in the token, marked deprecated**, but it
+**no longer takes part in authorization**. The two migration bridges that once
+fell back to it are both deleted: an **unresolvable** request org now denies
+(with a `console.warn('[authz-bridge] …')` when the denied caller organizes at
+least one org), and a **legacy token** with no `organizerOrgIds` claim denies too
+— bridging that granted organizer on **any host**, because the global flag is
+true for an organizer of any org. Holders of a pre-#635 token re-login once.
 
-**Removal condition** (shared with `src/lib/authz/organizer.ts` and
-`docs/TRPC_SERVER_ARCHITECTURE.md`): once every live conference has an
-`organization` and every issued token carries `organizerOrgIds`, delete the
-bridge so an unresolvable org **denies**, and drop the deprecated `isOrganizer`
-field and its remaining UI reads.
+**Remaining cleanup**: drop the deprecated `isOrganizer` field and its remaining
+UI / recipient-selection reads (see `src/lib/messaging/standing.ts` and
+`src/lib/notification/sanity.ts`, which still hold their own org-unresolvable
+fallbacks for recipient selection — not access).
 
 Key modules: `src/lib/authz/organizer.ts` (the shared `isOrganizerForOrg` /
-`isOrganizerForCurrentOrg` helpers + bridge), `src/server/trpc.ts`
+`isOrganizerForCurrentOrg` helpers), `src/server/trpc.ts`
 (`requireAdmin` waist + `resolveOrganizationId`), `src/lib/speaker/sanity.ts`
 (`ORGANIZER_ORG_IDS_FIELD` projection). Recipient-selection helpers
 (`getOrganizerSpeakerIds`, `getOrganizers`) are **org-scoped too** — they select

--- a/docs/ORGANIZATION_TIER.md
+++ b/docs/ORGANIZATION_TIER.md
@@ -156,7 +156,7 @@ org-scoped rather than a single global boolean.
 The old `isOrganizer` boolean is **kept in the token, marked deprecated**, but it
 **no longer takes part in authorization**. The two migration bridges that once
 fell back to it are both deleted: an **unresolvable** request org now denies
-(with a `console.warn('[authz-bridge] …')` when the denied caller organizes at
+(with a `console.warn('[authz-deny] …')` when the denied caller organizes at
 least one org), and a **legacy token** with no `organizerOrgIds` claim denies too
 — bridging that granted organizer on **any host**, because the global flag is
 true for an organizer of any org. Holders of a pre-#635 token re-login once.

--- a/docs/TRPC_SERVER_ARCHITECTURE.md
+++ b/docs/TRPC_SERVER_ARCHITECTURE.md
@@ -311,26 +311,26 @@ requires `organizerOrgIds` to include that org id (`isOrganizerForOrg` in
 `src/lib/authz/organizer.ts`). It **fails closed**: a resolvable org whose id is
 not in the caller's set is denied (`FORBIDDEN`), including a cross-org organizer.
 
-**The legacy bridge.** When the request's org **cannot** be resolved
-(pre-`044`-backfill conference without an `organization`, or an unknown domain),
-the check falls back to the **deprecated global** `speaker.isOrganizer` boolean
-(organizer of _any_ conference) and emits a `console.warn('[authz-bridge] …')`.
-This is a deliberate, temporary migration bridge so the org tier can roll out
-without locking legitimate organizers out; a resolution _throw_ also maps to the
-bridge rather than erroring the waist.
+**The legacy bridges are GONE.** Both fallbacks to the **deprecated global**
+`speaker.isOrganizer` boolean (organizer of _any_ conference) have been removed:
 
-**Removal condition.** Delete the bridge (make an unresolvable org **deny**) once
-every live conference has an `organization` **and** every issued token carries
-`organizerOrgIds` (all pre-#614 tokens expired / all users re-logged-in). At that
-point `resolveOrganizationId() === null` should produce `FORBIDDEN`, and the
-deprecated `isOrganizer` field (plus its UI reads) can be removed.
+- an **unresolvable** request org (unknown domain, or a resolution throw) now
+  **denies** (`FORBIDDEN`), emitting a `console.warn('[authz-bridge] …')` when the
+  denied caller organizes at least one org, so the failure mode stays observable;
+- a **legacy token** minted before #635 (no `organizerOrgIds` claim at all) now
+  **denies** too. Deferring to the global flag there granted organizer rights on
+  **any host**, since that flag is not org-scoped. Holders re-login (or hit the
+  `trigger === 'update'` session refresh) to get a modern token.
+
+The deprecated `isOrganizer` field is still minted and read by UI/non-authz code,
+but takes no part in any authorization decision.
 
 **Shared gates.** Handler/layout/route-handler gates that previously read
 `session.speaker.isOrganizer` (the `(admin)` layout, admin server actions'
 `requireOrganizer`, the `/launch` dispatcher, the `speaker-image` / `gallery` /
 upload API routes, the `(cfp)` organizer-view pages, and the
 dev-only impersonation gate in `src/lib/auth.ts`) all go through the **same**
-`isOrganizerForOrg` / `isOrganizerForCurrentOrg` helpers with the **same** bridge.
+`isOrganizerForOrg` / `isOrganizerForCurrentOrg` helpers.
 UI components still read the deprecated `isOrganizer` boolean this wave (a
 follow-up rewrites them).
 

--- a/docs/TRPC_SERVER_ARCHITECTURE.md
+++ b/docs/TRPC_SERVER_ARCHITECTURE.md
@@ -315,7 +315,7 @@ not in the caller's set is denied (`FORBIDDEN`), including a cross-org organizer
 `speaker.isOrganizer` boolean (organizer of _any_ conference) have been removed:
 
 - an **unresolvable** request org (unknown domain, or a resolution throw) now
-  **denies** (`FORBIDDEN`), emitting a `console.warn('[authz-bridge] …')` when the
+  **denies** (`FORBIDDEN`), emitting a `console.warn('[authz-deny] …')` when the
   denied caller organizes at least one org, so the failure mode stays observable;
 - a **legacy token** minted before #635 (no `organizerOrgIds` claim at all) now
   **denies** too. Deferring to the global flag there granted organizer rights on

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jsonld-signatures": "^11.6.0",
     "nanoid": "^5.1.16",
     "next": "^16.2.9",
-    "next-auth": "5.0.0-beta.31",
+    "next-auth": "5.0.0-beta.32",
     "next-sanity": "^13.1.1",
     "next-themes": "^0.4.6",
     "pdf-lib": "^1.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: ^16.2.9
         version: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-auth:
-        specifier: 5.0.0-beta.31
-        version: 5.0.0-beta.31(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        specifier: 5.0.0-beta.32
+        version: 5.0.0-beta.32(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       next-sanity:
         specifier: ^13.1.1
         version: 13.1.1(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.22.1)(@sanity/types@5.31.1(@types/react@19.2.15))(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-is@19.2.7)(react@19.2.6)(sanity@5.31.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@sanity/cli-core@1.3.4(@noble/hashes@2.2.0)(@types/node@25.9.1)(lightningcss@1.32.0)(yaml@2.9.0))(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(styled-components@6.4.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3))(styled-components@6.4.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
@@ -416,12 +416,12 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
-  '@auth/core@0.41.2':
-    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+  '@auth/core@0.41.3':
+    resolution: {integrity: sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
-      nodemailer: ^7.0.7
+      nodemailer: ^7.0.7 || ^8.0.5
     peerDependenciesMeta:
       '@simplewebauthn/browser':
         optional: true
@@ -8527,13 +8527,13 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  next-auth@5.0.0-beta.31:
-    resolution: {integrity: sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==}
+  next-auth@5.0.0-beta.32:
+    resolution: {integrity: sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
       next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
-      nodemailer: ^7.0.7
+      nodemailer: ^7.0.7 || ^8.0.5
       react: ^18.2.0 || ^19.0.0
     peerDependenciesMeta:
       '@simplewebauthn/browser':
@@ -11212,7 +11212,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@auth/core@0.41.2':
+  '@auth/core@0.41.3':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.2.3
@@ -20099,9 +20099,9 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-auth@5.0.0-beta.31(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  next-auth@5.0.0-beta.32(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@auth/core': 0.41.2
+      '@auth/core': 0.41.3
       next: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 

--- a/src/app/(admin)/admin/actions.ts
+++ b/src/app/(admin)/admin/actions.ts
@@ -59,8 +59,8 @@ import { resolveConferenceId } from '@/server/trpc'
 
 async function requireOrganizer(): Promise<void> {
   const session = await getAuthSession()
-  // ORG-SCOPED (CaaS T1-2, #614): organizer of the CURRENT domain's org, with the
-  // authz legacy bridge for unresolvable orgs.
+  // ORG-SCOPED (CaaS T1-2, #614): organizer of the CURRENT domain's org. No
+  // bridges — an unresolvable org, or a token without `organizerOrgIds`, denies.
   if (!(await isOrganizerForCurrentOrg(session?.speaker))) {
     throw new Error('Unauthorized: organizer access required')
   }

--- a/src/app/launch/route.test.ts
+++ b/src/app/launch/route.test.ts
@@ -6,6 +6,14 @@ vi.mock('@/lib/auth', () => ({
   getAuthSession: (...args: unknown[]) => getAuthSessionMock(...args),
 }))
 
+// `isOrganizerForCurrentOrg` derives the REQUEST's org from the domain
+// conference; the /admin branch only fires when the caller's `organizerOrgIds`
+// contains it, so pin the resolved org here.
+vi.mock('@/lib/organization/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getOrganizationRefForCurrentConference: async () => 'org-test',
+}))
+
 import { GET } from './route'
 
 const LAUNCH_URL = 'https://cloudnativebergen.dev/launch'
@@ -22,15 +30,42 @@ describe('/launch — role-aware PWA start page', () => {
     vi.clearAllMocks()
   })
 
-  it('redirects an organizer to /admin', async () => {
+  it('redirects an organizer OF THE CURRENT ORG to /admin', async () => {
     getAuthSessionMock.mockResolvedValue({
-      speaker: { _id: 'spk-org', isOrganizer: true },
+      speaker: {
+        _id: 'spk-org',
+        isOrganizer: true,
+        organizerOrgIds: ['org-test'],
+      },
     })
 
     const response = await GET(new Request(LAUNCH_URL))
 
     expect(response.status).toBe(307)
     expect(locationOf(response)).toBe('/admin')
+  })
+
+  it('sends a legacy token (global flag, no organizerOrgIds) to /cfp/list', async () => {
+    // The bridge to the deprecated GLOBAL `isOrganizer` is gone: it would have
+    // sent an organizer of ANY org to THIS tenant's /admin. Such a holder is an
+    // ordinary speaker until they sign in again.
+    getAuthSessionMock.mockResolvedValue({
+      speaker: { _id: 'spk-legacy', isOrganizer: true },
+    })
+
+    const response = await GET(new Request(LAUNCH_URL))
+
+    expect(locationOf(response)).toBe('/cfp/list')
+  })
+
+  it('sends an organizer of ANOTHER org to /cfp/list (cross-tenant denial)', async () => {
+    getAuthSessionMock.mockResolvedValue({
+      speaker: { _id: 'spk-other', organizerOrgIds: ['org-other'] },
+    })
+
+    const response = await GET(new Request(LAUNCH_URL))
+
+    expect(locationOf(response)).toBe('/cfp/list')
   })
 
   it('redirects a signed-in non-organizer speaker to /cfp/list', async () => {

--- a/src/app/launch/route.ts
+++ b/src/app/launch/route.ts
@@ -7,12 +7,12 @@ import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
  *
  * The installed app opens here on every fresh launch. This handler renders NO
  * UI: it resolves the signed-in speaker server-side (the SAME source the
- * `/admin` layout trusts — `getAuthSession()` → `session.speaker.isOrganizer`)
+ * `/admin` layout trusts — `getAuthSession()` → `isOrganizerForCurrentOrg()`)
  * and issues a per-request 307 redirect to the right home:
  *
- *   - organizer (`session.speaker.isOrganizer === true`)  → `/admin`
- *   - signed-in speaker (has session, not organizer)      → `/cfp/list`
- *   - no session (attendee / logged out)                  → `/program`
+ *   - organizer OF THE CURRENT DOMAIN'S ORG                → `/admin`
+ *   - signed-in speaker (has session, not organizer)       → `/cfp/list`
+ *   - no session (attendee / logged out)                   → `/program`
  *
  * The logged-out branch MUST land on the PUBLIC program page — never a login
  * wall. `/program` is the attendee home.
@@ -44,8 +44,9 @@ export async function GET(request: Request): Promise<NextResponse> {
   })
 
   // ORG-SCOPED (CaaS T1-2, #614): send to /admin only when the caller is an
-  // organizer of the CURRENT domain's organization (falls back to the deprecated
-  // global flag via the authz legacy bridge when the org can't be resolved).
+  // organizer of the CURRENT domain's organization. Fails closed — an
+  // unresolvable org, or a legacy token without `organizerOrgIds`, lands on
+  // `/cfp/list` rather than `/admin`.
   let target: string
   if (await isOrganizerForCurrentOrg(session?.speaker)) {
     target = '/admin'

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -679,7 +679,17 @@ export async function getAuthSession(req?: {
   headers?: Headers
 }): Promise<Session | null> {
   if (AppEnvironment.isTestMode) {
-    return AppEnvironment.createMockAuthContext()
+    const mock = AppEnvironment.createMockAuthContext()
+    // DEV-ONLY. The mock speaker used to reach `/admin` through the deprecated
+    // global `isOrganizer` flag, via the (now deleted) legacy-token bridge.
+    // Authorization is org-scoped, so stamp it with the CURRENT domain's org
+    // instead. Best-effort: an unresolvable org leaves `organizerOrgIds` empty
+    // and the mock session is denied organizer access — fail closed, same as any
+    // other caller.
+    const { resolveCurrentOrgId } = await import('@/lib/authz/organizer')
+    const orgId = await resolveCurrentOrgId()
+    if (mock.speaker) mock.speaker.organizerOrgIds = orgId ? [orgId] : []
+    return mock
   }
 
   const session = await _auth()
@@ -703,8 +713,9 @@ export async function getAuthSession(req?: {
   }
 
   // SECURITY: Only organizers can impersonate — ORG-SCOPED (CaaS T1-2, #614): the
-  // impersonator must be an organizer of the CURRENT domain's org (legacy-bridged
-  // to the deprecated global flag when the org can't be resolved). Dynamically
+  // impersonator must be an organizer of the CURRENT domain's org, decided from
+  // `organizerOrgIds` alone (no bridge to the deprecated global flag; an
+  // unresolvable org denies). Dynamically
   // imported to keep the org/conference read out of the edge middleware bundle,
   // mirroring the `getSpeaker` import below.
   const { isOrganizerForCurrentOrg } = await import('@/lib/authz/organizer')

--- a/src/lib/authz/organizer.test.ts
+++ b/src/lib/authz/organizer.test.ts
@@ -5,9 +5,10 @@
  * #614). This is THE security boundary the middleware waist and every gate share,
  * so we pin: an org member passes; an organizer of ANOTHER org is denied;
  * fail-closed when the org resolves but the caller is not a member; org
- * UNRESOLVABLE now FAILS CLOSED (bridge (1) removed post-044-backfill, with a warn
- * on a would-be organizer's denial); and the remaining legacy-TOKEN bridge
- * (bridge (2), no `organizerOrgIds` field → deprecated global flag) still grants.
+ * UNRESOLVABLE FAILS CLOSED (with a warn on a real organizer's denial); and — the
+ * point of the bridge removal — a LEGACY TOKEN (no `organizerOrgIds` field) is
+ * denied on EVERY host even with the deprecated global `isOrganizer` flag set,
+ * because that flag is global and would otherwise grant cross-tenant.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
@@ -58,8 +59,8 @@ describe('isOrganizerForOrg — pure org-scoped decision', () => {
   })
 
   it('FAILS CLOSED when the org resolves but the speaker is not a member', () => {
-    // A globally-flagged organizer with NO org membership is still denied for a
-    // resolvable org — the bridge only applies when the org is unresolvable.
+    // A globally-flagged organizer with NO org membership is denied: the global
+    // flag no longer participates in the decision at all.
     expect(
       isOrganizerForOrg(
         speaker({ organizerOrgIds: [], isOrganizer: true }),
@@ -73,16 +74,31 @@ describe('isOrganizerForOrg — pure org-scoped decision', () => {
     expect(isOrganizerForOrg(undefined, null)).toBe(false)
   })
 
-  describe('legacy-token bridge (organizerOrgIds absent)', () => {
-    it('GRANTS a pre-#614 token (no organizerOrgIds field) via the global flag and WARNS', () => {
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  describe('legacy token (organizerOrgIds ABSENT) — bridge REMOVED', () => {
+    // The deleted bridge deferred wholesale to the deprecated GLOBAL
+    // `isOrganizer` flag, which is true for an organizer of ANY org — so a
+    // pre-#635 token granted organizer on EVERY host. These pin that it cannot.
+    const HOSTS = ['org-a', 'org-b', 'org-cnb', 'org-platform']
+
+    it.each(HOSTS)(
+      'DENIES a pre-#635 token with isOrganizer: true on host org %s',
+      (orgId) => {
+        expect(
+          isOrganizerForOrg({ _id: 'sp-1', isOrganizer: true } as never, orgId),
+        ).toBe(false)
+      },
+    )
+
+    it('DENIES a pre-#635 token with isOrganizer: true when the org is unresolvable', () => {
       expect(
-        isOrganizerForOrg({ _id: 'sp-1', isOrganizer: true } as never, 'org-a'),
-      ).toBe(true)
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('legacy token without organizerOrgIds'),
-      )
-      warn.mockRestore()
+        isOrganizerForOrg({ _id: 'sp-1', isOrganizer: true } as never, null),
+      ).toBe(false)
+    })
+
+    it('does NOT log the removed legacy-token grant', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      isOrganizerForOrg({ _id: 'sp-1', isOrganizer: true } as never, 'org-a')
+      expect(warn).not.toHaveBeenCalled()
     })
 
     it('DENIES a present-but-EMPTY organizerOrgIds (organizer of no org)', () => {
@@ -104,12 +120,12 @@ describe('isOrganizerForOrg — pure org-scoped decision', () => {
     })
   })
 
-  describe('org unresolvable (orgId === null) — bridge (1) removed, FAILS CLOSED', () => {
-    it('DENIES a would-be organizer (global flag set) and WARNS on the denial', () => {
+  describe('org unresolvable (orgId === null) — FAILS CLOSED', () => {
+    it('DENIES a real organizer (member of some org) and WARNS on the denial', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      expect(isOrganizerForOrg(speaker({ isOrganizer: true }), null)).toBe(
-        false,
-      )
+      expect(
+        isOrganizerForOrg(speaker({ organizerOrgIds: ['org-A'] }), null),
+      ).toBe(false)
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('[authz-bridge]'),
       )
@@ -157,11 +173,21 @@ describe('isOrganizerForCurrentOrg — resolve + decide', () => {
     ).toBe(false)
   })
 
-  it('DENIES (fail-closed) when the org is unresolvable — bridge (1) removed', async () => {
+  it('DENIES (fail-closed) when the org is unresolvable', async () => {
     h.resolveOrg.mockResolvedValue(null)
     expect(await isOrganizerForCurrentOrg(speaker({ isOrganizer: true }))).toBe(
       false,
     )
+  })
+
+  it('DENIES a legacy token (no organizerOrgIds) on a resolvable host', async () => {
+    h.resolveOrg.mockResolvedValue('org-A')
+    expect(
+      await isOrganizerForCurrentOrg({
+        _id: 'sp-1',
+        isOrganizer: true,
+      } as never),
+    ).toBe(false)
   })
 
   it('short-circuits (no resolve) for an anonymous speaker', async () => {

--- a/src/lib/authz/organizer.test.ts
+++ b/src/lib/authz/organizer.test.ts
@@ -126,9 +126,7 @@ describe('isOrganizerForOrg — pure org-scoped decision', () => {
       expect(
         isOrganizerForOrg(speaker({ organizerOrgIds: ['org-A'] }), null),
       ).toBe(false)
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('[authz-bridge]'),
-      )
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[authz-deny]'))
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('DENYING (fail-closed'),
       )

--- a/src/lib/authz/organizer.ts
+++ b/src/lib/authz/organizer.ts
@@ -12,36 +12,34 @@ import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanit
  * REQUEST's organization is in that set. The request's org is ALWAYS derived from
  * the domain-resolved conference — never from client input.
  *
- * BRIDGE (1) — org UNRESOLVABLE — NOW FAILS CLOSED. The 044 backfill has run, so
- * every live conference has an `organization`; an unresolvable org id therefore no
- * longer means "pre-backfill data" but an unknown domain or a transient
- * resolution failure. Granting organizer access there via the deprecated global
- * `speaker.isOrganizer` was unnecessary permissiveness, so `orgId === null` now
- * DENIES. A `console.warn('[authz-bridge] …')` is still emitted when a would-be
- * organizer (global flag set) is denied, so the denial is observable.
+ * NO BRIDGES REMAIN. Both migration bridges to the deprecated GLOBAL
+ * `speaker.isOrganizer` flag are gone, so this decision reads `organizerOrgIds`
+ * and nothing else:
  *
- * BRIDGE (2) — LEGACY TOKEN — KEPT (SUNSET). A JWT minted before #635 has NO
- * `organizerOrgIds` field at all; denying those would 403 every logged-in
- * organizer until their token expires (session maxAge = 30d default) or they re-
- * login. We still bridge those via the deprecated global flag. This is the LAST
- * remaining bridge and is dated for removal — see the `TODO(sunset …)` below.
+ *   - org UNRESOLVABLE (`orgId === null`) DENIES. The 044 backfill has run, so
+ *     every live conference has an `organization`; an unresolvable org id means an
+ *     unknown domain or a transient resolution failure, not pre-backfill data.
+ *   - a LEGACY TOKEN (minted before #635, so `organizerOrgIds` is absent
+ *     entirely) DENIES. Bridging it via the global flag granted organizer rights
+ *     on ANY host, because that flag is true for an organizer of ANY org — a
+ *     cross-tenant grant. Anyone still holding such a token is an ordinary
+ *     non-organizer until they sign in again (or the `trigger === 'update'`
+ *     session refresh re-mints a modern token). See docs/AUTH.md.
  *
- * REMOVAL CONDITION. Delete bridge (2) — and with it Fix A's `trigger: 'update'`
- * session refresh becomes the mechanism by which any straggler re-mints a modern
- * token — once every pre-#635 token has expired (30d after #635). At that point a
- * present-but-absent `organizerOrgIds` should return `false`. See docs/AUTH.md.
+ * A `console.warn('[authz-bridge] …')` still records the unresolvable-org denial
+ * of a caller who organizes at least one org, so that failure mode stays
+ * observable without spamming on ordinary non-organizer traffic.
  */
 
 /** The minimum shape these checks read off a speaker/session token. */
-type OrganizerSpeaker = Pick<Speaker, '_id' | 'isOrganizer' | 'organizerOrgIds'>
+type OrganizerSpeaker = Pick<Speaker, '_id' | 'organizerOrgIds'>
 
 /**
  * PURE, synchronous org-scoped organizer check. Given a speaker and the already-
- * resolved request org id, decide organizer access. Order matters: a legacy TOKEN
- * (no `organizerOrgIds` field) defers wholesale to the deprecated global flag
- * (bridge (2), sunset) BEFORE org resolution is considered; a MODERN token with an
- * unresolvable `orgId === null` now FAILS CLOSED post-044-backfill (bridge (1)
- * removed). Extracted so the decision is unit-testable without a request context.
+ * resolved request org id, decide organizer access: membership of `orgId` in the
+ * token's `organizerOrgIds`, and nothing else. Fails closed on an unresolvable
+ * org and on a legacy token that carries no `organizerOrgIds` at all. Extracted
+ * so the decision is unit-testable without a request context.
  */
 export function isOrganizerForOrg(
   speaker: OrganizerSpeaker | null | undefined,
@@ -49,36 +47,16 @@ export function isOrganizerForOrg(
 ): boolean {
   if (!speaker?._id) return false
 
-  // BRIDGE (2) — LEGACY-TOKEN (SUNSET): checked FIRST because a pre-#635 JWT
-  // carries NO org-scoped info at all (organizerOrgIds absent), so neither the
-  // membership check nor bridge (1)'s fail-closed posture can meaningfully apply
-  // to it — we defer wholesale to the deprecated global flag REGARDLESS of whether
-  // the request org resolved. Denying these would 403 every logged-in organizer
-  // until their token expires or they re-login. A PRESENT but empty array is a
-  // MODERN token ("organizer of no org") and does NOT take this path — it falls
-  // through to the org-scoped logic below.
-  // TODO(sunset 2026-08-26): remove this block — 30d after #635, by when all
-  // pre-#635 tokens (session maxAge = 30d default) have expired. Removing it,
-  // together with Fix A's `trigger: 'update'` refresh, completes the bridge
-  // removal condition (see the module docs and docs/AUTH.md).
-  if (speaker.organizerOrgIds === undefined) {
-    if (speaker.isOrganizer === true) {
-      console.warn(
-        `[authz-bridge] legacy token without organizerOrgIds; granting via deprecated global isOrganizer for speaker ${speaker._id}`,
-      )
-      return true
-    }
-    return false
-  }
+  const organizerOrgIds = Array.isArray(speaker.organizerOrgIds)
+    ? speaker.organizerOrgIds
+    : []
 
-  // From here the token is MODERN (organizerOrgIds present).
   if (!orgId) {
-    // BRIDGE (1) REMOVED — FAIL CLOSED. Post-044-backfill an unresolvable org is
-    // an unknown domain / transient failure, not pre-backfill data, so a modern
-    // token is denied here rather than bridged via the deprecated global flag.
-    // Warn only when a would-be organizer (global flag set) is denied, so the
-    // denial is observable without spamming on ordinary non-organizer traffic.
-    if (speaker.isOrganizer === true) {
+    // FAIL CLOSED. Post-044-backfill an unresolvable org is an unknown domain or
+    // a transient failure, so deny. Warn only when a real organizer (of at least
+    // one org) is denied, so the denial is observable without spamming on
+    // ordinary non-organizer traffic.
+    if (organizerOrgIds.length > 0) {
       console.warn(
         `[authz-bridge] organizer org unresolvable; DENYING (fail-closed, post-044-backfill) for speaker ${speaker._id}`,
       )
@@ -86,15 +64,12 @@ export function isOrganizerForOrg(
     return false
   }
 
-  return (
-    Array.isArray(speaker.organizerOrgIds) &&
-    speaker.organizerOrgIds.includes(orgId)
-  )
+  return organizerOrgIds.includes(orgId)
 }
 
 /**
  * Resolve the CURRENT request's organization id from the domain conference, or
- * `null` when it cannot be resolved (pre-backfill / unknown domain). Thin wrapper
+ * `null` when it cannot be resolved (unknown domain / transient failure). Thin wrapper
  * over {@link getOrganizationRefForCurrentConference} named to mirror
  * `resolveConferenceId`; the underlying conference read is request-cached.
  */
@@ -104,9 +79,9 @@ export async function resolveCurrentOrgId(): Promise<string | null> {
 
 /**
  * Async org-scoped organizer check for the CURRENT request: resolves the request
- * org from the domain conference, then applies {@link isOrganizerForOrg} (with the
- * legacy bridge). This is the SHARED gate used by every handler/layout/route that
- * previously read `session.speaker.isOrganizer`. Pass the speaker to check —
+ * org from the domain conference, then applies {@link isOrganizerForOrg}. This is
+ * the SHARED gate used by every handler/layout/route that previously read the
+ * deprecated global `session.speaker.isOrganizer`. Pass the speaker to check —
  * usually `session?.speaker`, or `session.realAdmin` for impersonation gates.
  */
 export async function isOrganizerForCurrentOrg(

--- a/src/lib/authz/organizer.ts
+++ b/src/lib/authz/organizer.ts
@@ -26,9 +26,13 @@ import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanit
  *     non-organizer until they sign in again (or the `trigger === 'update'`
  *     session refresh re-mints a modern token). See docs/AUTH.md.
  *
- * A `console.warn('[authz-bridge] …')` still records the unresolvable-org denial
- * of a caller who organizes at least one org, so that failure mode stays
- * observable without spamming on ordinary non-organizer traffic.
+ * A `console.warn('[authz-deny] …')` records the unresolvable-org denial of a
+ * caller who organizes at least one org, so that failure mode stays observable
+ * without spamming on ordinary non-organizer traffic. (It was `[authz-bridge]`
+ * while the bridges existed; the tag is now `[authz-deny]` because nothing here
+ * bridges — the remaining `[authz-bridge]` logs belong to the RECIPIENT-selection
+ * fallbacks in `src/lib/notification/sanity.ts` and `src/lib/messaging/standing.ts`,
+ * which select who to notify rather than grant access.)
  */
 
 /** The minimum shape these checks read off a speaker/session token. */
@@ -58,7 +62,7 @@ export function isOrganizerForOrg(
     // ordinary non-organizer traffic.
     if (organizerOrgIds.length > 0) {
       console.warn(
-        `[authz-bridge] organizer org unresolvable; DENYING (fail-closed, post-044-backfill) for speaker ${speaker._id}`,
+        `[authz-deny] organizer org unresolvable; DENYING (fail-closed, post-044-backfill) for speaker ${speaker._id}`,
       )
     }
     return false

--- a/src/lib/authz/platform.test.ts
+++ b/src/lib/authz/platform.test.ts
@@ -2,10 +2,9 @@
  * @vitest-environment node
  *
  * Unit tests for the PLATFORM-OPERATOR gate (onboarding S1). This guards
- * cross-tenant creation, so it is deliberately STRICTER than the tenant waist:
- * no legacy-token bridge (the deprecated global `isOrganizer` never grants),
- * and fail-closed on every unresolvable input (env unset, unknown slug,
- * transient read failure).
+ * cross-tenant creation: the deprecated global `isOrganizer` never grants, and it
+ * fails closed on every unresolvable input (env unset, unknown slug, transient
+ * read failure).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 

--- a/src/lib/authz/platform.ts
+++ b/src/lib/authz/platform.ts
@@ -14,15 +14,13 @@ import { clientReadUncached } from '@/lib/sanity/client'
  *
  * THE MODEL. A caller is a platform operator iff their session token's
  * `organizerOrgIds` contains the id of the org whose `slug.current` equals
- * `PLATFORM_ORG_SLUG`. This is deliberately STRICTER than the tenant-admin
- * waist (`isOrganizerForOrg`):
- *
- *   - NO legacy-token bridge: a pre-#635 token (no `organizerOrgIds`) is DENIED
- *     even when the deprecated global `isOrganizer` flag is set — that flag is
- *     true for an organizer of ANY org and must never mint cross-tenant
- *     creation powers. Operators on legacy tokens simply re-login once.
- *   - FAIL CLOSED on every unresolvable input: env unset, org slug not found,
- *     transient read failure → deny.
+ * `PLATFORM_ORG_SLUG`. Like the tenant-admin waist (`isOrganizerForOrg`) it reads
+ * `organizerOrgIds` and nothing else — a pre-#635 token (no `organizerOrgIds`) is
+ * DENIED even when the deprecated global `isOrganizer` flag is set, since that
+ * flag is true for an organizer of ANY org and must never mint cross-tenant
+ * creation powers. Operators on legacy tokens simply re-login once. It FAILS
+ * CLOSED on every unresolvable input: env unset, org slug not found, transient
+ * read failure → deny.
  */
 
 /** The minimum shape the platform check reads off a session speaker. */
@@ -57,7 +55,7 @@ export async function getPlatformOrgId(): Promise<string | null> {
 
 /**
  * PURE platform-operator decision for an already-resolved platform org id.
- * STRICT membership only — no legacy-token bridge, fail closed on `null`.
+ * STRICT membership only — fail closed on `null`.
  */
 export function isPlatformOperatorForOrg(
   speaker: PlatformSpeaker | null | undefined,

--- a/src/lib/cospeaker/server.ts
+++ b/src/lib/cospeaker/server.ts
@@ -150,8 +150,17 @@ export async function createCoSpeakerInvitation(params: {
     // Hence `canonicalEmail`, NOT `normalizeEmail`: NFKC compatibility folding
     // would rewrite the local part (`oﬀice@ex.com` -> `office@ex.com`) and could
     // deliver the token to a different mailbox than the inviter typed. Case is
-    // safe to fold; compatibility codepoints are not. Acceptance compares with
-    // `normalizeEmail` on both sides, so matching is unaffected.
+    // safe to fold; compatibility codepoints are not.
+    //
+    // Acceptance (`proposal.respondToInvitation`) compares with `canonicalEmail`
+    // on both sides too, deliberately: that check GRANTS, so its key must be no
+    // WIDER than the set of mailboxes the token could have been delivered to —
+    // NFKC folding is not delivery-safe, and a wider key there would fail OPEN,
+    // letting a holder whose address merely folds to the same value claim an
+    // invitation never sent to them. The caller-side creation guards in
+    // `proposal.inviteCoSpeaker` (self-invite, duplicate-pending,
+    // already-a-speaker) keep `normalizeEmail` because they REJECT: a wider key
+    // rejects more, which fails CLOSED.
     const invitedEmail = canonicalEmail(params.invitedEmail)
 
     const tokenPayload: InvitationTokenPayload = {

--- a/src/lib/messaging/canAccess.orgscope.test.ts
+++ b/src/lib/messaging/canAccess.orgscope.test.ts
@@ -4,7 +4,10 @@
  * B2 (#642) — canAccessConversation's ORGANIZER branch must be ORG-SCOPED. Before
  * the fix it short-circuited on the DEPRECATED GLOBAL `speaker.isOrganizer`, so an
  * organizer of ANY org could read/write another tenant's thread by id. It now
- * keys on the conversation's OWN org (`conferenceOrgId`) via `isOrganizerForOrg`.
+ * keys on the conversation's OWN org (`conferenceOrgId`) via `isOrganizerForOrg`,
+ * and on `organizerOrgIds` ALONE — the legacy-token bridge to the global flag is
+ * gone, so a pre-#635 token without `organizerOrgIds` is denied on every thread,
+ * and a thread whose org is unresolvable fails closed.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { canAccessConversation } from './sanity'
@@ -61,15 +64,17 @@ describe('canAccessConversation — org-scoped organizer (B2)', () => {
     ).toBe(false)
   })
 
-  it('legacy-token bridge: an org-less global-flag organizer still passes (parity, sunset)', () => {
-    // No organizerOrgIds field → pre-#635 token → isOrganizerForOrg bridges via
-    // the global flag regardless of the thread org (matches #639 semantics).
+  it('DENIES a legacy token (no organizerOrgIds) even with the global flag set', () => {
+    // No organizerOrgIds field → pre-#635 token. The bridge that used to let the
+    // global flag stand in is GONE: it granted on ANY thread's org, because the
+    // flag is true for an organizer of ANY org. Such a holder is an ordinary
+    // non-organizer until they sign in again.
     expect(
       canAccessConversation(orgAThread(), {
         _id: 'legacy-admin',
         isOrganizer: true,
       }),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('a null thread org denies an org organizer (fail closed)', () => {

--- a/src/lib/messaging/sanity.ts
+++ b/src/lib/messaging/sanity.ts
@@ -531,7 +531,7 @@ export function resolveRecipients(
  * which let a CNB organizer read an external tenant's thread by id). It now keys
  * on {@link isOrganizerForOrg} against the CONVERSATION'S OWN org
  * (`conferenceOrgId`, projected from `conference->organization`) — the same
- * org-scoped decision (with legacy-token bridge) the middleware waist uses. A
+ * org-scoped decision the middleware waist uses. A
  * conversation whose org the caller does not organize falls through to the
  * speaker-party check, so a cross-tenant organizer is denied.
  */

--- a/src/lib/messaging/sponsor-thread.test.ts
+++ b/src/lib/messaging/sponsor-thread.test.ts
@@ -51,6 +51,8 @@ function sponsorConversation(): ConversationWithContext {
   return {
     _id: sponsorConversationId(SFC),
     conferenceId: 'conf-1',
+    // Organizer access is ORG-SCOPED: it keys on the thread's OWN org.
+    conferenceOrgId: 'org-test',
     conversationType: 'sponsor',
     proposalSpeakerIds: [],
     createdById: '',
@@ -87,11 +89,11 @@ describe('sponsor thread — id scheme + links', () => {
 })
 
 describe('sponsor thread — authorization', () => {
-  it('lets any organizer access a sponsor thread', () => {
+  it('lets an organizer of the owning org access a sponsor thread', () => {
     expect(
       canAccessConversation(sponsorConversation(), {
         _id: 'org-1',
-        isOrganizer: true,
+        organizerOrgIds: ['org-test'],
       }),
     ).toBe(true)
   })

--- a/src/lib/messaging/standing.ts
+++ b/src/lib/messaging/standing.ts
@@ -19,9 +19,11 @@ import { clientReadUncached } from '@/lib/sanity/client'
  * (which the picker legitimately offers) and talk-holding speakers.
  *
  * LEGACY BRIDGE: a conference with no resolvable organization (pre-044 backfill)
- * falls back to the global organizer scope with a warn — the same migration
- * bridge used by the authz layer and the recipient-selection helpers. Remove it
- * under the same condition as those bridges.
+ * falls back to the global organizer scope with a warn. This is a STANDING/
+ * recipient-selection bridge, not an access grant — the authz layer
+ * (`src/lib/authz/organizer.ts`) has no bridges left and denies an unresolvable
+ * org outright. Remove this one alongside its sibling in
+ * `src/lib/notification/sanity.ts`.
  *
  * This predicate lives in its own module so the E9 fix can be reviewed and
  * merged independently of the parallel messaging-authz work that owns the

--- a/src/lib/messaging/types.ts
+++ b/src/lib/messaging/types.ts
@@ -138,8 +138,9 @@ export function validateConversationParticipant(
 /** A speaker as needed for authorization decisions (server-derived). */
 export interface AccessSpeaker {
   _id: string
-  /** DEPRECATED GLOBAL flag — retained only for the legacy-token bridge inside
-   * {@link isOrganizerForOrg}; do NOT branch access on it directly (B2, #642). */
+  /** @deprecated GLOBAL flag — ACCEPTED BUT IGNORED by the access checks, which
+   * key on {@link organizerOrgIds} alone. Declared only so a legacy-shaped
+   * session still type-checks. NEVER branch access on it (B2, #642). */
   isOrganizer?: boolean
   /** ORG-SCOPED organizer capability: the org ids this speaker organizes. The
    * conversation-access check keys on this against the thread's own org. */

--- a/src/lib/speaker/types.ts
+++ b/src/lib/speaker/types.ts
@@ -127,12 +127,13 @@ export interface Speaker extends SpeakerBase {
   /**
    * @deprecated GLOBAL organizer flag — true iff this speaker is in ANY
    * conference's `organizers[]`. Superseded by {@link organizerOrgIds} for
-   * authorization (CaaS T1-2, #614): access is now org-SCOPED. Retained in the
-   * token as a backward-compat/migration bridge — the org-scoped middleware and
-   * gates fall back to this ONLY when the request's organization cannot be
-   * resolved (pre-044-backfill data / unknown domain). Prefer
+   * authorization (CaaS T1-2, #614): access is org-SCOPED, and this flag takes NO
+   * part in any authorization decision — both migration bridges that once fell
+   * back to it are removed. NEVER gate access on it: being an organizer of ANY org
+   * is not being an organizer of THIS one. Use
    * `isOrganizerForOrg`/`isOrganizerForCurrentOrg` (src/lib/authz/organizer.ts).
-   * UI still reads it this wave; a follow-up removes both the reads and the bridge.
+   * Still minted into the token and read by UI/recipient-selection code; a
+   * follow-up removes those reads and the field.
    */
   isOrganizer?: boolean
   /**
@@ -142,8 +143,9 @@ export interface Speaker extends SpeakerBase {
    * speaker. The authorization boundary keys on membership of the REQUEST's org
    * in this set; the request's org always comes from the domain-resolved
    * conference, never from client input. A handful of ids at most, so it is safe
-   * to bake into the JWT. Additive/optional; a legacy token without it degrades
-   * to the {@link isOrganizer} bridge.
+   * to bake into the JWT. Additive/optional in the type, but REQUIRED in practice:
+   * a legacy token minted before #635 lacks it and is therefore denied organizer
+   * access everywhere until the holder signs in again.
    */
   organizerOrgIds?: string[]
   /**

--- a/src/lib/travel-support/auth.orgscope.test.ts
+++ b/src/lib/travel-support/auth.orgscope.test.ts
@@ -92,9 +92,13 @@ describe('authorizeTravelSupportOperation — approve (B3)', () => {
     expect(r.authorized).toBe(false)
   })
 
-  it('legacy-token bridge: an org-less global-flag organizer still authorizes (parity, sunset)', async () => {
+  it('DENIES a legacy token (global isOrganizer, no organizerOrgIds)', async () => {
+    // The legacy-token bridge is gone (#642). The global `isOrganizer` flag is
+    // not org-scoped — it is true for an organizer of ANY org — so bridging it
+    // granted organizer rights on every tenant. Such a token is now an ordinary
+    // non-organizer until the holder signs in again and re-mints org claims.
     const legacy = { _id: 'legacy', name: 'Legacy', isOrganizer: true }
     const r = await authorizeTravelSupportOperation('ts-A', legacy, 'approve')
-    expect(r.authorized).toBe(true)
+    expect(r.authorized).toBe(false)
   })
 })

--- a/src/lib/travel-support/auth.ts
+++ b/src/lib/travel-support/auth.ts
@@ -12,16 +12,20 @@ import { isOrganizerForOrg } from '@/lib/authz/organizer'
 
 /**
  * The minimum speaker shape the travel-support authz needs: identity plus the
- * ORG-SCOPED organizer capability (`organizerOrgIds`, with `isOrganizer` kept
- * only for the legacy-token bridge inside {@link isOrganizerForOrg}). Callers pass
- * `ctx.speaker` (the session speaker). B3 (#642): the organizer grant is decided
- * against the REQUEST'S OWN org (the travel support's conference org), never the
- * deprecated global flag — so a cross-tenant organizer cannot reach another
- * tenant's banking PII.
+ * ORG-SCOPED organizer capability. `organizerOrgIds` is the ONLY claim
+ * {@link isOrganizerForOrg} reads. Callers pass `ctx.speaker` (the session
+ * speaker). B3 (#642): the organizer grant is decided against the REQUEST'S OWN
+ * org (the travel support's conference org), never the deprecated global flag —
+ * so a cross-tenant organizer cannot reach another tenant's banking PII.
  */
 export interface TravelSupportAuthSpeaker {
   _id: string
   name?: string
+  /**
+   * @deprecated The global organizer flag. ACCEPTED BUT IGNORED — it is declared
+   * only so a legacy-shaped session still type-checks here; nothing in this
+   * module reads it, and it grants nothing.
+   */
   isOrganizer?: boolean
   organizerOrgIds?: string[]
 }

--- a/src/server/routers/conference.createEdition.test.ts
+++ b/src/server/routers/conference.createEdition.test.ts
@@ -14,6 +14,8 @@ vi.mock('@/lib/conference/sanity', () => ({
 }))
 
 const SOURCE_ID = 'source-conf'
+/** The org the domain-resolved source conference belongs to. */
+const ORG_ID = 'org-test'
 
 const SOURCE_DOC = {
   _id: SOURCE_ID,
@@ -75,9 +77,19 @@ vi.mock('@/lib/sanity/client', () => ({
 import { conferenceRouter } from './conference'
 import { DOMAIN_ALREADY_CLAIMED } from '@/lib/conference/domains'
 
+/**
+ * Org-scoped authz keys on `organizerOrgIds` ALONE (the global `isOrganizer`
+ * bridge is gone), so an "organizer" caller must carry the SAME org the
+ * request's domain conference resolves to — hence `ORG_ID` on both sides.
+ */
 function makeCaller(opts: { isOrganizer?: boolean } | null) {
   const speaker = opts
-    ? { _id: 'sp-1', name: 'Org', isOrganizer: opts.isOrganizer ?? false }
+    ? {
+        _id: 'sp-1',
+        name: 'Org',
+        isOrganizer: opts.isOrganizer ?? false,
+        organizerOrgIds: opts.isOrganizer ? [ORG_ID] : [],
+      }
     : undefined
   const ctx = {
     session: speaker ? { speaker, user: { name: 'Org' } } : null,
@@ -101,8 +113,14 @@ beforeEach(() => {
   vi.clearAllMocks()
   claimedDomains = ['cloudnativebergen.no', '2025.cnb.no']
   commitMock.mockResolvedValue({})
+  // The domain conference carries the org the authz waist gates on, so
+  // `resolveOrganizationId()` yields ORG_ID for every request in this file.
   getConferenceMock.mockResolvedValue({
-    conference: { _id: SOURCE_ID },
+    conference: {
+      _id: SOURCE_ID,
+      organization: { _type: 'reference', _ref: ORG_ID },
+    },
+    domain: 'cloudnativebergen.no',
     error: null,
   })
 })

--- a/src/server/routers/conference.test.ts
+++ b/src/server/routers/conference.test.ts
@@ -79,10 +79,22 @@ import { DOMAIN_ALREADY_CLAIMED } from '@/lib/conference/domains'
 const revalidateTagMock = revalidateTag as unknown as ReturnType<typeof vi.fn>
 
 const CONFERENCE_ID = 'conf-1'
+/** The org the domain-resolved conference belongs to; see `ORG_ID` use below. */
+const ORG_ID = 'org-test'
 
+/**
+ * Org-scoped authz keys on `organizerOrgIds` ALONE (the global `isOrganizer`
+ * bridge is gone), so an "organizer" caller must carry the SAME org the
+ * request's domain conference resolves to — hence `ORG_ID` on both sides.
+ */
 function makeCaller(opts: { isOrganizer?: boolean } | null) {
   const speaker = opts
-    ? { _id: 'sp-1', name: 'Org', isOrganizer: opts.isOrganizer ?? false }
+    ? {
+        _id: 'sp-1',
+        name: 'Org',
+        isOrganizer: opts.isOrganizer ?? false,
+        organizerOrgIds: opts.isOrganizer ? [ORG_ID] : [],
+      }
     : undefined
   const ctx = {
     session: speaker ? { speaker, user: { name: 'Org' } } : null,
@@ -117,8 +129,14 @@ beforeEach(() => {
       return ['sp-1', 'sp-2']
     },
   )
+  // The domain conference carries the org the authz waist gates on, so
+  // `resolveOrganizationId()` yields ORG_ID for every request in this file.
   getConferenceMock.mockResolvedValue({
-    conference: { _id: CONFERENCE_ID },
+    conference: {
+      _id: CONFERENCE_ID,
+      organization: { _type: 'reference', _ref: ORG_ID },
+    },
+    domain: 'cloudnativebergen.no',
     error: null,
   })
 })

--- a/src/server/routers/platform.ts
+++ b/src/server/routers/platform.ts
@@ -23,9 +23,9 @@ import { UpdateEntitlementsSchema } from '../schemas/platform'
  * env contract unset the whole router fails closed.
  */
 const platformProcedure = adminProcedure.use(async ({ ctx, next }) => {
-  // `ctx.orgId` can still be null for a legacy-token bridge admin (see the
-  // waist's bridge (2)); a null org is never the platform org, so the
-  // isPlatformOrganization guard fails closed for those too.
+  // The waist already denies a null `ctx.orgId`, so this can only run with a
+  // resolved org — but a null is never the platform org anyway, so this guard
+  // fails closed independently.
   if (!(await isPlatformOrganization(ctx.orgId))) {
     throw new TRPCError({
       code: 'FORBIDDEN',

--- a/src/server/routers/schedule.test.ts
+++ b/src/server/routers/schedule.test.ts
@@ -32,9 +32,17 @@ const revalidateTagMock = revalidateTag as unknown as Mock
 
 const CONFERENCE_ID = 'conf-bergen'
 const OTHER_CONFERENCE_ID = 'conf-oslo'
+const ORG_ID = 'org-test'
 
 function makeCaller() {
-  const speaker = { _id: 'sp-1', name: 'Org', isOrganizer: true }
+  // Org-scoped authz: the admin waist grants only when `organizerOrgIds`
+  // contains the org the domain conference resolves to (see `getConferenceMock`).
+  const speaker = {
+    _id: 'sp-1',
+    name: 'Org',
+    isOrganizer: true,
+    organizerOrgIds: [ORG_ID],
+  }
   const ctx = {
     session: { speaker, user: { name: 'Org' } },
     speaker,
@@ -47,7 +55,10 @@ const validPayload = { _id: '', date: '2026-10-10', tracks: [] }
 beforeEach(() => {
   vi.clearAllMocks()
   getConferenceMock.mockResolvedValue({
-    conference: { _id: CONFERENCE_ID },
+    conference: {
+      _id: CONFERENCE_ID,
+      organization: { _type: 'reference', _ref: ORG_ID },
+    },
     error: null,
   })
   getValidTalkIdsMock.mockResolvedValue(new Set<string>())

--- a/src/server/routers/speaker.merge.test.ts
+++ b/src/server/routers/speaker.merge.test.ts
@@ -15,8 +15,25 @@ vi.mock('@/lib/speaker/merge', async () => {
   }
 })
 
+// The org-scoped admin waist derives the REQUEST's org from the domain
+// conference, then requires the caller's `organizerOrgIds` to contain it — so the
+// resolved conference must carry the org `makeCaller` grants below.
+vi.mock('@/lib/conference/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getConferenceForCurrentDomain: async () => ({
+    conference: {
+      _id: 'conf-1',
+      organization: { _type: 'reference', _ref: 'org-test' },
+    },
+    domain: 'localhost',
+    error: null,
+  }),
+}))
+
 import { speakerRouter } from './speaker'
 import { MergeValidationError } from '@/lib/speaker/merge'
+
+const ORG_ID = 'org-test'
 
 const PREVIEW = {
   survivorId: 'survivor',
@@ -33,16 +50,17 @@ const PREVIEW = {
 }
 
 function makeCaller(opts: { isOrganizer: boolean }) {
+  // `organizerOrgIds` is what the waist reads; the deprecated global flag is kept
+  // only because non-authz code still looks at it.
+  const speaker = {
+    _id: 'admin-1',
+    name: 'Admin',
+    isOrganizer: opts.isOrganizer,
+    organizerOrgIds: opts.isOrganizer ? [ORG_ID] : [],
+  }
   const ctx = {
-    session: {
-      speaker: {
-        _id: 'admin-1',
-        name: 'Admin',
-        isOrganizer: opts.isOrganizer,
-      },
-      user: { name: 'Admin' },
-    },
-    speaker: { _id: 'admin-1', name: 'Admin', isOrganizer: opts.isOrganizer },
+    session: { speaker, user: { name: 'Admin' } },
+    speaker,
   } as unknown as Context
   return speakerRouter.createCaller(ctx)
 }

--- a/src/server/routers/staff.test.ts
+++ b/src/server/routers/staff.test.ts
@@ -33,6 +33,20 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }))
 
+// The authz waist resolves the request org off the domain conference, so the
+// `adminProcedure` gate needs one that names the org the caller organizes.
+vi.mock('@/lib/conference/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getConferenceForCurrentDomain: async () => ({
+    conference: {
+      _id: 'conf-1',
+      organization: { _type: 'reference', _ref: 'org-test' },
+    },
+    domain: 'localhost',
+    error: null,
+  }),
+}))
+
 // Admin list reads through the data layer.
 const getAllStaffMock = vi.fn()
 vi.mock('@/lib/staff/sanity', () => ({
@@ -41,8 +55,18 @@ vi.mock('@/lib/staff/sanity', () => ({
 
 import { staffRouter } from './staff'
 
+/**
+ * Org-scoped authz keys on `organizerOrgIds` ALONE (the global `isOrganizer`
+ * bridge is gone), so an "organizer" caller must carry the SAME org the mocked
+ * domain conference above resolves to.
+ */
 function makeCaller(isOrganizer = true) {
-  const speaker = { _id: 'sp-1', name: 'Org', isOrganizer }
+  const speaker = {
+    _id: 'sp-1',
+    name: 'Org',
+    isOrganizer,
+    organizerOrgIds: isOrganizer ? ['org-test'] : [],
+  }
   const ctx = {
     session: { speaker, user: { name: 'Org' } },
     speaker,

--- a/src/server/routers/status.probes.test.ts
+++ b/src/server/routers/status.probes.test.ts
@@ -31,12 +31,22 @@ vi.mock('@/lib/email/config', () => ({
 
 import { statusRouter } from './status'
 
+/** The org the domain-resolved conference belongs to. */
+const ORG_ID = 'org-test'
+
+/**
+ * Org-scoped authz keys on `organizerOrgIds` ALONE (the global `isOrganizer`
+ * bridge is gone), so an "organizer" caller must carry the SAME org the
+ * request's domain conference resolves to — hence `ORG_ID` on both sides.
+ */
 function makeCaller(opts: { isOrganizer?: boolean; speakerId?: string } = {}) {
+  const isOrganizer = opts.isOrganizer ?? true
   const speaker = {
     _id: opts.speakerId ?? 'admin-1',
     name: 'Admin',
     email: 'admin@example.com',
-    isOrganizer: opts.isOrganizer ?? true,
+    isOrganizer,
+    organizerOrgIds: isOrganizer ? [ORG_ID] : [],
   }
   const ctx = {
     session: { speaker, user: { name: 'Admin' } },
@@ -47,6 +57,9 @@ function makeCaller(opts: { isOrganizer?: boolean; speakerId?: string } = {}) {
 
 const CONFERENCE = {
   _id: 'conf-1',
+  // The org the authz waist resolves off the domain conference; must match the
+  // caller's `organizerOrgIds` for `adminProcedure` to admit the request.
+  organization: { _type: 'reference', _ref: ORG_ID },
   organizer: 'Test Org',
   cfpEmail: 'cfp@example.com',
   salesNotificationChannel: '#updates',

--- a/src/server/routers/topic.test.ts
+++ b/src/server/routers/topic.test.ts
@@ -38,6 +38,21 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }))
 
+// The authz waist resolves the request org off the domain conference (NOT off
+// the org resolver mocked below), so `adminProcedure` needs one that names the
+// org the caller organizes.
+vi.mock('@/lib/conference/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getConferenceForCurrentDomain: async () => ({
+    conference: {
+      _id: 'conf-1',
+      organization: { _type: 'reference', _ref: 'org-test' },
+    },
+    domain: 'localhost',
+    error: null,
+  }),
+}))
+
 // E3: topic.list scopes to the current org. Mock the org resolver (and keep
 // organizationField behaving like the real helper for create).
 const getOrgRefMock = vi.fn()
@@ -49,8 +64,18 @@ vi.mock('@/lib/organization/sanity', () => ({
 
 import { topicRouter } from './topic'
 
+/**
+ * Org-scoped authz keys on `organizerOrgIds` ALONE (the global `isOrganizer`
+ * bridge is gone), so an "organizer" caller must carry the SAME org the mocked
+ * domain conference above resolves to.
+ */
 function makeCaller(isOrganizer = true) {
-  const speaker = { _id: 'sp-1', name: 'Org', isOrganizer }
+  const speaker = {
+    _id: 'sp-1',
+    name: 'Org',
+    isOrganizer,
+    organizerOrgIds: isOrganizer ? ['org-test'] : [],
+  }
   const ctx = {
     session: { speaker, user: { name: 'Org' } },
     speaker,

--- a/src/server/routers/volunteer.test.ts
+++ b/src/server/routers/volunteer.test.ts
@@ -4,6 +4,21 @@ import { Occupation } from '@/lib/volunteer/types'
 
 vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
 
+// adminProcedure resolves the REQUEST's org from the domain conference and grants
+// only when the caller's `organizerOrgIds` contains it, so the domain conference
+// has to point at the same org the caller below organizes.
+vi.mock('@/lib/conference/sanity', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getConferenceForCurrentDomain: async () => ({
+    conference: {
+      _id: 'conf-1',
+      organization: { _type: 'reference', _ref: 'org-test' },
+    },
+    domain: 'localhost',
+    error: null,
+  }),
+}))
+
 // Volunteer data layer — only the pieces admin.update touches.
 const getVolunteerByIdMock = vi.fn()
 const updateVolunteerDetailsMock = vi.fn()
@@ -19,7 +34,14 @@ vi.mock('@/lib/volunteer/sanity', () => ({
 import { volunteerRouter } from './volunteer'
 
 function makeCaller(isOrganizer = true) {
-  const speaker = { _id: 'sp-1', name: 'Org', isOrganizer }
+  // `organizerOrgIds` — NOT the deprecated global `isOrganizer` flag — is what the
+  // authz waist reads; it must contain the org the domain conference resolves to.
+  const speaker = {
+    _id: 'sp-1',
+    name: 'Org',
+    isOrganizer,
+    organizerOrgIds: isOrganizer ? ['org-test'] : [],
+  }
   const ctx = {
     session: { speaker, user: { name: 'Org' } },
     speaker,

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -142,9 +142,9 @@ const requireAuth = t.middleware(({ ctx, next }) => {
  * (`speaker.organizerOrgIds` includes it). FAIL CLOSED when the org resolves but
  * the caller is not a member AND when the org CANNOT be resolved (unknown domain /
  * transient failure) — post-044-backfill {@link isOrganizerForOrg} denies an
- * unresolvable org (the org-unresolvable bridge is gone). The one remaining bridge
- * is legacy TOKENS without `organizerOrgIds` (sunset). See
- * `src/lib/authz/organizer.ts` for the bridge's removal condition.
+ * unresolvable org. Both migration bridges to the deprecated global
+ * `speaker.isOrganizer` are gone, including the legacy-TOKEN one: a pre-#635 token
+ * without `organizerOrgIds` is denied everywhere. See `src/lib/authz/organizer.ts`.
  */
 const requireAdmin = t.middleware(async ({ ctx, next }) => {
   const orgId = await resolveOrganizationId()
@@ -177,8 +177,8 @@ const requireAdmin = t.middleware(async ({ ctx, next }) => {
  * acts on any of the ORG's). It replaces the DEPRECATED GLOBAL `ctx.speaker.isOrganizer`
  * (true for an organizer of ANY org) that dual-role endpoints used to branch on,
  * which let a CNB organizer reach an external tenant's data. The decision reuses
- * {@link isOrganizerForOrg} so the legacy-token bridge semantics match the waist
- * (#635/#639) exactly. Pure-organizer endpoints should use {@link adminProcedure}
+ * {@link isOrganizerForOrg} so its semantics match the waist (#635/#639) exactly.
+ * Pure-organizer endpoints should use {@link adminProcedure}
  * (which fails closed); this is for the dual-role surfaces only.
  */
 const withOrgOrganizer = t.middleware(async ({ ctx, next }) => {


### PR DESCRIPTION
Three small, related auth-hygiene changes.

## 1. Delete the legacy `isOrganizer` bridge (the main item)

`src/lib/authz/organizer.ts` granted organizer rights to any pre-#635 token — one
with no `organizerOrgIds` claim at all — by deferring wholesale to the
**deprecated global `speaker.isOrganizer` flag**. That flag is true for an
organizer of **any** org, so such a token was granted organizer **on any host**:
a cross-tenant grant. Its own `TODO(sunset 2026-08-26)` had not yet passed, but
removing it now, while there is exactly one tenant, is when the blast radius is
smallest.

`isOrganizerForOrg` now reads `organizerOrgIds` and nothing else:

- request org resolves and is in `organizerOrgIds` &rarr; **grant**
- request org resolves and is not &rarr; **deny** (unchanged)
- request org unresolvable &rarr; **deny**, fail-closed (unchanged; the warn that
  makes the denial observable is re-keyed off `organizerOrgIds` rather than the
  deprecated flag, so the module no longer reads that flag at all)
- no `organizerOrgIds` claim (legacy token) &rarr; **deny** (was: grant)

**Consequence, expected and accepted:** anyone still holding a pre-#635 token
loses organizer status until they sign in again (or until the `trigger: 'update'`
session refresh re-mints a modern token).

Also removed: the now-dead deprecation `console.warn`, the `TODO(sunset …)`, and
the bridge prose in `docs/AUTH.md`, `docs/TRPC_SERVER_ARCHITECTURE.md` and
`docs/ORGANIZATION_TIER.md` — two of which still described the *other*,
already-removed bridge as live.

### The deprecated flag is still read elsewhere — deliberately left alone

`isOrganizer` remains minted into the token and read by code that is **not**
authorization: badge sorting/eligibility display, messaging + notification
recipient selection (`src/lib/messaging/*`, `src/lib/notification/sanity.ts`),
`UserMenu`, the notification panels. Two of those — `messaging/standing.ts` and
`notification/sanity.ts` — carry their *own* `[authz-bridge]` fallback to the
global organizer set when an org is unresolvable; those select recipients rather
than grant access, and are out of scope here.

### Dev test-mode

`AppEnvironment.createMockAuthContext()`'s mock speaker reached `/admin` through
this bridge. `getAuthSession()` now stamps its `organizerOrgIds` with the current
domain's org instead; an unresolvable org denies, like any other caller.

## 2. `next-auth` 5.0.0-beta.31 &rarr; 5.0.0-beta.32

Housekeeping, not an exposure: both recent advisories are in the Email/nodemailer
sign-in flow and this app configures **GitHub and LinkedIn only**; the related
GHSA-5jpx-9hw9-2fx4 was fixed in beta.30. The lockfile change is `next-auth`
beta.31&rarr;32 and `@auth/core` 0.41.2&rarr;0.41.3 plus a widened `nodemailer`
peer range — nothing else moved.

Behavioural deltas, all in this app's favour, none requiring a change here:

- **`auth()` no longer fails open.** On a non-OK response from `@auth/core`
  (e.g. a config 500) beta.31 returned the parsed error body as the session, so
  `!!auth` passed for everyone. beta.32 maps it to `null`. Directly relevant
  given the #462 lazy-config incident.
- **OAuth `state`/`pkce`/`nonce` check cookies are now provider-bound** — the
  sealed payload carries the provider id and the callback rejects a mismatch.
  Deploy note: cookies sealed by beta.31 carry no provider id, so a sign-in
  already in flight fails once and the user retries. TTL is 15 minutes.
- `getToken()` returns `null` instead of throwing on a malformed percent-encoded
  Bearer header. This app decodes Bearer tokens itself
  (`getSessionFromBearerToken`) and never calls `getToken`.
- NFKC normalization in `defaultNormalizer` — Email provider only; unused here.

## 3. Stale comment in `src/lib/cospeaker/server.ts`

It claimed invitation acceptance compares with `normalizeEmail`. It has not since
#684 — `proposal.respondToInvitation` uses `canonicalEmail`, deliberately. The
comment now says so and says why: the acceptance check **grants**, so its key must
be no wider than the set of mailboxes the token could have been delivered to, and
NFKC folding is not delivery-safe. The creation guards above it correctly keep
`normalizeEmail`, because they **reject** and a wider key there fails closed.

## Tests

New/updated in `src/lib/authz/organizer.test.ts`: a token WITHOUT
`organizerOrgIds` must not be granted organizer on any host — asserted across
several host orgs, with the org unresolvable, and through
`isOrganizerForCurrentOrg`. Verified to bite: against the pre-change
implementation 8 of these fail.

The bridge turned out to be load-bearing in the **test harness**: 265 tests
across 33 files built organizer sessions in the legacy shape
(`{ _id, isOrganizer: true }`, no `organizerOrgIds`) and never resolved a request
org, so they passed only via the bridge. They now carry `organizerOrgIds` and
resolve the request org explicitly, so they exercise the real org-scoped model
rather than the compatibility path. The shared fixtures
(`__tests__/testdata/speakers.ts`, `__tests__/helpers/trpc.ts`) gained a
`TEST_ORG_ID`. Tests that deliberately pinned the bridge *granting* are inverted
to assert denial.
