### PR TITLE
feat(homepage): a content-status map the preview can trust

### DIFF
--- a/src/lib/homepage/contentStatus.test.tsx
+++ b/src/lib/homepage/contentStatus.test.tsx
@@ -1,0 +1,812 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { findRuntimeModuleImports } from '../../../__tests__/helpers/moduleImports'
+
+// The ONLY stub in this file, and it is not a section component: `next/link`
+// needs a router in jsdom. Everything the renderer maps to is the REAL
+// component — stubbing one would make the parity assertion below meaningless,
+// because a stub cannot self-hide the way the thing it stands in for does.
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string
+    children: React.ReactNode
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+import { HomepageSectionRenderer } from '@/components/homepage/SectionRenderer'
+import {
+  CONTENT_SOURCES,
+  sectionContentStatus,
+  type SectionContentSourceId,
+} from './contentStatus'
+import {
+  HOMEPAGE_SECTION_TYPES,
+  type HomepageSection,
+  type HomepageSectionType,
+} from './sections'
+import type { Conference } from '@/lib/conference/types'
+
+afterEach(cleanup)
+
+/**
+ * A conference with NOTHING on it — the day-one state, which is the state that
+ * makes every guard in `contentStatus.ts` fire. Cases below add exactly the one
+ * field they are about, so a passing render can never be explained by a
+ * neighbouring field left set in the fixture.
+ */
+function bareConference(overrides: Partial<Conference> = {}): Conference {
+  return {
+    _id: 'conf-1',
+    title: 'Test Conf',
+    city: '',
+    registrationEnabled: false,
+    organizers: [],
+    ...overrides,
+  } as unknown as Conference
+}
+
+/** Dates chosen so the REAL clock puts them unambiguously in the past/future. */
+const PAST = '2000-01-01'
+const FUTURE = '2099-01-01'
+
+function scheduleWith(status: 'confirmed' | 'submitted') {
+  return [
+    {
+      _id: 's1',
+      date: PAST,
+      tracks: [
+        {
+          trackTitle: 'Track 1',
+          trackDescription: '',
+          talks: [
+            {
+              startTime: '09:00',
+              endTime: '09:45',
+              talk: {
+                _id: 't1',
+                status,
+                title: 'A talk',
+                format: 'presentation_25',
+                speakers: [],
+                topics: [],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ] as never
+}
+
+interface Case {
+  /** Names the case in the test output. */
+  name: string
+  section: HomepageSection
+  conference: Conference
+  /** The expectation this file is about. Verified against a REAL render. */
+  willHide: boolean
+}
+
+/**
+ * The case table, keyed by section type.
+ *
+ * TYPE-LEVEL COVERAGE: `Record<HomepageSectionType, …>` means a fourteenth
+ * entry in `HOMEPAGE_SECTION_TYPES` fails to COMPILE here until it is given
+ * cases — the repo has already shipped a bug where a new field was added
+ * everywhere except one per-type mapping, and a table that silently skips a
+ * type would let the preview lie about it. The runtime assertion below pins the
+ * other direction (no stale keys, and at least one hiding case wherever the
+ * section can hide at all).
+ */
+const CASES: Record<HomepageSectionType, Case[]> = {
+  homepageHero: [
+    {
+      name: 'always renders — the page always has a top',
+      section: { _key: 'h', _type: 'homepageHero' },
+      conference: bareConference(),
+      willHide: false,
+    },
+  ],
+
+  homepageSaveTheDate: [
+    {
+      name: 'no dates and no place',
+      section: { _key: 's', _type: 'homepageSaveTheDate' },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'only a start date (the range needs both)',
+      section: { _key: 's', _type: 'homepageSaveTheDate' },
+      conference: bareConference({ startDate: FUTURE }),
+      willHide: true,
+    },
+    {
+      name: 'a city but no dates still announces something',
+      section: { _key: 's', _type: 'homepageSaveTheDate' },
+      conference: bareConference({ city: 'Bergen' }),
+      willHide: false,
+    },
+    {
+      name: 'both dates',
+      section: { _key: 's', _type: 'homepageSaveTheDate' },
+      conference: bareConference({ startDate: FUTURE, endDate: FUTURE }),
+      willHide: false,
+    },
+  ],
+
+  homepageFeaturedSpeakers: [
+    {
+      name: 'no featured speakers',
+      section: { _key: 'f', _type: 'homepageFeaturedSpeakers' },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'one featured speaker',
+      section: { _key: 'f', _type: 'homepageFeaturedSpeakers' },
+      conference: bareConference({
+        featuredSpeakers: [{ _id: 'sp1', name: 'Speaker', talks: [] }] as never,
+      }),
+      willHide: false,
+    },
+  ],
+
+  homepageProgramHighlights: [
+    {
+      name: 'no programme date',
+      section: { _key: 'p', _type: 'homepageProgramHighlights' },
+      conference: bareConference({ schedules: scheduleWith('confirmed') }),
+      willHide: true,
+    },
+    {
+      name: 'programme date still ahead',
+      section: { _key: 'p', _type: 'homepageProgramHighlights' },
+      conference: bareConference({
+        programDate: FUTURE,
+        schedules: scheduleWith('confirmed'),
+      }),
+      willHide: true,
+    },
+    {
+      name: 'published but the schedule holds no CONFIRMED talk',
+      section: { _key: 'p', _type: 'homepageProgramHighlights' },
+      conference: bareConference({
+        programDate: PAST,
+        schedules: scheduleWith('submitted'),
+      }),
+      willHide: true,
+    },
+    {
+      name: 'published with a confirmed talk',
+      section: { _key: 'p', _type: 'homepageProgramHighlights' },
+      conference: bareConference({
+        programDate: PAST,
+        startDate: FUTURE,
+        endDate: FUTURE,
+        schedules: scheduleWith('confirmed'),
+      }),
+      willHide: false,
+    },
+  ],
+
+  homepageOrganizers: [
+    {
+      name: 'no organizers',
+      section: { _key: 'o', _type: 'homepageOrganizers' },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'one organizer',
+      section: { _key: 'o', _type: 'homepageOrganizers' },
+      conference: bareConference({
+        organizers: [{ _id: 'o1', name: 'Organizer' }] as never,
+      }),
+      willHide: false,
+    },
+  ],
+
+  homepageSponsors: [
+    {
+      name: 'no sponsors — degrades to the pitch, never hides',
+      section: { _key: 'sp', _type: 'homepageSponsors' },
+      conference: bareConference(),
+      willHide: false,
+    },
+    {
+      // The band still emits its `<section>` wrapper: vertical whitespace and
+      // nothing else. Not a hide, and the status says so in words instead.
+      name: 'no sponsors AND the pitch switched off — an empty band, not a hide',
+      section: { _key: 'sp', _type: 'homepageSponsors', showCta: false },
+      conference: bareConference(),
+      willHide: false,
+    },
+    {
+      name: 'sponsors in a tier',
+      section: { _key: 'sp', _type: 'homepageSponsors' },
+      conference: bareConference({
+        sponsors: [
+          {
+            sponsor: { _id: 'x', name: 'Acme', website: 'https://acme.test' },
+            tier: { title: 'Gold', tagline: '', tierType: 'standard' },
+          },
+        ] as never,
+      }),
+      willHide: false,
+    },
+  ],
+
+  homepageGallery: [
+    {
+      name: 'no featured images',
+      section: { _key: 'g', _type: 'homepageGallery' },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'one featured image',
+      section: { _key: 'g', _type: 'homepageGallery' },
+      conference: bareConference({
+        featuredGalleryImages: [
+          {
+            _id: 'g1',
+            image: { asset: { _ref: 'image-abc-100x100-png' } },
+            speakers: [],
+          },
+        ] as never,
+      }),
+      willHide: false,
+    },
+  ],
+
+  homepageMetrics: [
+    {
+      name: 'no vanity metrics',
+      section: { _key: 'm', _type: 'homepageMetrics' },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'one vanity metric',
+      section: { _key: 'm', _type: 'homepageMetrics' },
+      conference: bareConference({
+        vanityMetrics: [{ label: 'Attendees', value: '500+' }] as never,
+      }),
+      willHide: false,
+    },
+  ],
+
+  homepageCtaBanner: [
+    {
+      name: 'complete banner',
+      section: {
+        _key: 'c',
+        _type: 'homepageCtaBanner',
+        heading: 'Join us',
+        buttonLabel: 'Get tickets',
+        buttonHref: '/tickets',
+      },
+      conference: bareConference(),
+      willHide: false,
+    },
+    {
+      name: 'no button — degraded, but the heading still renders',
+      section: {
+        _key: 'c',
+        _type: 'homepageCtaBanner',
+        heading: 'Join us',
+        buttonLabel: '',
+        buttonHref: '',
+      },
+      conference: bareConference(),
+      willHide: false,
+    },
+  ],
+
+  homepageRichText: [
+    {
+      name: 'no content at all',
+      section: { _key: 'r', _type: 'homepageRichText', content: [] },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      // The stored array is NON-empty; the sanitizer drops the block, which is
+      // exactly the case a naive `content.length > 0` predicate would lie about.
+      name: 'content the allowlist drops',
+      section: {
+        _key: 'r',
+        _type: 'homepageRichText',
+        content: [{ _type: 'notARichTextBlock', whatever: true }] as never,
+      },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'a paragraph of whitespace',
+      section: {
+        _key: 'r',
+        _type: 'homepageRichText',
+        content: [
+          {
+            _type: 'block',
+            _key: 'b1',
+            children: [{ _type: 'span', _key: 's1', text: '   ', marks: [] }],
+          },
+        ] as never,
+      },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'real prose',
+      section: {
+        _key: 'r',
+        _type: 'homepageRichText',
+        content: [
+          {
+            _type: 'block',
+            _key: 'b1',
+            style: 'normal',
+            children: [{ _type: 'span', _key: 's1', text: 'Hello', marks: [] }],
+          },
+        ] as never,
+      },
+      conference: bareConference(),
+      willHide: false,
+    },
+  ],
+
+  homepageFaq: [
+    {
+      name: 'own source with no items',
+      section: { _key: 'q', _type: 'homepageFaq' },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'ticket-FAQ source with no ticket FAQs',
+      section: { _key: 'q', _type: 'homepageFaq', source: 'ticketFaqs' },
+      conference: bareConference({
+        ticketFaqs: [],
+        // Own items are irrelevant once the source is switched — the band
+        // renders the ticket FAQs, and there are none.
+      }),
+      willHide: true,
+    },
+    {
+      name: 'own items',
+      section: {
+        _key: 'q',
+        _type: 'homepageFaq',
+        items: [{ question: 'Where?', answer: 'Here.' }],
+      },
+      conference: bareConference(),
+      willHide: false,
+    },
+    {
+      name: 'ticket FAQs',
+      section: { _key: 'q', _type: 'homepageFaq', source: 'ticketFaqs' },
+      conference: bareConference({
+        ticketFaqs: [{ question: 'Refunds?', answer: 'Yes.' }] as never,
+      }),
+      willHide: false,
+    },
+  ],
+
+  homepageCountdown: [
+    {
+      name: 'nothing to count down to',
+      section: { _key: 'd', _type: 'homepageCountdown' },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      // Two guards away: the target resolves, so the renderer mounts the block —
+      // and the client component then hides itself because the date has passed.
+      name: 'target already passed, no live message',
+      section: { _key: 'd', _type: 'homepageCountdown' },
+      conference: bareConference({ startDate: PAST }),
+      willHide: true,
+    },
+    {
+      name: 'target passed WITH a live message',
+      section: {
+        _key: 'd',
+        _type: 'homepageCountdown',
+        liveMessage: 'We are live!',
+      },
+      conference: bareConference({ startDate: PAST }),
+      willHide: false,
+    },
+    {
+      name: 'future target',
+      section: { _key: 'd', _type: 'homepageCountdown' },
+      conference: bareConference({ startDate: FUTURE }),
+      willHide: false,
+    },
+    {
+      name: 'a block-level override beats an absent start date',
+      section: {
+        _key: 'd',
+        _type: 'homepageCountdown',
+        targetOverride: FUTURE,
+      },
+      conference: bareConference(),
+      willHide: false,
+    },
+  ],
+
+  homepageVenue: [
+    {
+      name: 'no venue name or address',
+      section: { _key: 'v', _type: 'homepageVenue' },
+      conference: bareConference(),
+      willHide: true,
+    },
+    {
+      name: 'whitespace is not a venue',
+      section: { _key: 'v', _type: 'homepageVenue' },
+      conference: bareConference({ venueName: '  ', venueAddress: '\n' }),
+      willHide: true,
+    },
+    {
+      name: 'a venue name',
+      section: { _key: 'v', _type: 'homepageVenue' },
+      conference: bareConference({ venueName: 'Grieghallen' }),
+      willHide: false,
+    },
+  ],
+}
+
+/**
+ * THE test this module exists for.
+ *
+ * For every section type and every case: `willHide` is true EXACTLY when
+ * rendering that section through the real `HomepageSectionRenderer` — with the
+ * real section components — produces an empty container. A status that claims
+ * a band renders when the live page drops it makes the composer's preview lie
+ * to the organizer, which is worse than having no preview at all.
+ */
+describe('sectionContentStatus ⇔ the renderer', () => {
+  for (const type of HOMEPAGE_SECTION_TYPES) {
+    describe(type, () => {
+      for (const testCase of CASES[type]) {
+        it(`${testCase.willHide ? 'hides' : 'renders'}: ${testCase.name}`, () => {
+          const status = sectionContentStatus(
+            testCase.section,
+            testCase.conference,
+          )
+          expect(status.type).toBe(type)
+          expect(status.willHide).toBe(testCase.willHide)
+          expect(status.kind === 'empty-hides').toBe(status.willHide)
+
+          const { container } = render(
+            <HomepageSectionRenderer
+              sections={[testCase.section]}
+              conference={testCase.conference}
+            />,
+          )
+          expect(container.innerHTML === '').toBe(status.willHide)
+        })
+      }
+    })
+  }
+})
+
+describe('the case table itself', () => {
+  it('covers every registered section type, and nothing else', () => {
+    expect(Object.keys(CASES).sort()).toEqual(
+      [...HOMEPAGE_SECTION_TYPES].sort(),
+    )
+  })
+
+  /**
+   * Three bands cannot hide — the hero has no data guard, and the sponsors and
+   * CTA-banner components have no early return at all. Every OTHER type must
+   * bring a hiding case, so this suite can never degrade into "13 happy paths".
+   */
+  it('exercises the hiding path for every type that has one', () => {
+    const cannotHide: HomepageSectionType[] = [
+      'homepageHero',
+      'homepageSponsors',
+      'homepageCtaBanner',
+    ]
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      const hides = CASES[type].some((c) => c.willHide)
+      expect(hides, type).toBe(!cannotHide.includes(type))
+    }
+  })
+})
+
+describe('counts and summaries', () => {
+  it('counts the collection behind each band', () => {
+    const conference = bareConference({
+      featuredSpeakers: [{ _id: 'a' }, { _id: 'b' }] as never,
+      organizers: [{ _id: 'o1', name: 'A' }] as never,
+      featuredGalleryImages: [
+        { _id: 'g1' },
+        { _id: 'g2' },
+        { _id: 'g3' },
+      ] as never,
+      vanityMetrics: [{ label: 'x', value: '1' }] as never,
+      programDate: PAST,
+      schedules: scheduleWith('confirmed'),
+    })
+    const countOf = (section: HomepageSection) =>
+      sectionContentStatus(section, conference).count
+
+    expect(countOf({ _key: '1', _type: 'homepageFeaturedSpeakers' })).toBe(2)
+    expect(countOf({ _key: '2', _type: 'homepageOrganizers' })).toBe(1)
+    expect(countOf({ _key: '3', _type: 'homepageGallery' })).toBe(3)
+    expect(countOf({ _key: '4', _type: 'homepageMetrics' })).toBe(1)
+    expect(countOf({ _key: '5', _type: 'homepageProgramHighlights' })).toBe(1)
+    // Not collection-backed — a fabricated number would be worse than none.
+    expect(countOf({ _key: '6', _type: 'homepageHero' })).toBeNull()
+    expect(countOf({ _key: '7', _type: 'homepageVenue' })).toBeNull()
+  })
+
+  it('summarises sponsors the way the band groups them', () => {
+    const conference = bareConference({
+      sponsors: [
+        {
+          sponsor: { _id: '1', name: 'A', website: 'https://a.test' },
+          tier: { title: 'Gold', tagline: '' },
+        },
+        {
+          sponsor: { _id: '2', name: 'B', website: 'https://b.test' },
+          tier: { title: 'Silver', tagline: '' },
+        },
+        // Two `special` tiers collapse into ONE heading in the band, so they
+        // must collapse in the summary too.
+        {
+          sponsor: { _id: '3', name: 'C', website: 'https://c.test' },
+          tier: { title: 'Community', tagline: '', tierType: 'special' },
+        },
+        {
+          sponsor: { _id: '4', name: 'D', website: 'https://d.test' },
+          tier: { title: 'Media', tagline: '', tierType: 'special' },
+        },
+      ] as never,
+    })
+    const status = sectionContentStatus(
+      { _key: 's', _type: 'homepageSponsors' },
+      conference,
+    )
+    expect(status.summary).toBe('4 sponsors in 3 tiers')
+    expect(status.kind).toBe('ready')
+  })
+
+  it('flags sponsors that are not in any tier — no tier, no logo', () => {
+    const status = sectionContentStatus(
+      { _key: 's', _type: 'homepageSponsors' },
+      bareConference({
+        sponsors: [
+          {
+            sponsor: { _id: '1', name: 'A', website: 'https://a.test' },
+            tier: null,
+          },
+        ] as never,
+      }),
+    )
+    expect(status.kind).toBe('degraded')
+    expect(status.summary).toBe('1 sponsor, none in a tier')
+  })
+
+  it('says what an empty sponsors band actually looks like in each case', () => {
+    const withPitch = sectionContentStatus(
+      { _key: 's', _type: 'homepageSponsors' },
+      bareConference(),
+    )
+    expect(withPitch.reason).toContain('Become a Sponsor')
+
+    const noPitch = sectionContentStatus(
+      { _key: 's', _type: 'homepageSponsors', showCta: false },
+      bareConference(),
+    )
+    expect(noPitch.reason).toContain('empty band')
+
+    // Post-event suppresses the pitch too (SectionRenderer.tsx:398-410), so an
+    // old edition with no sponsors is an empty band even with `showCta` unset.
+    const postEvent = sectionContentStatus(
+      { _key: 's', _type: 'homepageSponsors' },
+      bareConference({ startDate: PAST, endDate: PAST }),
+    )
+    expect(postEvent.reason).toContain('empty band')
+  })
+})
+
+describe('manage links', () => {
+  it('points every band at the surface that owns its content', () => {
+    const conference = bareConference()
+    const sourceOf = (section: HomepageSection): SectionContentSourceId =>
+      sectionContentStatus(section, conference).source.id
+
+    expect(sourceOf({ _key: '1', _type: 'homepageFeaturedSpeakers' })).toBe(
+      'featured-speakers',
+    )
+    expect(sourceOf({ _key: '2', _type: 'homepageSponsors' })).toBe('sponsors')
+    expect(sourceOf({ _key: '3', _type: 'homepageGallery' })).toBe('gallery')
+    expect(sourceOf({ _key: '4', _type: 'homepageMetrics' })).toBe(
+      'vanity-metrics',
+    )
+    expect(sourceOf({ _key: '5', _type: 'homepageVenue' })).toBe('venue')
+    expect(sourceOf({ _key: '6', _type: 'homepageProgramHighlights' })).toBe(
+      'programme',
+    )
+  })
+
+  it('follows the FAQ source toggle rather than assuming one', () => {
+    const conference = bareConference()
+    expect(
+      sectionContentStatus({ _key: 'q', _type: 'homepageFaq' }, conference)
+        .source.id,
+    ).toBe('section-config')
+    expect(
+      sectionContentStatus(
+        { _key: 'q', _type: 'homepageFaq', source: 'ticketFaqs' },
+        conference,
+      ).source.id,
+    ).toBe('ticket-faqs')
+  })
+
+  it('sends the countdown to the dates unless the block overrides them', () => {
+    const conference = bareConference({ startDate: FUTURE })
+    expect(
+      sectionContentStatus(
+        { _key: 'd', _type: 'homepageCountdown' },
+        conference,
+      ).source.id,
+    ).toBe('dates')
+    expect(
+      sectionContentStatus(
+        { _key: 'd', _type: 'homepageCountdown', targetOverride: FUTURE },
+        conference,
+      ).source.id,
+    ).toBe('section-config')
+  })
+
+  it('offers a link for every source that has one, and none for composer-local content', () => {
+    for (const src of Object.values(CONTENT_SOURCES)) {
+      expect(src.label.length).toBeGreaterThan(0)
+      expect(src.manageLabel.length).toBeGreaterThan(0)
+      if (src.href !== null) expect(src.href.startsWith('/admin/')).toBe(true)
+    }
+    expect(CONTENT_SOURCES['section-config'].href).toBeNull()
+    expect(
+      sectionContentStatus(
+        { _key: 'r', _type: 'homepageRichText', content: [] },
+        bareConference(),
+      ).manage,
+    ).toBeNull()
+    expect(
+      sectionContentStatus(
+        { _key: 'f', _type: 'homepageFeaturedSpeakers' },
+        bareConference(),
+      ).manage,
+    ).toEqual({
+      label: 'Choose speakers',
+      href: '/admin/marketing/featured',
+    })
+  })
+})
+
+describe('what it deliberately does not answer', () => {
+  /**
+   * The visibility toggle and the cancelled/archived override both blank a
+   * section on the live page, and neither is a statement about CONTENT. The
+   * renderer applies them above `renderSection`; callers do the same. If this
+   * module folded them in, "add speakers to fix this" would appear on a band
+   * that is hidden because the organizer hid it.
+   */
+  it('ignores the hidden flag', () => {
+    const conference = bareConference({
+      featuredSpeakers: [{ _id: 'a' }] as never,
+    })
+    expect(
+      sectionContentStatus(
+        { _key: 'f', _type: 'homepageFeaturedSpeakers', hidden: true },
+        conference,
+      ),
+    ).toEqual(
+      sectionContentStatus(
+        { _key: 'f', _type: 'homepageFeaturedSpeakers' },
+        conference,
+      ),
+    )
+  })
+
+  it('ignores the cancelled/archived page override', () => {
+    const conference = bareConference({
+      lifecycleStatus: 'cancelled',
+      venueName: 'Grieghallen',
+    })
+    expect(
+      sectionContentStatus({ _key: 'v', _type: 'homepageVenue' }, conference)
+        .willHide,
+    ).toBe(false)
+    // …even though the page itself renders only the notice.
+    const { container } = render(
+      <HomepageSectionRenderer
+        sections={[{ _key: 'v', _type: 'homepageVenue' }]}
+        conference={conference}
+      />,
+    )
+    expect(container.textContent).toContain('cancelled')
+  })
+})
+
+describe('time-dependent guards', () => {
+  it('takes an injected clock so a preview can ask at a chosen instant', () => {
+    const conference = bareConference({ startDate: '2030-06-01' })
+    const section: HomepageSection = { _key: 'd', _type: 'homepageCountdown' }
+    const target = Date.UTC(2030, 5, 1, 12)
+
+    expect(
+      sectionContentStatus(section, conference, { now: target - 1 }).willHide,
+    ).toBe(false)
+    // The component hides at `remaining <= 0`, so the target instant itself is
+    // already too late.
+    expect(
+      sectionContentStatus(section, conference, { now: target }).willHide,
+    ).toBe(true)
+  })
+
+  it('anchors a bare date at noon UTC, like the renderer does', () => {
+    const conference = bareConference({ startDate: '2030-06-01' })
+    const justBeforeUtcMidnight = Date.UTC(2030, 5, 1, 6)
+    // A midnight-anchored parse would call this "passed"; the house anchoring
+    // says the countdown is still running.
+    expect(
+      sectionContentStatus(
+        { _key: 'd', _type: 'homepageCountdown' },
+        conference,
+        { now: justBeforeUtcMidnight },
+      ).willHide,
+    ).toBe(false)
+  })
+})
+
+/**
+ * Same hazard as `editor.ts` and `variants.ts` (see the twin tests there): this
+ * module is reachable from SERVER components through the composer and the
+ * preview route, and a single value import from a client-only package puts that
+ * package's React context in the RSC module graph — the production build then
+ * dies collecting page data with `createContext is not a function`. Invisible to
+ * typecheck and to every other test, so it is asserted on the PARSED module
+ * graph. `import type` is erased and therefore absent from the result.
+ */
+/**
+ * Located from the repo root rather than from `import.meta.url`: under the
+ * jsdom environment this file's `import.meta.url` is served from
+ * `http://localhost:3000/`, so the sibling tests' `new URL('./x.ts', …)` trick
+ * resolves to an HTTP URL that `fs` cannot read. A wrong path here fails the
+ * test loudly (`readFile` throws) rather than silently asserting nothing.
+ */
+const MODULE_PATH = 'src/lib/homepage/contentStatus.ts'
+
+describe('server safety', () => {
+  it('imports no package, and only the one sibling it cannot inline', async () => {
+    const path = join(process.cwd(), MODULE_PATH)
+    const imports = findRuntimeModuleImports(await readFile(path, 'utf8'), path)
+    // Stricter than `editor.ts`'s guard, which allows any relative sibling:
+    // the rich-text sanitizer is the ONE rule too large to transcribe, and
+    // everything else in this module is an inlined guard by design.
+    expect(imports.map((entry) => entry.specifier)).toEqual(['./richText'])
+  })
+})

--- a/src/lib/homepage/contentStatus.test.tsx
+++ b/src/lib/homepage/contentStatus.test.tsx
@@ -94,6 +94,46 @@ function scheduleWith(status: 'confirmed' | 'submitted') {
   ] as never
 }
 
+/**
+ * ONE confirmed talk, booked into TWO slots — a repeated workshop, and the
+ * shape that makes "sessions" and "talks" different numbers.
+ */
+function doubleBookedSchedule() {
+  const talk = {
+    _id: 't1',
+    status: 'confirmed',
+    title: 'A talk',
+    format: 'presentation_25',
+    speakers: [],
+    topics: [],
+  }
+  return [
+    {
+      _id: 's1',
+      date: PAST,
+      tracks: [
+        {
+          trackTitle: 'Track 1',
+          trackDescription: '',
+          talks: [
+            { startTime: '09:00', endTime: '09:45', talk },
+            { startTime: '13:00', endTime: '13:45', talk },
+          ],
+        },
+      ],
+    },
+  ] as never
+}
+
+/** N metrics, `label`/`value` numbered; `blankAt` indices carry neither. */
+function metrics(count: number, blankAt: number[] = []) {
+  return Array.from({ length: count }, (_, i) =>
+    blankAt.includes(i)
+      ? { label: '', value: '' }
+      : { label: `Metric ${i}`, value: `${i}` },
+  ) as never
+}
+
 interface Case {
   /** Names the case in the test output. */
   name: string
@@ -204,6 +244,17 @@ const CASES: Record<HomepageSectionType, Case[]> = {
       }),
       willHide: false,
     },
+    {
+      // One talk, two bookings — the band draws it twice and counts it twice.
+      // Renders, and the count assertions below pin WHICH number it reports.
+      name: 'one talk booked in two slots',
+      section: { _key: 'p', _type: 'homepageProgramHighlights' },
+      conference: bareConference({
+        programDate: PAST,
+        schedules: doubleBookedSchedule(),
+      }),
+      willHide: false,
+    },
   ],
 
   homepageOrganizers: [
@@ -305,6 +356,15 @@ const CASES: Record<HomepageSectionType, Case[]> = {
       conference: bareConference({
         vanityMetrics: [{ label: 'Attendees', value: '500+' }] as never,
       }),
+      willHide: false,
+    },
+    {
+      // `MetricsBlock` hides on the RAW array and filters nothing after that,
+      // so a stored-but-blank metric draws an empty cell inside a band that is
+      // very much rendered. Not a hide — degraded, and the status says so.
+      name: 'a metric with no label and no value — an empty cell, not a hide',
+      section: { _key: 'm', _type: 'homepageMetrics' },
+      conference: bareConference({ vanityMetrics: metrics(1, [0]) }),
       willHide: false,
     },
   ],
@@ -727,6 +787,122 @@ describe('counts and summaries', () => {
       bareConference({ startDate: PAST, endDate: PAST }),
     )
     expect(postEvent.reason).toContain('empty band')
+  })
+
+  /**
+   * The metrics twin of the sponsors regression. `MetricsBlock` draws the FIRST
+   * SIX entries and filters nothing after that, so `vanityMetrics.length`
+   * over-promises twice over: once for everything past the sixth, and once for
+   * an entry with neither a label nor a value, which takes one of the six and
+   * draws a cell with nothing in it. The expected number is read out of the
+   * RENDERED band — cells that came out with text — so this can only pass by
+   * being right about what the band draws.
+   */
+  it('counts only the metrics the band actually draws', () => {
+    const section: HomepageSection = { _key: 'm', _type: 'homepageMetrics' }
+    // Nine on file, the fourth of them blank.
+    const conference = bareConference({ vanityMetrics: metrics(9, [3]) })
+
+    const status = sectionContentStatus(section, conference)
+    const { container } = render(
+      <HomepageSectionRenderer sections={[section]} conference={conference} />,
+    )
+    const cells = [...container.querySelectorAll('dl > div')]
+    const drawn = cells.filter((cell) => cell.textContent?.trim())
+
+    // Sanity on the fixture: the cap is real, and the blank entry spends one of
+    // the six cells on nothing.
+    expect(cells.length).toBe(6)
+    expect(drawn.length).toBe(5)
+
+    expect(status.count).toBe(drawn.length)
+    expect(status.summary).toBe(`${drawn.length} metrics`)
+    // Numbers on file that the page will not show: thinner than intended, and
+    // the reason has to name both ways it is thinner.
+    expect(status.kind).toBe('degraded')
+    expect(status.reason).toContain('3 metrics past the sixth')
+    expect(status.reason).toContain('1 metric with no label or value')
+  })
+
+  it('is ready — not degraded — when every metric draws', () => {
+    const status = sectionContentStatus(
+      { _key: 'm', _type: 'homepageMetrics' },
+      bareConference({ vanityMetrics: metrics(6) }),
+    )
+    expect(status.kind).toBe('ready')
+    expect(status.count).toBe(6)
+    expect(status.summary).toBe('6 metrics')
+    expect(status.reason).toBeUndefined()
+  })
+
+  it('says what a metrics band of blanks actually looks like', () => {
+    const status = sectionContentStatus(
+      { _key: 'm', _type: 'homepageMetrics' },
+      bareConference({ vanityMetrics: metrics(2, [0, 1]) }),
+    )
+    // The band renders — `MetricsBlock` hides on the raw array — but there is
+    // nothing in it to read.
+    expect(status.willHide).toBe(false)
+    expect(status.count).toBe(0)
+    expect(status.summary).toBe('2 metrics, all blank')
+    expect(status.reason).toContain('empty band')
+  })
+
+  /**
+   * THE programme regression: one talk booked into two slots was reported as
+   * "2 confirmed talks", inventing a talk the conference does not have.
+   * `ProgramHighlights` counts one entry per BOOKED SLOT and prints it as
+   * "N+ Sessions" — two sessions, one talk — so the number is parsed back out
+   * of the band's own Sessions tile rather than restated here.
+   */
+  it('counts programme sessions the way the band prints them', () => {
+    const section: HomepageSection = {
+      _key: 'p',
+      _type: 'homepageProgramHighlights',
+    }
+    const conference = bareConference({
+      programDate: PAST,
+      schedules: doubleBookedSchedule(),
+    })
+
+    const status = sectionContentStatus(section, conference)
+    const { container } = render(
+      <HomepageSectionRenderer sections={[section]} conference={conference} />,
+    )
+    const sessionsTile = [...container.querySelectorAll('dt')].find(
+      (node) => node.textContent === 'Sessions',
+    )
+    const printed = Number(
+      sessionsTile?.nextElementSibling?.textContent?.replace('+', ''),
+    )
+
+    // Sanity on the fixture: the real band really does draw the one talk twice.
+    expect(printed).toBe(2)
+    expect(
+      [...container.querySelectorAll('h3')].filter(
+        (node) => node.textContent === 'A talk',
+      ).length,
+    ).toBe(2)
+
+    expect(status.count).toBe(printed)
+    expect(status.countLabel).toBe('sessions')
+    // Both numbers, and neither of them a talk the organizer has not written.
+    expect(status.summary).toBe('1 confirmed talk in 2 sessions')
+    expect(status.kind).toBe('ready')
+  })
+
+  it('counts nothing for a programme the page will not draw yet', () => {
+    const status = sectionContentStatus(
+      { _key: 'p', _type: 'homepageProgramHighlights' },
+      bareConference({
+        programDate: FUTURE,
+        schedules: scheduleWith('confirmed'),
+      }),
+    )
+    expect(status.willHide).toBe(true)
+    // Scheduled, not drawn — so it is in the summary, not in the count.
+    expect(status.count).toBe(0)
+    expect(status.summary).toBe('1 session waiting to be published')
   })
 })
 

