### PR TITLE
fix(scripts): make the domain-verification backfill runnable

### DIFF
--- a/scripts/backfill-domain-verification.ts
+++ b/scripts/backfill-domain-verification.ts
@@ -34,8 +34,13 @@ async function main() {
   const apply = process.argv.includes('--apply')
 
   const { clientReadUncached } = await import('../src/lib/sanity/client')
+  // Imported from the MODULE, not the package barrel. The barrel re-exports
+  // `sweep.ts`, which pulls in the notification/push stack and with it
+  // `server-only` — which throws outside a Server Component, so importing the
+  // barrel makes this script unrunnable. Same reasoning, and same fix, as the
+  // note in `src/lib/conference/sanity.ts`.
   const { ensureDomainVerification, getDomainVerification } =
-    await import('../src/lib/domain-verification')
+    await import('../src/lib/domain-verification/sanity')
   const { challengeRecordName, expectedTxtValue } =
     await import('../src/lib/domain-verification/challenge')
   const { normalizeDomain } = await import('../src/lib/conference/domains')


### PR DESCRIPTION
The backfill script that gates enabling `DOMAIN_VERIFICATION_ENFORCE_ROUTING` **could not run at all**.

Found while preparing a dry run. It imports the `domain-verification` package barrel, which re-exports `sweep.ts`, which imports `@/lib/notification/sanity` and with it the push stack — and that chain reaches `server-only`, which throws outside a Server Component:

```
Error: This module cannot be imported from a Client Component module.
    at import_sanity (src/lib/push/send.ts:1:8)
```

It failed before reaching Sanity, so the failure had nothing to do with credentials or data.

The fix is the convention the codebase already documents. `src/lib/conference/sanity.ts` carries this comment:

> Imported from the module, NOT the package barrel: `conference/sanity.ts` is on every page render's path, and the barrel would drag the sweep (and with it the notification/push stack) into that graph for a gate that is usually a no-op.

Same hazard, same fix: import `ensureDomainVerification`/`getDomainVerification` from `domain-verification/sanity` directly. That module pulls only the Sanity client, helpers, challenge and policy — no `server-only`.

Verified: the script now gets past module resolution and reaches Sanity, failing only on `Unauthorized — Session not found` because this checkout has no credentials. That is the expected outcome and it proves the import chain is fixed.

Dry run remains the default; `--apply` is still required to write anything.

`tsc --noEmit` clean, `prettier` clean, `eslint` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the domain-verification backfill runnable outside a Server Component by importing its Sanity operations directly instead of through the package barrel.
- Avoids loading the sweep and notification/push dependency chain.
- Preserves the existing dry-run default and explicit `--apply` write behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no blocking or non-blocking issues identified.

The narrowed import exposes the same functions used by the script while removing the transitive `server-only` dependency that previously prevented startup.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/backfill-domain-verification.ts | Replaces the problematic barrel import with the compatible direct Sanity-module import; no actionable issues identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scripts): import domain-verification..."](https://github.com/cloudnativebergen/website/commit/19963adc7e4c65162da54240a9c5bc8891de1a83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50089322)</sub>

<!-- /greptile_comment -->