### PR TITLE
feat(homepage): define every section's rendering in every lifecycle state

### DIFF
--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -1357,7 +1357,7 @@ export default defineType({
             type: 'text',
             rows: 2,
             description:
-              'Optional copy under the heading. Defaults to the dates and city.',
+              'Optional extra copy. There is no default: the card already shows the dates, the venue and city, a countdown and the milestone list, so leaving this empty simply adds no extra line.',
           }),
         ]),
         defineHomepageSection('homepageFeaturedSpeakers', 'Featured Speakers', [

--- a/sanity/schemaTypes/conference.ts
+++ b/sanity/schemaTypes/conference.ts
@@ -144,6 +144,15 @@ export default defineType({
         'Ordered list of homepage sections. Leave empty to render the default phase-aware layout (hero, gallery, featured speakers / program, sponsors).',
       options: { collapsible: true, collapsed: true },
     },
+    // Homepage lifecycle OVERRIDE (F5). Its own fieldset, appended last, for the
+    // same merge-conflict reason as `homepage` above.
+    {
+      name: 'lifecycle',
+      title: 'Event Status',
+      description:
+        'Only for calling an edition off or retiring it for good. Every other state (save-the-date, CFP open, programme published, post-event) is derived from the dates above and needs no switch here.',
+      options: { collapsible: true, collapsed: true },
+    },
   ],
   fields: [
     // === Basic Information ===
@@ -1335,6 +1344,22 @@ export default defineType({
             ],
           }),
         ]),
+        defineHomepageSection('homepageSaveTheDate', 'Save the Date', [
+          defineField({
+            name: 'heading',
+            title: 'Heading',
+            type: 'string',
+            description: 'Optional heading. Defaults to "Save the date".',
+          }),
+          defineField({
+            name: 'description',
+            title: 'Description',
+            type: 'text',
+            rows: 2,
+            description:
+              'Optional copy under the heading. Defaults to the dates and city.',
+          }),
+        ]),
         defineHomepageSection('homepageFeaturedSpeakers', 'Featured Speakers', [
           defineField({
             name: 'heading',
@@ -1570,6 +1595,67 @@ export default defineType({
           }),
         ]),
       ],
+    }),
+
+    // === Event Status (homepage lifecycle override) ===
+    // ABSENT is the norm: the homepage derives its stage from the CFP,
+    // programme and event dates. These fields exist ONLY for the two states no
+    // date can imply. Setting one REPLACES the homepage with a notice — it is
+    // not a banner above the usual page — so a cancelled event can never show a
+    // ticket CTA.
+    defineField({
+      name: 'lifecycleStatus',
+      title: 'Event Status',
+      type: 'string',
+      fieldset: 'lifecycle',
+      description:
+        'Leave unset for a normal event. Cancelled and Archived each REPLACE the homepage with a notice.',
+      options: {
+        list: [
+          {
+            title: 'Cancelled — this edition is not happening',
+            value: 'cancelled',
+          },
+          {
+            title: 'Archived — the event has ended for good',
+            value: 'archived',
+          },
+        ],
+        layout: 'radio',
+      },
+    }),
+    defineField({
+      name: 'lifecycleHeadline',
+      title: 'Status Headline',
+      type: 'string',
+      fieldset: 'lifecycle',
+      description:
+        'Optional. Leave blank for a sensible default built from the conference title.',
+    }),
+    defineField({
+      name: 'lifecycleMessage',
+      title: 'Status Message',
+      type: 'text',
+      rows: 4,
+      fieldset: 'lifecycle',
+      description:
+        'What happened, and what a visitor should do next (refunds, the next edition, where to ask). Blank falls back to house copy.',
+    }),
+    defineField({
+      name: 'lifecycleLinkLabel',
+      title: 'Status Link Label',
+      type: 'string',
+      fieldset: 'lifecycle',
+      description:
+        'Optional single link on the notice, e.g. "Read the full statement" or "Browse the archive".',
+    }),
+    defineField({
+      name: 'lifecycleLinkHref',
+      title: 'Status Link URL',
+      type: 'string',
+      fieldset: 'lifecycle',
+      validation: (Rule) => Rule.custom(safeLinkRule),
+      description: 'A site path (e.g. /info) or a full http(s) URL.',
     }),
   ],
 

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -27,6 +27,10 @@ import { HomepageSectionsEditor } from '@/components/admin/HomepageSectionsEdito
 import { CollapsibleSection } from '@/components/admin/CollapsibleSection'
 import { ActivationChecklist } from '@/components/admin/ActivationChecklist'
 import { resolveHomepageSections } from '@/lib/homepage'
