### PR TITLE
test(tenancy): cover the fail-open direction of the organizer arm

### DIFF
--- a/src/server/tenancy.exploits.test.ts
+++ b/src/server/tenancy.exploits.test.ts
@@ -127,6 +127,39 @@ describe('F1 — referencing standing must not convert into ownership standing',
     ).resolves.toBe(ORG_A)
   })
 
+  /**
+   * The FAIL-OPEN direction of the organizer arm, which nothing else covers.
+   *
+   * Every other `includeOrganizerStanding` case asserts a RESOLVE, and in each
+   * of them the victim's organizer standing is at our own `conf-A` — so the
+   * `organization._ref == $orgId` half of that arm is never the thing deciding
+   * the outcome. Delete it and the whole suite still passes, while the picker's
+   * corpus silently widens to every speaker listed in ANY tenant's
+   * `conference.organizers[]`.
+   *
+   * Here the victim organizes ONLY at a foreign conference, so the predicate is
+   * the only thing standing between us and a cross-tenant speaker.
+   */
+  const foreignOrganizerOnly: Doc[] = [
+    { _id: VICTIM, _type: 'speaker' },
+    // Organizer standing exists — but at ORG_B's conference, not ours.
+    {
+      _id: 'conf-B',
+      _type: 'conference',
+      organization: ref(ORG_B),
+      organizers: [ref(VICTIM)],
+    },
+    // Our own conference lists them nowhere.
+    { _id: 'conf-A', _type: 'conference', organization: ref(ORG_A) },
+  ]
+
+  it('organizer standing at a FOREIGN conference grants nothing here', async () => {
+    useDataset(foreignOrganizerOnly)
+    await expect(
+      requireSpeakersInCurrentOrg([VICTIM], { includeOrganizerStanding: true }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+
   it('but NOT referenceable from a talk — the exploit’s first step now fails', async () => {
     useDataset(organizerOnly)
     // This is `proposal.admin.update({ data: { speakers: [VICTIM] } })`.


### PR DESCRIPTION
**A tenant-scoping predicate that no test could observe.**

Found while verifying the groq-js 2.0 bump (#763) — the upgrade is clean, but the sabotage sweep that proved it surfaced this pre-existing hole.

## The gap

Delete `organization._ref == $orgId &&` from the organizer disjunct of `requireSpeakersInCurrentOrg({ includeOrganizerStanding: true })` and **the entire suite still passes**: 461 files, 6531 tests, zero failures.

What that predicate does is keep the speaker-picker's corpus tenant-scoped. Without it the arm admits any speaker listed in **any** tenant's `conference.organizers[]`, not just ours.

Why nothing caught it: every existing `includeOrganizerStanding` case asserts a **resolve**, and in each the victim's organizer standing is at our own `conf-A`. So the org half of the predicate never decides the outcome — only the `^._id in organizers[]._ref` half does. There was no fixture in which a speaker's *only* organizer standing was at a **foreign** conference, so the fail-open direction was untested.

## The fix

One fixture, one assertion: the victim organizes only at `conf-B` (owned by `ORG_B`), our `conf-A` lists them nowhere, and the call must be refused.

## Verification

Sabotage-proven, which is the only thing that makes this test worth having:

| state | result |
| --- | --- |
| predicate intact | 24/24 pass |
| `organization._ref == $orgId` removed | **1 failed** — `organizer standing at a FOREIGN conference grants nothing here` |
| restored | 24/24 pass |

Before this test, that same sabotage passed 6531/6531.

## Scope

Blast radius of the underlying gap is bounded — the wider set is still correctly barred from participation-creating writes like `talk.speakers[]`, which is covered by the neighbouring cases. This closes the observability gap, not an active exploit. No production code changes.

`tsc --noEmit` clean · `eslint` clean · `prettier` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds regression coverage for the fail-open direction of tenant-scoped organizer standing.
- Introduces a fixture where a speaker organizes only a foreign tenant’s conference.
- Verifies that organizer standing from another tenant does not make the speaker referenceable in the current organization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the added test correctly exercises the intended cross-tenant rejection path.

The fixture reaches the real organizer-standing GROQ predicate through the existing guard, isolates current organization A from foreign organization B, and asserts the guard’s established NOT_FOUND contract without changing production behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/tenancy.exploits.test.ts | Adds focused, isolated regression coverage proving that foreign organizer standing is rejected by the existing tenancy guard. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(tenancy): cover the fail-open direc..."](https://github.com/cloudnativebergen/website/commit/5f6f3b9c4134ab0562d8caadc2ca8cd19497b430) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50094803)</sub>

<!-- /greptile_comment -->