### PR TITLE
fix(admin): give the shared filter controls a visible border

### DIFF
--- a/src/components/admin/AdminFilterBar.tsx
+++ b/src/components/admin/AdminFilterBar.tsx
@@ -232,7 +232,7 @@ export function AdminFilterBar({
                 value={search.value}
                 onChange={(event) => search.onChange(event.target.value)}
                 placeholder={search.placeholder ?? 'Search...'}
-                className="block h-9 w-full rounded-md border-gray-300 bg-white py-1.5 pr-8 pl-9 text-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500"
+                className="block h-9 w-full rounded-md border border-gray-300 bg-white py-1.5 pr-8 pl-9 text-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500"
               />
               {search.value && (
                 <button

--- a/src/components/admin/gallery/GalleryFilters.tsx
+++ b/src/components/admin/gallery/GalleryFilters.tsx
@@ -231,7 +231,7 @@ export function GalleryFilters({
             }
             onChange={(e) => handleFeaturedChange(e.target.value)}
             className={clsx(
-              'h-11 appearance-none rounded-md border-gray-300 py-1.5 pr-8 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white',
+              'h-11 appearance-none rounded-md border border-gray-300 py-1.5 pr-8 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white',
               fieldWidth('w-32'),
             )}
             aria-label="Featured filter"
@@ -268,7 +268,7 @@ export function GalleryFilters({
               <Combobox.Input
                 id={`${idPrefix}-speaker`}
                 className={clsx(
-                  'h-11 rounded-md border-gray-300 py-1.5 pr-8 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
+                  'h-11 rounded-md border border-gray-300 py-1.5 pr-8 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
                   fieldWidth('w-40'),
                 )}
                 displayValue={(speaker: { _id: string; name: string } | null) =>
@@ -314,7 +314,7 @@ export function GalleryFilters({
             onChange={(e) => setLocalPhotographer(e.target.value)}
             placeholder="Photographer"
             className={clsx(
-              'h-11 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
+              'h-11 rounded-md border border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
               fieldWidth('w-36'),
             )}
             aria-label="Filter by photographer"
@@ -331,7 +331,7 @@ export function GalleryFilters({
             onChange={(e) => setLocalLocation(e.target.value)}
             placeholder="Location"
             className={clsx(
-              'h-11 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
+              'h-11 rounded-md border border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500',
               fieldWidth('w-32'),
             )}
             aria-label="Filter by location"
@@ -355,7 +355,7 @@ export function GalleryFilters({
               updateURL(newFilters)
             }}
             className={clsx(
-              'h-11 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:scheme-dark',
+              'h-11 rounded-md border border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:scheme-dark',
               fieldWidth('w-36'),
             )}
             aria-label="Filter from date"
@@ -379,7 +379,7 @@ export function GalleryFilters({
               updateURL(newFilters)
             }}
             className={clsx(
-              'h-11 rounded-md border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:scheme-dark',
+              'h-11 rounded-md border border-gray-300 py-1.5 pr-3 pl-8 text-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none lg:h-9 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:scheme-dark',
               fieldWidth('w-36'),
             )}
             aria-label="Filter to date"


### PR DESCRIPTION
Tailwind v4's preflight emits `*, ::before, … { border: 0 solid }`, so a control given only a border **colour** renders with no border at all. The search input in `AdminFilterBar` and six controls in `GalleryFilters` set `border-gray-300` without `border`.

They set explicit heights, which is why they read as floating text rather than as broken — unlike the invitation form (#700), where the same mistake on a height-less input made every field one line tall with the text flush against the edge, and invisible against the card in dark mode.

Verified in Storybook (`Systems/Admin/AdminFilterBar`): the search field now has a visible border.

## The root cause is wider than this PR

`@tailwindcss/forms` is listed in `tailwind.config.ts` but **is not in the build**: `src/styles/tailwind.css` never pulls that config in with `@config`, and Tailwind v4 does not auto-load a JS config. The built CSS contains no `[type='text']` rules, so no bare input anywhere gets the plugin's border, padding or height.

At least ten more files carry the same class pattern, including the shared `src/components/Form.tsx`, the budget config page, the tickets companies page and the platform org manager.

Loading the plugin — one `@config` line — would fix all of them at once, but it changes the rendering of every form in the app, including ones that may have been built to compensate. That wants its own PR with a full visual pass rather than riding along here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores visible one-pixel borders on shared administrative filter controls.
- Adds the Tailwind `border` utility to the AdminFilterBar search input.
- Adds the same utility to six GalleryFilters controls whose existing border-color classes previously rendered without a border width.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changes narrowly restoring the borders already implied by the controls' border-color classes.

Tailwind’s border-box sizing keeps the new one-pixel borders within the controls’ existing fixed dimensions, and the resulting classes match established sibling-control styling.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/AdminFilterBar.tsx | Adds the missing border-width utility to the search input without changing its dimensions or behavior. |
| src/components/admin/gallery/GalleryFilters.tsx | Consistently adds the missing border-width utility to six fixed-height gallery filter controls. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): give the shared filter contr..."](https://github.com/cloudnativebergen/website/commit/f9aa8121bc0595028aab178c4df7bec1df00c6f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49689512)</sub>

<!-- /greptile_comment -->