### PR TITLE
feat(homepage): the section variant registry

### DIFF
--- a/__tests__/helpers/moduleImports.test.ts
+++ b/__tests__/helpers/moduleImports.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import { findRuntimeModuleImports } from './moduleImports'
+
+/**
+ * The guard this file covers replaced a source-text regex that was copied into
+ * two test files and matched only `import … from '…'` with SINGLE quotes.
+ *
+ * `OLD_GUARD` is that exact regex, kept here as an executable record of what it
+ * missed. Every case below asserts BOTH that the parser sees the import and
+ * that the regex did not — so the fix is demonstrated, not just claimed.
+ */
+const OLD_GUARD = (source: string): string[] =>
+  Array.from(
+    source.matchAll(/^import\s+(?!type\b)[^;]*?from\s+'([^']+)'/gm),
+    (match) => match[1],
+  )
+
+const specifiers = (source: string) =>
+  findRuntimeModuleImports(source).map((i) => i.specifier)
+
+describe('findRuntimeModuleImports — forms the old regex was blind to', () => {
+  const blindSpots: Array<{
+    name: string
+    source: string
+    specifier: string
+    kind: string
+  }> = [
+    {
+      name: 'side-effect import',
+      source: `import '@dnd-kit/core'\n`,
+      specifier: '@dnd-kit/core',
+      kind: 'side-effect import',
+    },
+    {
+      name: 'named re-export',
+      source: `export { arrayMove } from '@dnd-kit/sortable'\n`,
+      specifier: '@dnd-kit/sortable',
+      kind: 're-export',
+    },
+    {
+      name: 'star re-export',
+      source: `export * from '@dnd-kit/core'\n`,
+      specifier: '@dnd-kit/core',
+      kind: 're-export',
+    },
+    {
+      name: 'dynamic import',
+      source: `export async function load() {\n  return import('@dnd-kit/core')\n}\n`,
+      specifier: '@dnd-kit/core',
+      kind: 'dynamic import',
+    },
+    {
+      name: 'double-quoted import',
+      source: `import { DndContext } from "@dnd-kit/core"\n`,
+      specifier: '@dnd-kit/core',
+      kind: 'import',
+    },
+    {
+      name: 'double-quoted side-effect import',
+      source: `import "@dnd-kit/core"\n`,
+      specifier: '@dnd-kit/core',
+      kind: 'side-effect import',
+    },
+    {
+      name: 'require call',
+      source: `const dnd = require('@dnd-kit/core')\n`,
+      specifier: '@dnd-kit/core',
+      kind: 'require',
+    },
+    {
+      name: 'import-equals',
+      source: `import dnd = require('@dnd-kit/core')\n`,
+      specifier: '@dnd-kit/core',
+      kind: 'import =',
+    },
+    {
+      name: 'indented re-export inside a namespace',
+      source: `namespace n {\n  export * from '@dnd-kit/core'\n}\n`,
+      specifier: '@dnd-kit/core',
+      kind: 're-export',
+    },
+  ]
+
+  for (const { name, source, specifier, kind } of blindSpots) {
+    it(`catches a ${name}, which the old regex missed`, () => {
+      expect(OLD_GUARD(source)).toEqual([])
+      expect(findRuntimeModuleImports(source)).toEqual([
+        { specifier, kind, line: expect.any(Number) },
+      ])
+    })
+  }
+
+  it('catches a computed dynamic import, quoting the expression', () => {
+    const source = `const name = 'core'\nexport const load = () => import(\`@dnd-kit/\${name}\`)\n`
+    expect(OLD_GUARD(source)).toEqual([])
+    expect(findRuntimeModuleImports(source)).toEqual([
+      {
+        specifier: '`@dnd-kit/${name}`',
+        kind: 'dynamic import',
+        line: 2,
+      },
+    ])
+  })
+})
+
+describe('findRuntimeModuleImports — no false positives', () => {
+  it('ignores an import that only lives inside a block comment', () => {
+    const source = `/*\nimport evil from 'evil'\n*/\nexport const ok = 1\n`
+    // The old regex matched `^import` at column 0 even inside the comment: it
+    // reported an import that does not exist.
+    expect(OLD_GUARD(source)).toEqual(['evil'])
+    expect(findRuntimeModuleImports(source)).toEqual([])
+  })
+
+  it('ignores an import-looking string literal', () => {
+    const source = `export const doc = \`\nimport evil from 'evil'\n\`\n`
+    expect(OLD_GUARD(source)).toEqual(['evil'])
+    expect(findRuntimeModuleImports(source)).toEqual([])
+  })
+
+  it('ignores erased type-only imports and re-exports', () => {
+    const source = [
+      `import type { A } from './a'`,
+      `import type B from './b'`,
+      `export type { C } from './c'`,
+      `export type * from './d'`,
+      `export { type E } from './e'`,
+    ].join('\n')
+    // `export { type E } from './e'` is NOT a type-only statement, so the
+    // specifier survives — the strict answer, deliberately.
+    expect(specifiers(source)).toEqual(['./e'])
+  })
+
+  it('ignores a local export with no module specifier', () => {
+    expect(findRuntimeModuleImports(`const a = 1\nexport { a }\n`)).toEqual([])
+  })
+
+  it('reports a non-type-only named import even when every binding is a type', () => {
+    // `import { type A }` is not erased at the statement level; being wrong
+    // here costs a broken production build, so the guard stays strict.
+    expect(specifiers(`import { type A } from './a'\n`)).toEqual(['./a'])
+  })
+})
+
+describe('findRuntimeModuleImports — ordering and shape', () => {
+  it('returns every specifier in source order with its line', () => {
+    const source = [
+      `import type { T } from './types'`,
+      `import './polyfill'`,
+      `import { a } from "pkg-a"`,
+      `export * from './barrel'`,
+      `export const load = () => import('lazy')`,
+    ].join('\n')
+
+    expect(findRuntimeModuleImports(source)).toEqual([
+      { specifier: './polyfill', kind: 'side-effect import', line: 2 },
+      { specifier: 'pkg-a', kind: 'import', line: 3 },
+      { specifier: './barrel', kind: 're-export', line: 4 },
+      { specifier: 'lazy', kind: 'dynamic import', line: 5 },
+    ])
+    // The old regex saw none of the four correctly. `[^;]*?` spans newlines,
+    // so it welded line 3's `import` onto line 4's `from './barrel'` and
+    // reported a specifier that no single statement contains — missing the
+    // side-effect import, the double-quoted import and the dynamic import,
+    // while inventing an import that is not there.
+    expect(OLD_GUARD(source)).toEqual(['./barrel'])
+  })
+
+  it('parses TSX when the file name says so', () => {
+    const source = `import { X } from './x'\nexport const El = () => <X a={1 as number} />\n`
+    expect(
+      findRuntimeModuleImports(source, 'component.tsx').map((i) => i.specifier),
+    ).toEqual(['./x'])
+  })
+})

