### PR TITLE
fix(admin): tint the whole collapsible header on hover

### DIFF
--- a/src/components/admin/CollapsibleSection.stories.tsx
+++ b/src/components/admin/CollapsibleSection.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { expect, userEvent, within } from 'storybook/test'
+import { PencilSquareIcon } from '@heroicons/react/24/outline'
 import { CollapsibleSection } from './CollapsibleSection'
 
 const meta = {
@@ -145,5 +146,56 @@ export const TogglesOpenAndClosed: Story = {
     await userEvent.click(toggle)
     await expect(toggle).toHaveAttribute('aria-expanded', 'true')
     await expect(canvas.getByText('Collapsible body.')).toBeVisible()
+  },
+}
+
+/**
+ * The header `action` slot — a status badge and an edit affordance — which has
+ * to live OUTSIDE the toggle button to stay valid HTML and independently
+ * clickable. No story covered this before, which is how the hover seam below
+ * went unnoticed.
+ */
+const headerAction = (
+  <>
+    <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/40 dark:text-green-300">
+      Ready
+    </span>
+    <button
+      type="button"
+      aria-label="Edit section"
+      className="rounded-md p-1 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+    >
+      <PencilSquareIcon className="h-5 w-5" />
+    </button>
+  </>
+)
+
+export const WithHeaderAction: Story = {
+  args: {
+    title: 'Get started',
+    action: headerAction,
+    children: <div className="p-6 text-gray-900 dark:text-white">Content.</div>,
+  },
+}
+
+/**
+ * Hovering the toggle must tint the WHOLE header row, including the area behind
+ * the action. Previously the tint sat on the button, so it stopped at the
+ * button's edge and left a visible vertical seam before the status badge.
+ */
+export const HeaderActionHovered: Story = {
+  args: WithHeaderAction.args,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.hover(canvas.getByRole('button', { name: /get started/i }))
+  },
+}
+
+/** Hovering the ACTION must NOT tint the row — it is a separate affordance. */
+export const HeaderActionSelfHovered: Story = {
+  args: WithHeaderAction.args,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.hover(canvas.getByRole('button', { name: 'Edit section' }))
   },
 }

--- a/src/components/admin/CollapsibleSection.tsx
+++ b/src/components/admin/CollapsibleSection.tsx
@@ -44,7 +44,14 @@ export function CollapsibleSection({
     <div
       className={`overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-gray-900/5 dark:bg-gray-900 dark:ring-gray-700 ${className}`}
     >
-      <div className="flex items-center">
+      {/* The hover tint belongs to the whole header ROW, not to the toggle
+          button. `action` (a status badge, an edit pencil) has to sit OUTSIDE
+          the button to stay valid HTML and independently clickable — so when
+          the tint lived on the button it stopped at the button's edge and left
+          a visible seam, with the right-hand side keeping the card background.
+          `has-*` scopes it to hovering the toggle specifically, so the row does
+          not light up merely because the pointer is over the action. */}
+      <div className="flex items-center transition-colors has-[button[aria-expanded]:hover]:bg-gray-50 dark:has-[button[aria-expanded]:hover]:bg-gray-800">
         {/* Accessible-disclosure pattern: the HEADING wraps the toggle button
             (h2 > button is valid; button/span > h2 is not — a heading is flow
             content and cannot sit inside phrasing content). */}
@@ -54,7 +61,7 @@ export function CollapsibleSection({
             onClick={() => setIsOpen(!isOpen)}
             aria-expanded={isOpen}
             aria-controls={contentId}
-            className="flex min-w-0 flex-1 items-center justify-between px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
+            className="flex min-w-0 flex-1 items-center justify-between px-6 py-4 text-left"
           >
             <span className="flex min-w-0 items-center">
               {icon ? (


### PR DESCRIPTION
Reported from the admin UI: on collapsible settings cards that carry a status badge or an edit pencil, the show/hide hover tint stops before the right-hand side, leaving a visible vertical seam.

## Cause

The tint was on the toggle **button** (`hover:bg-gray-50 dark:hover:bg-gray-800`). The `action` slot must render *outside* that button — a button cannot contain another button, and the action has to stay independently clickable — so it never received the tint. The button is `flex-1`, so the boundary landed mid-header and read as a seam.

Moved to the header row, scoped with `has-[button[aria-expanded]:hover]` so the row responds to the toggle specifically rather than lighting up whenever the pointer is anywhere in the header. Hovering the pencil still highlights only the pencil.

`ActivationChecklist` uses the same tint but its row is a single anchor, so it was never affected. `CollapsibleSection` was the only component with the split.

## On verification — worth reading before approving

No story exercised the `action` slot at all, which is how this shipped. There are now three, including one asserting that hovering the action must *not* tint the row.

But a screenshot cannot prove this fix. Testing Library's `userEvent.hover` dispatches pointer *events*; CSS `:hover` follows the real cursor position, which a play function cannot move — so a captured PNG shows the idle state whether the fix works or not. My first capture did exactly that and proved nothing.

The evidence is the compiled CSS from a production build (exit 0), which emits both rules:

```css
.has-\[button\[aria-expanded\]\:hover\]\:bg-gray-50:has(:is(button[aria-expanded]:hover)){background-color:var(--color-gray-50)}
.dark\:has-\[button\[aria-expanded\]\:hover\]\:bg-gray-800:where(.dark,.dark *):has(:is(button[aria-expanded]:hover)){background-color:var(--color-gray-800)}
```

That confirms the variant compiles and is scoped as intended in both colour schemes. The remaining check is a human hovering the card — worth doing on the Vercel preview.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the collapsible toggle hover tint onto the complete header row and adds Storybook action-slot scenarios.
- Uses a scoped `:has()` Tailwind variant so the header responds to toggle hover.
- Removes the old background hover classes from the toggle button.
- Adds stories for toggle hover and independent action hover.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking selector-scoping edge case for expandable action controls.

The visual fix applies to the intended toggle, but an action that itself uses `aria-expanded` will also activate the whole-row tint because both controls are descendants of the selected header.

**Files Needing Attention:** src/components/admin/CollapsibleSection.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/admin/CollapsibleSection.tsx | Moves hover styling to the header, but the descendant selector can also match an action button with `aria-expanded`. |
| src/components/admin/CollapsibleSection.stories.tsx | Adds representative action-slot and hover-state stories without introducing a concrete defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): tint the whole collapsible h..."](https://github.com/cloudnativebergen/website/commit/e15334d5a7c850e63ce5f030bbf8448a3e22819e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49781635)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->