### PR TITLE
feat(homepage): make section copy per-section configuration

### DIFF
--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -1335,14 +1335,101 @@ export default defineType({
             ],
           }),
         ]),
-        defineHomepageSection('homepageFeaturedSpeakers', 'Featured Speakers'),
+        defineHomepageSection('homepageFeaturedSpeakers', 'Featured Speakers', [
+          defineField({
+            name: 'heading',
+            title: 'Heading',
+            type: 'string',
+            description:
+              'Optional heading. Defaults to "Featured Speakers". The speakers themselves come from the conference configuration.',
+          }),
+          defineField({
+            name: 'description',
+            title: 'Sub-heading',
+            type: 'text',
+            rows: 2,
+            description:
+              'Optional copy under the heading. Defaults to "Meet the speakers at <conference title>".',
+          }),
+        ]),
         defineHomepageSection(
           'homepageProgramHighlights',
           'Program Highlights',
         ),
-        defineHomepageSection('homepageOrganizers', 'Organizers'),
-        defineHomepageSection('homepageSponsors', 'Sponsors'),
-        defineHomepageSection('homepageGallery', 'Photo Gallery'),
+        defineHomepageSection('homepageOrganizers', 'Organizers', [
+          defineField({
+            name: 'heading',
+            title: 'Heading',
+            type: 'string',
+            description: 'Optional heading. Defaults to "Meet Our Organizers".',
+          }),
+          defineField({
+            name: 'description',
+            title: 'Sub-heading',
+            type: 'text',
+            rows: 2,
+            description:
+              'Optional copy under the heading. Defaults to "The passionate team driving <conference title>".',
+          }),
+        ]),
+        defineHomepageSection('homepageSponsors', 'Sponsors', [
+          defineField({
+            name: 'heading',
+            title: 'Heading',
+            type: 'string',
+            description: 'Optional heading. Defaults to "Our sponsors".',
+          }),
+          defineField({
+            name: 'description',
+            title: 'Sub-heading',
+            type: 'text',
+            rows: 2,
+            description:
+              'Optional copy under the heading. Leave blank for the house default.',
+          }),
+          defineField({
+            name: 'showCta',
+            title: 'Show the “Become a Sponsor” card',
+            type: 'boolean',
+            initialValue: true,
+            description:
+              'Turn off to drop the prospective-sponsor call-to-action below the logos.',
+          }),
+          defineField({
+            name: 'ctaHeading',
+            title: 'Call-to-action Heading',
+            type: 'string',
+            hidden: ({ parent }) =>
+              (parent as { showCta?: boolean })?.showCta === false,
+            description: 'Optional. Defaults to "Become a Sponsor".',
+          }),
+          defineField({
+            name: 'ctaDescription',
+            title: 'Call-to-action Body',
+            type: 'text',
+            rows: 3,
+            hidden: ({ parent }) =>
+              (parent as { showCta?: boolean })?.showCta === false,
+            description:
+              'Optional pitch to prospective sponsors. Leave blank for the house default.',
+          }),
+        ]),
+        defineHomepageSection('homepageGallery', 'Photo Gallery', [
+          defineField({
+            name: 'heading',
+            title: 'Heading',
+            type: 'string',
+            description: 'Optional heading. Defaults to "Conference Moments".',
+          }),
+          defineField({
+            name: 'description',
+            title: 'Sub-heading',
+            type: 'text',
+            rows: 3,
+            description:
+              'Optional copy under the heading. Leave blank for the house default.',
+          }),
+        ]),
         defineHomepageSection('homepageMetrics', 'Vanity Metrics', [
           defineField({
             name: 'heading',

--- a/src/components/ImageGallery.stories.tsx
+++ b/src/components/ImageGallery.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { ImageGallery } from './ImageGallery'
+import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
+
+/**
+ * Homepage photo-gallery band. The heading and description are per-section
+ * config on the `homepageGallery` block — `Default` renders the built-in house
+ * copy (what every existing site sees), `CustomCopy` a tenant override.
+ */
+
+function mockImage(id: string, label: string): GalleryImageWithSpeakers {
+  return {
+    _id: id,
+    _rev: 'r1',
+    _createdAt: '2025-06-12T10:00:00Z',
+    _updatedAt: '2025-06-12T10:00:00Z',
+    photographer: 'Olav Nordmann',
+    date: '2025-06-12',
+    location: 'Grieghallen, Bergen',
+    featured: true,
+    imageAlt: label,
+    image: {
+      _type: 'image',
+      asset: {
+        _ref: `image-${id.replace(/-/g, '')}0000000000000000000000000000-1920x1080-jpg`,
+        _type: 'reference',
+      },
+    },
+    speakers: [],
+  } as unknown as GalleryImageWithSpeakers
+}
+
+const featuredImages: GalleryImageWithSpeakers[] = [
+  mockImage('gal1', 'Keynote presentation on the main stage'),
+  mockImage('gal2', 'Hands-on workshop session'),
+  mockImage('gal3', 'Networking break'),
+]
+
+const placeholderSvg = (w: number, h: number, label: string, hue: number) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">` +
+  `<rect width="${w}" height="${h}" fill="hsl(${hue} 40% 30%)"/>` +
+  `<text x="50%" y="50%" fill="hsl(${hue} 30% 75%)" font-family="sans-serif" font-size="${Math.round(h / 12)}" text-anchor="middle" dominant-baseline="middle">${label}</text>` +
+  `</svg>`
+
+const handlers = [
+  http.get('https://cdn.sanity.io/images/*', ({ request }) => {
+    const url = new URL(request.url)
+    const match = /gal(\d)/.exec(url.pathname)
+    const n = match ? Number(match[1]) : 1
+    return new HttpResponse(
+      placeholderSvg(1920, 1080, `Photo ${n}`, [210, 150, 30][n - 1] ?? 210),
+      { headers: { 'Content-Type': 'image/svg+xml' } },
+    )
+  }),
+]
+
+const meta = {
+  title: 'Systems/Homepage/Public/ImageGallery',
+  component: ImageGallery,
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers },
+    docs: {
+      description: {
+        component:
+          'Front-page photo carousel band. Heading and description default to the house copy and are overridable per section (front-page builder).',
+      },
+    },
+  },
+  args: { featuredImages },
+} satisfies Meta<typeof ImageGallery>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** House defaults — byte-identical to the pre-config copy. */
+export const Default: Story = {}
+
+export const DefaultDark: Story = {
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-gray-950">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/** A tenant replacing the house copy with its own voice. */
+export const CustomCopy: Story = {
+  args: {
+    heading: 'Photos from last year',
+    description:
+      'A look back at the 2025 edition — talks, hallway track and the after-party.',
+  },
+}

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -5,17 +5,27 @@ import { ImageCarousel } from '@/components/ImageCarousel'
 import { GalleryModal } from '@/components/GalleryModal'
 import { Container } from '@/components/Container'
 import { GalleryImageWithSpeakers } from '@/lib/gallery/types'
+import {
+  DEFAULT_GALLERY_DESCRIPTION,
+  DEFAULT_GALLERY_HEADING,
+} from '@/lib/homepage/sections'
 import { cn } from '@/lib/utils'
 
 interface ImageGalleryProps {
   featuredImages?: GalleryImageWithSpeakers[]
   allImages?: GalleryImageWithSpeakers[]
+  /** Band heading. Defaults to the house copy (`homepageGallery` config). */
+  heading?: string
+  /** Band sub-heading. Defaults to the house copy. */
+  description?: string
   className?: string
 }
 
 export function ImageGallery({
   featuredImages = [],
   allImages = [],
+  heading = DEFAULT_GALLERY_HEADING,
+  description = DEFAULT_GALLERY_DESCRIPTION,
   className,
 }: ImageGalleryProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -65,12 +75,10 @@ export function ImageGallery({
       <Container>
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="font-space-grotesk text-3xl font-bold tracking-tight text-brand-slate-gray sm:text-4xl dark:text-white">
-            Conference Moments
+            {heading}
           </h2>
           <p className="mt-4 text-lg text-brand-slate-gray/80 dark:text-gray-300">
-            Relive the energy and excitement from our past events. Browse
-            through captured moments featuring speakers, attendees, and the
-            vibrant community atmosphere.
+            {description}
           </p>
         </div>
 

--- a/src/components/Sponsors.stories.tsx
+++ b/src/components/Sponsors.stories.tsx
@@ -20,6 +20,10 @@ const meta: Meta<typeof Sponsors> = {
       control: 'boolean',
       description: 'Show call-to-action for prospective sponsors',
     },
+    heading: { control: 'text', description: 'Band heading override' },
+    description: { control: 'text', description: 'Band sub-heading override' },
+    ctaHeading: { control: 'text', description: 'CTA card heading override' },
+    ctaDescription: { control: 'text', description: 'CTA card body override' },
   },
 }
 
@@ -162,5 +166,23 @@ export const SingleTier: Story = {
     sponsors: mockSponsors.slice(0, 2) as ConferenceSponsor[],
     conference: mockConference as Conference,
     showCTA: true,
+  },
+}
+
+/**
+ * A tenant overriding the house copy from its `homepageSponsors` section
+ * config. Omitting any of these props restores the defaults shown in
+ * `WithSponsors` — the copy is configuration, not a fork.
+ */
+export const CustomCopy: Story = {
+  args: {
+    sponsors: mockSponsors as ConferenceSponsor[],
+    conference: mockConference as Conference,
+    showCTA: true,
+    heading: 'Our partners',
+    description: 'The organisations that make this conference possible.',
+    ctaHeading: 'Partner with us',
+    ctaDescription:
+      'Put your brand in front of the practitioners who build and run the systems your product serves.',
   },
 }

--- a/src/components/Sponsors.tsx
+++ b/src/components/Sponsors.tsx
@@ -11,15 +11,33 @@ import {
 } from '@/lib/sponsor/utils'
 import Link from 'next/link'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
+import {
+  DEFAULT_SPONSORS_CTA_DESCRIPTION,
+  DEFAULT_SPONSORS_CTA_HEADING,
+  DEFAULT_SPONSORS_DESCRIPTION,
+  DEFAULT_SPONSORS_HEADING,
+} from '@/lib/homepage/sections'
 
 export function Sponsors({
   sponsors,
   conference,
   showCTA = true,
+  heading = DEFAULT_SPONSORS_HEADING,
+  description = DEFAULT_SPONSORS_DESCRIPTION,
+  ctaHeading = DEFAULT_SPONSORS_CTA_HEADING,
+  ctaDescription = DEFAULT_SPONSORS_CTA_DESCRIPTION,
 }: {
   sponsors: ConferenceSponsor[]
   conference: Conference
   showCTA?: boolean
+  /** Band heading. Defaults to the house copy (`homepageSponsors` config). */
+  heading?: string
+  /** Band sub-heading. Defaults to the house copy. */
+  description?: string
+  /** "Become a Sponsor" card heading. Defaults to the house copy. */
+  ctaHeading?: string
+  /** "Become a Sponsor" card body. Defaults to the house copy. */
+  ctaDescription?: string
 }) {
   const hasSponsors = sponsors && sponsors.length > 0
 
@@ -47,11 +65,10 @@ export function Sponsors({
           <div className="mb-20">
             <div className="mx-auto max-w-2xl lg:mx-0">
               <h2 className="font-space-grotesk text-4xl font-medium tracking-tighter text-brand-cloud-blue sm:text-5xl">
-                Our sponsors
+                {heading}
               </h2>
               <p className="font-inter mt-4 text-2xl tracking-tight text-brand-slate-gray dark:text-gray-300">
-                Meet our sponsors who are fueling the cluster and keeping the
-                pods running!
+                {description}
               </p>
             </div>
           </div>
@@ -118,12 +135,10 @@ export function Sponsors({
                 </div>
                 <div className="flex-1">
                   <h3 className="font-space-grotesk mb-4 text-2xl font-bold tracking-tight text-brand-slate-gray md:text-3xl">
-                    Become a Sponsor
+                    {ctaHeading}
                   </h3>
                   <p className="font-inter mx-auto mb-8 max-w-2xl text-lg text-brand-slate-gray sm:mx-0">
-                    Level up your brand&apos;s visibility among Kubernetes
-                    enthusiasts, container wranglers, and cloud architects. We
-                    have sponsorship tiers for every cluster size.
+                    {ctaDescription}
                   </p>
                   {conference.sponsorTiers &&
                   conference.sponsorTiers.length > 0 ? (

--- a/src/components/admin/HomepageSectionsEditor.stories.tsx
+++ b/src/components/admin/HomepageSectionsEditor.stories.tsx
@@ -76,6 +76,26 @@ const f4Sections: HomepageSection[] = [
   },
 ]
 
+// The content bands, whose config is COPY ONLY (headings/sub-headings, plus the
+// sponsors CTA card and its on/off toggle) — the content itself still comes from
+// the conference.
+const copySections: HomepageSection[] = [
+  {
+    _key: 'gallery',
+    _type: 'homepageGallery',
+    heading: 'Photos from 2025',
+    description: 'Talks, hallway track and the after-party, in pictures.',
+  },
+  { _key: 'featured', _type: 'homepageFeaturedSpeakers' },
+  {
+    _key: 'sponsors',
+    _type: 'homepageSponsors',
+    heading: 'Our partners',
+    ctaHeading: 'Partner with us',
+    ctaDescription: 'Reach the people who build and run these systems.',
+  },
+]
+
 const meta = {
   title: 'Systems/Settings/Admin/HomepageSectionsEditor',
   component: HomepageSectionsEditor,
@@ -190,4 +210,34 @@ export const F4ConfigFormsDark: Story = {
   },
   parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
   play: F4ConfigForms.play,
+}
+
+/**
+ * The content bands' copy config, with the Sponsors accordion expanded — band
+ * heading/sub-heading, the "Become a Sponsor" on/off toggle and its copy. Every
+ * field is optional: blank means "use the house default".
+ */
+export const ContentBandCopyConfig: Story = {
+  args: {
+    initialSections: copySections,
+    usingDefault: false,
+    defaultOpen: true,
+  },
+  play: async () => {
+    const configure = await screen.findByRole('button', {
+      name: 'Configure Sponsors',
+    })
+    await userEvent.click(configure)
+  },
+}
+
+/** The content bands' copy config in dark mode, Sponsors accordion expanded. */
+export const ContentBandCopyConfigDark: Story = {
+  args: {
+    initialSections: copySections,
+    usingDefault: false,
+    defaultOpen: true,
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  play: ContentBandCopyConfig.play,
 }

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -992,6 +992,101 @@ function SectionConfig({
     )
   }
 
+  if (
+    row._type === 'homepageFeaturedSpeakers' ||
+    row._type === 'homepageOrganizers' ||
+    row._type === 'homepageGallery'
+  ) {
+    const label = SECTION_LABELS[row._type]
+    const headingPlaceholder =
+      row._type === 'homepageFeaturedSpeakers'
+        ? 'Heading (optional — default “Featured Speakers”)'
+        : row._type === 'homepageOrganizers'
+          ? 'Heading (optional — default “Meet Our Organizers”)'
+          : 'Heading (optional — default “Conference Moments”)'
+    return (
+      <div className="space-y-2">
+        <input
+          type="text"
+          value={row.heading ?? ''}
+          onChange={(e) => onChange({ heading: e.target.value })}
+          placeholder={headingPlaceholder}
+          aria-label={`${label} heading`}
+          className={inputClass}
+        />
+        <textarea
+          value={row.description ?? ''}
+          onChange={(e) => onChange({ description: e.target.value })}
+          placeholder="Sub-heading (optional — leave blank for the default)"
+          aria-label={`${label} sub-heading`}
+          rows={2}
+          className={inputClass}
+        />
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Copy only — the {label.toLowerCase()} themselves come from the
+          conference configuration.
+        </p>
+      </div>
+    )
+  }
+
+  if (row._type === 'homepageSponsors') {
+    const showCta = row.showCta !== false
+    return (
+      <div className="space-y-2">
+        <input
+          type="text"
+          value={row.heading ?? ''}
+          onChange={(e) => onChange({ heading: e.target.value })}
+          placeholder="Heading (optional — default “Our sponsors”)"
+          aria-label="Sponsors heading"
+          className={inputClass}
+        />
+        <textarea
+          value={row.description ?? ''}
+          onChange={(e) => onChange({ description: e.target.value })}
+          placeholder="Sub-heading (optional — leave blank for the default)"
+          aria-label="Sponsors sub-heading"
+          rows={2}
+          className={inputClass}
+        />
+        <label className="flex min-h-[44px] items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={showCta}
+            onChange={(e) => onChange({ showCta: e.target.checked })}
+            className="h-4 w-4 rounded border-gray-300 text-brand-cloud-blue focus:ring-brand-cloud-blue dark:border-gray-600"
+          />
+          Show the “Become a Sponsor” call-to-action
+        </label>
+        {showCta ? (
+          <>
+            <input
+              type="text"
+              value={row.ctaHeading ?? ''}
+              onChange={(e) => onChange({ ctaHeading: e.target.value })}
+              placeholder="Call-to-action heading (optional — default “Become a Sponsor”)"
+              aria-label="Sponsors call-to-action heading"
+              className={inputClass}
+            />
+            <textarea
+              value={row.ctaDescription ?? ''}
+              onChange={(e) => onChange({ ctaDescription: e.target.value })}
+              placeholder="Call-to-action body (optional — leave blank for the default)"
+              aria-label="Sponsors call-to-action body"
+              rows={3}
+              className={inputClass}
+            />
+          </>
+        ) : null}
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Copy only — sponsor logos and tiers come from the conference
+          configuration.
+        </p>
+      </div>
+    )
+  }
+
   if (row._type === 'homepageVenue') {
     return (
       <div className="space-y-2">

--- a/src/components/homepage/HomepageComposition.stories.tsx
+++ b/src/components/homepage/HomepageComposition.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
 import { HomepageSectionRenderer } from './SectionRenderer'
 import { getDefaultSections, type HomepageSection } from '@/lib/homepage'
+import { mockFeaturedSpeakers } from '@/components/featuredSpeakers.mocks'
 import type { Conference } from '@/lib/conference/types'
+import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import type { TypedObject } from 'sanity'
 
 /**
@@ -10,6 +13,70 @@ import type { TypedObject } from 'sanity'
  * CTA banner and rich-text block and hides a section — the two are diffed to
  * confirm the default path is unchanged and the new blocks sit correctly.
  */
+
+function mockGalleryImage(id: string, alt: string): GalleryImageWithSpeakers {
+  return {
+    _id: id,
+    _rev: 'r1',
+    _createdAt: '2025-06-12T10:00:00Z',
+    _updatedAt: '2025-06-12T10:00:00Z',
+    photographer: 'Olav Nordmann',
+    date: '2025-06-12',
+    location: 'Grieghallen, Bergen',
+    featured: true,
+    imageAlt: alt,
+    image: {
+      _type: 'image',
+      asset: {
+        _ref: `image-${id}0000000000000000000000000000-1920x1080-jpg`,
+        _type: 'reference',
+      },
+    },
+    speakers: [],
+  } as unknown as GalleryImageWithSpeakers
+}
+
+const sponsorLogo = (label: string, fill: string) =>
+  `<svg width="100" height="40" xmlns="http://www.w3.org/2000/svg"><text x="10" y="25" fill="${fill}">${label}</text></svg>`
+
+const mockSponsors = [
+  {
+    _id: 'cs-1',
+    sponsor: {
+      _id: 's-1',
+      name: 'Acme Corporation',
+      website: 'https://acme.example.com',
+      logo: sponsorLogo('ACME', '#2563eb'),
+    },
+    tier: { title: 'Ingress', tagline: 'Premium' },
+  },
+  {
+    _id: 'cs-2',
+    sponsor: {
+      _id: 's-2',
+      name: 'Tech Solutions',
+      website: 'https://tech.example.com',
+      logo: sponsorLogo('TECH', '#10b981'),
+    },
+    tier: { title: 'Pod', tagline: 'Base' },
+  },
+]
+
+const placeholderSvg = (label: string, hue: number) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080">` +
+  `<rect width="1920" height="1080" fill="hsl(${hue} 40% 30%)"/>` +
+  `<text x="50%" y="50%" fill="hsl(${hue} 30% 75%)" font-family="sans-serif" font-size="90" text-anchor="middle" dominant-baseline="middle">${label}</text>` +
+  `</svg>`
+
+const handlers = [
+  http.get('https://cdn.sanity.io/images/*', ({ request }) => {
+    const n = Number(/gal(\d)/.exec(new URL(request.url).pathname)?.[1] ?? 1)
+    return new HttpResponse(
+      placeholderSvg(`Photo ${n}`, [210, 150, 30][n - 1] ?? 210),
+      { headers: { 'Content-Type': 'image/svg+xml' } },
+    )
+  }),
+]
 
 const baseConference = {
   _id: 'conf-1',
@@ -45,8 +112,17 @@ const baseConference = {
   topics: [],
   organizers: [],
   socialLinks: [],
-  sponsors: [],
-  sponsorTiers: [],
+  featuredSpeakers: mockFeaturedSpeakers,
+  featuredGalleryImages: [
+    mockGalleryImage('gal1', 'Keynote presentation on the main stage'),
+    mockGalleryImage('gal2', 'Hands-on workshop session'),
+    mockGalleryImage('gal3', 'Networking break'),
+  ],
+  sponsors: mockSponsors,
+  sponsorTiers: [
+    { _id: 'tier-ingress', title: 'Ingress' },
+    { _id: 'tier-pod', title: 'Pod' },
+  ],
   vanityMetrics: [
     { label: 'Attendees', value: '450+' },
     { label: 'Speakers', value: '40' },
@@ -88,7 +164,18 @@ const customSections: HomepageSection[] = [
     buttonLabel: 'Submit a talk',
     buttonHref: '/cfp',
   },
-  { _key: 'gallery', _type: 'homepageGallery', hidden: true },
+  {
+    _key: 'gallery',
+    _type: 'homepageGallery',
+    heading: 'Photos from 2025',
+    description: 'Talks, hallway track and the after-party, in pictures.',
+  },
+  {
+    _key: 'featured',
+    _type: 'homepageFeaturedSpeakers',
+    heading: 'Who you will hear',
+    description: 'A hand-picked line-up from across the industry.',
+  },
   {
     _key: 'rich',
     _type: 'homepageRichText',
@@ -125,7 +212,15 @@ const customSections: HomepageSection[] = [
     heading: 'Where to find us',
     description: 'A short walk from Bergen train station.',
   },
-  { _key: 'sponsors', _type: 'homepageSponsors' },
+  {
+    _key: 'sponsors',
+    _type: 'homepageSponsors',
+    heading: 'Our partners',
+    description: 'The organisations that make this conference possible.',
+    ctaHeading: 'Partner with us',
+    ctaDescription:
+      'Put your brand in front of the practitioners who build and run the systems your product serves.',
+  },
 ]
 
 const meta = {
@@ -133,10 +228,11 @@ const meta = {
   component: HomepageSectionRenderer,
   parameters: {
     layout: 'fullscreen',
+    msw: { handlers },
     docs: {
       description: {
         component:
-          'Front-page builder (F2) whole-page renderer. The default composition reproduces the legacy layout pixel-for-pixel; a custom composition can insert CTA/rich-text blocks and hide sections.',
+          'Front-page builder (F2) whole-page renderer. The default composition reproduces the legacy layout pixel-for-pixel; a custom composition can insert CTA/rich-text blocks, hide sections and override each section’s copy.',
       },
     },
   },
@@ -145,12 +241,33 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+/**
+ * The zero-config baseline: no stored composition, so every section renders its
+ * built-in house copy. This is the story that proves the per-section copy
+ * config changes nothing for a conference that has not configured it.
+ */
 export const Default: Story = {
   args: {
     conference: baseConference,
     sections: getDefaultSections(baseConference),
     ticketsFromPrice: '3 490',
   },
+}
+
+export const DefaultDark: Story = {
+  args: {
+    conference: baseConference,
+    sections: getDefaultSections(baseConference),
+    ticketsFromPrice: '3 490',
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-gray-950">
+        <Story />
+      </div>
+    ),
+  ],
 }
 
 export const Custom: Story = {

--- a/src/components/homepage/SectionRenderer.test.tsx
+++ b/src/components/homepage/SectionRenderer.test.tsx
@@ -17,10 +17,37 @@ vi.mock('@/components/ProgramHighlights', () => ({
   ProgramHighlights: () => <div data-testid="program" />,
 }))
 vi.mock('@/components/Sponsors', () => ({
-  Sponsors: () => <div data-testid="sponsors" />,
+  Sponsors: ({
+    showCTA,
+    heading,
+    ctaHeading,
+  }: {
+    showCTA?: boolean
+    heading?: string
+    ctaHeading?: string
+  }) => (
+    <div
+      data-testid="sponsors"
+      data-show-cta={String(showCTA)}
+      data-heading={heading ?? ''}
+      data-cta-heading={ctaHeading ?? ''}
+    />
+  ),
 }))
 vi.mock('@/components/ImageGallery', () => ({
-  ImageGallery: () => <div data-testid="gallery" />,
+  ImageGallery: ({
+    heading,
+    description,
+  }: {
+    heading?: string
+    description?: string
+  }) => (
+    <div
+      data-testid="gallery"
+      data-heading={heading ?? ''}
+      data-description={description ?? ''}
+    />
+  ),
 }))
 vi.mock('@/components/FeaturedSpeakersShelf', () => ({
   FeaturedSpeakersShelf: () => <div data-testid="featured-shelf" />,
@@ -110,6 +137,117 @@ describe('HomepageSectionRenderer — default composition', () => {
     expect(ids[0]).toBe('hero')
     expect(ids).toContain('featured-shelf')
     expect(ids).not.toContain('program')
+  })
+})
+
+describe('HomepageSectionRenderer — per-section copy', () => {
+  it('renders the house copy when a section configures none', () => {
+    const conference = makeConference({
+      programDate: '2999-01-01',
+      schedules: [],
+    })
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={[
+          { _key: 'g', _type: 'homepageGallery' },
+          { _key: 'f', _type: 'homepageFeaturedSpeakers' },
+          { _key: 's', _type: 'homepageSponsors' },
+        ]}
+        conference={conference}
+      />,
+    )
+    // The inline bands render their defaults verbatim…
+    expect(container.textContent).toContain('Featured Speakers')
+    expect(container.textContent).toContain('Meet the speakers at Test Conf')
+    // …and the leaf components are handed NOTHING, so their own prop defaults
+    // (today's copy) apply — this is the zero-migration guarantee.
+    const gallery = container.querySelector('[data-testid="gallery"]')!
+    expect(gallery.getAttribute('data-heading')).toBe('')
+    expect(gallery.getAttribute('data-description')).toBe('')
+    const sponsors = container.querySelector('[data-testid="sponsors"]')!
+    expect(sponsors.getAttribute('data-heading')).toBe('')
+    expect(sponsors.getAttribute('data-cta-heading')).toBe('')
+    expect(sponsors.getAttribute('data-show-cta')).toBe('true')
+  })
+
+  it('renders configured copy for the inline bands', () => {
+    const conference = makeConference({
+      programDate: '2999-01-01',
+      schedules: [],
+    })
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={[
+          {
+            _key: 'f',
+            _type: 'homepageFeaturedSpeakers',
+            heading: 'Who you will hear',
+            description: 'A hand-picked line-up',
+          },
+          {
+            _key: 'o',
+            _type: 'homepageOrganizers',
+            heading: 'The crew',
+            description: 'Volunteers, all of them',
+          },
+        ]}
+        conference={conference}
+      />,
+    )
+    expect(container.textContent).toContain('Who you will hear')
+    expect(container.textContent).toContain('A hand-picked line-up')
+    expect(container.textContent).not.toContain('Featured Speakers')
+    expect(container.textContent).toContain('The crew')
+    expect(container.textContent).not.toContain('Meet Our Organizers')
+  })
+
+  it('passes configured copy and the CTA toggle down to the leaf components', () => {
+    const conference = makeConference()
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={[
+          { _key: 'g', _type: 'homepageGallery', heading: 'Photos' },
+          {
+            _key: 's',
+            _type: 'homepageSponsors',
+            heading: 'Our partners',
+            showCta: false,
+            ctaHeading: 'ignored while hidden',
+          },
+        ]}
+        conference={conference}
+      />,
+    )
+    expect(
+      container
+        .querySelector('[data-testid="gallery"]')
+        ?.getAttribute('data-heading'),
+    ).toBe('Photos')
+    const sponsors = container.querySelector('[data-testid="sponsors"]')!
+    expect(sponsors.getAttribute('data-heading')).toBe('Our partners')
+    expect(sponsors.getAttribute('data-show-cta')).toBe('false')
+  })
+
+  it('treats blank stored copy as absent (falls back to the default)', () => {
+    const conference = makeConference({
+      programDate: '2999-01-01',
+      schedules: [],
+    })
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={[
+          { _key: 'g', _type: 'homepageGallery', heading: '   ' },
+          { _key: 'f', _type: 'homepageFeaturedSpeakers', heading: '  ' },
+        ]}
+        conference={conference}
+      />,
+    )
+    expect(
+      container
+        .querySelector('[data-testid="gallery"]')
+        ?.getAttribute('data-heading'),
+    ).toBe('')
+    expect(container.textContent).toContain('Featured Speakers')
   })
 })
 

--- a/src/components/homepage/SectionRenderer.tsx
+++ b/src/components/homepage/SectionRenderer.tsx
@@ -22,7 +22,16 @@ import {
 import type { Conference } from '@/lib/conference/types'
 import { isCfpOpen, isRegistrationAvailable } from '@/lib/conference/state'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
-import { hasPublishedSchedule, type HomepageSection } from '@/lib/homepage'
+import {
+  DEFAULT_FEATURED_SPEAKERS_HEADING,
+  DEFAULT_ORGANIZERS_HEADING,
+  defaultFeaturedSpeakersDescription,
+  defaultOrganizersDescription,
+  hasPublishedSchedule,
+  type FeaturedSpeakersSection,
+  type HomepageSection,
+  type OrganizersSection,
+} from '@/lib/homepage'
 
 /** Unknown section `_type`s already warned about (once per process). */
 const warnedUnknownSectionTypes = new Set<string>()
@@ -136,9 +145,11 @@ function PhaseCtaRow({
 /** Featured-speakers band (legacy middle slot). Null when there are none. */
 function FeaturedSpeakersSectionView({
   conference,
+  section,
   ticketsFromPrice,
 }: {
   conference: Conference
+  section: FeaturedSpeakersSection
   ticketsFromPrice?: string | null
 }) {
   if (
@@ -147,15 +158,19 @@ function FeaturedSpeakersSectionView({
   ) {
     return null
   }
+  const heading = section.heading?.trim() || DEFAULT_FEATURED_SPEAKERS_HEADING
+  const description =
+    section.description?.trim() ||
+    defaultFeaturedSpeakersDescription(conference.title)
   return (
     <section className="py-20 sm:py-32">
       <Container>
         <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-4xl lg:pr-24">
           <h2 className="font-space-grotesk text-4xl font-medium tracking-tighter text-brand-cloud-blue sm:text-5xl dark:text-blue-400">
-            Featured Speakers
+            {heading}
           </h2>
           <p className="font-inter mt-4 text-2xl tracking-tight text-brand-slate-gray dark:text-gray-300">
-            Meet the speakers at {conference.title}
+            {description}
           </p>
         </div>
 
@@ -174,9 +189,11 @@ function FeaturedSpeakersSectionView({
 /** Organizers band (legacy fallback slot). Null when there are none. */
 function OrganizersSectionView({
   conference,
+  section,
   ticketsFromPrice,
 }: {
   conference: Conference
+  section: OrganizersSection
   ticketsFromPrice?: string | null
 }) {
   const sortedOrganizers =
@@ -186,15 +203,19 @@ function OrganizersSectionView({
         a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
       ) || []
   if (sortedOrganizers.length === 0) return null
+  const heading = section.heading?.trim() || DEFAULT_ORGANIZERS_HEADING
+  const description =
+    section.description?.trim() ||
+    defaultOrganizersDescription(conference.title)
   return (
     <section className="py-20 sm:py-32">
       <Container>
         <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-4xl lg:pr-24">
           <h2 className="font-space-grotesk text-4xl font-medium tracking-tighter text-brand-cloud-blue sm:text-5xl dark:text-blue-400">
-            Meet Our Organizers
+            {heading}
           </h2>
           <p className="font-inter mt-4 text-2xl tracking-tight text-brand-slate-gray dark:text-gray-300">
-            The passionate team driving {conference.title}
+            {description}
           </p>
         </div>
 
@@ -262,7 +283,12 @@ function renderSection(
     case 'homepageGallery':
       return conference.featuredGalleryImages &&
         conference.featuredGalleryImages.length > 0 ? (
-        <ImageGallery featuredImages={conference.featuredGalleryImages} />
+        // Blank/absent copy falls through to the component's house defaults.
+        <ImageGallery
+          featuredImages={conference.featuredGalleryImages}
+          heading={section.heading?.trim() || undefined}
+          description={section.description?.trim() || undefined}
+        />
       ) : null
     case 'homepageProgramHighlights':
       return <ProgramHighlightsSectionView conference={conference} />
@@ -270,6 +296,7 @@ function renderSection(
       return (
         <FeaturedSpeakersSectionView
           conference={conference}
+          section={section}
           ticketsFromPrice={ticketsFromPrice}
         />
       )
@@ -277,6 +304,7 @@ function renderSection(
       return (
         <OrganizersSectionView
           conference={conference}
+          section={section}
           ticketsFromPrice={ticketsFromPrice}
         />
       )
@@ -285,6 +313,11 @@ function renderSection(
         <Sponsors
           sponsors={conference.sponsors || []}
           conference={conference}
+          showCTA={section.showCta !== false}
+          heading={section.heading?.trim() || undefined}
+          description={section.description?.trim() || undefined}
+          ctaHeading={section.ctaHeading?.trim() || undefined}
+          ctaDescription={section.ctaDescription?.trim() || undefined}
         />
       )
     case 'homepageMetrics':

--- a/src/lib/homepage/editor.test.ts
+++ b/src/lib/homepage/editor.test.ts
@@ -74,12 +74,15 @@ describe('isConfigurable', () => {
     expect(isConfigurable('homepageMetrics')).toBe(true)
   })
 
-  it('is false for content-free blocks', () => {
-    expect(isConfigurable('homepageGallery')).toBe(false)
-    expect(isConfigurable('homepageSponsors')).toBe(false)
-    expect(isConfigurable('homepageFeaturedSpeakers')).toBe(false)
+  it('is true for the content bands that carry only copy config', () => {
+    expect(isConfigurable('homepageGallery')).toBe(true)
+    expect(isConfigurable('homepageSponsors')).toBe(true)
+    expect(isConfigurable('homepageFeaturedSpeakers')).toBe(true)
+    expect(isConfigurable('homepageOrganizers')).toBe(true)
+  })
+
+  it('is false for the block with nothing to configure', () => {
     expect(isConfigurable('homepageProgramHighlights')).toBe(false)
-    expect(isConfigurable('homepageOrganizers')).toBe(false)
   })
 })
 
@@ -338,6 +341,93 @@ describe('toPayload — trimming, omission and item filtering', () => {
     )
     expect(venue.heading).toBeUndefined()
     expect(venue.description).toBe('Grieghallen')
+  })
+
+  it('maps the content bands’ copy overrides in both directions', () => {
+    const stored: HomepageSection[] = [
+      {
+        _key: 'g',
+        _type: 'homepageGallery',
+        heading: 'Photos',
+        description: 'From last year',
+      },
+      {
+        _key: 'f',
+        _type: 'homepageFeaturedSpeakers',
+        heading: 'Our speakers',
+      },
+      {
+        _key: 'o',
+        _type: 'homepageOrganizers',
+        description: 'The crew',
+      },
+    ]
+    const editorRows = toEditorRows(stored)
+    expect(editorRows[0]).toMatchObject({
+      heading: 'Photos',
+      description: 'From last year',
+    })
+    const [gallery, featured, organizers] = toPayload(editorRows)
+    expect(gallery).toEqual({
+      _key: 'g',
+      _type: 'homepageGallery',
+      heading: 'Photos',
+      description: 'From last year',
+    })
+    expect(featured).toEqual({
+      _key: 'f',
+      _type: 'homepageFeaturedSpeakers',
+      heading: 'Our speakers',
+    })
+    expect(organizers).toEqual({
+      _key: 'o',
+      _type: 'homepageOrganizers',
+      description: 'The crew',
+    })
+  })
+
+  it('serializes an unconfigured sponsors block to bare _type/_key (zero migration)', () => {
+    const [out] = toPayload(
+      toEditorRows([{ _key: 's', _type: 'homepageSponsors' }]),
+    )
+    expect(out).toEqual({ _key: 's', _type: 'homepageSponsors' })
+  })
+
+  it('stores sponsors CTA copy and only the non-default hidden-CTA state', () => {
+    const [shown, hiddenCta] = toPayload([
+      {
+        _key: 's1',
+        _type: 'homepageSponsors',
+        showCta: true,
+        ctaHeading: '  Sponsor us  ',
+        ctaDescription: '  Reach our audience.  ',
+      },
+      {
+        _key: 's2',
+        _type: 'homepageSponsors',
+        showCta: false,
+        ctaHeading: 'ignored but kept as a draft in the form',
+      },
+    ])
+    expect(shown).toEqual({
+      _key: 's1',
+      _type: 'homepageSponsors',
+      ctaHeading: 'Sponsor us',
+      ctaDescription: 'Reach our audience.',
+    })
+    expect(hiddenCta).toMatchObject({ showCta: false })
+  })
+
+  it('round-trips a hidden sponsors CTA through the editor rows', () => {
+    const [row] = toEditorRows([
+      { _key: 's', _type: 'homepageSponsors', showCta: false },
+    ])
+    expect(row.showCta).toBe(false)
+    expect(toPayload([row])[0]).toEqual({
+      _key: 's',
+      _type: 'homepageSponsors',
+      showCta: false,
+    })
   })
 
   it('always carries _type and _key, plus hidden when set', () => {

--- a/src/lib/homepage/editor.ts
+++ b/src/lib/homepage/editor.ts
@@ -26,10 +26,11 @@ export const SECTION_LABELS: Record<HomepageSectionType, string> = {
 }
 
 /**
- * The block types that carry per-section config worth an inline accordion. The
- * content-free blocks (featured speakers, program, organizers, sponsors,
- * gallery) only source their content from the conference, so they need no form
- * — their cards render without an expandable config panel.
+ * The block types that carry per-section config worth an inline accordion.
+ * The content-sourced bands (featured speakers, organizers, sponsors, gallery)
+ * still pull their CONTENT from the conference, but their headings and body
+ * copy are per-section config, so they get a form too. Program highlights is
+ * the only block with nothing to configure.
  */
 const CONFIGURABLE_TYPES: ReadonlySet<HomepageSectionType> = new Set([
   'homepageHero',
@@ -39,6 +40,10 @@ const CONFIGURABLE_TYPES: ReadonlySet<HomepageSectionType> = new Set([
   'homepageFaq',
   'homepageCountdown',
   'homepageVenue',
+  'homepageFeaturedSpeakers',
+  'homepageOrganizers',
+  'homepageSponsors',
+  'homepageGallery',
 ])
 
 export function isConfigurable(type: HomepageSectionType): boolean {
@@ -77,8 +82,13 @@ export interface EditorRow {
   // Countdown block
   targetOverride?: string
   liveMessage?: string
-  // Venue block
+  // Venue block + the copy-configurable content bands (featured speakers,
+  // organizers, sponsors, gallery) share `heading`/`description`.
   description?: string
+  // Sponsors block
+  showCta?: boolean
+  ctaHeading?: string
+  ctaDescription?: string
 }
 
 let keyCounter = 0
@@ -144,6 +154,21 @@ export function toEditorRows(sections: HomepageSection[]): EditorRow[] {
     } else if (s._type === 'homepageVenue') {
       row.heading = s.heading
       row.description = s.description
+    } else if (
+      s._type === 'homepageFeaturedSpeakers' ||
+      s._type === 'homepageOrganizers' ||
+      s._type === 'homepageGallery'
+    ) {
+      row.heading = s.heading
+      row.description = s.description
+    } else if (s._type === 'homepageSponsors') {
+      row.heading = s.heading
+      row.description = s.description
+      // Absent means "shown" — surface it as the checked state so the form
+      // round-trips an unconfigured block to an identical payload.
+      row.showCta = s.showCta !== false
+      row.ctaHeading = s.ctaHeading
+      row.ctaDescription = s.ctaDescription
     }
     return row
   })
@@ -217,8 +242,21 @@ export function toPayload(rows: EditorRow[]): Record<string, unknown>[] {
         if (row.liveMessage?.trim()) out.liveMessage = row.liveMessage.trim()
         break
       case 'homepageVenue':
+      case 'homepageFeaturedSpeakers':
+      case 'homepageOrganizers':
+      case 'homepageGallery':
         if (row.heading?.trim()) out.heading = row.heading.trim()
         if (row.description?.trim()) out.description = row.description.trim()
+        break
+      case 'homepageSponsors':
+        if (row.heading?.trim()) out.heading = row.heading.trim()
+        if (row.description?.trim()) out.description = row.description.trim()
+        // Only the non-default state is stored, so an untouched sponsors block
+        // serializes to exactly `{_type, _key}` as it did before.
+        if (row.showCta === false) out.showCta = false
+        if (row.ctaHeading?.trim()) out.ctaHeading = row.ctaHeading.trim()
+        if (row.ctaDescription?.trim())
+          out.ctaDescription = row.ctaDescription.trim()
         break
       default:
         break

--- a/src/lib/homepage/sections.ts
+++ b/src/lib/homepage/sections.ts
@@ -39,8 +39,37 @@ export const HOMEPAGE_SECTION_TYPES = [
   'homepageVenue',
 ] as const
 
-/** Default heading for the FAQ block when none is configured. */
+/**
+ * DEFAULT SECTION COPY — the house wording each block falls back to when a
+ * tenant has configured nothing. These constants ARE the pre-config strings,
+ * moved out of the components verbatim, so an unconfigured section renders
+ * exactly what it rendered before the copy became configurable (the
+ * zero-migration guarantee above, extended to copy).
+ */
 export const DEFAULT_FAQ_HEADING = 'Frequently asked questions'
+export const DEFAULT_GALLERY_HEADING = 'Conference Moments'
+export const DEFAULT_GALLERY_DESCRIPTION =
+  'Relive the energy and excitement from our past events. Browse through captured moments featuring speakers, attendees, and the vibrant community atmosphere.'
+export const DEFAULT_FEATURED_SPEAKERS_HEADING = 'Featured Speakers'
+export const DEFAULT_ORGANIZERS_HEADING = 'Meet Our Organizers'
+export const DEFAULT_SPONSORS_HEADING = 'Our sponsors'
+export const DEFAULT_SPONSORS_DESCRIPTION =
+  'Meet our sponsors who are fueling the cluster and keeping the pods running!'
+export const DEFAULT_SPONSORS_CTA_HEADING = 'Become a Sponsor'
+export const DEFAULT_SPONSORS_CTA_DESCRIPTION =
+  "Level up your brand's visibility among Kubernetes enthusiasts, container wranglers, and cloud architects. We have sponsorship tiers for every cluster size."
+
+/** Default sub-heading under the featured-speakers heading. */
+export function defaultFeaturedSpeakersDescription(
+  conferenceTitle: string,
+): string {
+  return `Meet the speakers at ${conferenceTitle}`
+}
+
+/** Default sub-heading under the organizers heading. */
+export function defaultOrganizersDescription(conferenceTitle: string): string {
+  return `The passionate team driving ${conferenceTitle}`
+}
 
 export type HomepageSectionType = (typeof HOMEPAGE_SECTION_TYPES)[number]
 
@@ -80,24 +109,58 @@ export interface HeroSection extends BaseSection {
   ctaOverrides?: HeroCtaOverride[]
 }
 
+/**
+ * Featured-speakers band. Content is `conference.featuredSpeakers`; the block
+ * carries only the band's copy. Blank/absent renders the house default —
+ * {@link DEFAULT_FEATURED_SPEAKERS_HEADING} and
+ * {@link defaultFeaturedSpeakersDescription}.
+ */
 export interface FeaturedSpeakersSection extends BaseSection {
   _type: 'homepageFeaturedSpeakers'
+  heading?: string
+  description?: string
 }
 
 export interface ProgramHighlightsSection extends BaseSection {
   _type: 'homepageProgramHighlights'
 }
 
+/**
+ * Organizers band. Content is `conference.organizers`; blank/absent copy
+ * renders {@link DEFAULT_ORGANIZERS_HEADING} /
+ * {@link defaultOrganizersDescription}.
+ */
 export interface OrganizersSection extends BaseSection {
   _type: 'homepageOrganizers'
+  heading?: string
+  description?: string
 }
 
+/**
+ * Sponsors band. Logos come from `conference.sponsors`; the block carries the
+ * band copy plus the prospective-sponsor call-to-action card. `showCta` is
+ * tri-state by absence: undefined/true shows the card (today's behaviour),
+ * false hides it.
+ */
 export interface SponsorsSection extends BaseSection {
   _type: 'homepageSponsors'
+  heading?: string
+  description?: string
+  /** Absent = shown. Set false to drop the "Become a Sponsor" card. */
+  showCta?: boolean
+  ctaHeading?: string
+  ctaDescription?: string
 }
 
+/**
+ * Photo-gallery band. Images come from `conference.featuredGalleryImages`;
+ * blank/absent copy renders {@link DEFAULT_GALLERY_HEADING} /
+ * {@link DEFAULT_GALLERY_DESCRIPTION}.
+ */
 export interface GallerySection extends BaseSection {
   _type: 'homepageGallery'
+  heading?: string
+  description?: string
 }
 
 /** Standalone vanity-metrics band (content from `conference.vanityMetrics`). */

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -533,6 +533,27 @@ export const conferenceRouter = router({
               if (section.heading) base.heading = section.heading
               break
             }
+            case 'homepageFeaturedSpeakers':
+            case 'homepageOrganizers':
+            case 'homepageGallery': {
+              // Copy-only overrides: content still comes from the conference.
+              // An omitted field is what makes the band fall back to the house
+              // default copy, so blanks are never stored.
+              if (section.heading) base.heading = section.heading
+              if (section.description) base.description = section.description
+              break
+            }
+            case 'homepageSponsors': {
+              if (section.heading) base.heading = section.heading
+              if (section.description) base.description = section.description
+              // Only the NON-default (hidden) state is persisted, mirroring
+              // `hidden` — absent means the CTA card shows, as it always has.
+              if (section.showCta === false) base.showCta = false
+              if (section.ctaHeading) base.ctaHeading = section.ctaHeading
+              if (section.ctaDescription)
+                base.ctaDescription = section.ctaDescription
+              break
+            }
             case 'homepageCtaBanner': {
               base.heading = section.heading
               if (section.body) base.body = section.body
@@ -582,8 +603,8 @@ export const conferenceRouter = router({
               break
             }
             default:
-              // The content-free blocks (featured speakers, program, organizers,
-              // sponsors, gallery) carry only `_type`/`_key`/`hidden`.
+              // Program highlights carries no config of its own — only
+              // `_type`/`_key`/`hidden`.
               break
           }
           return base

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -607,6 +607,14 @@ const sectionKey = z.string().optional()
 const sectionHidden = z.boolean().optional()
 
 /**
+ * Optional per-section COPY (heading/sub-heading/CTA text). Blank is rejected
+ * rather than stored: an absent field is what makes a section fall back to the
+ * house default, so an empty string would be a third, meaningless state. The
+ * editor omits blanks before it builds the payload.
+ */
+const sectionCopy = z.string().trim().min(1).nullable().optional()
+
+/**
  * A link an ORGANIZER can point a public-page button at: a site-internal path
  * (`/tickets`) or an absolute http(s) URL. Anything else — `javascript:`,
  * `data:`, scheme-relative `//host` — is rejected: these are tenant-entered
@@ -677,6 +685,8 @@ const HomepageSectionSchema = z.discriminatedUnion('_type', [
     _type: z.literal('homepageFeaturedSpeakers'),
     _key: sectionKey,
     hidden: sectionHidden,
+    heading: sectionCopy,
+    description: sectionCopy,
   }),
   z.object({
     _type: z.literal('homepageProgramHighlights'),
@@ -687,16 +697,26 @@ const HomepageSectionSchema = z.discriminatedUnion('_type', [
     _type: z.literal('homepageOrganizers'),
     _key: sectionKey,
     hidden: sectionHidden,
+    heading: sectionCopy,
+    description: sectionCopy,
   }),
   z.object({
     _type: z.literal('homepageSponsors'),
     _key: sectionKey,
     hidden: sectionHidden,
+    heading: sectionCopy,
+    description: sectionCopy,
+    // Absent = the CTA card shows (today's behaviour); only `false` hides it.
+    showCta: z.boolean().optional(),
+    ctaHeading: sectionCopy,
+    ctaDescription: sectionCopy,
   }),
   z.object({
     _type: z.literal('homepageGallery'),
     _key: sectionKey,
     hidden: sectionHidden,
+    heading: sectionCopy,
+    description: sectionCopy,
   }),
   z.object({
     _type: z.literal('homepageMetrics'),

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -610,9 +610,15 @@ const sectionHidden = z.boolean().optional()
  * Optional per-section COPY (heading/sub-heading/CTA text). Blank is rejected
  * rather than stored: an absent field is what makes a section fall back to the
  * house default, so an empty string would be a third, meaningless state. The
- * editor omits blanks before it builds the payload.
+ * editor omits blanks before it builds the payload (`toPayload` only assigns a
+ * trimmed non-empty value), and the router only persists truthy values.
+ *
+ * Deliberately NOT `.nullable()`: the section types model these as
+ * `heading?: string`, so `null` would be a third state nothing downstream
+ * handles. Absent is the only way to mean "use the house default" — the same
+ * two-state shape as `sectionHidden`.
  */
-const sectionCopy = z.string().trim().min(1).nullable().optional()
+const sectionCopy = z.string().trim().min(1).optional()
 
 /**
  * A link an ORGANIZER can point a public-page button at: a site-internal path

--- a/src/server/schemas/homepageSections.test.ts
+++ b/src/server/schemas/homepageSections.test.ts
@@ -192,6 +192,98 @@ describe('UpdateHomepageSectionsSchema', () => {
     ).not.toThrow()
   })
 
+  it('round-trips per-section copy on the content bands', () => {
+    const parsed = UpdateHomepageSectionsSchema.parse({
+      homepageSections: [
+        {
+          _type: 'homepageGallery',
+          _key: 'g',
+          heading: 'Photos',
+          description: 'From last year',
+        },
+        {
+          _type: 'homepageFeaturedSpeakers',
+          _key: 'f',
+          heading: 'Our speakers',
+          description: 'The line-up',
+        },
+        {
+          _type: 'homepageOrganizers',
+          _key: 'o',
+          heading: 'The team',
+          description: 'Volunteers, all of them',
+        },
+      ],
+    })
+    expect(parsed.homepageSections).toHaveLength(3)
+    expect(parsed.homepageSections[0]).toMatchObject({ heading: 'Photos' })
+  })
+
+  it('round-trips the sponsors band copy and the CTA toggle', () => {
+    const parsed = UpdateHomepageSectionsSchema.parse({
+      homepageSections: [
+        {
+          _type: 'homepageSponsors',
+          _key: 's',
+          heading: 'Our partners',
+          description: 'They make it possible',
+          showCta: false,
+          ctaHeading: 'Sponsor us',
+          ctaDescription: 'Reach our audience.',
+        },
+      ],
+    })
+    expect(parsed.homepageSections[0]).toMatchObject({
+      _type: 'homepageSponsors',
+      showCta: false,
+      ctaHeading: 'Sponsor us',
+    })
+  })
+
+  it('still accepts the content bands with no copy at all (house defaults)', () => {
+    expect(() =>
+      UpdateHomepageSectionsSchema.parse({
+        homepageSections: [
+          { _type: 'homepageGallery', _key: 'g' },
+          { _type: 'homepageFeaturedSpeakers', _key: 'f' },
+          { _type: 'homepageOrganizers', _key: 'o' },
+          { _type: 'homepageSponsors', _key: 's' },
+        ],
+      }),
+    ).not.toThrow()
+  })
+
+  it('rejects blank section copy (absent is what selects the default)', () => {
+    expect(
+      UpdateHomepageSectionsSchema.safeParse({
+        homepageSections: [
+          { _type: 'homepageGallery', _key: 'g', heading: '' },
+        ],
+      }).success,
+    ).toBe(false)
+    expect(
+      UpdateHomepageSectionsSchema.safeParse({
+        homepageSections: [
+          { _type: 'homepageSponsors', _key: 's', ctaDescription: '   ' },
+        ],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('strips unknown fields off a content band (no smuggled raw HTML)', () => {
+    const parsed = UpdateHomepageSectionsSchema.parse({
+      homepageSections: [
+        {
+          _type: 'homepageGallery',
+          _key: 'g',
+          heading: 'Photos',
+          embedHtml: '<script>alert(1)</script>',
+        },
+      ],
+    })
+    expect(parsed.homepageSections[0]).not.toHaveProperty('embedHtml')
+  })
+
   it('round-trips a venue block (name/address come from the conference)', () => {
     const parsed = UpdateHomepageSectionsSchema.parse({
       homepageSections: [


### PR DESCRIPTION
Several homepage sections hardcode Cloud Native Days Norway's own voice, so it appears on every tenant's homepage. This moves that copy into per-section config, with the current wording as the default.

## What moved

| Block | New fields |
|---|---|
| `homepageGallery` | `heading`, `description` |
| `homepageFeaturedSpeakers` | `heading`, `description` |
| `homepageOrganizers` | `heading`, `description` |
| `homepageSponsors` | `heading`, `description`, `showCta`, `ctaHeading`, `ctaDescription` |

`showCta` exposes a prop `Sponsors` already accepted but that was never surfaced. It is tri-state-by-absence like `hidden`, so only a non-default `false` is persisted and an untouched sponsors block still serialises to `{_type, _key}`.

Defaults live next to `DEFAULT_FAQ_HEADING` in `src/lib/homepage/sections.ts` — constants plus two `default…Description(title)` helpers for the interpolated ones — so the components, the renderer and the tests share one source rather than three copies of the same string.

## The path was 10 files, not 9

Worth flagging for the next person doing this: beyond the schema, the Zod write schema, the section types, the editor and the renderer, the **tRPC router has a per-`_type` persistence mapping** (`src/server/routers/conference.ts`) that silently drops unmapped fields. Adding a field to the schema and Zod alone would have validated fine and written nothing.

Also found and fixed beyond the original list: `OrganizersSectionView` in the renderer had the same shape of bug — "Meet Our Organizers" hardcoded in the renderer rather than being section config.

## Zero migration, proven

`ImageGallery` and `Sponsors` stories are **SHA-256 byte-identical** before and after, light and dark.

`HomepageComposition` Default differs in 2571 sub-pixels out of 64.5M, confined to the x-range of one sentence — "Meet the speakers at Cloud Native Days Norway 2026" — because that string was two adjacent DOM text nodes and is now one interpolated string, shifting text shaping by a fraction of a pixel. Cropped and viewed both; visually indistinguishable.

The `Default` story was strengthened first: it previously had no gallery images, speakers or sponsors, so it rendered hero + CTA only and proved almost nothing. The before/after comparison was captured against the enriched story.

## Deliberately not in this PR

Each is a separate piece of work, and folding them in would have buried the zero-migration proof:

- **`ProgramHighlights.tsx`** — the heaviest remaining debt: "Ready to Join the Cloud Native Journey?", "local cloud native community", and ~8 editorial strings. Note `CallToAction.tsx` carries the *same* cloud-native defaults, so it needs fixing in two places.
- **`Hero.tsx` typewriter** — a logic bug, not a copy field: the animation branch sniffs `tagline.startsWith('Real ')` and then hardcodes CNDN's word list. Any tenant whose tagline begins with "Real " inherits Cloud Native Days' animation.
- **Currency/VAT** — `kr` and "excl. VAT" hardcoded in both `Hero.tsx` and `SectionRenderer.tsx`.
- **`PhaseCtaRow`** has no override hook at all, unlike the Hero's `ctaOverrides`.

Left hardcoded on purpose: "View Sponsorship Packages", "Contact Us About Sponsoring", "Get directions" — functional labels, not voice.

## Verification

`pnpm typecheck` clean, `pnpm lint` 0 errors, `pnpm format` clean, full suite 373 files / 4847 tests green. Visual verification at DPR 2 in light and dark.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes homepage content-band copy tenant-configurable while preserving the existing copy as defaults.
- Adds heading and description overrides for gallery, featured-speaker, organizer, and sponsor sections.
- Exposes sponsor CTA visibility and copy configuration.
- Carries the new fields through Sanity, validation, persistence, editor serialization, and rendering.
- Expands unit tests and Storybook coverage for default and customized configurations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the new configuration fields are consistently validated, persisted, loaded, and rendered with backward-compatible defaults.

The copy and CTA configuration follows a complete editor-to-storage-to-renderer path, absent values preserve existing behavior, and no concrete changed-code failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/homepage/sections.ts | Centralizes legacy section copy as defaults and extends the section union with optional copy and sponsor CTA configuration. |
| src/lib/homepage/editor.ts | Round-trips the new fields while trimming blank copy and persisting only the non-default false sponsor CTA state. |
| src/server/schemas/conference.ts | Extends strict homepage-section validation with optional nonblank copy and the sponsor CTA toggle. |
| src/server/routers/conference.ts | Adds the new fields to the per-section persistence mapping without changing zero-configuration behavior. |
| src/components/homepage/SectionRenderer.tsx | Applies configured copy to each relevant section and falls back to centralized defaults for absent or blank values. |
| src/components/admin/HomepageSectionsEditor.tsx | Adds inline controls for content-band copy and sponsor CTA visibility and text. |
| src/components/Sponsors.tsx | Accepts configurable section and CTA copy while retaining the previous strings as prop defaults. |
| src/components/ImageGallery.tsx | Accepts configurable heading and description with the previous gallery wording as defaults. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Homepage section editor] --> B[Editor payload serialization]
  B --> C[Zod section schema]
  C --> D[tRPC persistence mapping]
  D --> E[Sanity homepageSections]
  E --> F[Conference query]
  F --> G[Section renderer]
  G --> H[Configured copy or house defaults]
```

<sub>Reviews (1): Last reviewed commit: ["feat(homepage): make section copy per-se..."](https://github.com/cloudnativebergen/website/commit/a081d7711a4fdd26f5f2eac7095eeb7ad3bc364f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49707533)</sub>

<!-- /greptile_comment -->