--- a/src/lib/homepage/contentStatus.test.tsx
+++ b/src/lib/homepage/contentStatus.test.tsx
@@ -35,6 +35,8 @@ import {
 } from './contentStatus'
 import {
   HOMEPAGE_SECTION_TYPES,
+  SECTION_LABELS,
+  isHomepageSectionType,
   type HomepageSection,
   type HomepageSectionType,
 } from './sections'
@@ -244,6 +246,22 @@ const CASES: Record<HomepageSectionType, Case[]> = {
           {
             sponsor: { _id: 'x', name: 'Acme', website: 'https://acme.test' },
             tier: { title: 'Gold', tagline: '', tierType: 'standard' },
+          },
+        ] as never,
+      }),
+      willHide: false,
+    },
+    {
+      // No logo reaches the page — `groupSponsorsByTier` drops an untiered
+      // sponsor — but `Sponsors.tsx` keys its heading off the RAW array, so the
+      // band is not empty either. Both halves are asserted by the render below.
+      name: 'sponsors that are all untiered, with the pitch off — heading only',
+      section: { _key: 'sp', _type: 'homepageSponsors', showCta: false },
+      conference: bareConference({
+        sponsors: [
+          {
+            sponsor: { _id: 'x', name: 'Acme', website: 'https://acme.test' },
+            tier: null,
           },
         ] as never,
       }),
@@ -606,6 +624,87 @@ describe('counts and summaries', () => {
     )
     expect(status.kind).toBe('degraded')
     expect(status.summary).toBe('1 sponsor, none in a tier')
+    // Stored: one. Rendered: none. `count` is the second number.
+    expect(status.count).toBe(0)
+  })
+
+  /**
+   * THE regression this file exists to prevent on the sponsors band: a count
+   * read off `conference.sponsors.length` promises logos that
+   * `groupSponsorsByTier` never draws. Both numbers in the summary are checked
+   * against the REAL band — logo links and tier headings counted out of the
+   * rendered DOM — so a summary can only be right by being right about what
+   * renders, not by agreeing with a rule restated in the test.
+   */
+  it('counts only the sponsors the band actually draws', () => {
+    const section: HomepageSection = {
+      _key: 's',
+      _type: 'homepageSponsors',
+      // The pitch card off, so every remaining <h3> is a tier heading.
+      showCta: false,
+    }
+    const conference = bareConference({
+      sponsors: [
+        {
+          sponsor: { _id: '1', name: 'A', website: 'https://a.test' },
+          tier: { title: 'Gold', tagline: '', tierType: 'standard' },
+        },
+        {
+          sponsor: { _id: '2', name: 'B', website: 'https://b.test' },
+          tier: { title: 'Gold', tagline: '', tierType: 'standard' },
+        },
+        {
+          sponsor: { _id: '3', name: 'C', website: 'https://c.test' },
+          tier: { title: 'Silver', tagline: '', tierType: 'standard' },
+        },
+        // The two the band silently drops.
+        {
+          sponsor: { _id: '4', name: 'D', website: 'https://d.test' },
+          tier: null,
+        },
+        {
+          sponsor: { _id: '5', name: 'E', website: 'https://e.test' },
+          tier: undefined,
+        },
+      ] as never,
+    })
+
+    const status = sectionContentStatus(section, conference)
+    const { container } = render(
+      <HomepageSectionRenderer sections={[section]} conference={conference} />,
+    )
+    const logoLinks = container.querySelectorAll('a[aria-label^="Visit "]')
+    const tierHeadings = container.querySelectorAll('h3')
+
+    // Sanity on the fixture: the real component really does drop the two.
+    expect(logoLinks.length).toBe(3)
+    expect(tierHeadings.length).toBe(2)
+
+    expect(status.count).toBe(logoLinks.length)
+    expect(status.summary).toBe(
+      `${logoLinks.length} sponsors in ${tierHeadings.length} tiers`,
+    )
+    // Fewer logos than sponsors on file is exactly "renders, but thinner than
+    // intended" — and the reason must name how many are missing.
+    expect(status.kind).toBe('degraded')
+    expect(status.reason).toContain('2 sponsors in no tier')
+  })
+
+  it('is ready — not degraded — when every sponsor has a tier', () => {
+    const status = sectionContentStatus(
+      { _key: 's', _type: 'homepageSponsors' },
+      bareConference({
+        sponsors: [
+          {
+            sponsor: { _id: '1', name: 'A', website: 'https://a.test' },
+            tier: { title: 'Gold', tagline: '', tierType: 'standard' },
+          },
+        ] as never,
+      }),
+    )
+    expect(status.kind).toBe('ready')
+    expect(status.count).toBe(1)
+    expect(status.summary).toBe('1 sponsor in 1 tier')
   })
 
   it('says what an empty sponsors band actually looks like in each case', () => {
@@ -628,6 +727,75 @@ describe('counts and summaries', () => {
       bareConference({ startDate: PAST, endDate: PAST }),
     )
     expect(postEvent.reason).toContain('empty band')
+  })
+})
+
+/**
+ * The forward-compat path, held to the SAME parity bar as the registered types:
+ * the renderer skips an unknown `_type` with a warn, so the status must report
+ * it as hiding — and must not claim it is a section type this deploy knows.
+ */
+describe('a section type from the future', () => {
+  it('reports as hiding, exactly as the renderer skips it', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const section = {
+        _key: 'z',
+        _type: 'homepageSomethingNewer',
+      } as unknown as HomepageSection
+      const conference = bareConference()
+
+      const status = sectionContentStatus(section, conference)
+      expect(status.willHide).toBe(true)
+      expect(status.kind).toBe('empty-hides')
+
+      const { container } = render(
+        <HomepageSectionRenderer
+          sections={[section]}
+          conference={conference}
+        />,
+      )
+      expect(container.innerHTML === '').toBe(status.willHide)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  /**
+   * `type` carries the stored string verbatim, and `known: false` says so. The
+   * narrowing is the point: the label lookup below is a
+   * `Record<HomepageSectionType, …>`, and without the discriminant this status
+   * would key it with a string that is not in it — an `undefined` label in the
+   * composer rail, from a value the old signature swore was a section type.
+   */
+  it('does not pass itself off as a registered section type', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const status = sectionContentStatus(
+        {
+          _key: 'z',
+          _type: 'homepageSomethingNewer',
+        } as unknown as HomepageSection,
+        bareConference(),
+      )
+      expect(status.known).toBe(false)
+      expect(status.type).toBe('homepageSomethingNewer')
+      expect(isHomepageSectionType(status.type)).toBe(false)
+
+      const label = status.known ? SECTION_LABELS[status.type] : status.summary
+      expect(label).toBe('Unknown section type')
+
+      const known = sectionContentStatus(
+        { _key: 'h', _type: 'homepageHero' },
+        bareConference(),
+      )
+      expect(known.known).toBe(true)
+      expect(known.known && SECTION_LABELS[known.type]).toBe(
+        SECTION_LABELS.homepageHero,
+      )
+    } finally {
+      warn.mockRestore()
+    }
   })
 })
 

