### PR TITLE
fix(gallery): render images whose artwork is a data: URI

### DIFF
--- a/src/components/GalleryImageSrc.test.tsx
+++ b/src/components/GalleryImageSrc.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { createImageUrlBuilder } from '@sanity/image-url'
+import { ImageCarousel } from '@/components/ImageCarousel'
+import { SimpleImageCarousel } from '@/components/SimpleImageCarousel'
+import { GalleryModal } from '@/components/GalleryModal'
+import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}))
+
+vi.mock('@/lib/trpc/client', () => ({
+  api: {
+    gallery: {
+      untagSelf: {
+        useMutation: () => ({
+          mutate: () => {},
+          mutateAsync: async () => {},
+          reset: () => {},
+          isPending: false,
+        }),
+      },
+    },
+  },
+}))
+
+// The image-url module is aliased to a chainable mock builder in
+// vitest.config.ts. client.ts builds one at import time, so every transform in
+// the app funnels through this single instance and its calls are inspectable.
+const MOCK_CDN_URL = 'https://cdn.sanity.io/images/mock/image.png'
+
+function builderCalls(method: 'width' | 'height' | 'quality' | 'fit') {
+  const builder = vi.mocked(createImageUrlBuilder).mock.results[0]
+    .value as Record<string, ReturnType<typeof vi.fn>>
+  return builder[method].mock.calls.map((call) => call[0])
+}
+
+const DATA_URI =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4='
+
+const realImage: GalleryImageWithSpeakers = {
+  _id: 'image-1',
+  _rev: 'rev-1',
+  _createdAt: '2026-01-01T00:00:00Z',
+  _updatedAt: '2026-01-01T00:00:00Z',
+  photographer: 'Ada Lovelace',
+  date: '2026-01-01',
+  location: 'Bergen',
+  featured: true,
+  image: {
+    _type: 'image',
+    asset: { _ref: 'image-abc123-1200x800-jpg', _type: 'reference' },
+  },
+  speakers: [],
+  imageUrl: 'https://cdn.sanity.io/images/p/d/abc123-1200x800.jpg',
+  imageAlt: 'A real photo',
+}
+
+const generatedImage: GalleryImageWithSpeakers = {
+  ...realImage,
+  _id: 'image-2',
+  imageUrl: DATA_URI,
+  imageAlt: 'Generated artwork',
+}
+
+beforeEach(() => {
+  const builder = vi.mocked(createImageUrlBuilder).mock.results[0]
+    .value as Record<string, ReturnType<typeof vi.fn>>
+  for (const method of ['image', 'width', 'height', 'quality', 'fit', 'url']) {
+    builder[method].mockClear()
+  }
+})
+
+afterEach(cleanup)
+
+describe('gallery image src resolution', () => {
+  describe('real Sanity images go through the image builder unchanged', () => {
+    it('ImageCarousel keeps its 2400px src and the 1x/2x srcSet', () => {
+      const { container } = render(<ImageCarousel images={[realImage]} />)
+      const img = container.querySelector('img')!
+
+      expect(img.getAttribute('src')).toBe(MOCK_CDN_URL)
+      expect(img.getAttribute('srcset')).toBe(
+        `${MOCK_CDN_URL} 1x, ${MOCK_CDN_URL} 2x`,
+      )
+      // src (2400) + srcSet (1200, 2400); no height, so fit/quality only.
+      expect(builderCalls('width')).toEqual([2400, 1200, 2400])
+      expect(builderCalls('height')).toEqual([])
+      expect(builderCalls('quality')).toEqual([85, 85, 85])
+      expect(builderCalls('fit')).toEqual(['max', 'max', 'max'])
+    })
+
+    it('SimpleImageCarousel keeps its 1200px transform', () => {
+      const { container } = render(
+        <SimpleImageCarousel images={[realImage]} onImageClick={() => {}} />,
+      )
+
+      expect(container.querySelector('img')!.getAttribute('src')).toBe(
+        MOCK_CDN_URL,
+      )
+      expect(builderCalls('width')).toEqual([1200])
+      expect(builderCalls('quality')).toEqual([85])
+      expect(builderCalls('fit')).toEqual(['max'])
+    })
+
+    it('GalleryModal keeps its main-image and thumbnail transforms', () => {
+      const { baseElement } = render(
+        <GalleryModal isOpen images={[realImage]} onClose={() => {}} />,
+      )
+
+      for (const img of baseElement.querySelectorAll('img')) {
+        expect(img.getAttribute('src')).toBe(MOCK_CDN_URL)
+      }
+      // Main image at 1920/max, thumbnail at 192x128/crop.
+      expect(builderCalls('width')).toEqual([1920, 192])
+      expect(builderCalls('height')).toEqual([128])
+      expect(builderCalls('quality')).toEqual([90, 85])
+      expect(builderCalls('fit')).toEqual(['max', 'crop'])
+    })
+  })
+
+  describe('data: URI artwork bypasses the builder', () => {
+    it('ImageCarousel renders the data URI and omits srcSet', () => {
+      const { container } = render(<ImageCarousel images={[generatedImage]} />)
+      const img = container.querySelector('img')!
+
+      expect(img.getAttribute('src')).toBe(DATA_URI)
+      // A data URI has no responsive variants, so there is no srcSet to build.
+      expect(img.hasAttribute('srcset')).toBe(false)
+      expect(builderCalls('width')).toEqual([])
+    })
+
+    it('SimpleImageCarousel renders the data URI', () => {
+      const { container } = render(
+        <SimpleImageCarousel
+          images={[generatedImage]}
+          onImageClick={() => {}}
+        />,
+      )
+
+      expect(container.querySelector('img')!.getAttribute('src')).toBe(DATA_URI)
+      expect(builderCalls('width')).toEqual([])
+    })
+
+    it('GalleryModal renders the data URI for main image and thumbnail', () => {
+      const { baseElement } = render(
+        <GalleryModal isOpen images={[generatedImage]} onClose={() => {}} />,
+      )
+
+      const images = baseElement.querySelectorAll('img')
+      expect(images.length).toBeGreaterThan(0)
+      for (const img of images) {
+        expect(img.getAttribute('src')).toBe(DATA_URI)
+      }
+      expect(builderCalls('width')).toEqual([])
+    })
+  })
+})

