### PR TITLE
fix(program): treat schedule dates as local days, not UTC midnight

### DIFF
--- a/__tests__/lib/program/time-utils.test.ts
+++ b/__tests__/lib/program/time-utils.test.ts
@@ -99,12 +99,16 @@ describe('program/time-utils.ts', () => {
  */
 describe('program/time-utils.ts — viewer timezone', () => {
   const withTimeZone = (tz: string, run: () => void) => {
+    const hadTz = 'TZ' in process.env
     const original = process.env.TZ
     process.env.TZ = tz
     try {
       run()
     } finally {
-      process.env.TZ = original
+      // Reassigning an undefined original would set the STRING "undefined" and
+      // leak a bogus zone into every later test in this worker.
+      if (hadTz) process.env.TZ = original
+      else delete process.env.TZ
     }
   }
 
@@ -129,6 +133,20 @@ describe('program/time-utils.ts — viewer timezone', () => {
       const currentTime = new Date(2026, 10, 6, 10, 0, 0)
       expect(isScheduleToday('2026-11-05', currentTime)).toBe(false)
       expect(isScheduleInPast('2026-11-05', currentTime)).toBe(true)
+    })
+  })
+  it('falls back rather than rolling an impossible date forward', () => {
+    withTimeZone('America/Sao_Paulo', () => {
+      // 30 February would normalise to 2 March and then compare as a real day.
+      const currentTime = new Date(2026, 1, 30, 10, 0, 0)
+      expect(isScheduleToday('2026-02-30', currentTime)).toBe(false)
+    })
+  })
+
+  it('rejects a date string with trailing segments', () => {
+    withTimeZone('America/Sao_Paulo', () => {
+      const currentTime = new Date(2026, 10, 5, 10, 0, 0)
+      expect(isScheduleToday('2026-11-05-extra', currentTime)).toBe(false)
     })
   })
 })

--- a/__tests__/lib/program/time-utils.test.ts
+++ b/__tests__/lib/program/time-utils.test.ts
@@ -88,3 +88,47 @@ describe('program/time-utils.ts', () => {
     })
   })
 })
+
+/**
+ * Regression: a schedule date is a `YYYY-MM-DD` string, which `new Date()`
+ * parses as UTC midnight. For any viewer west of UTC that is the PREVIOUS local
+ * day, so day comparisons were off by one — a São Paulo conference's
+ * "happening now" rail never activated on the actual conference day.
+ *
+ * These pin the viewer's timezone rather than trusting the machine's.
+ */
+describe('program/time-utils.ts — viewer timezone', () => {
+  const withTimeZone = (tz: string, run: () => void) => {
+    const original = process.env.TZ
+    process.env.TZ = tz
+    try {
+      run()
+    } finally {
+      process.env.TZ = original
+    }
+  }
+
+  it('treats the conference day as today for a viewer west of UTC', () => {
+    withTimeZone('America/Sao_Paulo', () => {
+      // 10:00 local on the conference day itself.
+      const currentTime = new Date(2026, 10, 5, 10, 0, 0)
+      expect(isScheduleToday('2026-11-05', currentTime)).toBe(true)
+      expect(isScheduleInPast('2026-11-05', currentTime)).toBe(false)
+    })
+  })
+
+  it('still treats it as today east of UTC', () => {
+    withTimeZone('Europe/Oslo', () => {
+      const currentTime = new Date(2026, 10, 5, 10, 0, 0)
+      expect(isScheduleToday('2026-11-05', currentTime)).toBe(true)
+    })
+  })
+
+  it('does not swallow a genuinely past day west of UTC', () => {
+    withTimeZone('America/Sao_Paulo', () => {
+      const currentTime = new Date(2026, 10, 6, 10, 0, 0)
+      expect(isScheduleToday('2026-11-05', currentTime)).toBe(false)
+      expect(isScheduleInPast('2026-11-05', currentTime)).toBe(true)
+    })
+  })
+})

