### PR TITLE
chore(deps): bump groq-js to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-storybook": "^10.5.6",
-    "groq-js": "1.30.3",
+    "groq-js": "2.0.0",
     "http-server": "^14.1.1",
     "knip": "^6.15.0",
     "msw": "^2.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
         specifier: ^10.5.6
         version: 10.5.6(eslint@10.8.0(jiti@2.7.0))(storybook@10.5.6(@types/react@19.2.15)(prettier@3.9.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       groq-js:
-        specifier: 1.30.3
-        version: 1.30.3
+        specifier: 2.0.0
+        version: 2.0.0
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -6765,6 +6765,10 @@ packages:
   groq-js@1.30.3:
     resolution: {integrity: sha512-X3Zppy8KO/mDLSu5RylcO9zON+IwxV6y6aeIWsfNNBz0PaRboUmsTVgk3Zndqp9TgWCTFvCk+Z2W0uu0R3i5DA==}
     engines: {node: '>= 14'}
+
+  groq-js@2.0.0:
+    resolution: {integrity: sha512-kj56ZjnOFbgDt91zYwQ10jsVUtVGJqAKfRbAir0EvTK84O5ZsSyc0rDEm2P3jmAJkxs4X1DOG8vtaYJQIA/XCA==}
+    engines: {node: '>=22.12'}
 
   groq@3.88.1-typegen-experimental.0:
     resolution: {integrity: sha512-6TZD6H1y3P7zk0BQharjFa7BOivV9nFL6KKVZbRZRH0yOSSyu2xHglTO48b1/2mCEdYoBQpvE7rjCDUf6XmQYQ==}
@@ -18133,6 +18137,10 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  groq-js@2.0.0:
+    dependencies:
+      obug: 2.1.3
 
   groq@3.88.1-typegen-experimental.0: {}
 


### PR DESCRIPTION
## What

`groq-js` `1.30.3` → `2.0.0`. Nothing else. Exact pinning (no caret) preserved — see *Why it stays pinned* below.

`groq-js` **2.0.0 is a packaging-only major**:

- ESM-only — CJS build removed, `"type": "module"`
- `engines.node` `>= 14` → `>= 22.12` (we build and test on Node 24)
- `debug` → `obug`
- Entry points (`.`, `./1`, `./experimental`) unchanged

The upstream CHANGELOG lists **no** evaluation-semantics or API changes. This PR verifies that claim rather than trusting it.

## Why this one got a semantic review

`groq-js` is not an app dependency. Its **only** consumer is `src/server/tenancy.exploits.test.ts`, whose Sanity mock evaluates the GROQ text the tenancy guards *actually send* against a document fixture:

```ts
h.fetch.mockImplementation(
  async (query, params = {}) =>
    await (await evaluate(parse(query), { dataset, params })).get(),
)
```

That is the regression net for the cross-tenant read/write class closed by #616, #723, #728, #730, #731 — and it exists precisely because two earlier harnesses in this area were **incapable of failing** (one pinned results, one dispatched on `query.includes(...)` and passed 9/9 against deliberately fail-open predicates).

So the risk here was never a red build. It was a green one that no longer proves anything.

## Differential engine review — 1.30.3 vs 2.0.0

Both versions installed side by side and run against identical inputs.

| Check | Result |
|---|---|
| 637 (query × fixture × params) triples — all 7 queries in `src/server/tenancy.ts` × every dataset in the exploit suite × 7 param sets | **0 divergences** |
| 31 construct probes — `defined()`, `references()`, `in`, `count()`, `->`, `coalesce()`, `!`, `&&`/`\|\|` precedence, `^` parent scope, dangling derefs, slices, projections, `path("drafts.**")`, null-comparison semantics | **0 divergences** |
| `parse` / `evaluate` / `{dataset, params}` / `.get()` typecheck under TS 6.0.3, `strict`, `moduleResolution: bundler` | unchanged, compiles clean |

The one **documented** engine-vs-production divergence still holds: 2.0.0 also evaluates `null != \$param` as `true`. That is the entire reason `foreignReferencingDocCount` carries its `!defined(...) ||` arm and the reason the file contains exactly one deliberate TEXT assertion. The comment block at the top of the test file remains accurate as written — no edit needed.

No call site needed changing. The new exports map has no `types` condition, but `moduleResolution: bundler` resolves types from the adjacent `dist/index.d.ts`.

## Sabotage results — proving the net can still fail

Nine sabotages, each removing or weakening **exactly one** tenant predicate in `src/server/tenancy.ts`, run against `src/server/tenancy.exploits.test.ts` on **both** versions. Baseline is 23/23 passing.

| # | Sabotage | 1.30.3 | 2.0.0 |
|---|---|---|---|
| S1 | ownership arm — drop `&& conference->organization._ref == $orgId` | 22 pass / **1 fail** | 22 pass / **1 fail** |
| S2 | both arms — weaken `$orgId in organizations[]._ref` to "has ANY membership" | 21 / **2 fail** | 21 / **2 fail** |
| S3 | organizer arm — drop `organization._ref == $orgId &&` | 23 / **0 fail** ⚠️ | 23 / **0 fail** ⚠️ |
| S4 | `requireDocumentsInCurrentOrg` — weaken `coalesce(...) == $orgId` to "owned by someone" | 22 / **1 fail** | 22 / **1 fail** |
| S5 | `foreignReferencingDocCount` — drop the `!defined(...) \|\|` arm | 22 / **1 fail** | 22 / **1 fail** |
| S6 | `foreignReferencingDocCount` — neuter the reference probe | 20 / **3 fail** | 20 / **3 fail** |
| S7 | `speakerParticipationOrgIds` — neuter the participation probe | 19 / **4 fail** | 19 / **4 fail** |
| S8 | `getDocumentTenant` — drop `_id == $id` | 20 / **3 fail** | 20 / **3 fail** |
| S9 | `requireDocumentsInCurrentConference` — weaken `conference._ref == $conferenceId` | 23 / **0 fail** † | 23 / **0 fail** † |

**The failing test *names* are identical too, not just the counts.** The net's fail-sensitivity is bit-for-bit unchanged by this upgrade. Every sabotage was reverted; `src/server/tenancy.ts` is byte-identical to `main`.

† **S9 is covered elsewhere** — under a full-suite run it fails 2 tests in `__tests__/api/trpc/sponsor-pipeline-guards.test.ts`. Not a gap; that guard simply isn't exercised by the exploit file.

## ⚠️ One pre-existing gap this surfaced — S3

**Not caused by this upgrade, and not fixed here**, but it should be recorded.

Removing the tenant predicate from the organizer disjunct of `requireSpeakersInCurrentOrg({ includeOrganizerStanding: true })`:

```groq
count(*[_type == "conference" && organization._ref == $orgId && ^._id in organizers[]._ref]) > 0
                              // ^^^^^^^^^^^^^^^^^^^^^^^^^^ removed
```

…makes the guard admit a speaker listed in **any** conference's `organizers[]`, including another tenant's. **The entire test suite still passes: 461 files / 6531 tests, 0 failures.** Verified by full-suite run, not just the exploit file.

The reason the exploit file cannot see it: every `includeOrganizerStanding: true` case in the suite asserts a **resolve**, and the victim's only organizer standing is at `conf-A` (our own org). There is no fixture where a speaker's only organizer standing is at a **foreign** conference, so the fail-open direction is untested.

The blast radius is bounded — `includeOrganizerStanding` is documented as *"the wider set must never be used for a participation-creating write"*, and `talk.speakers[]` correctly keeps the default arm — but the predicate that keeps the picker's corpus tenant-scoped is currently unverified. Suggested follow-up: one fixture where the victim sits only in `conf-B.organizers[]`, asserting `requireSpeakersInCurrentOrg([VICTIM], { includeOrganizerStanding: true })` rejects. Left out of this PR to keep it a pure dependency bump.

## Why it stays pinned

`groq-js` is the only exact-pinned devDependency in `package.json`, introduced that way by #731 alongside the exploit suite. That is deliberate and preserved: this package is a **verification oracle**, and a silent floating bump to it could weaken a security regression net with no diff to review. Majors here should always arrive as their own reviewable PR — like this one.

## Gates (all run locally, real numbers)

| Gate | Result |
|---|---|
| `pnpm test` | **461 files / 6531 tests passed**, 0 failed |
| `pnpm typecheck` | exit 0 |
| `npx eslint .` | **0 errors, 216 warnings** (as expected; `next lint` is gone in Next 16 and exits 0 without linting — not used) |
| `npx prettier --check .` | all files clean |
| `pnpm knip` | exit 0 (one pre-existing config hint on `@workos-inc/node`) |
| `pnpm build` | exit 0, with the CI placeholder env from `.github/workflows/pr-checks.yml` |

## Not merging

Held for review per the usual gate.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR upgrades the exactly pinned, test-only `groq-js` dependency from 1.30.3 to 2.0.0 while preserving its existing usage.
- Updates the direct devDependency version in `package.json`.
- Refreshes the lockfile resolution, Node engine requirement, integrity hash, and replacement of `debug` with `obug`.
- Leaves application and tenancy-guard code unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no changed-code-triggered defects identified.

The dependency remains exactly pinned, all declared environments use a supported Node version, the sole consumer uses an ESM-compatible test path, and no application or tenancy-guard logic changes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Updates the exact `groq-js` devDependency pin to 2.0.0; repository Node and module configurations satisfy the new package requirements. |
| pnpm-lock.yaml | Consistently records groq-js 2.0.0, its Node >=22.12 engine requirement, integrity hash, and obug dependency. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump groq-js to 2.0.0"](https://github.com/cloudnativebergen/website/commit/ae70719293c1b765fdc25dc9a27329e7bac3e4e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50091143)</sub>

<!-- /greptile_comment -->