### PR TITLE
fix(gallery): route the mosaic through galleryImageSrc

### DIFF
--- a/src/components/ImageMosaic.tsx
+++ b/src/components/ImageMosaic.tsx
@@ -3,7 +3,11 @@
 import React from 'react'
 import { GalleryImageWithSpeakers } from '@/lib/gallery/types'
 import { cn } from '@/lib/utils'
-import { sanityImage } from '@/lib/sanity/client'
+import {
+  galleryImageSrc,
+  isInlineImageDataUri,
+  sanityImage,
+} from '@/lib/sanity/client'
 
 /**
  * A Sanity asset id encodes its own pixel dimensions (`image-<sha1>-<w>x<h>-<ext>`),
@@ -65,12 +69,19 @@ export function ImageMosaic({
           <>
             {image.image && (
               <img
-                src={sanityImage(image.image)
-                  .width(800)
-                  .quality(85)
-                  .fit('max')
-                  .url()}
-                srcSet={`${sanityImage(image.image).width(600).quality(85).fit('max').url()} 1x, ${sanityImage(image.image).width(1200).quality(85).fit('max').url()} 2x`}
+                src={galleryImageSrc(image, {
+                  width: 800,
+                  quality: 85,
+                  fit: 'max',
+                })}
+                // Inline artwork has no responsive renditions — a srcSet could
+                // only repeat the same bytes at 1x and 2x. Same rule as
+                // ImageCarousel.
+                srcSet={
+                  isInlineImageDataUri(image.imageUrl)
+                    ? undefined
+                    : `${sanityImage(image.image).width(600).quality(85).fit('max').url()} 1x, ${sanityImage(image.image).width(1200).quality(85).fit('max').url()} 2x`
+                }
                 alt={alt}
                 style={{ aspectRatio: tileAspectRatio(image) }}
                 className="w-full object-cover"


### PR DESCRIPTION
Closes #734.

`ImageMosaic` built `src` and `srcSet` from the Sanity CDN builder directly — the pattern #725 replaced in `ImageCarousel`, `SimpleImageCarousel` and `GalleryModal`, because the builder cannot render artwork stored as a `data:` URI: it composes a CDN URL that 404s and the component falls into its error state.

So the new `mosaic` gallery variant would show broken images in the front-page composer's live preview, whose placeholder tiles are generated gradient artwork — precisely the surface placeholders exist for. The default `carousel` path was unaffected, so no live tenant site was.

It slipped through because `ImageMosaic` and #725 were written in parallel and neither branch could see the other. Found while rebasing the variant stack, and deliberately not fixed inside that rebase — changing behaviour under cover of a merge is how regressions hide.

`srcSet` is omitted for inline artwork, matching `ImageCarousel`: inline bytes have no responsive renditions, so a srcSet could only repeat the same payload at 1x and 2x.

Typecheck clean; 352 component tests green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes mosaic image sources through the shared gallery helper and omits responsive sources for recognized inline artwork.
- Replaces direct Sanity URL construction for the primary mosaic source.
- Mirrors the carousel’s conditional `srcSet` behavior.
- Does not recognize the SVG data URIs used by the actual homepage placeholders, leaving the target preview failure unresolved.

<h3>Confidence Score: 4/5</h3>

This should be fixed before merging because the homepage mosaic’s real SVG placeholder path still resolves through synthetic Sanity CDN references and remains broken.

The new routing works for raster data URIs, but repository placeholders use `data:image/svg+xml`; the shared classifier rejects that MIME type, so both the primary source and responsive sources continue to use the invalid Sanity asset path.

**Files Needing Attention:** src/components/ImageMosaic.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/ImageMosaic.tsx | Adopts the shared image-source helper, but the helper’s raster-only inline check excludes the SVG placeholder format this change is intended to support. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gallery): route the mosaic through g..."](https://github.com/cloudnativebergen/website/commit/2aa3af22098e5e563ca7044ba8da778070e29d46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49958574)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->