### PR TITLE
chore(deps): bump @portabletext/react to 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@next/eslint-plugin-next": "^16.3.0",
     "@portabletext/editor": "^7.10.14",
     "@portabletext/markdown": "^1.4.4",
-    "@portabletext/react": "^6.2.0",
+    "@portabletext/react": "^7.0.1",
     "@portabletext/to-html": "^5.0.2",
     "@portabletext/types": "^4.0.2",
     "@react-email/render": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^1.4.4
         version: 1.4.4
       '@portabletext/react':
-        specifier: ^6.2.0
-        version: 6.2.0(react@19.2.6)
+        specifier: ^7.0.1
+        version: 7.0.1(react@19.2.6)
       '@portabletext/to-html':
         specifier: ^5.0.2
         version: 5.0.2

--- a/src/lib/portabletext/components.test.tsx
+++ b/src/lib/portabletext/components.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { PortableText } from '@portabletext/react'
+import { portableTextComponents } from './components'
+
+/**
+ * The href gate asserted where it is REGISTERED, not merely where it is used.
+ *
+ * `RichTextContent` already proves the homepage renders a hostile link inertly,
+ * but it sanitizes the value first — the mark is stripped before `<PortableText>`
+ * ever sees it, so that test passes even if this map's `link` entry stopped
+ * running. Every OTHER caller (speaker bios, sponsor terms, talk abstracts,
+ * workshop descriptions) hands stored blocks to `<PortableText>` with this map
+ * and no pre-pass, so `marks.link` IS the only thing standing between a stored
+ * `javascript:` href and a live link.
+ *
+ * That makes this file the regression net for the renderer contract itself: if
+ * a `@portabletext/react` upgrade ever changes how a `components.marks` entry is
+ * looked up or invoked, the mark silently falls back to the library default —
+ * which renders `value.href` verbatim — and these assertions are what notice.
+ *
+ * Asserted STRUCTURALLY, on the anchor's parsed `href`. A substring check like
+ * `not.toContain('javascript:')` is worthless against DOM output: the string
+ * survives escaping, so the assertion reads the same whether the scheme is live
+ * or inert.
+ */
+
+afterEach(cleanup)
+
+function linkBlock(href: unknown) {
+  return [
+    {
+      _type: 'block',
+      _key: 'b1',
+      style: 'normal',
+      markDefs: [{ _key: 'l1', _type: 'link', href }],
+      children: [{ _type: 'span', _key: 's1', text: 'click', marks: ['l1'] }],
+    },
+  ]
+}
+
+/** Every anchor's href, read off the DOM rather than out of the markup. */
+function hrefs(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('a')).map(
+    (a) => a.getAttribute('href') ?? '',
+  )
+}
+
+describe('portableTextComponents gates the link mark', () => {
+  it.each([
+    ['javascript:alert(1)'],
+    ['JavaScript:alert(1)'],
+    ['  javascript:alert(1)  '],
+    ['data:text/html,<script>alert(1)</script>'],
+    ['vbscript:msgbox(1)'],
+    ['//evil.example/takeover'],
+    ['https:evil.example'],
+  ])('renders %s as an inert anchor, never a live one', (href) => {
+    const { container } = render(
+      <PortableText
+        value={linkBlock(href)}
+        components={portableTextComponents}
+      />,
+    )
+
+    // The anchor may exist — it just must not carry an executable scheme.
+    for (const value of hrefs(container)) {
+      expect(value).toBe('#')
+    }
+    // Proof the mark ran at all: a fallback to the library default would emit
+    // the stored href, so an empty anchor list would make the loop vacuous.
+    expect(container.querySelectorAll('a')).toHaveLength(1)
+    expect(container.textContent).toContain('click')
+  })
+
+  it('leaves the schemes rich text is allowed to use alone', () => {
+    for (const href of [
+      'https://example.com/cfp',
+      'http://example.com/cfp',
+      '/tickets',
+      'mailto:hi@example.com',
+    ]) {
+      const { container } = render(
+        <PortableText
+          value={linkBlock(href)}
+          components={portableTextComponents}
+        />,
+      )
+      expect(hrefs(container)).toEqual([href])
+      cleanup()
+    }
+  })
+
+  it('hardens the anchors it does render', () => {
+    const { container } = render(
+      <PortableText
+        value={linkBlock('https://example.com/cfp')}
+        components={portableTextComponents}
+      />,
+    )
+    const anchor = container.querySelector('a')!
+    expect(anchor.getAttribute('rel')).toBe('noopener noreferrer')
+    expect(anchor.getAttribute('target')).toBe('_blank')
+  })
+})
+
+/**
+ * The rest of the map, so an upgrade that changes block/list/mark lookup is
+ * caught as a rendering failure rather than as an unstyled page nobody views.
+ */
+describe('portableTextComponents renders the styled block set', () => {
+  it('applies the house overrides for headings, lists and marks', () => {
+    const { container } = render(
+      <PortableText
+        components={portableTextComponents}
+        value={[
+          {
+            _type: 'block',
+            _key: 'h',
+            style: 'h2',
+            markDefs: [],
+            children: [
+              { _type: 'span', _key: 's', text: 'Heading', marks: [] },
+            ],
+          },
+          {
+            _type: 'block',
+            _key: 'q',
+            style: 'blockquote',
+            markDefs: [],
+            children: [{ _type: 'span', _key: 's', text: 'Quoted', marks: [] }],
+          },
+          {
+            _type: 'block',
+            _key: 'li',
+            style: 'normal',
+            listItem: 'bullet',
+            level: 1,
+            markDefs: [],
+            children: [{ _type: 'span', _key: 's', text: 'Item', marks: [] }],
+          },
+          {
+            _type: 'block',
+            _key: 'm',
+            style: 'normal',
+            markDefs: [],
+            children: [
+              { _type: 'span', _key: 'a', text: 'bold', marks: ['strong'] },
+              { _type: 'span', _key: 'b', text: 'italic', marks: ['em'] },
+              { _type: 'span', _key: 'c', text: 'code', marks: ['code'] },
+            ],
+          },
+        ]}
+      />,
+    )
+
+    // The house class is what distinguishes OUR override from the library
+    // default, which emits the same tag with no className.
+    expect(container.querySelector('h2')?.className).toContain('text-2xl')
+    expect(container.querySelector('blockquote')?.className).toContain(
+      'border-l-4',
+    )
+    expect(container.querySelector('ul')?.className).toContain('list-disc')
+    expect(container.querySelector('li')?.className).toContain(
+      'leading-relaxed',
+    )
+    expect(container.querySelector('strong')?.className).toContain(
+      'font-semibold',
+    )
+    expect(container.querySelector('em')?.className).toContain('italic')
+    expect(container.querySelector('code')?.className).toContain('font-mono')
+  })
+})


