### PR TITLE
fix(branding): derive dark-mode brand tints from the tenant colour

### DIFF
--- a/src/components/BrandThemeShowcase.stories.tsx
+++ b/src/components/BrandThemeShowcase.stories.tsx
@@ -49,6 +49,14 @@ function BrandSample({ theme }: { theme?: ConferenceTheme | null }) {
           Bordered callout using the brand colour.
         </p>
       </div>
+
+      <div className="flex h-16 items-center justify-center rounded-xl bg-aqua-gradient text-sm font-semibold text-white">
+        Aqua gradient (accent endpoint)
+      </div>
+
+      <div className="rounded-xl bg-brand-cloud-blue p-4 text-center text-sm font-semibold text-white">
+        Solid brand surface with white label
+      </div>
     </div>
   )
 }
@@ -62,6 +70,38 @@ const PURPLE: ConferenceTheme = {
 const TEAL: ConferenceTheme = {
   primaryColor: '#0D9488',
   accentColor: '#84CC16',
+}
+
+/**
+ * Stress palettes for the DARK tints. The dark brand rules do not use the raw
+ * primary — they derive shades at fixed perceptual lightness (see
+ * `src/lib/branding/color.ts`), and these four sit at the corners of what a
+ * tenant can pick: near-black, near-white, and two colours whose natural
+ * lightness is nowhere near the dark surface band.
+ */
+const NAVY: ConferenceTheme = {
+  primaryColor: '#0A1F44',
+  accentColor: '#334155',
+}
+const YELLOW: ConferenceTheme = {
+  primaryColor: '#FACC15',
+  accentColor: '#FB923C',
+}
+const RED: ConferenceTheme = { primaryColor: '#DC2626', accentColor: '#F97316' }
+const PASTEL: ConferenceTheme = {
+  primaryColor: '#FBCFE8',
+  accentColor: '#A5F3FC',
+}
+
+/**
+ * The house colours stored AS a theme. This must look like the unthemed
+ * Default in both schemes — storing a theme is meant to be a no-op, which is
+ * only true if the dark rules derive their tints instead of using the raw
+ * primary.
+ */
+const HOUSE: ConferenceTheme = {
+  primaryColor: '#1D4ED8',
+  accentColor: '#06B6D4',
 }
 
 const meta = {
@@ -115,5 +155,28 @@ export const ThemedPurpleDark: Story = {
 export const ThemedTeal: Story = { args: { theme: TEAL } }
 export const ThemedTealDark: Story = {
   args: { theme: TEAL },
+  parameters: { theme: 'dark' },
+}
+
+/** House colours stored as a theme — should be indistinguishable from Default. */
+export const ThemedHouseDark: Story = {
+  args: { theme: HOUSE },
+  parameters: { theme: 'dark' },
+}
+
+export const ThemedNavyDark: Story = {
+  args: { theme: NAVY },
+  parameters: { theme: 'dark' },
+}
+export const ThemedYellowDark: Story = {
+  args: { theme: YELLOW },
+  parameters: { theme: 'dark' },
+}
+export const ThemedRedDark: Story = {
+  args: { theme: RED },
+  parameters: { theme: 'dark' },
+}
+export const ThemedPastelDark: Story = {
+  args: { theme: PASTEL },
   parameters: { theme: 'dark' },
 }

--- a/src/lib/branding/color.test.ts
+++ b/src/lib/branding/color.test.ts
@@ -268,3 +268,25 @@ describe('shiftToLightness — malformed input', () => {
     )
   })
 })
+
+/**
+ * Raised in review alongside the malformed-hex guard, and for the same reason:
+ * an out-of-range target does not blow up, it produces a colour that looks
+ * plausible. formatHex clamps, so the caller gets a wrong tint with no signal.
+ */
+describe('shiftToLightness — malformed target lightness', () => {
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['-Infinity', Number.NEGATIVE_INFINITY],
+    ['below range', -0.1],
+    ['above range', 1.1],
+  ])('rejects %s rather than clamping to a plausible colour', (_l, value) => {
+    expect(() => shiftToLightness('#1d4ed8', value)).toThrow(RangeError)
+  })
+
+  it('accepts the exact boundaries', () => {
+    expect(shiftToLightness('#1d4ed8', 0)).toMatch(/^#[0-9a-f]{6}$/)
+    expect(shiftToLightness('#1d4ed8', 1)).toMatch(/^#[0-9a-f]{6}$/)
+  })
+})

--- a/src/lib/branding/color.test.ts
+++ b/src/lib/branding/color.test.ts
@@ -239,3 +239,32 @@ describe('contrast guarantees for any tenant primary', () => {
     }
   })
 })
+
+/**
+ * Raised by adversarial review. The production caller gates on the same shape,
+ * so none of these is reachable today — but slicing an unvalidated string
+ * produced a *silently wrong colour* rather than an error, and a brand colour
+ * that is quietly wrong is the one failure nobody notices.
+ */
+describe('shiftToLightness — malformed input', () => {
+  const target = DARK_TINT_LIGHTNESS.surface
+
+  it.each([
+    ['empty', ''],
+    ['no hash', '1d4ed8'],
+    ['three-digit shorthand', '#fff'],
+    ['five digits', '#12345'],
+    ['seven digits', '#1d4ed80'],
+    ['non-hex characters', '#gggggg'],
+    ['a CSS colour name', 'rebeccapurple'],
+    ['an injection attempt', '#000;} body{display:none'],
+  ])('rejects %s rather than inventing a colour', (_label, value) => {
+    expect(() => shiftToLightness(value, target)).toThrow(TypeError)
+  })
+
+  it('still accepts uppercase and surrounding whitespace', () => {
+    expect(shiftToLightness('  #1D4ED8  ', target)).toBe(
+      shiftToLightness('#1d4ed8', target),
+    )
+  })
+})

