### PR TITLE
fix(composer): stop the double scroll, and show real defaults in the inputs

### DIFF
--- a/src/components/admin/composer/ComposerRail.tsx
+++ b/src/components/admin/composer/ComposerRail.tsx
@@ -32,12 +32,18 @@ import {
 } from '@/lib/homepage'
 import type { SectionContentStatus } from '@/lib/homepage/contentStatus'
 import { SECTION_LABELS, type EditorRow } from '@/lib/homepage/editor'
+import type { PlaceholderConference } from './placeholderCopy'
 import { ComposerSectionCard } from './SectionCard'
 
 export interface ComposerRailProps {
   rows: EditorRow[]
   /** `_key`s whose config panel is open. */
   expanded: ReadonlySet<string>
+  /**
+   * The tenant's title/tagline/description — what the config panels quote as
+   * the copy each band renders when its field is left blank.
+   */
+  conference?: PlaceholderConference
   focusKey: string | null
   hoverKey: string | null
   /** `_key` → what the live site does with that section. */
@@ -77,6 +83,7 @@ export interface ComposerRailProps {
 export function ComposerRail({
   rows,
   expanded,
+  conference,
   focusKey,
   hoverKey,
   statuses,
@@ -163,6 +170,7 @@ export function ComposerRail({
                   index={index}
                   total={rows.length}
                   expanded={expanded.has(row._key)}
+                  conference={conference}
                   focused={focusKey === row._key}
                   hovered={hoverKey === row._key}
                   status={statuses.get(row._key)}

--- a/src/components/admin/composer/HomepageComposer.stories.tsx
+++ b/src/components/admin/composer/HomepageComposer.stories.tsx
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { ThemeProvider } from 'next-themes'
 import { screen, userEvent, within } from 'storybook/test'
 import { HomepagePreview } from '@/components/admin/preview'
+import { AdminLayout } from '@/components/admin/AdminLayout'
 import { NotificationProvider } from '@/components/admin/NotificationProvider'
 import { mockFeaturedSpeakers } from '@/components/featuredSpeakers.mocks'
 import type { Conference } from '@/lib/conference/types'
@@ -290,9 +291,26 @@ const meta = {
         >
           <NotificationProvider>
             <div className={dark ? 'dark' : ''}>
-              <div className="min-h-screen bg-white p-4 dark:bg-gray-950">
-                <Story />
-              </div>
+              {ctx.parameters.adminShell ? (
+                // THE REAL SHELL, for the stories that exist to prove the
+                // workspace fits inside it. `h-[100dvh]` on the outer box is
+                // also the marker `scripts/shoot-story.mjs` walks up from to
+                // flatten Storybook's own decorator padding, so the capture maps
+                // 1:1 to the app.
+                <div className="h-[100dvh]">
+                  <AdminLayout>
+                    <Story />
+                  </AdminLayout>
+                </div>
+              ) : (
+                // WITHOUT the shell, this box stands in for what `shell-fit:`
+                // hands the workspace: a viewport-tall column it divides itself.
+                // `min-h-screen` here would let the composer grow the page —
+                // exactly the double scroll these stories are shot to disprove.
+                <div className="flex h-[100dvh] flex-col bg-white p-4 dark:bg-gray-950">
+                  <Story />
+                </div>
+              )}
             </div>
           </NotificationProvider>
         </ThemeProvider>
@@ -427,6 +445,84 @@ export const MobilePreviewPaneDark: Story = {
     await MobilePreviewPane.play?.(context)
     await switchPreviewToDark()
   },
+}
+
+/**
+ * THE WORKSPACE INSIDE THE REAL ADMIN SHELL — the shape the double-scroll fix is
+ * about.
+ *
+ * The composer marks itself `data-shell-fit="viewport"`; `DashboardLayout`
+ * answers by becoming a fixed `dvh`-tall column (see the `shell-fit:` variant in
+ * tailwind.css). WHAT TO LOOK FOR: exactly one scrollbar on screen — the rail's
+ * or the preview's — and the workspace header, Save button and mode toggles
+ * still on screen no matter how far down either pane is scrolled. Before the
+ * fix the document scrolled underneath both panes and took all of that with it.
+ */
+export const InAdminShell: Story = {
+  parameters: { adminShell: true },
+}
+
+export const InAdminShellDark: Story = {
+  parameters: {
+    adminShell: true,
+    theme: 'dark',
+    backgrounds: { default: 'dark' },
+  },
+  play: switchPreviewToDark,
+}
+
+/** The same, on a phone: one pane at a time, and still one scrollbar. */
+export const InAdminShellMobile: Story = {
+  parameters: { adminShell: true, viewport: { defaultViewport: 'mobile1' } },
+}
+
+/**
+ * A composition with NO copy of its own, every config panel open: each box shows
+ * the wording that band renders today rather than an instruction about it.
+ *
+ * "Featured Speakers" / "Meet the speakers at Nordic Platform Days" is the
+ * house heading and the house intro, built from this conference's own name;
+ * "No heading — the numbers stand on their own" is the truth for a band that
+ * renders no heading at all. Sourced from `lib/homepage/sections`, the same
+ * constants the bands render, so they cannot drift apart.
+ */
+export const DefaultsInThePlaceholders: Story = {
+  args: {
+    initialSections: [
+      { _key: 'hero', _type: 'homepageHero' },
+      { _key: 'speakers', _type: 'homepageFeaturedSpeakers' },
+      { _key: 'metrics', _type: 'homepageMetrics' },
+      { _key: 'gallery', _type: 'homepageGallery' },
+      { _key: 'sponsors', _type: 'homepageSponsors' },
+      { _key: 'venue', _type: 'homepageVenue' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    for (const label of [
+      'Hero',
+      'Featured Speakers',
+      'Key Numbers',
+      'Photo Gallery',
+      'Sponsors',
+      'Venue',
+    ]) {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: `Configure ${label}` }),
+      )
+    }
+    // Opening the panels scrolled the rail to the last one; come back to the top
+    // so the capture starts where an organizer's eye does.
+    await userEvent.click(
+      canvasElement.querySelector('[data-composer-card="hero"]') as Element,
+    )
+  },
+}
+
+export const DefaultsInThePlaceholdersDark: Story = {
+  args: DefaultsInThePlaceholders.args,
+  parameters: { theme: 'dark', backgrounds: { default: 'dark' } },
+  play: DefaultsInThePlaceholders.play,
 }
 
 /**

--- a/src/components/admin/composer/HomepageComposer.tsx
+++ b/src/components/admin/composer/HomepageComposer.tsx
@@ -502,10 +502,26 @@ export function HomepageComposer({
   const showPreview = isWide || pane === 'preview'
 
   return (
-    <div className="space-y-4">
+    /**
+     * ONE SCROLLBAR PER PANE, NEVER ONE FOR THE PAGE.
+     *
+     * `data-shell-fit="viewport"` is the contract with `DashboardLayout` (see
+     * the `shell-fit:` variant in tailwind.css): the shell stops being a
+     * scrolling document and hands this element a box exactly as tall as what is
+     * left of the viewport. The workspace then divides that box — chrome at
+     * fixed height, panes taking the rest and scrolling inside themselves.
+     *
+     * Without it the page scrolled AND the panes scrolled: two scrollbars, and
+     * the header, the Save button and the mode toggles drifted off the top the
+     * moment an organizer reached for a card further down the rail.
+     */
+    <div
+      data-shell-fit="viewport"
+      className="flex min-h-0 flex-1 flex-col gap-4"
+    >
       {/* Two rows rather than one: at 393px a single row truncated the title to
           "Homepage comp…" and orphaned Save onto a line of its own. */}
-      <header className="space-y-3">
+      <header className="shrink-0 space-y-3">
         <div className="flex items-center gap-3">
           <Link
             href={APPEARANCE_HREF}
@@ -573,7 +589,7 @@ export function HomepageComposer({
       </header>
 
       {usingDefault ? (
-        <p className="rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
+        <p className="shrink-0 rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
           You are using the default layout — change anything below to make it
           your own. “Revert to default” brings back the automatic layout that
           adapts as your conference takes shape.
@@ -583,7 +599,7 @@ export function HomepageComposer({
       {submitError ? (
         <p
           role="alert"
-          className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
+          className="shrink-0 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-300"
         >
           {submitError}
         </p>
@@ -595,24 +611,39 @@ export function HomepageComposer({
         label="Workspace pane"
         value={pane}
         onChange={setPane}
-        className="lg:hidden"
+        className="shrink-0 lg:hidden"
         options={[
           { value: 'compose', label: 'Compose' },
           { value: 'preview', label: 'Preview' },
         ]}
       />
 
-      <div className="flex flex-col gap-4 lg:h-[calc(100vh-16rem)] lg:min-h-[38rem] lg:flex-row">
+      {/* The panes take ALL the height the chrome above did not, and no more:
+          `min-h-0` is what lets a flex child be shorter than its content, which
+          is the difference between a pane that scrolls and a pane that pushes
+          the page taller. The old `lg:h-[calc(100vh-16rem)]` guessed at the
+          chrome above it — and guessed 16rem in a shell whose header, banner and
+          pane toggle vary by breakpoint and by state, which is how the page came
+          to scroll behind two panes that were already scrolling. */}
+      <div className="flex min-h-0 flex-1 flex-col gap-4 lg:flex-row">
         {showRail ? (
           <div
             ref={railRef}
             className={cn(
-              'min-w-0 lg:w-[26rem] lg:shrink-0 lg:overflow-y-auto lg:pr-1',
+              // Below `lg` this IS the workspace's only pane, so it scrolls on
+              // its own there too — a phone must not scroll the page to reach
+              // the last card while the Save button rides off the top.
+              'min-h-0 min-w-0 flex-1 overflow-y-auto',
+              'lg:w-[26rem] lg:flex-none lg:pr-1',
             )}
           >
             <ComposerRail
               rows={rows}
               expanded={expanded}
+              // The same query the status rows read: the config panels quote
+              // this tenant's tagline, description and title back as the copy
+              // their bands render when a field is left blank.
+              conference={conference}
               focusKey={focusKey}
               hoverKey={hoverKey}
               statuses={statuses}

--- a/src/components/admin/composer/PreviewPane.tsx
+++ b/src/components/admin/composer/PreviewPane.tsx
@@ -272,7 +272,10 @@ export function PreviewPane({
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-      <div className="flex flex-wrap items-center gap-2 border-b border-gray-200 px-2 py-2 dark:border-gray-800">
+      {/* `shrink-0` on the toolbar and the mode strip: they are chrome the
+          organizer steers by, so the pane's scroll region gives up height
+          before either of them does. */}
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-gray-200 px-2 py-2 dark:border-gray-800">
         {showDeviceToggle ? (
           <SegmentedControl
             label="Preview width"
@@ -379,8 +382,8 @@ export function PreviewPane({
       <p
         className={
           ui.mode === 'design'
-            ? 'flex items-start gap-1.5 border-b border-violet-100 bg-violet-50/70 px-3 py-1.5 text-xs leading-snug text-violet-900 dark:border-violet-900/60 dark:bg-violet-950/40 dark:text-violet-100'
-            : 'flex items-start gap-1.5 border-b border-green-100 bg-green-50/70 px-3 py-1.5 text-xs leading-snug text-green-900 dark:border-green-900/60 dark:bg-green-950/40 dark:text-green-100'
+            ? 'flex shrink-0 items-start gap-1.5 border-b border-violet-100 bg-violet-50/70 px-3 py-1.5 text-xs leading-snug text-violet-900 dark:border-violet-900/60 dark:bg-violet-950/40 dark:text-violet-100'
+            : 'flex shrink-0 items-start gap-1.5 border-b border-green-100 bg-green-50/70 px-3 py-1.5 text-xs leading-snug text-green-900 dark:border-green-900/60 dark:bg-green-950/40 dark:text-green-100'
         }
       >
         {ui.mode === 'design' ? (
@@ -410,7 +413,11 @@ export function PreviewPane({
 
       <div
         ref={scrollRef}
-        className="min-h-[24rem] flex-1 overflow-auto bg-gray-100 p-4 dark:bg-gray-900"
+        // `min-h-0`, NOT a 24rem floor: the pane is sized by the viewport now,
+        // and a floor taller than the space available would push the toolbar
+        // above it back off the top of a short window — the double scroll,
+        // reintroduced one element lower down.
+        className="min-h-0 flex-1 overflow-auto bg-gray-100 p-4 dark:bg-gray-900"
       >
         <div
           className="mx-auto overflow-hidden rounded-xl bg-white shadow-lg ring-1 ring-black/10 dark:ring-white/10"

--- a/src/components/admin/composer/SectionCard.tsx
+++ b/src/components/admin/composer/SectionCard.tsx
@@ -22,6 +22,7 @@ import {
   type EditorRow,
 } from '@/lib/homepage/editor'
 import { cn } from '@/lib/utils'
+import type { PlaceholderConference } from './placeholderCopy'
 import { SectionConfig } from './SectionConfig'
 import { rowBtnClass } from './styles'
 
@@ -30,6 +31,11 @@ export interface ComposerSectionCardProps {
   index: number
   total: number
   expanded: boolean
+  /**
+   * The tenant's title/tagline/description, so the config panel can show the
+   * copy this band falls back to. Absent while the data query is in flight.
+   */
+  conference?: PlaceholderConference
   /** This card's section is the selected one — ringed on BOTH sides of the workspace. */
   focused: boolean
   /** The pointer is over this card, or over its band in the preview. */
@@ -67,6 +73,7 @@ export function ComposerSectionCard({
   index,
   total,
   expanded,
+  conference,
   focused,
   hovered,
   status,
@@ -232,7 +239,7 @@ export function ComposerSectionCard({
 
       {configurable && expanded ? (
         <div className="border-t border-gray-200 px-3 pt-2 pb-3 dark:border-gray-700">
-          <SectionConfig row={row} onChange={onPatch} />
+          <SectionConfig row={row} conference={conference} onChange={onPatch} />
         </div>
       ) : null}
     </li>

--- a/src/components/admin/composer/SectionConfig.test.tsx
+++ b/src/components/admin/composer/SectionConfig.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import {
+  DEFAULT_SPONSORS_HEADING,
+  defaultFeaturedSpeakersDescription,
+} from '@/lib/homepage/sections'
+import type { EditorRow } from '@/lib/homepage/editor'
+import { SectionConfig } from './SectionConfig'
+
+/**
+ * The WIRING test for the fallback placeholders: `placeholderCopy.test.ts`
+ * proves the strings are the ones the bands render, this proves each string
+ * reached the box it belongs to. Every field on this panel is optional and every
+ * one of them used to hold an instruction ("A line under the heading"), so a
+ * mis-wired field would look perfectly plausible on screen.
+ */
+const conference = {
+  title: 'Nordic Platform Days',
+  tagline: 'The conference for the people who run the platform',
+  description: 'A community conference for platform engineers.',
+}
+
+function renderConfig(row: EditorRow) {
+  return render(
+    <SectionConfig row={row} conference={conference} onChange={() => {}} />,
+  )
+}
+
+describe('SectionConfig placeholders', () => {
+  it('shows the featured-speakers band its own house copy', () => {
+    renderConfig({ _key: 'a', _type: 'homepageFeaturedSpeakers' })
+    expect(screen.getByLabelText('Featured Speakers heading')).toHaveAttribute(
+      'placeholder',
+      'Featured Speakers',
+    )
+    expect(
+      screen.getByLabelText('Featured Speakers sub-heading'),
+    ).toHaveAttribute(
+      'placeholder',
+      defaultFeaturedSpeakersDescription('Nordic Platform Days'),
+    )
+  })
+
+  it('shows the hero the tagline it actually falls back to', () => {
+    renderConfig({ _key: 'a', _type: 'homepageHero' })
+    // Excerpted at the width the box can show; still this tenant's own tagline.
+    expect(screen.getByLabelText('Hero headline override')).toHaveAttribute(
+      'placeholder',
+      expect.stringContaining(
+        'The conference for the people',
+      ) as unknown as string,
+    )
+  })
+
+  it('shows the sponsors band its own heading, not another band’s', () => {
+    renderConfig({ _key: 'a', _type: 'homepageSponsors' })
+    expect(screen.getByLabelText('Sponsors heading')).toHaveAttribute(
+      'placeholder',
+      DEFAULT_SPONSORS_HEADING,
+    )
+  })
+
+  it('says nothing is rendered where the band has no fallback', () => {
+    renderConfig({ _key: 'a', _type: 'homepageMetrics' })
+    expect(screen.getByLabelText('Metrics heading')).toHaveAttribute(
+      'placeholder',
+      expect.stringMatching(/^No heading —/) as unknown as string,
+    )
+  })
+})

--- a/src/components/admin/composer/SectionConfig.tsx
+++ b/src/components/admin/composer/SectionConfig.tsx
@@ -4,6 +4,11 @@ import type { ReactNode } from 'react'
 import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { RichTextContentEditor } from '@/components/admin/RichTextContentEditor'
 import { SECTION_LABELS, nextKey, type EditorRow } from '@/lib/homepage/editor'
+import {
+  composerPlaceholders,
+  type ComposerPlaceholders,
+  type PlaceholderConference,
+} from './placeholderCopy'
 import { VariantPicker, variantOptions } from './VariantPicker'
 import { inputClass, rowBtnClass } from './styles'
 
@@ -32,14 +37,28 @@ import { inputClass, rowBtnClass } from './styles'
  * the easy strings in the preview would give one section two editing grammars,
  * and editable twins of thirteen section types would forfeit the byte-identical
  * render that makes the preview worth trusting.
+ *
+ * PLACEHOLDERS ARE THE REAL FALLBACKS, not instructions — see
+ * {@link composerPlaceholders}. An empty optional field renders the house copy,
+ * so the box shows that copy: the organizer reads what their visitors read
+ * today, and each panel is named by its own band's default wording rather than
+ * by "A line under the heading" repeated down the rail.
  */
 export function SectionConfig({
   row,
+  conference,
   onChange,
 }: {
   row: EditorRow
+  /**
+   * The tenant's own copy, for the fallbacks the page BUILDS rather than
+   * declares (the hero's tagline, "Meet the speakers at …"). Absent only while
+   * the workspace's data query is in flight.
+   */
+  conference?: PlaceholderConference
   onChange: (patch: Partial<EditorRow>) => void
 }) {
+  const placeholders = composerPlaceholders(conference)
   return (
     <div className="space-y-3">
       <VariantPicker
@@ -48,7 +67,11 @@ export function SectionConfig({
         value={row.variant}
         onChange={(variant) => onChange({ variant })}
       />
-      <SectionFields row={row} onChange={onChange} />
+      <SectionFields
+        row={row}
+        placeholders={placeholders}
+        onChange={onChange}
+      />
     </div>
   )
 }
@@ -90,9 +113,11 @@ function Note({ children }: { children: ReactNode }) {
 /** Per-type copy/behaviour fields. `null` for a block with nothing but a layout. */
 function SectionFields({
   row,
+  placeholders,
   onChange,
 }: {
   row: EditorRow
+  placeholders: ComposerPlaceholders
   onChange: (patch: Partial<EditorRow>) => void
 }) {
   if (row._type === 'homepageHero') {
@@ -104,7 +129,7 @@ function SectionFields({
             type="text"
             value={row.heroHeadline ?? ''}
             onChange={(e) => onChange({ heroHeadline: e.target.value })}
-            placeholder="Your conference name"
+            placeholder={placeholders.homepageHero.heroHeadline}
             aria-label="Hero headline override"
             className={inputClass}
           />
@@ -113,12 +138,19 @@ function SectionFields({
           <textarea
             value={row.heroSubheadline ?? ''}
             onChange={(e) => onChange({ heroSubheadline: e.target.value })}
-            placeholder="Your tagline"
+            placeholder={placeholders.homepageHero.heroSubheadline}
             aria-label="Hero subheadline override"
             rows={2}
             className={inputClass}
           />
         </Field>
+        {/* Named because the two boxes above quote them: an organizer who sees
+            their own tagline greyed into the headline field should know it
+            comes from conference settings and not from this panel. */}
+        <Note>
+          Left empty, the hero uses your tagline and your conference
+          description.
+        </Note>
         <div className="space-y-2">
           <span className="block text-xs font-medium text-gray-600 dark:text-gray-300">
             Buttons{' '}
@@ -208,7 +240,7 @@ function SectionFields({
           <textarea
             value={row.body ?? ''}
             onChange={(e) => onChange({ body: e.target.value })}
-            placeholder="A line or two under the heading"
+            placeholder={placeholders.homepageCtaBanner.body}
             aria-label="CTA banner body"
             rows={2}
             className={inputClass}
@@ -252,7 +284,7 @@ function SectionFields({
             type="text"
             value={row.heading ?? ''}
             onChange={(e) => onChange({ heading: e.target.value })}
-            placeholder="A heading above your text"
+            placeholder={placeholders.homepageRichText.heading}
             aria-label="Rich text heading"
             className={inputClass}
           />
@@ -278,7 +310,7 @@ function SectionFields({
             type="text"
             value={row.heading ?? ''}
             onChange={(e) => onChange({ heading: e.target.value })}
-            placeholder="Save the date"
+            placeholder={placeholders.homepageSaveTheDate.heading}
             aria-label="Save the date heading"
             className={inputClass}
           />
@@ -288,7 +320,7 @@ function SectionFields({
             rows={2}
             value={row.description ?? ''}
             onChange={(e) => onChange({ description: e.target.value })}
-            placeholder="Anything you want to add"
+            placeholder={placeholders.homepageSaveTheDate.description}
             aria-label="Save the date description"
             className={inputClass}
           />
@@ -310,7 +342,7 @@ function SectionFields({
             type="text"
             value={row.heading ?? ''}
             onChange={(e) => onChange({ heading: e.target.value })}
-            placeholder="A heading above the numbers"
+            placeholder={placeholders.homepageMetrics.heading}
             aria-label="Metrics heading"
             className={inputClass}
           />
@@ -333,7 +365,7 @@ function SectionFields({
             type="text"
             value={row.heading ?? ''}
             onChange={(e) => onChange({ heading: e.target.value })}
-            placeholder="Frequently asked questions"
+            placeholder={placeholders.homepageFaq.heading}
             aria-label="FAQ heading"
             className={inputClass}
           />
@@ -432,7 +464,7 @@ function SectionFields({
             type="text"
             value={row.heading ?? ''}
             onChange={(e) => onChange({ heading: e.target.value })}
-            placeholder="A heading above the counter"
+            placeholder={placeholders.homepageCountdown.heading}
             aria-label="Countdown heading"
             className={inputClass}
           />
@@ -452,7 +484,7 @@ function SectionFields({
             type="text"
             value={row.liveMessage ?? ''}
             onChange={(e) => onChange({ liveMessage: e.target.value })}
-            placeholder="We are live!"
+            placeholder={placeholders.homepageCountdown.liveMessage}
             aria-label="Countdown live message"
             className={inputClass}
           />
@@ -471,12 +503,10 @@ function SectionFields({
     row._type === 'homepageGallery'
   ) {
     const label = SECTION_LABELS[row._type]
-    const headingPlaceholder =
-      row._type === 'homepageFeaturedSpeakers'
-        ? 'Featured Speakers'
-        : row._type === 'homepageOrganizers'
-          ? 'Meet Our Organizers'
-          : 'Conference Moments'
+    // Both boxes quote this band's own house copy, headings and intros alike —
+    // the intros are BUILT from the conference title ("Meet the speakers at
+    // Nordic Platform Days"), so the box shows this tenant's rendering of them.
+    const copy = placeholders[row._type]
     // "the featured speakers themselves come from the conference configuration"
     // named a screen no organizer has ever seen. Each of these says what is set
     // here and where the content itself lives, in the words the admin uses.
@@ -493,7 +523,7 @@ function SectionFields({
             type="text"
             value={row.heading ?? ''}
             onChange={(e) => onChange({ heading: e.target.value })}
-            placeholder={headingPlaceholder}
+            placeholder={copy.heading}
             aria-label={`${label} heading`}
             className={inputClass}
           />
@@ -502,7 +532,7 @@ function SectionFields({
           <textarea
             value={row.description ?? ''}
             onChange={(e) => onChange({ description: e.target.value })}
-            placeholder="A line under the heading"
+            placeholder={copy.description}
             aria-label={`${label} sub-heading`}
             rows={2}
             className={inputClass}
@@ -522,7 +552,7 @@ function SectionFields({
             type="text"
             value={row.heading ?? ''}
             onChange={(e) => onChange({ heading: e.target.value })}
-            placeholder="Our sponsors"
+            placeholder={placeholders.homepageSponsors.heading}
             aria-label="Sponsors heading"
             className={inputClass}
           />
@@ -531,7 +561,7 @@ function SectionFields({
           <textarea
             value={row.description ?? ''}
             onChange={(e) => onChange({ description: e.target.value })}
-            placeholder="A line under the heading"
+            placeholder={placeholders.homepageSponsors.description}
             aria-label="Sponsors sub-heading"
             rows={2}
             className={inputClass}
@@ -553,7 +583,7 @@ function SectionFields({
                 type="text"
                 value={row.ctaHeading ?? ''}
                 onChange={(e) => onChange({ ctaHeading: e.target.value })}
-                placeholder="Become a Sponsor"
+                placeholder={placeholders.homepageSponsors.ctaHeading}
                 aria-label="Sponsors call-to-action heading"
                 className={inputClass}
               />
@@ -562,7 +592,7 @@ function SectionFields({
               <textarea
                 value={row.ctaDescription ?? ''}
                 onChange={(e) => onChange({ ctaDescription: e.target.value })}
-                placeholder="Why someone should sponsor you"
+                placeholder={placeholders.homepageSponsors.ctaDescription}
                 aria-label="Sponsors call-to-action body"
                 rows={3}
                 className={inputClass}
@@ -585,7 +615,7 @@ function SectionFields({
             type="text"
             value={row.heading ?? ''}
             onChange={(e) => onChange({ heading: e.target.value })}
-            placeholder="Venue"
+            placeholder={placeholders.homepageVenue.heading}
             aria-label="Venue heading"
             className={inputClass}
           />
@@ -594,7 +624,7 @@ function SectionFields({
           <textarea
             value={row.description ?? ''}
             onChange={(e) => onChange({ description: e.target.value })}
-            placeholder="Anything visitors should know about getting there"
+            placeholder={placeholders.homepageVenue.description}
             aria-label="Venue description"
             rows={2}
             className={inputClass}

--- a/src/components/admin/composer/placeholderCopy.test.ts
+++ b/src/components/admin/composer/placeholderCopy.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_FAQ_HEADING,
+  DEFAULT_FEATURED_SPEAKERS_HEADING,
+  DEFAULT_GALLERY_DESCRIPTION,
+  DEFAULT_GALLERY_HEADING,
+  DEFAULT_ORGANIZERS_HEADING,
+  DEFAULT_SAVE_THE_DATE_HEADING,
+  DEFAULT_SPONSORS_CTA_HEADING,
+  DEFAULT_SPONSORS_HEADING,
+  DEFAULT_VENUE_HEADING,
+  defaultFeaturedSpeakersDescription,
+  defaultOrganizersDescription,
+} from '@/lib/homepage/sections'
+import {
+  BODY_EXCERPT,
+  composerPlaceholders,
+  excerpt,
+  HEADING_EXCERPT,
+} from './placeholderCopy'
+
+const conference = {
+  title: 'Nordic Platform Days',
+  tagline: 'The conference for the people who run the platform',
+  description:
+    'A community conference for platform engineers, SREs and everyone who keeps production up.',
+}
+
+describe('excerpt', () => {
+  it('leaves text that already fits untouched — no ellipsis on a whole string', () => {
+    expect(excerpt('Featured Speakers', HEADING_EXCERPT)).toBe(
+      'Featured Speakers',
+    )
+  })
+
+  it('cuts a long paragraph at a word boundary and marks it', () => {
+    const short = excerpt(DEFAULT_GALLERY_DESCRIPTION, BODY_EXCERPT)
+    expect(short.length).toBeLessThanOrEqual(BODY_EXCERPT + 1)
+    expect(short.endsWith('…')).toBe(true)
+    // The excerpt is a PREFIX of the real fallback, never a paraphrase of it.
+    expect(DEFAULT_GALLERY_DESCRIPTION.startsWith(short.slice(0, -1))).toBe(
+      true,
+    )
+    expect(short).not.toMatch(/[ ,.]…$/)
+  })
+
+  it('hard-cuts a single word with no boundary to break on', () => {
+    expect(excerpt('a'.repeat(40), 10)).toBe(`${'a'.repeat(10)}…`)
+  })
+
+  it('collapses newlines so a multi-line default stays one line of placeholder', () => {
+    expect(excerpt('Two\nlines', HEADING_EXCERPT)).toBe('Two lines')
+  })
+})
+
+describe('composerPlaceholders', () => {
+  it('quotes the house constants the bands actually render', () => {
+    const p = composerPlaceholders(conference)
+    expect(p.homepageFaq.heading).toBe(DEFAULT_FAQ_HEADING)
+    expect(p.homepageSaveTheDate.heading).toBe(DEFAULT_SAVE_THE_DATE_HEADING)
+    expect(p.homepageVenue.heading).toBe(DEFAULT_VENUE_HEADING)
+    expect(p.homepageGallery.heading).toBe(DEFAULT_GALLERY_HEADING)
+    expect(p.homepageSponsors.heading).toBe(DEFAULT_SPONSORS_HEADING)
+    expect(p.homepageSponsors.ctaHeading).toBe(DEFAULT_SPONSORS_CTA_HEADING)
+    expect(p.homepageFeaturedSpeakers.heading).toBe(
+      DEFAULT_FEATURED_SPEAKERS_HEADING,
+    )
+    expect(p.homepageOrganizers.heading).toBe(DEFAULT_ORGANIZERS_HEADING)
+  })
+
+  it('renders the computed intros with THIS conference, not a template', () => {
+    const p = composerPlaceholders(conference)
+    expect(p.homepageFeaturedSpeakers.description).toBe(
+      defaultFeaturedSpeakersDescription('Nordic Platform Days'),
+    )
+    expect(p.homepageOrganizers.description).toBe(
+      defaultOrganizersDescription('Nordic Platform Days'),
+    )
+    expect(p.homepageFeaturedSpeakers.description).not.toContain('{')
+  })
+
+  it('shows the hero its own fallbacks — the tagline and the description', () => {
+    const p = composerPlaceholders(conference)
+    expect(p.homepageHero.heroHeadline).toBe(
+      excerpt(conference.tagline, HEADING_EXCERPT),
+    )
+    expect(conference.tagline).toContain(
+      p.homepageHero.heroHeadline.replace('…', ''),
+    )
+    expect(p.homepageHero.heroSubheadline).toBe(
+      excerpt(conference.description, BODY_EXCERPT),
+    )
+  })
+
+  it('says nothing renders where the tenant has nothing to fall back to', () => {
+    const p = composerPlaceholders({ title: 'Day One Conf' })
+    expect(p.homepageHero.heroHeadline).toMatch(/^No headline —/)
+    expect(p.homepageHero.heroSubheadline).toMatch(/^No text —/)
+  })
+
+  it('does not invent a fallback for fields the page renders nothing for', () => {
+    const p = composerPlaceholders(conference)
+    expect(p.homepageMetrics.heading).toMatch(/^No heading —/)
+    expect(p.homepageCountdown.heading).toMatch(/^No heading —/)
+    expect(p.homepageRichText.heading).toMatch(/^No heading —/)
+    expect(p.homepageCountdown.liveMessage).toMatch(/^No message —/)
+    expect(p.homepageCtaBanner.body).toMatch(/^No body —/)
+    expect(p.homepageVenue.description).toMatch(/^No description —/)
+    expect(p.homepageSaveTheDate.description).toMatch(/^No extra line —/)
+  })
+
+  it('names the conference generically while the tenant query is in flight', () => {
+    const p = composerPlaceholders()
+    expect(p.homepageFeaturedSpeakers.description).toBe(
+      defaultFeaturedSpeakersDescription('your conference'),
+    )
+    expect(p.homepageHero.heroHeadline).toMatch(/^No headline —/)
+  })
+
+  it('ignores a Portable Text description — the hero only renders a string', () => {
+    const p = composerPlaceholders({
+      title: 'Nordic Platform Days',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      description: [{ _type: 'block' }] as any,
+    })
+    expect(p.homepageHero.heroSubheadline).toMatch(/^No text —/)
+  })
+})

--- a/src/components/admin/composer/placeholderCopy.ts
+++ b/src/components/admin/composer/placeholderCopy.ts
@@ -110,9 +110,14 @@ export function composerPlaceholders(
 ): ComposerPlaceholders {
   const title = conference?.title?.trim() || UNKNOWN_TITLE
   const tagline = conference?.tagline?.trim()
-  // The hero's own description column takes the conference description verbatim;
-  // it is Portable Text on some tenants, and the Hero renders it only when it is
-  // a plain string — so anything else is treated as "nothing renders".
+  // The hero's description column takes the conference description verbatim.
+  //
+  // The schema defines this field as `type: 'text'`, i.e. a plain string — an
+  // earlier version of this comment claimed it could be Portable Text on some
+  // tenants, which is not true of any schema in this repo. The `typeof` guard
+  // stays anyway: this reads dataset content, and the Hero itself renders the
+  // value only when it is a string, so a wrong-typed row must show "nothing
+  // renders" here rather than a placeholder the page would not produce.
   const description =
     typeof conference?.description === 'string'
       ? conference.description.trim()

--- a/src/components/admin/composer/placeholderCopy.ts
+++ b/src/components/admin/composer/placeholderCopy.ts
@@ -1,0 +1,178 @@
+import {
+  DEFAULT_FAQ_HEADING,
+  DEFAULT_FEATURED_SPEAKERS_HEADING,
+  DEFAULT_GALLERY_DESCRIPTION,
+  DEFAULT_GALLERY_HEADING,
+  DEFAULT_ORGANIZERS_HEADING,
+  DEFAULT_SAVE_THE_DATE_HEADING,
+  DEFAULT_SPONSORS_CTA_DESCRIPTION,
+  DEFAULT_SPONSORS_CTA_HEADING,
+  DEFAULT_SPONSORS_DESCRIPTION,
+  DEFAULT_SPONSORS_HEADING,
+  DEFAULT_VENUE_HEADING,
+  defaultFeaturedSpeakersDescription,
+  defaultOrganizersDescription,
+} from '@/lib/homepage/sections'
+
+/**
+ * WHAT THE PAGE PUTS THERE IF YOU LEAVE IT BLANK — the composer's config
+ * placeholders.
+ *
+ * Every optional copy field on the front page has a house fallback, and until
+ * now the input said none of it: "A line under the heading" told an organizer
+ * that a line goes under the heading, which they could see, and nothing about
+ * WHICH band they were editing or what their visitors read today. A placeholder
+ * that quotes the real fallback answers both at once — "Meet the speakers at
+ * Nordic Platform Days" is unmistakably the speakers band, and it is literally
+ * what renders.
+ *
+ * THE FALLBACKS ARE IMPORTED, NEVER RETYPED. Every string here comes from
+ * `lib/homepage/sections` — the same constants the band components render — so a
+ * copy change lands in the placeholder in the same commit. The only strings
+ * authored here are the ones describing an ABSENCE: where a field has no
+ * fallback the page renders nothing, and saying "no heading — the numbers stand
+ * on their own" is more honest than borrowing a heading from a neighbouring
+ * band.
+ *
+ * Fallbacks BUILT from tenant data (the hero's tagline, the "Meet the speakers
+ * at …" intros) are shown as a representative rendering with this conference's
+ * own values, not as a template with a hole in it.
+ */
+
+/** The tenant facts the computed fallbacks are built from. */
+export interface PlaceholderConference {
+  title?: string
+  tagline?: string
+  /** Free text on the conference; may be absent on a young tenant. */
+  description?: string
+}
+
+/**
+ * Stand-in for a conference title that has not loaded yet (the workspace fetches
+ * its tenant data client-side). Reads as a sentence rather than as a gap.
+ */
+const UNKNOWN_TITLE = 'your conference'
+
+/**
+ * What actually fits before the box clips it — measured at 393px, the narrowest
+ * the rail gets, because a placeholder cut off by the input edge ends mid-word
+ * with no ellipsis to say it was cut. One line of a single-line input is ~44
+ * characters there; two textarea rows are ~80.
+ */
+export const HEADING_EXCERPT = 44
+export const BODY_EXCERPT = 80
+
+/**
+ * The first {@link max} characters of `text`, cut at a word boundary and closed
+ * with an ellipsis. Text that already fits is returned untouched — an excerpt
+ * marker on a string that was not shortened would be a lie about the fallback.
+ */
+export function excerpt(text: string, max: number): string {
+  const clean = text.replace(/\s+/g, ' ').trim()
+  if (clean.length <= max) return clean
+  const cut = clean.slice(0, max)
+  const lastSpace = cut.lastIndexOf(' ')
+  // A single word longer than the budget has no boundary to cut on; hard-cut it
+  // rather than return the whole paragraph.
+  return `${(lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut).replace(/[.,;:—-]$/, '')}…`
+}
+
+export interface ComposerPlaceholders {
+  homepageHero: { heroHeadline: string; heroSubheadline: string }
+  homepageSaveTheDate: { heading: string; description: string }
+  homepageCtaBanner: { body: string }
+  homepageRichText: { heading: string }
+  homepageMetrics: { heading: string }
+  homepageFaq: { heading: string }
+  homepageCountdown: { heading: string; liveMessage: string }
+  homepageFeaturedSpeakers: { heading: string; description: string }
+  homepageOrganizers: { heading: string; description: string }
+  homepageGallery: { heading: string; description: string }
+  homepageSponsors: {
+    heading: string
+    description: string
+    ctaHeading: string
+    ctaDescription: string
+  }
+  homepageVenue: { heading: string; description: string }
+}
+
+/**
+ * The placeholder for every optional copy field in the composer, resolved
+ * against THIS conference.
+ *
+ * `conference` is undefined only while the workspace's own data query is in
+ * flight; the computed fallbacks then name "your conference" rather than
+ * flashing an empty template.
+ */
+export function composerPlaceholders(
+  conference?: PlaceholderConference,
+): ComposerPlaceholders {
+  const title = conference?.title?.trim() || UNKNOWN_TITLE
+  const tagline = conference?.tagline?.trim()
+  // The hero's own description column takes the conference description verbatim;
+  // it is Portable Text on some tenants, and the Hero renders it only when it is
+  // a plain string — so anything else is treated as "nothing renders".
+  const description =
+    typeof conference?.description === 'string'
+      ? conference.description.trim()
+      : ''
+
+  return {
+    // Hero: an absent override falls through to the tagline and the conference
+    // description (see `HeroHeadlineText` / `HeroDescription`), NOT to the
+    // conference title — which is what the old "Your conference name"
+    // placeholder promised and the page never did.
+    homepageHero: {
+      heroHeadline: tagline
+        ? excerpt(tagline, HEADING_EXCERPT)
+        : 'No headline — your tagline is empty',
+      heroSubheadline: description
+        ? excerpt(description, BODY_EXCERPT)
+        : 'No text — your conference description is empty',
+    },
+    homepageSaveTheDate: {
+      heading: DEFAULT_SAVE_THE_DATE_HEADING,
+      description: 'No extra line — just the dates, venue and countdown',
+    },
+    homepageCtaBanner: {
+      body: 'No body — just the heading and the button',
+    },
+    homepageRichText: {
+      heading: 'No heading — the band starts with your text',
+    },
+    homepageMetrics: {
+      heading: 'No heading — the numbers stand on their own',
+    },
+    homepageFaq: { heading: DEFAULT_FAQ_HEADING },
+    homepageCountdown: {
+      heading: 'No heading — the counter stands on its own',
+      liveMessage: 'No message — the counter disappears',
+    },
+    homepageFeaturedSpeakers: {
+      heading: DEFAULT_FEATURED_SPEAKERS_HEADING,
+      description: excerpt(
+        defaultFeaturedSpeakersDescription(title),
+        BODY_EXCERPT,
+      ),
+    },
+    homepageOrganizers: {
+      heading: DEFAULT_ORGANIZERS_HEADING,
+      description: excerpt(defaultOrganizersDescription(title), BODY_EXCERPT),
+    },
+    homepageGallery: {
+      heading: DEFAULT_GALLERY_HEADING,
+      description: excerpt(DEFAULT_GALLERY_DESCRIPTION, BODY_EXCERPT),
+    },
+    homepageSponsors: {
+      heading: DEFAULT_SPONSORS_HEADING,
+      description: excerpt(DEFAULT_SPONSORS_DESCRIPTION, BODY_EXCERPT),
+      ctaHeading: DEFAULT_SPONSORS_CTA_HEADING,
+      ctaDescription: excerpt(DEFAULT_SPONSORS_CTA_DESCRIPTION, BODY_EXCERPT),
+    },
+    homepageVenue: {
+      heading: DEFAULT_VENUE_HEADING,
+      description: 'No description — just the address and directions',
+    },
+  }
+}

--- a/src/components/admin/composer/styles.ts
+++ b/src/components/admin/composer/styles.ts
@@ -7,8 +7,15 @@
  * same panel.
  */
 
+/**
+ * The placeholder colours are PINNED rather than left to the user agent: these
+ * placeholders carry the copy the page renders when the field is blank (see
+ * `placeholderCopy`), so they are content to be read, not a hint to be ignored.
+ * `gray-500` on white and `gray-400` on `gray-700` both clear 4.5:1, where
+ * Chrome's default 54%-of-currentColor lands under it on the dark input.
+ */
 export const inputClass =
-  'block w-full min-h-[44px] rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+  'block w-full min-h-[44px] rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-gray-500 focus:border-brand-cloud-blue focus:ring-1 focus:ring-brand-cloud-blue focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400'
 
 /**
  * 44px on touch, 36px from `sm` up.

--- a/src/components/common/DashboardLayout.tsx
+++ b/src/components/common/DashboardLayout.tsx
@@ -199,7 +199,14 @@ export function DashboardLayout({
 
   return (
     <>
-      <div>
+      {/* VIEWPORT-CLAIMING PAGES (`shell-fit:`, see tailwind.css). By default this
+          is an ordinary scrolling document. When the page inside marks itself
+          `data-shell-fit="viewport"`, the shell becomes a fixed column exactly
+          one viewport tall: the sticky chrome can no longer scroll away, `main`
+          becomes the only flexible row, and the page owns every scrollbar
+          beneath it. `dvh` rather than `vh` so a phone's collapsing URL bar does
+          not leave the bottom of the workspace under the browser chrome. */}
+      <div className="shell-fit:flex shell-fit:h-dvh shell-fit:flex-col shell-fit:overflow-hidden">
         <Dialog
           open={sidebarOpen}
           onClose={setSidebarOpen}
@@ -485,8 +492,14 @@ export function DashboardLayout({
           </div>
         </div>
 
-        <main className="py-4 lg:py-10 lg:pl-20">
-          <div className="px-2 sm:px-4 lg:px-8">{children}</div>
+        {/* The generous `lg:py-10` is a reading rhythm for documents; a workspace
+            that must fit the viewport spends that height on content instead, so
+            `shell-fit:` trades it for a slim gutter. Horizontal padding is
+            untouched — it is alignment with the rest of the admin. */}
+        <main className="py-4 lg:py-10 lg:pl-20 shell-fit:flex shell-fit:min-h-0 shell-fit:flex-1 shell-fit:flex-col shell-fit:overflow-hidden shell-fit:py-3 lg:shell-fit:py-4">
+          <div className="px-2 sm:px-4 lg:px-8 shell-fit:flex shell-fit:min-h-0 shell-fit:flex-1 shell-fit:flex-col">
+            {children}
+          </div>
         </main>
       </div>
 

--- a/src/components/homepage/VenueBlock.tsx
+++ b/src/components/homepage/VenueBlock.tsx
@@ -1,7 +1,10 @@
 import { Container } from '@/components/Container'
 import { Button } from '@/components/Button'
 import { MapPinIcon } from '@heroicons/react/24/outline'
-import type { VenueSection } from '@/lib/homepage/sections'
+import {
+  DEFAULT_VENUE_HEADING,
+  type VenueSection,
+} from '@/lib/homepage/sections'
 import type { Conference } from '@/lib/conference/types'
 import { buildDirectionsUrl } from '@/lib/homepage/venue'
 import { resolveVariant } from '@/lib/homepage/variants'
@@ -34,7 +37,7 @@ export function VenueBlock({
   const address = conference.venueAddress?.trim()
   if (!name && !address) return null
 
-  const heading = section.heading?.trim() || 'Venue'
+  const heading = section.heading?.trim() || DEFAULT_VENUE_HEADING
   const description = section.description?.trim()
   const directionsUrl = buildDirectionsUrl(name, address)
 

--- a/src/lib/homepage/sections.ts
+++ b/src/lib/homepage/sections.ts
@@ -145,6 +145,9 @@ export function defaultOrganizersDescription(conferenceTitle: string): string {
 /** Default heading for the save-the-date band when none is configured. */
 export const DEFAULT_SAVE_THE_DATE_HEADING = 'Save the date'
 
+/** Default heading for the venue band when none is configured. */
+export const DEFAULT_VENUE_HEADING = 'Venue'
+
 export type HomepageSectionType = (typeof HOMEPAGE_SECTION_TYPES)[number]
 
 export function isHomepageSectionType(

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -11,6 +11,24 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /*
+ * `shell-fit:` — styles that apply only when a PAGE inside this element claims
+ * the viewport.
+ *
+ * The dashboard shell (`DashboardLayout`) is a scrolling document: the sticky
+ * chrome scrolls with it and the page below is as tall as its content. That is
+ * right for every list and form in the admin, and wrong for a workspace whose
+ * two panes scroll on their own — the homepage composer — where it produces the
+ * double scrollbar the shell and the panes then fight over.
+ *
+ * Such a page marks its own root `data-shell-fit="viewport"` and the shell
+ * reacts: `:has()` lets the ancestor chrome respond to a descendant without any
+ * prop threading through a server layout, and without a JS pass that would flash
+ * the scrolling layout on first paint. The marker is a CONTRACT, not a style —
+ * see `DashboardLayout` for the three elements that answer it.
+ */
+@custom-variant shell-fit (&:has([data-shell-fit='viewport']));
+
+/*
  * Prevent iOS auto-zoom on focus for form controls.
  *
  * iOS Safari (and installed PWAs) auto-zoom the viewport when a focused


### PR DESCRIPTION
Two problems the product owner reported after using the composer.

## Double scroll

The workspace sized its panes with `lg:h-[calc(100vh-16rem)]` inside a scrolling document. That `16rem` was a guess at chrome whose height actually varies by breakpoint, by the "using default layout" banner, and by the mobile pane toggle — so the composer was routinely taller than its space, the document scrolled *behind* two panes that were already scrolling, and the header, Save and mode toggles rode off the top. Below `lg` there was no height constraint at all, so the page was the scroller.

The fix lets a page claim the viewport rather than guessing at chrome: a new `shell-fit` variant keyed on a `data-shell-fit="viewport"` marker, which the dashboard shell answers by becoming an `h-dvh` flex column with `overflow-hidden`. Pure CSS via `:has()` — no prop threading through the server layout, and no JS pass that would flash the scrolling layout on first paint. **Pages without the marker are byte-for-byte unaffected.**

`dvh` rather than `vh` deliberately, for mobile browser chrome.

Measured with Playwright at 1600, 1280 and 393: `documentElement.scrollHeight === clientHeight`, exactly two scrollable elements on desktop and one on mobile, and the `h1` stays put after scrolling every internal scroller to the bottom.

## Placeholders now show what the page actually renders

The config inputs said "Your conference name" and "A line under the heading" — instructions that tell you nothing about which band you are editing or what happens if you leave it blank.

Each optional copy field now shows the **real fallback the renderer uses**, imported from the same constants the bands render so they cannot drift. Computed fallbacks are shown rendered with this tenant's values ("Meet the speakers at Nordic Platform Days"), not as templates. Fields with no fallback say so — "No heading — the numbers stand on their own", "No message — the counter disappears".

One of these was simply wrong before: the hero's placeholder claimed "Your conference name", but the hero actually falls back to the tenant's tagline and description.

Long copy is excerpted at a word boundary — 44 chars single-line, 80 for textareas, measured at 393px where the box clips without an ellipsis.

## Verification

426 files / 5978 tests, typecheck, knip and format clean, lint 0 errors with no new warnings, production build succeeds. New stories render inside the **real** `AdminLayout`, which is what proves the shell contract rather than asserting it.

Two notes: the mobile header is now permanently pinned and costs ~340px of an 852px phone screen — correct per the request, but a candidate for compacting if it feels heavy in use. And the fix relies on CSS `:has()`; where unsupported it degrades to exactly today's behaviour.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the composer’s guessed viewport height and establishes a shell-to-workspace flex contract so only the rail or preview scrolls. It also replaces instructional placeholders with excerpts of the actual homepage fallback copy and centralizes the venue heading default.
- Adds a `shell-fit` Tailwind variant activated by the composer’s viewport marker.
- Converts the dashboard shell and composer panes to bounded flex layouts with internal scrolling.
- Derives configuration placeholders from shared homepage defaults and tenant copy.
- Adds focused placeholder tests and real-shell Storybook scenarios.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failure identified.

The viewport marker activates a complete bounded flex chain whose panes retain dedicated scrolling, while the new placeholders were verified against the current renderer fallback and blank-value behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/styles/tailwind.css | Adds a descendant-aware `shell-fit` variant used to activate viewport-constrained shell styles. |
| src/components/common/DashboardLayout.tsx | Establishes the complete viewport-height flex and overflow chain only when a descendant requests shell fitting. |
| src/components/admin/composer/HomepageComposer.tsx | Replaces guessed pane heights with bounded flex sizing and makes each visible pane its own scroll container. |
| src/components/admin/composer/PreviewPane.tsx | Keeps preview controls fixed while allowing the preview body to shrink and scroll within available space. |
| src/components/admin/composer/placeholderCopy.ts | Builds readable placeholder excerpts from the same defaults and tenant values used by homepage renderers. |
| src/components/admin/composer/SectionConfig.tsx | Wires the resolved fallback copy into each optional configuration field. |
| src/lib/homepage/sections.ts | Adds a shared venue heading constant used by both rendering and composer placeholder logic. |
| src/components/homepage/VenueBlock.tsx | Replaces the inline venue fallback with the new shared constant. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Shell[DashboardLayout shell] -->|detects data-shell-fit marker| Viewport[Viewport-height flex column]
  Viewport --> Header[Dashboard navigation]
  Viewport --> Main[Flexible bounded main area]
  Main --> Composer[Homepage composer]
  Composer --> Chrome[Fixed composer controls]
  Composer --> Panes[Flexible pane area]
  Panes --> Rail[Composer rail internal scroll]
  Panes --> Preview[Preview internal scroll]
```

<sub>Reviews (1): Last reviewed commit: ["fix(composer): one viewport, one scrollb..."](https://github.com/cloudnativebergen/website/commit/d6a99225cead7f5fe5830a1e0153a2ecde1e6115) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50032317)</sub>

<!-- /greptile_comment -->