### PR DESCRIPTION
`@portabletext/react` `^6.2.0` → `^7.0.1`. Portable Text is how every piece of tenant-authored rich text reaches a visitor — talk abstracts, speaker bios, sponsor terms, `/info` copy, email bodies — so this was treated as a rendering-correctness and security change rather than a version bump.

## What v7 actually breaks

Reading the [upstream changelog](https://github.com/portabletext/react-portabletext/blob/main/CHANGELOG.md), v7.0.0 is a **packaging** major, not an API one.

`<PortableText>` now ships two builds selected by export condition: a `default` build optimized with React Compiler auto-memoization (client + SSR), and an uncompiled build under the `react-server` condition, because React Server Components refuse to load compiled output ([facebook/react#31702](https://github.com/facebook/react/issues/31702)). The compiled build loads `react/compiler-runtime`, which only exists in React 19 — hence the one stated breaking change: **`peerDependencies.react` narrows from `^18.2 || ^19` to `^19`.** We are on `react@^19.2.6`, so it is satisfied.

Explicitly **unchanged** in v7, and each one verified against our own code: the `components` registration shape, `PortableTextComponents` typing, unknown-type/unknown-mark handling, and `onMissingComponent`. v7.0.1 only gives the built-in components proper function names for React DevTools.

## Migration

**None was required.** No `components` map in `src/` needed a single edit — `pnpm typecheck` is clean against v7 with the maps exactly as they were on `main`. No component override was deleted or weakened to make anything pass.

## Sibling packages: not bumped, and why

The task asked whether `@portabletext/editor`, `@portabletext/markdown` or `@portabletext/to-html` need matching bumps. **They do not**, and I left them alone:

| package | on `main` | peer deps | verdict |
|---|---|---|---|
| `@portabletext/editor` | `^7.10.14` | `react@^19.2.7` | no dep on `@portabletext/react`; React 19 already satisfied |
| `@portabletext/markdown` | `^1.4.4` | `@portabletext/toolkit@^5`, `@portabletext/schema@^2`, `markdown-it`, `@mdit/plugin-alert` | no dep on `@portabletext/react` |
| `@portabletext/to-html` | `^5.0.2` | `@portabletext/toolkit@^5`, `@portabletext/types@^4` | no dep on `@portabletext/react` |

None of the three peer-depends on `@portabletext/react`, and v7 keeps the **same** `@portabletext/toolkit@^5.0.2` and `@portabletext/types@^4.0.2` dependencies that v6.2.0 had — so nothing shared between them moves. The lockfile diff is 4 lines, confined to `@portabletext/react`.

Worth noting for the email path specifically: `src/lib/email/portableTextToHTML.tsx` renders via `@portabletext/to-html`, **not** the React renderer, so it is untouched by this major.

## The href gate: verified, then sabotaged

`toSafeRichTextHref` (`src/lib/portabletext/safeHref.ts`) is applied to the `link` mark in `src/lib/portabletext/components.tsx` so a stored `javascript:` URL cannot render as a live link. Since v7 changes nothing about mark registration, the gate is structurally intact — but "structurally intact" is an argument, not evidence, so I went looking for the test that would catch it if I were wrong.

**There was a hole.** The email half is covered (`__tests__/lib/email/portableTextHref.test.ts`), and `RichTextContent.test.tsx` covers the homepage — but the latter runs `sanitizeRichTextContent` first, which strips the mark *before* `<PortableText>` ever sees it. That test therefore passes even if `marks.link` stopped being invoked entirely. And every *other* caller — speaker bios, sponsor terms, talk abstracts, workshop descriptions — passes stored blocks straight to `<PortableText>` with this map and no pre-pass. So the one entry that actually holds the line had no test asserting it at its registration site.

Added `src/lib/portabletext/components.test.tsx`: renders the real `portableTextComponents` through the real v7 `<PortableText>` and asserts **structurally** on the rendered anchor's parsed `href` — not `not.toContain('javascript:')`, which is worthless here since the string survives escaping and reads identically whether the scheme is live or inert.

**Sabotage result.** I replaced the gate with the raw stored href:

```diff
-      const href = toSafeRichTextHref((value as { href?: string })?.href)
+      const href = (value as { href?: string })?.href ?? '#'
```

**7 of 10 tests failed** — every refused-scheme case:

```
× renders javascript:alert(1) as an inert anchor, never a live one
× renders JavaScript:alert(1) ...
× renders   javascript:alert(1)   ...
× renders data:text/html,<script>alert(1)</script> ...
× renders vbscript:msgbox(1) ...
× renders //evil.example/takeover ...
× renders https:evil.example ...
```

The gate was then restored (`git diff` on `components.tsx` is empty — the file is byte-identical to `main`) and all 10 pass.

One detail the sabotage surfaced that is worth recording: React's own href scrubbing rewrites a bare `javascript:` URL into a throwing expression, but it does **nothing** for `data:`, `vbscript:`, scheme-relative `//evil.example` or the degenerate `https:evil.example` form — those came through completely raw. So `toSafeRichTextHref` is genuinely load-bearing, not belt-and-braces over a framework guarantee.

## Visual verification

Screenshotted five Portable-Text-rendering stories at 900×1400 (DPR 3) before and after the upgrade, on an isolated Storybook (`SHOOT_PORT=6106`) against a **real** `pnpm install` — confirmed `require('@portabletext/react/package.json').version` reported `6.2.0` before and `7.0.1` after, so neither run was reading stale modules.

| story | result |
|---|---|
| `systems-homepage-public-richtextblock--default` | byte-identical |
| `systems-homepage-public-richtextblock--boxed-rich-content` | byte-identical |
| `systems-homepage-public-richtextblock--awkward-content` | byte-identical |
| `systems-homepage-public-richtextblock--dark` | byte-identical |
| `systems-speakers-speakerprofilepreview--default` | byte-identical |

All five PNGs hash-match before and after. The baseline was visually inspected first (headings, paragraphs, code block, callout, table, list, links all rendering with correct styling), so identical hashes mean the styled output is preserved, not that both runs were equally broken.

## Gates

| gate | result |
|---|---|
| `pnpm build` | pass |
| `pnpm test` | **462 files, 6542 tests passed** |
| `pnpm typecheck` | pass, clean |
| `npx eslint .` | **0 errors, 216 warnings** (matches baseline) |
| `npx prettier --check .` | pass |
| `pnpm knip` | pass — 1 config hint (`@workos-inc/node`), confirmed pre-existing by re-running against stashed changes |
| `pnpm build-storybook` | pass |

## Unrelated observation, not fixed here

`src/components/SpeakerProfilePreview.tsx:223` and `src/components/proposal/ProposalDetailsForm.tsx:134` render `<PortableText value={…} />` with **no `components` prop**, so they use the library's default link mark — which emits `value.href` verbatim and does not run `toSafeRichTextHref`. That predates this PR and is out of scope for a dependency bump, but it is the gap this upgrade's testing made visible and probably deserves its own issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR upgrades `@portabletext/react` from v6.2.0 to v7.0.1 while retaining React 19 compatibility and adds focused regression coverage for the existing Portable Text rendering contract.
- Updates the dependency manifest and lockfile resolution.
- Verifies hostile rich-text links remain inert through the real component map.
- Covers custom heading, list, blockquote, and mark overrides.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The dependency resolves against the repository’s React 19 runtime, and the added integration tests exercise the real v7 renderer, component map, hostile-link gate, and styled overrides using production-compatible Portable Text shapes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Upgrades `@portabletext/react` to the React-19-only v7 release while the application already uses React 19.2.6. |
| pnpm-lock.yaml | Consistently resolves the direct dependency to `@portabletext/react@7.0.1` with React 19.2.6. |
| src/lib/portabletext/components.test.tsx | Adds deterministic jsdom integration coverage for safe links and the registered Portable Text component overrides. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump @portabletext/react to..."](https://github.com/cloudnativebergen/website/commit/4254f629feea1d2d1d4e47885bd1e55a81609099) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50112787)</sub>

<!-- /greptile_comment -->