### PR TITLE
fix(security): close the cross-tenant leaks hiding in the lint backlog

### DIFF
--- a/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
+++ b/__tests__/api/trpc/sponsor-pipeline-guards.test.ts
@@ -268,9 +268,12 @@ describe('sponsor CRM pipeline tier invariant — all write paths', () => {
         ids: ['a', 'b'],
         status: 'closed-won',
       } as any)
+      // The REQUEST's conference is passed through as the tenant boundary —
+      // never anything derived from `input`.
       expect(bulkUpdateSponsors).toHaveBeenCalledWith(
         expect.objectContaining({ ids: ['a', 'b'], status: 'closed-won' }),
         mockOrganizer._id,
+        mockConference._id,
       )
     })
   })

--- a/__tests__/api/trpc/sponsor-tenancy.test.ts
+++ b/__tests__/api/trpc/sponsor-tenancy.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { appRouter } from '@/server/_app'
+import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
+import {
+  bulkUpdateSponsors,
+  bulkDeleteSponsors,
+  BulkTenancyError,
+} from '@/lib/sponsor-crm/bulk'
+import { deleteSponsor, deleteSponsorTier } from '@/lib/sponsor/sanity'
+import { clientWrite } from '@/lib/sanity/client'
+
+/**
+ * ROUTER-LEVEL TENANCY REGRESSIONS for the sponsor router (#616, batch A1/A2).
+ *
+ * Two things are pinned here that a library unit test cannot see:
+ *
+ *  1. The REQUEST's tenant reaches the write helpers. The conference/org comes
+ *     from the resolved domain, never from `input` — so a crafted payload
+ *     cannot redirect a bulk write at another tenant.
+ *  2. A fail-closed REFUSAL survives the router's catch blocks as a client
+ *     error (NOT_FOUND), not as a 500. A refusal masked as INTERNAL_SERVER_ERROR
+ *     is indistinguishable from a server fault and hides the guard working.
+ */
+vi.mock('@/lib/conference/sanity')
+vi.mock('@/lib/speaker/sanity')
+vi.mock('@/lib/sponsor-crm/sanity')
+vi.mock('@/lib/sponsor-crm/activity')
+vi.mock('@/lib/sponsor-crm/bulk')
+vi.mock('@/lib/sponsor/sanity')
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn() }))
+vi.mock('next/cache', () => ({ revalidateTag: vi.fn() }))
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: vi.fn(), patch: vi.fn(), transaction: vi.fn() },
+  clientReadUncached: { fetch: vi.fn() },
+  clientRead: { fetch: vi.fn() },
+}))
+
+const ORG = 'org-test'
+const mockOrganizer = {
+  _id: 'spk-org-1',
+  name: 'Org',
+  email: 'org@test.com',
+  isOrganizer: true,
+  organizerOrgIds: [ORG],
+}
+const mockConference = {
+  _id: 'conf-1',
+  title: 'Test Conf',
+  organization: { _type: 'reference', _ref: ORG },
+}
+
+const createCaller = () =>
+  appRouter.createCaller({
+    session: { user: { email: mockOrganizer.email }, speaker: mockOrganizer },
+    speaker: mockOrganizer,
+    user: { email: mockOrganizer.email },
+  } as any)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getConferenceForCurrentDomain).mockResolvedValue({
+    conference: mockConference as any,
+    domain: 'test.com',
+    error: null,
+  })
+})
+
+describe('sponsor router — the request tenant reaches every bulk write', () => {
+  it('bulkDelete passes the REQUEST conference, not anything from input', async () => {
+    vi.mocked(bulkDeleteSponsors).mockResolvedValue({
+      success: true,
+      deletedCount: 1,
+      totalCount: 1,
+    })
+
+    await createCaller().sponsor.crm.bulkDelete({ ids: ['sfc-1'] } as any)
+
+    expect(bulkDeleteSponsors).toHaveBeenCalledWith(
+      ['sfc-1'],
+      mockConference._id,
+      expect.anything(),
+    )
+  })
+
+  it('sponsor.delete passes the REQUEST org', async () => {
+    vi.mocked(deleteSponsor).mockResolvedValue({})
+
+    await createCaller().sponsor.delete({ id: 's-1' } as any)
+
+    expect(deleteSponsor).toHaveBeenCalledWith('s-1', ORG)
+  })
+
+  it('tiers.delete passes the REQUEST conference', async () => {
+    vi.mocked(deleteSponsorTier).mockResolvedValue({})
+
+    await createCaller().sponsor.tiers.delete({ id: 'tier-1' } as any)
+
+    expect(deleteSponsorTier).toHaveBeenCalledWith('tier-1', mockConference._id)
+  })
+})
+
+describe('sponsor router — refusals are not masked as 500s', () => {
+  // MUTATION CHECK: remove the `instanceof BulkTenancyError` arm from either
+  // catch block and these fail with INTERNAL_SERVER_ERROR.
+  it('bulkUpdate surfaces a cross-tenant refusal as NOT_FOUND', async () => {
+    vi.mocked(clientWrite.fetch as any).mockResolvedValue([])
+    vi.mocked(bulkUpdateSponsors).mockRejectedValue(
+      new BulkTenancyError('refusing the batch'),
+    )
+
+    await expect(
+      createCaller().sponsor.crm.bulkUpdate({
+        ids: ['sfc-1', 'sfc-theirs'],
+        status: 'contacted',
+      } as any),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('bulkDelete surfaces a cross-tenant refusal as NOT_FOUND', async () => {
+    vi.mocked(bulkDeleteSponsors).mockRejectedValue(
+      new BulkTenancyError('refusing the batch'),
+    )
+
+    await expect(
+      createCaller().sponsor.crm.bulkDelete({
+        ids: ['sfc-1', 'sfc-theirs'],
+      } as any),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
+  it('still reports a genuine failure as INTERNAL_SERVER_ERROR', async () => {
+    vi.mocked(bulkDeleteSponsors).mockRejectedValue(new Error('sanity down'))
+
+    await expect(
+      createCaller().sponsor.crm.bulkDelete({ ids: ['sfc-1'] } as any),
+    ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' })
+  })
+})

--- a/__tests__/lib/sponsor-crm/bulk.test.ts
+++ b/__tests__/lib/sponsor-crm/bulk.test.ts
@@ -12,8 +12,15 @@ vi.mock('@/lib/sanity/client', () => ({
   },
 }))
 
-import { bulkUpdateSponsors, bulkDeleteSponsors } from '@/lib/sponsor-crm/bulk'
+import {
+  bulkUpdateSponsors,
+  bulkDeleteSponsors,
+  BulkTenancyError,
+} from '@/lib/sponsor-crm/bulk'
 import { clientWrite } from '@/lib/sanity/client'
+
+/** The conference every fixture below belongs to. */
+const CONF = 'conf-ours'
 
 function createMockTransaction() {
   return {
@@ -45,6 +52,7 @@ describe('Bulk Sponsor CRM Operations', () => {
       const result = await bulkUpdateSponsors(
         { ids: ['s1', 's2'], status: 'contacted' },
         mockUserId,
+        CONF,
       )
 
       expect(result).toEqual({
@@ -74,6 +82,7 @@ describe('Bulk Sponsor CRM Operations', () => {
       await bulkUpdateSponsors(
         { ids: ['s1'], addTags: ['high-priority'], removeTags: ['warm-lead'] },
         mockUserId,
+        CONF,
       )
 
       expect(tx.patch).toHaveBeenCalledWith(
@@ -96,6 +105,7 @@ describe('Bulk Sponsor CRM Operations', () => {
       await bulkUpdateSponsors(
         { ids: ['s1'], addTags: ['warm-lead', 'referral'] },
         mockUserId,
+        CONF,
       )
 
       expect(tx.patch).toHaveBeenCalledWith(
@@ -106,20 +116,6 @@ describe('Bulk Sponsor CRM Operations', () => {
       )
     })
 
-    it('skips commit when no sponsors match the IDs', async () => {
-      ;(clientWrite.fetch as any).mockResolvedValue([])
-      const tx = createMockTransaction()
-      ;(clientWrite.transaction as any).mockReturnValue(tx)
-
-      const result = await bulkUpdateSponsors(
-        { ids: ['nonexistent'], status: 'contacted' },
-        mockUserId,
-      )
-
-      expect(result.updatedCount).toBe(0)
-      expect(tx.commit).not.toHaveBeenCalled()
-    })
-
     it('does not create activity log when status is unchanged', async () => {
       ;(clientWrite.fetch as any).mockResolvedValue([
         { _id: 's1', _type: 'sponsorForConference', status: 'contacted' },
@@ -127,7 +123,11 @@ describe('Bulk Sponsor CRM Operations', () => {
       const tx = createMockTransaction()
       ;(clientWrite.transaction as any).mockReturnValue(tx)
 
-      await bulkUpdateSponsors({ ids: ['s1'], status: 'contacted' }, mockUserId)
+      await bulkUpdateSponsors(
+        { ids: ['s1'], status: 'contacted' },
+        mockUserId,
+        CONF,
+      )
 
       // patch is called (status field is set) but no activity log created
       expect(tx.patch).toHaveBeenCalled()
@@ -143,7 +143,11 @@ describe('Bulk Sponsor CRM Operations', () => {
       ;(clientWrite.transaction as any).mockReturnValue(tx)
 
       await expect(
-        bulkUpdateSponsors({ ids: ['s1'], status: 'contacted' }, mockUserId),
+        bulkUpdateSponsors(
+          { ids: ['s1'], status: 'contacted' },
+          mockUserId,
+          CONF,
+        ),
       ).rejects.toThrow('Transaction failed')
     })
 
@@ -159,6 +163,7 @@ describe('Bulk Sponsor CRM Operations', () => {
       await bulkUpdateSponsors(
         { ids: ['s1'], assignedTo: 'user-jane' },
         mockUserId,
+        CONF,
       )
 
       expect(tx.create).toHaveBeenCalledWith(
@@ -171,14 +176,13 @@ describe('Bulk Sponsor CRM Operations', () => {
 
   describe('bulkDeleteSponsors', () => {
     it('deletes sponsors and their related activities', async () => {
-      ;(clientWrite.fetch as any).mockResolvedValue([
-        'activity-1',
-        'activity-2',
-      ])
+      ;(clientWrite.fetch as any)
+        .mockResolvedValueOnce(['s1', 's2']) // ownership probe
+        .mockResolvedValueOnce(['activity-1', 'activity-2'])
       const tx = createMockTransaction()
       ;(clientWrite.transaction as any).mockReturnValue(tx)
 
-      const result = await bulkDeleteSponsors(['s1', 's2'])
+      const result = await bulkDeleteSponsors(['s1', 's2'], CONF)
 
       expect(result).toEqual({
         success: true,
@@ -194,13 +198,14 @@ describe('Bulk Sponsor CRM Operations', () => {
 
     it('deletes contract assets when deleteContractAssets option is true', async () => {
       ;(clientWrite.fetch as any)
+        .mockResolvedValueOnce(['s1']) // ownership probe
         .mockResolvedValueOnce(['activity-1'])
         .mockResolvedValueOnce(['asset-pdf-1', 'asset-pdf-2'])
         .mockResolvedValueOnce(['asset-pdf-1', 'asset-pdf-2'])
       const tx = createMockTransaction()
       ;(clientWrite.transaction as any).mockReturnValue(tx)
 
-      await bulkDeleteSponsors(['s1'], { deleteContractAssets: true })
+      await bulkDeleteSponsors(['s1'], CONF, { deleteContractAssets: true })
 
       expect(tx.delete).toHaveBeenCalledWith('s1')
       expect(tx.delete).toHaveBeenCalledWith('activity-1')
@@ -209,22 +214,151 @@ describe('Bulk Sponsor CRM Operations', () => {
     })
 
     it('does not fetch contract assets when deleteContractAssets is false', async () => {
-      ;(clientWrite.fetch as any).mockResolvedValue([])
+      ;(clientWrite.fetch as any)
+        .mockResolvedValueOnce(['s1']) // ownership probe
+        .mockResolvedValueOnce([])
       const tx = createMockTransaction()
       ;(clientWrite.transaction as any).mockReturnValue(tx)
 
-      await bulkDeleteSponsors(['s1'])
+      await bulkDeleteSponsors(['s1'], CONF)
 
-      expect(clientWrite.fetch).toHaveBeenCalledTimes(1)
+      // ownership probe + activity cascade only
+      expect(clientWrite.fetch).toHaveBeenCalledTimes(2)
     })
 
     it('propagates transaction commit failures', async () => {
-      ;(clientWrite.fetch as any).mockResolvedValue([])
+      ;(clientWrite.fetch as any)
+        .mockResolvedValueOnce(['s1'])
+        .mockResolvedValueOnce([])
       const tx = createMockTransaction()
       tx.commit.mockRejectedValue(new Error('Delete failed'))
       ;(clientWrite.transaction as any).mockReturnValue(tx)
 
-      await expect(bulkDeleteSponsors(['s1'])).rejects.toThrow('Delete failed')
+      await expect(bulkDeleteSponsors(['s1'], CONF)).rejects.toThrow(
+        'Delete failed',
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // TENANCY REGRESSIONS. `ids` is CLIENT INPUT; these assert the batch is
+  // refused AND that the fail-closed path issues no query and no write.
+  // MUTATION CHECK: delete the `assertAllOwned(...)` call in
+  // `bulkUpdateSponsors` and "refuses the WHOLE batch…" fails; delete the
+  // `conferenceId` guard and the "issues NO query" tests fail; drop the
+  // `scopedFetch` scope and the "binds the conference predicate" tests fail.
+  // -------------------------------------------------------------------------
+  describe('tenant scoping (#616/#730 write class)', () => {
+    it('bulkUpdateSponsors binds the conference predicate into the read', async () => {
+      ;(clientWrite.fetch as any).mockResolvedValue([
+        { _id: 's1', _type: 'sponsorForConference', status: 'prospect' },
+      ])
+      ;(clientWrite.transaction as any).mockReturnValue(createMockTransaction())
+
+      await bulkUpdateSponsors(
+        { ids: ['s1'], status: 'contacted' },
+        mockUserId,
+        CONF,
+      )
+
+      const [query, params] = (clientWrite.fetch as any).mock.calls[0]
+      expect(query).toContain('conference._ref == $conferenceId')
+      expect(params).toMatchObject({ ids: ['s1'], conferenceId: CONF })
+    })
+
+    it('bulkUpdateSponsors refuses the WHOLE batch when an id is not in this conference', async () => {
+      // The scoped read resolves only OUR id; `s-theirs` belongs to another
+      // tenant (or does not exist) and therefore does not come back.
+      ;(clientWrite.fetch as any).mockResolvedValue([
+        { _id: 's1', _type: 'sponsorForConference', status: 'prospect' },
+      ])
+      const tx = createMockTransaction()
+      ;(clientWrite.transaction as any).mockReturnValue(tx)
+
+      await expect(
+        bulkUpdateSponsors(
+          { ids: ['s1', 's-theirs'], status: 'contacted' },
+          mockUserId,
+          CONF,
+        ),
+      ).rejects.toBeInstanceOf(BulkTenancyError)
+
+      // Not even the owned subset is written: all or nothing.
+      expect(tx.patch).not.toHaveBeenCalled()
+      expect(tx.commit).not.toHaveBeenCalled()
+    })
+
+    it('bulkUpdateSponsors issues NO query and NO write without a conference', async () => {
+      const tx = createMockTransaction()
+      ;(clientWrite.transaction as any).mockReturnValue(tx)
+
+      await expect(
+        bulkUpdateSponsors(
+          { ids: ['s1'], status: 'contacted' },
+          mockUserId,
+          '',
+        ),
+      ).rejects.toThrow(/without a resolved conference/)
+
+      expect(clientWrite.fetch).not.toHaveBeenCalled()
+      expect(clientWrite.transaction).not.toHaveBeenCalled()
+    })
+
+    it('bulkDeleteSponsors binds the conference predicate into the ownership probe', async () => {
+      ;(clientWrite.fetch as any)
+        .mockResolvedValueOnce(['s1'])
+        .mockResolvedValueOnce([])
+      ;(clientWrite.transaction as any).mockReturnValue(createMockTransaction())
+
+      await bulkDeleteSponsors(['s1'], CONF)
+
+      const [query, params] = (clientWrite.fetch as any).mock.calls[0]
+      expect(query).toContain('conference._ref == $conferenceId')
+      expect(params).toMatchObject({ ids: ['s1'], conferenceId: CONF })
+    })
+
+    it('bulkDeleteSponsors refuses the WHOLE batch and deletes NOTHING when an id is foreign', async () => {
+      // Only `s1` resolves inside the conference.
+      ;(clientWrite.fetch as any).mockResolvedValueOnce(['s1'])
+      const tx = createMockTransaction()
+      ;(clientWrite.transaction as any).mockReturnValue(tx)
+
+      await expect(
+        bulkDeleteSponsors(['s1', 's-theirs'], CONF),
+      ).rejects.toBeInstanceOf(BulkTenancyError)
+
+      expect(tx.delete).not.toHaveBeenCalled()
+      expect(tx.commit).not.toHaveBeenCalled()
+      // The cascade reads never ran either — refusal happens before them.
+      expect(clientWrite.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('bulkDeleteSponsors cascades off the RESOLVED ids, never the client list', async () => {
+      ;(clientWrite.fetch as any)
+        .mockResolvedValueOnce(['s1'])
+        .mockResolvedValueOnce([])
+      ;(clientWrite.transaction as any).mockReturnValue(createMockTransaction())
+
+      await bulkDeleteSponsors(['s1'], CONF)
+
+      const [cascadeQuery, cascadeParams] = (clientWrite.fetch as any).mock
+        .calls[1]
+      expect(cascadeQuery).toContain(
+        'sponsorForConference->conference._ref == $conferenceId',
+      )
+      expect(cascadeParams).toMatchObject({ ids: ['s1'], conferenceId: CONF })
+    })
+
+    it('bulkDeleteSponsors issues NO query and NO delete without a conference', async () => {
+      const tx = createMockTransaction()
+      ;(clientWrite.transaction as any).mockReturnValue(tx)
+
+      await expect(bulkDeleteSponsors(['s1'], '')).rejects.toThrow(
+        /without a resolved conference/,
+      )
+
+      expect(clientWrite.fetch).not.toHaveBeenCalled()
+      expect(clientWrite.transaction).not.toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/lib/sponsor/delete.test.ts
+++ b/__tests__/lib/sponsor/delete.test.ts
@@ -12,12 +12,26 @@ vi.mock('@/lib/sanity/client', () => ({
 import { deleteSponsor } from '@/lib/sponsor/sanity'
 import { clientWrite } from '@/lib/sanity/client'
 
+const ORG = 'org-ours'
+
+/**
+ * Prime the ownership probe that now runs BEFORE any cascade read. `linkedOrgs`
+ * are the orgs reached through the sponsor's `sponsorForConference` links.
+ */
+function primeOwnership(
+  sponsorOrg: string | null = ORG,
+  linkedOrgs: (string | null)[] = [],
+) {
+  ;(clientWrite.fetch as any).mockResolvedValueOnce({ sponsorOrg, linkedOrgs })
+}
+
 describe('deleteSponsor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('deletes sponsor and all related sponsorForConference, activities, and assets', async () => {
+    primeOwnership()
     ;(clientWrite.fetch as any)
       .mockResolvedValueOnce([
         { _id: 'sfc-1', contractAssetRef: 'asset-1' },
@@ -33,7 +47,7 @@ describe('deleteSponsor', () => {
     }
     ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
 
-    const result = await deleteSponsor('sponsor-1')
+    const result = await deleteSponsor('sponsor-1', ORG)
 
     expect(result.error).toBeUndefined()
     expect(mockTransaction.delete).toHaveBeenCalledWith('sponsor-1')
@@ -46,6 +60,7 @@ describe('deleteSponsor', () => {
   })
 
   it('deletes sponsor with no related records', async () => {
+    primeOwnership()
     ;(clientWrite.fetch as any).mockResolvedValueOnce([]) // no SFC docs
 
     const mockTransaction = {
@@ -55,7 +70,7 @@ describe('deleteSponsor', () => {
     }
     ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
 
-    const result = await deleteSponsor('sponsor-1')
+    const result = await deleteSponsor('sponsor-1', ORG)
 
     expect(result.error).toBeUndefined()
     expect(mockTransaction.delete).toHaveBeenCalledTimes(1)
@@ -63,6 +78,7 @@ describe('deleteSponsor', () => {
   })
 
   it('does not fetch activities when no sponsorForConference records exist', async () => {
+    primeOwnership()
     ;(clientWrite.fetch as any).mockResolvedValueOnce([])
 
     const mockTransaction = {
@@ -72,13 +88,14 @@ describe('deleteSponsor', () => {
     }
     ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
 
-    await deleteSponsor('sponsor-1')
+    await deleteSponsor('sponsor-1', ORG)
 
-    // Only one fetch for SFC docs
-    expect(clientWrite.fetch).toHaveBeenCalledTimes(1)
+    // Ownership probe + the SFC docs read; no activity cascade.
+    expect(clientWrite.fetch).toHaveBeenCalledTimes(2)
   })
 
   it('skips asset deletion when assets are referenced by other sponsors', async () => {
+    primeOwnership()
     ;(clientWrite.fetch as any)
       .mockResolvedValueOnce([
         { _id: 'sfc-1', contractAssetRef: 'asset-shared' },
@@ -93,7 +110,7 @@ describe('deleteSponsor', () => {
     }
     ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
 
-    const result = await deleteSponsor('sponsor-1')
+    const result = await deleteSponsor('sponsor-1', ORG)
 
     expect(result.error).toBeUndefined()
     expect(mockTransaction.delete).toHaveBeenCalledWith('sponsor-1')
@@ -102,6 +119,7 @@ describe('deleteSponsor', () => {
   })
 
   it('deduplicates contract asset references', async () => {
+    primeOwnership()
     ;(clientWrite.fetch as any)
       .mockResolvedValueOnce([
         { _id: 'sfc-1', contractAssetRef: 'asset-1' },
@@ -117,7 +135,7 @@ describe('deleteSponsor', () => {
     }
     ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
 
-    await deleteSponsor('sponsor-1')
+    await deleteSponsor('sponsor-1', ORG)
 
     // Asset should only be deleted once
     const deleteCalls = (mockTransaction.delete as any).mock.calls.map(
@@ -127,6 +145,7 @@ describe('deleteSponsor', () => {
   })
 
   it('returns error when transaction fails', async () => {
+    primeOwnership()
     ;(clientWrite.fetch as any).mockResolvedValueOnce([])
 
     const mockTransaction = {
@@ -136,9 +155,98 @@ describe('deleteSponsor', () => {
     }
     ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
 
-    const result = await deleteSponsor('sponsor-1')
+    const result = await deleteSponsor('sponsor-1', ORG)
 
     expect(result.error).toBeDefined()
     expect(result.error?.message).toBe('Transaction failed')
+  })
+
+  // -------------------------------------------------------------------------
+  // TENANCY REGRESSIONS. The sponsor id is CLIENT INPUT and the cascade deletes
+  // every linked `sponsorForConference`. MUTATION CHECK: delete the
+  // `claimants.some(...)` refusal and "refuses a sponsor owned by another org"
+  // fails; delete the `!orgId` guard and "issues NO query" fails.
+  // -------------------------------------------------------------------------
+  describe('tenant scoping (#616/#730 write class)', () => {
+    it('refuses a sponsor owned by another org, and deletes nothing', async () => {
+      primeOwnership('org-theirs')
+      const mockTransaction = {
+        delete: vi.fn().mockReturnThis(),
+        // @ts-ignore
+        commit: vi.fn().mockResolvedValue({}),
+      }
+      ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
+
+      const result = await deleteSponsor('sponsor-theirs', ORG)
+
+      expect(result.error?.message).toMatch(/not found in this organization/)
+      expect(mockTransaction.delete).not.toHaveBeenCalled()
+      expect(mockTransaction.commit).not.toHaveBeenCalled()
+      // Only the probe ran — no cascade read reached another tenant's rows.
+      expect(clientWrite.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses when ANY linked conference belongs to another org', async () => {
+      // Backfill-independent arm: the sponsor doc itself has no org key, but it
+      // is linked to a conference owned by someone else.
+      primeOwnership(null, [ORG, 'org-theirs'])
+      const mockTransaction = {
+        delete: vi.fn().mockReturnThis(),
+        // @ts-ignore
+        commit: vi.fn().mockResolvedValue({}),
+      }
+      ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
+
+      const result = await deleteSponsor('sponsor-shared', ORG)
+
+      expect(result.error?.message).toMatch(/not found in this organization/)
+      expect(mockTransaction.delete).not.toHaveBeenCalled()
+    })
+
+    it('refuses an unattributable sponsor (no org key, no links) — fails closed', async () => {
+      primeOwnership(null, [])
+      const mockTransaction = {
+        delete: vi.fn().mockReturnThis(),
+        // @ts-ignore
+        commit: vi.fn().mockResolvedValue({}),
+      }
+      ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
+
+      const result = await deleteSponsor('sponsor-orphan', ORG)
+
+      expect(result.error?.message).toMatch(/not found in this organization/)
+      expect(mockTransaction.delete).not.toHaveBeenCalled()
+    })
+
+    it('accepts a sponsor whose only claim comes through its linked conferences', async () => {
+      primeOwnership(null, [ORG, ORG])
+      ;(clientWrite.fetch as any).mockResolvedValueOnce([])
+      const mockTransaction = {
+        delete: vi.fn().mockReturnThis(),
+        // @ts-ignore
+        commit: vi.fn().mockResolvedValue({}),
+      }
+      ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
+
+      const result = await deleteSponsor('sponsor-1', ORG)
+
+      expect(result.error).toBeUndefined()
+      expect(mockTransaction.delete).toHaveBeenCalledWith('sponsor-1')
+    })
+
+    it('issues NO query and NO delete without a resolved organization', async () => {
+      const mockTransaction = {
+        delete: vi.fn().mockReturnThis(),
+        // @ts-ignore
+        commit: vi.fn().mockResolvedValue({}),
+      }
+      ;(clientWrite.transaction as any).mockReturnValue(mockTransaction)
+
+      const result = await deleteSponsor('sponsor-1', null)
+
+      expect(result.error?.message).toMatch(/without a resolved organization/)
+      expect(clientWrite.fetch).not.toHaveBeenCalled()
+      expect(clientWrite.transaction).not.toHaveBeenCalled()
+    })
   })
 })

--- a/__tests__/lib/sponsor/sanity.test.ts
+++ b/__tests__/lib/sponsor/sanity.test.ts
@@ -8,6 +8,8 @@ vi.mock('@/lib/sanity/client', () => ({
 import { deleteSponsorTier } from '@/lib/sponsor/sanity'
 import { clientWrite } from '@/lib/sanity/client'
 
+const CONF = 'conf-ours'
+
 describe('deleteSponsorTier', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -24,10 +26,12 @@ describe('deleteSponsorTier', () => {
   }
 
   it('unsets the tier on referencing sponsors and deletes the tier in one transaction', async () => {
-    ;(clientWrite.fetch as any).mockResolvedValueOnce(['sfc-1', 'sfc-2'])
+    ;(clientWrite.fetch as any)
+      .mockResolvedValueOnce('tier-1') // ownership probe
+      .mockResolvedValueOnce(['sfc-1', 'sfc-2'])
     const tx = mockTransaction()
 
-    const result = await deleteSponsorTier('tier-1')
+    const result = await deleteSponsorTier('tier-1', CONF)
 
     expect(result.error).toBeUndefined()
     expect(tx.patch).toHaveBeenCalledWith('sfc-1', { unset: ['tier'] })
@@ -37,10 +41,12 @@ describe('deleteSponsorTier', () => {
   })
 
   it('deletes the tier even when no sponsor references it', async () => {
-    ;(clientWrite.fetch as any).mockResolvedValueOnce([])
+    ;(clientWrite.fetch as any)
+      .mockResolvedValueOnce('tier-1') // ownership probe
+      .mockResolvedValueOnce([])
     const tx = mockTransaction()
 
-    const result = await deleteSponsorTier('tier-1')
+    const result = await deleteSponsorTier('tier-1', CONF)
 
     expect(result.error).toBeUndefined()
     expect(tx.patch).not.toHaveBeenCalled()
@@ -49,12 +55,59 @@ describe('deleteSponsorTier', () => {
   })
 
   it('returns an error when the transaction fails', async () => {
-    ;(clientWrite.fetch as any).mockResolvedValueOnce([])
+    ;(clientWrite.fetch as any)
+      .mockResolvedValueOnce('tier-1') // ownership probe
+      .mockResolvedValueOnce([])
     const tx = mockTransaction()
     tx.commit.mockRejectedValueOnce(new Error('boom'))
 
-    const result = await deleteSponsorTier('tier-1')
+    const result = await deleteSponsorTier('tier-1', CONF)
 
     expect(result.error).toBeInstanceOf(Error)
+  })
+
+  // -------------------------------------------------------------------------
+  // TENANCY REGRESSIONS. MUTATION CHECK: delete the `if (!owned)` refusal and
+  // "refuses a tier from another conference" fails; delete the `!conferenceId`
+  // guard and "issues NO query" fails.
+  // -------------------------------------------------------------------------
+  describe('tenant scoping (#616/#730 write class)', () => {
+    it('binds the conference predicate into the ownership probe', async () => {
+      ;(clientWrite.fetch as any)
+        .mockResolvedValueOnce('tier-1')
+        .mockResolvedValueOnce([])
+      mockTransaction()
+
+      await deleteSponsorTier('tier-1', CONF)
+
+      const [query, params] = (clientWrite.fetch as any).mock.calls[0]
+      expect(query).toContain('conference._ref == $conferenceId')
+      expect(params).toMatchObject({ id: 'tier-1', conferenceId: CONF })
+    })
+
+    it('refuses a tier from another conference, and deletes nothing', async () => {
+      // The scoped point read does not resolve a foreign tier.
+      ;(clientWrite.fetch as any).mockResolvedValueOnce(null)
+      const tx = mockTransaction()
+
+      const result = await deleteSponsorTier('tier-theirs', CONF)
+
+      expect(result.error?.message).toMatch(/not found in this conference/)
+      expect(tx.patch).not.toHaveBeenCalled()
+      expect(tx.delete).not.toHaveBeenCalled()
+      expect(tx.commit).not.toHaveBeenCalled()
+      // The cascade read never ran either.
+      expect(clientWrite.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('issues NO query and NO delete without a resolved conference', async () => {
+      const tx = mockTransaction()
+
+      const result = await deleteSponsorTier('tier-1', '')
+
+      expect(result.error?.message).toMatch(/without a resolved conference/)
+      expect(clientWrite.fetch).not.toHaveBeenCalled()
+      expect(tx.delete).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/app/(admin)/admin/speakers/badge/page.tsx
+++ b/src/app/(admin)/admin/speakers/badge/page.tsx
@@ -49,7 +49,8 @@ export default async function AdminBadgePage() {
 
   // Also get organizers (who may not have talks) — scoped to the current
   // conference's organization so a multi-tenant dataset never surfaces another
-  // org's organizers on this page (falls back to global pre-backfill).
+  // org's organizers on this page. An unresolvable org now FAILS CLOSED: the
+  // list comes back empty with an error rather than every tenant's organizers.
   const { speakers: organizers, err: organizersErr } = await getOrganizers(
     conference.organization?._ref ?? null,
   )

--- a/src/lib/messaging/standing.test.ts
+++ b/src/lib/messaging/standing.test.ts
@@ -40,18 +40,38 @@ describe('speakerHasStandingInConference — org scoping (E9)', () => {
     expect(await speakerHasStandingInConference('spk-b', 'conf-1')).toBe(false)
   })
 
-  it('falls back to the GLOBAL organizer scope with a warn for an org-less conference', async () => {
+  // FAIL CLOSED (#723 shape). An org-less conference used to fall back to
+  // `*[_type == "conference"].organizers[]._ref` — every organizer of every
+  // tenant — behind nothing but a warn.
+  // MUTATION CHECK: delete the `if (!orgId) return false` branch and this test
+  // fails; the global organizer scope reappears in the standing query.
+  it('FAILS CLOSED for an org-less conference: no standing query, no standing', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     primeFetches(null, 'spk-1')
 
     const ok = await speakerHasStandingInConference('spk-1', 'legacy-conf')
 
-    expect(ok).toBe(true)
-    const [query, params] = fetchMock.mock.calls[1]
-    expect(query).not.toContain('organization._ref == $orgId')
-    expect(query).toContain('*[_type == "conference"].organizers[]._ref')
-    expect(params).not.toHaveProperty('orgId')
+    expect(ok).toBe(false)
+    // Only the org-resolution read ran; the standing query was never issued.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(warn).toHaveBeenCalled()
     warn.mockRestore()
+  })
+
+  it('never emits the global organizer scope', async () => {
+    primeFetches('org-A', 'spk-1')
+
+    await speakerHasStandingInConference('spk-1', 'conf-1')
+
+    const [query] = fetchMock.mock.calls[1]
+    expect(query).not.toContain('*[_type == "conference"].organizers[]._ref')
+    expect(query).toContain(
+      '*[_type == "conference" && organization._ref == $orgId].organizers[]._ref',
+    )
+  })
+
+  it('issues NO query at all without a conference id', async () => {
+    expect(await speakerHasStandingInConference('spk-1', '')).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/messaging/standing.ts
+++ b/src/lib/messaging/standing.ts
@@ -18,12 +18,14 @@ import { clientReadUncached } from '@/lib/sanity/client'
  * closes that leak while STILL matching same-org, cross-edition organizers
  * (which the picker legitimately offers) and talk-holding speakers.
  *
- * LEGACY BRIDGE: a conference with no resolvable organization (pre-044 backfill)
- * falls back to the global organizer scope with a warn. This is a STANDING/
- * recipient-selection bridge, not an access grant — the authz layer
- * (`src/lib/authz/organizer.ts`) has no bridges left and denies an unresolvable
- * org outright. Remove this one alongside its sibling in
- * `src/lib/notification/sanity.ts`.
+ * FAILS CLOSED (was the #723 shape). A conference with no resolvable
+ * organization used to fall back to `*[_type == "conference"].organizers[]._ref`
+ * — EVERY organizer of EVERY tenant — behind a warn. That is the fail-open
+ * bridge #723 named: an unresolvable tenant yielded the global set, so any
+ * tenant's organizer could be named as the subject of another tenant's thread.
+ * An unresolvable org now returns `false` and issues NO standing query at all,
+ * matching the authz layer (`src/lib/authz/organizer.ts`), which has no bridges
+ * left, and its sibling in `src/lib/notification/sanity.ts` (#728).
  *
  * This predicate lives in its own module so the E9 fix can be reviewed and
  * merged independently of the parallel messaging-authz work that owns the
@@ -33,7 +35,10 @@ export async function speakerHasStandingInConference(
   speakerId: string,
   conferenceId: string,
 ): Promise<boolean> {
+  if (!conferenceId) return false
+
   const orgId = await clientReadUncached.fetch<string | null>(
+    // groq-global: tenant RESOLUTION — reads the conference registry to find which org owns `conferenceId`, so it cannot itself be tenant-scoped.
     `*[_type == "conference" && _id == $conferenceId][0].organization._ref`,
     { conferenceId },
     { cache: 'no-store' },
@@ -41,17 +46,18 @@ export async function speakerHasStandingInConference(
 
   if (!orgId) {
     console.warn(
-      `[authz-bridge] speakerHasStandingInConference: conference ${conferenceId} has no resolvable organization; using the GLOBAL organizer scope (standing-check legacy bridge)`,
+      `[standing] speakerHasStandingInConference: conference ${conferenceId} has no resolvable organization; DENYING standing (fail closed)`,
     )
+    return false
   }
 
-  const organizerScope = orgId
-    ? `*[_type == "conference" && organization._ref == $orgId].organizers[]._ref`
-    : `*[_type == "conference"].organizers[]._ref`
-
   const id = await clientReadUncached.fetch<string | null>(
-    `*[_type == "speaker" && _id == $speakerId && (_id in ${organizerScope} || count(*[_type == "talk" && conference._ref == $conferenceId && ^._id in speakers[]._ref]) > 0)][0]._id`,
-    orgId ? { speakerId, conferenceId, orgId } : { speakerId, conferenceId },
+    // The tenant boundary lives inside the predicate and is UNCONDITIONAL: both
+    // arms are scoped — the organizer arm to `organization._ref == $orgId`, the
+    // proposal arm to `conference._ref == $conferenceId`.
+    // groq-global: `speaker` is the deliberate cross-tenant identity type (#615) and carries no tenant key of its own.
+    `*[_type == "speaker" && _id == $speakerId && (_id in *[_type == "conference" && organization._ref == $orgId].organizers[]._ref || count(*[_type == "talk" && conference._ref == $conferenceId && ^._id in speakers[]._ref]) > 0)][0]._id`,
+    { speakerId, conferenceId, orgId },
     { cache: 'no-store' },
   )
   return Boolean(id)

--- a/src/lib/speaker/push-exclusion.test.ts
+++ b/src/lib/speaker/push-exclusion.test.ts
@@ -75,7 +75,7 @@ describe('web-push field exclusion (#444)', () => {
   })
 
   it('getOrganizers (admin.search) excludes push fields', async () => {
-    await getOrganizers()
+    await getOrganizers('org-1')
     expectPushFieldsExcluded(capturedQuery())
   })
 

--- a/src/lib/speaker/sanity.test.ts
+++ b/src/lib/speaker/sanity.test.ts
@@ -682,14 +682,27 @@ describe('getOrganizers — org scoping', () => {
     expect(params).toEqual({ orgId: 'org-1' })
   })
 
-  it('returns the global organizer set when orgId is null', async () => {
+  // FAIL CLOSED (#723 shape). A null org used to return EVERY tenant's
+  // organizers, and was reachable by simply omitting the argument.
+  // MUTATION CHECK: delete the `if (!orgId)` guard in `getOrganizers` and this
+  // test fails — the global organizer query goes out again.
+  it('FAILS CLOSED on a null org: no query, no organizers', async () => {
     fetchMock.mockResolvedValue([])
 
-    await getOrganizers(null)
+    const { speakers, err } = await getOrganizers(null)
 
-    const [query, params] = fetchMock.mock.calls[0]
-    expect(query).not.toContain('$orgId')
-    expect(params).toEqual({})
+    expect(speakers).toEqual([])
+    expect(err).toBeInstanceOf(Error)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('never emits the global organizer scope', async () => {
+    fetchMock.mockResolvedValue([])
+
+    await getOrganizers('org-1')
+
+    const [query] = fetchMock.mock.calls[0]
+    expect(query).not.toContain('*[_type == "conference"].organizers')
   })
 })
 

--- a/src/lib/speaker/sanity.ts
+++ b/src/lib/speaker/sanity.ts
@@ -944,25 +944,43 @@ export async function getOrganizerCount(): Promise<{
 }
 
 /**
- * All organizers. When `orgId` is provided the set is scoped to organizers of
- * the CURRENT org's conferences (#615) — an exact scope (organizers are defined
- * by `conference.organizers`, so no membership fallback is needed). A null orgId
- * returns the global organizer set (prior behaviour), used only when the tenant
- * cannot be resolved.
+ * The organizers of the given org's conferences — an exact scope (organizers are
+ * defined by `conference.organizers`, so no membership fallback is needed).
+ *
+ * FAILS CLOSED (was the #723 shape). A null `orgId` used to return the GLOBAL
+ * organizer set — every organizer of every tenant — and was reachable by simply
+ * omitting the argument, which fed an admin speaker list directly. It now
+ * returns an empty list and an error WITHOUT issuing any query, mirroring
+ * `getSpeakers` and the notification-module sibling closed in #728. No caller
+ * wants the cross-org superset, so no escape hatch is exported; if one ever
+ * does, add an explicitly-named export rather than reinstating this default
+ * (that is what `getAllOrganizerSpeakerIdsAcrossOrgs` does in
+ * `src/lib/notification/sanity.ts`).
+ *
+ * `orgId` is REQUIRED (though nullable) so no call site can fall through to the
+ * global set by omission — the way the previous default did.
  */
-export async function getOrganizers(orgId?: string | null): Promise<{
+export async function getOrganizers(orgId: string | null | undefined): Promise<{
   speakers: Speaker[]
   err: Error | null
 }> {
+  if (!orgId) {
+    return {
+      speakers: [],
+      err: new Error(
+        'getOrganizers: refusing to list organizers without a resolved organization',
+      ),
+    }
+  }
+
   let speakers: Speaker[] = []
   let err = null
 
   try {
-    const organizerScope = orgId
-      ? `*[_type == "conference" && organization._ref == $orgId].organizers[]._ref`
-      : `*[_type == "conference"].organizers[]._ref`
-
-    const query = groq`*[_type == "speaker" && _id in ${organizerScope}] {
+    // The tenant boundary is the UNCONDITIONAL `organization._ref == $orgId`
+    // predicate on the organizer sub-query below.
+    // groq-global: `speaker` is the deliberate cross-tenant identity type (#615) and carries no tenant key.
+    const query = groq`*[_type == "speaker" && _id in *[_type == "conference" && organization._ref == $orgId].organizers[]._ref] {
       ...,
       ${EXCLUDE_PUSH_FIELDS},
       "slug": slug.current,
@@ -970,9 +988,13 @@ export async function getOrganizers(orgId?: string | null): Promise<{
       "isOrganizer": true
     } | order(name asc)`
 
-    speakers = await clientRead.fetch(query, orgId ? { orgId } : {}, {
-      cache: 'no-store',
-    })
+    speakers = await clientRead.fetch(
+      query,
+      { orgId },
+      {
+        cache: 'no-store',
+      },
+    )
   } catch (error) {
     err = error as Error
   }

--- a/src/lib/sponsor-crm/bulk.ts
+++ b/src/lib/sponsor-crm/bulk.ts
@@ -12,6 +12,39 @@ import {
   getOrganizationRefForCurrentConference,
   organizationField,
 } from '@/lib/organization/sanity'
+import { scopedFetch } from '@/lib/sanity/scoped'
+
+/**
+ * A bulk operation was refused because the batch referenced documents outside
+ * the caller's tenant. Distinct from a generic failure so the router can map it
+ * to a client-visible refusal instead of masking it as a 500.
+ */
+export class BulkTenancyError extends Error {
+  readonly name = 'BulkTenancyError'
+}
+
+/**
+ * Refuse a bulk operation unless EVERY supplied id resolved inside the caller's
+ * conference — the all-or-nothing rule. A partial match means the batch mixed in
+ * an id the tenant does not own (or one that no longer exists); silently acting
+ * on the subset would let a crafted batch probe another tenant's id space by
+ * observing which ids "succeeded".
+ *
+ * The message deliberately does not say WHICH ids were rejected, so a foreign
+ * id's existence never leaks.
+ */
+function assertAllOwned(
+  requestedIds: string[],
+  ownedIds: string[],
+  operation: string,
+): void {
+  const requested = new Set(requestedIds)
+  if (ownedIds.length !== requested.size) {
+    throw new BulkTenancyError(
+      `${operation}: refusing the batch — ${requested.size - ownedIds.length} of ${requested.size} sponsor records are not in this conference`,
+    )
+  }
+}
 
 export interface BulkUpdateParams {
   ids: string[]
@@ -27,17 +60,41 @@ export interface BulkUpdateParams {
 /**
  * Performs bulk updates on sponsor CRM records using a single transaction.
  * Also logs relevant activities for status and assignee changes.
+ *
+ * TENANCY: `conferenceId` is REQUIRED and is the tenant boundary for the whole
+ * operation. `ids` is CLIENT INPUT; the read below is scoped to the conference
+ * so a foreign id simply does not resolve, and {@link assertAllOwned} then
+ * refuses the batch outright rather than patching the owned subset. Previously
+ * this matched on `_id in $ids` with no tenant predicate at all, so an organizer
+ * of one tenant could rewrite another tenant's status/assignee/tags.
  */
 export async function bulkUpdateSponsors(
   params: BulkUpdateParams,
   userId: string,
+  conferenceId: string,
 ): Promise<{ success: true; updatedCount: number; totalCount: number }> {
   const { ids, ...input } = params
 
-  // SECURITY: Only fetch and update documents of type sponsorForConference
-  const sponsors = await clientWrite.fetch<SponsorForConference[]>(
+  // FAIL CLOSED: an unresolvable tenant must issue NO query, not a global one.
+  if (!conferenceId) {
+    throw new Error(
+      'bulkUpdateSponsors: refusing to run without a resolved conference',
+    )
+  }
+
+  // SECURITY: type-restricted AND conference-scoped. `scopedFetch` prepends
+  // `conference._ref == $conferenceId` and throws on an empty scope.
+  const sponsors = await scopedFetch<SponsorForConference[]>(
+    clientWrite,
+    { conferenceId },
     `*[_type == "sponsorForConference" && _id in $ids]`,
     { ids },
+  )
+
+  assertAllOwned(
+    ids,
+    sponsors.map((s) => s._id),
+    'bulkUpdateSponsors',
   )
 
   const transaction = clientWrite.transaction()
@@ -45,17 +102,17 @@ export async function bulkUpdateSponsors(
 
   // A bulk update operates within the CURRENT conference, so every logged
   // activity shares its organization (CaaS T1-1). Resolve once. Best-effort:
-  // absent before the 044 backfill. NOTE: the stamp follows this operation's
-  // existing conference scope — it does not itself validate that the supplied
-  // sfc ids belong to the current conference; cross-conference id validation
-  // is the query-scoping invariant's job (#616), and in the single-org dataset
-  // every stamp resolves to the same organization regardless.
+  // absent before the 044 backfill. The ids this stamp is applied to are now
+  // proven to belong to `conferenceId` by the scoped read above.
   const orgRef = await getOrganizationRefForCurrentConference()
 
   // Fetch the new assignee's name if we're assigning someone
   let assigneeName = ''
   if (input.assignedTo) {
     const assignee = await clientWrite.fetch<{ name: string }>(
+      // A name-only point read by an id the router has already validated as an
+      // organizer of this conference.
+      // groq-global: `speaker` is the deliberate cross-tenant identity type (#615) and carries no tenant key.
       `*[_type == "speaker" && _id == $id][0]{name}`,
       { id: input.assignedTo },
     )
@@ -177,42 +234,78 @@ export async function bulkUpdateSponsors(
 /**
  * Deletes multiple sponsor CRM records in a single transaction.
  * Also cleans up related activity documents and optionally contract assets.
+ *
+ * TENANCY: `conferenceId` is REQUIRED. `ids` is CLIENT INPUT and previously
+ * drove `transaction.delete(id)` directly with no tenant predicate anywhere in
+ * the function — a cross-tenant DELETE. The owned set is now resolved through a
+ * conference-scoped read FIRST, the batch is refused unless every id is ours,
+ * and only the resolved ids are deleted.
  */
 export async function bulkDeleteSponsors(
   ids: string[],
+  conferenceId: string,
   options?: { deleteContractAssets?: boolean },
 ): Promise<{ success: true; deletedCount: number; totalCount: number }> {
-  // Find all related activity documents
-  const relatedActivityIds = await clientWrite.fetch<string[]>(
-    `*[_type == "sponsorActivity" && sponsorForConference._ref in $ids]._id`,
+  // FAIL CLOSED: no tenant, no query, no delete.
+  if (!conferenceId) {
+    throw new Error(
+      'bulkDeleteSponsors: refusing to run without a resolved conference',
+    )
+  }
+
+  // OWNERSHIP FIRST: resolve which of the supplied ids actually live in this
+  // conference, and refuse the whole batch if any does not.
+  const ownedIds = await scopedFetch<string[]>(
+    clientWrite,
+    { conferenceId },
+    `*[_type == "sponsorForConference" && _id in $ids]._id`,
     { ids },
+  )
+  assertAllOwned(ids, ownedIds, 'bulkDeleteSponsors')
+
+  // Find all related activity documents. `sponsorActivity` carries no
+  // `conference` ref of its own (only the post-044 `organization` key, which is
+  // best-effort), so the tenant predicate is expressed by traversing the parent:
+  // `sponsorForConference->conference._ref == $conferenceId`. That is a real
+  // tenant predicate — the lint rule cannot yet recognise reference traversal,
+  // so this site keeps warning honestly rather than being annotated away.
+  const relatedActivityIds = await clientWrite.fetch<string[]>(
+    `*[_type == "sponsorActivity" && sponsorForConference._ref in $ids && sponsorForConference->conference._ref == $conferenceId]._id`,
+    { ids: ownedIds, conferenceId },
   )
 
   // Find contract asset IDs if cleanup requested (only delete assets not referenced elsewhere)
   let contractAssetIds: string[] = []
   if (options?.deleteContractAssets) {
-    const candidateAssetIds = await clientWrite.fetch<string[]>(
+    const candidateAssetIds = await scopedFetch<string[]>(
+      clientWrite,
+      { conferenceId },
       `*[_type == "sponsorForConference" && _id in $ids && defined(contractDocument.asset._ref)].contractDocument.asset._ref`,
-      { ids },
+      { ids: ownedIds },
     )
 
     if (candidateAssetIds.length > 0) {
       const unique = Array.from(new Set(candidateAssetIds.filter(Boolean)))
       contractAssetIds = await clientWrite.fetch<string[]>(
+        // The inner "is anyone else still using it?" count MUST stay
+        // cross-tenant — scoping it to this conference would delete an asset
+        // another edition or another tenant still references. The candidate set
+        // is already restricted to assets reached from THIS conference's rows.
+        // groq-global: `sanity.fileAsset` carries no tenant key of any kind.
         `*[
           _type == "sanity.fileAsset" &&
           _id in $assetIds &&
           count(*[_type == "sponsorForConference" && contractDocument.asset._ref == ^._id && !(_id in $ids)]) == 0
         ]._id`,
-        { assetIds: unique, ids },
+        { assetIds: unique, ids: ownedIds },
       )
     }
   }
 
   const transaction = clientWrite.transaction()
 
-  // Delete the sponsor-conference documents
-  for (const id of ids) {
+  // Delete the sponsor-conference documents — only the ids proven to be ours.
+  for (const id of ownedIds) {
     transaction.delete(id)
   }
 
@@ -229,7 +322,7 @@ export async function bulkDeleteSponsors(
   await transaction.commit()
   return {
     success: true,
-    deletedCount: ids.length,
+    deletedCount: ownedIds.length,
     totalCount: ids.length,
   }
 }

--- a/src/lib/sponsor/sanity.orgfilter.test.ts
+++ b/src/lib/sponsor/sanity.orgfilter.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // E10: the sponsor company pickers must be tenant-scoped. getAllSponsors /
-// searchSponsors take an optional orgId that adds a coalesce org clause,
-// tolerating org-less legacy sponsors; omitting it preserves the global catalog.
+// searchSponsors take a REQUIRED (nullable) orgId that adds a coalesce org
+// clause, tolerating org-less legacy sponsors. A null org now FAILS CLOSED —
+// it used to drop the clause entirely and read every tenant's sponsors.
 const fetchMock = vi.fn().mockResolvedValue([])
 vi.mock('@/lib/sanity/client', () => ({
   clientWrite: { fetch: (...a: unknown[]) => fetchMock(...a) },
@@ -28,11 +29,13 @@ describe('getAllSponsors — org scoping (E10)', () => {
     expect(params).toEqual({ orgId: 'org-A' })
   })
 
-  it('is unscoped (global catalog) when no org is provided', async () => {
-    await getAllSponsors()
-    const [query, params] = fetchMock.mock.calls[0]
-    expect(query).not.toContain('organization._ref')
-    expect(params).toEqual({})
+  // MUTATION CHECK: delete the `if (!orgId)` guard in `getAllSponsors` and this
+  // test fails — the query goes out unscoped again.
+  it('FAILS CLOSED on a null org: no query, no results', async () => {
+    const { sponsors, error } = await getAllSponsors(null)
+    expect(sponsors).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })
 
@@ -45,10 +48,12 @@ describe('searchSponsors — org scoping (E10)', () => {
     expect(params).toEqual({ searchQuery: 'acme*', orgId: 'org-A' })
   })
 
-  it('omits the org clause when unscoped', async () => {
-    await searchSponsors('acme')
-    const [query, params] = fetchMock.mock.calls[0]
-    expect(query).not.toContain('organization._ref')
-    expect(params).toEqual({ searchQuery: 'acme*' })
+  // MUTATION CHECK: delete the `if (!orgId)` guard in `searchSponsors` and this
+  // test fails.
+  it('FAILS CLOSED on a null org: no query, no results', async () => {
+    const { sponsors, error } = await searchSponsors('acme', null)
+    expect(sponsors).toBeUndefined()
+    expect(error).toBeInstanceOf(Error)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/sponsor/sanity.ts
+++ b/src/lib/sponsor/sanity.ts
@@ -93,15 +93,48 @@ export async function updateSponsorTier(
   }
 }
 
+/**
+ * TENANCY. `sponsorTier` carries a `conference` ref, so `conferenceId` is the
+ * tenant boundary and is REQUIRED: the tier is resolved through a scoped point
+ * read FIRST and the delete is refused when it does not belong to the caller's
+ * conference. Previously this deleted whatever id it was handed — a
+ * client-supplied id straight to `transaction.delete` — and cascaded an `unset`
+ * across every `sponsorForConference` referencing it, in any tenant.
+ */
 export async function deleteSponsorTier(
   id: string,
+  conferenceId: string,
 ): Promise<{ error?: Error }> {
+  // FAIL CLOSED: no tenant, no query, no delete.
+  if (!conferenceId) {
+    return {
+      error: new Error(
+        'deleteSponsorTier: refusing to delete without a resolved conference',
+      ),
+    }
+  }
+
   try {
+    // OWNERSHIP FIRST. A NOT-FOUND-shaped refusal either way, so a foreign id's
+    // existence is not distinguishable from a missing one.
+    const owned = await scopedFetch<string | null>(
+      clientWrite,
+      { conferenceId },
+      `*[_type == "sponsorTier" && _id == $id][0]._id`,
+      { id },
+    )
+    if (!owned) {
+      return { error: new Error('Sponsor tier not found in this conference') }
+    }
+
     // Clear the tier from any sponsor that references it before deleting, so we
     // never leave a dangling reference (which projects to null and would let a
     // tierless sponsor slip onto public surfaces). Referencing sponsors become
     // cleanly tierless: hidden from public, surfaced under "No Tier" in admin.
-    const referencingSponsorIds = await clientWrite.fetch<string[]>(
+    // Scoped to the same conference the tier belongs to.
+    const referencingSponsorIds = await scopedFetch<string[]>(
+      clientWrite,
+      { conferenceId },
       `*[_type == "sponsorForConference" && tier._ref == $id]._id`,
       { id },
     )
@@ -222,9 +255,54 @@ export async function updateSponsor(
   }
 }
 
-export async function deleteSponsor(id: string): Promise<{ error?: Error }> {
+/**
+ * TENANCY. `sponsor` is an ORG-level document (a shared company catalog entry)
+ * whose cascade deletes every `sponsorForConference` linking it — across all of
+ * the org's editions, which is why the cascade reads below are deliberately NOT
+ * conference-scoped. `orgId` is REQUIRED and ownership is proved first.
+ *
+ * The ownership probe is backfill-independent: it accepts the sponsor's own
+ * `organization` key (set on create, backfilled by migration 044) AND the orgs
+ * reached through the conferences it is linked to. It refuses unless the
+ * caller's org is the ONLY claimant, and refuses a sponsor with NO claimant at
+ * all — an orphan legacy row with neither an org key nor a conference link
+ * cannot be attributed to a tenant, so it fails closed rather than open.
+ */
+export async function deleteSponsor(
+  id: string,
+  orgId: string | null,
+): Promise<{ error?: Error }> {
+  // FAIL CLOSED: no tenant, no query, no delete.
+  if (!orgId) {
+    return {
+      error: new Error(
+        'deleteSponsor: refusing to delete without a resolved organization',
+      ),
+    }
+  }
+
   try {
-    // Find all sponsorForConference records referencing this sponsor
+    const claim = await clientWrite.fetch<{
+      sponsorOrg: string | null
+      linkedOrgs: (string | null)[] | null
+    }>(
+      // Nothing here is returned to the caller — only the comparison result.
+      // groq-global: an OWNERSHIP PROBE must see the document whichever tenant owns it; resolving its tenant is the whole point of REFUSING it.
+      `{"sponsorOrg": *[_type == "sponsor" && _id == $id][0].organization._ref,
+        "linkedOrgs": *[_type == "sponsorForConference" && sponsor._ref == $id].conference->organization._ref
+      }`,
+      { id },
+    )
+    const claimants = [claim.sponsorOrg, ...(claim.linkedOrgs ?? [])].filter(
+      (o): o is string => Boolean(o),
+    )
+    if (claimants.length === 0 || claimants.some((o) => o !== orgId)) {
+      return { error: new Error('Sponsor not found in this organization') }
+    }
+
+    // Find all sponsorForConference records referencing this sponsor. Org-wide
+    // by design (see the doc comment): ownership is already proven above, so
+    // `sponsor._ref == $id` cannot reach another tenant's rows.
     const sfcDocs = await clientWrite.fetch<
       Array<{
         _id: string
@@ -258,6 +336,10 @@ export async function deleteSponsor(id: string): Promise<{ error?: Error }> {
     let safeAssetIds: string[] = []
     if (candidateAssetIds.length > 0) {
       safeAssetIds = await clientWrite.fetch<string[]>(
+        // The inner "is anyone else still using it?" count MUST stay
+        // cross-tenant — scoping it would delete an asset another edition or
+        // another tenant still references.
+        // groq-global: `sanity.fileAsset` carries no tenant key of any kind.
         `*[
           _type == "sanity.fileAsset" &&
           _id in $assetIds &&
@@ -315,22 +397,25 @@ export async function getSponsor(id: string): Promise<{
 }
 
 /**
- * Optional tenant filter for the sponsor company pickers (E10). Sponsor entities
- * are currently global (a shared company catalog), so this is the CONSERVATIVE
- * scoping: when an org is provided, restrict to that org's sponsors, tolerating
- * org-less legacy sponsors (pre-044 backfill) via the coalesce fallback. When no
- * org is provided, behavior is unchanged (every sponsor).
+ * Tenant filter for the sponsor company pickers (E10).
  *
- * NOTE (flagged design question): whether sponsor companies should be shared
- * across tenants or partitioned per-org is an owner decision still pending. This
- * filter is written so the shared model can be restored by simply passing no
- * org, and the partitioned model tightened by dropping the coalesce clause.
+ * CALLERS MUST FAIL CLOSED FIRST. This helper is only ever reached with a
+ * resolved `orgId`; the `null` case is handled by the callers below, which
+ * return empty WITHOUT querying. Previously a null org produced an EMPTY clause
+ * — an unresolvable tenant read every tenant's sponsor list.
+ *
+ * NOTE (flagged design question, unchanged here): `!defined(organization)`
+ * tolerates org-less legacy sponsors (pre-044 backfill). That tolerance is a
+ * documented bridge with an owner decision still pending — whether sponsor
+ * companies are a shared catalog or partitioned per-org — and it is NOT touched
+ * by this change: dropping it would hide every un-backfilled sponsor from the
+ * live deployment. It must be closed (by confirming the 044 backfill ran, then
+ * deleting the clause) before a second tenant's sponsors enter the dataset.
  */
-function sponsorOrgFilter(orgId?: string | null): {
+function sponsorOrgFilter(orgId: string): {
   clause: string
   params: Record<string, string>
 } {
-  if (!orgId) return { clause: '', params: {} }
   return {
     clause: ' && (!defined(organization) || organization._ref == $orgId)',
     params: { orgId },
@@ -339,11 +424,21 @@ function sponsorOrgFilter(orgId?: string | null): {
 
 export async function searchSponsors(
   query: string,
-  orgId?: string | null,
+  orgId: string | null | undefined,
 ): Promise<{
   sponsors?: SponsorExisting[]
   error?: Error
 }> {
+  // FAIL CLOSED: an unresolvable org must return nothing, never every tenant's
+  // sponsors. No query is issued.
+  if (!orgId) {
+    return {
+      error: new Error(
+        'searchSponsors: refusing to search sponsors without a resolved organization',
+      ),
+    }
+  }
+
   try {
     const { clause, params } = sponsorOrgFilter(orgId)
     const sponsors = await clientWrite.fetch(
@@ -365,10 +460,21 @@ export async function searchSponsors(
   }
 }
 
-export async function getAllSponsors(orgId?: string | null): Promise<{
+export async function getAllSponsors(
+  orgId: string | null | undefined,
+): Promise<{
   sponsors?: SponsorExisting[]
   error?: Error
 }> {
+  // FAIL CLOSED: see `searchSponsors`.
+  if (!orgId) {
+    return {
+      error: new Error(
+        'getAllSponsors: refusing to list sponsors without a resolved organization',
+      ),
+    }
+  }
+
   try {
     const { clause, params } = sponsorOrgFilter(orgId)
     const sponsors = await clientWrite.fetch(

--- a/src/lib/travel-support/sanity.tenancy.test.ts
+++ b/src/lib/travel-support/sanity.tenancy.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * TENANCY REGRESSIONS for the travel-support reads (#616, batch A2).
+ *
+ * `travelSupport` carries the speaker's BANKING DETAILS. `getAllTravelSupport`
+ * used to take an OPTIONAL `conferenceId` and degrade to
+ * `*[_type == "travelSupport"]` when it was falsy — every tenant's speakers'
+ * bank account numbers. The unknown-host path made that reachable:
+ * `getConferenceForCurrentDomain()` returns a truthy `{}` for an unknown host,
+ * so the router's `if (!conference)` never fired and `conference._id` was
+ * `undefined`.
+ *
+ * Each test asserts BOTH that the fail-closed path returns nothing AND that it
+ * issues no query at all.
+ */
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: (...a: unknown[]) => fetchMock(...a) },
+  clientWrite: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+vi.mock('@/lib/organization/sanity', () => ({
+  getOrganizationRefViaParentConference: vi.fn(),
+  organizationField: () => ({}),
+}))
+
+import {
+  getAllTravelSupport,
+  getSpeakersRequiringTravelSupport,
+} from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockResolvedValue([])
+})
+
+describe('getAllTravelSupport — banking PII must never go global', () => {
+  it('binds the conference predicate into the read', async () => {
+    await getAllTravelSupport('conf-1')
+
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(params).toMatchObject({ conferenceId: 'conf-1' })
+  })
+
+  it('never emits the unscoped `*[_type == "travelSupport"]` root filter', async () => {
+    await getAllTravelSupport('conf-1')
+
+    const [query] = fetchMock.mock.calls[0]
+    // The root filter must LEAD with the tenant predicate, not `_type`.
+    expect(query).toMatch(/\*\[\s*conference\._ref == \$conferenceId/)
+  })
+
+  // MUTATION CHECK (verified): deleting the `if (!conferenceId)` guard does NOT
+  // make this fail — `scopedFetch` throws on an empty scope before reaching the
+  // client, so the read is closed by TWO independent layers. What DOES fail if
+  // the read is reverted to the old `conferenceId ? scoped : global` ternary is
+  // `expect(fetchMock).not.toHaveBeenCalled()`, because the global branch issues
+  // a real query. That is the regression this pins.
+  it('FAILS CLOSED on an unresolvable conference: no query, no records', async () => {
+    const { travelSupports, error } = await getAllTravelSupport(
+      undefined as unknown as string,
+    )
+
+    expect(travelSupports).toEqual([])
+    expect(error).toBeInstanceOf(Error)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('FAILS CLOSED on an empty-string conference id', async () => {
+    const { travelSupports, error } = await getAllTravelSupport('')
+
+    expect(travelSupports).toEqual([])
+    expect(error).toBeInstanceOf(Error)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('getSpeakersRequiringTravelSupport — scoped at the ROOT filter', () => {
+  it('roots the read at the conference’s talks, not a global speaker sweep', async () => {
+    await getSpeakersRequiringTravelSupport('conf-1')
+
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(query).toContain('_type == "talk"')
+    // The old shape swept every tenant's funding-flagged speakers.
+    expect(query).not.toContain('"requires-funding" in flags')
+    expect(params).toMatchObject({ conferenceId: 'conf-1' })
+  })
+
+  it('keeps only speakers flagged as requiring funding, grouped by person', async () => {
+    fetchMock
+      .mockResolvedValueOnce([
+        {
+          _id: 't1',
+          title: 'Talk One',
+          speakers: [
+            {
+              _id: 'spk-1',
+              name: 'A',
+              email: 'a@x',
+              flags: ['requires-funding'],
+            },
+            { _id: 'spk-2', name: 'B', email: 'b@x', flags: [] },
+          ],
+        },
+        {
+          _id: 't2',
+          title: 'Talk Two',
+          speakers: [
+            {
+              _id: 'spk-1',
+              name: 'A',
+              email: 'a@x',
+              flags: ['requires-funding'],
+            },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([{ speakerId: 'spk-1' }])
+
+    const { speakers, error } =
+      await getSpeakersRequiringTravelSupport('conf-1')
+
+    expect(error).toBeNull()
+    expect(speakers).toHaveLength(1)
+    expect(speakers[0]).toMatchObject({
+      _id: 'spk-1',
+      hasSubmitted: true,
+    })
+    expect(speakers[0].confirmedTalks.map((t) => t._id)).toEqual(['t1', 't2'])
+  })
+
+  it('FAILS CLOSED on an unresolvable conference: no query, no speakers', async () => {
+    const { speakers, error } = await getSpeakersRequiringTravelSupport('')
+
+    expect(speakers).toEqual([])
+    expect(error).toBeInstanceOf(Error)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/travel-support/sanity.ts
+++ b/src/lib/travel-support/sanity.ts
@@ -17,6 +17,7 @@ import {
   getOrganizationRefViaParentConference,
   organizationField,
 } from '@/lib/organization/sanity'
+import { scopedFetch } from '@/lib/sanity/scoped'
 
 export async function getTravelSupport(
   speakerId: string,
@@ -89,19 +90,36 @@ export async function getTravelSupportById(id: string): Promise<{
   }
 }
 
-export async function getAllTravelSupport(conferenceId?: string): Promise<{
+/**
+ * Every travel-support submission for ONE conference.
+ *
+ * TENANCY — FAILS CLOSED. `travelSupport` carries the speaker's BANKING DETAILS
+ * (see {@link BankingDetails}). This used to take an OPTIONAL `conferenceId` and
+ * degrade to `*[_type == "travelSupport"]` when it was falsy, so a single
+ * argument-less call would have returned every tenant's speakers' bank account
+ * numbers. The predicate is now unconditional: `conferenceId` is required, and
+ * an unresolvable tenant returns EMPTY without issuing any query at all.
+ */
+export async function getAllTravelSupport(conferenceId: string): Promise<{
   travelSupports: (TravelSupportWithSpeaker & { expenses?: TravelExpense[] })[]
   error: Error | null
 }> {
-  try {
-    const query = conferenceId
-      ? `*[_type == "travelSupport" && conference._ref == $conferenceId] | order(_createdAt desc)`
-      : `*[_type == "travelSupport"] | order(_createdAt desc)`
+  if (!conferenceId) {
+    return {
+      travelSupports: [],
+      error: new Error(
+        'getAllTravelSupport: refusing to read travel support (banking details) without a resolved conference',
+      ),
+    }
+  }
 
-    const travelSupports = await clientRead.fetch<
+  try {
+    const travelSupports = await scopedFetch<
       (TravelSupportWithSpeaker & { expenses?: TravelExpense[] })[]
     >(
-      `${query} {
+      clientRead,
+      { conferenceId },
+      `*[_type == "travelSupport"] | order(_createdAt desc) {
         ...,
         speaker-> {
           _id,
@@ -120,7 +138,6 @@ export async function getAllTravelSupport(conferenceId?: string): Promise<{
           }
         }
       }`,
-      conferenceId ? { conferenceId } : {},
     )
 
     return { travelSupports, error: null }
@@ -141,46 +158,77 @@ export async function getSpeakersRequiringTravelSupport(
   }>
   error: Error | null
 }> {
+  if (!conferenceId) {
+    return {
+      speakers: [],
+      error: new Error(
+        'getSpeakersRequiringTravelSupport: refusing to run without a resolved conference',
+      ),
+    }
+  }
+
   try {
-    // Get all speakers with confirmed talks who require travel funding
-    const allSpeakers = await clientRead.fetch<
+    // TENANCY: driven from the CONFERENCE'S confirmed talks, not from a global
+    // speaker sweep. The previous shape rooted at
+    // `*[_type == "speaker" && "requires-funding" in flags]` — every tenant's
+    // funding-flagged speakers — and relied on a JS filter to drop the ones
+    // whose (conference-scoped) nested talk list came back empty. No PII crossed,
+    // but it over-read every tenant. Rooting at `talk` makes the tenant
+    // predicate the ROOT filter, so nothing outside this conference is read.
+    const confirmedTalks = await scopedFetch<
       Array<{
+        _id: string
+        title: string
+        speakers: Array<{
+          _id: string
+          name: string
+          email: string
+          flags?: string[]
+        }> | null
+      }>
+    >(
+      clientRead,
+      { conferenceId },
+      `*[_type == "talk" && status == "confirmed"] {
+        _id,
+        title,
+        "speakers": speakers[]-> { _id, name, email, flags }
+      }`,
+    )
+
+    // Regroup by speaker, keeping only those flagged as requiring funding.
+    const bySpeaker = new Map<
+      string,
+      {
         _id: string
         name: string
         email: string
         confirmedTalks: Array<{ _id: string; title: string }>
-      }>
-    >(
-      `*[_type == "speaker" && "requires-funding" in flags] {
-        _id,
-        name,
-        email,
-        "confirmedTalks": *[
-          _type == "talk"
-          && status == "confirmed"
-          && conference._ref == $conferenceId
-          && references(^._id)
-        ] {
-          _id,
-          title
+      }
+    >()
+    for (const talk of confirmedTalks) {
+      for (const speaker of talk.speakers ?? []) {
+        if (!speaker?._id) continue
+        if (!speaker.flags?.includes('requires-funding')) continue
+        const entry = bySpeaker.get(speaker._id) ?? {
+          _id: speaker._id,
+          name: speaker.name,
+          email: speaker.email,
+          confirmedTalks: [],
         }
-      }`,
-      { conferenceId },
-    )
-
-    // Filter to only speakers with confirmed talks
-    const speakersWithConfirmedTalks = allSpeakers.filter(
-      (s) => s.confirmedTalks && s.confirmedTalks.length > 0,
-    )
+        entry.confirmedTalks.push({ _id: talk._id, title: talk.title })
+        bySpeaker.set(speaker._id, entry)
+      }
+    }
+    const speakersWithConfirmedTalks = [...bySpeaker.values()]
 
     // Get all travel support submissions for this conference (excluding drafts)
-    const existingSubmissions = await clientRead.fetch<
-      Array<{ speakerId: string }>
-    >(
-      `*[_type == "travelSupport" && conference._ref == $conferenceId && status != "draft"] {
+    const existingSubmissions = await scopedFetch<Array<{ speakerId: string }>>(
+      clientRead,
+      { conferenceId },
+      `*[_type == "travelSupport" && status != "draft"] {
         "speakerId": speaker._ref
       }`,
-      { conferenceId },
     )
 
     const submittedSpeakerIds = new Set(

--- a/src/lib/workshop/sanity.ts
+++ b/src/lib/workshop/sanity.ts
@@ -9,6 +9,7 @@ import type {
 import { WorkshopSignupStatus } from './types'
 import { getWorkshops } from '@/lib/proposal/data/sanity'
 import { Status } from '@/lib/proposal/types'
+import { scopedFetch } from '@/lib/sanity/scoped'
 
 const workshopSignupLocks = new Map<string, Promise<WorkshopSignupExisting>>()
 
@@ -401,31 +402,48 @@ export async function getWorkshopSignupStatisticsBySpeaker(
   })
 }
 
+/**
+ * Workshop signups for ONE conference.
+ *
+ * TENANCY — FAILS CLOSED. `conferenceId` is REQUIRED. It was optional, and the
+ * `signupIds`-only call path (`confirmSignup`, `batchConfirmSignups`,
+ * `cancelSignup`) built `*[_type == "workshopSignup" && _id in [...]]` with NO
+ * conference predicate at all, so an admin of one tenant could confirm another
+ * tenant's signups by id — the ids are client input. The predicate is now
+ * unconditional and issued through `scopedFetch`.
+ *
+ * INJECTION. Every filter used to be INTERPOLATED into the GROQ source with
+ * hand-rolled quoting (`_id in ["${id}", …]`, `status == "${status}"`), so a
+ * value containing `"` escaped the string literal and rewrote the predicate —
+ * including the tenant predicate. All values are now BOUND as parameters.
+ */
 export async function getAllWorkshopSignups(filters: {
-  conferenceId?: string
+  conferenceId: string
   workshopId?: string
   status?: string
   signupIds?: string[]
   page?: number
   pageSize?: number
 }): Promise<WorkshopSignupExisting[]> {
-  const conditions = ['_type == "workshopSignup"']
+  // FAIL CLOSED: an unresolvable tenant reads nothing, and issues no query.
+  if (!filters.conferenceId) return []
 
-  if (filters.conferenceId) {
-    conditions.push(`conference._ref == "${filters.conferenceId}"`)
-  }
+  const conditions = ['_type == "workshopSignup"']
+  const params: Record<string, unknown> = {}
 
   if (filters.workshopId) {
-    conditions.push(`workshop._ref == "${filters.workshopId}"`)
+    conditions.push(`workshop._ref == $workshopId`)
+    params.workshopId = filters.workshopId
   }
 
   if (filters.status) {
-    conditions.push(`status == "${filters.status}"`)
+    conditions.push(`status == $status`)
+    params.status = filters.status
   }
 
   if (filters.signupIds && filters.signupIds.length > 0) {
-    const ids = filters.signupIds.map((id) => `"${id}"`).join(', ')
-    conditions.push(`_id in [${ids}]`)
+    conditions.push(`_id in $signupIds`)
+    params.signupIds = filters.signupIds
   }
 
   const whereClause = conditions.join(' && ')
@@ -434,6 +452,8 @@ export async function getAllWorkshopSignups(filters: {
   const start = (page - 1) * pageSize
   const end = start + pageSize
 
+  // `start`/`end` are derived from numbers, never from raw strings, so the slice
+  // cannot carry injected GROQ.
   const query = groq`*[${whereClause}] | order(signedUpAt desc) [${start}...${end}] {
     _id,
     _type,
@@ -461,7 +481,12 @@ export async function getAllWorkshopSignups(filters: {
     _updatedAt
   }`
 
-  return await clientWrite.fetch(query)
+  return await scopedFetch<WorkshopSignupExisting[]>(
+    clientWrite,
+    { conferenceId: filters.conferenceId },
+    query,
+    params,
+  )
 }
 
 export async function getWorkshopsByConference(

--- a/src/lib/workshop/signups.tenancy.test.ts
+++ b/src/lib/workshop/signups.tenancy.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+/**
+ * TENANCY + INJECTION REGRESSIONS for `getAllWorkshopSignups` (#616, batch A1).
+ *
+ * The `signupIds`-only call path (`confirmSignup`, `batchConfirmSignups`,
+ * `cancelSignup`) built `*[_type == "workshopSignup" && _id in [...]]` with NO
+ * conference predicate, so an admin of one tenant could confirm another
+ * tenant's signups by id — and the ids are client input.
+ *
+ * The same builder INTERPOLATED every filter into the GROQ source with
+ * hand-rolled quoting, so a value containing a double quote escaped the string
+ * literal and could rewrite the predicate, including the tenant predicate.
+ */
+const fetchMock = vi.fn()
+vi.mock('@/lib/sanity/client', () => ({
+  clientWrite: { fetch: (...a: unknown[]) => fetchMock(...a) },
+}))
+vi.mock('@/lib/proposal/data/sanity', () => ({ getWorkshops: vi.fn() }))
+
+import { getAllWorkshopSignups } from './sanity'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockResolvedValue([])
+})
+
+describe('getAllWorkshopSignups — tenant scoping', () => {
+  it('binds the conference predicate even on the ids-only path', async () => {
+    await getAllWorkshopSignups({
+      conferenceId: 'conf-1',
+      signupIds: ['sg-1', 'sg-2'],
+    })
+
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).toContain('conference._ref == $conferenceId')
+    expect(params).toMatchObject({
+      conferenceId: 'conf-1',
+      signupIds: ['sg-1', 'sg-2'],
+    })
+  })
+
+  // MUTATION CHECK: delete the `if (!filters.conferenceId) return []` guard and
+  // this fails — `scopedFetch` would throw, but the contract pinned here is
+  // that NO query is issued for an unresolvable tenant.
+  it('FAILS CLOSED on an unresolvable conference: no query, no signups', async () => {
+    const signups = await getAllWorkshopSignups({
+      conferenceId: '',
+      signupIds: ['sg-1'],
+    })
+
+    expect(signups).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('getAllWorkshopSignups — GROQ injection', () => {
+  it('binds ids as a PARAMETER rather than splicing them into the query', async () => {
+    // A crafted id that would have closed the string literal and appended its
+    // own predicate under the old `_id in ["${id}"]` interpolation.
+    const hostile = 'sg-1"] || _type == "workshopSignup" && ["x'
+
+    await getAllWorkshopSignups({
+      conferenceId: 'conf-1',
+      signupIds: [hostile],
+    })
+
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).not.toContain(hostile)
+    expect(query).toContain('_id in $signupIds')
+    expect(params.signupIds).toEqual([hostile])
+  })
+
+  it('binds status and workshopId as parameters', async () => {
+    await getAllWorkshopSignups({
+      conferenceId: 'conf-1',
+      status: 'confirmed"] || ["',
+      workshopId: 'ws-1"] || ["',
+    })
+
+    const [query, params] = fetchMock.mock.calls[0]
+    expect(query).toContain('status == $status')
+    expect(query).toContain('workshop._ref == $workshopId')
+    expect(query).not.toContain('|| ["')
+    expect(params).toMatchObject({
+      status: 'confirmed"] || ["',
+      workshopId: 'ws-1"] || ["',
+    })
+  })
+})

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -102,7 +102,12 @@ import {
   listActivitiesForSponsor,
   listActivitiesForConference,
 } from '@/lib/sponsor-crm/activities'
-import { bulkUpdateSponsors, bulkDeleteSponsors } from '@/lib/sponsor-crm/bulk'
+import {
+  bulkUpdateSponsors,
+  bulkDeleteSponsors,
+  BulkTenancyError,
+} from '@/lib/sponsor-crm/bulk'
+import { scopedFetch } from '@/lib/sanity/scoped'
 import {
   listContractTemplates,
   getContractTemplate,
@@ -169,19 +174,29 @@ async function getSponsorForCurrentConference(id: string) {
   return result
 }
 
-async function getAllSponsorTiers(conferenceId?: string): Promise<{
+/**
+ * TENANCY — FAILS CLOSED. `conferenceId` used to be optional and the query
+ * degraded to `*[_type == "sponsorTier"]` when it was falsy, returning every
+ * tenant's tiers (and their PRICING) to whichever admin surface asked. The
+ * predicate is now unconditional and an unresolvable tenant issues no query.
+ */
+async function getAllSponsorTiers(conferenceId: string): Promise<{
   sponsorTiers?: SponsorTierExisting[]
   error?: Error
 }> {
+  if (!conferenceId) {
+    return {
+      error: new Error(
+        'getAllSponsorTiers: refusing to run without a resolved conference',
+      ),
+    }
+  }
+
   try {
-    const query = conferenceId
-      ? `*[_type == "sponsorTier" && conference._ref == $conferenceId]`
-      : `*[_type == "sponsorTier"]`
-
-    const params = conferenceId ? { conferenceId } : {}
-
-    const sponsorTiers = await clientWrite.fetch(
-      `${query}{
+    const sponsorTiers = await scopedFetch<SponsorTierExisting[]>(
+      clientWrite,
+      { conferenceId },
+      `*[_type == "sponsorTier"]{
         _id,
         _createdAt,
         _updatedAt,
@@ -202,7 +217,6 @@ async function getAllSponsorTiers(conferenceId?: string): Promise<{
         mostPopular,
         maxQuantity
       }`,
-      params,
     )
 
     return { sponsorTiers }
@@ -479,19 +493,24 @@ export const sponsorRouter = router({
       }
     }),
 
-  delete: adminProcedure.input(IdParamSchema).mutation(async ({ input }) => {
-    const { error } = await deleteSponsor(input.id)
+  delete: adminProcedure
+    .input(IdParamSchema)
+    .mutation(async ({ input, ctx }) => {
+      // TENANCY: the sponsor id is CLIENT INPUT. `deleteSponsor` proves the
+      // REQUEST's org owns it before cascading. `ctx.orgId` is the org the
+      // admin waist already gated on — never anything derived from `input`.
+      const { error } = await deleteSponsor(input.id, ctx.orgId)
 
-    if (error) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Failed to delete sponsor',
-        cause: error,
-      })
-    }
+      if (error) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to delete sponsor',
+          cause: error,
+        })
+      }
 
-    return { success: true }
-  }),
+      return { success: true }
+    }),
 
   tiers: router({
     list: adminProcedure.query(async () => {
@@ -653,7 +672,10 @@ export const sponsorRouter = router({
       }),
 
     delete: adminProcedure.input(IdParamSchema).mutation(async ({ input }) => {
-      const { error } = await deleteSponsorTier(input.id)
+      // TENANCY: the tier id is CLIENT INPUT; `deleteSponsorTier` resolves it
+      // inside the REQUEST's conference and refuses otherwise.
+      const conferenceId = await resolveConferenceId()
+      const { error } = await deleteSponsorTier(input.id, conferenceId)
 
       if (error) {
         throw new TRPCError({
@@ -664,7 +686,7 @@ export const sponsorRouter = router({
       }
 
       // Sponsor tiers belong to one conference — bust only this tenant.
-      revalidateTag(conferenceTag(await resolveConferenceId()), 'default')
+      revalidateTag(conferenceTag(conferenceId), 'default')
 
       return { success: true }
     }),
@@ -1449,9 +1471,22 @@ export const sponsorRouter = router({
             }
           }
 
-          return await bulkUpdateSponsors(input, userId)
+          // TENANCY: the bulk write is scoped to the REQUEST's conference, never
+          // to anything derived from `input`. `resolveConferenceId` throws
+          // NOT_FOUND (a TRPCError, rethrown below) on an unresolvable host.
+          return await bulkUpdateSponsors(
+            input,
+            userId,
+            await resolveConferenceId(),
+          )
         } catch (error) {
           if (error instanceof TRPCError) throw error
+          if (error instanceof BulkTenancyError) {
+            throw new TRPCError({
+              code: 'NOT_FOUND',
+              message: 'One or more sponsors were not found in this conference',
+            })
+          }
 
           console.error('Bulk update error:', error)
           throw new TRPCError({
@@ -1501,10 +1536,22 @@ export const sponsorRouter = router({
         }
 
         try {
-          return await bulkDeleteSponsors(input.ids, {
-            deleteContractAssets: input.deleteContractAssets,
-          })
+          // TENANCY: scoped to the REQUEST's conference (see bulkUpdate).
+          return await bulkDeleteSponsors(
+            input.ids,
+            await resolveConferenceId(),
+            { deleteContractAssets: input.deleteContractAssets },
+          )
         } catch (error) {
+          // Preserve refusals: a fail-closed tenancy denial must not surface as
+          // a 500, or the guard becomes indistinguishable from a server fault.
+          if (error instanceof TRPCError) throw error
+          if (error instanceof BulkTenancyError) {
+            throw new TRPCError({
+              code: 'NOT_FOUND',
+              message: 'One or more sponsors were not found in this conference',
+            })
+          }
           console.error('Bulk delete error:', error)
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',

--- a/src/server/routers/sponsor.ts
+++ b/src/server/routers/sponsor.ts
@@ -498,7 +498,7 @@ export const sponsorRouter = router({
     .mutation(async ({ input, ctx }) => {
       // TENANCY: the sponsor id is CLIENT INPUT. `deleteSponsor` proves the
       // REQUEST's org owns it before cascading. `ctx.orgId` is the org the
-      // admin waist already gated on — never anything derived from `input`.
+      // admin procedure already gated on — never anything from `input`.
       const { error } = await deleteSponsor(input.id, ctx.orgId)
 
       if (error) {

--- a/src/server/routers/travelSupport.ts
+++ b/src/server/routers/travelSupport.ts
@@ -74,7 +74,7 @@ export const travelSupportRouter = router({
     try {
       const { conference, error: confError } =
         await getConferenceForCurrentDomain()
-      if (confError || !conference) {
+      if (confError || !conference?._id) {
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
           message: 'Failed to get current conference',
@@ -131,7 +131,7 @@ export const travelSupportRouter = router({
 
         const { conference, error: confError } =
           await getConferenceForCurrentDomain()
-        if (confError || !conference) {
+        if (confError || !conference?._id) {
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Failed to get current conference',
@@ -628,7 +628,7 @@ export const travelSupportRouter = router({
       try {
         const { conference, error: confError } =
           await getConferenceForCurrentDomain()
-        if (confError || !conference) {
+        if (confError || !conference?._id) {
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Failed to get current conference',
@@ -850,7 +850,7 @@ export const travelSupportRouter = router({
       try {
         const { conference, error: confError } =
           await getConferenceForCurrentDomain()
-        if (confError || !conference) {
+        if (confError || !conference?._id) {
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Failed to get current conference',

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -590,7 +590,10 @@ export const workshopRouter = router({
       try {
         const actor = requireWorkshopUser(ctx)
 
+        // TENANCY: resolve the signup INSIDE the request's conference. Without
+        // the predicate this was a by-id lookup across every tenant.
         const signups = await getAllWorkshopSignups({
+          conferenceId: await resolveConferenceId(),
           signupIds: [input.signupId],
         })
 
@@ -696,7 +699,11 @@ export const workshopRouter = router({
       .input(confirmWorkshopSignupSchema)
       .mutation(async ({ input }) => {
         try {
+          // TENANCY: `workshopAdminProcedure` proves the caller organizes the
+          // REQUEST's org — it says nothing about the id in the payload. Confirm
+          // only signups that resolve inside the request's conference.
           const signups = await getAllWorkshopSignups({
+            conferenceId: await resolveConferenceId(),
             signupIds: [input.signupId],
           })
 
@@ -840,7 +847,10 @@ export const workshopRouter = router({
       .input(batchConfirmSignupsSchema)
       .mutation(async ({ input }) => {
         try {
+          // TENANCY: see `confirmSignup`. Ids outside the request's conference
+          // simply do not resolve, so they are never confirmed.
           const signups = await getAllWorkshopSignups({
+            conferenceId: await resolveConferenceId(),
             signupIds: input.signupIds,
           })
 

--- a/src/server/routers/workshop.ts
+++ b/src/server/routers/workshop.ts
@@ -848,11 +848,26 @@ export const workshopRouter = router({
       .mutation(async ({ input }) => {
         try {
           // TENANCY: see `confirmSignup`. Ids outside the request's conference
-          // simply do not resolve, so they are never confirmed.
+          // do not resolve — and the batch is then REFUSED WHOLE rather than
+          // acting on the subset that did.
+          //
+          // Two reasons. Acting on the subset lets a crafted batch enumerate
+          // another tenant's id space by observing which ids take effect, which
+          // is the same argument the sponsor bulk operations in this change
+          // already make. And reporting `total: input.signupIds.length` beside
+          // a `succeeded` counted only over RESOLVED rows told the caller five
+          // succeeded when two did — silently dropping the rest.
           const signups = await getAllWorkshopSignups({
             conferenceId: await resolveConferenceId(),
             signupIds: input.signupIds,
           })
+
+          if (signups.length !== input.signupIds.length) {
+            throw new TRPCError({
+              code: 'NOT_FOUND',
+              message: 'One or more signups were not found for this conference',
+            })
+          }
 
           const { conference } = await getConferenceForCurrentDomain({})
 
@@ -892,10 +907,11 @@ export const workshopRouter = router({
             results: {
               succeeded,
               failed,
-              total: input.signupIds.length,
+              total: signups.length,
             },
           }
         } catch (error) {
+          if (error instanceof TRPCError) throw error
           throw new TRPCError({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Failed to batch confirm signups',


### PR DESCRIPTION
Fixes the genuine cross-tenant leaks found while triaging the repo's 254 unread lint warnings. Not cleanup — the annotation work is a separate pass. These are security bugs that had been sitting behind a rule nobody could run.

## The one that matters most: banking PII, and it was reachable

`getAllTravelSupport(conferenceId?)` fell back to `*[_type == "travelSupport"]` — every tenant's speakers' **bank details** — when its argument was falsy.

That was not theoretical. `getConferenceForCurrentDomain()` returns a **truthy `{}`** on an unknown host, so the caller's `if (confError || !conference)` guard never fired and `conference._id` went in as `undefined`. The fallback was one unrecognised Host header away. All four of those guards are now `conference?._id`.

`getSpeakersRequiringTravelSupport` was also rewritten to root at the conference's confirmed talks rather than sweeping every tenant's funding-flagged speakers.

## Cross-tenant bulk writes

`bulkUpdateSponsors` matched `_id in $ids` with no tenant predicate; `bulkDeleteSponsors` issued **no tenant query at all** and passed client ids straight to `transaction.delete`. Both now require a conference, resolve the owned set, and refuse the **whole batch** unless every id resolves — acting on the owned subset would let a crafted batch enumerate another tenant's id space by observing which ids succeeded.

## Another GROQ injection

`getAllWorkshopSignups` was **interpolating client input into GROQ source** with hand-rolled quoting (`_id in ["${id}"]`, `status == "${status}"`) — into the very predicate that carries the tenant boundary. All values are bound now, with a test asserting a hostile id never appears in the query text.

## Global-organizer bridges

`getOrganizers` and `speakerHasStandingInConference` now fail closed, following #728's shape. No `getAllOrganizersAcrossOrgs` escape hatch was added — no caller wants one, and an unused global-read export is a liability.

## Fixed at the data-access layer, deliberately

`src/server/tenancy.ts` does not exist on `main` — #731 is still open — so the shared guard was unavailable. These are scoped in the **library functions** instead, which is strictly stronger: #731 guards the routers, this guards everything underneath, and the two compose as defence in depth. Expect a trivial textual conflict in `src/server/routers/sponsor.ts` if #731 lands first; the semantics agree.

## Two warnings left on purpose

`bulk.ts:273` and the `deleteSponsor` cascade express their tenant predicate as a reference traversal the lint rule cannot parse. Annotating them `groq-global:` would be a lie, so they stay as honest warnings with comments. Warnings in the touched files: 54 → 47.

## Verification

Mutation-checked: deleting each guard fails a named test, and that was actually run. Two honest exceptions are recorded in the test comments rather than claimed as stronger than they are — `getAllTravelSupport`'s guard is backstopped by `scopedFetch`'s empty-scope throw, so only reverting the ternary fails a test.

Single-tenant safety: making these parameters required produced compile errors in **test files only** — every production call site already passed a resolved tenant.

420 files / 5889 tests, typecheck clean, production build passes.

## Action needed before a second tenant's data exists

`sponsorOrgFilter`'s `!defined(organization)` tolerance is **not** fixed, deliberately. Its null-org fail-open half is. But the org-less tolerance is a documented pre-044 bridge, and dropping it would hide every un-backfilled sponsor from the live deployment. Confirm the 044 backfill ran, then delete that clause — it is a genuine leak for org-less rows.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds fail-closed tenant scoping to sensitive travel-support, sponsor, speaker, messaging, and workshop operations. Two sponsor bulk-operation ordering gaps remain:
- Mixed bulk-delete batches can cancel owned signing agreements before being refused.
- Closed-won bulk updates can disclose a foreign sponsor's tier state before ownership validation.

<h3>Confidence Score: 4/5</h3>

The sponsor bulk-operation ordering defects should be fixed before merging because refused requests can cancel valid agreements or disclose foreign sponsor metadata.

Tenant validation occurs only after signing cancellation and after a tier-dependent global preflight, so rejected mixed-tenant batches can still have observable effects.

**Files Needing Attention:** src/server/routers/sponsor.ts

<details open><summary><h3>Security Review</h3></summary>

The closed-won bulk-update preflight remains globally keyed by client-supplied ids, allowing response differences to reveal whether a foreign sponsor record has a tier.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/sponsor-crm/bulk.ts | Adds conference-scoped ownership resolution and all-or-nothing checks for bulk sponsor writes. |
| src/server/routers/sponsor.ts | Passes request-derived tenant ids into guarded helpers, but two pre-validation paths still cause side effects or disclose foreign record state. |
| src/lib/travel-support/sanity.ts | Replaces global fallbacks with mandatory conference scoping and roots funding candidates in confirmed talks. |
| src/lib/speaker/sanity.ts | Makes organizer and speaker population queries fail closed when tenant scope cannot be resolved. |
| src/lib/messaging/standing.ts | Removes the global organizer fallback and denies standing for unresolved conferences. |
| src/lib/workshop/sanity.ts | Parameterizes workshop signup filters and applies the conference boundary through scopedFetch. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Admin
  participant Router as Sponsor router
  participant Signing as Signing provider
  participant Guard as Tenant-scoped bulk helper
  Admin->>Router: bulkDelete(ownedId, foreignId)
  Router->>Signing: cancel owned agreement
  Router->>Guard: validate batch ownership
  Guard-->>Router: reject mixed batch
  Router-->>Admin: NOT_FOUND
  Note over Signing,Admin: Agreement remains cancelled although deletion was refused
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/server/routers/sponsor.ts`, line 4553-4557 ([link](https://github.com/cloudnativebergen/website/blob/c6186ec91865e98cb87faf5e040545c5b738baba/src/server/routers/sponsor.ts#L4553-L4557)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cancellation precedes ownership validation**

   When a bulk-delete request includes an owned sponsor with a pending agreement and a foreign or nonexistent ID, the router cancels the owned agreement before `bulkDeleteSponsors` rejects the mixed batch, leaving the agreement cancelled even though no sponsor records are deleted.

   **Knowledge Base Used:**
   - [Speaker and Sponsor Management](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/speaker-sponsor-management.md)
   - [tRPC API Layer](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/trpc-api-layer.md)

2. `src/server/routers/sponsor.ts`, line 4487-4491 ([link](https://github.com/cloudnativebergen/website/blob/c6186ec91865e98cb87faf5e040545c5b738baba/src/server/routers/sponsor.ts#L4487-L4491)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Tier check precedes tenant validation**

   When a closed-won bulk update contains a foreign sponsor ID, the unscoped tier preflight runs before the conference ownership check, so tierless foreign records return `PRECONDITION_FAILED` while tiered or nonexistent records return `NOT_FOUND`, exposing the foreign record's existence and tier state.

   **How this was verified:** The tier query filters only by client-supplied IDs and branches on its result before the conference-scoped helper validates ownership.

   **Knowledge Base Used:**
   - [Speaker and Sponsor Management](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/speaker-sponsor-management.md)
   - [tRPC API Layer](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/trpc-api-layer.md)
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(tenancy): close the fail-open reads ..."](https://github.com/cloudnativebergen/website/commit/c6186ec91865e98cb87faf5e040545c5b738baba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50006718)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Speaker and Sponsor Management](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/speaker-sponsor-management.md)
- Knowledge Base — [Messaging System](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/messaging-system.md)
- Knowledge Base — [tRPC API Layer](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/trpc-api-layer.md)
- Knowledge Base — [Workshop management and volunteer sign-up](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/workshop-volunteer.md)
</details>


<!-- /greptile_comment -->