--- a/src/lib/program/time-utils.ts
+++ b/src/lib/program/time-utils.ts
@@ -67,10 +67,31 @@ function stripTime(date: Date): Date {
  * 2026-11-05 reported `isScheduleToday === false`, so the "happening now" rail
  * never activated on the actual conference day for any Americas tenant.
  */
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/
+
 function startOfLocalDay(dateString: string): Date {
-  const [year, month, day] = dateString.split('-').map(Number)
-  if (!year || !month || !day) return stripTime(new Date(dateString))
-  return new Date(year, month - 1, day)
+  const match = DATE_ONLY.exec(dateString)
+  if (!match) return stripTime(new Date(dateString))
+
+  const [, y, m, d] = match
+  const year = Number(y)
+  const month = Number(m)
+  const day = Number(d)
+  const local = new Date(year, month - 1, day)
+
+  // Reject a date that does not exist. `new Date(2026, 1, 30)` silently rolls
+  // 30 February forward to 2 March, which would make the day comparisons agree
+  // on the wrong day rather than fall back. Round-tripping the components is
+  // the only way to tell a real date from a normalised one.
+  if (
+    local.getFullYear() !== year ||
+    local.getMonth() !== month - 1 ||
+    local.getDate() !== day
+  ) {
+    return stripTime(new Date(dateString))
+  }
+
+  return local
 }
 
 export function isConferenceDay(

--- a/src/lib/program/time-utils.ts
+++ b/src/lib/program/time-utils.ts
@@ -53,13 +53,33 @@ function stripTime(date: Date): Date {
   return stripped
 }
 
+/**
+ * Midnight LOCAL to the viewer for a `YYYY-MM-DD` schedule date.
+ *
+ * `new Date('2026-11-05')` is parsed as UTC midnight, so for any viewer west of
+ * UTC it lands on the PREVIOUS local day — in São Paulo (UTC-3) it is 4 November
+ * 21:00, and stripping to local midnight then yields the 4th. Every day
+ * comparison here is against the viewer's own clock (deliberately: an on-site
+ * attendee's "today" is their own), so the date string has to be read the same
+ * way. Building it from the parts keeps it local.
+ *
+ * Concretely, before this: at 10:00 on 5 November in São Paulo, a schedule dated
+ * 2026-11-05 reported `isScheduleToday === false`, so the "happening now" rail
+ * never activated on the actual conference day for any Americas tenant.
+ */
+function startOfLocalDay(dateString: string): Date {
+  const [year, month, day] = dateString.split('-').map(Number)
+  if (!year || !month || !day) return stripTime(new Date(dateString))
+  return new Date(year, month - 1, day)
+}
+
 export function isConferenceDay(
   startDate: string,
   endDate: string,
   currentTime: Date = getCurrentConferenceTime(),
 ): boolean {
-  const start = stripTime(new Date(startDate))
-  const end = stripTime(new Date(endDate))
+  const start = startOfLocalDay(startDate)
+  const end = startOfLocalDay(endDate)
   const now = stripTime(currentTime)
   return now >= start && now <= end
 }
@@ -69,8 +89,7 @@ export function isScheduleToday(
   currentTime: Date = getCurrentConferenceTime(),
 ): boolean {
   return (
-    stripTime(new Date(scheduleDate)).getTime() ===
-    stripTime(currentTime).getTime()
+    startOfLocalDay(scheduleDate).getTime() === stripTime(currentTime).getTime()
   )
 }
 
@@ -79,8 +98,7 @@ export function isScheduleInPast(
   currentTime: Date = getCurrentConferenceTime(),
 ): boolean {
   return (
-    stripTime(new Date(scheduleDate)).getTime() <
-    stripTime(currentTime).getTime()
+    startOfLocalDay(scheduleDate).getTime() < stripTime(currentTime).getTime()
   )
 }
 


### PR DESCRIPTION
A live bug, found while auditing the platform's Norwegian assumptions and confirmed by reproduction.

## The bug

A schedule date is a `YYYY-MM-DD` string. `new Date('2026-11-05')` parses that as **UTC midnight**, which for any viewer west of UTC is the *previous* local day — in São Paulo (UTC−3) it is 4 November at 21:00. `stripTime` then strips to local midnight and yields the 4th.

Reproduced directly:

```
TZ=America/Sao_Paulo   10:00 local on 5 Nov 2026, schedule 2026-11-05 → isScheduleToday = false
TZ=Europe/Oslo         same instant                                    → isScheduleToday = true
```

So a conference anywhere in the Americas never lights up its "happening now" rail on the actual conference day — and `isScheduleInPast` marks the current day as already over. Invisible from Norway, which is presumably why it survived.

## The fix

Day comparisons here are deliberately against the **viewer's own clock** — an on-site attendee's "today" is their own, which is right — so the date string now has to be read the same way. `startOfLocalDay` builds the date from its parts rather than parsing the string, giving local midnight, with a fallback to the old path for a malformed value.

Applies to `isConferenceDay`, `isScheduleToday` and `isScheduleInPast`.

## Tests

Three regression tests that pin the viewer timezone rather than trusting the machine's, covering west of UTC, east of UTC, and a genuinely past day west of UTC (so the fix cannot simply make everything "today").

**Verified they catch the bug**: with the previous implementation restored, one fails; with the fix, all pass. A timezone regression test that passes either way is worse than none, so this was checked rather than assumed.

## Verification

`pnpm typecheck` clean, `pnpm lint` 0 errors, full suite 375 files / 4870 tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects schedule-day comparisons to interpret `YYYY-MM-DD` values as local calendar days.
- Adds a local-day parser used by conference-day, today, and past-date checks.
- Adds timezone-specific regressions for viewers east and west of UTC.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the local-day behavior consistently applied and covered by timezone-specific regression tests.

The changed parser fixes the UTC-to-local day shift for valid schedule dates, and no concrete blocking or non-blocking defect remains in the reviewed paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/program/time-utils.ts | Replaces UTC parsing of date-only schedule values with local calendar-date construction across all day-comparison helpers. |
| __tests__/lib/program/time-utils.test.ts | Adds isolated timezone regressions covering current and past schedule days in São Paulo and Oslo. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(program): treat schedule dates as lo..."](https://github.com/cloudnativebergen/website/commit/756572a986ef74210dc3d2a2d34eaa24ba957959) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49719267)</sub>

<!-- /greptile_comment -->