### PR TITLE
fix(security): gate the href on two ungated PortableText renders

### DIFF
--- a/__tests__/lib/portabletext/gated-renders.test.ts
+++ b/__tests__/lib/portabletext/gated-renders.test.ts
@@ -34,6 +34,26 @@ function tsxFiles(dir: string, out: string[] = []): string[] {
 }
 
 /**
+ * Blank out comments, preserving offsets and line structure.
+ *
+ * Without this the scan matches prose. A doc comment that mentions
+ * `` `<PortableText>` `` looks exactly like a render whose very next character
+ * is `>`, so the walk below captures an empty element, finds no `components`
+ * attribute, and reports a false positive against a file that is in fact
+ * correct — which is what happened the first time this ran in CI.
+ *
+ * Replacing rather than deleting keeps every other index valid.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(
+      /(^|[^:])\/\/[^\n]*/g,
+      (m, lead) => lead + ' '.repeat(m.length - lead.length),
+    )
+}
+
+/**
  * The attribute text of each `<PortableText …>` element in `source`.
  *
  * Scans to the element's own closing bracket while tracking brace depth, so an
@@ -41,7 +61,8 @@ function tsxFiles(dir: string, out: string[] = []): string[] {
  * early — a regex stopping at the first `>` would silently skip elements and
  * make this whole test pass vacuously.
  */
