### PR TITLE
chore(deps): bump apexcharts to 6.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@workos-inc/authkit-nextjs": "^4.3.1",
     "@workos-inc/node": "^10.9.0",
     "@xmldom/xmldom": "^0.9.10",
-    "apexcharts": "^5.15.2",
+    "apexcharts": "^6.7.0",
     "bs58": "^6.0.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^0.9.10
         version: 0.9.10
       apexcharts:
-        specifier: ^5.15.2
-        version: 5.15.2
+        specifier: ^6.7.0
+        version: 6.7.0
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -166,7 +166,7 @@ importers:
         version: 19.2.6
       react-apexcharts:
         specifier: ^2.1.1
-        version: 2.1.1(apexcharts@5.15.2)(react@19.2.6)
+        version: 2.1.1(apexcharts@6.7.0)(react@19.2.6)
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
@@ -5028,8 +5028,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  apexcharts@5.15.2:
-    resolution: {integrity: sha512-qbd+ehDiRxo++wAqaGLmJcd683ktulTqoku4WYYyQ3XOgJIn4yhOQGV27KcdK7c2yhwxblyh4mgMm8ukI0wC0Q==}
+  apexcharts@6.7.0:
+    resolution: {integrity: sha512-1Z8AACzw2W2I/JOLh2jHVVHWYtOIf1Yr9/A99r1+YJwb31V2Wmi4fzfscWOJAAf47nW4qRWvLm+ZLEm0GeiqjQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   append-transform@2.0.0:
     resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
@@ -16199,7 +16200,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  apexcharts@5.15.2: {}
+  apexcharts@6.7.0: {}
 
   append-transform@2.0.0:
     dependencies:
@@ -20652,9 +20653,9 @@ snapshots:
     dependencies:
       setimmediate: 1.0.5
 
-  react-apexcharts@2.1.1(apexcharts@5.15.2)(react@19.2.6):
+  react-apexcharts@2.1.1(apexcharts@6.7.0)(react@19.2.6):
     dependencies:
-      apexcharts: 5.15.2
+      apexcharts: 6.7.0
       prop-types: 15.8.1
       react: 19.2.6
 


### PR DESCRIPTION
Bumps `apexcharts` `^5.15.2` → `^6.7.0`. One major, nothing else touched — the diff is `package.json` + `pnpm-lock.yaml` only.

## Why this one needed eyes

ApexCharts renders the admin dashboard's **Ticket Sales** widget (radial capacity gauge + sales-vs-target line chart) and the full `TicketSalesChartDisplay` analytics chart. A chart-library major can silently change colours, axis formatting, legend placement, tooltips, responsive breakpoints or animation defaults — none of which fail a unit test. So this was verified by screenshot and by DOM measurement, not just by a green suite.

## Breaking changes reviewed (v6.0 → v6.7)

Walked every release in the v6 line against our actual configs:

| Release | Change | Impact here |
|---|---|---|
| 6.0 | `chart.zoom.pinch` defaults **on** | **Inert.** `_pinchEnabled()` is `zoom.enabled && zoom.pinch`; we set `zoom.enabled: false`. |
| 6.0 | `chart.pan.inertia` defaults **on** | **Inert.** One-finger kinetic pan additionally requires `interact.panEnabled` (the toolbar pan tool); we set `toolbar.show: false`. |
| 6.0 | `dynamicAnimation` on for add/remove point updates | **No change.** Already `enabled: true, speed: 350` in 5.15.2. |
| 6.2 | One `.apexcharts-series-markers` group per series (was per point) | Not applicable — scatter/bubble only, and we target no per-point CSS. |
| 6.3 | DOM subtree preserved across `updateSeries` | Internal; output verified identical. |
| 6.4 | Three **heatmap** default changes | Not applicable — no heatmaps. |
| 6.5 | Premium modules enter trial mode with an `APEXCHARTS` watermark | **Not triggered.** See below. |
| 6.7 | Legend click toggles slices on pie/donut/polarArea | Not applicable — we use `line` and `radialBar`. |

**No option was renamed or removed**, so nothing had to be migrated or deleted. Types are purely additive/widening (`theme.mode` widened to `'light' | 'dark' | ''`, `toolbar.autoSelected` gained `'measure'`, `requestedType` gained `'waffle'`).

### The watermark question

v6.5 added client-side trial enforcement, which would have been a serious problem — a watermark stamped across dashboard charts. Confirmed from `LicenseEnforcer.js` that the gated set is **disjoint from ours**, and gating is on *use*, not on bundling:

> Gates these premium features, and ONLY when they are actually IN USE (not merely bundled): storyboard, link (crossfilter/linked views), ink, measure, context-menu, perspectives, history, PLUS the premium `unit` chart type. Everything else (all OTHER chart types, and the free modules weave / renderer-canvas / marks / facet / drilldown / morph / **annotations** / legend / toolbar / keyboard / exports, and the always-on core) is never gated.

We use `line`, `radialBar` and `annotations` — all free. The harness asserts no watermark node and no `APEXCHARTS` text in any rendered story; it found none.

### Module format

Not ESM-only. The `exports` map has the same shape as v5 (`node`/`browser` × `import`/`require`, dual `.esm.js`/`.common.js`), so the Next bundle and the `next/dynamic` + `ssr: false` client-only load path are unaffected. New engine floor is `node: ^20.19.0 || ^22.12.0 || >=24.0.0`; CI and local both run Node 24.

## react-apexcharts — no bump needed

Checked explicitly. `react-apexcharts@2.1.1` is **already the latest published version**, and its peer range is `apexcharts: >=5.10.1`, which 6.7.0 satisfies. It re-resolved cleanly against the new major with no peer warning:

```
react-apexcharts 2.1.1
└── apexcharts 6.7.0 peer
```

## Visual verification

Every story that renders an ApexCharts chart is in `TicketSales.matrix.stories.tsx` (the only chart-bearing story file). All five stories were shot at 1600×1200 @2× DPR, **light and dark**, from `origin/main` and again after the bump, using an identical harness.

**8 of 10 screenshots are byte-identical (SHA-256).**

The two that differ are `AllStatesDefaultSize` light/dark, and the difference is not ApexCharts:

- `maxDelta: 1` — a single 8-bit level.
- The diff bounding box is confined to the **first frame**, the `loading` skeleton, which contains **zero charts** and an `animate-pulse`.
- Shooting the **same** build twice reproduces the same diff in the same bbox (943,370 px vs 943,417 px), proving it is inherent animation-phase noise, not version drift.

Beyond pixels, the harness measured the DOM per widget cell and diffed it. Across all 5 stories × 2 themes × every cell: **zero differences** in chart width/height/SVG height, overflow-past-slot, series count, legend item count and text, x-axis labels, y-axis labels, radial data labels, line stroke colours, dash arrays, stroke widths, radial track/area colours, grid stroke colour, watermark presence, and document scroll width.

Concretely, nothing moved: gauge stays 300px with `Capacity` / `66%`; the trend chart keeps 2 series and 2 legend entries, x labels `1. juni … 14. juni`, y labels `400 / 200 / 0`; strokes stay `rgba(37,99,235,.85)` + `rgba(209,213,219,.85)` in light and `rgba(59,130,246,.85)` + `rgba(82,82,91,.85)` in dark, with the target series still dashed at `stroke-dasharray: 5`; grid stays `#e5e7eb` light / `#3f3f46` dark.

### WidgetBody height contract (#596–#598) — holds

This was the specific regression risk, and it is clean. Every cell's `WidgetBody` reports **identical** `clientHeight`, `scrollHeight`, `scrollable`, computed `overflow-y`, `min-height` and `flex-grow` before and after — e.g. `min · 3×3` is `272/747`, `default/medium · 6×4` is `384/613`, `max · 8×6` is `608/613`, all still `overflow-y: auto`.

**Nothing is hard-clipped.** Taller-than-slot content still scrolls inside `WidgetBody` exactly as before, including the two flagged narrow cells in `KnownRiskCells` (3×3 true minimum and the 3×4 narrow preset), which are byte-identical in both themes. No chart overflows its slot (`overflowsSlotBy: 0` everywhere, unchanged).

**Verdict: no drift to accept or reject — the rendering is identical.**

Also confirmed the AFTER screenshots really ran v6 rather than a cached v5 bundle: the module Storybook served contains v6-only markers (`LicenseEnforcer`, `apexcharts.com/pricing`, `panInertiaEnabled`, `registerSeriesType`, `registerTheme`), none of which exist in 5.15.2's dist.

## Gates

All run locally, real numbers:

| Gate | Result |
|---|---|
| `pnpm build` | pass (CI placeholder env per `pr-checks.yml`) |
| `pnpm test` | **461 files, 6531 tests, all passed** |
| `pnpm typecheck` | pass, clean |
| `npx eslint .` | **0 errors, 216 warnings** (expected count) |
| `npx prettier --check .` | pass |
| `pnpm knip` | exit 0 (only the pre-existing `@workos-inc/node` config hint) |
| `pnpm build-storybook` | pass |

## Note

Unminified `dist/apexcharts.esm.js` grows 1.2M → 1.8M (the new tree-shakeable feature entrypoints ship more surface). It is loaded lazily via `next/dynamic` with `ssr: false`, so it stays a deferred chunk rather than entering the main bundle. If it matters later, v6's per-feature subpaths (`apexcharts/line`, `apexcharts/radialBar`) would let us import only what the widgets use — deliberately out of scope for a version bump.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR upgrades ApexCharts from 5.15.2 to 6.7.0 and updates the lockfile resolution for `react-apexcharts`.
- Updates the direct ApexCharts dependency to the v6 release line.
- Records ApexCharts 6.7.0’s integrity and Node engine requirements.
- Re-resolves `react-apexcharts@2.1.1` against ApexCharts 6.7.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the dependency resolution, wrapper peer range, runtime version, and documented chart verification all aligned.

The committed lockfile pins ApexCharts 6.7.0, supported Node 24 environments satisfy its engine constraint, and no concrete build, loading, or rendering failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Updates ApexCharts from `^5.15.2` to `^6.7.0`; no actionable compatibility or policy issue was identified. |
| pnpm-lock.yaml | Pins ApexCharts 6.7.0 and consistently updates the React wrapper’s peer resolution, integrity, and engine metadata. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump apexcharts to 6.7.0"](https://github.com/cloudnativebergen/website/commit/b755dcc4f1e5223c46abefed2939883506fafd94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50103883)</sub>

<!-- /greptile_comment -->