+// Shared label map — the settings page previously carried its own copy, which
+// silently went stale (it was missing FAQ, Countdown and Venue) and rendered raw
+// `_type` strings for them.
+import { SECTION_LABELS } from '@/lib/homepage/editor'
 import { SETTINGS_GROUPS, type SettingsGroup } from '@/lib/settings/groups'
 import { buildActivationChecklist } from '@/lib/settings/activation'
 import {
@@ -159,17 +163,6 @@ export default async function AdminSettings() {
   const usingDefaultHomepage =
     !conference.homepageSections || conference.homepageSections.length === 0
   const homepageSectionsForEditor = resolveHomepageSections(conference)
-  const HOMEPAGE_SECTION_LABELS: Record<string, string> = {
-    homepageHero: 'Hero',
-    homepageFeaturedSpeakers: 'Featured Speakers',
-    homepageProgramHighlights: 'Program Highlights',
-    homepageOrganizers: 'Organizers',
-    homepageSponsors: 'Sponsors',
-    homepageGallery: 'Photo Gallery',
-    homepageMetrics: 'Vanity Metrics',
-    homepageCtaBanner: 'Call-to-action Banner',
-    homepageRichText: 'Rich Text',
-  }
 
   return (
     <div className="space-y-6">
@@ -797,7 +790,7 @@ export default async function AdminSettings() {
                   >
                     <span>
                       {idx + 1}.{' '}
-                      {HOMEPAGE_SECTION_LABELS[section._type] ?? section._type}
+                      {SECTION_LABELS[section._type] ?? section._type}
                     </span>
                     {section.hidden ? (
                       <StatusBadge label="Hidden" color="yellow" />

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -69,6 +69,9 @@ import {
   SparklesIcon,
   EyeIcon,
   EyeSlashIcon,
+  ArchiveBoxIcon,
+  ExclamationTriangleIcon,
+  CalendarDaysIcon,
 } from '@heroicons/react/24/outline'
 
 /** Group id → group metadata, so tier-1 subsections stay single-sourced. */
@@ -313,6 +316,52 @@ export default async function AdminSettings() {
                 {visibility === 'unlisted'
                   ? 'Reachable by direct link but excluded from sitemaps, robots and search indexing.'
                   : 'Publicly listed and indexed by search engines.'}
+              </p>
+            </InfoCard>
+
+            <InfoCard
+              title="Event Status"
+              icon={
+                conference.lifecycleStatus === 'cancelled'
+                  ? ExclamationTriangleIcon
+                  : conference.lifecycleStatus === 'archived'
+                    ? ArchiveBoxIcon
+                    : CalendarDaysIcon
+              }
+              action={
+                <EditConferenceCard
+                  fieldset="lifecycle"
+                  initialValues={{
+                    lifecycleStatus: conference.lifecycleStatus ?? '',
+                    lifecycleHeadline: conference.lifecycleHeadline ?? '',
+                    lifecycleMessage: conference.lifecycleMessage ?? '',
+                    lifecycleLinkLabel: conference.lifecycleLinkLabel ?? '',
+                    lifecycleLinkHref: conference.lifecycleLinkHref ?? '',
+                  }}
+                />
+              }
+            >
+              <div
+                id="lifecycle"
+                className="flex scroll-mt-24 items-center justify-between gap-3 border-b border-gray-200 py-2 last:border-b-0 dark:border-gray-700"
+              >
+                <dt className="shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Status
+                </dt>
+                <dd className="min-w-0 text-right text-sm">
+                  {conference.lifecycleStatus === 'cancelled' ? (
+                    <StatusBadge label="Cancelled" color="red" />
+                  ) : conference.lifecycleStatus === 'archived' ? (
+                    <StatusBadge label="Archived" color="gray" />
+                  ) : (
+                    <StatusBadge label="Running" color="green" />
+                  )}
+                </dd>
+              </div>
+              <p className="pt-1 text-sm text-gray-500 dark:text-gray-400">
+                {conference.lifecycleStatus
+                  ? 'The homepage is REPLACED by a notice. The programme, speakers and every ticket link are hidden.'
+                  : 'The homepage follows the dates above on its own — save-the-date, call for speakers, programme, then post-event. Only cancelling or retiring the event needs a switch.'}
               </p>
             </InfoCard>
 

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -133,6 +133,7 @@ async function CachedHomeContent({ domain }: { domain: string }) {
         conference={conference}
         domain={domain}
         lowestTicketPrice={lowestTicketPrice}
+        ticketAvailability={ticketAvailability}
       />
       <HomepageSectionRenderer
         sections={sections}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -4,7 +4,9 @@ import { isUnknownHost } from '@/lib/conference/guard'
 import {
   getPublicTicketTypes,
   getLowestTicketPrice,
+  getTicketAvailability,
   type LowestTicketPrice,
+  type TicketAvailability,
 } from '@/lib/tickets/public'
 import { hasTicketingBinding, ticketingBinding } from '@/lib/tickets/provider'
 import { formatDatesSafe } from '@/lib/time'
@@ -98,6 +100,11 @@ async function CachedHomeContent({ domain }: { domain: string }) {
   // back silently to plain labels — the homepage must never fail because
   // checkin.no is unavailable.
   let lowestTicketPrice: LowestTicketPrice | null = null
+  // Live availability, so the page can tell "not yet on sale" from "on sale"
+  // from "sold out" instead of guessing from the registration toggle. Left null
+  // on any failure — the lifecycle model degrades that to "on sale" and never
+  // to a sold-out claim.
+  let ticketAvailability: TicketAvailability | null = null
   // Gate on the FULL binding (customer + event id — what the resolver
   // requires) and pass only the minimal binding so the 'use cache' key stays
   // stable across unrelated conference-field changes.
@@ -108,6 +115,7 @@ async function CachedHomeContent({ domain }: { domain: string }) {
       )
       if (ticketData) {
         lowestTicketPrice = getLowestTicketPrice(ticketData.tickets)
+        ticketAvailability = getTicketAvailability(ticketData.tickets)
       }
     } catch (ticketError) {
       console.error('Failed to fetch ticket prices for homepage:', ticketError)
@@ -130,6 +138,7 @@ async function CachedHomeContent({ domain }: { domain: string }) {
         sections={sections}
         conference={conference}
         ticketsFromPrice={lowestTicketPrice?.formatted}
+        ticketAvailability={ticketAvailability}
       />
     </>
   )

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -187,7 +187,10 @@ function ActionButtons({
   )
   if (!hasVisitorCta && displayButtons.some((b) => b.href === '/sponsor')) {
     displayButtons = [
-      ...displayButtons.filter((b) => b.href === '/info'),
+      ...displayButtons
+        .filter((b) => b.href === '/info')
+        // Promoted, or the row would be two outline buttons with no lead.
+        .map((b) => ({ ...b, variant: 'primary' as const })),
       ...displayButtons
         .filter((b) => b.href === '/sponsor')
         .map((b) => ({ ...b, variant: 'outline' as const })),

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -177,6 +177,23 @@ function ActionButtons({
     displayButtons = reversedButtons.slice(0, 3)
   }
 
+  // On a page with no CFP, no programme and no tickets — day one — the reversal
+  // above leaves "Become a Sponsor" as the first and loudest thing a visitor
+  // sees. Asking for money is the wrong opening move for an event nobody has
+  // heard of yet, so the visitor-facing link leads and the sponsor pitch is
+  // demoted to an outline button beside it.
+  const hasVisitorCta = displayButtons.some(
+    (b) => b.href !== '/sponsor' && b.href !== '/info',
+  )
+  if (!hasVisitorCta && displayButtons.some((b) => b.href === '/sponsor')) {
+    displayButtons = [
+      ...displayButtons.filter((b) => b.href === '/info'),
+      ...displayButtons
+        .filter((b) => b.href === '/sponsor')
+        .map((b) => ({ ...b, variant: 'outline' as const })),
+    ]
+  }
+
   const showsPrice =
     ticketsFromPrice && displayButtons.some((b) => b.href === '/tickets')
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -11,15 +11,15 @@ import {
   MicrophoneIcon,
   CalendarDaysIcon,
   MapPinIcon,
+  PlayCircleIcon,
   TicketIcon,
 } from '@heroicons/react/24/outline'
 import { Conference } from '@/lib/conference/types'
+import { isSeekingSponsors } from '@/lib/conference/state'
 import {
-  isCfpOpen,
-  isProgramPublished,
-  isRegistrationAvailable,
-  isSeekingSponsors,
-} from '@/lib/conference/state'
+  resolveHomepageLifecycle,
+  type HomepageLifecycle,
+} from '@/lib/homepage/lifecycle'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { PortableText } from '@portabletext/react'
 import { TypedObject } from 'sanity'
@@ -55,10 +55,12 @@ function isPortableTextEmpty(content?: TypedObject[]): boolean {
 
 function ActionButtons({
   conference,
+  lifecycle,
   ticketsFromPrice,
   ctaOverrides,
 }: {
   conference: Conference
+  lifecycle: HomepageLifecycle
   ticketsFromPrice?: string | null
   /**
    * F1 homepage-builder override. When non-empty, these buttons REPLACE the
@@ -110,7 +112,7 @@ function ActionButtons({
     })
   }
 
-  if (isCfpOpen(conference)) {
+  if (lifecycle.cfp === 'open') {
     buttons.push({
       label: 'Submit to Speak',
       href: '/cfp',
@@ -120,17 +122,30 @@ function ActionButtons({
     })
   }
 
-  if (isProgramPublished(conference)) {
+  // Gated on programme CONTENT, not on the publish date having passed: linking
+  // "View Program" at an empty programme page is the same broken promise as the
+  // zero-statistics band. After the event the label follows what is actually
+  // there — "Watch the talks" only when a recording exists.
+  if (lifecycle.content.hasProgramme) {
     buttons.push({
-      label: 'View Program',
+      label:
+        lifecycle.stage === 'post-event' && lifecycle.content.hasRecordings
+          ? 'Watch the talks'
+          : 'View Program',
       href: '/program',
       variant: 'primary',
-      icon: CalendarDaysIcon,
+      icon:
+        lifecycle.stage === 'post-event' && lifecycle.content.hasRecordings
+          ? PlayCircleIcon
+          : CalendarDaysIcon,
       event: PIRSCH_EVENTS.programHero,
     })
   }
 
-  if (isRegistrationAvailable(conference)) {
+  // A sold-out or not-yet-opened sale renders no ticket button at all — the
+  // save-the-date roadmap and the sold-out notice carry that information
+  // instead, rather than a button that leads to a dead end.
+  if (lifecycle.tickets === 'on-sale') {
     buttons.push({
       // Checkin.no prices are excl. VAT — disclosed in the caption rendered
       // under the button row, consistent with the note on /tickets
@@ -199,6 +214,7 @@ export function Hero({
   headlineOverride,
   subheadlineOverride,
   ctaOverrides,
+  lifecycle,
 }: {
   conference: Conference
   /** Lowest ticket price formatted for display (e.g. "1 234"), excl. VAT */
@@ -213,7 +229,14 @@ export function Hero({
   headlineOverride?: string
   subheadlineOverride?: string
   ctaOverrides?: HeroCtaOverride[]
+  /**
+   * Resolved lifecycle state. The renderer resolves it once for the whole page
+   * and passes it down; standalone use (stories) may omit it and the Hero
+   * derives it from the conference itself.
+   */
+  lifecycle?: HomepageLifecycle
 }) {
+  const resolved = lifecycle ?? resolveHomepageLifecycle(conference)
   return (
     <div className="relative py-10 sm:pt-36 sm:pb-24">
       <BackgroundImage className="-top-36 -bottom-14" />
@@ -307,9 +330,16 @@ export function Hero({
 
           <ActionButtons
             conference={conference}
+            lifecycle={resolved}
             ticketsFromPrice={ticketsFromPrice}
             ctaOverrides={ctaOverrides}
           />
+
+          {resolved.tickets === 'sold-out' && (
+            <p className="font-jetbrains mt-4 text-center text-sm font-semibold tracking-wide text-brand-slate-gray/80 uppercase dark:text-gray-300">
+              Tickets are sold out
+            </p>
+          )}
 
           {conference.venueName && (
             <p className="font-jetbrains mt-6 flex items-start justify-center gap-x-2 text-sm text-brand-cloud-blue sm:mt-8 dark:text-blue-400">

--- a/src/components/ProgramHighlights.tsx
+++ b/src/components/ProgramHighlights.tsx
@@ -399,6 +399,74 @@ export function ProgramHighlights({
     return null
   }
 
+  // A published schedule with no confirmed talks in it produced the worst empty
+  // state this page had: "0+ Sessions / 0+ Speakers / 0 Workshops / 0+ Topics /
+  // 0 Tracks", live in production. Featured speakers configured on the
+  // conference are enough to get past the guard above, so the statistics band
+  // has to defend itself: bail out entirely when the schedule holds nothing.
+  if (stats.totalSessions === 0) {
+    return null
+  }
+
+  // Render only the tiles that have a number worth printing. A zero is never a
+  // fact about a conference — it is a fact about the data not being entered yet.
+  const statTiles = [
+    {
+      key: 'sessions',
+      label: 'Sessions',
+      value: `${stats.totalSessions}+`,
+      count: stats.totalSessions,
+      icon: PresentationChartBarIcon,
+      chip: 'bg-brand-cloud-blue/10 dark:bg-blue-900/20',
+      tone: 'text-brand-cloud-blue dark:text-blue-400',
+    },
+    {
+      key: 'speakers',
+      label: 'Speakers',
+      value: `${stats.totalSpeakers}+`,
+      count: stats.totalSpeakers,
+      icon: UserGroupIcon,
+      chip: 'bg-brand-fresh-green/10 dark:bg-green-900/20',
+      tone: 'text-brand-fresh-green dark:text-green-400',
+    },
+    {
+      key: 'workshops',
+      label: 'Workshops',
+      value: String(stats.workshopCount),
+      count: stats.workshopCount,
+      icon: MicrophoneIcon,
+      chip: 'bg-accent-yellow/10 dark:bg-yellow-900/20',
+      tone: 'text-accent-yellow dark:text-yellow-400',
+    },
+    {
+      key: 'days',
+      label: stats.days === 1 ? 'Day' : 'Days',
+      value: String(stats.days),
+      count: stats.days,
+      icon: CalendarDaysIcon,
+      chip: 'bg-brand-cloud-blue/10 dark:bg-blue-900/20',
+      tone: 'text-brand-cloud-blue dark:text-blue-400',
+    },
+    {
+      key: 'topics',
+      label: 'Topics',
+      value: `${stats.topicCount}+`,
+      count: stats.topicCount,
+      icon: ClockIcon,
+      chip: 'bg-brand-fresh-green/10 dark:bg-green-900/20',
+      tone: 'text-brand-fresh-green dark:text-green-400',
+    },
+    {
+      key: 'tracks',
+      label: stats.trackCount === 1 ? 'Track' : 'Tracks',
+      value: String(stats.trackCount),
+      count: stats.trackCount,
+      icon: Squares2X2Icon,
+      chip: 'bg-purple-500/10 dark:bg-purple-900/20',
+      tone: 'text-purple-500 dark:text-purple-400',
+    },
+  ].filter((tile) => tile.count > 0)
+
   return (
     <section
       id="program-highlights"
@@ -415,80 +483,34 @@ export function ProgramHighlights({
           </h2>
           <p className="font-inter mt-4 text-2xl tracking-tight text-brand-slate-gray dark:text-gray-300">
             Experience world-class content from industry experts. From hands-on
-            workshops to cutting-edge talks, get ready for {stats.days} days of
-            learning and networking.
+            workshops to cutting-edge talks, get ready for {stats.days}{' '}
+            {stats.days === 1 ? 'day' : 'days'} of learning and networking.
           </p>
         </div>
 
-        {/* Program Stats */}
-        <div className="mt-12 grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-6">
-          <div className="text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-brand-cloud-blue/10 dark:bg-blue-900/20">
-              <PresentationChartBarIcon className="h-6 w-6 text-brand-cloud-blue dark:text-blue-400" />
-            </div>
-            <dt className="font-jetbrains mt-2 text-sm text-brand-cloud-blue dark:text-blue-400">
-              Sessions
-            </dt>
-            <dd className="font-space-grotesk text-2xl font-semibold text-brand-slate-gray dark:text-gray-200">
-              {stats.totalSessions}+
-            </dd>
+        {/* Program Stats — only tiles with a non-zero number are rendered. */}
+        {statTiles.length > 0 && (
+          <div className="mt-12 grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-6">
+            {statTiles.map((tile) => {
+              const Icon = tile.icon
+              return (
+                <div key={tile.key} className="text-center">
+                  <div
+                    className={`mx-auto flex h-12 w-12 items-center justify-center rounded-xl ${tile.chip}`}
+                  >
+                    <Icon className={`h-6 w-6 ${tile.tone}`} />
+                  </div>
+                  <dt className={`font-jetbrains mt-2 text-sm ${tile.tone}`}>
+                    {tile.label}
+                  </dt>
+                  <dd className="font-space-grotesk text-2xl font-semibold text-brand-slate-gray dark:text-gray-200">
+                    {tile.value}
+                  </dd>
+                </div>
+              )
+            })}
           </div>
-          <div className="text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-brand-fresh-green/10 dark:bg-green-900/20">
-              <UserGroupIcon className="h-6 w-6 text-brand-fresh-green dark:text-green-400" />
-            </div>
-            <dt className="font-jetbrains mt-2 text-sm text-brand-fresh-green dark:text-green-400">
-              Speakers
-            </dt>
-            <dd className="font-space-grotesk text-2xl font-semibold text-brand-slate-gray dark:text-gray-200">
-              {stats.totalSpeakers}+
-            </dd>
-          </div>
-          <div className="text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-accent-yellow/10 dark:bg-yellow-900/20">
-              <MicrophoneIcon className="h-6 w-6 text-accent-yellow dark:text-yellow-400" />
-            </div>
-            <dt className="font-jetbrains mt-2 text-sm text-accent-yellow dark:text-yellow-400">
-              Workshops
-            </dt>
-            <dd className="font-space-grotesk text-2xl font-semibold text-brand-slate-gray dark:text-gray-200">
-              {stats.workshopCount}
-            </dd>
-          </div>
-          <div className="text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-brand-cloud-blue/10 dark:bg-blue-900/20">
-              <CalendarDaysIcon className="h-6 w-6 text-brand-cloud-blue dark:text-blue-400" />
-            </div>
-            <dt className="font-jetbrains mt-2 text-sm text-brand-cloud-blue dark:text-blue-400">
-              Days
-            </dt>
-            <dd className="font-space-grotesk text-2xl font-semibold text-brand-slate-gray dark:text-gray-200">
-              {stats.days}
-            </dd>
-          </div>
-          <div className="text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-brand-fresh-green/10 dark:bg-green-900/20">
-              <ClockIcon className="h-6 w-6 text-brand-fresh-green dark:text-green-400" />
-            </div>
-            <dt className="font-jetbrains mt-2 text-sm text-brand-fresh-green dark:text-green-400">
-              Topics
-            </dt>
-            <dd className="font-space-grotesk text-2xl font-semibold text-brand-slate-gray dark:text-gray-200">
-              {stats.topicCount}+
-            </dd>
-          </div>
-          <div className="text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-purple-500/10 dark:bg-purple-900/20">
-              <Squares2X2Icon className="h-6 w-6 text-purple-500 dark:text-purple-400" />
-            </div>
-            <dt className="font-jetbrains mt-2 text-sm text-purple-500 dark:text-purple-400">
-              Tracks
-            </dt>
-            <dd className="font-space-grotesk text-2xl font-semibold text-brand-slate-gray dark:text-gray-200">
-              {stats.trackCount}
-            </dd>
-          </div>
-        </div>
+        )}
 
         {/* Community & Diversity Stats - Optional */}
         {(stats.localSpeakerCount > 0 || stats.firstTimeSpeakerCount > 0) && (

--- a/src/components/admin/EditConferenceCard.stories.tsx
+++ b/src/components/admin/EditConferenceCard.stories.tsx
@@ -23,6 +23,7 @@ const handlers = [
   http.post('/api/trpc/conference.updateSponsorshipCustomization', ok),
   http.post('/api/trpc/conference.updateDomains', ok),
   http.post('/api/trpc/conference.updateAnnouncement', ok),
+  http.post('/api/trpc/conference.updateLifecycleStatus', ok),
 ]
 
 /**
@@ -389,4 +390,35 @@ export const DomainsConfirmGating: Story = {
     await userEvent.type(confirm, 'cloudnativebergen.no')
     expect(save).toBeEnabled()
   },
+}
+
+const lifecycleInitial = {
+  lifecycleStatus: 'cancelled',
+  lifecycleHeadline: '',
+  lifecycleMessage:
+    'After a great deal of deliberation we have decided not to run the 2026 edition. Everyone who bought a ticket has been refunded in full.',
+  lifecycleLinkLabel: 'Read the full statement',
+  lifecycleLinkHref: '/info',
+}
+
+/**
+ * The Event Status fieldset — the ONLY lifecycle switch in the product. A select
+ * with a "— None —" option (the normal state) plus the notice copy, so an
+ * organizer can call an edition off without opening Sanity Studio.
+ */
+export const LifecycleStatusFieldset: Story = {
+  args: {
+    fieldset: 'lifecycle',
+    initialValues: lifecycleInitial,
+    defaultOpen: true,
+  },
+}
+
+export const LifecycleStatusFieldsetDark: Story = {
+  args: {
+    fieldset: 'lifecycle',
+    initialValues: lifecycleInitial,
+    defaultOpen: true,
+  },
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
 }

--- a/src/components/admin/EditConferenceCard.tsx
+++ b/src/components/admin/EditConferenceCard.tsx
@@ -61,6 +61,7 @@ import { useNotification } from './NotificationProvider'
 export type ConferenceFieldsetKey =
   | 'basicInfo'
   | 'visibility'
+  | 'lifecycle'
   | 'venue'
   | 'branding'
   | 'dates'
@@ -174,6 +175,63 @@ export const FIELDSET_DEFS: Record<ConferenceFieldsetKey, FieldsetDef> = {
         ],
         description:
           'Unlisted conferences still render for direct visitors so you can preview and share them, but they are excluded from sitemaps, robots and search indexing.',
+      },
+    ],
+  },
+  // The two homepage states no date can imply. Everything else — save-the-date,
+  // CFP open, programme published, post-event — is derived, so this card is
+  // deliberately the ONLY lifecycle switch an organizer ever sees.
+  lifecycle: {
+    title: 'Event Status',
+    subtitle: 'Call off this edition, or retire the event',
+    fields: [
+      {
+        name: 'lifecycleStatus',
+        label: 'Status',
+        type: 'select',
+        nullableWhenEmpty: true,
+        options: [
+          {
+            value: 'cancelled',
+            title: 'Cancelled — this edition is not happening',
+          },
+          {
+            value: 'archived',
+            title: 'Archived — the event has ended for good',
+          },
+        ],
+        description:
+          'Leave as None for a normal event. Either value REPLACES the homepage with a notice — the programme, speakers and every ticket link stop being shown.',
+      },
+      {
+        name: 'lifecycleHeadline',
+        label: 'Headline',
+        type: 'text',
+        nullableWhenEmpty: true,
+        description:
+          'Optional. Blank falls back to a headline built from the conference title.',
+      },
+      {
+        name: 'lifecycleMessage',
+        label: 'Message',
+        type: 'textarea',
+        nullableWhenEmpty: true,
+        description:
+          'What happened and what a visitor should do next (refunds, the next edition, where to ask). Blank falls back to house copy.',
+      },
+      {
+        name: 'lifecycleLinkLabel',
+        label: 'Link label',
+        type: 'text',
+        nullableWhenEmpty: true,
+        description: 'e.g. "Read the full statement" or "Browse the archive".',
+      },
+      {
+        name: 'lifecycleLinkHref',
+        label: 'Link URL',
+        type: 'text',
+        nullableWhenEmpty: true,
+        description: 'A site path (e.g. /info) or a full http(s) URL.',
       },
     ],
   },
@@ -587,6 +645,7 @@ const MUTATION_BY_FIELDSET: Record<
 > = {
   basicInfo: 'updateBasicInfo',
   visibility: 'updateVisibility',
+  lifecycle: 'updateLifecycleStatus',
   venue: 'updateVenue',
   branding: 'updateBranding',
   dates: 'updateDates',

--- a/src/components/admin/HomepageSectionsEditor.stories.tsx
+++ b/src/components/admin/HomepageSectionsEditor.stories.tsx
@@ -96,6 +96,15 @@ const copySections: HomepageSection[] = [
   },
 ]
 
+// The Save-the-date band, whose config is heading + an OPTIONAL extra line.
+// Both fields are blank here so the placeholders — which must describe what the
+// band actually renders, not a default it never derives — are visible.
+const saveTheDateSections: HomepageSection[] = [
+  { _key: 'hero', _type: 'homepageHero' },
+  { _key: 'std', _type: 'homepageSaveTheDate' },
+  { _key: 'sponsors', _type: 'homepageSponsors' },
+]
+
 const meta = {
   title: 'Systems/Settings/Admin/HomepageSectionsEditor',
   component: HomepageSectionsEditor,
@@ -240,4 +249,25 @@ export const ContentBandCopyConfigDark: Story = {
   },
   parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
   play: ContentBandCopyConfig.play,
+}
+
+/**
+ * The Save-the-date config, accordion expanded. Both fields are blank, so this
+ * is the view an organizer meets first — and the placeholders have to be true:
+ * the heading has a house default, the description does NOT. The dates, venue
+ * and city are already the band's headline and place line, so an empty
+ * description adds no line rather than repeating them.
+ */
+export const SaveTheDateConfig: Story = {
+  args: {
+    initialSections: saveTheDateSections,
+    usingDefault: false,
+    defaultOpen: true,
+  },
+  play: async () => {
+    const configure = await screen.findByRole('button', {
+      name: 'Configure Save the Date',
+    })
+    await userEvent.click(configure)
+  },
 }

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -842,6 +842,34 @@ function SectionConfig({
     )
   }
 
+  if (row._type === 'homepageSaveTheDate') {
+    return (
+      <div className="space-y-2">
+        <input
+          type="text"
+          value={row.heading ?? ''}
+          onChange={(e) => onChange({ heading: e.target.value })}
+          placeholder="Heading (optional — default “Save the date”)"
+          aria-label="Save the date heading"
+          className={inputClass}
+        />
+        <textarea
+          rows={2}
+          value={row.description ?? ''}
+          onChange={(e) => onChange({ description: e.target.value })}
+          placeholder="Description (optional — defaults to the dates and city)"
+          aria-label="Save the date description"
+          className={inputClass}
+        />
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Shows the dates, venue, a countdown, and what happens next (call for
+          speakers, programme, tickets) from the dates already configured. Steps
+          with no date are left out rather than shown as unknown.
+        </p>
+      </div>
+    )
+  }
+
   if (row._type === 'homepageMetrics') {
     return (
       <div>

--- a/src/components/admin/HomepageSectionsEditor.tsx
+++ b/src/components/admin/HomepageSectionsEditor.tsx
@@ -857,14 +857,16 @@ function SectionConfig({
           rows={2}
           value={row.description ?? ''}
           onChange={(e) => onChange({ description: e.target.value })}
-          placeholder="Description (optional — defaults to the dates and city)"
+          placeholder="Description (optional — extra copy, no default)"
           aria-label="Save the date description"
           className={inputClass}
         />
         <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
           Shows the dates, venue, a countdown, and what happens next (call for
           speakers, programme, tickets) from the dates already configured. Steps
-          with no date are left out rather than shown as unknown.
+          with no date are left out rather than shown as unknown. The
+          description is an extra line on top of that — leave it empty and the
+          card simply shows no extra line.
         </p>
       </div>
     )

--- a/src/components/homepage/Countdown.tsx
+++ b/src/components/homepage/Countdown.tsx
@@ -41,16 +41,39 @@ export function countdownBreakdown(remainingMs: number): Breakdown {
 const headingClass =
   'font-space-grotesk mb-10 text-center text-4xl font-medium tracking-tighter text-brand-cloud-blue sm:text-5xl dark:text-blue-400'
 
-function Unit({ value, label }: { value: string; label: string }) {
+function Unit({
+  value,
+  label,
+  compact = false,
+}: {
+  value: string
+  label: string
+  /**
+   * Embedded inside another card rather than owning a full-width section. The
+   * standalone size overflows its column on a 393px viewport once the day count
+   * reaches three digits — which is the NORMAL case for a save-the-date band.
+   */
+  compact?: boolean
+}) {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex min-w-0 flex-col items-center">
       <span
-        className="font-space-grotesk text-4xl font-bold text-brand-slate-gray tabular-nums sm:text-6xl dark:text-gray-100"
+        className={
+          compact
+            ? 'font-space-grotesk text-2xl font-bold text-brand-slate-gray tabular-nums sm:text-4xl dark:text-gray-100'
+            : 'font-space-grotesk text-4xl font-bold text-brand-slate-gray tabular-nums sm:text-6xl dark:text-gray-100'
+        }
         aria-hidden={value === '--'}
       >
         {value}
       </span>
-      <span className="font-inter mt-1 text-xs font-medium tracking-wide text-brand-slate-gray/60 uppercase sm:text-sm dark:text-gray-400">
+      <span
+        className={
+          compact
+            ? 'font-inter mt-1 text-[10px] font-medium tracking-wide text-brand-slate-gray/60 uppercase sm:text-xs dark:text-gray-400'
+            : 'font-inter mt-1 text-xs font-medium tracking-wide text-brand-slate-gray/60 uppercase sm:text-sm dark:text-gray-400'
+        }
+      >
         {label}
       </span>
     </div>
@@ -84,9 +107,11 @@ function useCountdownRemaining(targetMs: number): number | null {
 /** The bare d/h/m/s grid, with no section chrome. */
 function CountdownUnits({
   remaining,
+  compact = false,
   className = 'mx-auto grid max-w-2xl grid-cols-4 gap-4 sm:gap-8',
 }: {
   remaining: number | null
+  compact?: boolean
   className?: string
 }) {
   const parts = remaining === null ? null : countdownBreakdown(remaining)
@@ -111,7 +136,7 @@ function CountdownUnits({
   return (
     <div className={className} role="timer" aria-live="off">
       {units.map((u) => (
-        <Unit key={u.label} value={u.value} label={u.label} />
+        <Unit key={u.label} value={u.value} label={u.label} compact={compact} />
       ))}
     </div>
   )
@@ -129,7 +154,8 @@ export function CountdownStrip({ targetMs }: { targetMs: number }) {
   return (
     <CountdownUnits
       remaining={remaining}
-      className="mx-auto grid max-w-lg grid-cols-4 gap-3 sm:gap-6"
+      compact
+      className="mx-auto grid max-w-md grid-cols-4 gap-2 sm:gap-5"
     />
   )
 }

--- a/src/components/homepage/Countdown.tsx
+++ b/src/components/homepage/Countdown.tsx
@@ -57,17 +57,12 @@ function Unit({ value, label }: { value: string; label: string }) {
   )
 }
 
-export function Countdown({
-  targetMs,
-  heading,
-  liveMessage,
-}: {
-  targetMs: number
-  heading?: string
-  liveMessage?: string
-}) {
-  // `null` = not yet measured on the client. Server render and the first client
-  // render both see `null`, guaranteeing identical markup (the placeholder).
+/**
+ * Milliseconds remaining until `targetMs`, or `null` until the client has
+ * measured. Server render and first client render both see `null` — see the
+ * SSR-safety note on this module.
+ */
+function useCountdownRemaining(targetMs: number): number | null {
   const [remaining, setRemaining] = useState<number | null>(null)
 
   useEffect(() => {
@@ -83,18 +78,17 @@ export function Countdown({
     return () => clearInterval(id)
   }, [targetMs])
 
-  // Post-hydration, once the target has passed.
-  if (remaining !== null && remaining <= 0) {
-    if (!liveMessage) return null
-    return (
-      <section className="py-20 sm:py-32">
-        <Container>
-          <p className={headingClass}>{liveMessage}</p>
-        </Container>
-      </section>
-    )
-  }
+  return remaining
+}
 
+/** The bare d/h/m/s grid, with no section chrome. */
+function CountdownUnits({
+  remaining,
+  className = 'mx-auto grid max-w-2xl grid-cols-4 gap-4 sm:gap-8',
+}: {
+  remaining: number | null
+  className?: string
+}) {
   const parts = remaining === null ? null : countdownBreakdown(remaining)
   const units: { label: string; value: string }[] = [
     {
@@ -114,20 +108,60 @@ export function Countdown({
       value: parts ? String(parts.seconds).padStart(2, '0') : '--',
     },
   ]
+  return (
+    <div className={className} role="timer" aria-live="off">
+      {units.map((u) => (
+        <Unit key={u.label} value={u.value} label={u.label} />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * The countdown grid WITHOUT the section wrapper, for embedding inside another
+ * band (the save-the-date block). Hides itself once the target has passed —
+ * a counter reading all zeros on a finished event is exactly the kind of
+ * undefined empty state this work exists to remove.
+ */
+export function CountdownStrip({ targetMs }: { targetMs: number }) {
+  const remaining = useCountdownRemaining(targetMs)
+  if (remaining !== null && remaining <= 0) return null
+  return (
+    <CountdownUnits
+      remaining={remaining}
+      className="mx-auto grid max-w-lg grid-cols-4 gap-3 sm:gap-6"
+    />
+  )
+}
+
+export function Countdown({
+  targetMs,
+  heading,
+  liveMessage,
+}: {
+  targetMs: number
+  heading?: string
+  liveMessage?: string
+}) {
+  const remaining = useCountdownRemaining(targetMs)
+
+  // Post-hydration, once the target has passed.
+  if (remaining !== null && remaining <= 0) {
+    if (!liveMessage) return null
+    return (
+      <section className="py-20 sm:py-32">
+        <Container>
+          <p className={headingClass}>{liveMessage}</p>
+        </Container>
+      </section>
+    )
+  }
 
   return (
     <section className="py-20 sm:py-32">
       <Container>
         {heading ? <h2 className={headingClass}>{heading}</h2> : null}
-        <div
-          className="mx-auto grid max-w-2xl grid-cols-4 gap-4 sm:gap-8"
-          role="timer"
-          aria-live="off"
-        >
-          {units.map((u) => (
-            <Unit key={u.label} value={u.value} label={u.label} />
-          ))}
-        </div>
+        <CountdownUnits remaining={remaining} />
       </Container>
     </section>
   )

--- a/src/components/homepage/HomepageLifecycle.stories.tsx
+++ b/src/components/homepage/HomepageLifecycle.stories.tsx
@@ -1,0 +1,244 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { HomepageSectionRenderer } from './SectionRenderer'
+import { getDefaultSections } from '@/lib/homepage'
+import type { Conference } from '@/lib/conference/types'
+import {
+  announcedConference,
+  archivedConference,
+  cancelledConference,
+  cfpOpenConference,
+  dayOneConference,
+  midCycleConference,
+  pinClock,
+  postEventConference,
+  soldOutConference,
+} from './lifecycle.mocks'
+
+/**
+ * THE HOMEPAGE IN EVERY LIFECYCLE STATE.
+ *
+ * One story per state, each rendering the WHOLE page — deliberately not one
+ * story per state per section, which would multiply the Chromatic snapshot count
+ * without telling you anything the whole-page view does not.
+ *
+ * The clock is pinned so the date-derived stages (and the countdown) are stable
+ * across snapshots. Read these top to bottom and the question the work exists to
+ * answer is visible: does a brand-new event with nothing get a page that looks
+ * deliberate?
+ */
+
+/** Placeholder photos for the gallery, so populated states actually render. */
+const placeholderSvg = (w: number, h: number, label: string, hue: number) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">` +
+  `<rect width="${w}" height="${h}" fill="hsl(${hue} 40% 32%)"/>` +
+  `<text x="50%" y="50%" fill="hsl(${hue} 30% 78%)" font-family="sans-serif" font-size="${Math.round(
+    h / 10,
+  )}" text-anchor="middle" dominant-baseline="middle">${label}</text>` +
+  `</svg>`
+
+const mswHandlers = [
+  http.get('https://cdn.sanity.io/images/*', ({ request }) => {
+    const url = new URL(request.url)
+    const n = Number(/gal(\d)/.exec(url.pathname)?.[1] ?? 1)
+    const thumb = url.searchParams.get('w') === '512'
+    return new HttpResponse(
+      placeholderSvg(
+        thumb ? 512 : 1920,
+        thumb ? 320 : 1080,
+        `Photo ${n}`,
+        [210, 150, 30, 280][n - 1] ?? 210,
+      ),
+      { headers: { 'Content-Type': 'image/svg+xml' } },
+    )
+  }),
+]
+
+const meta = {
+  // Pinning the clock is load-bearing here, not cosmetic: every stage in the
+  // model is derived from `Date.now()` against the conference dates, so an
+  // unpinned clock would eventually flip a story into a different state.
+  beforeEach: () => pinClock(),
+  title: 'Systems/Homepage/Public/Matrix/HomepageLifecycle',
+  tags: ['matrix'],
+  parameters: {
+    layout: 'fullscreen',
+    msw: { handlers: mswHandlers },
+    docs: {
+      description: {
+        component:
+          'The homepage rendered in each lifecycle state. Stage is derived from the CFP / programme / event dates; only cancelled and archived are explicit. Every section either hides itself or renders a deliberate placeholder — no zeroes, no empty grids, no lonely headings.',
+      },
+    },
+  },
+} satisfies Meta<typeof HomepageSectionRenderer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function page(
+  conference: Conference,
+  extra: Partial<React.ComponentProps<typeof HomepageSectionRenderer>> = {},
+) {
+  return {
+    render: () => (
+      <HomepageSectionRenderer
+        sections={getDefaultSections(conference)}
+        conference={conference}
+        {...extra}
+      />
+    ),
+  }
+}
+
+/**
+ * DAY ONE — the state that decides adoption. Title, tagline, dates, city and
+ * venue; nothing else exists. No CFP dates, no programme date, no ticketing, no
+ * team, no photos, no sponsors.
+ */
+export const DayOne: Story = {
+  ...page(dayOneConference),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A brand-new event with nothing but its dates and venue. The save-the-date band carries the page: dates, place and a live countdown. The roadmap is absent rather than three "TBA" rows, because none of the CFP / programme / ticket dates are set yet.',
+      },
+    },
+  },
+}
+
+export const DayOneDark: Story = {
+  ...page(dayOneConference),
+  parameters: {
+    theme: 'dark',
+    backgrounds: { default: 'dark' },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-gray-950">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/**
+ * Day one plus the team and the dates they have committed to — the realistic
+ * second day of setup, and the state most new events actually sit in.
+ */
+export const Announced: Story = {
+  ...page(announcedConference),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Dates announced, CFP not open yet. The roadmap now has all three steps — call for speakers opening on a date, programme announced on a date, and no ticket row because nothing is known about sales. The organizers band fills the middle slot.',
+      },
+    },
+  },
+}
+
+/**
+ * CFP open on a FIRST edition: no past photos, no speakers, no sponsors yet.
+ * Distinct from day one — the event is real, there is simply no history.
+ */
+export const CfpOpenFirstEdition: Story = {
+  ...page(cfpOpenConference, { ticketAvailability: 'upcoming' }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'First edition with the CFP open and ticket sales not started. The hero leads with "Submit to Speak", the roadmap shows the CFP open and tickets not yet on sale, and the gallery hides itself entirely rather than leaving a "Conference Moments" heading over nothing.',
+      },
+    },
+  },
+}
+
+/** A returning edition mid-cycle. This is the shape the page has always had. */
+export const ProgrammePublished: Story = {
+  ...page(midCycleConference, { ticketsFromPrice: '3 490' }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Programme published, tickets on sale, photos from the last edition. No save-the-date band: the page has real content to lead with, so the composition is exactly what it was before the lifecycle work.',
+      },
+    },
+  },
+}
+
+/** Same conference, but the provider reports every active type at zero. */
+export const SoldOut: Story = {
+  ...page(soldOutConference, {
+    ticketsFromPrice: '3 490',
+    ticketAvailability: 'sold-out',
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Sold out. No ticket button anywhere — the hero and the section CTA rows both drop it and state the fact instead, rather than sending visitors to a checkout that cannot serve them.',
+      },
+    },
+  },
+}
+
+/** After the event: photos and recordings lead, the CTA becomes the programme. */
+export const PostEvent: Story = {
+  ...page(postEventConference),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The event has happened. Photos sit directly under the hero, the primary CTA is "Watch the talks" (only because recordings actually exist on the talks), and the "Become a Sponsor" pitch is suppressed while the sponsors themselves stay as a thank-you wall.',
+      },
+    },
+  },
+}
+
+/** Explicit override: replaces the page, not a banner on it. */
+export const Cancelled: Story = {
+  ...page(cancelledConference, { ticketsFromPrice: '3 490' }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A cancelled edition. The notice REPLACES the page — the speaker shelf, the countdown and every ticket CTA are gone, because visitors act on buttons rather than on paragraphs. The conference here still has a full composition stored; it is not rendered.',
+      },
+    },
+  },
+}
+
+/** The tombstone. */
+export const Archived: Story = {
+  ...page(archivedConference),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Ended for good. A headline, the years, a thank-you and one link to the archive. Nothing else.',
+      },
+    },
+  },
+}
+
+/**
+ * The regression this whole change exists to prevent: a schedule that has been
+ * published but holds no confirmed talks.
+ */
+export const PublishedButEmptySchedule: Story = {
+  ...page({
+    ...midCycleConference,
+    schedules: [{ _id: 's1', date: '2026-06-10', tracks: [] }],
+    featuredGalleryImages: [],
+  } as unknown as Conference),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Programme date passed, schedule document empty. This rendered "0+ Sessions / 0+ Speakers / 0 Workshops / 0+ Topics / 0 Tracks" in production. The slot now falls through to the featured speakers, who do have something to show.',
+      },
+    },
+  },
+}

--- a/src/components/homepage/HomepageLifecycle.stories.tsx
+++ b/src/components/homepage/HomepageLifecycle.stories.tsx
@@ -58,6 +58,11 @@ const meta = {
   // Pinning the clock is load-bearing here, not cosmetic: every stage in the
   // model is derived from `Date.now()` against the conference dates, so an
   // unpinned clock would eventually flip a story into a different state.
+  //
+  // `pinClock()` RETURNS the restore function and this arrow returns it, which
+  // is how Storybook `beforeEach` teardown works (house pattern — see
+  // `mockDateBeforeEach`). Do not swallow the return value: the pinned `Date`
+  // would then leak into every story rendered afterwards in the same session.
   beforeEach: () => pinClock(),
   title: 'Systems/Homepage/Public/Matrix/HomepageLifecycle',
   tags: ['matrix'],

--- a/src/components/homepage/LifecycleNotice.tsx
+++ b/src/components/homepage/LifecycleNotice.tsx
@@ -81,7 +81,13 @@ export function LifecycleNotice({
                 {headline}
               </h1>
 
-              {dates !== 'TBD' ? (
+              {/*
+                Dates only for a CANCELLED edition, where "this was going to
+                happen on these dates" is the whole point. An archived event is
+                not about one edition, so printing the last one's dates under a
+                tombstone reads like it is still being scheduled.
+              */}
+              {cancelled && dates !== 'TBD' ? (
                 <p className="font-jetbrains mb-6 text-sm tracking-wide text-brand-cloud-blue uppercase dark:text-blue-400">
                   <time dateTime={conference.startDate}>{dates}</time>
                   {conference.city ? ` · ${conference.city}` : ''}

--- a/src/components/homepage/LifecycleNotice.tsx
+++ b/src/components/homepage/LifecycleNotice.tsx
@@ -1,0 +1,124 @@
+import { Container } from '@/components/Container'
+import { BackgroundImage } from '@/components/BackgroundImage'
+import { Button } from '@/components/Button'
+import type { Conference } from '@/lib/conference/types'
+import type { LifecycleStatus } from '@/lib/homepage/lifecycle'
+import { formatDatesSafe } from '@/lib/time'
+import {
+  ArchiveBoxIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/react/24/outline'
+
+/**
+ * The cancelled / archived homepage.
+ *
+ * These REPLACE the page rather than banner it. A cancelled conference that
+ * still renders its speaker shelf, its countdown and a "Get tickets" button
+ * below a notice is worse than no site at all — visitors act on the buttons, not
+ * the paragraph. So `HomepageSectionRenderer` short-circuits to this component
+ * and the stored composition is never rendered.
+ *
+ * Every string has a derived fallback, because the failure mode being designed
+ * out is a heading with nothing under it: an organizer who flips the status and
+ * writes no copy still gets a complete, correct page.
+ */
+export function LifecycleNotice({
+  conference,
+  status,
+}: {
+  conference: Conference
+  status: LifecycleStatus
+}) {
+  const cancelled = status === 'cancelled'
+  const Icon = cancelled ? ExclamationTriangleIcon : ArchiveBoxIcon
+  const dates = formatDatesSafe(conference.startDate, conference.endDate)
+
+  const headline =
+    conference.lifecycleHeadline?.trim() ||
+    (cancelled
+      ? `${conference.title} has been cancelled`
+      : `${conference.title} has ended`)
+
+  const message =
+    conference.lifecycleMessage?.trim() ||
+    (cancelled
+      ? `This edition is not going ahead${
+          dates !== 'TBD'
+            ? ` and will not take place as planned on ${dates}`
+            : ''
+        }. Ticket holders will be contacted directly. Thank you for your support — please get in touch if you have questions.`
+      : 'This conference has ended for good. Thank you to everyone who spoke, sponsored, volunteered and attended over the years.')
+
+  const linkLabel = conference.lifecycleLinkLabel?.trim()
+  const linkHref = conference.lifecycleLinkHref?.trim()
+  const contactEmail = conference.contactEmail?.trim()
+
+  return (
+    <div className="relative py-20 sm:pt-36 sm:pb-24">
+      <BackgroundImage className="-top-36 -bottom-14" />
+      <Container className="relative">
+        <div className="mx-auto max-w-3xl">
+          <div className="overflow-hidden rounded-2xl bg-white/95 shadow-xl ring-1 ring-brand-cloud-blue/10 backdrop-blur-sm dark:bg-gray-800/95 dark:ring-gray-700">
+            <div className="px-6 py-10 text-center sm:px-10 sm:py-14">
+              <div
+                className={
+                  cancelled
+                    ? 'mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/50'
+                    : 'mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-brand-sky-mist dark:bg-blue-900/50'
+                }
+              >
+                <Icon
+                  className={
+                    cancelled
+                      ? 'h-8 w-8 text-amber-700 dark:text-amber-300'
+                      : 'h-8 w-8 text-brand-cloud-blue dark:text-blue-400'
+                  }
+                  aria-hidden="true"
+                />
+              </div>
+
+              <h1 className="font-jetbrains mb-4 text-3xl font-bold tracking-tighter text-brand-slate-gray sm:text-5xl dark:text-white">
+                {headline}
+              </h1>
+
+              {dates !== 'TBD' ? (
+                <p className="font-jetbrains mb-6 text-sm tracking-wide text-brand-cloud-blue uppercase dark:text-blue-400">
+                  <time dateTime={conference.startDate}>{dates}</time>
+                  {conference.city ? ` · ${conference.city}` : ''}
+                </p>
+              ) : null}
+
+              <p className="font-inter mx-auto max-w-xl text-lg leading-relaxed whitespace-pre-line text-brand-slate-gray dark:text-gray-300">
+                {message}
+              </p>
+
+              {linkLabel && linkHref ? (
+                <div className="mt-10 flex justify-center">
+                  <Button
+                    href={linkHref}
+                    variant="primary"
+                    className="inline-flex items-center px-8 py-4 font-semibold"
+                  >
+                    {linkLabel}
+                  </Button>
+                </div>
+              ) : null}
+
+              {contactEmail ? (
+                <p className="font-inter mt-8 text-sm text-brand-slate-gray/70 dark:text-gray-400">
+                  Questions?{' '}
+                  <a
+                    href={`mailto:${contactEmail}`}
+                    className="font-semibold text-brand-cloud-blue underline decoration-brand-cloud-blue/30 underline-offset-2 hover:decoration-brand-cloud-blue"
+                  >
+                    {contactEmail}
+                  </a>
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </Container>
+    </div>
+  )
+}

--- a/src/components/homepage/SaveTheDate.stories.tsx
+++ b/src/components/homepage/SaveTheDate.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { SaveTheDate } from './SaveTheDate'
+import type { Conference } from '@/lib/conference/types'
+import type { HomepageLifecycle } from '@/lib/homepage/lifecycle'
+
+const FIXED_NOW = new Date('2026-03-01T12:00:00Z').getTime()
+
+const conference = {
+  _id: 'conf-1',
+  title: 'Cloud Native Days Bergen',
+  organizer: 'CNDN',
+  city: 'Bergen',
+  country: 'Norway',
+  venueName: 'Grieghallen',
+  startDate: '2026-10-27',
+  endDate: '2026-10-28',
+  cfpStartDate: '2026-04-01',
+  cfpEndDate: '2026-06-15',
+  programDate: '2026-08-15',
+  registrationEnabled: false,
+} as unknown as Conference
+
+const lifecycle: HomepageLifecycle = {
+  stage: 'announced',
+  cfp: 'upcoming',
+  tickets: 'unavailable',
+  content: {
+    hasGallery: false,
+    hasFeaturedSpeakers: false,
+    hasOrganizers: false,
+    hasSponsors: false,
+    hasVanityMetrics: false,
+    hasProgramme: false,
+    hasRecordings: false,
+    isFirstEdition: true,
+  },
+  primaryCta: 'info',
+  isOverridden: false,
+}
+
+const meta = {
+  beforeEach: () => {
+    // Pin the clock (house pattern — see Countdown.stories): the countdown
+    // strip reads Date.now() every tick, so an unpinned clock drifts snapshots.
+    const OriginalDate = globalThis.Date
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const MockDate: any = function (...args: any[]) {
+      if (args.length === 0) return new OriginalDate(FIXED_NOW)
+      return new (
+        Function.prototype.bind.apply(OriginalDate, [
+          null,
+          ...args,
+        ]) as typeof OriginalDate
+      )()
+    }
+    Object.setPrototypeOf(MockDate, OriginalDate)
+    MockDate.prototype = Object.create(OriginalDate.prototype)
+    MockDate.now = () => FIXED_NOW
+    MockDate.parse = OriginalDate.parse.bind(OriginalDate)
+    MockDate.UTC = OriginalDate.UTC.bind(OriginalDate)
+    globalThis.Date = MockDate
+    return () => {
+      globalThis.Date = OriginalDate
+    }
+  },
+
+  title: 'Systems/Homepage/Public/SaveTheDate',
+  component: SaveTheDate,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The day-one band. Built entirely from what a brand-new organizer has already entered — the dates, the venue and city, a live countdown, and whichever CFP / programme / ticket milestones carry a date. The `description` is OPTIONAL EXTRA COPY with no derived default: the dates and the place are already the card’s headline and place line, so an empty description simply adds no line rather than restating them.',
+      },
+    },
+  },
+  args: { conference, lifecycle },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SaveTheDate>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** The unconfigured case: no description. The card is still complete. */
+export const WithoutDescription: Story = {
+  args: { section: { _key: 'std', _type: 'homepageSaveTheDate' } },
+}
+
+/** An organizer-written extra line, rendered verbatim under the place. */
+export const WithDescription: Story = {
+  args: {
+    section: {
+      _key: 'std',
+      _type: 'homepageSaveTheDate',
+      description:
+        'Two days of talks, workshops and hallway track on the western fjords.',
+    },
+  },
+}
+
+/** Venue not booked yet — the place line shows the city alone, no stray comma. */
+export const CityOnly: Story = {
+  args: {
+    section: { _key: 'std', _type: 'homepageSaveTheDate' },
+    conference: { ...conference, venueName: undefined } as Conference,
+  },
+}
+
+/** Dates not fixed yet — the title takes the headline slot instead of "TBD". */
+export const NoDatesYet: Story = {
+  args: {
+    section: { _key: 'std', _type: 'homepageSaveTheDate' },
+    conference: { ...conference, startDate: '', endDate: '' } as Conference,
+  },
+}

--- a/src/components/homepage/SaveTheDate.test.tsx
+++ b/src/components/homepage/SaveTheDate.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+import { SaveTheDate } from './SaveTheDate'
+import type { SaveTheDateSection } from '@/lib/homepage/sections'
+import type { HomepageLifecycle } from '@/lib/homepage/lifecycle'
+import type { Conference } from '@/lib/conference/types'
+
+afterEach(cleanup)
+
+/**
+ * The band's CONTRACT, pinned here because the admin editor and the Sanity
+ * schema both describe it to organizers in prose: the description is EXTRA
+ * copy with no derived default. The dates, the venue/city and the countdown
+ * are first-class elements of the card, so an empty description must render
+ * nothing at all rather than a restatement of the two lines above it — and
+ * must never leave a half-built fragment behind when a field is missing.
+ */
+
+function makeConference(overrides: Partial<Conference> = {}): Conference {
+  return {
+    _id: 'conf-1',
+    title: 'Cloud Native Days Bergen',
+    organizer: 'CNDN',
+    city: 'Bergen',
+    country: 'Norway',
+    venueName: 'Grieghallen',
+    startDate: '2026-10-27',
+    endDate: '2026-10-28',
+    registrationEnabled: false,
+    ...overrides,
+  } as unknown as Conference
+}
+
+function makeLifecycle(
+  overrides: Partial<HomepageLifecycle> = {},
+): HomepageLifecycle {
+  return {
+    stage: 'announced',
+    cfp: 'absent',
+    tickets: 'unavailable',
+    content: {
+      hasGallery: false,
+      hasFeaturedSpeakers: false,
+      hasOrganizers: false,
+      hasSponsors: false,
+      hasVanityMetrics: false,
+      hasProgramme: false,
+      hasRecordings: false,
+      isFirstEdition: true,
+    },
+    primaryCta: 'info',
+    isOverridden: false,
+    ...overrides,
+  }
+}
+
+function section(
+  overrides: Partial<SaveTheDateSection> = {},
+): SaveTheDateSection {
+  return { _key: 'std', _type: 'homepageSaveTheDate', ...overrides }
+}
+
+function renderBand(
+  sectionOverrides: Partial<SaveTheDateSection> = {},
+  conferenceOverrides: Partial<Conference> = {},
+) {
+  return render(
+    <SaveTheDate
+      section={section(sectionOverrides)}
+      conference={makeConference(conferenceOverrides)}
+      lifecycle={makeLifecycle()}
+    />,
+  )
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+/** Every leaf element must carry real text — never blank, never a dangling
+ * connector left over from a value the conference does not have. */
+function expectNoBrokenFragments(container: HTMLElement) {
+  const text = container.textContent ?? ''
+  expect(text).not.toContain('TBD')
+  expect(text).not.toContain('Invalid Date')
+  expect(text).not.toContain('undefined')
+  expect(text).not.toContain('null')
+
+  for (const el of Array.from(container.querySelectorAll('p, h2, h3, li'))) {
+    if (el.querySelector('p, h2, h3, li')) continue
+    const leaf = (el.textContent ?? '').trim()
+    expect(leaf).not.toBe('')
+    // A connector with nothing after it ("in ", "…, ", "27. oktober – ").
+    expect(leaf).not.toMatch(/(?:\bin|,|–|-)$/)
+    expect(leaf).not.toMatch(/^(?:in\b|,|–)/)
+  }
+}
+
+describe('SaveTheDate — description', () => {
+  it('renders a configured description verbatim', () => {
+    const { container } = renderBand({
+      description: 'Two days of talks and hallway track by the fjord.',
+    })
+
+    expect(container.textContent).toContain(
+      'Two days of talks and hallway track by the fjord.',
+    )
+    expectNoBrokenFragments(container)
+  })
+
+  it('adds no copy when the description is empty — the dates and city are not restated', () => {
+    const { container } = renderBand({})
+    const text = container.textContent ?? ''
+
+    // The card is still complete: dates headline + place line.
+    expect(text).toContain('27.–28. oktober 2026')
+    expect(text).toContain('Grieghallen, Bergen')
+
+    // ...and each appears exactly ONCE. A derived default built from the dates
+    // and the city would duplicate the two lines directly above it.
+    expect(occurrences(text, '27.–28. oktober 2026')).toBe(1)
+    expect(occurrences(text, 'Bergen')).toBe(1)
+    expectNoBrokenFragments(container)
+  })
+
+  it('treats a whitespace-only description as empty', () => {
+    const { container } = renderBand({ description: '   \n  ' })
+
+    expect(occurrences(container.textContent ?? '', 'Bergen')).toBe(1)
+    expectNoBrokenFragments(container)
+  })
+
+  it('does not persist or echo a derived description back into the section', () => {
+    const configured = section({})
+    render(
+      <SaveTheDate
+        section={configured}
+        conference={makeConference()}
+        lifecycle={makeLifecycle()}
+      />,
+    )
+
+    // Render-time only: nothing is written back onto the section document.
+    expect(configured.description).toBeUndefined()
+  })
+})
+
+describe('SaveTheDate — missing conference data', () => {
+  it('renders the venue alone when the city is missing', () => {
+    const { container } = renderBand({}, { city: '' })
+    const text = container.textContent ?? ''
+
+    expect(text).toContain('Grieghallen')
+    expect(text).not.toContain('Grieghallen,')
+    expectNoBrokenFragments(container)
+  })
+
+  it('renders the city alone when the venue is missing', () => {
+    const { container } = renderBand({}, { venueName: undefined })
+    const text = container.textContent ?? ''
+
+    expect(text).toContain('Bergen')
+    expect(text).not.toContain(', Bergen')
+    expectNoBrokenFragments(container)
+  })
+
+  it('falls back to the conference title when the dates are missing', () => {
+    const { container } = renderBand({}, { startDate: '', endDate: '' })
+    const text = container.textContent ?? ''
+
+    expect(text).toContain('Cloud Native Days Bergen')
+    expect(text).toContain('Grieghallen, Bergen')
+    expectNoBrokenFragments(container)
+  })
+
+  it('keeps a configured description when the dates are missing', () => {
+    const { container } = renderBand(
+      { description: 'Dates to be confirmed — the venue is booked.' },
+      { startDate: '', endDate: '' },
+    )
+
+    expect(container.textContent).toContain(
+      'Dates to be confirmed — the venue is booked.',
+    )
+    expectNoBrokenFragments(container)
+  })
+
+  it('renders nothing at all when there are neither dates nor a place', () => {
+    const { container } = renderBand(
+      {},
+      { startDate: '', endDate: '', city: '', venueName: undefined },
+    )
+
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/src/components/homepage/SaveTheDate.tsx
+++ b/src/components/homepage/SaveTheDate.tsx
@@ -1,0 +1,186 @@
+import { Container } from '@/components/Container'
+import { Button } from '@/components/Button'
+import { CountdownStrip } from '@/components/homepage/Countdown'
+import { resolveCountdownTarget } from '@/lib/homepage/countdown'
+import {
+  DEFAULT_SAVE_THE_DATE_HEADING,
+  type SaveTheDateSection,
+} from '@/lib/homepage/sections'
+import {
+  resolveRoadmapSteps,
+  type HomepageLifecycle,
+  type RoadmapStep,
+} from '@/lib/homepage/lifecycle'
+import type { Conference } from '@/lib/conference/types'
+import { formatDatesSafe, formatDateSafe } from '@/lib/time'
+import {
+  CalendarDaysIcon,
+  CheckCircleIcon,
+  MapPinIcon,
+} from '@heroicons/react/24/outline'
+
+/**
+ * The DAY-ONE band.
+ *
+ * A brand-new conference has no speakers, no sponsors, no schedule and no
+ * photos, so every content band on the homepage correctly renders nothing —
+ * leaving a hero sitting directly on top of a "Become a Sponsor" pitch. That is
+ * the state 64% of new community events would land in, and it reads as a broken
+ * template rather than an announcement.
+ *
+ * This band fills it using ONLY what a day-one organizer has already entered:
+ * the dates, the city and venue, and whichever of the CFP / programme / ticket
+ * dates are configured. Nothing is invented and nothing unknown is rendered —
+ * a milestone with no date is omitted (see {@link resolveRoadmapSteps}), and
+ * with no milestones at all the band is still a complete save-the-date: dates,
+ * place and a live countdown.
+ */
+export function SaveTheDate({
+  section,
+  conference,
+  lifecycle,
+}: {
+  section: SaveTheDateSection
+  conference: Conference
+  lifecycle: HomepageLifecycle
+}) {
+  const dates = formatDatesSafe(conference.startDate, conference.endDate)
+  const place = [conference.venueName, conference.city]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(', ')
+
+  // Nothing to save the date FOR. Rather than render a heading over an empty
+  // card, the band removes itself — the hero already carries the title.
+  if (dates === 'TBD' && !place) return null
+
+  const heading = section.heading?.trim() || DEFAULT_SAVE_THE_DATE_HEADING
+  const description = section.description?.trim()
+  const steps = resolveRoadmapSteps(conference, lifecycle, formatDateSafe)
+  const countdownTarget = resolveCountdownTarget(conference, {})
+
+  return (
+    <section className="py-16 sm:py-24" aria-labelledby="save-the-date-title">
+      <Container>
+        <div className="mx-auto max-w-3xl">
+          <div className="overflow-hidden rounded-2xl bg-white/95 shadow-xl ring-1 ring-brand-cloud-blue/10 backdrop-blur-sm dark:bg-gray-800/95 dark:ring-gray-700">
+            <div className="px-6 py-8 text-center sm:px-10 sm:py-12">
+              <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-full bg-brand-sky-mist dark:bg-blue-900/50">
+                <CalendarDaysIcon
+                  className="h-7 w-7 text-brand-cloud-blue dark:text-blue-400"
+                  aria-hidden="true"
+                />
+              </div>
+
+              <p className="font-jetbrains text-sm tracking-wide text-brand-cloud-blue uppercase dark:text-blue-400">
+                {heading}
+              </p>
+
+              {dates !== 'TBD' ? (
+                <h2
+                  id="save-the-date-title"
+                  className="font-space-grotesk mt-2 text-3xl font-bold tracking-tighter text-brand-slate-gray sm:text-5xl dark:text-white"
+                >
+                  <time dateTime={conference.startDate}>{dates}</time>
+                </h2>
+              ) : (
+                <h2
+                  id="save-the-date-title"
+                  className="font-space-grotesk mt-2 text-3xl font-bold tracking-tighter text-brand-slate-gray sm:text-5xl dark:text-white"
+                >
+                  {conference.title}
+                </h2>
+              )}
+
+              {place ? (
+                <p className="font-jetbrains mt-3 flex items-center justify-center gap-x-2 text-sm text-brand-cloud-blue dark:text-blue-400">
+                  <MapPinIcon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span>{place}</span>
+                </p>
+              ) : null}
+
+              {description ? (
+                <p className="font-inter mx-auto mt-5 max-w-xl text-lg text-brand-slate-gray dark:text-gray-300">
+                  {description}
+                </p>
+              ) : null}
+
+              {countdownTarget !== null ? (
+                <div className="mt-8">
+                  <CountdownStrip targetMs={countdownTarget} />
+                </div>
+              ) : null}
+
+              {steps.length > 0 ? (
+                <div className="mt-10 rounded-xl bg-brand-sky-mist p-5 sm:p-6 dark:bg-blue-900/40">
+                  <h3 className="font-space-grotesk text-base font-semibold text-brand-cloud-blue dark:text-blue-300">
+                    What happens next
+                  </h3>
+                  <ol className="mt-4 space-y-3 text-left">
+                    {steps.map((step) => (
+                      <RoadmapRow key={step.key} step={step} />
+                    ))}
+                  </ol>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </Container>
+    </section>
+  )
+}
+
+/** One roadmap row. `open` steps are linkable; the rest are plain statements. */
+function RoadmapRow({ step }: { step: RoadmapStep }) {
+  const done = step.status === 'done'
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
+      <span className="flex items-center gap-x-2">
+        {done ? (
+          <CheckCircleIcon
+            className="h-5 w-5 shrink-0 text-brand-slate-gray/40 dark:text-gray-500"
+            aria-hidden="true"
+          />
+        ) : (
+          <span
+            className={
+              step.status === 'open'
+                ? 'h-2.5 w-2.5 shrink-0 rounded-full bg-brand-fresh-green'
+                : 'h-2.5 w-2.5 shrink-0 rounded-full bg-brand-cloud-blue/30 dark:bg-blue-400/40'
+            }
+            aria-hidden="true"
+          />
+        )}
+        <span
+          className={
+            done
+              ? 'font-inter text-brand-slate-gray/60 dark:text-gray-400'
+              : 'font-inter font-medium text-brand-slate-gray dark:text-gray-200'
+          }
+        >
+          {step.label}
+        </span>
+      </span>
+      {step.href ? (
+        <Button
+          href={step.href}
+          variant="primary"
+          className="px-4 py-1.5 text-sm font-semibold"
+        >
+          {step.detail}
+        </Button>
+      ) : (
+        <span
+          className={
+            done
+              ? 'font-jetbrains text-sm text-brand-slate-gray/50 dark:text-gray-500'
+              : 'font-jetbrains text-sm text-brand-slate-gray/80 dark:text-gray-300'
+          }
+        >
+          {step.detail}
+        </span>
+      )}
+    </li>
+  )
+}

--- a/src/components/homepage/SaveTheDate.tsx
+++ b/src/components/homepage/SaveTheDate.tsx
@@ -131,56 +131,63 @@ export function SaveTheDate({
   )
 }
 
-/** One roadmap row. `open` steps are linkable; the rest are plain statements. */
+/**
+ * One roadmap row: the milestone and where it stands on the left, and — only
+ * when the step is actionable today — a button on the right. The status line is
+ * never the button label, so the button says what a visitor gets to DO.
+ */
 function RoadmapRow({ step }: { step: RoadmapStep }) {
   const done = step.status === 'done'
   return (
-    <li className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
-      <span className="flex items-center gap-x-2">
+    <li className="flex flex-col gap-y-2 sm:flex-row sm:items-center sm:justify-between sm:gap-x-4">
+      <span className="flex items-start gap-x-2">
         {done ? (
           <CheckCircleIcon
-            className="h-5 w-5 shrink-0 text-brand-slate-gray/40 dark:text-gray-500"
+            className="mt-0.5 h-4 w-4 shrink-0 text-brand-slate-gray/40 dark:text-gray-500"
             aria-hidden="true"
           />
         ) : (
           <span
             className={
               step.status === 'open'
-                ? 'h-2.5 w-2.5 shrink-0 rounded-full bg-brand-fresh-green'
-                : 'h-2.5 w-2.5 shrink-0 rounded-full bg-brand-cloud-blue/30 dark:bg-blue-400/40'
+                ? 'mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full bg-brand-fresh-green'
+                : 'mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full bg-brand-cloud-blue/30 dark:bg-blue-400/40'
             }
             aria-hidden="true"
           />
         )}
-        <span
-          className={
-            done
-              ? 'font-inter text-brand-slate-gray/60 dark:text-gray-400'
-              : 'font-inter font-medium text-brand-slate-gray dark:text-gray-200'
-          }
-        >
-          {step.label}
+        <span className="flex flex-col">
+          <span
+            className={
+              done
+                ? 'font-inter text-brand-slate-gray/60 dark:text-gray-400'
+                : 'font-inter font-medium text-brand-slate-gray dark:text-gray-200'
+            }
+          >
+            {step.label}
+          </span>
+          <span
+            className={
+              done
+                ? 'font-jetbrains text-xs text-brand-slate-gray/50 dark:text-gray-500'
+                : 'font-jetbrains text-xs text-brand-slate-gray/70 dark:text-gray-400'
+            }
+          >
+            {step.detail}
+          </span>
         </span>
       </span>
-      {step.href ? (
-        <Button
-          href={step.href}
-          variant="primary"
-          className="px-4 py-1.5 text-sm font-semibold"
-        >
-          {step.detail}
-        </Button>
-      ) : (
-        <span
-          className={
-            done
-              ? 'font-jetbrains text-sm text-brand-slate-gray/50 dark:text-gray-500'
-              : 'font-jetbrains text-sm text-brand-slate-gray/80 dark:text-gray-300'
-          }
-        >
-          {step.detail}
+      {step.href && step.actionLabel ? (
+        <span className="pl-6 sm:shrink-0 sm:pl-0">
+          <Button
+            href={step.href}
+            variant="primary"
+            className="px-4 py-1.5 text-sm font-semibold"
+          >
+            {step.actionLabel}
+          </Button>
         </span>
-      )}
+      ) : null}
     </li>
   )
 }

--- a/src/components/homepage/SectionRenderer.test.tsx
+++ b/src/components/homepage/SectionRenderer.test.tsx
@@ -4,11 +4,28 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render, cleanup } from '@testing-library/react'
 
-// Stub every leaf component the renderer maps to, so the test verifies the
+// Stub the leaf components the renderer maps to, so the test verifies the
 // mapping/order/skip logic — not the (separately tested) leaf components.
+// `SaveTheDate` and `LifecycleNotice` are deliberately NOT stubbed: this file is
+// the only test that covers them, so a stand-in would assert nothing.
+//
+// next/link → a plain anchor so `Button href=…` renders in jsdom. `...rest` is
+// forwarded because the analytics contract lives in `data-pirsch-event`
+// attributes on those anchors.
 vi.mock('next/link', () => ({
   __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
 }))
 vi.mock('@/components/Hero', () => ({
   Hero: () => <div data-testid="hero" />,
@@ -67,21 +84,20 @@ vi.mock('@/components/homepage/MetricsBlock', () => ({
 vi.mock('@/components/homepage/FaqBlock', () => ({
   FaqBlock: () => <div data-testid="faq" />,
 }))
+// The clock-driven halves of the countdown are stubbed (they tick on a timer);
+// `CountdownStrip` is what the REAL SaveTheDate embeds, so the stub keeps that
+// band renderable. Neither stub carries a `data-testid`-free marker by accident:
+// `countdown` is asserted on directly, the strip deliberately is not.
 vi.mock('@/components/homepage/Countdown', () => ({
   Countdown: ({ targetMs }: { targetMs: number }) => (
     <div data-testid="countdown" data-target={targetMs} />
   ),
+  CountdownStrip: ({ targetMs }: { targetMs: number }) => (
+    <div data-countdown-strip={targetMs} />
+  ),
 }))
 vi.mock('@/components/homepage/VenueBlock', () => ({
   VenueBlock: () => <div data-testid="venue" />,
-}))
-vi.mock('@/components/homepage/SaveTheDate', () => ({
-  SaveTheDate: () => <div data-testid="save-the-date" />,
-}))
-vi.mock('@/components/homepage/LifecycleNotice', () => ({
-  LifecycleNotice: ({ status }: { status: string }) => (
-    <div data-testid="lifecycle-notice" data-status={status} />
-  ),
 }))
 
 import { HomepageSectionRenderer } from './SectionRenderer'
@@ -129,6 +145,20 @@ function testIdsInOrder(container: HTMLElement): string[] {
   return Array.from(container.querySelectorAll('[data-testid]')).map((el) =>
     el.getAttribute('data-testid')!,
   )
+}
+
+/**
+ * Section markers in document order. Stubbed leaves expose a `data-testid`; the
+ * REAL save-the-date band is identified by the heading id its own component
+ * owns, so it joins the ordering assertions without the production component
+ * having to carry a test-only attribute.
+ */
+function sectionsInOrder(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll(
+      '[data-testid], [aria-labelledby="save-the-date-title"]',
+    ),
+  ).map((el) => el.getAttribute('data-testid') ?? 'save-the-date')
 }
 
 describe('HomepageSectionRenderer — default composition', () => {
@@ -342,10 +372,13 @@ describe('HomepageSectionRenderer — F4 blocks', () => {
 describe('HomepageSectionRenderer — lifecycle states', () => {
   it('inserts the save-the-date band on a day-one conference', () => {
     const conference = makeConference({
+      startDate: '2999-01-01',
       programDate: '2999-01-01',
       schedules: [],
       featuredSpeakers: [],
       featuredGalleryImages: [],
+      venueName: 'Grieghallen',
+      city: 'Bergen',
     })
     const { container } = render(
       <HomepageSectionRenderer
@@ -353,9 +386,13 @@ describe('HomepageSectionRenderer — lifecycle states', () => {
         conference={conference}
       />,
     )
-    const ids = testIdsInOrder(container)
+    const ids = sectionsInOrder(container)
     expect(ids[0]).toBe('hero')
     expect(ids[1]).toBe('save-the-date')
+    // The REAL band, not a stand-in: its house heading plus the dates and place
+    // it derives from the conference document.
+    expect(container.textContent).toContain('Save the date')
+    expect(container.textContent).toContain('Grieghallen, Bergen')
   })
 
   for (const status of ['cancelled', 'archived'] as const) {
@@ -367,12 +404,14 @@ describe('HomepageSectionRenderer — lifecycle states', () => {
           conference={conference}
         />,
       )
-      expect(testIdsInOrder(container)).toEqual(['lifecycle-notice'])
-      expect(
-        container
-          .querySelector('[data-testid="lifecycle-notice"]')
-          ?.getAttribute('data-status'),
-      ).toBe(status)
+      // NOTHING from the section list survives — that is the whole point of the
+      // short-circuit; the notice below is all there is.
+      expect(sectionsInOrder(container)).toEqual([])
+      expect(container.textContent).toContain(
+        status === 'cancelled'
+          ? 'Test Conf has been cancelled'
+          : 'Test Conf has ended',
+      )
     })
 
     it(`ignores a STORED composition for a ${status} conference`, () => {
@@ -384,7 +423,8 @@ describe('HomepageSectionRenderer — lifecycle states', () => {
       const { container } = render(
         <HomepageSectionRenderer sections={sections} conference={conference} />,
       )
-      expect(testIdsInOrder(container)).toEqual(['lifecycle-notice'])
+      expect(sectionsInOrder(container)).toEqual([])
+      expect(container.textContent).toContain('Test Conf has')
     })
   }
 
@@ -399,5 +439,130 @@ describe('HomepageSectionRenderer — lifecycle states', () => {
       <HomepageSectionRenderer sections={sections} conference={conference} />,
     )
     expect(container.querySelector('[data-testid="program"]')).toBeNull()
+  })
+})
+
+describe('HomepageSectionRenderer — phase CTA row', () => {
+  /** A published schedule whose one confirmed talk carries a recording URL. */
+  function schedulesWithRecording() {
+    return [
+      {
+        _id: 's1',
+        date: '2000-01-01',
+        tracks: [
+          {
+            trackTitle: 'Track 1',
+            trackDescription: '',
+            talks: [
+              {
+                startTime: '09:00',
+                endTime: '09:45',
+                talk: {
+                  _id: 't1',
+                  status: 'confirmed',
+                  attachments: [
+                    {
+                      _key: 'a1',
+                      _type: 'urlAttachment',
+                      attachmentType: 'recording',
+                      url: 'https://example.com/watch',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ] as never
+  }
+
+  const featuredSpeakersOnly = [
+    { _key: 'f', _type: 'homepageFeaturedSpeakers' },
+  ] as unknown as HomepageSection[]
+  const organizersOnly = [
+    { _key: 'o', _type: 'homepageOrganizers' },
+  ] as unknown as HomepageSection[]
+
+  function programmeLink(container: HTMLElement) {
+    return container.querySelector('a[href="/program"]')
+  }
+
+  it('tracks the programme CTA as its OWN event, not as the info CTA', () => {
+    const conference = makeConference({
+      startDate: '2000-01-01',
+      endDate: '2000-01-02',
+      schedules: schedulesWithRecording(),
+    })
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={featuredSpeakersOnly}
+        conference={conference}
+      />,
+    )
+    const link = programmeLink(container)
+    expect(link?.getAttribute('data-pirsch-event')).toBe(
+      'cta-program-featured-speakers',
+    )
+    // …and it is NOT conflated with the /info CTA, which is the bug.
+    expect(link?.getAttribute('data-pirsch-event')).not.toBe(
+      'cta-info-featured-speakers',
+    )
+  })
+
+  it('uses the organizers-scoped programme event in the organizers band', () => {
+    const conference = makeConference({
+      startDate: '2000-01-01',
+      endDate: '2000-01-02',
+      schedules: schedulesWithRecording(),
+    })
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={organizersOnly}
+        conference={conference}
+      />,
+    )
+    expect(programmeLink(container)?.getAttribute('data-pirsch-event')).toBe(
+      'cta-program-featured-organizers',
+    )
+  })
+
+  it('offers "Watch the talks" only AFTER the event', () => {
+    const conference = makeConference({
+      startDate: '2000-01-01',
+      endDate: '2000-01-02',
+      schedules: schedulesWithRecording(),
+    })
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={featuredSpeakersOnly}
+        conference={conference}
+      />,
+    )
+    expect(programmeLink(container)?.textContent).toContain('Watch the talks')
+  })
+
+  it('never advertises recordings on a PRE-EVENT page', () => {
+    // Programme published, event still ahead, and a talk already carries a
+    // recording link (a re-run, a teaser). The label must stay forward-looking.
+    const conference = makeConference({
+      startDate: '2999-01-01',
+      endDate: '2999-01-02',
+      programDate: '2000-01-01',
+      schedules: schedulesWithRecording(),
+    })
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={featuredSpeakersOnly}
+        conference={conference}
+      />,
+    )
+    const link = programmeLink(container)
+    expect(link?.textContent).toContain('See the programme')
+    expect(container.textContent).not.toContain('Watch the talks')
+    // The event name does not depend on the label.
+    expect(link?.getAttribute('data-pirsch-event')).toBe(
+      'cta-program-featured-speakers',
+    )
   })
 })

--- a/src/components/homepage/SectionRenderer.test.tsx
+++ b/src/components/homepage/SectionRenderer.test.tsx
@@ -75,6 +75,14 @@ vi.mock('@/components/homepage/Countdown', () => ({
 vi.mock('@/components/homepage/VenueBlock', () => ({
   VenueBlock: () => <div data-testid="venue" />,
 }))
+vi.mock('@/components/homepage/SaveTheDate', () => ({
+  SaveTheDate: () => <div data-testid="save-the-date" />,
+}))
+vi.mock('@/components/homepage/LifecycleNotice', () => ({
+  LifecycleNotice: ({ status }: { status: string }) => (
+    <div data-testid="lifecycle-notice" data-status={status} />
+  ),
+}))
 
 import { HomepageSectionRenderer } from './SectionRenderer'
 import { getDefaultSections, type HomepageSection } from '@/lib/homepage'
@@ -87,7 +95,25 @@ function makeConference(overrides: Partial<Conference> = {}): Conference {
     programDate: '2000-01-01',
     endDate: '2999-01-01',
     registrationEnabled: false,
-    schedules: [{ _id: 's1' }],
+    schedules: [
+      {
+        _id: 's1',
+        date: '2999-01-01',
+        tracks: [
+          {
+            trackTitle: 'Track 1',
+            trackDescription: '',
+            talks: [
+              {
+                startTime: '09:00',
+                endTime: '09:45',
+                talk: { _id: 't1', status: 'confirmed' },
+              },
+            ],
+          },
+        ],
+      },
+    ],
     featuredSpeakers: [{ _id: 'sp1', name: 'Speaker' }],
     organizers: [{ _id: 'o1', name: 'Org' }],
     featuredGalleryImages: [{ _id: 'g1' }],
@@ -310,5 +336,68 @@ describe('HomepageSectionRenderer — F4 blocks', () => {
       <HomepageSectionRenderer sections={sections} conference={conference} />,
     )
     expect(container.querySelector('[data-testid="countdown"]')).toBeNull()
+  })
+})
+
+describe('HomepageSectionRenderer — lifecycle states', () => {
+  it('inserts the save-the-date band on a day-one conference', () => {
+    const conference = makeConference({
+      programDate: '2999-01-01',
+      schedules: [],
+      featuredSpeakers: [],
+      featuredGalleryImages: [],
+    })
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={getDefaultSections(conference)}
+        conference={conference}
+      />,
+    )
+    const ids = testIdsInOrder(container)
+    expect(ids[0]).toBe('hero')
+    expect(ids[1]).toBe('save-the-date')
+  })
+
+  for (const status of ['cancelled', 'archived'] as const) {
+    it(`REPLACES the whole page for a ${status} conference`, () => {
+      const conference = makeConference({ lifecycleStatus: status })
+      const { container } = render(
+        <HomepageSectionRenderer
+          sections={getDefaultSections(conference)}
+          conference={conference}
+        />,
+      )
+      expect(testIdsInOrder(container)).toEqual(['lifecycle-notice'])
+      expect(
+        container
+          .querySelector('[data-testid="lifecycle-notice"]')
+          ?.getAttribute('data-status'),
+      ).toBe(status)
+    })
+
+    it(`ignores a STORED composition for a ${status} conference`, () => {
+      const conference = makeConference({ lifecycleStatus: status })
+      const sections = [
+        { _key: '1', _type: 'homepageHero' },
+        { _key: '2', _type: 'homepageSponsors' },
+      ] as unknown as HomepageSection[]
+      const { container } = render(
+        <HomepageSectionRenderer sections={sections} conference={conference} />,
+      )
+      expect(testIdsInOrder(container)).toEqual(['lifecycle-notice'])
+    })
+  }
+
+  it('drops the program band when the published schedule holds no talks', () => {
+    const conference = makeConference({
+      schedules: [{ _id: 's1', date: '2999-01-01', tracks: [] }] as never,
+    })
+    const sections = [
+      { _key: '1', _type: 'homepageProgramHighlights' },
+    ] as unknown as HomepageSection[]
+    const { container } = render(
+      <HomepageSectionRenderer sections={sections} conference={conference} />,
+    )
+    expect(container.querySelector('[data-testid="program"]')).toBeNull()
   })
 })

--- a/src/components/homepage/SectionRenderer.tsx
+++ b/src/components/homepage/SectionRenderer.tsx
@@ -13,25 +13,32 @@ import { MetricsBlock } from '@/components/homepage/MetricsBlock'
 import { FaqBlock } from '@/components/homepage/FaqBlock'
 import { Countdown } from '@/components/homepage/Countdown'
 import { VenueBlock } from '@/components/homepage/VenueBlock'
+import { SaveTheDate } from '@/components/homepage/SaveTheDate'
+import { LifecycleNotice } from '@/components/homepage/LifecycleNotice'
 import { resolveCountdownTarget } from '@/lib/homepage/countdown'
 import {
+  CalendarDaysIcon,
   InformationCircleIcon,
   MicrophoneIcon,
+  PlayCircleIcon,
   TicketIcon,
 } from '@heroicons/react/24/outline'
 import type { Conference } from '@/lib/conference/types'
-import { isCfpOpen, isRegistrationAvailable } from '@/lib/conference/state'
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import {
   DEFAULT_FEATURED_SPEAKERS_HEADING,
   DEFAULT_ORGANIZERS_HEADING,
   defaultFeaturedSpeakersDescription,
   defaultOrganizersDescription,
-  hasPublishedSchedule,
   type FeaturedSpeakersSection,
   type HomepageSection,
   type OrganizersSection,
 } from '@/lib/homepage'
+import {
+  resolveHomepageLifecycle,
+  type HomepageLifecycle,
+} from '@/lib/homepage/lifecycle'
+import type { TicketAvailability } from '@/lib/tickets/public'
 
 /** Unknown section `_type`s already warned about (once per process). */
 const warnedUnknownSectionTypes = new Set<string>()
@@ -49,16 +56,21 @@ const warnedUnknownSectionTypes = new Set<string>()
  */
 
 /**
- * Phase-appropriate CTA row for homepage sections that otherwise end without a
- * call to action: CFP first while open, then tickets, then practical info.
- * (Moved verbatim from the legacy `page.tsx`.)
+ * Lifecycle-appropriate CTA row for homepage sections that otherwise end without
+ * a call to action.
+ *
+ * ORDER: after the event the PROGRAMME leads — a "Get tickets" button on a
+ * finished conference is the single clearest signal that a site is unmaintained,
+ * and what a post-event visitor actually wants is the talks. Before the event
+ * the CFP leads while open (speakers are the scarcer supply), then tickets, then
+ * practical info. A sold-out event never renders a ticket CTA.
  */
 function PhaseCtaRow({
-  conference,
+  lifecycle,
   section,
   ticketsFromPrice,
 }: {
-  conference: Conference
+  lifecycle: HomepageLifecycle
   section: 'featured-speakers' | 'featured-organizers'
   ticketsFromPrice?: string | null
 }) {
@@ -75,67 +87,103 @@ function PhaseCtaRow({
           info: PIRSCH_EVENTS.infoFeaturedOrganizers,
         }
 
-  const cfpOpen = isCfpOpen(conference)
-  const registrationAvailable = isRegistrationAvailable(conference)
+  const { primaryCta, cfp, tickets, content } = lifecycle
+  const ticketsOnSale = tickets === 'on-sale'
   const buttonClassName =
     'inline-flex items-center space-x-2 px-8 py-4 font-semibold'
   // Checkin.no prices are excl. VAT — disclosed in the caption below the row
   const ticketsLabel = ticketsFromPrice
     ? `Get tickets — from ${ticketsFromPrice} kr`
     : 'Get tickets'
-  const showsPrice = Boolean(ticketsFromPrice) && registrationAvailable
+  const showsPrice = Boolean(ticketsFromPrice) && ticketsOnSale
+
+  const programmeButton = (
+    <Button
+      href="/program"
+      variant="primary"
+      className={buttonClassName}
+      data-pirsch-event={events.info}
+    >
+      {content.hasRecordings ? (
+        <>
+          <PlayCircleIcon className="h-5 w-5" aria-hidden="true" />
+          <span>Watch the talks</span>
+        </>
+      ) : (
+        <>
+          <CalendarDaysIcon className="h-5 w-5" aria-hidden="true" />
+          <span>See the programme</span>
+        </>
+      )}
+    </Button>
+  )
+
+  const ticketsButton = (variant: 'primary' | 'outline') => (
+    <Button
+      href="/tickets"
+      variant={variant}
+      className={buttonClassName}
+      data-pirsch-event={events.tickets}
+    >
+      <TicketIcon className="h-5 w-5" aria-hidden="true" />
+      <span>{ticketsLabel}</span>
+    </Button>
+  )
+
+  const infoButton = (
+    <Button
+      href="/info"
+      variant="primary"
+      className={buttonClassName}
+      data-pirsch-event={events.info}
+    >
+      <InformationCircleIcon className="h-5 w-5" aria-hidden="true" />
+      <span>Practical information</span>
+    </Button>
+  )
+
+  let buttons: ReactNode
+  if (primaryCta === 'programme') {
+    buttons = (
+      <>
+        {programmeButton}
+        {ticketsOnSale && ticketsButton('outline')}
+      </>
+    )
+  } else if (primaryCta === 'cfp' || cfp === 'open') {
+    buttons = (
+      <>
+        <Button
+          href="/cfp"
+          variant="primary"
+          className={buttonClassName}
+          data-pirsch-event={events.cfp}
+        >
+          <MicrophoneIcon className="h-5 w-5" aria-hidden="true" />
+          <span>Submit a talk</span>
+        </Button>
+        {ticketsOnSale && ticketsButton('outline')}
+      </>
+    )
+  } else if (primaryCta === 'tickets') {
+    buttons = ticketsButton('primary')
+  } else {
+    buttons = infoButton
+  }
 
   return (
     <>
       <div className="mt-12 flex flex-col gap-4 sm:flex-row sm:justify-center">
-        {cfpOpen ? (
-          <>
-            <Button
-              href="/cfp"
-              variant="primary"
-              className={buttonClassName}
-              data-pirsch-event={events.cfp}
-            >
-              <MicrophoneIcon className="h-5 w-5" aria-hidden="true" />
-              <span>Submit a talk</span>
-            </Button>
-            {registrationAvailable && (
-              <Button
-                href="/tickets"
-                variant="outline"
-                className={buttonClassName}
-                data-pirsch-event={events.tickets}
-              >
-                <TicketIcon className="h-5 w-5" aria-hidden="true" />
-                <span>{ticketsLabel}</span>
-              </Button>
-            )}
-          </>
-        ) : registrationAvailable ? (
-          <Button
-            href="/tickets"
-            variant="primary"
-            className={buttonClassName}
-            data-pirsch-event={events.tickets}
-          >
-            <TicketIcon className="h-5 w-5" aria-hidden="true" />
-            <span>{ticketsLabel}</span>
-          </Button>
-        ) : (
-          <Button
-            href="/info"
-            variant="primary"
-            className={buttonClassName}
-            data-pirsch-event={events.info}
-          >
-            <InformationCircleIcon className="h-5 w-5" aria-hidden="true" />
-            <span>Practical information</span>
-          </Button>
-        )}
+        {buttons}
       </div>
       {showsPrice && (
         <p className="mt-2 text-center text-xs text-brand-slate-gray/70 dark:text-gray-400">
           Ticket prices excl. VAT
+        </p>
+      )}
+      {tickets === 'sold-out' && (
+        <p className="font-jetbrains mt-4 text-center text-sm font-semibold tracking-wide text-brand-slate-gray/80 uppercase dark:text-gray-300">
+          Tickets are sold out
         </p>
       )}
     </>
@@ -146,10 +194,12 @@ function PhaseCtaRow({
 function FeaturedSpeakersSectionView({
   conference,
   section,
+  lifecycle,
   ticketsFromPrice,
 }: {
   conference: Conference
   section: FeaturedSpeakersSection
+  lifecycle: HomepageLifecycle
   ticketsFromPrice?: string | null
 }) {
   if (
@@ -177,7 +227,7 @@ function FeaturedSpeakersSectionView({
         <FeaturedSpeakersShelf speakers={conference.featuredSpeakers} />
 
         <PhaseCtaRow
-          conference={conference}
+          lifecycle={lifecycle}
           section="featured-speakers"
           ticketsFromPrice={ticketsFromPrice}
         />
@@ -190,10 +240,12 @@ function FeaturedSpeakersSectionView({
 function OrganizersSectionView({
   conference,
   section,
+  lifecycle,
   ticketsFromPrice,
 }: {
   conference: Conference
   section: OrganizersSection
+  lifecycle: HomepageLifecycle
   ticketsFromPrice?: string | null
 }) {
   const sortedOrganizers =
@@ -233,7 +285,7 @@ function OrganizersSectionView({
         </div>
 
         <PhaseCtaRow
-          conference={conference}
+          lifecycle={lifecycle}
           section="featured-organizers"
           ticketsFromPrice={ticketsFromPrice}
         />
@@ -245,10 +297,14 @@ function OrganizersSectionView({
 /** Program-highlights band (legacy middle slot). Null without a live schedule. */
 function ProgramHighlightsSectionView({
   conference,
+  lifecycle,
 }: {
   conference: Conference
+  lifecycle: HomepageLifecycle
 }) {
-  if (!hasPublishedSchedule(conference)) return null
+  // A published-but-EMPTY schedule is not a programme. Guarding on content (not
+  // just on "publish was pressed") is what stops the all-zero statistics band.
+  if (!lifecycle.content.hasProgramme) return null
   return (
     <ProgramHighlights
       schedules={conference.schedules!}
@@ -261,19 +317,21 @@ function ProgramHighlightsSectionView({
 
 interface RenderContext {
   conference: Conference
+  lifecycle: HomepageLifecycle
   ticketsFromPrice?: string | null
 }
 
 /** Map ONE section config to its rendered node (or null). */
 function renderSection(
   section: HomepageSection,
-  { conference, ticketsFromPrice }: RenderContext,
+  { conference, lifecycle, ticketsFromPrice }: RenderContext,
 ): ReactNode {
   switch (section._type) {
     case 'homepageHero':
       return (
         <Hero
           conference={conference}
+          lifecycle={lifecycle}
           ticketsFromPrice={ticketsFromPrice}
           headlineOverride={section.heroHeadline}
           subheadlineOverride={section.heroSubheadline}
@@ -290,13 +348,27 @@ function renderSection(
           description={section.description?.trim() || undefined}
         />
       ) : null
+    case 'homepageSaveTheDate':
+      return (
+        <SaveTheDate
+          section={section}
+          conference={conference}
+          lifecycle={lifecycle}
+        />
+      )
     case 'homepageProgramHighlights':
-      return <ProgramHighlightsSectionView conference={conference} />
+      return (
+        <ProgramHighlightsSectionView
+          conference={conference}
+          lifecycle={lifecycle}
+        />
+      )
     case 'homepageFeaturedSpeakers':
       return (
         <FeaturedSpeakersSectionView
           conference={conference}
           section={section}
+          lifecycle={lifecycle}
           ticketsFromPrice={ticketsFromPrice}
         />
       )
@@ -305,15 +377,20 @@ function renderSection(
         <OrganizersSectionView
           conference={conference}
           section={section}
+          lifecycle={lifecycle}
           ticketsFromPrice={ticketsFromPrice}
         />
       )
     case 'homepageSponsors':
+      // The "Become a Sponsor" pitch is suppressed once the event is over: it is
+      // the loudest thing on an empty homepage and, after the fact, it asks for
+      // money for something that has already happened. Sponsors that DO exist
+      // still render — a thank-you wall is exactly what a post-event page wants.
       return (
         <Sponsors
           sponsors={conference.sponsors || []}
           conference={conference}
-          showCTA={section.showCta !== false}
+          showCTA={section.showCta !== false && lifecycle.stage !== 'post-event'}
           heading={section.heading?.trim() || undefined}
           description={section.description?.trim() || undefined}
           ctaHeading={section.ctaHeading?.trim() || undefined}
@@ -367,18 +444,43 @@ export function HomepageSectionRenderer({
   sections,
   conference,
   ticketsFromPrice,
+  ticketAvailability,
 }: {
   sections: HomepageSection[]
   conference: Conference
   ticketsFromPrice?: string | null
+  /**
+   * Live availability from the ticketing provider (see `getTicketAvailability`).
+   * Absent degrades to "on sale" — never to a sold-out claim.
+   */
+  ticketAvailability?: TicketAvailability | null
 }) {
+  const lifecycle = resolveHomepageLifecycle(conference, { ticketAvailability })
+
+  // `cancelled` / `archived` REPLACE the page. Short-circuiting above the
+  // section list is deliberate: rendering the notice as one more section would
+  // leave the hero's ticket CTA, the countdown and the speaker shelf underneath
+  // it, and visitors act on buttons rather than on paragraphs.
+  if (lifecycle.isOverridden) {
+    return (
+      <LifecycleNotice
+        conference={conference}
+        status={lifecycle.stage as 'cancelled' | 'archived'}
+      />
+    )
+  }
+
   return (
     <>
       {sections
         .filter((section) => !section.hidden)
         .map((section) => (
           <Fragment key={section._key}>
-            {renderSection(section, { conference, ticketsFromPrice })}
+            {renderSection(section, {
+              conference,
+              lifecycle,
+              ticketsFromPrice,
+            })}
           </Fragment>
         ))}
     </>

--- a/src/components/homepage/SectionRenderer.tsx
+++ b/src/components/homepage/SectionRenderer.tsx
@@ -80,14 +80,16 @@ function PhaseCtaRow({
           cfp: PIRSCH_EVENTS.cfpFeaturedSpeakers,
           tickets: PIRSCH_EVENTS.ticketsFeaturedSpeakers,
           info: PIRSCH_EVENTS.infoFeaturedSpeakers,
+          programme: PIRSCH_EVENTS.programFeaturedSpeakers,
         }
       : {
           cfp: PIRSCH_EVENTS.cfpFeaturedOrganizers,
           tickets: PIRSCH_EVENTS.ticketsFeaturedOrganizers,
           info: PIRSCH_EVENTS.infoFeaturedOrganizers,
+          programme: PIRSCH_EVENTS.programFeaturedOrganizers,
         }
 
-  const { primaryCta, cfp, tickets, content } = lifecycle
+  const { primaryCta, cfp, tickets, content, stage } = lifecycle
   const ticketsOnSale = tickets === 'on-sale'
   const buttonClassName =
     'inline-flex items-center space-x-2 px-8 py-4 font-semibold'
@@ -97,14 +99,21 @@ function PhaseCtaRow({
     : 'Get tickets'
   const showsPrice = Boolean(ticketsFromPrice) && ticketsOnSale
 
+  // "Watch the talks" is a POST-EVENT promise. `hasRecordings` alone is not
+  // enough: a recording can be attached to a confirmed talk before the event
+  // (a re-run, a teaser), and the pre-event `programme` stage also renders this
+  // button — which would advertise talks nobody has given yet. The stage is the
+  // half of the condition that says the event has actually happened.
+  const showsRecordings = stage === 'post-event' && content.hasRecordings
+
   const programmeButton = (
     <Button
       href="/program"
       variant="primary"
       className={buttonClassName}
-      data-pirsch-event={events.info}
+      data-pirsch-event={events.programme}
     >
-      {content.hasRecordings ? (
+      {showsRecordings ? (
         <>
           <PlayCircleIcon className="h-5 w-5" aria-hidden="true" />
           <span>Watch the talks</span>

--- a/src/components/homepage/SectionRenderer.tsx
+++ b/src/components/homepage/SectionRenderer.tsx
@@ -390,7 +390,9 @@ function renderSection(
         <Sponsors
           sponsors={conference.sponsors || []}
           conference={conference}
-          showCTA={section.showCta !== false && lifecycle.stage !== 'post-event'}
+          showCTA={
+            section.showCta !== false && lifecycle.stage !== 'post-event'
+          }
           heading={section.heading?.trim() || undefined}
           description={section.description?.trim() || undefined}
           ctaHeading={section.ctaHeading?.trim() || undefined}

--- a/src/components/homepage/lifecycle.mocks.ts
+++ b/src/components/homepage/lifecycle.mocks.ts
@@ -386,8 +386,20 @@ export const midCycleConference = {
   ],
 } as unknown as Conference
 
-/** Mid-cycle, but the vendor reports every active ticket type at zero. */
-export const soldOutConference = midCycleConference
+/**
+ * Mid-cycle, but the vendor reports every active ticket type at zero.
+ *
+ * The conference document is deliberately identical to {@link midCycleConference} —
+ * being sold out is something the TICKET VENDOR reports, never a field an
+ * organizer sets — so the difference lives in the mocked ticket data, not here.
+ * It still gets its own `_id`: a bare alias made the two fixtures the same
+ * object, which knip flags as a duplicate export and which makes any test that
+ * keys on `_id` unable to tell the two stories apart.
+ */
+export const soldOutConference = {
+  ...midCycleConference,
+  _id: 'conf-sold-out',
+} as unknown as Conference
 
 /** After the event, with photos and recordings to lead with. */
 export const postEventConference = {

--- a/src/components/homepage/lifecycle.mocks.ts
+++ b/src/components/homepage/lifecycle.mocks.ts
@@ -1,0 +1,434 @@
+import type { Conference } from '@/lib/conference/types'
+import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
+import type { ConferenceSponsor } from '@/lib/sponsor/types'
+import type { ProposalExisting } from '@/lib/proposal/types'
+import {
+  plainSpeaker,
+  shortRoleSpeaker,
+  workshopSpeaker,
+} from '@/components/featuredSpeakers.mocks'
+
+/**
+ * Fixtures for the homepage lifecycle stories.
+ *
+ * Every conference here differs from the others ONLY in the fields the
+ * lifecycle model reads (dates, registration, content), so the stories compare
+ * states rather than unrelated copy. The clock is pinned to {@link FIXED_NOW} by
+ * the story `beforeEach`, which is what makes the date-derived stages
+ * deterministic in Chromatic.
+ */
+
+export const FIXED_NOW_ISO = '2026-03-01T12:00:00Z'
+export const FIXED_NOW = new Date(FIXED_NOW_ISO).getTime()
+
+/**
+ * The house clock-pinning hook (see `Countdown.stories`). Returned as a factory
+ * so several story files can share it without sharing module state.
+ */
+export function pinClock(now: number = FIXED_NOW) {
+  const OriginalDate = globalThis.Date
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockDate: any = function (...args: any[]) {
+    if (args.length === 0) return new OriginalDate(now)
+    return new (
+      Function.prototype.bind.apply(OriginalDate, [
+        null,
+        ...args,
+      ]) as typeof OriginalDate
+    )()
+  }
+  Object.setPrototypeOf(MockDate, OriginalDate)
+  MockDate.prototype = Object.create(OriginalDate.prototype)
+  MockDate.now = () => now
+  MockDate.parse = OriginalDate.parse.bind(OriginalDate)
+  MockDate.UTC = OriginalDate.UTC.bind(OriginalDate)
+  globalThis.Date = MockDate
+  return () => {
+    globalThis.Date = OriginalDate
+  }
+}
+
+// ── Content fixtures ────────────────────────────────────────────────────────
+
+/**
+ * A Sanity asset ref must be syntactically valid or the image-url builder
+ * produces nothing — 40 hex characters then `-WIDTHxHEIGHT-ext`.
+ */
+function galleryImage(n: number): GalleryImageWithSpeakers {
+  const id = `gal${n}`
+  return {
+    _id: id,
+    _rev: 'r1',
+    _createdAt: '2025-06-12T10:00:00Z',
+    _updatedAt: '2025-06-12T10:00:00Z',
+    photographer: 'Olav Nordmann',
+    date: '2025-06-12',
+    location: 'Grieghallen, Bergen',
+    featured: true,
+    image: {
+      _type: 'image',
+      asset: {
+        _ref: `image-${id}${'0'.repeat(40 - id.length)}-1920x1080-jpg`,
+        _type: 'reference',
+      },
+    },
+    speakers: [],
+  } as unknown as GalleryImageWithSpeakers
+}
+
+export const galleryImages = [1, 2, 3, 4].map(galleryImage)
+
+const sponsorLogo = (label: string, color: string) =>
+  `<svg viewBox="0 0 200 60" xmlns="http://www.w3.org/2000/svg">` +
+  `<text x="100" y="38" font-family="sans-serif" font-size="26" fill="${color}" text-anchor="middle">${label}</text>` +
+  `</svg>`
+
+export const sponsors = [
+  {
+    _id: 'cs-1',
+    sponsor: {
+      _id: 's-1',
+      name: 'Acme Corporation',
+      website: 'https://acme.example.com',
+      logo: sponsorLogo('ACME', '#2563eb'),
+    },
+    tier: { title: 'Ingress', tagline: 'Premium' },
+  },
+  {
+    _id: 'cs-2',
+    sponsor: {
+      _id: 's-2',
+      name: 'Tech Solutions',
+      website: 'https://tech.example.com',
+      logo: sponsorLogo('TECH', '#10b981'),
+    },
+    tier: { title: 'Ingress', tagline: 'Premium' },
+  },
+  {
+    _id: 'cs-3',
+    sponsor: {
+      _id: 's-3',
+      name: 'Cloud Services',
+      website: 'https://cloud.example.com',
+      logo: sponsorLogo('CLOUD', '#8b5cf6'),
+    },
+    tier: { title: 'Pod', tagline: 'Base' },
+  },
+] as unknown as ConferenceSponsor[]
+
+export const sponsorTiers = [
+  {
+    _id: 'tier-ingress',
+    title: 'Ingress',
+    tagline: 'Premium tier',
+    tierType: 'standard' as const,
+    price: [{ _key: 'p1', amount: 100000, currency: 'NOK' }],
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    soldOut: false,
+    mostPopular: false,
+  },
+  {
+    _id: 'tier-pod',
+    title: 'Pod',
+    tagline: 'Base tier',
+    tierType: 'standard' as const,
+    price: [{ _key: 'p2', amount: 25000, currency: 'NOK' }],
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    soldOut: false,
+    mostPopular: false,
+  },
+]
+
+export const organizers = [
+  { _id: 'org-1', name: 'Ingrid Halvorsen', title: 'Programme chair' },
+  { _id: 'org-2', name: 'Mateusz Nowak', title: 'Community lead' },
+  { _id: 'org-3', name: 'Sara Lindqvist', title: 'Sponsorship' },
+]
+
+export const featuredSpeakers = [
+  workshopSpeaker,
+  plainSpeaker,
+  shortRoleSpeaker,
+]
+
+/** One confirmed talk, optionally carrying a recording attachment. */
+function talk(
+  id: string,
+  title: string,
+  speaker: (typeof featuredSpeakers)[number],
+  format: string,
+  topic: string,
+  withRecording = false,
+): ProposalExisting {
+  return {
+    _id: id,
+    title,
+    status: 'confirmed',
+    format,
+    speakers: [speaker],
+    topics: [{ _id: `topic-${topic}`, title: topic }],
+    ...(withRecording
+      ? {
+          attachments: [
+            {
+              _key: `a-${id}`,
+              _type: 'urlAttachment',
+              attachmentType: 'recording',
+              url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+              title: 'Recording',
+            },
+          ],
+        }
+      : {}),
+  } as unknown as ProposalExisting
+}
+
+function slot(
+  start: string,
+  end: string,
+  proposal: ProposalExisting,
+): Record<string, unknown> {
+  return { startTime: start, endTime: end, hasTalkRef: true, talk: proposal }
+}
+
+/**
+ * A published two-day schedule with real content in every dimension the
+ * Program Highlights statistics band counts — sessions, speakers, workshops,
+ * days, topics and tracks. Deliberately non-zero across the board: the band
+ * drops zero-valued tiles, so a fixture with an empty dimension would silently
+ * change the shape of the band it is meant to exercise.
+ */
+export function schedules(withRecordings = false) {
+  return [
+    {
+      _id: 'sched-1',
+      date: '2026-06-10',
+      tracks: [
+        {
+          trackTitle: 'Main stage',
+          trackDescription: 'Keynotes and headline talks',
+          talks: [
+            slot(
+              '09:00',
+              '09:45',
+              talk(
+                't1',
+                'Running Kubernetes without a platform team',
+                featuredSpeakers[0],
+                'presentation_45',
+                'Platform Engineering',
+                withRecordings,
+              ),
+            ),
+            slot(
+              '10:00',
+              '10:45',
+              talk(
+                't2',
+                'What we learned migrating 400 services',
+                featuredSpeakers[1],
+                'presentation_45',
+                'Migration',
+                withRecordings,
+              ),
+            ),
+          ],
+        },
+        {
+          trackTitle: 'Workshops',
+          trackDescription: 'Hands-on sessions',
+          talks: [
+            slot(
+              '09:00',
+              '11:00',
+              talk(
+                't3',
+                'Build your own operator',
+                featuredSpeakers[2],
+                'workshop_120',
+                'Operators',
+                withRecordings,
+              ),
+            ),
+          ],
+        },
+      ],
+    },
+    {
+      _id: 'sched-2',
+      date: '2026-06-11',
+      tracks: [
+        {
+          trackTitle: 'Main stage',
+          trackDescription: 'Keynotes and headline talks',
+          talks: [
+            slot(
+              '09:00',
+              '09:45',
+              talk(
+                't4',
+                'Observability that survives an incident',
+                featuredSpeakers[1],
+                'presentation_45',
+                'Observability',
+                withRecordings,
+              ),
+            ),
+          ],
+        },
+        {
+          trackTitle: 'Workshops',
+          trackDescription: 'Hands-on sessions',
+          talks: [
+            slot(
+              '13:00',
+              '15:00',
+              talk(
+                't5',
+                'Debugging a cluster live',
+                featuredSpeakers[0],
+                'workshop_120',
+                'Operations',
+                withRecordings,
+              ),
+            ),
+          ],
+        },
+      ],
+    },
+  ] as unknown as Conference['schedules']
+}
+
+// ── Conference fixtures, one per lifecycle state ────────────────────────────
+
+/**
+ * The floor: everything a brand-new organizer has entered on day one and
+ * nothing else. No CFP dates, no programme date, no ticketing, no people, no
+ * photos. This is the fixture the day-one design has to survive.
+ */
+export const dayOneConference = {
+  _id: 'conf-day-one',
+  title: 'Kubernetes Community Day Trondheim 2026',
+  organizer: 'KCD Trondheim',
+  tagline: 'Cloud native, in the north',
+  description:
+    'A one-day community conference for everyone building and running cloud native systems in mid-Norway.',
+  city: 'Trondheim',
+  country: 'Norway',
+  venueName: 'Clarion Hotel Trondheim',
+  venueAddress: 'Brattørkaia 1\n7010 Trondheim\nNorway',
+  startDate: '2026-09-17',
+  endDate: '2026-09-17',
+  contactEmail: 'hello@kcdtrondheim.example',
+  sponsorEmail: 'sponsors@kcdtrondheim.example',
+  registrationEnabled: false,
+  domains: ['kcdtrondheim.example'],
+  formats: [],
+  topics: [],
+  organizers: [],
+  socialLinks: [],
+  sponsors: [],
+  sponsorTiers: [],
+} as unknown as Conference
+
+/**
+ * Day one plus the organizing team and the dates they have committed to — the
+ * realistic second day of setup, and the state most new events actually sit in.
+ */
+export const announcedConference = {
+  ...dayOneConference,
+  _id: 'conf-announced',
+  organizers,
+  cfpStartDate: '2026-04-01',
+  cfpEndDate: '2026-05-15',
+  programDate: '2026-06-15',
+} as unknown as Conference
+
+/** CFP window open. Still a first edition: no photos, no speakers, no sponsors. */
+export const cfpOpenConference = {
+  ...announcedConference,
+  _id: 'conf-cfp-open',
+  cfpStartDate: '2026-02-01',
+  cfpEndDate: '2026-04-15',
+  registrationEnabled: true,
+  registrationLink: 'https://tickets.example.com',
+} as unknown as Conference
+
+/** A returning edition mid-cycle: programme published, tickets on sale. */
+export const midCycleConference = {
+  ...dayOneConference,
+  _id: 'conf-mid-cycle',
+  title: 'Cloud Native Days Norway 2026',
+  organizer: 'Cloud Native Days Norway',
+  city: 'Bergen',
+  venueName: 'Grieghallen',
+  venueAddress: 'Edvard Griegs plass 1\n5015 Bergen\nNorway',
+  startDate: '2026-06-10',
+  endDate: '2026-06-11',
+  cfpStartDate: '2025-11-01',
+  cfpEndDate: '2026-01-15',
+  programDate: '2026-02-15',
+  registrationEnabled: true,
+  registrationLink: 'https://tickets.example.com',
+  organizers,
+  featuredSpeakers,
+  featuredTalks: [],
+  schedules: schedules(),
+  sponsors,
+  sponsorTiers,
+  featuredGalleryImages: galleryImages,
+  vanityMetrics: [
+    { label: 'Attendees', value: '450+' },
+    { label: 'Speakers', value: '40' },
+    { label: 'Tracks', value: '4' },
+  ],
+} as unknown as Conference
+
+/** Mid-cycle, but the vendor reports every active ticket type at zero. */
+export const soldOutConference = midCycleConference
+
+/** After the event, with photos and recordings to lead with. */
+export const postEventConference = {
+  ...midCycleConference,
+  _id: 'conf-post-event',
+  title: 'Cloud Native Days Norway 2025',
+  startDate: '2025-06-10',
+  endDate: '2025-06-11',
+  cfpStartDate: '2024-11-01',
+  cfpEndDate: '2025-01-15',
+  programDate: '2025-02-15',
+  schedules: schedules(true),
+} as unknown as Conference
+
+/** An edition called off. Explicit — no date can imply it. */
+export const cancelledConference = {
+  ...midCycleConference,
+  _id: 'conf-cancelled',
+  title: 'Cloud Native Days Amsterdam 2026',
+  city: 'Amsterdam',
+  country: 'Netherlands',
+  venueName: 'Beurs van Berlage',
+  lifecycleStatus: 'cancelled',
+  lifecycleMessage:
+    'After a great deal of deliberation we have decided not to run the 2026 edition. Everyone who bought a ticket has been refunded in full, and our sponsors have been contacted directly.\n\nWe intend to be back in 2027 — thank you for the support.',
+  lifecycleLinkLabel: 'Read the full statement',
+  lifecycleLinkHref: '/info',
+} as unknown as Conference
+
+/** Ended for good — the tombstone. */
+export const archivedConference = {
+  ...postEventConference,
+  _id: 'conf-archived',
+  title: 'The Strange Loop',
+  organizer: 'Strange Loop',
+  city: 'St. Louis',
+  country: 'USA',
+  lifecycleStatus: 'archived',
+  lifecycleHeadline: 'The Strange Loop — 2009 to 2023',
+  lifecycleMessage:
+    'Strange Loop has ended. Fifteen years, thousands of attendees, and over a thousand talks — all of which remain online and free to watch.\n\nThank you to every speaker, volunteer, sponsor and attendee.',
+  lifecycleLinkLabel: 'Browse the talk archive',
+  lifecycleLinkHref: 'https://example.com/archive',
+} as unknown as Conference

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -29,9 +29,13 @@
  * - `cta-cfp-featured-speakers`       Featured Speakers section "Submit a talk"
  * - `cta-tickets-featured-speakers`   Featured Speakers section tickets button
  * - `cta-info-featured-speakers`      Featured Speakers section info button
+ * - `cta-program-featured-speakers`   Featured Speakers section programme button
+ *                                     ("See the programme" / "Watch the talks")
  * - `cta-cfp-featured-organizers`     Organizers section "Submit a talk"
  * - `cta-tickets-featured-organizers` Organizers section tickets button
  * - `cta-info-featured-organizers`    Organizers section info button
+ * - `cta-program-featured-organizers` Organizers section programme button
+ *                                     ("See the programme" / "Watch the talks")
  * - `outbound-checkin-tickets-page`   /tickets external registration button
  *                                     (outbound to checkin.no)
  */
@@ -51,8 +55,10 @@ export const PIRSCH_EVENTS = {
   cfpFeaturedSpeakers: 'cta-cfp-featured-speakers',
   ticketsFeaturedSpeakers: 'cta-tickets-featured-speakers',
   infoFeaturedSpeakers: 'cta-info-featured-speakers',
+  programFeaturedSpeakers: 'cta-program-featured-speakers',
   cfpFeaturedOrganizers: 'cta-cfp-featured-organizers',
   ticketsFeaturedOrganizers: 'cta-tickets-featured-organizers',
   infoFeaturedOrganizers: 'cta-info-featured-organizers',
+  programFeaturedOrganizers: 'cta-program-featured-organizers',
   outboundCheckinTicketsPage: 'outbound-checkin-tickets-page',
 } as const

--- a/src/lib/conference/types.ts
+++ b/src/lib/conference/types.ts
@@ -10,6 +10,7 @@ import type { OrganizerTeam } from '@/lib/teams/types'
 import type { ConferenceVisibility } from './visibility'
 import type { BackgroundPattern } from './backgroundPattern'
 import type { HomepageSection } from '@/lib/homepage/sections'
+import type { LifecycleStatus } from '@/lib/homepage/lifecycle'
 
 export interface CrmActivityThreshold {
   _key?: string
@@ -234,4 +235,21 @@ export interface Conference {
    * `...` spread; sections carry only their own presentation config.
    */
   homepageSections?: HomepageSection[]
+  /**
+   * Homepage lifecycle OVERRIDE (F5). ABSENT (every legacy conference) means the
+   * stage is derived from the CFP / programme / event dates — see
+   * `@/lib/homepage/lifecycle`. The two values here are the only states no date
+   * can imply: an event is `cancelled` or `archived` because a human says so.
+   * Both REPLACE the homepage rather than adding a banner to it. Projected by
+   * the main conference projection's `...` spread.
+   */
+  lifecycleStatus?: LifecycleStatus
+  /** Headline for the cancelled/archived notice. Blank → a derived default. */
+  lifecycleHeadline?: string
+  /** Body copy for the cancelled/archived notice. Plain text, newline-aware. */
+  lifecycleMessage?: string
+  /** Label for the single link on the notice (e.g. "Read the full statement"). */
+  lifecycleLinkLabel?: string
+  /** Destination for the notice link. Same safe-link rules as hero CTAs. */
+  lifecycleLinkHref?: string
 }

--- a/src/lib/homepage/editor.test.ts
+++ b/src/lib/homepage/editor.test.ts
@@ -441,3 +441,28 @@ describe('toPayload — trimming, omission and item filtering', () => {
     })
   })
 })
+
+/**
+ * This module is reachable from SERVER components (`page.tsx` imports its label
+ * maps). A single value import from a client-only package — even for a pure
+ * helper — puts that package's React context in the RSC module graph, and the
+ * production build dies collecting page data with `createContext is not a
+ * function`. That is invisible to typecheck and to every unit test, so it is
+ * asserted on the source text instead. `import type` is fine: it is erased.
+ */
+describe('server safety', () => {
+  it('has no runtime dependency on any package', async () => {
+    const { readFile } = await import('node:fs/promises')
+    const source = await readFile(
+      new URL('./editor.ts', import.meta.url),
+      'utf8',
+    )
+
+    const runtimeImports = Array.from(
+      source.matchAll(/^import\s+(?!type\b)[^;]*?from\s+'([^']+)'/gm),
+      (match) => match[1],
+    ).filter((specifier) => !specifier.startsWith('.'))
+
+    expect(runtimeImports).toEqual([])
+  })
+})

--- a/src/lib/homepage/editor.ts
+++ b/src/lib/homepage/editor.ts
@@ -1,6 +1,13 @@
 import { arrayMove } from '@dnd-kit/sortable'
 import type { PortableTextBlock } from '@portabletext/editor'
-import { type HomepageSection, type HomepageSectionType } from './sections'
+import {
+  SECTION_LABELS,
+  type HomepageSection,
+  type HomepageSectionType,
+} from './sections'
+
+// Re-exported for the editor surface, which historically imported it from here.
+export { SECTION_LABELS }
 
 /**
  * Front-page builder (F3): the PURE editor logic behind the drag-and-drop
@@ -8,22 +15,6 @@ import { type HomepageSection, type HomepageSectionType } from './sections'
  * payload mapping, dirty check and structural-preview mapping are unit-testable
  * in isolation from the modal surface that drives them.
  */
-
-/** Human labels for each block type — shared by the list rows and the preview. */
-export const SECTION_LABELS: Record<HomepageSectionType, string> = {
-  homepageHero: 'Hero',
-  homepageFeaturedSpeakers: 'Featured Speakers',
-  homepageProgramHighlights: 'Program Highlights',
-  homepageOrganizers: 'Organizers',
-  homepageSponsors: 'Sponsors',
-  homepageGallery: 'Photo Gallery',
-  homepageMetrics: 'Vanity Metrics',
-  homepageCtaBanner: 'Call-to-action Banner',
-  homepageRichText: 'Rich Text',
-  homepageFaq: 'FAQ',
-  homepageCountdown: 'Countdown',
-  homepageVenue: 'Venue',
-}
 
 /**
  * The block types that carry per-section config worth an inline accordion.
@@ -34,6 +25,7 @@ export const SECTION_LABELS: Record<HomepageSectionType, string> = {
  */
 const CONFIGURABLE_TYPES: ReadonlySet<HomepageSectionType> = new Set([
   'homepageHero',
+  'homepageSaveTheDate',
   'homepageCtaBanner',
   'homepageRichText',
   'homepageMetrics',
@@ -61,6 +53,9 @@ const PHASE_SLOT_DEFAULT_KEYS: ReadonlySet<string> = new Set([
   'default-program',
   'default-featured-speakers',
   'default-organizers',
+  // The save-the-date band is itself lifecycle-conditional: it appears only
+  // while the event has no programme and no featured speakers to show.
+  'default-save-the-date',
 ])
 
 /** Working row shape — a superset of every block's fields, keyed for the list. */
@@ -137,8 +132,12 @@ export function toEditorRows(sections: HomepageSection[]): EditorRow[] {
     } else if (s._type === 'homepageRichText') {
       row.heading = s.heading
       row.content = (s.content as PortableTextBlock[]) ?? []
-    } else if (s._type === 'homepageMetrics') {
+    } else if (
+      s._type === 'homepageMetrics' ||
+      s._type === 'homepageSaveTheDate'
+    ) {
       row.heading = s.heading
+      if (s._type === 'homepageSaveTheDate') row.description = s.description
     } else if (s._type === 'homepageFaq') {
       row.heading = s.heading
       row.source = s.source ?? 'own'
@@ -211,6 +210,10 @@ export function toPayload(rows: EditorRow[]): Record<string, unknown>[] {
         break
       case 'homepageMetrics':
         if (row.heading?.trim()) out.heading = row.heading.trim()
+        break
+      case 'homepageSaveTheDate':
+        if (row.heading?.trim()) out.heading = row.heading.trim()
+        if (row.description?.trim()) out.description = row.description.trim()
         break
       case 'homepageFaq': {
         if (row.heading?.trim()) out.heading = row.heading.trim()

--- a/src/lib/homepage/editor.ts
+++ b/src/lib/homepage/editor.ts
@@ -1,4 +1,20 @@
-import { arrayMove } from '@dnd-kit/sortable'
+/**
+ * Local copy of `@dnd-kit/sortable`'s `arrayMove`, semantics preserved
+ * (including the negative-index handling this module never relies on).
+ *
+ * Inlined DELIBERATELY. `arrayMove` is a pure four-line array helper, but
+ * importing it from `@dnd-kit/sortable` pulls that package's React context into
+ * whatever module graph reaches this file. The package is client-only, so any
+ * server component importing anything from here — a label map, a type guard —
+ * died at build time with `createContext is not a function` while collecting
+ * page data. Four lines of duplication buys this module ZERO runtime
+ * dependencies, which is what a pure model/logic module should have.
+ */
+function arrayMove<T>(array: readonly T[], from: number, to: number): T[] {
+  const next = array.slice()
+  next.splice(to < 0 ? next.length + to : to, 0, next.splice(from, 1)[0])
+  return next
+}
 import type { PortableTextBlock } from '@portabletext/editor'
 import { type HomepageSection, type HomepageSectionType } from './sections'
 

--- a/src/lib/homepage/index.ts
+++ b/src/lib/homepage/index.ts
@@ -1,6 +1,8 @@
-// Server-safe barrel: ONLY the registry/model module. The editor logic
-// (./editor) deliberately stays a deep import — it pulls in @dnd-kit, a
-// client-only dependency, and this barrel is imported by server components
-// (page.tsx), so re-exporting it here would drag-and-drop code into the
-// RSC module graph and break the build.
+// The registry/model module — the homepage vocabulary every layer shares.
+//
+// The editor logic (./editor) stays a deep import to keep this surface small,
+// NOT because it is unsafe to reach from a server component: it no longer has
+// any runtime dependency (see the inlined `arrayMove` there), so importing a
+// label map or a type guard from it does not drag client-only code into the
+// RSC graph. That property is load-bearing — keep ./editor dependency-free.
 export * from './sections'

--- a/src/lib/homepage/lifecycle.test.ts
+++ b/src/lib/homepage/lifecycle.test.ts
@@ -1,0 +1,592 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  hasProgrammeContent,
+  isLifecycleStatus,
+  resolveCfpState,
+  resolveHomepageContent,
+  resolveHomepageLifecycle,
+  resolveHomepageStage,
+  resolvePrimaryCta,
+  resolveRoadmapSteps,
+  resolveTicketState,
+} from './lifecycle'
+import type { Conference } from '@/lib/conference/types'
+
+/**
+ * State derivation is pure logic, so it is tested here rather than through
+ * snapshots. `Date.now()` is frozen per test via fake timers so the date-driven
+ * stages are deterministic.
+ */
+
+const NOW = new Date('2026-06-15T12:00:00.000Z')
+
+function at(now: Date | string = NOW) {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(now))
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function makeConference(overrides: Partial<Conference> = {}): Conference {
+  return {
+    _id: 'conf-1',
+    title: 'Test Conf',
+    startDate: '2026-09-15',
+    endDate: '2026-09-15',
+    registrationEnabled: false,
+    schedules: [],
+    featuredSpeakers: [],
+    organizers: [],
+    sponsors: [],
+    ...overrides,
+  } as unknown as Conference
+}
+
+/** A schedule day containing one talk with the given status. */
+function scheduleWith(status: string | undefined) {
+  return [
+    {
+      _id: 's1',
+      date: '2026-09-15',
+      tracks: [
+        {
+          trackTitle: 'Track 1',
+          trackDescription: '',
+          talks: [
+            {
+              startTime: '09:00',
+              endTime: '09:45',
+              ...(status ? { talk: { _id: 't1', status } } : {}),
+            },
+          ],
+        },
+      ],
+    },
+  ] as unknown as Conference['schedules']
+}
+
+describe('hasProgrammeContent', () => {
+  it('is false when the programme date has not passed', () => {
+    at()
+    expect(
+      hasProgrammeContent(
+        makeConference({
+          programDate: '2026-08-01',
+          schedules: scheduleWith('confirmed'),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false for a PUBLISHED but EMPTY schedule (the zero-stats bug)', () => {
+    at()
+    const conference = makeConference({
+      programDate: '2026-01-01',
+      schedules: [
+        { _id: 's1', date: '2026-09-15', tracks: [] },
+      ] as unknown as Conference['schedules'],
+    })
+    expect(hasProgrammeContent(conference)).toBe(false)
+  })
+
+  it('is false when the only talks are not confirmed', () => {
+    at()
+    expect(
+      hasProgrammeContent(
+        makeConference({
+          programDate: '2026-01-01',
+          schedules: scheduleWith('accepted'),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false for service slots that carry no talk reference', () => {
+    at()
+    expect(
+      hasProgrammeContent(
+        makeConference({
+          programDate: '2026-01-01',
+          schedules: scheduleWith(undefined),
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('is true for a published schedule with a confirmed talk', () => {
+    at()
+    expect(
+      hasProgrammeContent(
+        makeConference({
+          programDate: '2026-01-01',
+          schedules: scheduleWith('confirmed'),
+        }),
+      ),
+    ).toBe(true)
+  })
+})
+
+describe('resolveCfpState', () => {
+  it('is absent without CFP dates', () => {
+    at()
+    expect(resolveCfpState(makeConference())).toBe('absent')
+  })
+
+  it('is upcoming before the window opens', () => {
+    at()
+    expect(
+      resolveCfpState(
+        makeConference({
+          cfpStartDate: '2026-07-01',
+          cfpEndDate: '2026-08-01',
+        }),
+      ),
+    ).toBe('upcoming')
+  })
+
+  it('is open inside the window', () => {
+    at()
+    expect(
+      resolveCfpState(
+        makeConference({
+          cfpStartDate: '2026-06-01',
+          cfpEndDate: '2026-07-01',
+        }),
+      ),
+    ).toBe('open')
+  })
+
+  it('is closed after the window', () => {
+    at()
+    expect(
+      resolveCfpState(
+        makeConference({
+          cfpStartDate: '2026-01-01',
+          cfpEndDate: '2026-02-01',
+        }),
+      ),
+    ).toBe('closed')
+  })
+})
+
+describe('resolveTicketState', () => {
+  it('is unavailable when registration is switched off', () => {
+    at()
+    expect(resolveTicketState(makeConference())).toBe('unavailable')
+  })
+
+  it('is unavailable when enabled but no registration link exists', () => {
+    at()
+    expect(
+      resolveTicketState(makeConference({ registrationEnabled: true })),
+    ).toBe('unavailable')
+  })
+
+  it('is on-sale when registration is configured', () => {
+    at()
+    expect(
+      resolveTicketState(
+        makeConference({
+          registrationEnabled: true,
+          registrationLink: 'https://tickets.example.com',
+        }),
+      ),
+    ).toBe('on-sale')
+  })
+
+  it('is sold-out only on an explicit signal', () => {
+    at()
+    const conference = makeConference({
+      registrationEnabled: true,
+      registrationLink: 'https://tickets.example.com',
+    })
+    expect(resolveTicketState(conference, 'sold-out')).toBe('sold-out')
+  })
+
+  it('is not-yet-on-sale when every sale window is still upcoming', () => {
+    at()
+    const conference = makeConference({
+      registrationEnabled: true,
+      registrationLink: 'https://tickets.example.com',
+    })
+    expect(resolveTicketState(conference, 'upcoming')).toBe('not-yet-on-sale')
+  })
+
+  it('never invents sold-out from a missing signal', () => {
+    at()
+    const conference = makeConference({
+      registrationEnabled: true,
+      registrationLink: 'https://tickets.example.com',
+    })
+    expect(resolveTicketState(conference, null)).toBe('on-sale')
+    expect(resolveTicketState(conference, undefined)).toBe('on-sale')
+    expect(resolveTicketState(conference, 'unknown')).toBe('on-sale')
+  })
+
+  it('is closed once the conference is over', () => {
+    at()
+    expect(
+      resolveTicketState(
+        makeConference({
+          startDate: '2026-01-10',
+          endDate: '2026-01-10',
+          registrationEnabled: true,
+          registrationLink: 'https://tickets.example.com',
+        }),
+      ),
+    ).toBe('closed')
+  })
+})
+
+describe('resolveHomepageStage', () => {
+  it('is announced for a conference with dates and nothing else', () => {
+    at()
+    expect(resolveHomepageStage(makeConference())).toBe('announced')
+  })
+
+  it('is announced while the CFP is still upcoming', () => {
+    at()
+    expect(
+      resolveHomepageStage(
+        makeConference({
+          cfpStartDate: '2026-07-01',
+          cfpEndDate: '2026-08-01',
+        }),
+      ),
+    ).toBe('announced')
+  })
+
+  it('is cfp-open inside the CFP window', () => {
+    at()
+    expect(
+      resolveHomepageStage(
+        makeConference({
+          cfpStartDate: '2026-06-01',
+          cfpEndDate: '2026-07-01',
+        }),
+      ),
+    ).toBe('cfp-open')
+  })
+
+  it('is curating once the CFP has closed but no programme is published', () => {
+    at()
+    expect(
+      resolveHomepageStage(
+        makeConference({
+          cfpStartDate: '2026-01-01',
+          cfpEndDate: '2026-02-01',
+          programDate: '2026-08-01',
+        }),
+      ),
+    ).toBe('curating')
+  })
+
+  it('is programme once the programme date has passed', () => {
+    at()
+    expect(
+      resolveHomepageStage(makeConference({ programDate: '2026-06-01' })),
+    ).toBe('programme')
+  })
+
+  it('is post-event the day after the end date', () => {
+    at()
+    expect(
+      resolveHomepageStage(
+        makeConference({ startDate: '2026-06-01', endDate: '2026-06-01' }),
+      ),
+    ).toBe('post-event')
+  })
+
+  it('is still programme on the final day of the event', () => {
+    at('2026-09-15T09:00:00.000Z')
+    expect(
+      resolveHomepageStage(
+        makeConference({
+          startDate: '2026-09-15',
+          endDate: '2026-09-15',
+          programDate: '2026-08-01',
+        }),
+      ),
+    ).toBe('programme')
+  })
+
+  it('lets an explicit cancelled status win over every derived stage', () => {
+    at()
+    expect(
+      resolveHomepageStage(
+        makeConference({
+          programDate: '2026-01-01',
+          lifecycleStatus: 'cancelled',
+        }),
+      ),
+    ).toBe('cancelled')
+  })
+
+  it('lets an explicit archived status win over post-event', () => {
+    at()
+    expect(
+      resolveHomepageStage(
+        makeConference({
+          startDate: '2020-01-01',
+          endDate: '2020-01-01',
+          lifecycleStatus: 'archived',
+        }),
+      ),
+    ).toBe('archived')
+  })
+
+  it('ignores an unrecognised status value rather than blanking the page', () => {
+    at()
+    expect(
+      resolveHomepageStage(
+        makeConference({
+          lifecycleStatus: 'postponed' as never,
+        }),
+      ),
+    ).toBe('announced')
+  })
+})
+
+describe('isLifecycleStatus', () => {
+  it('accepts only the two explicit statuses', () => {
+    expect(isLifecycleStatus('cancelled')).toBe(true)
+    expect(isLifecycleStatus('archived')).toBe(true)
+    expect(isLifecycleStatus('post-event')).toBe(false)
+    expect(isLifecycleStatus(undefined)).toBe(false)
+  })
+})
+
+describe('resolveHomepageContent', () => {
+  it('reports an empty conference as first edition with nothing to show', () => {
+    at()
+    const content = resolveHomepageContent(makeConference())
+    expect(content).toEqual({
+      hasGallery: false,
+      hasVanityMetrics: false,
+      hasFeaturedSpeakers: false,
+      hasOrganizers: false,
+      hasSponsors: false,
+      hasProgramme: false,
+      hasRecordings: false,
+      isFirstEdition: true,
+    })
+  })
+
+  it('stops being a first edition once there are past photos', () => {
+    at()
+    const content = resolveHomepageContent(
+      makeConference({
+        featuredGalleryImages: [{ _id: 'g1' }] as never,
+      }),
+    )
+    expect(content.hasGallery).toBe(true)
+    expect(content.isFirstEdition).toBe(false)
+  })
+
+  it('treats quoted vanity metrics as evidence of history', () => {
+    at()
+    expect(
+      resolveHomepageContent(
+        makeConference({
+          vanityMetrics: [{ label: 'Attendees', value: '400' }],
+        }),
+      ).isFirstEdition,
+    ).toBe(false)
+  })
+})
+
+describe('resolvePrimaryCta', () => {
+  const empty = {
+    hasGallery: false,
+    hasVanityMetrics: false,
+    hasFeaturedSpeakers: false,
+    hasOrganizers: false,
+    hasSponsors: false,
+    hasProgramme: false,
+    hasRecordings: false,
+    isFirstEdition: true,
+  }
+
+  it('pushes the programme after the event, never tickets', () => {
+    expect(
+      resolvePrimaryCta('post-event', 'closed', 'closed', {
+        ...empty,
+        hasProgramme: true,
+      }),
+    ).toBe('programme')
+  })
+
+  it('falls back to practical info after an event with no programme', () => {
+    expect(resolvePrimaryCta('post-event', 'closed', 'closed', empty)).toBe(
+      'info',
+    )
+  })
+
+  it('puts the CFP ahead of tickets while it is open', () => {
+    expect(resolvePrimaryCta('cfp-open', 'open', 'on-sale', empty)).toBe('cfp')
+  })
+
+  it('pushes tickets once the CFP is closed', () => {
+    expect(resolvePrimaryCta('curating', 'closed', 'on-sale', empty)).toBe(
+      'tickets',
+    )
+  })
+
+  it('does not push sold-out tickets', () => {
+    expect(
+      resolvePrimaryCta('programme', 'closed', 'sold-out', {
+        ...empty,
+        hasProgramme: true,
+      }),
+    ).toBe('programme')
+  })
+
+  it('falls back to practical info on day one', () => {
+    expect(resolvePrimaryCta('announced', 'absent', 'unavailable', empty)).toBe(
+      'info',
+    )
+  })
+})
+
+describe('resolveHomepageLifecycle', () => {
+  it('resolves the day-one state end to end', () => {
+    at()
+    const lifecycle = resolveHomepageLifecycle(makeConference())
+    expect(lifecycle.stage).toBe('announced')
+    expect(lifecycle.cfp).toBe('absent')
+    expect(lifecycle.tickets).toBe('unavailable')
+    expect(lifecycle.content.isFirstEdition).toBe(true)
+    expect(lifecycle.primaryCta).toBe('info')
+    expect(lifecycle.isOverridden).toBe(false)
+  })
+
+  it('marks cancelled and archived as page overrides with no ticket claim', () => {
+    at()
+    for (const status of ['cancelled', 'archived'] as const) {
+      const lifecycle = resolveHomepageLifecycle(
+        makeConference({
+          lifecycleStatus: status,
+          registrationEnabled: true,
+          registrationLink: 'https://tickets.example.com',
+        }),
+      )
+      expect(lifecycle.isOverridden).toBe(true)
+      expect(lifecycle.tickets).toBe('unavailable')
+    }
+  })
+
+  it('threads the live availability signal through', () => {
+    at()
+    const lifecycle = resolveHomepageLifecycle(
+      makeConference({
+        registrationEnabled: true,
+        registrationLink: 'https://tickets.example.com',
+      }),
+      { ticketAvailability: 'sold-out' },
+    )
+    expect(lifecycle.tickets).toBe('sold-out')
+  })
+})
+
+describe('resolveRoadmapSteps', () => {
+  const iso = (v: string) => v
+
+  function steps(conference: Conference) {
+    return resolveRoadmapSteps(
+      conference,
+      resolveHomepageLifecycle(conference),
+      iso,
+    )
+  }
+
+  it('is EMPTY for a conference that has only set its event dates', () => {
+    at()
+    // The day-one floor: no CFP dates, no programme date, no ticketing. The band
+    // must render dates + venue + countdown rather than three "TBA" rows.
+    expect(steps(makeConference())).toEqual([])
+  })
+
+  it('omits the CFP step when no CFP dates exist', () => {
+    at()
+    const conference = makeConference({ programDate: '2026-08-01' })
+    expect(steps(conference).map((s) => s.key)).toEqual(['programme'])
+  })
+
+  it('announces an upcoming CFP with its opening date', () => {
+    at()
+    const conference = makeConference({
+      cfpStartDate: '2026-07-01',
+      cfpEndDate: '2026-08-01',
+    })
+    expect(steps(conference)[0]).toMatchObject({
+      key: 'cfp',
+      status: 'upcoming',
+      detail: 'Opens 2026-07-01',
+    })
+    expect(steps(conference)[0].href).toBeUndefined()
+  })
+
+  it('links an open CFP', () => {
+    at()
+    const conference = makeConference({
+      cfpStartDate: '2026-06-01',
+      cfpEndDate: '2026-07-01',
+    })
+    expect(steps(conference)[0]).toMatchObject({
+      key: 'cfp',
+      status: 'open',
+      href: '/cfp',
+    })
+  })
+
+  it('does NOT link a programme that is published but empty', () => {
+    at()
+    const conference = makeConference({
+      programDate: '2026-01-01',
+      schedules: [
+        { _id: 's1', date: '2026-09-15', tracks: [] },
+      ] as unknown as Conference['schedules'],
+    })
+    const programme = steps(conference).find((s) => s.key === 'programme')
+    expect(programme).toMatchObject({ status: 'upcoming' })
+    expect(programme?.href).toBeUndefined()
+  })
+
+  it('links a programme that has content', () => {
+    at()
+    const conference = makeConference({
+      programDate: '2026-01-01',
+      schedules: scheduleWith('confirmed'),
+    })
+    expect(steps(conference).find((s) => s.key === 'programme')).toMatchObject({
+      status: 'open',
+      detail: 'Published',
+      href: '/program',
+    })
+  })
+
+  it('omits the ticket step when nothing is known about sales', () => {
+    at()
+    expect(steps(makeConference()).some((s) => s.key === 'tickets')).toBe(false)
+  })
+
+  it('renders a sold-out ticket step without a link', () => {
+    at()
+    const conference = makeConference({
+      registrationEnabled: true,
+      registrationLink: 'https://tickets.example.com',
+    })
+    const result = resolveRoadmapSteps(
+      conference,
+      resolveHomepageLifecycle(conference, { ticketAvailability: 'sold-out' }),
+      iso,
+    )
+    expect(result.find((s) => s.key === 'tickets')).toMatchObject({
+      status: 'done',
+      detail: 'Sold out',
+    })
+    expect(result.find((s) => s.key === 'tickets')?.href).toBeUndefined()
+  })
+})

--- a/src/lib/homepage/lifecycle.ts
+++ b/src/lib/homepage/lifecycle.ts
@@ -1,0 +1,380 @@
+import type { Conference } from '@/lib/conference/types'
+import {
+  isCfpOpen,
+  isConferenceOver,
+  isProgramPublished,
+  isRegistrationAvailable,
+} from '@/lib/conference/state'
+import { toOsloAnchoredDate } from '@/lib/time'
+import { hasProposalVideo } from '@/lib/proposal/video'
+import type { TicketAvailability } from '@/lib/tickets/public'
+
+/**
+ * Homepage lifecycle model (F5).
+ *
+ * WHY THIS EXISTS: a brand-new conference has no speakers, no sponsors, no
+ * schedule and no photos. Before this module the homepage had no defined
+ * rendering for that state — sections either vanished (leaving a hero above a
+ * "Become a Sponsor" pitch) or rendered their scaffolding around nothing (the
+ * Program Highlights band happily printing `0+ Sessions / 0+ Speakers` for a
+ * published-but-empty schedule, live in production). Every section now has a
+ * DEFINED rendering in every state: it either hides itself or renders a
+ * deliberate placeholder.
+ *
+ * SHAPE OF THE MODEL: one ordered {@link HomepageStage} (mutually exclusive,
+ * "where is this event in its life") plus orthogonal FACETS (CFP, tickets, and
+ * what content actually exists). A single flat enum would have to be the cross
+ * product — "cfp-open-with-programme-and-no-sponsors" — which is unusable.
+ *
+ * DERIVED, NOT CONFIGURED: every stage but `cancelled` and `archived` falls out
+ * of dates the organizer already fills in (`cfpStartDate`, `cfpEndDate`,
+ * `programDate`, `startDate`, `endDate`) plus the presence of content. Those two
+ * exceptions cannot be derived from any date — an event is cancelled because a
+ * human says so — so they are the only explicit switch (`lifecycleStatus`).
+ */
+
+/** Ordered life of an event. Exactly one applies at any moment. */
+export type HomepageStage =
+  /** Dates announced, CFP not yet open. THE DAY-ONE STATE. */
+  | 'announced'
+  /** Call for papers is open. */
+  | 'cfp-open'
+  /** CFP has closed; the programme is not published yet (review/selection). */
+  | 'curating'
+  /** Programme published, event still ahead. */
+  | 'programme'
+  /** The event has happened. Lead with what came out of it. */
+  | 'post-event'
+  /** Explicit override: the edition was called off. Replaces the page. */
+  | 'cancelled'
+  /** Explicit override: the event has ended for good. A tombstone. */
+  | 'archived'
+
+/** Where the call for papers stands. `absent` = no CFP dates configured. */
+export type CfpState = 'absent' | 'upcoming' | 'open' | 'closed'
+
+/** Where ticket sales stand, as far as the PUBLIC homepage can tell. */
+export type TicketState =
+  /** No registration link / registration switched off. */
+  | 'unavailable'
+  /** Sale windows exist but none has opened yet. */
+  | 'not-yet-on-sale'
+  /** Registration configured and (as far as we know) buyable. */
+  | 'on-sale'
+  /** Every active public ticket type positively reports zero remaining. */
+  | 'sold-out'
+  /** Sales are over because the event is over. */
+  | 'closed'
+
+/** The one action the page should push hardest in the current state. */
+export type PrimaryCta = 'cfp' | 'tickets' | 'programme' | 'info'
+
+/**
+ * What the conference actually HAS. Every flag here answers "would this section
+ * render anything?", so section-selection logic never has to re-derive it.
+ */
+export interface HomepageContent {
+  /** Featured gallery images — for a first edition this is always false. */
+  hasGallery: boolean
+  hasFeaturedSpeakers: boolean
+  hasOrganizers: boolean
+  hasSponsors: boolean
+  hasVanityMetrics: boolean
+  /**
+   * A published schedule that contains at least one CONFIRMED talk. Deliberately
+   * stricter than "a schedule document exists": an empty published schedule is
+   * what produced the all-zero stat band in production.
+   */
+  hasProgramme: boolean
+  /**
+   * At least one talk carries a `recording` URL attachment — the platform's only
+   * model of post-event media (there is no conference-level video field). Drives
+   * the post-event call to action: "Watch the talks" is a promise, so it is only
+   * made when a recording actually exists.
+   */
+  hasRecordings: boolean
+  /**
+   * No evidence of a previous edition — no past photos and no vanity metrics to
+   * quote. A PROXY, not a fact: the platform models editions as independent
+   * conference documents and the homepage render has no cross-edition query, so
+   * "did this organizer run this before" is not knowable here. What the homepage
+   * needs to decide is narrower and this does answer it: is there any history to
+   * SHOW? When false the page must not leave a hole where the retrospective
+   * material normally goes.
+   */
+  isFirstEdition: boolean
+}
+
+/** The full resolved state the renderer and section selector work from. */
+export interface HomepageLifecycle {
+  stage: HomepageStage
+  cfp: CfpState
+  tickets: TicketState
+  content: HomepageContent
+  primaryCta: PrimaryCta
+  /** True for `cancelled` / `archived`: the notice REPLACES the page. */
+  isOverridden: boolean
+}
+
+/** Explicit, non-derivable statuses an organizer can put a conference into. */
+export const LIFECYCLE_STATUS_VALUES = ['cancelled', 'archived'] as const
+export type LifecycleStatus = (typeof LIFECYCLE_STATUS_VALUES)[number]
+
+export function isLifecycleStatus(value: unknown): value is LifecycleStatus {
+  return (
+    typeof value === 'string' &&
+    (LIFECYCLE_STATUS_VALUES as readonly string[]).includes(value)
+  )
+}
+
+/** One milestone on the save-the-date roadmap. */
+export interface RoadmapStep {
+  key: 'cfp' | 'programme' | 'tickets'
+  label: string
+  /** `done` renders muted; `open` renders as the live, linkable step. */
+  status: 'upcoming' | 'open' | 'done'
+  detail: string
+  /** Present only when the step is something a visitor can act on today. */
+  href?: string
+}
+
+/**
+ * The "what happens next" roadmap for the save-the-date band, derived entirely
+ * from dates the organizer has already entered.
+ *
+ * THE RULE THAT MATTERS: a milestone with no date is OMITTED, never rendered as
+ * "TBA" or a blank row. A brand-new conference that has only set its event dates
+ * gets an empty roadmap and the band falls back to dates + venue + countdown,
+ * which is still a complete announcement. Half-configured events get exactly the
+ * steps they have configured.
+ */
+export function resolveRoadmapSteps(
+  conference: Conference,
+  lifecycle: Pick<HomepageLifecycle, 'cfp' | 'tickets' | 'content'>,
+  formatDate: (value: string) => string,
+): RoadmapStep[] {
+  const steps: RoadmapStep[] = []
+
+  if (lifecycle.cfp !== 'absent') {
+    if (lifecycle.cfp === 'upcoming') {
+      steps.push({
+        key: 'cfp',
+        label: 'Call for speakers',
+        status: 'upcoming',
+        detail: `Opens ${formatDate(conference.cfpStartDate)}`,
+      })
+    } else if (lifecycle.cfp === 'open') {
+      steps.push({
+        key: 'cfp',
+        label: 'Call for speakers',
+        status: 'open',
+        detail: `Open until ${formatDate(conference.cfpEndDate)}`,
+        href: '/cfp',
+      })
+    } else {
+      steps.push({
+        key: 'cfp',
+        label: 'Call for speakers',
+        status: 'done',
+        detail: `Closed ${formatDate(conference.cfpEndDate)}`,
+      })
+    }
+  }
+
+  if (conference.programDate?.trim()) {
+    if (lifecycle.content.hasProgramme) {
+      steps.push({
+        key: 'programme',
+        label: 'Programme',
+        status: 'open',
+        detail: 'Published',
+        href: '/program',
+      })
+    } else {
+      // The programme date may already have passed with nothing published yet.
+      // "Coming soon" is the honest reading; linking to an empty programme page
+      // is the promise this whole module exists to stop making.
+      steps.push({
+        key: 'programme',
+        label: 'Programme',
+        status: 'upcoming',
+        detail: `Announced ${formatDate(conference.programDate)}`,
+      })
+    }
+  }
+
+  // `unavailable` and `closed` mean we know nothing a visitor can use, so the
+  // step is omitted rather than rendered as an empty promise.
+  if (lifecycle.tickets === 'on-sale') {
+    steps.push({
+      key: 'tickets',
+      label: 'Tickets',
+      status: 'open',
+      detail: 'On sale now',
+      href: '/tickets',
+    })
+  } else if (lifecycle.tickets === 'not-yet-on-sale') {
+    steps.push({
+      key: 'tickets',
+      label: 'Tickets',
+      status: 'upcoming',
+      detail: 'Not yet on sale',
+    })
+  } else if (lifecycle.tickets === 'sold-out') {
+    steps.push({
+      key: 'tickets',
+      label: 'Tickets',
+      status: 'done',
+      detail: 'Sold out',
+    })
+  }
+
+  return steps
+}
+
+/** Parse a `YYYY-MM-DD` (or ISO) field to epoch ms; `null` when unusable. */
+function toMs(value?: string | null): number | null {
+  const raw = value?.trim()
+  if (!raw) return null
+  const ms = toOsloAnchoredDate(raw).getTime()
+  return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * Whether a published schedule carries at least one confirmed talk.
+ *
+ * THE PRODUCTION BUG THIS CLOSES: `programDate` in the past plus a schedule
+ * document that has no confirmed talks in it satisfied the old
+ * "programme published" test, so the Program Highlights band rendered with
+ * every computed statistic at zero. Counting the talks is the only honest test
+ * of whether there is a programme to highlight.
+ */
+export function hasProgrammeContent(conference: Conference): boolean {
+  if (!isProgramPublished(conference)) return false
+  const schedules = conference.schedules ?? []
+  return schedules.some((schedule) =>
+    (schedule.tracks ?? []).some((track) =>
+      (track.talks ?? []).some((slot) => slot.talk?.status === 'confirmed'),
+    ),
+  )
+}
+
+/** Resolve the CFP facet from the two CFP date fields. */
+export function resolveCfpState(conference: Conference): CfpState {
+  const start = toMs(conference.cfpStartDate)
+  const end = toMs(conference.cfpEndDate)
+  if (start === null || end === null) return 'absent'
+  if (isCfpOpen(conference)) return 'open'
+  return Date.now() < start ? 'upcoming' : 'closed'
+}
+
+/**
+ * Resolve the ticket facet.
+ *
+ * `availability` is passed in rather than read off the conference because the
+ * public homepage learns it from the TICKETING PROVIDER at render time, not from
+ * Sanity (see `getTicketAvailability`). Absent — no binding, or the provider was
+ * unreachable — it degrades to `on-sale`, because the conference-level
+ * registration toggle is the organizer's own statement that tickets exist. The
+ * page must never manufacture a "sold out" claim out of a failed fetch.
+ */
+export function resolveTicketState(
+  conference: Conference,
+  availability?: TicketAvailability | null,
+): TicketState {
+  if (isConferenceOver(conference)) return 'closed'
+  if (!isRegistrationAvailable(conference)) return 'unavailable'
+  if (availability === 'sold-out') return 'sold-out'
+  if (availability === 'upcoming') return 'not-yet-on-sale'
+  return 'on-sale'
+}
+
+/** True when any talk in the published schedule links a recording. */
+function scheduleHasRecordings(conference: Conference): boolean {
+  return (conference.schedules ?? []).some((schedule) =>
+    (schedule.tracks ?? []).some((track) =>
+      (track.talks ?? []).some(
+        (slot) => slot.talk && hasProposalVideo(slot.talk),
+      ),
+    ),
+  )
+}
+
+/** Resolve which content-bearing sections have anything to show. */
+export function resolveHomepageContent(
+  conference: Conference,
+): HomepageContent {
+  const hasGallery = (conference.featuredGalleryImages?.length ?? 0) > 0
+  const hasVanityMetrics = (conference.vanityMetrics?.length ?? 0) > 0
+  return {
+    hasGallery,
+    hasVanityMetrics,
+    hasFeaturedSpeakers: (conference.featuredSpeakers?.length ?? 0) > 0,
+    hasOrganizers: (conference.organizers?.length ?? 0) > 0,
+    hasSponsors: (conference.sponsors?.length ?? 0) > 0,
+    hasProgramme: hasProgrammeContent(conference),
+    hasRecordings:
+      (conference.featuredTalks ?? []).some(hasProposalVideo) ||
+      scheduleHasRecordings(conference),
+    isFirstEdition: !hasGallery && !hasVanityMetrics,
+  }
+}
+
+/** Resolve the ordered stage. Explicit status wins over any derivation. */
+export function resolveHomepageStage(conference: Conference): HomepageStage {
+  if (isLifecycleStatus(conference.lifecycleStatus)) {
+    return conference.lifecycleStatus
+  }
+  if (isConferenceOver(conference)) return 'post-event'
+  if (isProgramPublished(conference)) return 'programme'
+  if (isCfpOpen(conference)) return 'cfp-open'
+  // CFP dates exist and the window has passed → review/selection, not day one.
+  return resolveCfpState(conference) === 'closed' ? 'curating' : 'announced'
+}
+
+/**
+ * The single action the page should push. Post-event this is deliberately the
+ * PROGRAMME, not tickets — after the event the thing a visitor wants is what
+ * happened, and a "Get tickets" button on a finished conference reads as
+ * abandonware. Before the event the CFP outranks tickets while it is open,
+ * because speakers are the scarcer supply.
+ */
+export function resolvePrimaryCta(
+  stage: HomepageStage,
+  cfp: CfpState,
+  tickets: TicketState,
+  content: HomepageContent,
+): PrimaryCta {
+  if (stage === 'post-event') return content.hasProgramme ? 'programme' : 'info'
+  if (cfp === 'open') return 'cfp'
+  if (tickets === 'on-sale') return 'tickets'
+  if (content.hasProgramme) return 'programme'
+  return 'info'
+}
+
+/**
+ * Resolve the complete lifecycle state for a conference.
+ *
+ * Pure: everything comes from the conference document plus the optional live
+ * `soldOut` signal, so this is unit-testable without a renderer.
+ */
+export function resolveHomepageLifecycle(
+  conference: Conference,
+  options: { ticketAvailability?: TicketAvailability | null } = {},
+): HomepageLifecycle {
+  const stage = resolveHomepageStage(conference)
+  const cfp = resolveCfpState(conference)
+  const content = resolveHomepageContent(conference)
+  const tickets =
+    stage === 'cancelled' || stage === 'archived'
+      ? 'unavailable'
+      : resolveTicketState(conference, options.ticketAvailability)
+  return {
+    stage,
+    cfp,
+    tickets,
+    content,
+    primaryCta: resolvePrimaryCta(stage, cfp, tickets, content),
+    isOverridden: stage === 'cancelled' || stage === 'archived',
+  }
+}

--- a/src/lib/homepage/lifecycle.ts
+++ b/src/lib/homepage/lifecycle.ts
@@ -133,9 +133,12 @@ export interface RoadmapStep {
   label: string
   /** `done` renders muted; `open` renders as the live, linkable step. */
   status: 'upcoming' | 'open' | 'done'
+  /** The status line — a date or a state, never an action. */
   detail: string
   /** Present only when the step is something a visitor can act on today. */
   href?: string
+  /** Button copy for an actionable step. Always paired with `href`. */
+  actionLabel?: string
 }
 
 /**
@@ -170,6 +173,7 @@ export function resolveRoadmapSteps(
         status: 'open',
         detail: `Open until ${formatDate(conference.cfpEndDate)}`,
         href: '/cfp',
+        actionLabel: 'Submit a talk',
       })
     } else {
       steps.push({
@@ -189,6 +193,7 @@ export function resolveRoadmapSteps(
         status: 'open',
         detail: 'Published',
         href: '/program',
+        actionLabel: 'See the programme',
       })
     } else {
       // The programme date may already have passed with nothing published yet.
@@ -212,6 +217,7 @@ export function resolveRoadmapSteps(
       status: 'open',
       detail: 'On sale now',
       href: '/tickets',
+      actionLabel: 'Get tickets',
     })
   } else if (lifecycle.tickets === 'not-yet-on-sale') {
     steps.push({

--- a/src/lib/homepage/sections.test.ts
+++ b/src/lib/homepage/sections.test.ts
@@ -24,12 +24,37 @@ function makeConference(overrides: Partial<Conference> = {}): Conference {
 
 const PAST = '2000-01-01'
 
+/** A published schedule that actually contains a confirmed talk. */
+const LIVE_SCHEDULE = [
+  {
+    _id: 's1',
+    date: '2999-01-01',
+    tracks: [
+      {
+        trackTitle: 'Track 1',
+        trackDescription: '',
+        talks: [
+          {
+            startTime: '09:00',
+            endTime: '09:45',
+            talk: { _id: 't1', status: 'confirmed' },
+          },
+        ],
+      },
+    ],
+  },
+] as never
+
 describe('getDefaultSections — legacy layout equivalence', () => {
-  it('always starts with hero then gallery, and ends with sponsors', () => {
+  it('always starts with hero, ends with sponsors, and keeps gallery above the middle slot', () => {
     const sections = getDefaultSections(makeConference())
     expect(sections[0]._type).toBe('homepageHero')
-    expect(sections[1]._type).toBe('homepageGallery')
     expect(sections[sections.length - 1]._type).toBe('homepageSponsors')
+    const types = sections.map((s) => s._type)
+    expect(types).toContain('homepageGallery')
+    expect(types.indexOf('homepageGallery')).toBeLessThan(
+      types.indexOf('homepageSponsors'),
+    )
   })
 
   it('every section carries a stable _key', () => {
@@ -41,11 +66,11 @@ describe('getDefaultSections — legacy layout equivalence', () => {
     expect(new Set(keys).size).toBe(keys.length)
   })
 
-  it('uses ProgramHighlights as the middle slot when a schedule is published', () => {
+  it('uses ProgramHighlights as the middle slot when a programme is published', () => {
     const conference = makeConference({
       programDate: PAST,
-      schedules: [{ _id: 's1' }] as never,
-      // Featured speakers exist but a published schedule WINS (legacy if/else).
+      schedules: LIVE_SCHEDULE,
+      // Featured speakers exist but a published programme WINS (legacy if/else).
       featuredSpeakers: [{ _id: 'sp1' }] as never,
     })
     const types = getDefaultSections(conference).map((s) => s._type)
@@ -78,6 +103,7 @@ describe('getDefaultSections — legacy layout equivalence', () => {
     const types = getDefaultSections(conference).map((s) => s._type)
     expect(types).toEqual([
       'homepageHero',
+      'homepageSaveTheDate',
       'homepageGallery',
       'homepageOrganizers',
       'homepageSponsors',
@@ -88,9 +114,70 @@ describe('getDefaultSections — legacy layout equivalence', () => {
     const types = getDefaultSections(makeConference()).map((s) => s._type)
     expect(types).toEqual([
       'homepageHero',
+      'homepageSaveTheDate',
       'homepageGallery',
       'homepageSponsors',
     ])
+  })
+})
+
+describe('getDefaultSections — lifecycle behaviour', () => {
+  it('does NOT change the composition for a conference that has a programme', () => {
+    const conference = makeConference({
+      programDate: PAST,
+      schedules: LIVE_SCHEDULE,
+    })
+    expect(getDefaultSections(conference).map((s) => s._type)).toEqual([
+      'homepageHero',
+      'homepageGallery',
+      'homepageProgramHighlights',
+      'homepageSponsors',
+    ])
+  })
+
+  it('does NOT change the composition for a conference that has featured speakers', () => {
+    const conference = makeConference({
+      featuredSpeakers: [{ _id: 'sp1' }] as never,
+    })
+    expect(getDefaultSections(conference).map((s) => s._type)).toEqual([
+      'homepageHero',
+      'homepageGallery',
+      'homepageFeaturedSpeakers',
+      'homepageSponsors',
+    ])
+  })
+
+  it('falls through to featured speakers when the published schedule is EMPTY', () => {
+    // The cloudnativedaysitaly.org failure: publish pressed, schedule empty.
+    // The old predicate handed the slot to ProgramHighlights, which then printed
+    // a band of zeroes.
+    const conference = makeConference({
+      programDate: PAST,
+      schedules: [{ _id: 's1', date: '2999-01-01', tracks: [] }] as never,
+      featuredSpeakers: [{ _id: 'sp1' }] as never,
+    })
+    expect(getDefaultSections(conference).map((s) => s._type)).toEqual([
+      'homepageHero',
+      'homepageGallery',
+      'homepageFeaturedSpeakers',
+      'homepageSponsors',
+    ])
+  })
+
+  it('adds the save-the-date band on day one', () => {
+    const types = getDefaultSections(makeConference()).map((s) => s._type)
+    expect(types[1]).toBe('homepageSaveTheDate')
+  })
+
+  it('does not add the save-the-date band after the event', () => {
+    const conference = makeConference({
+      startDate: PAST,
+      endDate: PAST,
+      organizers: [{ _id: 'o1', name: 'A' }] as never,
+    })
+    expect(getDefaultSections(conference).map((s) => s._type)).not.toContain(
+      'homepageSaveTheDate',
+    )
   })
 })
 

--- a/src/lib/homepage/sections.test.ts
+++ b/src/lib/homepage/sections.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import {
   getDefaultSections,
   resolveHomepageSections,
-  hasPublishedSchedule,
   isHomepageSectionType,
   HOMEPAGE_SECTION_TYPES,
   type HomepageSection,
@@ -178,36 +177,6 @@ describe('getDefaultSections — lifecycle behaviour', () => {
     expect(getDefaultSections(conference).map((s) => s._type)).not.toContain(
       'homepageSaveTheDate',
     )
-  })
-})
-
-describe('hasPublishedSchedule', () => {
-  it('is false without schedules even after the program date', () => {
-    expect(
-      hasPublishedSchedule(
-        makeConference({ programDate: PAST, schedules: [] }),
-      ),
-    ).toBe(false)
-  })
-  it('is false before the program date even with schedules', () => {
-    expect(
-      hasPublishedSchedule(
-        makeConference({
-          programDate: '2999-01-01',
-          schedules: [{ _id: 's' }] as never,
-        }),
-      ),
-    ).toBe(false)
-  })
-  it('is true after the program date with at least one schedule', () => {
-    expect(
-      hasPublishedSchedule(
-        makeConference({
-          programDate: PAST,
-          schedules: [{ _id: 's' }] as never,
-        }),
-      ),
-    ).toBe(true)
   })
 })
 

--- a/src/lib/homepage/sections.test.ts
+++ b/src/lib/homepage/sections.test.ts
@@ -168,6 +168,47 @@ describe('getDefaultSections — lifecycle behaviour', () => {
     expect(types[1]).toBe('homepageSaveTheDate')
   })
 
+  it('does NOT add the save-the-date band once a real programme is published', () => {
+    // Programme stage WITH content: the page leads with the programme, so the
+    // band would be redundant.
+    const conference = makeConference({
+      programDate: PAST,
+      schedules: LIVE_SCHEDULE,
+    })
+    const types = getDefaultSections(conference).map((s) => s._type)
+    expect(types).not.toContain('homepageSaveTheDate')
+    expect(types).toContain('homepageProgramHighlights')
+  })
+
+  it('keeps the save-the-date band when the programme date passed with an EMPTY schedule', () => {
+    // The date-rollover hole: `programDate` in the past puts the conference in
+    // the `programme` stage, but an empty schedule means `hasProgramme` is
+    // false, so the programme slot is empty too. Without the band this page is
+    // a hero above a sponsorship pitch, triggered purely by a date passing.
+    const conference = makeConference({
+      programDate: PAST,
+      schedules: [{ _id: 's1', date: '2999-01-01', tracks: [] }] as never,
+    })
+    expect(getDefaultSections(conference).map((s) => s._type)).toEqual([
+      'homepageHero',
+      'homepageSaveTheDate',
+      'homepageGallery',
+      'homepageSponsors',
+    ])
+  })
+
+  it('drops the save-the-date band when an empty programme falls through to speakers', () => {
+    // Same stage, but there IS something to lead with — the band is not needed.
+    const conference = makeConference({
+      programDate: PAST,
+      schedules: [{ _id: 's1', date: '2999-01-01', tracks: [] }] as never,
+      featuredSpeakers: [{ _id: 'sp1' }] as never,
+    })
+    expect(getDefaultSections(conference).map((s) => s._type)).not.toContain(
+      'homepageSaveTheDate',
+    )
+  })
+
   it('does not add the save-the-date band after the event', () => {
     const conference = makeConference({
       startDate: PAST,

--- a/src/lib/homepage/sections.ts
+++ b/src/lib/homepage/sections.ts
@@ -1,6 +1,6 @@
 import type { TypedObject } from 'sanity'
 import type { Conference } from '@/lib/conference/types'
-import { resolveHomepageLifecycle } from './lifecycle'
+import { resolveHomepageLifecycle, type HomepageStage } from './lifecycle'
 
 /**
  * Front-page builder (F1 + F2): the CLOSED, typed section registry.
@@ -295,6 +295,25 @@ export type HomepageSection =
   | VenueSection
 
 /**
+ * Stages in which the event is still AHEAD, so a save-the-date band is honest.
+ *
+ * `programme` belongs here: it means "programme published, event still ahead"
+ * ({@link HomepageStage}), and it is reached the moment `programDate` rolls past
+ * — whether or not anything was actually published. The stages left out are the
+ * ones where a countdown to the event would be a lie: `post-event`, plus the
+ * `cancelled` / `archived` overrides (which the renderer replaces the page for
+ * anyway, but which must never grow a countdown if called directly).
+ */
+function isPreEventStage(stage: HomepageStage): boolean {
+  return (
+    stage === 'announced' ||
+    stage === 'cfp-open' ||
+    stage === 'curating' ||
+    stage === 'programme'
+  )
+}
+
+/**
  * The default homepage, as an ordered section list. This is what renders when
  * `homepageSections` is ABSENT (every legacy conference):
  *
@@ -320,6 +339,15 @@ export type HomepageSection =
  *     speakers, before the event. That is the day-one page, and without the band
  *     it is a hero sitting directly on top of a sponsorship pitch.
  *
+ *     "Before the event" is the whole pre-event span ({@link isPreEventStage}),
+ *     NOT just the stages up to `curating`. The `programme` stage is entered by
+ *     `programDate` rolling past, which says nothing about whether a programme
+ *     exists: an organizer who set a programme date and has not published yet
+ *     loses the band AND fails the `hasProgramme` middle-slot test on the same
+ *     day, leaving a hero over a sponsorship pitch purely because a date passed.
+ *     The two conditions are therefore driven by the SAME fact — the band shows
+ *     exactly while there is no programme and no speakers to lead with.
+ *
  * A conference that already has a programme or featured speakers is untouched.
  */
 export function getDefaultSections(conference: Conference): HomepageSection[] {
@@ -329,9 +357,11 @@ export function getDefaultSections(conference: Conference): HomepageSection[] {
     { _key: 'default-hero', _type: 'homepageHero' },
   ]
 
-  const isPreEvent =
-    stage === 'announced' || stage === 'cfp-open' || stage === 'curating'
-  if (isPreEvent && !content.hasProgramme && !content.hasFeaturedSpeakers) {
+  if (
+    isPreEventStage(stage) &&
+    !content.hasProgramme &&
+    !content.hasFeaturedSpeakers
+  ) {
     sections.push({
       _key: 'default-save-the-date',
       _type: 'homepageSaveTheDate',

--- a/src/lib/homepage/sections.ts
+++ b/src/lib/homepage/sections.ts
@@ -1,6 +1,5 @@
 import type { TypedObject } from 'sanity'
 import type { Conference } from '@/lib/conference/types'
-import { isProgramPublished } from '@/lib/conference/state'
 import { resolveHomepageLifecycle } from './lifecycle'
 
 /**
@@ -296,20 +295,6 @@ export type HomepageSection =
   | VenueSection
 
 /**
- * True when the program is published AND at least one schedule day exists.
- *
- * DELIBERATELY WEAK — it does not look inside the schedule. Prefer
- * {@link hasProgrammeContent}, which additionally requires a confirmed talk;
- * this predicate is retained because a published-but-empty schedule still means
- * "the organizer has pressed publish", which some callers care about.
- */
-export function hasPublishedSchedule(conference: Conference): boolean {
-  return (
-    isProgramPublished(conference) && (conference.schedules?.length ?? 0) > 0
-  )
-}
-
-/**
  * The default homepage, as an ordered section list. This is what renders when
  * `homepageSections` is ABSENT (every legacy conference):
  *
@@ -325,7 +310,8 @@ export function hasPublishedSchedule(conference: Conference): boolean {
  * only fire in states that previously rendered a hole:
  *
  *  1. The middle slot now tests {@link hasProgrammeContent}, not
- *     `hasPublishedSchedule`. A published-but-EMPTY schedule used to win the
+ *     the old "a schedule document exists" test. A published-but-EMPTY
+ *     schedule used to win the
  *     slot and then render an all-zero statistics band (live in production);
  *     it now falls through to featured speakers or organizers, which have
  *     something to show.

--- a/src/lib/homepage/sections.ts
+++ b/src/lib/homepage/sections.ts
@@ -1,6 +1,7 @@
 import type { TypedObject } from 'sanity'
 import type { Conference } from '@/lib/conference/types'
 import { isProgramPublished } from '@/lib/conference/state'
+import { resolveHomepageLifecycle } from './lifecycle'
 
 /**
  * Front-page builder (F1 + F2): the CLOSED, typed section registry.
@@ -13,10 +14,15 @@ import { isProgramPublished } from '@/lib/conference/state'
  * multi-tenant deployment.
  *
  * ZERO-MIGRATION GUARANTEE: when `homepageSections` is ABSENT (every legacy
- * conference), the page renders {@link getDefaultSections} — a phase-aware
- * reproduction of the pre-builder homepage, pixel-for-pixel. Sections carry only
- * their OWN presentation config; their content still comes from the existing
- * conference sources (featured speakers, schedules, sponsors, gallery, …).
+ * conference), the page renders {@link getDefaultSections} — a lifecycle-aware
+ * reproduction of the pre-builder homepage. Sections carry only their OWN
+ * presentation config; their content still comes from the existing conference
+ * sources (featured speakers, schedules, sponsors, gallery, …).
+ *
+ * The guarantee is precise: a conference that has ANY event content to show —
+ * a programme, or featured speakers — renders the identical section list it did
+ * before the lifecycle work. The composition only changes in states that
+ * previously rendered a hole or an all-zero band; see {@link getDefaultSections}.
  */
 
 /**
@@ -26,6 +32,7 @@ import { isProgramPublished } from '@/lib/conference/state'
  */
 export const HOMEPAGE_SECTION_TYPES = [
   'homepageHero',
+  'homepageSaveTheDate',
   'homepageFeaturedSpeakers',
   'homepageProgramHighlights',
   'homepageOrganizers',
@@ -38,6 +45,28 @@ export const HOMEPAGE_SECTION_TYPES = [
   'homepageCountdown',
   'homepageVenue',
 ] as const
+
+/**
+ * Human labels for each block type. Lives in this SERVER-SAFE module (not
+ * `./editor`, which pulls in the client-only @dnd-kit) so the admin settings
+ * page — a server component — can render section names without dragging
+ * drag-and-drop code into the RSC module graph.
+ */
+export const SECTION_LABELS: Record<HomepageSectionType, string> = {
+  homepageHero: 'Hero',
+  homepageSaveTheDate: 'Save the Date',
+  homepageFeaturedSpeakers: 'Featured Speakers',
+  homepageProgramHighlights: 'Program Highlights',
+  homepageOrganizers: 'Organizers',
+  homepageSponsors: 'Sponsors',
+  homepageGallery: 'Photo Gallery',
+  homepageMetrics: 'Vanity Metrics',
+  homepageCtaBanner: 'Call-to-action Banner',
+  homepageRichText: 'Rich Text',
+  homepageFaq: 'FAQ',
+  homepageCountdown: 'Countdown',
+  homepageVenue: 'Venue',
+}
 
 /**
  * DEFAULT SECTION COPY — the house wording each block falls back to when a
@@ -70,6 +99,9 @@ export function defaultFeaturedSpeakersDescription(
 export function defaultOrganizersDescription(conferenceTitle: string): string {
   return `The passionate team driving ${conferenceTitle}`
 }
+
+/** Default heading for the save-the-date band when none is configured. */
+export const DEFAULT_SAVE_THE_DATE_HEADING = 'Save the date'
 
 export type HomepageSectionType = (typeof HOMEPAGE_SECTION_TYPES)[number]
 
@@ -107,6 +139,18 @@ export interface HeroSection extends BaseSection {
   heroSubheadline?: string
   /** When non-empty, replaces the phase-aware CTA row with these buttons. */
   ctaOverrides?: HeroCtaOverride[]
+}
+
+/**
+ * The day-one band: dates, place, countdown and the "what happens next" roadmap
+ * (CFP → programme → tickets), built entirely from dates the organizer has
+ * already entered. It is what stands between a brand-new event and a homepage
+ * that is a hero above a "Become a Sponsor" pitch.
+ */
+export interface SaveTheDateSection extends BaseSection {
+  _type: 'homepageSaveTheDate'
+  heading?: string
+  description?: string
 }
 
 /**
@@ -238,6 +282,7 @@ export interface VenueSection extends BaseSection {
 
 export type HomepageSection =
   | HeroSection
+  | SaveTheDateSection
   | FeaturedSpeakersSection
   | ProgramHighlightsSection
   | OrganizersSection
@@ -250,7 +295,14 @@ export type HomepageSection =
   | CountdownSection
   | VenueSection
 
-/** True when the program is published AND at least one schedule day exists. */
+/**
+ * True when the program is published AND at least one schedule day exists.
+ *
+ * DELIBERATELY WEAK — it does not look inside the schedule. Prefer
+ * {@link hasProgrammeContent}, which additionally requires a confirmed talk;
+ * this predicate is retained because a published-but-empty schedule still means
+ * "the organizer has pressed publish", which some callers care about.
+ */
 export function hasPublishedSchedule(conference: Conference): boolean {
   return (
     isProgramPublished(conference) && (conference.schedules?.length ?? 0) > 0
@@ -258,37 +310,61 @@ export function hasPublishedSchedule(conference: Conference): boolean {
 }
 
 /**
- * The pre-builder homepage, reproduced as an ordered section list. This is what
- * renders when `homepageSections` is ABSENT — it MUST stay pixel-identical to the
- * legacy page, including the phase-dependent MIDDLE slot:
+ * The default homepage, as an ordered section list. This is what renders when
+ * `homepageSections` is ABSENT (every legacy conference):
  *
- *   Hero → Gallery → (ProgramHighlights | FeaturedSpeakers | Organizers) → Sponsors
+ *   Hero → [SaveTheDate] → Gallery → (ProgramHighlights | FeaturedSpeakers |
+ *   Organizers) → Sponsors
  *
  * The middle slot is mutually exclusive exactly as the legacy `if/else` chain:
- * a published schedule wins over featured speakers, which win over the organizers
- * fallback. Each section's own renderer additionally data-guards (e.g. Gallery
- * renders nothing without featured images), matching the legacy conditionals.
+ * a programme with content wins over featured speakers, which win over the
+ * organizers fallback. Each section's own renderer additionally data-guards
+ * (e.g. Gallery renders nothing without featured images).
+ *
+ * TWO LIFECYCLE-DRIVEN DEPARTURES from the pre-lifecycle layout, both of which
+ * only fire in states that previously rendered a hole:
+ *
+ *  1. The middle slot now tests {@link hasProgrammeContent}, not
+ *     `hasPublishedSchedule`. A published-but-EMPTY schedule used to win the
+ *     slot and then render an all-zero statistics band (live in production);
+ *     it now falls through to featured speakers or organizers, which have
+ *     something to show.
+ *  2. {@link SaveTheDateSection} is inserted after the Hero while the event has
+ *     nothing to say about its own content yet — no programme AND no featured
+ *     speakers, before the event. That is the day-one page, and without the band
+ *     it is a hero sitting directly on top of a sponsorship pitch.
+ *
+ * A conference that already has a programme or featured speakers is untouched.
  */
 export function getDefaultSections(conference: Conference): HomepageSection[] {
+  const { stage, content } = resolveHomepageLifecycle(conference)
+
   const sections: HomepageSection[] = [
     { _key: 'default-hero', _type: 'homepageHero' },
-    { _key: 'default-gallery', _type: 'homepageGallery' },
   ]
 
-  const hasFeaturedSpeakers = (conference.featuredSpeakers?.length ?? 0) > 0
-  const hasOrganizers = (conference.organizers?.length ?? 0) > 0
+  const isPreEvent =
+    stage === 'announced' || stage === 'cfp-open' || stage === 'curating'
+  if (isPreEvent && !content.hasProgramme && !content.hasFeaturedSpeakers) {
+    sections.push({
+      _key: 'default-save-the-date',
+      _type: 'homepageSaveTheDate',
+    })
+  }
 
-  if (hasPublishedSchedule(conference)) {
+  sections.push({ _key: 'default-gallery', _type: 'homepageGallery' })
+
+  if (content.hasProgramme) {
     sections.push({
       _key: 'default-program',
       _type: 'homepageProgramHighlights',
     })
-  } else if (hasFeaturedSpeakers) {
+  } else if (content.hasFeaturedSpeakers) {
     sections.push({
       _key: 'default-featured-speakers',
       _type: 'homepageFeaturedSpeakers',
     })
-  } else if (hasOrganizers) {
+  } else if (content.hasOrganizers) {
     sections.push({ _key: 'default-organizers', _type: 'homepageOrganizers' })
   }
 
@@ -298,9 +374,14 @@ export function getDefaultSections(conference: Conference): HomepageSection[] {
 
 /**
  * Resolve the ordered section list to render for a conference. A NON-EMPTY
- * stored `homepageSections` composition wins; otherwise the phase-aware default
- * (the legacy layout). An empty stored array falls back to the default so a
- * tenant can never accidentally blank their whole homepage.
+ * stored `homepageSections` composition wins; otherwise the lifecycle-aware
+ * default. An empty stored array falls back to the default so a tenant can never
+ * accidentally blank their whole homepage.
+ *
+ * NOTE: `cancelled` / `archived` do NOT appear here. Those states REPLACE the
+ * page rather than reorder it, so the renderer short-circuits above the section
+ * list — see `HomepageSectionRenderer`. Returning a section list for them would
+ * let a stored composition leak a ticket CTA onto a cancelled event.
  */
 export function resolveHomepageSections(
   conference: Conference,

--- a/src/lib/seo/__tests__/eventJsonLd.test.ts
+++ b/src/lib/seo/__tests__/eventJsonLd.test.ts
@@ -269,3 +269,57 @@ describe('serializeJsonLd', () => {
     )
   })
 })
+
+describe('buildEventJsonLd — lifecycle overrides', () => {
+  it('marks a cancelled edition as EventCancelled and emits no offer', () => {
+    const json = buildEventJsonLd({
+      conference: makeConference({
+        lifecycleStatus: 'cancelled',
+        registrationEnabled: true,
+        registrationLink: 'https://tickets.example.com',
+      }),
+      domain: 'example.com',
+    })
+    expect(json.eventStatus).toBe('https://schema.org/EventCancelled')
+    expect(json.offers).toBeUndefined()
+  })
+
+  it('emits no offer for an archived event', () => {
+    const json = buildEventJsonLd({
+      conference: makeConference({
+        lifecycleStatus: 'archived',
+        registrationEnabled: true,
+        registrationLink: 'https://tickets.example.com',
+      }),
+      domain: 'example.com',
+    })
+    expect(json.offers).toBeUndefined()
+  })
+
+  it('reports SoldOut availability rather than InStock', () => {
+    const json = buildEventJsonLd({
+      conference: makeConference({
+        registrationEnabled: true,
+        registrationLink: 'https://tickets.example.com',
+      }),
+      domain: 'example.com',
+      ticketAvailability: 'sold-out',
+    })
+    expect(json.offers).toMatchObject({
+      availability: 'https://schema.org/SoldOut',
+    })
+  })
+
+  it('never invents SoldOut from a missing availability signal', () => {
+    const json = buildEventJsonLd({
+      conference: makeConference({
+        registrationEnabled: true,
+        registrationLink: 'https://tickets.example.com',
+      }),
+      domain: 'example.com',
+    })
+    expect(json.offers).toMatchObject({
+      availability: 'https://schema.org/InStock',
+    })
+  })
+})

--- a/src/lib/seo/eventJsonLd.ts
+++ b/src/lib/seo/eventJsonLd.ts
@@ -1,6 +1,9 @@
 import type { Conference, ConferenceSchedule } from '@/lib/conference/types'
 import { isRegistrationAvailable } from '@/lib/conference/state'
-import type { LowestTicketPrice } from '@/lib/tickets/public'
+import type {
+  LowestTicketPrice,
+  TicketAvailability,
+} from '@/lib/tickets/public'
 import { Status } from '@/lib/proposal/types'
 import type { Speaker } from '@/lib/speaker/types'
 
@@ -25,6 +28,13 @@ export interface BuildEventJsonLdOptions {
    */
   lowestTicketPrice?: LowestTicketPrice | null
   /**
+   * Live availability from the ticketing provider. Drives `offers.availability`
+   * so the structured data cannot advertise `InStock` for an event whose own
+   * page says sold out. Absent leaves the offer as `InStock`, matching the
+   * lifecycle model's refusal to invent a sold-out claim from a missing signal.
+   */
+  ticketAvailability?: TicketAvailability | null
+  /**
    * Confirmed speakers to expose as `performer`. Supplied only on the program
    * page; the home page keeps the block simple and omits performers.
    */
@@ -46,6 +56,7 @@ export function buildEventJsonLd({
   conference,
   domain,
   lowestTicketPrice,
+  ticketAvailability,
   performers,
 }: BuildEventJsonLdOptions): Record<string, unknown> {
   const protocol = domain.includes('localhost') ? 'http' : 'https'
@@ -67,7 +78,13 @@ export function buildEventJsonLd({
     startDate: conference.startDate,
     endDate: conference.endDate,
     eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
-    eventStatus: 'https://schema.org/EventScheduled',
+    // Mirrors the homepage lifecycle override: a cancelled edition renders a
+    // notice instead of a page, and its structured data has to say the same
+    // thing or search results keep advertising an event that is not happening.
+    eventStatus:
+      conference.lifecycleStatus === 'cancelled'
+        ? 'https://schema.org/EventCancelled'
+        : 'https://schema.org/EventScheduled',
     url: siteUrl,
     image: [`${siteUrl}/opengraph-image`],
     organizer,
@@ -101,11 +118,26 @@ export function buildEventJsonLd({
   // Offers only while registration is genuinely available (registrationEnabled
   // + link + conference not over) — structured data must never claim tickets
   // are purchasable while the site itself hides every ticket CTA.
-  if (isRegistrationAvailable(conference) && conference.registrationLink) {
+  // A cancelled or archived event emits NO offer at all: its homepage has no
+  // ticket CTA, and an Offer on a cancelled event is a straightforwardly false
+  // claim regardless of what the registration toggle still says.
+  const lifecycleBlocksOffers =
+    conference.lifecycleStatus === 'cancelled' ||
+    conference.lifecycleStatus === 'archived'
+  if (
+    !lifecycleBlocksOffers &&
+    isRegistrationAvailable(conference) &&
+    conference.registrationLink
+  ) {
     const offers: Record<string, unknown> = {
       '@type': 'Offer',
       url: conference.registrationLink,
-      availability: 'https://schema.org/InStock',
+      availability:
+        ticketAvailability === 'sold-out'
+          ? 'https://schema.org/SoldOut'
+          : ticketAvailability === 'upcoming'
+            ? 'https://schema.org/PreOrder'
+            : 'https://schema.org/InStock',
     }
     if (lowestTicketPrice) {
       // Google's Event spec wants the lowest price including all mandatory

--- a/src/lib/tickets/public.test.ts
+++ b/src/lib/tickets/public.test.ts
@@ -14,7 +14,8 @@ vi.mock('./provider', () => ({
     resolveTicketingProviderMock(...a),
 }))
 
-import { getPublicTicketTypes } from './public'
+import { getPublicTicketTypes, getTicketAvailability } from './public'
+import type { PublicTicketType } from './provider/types'
 
 const CONF = {
   checkinCustomerId: 42,
@@ -80,5 +81,70 @@ describe('getPublicTicketTypes — resolver routing (B7)', () => {
       eventRef: { customerId: 42, eventId: 7 },
     })
     expect(await getPublicTicketTypes(CONF)).toBeNull()
+  })
+})
+
+describe('getTicketAvailability', () => {
+  const FUTURE = '2999-01-01T00:00:00Z'
+  const PAST = '2000-01-01T00:00:00Z'
+
+  function t(over: Record<string, unknown>): PublicTicketType {
+    return pubTicket({
+      available: null,
+      visibleStartsAt: null,
+      visibleEndsAt: null,
+      type: 'standard',
+      ...over,
+    }) as unknown as PublicTicketType
+  }
+
+  it('is unknown with no tickets at all', () => {
+    expect(getTicketAvailability([])).toBe('unknown')
+  })
+
+  it('is unknown when every ticket has expired', () => {
+    expect(getTicketAvailability([t({ visibleEndsAt: PAST })])).toBe('unknown')
+  })
+
+  it('is upcoming when nothing is on sale yet', () => {
+    expect(getTicketAvailability([t({ visibleStartsAt: FUTURE })])).toBe(
+      'upcoming',
+    )
+  })
+
+  it('is on-sale when a ticket is inside its window', () => {
+    expect(getTicketAvailability([t({})])).toBe('on-sale')
+  })
+
+  it('is sold-out only when every active ticket positively reports zero', () => {
+    expect(
+      getTicketAvailability([t({ available: 0 }), t({ available: 0 })]),
+    ).toBe('sold-out')
+  })
+
+  it('degrades to on-sale when any active ticket reports an unknown count', () => {
+    expect(
+      getTicketAvailability([t({ available: 0 }), t({ available: null })]),
+    ).toBe('on-sale')
+  })
+
+  it('is on-sale when some tickets remain', () => {
+    expect(
+      getTicketAvailability([t({ available: 0 }), t({ available: 5 })]),
+    ).toBe('on-sale')
+  })
+
+  it('ignores invitation-only types entirely', () => {
+    // An invite-only type with stock left must not mask a public sell-out...
+    expect(
+      getTicketAvailability([
+        t({ available: 0 }),
+        t({ available: 10, requiresInvitation: true }),
+      ]),
+    ).toBe('sold-out')
+    // ...and an invite-only type alone is not a public sale.
+    expect(
+      getTicketAvailability([t({ available: 0, requiresInvitation: true })]),
+    ).toBe('unknown')
   })
 })

--- a/src/lib/tickets/public.ts
+++ b/src/lib/tickets/public.ts
@@ -91,6 +91,52 @@ export function getTicketSaleStatus(
 }
 
 /**
+ * What the PUBLIC can be told about ticket availability, derived from the
+ * vendor's ticket list.
+ *
+ * `unknown` is a first-class outcome, not a failure to handle: the ticket list
+ * may be empty, every type may be invitation-only, or the vendor may not report
+ * remaining counts at all (Checkin passes `available` through raw and it is
+ * frequently `null`). Callers must render `unknown` as "no availability claim",
+ * never as sold out — a wrong "Sold out" costs an organizer real ticket sales.
+ */
+export type TicketAvailability = 'upcoming' | 'on-sale' | 'sold-out' | 'unknown'
+
+/**
+ * Derive public ticket availability from the vendor ticket list.
+ *
+ *  - `sold-out` — tickets ARE in their sale window, every one of them reports a
+ *    remaining count, and every count is zero. Requires positive evidence from
+ *    the vendor: if even one active type reports `available: null` (unknown) the
+ *    answer degrades to `on-sale`.
+ *  - `on-sale` — at least one type is inside its sale window.
+ *  - `upcoming` — nothing is on sale yet but at least one type has a sale window
+ *    that has not opened. This is the "tickets not yet on sale" state.
+ *  - `unknown` — no types at all, or every type has expired.
+ */
+export function getTicketAvailability(
+  tickets: PublicTicketType[],
+): TicketAvailability {
+  const active: PublicTicketType[] = []
+  let hasUpcoming = false
+
+  for (const ticket of tickets) {
+    // Invitation-only types are not part of the public availability picture:
+    // they are neither buyable by a visitor nor evidence of a sell-out.
+    if (ticket.requiresInvitation) continue
+    const status = getTicketSaleStatus(ticket)
+    if (status === 'active') active.push(ticket)
+    else if (status === 'upcoming') hasUpcoming = true
+  }
+
+  if (active.length > 0) {
+    const allReportZero = active.every((t) => t.available === 0)
+    return allReportZero ? 'sold-out' : 'on-sale'
+  }
+  return hasUpcoming ? 'upcoming' : 'unknown'
+}
+
+/**
  * Format price in NOK with proper formatting.
  * Prices from Checkin.no are excl. VAT.
  */

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -27,6 +27,7 @@ import {
 import {
   UpdateBasicInfoSchema,
   UpdateVisibilitySchema,
+  UpdateLifecycleStatusSchema,
   UpdateVenueSchema,
   UpdateBrandingSchema,
   UpdateDatesSchema,
@@ -213,6 +214,22 @@ export const conferenceRouter = router({
    */
   updateVisibility: adminProcedure
     .input(UpdateVisibilitySchema)
+    .mutation(async ({ input }) => {
+      const conferenceId = await resolveConferenceId()
+      return applyConferencePatch(conferenceId, input)
+    }),
+
+  /**
+   * Set or clear the homepage lifecycle OVERRIDE (cancelled / archived).
+   *
+   * Deliberately its own mutation rather than a field on `updateBasicInfo`:
+   * cancelling an event REPLACES the public homepage, so it must be an explicit,
+   * auditable action and not a side effect of editing the tagline. Passing
+   * `lifecycleStatus: null` clears the override and hands the page back to
+   * date-derived behaviour.
+   */
+  updateLifecycleStatus: adminProcedure
+    .input(UpdateLifecycleStatusSchema)
     .mutation(async ({ input }) => {
       const conferenceId = await resolveConferenceId()
       return applyConferencePatch(conferenceId, input)
@@ -527,6 +544,11 @@ export const conferenceRouter = router({
                   'cta',
                 )
               }
+              break
+            }
+            case 'homepageSaveTheDate': {
+              if (section.heading) base.heading = section.heading
+              if (section.description) base.description = section.description
               break
             }
             case 'homepageMetrics': {

--- a/src/server/schemas/conference.ts
+++ b/src/server/schemas/conference.ts
@@ -6,6 +6,10 @@ import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
 import { isValidTeamKey } from '@/lib/teams/validation'
 import { CLONE_FAMILIES } from '@/lib/conference/edition'
 import {
+  LIFECYCLE_STATUS_VALUES,
+  type LifecycleStatus,
+} from '@/lib/homepage/lifecycle'
+import {
   CONFERENCE_VISIBILITY_VALUES,
   type ConferenceVisibility,
 } from '@/lib/conference/visibility'
@@ -688,6 +692,13 @@ const HomepageSectionSchema = z.discriminatedUnion('_type', [
     ctaOverrides: z.array(HeroCtaOverrideSchema).optional(),
   }),
   z.object({
+    _type: z.literal('homepageSaveTheDate'),
+    _key: sectionKey,
+    hidden: sectionHidden,
+    heading: z.string().trim().min(1).nullable().optional(),
+    description: z.string().trim().min(1).nullable().optional(),
+  }),
+  z.object({
     _type: z.literal('homepageFeaturedSpeakers'),
     _key: sectionKey,
     hidden: sectionHidden,
@@ -773,6 +784,26 @@ const HomepageSectionSchema = z.discriminatedUnion('_type', [
     description: z.string().trim().min(1).nullable().optional(),
   }),
 ])
+
+// === Event status (homepage lifecycle override) ===
+// The ONLY non-derivable homepage states. `lifecycleStatus: null` clears the
+// override and returns the page to date-derived behaviour. The copy fields are
+// nullable-when-blank so an organizer can wipe a stale statement without
+// leaving an empty string behind (see the null-means-unset rule above).
+export const UpdateLifecycleStatusSchema = z.object({
+  lifecycleStatus: z
+    .enum(
+      LIFECYCLE_STATUS_VALUES as unknown as [
+        LifecycleStatus,
+        ...LifecycleStatus[],
+      ],
+    )
+    .nullable(),
+  lifecycleHeadline: z.string().trim().nullable().optional(),
+  lifecycleMessage: z.string().trim().nullable().optional(),
+  lifecycleLinkLabel: z.string().trim().nullable().optional(),
+  lifecycleLinkHref: safeLinkHref.nullable().optional(),
+})
 
 export const UpdateHomepageSectionsSchema = z.object({
   homepageSections: z.array(HomepageSectionSchema),

--- a/src/server/schemas/homepageSections.test.ts
+++ b/src/server/schemas/homepageSections.test.ts
@@ -297,4 +297,31 @@ describe('UpdateHomepageSectionsSchema', () => {
     })
     expect(parsed.homepageSections[0]).toMatchObject({ _type: 'homepageVenue' })
   })
+
+  it('round-trips a save-the-date block with optional copy', () => {
+    const parsed = UpdateHomepageSectionsSchema.parse({
+      homepageSections: [
+        {
+          _type: 'homepageSaveTheDate',
+          _key: 'std',
+          heading: 'Mark your calendar',
+          description: 'Two days of cloud native in Bergen.',
+        },
+      ],
+    })
+    expect(parsed.homepageSections[0]).toMatchObject({
+      _type: 'homepageSaveTheDate',
+      heading: 'Mark your calendar',
+    })
+  })
+
+  it('accepts a bare save-the-date block (all copy derived)', () => {
+    const parsed = UpdateHomepageSectionsSchema.parse({
+      homepageSections: [{ _type: 'homepageSaveTheDate', _key: 'std' }],
+    })
+    expect(parsed.homepageSections[0]).toEqual({
+      _type: 'homepageSaveTheDate',
+      _key: 'std',
+    })
+  })
 })


### PR DESCRIPTION
64% of 2026 Kubernetes Community Day events have no website at all. Konf's competition for those organisers is nothing — so what decides adoption is whether a brand-new event with no speakers, no sponsors, no photos and no schedule gets a homepage that looks *deliberate* on day one.

The canonical failure is live on another conference's site today: it renders `0` for all four of its auto-computed stats rather than hiding the section.

**We had the same bug.** Verified by reverting these files in a running Storybook and shooting the regression story — it reproduced exactly: `Sessions 0+ / Speakers 0+ / Workshops 0 / Days 1 / Topics 0+ / Tracks 0`, plus "1 days", plus a "Get Your Tickets Now" button under "Don't Miss These Standouts" with no standouts beneath it.

## The state model

One ordered **stage** plus orthogonal **facets**, because a flat enum would have to be the cross product.

- **Stage**: `announced` → `cfp-open` → `curating` → `programme` → `post-event`, plus `cancelled` / `archived`
- **Facets**: cfp, tickets, content flags, and a resolved primary CTA

Everything except `cancelled` and `archived` is **derived** from fields organisers already fill in — an organiser should not have to flip switches to get a sensible page.

Two signals the code was throwing away:

- **Sold out / not yet on sale** was unknowable because `page.tsx` discarded `ticketData.tickets` and kept only the price. Now derived from each type's sale window plus availability — and it **fails closed on the claim**: `sold-out` requires every active public type to positively report zero, and a single `null` degrades to `on-sale`. A wrong "sold out" costs an organiser real money.
- **`hasRecordings`** from the existing attachment model, so "watch the talks" is only promised when a recording actually exists.

`isFirstEdition` is a **documented proxy, not a fact** — there is no cross-edition link in the data model at all, so it uses "no past photos and no vanity metrics", which answers the only question the page asks: *is there history to show?*

## Per section

| Section | Empty behaviour | Why |
|---|---|---|
| ProgramHighlights | Only tiles with a non-zero number; `null` when the schedule holds no confirmed talk | A zero is never a fact about a conference, only about data not entered |
| SaveTheDate (new) | Deliberate placeholder | The one place a placeholder beats hiding — day one has nothing else |
| Gallery / Metrics / FAQ / Venue / Countdown | Hide | A heading over nothing is worse than nothing |
| Sponsors | Logos render; the "Become a Sponsor" pitch is suppressed post-event | After the fact it asks for money for something that already happened |
| Hero | Programme button gated on programme *content*, not the publish date; no ticket button when sold out or not on sale | A "View Program" that opens an empty page is the same broken promise as the zero band |
| Cancelled / Archived | **Replace the page** | Visitors act on buttons, not paragraphs |

## Four bugs found by looking, not by reading

1. **Day one** rendered the countdown as `200 00 00 00` — three-digit day counts overflowed the column at 393px, which is the *normal* case for a save-the-date.
2. **Day one** made "Become a Sponsor" the loudest, first, green button on a brand-new event's homepage. The visitor-facing link now leads.
3. **Roadmap rows** used the action button as status text — "Open until 15. apr. 2026" wrapping to two lines. Split into a status line and an action.
4. **Archived** printed the last edition's dates under a tombstone, reading as though it were still being scheduled. Dates now appear only on `cancelled`, where "was going to happen on these dates" is the point.

## Zero migration, proven

`HomepageComposition` **Default and CustomDark are SHA-256 byte-identical** before and after at 1280×4200, against main's own story fixture. `getDefaultSections` has exactly two departures from the old layout, and both fire only where the page previously rendered a hole.

Cancelling is also now possible **without Sanity Studio** — a `lifecycle` fieldset, its own tRPC mutation and a settings card.

## Also fixed

Event JSON-LD now reports `EventCancelled`, emits no Offer for cancelled or archived events, and reports `SoldOut` for a sold-out sale. The file already stated the principle — that structured data must never claim tickets are purchasable while the site hides every ticket CTA — it just predated these states.

## Known, not fixed

- The house locale is `nb-NO`, so a Trondheim save-the-date renders "17. september 2026". Out of scope here; it is the next thing a non-Norwegian organiser notices.
- Only the homepage is lifecycle-aware — a direct link to `/tickets` on a cancelled event still shows a checkout.

376 files / tests green; typecheck, lint, format clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a derived homepage lifecycle model and applies it across homepage composition, ticket availability, structured event data, and administration.
- Adds lifecycle-aware rendering, save-the-date and terminal-state notices, and content-sensitive homepage sections and CTAs.
- Derives public ticket availability from provider inventory and propagates it to homepage and JSON-LD output.
- Adds organizer controls for cancelling, archiving, and restoring an event.
- Expands lifecycle, section-rendering, ticketing, SEO, and Storybook coverage.

<h3>Confidence Score: 4/5</h3>

The empty-programme composition defect should be fixed before merging because it removes the deliberate save-the-date experience from a realistic upcoming-event state.

A passed programme publication date changes the stage to programme even without confirmed talks, causing the default section selector to suppress Save the Date while selecting no content-bearing replacement.

**Files Needing Attention:** src/lib/homepage/sections.ts and src/lib/homepage/lifecycle.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/homepage/lifecycle.ts | Introduces the central lifecycle stage and facet derivation; its date-only programme stage can diverge from actual programme content. |
| src/lib/homepage/sections.ts | Defines lifecycle-aware default composition, but drops Save the Date when a programme date has passed without programme content. |
| src/components/homepage/SectionRenderer.tsx | Applies lifecycle state to section visibility, CTAs, sold-out messaging, and terminal-state page replacement. |
| src/lib/tickets/public.ts | Adds fail-closed derivation of upcoming, on-sale, sold-out, and unknown ticket availability. |
| src/server/routers/conference.ts | Adds a tenant-resolved, schema-validated mutation for lifecycle status and notice fields. |
| src/lib/seo/eventJsonLd.ts | Updates event status and offer output for cancelled, archived, and sold-out lifecycle states. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Conference fields and current time] --> B{Cancelled or archived?}
  B -- Yes --> C[Replace homepage with lifecycle notice]
  B -- No --> D[Derive CFP, ticket, and content facets]
  D --> E[Resolve lifecycle stage]
  E --> F[Choose default homepage sections]
  F --> G[Render content-aware sections and CTAs]
  D --> H[Generate ticket-aware Event JSON-LD]
```

<sub>Reviews (1): Last reviewed commit: ["fix(seo): stop advertising a cancelled e..."](https://github.com/cloudnativebergen/website/commit/42b113ec4976f8b9037d68d6d0e772fca68acb06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49726525)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->