-function portableTextElements(source: string): string[] {
+function portableTextElements(input: string): string[] {
+  const source = stripComments(input)
   const elements: string[] = []
   // `\b` alone would also match PortableTextEditor / PortableTextBlock.
   const opening = /<PortableText(?![A-Za-z0-9_])/g
@@ -69,7 +90,8 @@ function portableTextElements(source: string): string[] {
  * exactly that, and the presence-only check above accepted it — so this second
  * scan looks at what the mark DOES, not merely that a map was supplied.
  */
-function linkMarkBodies(source: string): string[] {
+function linkMarkBodies(input: string): string[] {
+  const source = stripComments(input)
   const bodies: string[] = []
   const opening = /\blink:\s*(\(|function)/g
   let match: RegExpExecArray | null

--- a/__tests__/lib/portabletext/gated-renders.test.ts
+++ b/__tests__/lib/portabletext/gated-renders.test.ts
@@ -1,0 +1,94 @@
+/**
+ * EVERY `<PortableText>` render must pass the gated `components` map.
+ *
+ * The library's DEFAULT link mark emits `value.href` verbatim. Portable Text
+ * here is author-supplied — speaker bios, talk abstracts, sponsor terms — so an
+ * ungated render turns stored content into a live anchor with an attacker's
+ * scheme. `portableTextComponents` exists precisely to stop that: its `link`
+ * mark runs every href through `toSafeRichTextHref`.
+ *
+ * React is NOT a substitute for that gate. It scrubs a bare `javascript:` href,
+ * but passes `data:`, `vbscript:`, protocol-relative `//evil.example` and
+ * `https:evil.example` straight through.
+ *
+ * Two call sites were rendering ungated — a talk description and a proposal
+ * abstract, both author-supplied — and nothing failed, because the omission is
+ * invisible to type-checking and to every rendering test that does not happen to
+ * contain a hostile href. This scans the source instead, so the next one fails
+ * here rather than in production.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { join } from 'path'
+
+const SRC = join(process.cwd(), 'src')
+
+/** Every `.tsx` under `src/`. */
+function tsxFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) tsxFiles(full, out)
+    else if (entry.endsWith('.tsx')) out.push(full)
+  }
+  return out
+}
+
+/**
+ * The attribute text of each `<PortableText …>` element in `source`.
+ *
+ * Scans to the element's own closing bracket while tracking brace depth, so an
+ * attribute value containing `>` (`({ children }) => …`) does not end the match
+ * early — a regex stopping at the first `>` would silently skip elements and
+ * make this whole test pass vacuously.
+ */
+function portableTextElements(source: string): string[] {
+  const elements: string[] = []
+  // `\b` alone would also match PortableTextEditor / PortableTextBlock.
+  const opening = /<PortableText(?![A-Za-z0-9_])/g
+  let match: RegExpExecArray | null
+
+  while ((match = opening.exec(source)) !== null) {
+    let depth = 0
+    let i = match.index + match[0].length
+    for (; i < source.length; i++) {
+      const c = source[i]
+      if (c === '{') depth++
+      else if (c === '}') depth--
+      else if (c === '>' && depth === 0) break
+    }
+    elements.push(source.slice(match.index, i))
+  }
+  return elements
+}
+
+describe('every PortableText render is gated', () => {
+  const files = tsxFiles(SRC)
+
+  it('finds renders to check — the scan cannot pass vacuously', () => {
+    const total = files
+      .map((f) => portableTextElements(readFileSync(f, 'utf8')).length)
+      .reduce((a, b) => a + b, 0)
+
+    // Guards the parser itself: if `portableTextElements` silently stopped
+    // matching, every assertion below would pass on an empty set.
+    expect(total).toBeGreaterThanOrEqual(8)
+  })
+
+  it('passes a `components` map at every call site', () => {
+    const ungated: string[] = []
+
+    for (const file of files) {
+      for (const element of portableTextElements(readFileSync(file, 'utf8'))) {
+        if (!/\bcomponents=/.test(element)) {
+          ungated.push(
+            `${file.replace(process.cwd() + '/', '')}: ${element
+              .replace(/\s+/g, ' ')
+              .slice(0, 80)}`,
+          )
+        }
+      }
+    }
+
+    expect(ungated).toEqual([])
+  })
+})

--- a/__tests__/lib/portabletext/gated-renders.test.ts
+++ b/__tests__/lib/portabletext/gated-renders.test.ts
@@ -61,6 +61,41 @@ function portableTextElements(source: string): string[] {
   return elements
 }
 
+/**
+ * The body of every `link:` mark defined in `source`.
+ *
+ * A render can pass `components=` and still be unsafe: an INLINE map may define
+ * its own `link` mark that assigns the raw href. The Hero's announcement did
+ * exactly that, and the presence-only check above accepted it — so this second
+ * scan looks at what the mark DOES, not merely that a map was supplied.
+ */
+function linkMarkBodies(source: string): string[] {
+  const bodies: string[] = []
+  const opening = /\blink:\s*(\(|function)/g
+  let match: RegExpExecArray | null
+
+  while ((match = opening.exec(source)) !== null) {
+    // `link` is an OBJECT PROPERTY, so its value ends at the comma that closes
+    // it (at nesting depth 0) or when the enclosing object closes. Stopping at
+    // the first balanced bracket instead would end at the parameter list —
+    // `({ children, value })` — and never reach the body where the href is
+    // assigned, which is exactly how the first version of this scan silently
+    // matched nothing.
+    let depth = 0
+    let i = match.index + match[0].length - 1
+    for (; i < source.length; i++) {
+      const c = source[i]
+      if (c === '(' || c === '{' || c === '[') depth++
+      else if (c === ')' || c === '}' || c === ']') {
+        if (depth === 0) break
+        depth--
+      } else if (c === ',' && depth === 0) break
+    }
+    bodies.push(source.slice(match.index, i))
+  }
+  return bodies
+}
+
 describe('every PortableText render is gated', () => {
   const files = tsxFiles(SRC)
 
@@ -90,5 +125,27 @@ describe('every PortableText render is gated', () => {
     }
 
     expect(ungated).toEqual([])
+  })
+
+  it('routes every link mark through toSafeRichTextHref', () => {
+    const raw: string[] = []
+    let found = 0
+
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8')
+      for (const body of linkMarkBodies(source)) {
+        // Only marks that actually emit an href are in scope.
+        if (!/href=\{/.test(body)) continue
+        found++
+        if (!/toSafeRichTextHref/.test(body)) {
+          raw.push(file.replace(process.cwd() + '/', ''))
+        }
+      }
+    }
+
+    // Same anti-vacuity guard as above: a parser that stopped matching would
+    // otherwise report a clean sweep over nothing.
+    expect(found).toBeGreaterThanOrEqual(2)
+    expect(raw).toEqual([])
   })
 })

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -26,6 +26,7 @@ import {
 import { PIRSCH_EVENTS } from '@/lib/analytics'
 import { formatDatesSafe } from '@/lib/time'
 import { PortableText } from '@portabletext/react'
+import { toSafeRichTextHref } from '@/lib/portabletext/safeHref'
 import { TypedObject } from 'sanity'
 
 interface PortableTextChild {
@@ -315,22 +316,27 @@ function HeroAnnouncement({ conference }: { conference: Conference }) {
                     {children}
                   </strong>
                 ),
-                link: ({ children, value }) => (
-                  <a
-                    href={value?.href}
-                    className="font-semibold text-brand-cloud-blue underline decoration-brand-cloud-blue/30 underline-offset-2 transition-colors hover:decoration-brand-cloud-blue"
-                    target={
-                      value?.href?.startsWith('http') ? '_blank' : undefined
-                    }
-                    rel={
-                      value?.href?.startsWith('http')
-                        ? 'noopener noreferrer'
-                        : undefined
-                    }
-                  >
-                    {children}
-                  </a>
-                ),
+                link: ({ children, value }) => {
+                  // Gated like every other link mark: the announcement is
+                  // author-supplied, so a stored `javascript:`/`data:` href
+                  // must degrade to an inert anchor rather than render live.
+                  // Derive `target`/`rel` from the SAFE href, not the raw one,
+                  // so a refused scheme cannot still open a new context.
+                  const href = toSafeRichTextHref(
+                    (value as { href?: string })?.href,
+                  )
+                  const external = href.startsWith('http')
+                  return (
+                    <a
+                      href={href}
+                      className="font-semibold text-brand-cloud-blue underline decoration-brand-cloud-blue/30 underline-offset-2 transition-colors hover:decoration-brand-cloud-blue"
+                      target={external ? '_blank' : undefined}
+                      rel={external ? 'noopener noreferrer' : undefined}
+                    >
+                      {children}
+                    </a>
+                  )
+                },
               },
             }}
           />

--- a/src/components/SpeakerProfilePreview.tsx
+++ b/src/components/SpeakerProfilePreview.tsx
@@ -220,7 +220,10 @@ export default function SpeakerProfilePreview({
                                 {talk.description}
                               </p>
                             ) : (
-                              <PortableText value={talk.description} />
+                              <PortableText
+                                value={talk.description}
+                                components={portableTextComponents}
+                              />
                             )}
                           </div>
                         )}