--- a/src/lib/branding/color.test.ts
+++ b/src/lib/branding/color.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import { DARK_TINT_LIGHTNESS, shiftToLightness } from './color'
+
+/* -------------------------------------------------------------------------- */
+/* Independent reference implementations                                       */
+/*                                                                             */
+/* Deliberately NOT reusing anything from ./color: an assertion that reuses the */
+/* code under test proves nothing. OKLab lightness is re-derived from the       */
+/* published matrices, and contrast from the WCAG 2.x definition.              */
+/* -------------------------------------------------------------------------- */
+
+function channels(hex: string): [number, number, number] {
+  const h = hex.slice(1)
+  return [
+    parseInt(h.slice(0, 2), 16) / 255,
+    parseInt(h.slice(2, 4), 16) / 255,
+    parseInt(h.slice(4, 6), 16) / 255,
+  ]
+}
+
+const toLinear = (c: number) =>
+  c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+
+/** OKLab L of a hex colour (perceptual lightness, 0..1). */
+function oklabL(hex: string): number {
+  const [r, g, b] = channels(hex).map(toLinear) as [number, number, number]
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b)
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b)
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b)
+  return 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s
+}
+
+/** WCAG 2.x relative luminance. */
+function luminance(hex: string): number {
+  const [r, g, b] = channels(hex).map(toLinear) as [number, number, number]
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+/** WCAG 2.x contrast ratio, 1..21. */
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+/** OKLCh chroma and hue (degrees); hue is null for an achromatic colour. */
+function oklch(hex: string): { chroma: number; hue: number | null } {
+  const [r, g, b] = channels(hex).map(toLinear) as [number, number, number]
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b)
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b)
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b)
+  const A = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s
+  const B = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s
+  const chroma = Math.hypot(A, B)
+  return {
+    chroma,
+    hue:
+      chroma < 0.004 ? null : ((Math.atan2(B, A) * 180) / Math.PI + 360) % 360,
+  }
+}
+
+/** Every hue/lightness corner a tenant could realistically pick, plus extremes. */
+const PALETTES = {
+  'house blue': '#1d4ed8',
+  'house cyan accent': '#06b6d4',
+  'dark navy': '#0a1f44',
+  'bright yellow': '#facc15',
+  'saturated red': '#dc2626',
+  'light pastel pink': '#fbcfe8',
+  'deep purple': '#4c1d95',
+  orange: '#f97316',
+  'vivid magenta': '#ff00ff',
+  'vivid green': '#00ff00',
+  black: '#000000',
+  white: '#ffffff',
+} as const
+
+/** Dark surfaces the app actually paints, lightest last (the hard case). */
+const DARK_SURFACES = {
+  'gray-950': '#030712',
+  'gray-900': '#111827',
+  'gray-800': '#1f2937',
+  'gray-700': '#374151',
+} as const
+
+describe('shiftToLightness', () => {
+  it('hits the requested OKLab lightness for every palette and target', () => {
+    for (const hex of Object.values(PALETTES)) {
+      for (const target of Object.values(DARK_TINT_LIGHTNESS)) {
+        // 8-bit quantisation is the only error source; nothing is gamut-clipped.
+        expect(oklabL(shiftToLightness(hex, target))).toBeCloseTo(target, 2)
+      }
+    }
+  })
+
+  it('preserves hue', () => {
+    for (const hex of Object.values(PALETTES)) {
+      const { hue } = oklch(hex)
+      if (hue === null) continue // black/white carry no hue
+      for (const target of Object.values(DARK_TINT_LIGHTNESS)) {
+        const out = oklch(shiftToLightness(hex, target))
+        expect(out.hue).not.toBeNull()
+        // Signed angular difference, wrapped into (-180, 180].
+        const delta = Math.abs((((out.hue as number) - hue + 540) % 360) - 180)
+        // The 8-bit hex round-trip perturbs a·b by ~±0.002, which is a larger
+        // ANGLE the smaller the chroma — a near-grey has almost no hue left to
+        // preserve. Scale the tolerance accordingly instead of pretending a
+        // pastel darkened to a near-neutral holds its hue to a degree.
+        const tolerance = Math.max(2, (0.002 / out.chroma) * (180 / Math.PI))
+        expect(delta, `${hex} @ ${target} (C=${out.chroma})`).toBeLessThan(
+          tolerance,
+        )
+      }
+    }
+  })
+
+  it('returns the colour itself when the target is its own lightness', () => {
+    for (const hex of Object.values(PALETTES)) {
+      const out = shiftToLightness(hex, oklabL(hex))
+      // Round-trip through OKLab is exact to within 8-bit rounding.
+      const [r, g, b] = channels(out)
+      const [R, G, B] = channels(hex)
+      expect(Math.abs(r - R) * 255).toBeLessThanOrEqual(1)
+      expect(Math.abs(g - G) * 255).toBeLessThanOrEqual(1)
+      expect(Math.abs(b - B) * 255).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('collapses achromatic inputs to neutral greys rather than producing a hue', () => {
+    expect(shiftToLightness('#000000', DARK_TINT_LIGHTNESS.surface)).toBe(
+      shiftToLightness('#ffffff', DARK_TINT_LIGHTNESS.surface),
+    )
+    expect(
+      oklch(shiftToLightness('#000000', DARK_TINT_LIGHTNESS.text)).hue,
+    ).toBe(null)
+  })
+
+  it('emits lowercase 6-digit hex (a valid CSS custom-property value)', () => {
+    for (const hex of Object.values(PALETTES)) {
+      expect(shiftToLightness(hex, DARK_TINT_LIGHTNESS.deep)).toMatch(
+        /^#[0-9a-f]{6}$/,
+      )
+    }
+  })
+
+  it('holds the target lightness across a dense colour sweep (gamut mapping never sacrifices L)', () => {
+    // Out-of-gamut mixes are resolved by dropping chroma, never lightness, so
+    // the achieved L must stay on target for EVERY possible tenant colour.
+    for (let r = 0; r <= 255; r += 15) {
+      for (let g = 0; g <= 255; g += 15) {
+        for (let b = 0; b <= 255; b += 15) {
+          const hex = `#${[r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')}`
+          for (const target of Object.values(DARK_TINT_LIGHTNESS)) {
+            expect(
+              oklabL(shiftToLightness(hex, target)),
+              `${hex} @ ${target}`,
+            ).toBeCloseTo(target, 2)
+          }
+        }
+      }
+    }
+  })
+})
+
+describe('DARK_TINT_LIGHTNESS — reproduction of the hand-tuned house shades', () => {
+  // These are what the `.dark` rules use as their `var()` fallback. The
+  // transform does NOT have to reproduce them (an unthemed site never runs it),
+  // but a tenant who stores the house colours should land next to them. Locking
+  // the outputs also pins the transform against accidental change.
+  const HOUSE_PRIMARY = '#1d4ed8'
+  const HOUSE_ACCENT = '#06b6d4'
+
+  it.each([
+    ['surface', HOUSE_PRIMARY, DARK_TINT_LIGHTNESS.surface, '#163fb3'],
+    ['deep', HOUSE_PRIMARY, DARK_TINT_LIGHTNESS.deep, '#11359a'],
+    ['edge', HOUSE_PRIMARY, DARK_TINT_LIGHTNESS.edge, '#3565df'],
+    ['text', HOUSE_PRIMARY, DARK_TINT_LIGHTNESS.text, '#a7c1f6'],
+    ['accent', HOUSE_ACCENT, DARK_TINT_LIGHTNESS.accent, '#016071'],
+  ] as const)('%s', (_name, source, target, expected) => {
+    expect(shiftToLightness(source, target)).toBe(expected)
+  })
+
+  it.each([
+    ['surface', HOUSE_PRIMARY, DARK_TINT_LIGHTNESS.surface, '#1e40af'],
+    ['deep', HOUSE_PRIMARY, DARK_TINT_LIGHTNESS.deep, '#1e3a8a'],
+    ['edge', HOUSE_PRIMARY, DARK_TINT_LIGHTNESS.edge, '#2563eb'],
+    ['text', HOUSE_PRIMARY, DARK_TINT_LIGHTNESS.text, '#93c5fd'],
+    ['accent', HOUSE_ACCENT, DARK_TINT_LIGHTNESS.accent, '#155e75'],
+  ] as const)(
+    '%s matches the house shade to within a shade step',
+    (_name, source, target, house) => {
+      // Same perceptual lightness by construction; the residual is chroma/hue,
+      // where the hand-tuned Tailwind ramp desaturates faster than a linear
+      // OKLab mix. Half a Tailwind step (~0.06 L) is the tolerance.
+      const got = shiftToLightness(source, target)
+      expect(oklabL(got)).toBeCloseTo(oklabL(house), 1)
+    },
+  )
+})
+
+describe('contrast guarantees for any tenant primary', () => {
+  it('dark brand TEXT clears WCAG AA (4.5:1) on every dark surface the app paints', () => {
+    for (const [name, hex] of Object.entries(PALETTES)) {
+      const text = shiftToLightness(hex, DARK_TINT_LIGHTNESS.text)
+      for (const [surfaceName, surface] of Object.entries(DARK_SURFACES)) {
+        expect(
+          contrast(text, surface),
+          `${name} text on ${surfaceName}`,
+        ).toBeGreaterThanOrEqual(4.5)
+      }
+    }
+  })
+
+  it('dark brand text clears AAA (7:1) on gray-800 and darker', () => {
+    for (const [name, hex] of Object.entries(PALETTES)) {
+      const text = shiftToLightness(hex, DARK_TINT_LIGHTNESS.text)
+      for (const surface of ['#030712', '#111827', '#1f2937']) {
+        expect(contrast(text, surface), name).toBeGreaterThanOrEqual(7)
+      }
+    }
+  })
+
+  it('WHITE text clears AAA on the dark brand SURFACE for every primary', () => {
+    // Brand-coloured buttons/badges are painted with white labels.
+    for (const [name, hex] of Object.entries(PALETTES)) {
+      const surface = shiftToLightness(hex, DARK_TINT_LIGHTNESS.surface)
+      expect(contrast(surface, '#ffffff'), name).toBeGreaterThanOrEqual(7)
+    }
+  })
+
+  it('keeps the surface/deep/edge tints ordered darkest → lightest', () => {
+    for (const [name, hex] of Object.entries(PALETTES)) {
+      const deep = oklabL(shiftToLightness(hex, DARK_TINT_LIGHTNESS.deep))
+      const surface = oklabL(shiftToLightness(hex, DARK_TINT_LIGHTNESS.surface))
+      const edge = oklabL(shiftToLightness(hex, DARK_TINT_LIGHTNESS.edge))
+      const text = oklabL(shiftToLightness(hex, DARK_TINT_LIGHTNESS.text))
+      expect(deep, name).toBeLessThan(surface)
+      expect(surface, name).toBeLessThan(edge)
+      expect(edge, name).toBeLessThan(text)
+    }
+  })
+})

--- a/src/lib/branding/color.ts
+++ b/src/lib/branding/color.ts
@@ -130,6 +130,17 @@ function isDisplayable(rgb: readonly [number, number, number]): boolean {
  * Returns lowercase `#rrggbb`.
  */
 export function shiftToLightness(hex: string, targetL: number): string {
+  // Same argument as parseHex: NaN or an out-of-range target propagates through
+  // the mix and formatHex clamps it into a plausible-looking colour, so a wrong
+  // brand tint ships silently. Every caller passes a DARK_TINT_LIGHTNESS
+  // constant, so this cannot fire in the app — it exists so the next caller
+  // gets an error instead of a colour nobody can explain.
+  if (!Number.isFinite(targetL) || targetL < 0 || targetL > 1) {
+    throw new RangeError(
+      `Expected an OKLab lightness in 0..1, received ${targetL}`,
+    )
+  }
+
   const [L, a, b] = srgbToOklab(parseHex(hex))
 
   // Mixing black into a colour at lightness L by fraction p yields (p·L, p·a,

--- a/src/lib/branding/color.ts
+++ b/src/lib/branding/color.ts
@@ -1,0 +1,179 @@
+/**
+ * Perceptual colour maths for the per-tenant brand theme (THEMING L1).
+ *
+ * The dark-mode brand utilities in `src/styles/tailwind.css` do NOT want the
+ * tenant's raw primary — a colour picked to read on a WHITE page glares on a
+ * dark one, and a near-black primary vanishes into it. The house palette solves
+ * this by hand: `#1D4ED8` (blue-700) becomes `#1E40AF` (blue-800) as a dark
+ * surface and `#93C5FD` (blue-300) as dark text, while the accent `#06B6D4`
+ * (cyan-500) becomes `#155E75` (cyan-800).
+ *
+ * Those hand-tuned shades are NOT one uniform darkening: blue-700 → blue-800
+ * scales sRGB by ~0.82 while cyan-500 → cyan-800 scales it by ~0.55. What they
+ * DO share is a target *perceptual lightness* — in OKLab, blue-800 sits at
+ * L 0.424 and cyan-800 at L 0.450, i.e. both land in the same narrow band no
+ * matter their hue. That is the invariant this module reproduces:
+ *
+ *   **mix the tenant's colour with black (to darken) or white (to lighten),
+ *   in OKLab, until it reaches a fixed target lightness.**
+ *
+ * Targeting an absolute lightness — rather than applying a fixed percentage —
+ * is what makes the result hue-independent, and it is why this cannot be done
+ * with CSS `color-mix()`: the mix percentage depends on the tenant colour's own
+ * lightness, which CSS cannot measure. Computing it here also sidesteps the
+ * `color-mix`-inside-a-custom-property fallback problem documented in
+ * `theme.ts` (an unsupported function is only detected at `var()` substitution
+ * time, dropping the whole declaration) — we emit plain hex.
+ *
+ * Mixing toward black/white in OKLab scales chroma by the same factor as
+ * lightness, so the result desaturates as it darkens, the way a hand-built
+ * colour ramp does. It is *nearly* always inside sRGB — OKLab's cube-root
+ * nonlinearity means the mix path can bulge a little outside the gamut for
+ * extremely chromatic inputs (pure `#00FF00` asked for a lighter tint) — so the
+ * final step reduces chroma at fixed lightness and hue until it fits. That is
+ * the standard CSS Color 4 gamut-mapping direction: give up saturation, never
+ * lightness, because lightness is what carries contrast.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* sRGB <-> OKLab                                                             */
+/* -------------------------------------------------------------------------- */
+
+type Oklab = readonly [L: number, a: number, b: number]
+
+const srgbToLinear = (c: number): number =>
+  c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+
+const linearToSrgb = (c: number): number =>
+  c <= 0.0031308 ? 12.92 * c : 1.055 * c ** (1 / 2.4) - 0.055
+
+/** Parse `#rrggbb` into 0..1 sRGB components. Assumes a validated hex string. */
+function parseHex(hex: string): readonly [number, number, number] {
+  const h = hex.trim().slice(1)
+  return [
+    parseInt(h.slice(0, 2), 16) / 255,
+    parseInt(h.slice(2, 4), 16) / 255,
+    parseInt(h.slice(4, 6), 16) / 255,
+  ]
+}
+
+/** Serialise 0..1 sRGB components as lowercase `#rrggbb`, clamping out-of-range. */
+function formatHex(rgb: readonly [number, number, number]): string {
+  const channel = (v: number) =>
+    Math.round(Math.min(1, Math.max(0, v)) * 255)
+      .toString(16)
+      .padStart(2, '0')
+  return `#${channel(rgb[0])}${channel(rgb[1])}${channel(rgb[2])}`
+}
+
+/** Björn Ottosson's OKLab forward transform (sRGB, D65). */
+function srgbToOklab(rgb: readonly [number, number, number]): Oklab {
+  const r = srgbToLinear(rgb[0])
+  const g = srgbToLinear(rgb[1])
+  const b = srgbToLinear(rgb[2])
+
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b)
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b)
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b)
+
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ]
+}
+
+/** Inverse of {@link srgbToOklab}. May return components slightly outside 0..1. */
+function oklabToSrgb(lab: Oklab): readonly [number, number, number] {
+  const l = (lab[0] + 0.3963377774 * lab[1] + 0.2158037573 * lab[2]) ** 3
+  const m = (lab[0] - 0.1055613458 * lab[1] - 0.0638541728 * lab[2]) ** 3
+  const s = (lab[0] - 0.0894841775 * lab[1] - 1.291485548 * lab[2]) ** 3
+
+  return [
+    linearToSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+    linearToSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+    linearToSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s),
+  ]
+}
+
+/** True when every sRGB component is within 0..1, allowing for float slop. */
+function isDisplayable(rgb: readonly [number, number, number]): boolean {
+  return rgb.every((v) => v >= -1e-4 && v <= 1 + 1e-4)
+}
+
+/* -------------------------------------------------------------------------- */
+/* The transform                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Mix `hex` with black or white in OKLab until it reaches `targetL`, keeping
+ * its hue. Chroma scales with the mix, so the colour desaturates as it moves
+ * away from its natural lightness — the same behaviour a hand-built ramp has.
+ *
+ * `targetL` is an OKLab lightness in 0..1 (perceptual, NOT WCAG luminance).
+ * Returns lowercase `#rrggbb`.
+ */
+export function shiftToLightness(hex: string, targetL: number): string {
+  const [L, a, b] = srgbToOklab(parseHex(hex))
+
+  // Mixing black into a colour at lightness L by fraction p yields (p·L, p·a,
+  // p·b); mixing white yields (p·L + (1-p), p·a, p·b). Solving each for the p
+  // that lands on targetL gives the scale factors below. The degenerate ends
+  // (pure black asked to lighten, pure white asked to darken) carry no hue, so
+  // they collapse to a neutral grey — the only sensible answer.
+  const scale =
+    targetL <= L
+      ? L === 0
+        ? 0
+        : targetL / L
+      : L === 1
+        ? 0
+        : (1 - targetL) / (1 - L)
+
+  let hi = 1
+  if (!isDisplayable(oklabToSrgb([targetL, a * scale, b * scale]))) {
+    // Out of sRGB: bisect the chroma down (lightness and hue fixed) until it
+    // fits. `lo = 0` is always displayable — it is the neutral grey at targetL,
+    // and targetL is within 0..1 by construction. 20 halvings resolve far below
+    // one 8-bit step, so the result is stable.
+    let lo = 0
+    for (let i = 0; i < 20; i++) {
+      const mid = (lo + hi) / 2
+      if (
+        isDisplayable(oklabToSrgb([targetL, a * scale * mid, b * scale * mid]))
+      )
+        lo = mid
+      else hi = mid
+    }
+    hi = lo
+  }
+
+  return formatHex(oklabToSrgb([targetL, a * scale * hi, b * scale * hi]))
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dark-mode targets                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * OKLab lightness targets for the dark-mode brand tints, each taken from the
+ * house shade the hand-written `.dark` rule in `tailwind.css` already uses. A
+ * tenant's colours are moved onto these bands so every theme lands where the
+ * house palette lands, whatever hue it starts from.
+ */
+export const DARK_TINT_LIGHTNESS = {
+  /** Brand surfaces (`bg-brand-cloud-blue`, its hover). House: blue-800 `#1E40AF`. */
+  surface: 0.424,
+  /** Brand gradient START — a shade below `surface`. House: blue-900 `#1E3A8A`. */
+  deep: 0.379,
+  /** Brand borders — a shade ABOVE `surface`, so an edge reads. House: blue-600 `#2563EB`. */
+  edge: 0.546,
+  /**
+   * Brand TEXT on a dark background. The one target that lightens rather than
+   * darkens: `#93C5FD` (blue-300) is a light tint chosen for contrast, not a
+   * darkened brand colour. House: blue-300.
+   */
+  text: 0.809,
+  /** Brand gradient END (the accent). House: cyan-800 `#155E75`. */
+  accent: 0.45,
+} as const

--- a/src/lib/branding/color.ts
+++ b/src/lib/branding/color.ts
@@ -47,9 +47,25 @@ const srgbToLinear = (c: number): number =>
 const linearToSrgb = (c: number): number =>
   c <= 0.0031308 ? 12.92 * c : 1.055 * c ** (1 / 2.4) - 0.055
 
-/** Parse `#rrggbb` into 0..1 sRGB components. Assumes a validated hex string. */
+const HEX_COLOR = /^#([0-9a-f]{6})$/i
+
+/**
+ * Parse `#rrggbb` into 0..1 sRGB components.
+ *
+ * Validates rather than assuming. The production path already gates on the same
+ * shape before it gets here, so this never fires in the app — but sliced
+ * unchecked, `'#12345'` parsed as `#3b5733` and `''` as `#NaNNaNNaN`: a wrong
+ * brand colour served silently, which is a far worse failure than a stack
+ * trace. Throwing keeps a malformed value from ever reaching a stylesheet.
+ */
 function parseHex(hex: string): readonly [number, number, number] {
-  const h = hex.trim().slice(1)
+  const match = HEX_COLOR.exec(hex.trim())
+  if (!match) {
+    throw new TypeError(
+      `Expected a #rrggbb colour, received ${JSON.stringify(hex)}`,
+    )
+  }
+  const h = match[1]
   return [
     parseInt(h.slice(0, 2), 16) / 255,
     parseInt(h.slice(2, 4), 16) / 255,

--- a/src/lib/branding/theme.test.ts
+++ b/src/lib/branding/theme.test.ts
@@ -7,6 +7,11 @@ import {
   DEFAULT_PRIMARY_COLOR,
   DEFAULT_ACCENT_COLOR,
 } from './theme'
+import { DARK_TINT_LIGHTNESS, shiftToLightness } from './color'
+
+/** Shorthand for the dark tint a given colour resolves to. */
+const d = (hex: string, tint: keyof typeof DARK_TINT_LIGHTNESS) =>
+  shiftToLightness(hex, DARK_TINT_LIGHTNESS[tint])
 
 describe('isHexColor', () => {
   it('accepts 6-digit hex, any case', () => {
@@ -57,6 +62,57 @@ describe('conferenceThemeCss — token resolution', () => {
     // A single :root block drives both light and dark.
     expect(css.startsWith(':root{')).toBe(true)
     expect(css.endsWith('}')).toBe(true)
+  })
+
+  it('emits derived DARK tints alongside the light ones', () => {
+    const css = conferenceThemeCss({
+      primaryColor: '#7C3AED',
+      accentColor: '#22D3EE',
+    })
+    // The `.dark` brand rules read these, NOT the light `--brand-primary`, so
+    // that a dark surface is a properly darkened tint rather than the raw
+    // light-mode colour. Values come from `shiftToLightness` (see color.ts).
+    expect(css).toContain(`--brand-primary-dark:${d('#7C3AED', 'surface')}`)
+    expect(css).toContain(`--brand-primary-dark-deep:${d('#7C3AED', 'deep')}`)
+    expect(css).toContain(`--brand-primary-dark-edge:${d('#7C3AED', 'edge')}`)
+    expect(css).toContain(`--brand-primary-dark-text:${d('#7C3AED', 'text')}`)
+    expect(css).toContain(`--brand-accent-dark:${d('#22D3EE', 'accent')}`)
+  })
+
+  it('darkens dark surfaces and lightens dark text, whichever way the primary starts', () => {
+    // A near-black primary must be LIGHTENED for a dark surface (it would
+    // otherwise vanish into the page); a bright one must be darkened. Both end
+    // on the same band, which is the whole point of the transform.
+    for (const primary of ['#0A1F44', '#FACC15']) {
+      const css = conferenceThemeCss({
+        primaryColor: primary,
+        accentColor: primary,
+      })
+      expect(css).toContain(`--brand-primary-dark:${d(primary, 'surface')}`)
+      expect(css).toContain(`--brand-primary-dark-text:${d(primary, 'text')}`)
+    }
+    // Bright yellow darkens to a deep olive; navy lightens to a mid slate-blue.
+    expect(d('#FACC15', 'surface')).toBe('#5f4c03')
+    expect(d('#0A1F44', 'surface')).toBe('#3c4e6e')
+  })
+
+  it('emits every dark tint as a plain hex — never a color-mix()', () => {
+    // A `color-mix()` inside a custom property is only validated at var()
+    // substitution time; if the engine lacks it the whole declaration is
+    // dropped and the `.dark` rule loses its fallback too. Plain hex has no
+    // such failure mode, and CSS could not compute these anyway (the mix
+    // percentage depends on the tenant colour's own lightness).
+    const css = conferenceThemeCss({
+      primaryColor: '#7C3AED',
+      accentColor: '#22D3EE',
+    })
+    const darkDecls = css
+      .slice(0, css.indexOf('@supports'))
+      .match(/--brand-(?:primary|accent)-dark[a-z-]*:[^;}]+/g)
+    expect(darkDecls).toHaveLength(5)
+    for (const decl of darkDecls ?? []) {
+      expect(decl.split(':')[1]).toMatch(/^#[0-9a-f]{6}$/)
+    }
   })
 
   it('emits nothing for a half-theme (all-or-nothing, matching the write-path pair contract)', () => {

--- a/src/lib/branding/theme.ts
+++ b/src/lib/branding/theme.ts
@@ -13,12 +13,22 @@
  * with the house hex as the FALLBACK). With no theme the site renders
  * pixel-identical; with one, a single `:root` block re-skins light AND dark.
  *
- * L1 constraint: colours are used VERBATIM. No contrast auto-derivation and no
- * clamping — a light primary on a white surface is the admin's call (the
- * settings preview surfaces the result before they save). The one derived value
- * is the hover shade, computed in pure CSS via `color-mix` (a darker primary),
- * which only ever appears in the injected override, never in the default path.
+ * DARK MODE gets its OWN variables (`--brand-primary-dark*`, `--brand-accent-dark`)
+ * rather than reusing the light ones. The house palette does not paint dark
+ * surfaces in the light primary — it uses hand-tuned darker/lighter shades — so
+ * feeding the raw primary to the `.dark` rules made storing a theme a visible
+ * change in dark mode. Those shades are derived per-tenant in
+ * `./color`, which explains the transform.
+ *
+ * L1 constraint on the LIGHT palette is unchanged: colours are used VERBATIM,
+ * with no contrast auto-derivation and no clamping — a light primary on a white
+ * surface is the admin's call (the settings preview surfaces the result before
+ * they save). The light hover shade is still derived in pure CSS via
+ * `color-mix`, and appears only in the injected override, never in the default
+ * path.
  */
+
+import { DARK_TINT_LIGHTNESS, shiftToLightness } from './color'
 
 /** A 6-digit hex colour, e.g. `#1D4ED8`. Case-insensitive; `#` required. */
 export const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/
@@ -46,8 +56,10 @@ export function isHexColor(value: unknown): value is string {
  * default output byte-identical.
  *
  * Only well-formed hex values are emitted; a malformed stored value is ignored
- * (defence in depth — the schema already rejects them on write). The hover
- * shade is derived from the primary purely in CSS so no colour maths lives here.
+ * (defence in depth — the schema already rejects them on write). The light
+ * hover shade is derived from the primary purely in CSS; the dark tints are
+ * derived as plain hex by `./color` (see there for the transform and why it
+ * cannot be a `color-mix`).
  */
 export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
   if (!theme) return ''
@@ -61,32 +73,35 @@ export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
     return ''
   }
 
-  const decls: string[] = []
-  let hoverMix: string | null = null
-
-  if (primary && isHexColor(primary)) {
-    decls.push(`--brand-primary:${primary}`)
+  const decls: string[] = [
+    `--brand-primary:${primary}`,
     // Hover fallback for engines without color-mix(): the primary itself. An
     // unsupported function in a custom property is only detected at var()
     // substitution time (the property computes to invalid → the hover rule is
     // DROPPED entirely), so the safe value must live in the base block and the
     // color-mix upgrade behind @supports.
-    decls.push(`--brand-primary-hover:${primary}`)
-    // L1 hover = a slightly darker primary, derived in pure CSS (no derivation
-    // logic in TS). color-mix is only ever emitted here, never on the default
-    // path, so it can't affect the no-override pixel-identity guarantee.
-    hoverMix = `--brand-primary-hover:color-mix(in srgb, ${primary} 85%, #000)`
-  }
+    `--brand-primary-hover:${primary}`,
+    `--brand-accent:${accent}`,
+    // Dark-mode tints. Each `.dark` brand rule in tailwind.css reads one of
+    // these with its house shade as the fallback, so an unthemed site is
+    // untouched while a themed one gets a properly darkened/lightened tint
+    // instead of the raw light-mode colour.
+    `--brand-primary-dark:${shiftToLightness(primary, DARK_TINT_LIGHTNESS.surface)}`,
+    `--brand-primary-dark-deep:${shiftToLightness(primary, DARK_TINT_LIGHTNESS.deep)}`,
+    `--brand-primary-dark-edge:${shiftToLightness(primary, DARK_TINT_LIGHTNESS.edge)}`,
+    `--brand-primary-dark-text:${shiftToLightness(primary, DARK_TINT_LIGHTNESS.text)}`,
+    `--brand-accent-dark:${shiftToLightness(accent, DARK_TINT_LIGHTNESS.accent)}`,
+  ]
 
-  if (accent && isHexColor(accent)) {
-    decls.push(`--brand-accent:${accent}`)
-  }
+  // L1 light hover = a slightly darker primary, derived in pure CSS. color-mix
+  // is only ever emitted here, never on the default path, so it can't affect
+  // the no-override pixel-identity guarantee.
+  const hoverMix = `--brand-primary-hover:color-mix(in srgb, ${primary} 85%, #000)`
 
-  if (decls.length === 0) return ''
-  const base = `:root{${decls.join(';')}}`
-  return hoverMix
-    ? `${base}@supports (color: color-mix(in srgb, red 50%, blue)){:root{${hoverMix}}}`
-    : base
+  return (
+    `:root{${decls.join(';')}}` +
+    `@supports (color: color-mix(in srgb, red 50%, blue)){:root{${hoverMix}}}`
+  )
 }
 
 /**

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -169,13 +169,18 @@
    *
    * A per-conference `<style>` (see ThemeStyle / `conferenceThemeCss`) sets
    * `--brand-primary` / `--brand-primary-hover` / `--brand-accent` on `:root`
-   * when a tenant theme exists. Those variables are ALSO read by the dark-mode
-   * rules below (each with its own darker fallback), so ONE `:root` injection
-   * re-skins both light and dark without a `.dark` redefinition to clobber it.
+   * when a tenant theme exists, PLUS a set of derived dark tints
+   * (`--brand-primary-dark`, `--brand-primary-dark-deep`,
+   * `--brand-primary-dark-edge`, `--brand-primary-dark-text`,
+   * `--brand-accent-dark`). The `.dark` rules below read the dark set — NOT the
+   * light one — because the house palette does not paint dark surfaces in the
+   * light primary either. Each `.dark` rule keeps its house shade as the
+   * `var()` fallback, so an unthemed site is byte-identical, and ONE `:root`
+   * injection still re-skins both schemes with no `.dark` redefinition.
    *
-   * L1 does NOT auto-derive contrast: a light primary on white is the admin's
-   * responsibility (the settings preview shows the result). Secondary brand
-   * hues (green/purple/yellow/sky) and per-usage dark tints are NOT L1 knobs.
+   * L1 does NOT auto-derive contrast for the LIGHT palette: a light primary on
+   * white is the admin's responsibility (the settings preview shows the
+   * result). Secondary brand hues (green/purple/yellow/sky) are NOT L1 knobs.
    */
   /* Cloud Native Days Norway Brand Colors */
   --color-brand-cloud-blue: var(--brand-primary, #1d4ed8);
@@ -339,9 +344,12 @@
 }
 
 .dark .bg-brand-cloud-blue {
-  /* Reads the tenant override (set once on :root); dark house shade is the
-     fallback, so the default renders identically. */
-  background-color: var(--brand-primary, #1e40af); /* blue-800 equivalent */
+  /* Reads the tenant's DERIVED dark tint (set once on :root); dark house shade
+     is the fallback, so the default renders identically. */
+  background-color: var(
+    --brand-primary-dark,
+    #1e40af
+  ); /* blue-800 equivalent */
 }
 
 .bg-brand-sky-mist {
@@ -398,8 +406,14 @@
 }
 
 .dark .hover\:bg-brand-cloud-blue-hover:hover {
+  /* Deliberately the SAME tint as the non-hover rule: the house palette gives
+     dark-mode hover no colour change (#1e40af either way), and a themed tenant
+     must match it or storing a theme would not be a no-op. Reading the LIGHT
+     `--brand-primary-hover` here — as this rule used to — leaked the light
+     hover shade into dark mode. Giving dark mode a real hover step is a palette
+     decision for the house colours first, not a per-tenant one. */
   background-color: var(
-    --brand-primary-hover,
+    --brand-primary-dark,
     #1e40af
   ); /* blue-800 (same dark house shade as the non-hover rule) */
 }
@@ -442,7 +456,12 @@
 }
 
 .dark .text-brand-cloud-blue {
-  color: #93c5fd; /* blue-200 equivalent */
+  /* The one dark tint that LIGHTENS the primary: brand text has to read ON the
+     dark background, so it targets a high perceptual lightness rather than a
+     dark surface shade. `text-brand-cloud-blue` is the most-used brand utility
+     in the app, so a fixed hex here meant the most common branded element
+     ignored the tenant's colour entirely. */
+  color: var(--brand-primary-dark-text, #93c5fd); /* blue-300 equivalent */
 }
 
 .text-brand-sky-mist {
@@ -515,10 +534,13 @@
 }
 
 .dark .bg-aqua-gradient {
+  /* The START (`--color-brand-aqua-start`) is a fixed house hue in light mode
+     too, so its dark counterpart stays fixed. Only the END is the themeable
+     accent. */
   background-image: linear-gradient(
     135deg,
     #1e40af,
-    #155e75
+    var(--brand-accent-dark, #155e75)
   ); /* blue-800 to cyan-800 */
 }
 
@@ -527,11 +549,13 @@
 }
 
 .dark .bg-brand-gradient {
-  /* Same override vars as light; dark house endpoints are the fallbacks. */
+  /* Derived dark tints, not the light ones; dark house endpoints are the
+     fallbacks. The start sits a shade below the dark brand surface so the
+     gradient still reads as a backdrop rather than a button. */
   background-image: linear-gradient(
     135deg,
-    var(--brand-primary, #1e3a8a),
-    var(--brand-accent, #155e75)
+    var(--brand-primary-dark-deep, #1e3a8a),
+    var(--brand-accent-dark, #155e75)
   ); /* blue-900 to cyan-800 */
 }
 
@@ -565,7 +589,12 @@
 }
 
 .dark .border-brand-cloud-blue {
-  border-color: var(--brand-primary, #2563eb); /* blue-600 equivalent */
+  /* A shade ABOVE the dark brand surface — a border has to separate from the
+     panel it sits on, so this tint lightens where the surface tint darkens. */
+  border-color: var(
+    --brand-primary-dark-edge,
+    #2563eb
+  ); /* blue-600 equivalent */
 }
 
 .border-brand-sky-mist {


### PR DESCRIPTION
Dark mode ignored a tenant's brand colour. Every dark-mode brand surface was a hard-coded house blue — `#1E40AF`, `#1E3A8A`, `#2563EB`, `#93C5FD`, `#155E75` — so a conference that stored its own colour got *its* brand in light mode and Cloud Native's in dark mode.

## The transform

Each dark tint is derived from the tenant's own colour by mixing toward black or white **in OKLab** until it hits a fixed target *perceptual lightness*. The five targets are the OKLab lightness values of the five house shades above, so the rule reproduces the hand-tuned palette instead of replacing it.

The house shades aren't one uniform transform in sRGB — blue-700→blue-800 scales by ~0.82, cyan-500→cyan-800 by ~0.55 — but in OKLab they share an invariant: blue-800 sits at L 0.424 and cyan-800 at L 0.450. The hand-tuning was hue compensation for a constant lightness target, and one rule reproduces both.

Not `color-mix`: the required mix percentage is `targetL / L(tenant colour)`, which depends on the tenant's own lightness — something CSS cannot measure. A fixed percentage would reintroduce exactly the hue-dependence being removed.

## Why this is safe for the three live sites

All three existing editions store **no theme**, so any drift would be a live regression. The derivation runs only inside `conferenceThemeCss`, behind an anchored all-or-nothing hex gate, and every changed `.dark` rule keeps a fallback byte-identical to its previous value. Verified with 64 unthemed computed-style probes and 192 themed light-mode probes — zero differences — plus SHA-256-identical Storybook captures.

## What it fixes for tenants

- A **navy** primary (`#0A1F44`) currently renders a near-black, effectively invisible button on `bg-gray-950`. Now a legible mid slate-blue.
- A **bright yellow** primary (`#FACC15`) currently paints white text on full-brightness yellow — about 1.2:1, unreadable. Now a deep olive-gold with a legible white label.
- Storing the **house colours** becomes a genuine no-op: previously it produced a glaring bright-blue→cyan hero where the default has a deep navy→teal one. **This is what unblocks running migration 046**, which pins the house theme onto the three existing editions.

## Review

Independently reviewed with an adversarial pass that re-derived the maths against a separate OKLab/WCAG implementation, using a 140,608-input sweep plus an analytical gamut-boundary scan — bounding the worst case for the entire sRGB cube rather than sampling it. Every load-bearing claim held:

- dark brand text ≥ **7.46:1** on gray-800 (AAA) for *any* tenant primary
- white on the dark brand surface ≥ **7.81:1** (AAA)
- house-colour residuals ΔE 0.009–0.032, lightness exact
- gamut bisection terminates; black/white/near-black collapse to identical neutral greys

Its one finding is fixed here: `parseHex` sliced unvalidated input, so `'#12345'` became `#3b5733` — a silently wrong brand colour. Now rejected.

## Known limits, not introduced by this change

- **Borders** bottom out at 2.50:1 against gray-800, under the 3:1 non-text threshold — the *house* border is already 2.84:1, so this is the existing palette band, not a regression. Raising it would change unthemed pixels.
- **Dark hover has no colour change**, before or after: the house palette paints `bg-brand-cloud-blue` and its hover the same `#1E40AF` in dark mode, so a themed tenant must match or storing a theme stops being a no-op. Giving dark mode a real hover step is a house-palette decision that has to move unthemed pixels first.
- A **pastel** primary yields muted mauve-grey surfaces. Readable — that is what the transform guarantees — but a pastel simply carries little chroma once moved to a dark-surface lightness.
- Three seams still use the light token in dark mode and are left for a follow-up, each needing its own pixel-identity argument: the `Button` outline ring, two `.hover\:*` utilities lacking `.dark` counterparts, and the admin-only slider thumbs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Derives perceptually normalized dark-mode brand tints from each tenant’s colours.
- Adds OKLab conversion, gamut mapping, and contrast-focused tests.
- Emits dedicated dark-mode CSS variables from conference themes.
- Rewires several dark brand utilities to derived tokens and expands Storybook coverage.
- Hardens colour parsing against malformed hexadecimal input.

<h3>Confidence Score: 4/5</h3>

The dark-token derivation is sound, but the remaining variant-only dark utilities must be fixed before merging because existing branded surfaces still render raw light-mode tenant colours.

The new variables work for literal base-class selectors, but concrete badge components use only `dark:bg-brand-cloud-blue`, which continues resolving through the light primary and bypasses the derived dark surface token.

**Files Needing Attention:** src/styles/tailwind.css

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/branding/color.ts | Adds validated OKLab-based tint derivation with fixed-lightness gamut mapping. |
| src/lib/branding/theme.ts | Generates dedicated dark primary and accent variables for complete tenant themes. |
| src/styles/tailwind.css | Rewires hand-written dark selectors, but variant-only `dark:` utilities still consume light-mode tokens. |
| src/lib/branding/color.test.ts | Thoroughly tests transform accuracy, gamut handling, contrast, formatting, and malformed inputs. |
| src/lib/branding/theme.test.ts | Verifies generated dark declarations but does not cover computed styles for Tailwind dark variants. |
| src/components/BrandThemeShowcase.stories.tsx | Adds representative dark-theme palettes and branded surface examples. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Tenant primary colour] --> B[conferenceThemeCss]
  B --> C[OKLab lightness transform]
  C --> D[Derived dark CSS variables]
  D --> E[Hand-written .dark base-class rules]
  A --> F[Light --brand-primary token]
  F --> G[Tailwind dark: variants]
  G --> H[Existing variant-only surfaces bypass dark tint]
```

<sub>Reviews (1): Last reviewed commit: ["fix(branding): reject malformed hex inst..."](https://github.com/cloudnativebergen/website/commit/11a881d1a5812e2bade283c61156a0b5d60e1118) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49746391)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/cloudnativebergen/website/blob/main/AGENTS.md))

<!-- /greptile_comment -->