--- a/__tests__/helpers/moduleImports.ts
+++ b/__tests__/helpers/moduleImports.ts
@@ -1,0 +1,148 @@
+import ts from 'typescript'
+
+/**
+ * "Does this module drag anything into the runtime module graph?" — answered by
+ * PARSING the module, not by pattern-matching its text.
+ *
+ * WHY THIS EXISTS. Some modules must stay free of runtime imports because a
+ * single value import from a client-only package puts that package's React
+ * context into the RSC module graph, and the production build then dies while
+ * collecting page data with `createContext is not a function`. That failure is
+ * invisible to `tsc` and to every unit test — it only appears in `next build` —
+ * so it is guarded here instead. It has already happened once, via a `@dnd-kit`
+ * import in `src/lib/homepage/editor.ts`.
+ *
+ * WHY AN AST AND NOT A REGEX. The guard this replaces matched only
+ * `import … from '…'` with SINGLE quotes, which silently permitted every other
+ * way a module can reach another one: `import 'x'`, `export … from 'x'`,
+ * `export * from 'x'`, `import('x')`, `require('x')`, `import x = require('x')`,
+ * and anything written with double quotes — while ALSO false-positiving on an
+ * `import` line inside a block comment. A guard with holes is worse than no
+ * guard, because it reads as protection that is not there. TypeScript is
+ * already a dependency and is the same parser that compiles these files, so the
+ * answer here is exactly the compiler's answer.
+ *
+ * The alternatives were weighed and rejected: an ESLint rule cannot see dynamic
+ * `import()` and runs in a different command than the tests (and is currently
+ * broken in git worktrees); asserting on the BUILT output would catch it, but
+ * only after a multi-minute `next build`, which is precisely the slow feedback
+ * loop this guard exists to shortcut.
+ */
+export interface RuntimeModuleImport {
+  /** The module specifier as written, or the expression text when computed. */
+  specifier: string
+  /** How the module is reached — named so a failing assertion explains itself. */
+  kind:
+    | 'import'
+    | 'side-effect import'
+    | 're-export'
+    | 'dynamic import'
+    | 'require'
+    | 'import ='
+  /** 1-based line, so a failure points at the offending statement. */
+  line: number
+}
+
+/** Longest expression text quoted back for a computed specifier. */
+const MAX_SPECIFIER_TEXT = 80
+
+/**
+ * Every module specifier the module reaches at RUNTIME, in source order.
+ *
+ * ERASED, and therefore absent from the result: `import type … from 'x'` and
+ * `export type … from 'x'`, both of which the compiler removes wholesale.
+ *
+ * NOT erased, and therefore reported: `import { type A } from 'x'`. The
+ * statement is not type-only, so whether the specifier survives depends on the
+ * bundler's elision settings — and this guard deliberately answers the strict
+ * question, since being wrong here costs a broken production build.
+ */
+export function findRuntimeModuleImports(
+  source: string,
+  fileName = 'module.ts',
+): RuntimeModuleImport[] {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    // setParentNodes: needed for getStart()/getText() below.
+    true,
+    fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+
+  const found: RuntimeModuleImport[] = []
+
+  const record = (
+    kind: RuntimeModuleImport['kind'],
+    node: ts.Node,
+    specifier: ts.Expression,
+  ) => {
+    const text = ts.isStringLiteralLike(specifier)
+      ? specifier.text
+      : specifier.getText(sourceFile).slice(0, MAX_SPECIFIER_TEXT)
+    found.push({
+      specifier: text,
+      kind,
+      line:
+        sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+          .line + 1,
+    })
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node)) {
+      // `import type … from 'x'` is erased; a bare `import 'x'` (no clause) is
+      // the side-effect form and is emphatically NOT.
+      if (!node.importClause?.isTypeOnly) {
+        record(
+          node.importClause ? 'import' : 'side-effect import',
+          node,
+          node.moduleSpecifier,
+        )
+      }
+    } else if (ts.isExportDeclaration(node)) {
+      // Covers both `export { a } from 'x'` and `export * from 'x'`; a local
+      // `export { a }` has no module specifier and reaches nothing.
+      if (!node.isTypeOnly && node.moduleSpecifier) {
+        record('re-export', node, node.moduleSpecifier)
+      }
+    } else if (ts.isImportEqualsDeclaration(node)) {
+      if (
+        !node.isTypeOnly &&
+        ts.isExternalModuleReference(node.moduleReference)
+      ) {
+        record('import =', node, node.moduleReference.expression)
+      }
+    } else if (ts.isCallExpression(node)) {
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        // `import('x')`, including a computed or template specifier.
+        if (node.arguments.length > 0) {
+          record('dynamic import', node, node.arguments[0])
+        }
+      } else if (
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'require' &&
+        node.arguments.length > 0
+      ) {
+        record('require', node, node.arguments[0])
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  ts.forEachChild(sourceFile, visit)
+  return found
+}
+
+/**
+ * {@link findRuntimeModuleImports} for a file on disk. Call it with
+ * `new URL('./thing.ts', import.meta.url)` from a colocated test.
+ */
+export async function readRuntimeModuleImports(
+  fileUrl: URL | string,
+): Promise<RuntimeModuleImport[]> {
+  const { readFile } = await import('node:fs/promises')
+  const url = typeof fileUrl === 'string' ? new URL(fileUrl) : fileUrl
+  const source = await readFile(url, 'utf8')
+  return findRuntimeModuleImports(source, url.pathname)
+}