--- a/src/components/proposal/ProposalDetailsForm.tsx
+++ b/src/components/proposal/ProposalDetailsForm.tsx
@@ -16,6 +16,7 @@ import {
 import { Topic } from '@/lib/topic/types'
 import { PortableTextBlock } from '@portabletext/editor'
 import { PortableText } from '@portabletext/react'
+import { portableTextComponents } from '@/lib/portabletext/components'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import {
@@ -131,7 +132,10 @@ export function ProposalDetailsForm({
             </label>
             <div className="prose prose-sm dark:prose-invert mt-2 max-w-none text-gray-900 dark:text-white">
               {description && description.length > 0 ? (
-                <PortableText value={description} />
+                <PortableText
+                  value={description}
+                  components={portableTextComponents}
+                />
               ) : (
                 <p className="text-gray-600 dark:text-gray-400">
                   No abstract provided


### PR DESCRIPTION
**The third instance of this class today**, after the email-template href injection (#727) and the `/info` stored XSS (#737). Found while verifying the `@portabletext/react` 6→7 bump (#768), which is itself clean.

## The hole

Two call sites rendered author-supplied Portable Text with **no `components` map**, so they fell back to the library's default link mark — which emits `value.href` verbatim:

- `src/components/SpeakerProfilePreview.tsx:223` — a talk description
- `src/components/proposal/ProposalDetailsForm.tsx:134` — a proposal abstract

Both render content the speaker wrote. Every other `<PortableText>` in the repo passes `portableTextComponents`, whose `link` mark runs each href through `toSafeRichTextHref`.

**React is not a substitute for that gate.** It scrubs a bare `javascript:` href, but `data:`, `vbscript:`, protocol-relative `//evil.example` and `https:evil.example` pass straight through — verified by sabotaging the gate and observing what survived.

## Why nothing caught it

The omission is invisible to type-checking — `components` is optional — and invisible to any rendering test that does not happen to feed it a hostile href. It was found by reading call sites, which is not a control.

So the fix is not just the two props: **`__tests__/lib/portabletext/gated-renders.test.ts` scans every `.tsx` under `src/` and fails if any `<PortableText>` omits `components`.**

Two things make that scan trustworthy rather than decorative:
- It tracks **brace depth** when finding each element's closing bracket, so an attribute containing `>` (an arrow function, e.g. `({ children }) => …`) cannot end the match early and silently skip elements.
- It asserts it found **at least 8** renders, so a parser that stopped matching would fail loudly instead of passing on an empty set.

## Verification

| state | result |
| --- | --- |
| both sites gated | 2/2 pass |
| one site reverted to the ungated form | **1 failed**, naming `ProposalDetailsForm.tsx` |
| restored | 2/2 pass |

Full suite **6534 passed** · `tsc --noEmit` clean · `eslint .` 0 errors / 216 warnings · `prettier --check` clean.

## Scope

No behaviour change for well-formed content — the gate only rewrites hrefs it refuses. Ungated rendering was the bug.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the shared Portable Text components map to two previously ungated author-content renders and introduces a source scan intended to prevent future omissions. The two production fixes use the canonical href gate, but the scan accepts any components map and therefore misses an existing inline raw-href renderer.

- Gates talk descriptions in `SpeakerProfilePreview`.
- Gates read-only proposal abstracts in `ProposalDetailsForm`.
- Adds a repository-wide Portable Text render scan.

<h3>Confidence Score: 4/5</h3>

The two targeted render fixes are sound, but the repository-wide security control must be corrected because it currently passes while the same unsafe-link behavior remains reachable in the homepage hero.

The scan treats every components map as gated even though an existing inline link renderer writes author-controlled hrefs directly, undermining the security guarantee introduced by this PR.

**Files Needing Attention:** __tests__/lib/portabletext/gated-renders.test.ts and src/components/Hero.tsx

<details open><summary><h3>Security Review</h3></summary>

The new regression test does not establish that a render uses the safe link handler: `Hero.tsx` supplies an inline components map but emits `value.href` directly, so hostile organizer-authored links remain reachable while the test passes.

**How this was verified:** The scan checks only for `components=`, while the Hero link mark assigns `value?.href` directly instead of calling `toSafeRichTextHref`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| __tests__/lib/portabletext/gated-renders.test.ts | Adds a non-vacuous source scan, but checks only for a components prop and false-passes inline maps that do not gate links. |
| src/components/SpeakerProfilePreview.tsx | Correctly applies the canonical gated components map to Portable Text talk descriptions. |
| src/components/proposal/ProposalDetailsForm.tsx | Correctly applies the canonical gated components map to read-only proposal abstracts. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["Organizer-authored announcement"] --> B["Hero PortableText"]
  B --> C["Inline components map"]
  C --> D["link mark: href=value.href"]
  D --> E["Ungated anchor"]
  T["New source scan"] --> P{"components= present?"}
  P -->|Yes| G["Test passes"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(security): gate the href on two unga..."](https://github.com/cloudnativebergen/website/commit/6a320a620e4c5a9b9fa3b0f0948453eb0e0afd1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50114474)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Call for Papers: Proposal Submission and Review Flow](https://app.greptile.com/cloudnativedays/-/custom-context/knowledge-base/cloudnativebergen/website/-/docs/proposal-cfp.md)

<!-- /greptile_comment -->