### PR TITLE
fix(og): make social share cards follow the tenant's brand

### DIFF
--- a/src/app/(main)/speaker/[slug]/opengraph-image.tsx
+++ b/src/app/(main)/speaker/[slug]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ImageResponse } from 'next/og'
 import { speakerImageUrl } from '@/lib/sanity/client'
 import { STYLES, OG_IMAGE_SIZE } from '@/lib/og/styles'
+import { ogBrandColors } from '@/lib/og/brand'
 import { ogImageMetadata } from '@/lib/og/metadata'
 import { PLATFORM_NAME } from '@/lib/branding/platform'
 import {
@@ -26,6 +27,7 @@ const createSponsorLogo = (
   logoBrightSvg: string | null,
   sponsorName: string,
   isLarge: boolean,
+  textColor: string,
 ) => {
   const commonStyle = {
     padding: isLarge ? '12px 20px' : '8px 16px',
@@ -35,7 +37,7 @@ const createSponsorLogo = (
       : STYLES.borderRadius.tiny,
     fontSize: isLarge ? '16px' : '14px',
     fontWeight: '600',
-    color: STYLES.colors.blue,
+    color: textColor,
     fontFamily: STYLES.fontFamily,
   }
 
@@ -72,8 +74,16 @@ const renderSponsorLogo = (
   logoSvg: string | null,
   logoBrightSvg: string | null,
   sponsorName: string,
-  size: 'small' | 'large' = 'small',
-) => createSponsorLogo(logoSvg, logoBrightSvg, sponsorName, size === 'large')
+  size: 'small' | 'large',
+  textColor: string,
+) =>
+  createSponsorLogo(
+    logoSvg,
+    logoBrightSvg,
+    sponsorName,
+    size === 'large',
+    textColor,
+  )
 
 export function generateImageMetadata() {
   return ogImageMetadata((brand) => `${brand} Speaker Profile`)
@@ -222,6 +232,8 @@ export default async function Image({
   }
 
   const fonts = await loadBrandFonts(domain)
+  // Per-tenant brand gradient; unthemed conferences resolve to the house pair.
+  const brand = ogBrandColors(conference.theme)
   const { speaker, talks, err } = await getPublicSpeaker(
     conference._id,
     decodedSlug,
@@ -236,7 +248,7 @@ export default async function Image({
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          background: STYLES.gradient,
+          background: brand.gradient,
           color: 'white',
           fontSize: 48,
           fontWeight: 'bold',
@@ -291,7 +303,7 @@ export default async function Image({
         height: '100%',
         display: 'flex',
         flexDirection: 'row',
-        background: STYLES.gradient,
+        background: brand.gradient,
         color: 'white',
         padding: '40px 40px 80px 40px',
         fontFamily: STYLES.fontFamily,
@@ -407,6 +419,7 @@ export default async function Image({
                     sponsor?.sponsor?.logoBright || null,
                     sponsor?.sponsor?.name || `Sponsor ${index + 1}`,
                     'small',
+                    brand.textOnLight,
                   )}
                 </div>
               ))}
@@ -610,6 +623,7 @@ export default async function Image({
                     sponsor?.sponsor?.logoBright || null,
                     sponsor?.sponsor?.name || `Sponsor ${index + 1}`,
                     'small',
+                    brand.textOnLight,
                   )}
                 </div>
               ))}

--- a/src/app/(public)/badge/[badgeId]/opengraph-image.tsx
+++ b/src/app/(public)/badge/[badgeId]/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { ImageResponse } from 'next/og'
 import { getBadgeById, getBadgeSVGUrl } from '@/lib/badge/sanity'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { PLATFORM_NAME } from '@/lib/branding/platform'
+import { ogBrandColors } from '@/lib/og/brand'
 import { notFound } from 'next/navigation'
 
 export const runtime = 'edge'
@@ -16,8 +17,18 @@ const SHIELD_ICON_SVG =
     `<svg width="24" height="24" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M12.516 2.17a.75.75 0 00-.532 0 11.047 11.047 0 01-4.25.905A.75.75 0 007.25 3v6.396a8.75 8.75 0 003.89 7.283l.59.394a.75.75 0 00.78 0l.59-.394A8.75 8.75 0 0016.75 9.396V3a.75.75 0 00-.484-.075 11.047 11.047 0 01-4.25-.905zm-3.766 14.05a7.25 7.25 0 01-3-5.824V4.204a12.547 12.547 0 004.534-.956c.184-.076.38-.076.563 0a12.547 12.547 0 004.534.956v6.012a7.25 7.25 0 01-3 5.824l-.59.394-.59-.394z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M15.28 8.22a.75.75 0 010 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-2-2a.75.75 0 111.06-1.06l1.47 1.47 3.97-3.97a.75.75 0 011.06 0z" clip-rule="evenodd"/></svg>`,
   ).toString('base64')
 
+/**
+ * The badge card's own house pair — a deeper blue into the "verified" green,
+ * deliberately distinct from the main cards' blue→cyan. An unthemed conference
+ * still renders exactly these two hexes; a themed one substitutes its stored
+ * pair (see `ogBrandColors`).
+ *
+ * `@/lib/og/brand` is pure arithmetic with no Node built-ins, so it is safe to
+ * import here even though this route runs on the EDGE runtime.
+ */
+const BADGE_HOUSE_PAIR = { primary: '#1e40af', accent: '#10b981' }
+
 const STYLES = {
-  gradient: 'linear-gradient(135deg, #1e40af, #10b981)',
   fontFamily: 'system-ui, -apple-system, sans-serif',
   colors: {
     white: 'white',
@@ -114,6 +125,8 @@ export default async function Image({
       ? `${conference.city}, ${conference.country}`
       : 'Location TBA'
   const badgeTypeName = badge.badgeType === 'speaker' ? 'Speaker' : 'Organizer'
+  // Per-tenant brand gradient; unthemed conferences keep the badge house pair.
+  const brand = ogBrandColors(currentConference.theme, BADGE_HOUSE_PAIR)
 
   // Get badge SVG URL
   const badgeSvgUrl = getBadgeSVGUrl(badge)
@@ -140,7 +153,7 @@ export default async function Image({
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        background: STYLES.gradient,
+        background: brand.gradient,
         color: 'white',
         padding: '60px',
         fontFamily: STYLES.fontFamily,
@@ -181,7 +194,7 @@ export default async function Image({
           backgroundColor: STYLES.colors.whiteTransparent,
           padding: '8px 16px',
           borderRadius: '12px',
-          color: '#1e40af',
+          color: brand.textOnLight,
           fontSize: '14px',
           fontWeight: '600',
           zIndex: 2,

--- a/src/lib/branding/theme.ts
+++ b/src/lib/branding/theme.ts
@@ -40,6 +40,32 @@ export function isHexColor(value: unknown): value is string {
 }
 
 /**
+ * The conference's brand pair resolved to concrete hex values, or `null` when
+ * the conference is UNTHEMED.
+ *
+ * This is the single place the ALL-OR-NOTHING pair rule lives: a theme counts
+ * only when BOTH colours are present and well-formed. A half-theme (legacy or
+ * malformed data with one valid colour) or a malformed value resolves to `null`
+ * — unthemed everywhere — so the site CSS, email, manifest and the OpenGraph
+ * cards can never disagree about whether a tenant is themed.
+ *
+ * Returned values are TRIMMED but otherwise verbatim: no contrast derivation,
+ * no clamping, no case normalisation (L1 constraint). Consumers that cannot use
+ * a colour verbatim — the OG cards bake white text onto the brand gradient — do
+ * their own bounded adjustment on top; see `@/lib/og/brand`.
+ */
+export function resolveBrandPair(
+  theme?: ConferenceTheme | null,
+): { primary: string; accent: string } | null {
+  const primary = theme?.primaryColor?.trim()
+  const accent = theme?.accentColor?.trim()
+  if (!primary || !isHexColor(primary) || !accent || !isHexColor(accent)) {
+    return null
+  }
+  return { primary, accent }
+}
+
+/**
  * Build the `<style>` body that injects a conference's theme onto `:root`.
  * Returns an EMPTY string when there is nothing to override (no theme, or no
  * valid colour) — callers render no `<style>` at all in that case, keeping the
@@ -50,43 +76,29 @@ export function isHexColor(value: unknown): value is string {
  * shade is derived from the primary purely in CSS so no colour maths lives here.
  */
 export function conferenceThemeCss(theme?: ConferenceTheme | null): string {
-  if (!theme) return ''
-
   // ALL-OR-NOTHING, matching the write-path contract (Zod + Studio both
   // enforce the pair): a half-theme — legacy or malformed data with only one
   // valid colour — renders NO override at all rather than a half-themed UI.
-  const primary = theme.primaryColor?.trim()
-  const accent = theme.accentColor?.trim()
-  if (!primary || !isHexColor(primary) || !accent || !isHexColor(accent)) {
-    return ''
-  }
+  const pair = resolveBrandPair(theme)
+  if (!pair) return ''
+  const { primary, accent } = pair
 
-  const decls: string[] = []
-  let hoverMix: string | null = null
-
-  if (primary && isHexColor(primary)) {
-    decls.push(`--brand-primary:${primary}`)
+  const decls = [
+    `--brand-primary:${primary}`,
     // Hover fallback for engines without color-mix(): the primary itself. An
     // unsupported function in a custom property is only detected at var()
     // substitution time (the property computes to invalid → the hover rule is
     // DROPPED entirely), so the safe value must live in the base block and the
     // color-mix upgrade behind @supports.
-    decls.push(`--brand-primary-hover:${primary}`)
-    // L1 hover = a slightly darker primary, derived in pure CSS (no derivation
-    // logic in TS). color-mix is only ever emitted here, never on the default
-    // path, so it can't affect the no-override pixel-identity guarantee.
-    hoverMix = `--brand-primary-hover:color-mix(in srgb, ${primary} 85%, #000)`
-  }
+    `--brand-primary-hover:${primary}`,
+    `--brand-accent:${accent}`,
+  ]
+  // L1 hover = a slightly darker primary, derived in pure CSS (no derivation
+  // logic in TS). color-mix is only ever emitted here, never on the default
+  // path, so it can't affect the no-override pixel-identity guarantee.
+  const hoverMix = `--brand-primary-hover:color-mix(in srgb, ${primary} 85%, #000)`
 
-  if (accent && isHexColor(accent)) {
-    decls.push(`--brand-accent:${accent}`)
-  }
-
-  if (decls.length === 0) return ''
-  const base = `:root{${decls.join(';')}}`
-  return hoverMix
-    ? `${base}@supports (color: color-mix(in srgb, red 50%, blue)){:root{${hoverMix}}}`
-    : base
+  return `:root{${decls.join(';')}}@supports (color: color-mix(in srgb, red 50%, blue)){:root{${hoverMix}}}`
 }
 
 /**
@@ -99,11 +111,7 @@ export function emailBrandColor(theme?: ConferenceTheme | null): string {
   // Same ALL-OR-NOTHING pair rule as `conferenceThemeCss`: a half-theme
   // (legacy/malformed data) is unthemed EVERYWHERE — site, email and manifest
   // must never disagree about whether a tenant is themed.
-  const primary = theme?.primaryColor?.trim()
-  const accent = theme?.accentColor?.trim()
-  const isCompletePair =
-    primary && isHexColor(primary) && accent && isHexColor(accent)
-  return isCompletePair ? primary : DEFAULT_PRIMARY_COLOR
+  return resolveBrandPair(theme)?.primary ?? DEFAULT_PRIMARY_COLOR
 }
 
 /**

--- a/src/lib/og/brand.test.ts
+++ b/src/lib/og/brand.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
+  compositeWhiteOver,
+  contrastRatio,
   HOUSE_OG_PAIR,
+  OG_CHIP_BACKGROUND_ALPHA,
+  OG_DARKEST_CHIP_BACKGROUND,
   OG_MAX_BACKGROUND_LUMINANCE,
   OG_MAX_TEXT_LUMINANCE,
   ogBrandColors,
@@ -174,6 +178,146 @@ describe('ogBrandColors — contrast clamp', () => {
       accentColor: '#000000',
     })
     expect(brand.gradient).toBe('linear-gradient(135deg, #000000, #000000)')
+  })
+})
+
+/**
+ * The chips are `rgba(255, 255, 255, 0.9)`, not white. These tests pin the
+ * composite arithmetic that `OG_MAX_TEXT_LUMINANCE` is derived from, so the
+ * ceiling cannot silently drift back to being measured against pure white.
+ *
+ * Chip sites, all `backgroundColor: rgba(255,255,255,0.9)` + `color:
+ * brand.textOnLight`:
+ *   - speaker card, sponsor-name fallback (14px / weight 600) — ingress and
+ *     service sponsor rows, `createSponsorLogo`
+ *   - badge card, "OpenBadges 3.0 Verified" pill (14px / weight 600)
+ */
+describe('chip contrast — measured on the real composite, not on white', () => {
+  /** WCAG AA for text below 24px (or below 18.66px bold), which the chips are. */
+  const SMALL_TEXT_BAR = 4.5
+
+  it('the chip background is NOT white', () => {
+    expect(OG_CHIP_BACKGROUND_ALPHA).toBe(0.9)
+    expect(OG_DARKEST_CHIP_BACKGROUND).not.toBe('#FFFFFF')
+    // 0.9 * 255 = 229.5, floored to 229 = 0xE5.
+    expect(OG_DARKEST_CHIP_BACKGROUND).toBe('#E5E5E5')
+    expect(relativeLuminance(OG_DARKEST_CHIP_BACKGROUND)).toBeCloseTo(0.7835, 4)
+  })
+
+  it('composites in gamma-encoded sRGB, per channel', () => {
+    expect(compositeWhiteOver('#000000', 0)).toBe('#000000')
+    expect(compositeWhiteOver('#000000', 1)).toBe('#FFFFFF')
+    expect(compositeWhiteOver('#FFFFFF', 0.9)).toBe('#FFFFFF')
+    // 0.9*255 + 0.1*0x1D = 229.5 + 2.9 = 232.4 → 232 = 0xE8
+    expect(compositeWhiteOver('#1D4ED8', 0.9)).toBe('#E8EDFB')
+  })
+
+  it('the ceiling is derived FROM the composite, and clears 4.5:1 on it', () => {
+    const required =
+      (relativeLuminance(OG_DARKEST_CHIP_BACKGROUND) + 0.05) / SMALL_TEXT_BAR -
+      0.05
+    expect(OG_MAX_TEXT_LUMINANCE).toBeLessThanOrEqual(required)
+    expect(required).toBeCloseTo(0.1352, 4)
+  })
+
+  it('REGRESSION: the old 0.18 ceiling did not clear the bar on the composite', () => {
+    // 0.18 was solved against pure white — 1.05/0.23 = 4.57:1 — but applied on
+    // a 90%-opaque chip, where it is only 3.64:1. This is the bug being fixed.
+    const stale = 0.18
+    const onWhite = 1.05 / (stale + 0.05)
+    const onComposite =
+      (relativeLuminance(OG_DARKEST_CHIP_BACKGROUND) + 0.05) / (stale + 0.05)
+    expect(onWhite).toBeGreaterThan(SMALL_TEXT_BAR)
+    expect(onComposite).toBeCloseTo(3.6241, 3)
+    expect(onComposite).toBeLessThan(SMALL_TEXT_BAR)
+  })
+
+  it.each([
+    ['#FFFFFF', 'pure white'],
+    ['#FDE68A', 'amber-200'],
+    ['#F59E0B', 'amber-500'],
+    ['#A7F3D0', 'emerald-200'],
+    ['#E0F2FE', 'sky-100'],
+    ['#FF00FF', 'magenta'],
+    ['#7C2D12', 'already dark'],
+    ['#000000', 'black'],
+  ])('themed %s (%s) clears 4.5:1 against the darkest possible chip', (hex) => {
+    const { textOnLight } = ogBrandColors({
+      primaryColor: hex,
+      accentColor: hex,
+    })
+    expect(
+      contrastRatio(textOnLight, OG_DARKEST_CHIP_BACKGROUND),
+    ).toBeGreaterThanOrEqual(SMALL_TEXT_BAR)
+  })
+
+  it('holds over the chip on any clamped gradient pixel, not just black', () => {
+    // A chip can sit anywhere on the card, so the colour behind it is any pixel
+    // of the clamped gradient. Every one of them is lighter than black, so the
+    // black-backed bound is the binding one — assert that directly.
+    const { primary, accent, textOnLight } = ogBrandColors({
+      primaryColor: '#FDE68A',
+      accentColor: '#000000',
+    })
+    const ch = (hex: string) =>
+      [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16))
+    const [a, b] = [ch(primary), ch(accent)]
+    for (let t = 0; t <= 1.0001; t += 0.05) {
+      const behind =
+        '#' +
+        a
+          .map((c, i) =>
+            Math.round(c + (b[i] - c) * t)
+              .toString(16)
+              .padStart(2, '0'),
+          )
+          .join('')
+      const chip = compositeWhiteOver(behind, OG_CHIP_BACKGROUND_ALPHA)
+      expect(contrastRatio(textOnLight, chip)).toBeGreaterThanOrEqual(
+        SMALL_TEXT_BAR,
+      )
+    }
+  })
+
+  it('leaves realistic dark brand colours untouched despite the tighter bar', () => {
+    // The tightening from 0.18 to 0.135 only moves pastels; real brand colours
+    // are far below both, so a themed tenant still gets its stored hex verbatim.
+    for (const hex of ['#7C2D12', '#1D4ED8', '#166534', '#1e40af']) {
+      expect(
+        ogBrandColors({ primaryColor: hex, accentColor: hex }).textOnLight,
+      ).toBe(hex)
+    }
+  })
+})
+
+describe('contrastRatio', () => {
+  it('is order-independent and anchors on the extremes', () => {
+    expect(contrastRatio('#000000', '#FFFFFF')).toBeCloseTo(21, 6)
+    expect(contrastRatio('#FFFFFF', '#000000')).toBeCloseTo(21, 6)
+    expect(contrastRatio('#FF00FF', '#FF00FF')).toBeCloseTo(1, 6)
+  })
+})
+
+/**
+ * `OG_MAX_BACKGROUND_LUMINANCE` guarantees the LARGE-text bar only. The cards
+ * also carry sub-24px white type on the gradient; that is inherited from the
+ * house design and is NOT covered. Pinned so the doc comment cannot quietly
+ * regrow the claim that it covers "every text element".
+ */
+describe('background ceiling — what it does and does not guarantee', () => {
+  it('gives large text (≥24px) exactly 3:1', () => {
+    expect(1.05 / (OG_MAX_BACKGROUND_LUMINANCE + 0.05)).toBeCloseTo(3, 6)
+  })
+
+  it('does NOT give the 12–18px white labels 4.5:1 — a known, inherited gap', () => {
+    expect(1.05 / (OG_MAX_BACKGROUND_LUMINANCE + 0.05)).toBeLessThan(4.5)
+    // What the ceiling would have to be for those to pass.
+    expect(1.05 / 4.5 - 0.05).toBeCloseTo(0.18333, 5)
+    // And the house palette is already worse than any themed tenant can be.
+    expect(relativeLuminance(DEFAULT_ACCENT_COLOR)).toBeGreaterThan(
+      OG_MAX_BACKGROUND_LUMINANCE,
+    )
+    expect(contrastRatio('#FFFFFF', DEFAULT_ACCENT_COLOR)).toBeLessThan(3)
   })
 })
 

--- a/src/lib/og/brand.test.ts
+++ b/src/lib/og/brand.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest'
+import {
+  HOUSE_OG_PAIR,
+  OG_MAX_BACKGROUND_LUMINANCE,
+  OG_MAX_TEXT_LUMINANCE,
+  ogBrandColors,
+  relativeLuminance,
+} from './brand'
+import {
+  DEFAULT_ACCENT_COLOR,
+  DEFAULT_PRIMARY_COLOR,
+} from '@/lib/branding/theme'
+
+/** The literal gradient string the OG routes hard-coded before theming. */
+const LEGACY_HOUSE_GRADIENT = 'linear-gradient(135deg, #1D4ED8, #06B6D4)'
+/** The literal gradient string the badge card hard-coded before theming. */
+const LEGACY_BADGE_GRADIENT = 'linear-gradient(135deg, #1e40af, #10b981)'
+const BADGE_PAIR = { primary: '#1e40af', accent: '#10b981' }
+
+describe('relativeLuminance', () => {
+  it('anchors on black and white', () => {
+    expect(relativeLuminance('#000000')).toBeCloseTo(0, 6)
+    expect(relativeLuminance('#FFFFFF')).toBeCloseTo(1, 6)
+  })
+
+  it('is case-insensitive and tolerates surrounding whitespace', () => {
+    expect(relativeLuminance(' #1d4ed8 ')).toBeCloseTo(
+      relativeLuminance('#1D4ED8'),
+      12,
+    )
+  })
+})
+
+describe('ogBrandColors — UNTHEMED is byte-identical to the pre-theming output', () => {
+  it.each([
+    ['no theme', undefined],
+    ['null theme', null],
+    ['empty theme', {}],
+    ['half theme (primary only)', { primaryColor: '#7C3AED' }],
+    ['half theme (accent only)', { accentColor: '#22D3EE' }],
+    ['malformed primary', { primaryColor: 'purple', accentColor: '#22D3EE' }],
+    ['malformed accent', { primaryColor: '#7C3AED', accentColor: '#zzz' }],
+    ['3-digit hex', { primaryColor: '#fff', accentColor: '#000' }],
+  ])('%s → the house gradient string, verbatim', (_label, theme) => {
+    const brand = ogBrandColors(theme)
+    expect(brand.themed).toBe(false)
+    expect(brand.gradient).toBe(LEGACY_HOUSE_GRADIENT)
+    expect(brand.primary).toBe(DEFAULT_PRIMARY_COLOR)
+    expect(brand.accent).toBe(DEFAULT_ACCENT_COLOR)
+    expect(brand.textOnLight).toBe(DEFAULT_PRIMARY_COLOR)
+  })
+
+  it('keeps the badge card on ITS own house pair', () => {
+    const brand = ogBrandColors(undefined, BADGE_PAIR)
+    expect(brand.gradient).toBe(LEGACY_BADGE_GRADIENT)
+    expect(brand.textOnLight).toBe('#1e40af')
+  })
+
+  it('never clamps the house palette, even though the accent is light', () => {
+    // The house cyan sits ABOVE the tenant ceiling. It is grandfathered: the
+    // unthemed path returns colours verbatim, which is what makes the legacy
+    // output byte-identical.
+    expect(relativeLuminance(DEFAULT_ACCENT_COLOR)).toBeGreaterThan(
+      OG_MAX_BACKGROUND_LUMINANCE,
+    )
+    expect(ogBrandColors(undefined).accent).toBe(DEFAULT_ACCENT_COLOR)
+  })
+})
+
+describe('ogBrandColors — THEMED', () => {
+  it('uses a dark-enough stored pair verbatim', () => {
+    const brand = ogBrandColors({
+      primaryColor: '#7C2D12',
+      accentColor: '#166534',
+    })
+    expect(brand.themed).toBe(true)
+    expect(brand.primary).toBe('#7C2D12')
+    expect(brand.accent).toBe('#166534')
+    expect(brand.gradient).toBe('linear-gradient(135deg, #7C2D12, #166534)')
+  })
+
+  it('trims stored whitespace', () => {
+    expect(
+      ogBrandColors({ primaryColor: ' #7C2D12 ', accentColor: ' #166534 ' })
+        .gradient,
+    ).toBe('linear-gradient(135deg, #7C2D12, #166534)')
+  })
+
+  it('differs from the house gradient (the bug this fixes)', () => {
+    expect(
+      ogBrandColors({ primaryColor: '#7C2D12', accentColor: '#F59E0B' })
+        .gradient,
+    ).not.toBe(LEGACY_HOUSE_GRADIENT)
+  })
+})
+
+describe('ogBrandColors — contrast clamp', () => {
+  const LIGHT_BRANDS = [
+    '#FFFFFF', // pure white
+    '#FDE68A', // amber-200
+    '#F59E0B', // amber-500
+    '#A7F3D0', // emerald-200
+    '#E0F2FE', // sky-100
+    '#FF00FF', // full-saturation magenta
+  ]
+
+  it.each(LIGHT_BRANDS)('%s is darkened until white text clears 3:1', (hex) => {
+    const brand = ogBrandColors({ primaryColor: hex, accentColor: hex })
+    expect(relativeLuminance(brand.primary)).toBeLessThanOrEqual(
+      OG_MAX_BACKGROUND_LUMINANCE,
+    )
+    expect(relativeLuminance(brand.accent)).toBeLessThanOrEqual(
+      OG_MAX_BACKGROUND_LUMINANCE,
+    )
+    // …and the chip variant clears the stricter small-text bar.
+    expect(relativeLuminance(brand.textOnLight)).toBeLessThanOrEqual(
+      OG_MAX_TEXT_LUMINANCE,
+    )
+  })
+
+  it('preserves hue by scaling channels, not by desaturating', () => {
+    // Pure magenta stays pure magenta: the zero channel stays zero and the two
+    // equal channels stay equal.
+    const { primary } = ogBrandColors({
+      primaryColor: '#FF00FF',
+      accentColor: '#FF00FF',
+    })
+    const [r, g, b] = [1, 3, 5].map((i) =>
+      parseInt(primary.slice(i, i + 2), 16),
+    )
+    expect(g).toBe(0)
+    expect(r).toBe(b)
+    expect(r).toBeGreaterThan(0)
+  })
+
+  it('clamps only what needs clamping (a dark colour is untouched)', () => {
+    const { primary } = ogBrandColors({
+      primaryColor: '#1D4ED8',
+      accentColor: '#1D4ED8',
+    })
+    expect(primary).toBe('#1D4ED8')
+  })
+
+  it('bounds every pixel of the gradient, not just its endpoints', () => {
+    // The sRGB transfer function is convex, so a channel-wise interpolation
+    // never exceeds the interpolation of the endpoint luminances. Sample it.
+    const { primary, accent } = ogBrandColors({
+      primaryColor: '#FFFFFF',
+      accentColor: '#FDE68A',
+    })
+    const channels = (hex: string) =>
+      [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16))
+    const a = channels(primary)
+    const b = channels(accent)
+    for (let t = 0; t <= 1.0001; t += 0.05) {
+      const mixed =
+        '#' +
+        a
+          .map((c, i) =>
+            Math.round(c + (b[i] - c) * t)
+              .toString(16)
+              .padStart(2, '0'),
+          )
+          .join('')
+      expect(relativeLuminance(mixed)).toBeLessThanOrEqual(
+        OG_MAX_BACKGROUND_LUMINANCE + 1e-9,
+      )
+    }
+  })
+
+  it('handles black without dividing by zero', () => {
+    const brand = ogBrandColors({
+      primaryColor: '#000000',
+      accentColor: '#000000',
+    })
+    expect(brand.gradient).toBe('linear-gradient(135deg, #000000, #000000)')
+  })
+})
+
+describe('HOUSE_OG_PAIR', () => {
+  it('is the shared branding default, not a second copy of the hexes', () => {
+    expect(HOUSE_OG_PAIR.primary).toBe(DEFAULT_PRIMARY_COLOR)
+    expect(HOUSE_OG_PAIR.accent).toBe(DEFAULT_ACCENT_COLOR)
+  })
+})

--- a/src/lib/og/brand.ts
+++ b/src/lib/og/brand.ts
@@ -1,0 +1,194 @@
+/**
+ * Per-tenant brand colours for the OpenGraph share cards.
+ *
+ * The cards are the platform's most outward-facing surface: every share of a
+ * tenant's site posts one. They used to be painted with the house gradient
+ * unconditionally, so a conference with its own brand still advertised somebody
+ * else's blue. This resolves the SAME stored `theme` pair the site CSS, the
+ * email templates and the PWA manifest read (`@/lib/branding/theme`) into the
+ * concrete hex values an `ImageResponse` needs.
+ *
+ * WHY A SEPARATE HELPER: the site consumes the theme as CSS custom properties
+ * (`conferenceThemeCss`) — a card has no cascade and no `color-mix()`, it needs
+ * literal hex. And unlike the site, the card BAKES WHITE TEXT onto the brand
+ * colour, so a very light brand cannot be used verbatim (see the clamp below).
+ * The pair-validity rule itself is NOT re-derived here; it comes from
+ * `resolveBrandPair`.
+ *
+ * RUNTIME: pure arithmetic on strings — no Node built-ins, no `Buffer`, no
+ * `fetch`. Safe to import from the Node-runtime routes under `(main)` AND from
+ * the edge-runtime badge card under `(public)/badge/[badgeId]`.
+ *
+ * BACK-COMPAT: an unthemed conference (no theme, half a theme, or a malformed
+ * value) returns the caller's house fallback VERBATIM — the same literal hex
+ * strings the routes hard-coded before — so the rendered bytes are unchanged.
+ * The clamp below only ever runs on tenant-supplied colours.
+ */
+
+import {
+  DEFAULT_ACCENT_COLOR,
+  DEFAULT_PRIMARY_COLOR,
+  resolveBrandPair,
+  type ConferenceTheme,
+} from '@/lib/branding/theme'
+
+/**
+ * Ceiling on the relative luminance of anything the card paints WHITE TEXT on.
+ * 0.3 is the WCAG 2.x AA bar for large text (contrast ≥ 3:1 against white:
+ * 1.05 / (0.3 + 0.05) = 3.0), and every text element on the cards is ≥ 24px
+ * bold, i.e. "large".
+ *
+ * The bound holds across the whole gradient, not just its endpoints: the sRGB
+ * transfer function is convex, so the luminance of a channel-wise interpolation
+ * never exceeds the interpolation of the endpoint luminances. Clamping both
+ * ends therefore clamps every pixel between them.
+ */
+export const OG_MAX_BACKGROUND_LUMINANCE = 0.3
+
+/**
+ * Ceiling for the brand colour used as TEXT on the cards' near-white chips
+ * (the sponsor-name fallback, the "OpenBadges verified" pill). 0.18 keeps it at
+ * ≥ 4.5:1 against white — the AA bar for small text, which those chips are.
+ */
+export const OG_MAX_TEXT_LUMINANCE = 0.18
+
+/** The house gradient pair, used when a conference is unthemed. */
+export const HOUSE_OG_PAIR = {
+  primary: DEFAULT_PRIMARY_COLOR,
+  accent: DEFAULT_ACCENT_COLOR,
+} as const
+
+export interface OgBrandPair {
+  primary: string
+  accent: string
+}
+
+export interface OgBrandColors {
+  /** Gradient start — the tenant primary, contrast-clamped, or the fallback. */
+  primary: string
+  /** Gradient end — the tenant accent, contrast-clamped, or the fallback. */
+  accent: string
+  /** Ready-to-use CSS value for the card background. */
+  gradient: string
+  /** The brand colour as TEXT on a near-white chip (darker clamp). */
+  textOnLight: string
+  /** True when the conference supplied a complete, valid theme pair. */
+  themed: boolean
+}
+
+function parseChannels(hex: string): [number, number, number] {
+  const v = hex.trim().replace('#', '')
+  return [
+    parseInt(v.slice(0, 2), 16),
+    parseInt(v.slice(2, 4), 16),
+    parseInt(v.slice(4, 6), 16),
+  ]
+}
+
+function toHex(channels: [number, number, number]): string {
+  return (
+    '#' +
+    channels
+      .map((c) =>
+        Math.max(0, Math.min(255, Math.round(c)))
+          .toString(16)
+          .padStart(2, '0'),
+      )
+      .join('')
+      .toUpperCase()
+  )
+}
+
+/** sRGB electro-optical transfer function for one 0–255 channel. */
+function linearize(channel: number): number {
+  const c = channel / 255
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+}
+
+/** WCAG relative luminance (0 = black, 1 = white) of a 6-digit hex colour. */
+export function relativeLuminance(hex: string): number {
+  const [r, g, b] = parseChannels(hex)
+  if ([r, g, b].some(Number.isNaN)) return 0
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+}
+
+/**
+ * Darken `hex` just enough to bring its relative luminance to `max`, by scaling
+ * all three channels by a single factor. Scaling (rather than mixing toward
+ * black in a perceptual space) keeps the hue and the channel ratios intact, so
+ * a pastel brand reads as a deeper shade of the SAME colour rather than as a
+ * different one.
+ *
+ * Returns the input UNCHANGED when it is already dark enough — which is the
+ * common case for real brand colours and the reason a themed conference usually
+ * gets its stored hex verbatim.
+ */
+function clampLuminance(hex: string, max: number): string {
+  if (relativeLuminance(hex) <= max) return hex
+
+  const channels = parseChannels(hex)
+  // Luminance is monotonic in the scale factor, so binary-search it.
+  let lo = 0
+  let hi = 1
+  for (let i = 0; i < 24; i++) {
+    const mid = (lo + hi) / 2
+    const scaled = toHex([
+      channels[0] * mid,
+      channels[1] * mid,
+      channels[2] * mid,
+    ])
+    if (relativeLuminance(scaled) > max) hi = mid
+    else lo = mid
+  }
+  // Floor the channels: flooring can only lower luminance, so the result is
+  // guaranteed to satisfy the ceiling even after integer rounding.
+  return toHex([
+    Math.floor(channels[0] * lo),
+    Math.floor(channels[1] * lo),
+    Math.floor(channels[2] * lo),
+  ])
+}
+
+/**
+ * Resolve the colours an OpenGraph card should paint for a conference.
+ *
+ * `fallback` is the card's own house pair — the literal hexes it used before
+ * theming existed. The badge card's blue→green differs from the main cards'
+ * blue→cyan, so each caller passes its own; unthemed conferences keep exactly
+ * what they rendered before.
+ */
+export function ogBrandColors(
+  theme?: ConferenceTheme | null,
+  fallback: OgBrandPair = HOUSE_OG_PAIR,
+): OgBrandColors {
+  const pair = resolveBrandPair(theme)
+
+  if (!pair) {
+    // UNTHEMED: verbatim house values, no clamping. This is the byte-identical
+    // path the three live editions without a stored theme take.
+    return {
+      primary: fallback.primary,
+      accent: fallback.accent,
+      gradient: ogGradient(fallback.primary, fallback.accent),
+      textOnLight: fallback.primary,
+      themed: false,
+    }
+  }
+
+  const primary = clampLuminance(pair.primary, OG_MAX_BACKGROUND_LUMINANCE)
+  const accent = clampLuminance(pair.accent, OG_MAX_BACKGROUND_LUMINANCE)
+
+  return {
+    primary,
+    accent,
+    gradient: ogGradient(primary, accent),
+    textOnLight: clampLuminance(pair.primary, OG_MAX_TEXT_LUMINANCE),
+    themed: true,
+  }
+}
+
+/** The card background gradient. Format is load-bearing: it must reproduce the
+ * previously hard-coded string exactly for the unthemed case. */
+function ogGradient(primary: string, accent: string): string {
+  return `linear-gradient(135deg, ${primary}, ${accent})`
+}

--- a/src/lib/og/brand.ts
+++ b/src/lib/og/brand.ts
@@ -33,10 +33,20 @@ import {
 } from '@/lib/branding/theme'
 
 /**
- * Ceiling on the relative luminance of anything the card paints WHITE TEXT on.
- * 0.3 is the WCAG 2.x AA bar for large text (contrast ≥ 3:1 against white:
- * 1.05 / (0.3 + 0.05) = 3.0), and every text element on the cards is ≥ 24px
- * bold, i.e. "large".
+ * Ceiling on the relative luminance of the gradient the card paints WHITE TEXT
+ * on. 0.3 is the WCAG 2.x AA bar for LARGE text: 1.05 / (0.3 + 0.05) = 3.0:1.
+ *
+ * SCOPE, precisely: the cards' headline/subtitle/detail type (24–80px) is large
+ * text and this ceiling is its AA guarantee. The cards ALSO carry some smaller
+ * white type directly on the gradient — the 12px sponsor-section labels and the
+ * 16–18px date/location/domain lines — which by WCAG needs 4.5:1 and therefore a
+ * background at luminance ≤ 0.1833. Those elements are NOT covered by this
+ * ceiling. That is inherited from the house design, not introduced by theming:
+ * the house cyan (#06B6D4, luminance 0.3825) gives them 2.43:1 today. Tightening
+ * this constant to 0.1833 would fix it for themed tenants, but it darkens every
+ * themed gradient, so it is a design decision rather than a correctness fix and
+ * is deliberately left alone here. Do not restate this ceiling as covering
+ * "every text element" — it does not.
  *
  * The bound holds across the whole gradient, not just its endpoints: the sRGB
  * transfer function is convex, so the luminance of a channel-wise interpolation
@@ -46,11 +56,34 @@ import {
 export const OG_MAX_BACKGROUND_LUMINANCE = 0.3
 
 /**
- * Ceiling for the brand colour used as TEXT on the cards' near-white chips
- * (the sponsor-name fallback, the "OpenBadges verified" pill). 0.18 keeps it at
- * ≥ 4.5:1 against white — the AA bar for small text, which those chips are.
+ * Alpha of the near-white chips the brand colour is painted ON as text — the
+ * sponsor-name fallback on the speaker card and the "OpenBadges 3.0 Verified"
+ * pill on the badge card. Both are `rgba(255, 255, 255, 0.9)`, i.e. NOT white:
+ * they let 10% of the brand gradient through.
  */
-export const OG_MAX_TEXT_LUMINANCE = 0.18
+export const OG_CHIP_BACKGROUND_ALPHA = 0.9
+
+/**
+ * Ceiling for the brand colour used as TEXT on those chips.
+ *
+ * The chips' type is 14–16px at weight 600. That is not "large" by WCAG (which
+ * needs ≥ 24px, or ≥ 18.66px bold), so the bar is the small-text one, 4.5:1.
+ *
+ * The bar must be met against what is actually PAINTED behind the glyphs, and
+ * that is not white — it is the 90%-opaque white chip composited over the card's
+ * own gradient, which is darker than white by construction. The worst case is a
+ * tenant whose gradient runs to black there: the composite is then
+ * 0.9 x 255 = 229.5 per channel, relative luminance 0.7874, not 1.0. Solving
+ * (0.7874 + 0.05) / 4.5 - 0.05 gives 0.1361, and 0.135 is the value under it
+ * that still clears the bar after the renderer quantises the composite down to
+ * an integer channel (229 → 4.51:1).
+ *
+ * The previous 0.18 was derived against pure white (1.05 / 0.23 = 4.57:1) but
+ * applied on the composite, where it is only 3.64:1 — it never delivered AA for
+ * small text. `contrastRatio` + `compositeWhiteOver` below express this
+ * derivation as code so the test suite can recompute it rather than trust prose.
+ */
+export const OG_MAX_TEXT_LUMINANCE = 0.135
 
 /** The house gradient pair, used when a conference is unthemed. */
 export const HOUSE_OG_PAIR = {
@@ -111,6 +144,44 @@ export function relativeLuminance(hex: string): number {
   if ([r, g, b].some(Number.isNaN)) return 0
   return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
 }
+
+/**
+ * WCAG contrast ratio between two 6-digit hex colours, order-independent.
+ */
+export function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a)
+  const lb = relativeLuminance(b)
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+}
+
+/**
+ * The colour actually painted when white at `alpha` covers `behind`.
+ *
+ * Alpha compositing in an `ImageResponse` happens in gamma-encoded sRGB — satori
+ * emits SVG and resvg blends the encoded channels directly — so this is a plain
+ * per-channel lerp on the 0–255 values, NOT a blend of linearised light. The
+ * channels are floored rather than rounded: flooring can only make the composite
+ * darker, so a contrast bound computed from it holds for the rounded pixel the
+ * renderer actually emits.
+ */
+export function compositeWhiteOver(behind: string, alpha: number): string {
+  const channels = parseChannels(behind)
+  return toHex([
+    Math.floor(alpha * 255 + (1 - alpha) * channels[0]),
+    Math.floor(alpha * 255 + (1 - alpha) * channels[1]),
+    Math.floor(alpha * 255 + (1 - alpha) * channels[2]),
+  ])
+}
+
+/**
+ * The darkest a chip's background can ever be: the chip over a black gradient.
+ * This is the background `OG_MAX_TEXT_LUMINANCE` is derived against — every real
+ * gradient is lighter than black, so every real chip has MORE contrast than this.
+ */
+export const OG_DARKEST_CHIP_BACKGROUND = compositeWhiteOver(
+  '#000000',
+  OG_CHIP_BACKGROUND_ALPHA,
+)
 
 /**
  * Darken `hex` just enough to bring its relative luminance to `max`, by scaling

--- a/src/lib/og/styles.ts
+++ b/src/lib/og/styles.ts
@@ -1,6 +1,12 @@
+/**
+ * Brand-NEUTRAL layout tokens for the OpenGraph cards.
+ *
+ * The card's brand COLOURS are not here: they depend on the conference's stored
+ * theme and are resolved per-request by `ogBrandColors` in `@/lib/og/brand`
+ * (which falls back to the house palette in `@/lib/branding/theme`). Only values
+ * that are the same for every tenant live in this table.
+ */
 export const STYLES = {
-  // Brand gradient: Cloud Blue (#1D4ED8) to Cyan (#06B6D4)
-  gradient: 'linear-gradient(135deg, #1D4ED8, #06B6D4)',
   // Brand typography for OG images
   fontFamily: 'Space Grotesk, system-ui, -apple-system, sans-serif',
   fontFamilyHeading: 'JetBrains Mono, Space Grotesk, monospace, sans-serif',
@@ -23,8 +29,6 @@ export const STYLES = {
     whiteLight: 'rgba(255, 255, 255, 0.2)',
     whiteVeryLight: 'rgba(255, 255, 255, 0.1)',
     blackTransparent: 'rgba(0, 0, 0, 0.3)',
-    blue: '#1D4ED8',
-    cyan: '#06B6D4',
   },
   shadow: {
     text: '0 4px 8px rgba(0, 0, 0, 0.3)',

--- a/src/lib/og/template.tsx
+++ b/src/lib/og/template.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ImageResponse } from 'next/og'
 import { STYLES, OG_IMAGE_SIZE } from './styles'
+import { ogBrandColors } from './brand'
 import { BackgroundPatterns, ConferenceLogo } from './components'
 import { formatDateRange, loadBrandFonts } from './helpers'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
@@ -83,6 +84,9 @@ export async function generateOGImage(
     }
 
     const fonts = await loadBrandFonts(domain)
+    // Per-tenant brand gradient; an unthemed conference resolves to the house
+    // pair and the exact string this used to hard-code.
+    const brand = ogBrandColors(conference.theme)
 
     return new ImageResponse(
       <div
@@ -91,7 +95,7 @@ export async function generateOGImage(
           height: '100%',
           display: 'flex',
           flexDirection: 'row',
-          background: STYLES.gradient,
+          background: brand.gradient,
           color: STYLES.colors.white,
           padding: STYLES.spacing.large,
           fontFamily: STYLES.fontFamily,


### PR DESCRIPTION
Every tenant's Open Graph card rendered in the Cloud Native house blue. A conference that had configured its own brand colour still posted competitor-branded imagery every time anyone shared its site — the most outward-facing un-themed surface in the product.

## The surface

Six routes generate cards; five share `src/lib/og/template.tsx`, and `badge/[badgeId]` carries its own styles and is the only one on the **edge** runtime. That constrained the fix: `conferenceThemeCss` emits CSS custom properties and `color-mix()`, and Satori supports neither, so cards need literal hex. The all-or-nothing pair rule is now extracted once as `resolveBrandPair()` in `src/lib/branding/theme.ts` and shared by `conferenceThemeCss`, `emailBrandColor` and the new `ogBrandColors()` — rather than re-derived per context.

Each caller passes its own house fallback, which is why the badge card keeps its distinct blue→green when unthemed instead of being flattened onto the main gradient.

## Back-compat, measured not argued

The three live editions store no theme, so unthemed output had to be untouched. Both cards were rendered headlessly on `main` and on this branch and hashed:

- unthemed before = unthemed after = **half-theme** after = **malformed-theme** after → `10295e56…`, byte-identical
- speaker card before = after → `7d78e182…`, byte-identical
- **themed** on `main` also hashes `10295e56…` — i.e. a themed conference rendered the house card. That is the bug, demonstrated rather than asserted.

A half-configured theme (primary without accent) and a malformed value both resolve to unthemed and take the verbatim path, so they render the house card rather than anything broken.

## Contrast

These cards bake white text and white decorative fills onto the brand colour, so a light tenant colour would render unreadable. Rather than flipping the foreground — which would mean re-authoring the baked-white icon SVGs and every `rgba(255,…)` overlay — the background is clamped: channels scale proportionally, preserving hue and channel ratios (pure magenta stays pure magenta), until relative luminance ≤ 0.3, i.e. ≥ 3:1 against white. Every text element on these cards is ≥ 24px bold, so the WCAG AA large-text bar applies. Because the sRGB transfer function is convex, clamping both gradient endpoints bounds every interpolated pixel between them — asserted in the tests, not just argued.

Two limitations, stated rather than hidden:
- The house palette is deliberately **grandfathered** above the ceiling (`#06B6D4` is ~2.4:1), because leaving it verbatim is exactly what makes unthemed output byte-identical. A tenant who stores that same cyan does get nudged to `#05A4BF`.
- The 12px sponsor-tier labels on the speaker card clear 3:1 but not 4.5:1. Pre-existing, unchanged, not made worse.

## Known issue, pre-existing and NOT fixed here

Long conference titles **clip at the right edge** — visible identically in the before and after captures, so it is not a regression, but it does mean a long name is cut off on every share. "Cloud Native Days Norway 2026" is in that range. Deliberately left out of this PR so the byte-identity proof above stays clean; follow-up to come.

30 new tests covering the unthemed-verbatim matrix, clamping, hue preservation and the gradient-interior bound. 5014 tests green, typecheck and knip clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds tenant-aware Open Graph branding while preserving route-specific house fallbacks.
- Extracts the all-or-nothing brand-pair resolver for site CSS, email, and OG consumers.
- Adds literal OG gradient generation and luminance clamping for tenant colors.
- Applies themed gradients to shared, speaker, and edge-runtime badge cards.
- Adds tests for fallback identity, validation, clamping, hue preservation, and gradient bounds.

<h3>Confidence Score: 4/5</h3>

The small-text contrast calculation should be corrected before merging because the affected labels render on translucent rather than opaque white backgrounds.

The new text color ceiling guarantees contrast only against pure white, while both current consumers composite their white backgrounds over the tenant gradient and can therefore render valid themed labels below the promised contrast ratio.

**Files Needing Attention:** src/lib/og/brand.ts, src/app/(main)/speaker/[slug]/opengraph-image.tsx, src/app/(public)/badge/[badgeId]/opengraph-image.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/branding/theme.ts | Centralizes complete-pair validation and reuses it for CSS and email branding. |
| src/lib/og/brand.ts | Introduces OG color resolution and contrast clamping, but small-text contrast is calculated against the wrong chip background. |
| src/lib/og/brand.test.ts | Thoroughly covers fallback and color arithmetic but does not test contrast after translucent chip-background compositing. |
| src/lib/og/template.tsx | Replaces the shared house gradient with the resolved tenant gradient. |
| src/app/(main)/speaker/[slug]/opengraph-image.tsx | Themes the speaker card and sponsor fallback text; the translucent sponsor chips expose the contrast issue. |
| src/app/(public)/badge/[badgeId]/opengraph-image.tsx | Preserves the badge-specific fallback and adds tenant branding on edge, while its translucent verification pill exposes the contrast issue. |
| src/lib/og/styles.ts | Removes brand-specific colors from the shared layout token collection. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Theme[Conference theme] --> Resolve[resolveBrandPair]
  Resolve -->|Valid pair| Clamp[Clamp tenant colors]
  Resolve -->|Missing or malformed| Fallback[Route-specific house pair]
  Clamp --> Brand[ogBrandColors]
  Fallback --> Brand
  Brand --> Shared[Shared OG template]
  Brand --> Speaker[Speaker card]
  Brand --> Badge[Badge card]
```

<sub>Reviews (1): Last reviewed commit: ["fix(og): paint the share cards in the te..."](https://github.com/cloudnativebergen/website/commit/7bd558f966f652e66e4b4b078afe182feb445ed7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49765703)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->