--- a/src/lib/homepage/editor.test.ts
+++ b/src/lib/homepage/editor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { readRuntimeModuleImports } from '../../../__tests__/helpers/moduleImports'
 import {
   EditorRow,
   isConfigurable,
@@ -448,21 +449,23 @@ describe('toPayload — trimming, omission and item filtering', () => {
  * helper — puts that package's React context in the RSC module graph, and the
  * production build dies collecting page data with `createContext is not a
  * function`. That is invisible to typecheck and to every unit test, so it is
- * asserted on the source text instead. `import type` is fine: it is erased.
+ * asserted on the parsed module graph instead. `import type` is fine: it is
+ * erased.
+ *
+ * The check itself lives in {@link readRuntimeModuleImports} so this test and
+ * its twin in `variants.test.ts` cannot drift: they were regex copies of each
+ * other, and both copies missed side-effect imports, re-exports, dynamic
+ * imports and double quotes.
  */
 describe('server safety', () => {
   it('has no runtime dependency on any package', async () => {
-    const { readFile } = await import('node:fs/promises')
-    const source = await readFile(
+    const imports = await readRuntimeModuleImports(
       new URL('./editor.ts', import.meta.url),
-      'utf8',
     )
-
-    const runtimeImports = Array.from(
-      source.matchAll(/^import\s+(?!type\b)[^;]*?from\s+'([^']+)'/gm),
-      (match) => match[1],
-    ).filter((specifier) => !specifier.startsWith('.'))
-
-    expect(runtimeImports).toEqual([])
+    // Relative siblings are allowed here (unlike variants.ts, which permits
+    // none at all); a PACKAGE is what puts a React context in the RSC graph.
+    expect(imports.filter((entry) => !entry.specifier.startsWith('.'))).toEqual(
+      [],
+    )
   })
 })

--- a/src/lib/homepage/index.ts
+++ b/src/lib/homepage/index.ts
@@ -7,3 +7,6 @@
 // RSC graph. That property is load-bearing — keep ./editor dependency-free.
 export * from './sections'
 export * from './richText'
+// The variant registry is part of the shared vocabulary (the renderer, the write
+// path and the Studio schema all read it) and is itself dependency-free.
+export * from './variants'

--- a/src/lib/homepage/sections.ts
+++ b/src/lib/homepage/sections.ts
@@ -1,6 +1,7 @@
 import type { TypedObject } from 'sanity'
 import type { Conference } from '@/lib/conference/types'
 import { resolveHomepageLifecycle, type HomepageStage } from './lifecycle'
+import type { SectionVariant } from './variants'
 import type { RichTextContentBlock } from './richText'
 
 /**
@@ -141,6 +142,8 @@ interface BaseSection {
  */
 export interface HeroSection extends BaseSection {
   _type: 'homepageHero'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageHero'>
   heroHeadline?: string
   heroSubheadline?: string
   /** When non-empty, replaces the phase-aware CTA row with these buttons. */
@@ -155,6 +158,8 @@ export interface HeroSection extends BaseSection {
  */
 export interface SaveTheDateSection extends BaseSection {
   _type: 'homepageSaveTheDate'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageSaveTheDate'>
   heading?: string
   description?: string
 }
@@ -167,12 +172,16 @@ export interface SaveTheDateSection extends BaseSection {
  */
 export interface FeaturedSpeakersSection extends BaseSection {
   _type: 'homepageFeaturedSpeakers'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageFeaturedSpeakers'>
   heading?: string
   description?: string
 }
 
 export interface ProgramHighlightsSection extends BaseSection {
   _type: 'homepageProgramHighlights'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageProgramHighlights'>
 }
 
 /**
@@ -182,6 +191,8 @@ export interface ProgramHighlightsSection extends BaseSection {
  */
 export interface OrganizersSection extends BaseSection {
   _type: 'homepageOrganizers'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageOrganizers'>
   heading?: string
   description?: string
 }
@@ -194,6 +205,8 @@ export interface OrganizersSection extends BaseSection {
  */
 export interface SponsorsSection extends BaseSection {
   _type: 'homepageSponsors'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageSponsors'>
   heading?: string
   description?: string
   /** Absent = shown. Set false to drop the "Become a Sponsor" card. */
@@ -209,6 +222,8 @@ export interface SponsorsSection extends BaseSection {
  */
 export interface GallerySection extends BaseSection {
   _type: 'homepageGallery'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageGallery'>
   heading?: string
   description?: string
 }
@@ -216,12 +231,16 @@ export interface GallerySection extends BaseSection {
 /** Standalone vanity-metrics band (content from `conference.vanityMetrics`). */
 export interface MetricsSection extends BaseSection {
   _type: 'homepageMetrics'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageMetrics'>
   heading?: string
 }
 
 /** Generic call-to-action banner (heading + body + one house Button). */
 export interface CtaBannerSection extends BaseSection {
   _type: 'homepageCtaBanner'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageCtaBanner'>
   heading: string
   body?: string
   buttonLabel: string
@@ -238,6 +257,8 @@ export interface CtaBannerSection extends BaseSection {
  */
 export interface RichTextSection extends BaseSection {
   _type: 'homepageRichText'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageRichText'>
   heading?: string
   content: TypedObject[] | RichTextContentBlock[]
 }
@@ -260,6 +281,8 @@ export interface HomepageFaqItem {
  */
 export interface FaqSection extends BaseSection {
   _type: 'homepageFaq'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageFaq'>
   heading?: string
   /** `'own'` (default) renders `items`; `'ticketFaqs'` renders the ticket FAQs. */
   source?: 'own' | 'ticketFaqs'
@@ -274,6 +297,8 @@ export interface FaqSection extends BaseSection {
  */
 export interface CountdownSection extends BaseSection {
   _type: 'homepageCountdown'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageCountdown'>
   heading?: string
   /** ISO date/timestamp that overrides `conference.startDate` as the target. */
   targetOverride?: string
@@ -289,6 +314,8 @@ export interface CountdownSection extends BaseSection {
  */
 export interface VenueSection extends BaseSection {
   _type: 'homepageVenue'
+  /** Presentation variant. Absent = the default (see SECTION_VARIANTS). */
+  variant?: SectionVariant<'homepageVenue'>
   heading?: string
   description?: string
 }

--- a/src/lib/homepage/variants.test.ts
+++ b/src/lib/homepage/variants.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { HOMEPAGE_SECTION_TYPES, type HomepageSectionType } from './sections'
+import {
+  SECTION_VARIANTS,
+  type SectionVariant,
+  VARIANT_DESCRIPTIONS,
+  VARIANT_LABELS,
+  defaultVariant,
+  isSectionVariant,
+  resolveVariant,
+} from './variants'
+
+/**
+ * The registry these snapshots pin is a CONTRACT, not an implementation detail:
+ * the first entry of every list is the default and must render today's markup,
+ * and stored data is validated against these exact strings. Appending is a
+ * feature change; reordering or renaming is a data migration.
+ */
+describe('SECTION_VARIANTS registry', () => {
+  it('covers every section type, and nothing else', () => {
+    expect(Object.keys(SECTION_VARIANTS).sort()).toEqual(
+      [...HOMEPAGE_SECTION_TYPES].sort(),
+    )
+  })
+
+  it('pins the variant names each section type accepts', () => {
+    expect(SECTION_VARIANTS).toEqual({
+      homepageHero: ['classic', 'minimal', 'emblem'],
+      homepageSaveTheDate: ['card', 'strip'],
+      homepageFeaturedSpeakers: ['shelf', 'grid'],
+      homepageProgramHighlights: ['full', 'talks'],
+      homepageOrganizers: ['cards', 'compact'],
+      homepageSponsors: ['tiers', 'logo-wall'],
+      homepageGallery: ['carousel', 'mosaic'],
+      homepageMetrics: ['row', 'band'],
+      homepageCtaBanner: ['plain', 'panel'],
+      homepageRichText: ['article', 'boxed'],
+      homepageFaq: ['accordion', 'list'],
+      homepageCountdown: ['units', 'strip'],
+      homepageVenue: ['card', 'split'],
+    })
+  })
+
+  it('gives every type at least one variant, with no duplicates', () => {
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      const variants: readonly string[] = SECTION_VARIANTS[type]
+      expect(variants.length).toBeGreaterThan(0)
+      expect(new Set(variants).size).toBe(variants.length)
+    }
+  })
+
+  it('uses kebab-case names so they are safe as stored values and CSS hooks', () => {
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      for (const variant of SECTION_VARIANTS[type] as readonly string[]) {
+        expect(variant).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/)
+      }
+    }
+  })
+
+  it('labels and describes every variant, and only real ones', () => {
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      const variants = [...(SECTION_VARIANTS[type] as readonly string[])].sort()
+      const labels: Record<string, string> = VARIANT_LABELS[type]
+      const descriptions: Record<string, string> = VARIANT_DESCRIPTIONS[type]
+      expect(Object.keys(labels).sort()).toEqual(variants)
+      expect(Object.keys(descriptions).sort()).toEqual(variants)
+      for (const variant of variants) {
+        expect(labels[variant].length).toBeGreaterThan(0)
+        expect(descriptions[variant].length).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+describe('defaultVariant', () => {
+  it('is the first entry for every type', () => {
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      expect(defaultVariant(type)).toBe(
+        (SECTION_VARIANTS[type] as readonly string[])[0],
+      )
+    }
+  })
+
+  it('pins the defaults — these are the pre-variant renderings', () => {
+    expect(defaultVariant('homepageHero')).toBe('classic')
+    expect(defaultVariant('homepageSponsors')).toBe('tiers')
+    expect(defaultVariant('homepageFaq')).toBe('accordion')
+  })
+})
+
+describe('isSectionVariant', () => {
+  it('accepts registered variants of that exact type only', () => {
+    expect(isSectionVariant('homepageHero', 'emblem')).toBe(true)
+    // 'shelf' is a real variant — of a DIFFERENT type.
+    expect(isSectionVariant('homepageHero', 'shelf')).toBe(false)
+  })
+
+  it('rejects non-strings', () => {
+    expect(isSectionVariant('homepageHero', undefined)).toBe(false)
+    expect(isSectionVariant('homepageHero', null)).toBe(false)
+    expect(isSectionVariant('homepageHero', 0)).toBe(false)
+  })
+})
+
+describe('resolveVariant', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('resolves an ABSENT variant to the default for every type — the back-compat path', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      expect(resolveVariant(type, undefined)).toBe(defaultVariant(type))
+    }
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('returns every registered variant unchanged, silently', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      for (const variant of SECTION_VARIANTS[type] as readonly string[]) {
+        expect(resolveVariant(type, variant)).toBe(variant)
+      }
+    }
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the default for an unknown variant rather than dropping the section', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(resolveVariant('homepageHero', 'from-the-future')).toBe('classic')
+    // A variant belonging to another section type is just as unknown here.
+    expect(resolveVariant('homepageHero', 'logo-wall')).toBe('classic')
+    expect(resolveVariant('homepageSponsors', '')).toBe('tiers')
+  })
+
+  it('warns once per (type, variant) pair, not once per render', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    resolveVariant('homepageFaq', 'unknown-faq-a')
+    resolveVariant('homepageFaq', 'unknown-faq-a')
+    resolveVariant('homepageFaq', 'unknown-faq-a')
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain('unknown-faq-a')
+    expect(warn.mock.calls[0][0]).toContain('homepageFaq')
+
+    // A different variant on the same type warns again…
+    resolveVariant('homepageFaq', 'unknown-faq-b')
+    expect(warn).toHaveBeenCalledTimes(2)
+    // …and so does the same variant name on a different type.
+    resolveVariant('homepageVenue', 'unknown-faq-a')
+    expect(warn).toHaveBeenCalledTimes(3)
+  })
+})
+
+/**
+ * Same hazard as `editor.ts` (see the twin test there): this module is reachable
+ * from SERVER components via the render tree, and it is imported by the Sanity
+ * Studio's Vite build by relative path. A single value import from any package —
+ * even a pure helper — can put a client-only React context in the RSC module
+ * graph, and the production build then dies collecting page data with
+ * `createContext is not a function`. Invisible to typecheck and to every other
+ * test, so it is asserted on the source text. `import type` is fine: it is erased.
+ */
+describe('server safety', () => {
+  it('has no runtime import at all — not even a relative one', async () => {
+    const { readFile } = await import('node:fs/promises')
+    const source = await readFile(
+      new URL('./variants.ts', import.meta.url),
+      'utf8',
+    )
+
+    // Everything that is not `import type`. The back-edge to ./sections is
+    // type-only by design, so this list must be empty: no package can sneak in,
+    // and the sections.ts ↔ variants.ts cycle stays erased.
+    const runtimeImports = Array.from(
+      source.matchAll(/^import\s+(?!type\b)[^;]*?from\s+'([^']+)'/gm),
+      (match) => match[1],
+    )
+
+    expect(runtimeImports).toEqual([])
+  })
+})
+
+/** Type-level guard — a regression here fails the build, not the runner. */
+describe('typing', () => {
+  it('keeps the registry closed at the type level', () => {
+    const type: HomepageSectionType = 'homepageGallery'
+    const resolved: SectionVariant<'homepageGallery' | 'homepageHero'> =
+      resolveVariant(type, 'mosaic') as SectionVariant<'homepageGallery'>
+    expect(resolved).toBe('mosaic')
+
+    // @ts-expect-error 'mosaic' is not a hero variant.
+    const notAHeroVariant: SectionVariant<'homepageHero'> = 'mosaic'
+    expect(notAHeroVariant).toBe('mosaic')
+  })
+})

--- a/src/lib/homepage/variants.test.ts
+++ b/src/lib/homepage/variants.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readRuntimeModuleImports } from '../../../__tests__/helpers/moduleImports'
 import { HOMEPAGE_SECTION_TYPES, type HomepageSectionType } from './sections'
 import {
   SECTION_VARIANTS,
   type SectionVariant,
   VARIANT_DESCRIPTIONS,
   VARIANT_LABELS,
+  VARIANT_WARN_LIMITS,
   defaultVariant,
   isSectionVariant,
   resolveVariant,
@@ -150,6 +152,69 @@ describe('resolveVariant', () => {
     resolveVariant('homepageVenue', 'unknown-faq-a')
     expect(warn).toHaveBeenCalledTimes(3)
   })
+
+  /**
+   * `stored` is read off a Sanity document, so at runtime it can be anything.
+   * The precedent is `isBlank()` in migration 046: a wrong-typed value must not
+   * be quietly folded into the benign case. Here that means the same safe
+   * default rendering, but REPORTED — and reported by type, so a `variant`
+   * stored as a number is not disguised as a misspelt variant name.
+   */
+  it('renders the default for a wrong-typed value, and says what the type was', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    for (const bad of [null, 0, 42, true, {}, [], Symbol.iterator]) {
+      expect(resolveVariant('homepageHero', bad)).toBe('classic')
+    }
+
+    const messages = warn.mock.calls.map((call) => String(call[0]))
+    expect(messages).toEqual([
+      expect.stringContaining('null'),
+      expect.stringContaining('[number]'),
+      expect.stringContaining('[boolean]'),
+      expect.stringContaining('[object]'),
+      expect.stringContaining('[symbol]'),
+    ])
+    // `0` and `42` collapse to one `[number]` warning; `{}` and `[]` to one
+    // `[object]`. Deduping by TYPE is what stops junk data flooding the log.
+    expect(warn).toHaveBeenCalledTimes(5)
+  })
+
+  it('clips a very long stored value instead of logging it whole', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const long = 'x'.repeat(VARIANT_WARN_LIMITS.storedValue * 4)
+
+    expect(resolveVariant('homepageMetrics', long)).toBe('row')
+
+    const message = String(warn.mock.calls[0][0])
+    expect(message).toContain('…')
+    expect(message).not.toContain(long)
+    expect(message.length).toBeLessThan(
+      VARIANT_WARN_LIMITS.storedValue + long.length,
+    )
+  })
+
+  /**
+   * The ledger is fed by stored data in a long-lived server process, so it is
+   * capped in both directions: bounded memory, and bounded log volume once the
+   * cap is hit. A fresh module instance keeps this out of the other tests'
+   * ledger (and theirs out of this one's).
+   */
+  it('caps the ledger so junk data cannot grow it, or the log, without bound', async () => {
+    vi.resetModules()
+    const fresh = await import('./variants')
+    const cap = fresh.VARIANT_WARN_LIMITS.distinctPairs
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    for (let i = 0; i < cap * 3; i++) {
+      expect(fresh.resolveVariant('homepageHero', `junk-${i}`)).toBe('classic')
+    }
+
+    // `cap` distinct warnings, then exactly ONE notice, then silence — however
+    // many more distinct unknown values arrive.
+    expect(warn).toHaveBeenCalledTimes(cap + 1)
+    expect(String(warn.mock.calls[cap][0])).toContain('suppressing')
+  })
 })
 
 /**
@@ -159,25 +224,22 @@ describe('resolveVariant', () => {
  * even a pure helper — can put a client-only React context in the RSC module
  * graph, and the production build then dies collecting page data with
  * `createContext is not a function`. Invisible to typecheck and to every other
- * test, so it is asserted on the source text. `import type` is fine: it is erased.
+ * test, so it is asserted on the parsed module graph. `import type` is fine: it
+ * is erased.
+ *
+ * The check lives in ONE place ({@link readRuntimeModuleImports}) precisely
+ * because it used to be a regex duplicated here and in `editor.test.ts`, where
+ * both copies missed side-effect imports, re-exports, dynamic imports and
+ * double quotes. See `__tests__/helpers/moduleImports.test.ts`.
  */
 describe('server safety', () => {
   it('has no runtime import at all — not even a relative one', async () => {
-    const { readFile } = await import('node:fs/promises')
-    const source = await readFile(
-      new URL('./variants.ts', import.meta.url),
-      'utf8',
-    )
-
-    // Everything that is not `import type`. The back-edge to ./sections is
-    // type-only by design, so this list must be empty: no package can sneak in,
-    // and the sections.ts ↔ variants.ts cycle stays erased.
-    const runtimeImports = Array.from(
-      source.matchAll(/^import\s+(?!type\b)[^;]*?from\s+'([^']+)'/gm),
-      (match) => match[1],
-    )
-
-    expect(runtimeImports).toEqual([])
+    // The back-edge to ./sections is type-only by design, so this list must be
+    // empty: no package can sneak in, and the sections.ts ↔ variants.ts cycle
+    // stays erased.
+    expect(
+      await readRuntimeModuleImports(new URL('./variants.ts', import.meta.url)),
+    ).toEqual([])
   })
 })
 

--- a/src/lib/homepage/variants.ts
+++ b/src/lib/homepage/variants.ts
@@ -1,0 +1,194 @@
+import type { HomepageSectionType } from './sections'
+
+/**
+ * Front-page builder: the CLOSED per-section VARIANT registry.
+ *
+ * A variant is a presentation hint — "how should this section look?" — kept
+ * strictly separate from a section's content and from its behaviour toggles
+ * (`hidden`, FAQ `source`, sponsors `showCta`), which remain independent
+ * fields. Like the section-type registry itself, the variant list is CLOSED:
+ * every entry maps to vetted house markup, and the write
+ * path validates against this table, so a tenant can never invent a layout.
+ *
+ * ZERO-MIGRATION GUARANTEE, extended to variants:
+ *
+ *  1. The FIRST entry of every list is the DEFAULT, and the default renders
+ *     byte-identically to the pre-variant markup. Order is load-bearing —
+ *     APPEND new variants, never reorder.
+ *  2. An ABSENT variant resolves to that default ({@link resolveVariant}), so
+ *     the conference editions that store no variant keep rendering exactly what
+ *     they render today.
+ *  3. The default is never PERSISTED (the save path only writes a non-default
+ *     variant), so a composition saved without touching the picker serializes to
+ *     the same bytes it does today.
+ *
+ * SERVER SAFETY: this module has ZERO runtime imports — only an erased
+ * `import type` back-edge to `./sections` — for two reasons. It is reachable
+ * from server components through the render tree (a value import from a
+ * client-only package would put that package's React context in the RSC module
+ * graph and kill the production build with `createContext is not a function`),
+ * and the Sanity Studio's Vite build imports it by relative path to drive the
+ * schema's variant option lists. Asserted on the source text in
+ * `variants.test.ts` — typecheck cannot see either hazard.
+ */
+export const SECTION_VARIANTS = {
+  homepageHero: ['classic', 'minimal', 'emblem'],
+  homepageSaveTheDate: ['card', 'strip'],
+  homepageFeaturedSpeakers: ['shelf', 'grid'],
+  homepageProgramHighlights: ['full', 'talks'],
+  homepageOrganizers: ['cards', 'compact'],
+  homepageSponsors: ['tiers', 'logo-wall'],
+  homepageGallery: ['carousel', 'mosaic'],
+  homepageMetrics: ['row', 'band'],
+  homepageCtaBanner: ['plain', 'panel'],
+  homepageRichText: ['article', 'boxed'],
+  homepageFaq: ['accordion', 'list'],
+  homepageCountdown: ['units', 'strip'],
+  homepageVenue: ['card', 'split'],
+} as const satisfies Record<HomepageSectionType, readonly [string, ...string[]]>
+
+export type SectionVariantMap = typeof SECTION_VARIANTS
+
+/** The allowed variant names for one section type. */
+export type SectionVariant<T extends HomepageSectionType> =
+  SectionVariantMap[T][number]
+
+/** Any variant name in the registry — the union across all section types. */
+export type AnySectionVariant = SectionVariant<HomepageSectionType>
+
+/**
+ * The default variant for a section type: the FIRST entry, which by the
+ * invariant above is today's rendering.
+ */
+export function defaultVariant<T extends HomepageSectionType>(
+  type: T,
+): SectionVariant<T> {
+  return SECTION_VARIANTS[type][0] as SectionVariant<T>
+}
+
+/** Whether `value` is a registered variant of `type`. */
+export function isSectionVariant<T extends HomepageSectionType>(
+  type: T,
+  value: unknown,
+): value is SectionVariant<T> {
+  return (
+    typeof value === 'string' &&
+    (SECTION_VARIANTS[type] as readonly string[]).includes(value)
+  )
+}
+
+/** Unknown `type:variant` pairs already warned about (once per process). */
+const warnedUnknownVariants = new Set<string>()
+
+/**
+ * Resolve the variant to render: ABSENT → the default; a registered variant →
+ * itself; anything else → the default, with a `console.warn` once per distinct
+ * `(type, variant)` per process (this runs on every render of the page).
+ *
+ * FORWARD COMPAT: the variant sibling of the renderer's unknown-`_type`
+ * skip-with-warn, with one deliberate difference — an unknown VARIANT falls back
+ * to the default RENDERING instead of skipping the section. The section's
+ * content is still valid; only its presentation hint comes from the future.
+ * Skipping would hide real content on an older deploy during a rollout.
+ *
+ * `type` must be a registered section type: the renderer has already skipped
+ * unknown `_type`s before any variant is resolved.
+ */
+export function resolveVariant<T extends HomepageSectionType>(
+  type: T,
+  stored: string | undefined,
+): SectionVariant<T> {
+  if (stored === undefined) return defaultVariant(type)
+  if (isSectionVariant(type, stored)) return stored
+  const key = `${type}:${stored}`
+  if (!warnedUnknownVariants.has(key)) {
+    warnedUnknownVariants.add(key)
+    console.warn(
+      `[homepage] unknown variant '${stored}' for ${type} — rendering '${defaultVariant(type)}'`,
+    )
+  }
+  return defaultVariant(type)
+}
+
+/** Picker labels, per section type. Server-safe, like `SECTION_LABELS`. */
+export const VARIANT_LABELS: {
+  [T in HomepageSectionType]: Record<SectionVariant<T>, string>
+} = {
+  homepageHero: {
+    classic: 'Classic',
+    minimal: 'Minimal',
+    emblem: 'Emblem',
+  },
+  homepageSaveTheDate: { card: 'Card', strip: 'Strip' },
+  homepageFeaturedSpeakers: { shelf: 'Shelf', grid: 'Grid' },
+  homepageProgramHighlights: { full: 'Full', talks: 'Talks only' },
+  homepageOrganizers: { cards: 'Cards', compact: 'Compact' },
+  homepageSponsors: { tiers: 'Tiers', 'logo-wall': 'Logo wall' },
+  homepageGallery: { carousel: 'Carousel', mosaic: 'Mosaic' },
+  homepageMetrics: { row: 'Row', band: 'Band' },
+  homepageCtaBanner: { plain: 'Plain', panel: 'Panel' },
+  homepageRichText: { article: 'Article', boxed: 'Boxed' },
+  homepageFaq: { accordion: 'Accordion', list: 'Open list' },
+  homepageCountdown: { units: 'Units', strip: 'Strip' },
+  homepageVenue: { card: 'Card', split: 'Split' },
+}
+
+/** One-line picker helper text, per section type. */
+export const VARIANT_DESCRIPTIONS: {
+  [T in HomepageSectionType]: Record<SectionVariant<T>, string>
+} = {
+  homepageHero: {
+    classic: 'Tagline, description, call to action, venue line and metrics.',
+    minimal:
+      'Tagline, description and call to action only — no venue line, metrics or social row.',
+    emblem: 'Text on the left, a large conference mark on the right.',
+  },
+  homepageSaveTheDate: {
+    card: 'Boxed card with a countdown and the “what happens next” roadmap.',
+    strip: 'One slim band: dates, place and a compact countdown.',
+  },
+  homepageFeaturedSpeakers: {
+    shelf: 'Horizontal carousel that scrolls sideways.',
+    grid: 'Static grid — every speaker visible at once.',
+  },
+  homepageProgramHighlights: {
+    full: 'Statistics tiles, featured talks and speakers, and a call to action.',
+    talks: 'Featured talks and speakers only, without the statistics tiles.',
+  },
+  homepageOrganizers: {
+    cards: 'One card per organizer.',
+    compact: 'Dense avatar, name and role rows without cards.',
+  },
+  homepageSponsors: {
+    tiers: 'Sponsors grouped under their tier headings.',
+    'logo-wall': 'One flat logo grid with no tier headings.',
+  },
+  homepageGallery: {
+    carousel: 'Auto-playing image carousel.',
+    mosaic: 'Static image grid — no motion; opens the full gallery on click.',
+  },
+  homepageMetrics: {
+    row: 'Plain row of numbers on the page background.',
+    band: 'The same numbers on a full-width tinted band.',
+  },
+  homepageCtaBanner: {
+    plain: 'Centered heading, body and button on the page background.',
+    panel: 'The same content inside a boxed gradient panel.',
+  },
+  homepageRichText: {
+    article: 'A plain prose column.',
+    boxed: 'The same content inside the house card chrome.',
+  },
+  homepageFaq: {
+    accordion: 'Questions collapse and expand on click.',
+    list: 'Every answer shown, in two columns on wide screens.',
+  },
+  homepageCountdown: {
+    units: 'Large days, hours, minutes and seconds tiles.',
+    strip: 'One compact line.',
+  },
+  homepageVenue: {
+    card: 'Centered card with a directions button.',
+    split: 'Heading and description on the left, address card on the right.',
+  },
+}

--- a/src/lib/homepage/variants.ts
+++ b/src/lib/homepage/variants.ts
@@ -28,8 +28,9 @@ import type { HomepageSectionType } from './sections'
  * client-only package would put that package's React context in the RSC module
  * graph and kill the production build with `createContext is not a function`),
  * and the Sanity Studio's Vite build imports it by relative path to drive the
- * schema's variant option lists. Asserted on the source text in
- * `variants.test.ts` — typecheck cannot see either hazard.
+ * schema's variant option lists. Asserted in `variants.test.ts` by PARSING this
+ * file and rejecting every runtime module reference — static, side-effect,
+ * re-export or dynamic — since typecheck can see neither hazard.
  */
 export const SECTION_VARIANTS = {
   homepageHero: ['classic', 'minimal', 'emblem'],
@@ -77,13 +78,73 @@ export function isSectionVariant<T extends HomepageSectionType>(
   )
 }
 
-/** Unknown `type:variant` pairs already warned about (once per process). */
+/**
+ * Bounds on the unknown-variant warning ledger, in the house style of
+ * `RICH_TEXT_LIMITS` in `./richText` — named, never magic numbers at the use
+ * site. (Named here rather than imported: this module stays import-free.)
+ *
+ * The ledger exists only to warn ONCE per bad value, but it is fed by STORED
+ * data in a long-lived server process. A corrupt or hostile dataset with many
+ * distinct junk variants would otherwise grow it without bound, and would emit
+ * one log line per distinct value forever. Both are capped: memory by
+ * {@link distinctPairs}, log volume by going quiet once that cap is reached.
+ */
+export const VARIANT_WARN_LIMITS = {
+  /**
+   * Distinct `(type, value)` pairs remembered. The whole registry is ~28
+   * variants, so a healthy process never reaches double digits here; anything
+   * near this cap is already a data problem the first warnings have reported.
+   */
+  distinctPairs: 100,
+  /**
+   * Longest stored value quoted back in a warning — and therefore the longest
+   * string a single ledger entry can hold. Two junk values sharing a prefix
+   * this long collapse to one warning, which is the right trade: the message
+   * has already identified the section type and the shape of the bad data.
+   */
+  storedValue: 80,
+} as const
+
+/** Unknown `type:value` pairs already warned about (once per process). */
 const warnedUnknownVariants = new Set<string>()
+/** Set once the ledger fills; from then on unknown variants resolve silently. */
+let unknownVariantWarningsExhausted = false
+
+/**
+ * How a rejected value is named in a warning: strings quoted and clipped,
+ * anything else reported by TYPE. A wrong-typed value is a different bug from a
+ * misspelt one and the message should not disguise it as a variant name.
+ */
+function describeStoredVariant(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value !== 'string') return `[${typeof value}]`
+  return value.length > VARIANT_WARN_LIMITS.storedValue
+    ? `'${value.slice(0, VARIANT_WARN_LIMITS.storedValue)}…'`
+    : `'${value}'`
+}
+
+function warnUnknownVariant(type: HomepageSectionType, stored: unknown): void {
+  if (unknownVariantWarningsExhausted) return
+  const described = describeStoredVariant(stored)
+  const key = `${type}:${described}`
+  if (warnedUnknownVariants.has(key)) return
+  if (warnedUnknownVariants.size >= VARIANT_WARN_LIMITS.distinctPairs) {
+    unknownVariantWarningsExhausted = true
+    console.warn(
+      `[homepage] more than ${VARIANT_WARN_LIMITS.distinctPairs} distinct unknown variants seen — suppressing further variant warnings for this process`,
+    )
+    return
+  }
+  warnedUnknownVariants.add(key)
+  console.warn(
+    `[homepage] unknown variant ${described} for ${type} — rendering '${defaultVariant(type)}'`,
+  )
+}
 
 /**
  * Resolve the variant to render: ABSENT → the default; a registered variant →
  * itself; anything else → the default, with a `console.warn` once per distinct
- * `(type, variant)` per process (this runs on every render of the page).
+ * `(type, value)` per process (this runs on every render of the page).
  *
  * FORWARD COMPAT: the variant sibling of the renderer's unknown-`_type`
  * skip-with-warn, with one deliberate difference — an unknown VARIANT falls back
@@ -91,22 +152,27 @@ const warnedUnknownVariants = new Set<string>()
  * content is still valid; only its presentation hint comes from the future.
  * Skipping would hide real content on an older deploy during a rollout.
  *
+ * `stored` is `unknown`, not `string | undefined`. The value comes off a stored
+ * Sanity document, and the type that says otherwise is an assertion about the
+ * dataset rather than a fact about it. The behaviour for a non-string is
+ * therefore EXPLICIT rather than accidental, and it follows the precedent set by
+ * `isBlank()` in migration 046: a wrong-typed value is not quietly folded into
+ * the benign case. Only `undefined` — the shape of an absent optional field, and
+ * the only shape the write path can produce, since it omits the default rather
+ * than writing null — resolves silently. `null`, numbers and objects resolve to
+ * the same safe default but are REPORTED, because they are data bugs that
+ * nothing else in the render path will surface.
+ *
  * `type` must be a registered section type: the renderer has already skipped
  * unknown `_type`s before any variant is resolved.
  */
 export function resolveVariant<T extends HomepageSectionType>(
   type: T,
-  stored: string | undefined,
+  stored: unknown,
 ): SectionVariant<T> {
   if (stored === undefined) return defaultVariant(type)
   if (isSectionVariant(type, stored)) return stored
-  const key = `${type}:${stored}`
-  if (!warnedUnknownVariants.has(key)) {
-    warnedUnknownVariants.add(key)
-    console.warn(
-      `[homepage] unknown variant '${stored}' for ${type} — rendering '${defaultVariant(type)}'`,
-    )
-  }
+  warnUnknownVariant(type, stored)
   return defaultVariant(type)
 }
 


### PR DESCRIPTION
Foundation for per-section variants — the mechanism all 13 section types will follow, so the front page can offer a choice of how each section LOOKS, not just what it says.

Purely additive. Nothing consumes the registry yet, so this changes no rendering and no stored document.

## What it adds

`src/lib/homepage/variants.ts` — a CLOSED `SECTION_VARIANTS` registry where the first entry per type is the default, plus `defaultVariant()`, `resolveVariant()` and a type guard. Unknown variants fall back to the default with a warn-once, a softer sibling of the renderer's existing unknown-`_type` skip: content still renders rather than vanishing.

| Type | Variants (first = default = today) |
|---|---|
| Hero | `classic`, `minimal`, `emblem` |
| Save the date | `card`, `strip` |
| Featured speakers | `shelf`, `grid` |
| Program highlights | `full`, `talks` |
| Organizers | `cards`, `compact` |
| Sponsors | `tiers`, `logo-wall` |
| Gallery | `carousel`, `mosaic` |
| Metrics | `row`, `band` |
| CTA banner | `plain`, `panel` |
| Rich text | `article`, `boxed` |
| FAQ | `accordion`, `list` |
| Countdown | `units`, `strip` |
| Venue | `card`, `split` |

Four types get exactly two variants rather than three — metrics, countdown, venue and program highlights genuinely have little meaningful variation, and padding the matrix would produce options nobody wants.

## Back-compat is structural, not tested-in

The default variant is **never persisted**. The three live editions' documents are untouched, and an absent variant resolves to the first entry — which is today's rendering. There is no migration and nothing to roll back.

## Zero runtime dependencies

`variants.ts` has no imports at all, and `sections.ts` imports only its *type*. That is enforced by a source-text test, not convention — a `@dnd-kit` import in the neighbouring `editor.ts` recently broke the production build with `createContext is not a function` during page-data collection, which typecheck and 4900 unit tests could not see. Both edges of this module boundary are now erased at compile time.

205 tests green in `src/lib/homepage` (+12), typecheck and knip clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a closed, dependency-free homepage section-variant registry.
- Defines variants, labels, descriptions, defaults, validation, and fallback resolution for all 13 section types.
- Extends section interfaces with optional, type-specific variant fields.
- Re-exports the registry through the homepage barrel.
- Adds contract, fallback, typing, and server-safety tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the additive registry foundation.

The registry covers every existing homepage section type, preserves absent-value defaults, keeps section-to-variant typing aligned, and introduces no runtime dependency or active rendering and persistence behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/homepage/variants.ts | Adds the complete typed registry and dependency-free resolution helpers; no actionable defect was identified. |
| src/lib/homepage/sections.ts | Adds optional section-specific variant typing consistently across all 13 section interfaces. |
| src/lib/homepage/variants.test.ts | Covers registry completeness, metadata alignment, defaults, validation, fallback warnings, typing, and runtime-import safety. |
| src/lib/homepage/index.ts | Exposes the new dependency-free registry through the existing homepage barrel. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(homepage): add the closed per-secti..."](https://github.com/cloudnativebergen/website/commit/c29c051e23b128f654b826203641fcb1a1704bc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49766580)</sub>

<!-- /greptile_comment -->