### PR TITLE
fix(security): close cross-tenant leaks before a second customer exists

### DIFF
--- a/__tests__/lib/messaging/notify.test.ts
+++ b/__tests__/lib/messaging/notify.test.ts
@@ -18,7 +18,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('@/lib/notification/sanity', () => ({
   upsertMessageNotifications: vi.fn(async () => {}),
-  getOrganizerSpeakerIds: vi.fn(async () => ['org-1']),
+  // The fan-out reads the CONFERENCE's org explicitly (#723).
+  getOrganizerSpeakerIdsForOrg: vi.fn(async () => ['org-1']),
 }))
 
 vi.mock('@/lib/sanity/client', () => ({
@@ -44,7 +45,7 @@ vi.mock('@/lib/messaging/sanity', async (importActual) => {
 
 import {
   upsertMessageNotifications,
-  getOrganizerSpeakerIds,
+  getOrganizerSpeakerIdsForOrg,
 } from '@/lib/notification/sanity'
 import { clientReadUncached } from '@/lib/sanity/client'
 import { getConversationPreferencesFor } from '@/lib/messaging/sanity'
@@ -57,7 +58,7 @@ import type { Conference } from '@/lib/conference/types'
 
 type LooseMock = ReturnType<typeof vi.fn>
 const upsertMock = upsertMessageNotifications as unknown as LooseMock
-const organizersMock = getOrganizerSpeakerIds as unknown as LooseMock
+const organizersMock = getOrganizerSpeakerIdsForOrg as unknown as LooseMock
 const fetchMock = (clientReadUncached as unknown as { fetch: LooseMock }).fetch
 const prefsMock = getConversationPreferencesFor as unknown as LooseMock
 const emailMock = sendMessageEmails as unknown as LooseMock

--- a/__tests__/lib/messaging/nudge.test.ts
+++ b/__tests__/lib/messaging/nudge.test.ts
@@ -12,7 +12,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('@/lib/notification/sanity', () => ({
-  getOrganizerSpeakerIds: vi.fn(async () => ['org-1', 'org-2']),
+  getOrganizerSpeakerIdsForOrg: vi.fn(async () => ['org-1', 'org-2']),
+  // The candidacy superset is now an explicitly named cross-org read (#723).
+  getAllOrganizerSpeakerIdsAcrossOrgs: vi.fn(async () => ['org-1', 'org-2']),
   createNotifications: vi.fn(async () => {}),
 }))
 
@@ -23,7 +25,7 @@ vi.mock('@/lib/sanity/client', () => ({
 
 import { clientReadUncached, clientWrite } from '@/lib/sanity/client'
 import {
-  getOrganizerSpeakerIds,
+  getOrganizerSpeakerIdsForOrg,
   createNotifications,
 } from '@/lib/notification/sanity'
 import {
@@ -82,7 +84,7 @@ beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {})
   vi.spyOn(console, 'log').mockImplementation(() => {})
   vi.spyOn(console, 'warn').mockImplementation(() => {})
-  vi.mocked(getOrganizerSpeakerIds).mockResolvedValue(['org-1', 'org-2'])
+  vi.mocked(getOrganizerSpeakerIdsForOrg).mockResolvedValue(['org-1', 'org-2'])
   // B4: the loop now batch-resolves each conversation's conference → owning org
   // before scoping recipients. That extra read is the ONLY fetch carrying
   // `organization._ref`; route it to a stable mapping so conf-1 owns org-1 (the
@@ -187,7 +189,7 @@ describe('routing + stamping', () => {
   })
 
   it('skips (does not stamp) an unassigned thread when there are no organizers', async () => {
-    vi.mocked(getOrganizerSpeakerIds).mockResolvedValue([])
+    vi.mocked(getOrganizerSpeakerIdsForOrg).mockResolvedValue([])
     installPatch()
     readMock.fetch.mockResolvedValueOnce([{ ...unassignedProposalConv }])
 

--- a/__tests__/lib/notification/sanity.test.ts
+++ b/__tests__/lib/notification/sanity.test.ts
@@ -35,9 +35,9 @@ vi.mock('@/lib/push/send', () => ({
   sendPushForNotifications: vi.fn(async () => {}),
 }))
 
-// getOrganizerSpeakerIds resolves the CURRENT org (CaaS T1-2, #614) when called
-// without an explicit id. Control that resolver; the default (null) keeps the
-// pre-existing GLOBAL-set assertions valid via the legacy bridge.
+// getOrganizerSpeakerIds resolves the CURRENT org (CaaS T1-2, #614). Control
+// that resolver; the default (null) is the UNRESOLVABLE-tenant case, which must
+// fail closed (#723).
 const resolveOrgMock = vi.fn<() => Promise<string | null>>()
 vi.mock('@/lib/organization/sanity', () => ({
   getOrganizationRefForCurrentConference: resolveOrgMock,
@@ -57,6 +57,8 @@ import {
   deleteNotificationsOlderThan,
   deleteMessageNotificationsFor,
   getOrganizerSpeakerIds,
+  getOrganizerSpeakerIdsForOrg,
+  getAllOrganizerSpeakerIdsAcrossOrgs,
   clearOrganizerSpeakerIdsCache,
 } from '@/lib/notification/sanity'
 import type {
@@ -936,6 +938,11 @@ describe('deleteMessageNotificationsFor — access-loss cleanup (B3)', () => {
 })
 
 describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () => {
+  beforeEach(() => {
+    // These tests are about the SCOPED path; give them a resolvable org.
+    resolveOrgMock.mockResolvedValue('org-A')
+  })
+
   it('bounds the fetch to [0...200] and caches within the TTL (ONE read for two calls)', async () => {
     readMock.fetch.mockResolvedValue(['org-1', 'org-2'])
 
@@ -947,13 +954,10 @@ describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () 
     // Cached: only one underlying read despite two calls.
     expect(readMock.fetch).toHaveBeenCalledTimes(1)
     const [query] = readMock.fetch.mock.calls[0]
-    // Org unresolvable (default) → the GLOBAL organizer query (legacy bridge).
-    expect(query).toContain('_id in *[_type == "conference"].organizers[]._ref')
     expect(query).toContain('[0...200]')
   })
 
   it('ORG-SCOPED: scopes the query to the resolved current org and passes $orgId', async () => {
-    resolveOrgMock.mockResolvedValue('org-A')
     readMock.fetch.mockResolvedValue(['org-1'])
 
     const ids = await getOrganizerSpeakerIds()
@@ -969,7 +973,7 @@ describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () 
   it('scopes to an EXPLICIT orgId argument without resolving the domain', async () => {
     readMock.fetch.mockResolvedValue(['org-9'])
 
-    const ids = await getOrganizerSpeakerIds('org-Z')
+    const ids = await getOrganizerSpeakerIdsForOrg('org-Z')
 
     expect(ids).toEqual(['org-9'])
     // Explicit id → no domain resolution.
@@ -982,26 +986,15 @@ describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () 
   it('caches PER ORG — different orgs do not share a cache entry', async () => {
     readMock.fetch.mockResolvedValueOnce(['a']).mockResolvedValueOnce(['b'])
 
-    const a = await getOrganizerSpeakerIds('org-A')
-    const b = await getOrganizerSpeakerIds('org-B')
-    const aAgain = await getOrganizerSpeakerIds('org-A')
+    const a = await getOrganizerSpeakerIdsForOrg('org-A')
+    const b = await getOrganizerSpeakerIdsForOrg('org-B')
+    const aAgain = await getOrganizerSpeakerIdsForOrg('org-A')
 
     expect(a).toEqual(['a'])
     expect(b).toEqual(['b'])
     expect(aAgain).toEqual(['a']) // served from org-A's cache
     // Two distinct orgs → two reads; the third call hit org-A's cache.
     expect(readMock.fetch).toHaveBeenCalledTimes(2)
-  })
-
-  it('LEGACY BRIDGE: warns and uses the GLOBAL set when the org is null', async () => {
-    resolveOrgMock.mockResolvedValue(null)
-    readMock.fetch.mockResolvedValue(['org-1'])
-
-    await getOrganizerSpeakerIds()
-
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('[authz-bridge]'),
-    )
   })
 
   it('re-fetches after the cache is cleared', async () => {
@@ -1029,5 +1022,57 @@ describe('getOrganizerSpeakerIds — bounded + per-instance TTL cache (B9)', () 
     expect(await getOrganizerSpeakerIds()).toEqual(['org-1'])
     // Two real reads: the failed one was NOT cached.
     expect(readMock.fetch).toHaveBeenCalledTimes(2)
+  })
+})
+
+// REGRESSION (#723). An unresolvable tenant used to yield the organizers of
+// EVERY conference in the dataset, and that branch was reachable by simply
+// calling `getOrganizerSpeakerIds()` with no argument — which two workshop
+// AUTHZ gates did. The global read now has exactly one entry point that a caller
+// must name.
+describe('organizer id sets — fail CLOSED on an unresolvable tenant (#723)', () => {
+  it('returns [] and NEVER issues a global query when the current org does not resolve', async () => {
+    resolveOrgMock.mockResolvedValue(null)
+    readMock.fetch.mockResolvedValue(['leaked-from-another-tenant'])
+
+    expect(await getOrganizerSpeakerIds()).toEqual([])
+    // The decisive assertion: no read at all, so no global read either.
+    expect(readMock.fetch).not.toHaveBeenCalled()
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[scope-deny]'),
+    )
+  })
+
+  it('returns [] for an explicitly null org id (a conference with no organization)', async () => {
+    readMock.fetch.mockResolvedValue(['leaked-from-another-tenant'])
+
+    expect(await getOrganizerSpeakerIdsForOrg(null)).toEqual([])
+    expect(readMock.fetch).not.toHaveBeenCalled()
+  })
+
+  it('never emits an unscoped `*[_type == "conference"]` organizer query on any tenant-scoped path', async () => {
+    resolveOrgMock.mockResolvedValue('org-A')
+    readMock.fetch.mockResolvedValue([])
+
+    await getOrganizerSpeakerIds()
+    await getOrganizerSpeakerIdsForOrg('org-B')
+
+    for (const [query] of readMock.fetch.mock.calls) {
+      expect(query).not.toContain('*[_type == "conference"].organizers')
+      expect(query).toContain('organization._ref == $orgId')
+    }
+  })
+
+  it('the ONLY cross-org read is the explicitly named one', async () => {
+    readMock.fetch.mockResolvedValue(['a', 'b'])
+
+    const ids = await getAllOrganizerSpeakerIdsAcrossOrgs()
+
+    expect(ids).toEqual(['a', 'b'])
+    const [query, params] = readMock.fetch.mock.calls[0]
+    expect(query).toContain('_id in *[_type == "conference"].organizers[]._ref')
+    expect(params).toEqual({})
+    // Not reached by resolving a domain.
+    expect(resolveOrgMock).not.toHaveBeenCalled()
   })
 })

--- a/docs/ORGANIZATION_TIER.md
+++ b/docs/ORGANIZATION_TIER.md
@@ -161,10 +161,17 @@ least one org), and a **legacy token** with no `organizerOrgIds` claim denies to
 — bridging that granted organizer on **any host**, because the global flag is
 true for an organizer of any org. Holders of a pre-#635 token re-login once.
 
+The recipient-selection helper in `src/lib/notification/sanity.ts` has no
+org-unresolvable fallback either: `getOrganizerSpeakerIds()` (current request's
+org) and `getOrganizerSpeakerIdsForOrg(orgId)` both return `[]` when the org
+cannot be resolved. The cross-org set has exactly one entry point,
+`getAllOrganizerSpeakerIdsAcrossOrgs()`, which a caller must name — it exists for
+the stale-nudge cron's candidacy filter and is never a recipient list. No
+authorization path may call any of them; access is `isOrganizerForCurrentOrg`.
+
 **Remaining cleanup**: drop the deprecated `isOrganizer` field and its remaining
-UI / recipient-selection reads (see `src/lib/messaging/standing.ts` and
-`src/lib/notification/sanity.ts`, which still hold their own org-unresolvable
-fallbacks for recipient selection — not access).
+UI reads, and the org-unresolvable fallback still held by
+`src/lib/messaging/standing.ts` (standing selection — not access).
 
 Key modules: `src/lib/authz/organizer.ts` (the shared `isOrganizerForOrg` /
 `isOrganizerForCurrentOrg` helpers), `src/server/trpc.ts`

--- a/docs/TENANT_SCOPING.md
+++ b/docs/TENANT_SCOPING.md
@@ -64,8 +64,10 @@ const count = await scopedFetch<number>(
 
 - `scope`: `{ orgId?, conferenceId? }`. Present dimensions are prepended (conference
   first, then org) and bound; absent/`null` dimensions contribute nothing. An
-  **empty** scope returns the body unchanged — a best-effort degrade so a request
-  path with an unresolvable tenant reads globally rather than throwing.
+  **empty** scope (both absent/null) **throws** — an unresolvable tenant must fail
+  closed, never widen to a global read. Resolve the tenant first and handle the
+  null case explicitly. (The pure `scopedQuery` string helper still returns the
+  body unchanged; only the IO entry point enforces this.)
 - Scope bindings **win** over caller params of the same name — the scope is the
   invariant.
 - `options` is forwarded verbatim (e.g. `{ cache: 'no-store' }`).
@@ -92,8 +94,14 @@ for the pure string transform (both are unit-tested).
 ## The lint rule — `tenancy/no-unscoped-groq`
 
 A local flat-config rule (`eslint-rules/no-unscoped-groq.js`, registered in
-`eslint.config.js`) flags GROQ root filters written as `*[_type == …` string or
-template literals in `src/**`.
+`eslint.config.js`) flags four fail-open GROQ shapes in `src/**`:
+
+| messageId              | Shape                                                                                      | Why                                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `unscoped`             | `` `*[_type == "x" && …]` `` with no tenant predicate                                      | reads every tenant                                                                                                         |
+| `interpolatedFilter`   | `` `*[${filter}]` `` — the root predicate STARTS with an interpolation                     | the scoping is invisible to review and to the rule; several leaks shipped in this shape                                    |
+| `optionalTenantFilter` | `!defined($conferenceId) \|\| conference._ref == $conferenceId`, or `!defined(conference)` | a CONDITIONAL tenant predicate: no key ⇒ every tenant, and tenant-less documents leak to everyone (the gallery leak, #616) |
+| `nullScope`            | `scopedFetch(client, { orgId: null }, …)`                                                  | the callee looks scoped, but a null tenant key makes the builder drop the predicate                                        |
 
 **Severity is `warn`, deliberately.** The repo carries ~230 pre-existing unscoped
 queries; an error would block CI. Warn makes NEW unscoped queries visible in
@@ -103,16 +111,20 @@ rule does **not** fail `mise run check` (`eslint` exits 0 with only warnings).
 A query is **not** flagged when:
 
 1. **It is passed to `scopedFetch(...)`.** The literal sits inside a `scopedFetch`
-   call (direct or member form); the tenant predicate is prepended at runtime, so
-   the body legitimately omits it. Prefer passing the body **inline** to
-   `scopedFetch` so the rule recognizes it (a body hoisted to a `const` and passed
-   by variable is not recognized).
+   call (direct or member form) whose scope is not explicitly `null`; the tenant
+   predicate is prepended at runtime, so the body legitimately omits it. Prefer
+   passing the body **inline** to `scopedFetch` so the rule recognizes it (a body
+   hoisted to a `const` and passed by variable is not recognized). This exemption
+   does **not** cover `optionalTenantFilter` — a fail-open predicate inside the
+   body is not undone by a prefix.
 2. **It is annotated `// groq-global: <reason>`** on the same line as, or the line
    directly above, the query opener.
 
 **Allowlisted paths** (never flagged): the builder module itself
 (`src/lib/sanity/scoped.ts`), `migrations/**`, `scripts/**`, `__tests__/**`, and
-`*.test.*` / `*.spec.*` files.
+`*.test.*` / `*.spec.*` files. The `scripts/**` exemption is a known gap — those
+run with the WRITE token — but the cross-tenant reporting scripts are global by
+design, so tightening it needs per-script `groq-global` annotations first.
 
 ### Suppression convention — reviewed-global queries
 
@@ -139,9 +151,13 @@ time). For each unscoped query:
    (most content) or only an `organization` ref (global tenant-scoped types)? Both?
 2. **Resolve the scope** in the caller: `conferenceId` from
    `getConferenceForCurrentDomain()` / `resolveConferenceId()`; `orgId` from
-   `getOrganizationRefForCurrentConference()`. Both resolvers are best-effort and
-   may be null pre-backfill — pass what you have; an empty scope degrades to the
-   prior global read.
+   `getOrganizationRefForCurrentConference()` / `resolveOrganizationId()`. Both
+   resolvers can return null (unknown host, transient read). **A null scope must
+   FAIL CLOSED** — return empty, or throw — never fall back to a global read.
+   `getConferenceForDomain` returns a truthy `{} as Conference` on an unknown
+   host, so guard with `isUnknownHost()` (or `resolveConferenceId()`, which
+   throws); a bare `if (!conference)` never fires and leaves the scope
+   `undefined`.
 3. **Rewrite the read** with `scopedFetch` (drop the `conference._ref` /
    `organization._ref` predicate and its binding from the body — the builder adds
    them), OR, for dynamic queries, compose `CONFERENCE_FILTER` / `ORG_FILTER` by

--- a/eslint-rules/no-unscoped-groq.js
+++ b/eslint-rules/no-unscoped-groq.js
@@ -1,31 +1,74 @@
 /**
  * ESLint rule: no-unscoped-groq (CaaS #616)
  *
- * Flags GROQ root filters written as `*[_type == ...` string/template literals,
- * which return documents across ALL tenants. The tenant-scoped query invariant
- * (docs/TENANT_SCOPING.md) requires such reads to be constrained to one tenant
- * via `src/lib/sanity/scoped.ts` (`scopedFetch`, or the `CONFERENCE_FILTER` /
- * `ORG_FILTER` predicate constants for hand-written queries).
+ * Flags GROQ root filters that can return documents across ALL tenants. The
+ * tenant-scoped query invariant (docs/TENANT_SCOPING.md) requires such reads to
+ * be constrained to one tenant via `src/lib/sanity/scoped.ts` (`scopedFetch`, or
+ * the `CONFERENCE_FILTER` / `ORG_FILTER` predicate constants for hand-written
+ * queries).
  *
- * Severity is WARN, not ERROR: the repo carries ~170 pre-existing unscoped
- * queries, so an error would block CI. Warn makes NEW unscoped queries visible
- * in review and keeps the outstanding count trackable while sites migrate.
+ * FOUR shapes are recognized:
+ *
+ *  1. `unscoped` — a literal root filter `*[_type == …` with no tenant
+ *     predicate. The original check.
+ *  2. `interpolatedFilter` — a root filter whose predicate STARTS with an
+ *     interpolation (`` *[${filter}] ``). The filter text is not visible to this
+ *     rule, so scoping cannot be established; it must be routed through
+ *     `scopedFetch` or annotated. This form is how several cross-tenant leaks
+ *     shipped unnoticed.
+ *  3. `optionalTenantFilter` — a tenant predicate made CONDITIONAL on its own
+ *     parameter being defined (`!defined($conferenceId) || conference._ref ==
+ *     $conferenceId`) or on the document HAVING a tenant ref (`!defined(
+ *     conference)`). Both mean "no tenant ⇒ every tenant" — fail-OPEN by
+ *     construction. Scope unconditionally instead, and fail closed in the caller.
+ *  4. `nullScope` — `scopedFetch(client, { orgId: null }, …)`: the callee name
+ *     looks scoped, but a null tenant key drops the predicate at runtime.
+ *
+ * Severity is WARN, not ERROR: the repo carries a large tail of pre-existing
+ * unscoped queries, so an error would block CI. Warn makes NEW ones visible in
+ * review and keeps the outstanding count trackable while sites migrate.
  *
  * NOT flagged:
  *  - A query literal passed as an argument to `scopedFetch(...)` — the tenant
- *    predicate is prepended at runtime by the builder, so the body is scoped.
+ *    predicate is prepended at runtime by the builder, so the body is scoped
+ *    (unless the scope argument is explicitly null; see `nullScope`).
  *  - A query annotated `// groq-global: <reason>` on the same line as, or the
  *    line directly above, the query opener (SUPPRESSION for reviewed-global
  *    reads: a cross-tenant identity join, or an inherently global aggregate).
  *
  * ALLOWLIST: the scoped builder module itself, migrations, scripts, and test
- * files are exempt (they are tooling / data-plane / fixtures, not tenant reads).
+ * files are exempt (tooling / data-plane / fixtures, not tenant reads). NOTE:
+ * `scripts/` runs with the WRITE token and its exemption is a known gap — the
+ * cross-tenant reporting scripts are deliberately global, so tightening it needs
+ * per-script `groq-global` annotations first.
  */
 
 'use strict'
 
 // Matches a GROQ root filter opener: `*[_type ==` with optional inner spacing.
 const GROQ_ROOT_FILTER = /\*\[\s*_type\s*==/
+
+// A root filter whose predicate begins with an interpolation: `*[${…}`. The
+// placeholder `${}` is what `joinTemplate` below substitutes for expressions.
+const GROQ_INTERPOLATED_FILTER = /\*\[\s*\$\{\}/
+
+// Any root filter opener at all (used to decide whether an optional-tenant
+// predicate is part of a query rather than incidental text).
+const GROQ_ANY_ROOT = /\*\[/
+
+// A tenant predicate that evaporates when its own parameter (or the document's
+// tenant ref) is absent — `!defined($conferenceId) ||`, `!defined(conference) ||`
+// and friends, in either order around the `||`.
+const OPTIONAL_TENANT_PREDICATE =
+  /!\s*defined\(\s*\$?(?:conferenceId|orgId|organizationId|organisationId|conference|organization)\s*\)/
+
+/** Property names that carry the tenant key into `scopedFetch`. */
+const TENANT_SCOPE_KEYS = new Set([
+  'orgId',
+  'conferenceId',
+  'organizationId',
+  'organisationId',
+])
 
 function isAllowlisted(filename) {
   if (!filename) return true
@@ -47,13 +90,19 @@ module.exports = {
     type: 'problem',
     docs: {
       description:
-        'Require tenant scoping on GROQ root filters; flag unscoped `*[_type == ...` queries (CaaS #616).',
+        'Require tenant scoping on GROQ root filters; flag unscoped, interpolated, optionally-scoped and null-scoped queries (CaaS #616).',
       recommended: false,
     },
     schema: [],
     messages: {
       unscoped:
         'Unscoped GROQ query (`*[_type == ...`). Scope it to a tenant via src/lib/sanity/scoped.ts (scopedFetch, or the CONFERENCE_FILTER / ORG_FILTER predicate constants). If the query is intentionally global, annotate it with `// groq-global: <reason>`. See docs/TENANT_SCOPING.md (#616).',
+      interpolatedFilter:
+        'GROQ root filter built by interpolation (`*[${...}]`) — its tenant scoping is invisible to review and to this rule. Pass the body to scopedFetch, or put the literal `_type == ...` + tenant predicate in the template. If it is intentionally global, annotate it with `// groq-global: <reason>`. See docs/TENANT_SCOPING.md (#616).',
+      optionalTenantFilter:
+        'CONDITIONAL tenant predicate (`!defined($conferenceId) || ...` / `!defined(conference)`): a missing tenant key silently widens the read to every tenant (fail-OPEN). Make the predicate unconditional and fail closed in the caller. See docs/TENANT_SCOPING.md (#616).',
+      nullScope:
+        'scopedFetch called with an explicitly null tenant scope: the builder drops the predicate, so this reads across every tenant. Resolve the tenant and fail closed when it is null. See docs/TENANT_SCOPING.md (#616).',
     },
   },
 
@@ -74,14 +123,37 @@ module.exports = {
       )
     }
 
-    // A query literal is considered scoped when it sits anywhere inside a
-    // `scopedFetch(...)` call — the builder prepends the tenant predicate at
-    // runtime, so the body legitimately omits it. Covers `scopedFetch` and any
-    // member form (`x.scopedFetch(...)`).
-    function isInsideScopedFetch(node) {
+    /**
+     * A scope argument is EXPLICITLY null when the call passes an object literal
+     * whose tenant keys are all the `null` literal (`{ orgId: null }`). That
+     * reads globally at runtime despite the scoped-looking callee.
+     */
+    function hasExplicitlyNullScope(callExpr) {
+      for (const arg of callExpr.arguments) {
+        if (arg.type !== 'ObjectExpression') continue
+        const tenantProps = arg.properties.filter(
+          (p) =>
+            p.type === 'Property' &&
+            p.key &&
+            ((p.key.type === 'Identifier' &&
+              TENANT_SCOPE_KEYS.has(p.key.name)) ||
+              (p.key.type === 'Literal' && TENANT_SCOPE_KEYS.has(p.key.value))),
+        )
+        if (tenantProps.length === 0) continue
+        const allNull = tenantProps.every(
+          (p) => p.value.type === 'Literal' && p.value.value === null,
+        )
+        if (allNull) return true
+      }
+      return false
+    }
+
+    /** The nearest enclosing `scopedFetch(...)` call, or null. */
+    function enclosingScopedFetch(node) {
       const ancestors = sourceCode ? sourceCode.getAncestors(node) : []
-      return ancestors.some((a) => {
-        if (a.type !== 'CallExpression') return false
+      for (let i = ancestors.length - 1; i >= 0; i--) {
+        const a = ancestors[i]
+        if (a.type !== 'CallExpression') continue
         const callee = a.callee
         const name =
           callee.type === 'Identifier'
@@ -90,30 +162,99 @@ module.exports = {
                 callee.property.type === 'Identifier'
               ? callee.property.name
               : null
-        return name === 'scopedFetch'
-      })
+        if (name === 'scopedFetch') return a
+      }
+      return null
     }
 
-    // `raw` is the literal text; `rawStartLine` is the source line of raw[0].
-    function checkRaw(node, raw, rawStartLine) {
-      const match = GROQ_ROOT_FILTER.exec(raw)
-      if (!match) return
-      if (isInsideScopedFetch(node)) return
-      const newlinesBefore = (raw.slice(0, match.index).match(/\n/g) || [])
-        .length
-      const matchLine = rawStartLine + newlinesBefore
-      if (isSuppressed(matchLine)) return
-      context.report({ node, messageId: 'unscoped' })
+    /**
+     * A query literal is considered scoped when it sits inside a `scopedFetch(...)`
+     * call whose scope is not explicitly null — the builder prepends the tenant
+     * predicate at runtime, so the body legitimately omits it.
+     */
+    function isInsideScopedFetch(node) {
+      const call = enclosingScopedFetch(node)
+      return call !== null && !hasExplicitlyNullScope(call)
+    }
+
+    /**
+     * Flatten a template literal to a single string, substituting `${}` for every
+     * interpolation, and return a resolver that maps an index in that string back
+     * to a source line.
+     */
+    function joinTemplate(node) {
+      const PLACEHOLDER = '${}'
+      let text = ''
+      const spans = [] // { start, end, quasi }
+      node.quasis.forEach((quasi, i) => {
+        const start = text.length
+        text += quasi.value.raw
+        spans.push({ start, end: text.length, quasi })
+        if (i < node.quasis.length - 1) text += PLACEHOLDER
+      })
+      const lineAt = (index) => {
+        const span =
+          spans.find((s) => index >= s.start && index < s.end) ?? spans[0]
+        const before = text.slice(span.start, Math.max(index, span.start))
+        const newlines = (before.match(/\n/g) || []).length
+        return span.quasi.loc.start.line + newlines
+      }
+      return { text, lineAt }
+    }
+
+    /** Run every shape check over one flattened query string. */
+    function checkQuery(node, text, lineAt) {
+      const scoped = isInsideScopedFetch(node)
+
+      const rootMatch = GROQ_ROOT_FILTER.exec(text)
+      if (rootMatch && !scoped && !isSuppressed(lineAt(rootMatch.index))) {
+        context.report({ node, messageId: 'unscoped' })
+      }
+
+      const interpMatch = GROQ_INTERPOLATED_FILTER.exec(text)
+      if (interpMatch && !scoped && !isSuppressed(lineAt(interpMatch.index))) {
+        context.report({ node, messageId: 'interpolatedFilter' })
+      }
+
+      // A conditional tenant predicate is fail-open even INSIDE scopedFetch and
+      // even in a query that is otherwise scoped, so it is reported regardless of
+      // the builder — only an explicit `groq-global` annotation silences it.
+      if (GROQ_ANY_ROOT.test(text)) {
+        const optMatch = OPTIONAL_TENANT_PREDICATE.exec(text)
+        if (optMatch && !isSuppressed(lineAt(optMatch.index))) {
+          context.report({ node, messageId: 'optionalTenantFilter' })
+        }
+      }
     }
 
     return {
       Literal(node) {
-        if (typeof node.value === 'string' && typeof node.raw === 'string') {
-          checkRaw(node, node.raw, node.loc.start.line)
+        if (typeof node.value !== 'string' || typeof node.raw !== 'string') {
+          return
         }
+        const line = node.loc.start.line
+        checkQuery(node, node.raw, (index) => {
+          const before = node.raw.slice(0, index)
+          return line + (before.match(/\n/g) || []).length
+        })
       },
-      TemplateElement(node) {
-        checkRaw(node, node.value.raw, node.loc.start.line)
+      TemplateLiteral(node) {
+        const { text, lineAt } = joinTemplate(node)
+        checkQuery(node, text, lineAt)
+      },
+      CallExpression(node) {
+        const callee = node.callee
+        const name =
+          callee.type === 'Identifier'
+            ? callee.name
+            : callee.type === 'MemberExpression' &&
+                callee.property.type === 'Identifier'
+              ? callee.property.name
+              : null
+        if (name !== 'scopedFetch') return
+        if (!hasExplicitlyNullScope(node)) return
+        if (isSuppressed(node.loc.start.line)) return
+        context.report({ node, messageId: 'nullScope' })
       },
     }
   },

--- a/eslint-rules/no-unscoped-groq.test.ts
+++ b/eslint-rules/no-unscoped-groq.test.ts
@@ -67,6 +67,24 @@ ruleTester.run(
         filename: 'src/lib/x/sanity.test.ts',
         code: 'const q = `*[_type == "speaker"]`',
       },
+      // An interpolated root filter routed through the builder is fine.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const r = await scopedFetch(client, { orgId }, `*[${filter}]`)',
+      },
+      // An interpolated root filter can be annotated like any other global read.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: [
+          '// groq-global: aggregate across tenants for the platform console',
+          'const q = `*[${filter}]`',
+        ].join('\n'),
+      },
+      // A non-null scope argument keeps scopedFetch bodies exempt.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const r = await scopedFetch(client, { orgId: resolved }, `*[_type == "talk"]`)',
+      },
     ],
     invalid: [
       // A bare unscoped template-literal query in app source.
@@ -88,6 +106,61 @@ ruleTester.run(
           '// just a normal comment',
           'const q = `*[_type == "speaker"]`',
         ].join('\n'),
+        errors: [{ messageId: 'unscoped' }],
+      },
+      // INTERPOLATED root filter — the predicate is invisible to review (#616).
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const q = `*[${filter}] | order(date asc)`',
+        errors: [{ messageId: 'interpolatedFilter' }],
+      },
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const q = `*[ ${predicate} && _id == $id][0]`',
+        errors: [{ messageId: 'interpolatedFilter' }],
+      },
+      // CONDITIONAL tenant predicate: no id ⇒ every tenant (the gallery leak).
+      {
+        filename: 'src/lib/gallery/sanity.ts',
+        code: 'const q = `*[_type == "imageGallery" && (!defined($conferenceId) || conference._ref == $conferenceId)]`',
+        errors: [
+          { messageId: 'unscoped' },
+          { messageId: 'optionalTenantFilter' },
+        ],
+      },
+      // Documents with NO tenant ref must not be handed to every tenant.
+      {
+        filename: 'src/lib/gallery/sanity.ts',
+        code: 'const q = `*[_type == "imageGallery" && (conference._ref == $conferenceId || !defined(conference))]`',
+        errors: [
+          { messageId: 'unscoped' },
+          { messageId: 'optionalTenantFilter' },
+        ],
+      },
+      // …reported even inside scopedFetch, whose prefix cannot undo a fail-open
+      // predicate inside the body.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const r = await scopedFetch(client, { orgId }, `*[_type == "imageGallery" && (!defined($orgId) || organization._ref == $orgId)]`)',
+        errors: [{ messageId: 'optionalTenantFilter' }],
+      },
+      // A scoped-looking call with a NULL tenant key reads globally at runtime.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const r = await scopedFetch(client, { orgId: null }, `*[_type == "talk"]`)',
+        errors: [
+          // The call itself is flagged…
+          { messageId: 'nullScope' },
+          // …and the body is no longer treated as scoped.
+          { messageId: 'unscoped' },
+        ],
+      },
+      // `!defined($featured)` is an ordinary optional FILTER, not a tenant one:
+      // the query is still reported as `unscoped` (no builder, no annotation),
+      // but exactly once — the optional-tenant check must NOT fire on it.
+      {
+        filename: 'src/lib/x/sanity.ts',
+        code: 'const q = `*[_type == "imageGallery" && conference._ref == $conferenceId && (!defined($featured) || featured == $featured)]`',
         errors: [{ messageId: 'unscoped' }],
       },
       // Multi-line template: the query opener is several lines below the backtick;

--- a/src/app/(admin)/admin/speakers/badge/page.tsx
+++ b/src/app/(admin)/admin/speakers/badge/page.tsx
@@ -1,4 +1,5 @@
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { isUnknownHost } from '@/lib/conference/guard'
 import { ErrorDisplay, AdminPageHeader } from '@/components/admin'
 import { BadgeManagementClient } from '@/components/admin/BadgeManagementClient'
 import { AcademicCapIcon } from '@heroicons/react/24/outline'
@@ -16,7 +17,10 @@ export default async function AdminBadgePage() {
     )
   }
 
-  if (!conference) {
+  // `getConferenceForDomain` returns a TRUTHY `{} as Conference` on an unknown
+  // host, so a bare `!conference` never fires and every query below would run
+  // with `conferenceId: undefined`. Use the canonical guard.
+  if (isUnknownHost({ conference })) {
     return (
       <ErrorDisplay
         title="No Conference Found"
@@ -28,11 +32,16 @@ export default async function AdminBadgePage() {
   // Fetch all data on server to prevent loading states
   const stats = await getBadgeStats(conference._id)
 
-  // Fetch speakers with accepted/confirmed talks
+  // Fetch speakers with accepted/confirmed talks. The proposals projection
+  // crosses editions (a badge shows a speaker's history), so it MUST carry the
+  // org id — without it the nested query was unscoped and listed a shared
+  // speaker's proposals from every organization (#616). A conference with no
+  // resolvable org degrades to this conference's proposals only.
   const { speakers, err: speakersErr } = await getSpeakers(
     conference._id,
     [Status.confirmed, Status.accepted],
     true,
+    conference.organization?._ref ?? null,
   )
   if (speakersErr) {
     console.error('Failed to get speakers:', speakersErr)

--- a/src/app/(admin)/admin/speakers/page.tsx
+++ b/src/app/(admin)/admin/speakers/page.tsx
@@ -59,9 +59,13 @@ export default async function AdminSpeakers() {
       )
     }
 
+    // The cross-edition proposals projection MUST carry the org id, or it is
+    // unscoped and lists a shared speaker's proposals from every organization
+    // (#616). Null org → this conference's proposals only (fail closed).
     const { speakers, err: speakersError } = await getSpeakersWithAcceptedTalks(
       conference._id,
       true,
+      conference.organization?._ref ?? null,
     )
 
     if (speakersError) {

--- a/src/app/api/admin/gallery/upload/route.ts
+++ b/src/app/api/admin/gallery/upload/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth'
 import { createGalleryImage } from '@/lib/gallery/sanity'
 import { galleryImageCreateSchema } from '@/server/schemas/gallery'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import { isUnknownHost } from '@/lib/conference/guard'
 import { isOrganizerForCurrentOrg } from '@/lib/authz/organizer'
 import type { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import { getCurrentDateTime } from '@/lib/time'
@@ -37,8 +38,11 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // `isUnknownHost`, not `!conference`: an unknown host resolves to a TRUTHY
+    // `{} as Conference`, so the old check never fired and the upload would have
+    // been created with an undefined conference reference.
     const { conference } = await getConferenceForCurrentDomain({})
-    if (!conference) {
+    if (isUnknownHost({ conference })) {
       return NextResponse.json(
         { error: 'Conference not found for current domain' },
         { status: 404 },

--- a/src/lib/authz/organizer.ts
+++ b/src/lib/authz/organizer.ts
@@ -36,7 +36,7 @@ import { getOrganizationRefForCurrentConference } from '@/lib/organization/sanit
  */
 
 /** The minimum shape these checks read off a speaker/session token. */
-type OrganizerSpeaker = Pick<Speaker, '_id' | 'organizerOrgIds'>
+export type OrganizerSpeaker = Pick<Speaker, '_id' | 'organizerOrgIds'>
 
 /**
  * PURE, synchronous org-scoped organizer check. Given a speaker and the already-

--- a/src/lib/conference/sanity.ts
+++ b/src/lib/conference/sanity.ts
@@ -321,29 +321,13 @@ export async function getConferenceForDomain(
       error = new Error('Conference not found for domain: ' + host)
       conference = {} as Conference
 
-      // If gallery was requested, fetch unscoped images
+      // UNKNOWN HOST → NO GALLERY (#616). This branch used to fetch gallery
+      // images UNSCOPED, so any host that resolved to no conference — a stray
+      // DNS entry, a preview URL, a probe — was served every tenant's photos.
+      // An unresolvable tenant gets nothing.
       if (gallery) {
-        const galleryOptions =
-          typeof gallery === 'object'
-            ? gallery
-            : { featuredLimit: 8, limit: 50 }
-
-        const featuredOnly = galleryOptions.featuredOnly ?? false
-
-        if (featuredOnly) {
-          const featuredGalleryImages = await getFeaturedGalleryImages(
-            galleryOptions.featuredLimit,
-          )
-          conference.featuredGalleryImages = featuredGalleryImages
-        } else {
-          const [featuredGalleryImages, galleryImages] = await Promise.all([
-            getFeaturedGalleryImages(galleryOptions.featuredLimit ?? 8),
-            getGalleryImages({ limit: galleryOptions.limit ?? 50 }),
-          ])
-
-          conference.featuredGalleryImages = featuredGalleryImages
-          conference.galleryImages = galleryImages
-        }
+        conference.featuredGalleryImages = []
+        conference.galleryImages = []
       }
     }
   } catch (err) {

--- a/src/lib/conference/unknown-host.test.ts
+++ b/src/lib/conference/unknown-host.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * REGRESSION (#616): the unknown-host branch of `getConferenceForDomain` used to
+ * fetch gallery images UNSCOPED — "conference not found → show everything" — so
+ * any Host that resolved to no conference (a stray DNS record, a preview URL, a
+ * scanner) was served every tenant's photos. An unresolvable tenant must get
+ * NOTHING.
+ */
+
+const conferenceFetchMock = vi.fn()
+vi.mock('../sanity/client', () => ({
+  clientWrite: { fetch: (...args: unknown[]) => conferenceFetchMock(...args) },
+  clientReadUncached: {
+    fetch: (...args: unknown[]) => conferenceFetchMock(...args),
+  },
+}))
+
+vi.mock('next/cache', () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers()),
+}))
+
+const getGalleryImagesMock = vi.fn((...args: unknown[]) => {
+  void args
+  return Promise.resolve([])
+})
+const getFeaturedGalleryImagesMock = vi.fn((...args: unknown[]) => {
+  void args
+  return Promise.resolve([])
+})
+vi.mock('@/lib/gallery/sanity', () => ({
+  getGalleryImages: (...args: unknown[]) => getGalleryImagesMock(...args),
+  getFeaturedGalleryImages: (...args: unknown[]) =>
+    getFeaturedGalleryImagesMock(...args),
+}))
+
+vi.mock('@/lib/sponsor-crm/sanity', () => ({
+  getPublicSponsorsForConference: vi.fn(async () => []),
+}))
+
+import { getConferenceForDomain } from './sanity'
+import { isUnknownHost } from './guard'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getConferenceForDomain — unknown host gets NO gallery (#616)', () => {
+  it('does not issue ANY gallery read for a host that resolves to no conference', async () => {
+    conferenceFetchMock.mockResolvedValue(null)
+
+    const result = await getConferenceForDomain('nobody.example.com', {
+      gallery: true,
+    })
+
+    expect(isUnknownHost(result)).toBe(true)
+    expect(result.error).toBeInstanceOf(Error)
+    // The decisive assertions: no gallery query ran, and nothing is rendered.
+    expect(getGalleryImagesMock).not.toHaveBeenCalled()
+    expect(getFeaturedGalleryImagesMock).not.toHaveBeenCalled()
+    expect(result.conference.galleryImages).toEqual([])
+    expect(result.conference.featuredGalleryImages).toEqual([])
+  })
+
+  it('featuredOnly on an unknown host is empty too', async () => {
+    conferenceFetchMock.mockResolvedValue(null)
+
+    const result = await getConferenceForDomain('nobody.example.com', {
+      gallery: { featuredOnly: true, featuredLimit: 8 },
+    })
+
+    expect(getFeaturedGalleryImagesMock).not.toHaveBeenCalled()
+    expect(result.conference.featuredGalleryImages).toEqual([])
+  })
+
+  it('a KNOWN host still gets its own conference-scoped gallery (unchanged)', async () => {
+    conferenceFetchMock.mockResolvedValue({
+      _id: 'conf-1',
+      title: 'Cloud Native Days',
+      domains: ['cnd.example'],
+    })
+
+    const result = await getConferenceForDomain('cnd.example', {
+      gallery: { featuredLimit: 8, limit: 50 },
+    })
+
+    expect(result.error).toBeNull()
+    // Every gallery read carries this conference's id.
+    expect(getFeaturedGalleryImagesMock).toHaveBeenCalledWith(8, 'conf-1')
+    expect(getGalleryImagesMock).toHaveBeenCalledWith({
+      limit: 50,
+      conferenceId: 'conf-1',
+    })
+  })
+})

--- a/src/lib/gallery/sanity.ts
+++ b/src/lib/gallery/sanity.ts
@@ -263,6 +263,35 @@ export async function updateGalleryImage(
 }
 
 /**
+ * The TENANT an image belongs to — its conference and that conference's org — or
+ * `null` when the image does not exist. A by-id read whose ONLY purpose is to be
+ * compared against the request's tenant before a mutation is allowed; every
+ * gallery mutation takes an image id from client input, so without this check an
+ * organizer of tenant A could edit or delete tenant B's photos.
+ */
+export async function getGalleryImageTenant(
+  id: string,
+): Promise<{ conferenceId: string | null; orgId: string | null } | null> {
+  try {
+    // groq-global: resolves the tenant OF a client-supplied image id so the
+    // caller can compare it with the request's tenant (an ownership check, not
+    // a listing).
+    const query = groq`*[_type == "imageGallery" && _id == $id][0]{
+      "conferenceId": conference._ref,
+      "orgId": conference->organization._ref
+    }`
+    return await clientReadUncached.fetch(query, { id }, { cache: 'no-store' })
+  } catch (error) {
+    logger.error('Error resolving gallery image tenant', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      imageId: id,
+    })
+    // FAIL CLOSED: an unknown tenant must not authorize a mutation.
+    return null
+  }
+}
+
+/**
  * Get a single gallery image by ID
  * Uses uncached client for immediate consistency after mutations
  */
@@ -308,17 +337,59 @@ export async function getGalleryImage(
 }
 
 /**
- * Get count of gallery images with optional filtering
- * Uses cached client with CDN for performance, similar to conference module
+ * The TENANT SCOPE every gallery read must carry (#616): exactly one conference,
+ * or exactly one organization (all of that org's conferences — what a speaker's
+ * cross-edition "my photos" list needs). There is deliberately no "unscoped"
+ * member: a gallery read that cannot name its tenant must not run.
+ */
+export type GalleryScope =
+  | { conferenceId: string; orgId?: undefined }
+  | { orgId: string; conferenceId?: undefined }
+
+/**
+ * Turn a {@link GalleryScope} into a GROQ predicate + params, or `null` when the
+ * scope is blank/absent (fail CLOSED — callers must return empty, never query).
+ */
+function galleryScopeClause(
+  scope: Partial<GalleryScope> | undefined,
+): { clause: string; params: Record<string, string> } | null {
+  if (scope?.conferenceId) {
+    return {
+      clause: 'conference._ref == $conferenceId',
+      params: { conferenceId: scope.conferenceId },
+    }
+  }
+  if (scope?.orgId) {
+    return {
+      clause: 'conference->organization._ref == $orgId',
+      params: { orgId: scope.orgId },
+    }
+  }
+  return null
+}
+
+/**
+ * Count gallery images within ONE tenant scope.
+ *
+ * TENANT SCOPING (#616): a {@link GalleryScope} is REQUIRED and its predicate is
+ * unconditional — see {@link getGalleryImages} for why. A blank scope fails
+ * CLOSED (returns 0) rather than counting the whole dataset.
  */
 export async function getGalleryImageCount(
-  filter?: GalleryImageFilter & { conferenceId?: string },
+  filter: GalleryImageFilter & GalleryScope,
   useCache = true,
 ): Promise<number> {
+  const scope = galleryScopeClause(filter)
+  if (!scope) {
+    logger.error(
+      'getGalleryImageCount called without a tenant scope; returning 0 (#616)',
+    )
+    return 0
+  }
   try {
     const query = groq`
       count(*[_type == "imageGallery"
-        && (!defined($conferenceId) || conference._ref == $conferenceId)
+        && ${scope.clause}
         && (!defined($featured) || featured == $featured)
         && (!defined($speakerId) || $speakerId in speakers[]._ref)
         && (!defined($dateFrom) || date >= $dateFrom)
@@ -329,7 +400,7 @@ export async function getGalleryImageCount(
     `
 
     const queryParams: Record<string, unknown> = {
-      conferenceId: filter?.conferenceId ?? null,
+      ...scope.params,
       featured: filter?.featured ?? null,
       speakerId: filter?.speakerId ?? null,
       dateFrom: filter?.dateFrom ?? null,
@@ -353,23 +424,44 @@ export async function getGalleryImageCount(
 }
 
 /**
- * Get gallery images with optional filtering
- * Uses cached client with CDN for performance, similar to conference module
+ * Get gallery images within ONE tenant scope (a conference, or an org's
+ * conferences).
+ *
+ * TENANT SCOPING (#616). A {@link GalleryScope} is REQUIRED and its predicate is
+ * UNCONDITIONAL. Both properties are load-bearing; the previous filter read
+ * `(!defined($conferenceId) || conference._ref == $conferenceId ||
+ * !defined(conference))`, which
+ *   1. returned the WHOLE dataset's images when no id was passed (the speaker
+ *      "my photos" queries and the unknown-host branch of
+ *      `getConferenceForDomain` both did exactly that), and
+ *   2. leaked every conference-LESS image into every tenant's gallery via the
+ *      `!defined(conference)` arm.
+ * An image that references no conference now belongs to no tenant and is
+ * returned to nobody; `createGalleryImage` has always required a conference, so
+ * only documents hand-made in Studio can be in that state (they must be given a
+ * conference to reappear).
+ *
+ * A blank scope fails CLOSED (returns []) rather than reading globally.
  */
 export async function getGalleryImages(
-  filter?: GalleryImageFilter & { conferenceId?: string },
+  filter: GalleryImageFilter & GalleryScope,
   options?: { useCache?: boolean },
 ): Promise<GalleryImageWithSpeakers[]> {
+  const scope = galleryScopeClause(filter)
+  if (!scope) {
+    logger.error(
+      'getGalleryImages called without a tenant scope; returning [] (#616)',
+    )
+    return []
+  }
   try {
     const limit = filter?.limit || 100
     const offset = filter?.offset || 0
     const useCache = options?.useCache ?? true
 
-    // For backward compatibility: if images don't have conference field, they'll still be fetched
-    // Once conference field is added to images, filtering will work properly
     const query = groq`
       *[_type == "imageGallery"
-        && (!defined($conferenceId) || conference._ref == $conferenceId || !defined(conference))
+        && ${scope.clause}
         && (!defined($featured) || featured == $featured)
         && (!defined($speakerId) || $speakerId in speakers[]._ref)
         && (!defined($dateFrom) || date >= $dateFrom)
@@ -405,7 +497,7 @@ export async function getGalleryImages(
     const queryParams: Record<string, unknown> = {
       offset,
       end: offset + limit,
-      conferenceId: filter?.conferenceId ?? null,
+      ...scope.params,
       featured: filter?.featured ?? null,
       speakerId: filter?.speakerId ?? null,
       dateFrom: filter?.dateFrom ?? null,
@@ -429,11 +521,12 @@ export async function getGalleryImages(
 }
 
 /**
- * Get featured gallery images
+ * Get featured gallery images for ONE conference. `conferenceId` is REQUIRED
+ * (tenant scoping, #616) — see {@link getGalleryImages}.
  */
 export async function getFeaturedGalleryImages(
-  limit?: number,
-  conferenceId?: string,
+  limit: number | undefined,
+  conferenceId: string,
 ): Promise<GalleryImageWithSpeakers[]> {
   return getGalleryImages(
     { featured: true, limit: limit || 1000, conferenceId },

--- a/src/lib/gallery/scoping.test.ts
+++ b/src/lib/gallery/scoping.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * REGRESSION (#616): gallery reads were UNSCOPED BY CONSTRUCTION.
+ *
+ * The old root filter was
+ *   `(!defined($conferenceId) || conference._ref == $conferenceId || !defined(conference))`
+ * which returned
+ *   1. the ENTIRE dataset's images whenever no conference id was passed — the
+ *      speaker "my photos" endpoints passed only a `speakerId`, and the
+ *      unknown-host branch of `getConferenceForDomain` deliberately fetched with
+ *      no id at all; and
+ *   2. every conference-LESS image to every tenant, via `!defined(conference)`.
+ *
+ * These tests assert the SHAPE of the emitted GROQ, not just a happy path, so a
+ * future edit that re-introduces an optional tenant predicate fails here rather
+ * than in review.
+ */
+
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadCached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+  clientReadUncached: { fetch: (...args: unknown[]) => fetchMock(...args) },
+  clientWrite: { fetch: (...args: unknown[]) => fetchMock(...args) },
+}))
+
+vi.mock('@/lib/gallery/events', () => ({
+  publishSpeakerTaggedEvent: vi.fn(),
+}))
+
+import {
+  getGalleryImages,
+  getGalleryImageCount,
+  getFeaturedGalleryImages,
+} from './sanity'
+
+/** The two — and only two — tenant predicates a gallery read may carry. */
+const CONFERENCE_SCOPE = 'conference._ref == $conferenceId'
+const ORG_SCOPE = 'conference->organization._ref == $orgId'
+
+function lastQuery(): string {
+  const call = fetchMock.mock.calls.at(-1)
+  return String(call?.[0] ?? '')
+}
+
+function lastParams(): Record<string, unknown> {
+  const call = fetchMock.mock.calls.at(-1)
+  return (call?.[1] ?? {}) as Record<string, unknown>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockResolvedValue([])
+})
+
+describe('gallery reads are tenant-scoped by construction (#616)', () => {
+  it('getGalleryImages scopes to the conference UNCONDITIONALLY', async () => {
+    await getGalleryImages({ conferenceId: 'conf-1', limit: 10 })
+
+    const query = lastQuery()
+    expect(query).toContain(CONFERENCE_SCOPE)
+    // The predicate must NOT be conditional on the parameter being defined…
+    expect(query).not.toContain('!defined($conferenceId)')
+    // …and conference-LESS images must NOT be readmitted.
+    expect(query).not.toContain('!defined(conference)')
+    expect(lastParams()).toMatchObject({ conferenceId: 'conf-1' })
+  })
+
+  it('getGalleryImageCount scopes to the conference UNCONDITIONALLY', async () => {
+    fetchMock.mockResolvedValue(0)
+    await getGalleryImageCount({ conferenceId: 'conf-1' })
+
+    const query = lastQuery()
+    expect(query).toContain(CONFERENCE_SCOPE)
+    expect(query).not.toContain('!defined($conferenceId)')
+    expect(lastParams()).toMatchObject({ conferenceId: 'conf-1' })
+  })
+
+  it('getFeaturedGalleryImages scopes to the conference', async () => {
+    await getFeaturedGalleryImages(8, 'conf-1')
+
+    expect(lastQuery()).toContain(CONFERENCE_SCOPE)
+    expect(lastParams()).toMatchObject({
+      conferenceId: 'conf-1',
+      featured: true,
+    })
+  })
+
+  it('the ORG scope (cross-edition "my photos") stays inside one organization', async () => {
+    await getGalleryImages({ orgId: 'org-A', speakerId: 'sp-1' })
+
+    const query = lastQuery()
+    expect(query).toContain(ORG_SCOPE)
+    expect(query).not.toContain('!defined(conference)')
+    expect(lastParams()).toMatchObject({ orgId: 'org-A', speakerId: 'sp-1' })
+  })
+
+  it('EVERY emitted gallery query carries one of the two tenant predicates', async () => {
+    fetchMock.mockResolvedValue([])
+    await getGalleryImages({ conferenceId: 'conf-1' })
+    await getGalleryImages({ orgId: 'org-A' })
+    await getGalleryImageCount({ conferenceId: 'conf-1' })
+    await getGalleryImageCount({ orgId: 'org-A' })
+    await getFeaturedGalleryImages(4, 'conf-1')
+
+    expect(fetchMock).toHaveBeenCalledTimes(5)
+    for (const [query] of fetchMock.mock.calls) {
+      const q = String(query)
+      expect(q).toContain('_type == "imageGallery"')
+      expect(
+        q.includes(CONFERENCE_SCOPE) || q.includes(ORG_SCOPE),
+        `unscoped gallery query emitted:\n${q}`,
+      ).toBe(true)
+    }
+  })
+})
+
+describe('gallery reads FAIL CLOSED without a tenant scope (#616)', () => {
+  // The type system rejects these call shapes; the runtime guard is the second
+  // line of defence for an id that is present but empty (an unresolved
+  // conference threaded through as `''`/undefined).
+  const unscoped = {} as { conferenceId: string }
+  const blank = { conferenceId: '' }
+
+  it('getGalleryImages returns [] and issues NO query when the scope is missing', async () => {
+    await expect(getGalleryImages(unscoped)).resolves.toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('getGalleryImages returns [] and issues NO query when the id is blank', async () => {
+    await expect(getGalleryImages(blank)).resolves.toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('getGalleryImageCount returns 0 and issues NO query when the scope is missing', async () => {
+    await expect(getGalleryImageCount(unscoped)).resolves.toBe(0)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('getFeaturedGalleryImages returns [] for a blank conference id', async () => {
+    await expect(getFeaturedGalleryImages(8, '' as string)).resolves.toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/messaging/notify.test.ts
+++ b/src/lib/messaging/notify.test.ts
@@ -8,7 +8,10 @@ const getOrganizerSpeakerIdsMock = vi
   .mockResolvedValue(['org-1', 'org-2', 'org-3'])
 vi.mock('@/lib/notification/sanity', () => ({
   upsertMessageNotifications: (...a: unknown[]) => upsertMock(...a),
-  getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
+  // The fan-out passes the CONFERENCE's own org id (#723): no request-domain
+  // dependency and no fallback to every tenant's organizers.
+  getOrganizerSpeakerIdsForOrg: (orgId: string | null) =>
+    getOrganizerSpeakerIdsMock(orgId),
 }))
 
 // TEAMS-2 teams SOURCE: default [] ⇒ ABSENT-MEANS-TODAY (all organizers);

--- a/src/lib/messaging/notify.ts
+++ b/src/lib/messaging/notify.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 import {
   upsertMessageNotifications,
-  getOrganizerSpeakerIds,
+  getOrganizerSpeakerIdsForOrg,
 } from '@/lib/notification/sanity'
 import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import { clientReadUncached } from '@/lib/sanity/client'
@@ -111,9 +111,9 @@ export async function notifyNewMessage({
     // (audience-dependent email default + link variant), whether any recipient is
     // a speaker. That is an access/participant question. ORG-SCOPED (CaaS T1-2,
     // #614): pass the conference's own org so a background send does not depend on
-    // request domain; a pre-backfill conference (no org) falls back to the global
-    // set via the recipient-selection legacy bridge.
-    const organizerIds = await getOrganizerSpeakerIds(
+    // request domain; a conference with no resolvable org FAILS CLOSED to an empty
+    // set (it no longer widens to every tenant's organizers).
+    const organizerIds = await getOrganizerSpeakerIdsForOrg(
       conference.organization?._ref ?? null,
     )
     const organizerSet = new Set(organizerIds)

--- a/src/lib/messaging/nudge.test.ts
+++ b/src/lib/messaging/nudge.test.ts
@@ -9,10 +9,16 @@ const createNotificationsMock = vi.fn().mockResolvedValue(undefined)
 const getOrganizerSpeakerIdsMock = vi
   .fn()
   .mockResolvedValue(['org-1', 'org-2', 'org-3'])
+const getAllOrganizersMock = vi
+  .fn()
+  .mockResolvedValue(['org-1', 'org-2', 'org-3', 'org-9'])
 vi.mock('@/lib/notification/sanity', () => ({
   createNotifications: (...a: unknown[]) => createNotificationsMock(...a),
-  getOrganizerSpeakerIds: (orgId?: string | null) =>
+  getOrganizerSpeakerIdsForOrg: (orgId: string | null) =>
     getOrganizerSpeakerIdsMock(orgId),
+  // The candidacy filter's cross-org superset is now an EXPLICITLY named read
+  // (#723) — it can no longer be reached by omitting an argument.
+  getAllOrganizerSpeakerIdsAcrossOrgs: () => getAllOrganizersMock(),
 }))
 
 // TEAMS-2 teams SOURCE keyed by conference id, so the REAL
@@ -177,8 +183,11 @@ describe('nudgeStaleConversations — per-org recipient isolation (B4)', () => {
     expect(recipientsFor('c-b')).not.toContain('a1')
     expect(summary.nudged).toBe(2)
     expect(summary.notifications).toBe(4)
-    // The GLOBAL organizer set is never requested for recipient resolution.
+    // The GLOBAL organizer set is never requested for recipient resolution:
+    // recipients only ever come from the per-org read, and the cross-org read is
+    // used solely for the candidacy filter (#723).
     expect(getOrganizerSpeakerIdsMock).not.toHaveBeenCalledWith(undefined)
+    expect(getOrganizerSpeakerIdsMock).not.toHaveBeenCalledWith(null)
   })
 
   it('skips a conversation whose org is unresolvable — never broadcasts', async () => {

--- a/src/lib/messaging/nudge.ts
+++ b/src/lib/messaging/nudge.ts
@@ -2,7 +2,8 @@ import 'server-only'
 import { clientWrite, clientReadUncached } from '@/lib/sanity/client'
 import {
   createNotifications,
-  getOrganizerSpeakerIds,
+  getAllOrganizerSpeakerIdsAcrossOrgs,
+  getOrganizerSpeakerIdsForOrg,
 } from '@/lib/notification/sanity'
 import { resolveRoutedOrganizerIds } from '@/lib/teams'
 import type { NotificationInput } from '@/lib/notification/types'
@@ -96,7 +97,7 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
     // recipient list. Recipients are resolved PER-ORG inside the loop (B4): the
     // prior code reused this global set as the team-else-all fallback, which
     // push-notified every tenant's organizers about one tenant's threads.
-    const selectionOrganizerIds = await getOrganizerSpeakerIds(null)
+    const selectionOrganizerIds = await getAllOrganizerSpeakerIdsAcrossOrgs()
     const cutoff = staleConversationCutoff()
 
     // Selection: open (or absent status) AND no activity since the cutoff AND
@@ -194,7 +195,7 @@ export async function nudgeStaleConversations(): Promise<StaleNudgeSummary> {
                 conversation.conversationType === 'sponsor'
                   ? 'sponsors'
                   : 'cfp',
-              allOrganizerIds: await getOrganizerSpeakerIds(orgId),
+              allOrganizerIds: await getOrganizerSpeakerIdsForOrg(orgId),
             })
         if (recipientIds.length === 0) continue
 

--- a/src/lib/notification/sanity.ts
+++ b/src/lib/notification/sanity.ts
@@ -680,7 +680,7 @@ const ORGANIZER_CACHE_TTL_MS = 60_000
 /** Upper bound on the organizer fetch; the organizer set is tiny in practice. */
 const ORGANIZER_FETCH_LIMIT = 200
 
-/** Cache-map key for the GLOBAL (legacy-bridge) organizer set. */
+/** Cache-map key for the GLOBAL (explicitly opted-in) organizer set. */
 const GLOBAL_ORGANIZER_CACHE_KEY = '__global__'
 
 // Per-org (and global) organizer-id cache, keyed by resolved org id. Keying by
@@ -689,46 +689,16 @@ const GLOBAL_ORGANIZER_CACHE_KEY = '__global__'
 const organizerCache = new Map<string, { ids: string[]; expiresAt: number }>()
 
 /**
- * The `_id`s of the organizer speakers for a TENANT (bounded to
- * [0...{@link ORGANIZER_FETCH_LIMIT}]). An organizer is a speaker in the
- * `organizers[]` of one of the org's conferences — the org-SCOPED reading of the
- * canonical organizer definition (CaaS T1-2, #614). This selects MESSAGE
- * RECIPIENTS (fan-out targets, needs-reply, assignee validation, participant
- * classification), NOT access — but it must agree with the org-scoped auth
- * boundary so a cross-org organizer is neither notified about nor allowed to own
- * another tenant's threads.
- *
- * ORG RESOLUTION:
- *  - `orgId` omitted (default) → resolve the CURRENT domain's org. In a request
- *    this scopes to that tenant; in a context without a domain (e.g. the stale-
- *    thread cron) it resolves to `null` and falls through to the GLOBAL set.
- *  - `orgId` a string → scope to that org (callers with a conference in hand,
- *    e.g. the message fan-out, pass `conference.organization._ref` so background
- *    sends don't depend on request domain).
- *  - `orgId` explicitly `null` → the GLOBAL set (every conference's organizers).
- *
- * LEGACY BRIDGE: an `undefined` orgId that RESOLVES to null (pre-044-backfill
- * conference / no domain) yields the GLOBAL organizer set with a
- * `console.warn`, mirroring the auth bridge in `src/lib/authz/organizer.ts`.
- * This historical behaviour ("organizer of one edition = organizer everywhere")
- * is retained ONLY as the migration bridge; remove it under the same condition
- * as the auth bridge. An EXPLICIT `null` is an intentional global read (e.g.
- * the nudge candidacy superset) and does NOT log the bridge warning.
- *
- * Cached per instance for {@link ORGANIZER_CACHE_TTL_MS}, keyed by resolved org.
- * The returned array is treated as read-only by callers (they wrap it in a Set).
+ * Read + cache the organizer id set for ONE tenant, or — when `orgId` is `null`
+ * — for EVERY conference in the dataset. The `null` (global) branch is private
+ * on purpose: it is reachable only through
+ * {@link getAllOrganizerSpeakerIdsAcrossOrgs}, which every caller must name
+ * explicitly. No exported entry point can fall through to it by omission.
  */
-export async function getOrganizerSpeakerIds(
-  orgId?: string | null,
+async function readOrganizerSpeakerIds(
+  orgId: string | null,
 ): Promise<string[]> {
-  const resolvedOrgId =
-    orgId === undefined
-      ? await (
-          await import('@/lib/organization/sanity')
-        ).getOrganizationRefForCurrentConference()
-      : orgId
-
-  const cacheKey = resolvedOrgId ?? GLOBAL_ORGANIZER_CACHE_KEY
+  const cacheKey = orgId ?? GLOBAL_ORGANIZER_CACHE_KEY
 
   const now = Date.now()
   const cached = organizerCache.get(cacheKey)
@@ -741,17 +711,11 @@ export async function getOrganizerSpeakerIds(
     if (entry.expiresAt <= now) organizerCache.delete(key)
   }
 
-  const organizerScope = resolvedOrgId
+  const organizerScope = orgId
     ? `*[_type == "conference" && organization._ref == $orgId].organizers[]._ref`
-    : `*[_type == "conference"].organizers[]._ref`
-
-  // Warn only when the org was supposed to resolve and didn't — an explicit
-  // `null` is an intentional global read, not a bridge event.
-  if (!resolvedOrgId && orgId === undefined) {
-    console.warn(
-      '[authz-bridge] getOrganizerSpeakerIds: org unresolvable; using the GLOBAL organizer set (recipient-selection legacy bridge)',
-    )
-  }
+    : // groq-global: explicit cross-org organizer superset; only reachable via
+      // getAllOrganizerSpeakerIdsAcrossOrgs(), never by an unresolved tenant.
+      `*[_type == "conference"].organizers[]._ref`
 
   // ONLY successes are cached (R2): the `await` throws on a failed read BEFORE
   // the cache assignment below, so a transient Sanity failure is never poisoned
@@ -761,7 +725,7 @@ export async function getOrganizerSpeakerIds(
   // and is cached normally.
   const ids = await clientReadUncached.fetch<string[]>(
     `*[_type == "speaker" && _id in ${organizerScope}][0...${ORGANIZER_FETCH_LIMIT}]._id`,
-    resolvedOrgId ? { orgId: resolvedOrgId } : {},
+    orgId ? { orgId } : {},
   )
   const resolved = ids || []
   organizerCache.set(cacheKey, {
@@ -769,6 +733,75 @@ export async function getOrganizerSpeakerIds(
     expiresAt: now + ORGANIZER_CACHE_TTL_MS,
   })
   return resolved
+}
+
+/**
+ * The `_id`s of the organizer speakers of the CURRENT request's tenant (bounded
+ * to [0...{@link ORGANIZER_FETCH_LIMIT}]). An organizer is a speaker in the
+ * `organizers[]` of one of the org's conferences — the org-SCOPED reading of the
+ * canonical organizer definition (CaaS T1-2, #614). This selects MESSAGE
+ * RECIPIENTS (fan-out targets, needs-reply, assignee validation, participant
+ * classification), NOT access — but it must agree with the org-scoped auth
+ * boundary so a cross-org organizer is neither notified about nor allowed to own
+ * another tenant's threads.
+ *
+ * FAILS CLOSED. When the request's org cannot be resolved (unknown host, no
+ * request context, transient read failure) this returns `[]` — it does NOT fall
+ * back to every conference's organizers. The former global fallback was reachable
+ * by simply omitting an argument, and two workshop-router AUTHZ gates did exactly
+ * that, letting any tenant's organizer pass another tenant's gate. A caller that
+ * genuinely wants the cross-org superset must say so via
+ * {@link getAllOrganizerSpeakerIdsAcrossOrgs}.
+ *
+ * NOT AN AUTHZ GATE. Access decisions belong to `src/lib/authz/organizer.ts`
+ * (`isOrganizerForCurrentOrg`), which reads the session's `organizerOrgIds`.
+ *
+ * Cached per instance for {@link ORGANIZER_CACHE_TTL_MS}, keyed by resolved org.
+ * The returned array is treated as read-only by callers (they wrap it in a Set).
+ */
+export async function getOrganizerSpeakerIds(): Promise<string[]> {
+  const resolvedOrgId = await (
+    await import('@/lib/organization/sanity')
+  ).getOrganizationRefForCurrentConference()
+
+  return getOrganizerSpeakerIdsForOrg(resolvedOrgId)
+}
+
+/**
+ * {@link getOrganizerSpeakerIds} for an org the caller already has in hand (e.g.
+ * a background send passing `conference.organization._ref`, so it does not depend
+ * on a request domain).
+ *
+ * FAILS CLOSED on `null`: an unresolvable org yields `[]`, never the cross-org
+ * set. Post-044-backfill every live conference has an `organization`, so a `null`
+ * here means an unknown domain, a transient read failure, or a malformed
+ * conference — none of which may widen a recipient set to other tenants.
+ */
+export async function getOrganizerSpeakerIdsForOrg(
+  orgId: string | null,
+): Promise<string[]> {
+  if (!orgId) {
+    console.warn(
+      '[scope-deny] getOrganizerSpeakerIds: org unresolvable; returning an EMPTY organizer set (fail-closed)',
+    )
+    return []
+  }
+  return readOrganizerSpeakerIds(orgId)
+}
+
+/**
+ * EVERY conference's organizers, across ALL organizations. Cross-tenant BY
+ * DESIGN and therefore only ever valid as a conservative SUPERSET for a
+ * classification question that is not tenant-specific — today exactly one caller:
+ * the stale-thread nudge cron's candidacy filter ("was this thread's last message
+ * written by an organizer?"), which runs without a request domain and never uses
+ * the result as a recipient list (recipients are resolved per-org inside its
+ * loop).
+ *
+ * Do NOT use this for recipients, and NEVER for authorization.
+ */
+export async function getAllOrganizerSpeakerIdsAcrossOrgs(): Promise<string[]> {
+  return readOrganizerSpeakerIds(null)
 }
 
 /**

--- a/src/lib/sanity/scoped.test.ts
+++ b/src/lib/sanity/scoped.test.ts
@@ -133,9 +133,24 @@ describe('scopedFetch', () => {
     )
   })
 
-  it('runs the raw body unchanged when the scope is empty', async () => {
+  // FAIL CLOSED (#616): an unresolvable tenant must never become a global read.
+  it('THROWS instead of running the body unscoped when the scope is empty', async () => {
     const fetch = vi.fn().mockResolvedValue([])
-    await scopedFetch({ fetch }, {}, `*[_type == "x"]`, { a: 1 })
-    expect(fetch).toHaveBeenCalledWith(`*[_type == "x"]`, { a: 1 }, undefined)
+    await expect(
+      scopedFetch({ fetch }, {}, `*[_type == "x"]`, { a: 1 }),
+    ).rejects.toThrow(/empty tenant scope/)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('THROWS on a scope whose dimensions are explicitly null', async () => {
+    const fetch = vi.fn().mockResolvedValue([])
+    await expect(
+      scopedFetch(
+        { fetch },
+        { orgId: null, conferenceId: null },
+        `*[_type == "x"]`,
+      ),
+    ).rejects.toThrow(/empty tenant scope/)
+    expect(fetch).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/sanity/scoped.ts
+++ b/src/lib/sanity/scoped.ts
@@ -130,6 +130,12 @@ export interface ScopedFetchOptions {
  * names the tenant ONCE and cannot forget to bind a `$conferenceId`/`$orgId` it
  * referenced. Scope bindings win over caller params of the same name — the scope
  * is the invariant. `options` is forwarded verbatim (e.g. `{ cache: 'no-store' }`).
+ *
+ * FAILS CLOSED on an EMPTY scope (both dimensions absent/null): it THROWS rather
+ * than running the body unscoped. `scopedQuery` — a pure string helper — still
+ * returns the body unchanged, but the IO entry point must not turn "I could not
+ * resolve the tenant" into "read every tenant". Resolve the tenant before
+ * calling, and handle an unresolvable one explicitly (empty result or an error).
  */
 export async function scopedFetch<T>(
   client: ScopedFetchClient,
@@ -138,6 +144,11 @@ export async function scopedFetch<T>(
   params: Record<string, unknown> = {},
   options?: ScopedFetchOptions,
 ): Promise<T> {
+  if (!scopePredicate(scope)) {
+    throw new Error(
+      'scopedFetch: empty tenant scope (no conferenceId and no orgId). A read with an unresolvable tenant must fail closed — resolve the tenant, or handle the null case in the caller.',
+    )
+  }
   const query = scopedQuery(scope, groqBody)
   const mergedParams = { ...params, ...scopeParams(scope) }
   return client.fetch<T>(query, mergedParams, options)

--- a/src/lib/speaker/sanity.test.ts
+++ b/src/lib/speaker/sanity.test.ts
@@ -596,6 +596,81 @@ describe('getSpeakers — org scoping', () => {
   })
 })
 
+/**
+ * REGRESSION (#616): `includeProposalsFromOtherConferences` with NO org id left
+ * the NESTED proposals projection completely unscoped (`''`), so a speaker who
+ * has spoken for two organizations had BOTH organizations' proposals rendered —
+ * on the admin badge page and the admin speakers page, which both called exactly
+ * that way. It is also a `'use cache'` function, so the cross-org result cached
+ * under a tenant-looking key.
+ */
+describe('getSpeakers — the nested proposals projection is never unscoped (#616)', () => {
+  /**
+   * The filter of the nested `"proposals": *[ … ]` projection — bracket-matched,
+   * because the status list (`status in ["confirmed", …]`) nests brackets.
+   */
+  function proposalsFilter(query: string): string {
+    const open = query.indexOf('"proposals": *[')
+    expect(open).toBeGreaterThan(-1)
+    const from = open + '"proposals": *['.length
+    let depth = 1
+    for (let i = from; i < query.length; i++) {
+      if (query[i] === '[') depth++
+      else if (query[i] === ']') {
+        depth--
+        if (depth === 0) return query.slice(from, i)
+      }
+    }
+    throw new Error('unterminated proposals projection')
+  }
+
+  it('scopes cross-conference proposals to the ORG when an org id is passed', async () => {
+    fetchMock.mockResolvedValue([])
+
+    await getSpeakers('conf-1', undefined, true, 'org-1')
+
+    const filter = proposalsFilter(fetchMock.mock.calls[0][0])
+    expect(filter).toContain('conference->organization._ref == $orgId')
+  })
+
+  it('FAILS CLOSED to this conference when cross-conference is asked for WITHOUT an org', async () => {
+    fetchMock.mockResolvedValue([])
+
+    await getSpeakers('conf-1', undefined, true, null)
+
+    const filter = proposalsFilter(fetchMock.mock.calls[0][0])
+    // The decisive assertion: some conference/org predicate is present, so the
+    // projection can never span the dataset.
+    expect(filter).toContain('conference._ref == $conferenceId')
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ conferenceId: 'conf-1' })
+  })
+
+  it('scopes to this conference when cross-conference is NOT requested', async () => {
+    fetchMock.mockResolvedValue([])
+
+    await getSpeakers('conf-1', undefined, false, 'org-1')
+
+    expect(proposalsFilter(fetchMock.mock.calls[0][0])).toContain(
+      'conference._ref == $conferenceId',
+    )
+  })
+
+  it('refuses to run at all with neither a conference nor an org', async () => {
+    fetchMock.mockResolvedValue([])
+
+    const { speakers, err } = await getSpeakers(
+      undefined,
+      undefined,
+      true,
+      null,
+    )
+
+    expect(speakers).toEqual([])
+    expect(err).toBeInstanceOf(Error)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
 describe('getOrganizers — org scoping', () => {
   it('scopes organizers to the current org conferences and binds $orgId', async () => {
     fetchMock.mockResolvedValue([])

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -830,6 +830,18 @@ export async function getSpeakers(
   let speakers: (Speaker & { proposals: ProposalExisting[] })[] = []
   let err = null
 
+  // TENANT SCOPING (#616): with neither a conference nor an org there is no
+  // predicate to scope EITHER the speaker list or the nested proposals, so the
+  // query would read the whole dataset. Refuse instead of running it.
+  if (!conferenceId && !orgId) {
+    return {
+      speakers,
+      err: new Error(
+        'getSpeakers requires a conferenceId or an orgId (tenant scoping, #616)',
+      ),
+    }
+  }
+
   try {
     const conferenceFilter = conferenceId
       ? `&& conference._ref == $conferenceId`
@@ -846,10 +858,17 @@ export async function getSpeakers(
     // Crossing conferences must still stay INSIDE the org: without this, an
     // org-scoped speaker list would expose a shared speaker's proposals from
     // ANOTHER organization's conferences.
+    //
+    // FAILS CLOSED when no org resolves (#616). The fallback used to be `''` —
+    // an entirely UNSCOPED nested projection — so a caller that asked for
+    // cross-conference proposals without an org id (the admin badge page and the
+    // admin speakers page both did) rendered a shared speaker's proposals from
+    // EVERY organization. Falling back to the single-conference filter keeps the
+    // page working (it just stops crossing editions) and can never cross tenants.
     const proposalsConferenceFilter = includeProposalsFromOtherConferences
       ? orgId
         ? '&& conference->organization._ref == $orgId'
-        : ''
+        : conferenceFilter
       : conferenceFilter
 
     const query = groq`*[_type == "speaker" && count(*[_type == "talk" && references(^._id) && status in [${statusFilter}] ${conferenceFilter}]) > 0 ${orgFilter}] {

--- a/src/server/routers/gallery.tenancy.test.ts
+++ b/src/server/routers/gallery.tenancy.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Context } from '@/server/trpc'
+
+/**
+ * TENANT ISOLATION for the gallery router (#616).
+ *
+ * READS: the admin list/count used to guard with `if (!conference)`, which never
+ * fires (`getConferenceForDomain` returns a truthy `{} as Conference`), so an
+ * unknown host queried with `conferenceId: undefined` and got every tenant's
+ * photos. `listMine`/`countMine` passed only a `speakerId` — unscoped by
+ * construction.
+ *
+ * WRITES: every mutation takes an image id from CLIENT INPUT and did not check
+ * which tenant owns it, so an organizer of tenant A could edit or delete tenant
+ * B's photos by id.
+ */
+
+const getConferenceMock = vi.fn()
+vi.mock('@/lib/conference/sanity', () => ({
+  getConferenceForCurrentDomain: (...args: unknown[]) =>
+    getConferenceMock(...args),
+}))
+
+type LooseAsyncMock = ReturnType<typeof vi.fn<(...args: unknown[]) => unknown>>
+const getGalleryImagesMock: LooseAsyncMock = vi.fn(async () => [])
+const getGalleryImageCountMock: LooseAsyncMock = vi.fn(async () => 0)
+const getGalleryImageTenantMock: LooseAsyncMock = vi.fn()
+const updateGalleryImageMock: LooseAsyncMock = vi.fn(async () => ({
+  image: { _id: 'img-1' },
+}))
+const deleteGalleryImageMock: LooseAsyncMock = vi.fn(async () => true)
+const untagSpeakerFromImageMock: LooseAsyncMock = vi.fn(async () => ({
+  success: true,
+}))
+vi.mock('@/lib/gallery/sanity', () => ({
+  getGalleryImages: (...a: unknown[]) => getGalleryImagesMock(...a),
+  getGalleryImageCount: (...a: unknown[]) => getGalleryImageCountMock(...a),
+  getGalleryImageTenant: (...a: unknown[]) => getGalleryImageTenantMock(...a),
+  updateGalleryImage: (...a: unknown[]) => updateGalleryImageMock(...a),
+  deleteGalleryImage: (...a: unknown[]) => deleteGalleryImageMock(...a),
+  untagSpeakerFromImage: (...a: unknown[]) => untagSpeakerFromImageMock(...a),
+}))
+
+import { galleryRouter } from './gallery'
+
+const CONFERENCE_ID = 'conf-1'
+const ORG_ID = 'org-A'
+const SPEAKER_ID = 'sp-1'
+
+function caller() {
+  const speaker = {
+    _id: SPEAKER_ID,
+    name: 'Speaker',
+    organizerOrgIds: [ORG_ID],
+  }
+  const ctx = {
+    session: { speaker, user: { name: 'Speaker' } },
+    speaker,
+  } as unknown as Context
+  return galleryRouter.createCaller(ctx)
+}
+
+/** The Host resolves to a conference of ORG_ID. */
+function knownHost() {
+  getConferenceMock.mockResolvedValue({
+    conference: { _id: CONFERENCE_ID, organization: { _ref: ORG_ID } },
+    error: null,
+  })
+}
+
+/** The Host resolves to NOTHING — the truthy-`{}` unknown-host case. */
+function unknownHost() {
+  getConferenceMock.mockResolvedValue({
+    conference: {},
+    error: new Error('Conference not found for domain: nobody.example.com'),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  knownHost()
+  getGalleryImageTenantMock.mockResolvedValue({
+    conferenceId: CONFERENCE_ID,
+    orgId: ORG_ID,
+  })
+  updateGalleryImageMock.mockResolvedValue({ image: { _id: 'img-1' } })
+  deleteGalleryImageMock.mockResolvedValue(true)
+  untagSpeakerFromImageMock.mockResolvedValue({ success: true })
+})
+
+describe('gallery reads are scoped to the resolved tenant (#616)', () => {
+  it('admin.list scopes to the resolved conference', async () => {
+    await caller().admin.list({ limit: 50, offset: 0 })
+    expect(getGalleryImagesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ conferenceId: CONFERENCE_ID }),
+      expect.anything(),
+    )
+  })
+
+  it('listMine scopes to the resolved ORG, not to the speaker alone', async () => {
+    await caller().listMine()
+    expect(getGalleryImagesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: ORG_ID, speakerId: SPEAKER_ID }),
+    )
+  })
+
+  it('countMine scopes to the resolved ORG', async () => {
+    await caller().countMine()
+    expect(getGalleryImageCountMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: ORG_ID, speakerId: SPEAKER_ID }),
+    )
+  })
+
+  it('an UNKNOWN host reads nothing — every read path throws instead', async () => {
+    unknownHost()
+    await expect(
+      caller().admin.list({ limit: 50, offset: 0 }),
+    ).rejects.toBeTruthy()
+    await expect(
+      caller().admin.count({ limit: 50, offset: 0 }),
+    ).rejects.toBeTruthy()
+    await expect(caller().listMine()).rejects.toBeTruthy()
+    await expect(caller().countMine()).rejects.toBeTruthy()
+    expect(getGalleryImagesMock).not.toHaveBeenCalled()
+    expect(getGalleryImageCountMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('gallery mutations reject another tenant’s image id (#616)', () => {
+  /** The image id belongs to a DIFFERENT tenant. */
+  function foreignImage() {
+    getGalleryImageTenantMock.mockResolvedValue({
+      conferenceId: 'conf-OTHER',
+      orgId: 'org-B',
+    })
+  }
+
+  it('update: NOT_FOUND, and nothing is written', async () => {
+    foreignImage()
+    await expect(
+      caller().admin.update({ id: 'img-foreign', photographer: 'me' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(updateGalleryImageMock).not.toHaveBeenCalled()
+  })
+
+  it('delete: NOT_FOUND, and nothing is deleted', async () => {
+    foreignImage()
+    await expect(
+      caller().admin.delete({ id: 'img-foreign' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(deleteGalleryImageMock).not.toHaveBeenCalled()
+  })
+
+  it('toggleFeatured: NOT_FOUND, and nothing is written', async () => {
+    foreignImage()
+    await expect(
+      caller().admin.toggleFeatured({ id: 'img-foreign', featured: true }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(updateGalleryImageMock).not.toHaveBeenCalled()
+  })
+
+  it('untagSelf: NOT_FOUND for an image outside the caller’s org', async () => {
+    foreignImage()
+    await expect(
+      caller().untagSelf({ imageId: 'img-foreign' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(untagSpeakerFromImageMock).not.toHaveBeenCalled()
+  })
+
+  it('an image with NO conference is refused (fail closed)', async () => {
+    getGalleryImageTenantMock.mockResolvedValue({
+      conferenceId: null,
+      orgId: null,
+    })
+    await expect(
+      caller().admin.delete({ id: 'img-orphan' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(deleteGalleryImageMock).not.toHaveBeenCalled()
+  })
+
+  it('a missing image is refused (fail closed)', async () => {
+    getGalleryImageTenantMock.mockResolvedValue(null)
+    await expect(
+      caller().admin.delete({ id: 'img-missing' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+    expect(deleteGalleryImageMock).not.toHaveBeenCalled()
+  })
+
+  it('update cannot REASSIGN an owned image to another conference', async () => {
+    await expect(
+      caller().admin.update({ id: 'img-1', conference: 'conf-OTHER' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    expect(updateGalleryImageMock).not.toHaveBeenCalled()
+  })
+
+  it('the caller’s OWN image still updates (single-tenant behaviour unchanged)', async () => {
+    const result = await caller().admin.update({
+      id: 'img-1',
+      photographer: 'me',
+    })
+    expect(result).toEqual({ _id: 'img-1' })
+    expect(updateGalleryImageMock).toHaveBeenCalledOnce()
+  })
+})

--- a/src/server/routers/gallery.ts
+++ b/src/server/routers/gallery.ts
@@ -233,6 +233,11 @@ export const galleryRouter = router({
       })
       return images
     } catch (error) {
+      // requireCurrentOrgId throws NOT_FOUND on an unresolvable host — that is
+      // the fail-closed signal this PR introduces, and wrapping it as a 500
+      // would hide a tenancy failure behind a generic server error in the
+      // client AND in monitoring. Same rethrow the admin paths already use.
+      if (error instanceof TRPCError) throw error
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: 'Failed to fetch your photos',
@@ -250,6 +255,11 @@ export const galleryRouter = router({
       })
       return count
     } catch (error) {
+      // requireCurrentOrgId throws NOT_FOUND on an unresolvable host — that is
+      // the fail-closed signal this PR introduces, and wrapping it as a 500
+      // would hide a tenancy failure behind a generic server error in the
+      // client AND in monitoring. Same rethrow the admin paths already use.
+      if (error instanceof TRPCError) throw error
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: 'Failed to count your photos',

--- a/src/server/routers/gallery.ts
+++ b/src/server/routers/gallery.ts
@@ -1,5 +1,11 @@
 import { TRPCError } from '@trpc/server'
-import { adminProcedure, protectedProcedure, router } from '../trpc'
+import {
+  adminProcedure,
+  protectedProcedure,
+  resolveConferenceId,
+  resolveOrganizationId,
+  router,
+} from '../trpc'
 import {
   galleryImageUpdateSchema,
   galleryImageFilterSchema,
@@ -10,11 +16,58 @@ import {
 import {
   getGalleryImages,
   getGalleryImageCount,
+  getGalleryImageTenant,
   updateGalleryImage,
   deleteGalleryImage,
   untagSpeakerFromImage,
 } from '@/lib/gallery/sanity'
-import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+
+/**
+ * The current request's org id, or NOT_FOUND. `resolveOrganizationId` returns
+ * `null` on an unresolvable host; a gallery read must never continue with that
+ * (an unscoped gallery query returns every tenant's photos), so this throws.
+ */
+async function requireCurrentOrgId(): Promise<string> {
+  const orgId = await resolveOrganizationId()
+  if (!orgId) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Could not resolve organization from domain',
+    })
+  }
+  return orgId
+}
+
+/**
+ * Every gallery mutation takes an image id from CLIENT INPUT, so each one must
+ * prove the image belongs to the caller's tenant before touching it — otherwise
+ * an organizer of tenant A can edit or delete tenant B's photos by id. Admin
+ * mutations require the CONFERENCE (the surface they manage); the speaker's
+ * self-untag requires only the ORG, so it keeps working across editions.
+ * Fails closed: a missing image, or one with no conference, is NOT_FOUND.
+ */
+async function requireImageInConference(imageId: string): Promise<string> {
+  const conferenceId = await resolveConferenceId()
+  const tenant = await getGalleryImageTenant(imageId)
+  if (!tenant?.conferenceId || tenant.conferenceId !== conferenceId) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Gallery image not found for this conference',
+    })
+  }
+  return conferenceId
+}
+
+async function requireImageInOrg(imageId: string): Promise<void> {
+  const orgId = await requireCurrentOrgId()
+  const tenant = await getGalleryImageTenant(imageId)
+  if (!tenant?.orgId || tenant.orgId !== orgId) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Gallery image not found',
+    })
+  }
+}
 
 export const galleryRouter = router({
   admin: router({
@@ -22,17 +75,15 @@ export const galleryRouter = router({
       .input(galleryImageFilterSchema)
       .query(async ({ input }) => {
         try {
-          const { conference } = await getConferenceForCurrentDomain({})
-          if (!conference) {
-            throw new TRPCError({
-              code: 'NOT_FOUND',
-              message: 'Conference not found for current domain',
-            })
-          }
+          // `resolveConferenceId` THROWS on an unresolvable host. The previous
+          // `if (!conference)` guard never fired — `getConferenceForDomain`
+          // returns a truthy `{} as Conference` — so an unknown host reached the
+          // query with `conferenceId: undefined` and read every tenant's images.
+          const conferenceId = await resolveConferenceId()
 
           const images = await getGalleryImages(
             {
-              conferenceId: conference._id,
+              conferenceId,
               featured: input.featured,
               speakerId: input.speakerId,
               dateFrom: input.dateFrom,
@@ -60,6 +111,14 @@ export const galleryRouter = router({
       .mutation(async ({ input }) => {
         try {
           const { id, ...updateData } = input
+          const conferenceId = await requireImageInConference(id)
+          // A patch may not MOVE an image to another tenant's conference.
+          if (updateData.conference && updateData.conference !== conferenceId) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Cannot reassign a gallery image to another conference',
+            })
+          }
           const res = await updateGalleryImage(id, updateData)
           if (!res.image) {
             throw new TRPCError({
@@ -82,6 +141,7 @@ export const galleryRouter = router({
       .input(galleryImageDeleteSchema)
       .mutation(async ({ input }) => {
         try {
+          await requireImageInConference(input.id)
           const ok = await deleteGalleryImage(input.id)
           if (!ok) {
             throw new TRPCError({
@@ -91,6 +151,7 @@ export const galleryRouter = router({
           }
           return { success: ok }
         } catch (error) {
+          if (error instanceof TRPCError) throw error
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Failed to delete gallery image',
@@ -103,6 +164,7 @@ export const galleryRouter = router({
       .input(galleryImageToggleFeaturedSchema)
       .mutation(async ({ input }) => {
         try {
+          await requireImageInConference(input.id)
           const res = await updateGalleryImage(input.id, {
             featured: input.featured,
           })
@@ -127,17 +189,12 @@ export const galleryRouter = router({
       .input(galleryImageFilterSchema)
       .query(async ({ input }) => {
         try {
-          const { conference } = await getConferenceForCurrentDomain({})
-          if (!conference) {
-            throw new TRPCError({
-              code: 'NOT_FOUND',
-              message: 'Conference not found for current domain',
-            })
-          }
+          // Fail closed on an unresolvable host — see `admin.list` above.
+          const conferenceId = await resolveConferenceId()
 
           const count = await getGalleryImageCount(
             {
-              conferenceId: conference._id,
+              conferenceId,
               featured: input.featured,
               speakerId: input.speakerId,
               dateFrom: input.dateFrom,
@@ -159,9 +216,17 @@ export const galleryRouter = router({
       }),
   }),
 
+  // A speaker's own photos, SCOPED TO THE CURRENT TENANT'S ORG (#616):
+  // previously this filtered on `speakerId` alone, so a speaker tagged in two
+  // orgs' galleries was served BOTH orgs' photos from either host. The scope is
+  // the ORG (not the single conference) so a speaker keeps seeing their photos
+  // from every edition of the same organizer — unchanged for the CND editions,
+  // which all belong to one org.
   listMine: protectedProcedure.query(async ({ ctx }) => {
     try {
+      const orgId = await requireCurrentOrgId()
       const images = await getGalleryImages({
+        orgId,
         speakerId: ctx.speaker._id,
         limit: 50,
         offset: 0,
@@ -178,7 +243,9 @@ export const galleryRouter = router({
 
   countMine: protectedProcedure.query(async ({ ctx }) => {
     try {
+      const orgId = await requireCurrentOrgId()
       const count = await getGalleryImageCount({
+        orgId,
         speakerId: ctx.speaker._id,
       })
       return count
@@ -195,6 +262,7 @@ export const galleryRouter = router({
     .input(galleryImageUntagSelfSchema)
     .mutation(async ({ ctx, input }) => {
       try {
+        await requireImageInOrg(input.imageId)
         const result = await untagSpeakerFromImage(
           input.imageId,
           ctx.speaker._id,

--- a/src/server/routers/workshop.announce.test.ts
+++ b/src/server/routers/workshop.announce.test.ts
@@ -11,10 +11,24 @@ vi.mock('@/lib/conference/sanity', () => ({
     getConferenceMock(...args),
 }))
 
-// --- Organizer set ----------------------------------------------------------
-const getOrganizerSpeakerIdsMock = vi.fn()
+// Organizer authorization runs through the REAL `isOrganizerForCurrentOrg`
+// (session `organizerOrgIds` × the domain-resolved org). Its org resolution goes
+// through `getConferenceForCurrentDomain`, mocked above.
+//
+// TRIPWIRE (#723): the organizer-ID readers select message RECIPIENTS and must
+// never be consulted for an access decision in this router — one of them used to
+// be this gate, and returned every tenant's organizers. Any call from a workshop
+// code path fails the suite loudly rather than silently widening a gate.
+function organizerIdTripwire(): never {
+  throw new Error(
+    'workshop authz must not consult the organizer-id set (#723): use isOrganizerForCurrentOrg',
+  )
+}
 vi.mock('@/lib/notification/sanity', () => ({
-  getOrganizerSpeakerIds: () => getOrganizerSpeakerIdsMock(),
+  getOrganizerSpeakerIds: organizerIdTripwire,
+  getOrganizerSpeakerIdsForOrg: organizerIdTripwire,
+  getAllOrganizerSpeakerIdsAcrossOrgs: organizerIdTripwire,
+  createNotifications: vi.fn(async () => {}),
 }))
 
 // --- Announcements data layer (keep isWorkshopFormat real) ------------------
@@ -58,13 +72,26 @@ vi.mock('@/lib/workshop/announcementRateLimit', () => ({
 import { workshopRouter } from './workshop'
 
 const CONFERENCE_ID = 'conf-1'
+const ORG_ID = 'org-A'
+const OTHER_ORG_ID = 'org-B'
 const OWNER_ID = 'sp-owner'
 const ORGANIZER_ID = 'sp-org'
+const CROSS_TENANT_ORGANIZER_ID = 'sp-org-other-tenant'
 const STRANGER_ID = 'sp-stranger'
+
+/** Which orgs each fixture speaker organizes (the session token's claim). */
+const ORGANIZER_ORG_IDS: Record<string, string[]> = {
+  [ORGANIZER_ID]: [ORG_ID],
+  [CROSS_TENANT_ORGANIZER_ID]: [OTHER_ORG_ID],
+}
 
 function makeCaller(speakerId: string | null) {
   const speaker = speakerId
-    ? { _id: speakerId, name: 'Test Speaker', isOrganizer: false }
+    ? {
+        _id: speakerId,
+        name: 'Test Speaker',
+        organizerOrgIds: ORGANIZER_ORG_IDS[speakerId] ?? [],
+      }
     : undefined
   const ctx = {
     session: speaker ? { speaker, user: { name: 'Test Speaker' } } : null,
@@ -76,7 +103,11 @@ function makeCaller(speakerId: string | null) {
 beforeEach(() => {
   vi.clearAllMocks()
   getConferenceMock.mockResolvedValue({
-    conference: { _id: CONFERENCE_ID, organizer: 'CNB' },
+    conference: {
+      _id: CONFERENCE_ID,
+      organizer: 'CNB',
+      organization: { _ref: ORG_ID },
+    },
     error: null,
   })
   getWorkshopForAnnouncementMock.mockResolvedValue({
@@ -86,7 +117,6 @@ beforeEach(() => {
     conferenceId: CONFERENCE_ID,
     speakerIds: [OWNER_ID],
   })
-  getOrganizerSpeakerIdsMock.mockResolvedValue([ORGANIZER_ID])
   getConfirmedRecipientsMock.mockResolvedValue([
     { userEmail: 'a@example.com', userName: 'A' },
   ])
@@ -118,8 +148,6 @@ describe('workshop.announce — authorization', () => {
     expect(result.recipientCount).toBe(1)
     expect(createAnnouncementMock).toHaveBeenCalledOnce()
     expect(fanOutMock).toHaveBeenCalledOnce()
-    // An owner is authorized without needing the organizer lookup.
-    expect(getOrganizerSpeakerIdsMock).not.toHaveBeenCalled()
   })
 
   it('allows an ORGANIZER who is not a workshop speaker', async () => {
@@ -128,7 +156,6 @@ describe('workshop.announce — authorization', () => {
       body: 'Room change',
     })
     expect(result.success).toBe(true)
-    expect(getOrganizerSpeakerIdsMock).toHaveBeenCalledOnce()
     expect(createAnnouncementMock).toHaveBeenCalledOnce()
   })
 
@@ -145,6 +172,78 @@ describe('workshop.announce — authorization', () => {
       makeCaller(null).announce({ workshopId: 'ws-1', body: 'hi' }),
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' })
     expect(createAnnouncementMock).not.toHaveBeenCalled()
+  })
+})
+
+// REGRESSION (#723): the organizer arm of these gates used to be
+// `getOrganizerSpeakerIds()` — called with NO argument, so on an unresolvable
+// org it returned the organizers of EVERY conference in the dataset. An
+// organizer of tenant B therefore passed tenant A's gate and could broadcast to
+// A's workshop attendees. Authorization is now org-scoped and fails closed.
+describe('workshop announcements — CROSS-TENANT organizer is denied (#723)', () => {
+  it('announce: FORBIDDEN for an organizer of ANOTHER org', async () => {
+    await expect(
+      makeCaller(CROSS_TENANT_ORGANIZER_ID).announce({
+        workshopId: 'ws-1',
+        body: 'Hello other tenant’s attendees',
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(createAnnouncementMock).not.toHaveBeenCalled()
+    expect(fanOutMock).not.toHaveBeenCalled()
+  })
+
+  it('updateAnnouncement: FORBIDDEN for an organizer of ANOTHER org', async () => {
+    await expect(
+      makeCaller(CROSS_TENANT_ORGANIZER_ID).updateAnnouncement({
+        announcementId: 'ann-1',
+        body: 'edited',
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(updateAnnouncementBodyMock).not.toHaveBeenCalled()
+  })
+
+  it('deleteAnnouncement: FORBIDDEN for an organizer of ANOTHER org', async () => {
+    await expect(
+      makeCaller(CROSS_TENANT_ORGANIZER_ID).deleteAnnouncement({
+        announcementId: 'ann-1',
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(deleteAnnouncementMock).not.toHaveBeenCalled()
+  })
+
+  it('FAILS CLOSED: even a same-org organizer is denied when the conference has no resolvable org', async () => {
+    getConferenceMock.mockResolvedValue({
+      conference: { _id: CONFERENCE_ID, organizer: 'CNB' }, // no `organization`
+      error: null,
+    })
+    await expect(
+      makeCaller(ORGANIZER_ID).announce({ workshopId: 'ws-1', body: 'hi' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(createAnnouncementMock).not.toHaveBeenCalled()
+  })
+
+  it('a LEGACY session token with no organizerOrgIds is denied', async () => {
+    const ctx = {
+      session: { speaker: { _id: 'sp-legacy', name: 'Legacy' } },
+      speaker: { _id: 'sp-legacy', name: 'Legacy' },
+    } as unknown as Context
+    await expect(
+      workshopRouter
+        .createCaller(ctx)
+        .announce({ workshopId: 'ws-1', body: 'hi' }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    expect(createAnnouncementMock).not.toHaveBeenCalled()
+  })
+
+  // Belt-and-braces for the tripwire above: an ALLOWED organizer must also reach
+  // success without any organizer-id read (the tripwire would have thrown
+  // INTERNAL_SERVER_ERROR instead of returning success).
+  it('an allowed organizer is authorized without reading the organizer-id set', async () => {
+    const result = await makeCaller(ORGANIZER_ID).announce({
+      workshopId: 'ws-1',
+      body: 'Room change',
+    })
+    expect(result.success).toBe(true)
   })
 })
 
@@ -224,8 +323,6 @@ describe('workshop.updateAnnouncement — authorization + immutability', () => {
       'ann-1',
       'Corrected copy',
     )
-    // Owner is authorized without the organizer lookup.
-    expect(getOrganizerSpeakerIdsMock).not.toHaveBeenCalled()
   })
 
   it('allows an ORGANIZER who is not a workshop speaker', async () => {
@@ -234,7 +331,6 @@ describe('workshop.updateAnnouncement — authorization + immutability', () => {
       body: 'Room change',
     })
     expect(result.success).toBe(true)
-    expect(getOrganizerSpeakerIdsMock).toHaveBeenCalledOnce()
   })
 
   it('rejects an unrelated speaker (FORBIDDEN)', async () => {

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -48,7 +48,10 @@ import { Status } from '@/lib/proposal/types'
 import { sendBasicWorkshopConfirmation } from '@/lib/email/workshop'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { WorkshopSignupStatus } from '@/lib/workshop/types'
-import { getOrganizerSpeakerIds } from '@/lib/notification/sanity'
+import {
+  isOrganizerForCurrentOrg,
+  type OrganizerSpeaker,
+} from '@/lib/authz/organizer'
 import {
   getWorkshopForAnnouncement,
   getConfirmedAnnouncementRecipients,
@@ -81,16 +84,21 @@ function requireWorkshopUser(ctx: Context): WorkshopUserIdentity {
 
 /**
  * Authorize an announcement edit/delete: the caller must OWN the workshop the
- * announcement belongs to (be one of its speakers) OR be an organizer — the
- * SAME rule as `announce`. Also re-checks multi-tenant isolation (the
- * announcement must live in the caller's resolved conference). Throws
- * NOT_FOUND / FORBIDDEN; returns nothing on success. Author/createdAt are NOT
- * consulted — ownership is by the workshop, not the original author.
+ * announcement belongs to (be one of its speakers) OR be an organizer OF THIS
+ * REQUEST'S ORG — the SAME rule as `announce`. Also re-checks multi-tenant
+ * isolation (the announcement must live in the caller's resolved conference).
+ * Throws NOT_FOUND / FORBIDDEN; returns nothing on success. Author/createdAt are
+ * NOT consulted — ownership is by the workshop, not the original author.
+ *
+ * ORG-SCOPED (see the `announce` gate for the full rationale): the organizer arm
+ * goes through `isOrganizerForCurrentOrg`, never through a set of "organizers of
+ * any conference".
  */
 async function authorizeAnnouncementMutation(
-  speakerId: string,
+  speaker: OrganizerSpeaker,
   announcementId: string,
 ): Promise<void> {
+  const speakerId = speaker._id
   const conferenceId = await resolveConferenceId()
   const announcement = await getWorkshopAnnouncementForAuthz(announcementId)
 
@@ -114,9 +122,7 @@ async function authorizeAnnouncementMutation(
   }
 
   const isOwner = workshop.speakerIds.includes(speakerId)
-  const isOrganizer = isOwner
-    ? false
-    : (await getOrganizerSpeakerIds()).includes(speakerId)
+  const isOrganizer = isOwner ? false : await isOrganizerForCurrentOrg(speaker)
 
   if (!isOwner && !isOrganizer) {
     throw new TRPCError({
@@ -214,14 +220,21 @@ export const workshopRouter = router({
         }
 
         // Authorization: the caller must OWN the workshop (be one of its
-        // speakers) OR be an organizer. Organizer = membership in any
-        // conference's organizers[] (the canonical getOrganizerSpeakerIds
-        // definition); there is NO stored isOrganizer field on speaker docs.
+        // speakers) OR be an organizer OF THIS REQUEST'S ORG.
+        //
+        // ORG-SCOPED (#723). This gate previously asked
+        // `getOrganizerSpeakerIds()` — which, with no argument and an
+        // unresolvable org, returned the organizers of EVERY conference in the
+        // dataset. That made an organizer of tenant A an organizer of tenant B
+        // here, letting them broadcast to B's workshop attendees. Authorization
+        // now goes through the one org-scoped gate (`isOrganizerForCurrentOrg`,
+        // session `organizerOrgIds` vs the domain-resolved org), which fails
+        // CLOSED when the org cannot be resolved.
         const speakerId = ctx.speaker._id
         const isOwner = workshop.speakerIds.includes(speakerId)
         const isOrganizer = isOwner
           ? false
-          : (await getOrganizerSpeakerIds()).includes(speakerId)
+          : await isOrganizerForCurrentOrg(ctx.speaker)
 
         if (!isOwner && !isOrganizer) {
           throw new TRPCError({
@@ -301,10 +314,7 @@ export const workshopRouter = router({
     .input(workshopUpdateAnnouncementSchema)
     .mutation(async ({ input, ctx }) => {
       try {
-        await authorizeAnnouncementMutation(
-          ctx.speaker._id,
-          input.announcementId,
-        )
+        await authorizeAnnouncementMutation(ctx.speaker, input.announcementId)
 
         await updateWorkshopAnnouncementBody(input.announcementId, input.body)
 
@@ -328,10 +338,7 @@ export const workshopRouter = router({
     .input(workshopDeleteAnnouncementSchema)
     .mutation(async ({ input, ctx }) => {
       try {
-        await authorizeAnnouncementMutation(
-          ctx.speaker._id,
-          input.announcementId,
-        )
+        await authorizeAnnouncementMutation(ctx.speaker, input.announcementId)
 
         await deleteWorkshopAnnouncement(input.announcementId)
 


### PR DESCRIPTION
Closes #723. Found by the multi-tenant readiness audit. **Nothing here is exploitable today** — one organization exists — but every one becomes live the moment a second paying customer's data is in the shared dataset.

## 1. Organizer authz gate (#723) — confirmed, and wider than reported

`getOrganizerSpeakerIds()` fell back to `*[_type == "conference"].organizers[]._ref` — every organizer of every conference — and both workshop gates called it with **no arguments**, so the global branch was taken every time. An organizer of conference A could manage and send announcements to conference B's workshop attendees.

Both gates now use the already-fail-closed `isOrganizerForCurrentOrg`. More importantly the trap is removed **structurally**: the global branch is now a private function, and the three exports are explicit — current-org (empty when unresolvable), for-a-named-org (empty on null), and one clearly-named cross-org read used only by the nudge cron. No exported path reaches global by omission, so the next caller cannot repeat this by writing zero arguments.

## 2. Gallery reads — confirmed

Two defects: no id meant the whole dataset, and `!defined(conference)` handed every conference-less image to every tenant. An unknown host returned **all tenants' featured images plus 50 more**. Scope is now required and its predicate unconditional; a blank scope returns empty **without querying at all**.

`listMine`/`countMine` deliberately scope to the ORG rather than the conference, so a CND speaker still sees their photos across all three editions.

## 3. Shared-speaker proposals — confirmed, plus a call site the audit missed

The conference filter fell back to `''`. The audit named the badge page; `/admin/speakers` had the identical hole.

## Beyond the brief: cross-tenant gallery WRITES

Not in the audit, and a different and more serious class — missing ownership check rather than fail-open read. `gallery.admin.update/delete/toggleFeatured` and `untagSelf` took an image id straight from client input with no tenant check, so an organizer of A could **edit or delete B's photos** by id. Closed, including a guard that a patch may not reassign an image to another conference. Happy to split it out if you'd rather review it separately.

## Root enablers

**The lint rule was strengthened and pays out immediately.** `no-unscoped-groq` now sees interpolated filters (`*[${filter}]` — previously invisible, and the exact shape of two of these bugs), optional tenant filters, and `scopedFetch({orgId: null})`. It flags 9 real sites including the ones the audit named. Verified no coverage regression: the `unscoped` count moved 241 → 234 and every drop is duplicate collapse within a single template.

**`scopedFetch` now throws on an empty scope** rather than degrading to a global read — safe to do now because it has zero production call sites, so the trap is gone before it acquires users.

**`getConferenceForDomain`'s truthy `{}` is NOT fixed** — a ~100-call-site refactor judged too large to ride along with a security fix. Two dead `if (!conference)` checks on touched paths were replaced with a real `isUnknownHost` guard; **~13 remain** elsewhere and are tracked as their own work item.

## One check needed before merge

Dropping `!defined(conference)` means a gallery image with no conference reference is now returned to nobody. `createGalleryImage` has always required one, so only hand-made Studio documents could be in that state — but this could not be confirmed without a dataset token:

```groq
count(*[_type == "imageGallery" && !defined(conference)])
```

If that is non-zero, those images need a conference assigned or CND loses them from its public gallery.

## Not fixed, named deliberately

`src/lib/messaging/standing.ts` holds the same global-organizer bridge, gating who an organizer may name as a thread subject. Left as its own review surface and documented in `docs/ORGANIZATION_TIER.md`. `scripts/**` stays lint-allowlisted despite running with the write token — cross-tenant by design, needs per-script annotations first.

5281 tests green, production build exit 0.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes several fail-open tenant-scoping paths.
- Replaces workshop organizer-set authorization with current-organization authorization.
- Requires gallery read scopes and adds ownership checks to gallery mutations.
- Scopes shared-speaker proposal projections and organizer notification routing.
- Makes scopedFetch reject empty scopes and strengthens the GROQ lint rule.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking recommendation to make gallery ownership checks revision-bound so concurrent reassignment cannot invalidate authorization before mutation.

The changed paths consistently fail closed and enforce tenant scopes, but gallery mutations still rely on a separate ownership read followed by an unconditional ID-based write.

**Files Needing Attention:** src/server/routers/gallery.ts, src/lib/gallery/sanity.ts

<details open><summary><h3>Security Review</h3></summary>

The gallery ownership checks substantially improve isolation, but their read-before-write design leaves a narrow concurrent reassignment window because the final mutation is not revision-bound.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/routers/gallery.ts | Adds tenant-scoped reads and mutation ownership guards; the guards are not atomic with their subsequent writes. |
| src/lib/gallery/sanity.ts | Requires explicit gallery scopes and adds tenant lookup support, while existing ID-based mutations remain unconditional. |
| src/server/routers/workshop.ts | Replaces global organizer-set checks with the shared current-organization authorization gate. |
| src/lib/notification/sanity.ts | Splits current-org, named-org, and explicitly cross-org organizer reads into fail-closed APIs. |
| src/lib/sanity/scoped.ts | Makes scopedFetch throw before querying when no tenant scope is available. |
| src/lib/speaker/sanity.ts | Prevents cross-organization proposal projections by falling back to conference scope when organization scope is unavailable. |
| eslint-rules/no-unscoped-groq.js | Expands lint detection to interpolated, optional, and explicitly null tenant-scope patterns. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant A as Tenant A request
  participant G as Gallery router
  participant S as Sanity
  participant E as Concurrent editor
  A->>G: update/delete image ID
  G->>S: read image tenant
  S-->>G: tenant A
  E->>S: reassign image to tenant B
  G->>S: unconditional patch/delete by ID
  S-->>G: mutation succeeds on tenant B document
```

<sub>Reviews (1): Last reviewed commit: ["fix(tenancy): fail closed on an unresolv..."](https://github.com/cloudnativebergen/website/commit/b27e54da0f866876606bb2d6bff1059d9bd8e133) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49837372)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/cloudnativebergen/website/blob/main/AGENTS.md))

<!-- /greptile_comment -->