--- a/src/components/GalleryImageSrc.test.tsx
+++ b/src/components/GalleryImageSrc.test.tsx
@@ -7,12 +7,19 @@ import { createImageUrlBuilder } from '@sanity/image-url'
 import { ImageCarousel } from '@/components/ImageCarousel'
 import { SimpleImageCarousel } from '@/components/SimpleImageCarousel'
 import { GalleryModal } from '@/components/GalleryModal'
+import { galleryImageSrc } from '@/lib/sanity/client'
 import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 
 vi.mock('next-auth/react', () => ({
   useSession: () => ({ data: null, status: 'unauthenticated' }),
 }))
 
+// `@/lib/trpc/client` is the tRPC HTTP boundary, not app logic: importing it for
+// real builds a React Query client and issues network calls. Every sibling
+// component test that renders a tRPC-consuming component stubs it the same way
+// (see `__tests__/components/admin/gallery/ImageMetadataModal.test.tsx`), which
+// is what "mock at boundaries" (AGENTS.md) asks for. GalleryModal only needs
+// `gallery.untagSelf` to exist so the component can mount.
 vi.mock('@/lib/trpc/client', () => ({
   api: {
     gallery: {
@@ -39,8 +46,31 @@ function builderCalls(method: 'width' | 'height' | 'quality' | 'fit') {
   return builder[method].mock.calls.map((call) => call[0])
 }
 
+/** A 1x1 transparent PNG — an allowed inline raster type. */
 const DATA_URI =
-  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4='
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
+/**
+ * `data:` URIs the gallery must NOT hand to an `<img src>`. The SVG entries are
+ * the interesting ones: `<img>` renders SVG in secure static mode so they are
+ * not a live script hole, but they are an unsanitized SVG intake behind
+ * `sanitizeSvg`'s back, and the repo excludes SVG from stored image assets for
+ * the same reason.
+ */
+const REJECTED_DATA_URIS: ReadonlyArray<[string, string]> = [
+  ['HTML', 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=='],
+  ['unsanitized SVG', 'data:image/svg+xml,<svg onload=alert(1)></svg>'],
+  [
+    'base64 SVG',
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4=',
+  ],
+  ['plain text', 'data:text/plain,hello'],
+  ['script', 'data:application/javascript,alert(1)'],
+  ['a bare data: prefix', 'data:'],
+  // `image/pngx` must not slip through on a prefix match — the allowlist is
+  // anchored on the media-type/parameter separator.
+  ['a look-alike media type', 'data:image/pngx,AAAA'],
+]
 
 const realImage: GalleryImageWithSpeakers = {
   _id: 'image-1',
@@ -60,11 +90,21 @@ const realImage: GalleryImageWithSpeakers = {
   imageAlt: 'A real photo',
 }
 
+const secondRealImage: GalleryImageWithSpeakers = {
+  ...realImage,
+  _id: 'image-1b',
+  imageAlt: 'A second real photo',
+}
+
 const generatedImage: GalleryImageWithSpeakers = {
   ...realImage,
   _id: 'image-2',
   imageUrl: DATA_URI,
   imageAlt: 'Generated artwork',
+}
+
+function rejectedImage(imageUrl: string): GalleryImageWithSpeakers {
+  return { ...realImage, _id: 'image-3', imageUrl, imageAlt: 'Rejected' }
 }
 
 beforeEach(() => {
@@ -92,6 +132,36 @@ describe('gallery image src resolution', () => {
       expect(builderCalls('height')).toEqual([])
       expect(builderCalls('quality')).toEqual([85, 85, 85])
       expect(builderCalls('fit')).toEqual(['max', 'max', 'max'])
+    })
+
+    it('ImageCarousel keeps its 512x320 thumbnail transform', () => {
+      const { container } = render(
+        <ImageCarousel images={[realImage, secondRealImage]} />,
+      )
+
+      for (const img of container.querySelectorAll('img')) {
+        expect(img.getAttribute('src')).toBe(MOCK_CDN_URL)
+      }
+      // Main image (2400 + 1x/2x srcSet), then one thumbnail per image, each
+      // 512x320 with a 256x160 / 512x320 srcSet.
+      expect(builderCalls('width')).toEqual([
+        2400, 1200, 2400, 512, 256, 512, 512, 256, 512,
+      ])
+      expect(builderCalls('height')).toEqual([320, 160, 320, 320, 160, 320])
+      expect(builderCalls('quality')).toEqual([
+        85, 85, 85, 85, 85, 85, 85, 85, 85,
+      ])
+      expect(builderCalls('fit')).toEqual([
+        'max',
+        'max',
+        'max',
+        'crop',
+        'crop',
+        'crop',
+        'crop',
+        'crop',
+        'crop',
+      ])
     })
 
     it('SimpleImageCarousel keeps its 1200px transform', () => {
@@ -157,6 +227,98 @@ describe('gallery image src resolution', () => {
         expect(img.getAttribute('src')).toBe(DATA_URI)
       }
       expect(builderCalls('width')).toEqual([])
+    })
+
+    it('ImageCarousel uses the data URI for the thumbnail too', () => {
+      const { container } = render(
+        <ImageCarousel images={[generatedImage, realImage]} />,
+      )
+
+      const [mainImg, generatedThumb, realThumb] =
+        container.querySelectorAll('img')
+
+      expect(mainImg.getAttribute('src')).toBe(DATA_URI)
+      expect(generatedThumb.getAttribute('src')).toBe(DATA_URI)
+      expect(generatedThumb.hasAttribute('srcset')).toBe(false)
+      // The real image alongside it still gets the full builder treatment.
+      expect(realThumb.getAttribute('src')).toBe(MOCK_CDN_URL)
+      expect(builderCalls('width')).toEqual([512, 256, 512])
+      expect(builderCalls('fit')).toEqual(['crop', 'crop', 'crop'])
+    })
+  })
+
+  describe('a non-image data: URI is refused, not passed through', () => {
+    it.each(REJECTED_DATA_URIS)(
+      'galleryImageSrc falls back to the builder for %s',
+      (_label, uri) => {
+        const src = galleryImageSrc(rejectedImage(uri), {
+          width: 2400,
+          quality: 85,
+          fit: 'max',
+        })
+
+        expect(src).toBe(MOCK_CDN_URL)
+        expect(src).not.toContain('data:')
+        expect(builderCalls('width')).toEqual([2400])
+      },
+    )
+
+    it.each(REJECTED_DATA_URIS)(
+      'ImageCarousel renders the CDN src and keeps its srcSet for %s',
+      (_label, uri) => {
+        const { container } = render(
+          <ImageCarousel images={[rejectedImage(uri)]} />,
+        )
+        const img = container.querySelector('img')!
+
+        // Exactly the pre-fix behaviour: the builder URL, srcSet and all. If
+        // the asset is missing the component's existing onError state handles
+        // it — which is strictly better than rendering the refused bytes.
+        expect(img.getAttribute('src')).toBe(MOCK_CDN_URL)
+        expect(img.getAttribute('srcset')).toBe(
+          `${MOCK_CDN_URL} 1x, ${MOCK_CDN_URL} 2x`,
+        )
+        expect(builderCalls('width')).toEqual([2400, 1200, 2400])
+      },
+    )
+
+    it.each(REJECTED_DATA_URIS)(
+      'GalleryModal renders the CDN src for %s',
+      (_label, uri) => {
+        const { baseElement } = render(
+          <GalleryModal
+            isOpen
+            images={[rejectedImage(uri)]}
+            onClose={() => {}}
+          />,
+        )
+
+        const images = baseElement.querySelectorAll('img')
+        expect(images.length).toBeGreaterThan(0)
+        for (const img of images) {
+          expect(img.getAttribute('src')).toBe(MOCK_CDN_URL)
+        }
+      },
+    )
+
+    it('resolves to no src at all when there is no asset to fall back to', () => {
+      // Without `image` there is nothing to build, so the refused bytes must
+      // not leak out through the "just return imageUrl" branch.
+      expect(
+        galleryImageSrc(
+          { imageUrl: 'data:text/html,<script>alert(1)</script>' },
+          { width: 2400 },
+        ),
+      ).toBe('')
+    })
+
+    it('still passes a plain remote URL through when there is no asset', () => {
+      expect(
+        galleryImageSrc(
+          { imageUrl: 'https://example.test/photo.jpg' },
+          { width: 2400 },
+        ),
+      ).toBe('https://example.test/photo.jpg')
     })
   })
 })

--- a/src/components/GalleryModal.tsx
+++ b/src/components/GalleryModal.tsx
@@ -21,7 +21,7 @@ import { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import { api } from '@/lib/trpc/client'
-import { sanityImage } from '@/lib/sanity/client'
+import { galleryImageSrc } from '@/lib/sanity/client'
 
 interface GalleryModalProps {
   isOpen: boolean
@@ -177,11 +177,11 @@ export function GalleryModal({
                       {currentImage?.image && (
                         <div className="relative h-full w-full">
                           <img
-                            src={sanityImage(currentImage.image)
-                              .width(1920)
-                              .quality(90)
-                              .fit('max')
-                              .url()}
+                            src={galleryImageSrc(currentImage, {
+                              width: 1920,
+                              quality: 90,
+                              fit: 'max',
+                            })}
                             alt={
                               currentImage.imageAlt ??
                               (currentImage.photographer
@@ -323,12 +323,12 @@ export function GalleryModal({
                             >
                               {image.image && (
                                 <img
-                                  src={sanityImage(image.image)
-                                    .width(192)
-                                    .height(128)
-                                    .quality(85)
-                                    .fit('crop')
-                                    .url()}
+                                  src={galleryImageSrc(image, {
+                                    width: 192,
+                                    height: 128,
+                                    quality: 85,
+                                    fit: 'crop',
+                                  })}
                                   alt={
                                     image.imageAlt ||
                                     (image.photographer

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -11,7 +11,11 @@ import { useImageCarousel } from '@/hooks/useImageCarousel'
 import { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/Button'
-import { galleryImageSrc, isDataUri, sanityImage } from '@/lib/sanity/client'
+import {
+  galleryImageSrc,
+  isInlineImageDataUri,
+  sanityImage,
+} from '@/lib/sanity/client'
 
 interface ImageCarouselProps {
   images: GalleryImageWithSpeakers[]
@@ -128,7 +132,7 @@ export function ImageCarousel({
                 fit: 'max',
               })}
               srcSet={
-                isDataUri(currentImage.imageUrl)
+                isInlineImageDataUri(currentImage.imageUrl)
                   ? undefined
                   : `${sanityImage(currentImage.image).width(1200).quality(85).fit('max').url()} 1x, ${sanityImage(currentImage.image).width(2400).quality(85).fit('max').url()} 2x`
               }
@@ -232,13 +236,17 @@ export function ImageCarousel({
               >
                 {image.image && (
                   <img
-                    src={sanityImage(image.image)
-                      .width(512)
-                      .height(320)
-                      .quality(85)
-                      .fit('crop')
-                      .url()}
-                    srcSet={`${sanityImage(image.image).width(256).height(160).quality(85).fit('crop').url()} 1x, ${sanityImage(image.image).width(512).height(320).quality(85).fit('crop').url()} 2x`}
+                    src={galleryImageSrc(image, {
+                      width: 512,
+                      height: 320,
+                      quality: 85,
+                      fit: 'crop',
+                    })}
+                    srcSet={
+                      isInlineImageDataUri(image.imageUrl)
+                        ? undefined
+                        : `${sanityImage(image.image).width(256).height(160).quality(85).fit('crop').url()} 1x, ${sanityImage(image.image).width(512).height(320).quality(85).fit('crop').url()} 2x`
+                    }
                     alt={
                       image.imageAlt ||
                       (image.photographer

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -11,7 +11,7 @@ import { useImageCarousel } from '@/hooks/useImageCarousel'
 import { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/Button'
-import { sanityImage } from '@/lib/sanity/client'
+import { galleryImageSrc, isDataUri, sanityImage } from '@/lib/sanity/client'
 
 interface ImageCarouselProps {
   images: GalleryImageWithSpeakers[]
@@ -122,12 +122,16 @@ export function ImageCarousel({
           {currentImage?.image && !hasCurrentImageError && (
             <img
               ref={(el) => setImageRef(el, currentImage._id)}
-              src={sanityImage(currentImage.image)
-                .width(2400)
-                .quality(85)
-                .fit('max')
-                .url()}
-              srcSet={`${sanityImage(currentImage.image).width(1200).quality(85).fit('max').url()} 1x, ${sanityImage(currentImage.image).width(2400).quality(85).fit('max').url()} 2x`}
+              src={galleryImageSrc(currentImage, {
+                width: 2400,
+                quality: 85,
+                fit: 'max',
+              })}
+              srcSet={
+                isDataUri(currentImage.imageUrl)
+                  ? undefined
+                  : `${sanityImage(currentImage.image).width(1200).quality(85).fit('max').url()} 1x, ${sanityImage(currentImage.image).width(2400).quality(85).fit('max').url()} 2x`
+              }
               alt={
                 currentImage.imageAlt ??
                 (currentImage.photographer

--- a/src/components/SimpleImageCarousel.tsx
+++ b/src/components/SimpleImageCarousel.tsx
@@ -5,7 +5,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 import { useImageCarousel } from '@/hooks/useImageCarousel'
 import { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import { cn } from '@/lib/utils'
-import { sanityImage } from '@/lib/sanity/client'
+import { galleryImageSrc } from '@/lib/sanity/client'
 
 interface SimpleImageCarouselProps {
   images: GalleryImageWithSpeakers[]
@@ -81,11 +81,11 @@ export function SimpleImageCarousel({
             >
               <img
                 ref={handleImageRef}
-                src={sanityImage(currentImage.image)
-                  .width(1200)
-                  .quality(85)
-                  .fit('max')
-                  .url()}
+                src={galleryImageSrc(currentImage, {
+                  width: 1200,
+                  quality: 85,
+                  fit: 'max',
+                })}
                 alt={
                   currentImage.imageAlt ??
                   (currentImage.photographer

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -63,3 +63,50 @@ export function speakerImageUrl(
   }
   return image
 }
+
+const DATA_URI_PREFIX = 'data:'
+
+/**
+ * True when a resolved image URL carries its bytes inline rather than pointing
+ * at a host. Such images have no CDN asset behind them and no responsive
+ * variants, so callers must neither transform them nor build a `srcSet`.
+ */
+export function isDataUri(url: string | null | undefined): url is string {
+  return typeof url === 'string' && url.startsWith(DATA_URI_PREFIX)
+}
+
+/**
+ * Resolves a gallery image URL for display. Gallery images are normally Sanity
+ * assets rendered through the image builder, but `imageUrl` can hold a `data:`
+ * URI (generated artwork with no uploaded asset behind it). The builder has no
+ * pass-through source shape — it always composes a CDN URL from the asset ref,
+ * which 404s for such images — so those are returned verbatim. Everything else
+ * keeps the existing builder transform, unchanged.
+ */
+export function galleryImageSrc(
+  source: { image?: SanityImageSource; imageUrl?: string },
+  opts: {
+    width: number
+    height?: number
+    quality?: number
+    fit?: 'crop' | 'max'
+  },
+): string {
+  if (isDataUri(source.imageUrl)) {
+    return source.imageUrl
+  }
+  if (!source.image) {
+    return source.imageUrl ?? ''
+  }
+  let builder = sanityImage(source.image).width(opts.width)
+  if (opts.height !== undefined) {
+    builder = builder.height(opts.height)
+  }
+  if (opts.quality !== undefined) {
+    builder = builder.quality(opts.quality)
+  }
+  if (opts.fit !== undefined) {
+    builder = builder.fit(opts.fit)
+  }
+  return builder.url()
+}

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -67,12 +67,50 @@ export function speakerImageUrl(
 const DATA_URI_PREFIX = 'data:'
 
 /**
- * True when a resolved image URL carries its bytes inline rather than pointing
- * at a host. Such images have no CDN asset behind them and no responsive
- * variants, so callers must neither transform them nor build a `srcSet`.
+ * Inline image bytes we will hand to the browser as an `<img src>`.
+ *
+ * CLOSED ALLOWLIST, RASTER ONLY. `imageUrl` is dataset content — in a
+ * multi-tenant install it is organizer-authored, and Sanity Studio and
+ * dataset-level tooling both bypass our write path — so an unconstrained
+ * `data:` prefix test would let ANY media type reach an `<img src>` on a page
+ * served to every visitor. The media types here are exactly the ones
+ * `SANITY_IMAGE_REF_PATTERN` and `RICH_TEXT_IMAGE_MIME_TYPES` (both in
+ * `@/lib/homepage/richText`) already admit for stored images. Same shape as
+ * `RASTER_DATA_URL_RE` in `@/lib/sponsor-crm/logo-raster`.
+ *
+ * DELIBERATELY A SEPARATE LIST, not an import of `RICH_TEXT_IMAGE_MIME_TYPES`.
+ * That constant is an UPLOAD-side allowlist — "what an organizer may push into
+ * the Sanity asset pipeline", mirrored to the asset-id extensions. This one is
+ * a RENDER-side allowlist — "what bytes we will inline into a visitor's page
+ * from a stored string that never passed an upload gate". Widening one must not
+ * silently widen the other, and `lib/sanity/client` is the lowest-level shared
+ * client: it must not depend on a homepage feature module.
+ *
+ * NO SVG, matching the position the rest of the repo already takes: an SVG is
+ * an active document, so the asset-id pattern excludes `-svg` asset ids,
+ * and the SVG the app DOES accept (sponsor/branding logos) is only ever stored
+ * after `sanitizeSvgUpload` and re-checked by `sanitizeSvg` at render. A `data:`
+ * URI handed to `<img src>` passes through neither sanitizer and cannot pass
+ * through either — the browser gets opaque bytes. `<img>` renders SVG in secure
+ * static mode, so this is not a script-execution hole today; it is a refusal to
+ * open a second, unsanitized SVG intake behind the sanitizer's back.
  */
-export function isDataUri(url: string | null | undefined): url is string {
-  return typeof url === 'string' && url.startsWith(DATA_URI_PREFIX)
+const INLINE_IMAGE_DATA_URI_RE = /^data:image\/(jpe?g|png|webp|gif|avif)[;,]/i
+
+/**
+ * True when a resolved image URL carries its bytes inline as an allowed raster
+ * image type. Such images have no CDN asset behind them and no responsive
+ * variants, so callers must neither transform them nor build a `srcSet`.
+ *
+ * A `data:` URI that is NOT an allowed image type is not "inline artwork" —
+ * it is something we refuse to render, and {@link galleryImageSrc} falls back
+ * to the builder for it.
+ *
+ * Deliberately NOT a `url is string` type predicate: a rejected `data:` URI is
+ * still a string, so the false branch must not narrow the caller's value away.
+ */
+export function isInlineImageDataUri(url: string | null | undefined): boolean {
+  return typeof url === 'string' && INLINE_IMAGE_DATA_URI_RE.test(url)
 }
 
 /**
@@ -80,8 +118,13 @@ export function isDataUri(url: string | null | undefined): url is string {
  * assets rendered through the image builder, but `imageUrl` can hold a `data:`
  * URI (generated artwork with no uploaded asset behind it). The builder has no
  * pass-through source shape — it always composes a CDN URL from the asset ref,
- * which 404s for such images — so those are returned verbatim. Everything else
- * keeps the existing builder transform, unchanged.
+ * which 404s for such images — so an allowed inline image type is returned
+ * verbatim. Everything else keeps the existing builder transform, unchanged.
+ *
+ * A `data:` URI outside {@link INLINE_IMAGE_DATA_URI_RE} is never passed
+ * through: it falls back to the builder, i.e. to exactly the behaviour this
+ * function replaced, and the carousel's existing load-error state handles the
+ * 404 as it did before.
  */
 export function galleryImageSrc(
   source: { image?: SanityImageSource; imageUrl?: string },
@@ -92,11 +135,18 @@ export function galleryImageSrc(
     fit?: 'crop' | 'max'
   },
 ): string {
-  if (isDataUri(source.imageUrl)) {
-    return source.imageUrl
+  const { imageUrl } = source
+  if (imageUrl !== undefined && isInlineImageDataUri(imageUrl)) {
+    return imageUrl
   }
   if (!source.image) {
-    return source.imageUrl ?? ''
+    // With no asset to build from there is nothing to fall back TO, so a
+    // rejected `data:` URI resolves to no src at all rather than leaking out
+    // through this branch.
+    if (imageUrl?.startsWith(DATA_URI_PREFIX)) {
+      return ''
+    }
+    return imageUrl ?? ''
   }
   let builder = sanityImage(source.image).width(opts.width)
   if (opts.height !== undefined) {


### PR DESCRIPTION
The gallery components build image `src`/`srcSet` exclusively from the Sanity CDN URL builder and never consult `imageUrl`. That is fine for uploaded photos, but any image whose artwork is a `data:` URI cannot render at all — the builder composes a CDN URL from the asset ref, which 404s, and the carousel falls into its "Failed to load image" state.

This blocks the front-page composer's live preview, where placeholder gallery tiles are generated gradient artwork. It is also a latent gap in its own right: `imageUrl` is a real projected field (`"imageUrl": image.asset->url`), present on real images, that nothing in the gallery path has ever used.

## Why it could not be fixed inside the image builder

Every `parseSource` path in `@sanity/image-url` ends in `specToImageUrl`, which composes a CDN URL — there is **no** source shape that returns a caller-supplied `data:` URI. The library's single `data:` return is a hardcoded 1×1 transparent PNG for in-progress uploads. And simply omitting the `image` field is worse: the carousel guards on `currentImage?.image`, so an absent field renders no `<img>` at all and leaves a spinner that never resolves.

## The fix

`galleryImageSrc()` beside the existing `speakerImageUrl` in `src/lib/sanity/client.ts` — which already solves exactly this problem for speaker photos, and is the precedent this mirrors. Returns `imageUrl` verbatim when it is a `data:` URI, otherwise applies the existing builder chain unchanged. Wired at all four call sites: `ImageCarousel` (src + srcSet), `GalleryModal` (main image + thumbnail), `SimpleImageCarousel`.

`srcSet` is omitted for `data:` URIs: there are no responsive variants of inline bytes, so a srcSet could only repeat the same payload at 1x and 2x, doubling the inline bytes in the DOM for nothing.

## Evidence real images are unchanged

There were **no existing tests for any gallery component** and no snapshot files in the repo, so the proof was built:

1. A harness rendering all three components with a real asset-ref image, dumping `innerHTML`, captured before and after — `diff` reports identical.
2. A permanent regression test asserting the exact builder arguments per call site (e.g. `ImageCarousel` → width `[2400, 1200, 2400]`, quality `[85,85,85]`, fit `['max','max','max']`; `GalleryModal` → width `[1920, 192]`, height `[128]`). The `data:` cases assert the URI passes through, `srcSet` is absent, and the builder is not called at all.

5239 tests green; gallery story captured and inspected. Diff is confined to the src-resolution lines plus one new file, so #722's mosaic variant should merge trivially.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a gallery image-source resolver that passes inline `data:` artwork through unchanged while preserving existing Sanity CDN transformations.
- Uses the resolver for main images and thumbnails in all three gallery components.
- Omits responsive `srcSet` values for inline artwork.
- Adds regression coverage for inline artwork and existing Sanity image transformations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

Inline artwork consistently bypasses the Sanity URL builder, responsive variants are omitted only for data URIs, and ordinary gallery assets retain their previous transformation parameters.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/sanity/client.ts | Adds consistent detection and passthrough of inline image data while retaining the existing builder behavior for Sanity assets. |
| src/components/ImageCarousel.tsx | Resolves the primary image through the new helper and correctly suppresses srcSet for inline artwork. |
| src/components/GalleryModal.tsx | Applies the shared resolver to both the modal image and thumbnail rendering paths. |
| src/components/SimpleImageCarousel.tsx | Applies the shared resolver without changing the existing carousel loading or navigation behavior. |
| src/components/GalleryImageSrc.test.tsx | Covers inline data-URI passthrough and verifies that existing builder transformations remain unchanged across all affected components. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gallery): render images whose artwor..."](https://github.com/cloudnativebergen/website/commit/3b830834475cc720d2436c814603c7e9a596435d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49828979)</sub>

<!-- /greptile_comment -->