--- a/src/lib/homepage/contentStatus.ts
+++ b/src/lib/homepage/contentStatus.ts
@@ -347,12 +347,17 @@ function tallyProgramme(conference: Conference): ProgrammeTally {
  * `hasProgrammeContent` (`./lifecycle`): published AND holding at least one
  * confirmed talk. The second half is the guard that closed the production bug
  * where an empty published schedule rendered `0+ Sessions / 0+ Speakers`.
+ *
+ * Takes the tally rather than recomputing it: its one caller already needs the
+ * session and talk counts for the status it returns, and walking every track of
+ * every schedule a second time to answer "> 0" was pure waste.
  */
-function hasProgramme(conference: Conference, now: number): boolean {
-  return (
-    isProgramPublished(conference, now) &&
-    tallyProgramme(conference).sessions > 0
-  )
+function hasProgramme(
+  conference: Conference,
+  now: number,
+  sessions: number,
+): boolean {
+  return isProgramPublished(conference, now) && sessions > 0
 }
 
 /**
@@ -622,7 +627,7 @@ export function sectionContentStatus(
     // summary names the distinct talks behind it when the two differ.
     case 'homepageProgramHighlights': {
       const { sessions, talks } = tallyProgramme(conference)
-      if (!hasProgramme(conference, now)) {
+      if (!hasProgramme(conference, now, sessions)) {
         const published = isProgramPublished(conference, now)
         return status(
           'homepageProgramHighlights',

--- a/src/lib/homepage/contentStatus.ts
+++ b/src/lib/homepage/contentStatus.ts
@@ -304,17 +304,43 @@ function isProgramPublished(conference: Conference, now: number): boolean {
   return now >= new Date(conference.programDate).getTime()
 }
 
-/** Confirmed talks in the published schedules — what the programme band counts. */
-function confirmedTalkCount(conference: Conference): number {
-  let count = 0
+/** What the programme band will actually draw, counted the way it draws it. */
+interface ProgrammeTally {
+  /**
+   * Booked slots holding a confirmed talk. This is the band's OWN headline
+   * number: `calculateProgramStats` (`ProgramHighlights.tsx`) pushes one entry
+   * per slot and prints it as "N+ Sessions".
+   */
+  sessions: number
+  /**
+   * DISTINCT confirmed talks behind those slots. Lower than `sessions` when a
+   * talk is booked more than once — a repeated workshop is two sessions and one
+   * talk, and calling it "2 confirmed talks" invents a talk the organizer does
+   * not have.
+   */
+  talks: number
+}
+
+/**
+ * `calculateProgramStats` (`ProgramHighlights.tsx:257-327`): every slot whose
+ * talk is `confirmed`, across every track of every schedule. No dedupe there —
+ * two bookings of one talk are two sessions and draw two cards — so `sessions`
+ * is transcribed the same way, and the distinct-talk number is tracked
+ * ALONGSIDE it rather than replacing it.
+ */
+function tallyProgramme(conference: Conference): ProgrammeTally {
+  const talkIds = new Set<string>()
+  let sessions = 0
   for (const schedule of conference.schedules ?? []) {
     for (const track of schedule.tracks ?? []) {
       for (const slot of track.talks ?? []) {
-        if (slot.talk?.status === 'confirmed') count++
+        if (slot.talk?.status !== 'confirmed') continue
+        sessions++
+        talkIds.add(String(slot.talk._id))
       }
     }
   }
-  return count
+  return { sessions, talks: talkIds.size }
 }
 
 /**
@@ -324,7 +350,8 @@ function confirmedTalkCount(conference: Conference): number {
  */
 function hasProgramme(conference: Conference, now: number): boolean {
   return (
-    isProgramPublished(conference, now) && confirmedTalkCount(conference) > 0
+    isProgramPublished(conference, now) &&
+    tallyProgramme(conference).sessions > 0
   )
 }
 
@@ -379,6 +406,44 @@ function tallySponsors(conference: Conference): SponsorTally {
     )
   }
   return { shown, untiered, tiers: tiers.size }
+}
+
+/** `MetricsBlock.tsx:29` — `metrics.slice(0, 6)`. Six cells, no more. */
+const METRICS_SHOWN_LIMIT = 6
+
+/** What the metrics band will actually draw, counted the way it slices. */
+interface MetricsTally {
+  /** Cells the band draws WITH something in them. */
+  shown: number
+  /** Entries on file. The band's hide guard reads this, not `shown`. */
+  stored: number
+  /** Entries past the sixth: stored, and never drawn. */
+  overflow: number
+  /** Entries inside the six with neither label nor value — an empty cell. */
+  blank: number
+}
+
+/**
+ * `MetricsBlock.tsx:18-39`: the band renders the FIRST SIX entries, one cell
+ * each, and filters nothing — so an entry with no label and no value still
+ * takes one of the six and draws a cell with nothing in it. Both facts cut the
+ * number an organizer can actually count on the page, and neither is visible in
+ * `vanityMetrics.length`.
+ */
+function tallyMetrics(conference: Conference): MetricsTally {
+  const metrics = conference.vanityMetrics ?? []
+  let shown = 0
+  let blank = 0
+  for (const metric of metrics.slice(0, METRICS_SHOWN_LIMIT)) {
+    if (metric?.label?.trim() || metric?.value?.trim()) shown++
+    else blank++
+  }
+  return {
+    shown,
+    blank,
+    stored: metrics.length,
+    overflow: Math.max(0, metrics.length - METRICS_SHOWN_LIMIT),
+  }
 }
 
 /**
@@ -460,8 +525,10 @@ function status(
 
 /**
  * A collection-backed band: renders iff the collection is non-empty. Covers
- * featured speakers, organizers, gallery, metrics and FAQ, whose guards differ
- * only in which collection they read.
+ * featured speakers, organizers, gallery and FAQ, whose guards differ
+ * only in which collection they read. (Metrics and sponsors need MORE than
+ * this — the band draws fewer than it holds — so they build their status by
+ * hand from a tally.)
  */
 function collectionStatus(
   type: HomepageSectionType,
@@ -545,8 +612,16 @@ export function sectionContentStatus(
 
     // SectionRenderer.tsx:316 — `lifecycle.content.hasProgramme`, which is
     // "published AND at least one confirmed talk", not "a schedule exists".
+    //
+    // The COUNT is sessions, not talks, because sessions is what the band
+    // draws: `ProgramHighlights.tsx` prints "N+ Sessions" from one entry per
+    // booked slot, and a talk booked twice really does get two slots, two cards
+    // and two tallies there. Counting the same slots and calling them "confirmed
+    // talks" was the lie — it reported two talks to a conference that has one.
+    // Both numbers are now carried: `count` is what the page will say, and the
+    // summary names the distinct talks behind it when the two differ.
     case 'homepageProgramHighlights': {
-      const talks = confirmedTalkCount(conference)
+      const { sessions, talks } = tallyProgramme(conference)
       if (!hasProgramme(conference, now)) {
         const published = isProgramPublished(conference, now)
         return status(
@@ -554,11 +629,16 @@ export function sectionContentStatus(
           'empty-hides',
           source('programme'),
           {
-            count: talks,
-            countLabel: 'confirmed talks',
+            // Nothing renders, so nothing is counted — the scheduled sessions
+            // of an unpublished programme belong in the summary, where they
+            // read as "waiting", not as content already on the page.
+            count: 0,
+            countLabel: 'sessions',
             summary: published
               ? 'No confirmed talks yet'
-              : 'Programme not published',
+              : sessions > 0
+                ? `${pluralize(sessions, 'sessions')} waiting to be published`
+                : 'Programme not published',
             reason: published
               ? 'Hidden on the live site — the published schedule holds no confirmed talks.'
               : 'Hidden on the live site — the programme date has not arrived, so no schedule is published yet.',
@@ -566,9 +646,12 @@ export function sectionContentStatus(
         )
       }
       return status('homepageProgramHighlights', 'ready', source('programme'), {
-        count: talks,
-        countLabel: 'confirmed talks',
-        summary: pluralize(talks, 'confirmed talks'),
+        count: sessions,
+        countLabel: 'sessions',
+        summary:
+          talks === sessions
+            ? pluralize(sessions, 'sessions')
+            : `${pluralize(talks, 'confirmed talks')} in ${pluralize(sessions, 'sessions')}`,
       })
     }
 
@@ -642,15 +725,55 @@ export function sectionContentStatus(
         'Hidden on the live site — this band renders nothing without featured gallery images.',
       )
 
-    // MetricsBlock.tsx:19 — no metrics, no band. (It shows at most six.)
-    case 'homepageMetrics':
-      return collectionStatus(
-        'homepageMetrics',
-        source('vanity-metrics'),
-        conference.vanityMetrics?.length ?? 0,
-        'metrics',
-        'Hidden on the live site — this band renders nothing until vanity metrics are added.',
-      )
+    // MetricsBlock.tsx:19 — no metrics, no band. The HIDE guard reads the raw
+    // array, but the band then draws only the first six, and draws an empty
+    // cell for an entry with no label and no value. So a band CAN render while
+    // showing fewer numbers than are stored — or none at all — which is the
+    // sponsors bug in a second place: the count is the cells with something in
+    // them, and everything the band leaves out is named in the reason.
+    case 'homepageMetrics': {
+      const { shown, stored, overflow, blank } = tallyMetrics(conference)
+      const src = source('vanity-metrics')
+      if (stored === 0) {
+        return status('homepageMetrics', 'empty-hides', src, {
+          count: 0,
+          countLabel: 'metrics',
+          summary: 'No metrics yet',
+          reason:
+            'Hidden on the live site — this band renders nothing until vanity metrics are added.',
+        })
+      }
+      if (shown === 0) {
+        return status('homepageMetrics', 'degraded', src, {
+          count: 0,
+          countLabel: 'metrics',
+          summary: `${pluralize(stored, 'metrics')}, all blank`,
+          reason:
+            'Renders as an empty band — every metric on file is missing both its label and its value.',
+        })
+      }
+      const leftOut = [
+        overflow > 0
+          ? `${pluralize(overflow, 'metrics')} past the sixth ${overflow === 1 ? 'is' : 'are'} not drawn — the band shows at most six.`
+          : null,
+        blank > 0
+          ? `${pluralize(blank, 'metrics')} with no label or value ${blank === 1 ? 'draws' : 'draw'} an empty cell.`
+          : null,
+      ].filter(Boolean)
+      if (leftOut.length > 0) {
+        return status('homepageMetrics', 'degraded', src, {
+          count: shown,
+          countLabel: 'metrics',
+          summary: pluralize(shown, 'metrics'),
+          reason: leftOut.join(' '),
+        })
+      }
+      return status('homepageMetrics', 'ready', src, {
+        count: shown,
+        countLabel: 'metrics',
+        summary: pluralize(shown, 'metrics'),
+      })
+    }
 
     // CtaBanner.tsx has no early return: the heading always renders. The button
     // needs BOTH a label and a href (`CtaBanner.tsx:24`), so half a button is a

--- a/src/lib/homepage/contentStatus.ts
+++ b/src/lib/homepage/contentStatus.ts
@@ -19,8 +19,10 @@ import type {
  * with a count ("6 sponsors in 2 tiers"), a reason, and a link to the surface
  * where that content is actually edited.
  *
- * THE CORRECTNESS BAR: {@link SectionContentStatus.willHide} must be TRUE
- * exactly when the real renderer produces nothing for that section. A preview
+ * THE CORRECTNESS BAR: the `willHide` flag of {@link SectionContentStatus} must
+ * be TRUE exactly when the real renderer produces nothing for that section — and
+ * its `count` must be what the renderer will actually DRAW, not what the
+ * collection behind it happens to hold. A preview
  * that shows a band the live page drops is worse than no preview, because the
  * organizer ships believing the page is full. The predicates below are
  * therefore transcriptions of the renderer's own guards, each annotated with
@@ -172,13 +174,14 @@ export const CONTENT_SOURCES: Record<SectionContentSourceId, ContentSource> = {
  *
  *  - `ready` — real content behind it; it renders in full.
  *  - `degraded` — it renders, but thinner than intended (the sponsors band with
- *    no sponsors is the canonical case: the "Become a Sponsor" pitch alone).
+ *    no sponsors is the canonical case: the "Become a Sponsor" pitch alone; the
+ *    band holding untiered sponsors is the same fact one step in — those logos
+ *    are stored, and the page will not draw them).
  *  - `empty-hides` — the live site renders NOTHING for it.
  */
 export type SectionContentKind = 'ready' | 'degraded' | 'empty-hides'
 
-export interface SectionContentStatus {
-  type: HomepageSectionType
+interface SectionContentStatusFacts {
   kind: SectionContentKind
   /**
    * TRUE iff the renderer emits nothing for this section — the property the
@@ -187,8 +190,14 @@ export interface SectionContentStatus {
    */
   willHide: boolean
   /**
-   * How many items back the band, or `null` when the section is not backed by
-   * a countable collection (hero, save-the-date, CTA banner, countdown, venue).
+   * How many items the band will ACTUALLY RENDER, or `null` when the section is
+   * not backed by a countable collection (hero, save-the-date, CTA banner,
+   * countdown, venue).
+   *
+   * "Will render", not "is stored": the sponsors band drops every sponsor with
+   * no tier, so a conference holding ten sponsors of which three are untiered
+   * counts SEVEN here. A count the organizer cannot find on the page is the
+   * same lie as a band the page does not draw.
    */
   count: number | null
   /** Plural noun for {@link count}: "speakers", "sponsors", "photos". */
@@ -202,6 +211,40 @@ export interface SectionContentStatus {
   /** Ready-to-render deep link, or `null` for composer-local content. */
   manage: { label: string; href: string } | null
 }
+
+/** A section this deploy's registry knows — the overwhelmingly common case. */
+export interface KnownSectionContentStatus extends SectionContentStatusFacts {
+  /** Narrowing discriminant: `type` is a registered section type. */
+  known: true
+  type: HomepageSectionType
+}
+
+/**
+ * A stored section whose `_type` this deploy has never heard of — data written
+ * by a newer schema during deploy skew.
+ *
+ * A SEPARATE shape rather than a widened `type`, because `type` is what callers
+ * key label maps, icon maps and variant pickers by, and every one of those is a
+ * `Record<HomepageSectionType, …>` that this value would miss. The union makes
+ * the miss a compile error at the point of use instead of an `undefined` label
+ * in the composer rail, and `known` is the one check needed to clear it.
+ *
+ * The BEHAVIOUR mirrors the renderer's unknown-`_type` skip
+ * (`SectionRenderer.tsx`): the section contributes nothing to the page, so this
+ * reports as hiding. No warning is logged here — the renderer already warns
+ * once per process for exactly this `_type`, and the composer surfaces the same
+ * fact where it matters more, as a row that says so in words.
+ */
+export interface UnknownSectionContentStatus extends SectionContentStatusFacts {
+  known: false
+  /** The stored `_type`, verbatim. NOT a registered section type. */
+  type: string
+  kind: 'empty-hides'
+  willHide: true
+}
+
+export type SectionContentStatus =
+  KnownSectionContentStatus | UnknownSectionContentStatus
 
 export interface SectionContentStatusOptions {
   /**
@@ -302,19 +345,40 @@ function hasSaveTheDateDates(conference: Conference): boolean {
   return Boolean(conference.startDate && conference.endDate)
 }
 
+/** What the sponsors band will actually draw, counted the way it groups. */
+interface SponsorTally {
+  /** Sponsors that reach a logo grid — i.e. the ones with a tier. */
+  shown: number
+  /** Sponsors dropped for having no tier. Stored, but never on the page. */
+  untiered: number
+  /** Tier HEADINGS, after `special` collapses. */
+  tiers: number
+}
+
 /**
  * `groupSponsorsByTier` (`@/lib/sponsor/utils`): an untiered sponsor is skipped
  * — it never reaches a logo grid — and every `special` tier collapses into one
- * `SPECIAL` heading. Counting tiers the same way keeps "6 sponsors in 2 tiers"
- * honest about what the band will actually show.
+ * `SPECIAL` heading. BOTH numbers in "6 sponsors in 2 tiers" come from this
+ * walk, so neither can over-report what the band will show.
  */
-function sponsorTierCount(conference: Conference): number {
+function tallySponsors(conference: Conference): SponsorTally {
   const tiers = new Set<string>()
+  let shown = 0
+  let untiered = 0
   for (const entry of conference.sponsors ?? []) {
-    if (!entry.tier) continue
-    tiers.add(entry.tier.tierType === 'special' ? 'SPECIAL' : entry.tier.title)
+    if (!entry?.tier) {
+      untiered++
+      continue
+    }
+    shown++
+    // `String(...)` because upstream uses the title as an OBJECT KEY, and an
+    // object key coerces. A tier whose title is missing in stored data groups
+    // under `'undefined'` there, so it must group under `'undefined'` here too.
+    tiers.add(
+      entry.tier.tierType === 'special' ? 'SPECIAL' : String(entry.tier.title),
+    )
   }
-  return tiers.size
+  return { shown, untiered, tiers: tiers.size }
 }
 
 /**
@@ -379,8 +443,9 @@ function status(
     summary: string
     reason?: string
   },
-): SectionContentStatus {
+): KnownSectionContentStatus {
   return {
+    known: true,
     type,
     kind,
     willHide: kind === 'empty-hides',
@@ -404,7 +469,7 @@ function collectionStatus(
   count: number,
   noun: string,
   reason: string,
-): SectionContentStatus {
+): KnownSectionContentStatus {
   if (count === 0) {
     return status(type, 'empty-hides', src, {
       count: 0,
@@ -524,10 +589,9 @@ export function sectionContentStatus(
     // section: vertical whitespace and nothing else. That is not a hide, so
     // `willHide` stays false; it is called out as a degraded state instead.
     case 'homepageSponsors': {
-      const count = conference.sponsors?.length ?? 0
-      const tiers = sponsorTierCount(conference)
+      const { shown, untiered, tiers } = tallySponsors(conference)
       const src = source('sponsors')
-      if (count === 0) {
+      if (shown === 0 && untiered === 0) {
         const cta = sponsorsShowCta(section, conference, now)
         return status('homepageSponsors', 'degraded', src, {
           count: 0,
@@ -538,19 +602,33 @@ export function sectionContentStatus(
             : 'Renders as an empty band — there are no sponsors and the sponsor call-to-action is switched off.',
         })
       }
-      if (tiers === 0) {
+      // Stored sponsors, none of them tiered: `Sponsors.tsx` keys its heading
+      // off the RAW array, so the band still draws its title and blurb — above
+      // an empty space where every logo was dropped.
+      if (shown === 0) {
         return status('homepageSponsors', 'degraded', src, {
-          count,
+          count: 0,
           countLabel: 'sponsors',
-          summary: `${pluralize(count, 'sponsors')}, none in a tier`,
+          summary: `${pluralize(untiered, 'sponsors')}, none in a tier`,
           reason:
             'No logos render — a sponsor is only shown once it is assigned to a tier.',
         })
       }
+      const summary = `${pluralize(shown, 'sponsors')} in ${pluralize(tiers, 'tiers')}`
+      // Some render, some do not. Thinner than the organizer thinks it is,
+      // which is the whole reason this module exists — say the number.
+      if (untiered > 0) {
+        return status('homepageSponsors', 'degraded', src, {
+          count: shown,
+          countLabel: 'sponsors',
+          summary,
+          reason: `${pluralize(untiered, 'sponsors')} in no tier ${untiered === 1 ? 'is' : 'are'} left out — a sponsor is only shown once it is assigned to a tier.`,
+        })
+      }
       return status('homepageSponsors', 'ready', src, {
-        count,
+        count: shown,
         countLabel: 'sponsors',
-        summary: `${pluralize(count, 'sponsors')} in ${pluralize(tiers, 'tiers')}`,
+        summary,
       })
     }
 
@@ -689,18 +767,26 @@ export function sectionContentStatus(
       // composer. The `never` binding is the compile-time half — adding a
       // fourteenth section type to the registry fails to build here until it
       // gets a real case above.
+      //
+      // The returned `type` is the raw stored string, and it is typed as such:
+      // see {@link UnknownSectionContentStatus} for why this is a shape of its
+      // own rather than a `HomepageSectionType` it demonstrably is not.
       const exhaustive: never = section
       const unknown = exhaustive as { _type?: string }
-      return status(
-        String(unknown?._type) as HomepageSectionType,
-        'empty-hides',
-        source('section-config'),
-        {
-          summary: 'Unknown section type',
-          reason:
-            'Hidden on the live site — this section type is not in the registry this deploy knows.',
-        },
-      )
+      const src = source('section-config')
+      return {
+        known: false,
+        type: String(unknown?._type),
+        kind: 'empty-hides',
+        willHide: true,
+        count: null,
+        countLabel: null,
+        summary: 'Unknown section type',
+        reason:
+          'Hidden on the live site — this section type is not in the registry this deploy knows.',
+        source: src,
+        manage: manageOf(src),
+      }
     }
   }
 }

--- a/src/lib/homepage/contentStatus.ts
+++ b/src/lib/homepage/contentStatus.ts
@@ -1,0 +1,706 @@
+import { isRichTextContentEmpty, sanitizeRichTextContent } from './richText'
+import type { Conference } from '@/lib/conference/types'
+import type {
+  CountdownSection,
+  FaqSection,
+  HomepageSection,
+  HomepageSectionType,
+  SponsorsSection,
+} from './sections'
+
+/**
+ * "Does this band have anything behind it?" — the one module that answers it.
+ *
+ * WHY THIS EXISTS. Every content band on the homepage SELF-HIDES when its
+ * source collection is empty (see the guard table below). That is correct on
+ * the live site and invisible in the composer: an organizer adds a Featured
+ * Speakers section, saves, and the section renders as literally nothing. The
+ * composition editor and the live preview need to say so BEFORE the save —
+ * with a count ("6 sponsors in 2 tiers"), a reason, and a link to the surface
+ * where that content is actually edited.
+ *
+ * THE CORRECTNESS BAR: {@link SectionContentStatus.willHide} must be TRUE
+ * exactly when the real renderer produces nothing for that section. A preview
+ * that shows a band the live page drops is worse than no preview, because the
+ * organizer ships believing the page is full. The predicates below are
+ * therefore transcriptions of the renderer's own guards, each annotated with
+ * the file and guard it mirrors, and `contentStatus.test.ts` pins the
+ * equivalence by RENDERING every case through `HomepageSectionRenderer` and
+ * asserting an empty container exactly when `willHide` is true. If a guard
+ * moves, that test fails — this file is not allowed to drift.
+ *
+ * WHAT IT DELIBERATELY DOES NOT ANSWER:
+ *
+ *  - `section.hidden` — the F1 visibility toggle. That is the organizer's own
+ *    choice, already visible in the editor, and orthogonal to whether there is
+ *    content. The renderer filters hidden sections above `renderSection`, so a
+ *    caller composing "will this appear on the page?" must AND the two.
+ *  - `cancelled` / `archived` — those lifecycle states REPLACE the whole page
+ *    with a notice (`HomepageSectionRenderer`'s `isOverridden` short-circuit),
+ *    which is a page-level fact, not a per-section one. Callers check it once
+ *    above the loop, exactly as the renderer does.
+ *
+ * SERVER SAFETY: no PACKAGE import — this module is reachable from server
+ * components through the composer and the preview route, and a single value
+ * import from a client-only package puts that package's React context in the
+ * RSC module graph, killing the production build with `createContext is not a
+ * function` (it has happened once already, via `@dnd-kit` in `./editor`). The
+ * one runtime import is the relative sibling `./richText`, and it is
+ * load-bearing: the rich-text guard is "does the SANITIZED content render
+ * anything", and hand-copying a 500-line sanitizer here to avoid an import
+ * would be exactly the drift this module exists to prevent — `./editor` takes
+ * the same import for the same reason. `contentStatus.test.ts` asserts the
+ * parsed module graph: no packages, and no relative import beyond that one.
+ */
+
+/** Where a section's content is edited. Stable ids — safe to switch on. */
+export type SectionContentSourceId =
+  /** Title, tagline, description — the identity fieldset. */
+  | 'conference-basics'
+  /** `startDate` / `endDate` / CFP / programme dates. */
+  | 'dates'
+  /** `venueName` / `venueAddress` (and `city`, on basics). */
+  | 'venue'
+  /** `conference.organizers`. */
+  | 'organizers'
+  /** `conference.featuredSpeakers`. */
+  | 'featured-speakers'
+  /** Published schedule + confirmed talks. */
+  | 'programme'
+  /** `conference.sponsors` and their tiers. */
+  | 'sponsors'
+  /** `conference.featuredGalleryImages`. */
+  | 'gallery'
+  /** `conference.vanityMetrics`. */
+  | 'vanity-metrics'
+  /** `conference.ticketFaqs`. */
+  | 'ticket-faqs'
+  /** The section's OWN fields — edited in the composer, so no deep link. */
+  | 'section-config'
+
+export interface ContentSource {
+  id: SectionContentSourceId
+  /** What the section pulls, as a noun phrase: "Featured speakers". */
+  label: string
+  /**
+   * Admin route that edits it, or `null` for content edited in the composer
+   * itself. Route-only (no anchors): the settings page has no stable fieldset
+   * ids, and a link to a hash that does not exist is a worse promise than a
+   * link to the page that owns the field.
+   */
+  href: string | null
+  /** Link copy at the point of display: "Choose speakers". */
+  manageLabel: string
+}
+
+/**
+ * The content-source map. ONE definition, consumed by the composer rail, the
+ * preview's sample-content chips and the appearance page's content-source rows
+ * — three surfaces that must never disagree about where a thing is edited.
+ */
+export const CONTENT_SOURCES: Record<SectionContentSourceId, ContentSource> = {
+  'conference-basics': {
+    id: 'conference-basics',
+    label: 'Conference basics',
+    href: '/admin/settings',
+    manageLabel: 'Edit basics',
+  },
+  dates: {
+    id: 'dates',
+    label: 'Conference dates',
+    href: '/admin/settings',
+    manageLabel: 'Edit dates',
+  },
+  venue: {
+    id: 'venue',
+    label: 'Venue',
+    href: '/admin/settings',
+    manageLabel: 'Edit venue',
+  },
+  organizers: {
+    id: 'organizers',
+    label: 'Organizers',
+    href: '/admin/settings',
+    manageLabel: 'Manage organizers',
+  },
+  'featured-speakers': {
+    id: 'featured-speakers',
+    label: 'Featured speakers',
+    href: '/admin/marketing/featured',
+    manageLabel: 'Choose speakers',
+  },
+  programme: {
+    id: 'programme',
+    label: 'Programme',
+    href: '/admin/schedule',
+    manageLabel: 'Edit the schedule',
+  },
+  sponsors: {
+    id: 'sponsors',
+    label: 'Sponsors',
+    href: '/admin/sponsors',
+    manageLabel: 'Manage sponsors',
+  },
+  gallery: {
+    id: 'gallery',
+    label: 'Photo gallery',
+    href: '/admin/marketing/gallery',
+    manageLabel: 'Manage photos',
+  },
+  'vanity-metrics': {
+    id: 'vanity-metrics',
+    label: 'Vanity metrics',
+    href: '/admin/settings/appearance/homepage',
+    manageLabel: 'Edit metrics',
+  },
+  'ticket-faqs': {
+    id: 'ticket-faqs',
+    label: 'Ticket FAQs',
+    href: '/admin/tickets/content',
+    manageLabel: 'Edit ticket FAQs',
+  },
+  'section-config': {
+    id: 'section-config',
+    label: 'This section',
+    href: null,
+    manageLabel: 'Edit below',
+  },
+}
+
+/**
+ * How much of the page this band will actually be.
+ *
+ *  - `ready` — real content behind it; it renders in full.
+ *  - `degraded` — it renders, but thinner than intended (the sponsors band with
+ *    no sponsors is the canonical case: the "Become a Sponsor" pitch alone).
+ *  - `empty-hides` — the live site renders NOTHING for it.
+ */
+export type SectionContentKind = 'ready' | 'degraded' | 'empty-hides'
+
+export interface SectionContentStatus {
+  type: HomepageSectionType
+  kind: SectionContentKind
+  /**
+   * TRUE iff the renderer emits nothing for this section — the property the
+   * parity test pins. `kind === 'empty-hides'` is the same fact, named for the
+   * UI; this boolean is the one to branch on.
+   */
+  willHide: boolean
+  /**
+   * How many items back the band, or `null` when the section is not backed by
+   * a countable collection (hero, save-the-date, CTA banner, countdown, venue).
+   */
+  count: number | null
+  /** Plural noun for {@link count}: "speakers", "sponsors", "photos". */
+  countLabel: string | null
+  /** One line for the UI: "6 sponsors in 2 tiers", "No photos yet". */
+  summary: string
+  /** Why it hides or why it is thin. Absent when `ready`. */
+  reason?: string
+  /** Where the content behind this band is edited. */
+  source: ContentSource
+  /** Ready-to-render deep link, or `null` for composer-local content. */
+  manage: { label: string; href: string } | null
+}
+
+export interface SectionContentStatusOptions {
+  /**
+   * "Now" in epoch ms, for the two time-dependent guards (programme published,
+   * countdown target passed). Injectable so a test — and a preview rendering a
+   * hypothetical — can ask the question at a chosen instant.
+   */
+  now?: number
+}
+
+// === renderer-guard transcriptions =======================================
+//
+// Each helper below reproduces ONE upstream rule. They are inlined rather than
+// imported so this module keeps its no-package property, and every one of them
+// is pinned by the parity test.
+
+/**
+ * `toOsloAnchoredDate` (`@/lib/time`): a bare `YYYY-MM-DD` is pinned to 12:00
+ * UTC so the day is stable in every viewer timezone; anything else is parsed
+ * as written. `NaN` for an unusable value.
+ */
+function anchoredMs(value: string): number {
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (dateOnly) {
+    return Date.UTC(
+      Number(dateOnly[1]),
+      Number(dateOnly[2]) - 1,
+      Number(dateOnly[3]),
+      12,
+    )
+  }
+  return new Date(value).getTime()
+}
+
+/**
+ * `resolveCountdownTarget` (`./countdown`): the override wins over the start
+ * date; an absent or unparseable value is `null`, and the block renders
+ * nothing.
+ */
+function countdownTargetMs(
+  conference: Conference,
+  section: Pick<CountdownSection, 'targetOverride'>,
+): number | null {
+  const raw = section.targetOverride?.trim() || conference.startDate?.trim()
+  if (!raw) return null
+  const ms = anchoredMs(raw)
+  return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * `isProgramPublished` (`@/lib/conference/state`): the programme date exists
+ * and has arrived. NOTE the parse — plain `new Date()`, i.e. UTC midnight for
+ * a bare date, NOT the noon anchoring above. Mirrored as written.
+ */
+function isProgramPublished(conference: Conference, now: number): boolean {
+  if (!conference.programDate) return false
+  return now >= new Date(conference.programDate).getTime()
+}
+
+/** Confirmed talks in the published schedules — what the programme band counts. */
+function confirmedTalkCount(conference: Conference): number {
+  let count = 0
+  for (const schedule of conference.schedules ?? []) {
+    for (const track of schedule.tracks ?? []) {
+      for (const slot of track.talks ?? []) {
+        if (slot.talk?.status === 'confirmed') count++
+      }
+    }
+  }
+  return count
+}
+
+/**
+ * `hasProgrammeContent` (`./lifecycle`): published AND holding at least one
+ * confirmed talk. The second half is the guard that closed the production bug
+ * where an empty published schedule rendered `0+ Sessions / 0+ Speakers`.
+ */
+function hasProgramme(conference: Conference, now: number): boolean {
+  return (
+    isProgramPublished(conference, now) && confirmedTalkCount(conference) > 0
+  )
+}
+
+/**
+ * `SaveTheDate.tsx:47-55`: `formatDatesSafe` returns the literal `'TBD'` when
+ * EITHER date is missing (an unparseable pair returns `'Invalid Date Range'`
+ * and the band still renders), and `place` joins the trimmed venue name and
+ * city. With no dates and no place there is nothing to save the date for.
+ */
+function saveTheDatePlace(conference: Conference): string {
+  return [conference.venueName, conference.city]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(', ')
+}
+
+function hasSaveTheDateDates(conference: Conference): boolean {
+  return Boolean(conference.startDate && conference.endDate)
+}
+
+/**
+ * `groupSponsorsByTier` (`@/lib/sponsor/utils`): an untiered sponsor is skipped
+ * — it never reaches a logo grid — and every `special` tier collapses into one
+ * `SPECIAL` heading. Counting tiers the same way keeps "6 sponsors in 2 tiers"
+ * honest about what the band will actually show.
+ */
+function sponsorTierCount(conference: Conference): number {
+  const tiers = new Set<string>()
+  for (const entry of conference.sponsors ?? []) {
+    if (!entry.tier) continue
+    tiers.add(entry.tier.tierType === 'special' ? 'SPECIAL' : entry.tier.title)
+  }
+  return tiers.size
+}
+
+/**
+ * `SectionRenderer.tsx:398-410`: the "Become a Sponsor" pitch is suppressed
+ * once the event is over, so it cannot prop up an otherwise-empty band.
+ * `stage === 'post-event'` is `isConferenceOver` unless an explicit
+ * `lifecycleStatus` overrides the stage — and in those two states the notice
+ * replaces the page anyway.
+ */
+function isConferenceOver(conference: Conference, now: number): boolean {
+  // Transcribed verbatim from `isConferenceOver`, including the calendar-day
+  // increment (NOT +24h) and the `>=`. A missing or unparseable `endDate`
+  // yields an Invalid Date, and `now >= NaN` is false — the event is not over.
+  const dayAfterEnd = new Date(conference.endDate)
+  dayAfterEnd.setDate(dayAfterEnd.getDate() + 1)
+  return now >= dayAfterEnd.getTime()
+}
+
+function sponsorsShowCta(
+  section: Pick<SponsorsSection, 'showCta'>,
+  conference: Conference,
+  now: number,
+): boolean {
+  const overridden =
+    conference.lifecycleStatus === 'cancelled' ||
+    conference.lifecycleStatus === 'archived'
+  const postEvent = !overridden && isConferenceOver(conference, now)
+  return section.showCta !== false && !postEvent
+}
+
+/** `FaqBlock.tsx:19-23`: own items by default, ticket FAQs on request. */
+function faqItemCount(
+  section: Pick<FaqSection, 'source' | 'items'>,
+  conference: Conference,
+): number {
+  return section.source === 'ticketFaqs'
+    ? (conference.ticketFaqs?.length ?? 0)
+    : (section.items?.length ?? 0)
+}
+
+// === status construction =================================================
+
+function pluralize(count: number, noun: string): string {
+  return `${count} ${count === 1 ? noun.replace(/e?s$/, '') : noun}`
+}
+
+function source(id: SectionContentSourceId): ContentSource {
+  return CONTENT_SOURCES[id]
+}
+
+function manageOf(src: ContentSource): SectionContentStatus['manage'] {
+  return src.href === null ? null : { label: src.manageLabel, href: src.href }
+}
+
+function status(
+  type: HomepageSectionType,
+  kind: SectionContentKind,
+  src: ContentSource,
+  fields: {
+    count?: number | null
+    countLabel?: string | null
+    summary: string
+    reason?: string
+  },
+): SectionContentStatus {
+  return {
+    type,
+    kind,
+    willHide: kind === 'empty-hides',
+    count: fields.count ?? null,
+    countLabel: fields.countLabel ?? null,
+    summary: fields.summary,
+    ...(fields.reason === undefined ? {} : { reason: fields.reason }),
+    source: src,
+    manage: manageOf(src),
+  }
+}
+
+/**
+ * A collection-backed band: renders iff the collection is non-empty. Covers
+ * featured speakers, organizers, gallery, metrics and FAQ, whose guards differ
+ * only in which collection they read.
+ */
+function collectionStatus(
+  type: HomepageSectionType,
+  src: ContentSource,
+  count: number,
+  noun: string,
+  reason: string,
+): SectionContentStatus {
+  if (count === 0) {
+    return status(type, 'empty-hides', src, {
+      count: 0,
+      countLabel: noun,
+      summary: `No ${noun} yet`,
+      reason,
+    })
+  }
+  return status(type, 'ready', src, {
+    count,
+    countLabel: noun,
+    summary: pluralize(count, noun),
+  })
+}
+
+/**
+ * The content status of ONE section against ONE conference.
+ *
+ * Pure and synchronous. `section` rather than a bare `_type` because five of
+ * the guards read the section's own config (the countdown target and live
+ * message, the FAQ source and items, the rich-text content, the CTA banner's
+ * button, the sponsors CTA toggle) — a type-only signature could not answer
+ * them and would have to guess.
+ */
+export function sectionContentStatus(
+  section: HomepageSection,
+  conference: Conference,
+  options: SectionContentStatusOptions = {},
+): SectionContentStatus {
+  const now = options.now ?? Date.now()
+
+  switch (section._type) {
+    // The hero is the one band with no data guard at all — it renders from the
+    // conference title alone, which every conference has. `Hero.tsx` has no
+    // early return, by design: a homepage always has a top.
+    case 'homepageHero':
+      return status('homepageHero', 'ready', source('conference-basics'), {
+        summary: conference.title,
+      })
+
+    // SaveTheDate.tsx:55 — `dates === 'TBD' && !place`.
+    case 'homepageSaveTheDate': {
+      const place = saveTheDatePlace(conference)
+      const dates = hasSaveTheDateDates(conference)
+      if (!dates && !place) {
+        return status('homepageSaveTheDate', 'empty-hides', source('dates'), {
+          summary: 'No dates or venue yet',
+          reason:
+            'Hidden on the live site — there are no conference dates and no venue or city to announce.',
+        })
+      }
+      if (!dates) {
+        return status('homepageSaveTheDate', 'degraded', source('dates'), {
+          summary: `${place} · dates missing`,
+          reason:
+            'Renders without a date line — set the start and end dates to complete the announcement.',
+        })
+      }
+      return status('homepageSaveTheDate', 'ready', source('dates'), {
+        summary: place ? `Dates and ${place}` : 'Conference dates',
+      })
+    }
+
+    // SectionRenderer.tsx:214-219 — no featured speakers, no band.
+    case 'homepageFeaturedSpeakers':
+      return collectionStatus(
+        'homepageFeaturedSpeakers',
+        source('featured-speakers'),
+        conference.featuredSpeakers?.length ?? 0,
+        'featured speakers',
+        'Hidden on the live site — this band renders nothing until speakers are featured.',
+      )
+
+    // SectionRenderer.tsx:316 — `lifecycle.content.hasProgramme`, which is
+    // "published AND at least one confirmed talk", not "a schedule exists".
+    case 'homepageProgramHighlights': {
+      const talks = confirmedTalkCount(conference)
+      if (!hasProgramme(conference, now)) {
+        const published = isProgramPublished(conference, now)
+        return status(
+          'homepageProgramHighlights',
+          'empty-hides',
+          source('programme'),
+          {
+            count: talks,
+            countLabel: 'confirmed talks',
+            summary: published
+              ? 'No confirmed talks yet'
+              : 'Programme not published',
+            reason: published
+              ? 'Hidden on the live site — the published schedule holds no confirmed talks.'
+              : 'Hidden on the live site — the programme date has not arrived, so no schedule is published yet.',
+          },
+        )
+      }
+      return status('homepageProgramHighlights', 'ready', source('programme'), {
+        count: talks,
+        countLabel: 'confirmed talks',
+        summary: pluralize(talks, 'confirmed talks'),
+      })
+    }
+
+    // SectionRenderer.tsx:260-266 — no organizers, no band.
+    case 'homepageOrganizers':
+      return collectionStatus(
+        'homepageOrganizers',
+        source('organizers'),
+        conference.organizers?.length ?? 0,
+        'organizers',
+        'Hidden on the live site — this band renders nothing until organizers are added.',
+      )
+
+    // Sponsors.tsx NEVER returns null: the band is a `<section>` wrapper around
+    // an optional logo wall and an optional pitch card. With no sponsors it
+    // degrades to the pitch — and with no sponsors AND the pitch switched off
+    // (or the event over, which suppresses the pitch) it renders an EMPTY
+    // section: vertical whitespace and nothing else. That is not a hide, so
+    // `willHide` stays false; it is called out as a degraded state instead.
+    case 'homepageSponsors': {
+      const count = conference.sponsors?.length ?? 0
+      const tiers = sponsorTierCount(conference)
+      const src = source('sponsors')
+      if (count === 0) {
+        const cta = sponsorsShowCta(section, conference, now)
+        return status('homepageSponsors', 'degraded', src, {
+          count: 0,
+          countLabel: 'sponsors',
+          summary: 'No sponsors yet',
+          reason: cta
+            ? 'Renders as the “Become a Sponsor” pitch only — there are no sponsor logos to show.'
+            : 'Renders as an empty band — there are no sponsors and the sponsor call-to-action is switched off.',
+        })
+      }
+      if (tiers === 0) {
+        return status('homepageSponsors', 'degraded', src, {
+          count,
+          countLabel: 'sponsors',
+          summary: `${pluralize(count, 'sponsors')}, none in a tier`,
+          reason:
+            'No logos render — a sponsor is only shown once it is assigned to a tier.',
+        })
+      }
+      return status('homepageSponsors', 'ready', src, {
+        count,
+        countLabel: 'sponsors',
+        summary: `${pluralize(count, 'sponsors')} in ${pluralize(tiers, 'tiers')}`,
+      })
+    }
+
+    // SectionRenderer.tsx:350-359 (and ImageGallery.tsx:62) — no images, no band.
+    case 'homepageGallery':
+      return collectionStatus(
+        'homepageGallery',
+        source('gallery'),
+        conference.featuredGalleryImages?.length ?? 0,
+        'photos',
+        'Hidden on the live site — this band renders nothing without featured gallery images.',
+      )
+
+    // MetricsBlock.tsx:19 — no metrics, no band. (It shows at most six.)
+    case 'homepageMetrics':
+      return collectionStatus(
+        'homepageMetrics',
+        source('vanity-metrics'),
+        conference.vanityMetrics?.length ?? 0,
+        'metrics',
+        'Hidden on the live site — this band renders nothing until vanity metrics are added.',
+      )
+
+    // CtaBanner.tsx has no early return: the heading always renders. The button
+    // needs BOTH a label and a href (`CtaBanner.tsx:24`), so half a button is a
+    // banner with no way out of it.
+    case 'homepageCtaBanner': {
+      const src = source('section-config')
+      const hasButton = Boolean(section.buttonLabel && section.buttonHref)
+      if (!hasButton) {
+        return status('homepageCtaBanner', 'degraded', src, {
+          summary: section.heading?.trim() || 'Untitled banner',
+          reason:
+            'Renders without a button — a call-to-action banner needs both a button label and a link.',
+        })
+      }
+      return status('homepageCtaBanner', 'ready', src, {
+        summary: section.heading?.trim() || 'Untitled banner',
+      })
+    }
+
+    // RichTextBlock.tsx:22-23 — the guard is on the SANITIZED content, so an
+    // array of blocks the allowlist drops (or of blank paragraphs) hides the
+    // band even though the stored array is non-empty.
+    case 'homepageRichText': {
+      const blocks = sanitizeRichTextContent(section.content)
+      const src = source('section-config')
+      if (blocks.length === 0 || isRichTextContentEmpty(blocks)) {
+        return status('homepageRichText', 'empty-hides', src, {
+          count: 0,
+          countLabel: 'blocks',
+          summary: 'Nothing written yet',
+          reason:
+            'Hidden on the live site — this block has no renderable content.',
+        })
+      }
+      return status('homepageRichText', 'ready', src, {
+        count: blocks.length,
+        countLabel: 'blocks',
+        summary: pluralize(blocks.length, 'blocks'),
+      })
+    }
+
+    // FaqBlock.tsx:19-23 — whichever source is selected must be non-empty.
+    case 'homepageFaq': {
+      const usesTicketFaqs = section.source === 'ticketFaqs'
+      return collectionStatus(
+        'homepageFaq',
+        source(usesTicketFaqs ? 'ticket-faqs' : 'section-config'),
+        faqItemCount(section, conference),
+        'questions',
+        usesTicketFaqs
+          ? 'Hidden on the live site — this block is set to show the ticket FAQs, and there are none.'
+          : 'Hidden on the live site — add at least one question and answer.',
+      )
+    }
+
+    // TWO guards, in two files. SectionRenderer.tsx:422-423 drops the block when
+    // there is no resolvable target; Countdown.tsx:175-176 then hides it again
+    // once the target has PASSED, unless a live message is configured. The
+    // second is post-hydration, so the server render of a passed countdown
+    // briefly shows placeholder dashes — what a visitor ends up looking at is
+    // nothing, and that is what the composer must report.
+    case 'homepageCountdown': {
+      const target = countdownTargetMs(conference, section)
+      const src = source(
+        section.targetOverride?.trim() ? 'section-config' : 'dates',
+      )
+      if (target === null) {
+        return status('homepageCountdown', 'empty-hides', src, {
+          summary: 'No target date',
+          reason:
+            'Hidden on the live site — set a conference start date, or a target date on this block.',
+        })
+      }
+      if (target - now <= 0) {
+        if (!section.liveMessage) {
+          return status('homepageCountdown', 'empty-hides', src, {
+            summary: 'Target date has passed',
+            reason:
+              'Hidden on the live site — the countdown target has passed and no message is set to replace it.',
+          })
+        }
+        return status('homepageCountdown', 'degraded', src, {
+          summary: 'Target passed — showing the message',
+          reason:
+            'The countdown has run out; visitors see the live message instead of a counter.',
+        })
+      }
+      return status('homepageCountdown', 'ready', src, {
+        summary: 'Counting down',
+      })
+    }
+
+    // VenueBlock.tsx:21-23 — neither a name nor an address, no band. Both are
+    // trimmed, so whitespace is not a venue.
+    case 'homepageVenue': {
+      const name = conference.venueName?.trim()
+      const address = conference.venueAddress?.trim()
+      const src = source('venue')
+      if (!name && !address) {
+        return status('homepageVenue', 'empty-hides', src, {
+          summary: 'No venue set',
+          reason:
+            'Hidden on the live site — add a venue name or address to the conference.',
+        })
+      }
+      return status('homepageVenue', 'ready', src, {
+        summary: [name, address].filter(Boolean).join(' · '),
+      })
+    }
+
+    default: {
+      // FORWARD COMPAT, mirroring the renderer's unknown-`_type` skip: stored
+      // data from a newer schema reports as hiding rather than crashing the
+      // composer. The `never` binding is the compile-time half — adding a
+      // fourteenth section type to the registry fails to build here until it
+      // gets a real case above.
+      const exhaustive: never = section
+      const unknown = exhaustive as { _type?: string }
+      return status(
+        String(unknown?._type) as HomepageSectionType,
+        'empty-hides',
+        source('section-config'),
+        {
+          summary: 'Unknown section type',
+          reason:
+            'Hidden on the live site — this section type is not in the registry this deploy knows.',
+        },
+      )
+    }
+  }
+}


### PR DESCRIPTION
Foundation for the front-page composer's live preview (batch E1). Two new files, nothing else touched.

Answers, for each of the 13 section types against a given conference: does this band have what it needs, will it SELF-HIDE on the live site, how much content does it have, and where is that content edited.

## Why it has to be exact

If the status says a band renders and the real renderer hides it, the preview lies to the organizer — which is worse than having no preview. So the guards were derived from the renderer's code, and equivalence is **pinned by rendering**: the test drives 32 cases across all 13 types through the *real* `HomepageSectionRenderer` with the *real* section components (only `next/link` is stubbed, since it needs a router — stubbing a section would make the assertion vacuous) and asserts `(rendered HTML is empty) === willHide`, in both directions. The case table is a `Record<HomepageSectionType, Case[]>`, so a 14th section type fails to compile rather than going silently uncovered.

## Two live-site bugs found while mapping the guards

Not caused by this work, not fixed here — reported so they are not lost:

1. **Sponsors with no sponsors renders an EMPTY BAND, not nothing.** `Sponsors.tsx` has no early return, so a conference without sponsors ships ~10rem of blank whitespace on its front page. Same shape post-event, where the pitch is suppressed regardless of `showCta`. Reported here as `degraded` rather than hidden, because that is the truth.
2. **A CTA banner with only a label or only a URL renders a banner with no way out** — half a button produces a dead call-to-action.

## Other guards worth knowing

- The **countdown has two guards in two files**, and the second runs only after hydration: a passed target server-renders placeholder dashes, then hides on the client. What a visitor ends up seeing is nothing, so `willHide` is true — a server-render-only parity check would have disagreed.
- **Rich text hides on non-empty stored content**: the guard is on the *sanitized* array, so blocks the allowlist drops still hide the band. A naive `content.length > 0` predicate lies here.
- **Sponsors without a tier never render**, and all `special` tiers collapse under one heading — so counts must be computed the way the band groups, not the way the array reads.

## One deliberate deviation

The module takes exactly one runtime import: the sibling `./richText`. The rich-text guard is "does the sanitized content render anything", which is ~200 lines of allowlist logic — copying it here would create precisely the drift this module exists to prevent. `richText.ts` is itself package-free, and `editor.ts` takes the same import for the same reason. The purity test is stricter than its siblings' as compensation: it asserts the import list equals exactly `['./richText']`, so nothing else can slip in.

278 tests green, typecheck, eslint and knip clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a centralized homepage content-status map and renderer-backed parity tests.
- Reports readiness, self-hiding behavior, counts, summaries, and management destinations for all 13 homepage section types.
- Covers time-dependent, sanitized rich-text, sponsor-tier, FAQ-source, and lifecycle-related behavior with real section rendering.

<h3>Confidence Score: 4/5</h3>

The sponsor count discrepancy should be fixed before merging because the new status map can overstate live content for partially tiered sponsor collections.

The visibility guards and management routes align with their live counterparts, but sponsor status counts every stored sponsor while the live band renders only tiered entries.

**Files Needing Attention:** src/lib/homepage/contentStatus.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/homepage/contentStatus.ts | Adds statuses and content-source mappings for every homepage section type, but mixed tiered and untiered sponsors produce an inflated ready count. |
| src/lib/homepage/contentStatus.test.tsx | Adds comprehensive renderer-parity and metadata tests, though the sponsor cases omit the mixed tiered/untiered state that exposes the count discrepancy. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  S[Homepage section] --> C[sectionContentStatus]
  D[Conference content] --> C
  C --> H[Hide or render status]
  C --> N[Count and summary]
  C --> M[Management destination]
  S --> R[HomepageSectionRenderer]
  D --> R
  R --> P[Parity tests]
  H --> P
```

<sub>Reviews (1): Last reviewed commit: ["feat(homepage): content status for every..."](https://github.com/cloudnativebergen/website/commit/a27d08b44a326279a9585639b78e18aff22d5701) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49813507)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->