### PR TITLE
feat(domains): platform-owned verification for hosts in our own zone

### DIFF
--- a/.env
+++ b/.env
@@ -16,11 +16,15 @@ NEXT_TELEMETRY_DISABLED=1
 # PLATFORM_ORG_SLUG="cloud-native-bergen"
 
 # The zone the PLATFORM itself operates and mints tenant subdomains in
-# (`<slug>.konf.run`). Any host strictly BELOW this suffix is treated as
-# ownership-verified by construction (`method: "platform-owned"`) — permanently,
-# not on a grace period — because its DNS is ours and no tenant could ever
-# publish the challenge record there. See docs/DOMAIN_VERIFICATION.md.
-# Unset = NO host is platform-owned (fail closed). It is never "match
+# (`<slug>.konf.run`). A host strictly BELOW this suffix is ALLOCATABLE: tenant
+# provisioning may grant it to one conference, and the resulting record
+# (`method: "platform-owned"`) is then ownership-verified by construction —
+# permanently, not on a grace period — because its DNS is ours and no tenant
+# could ever publish the challenge record there.
+# Being under the suffix is NOT by itself an entitlement: an unallocated host is
+# refused when an organizer tries to claim it, and grants nothing if one ever
+# slips through. See docs/DOMAIN_VERIFICATION.md.
+# Unset = NO host is in the platform zone (fail closed). It is never "match
 # everything". Matching is label-wise: `evil-konf.run` and
 # `konf.run.attacker.com` do NOT match `konf.run`, and neither does the apex nor
 # a `*.konf.run` wildcard claim. Custom domains are unaffected either way.

--- a/.env
+++ b/.env
@@ -15,6 +15,18 @@ NEXT_TELEMETRY_DISABLED=1
 # Set it in .env.local / Vercel, e.g.:
 # PLATFORM_ORG_SLUG="cloud-native-bergen"
 
+# The zone the PLATFORM itself operates and mints tenant subdomains in
+# (`<slug>.konf.run`). Any host strictly BELOW this suffix is treated as
+# ownership-verified by construction (`method: "platform-owned"`) — permanently,
+# not on a grace period — because its DNS is ours and no tenant could ever
+# publish the challenge record there. See docs/DOMAIN_VERIFICATION.md.
+# Unset = NO host is platform-owned (fail closed). It is never "match
+# everything". Matching is label-wise: `evil-konf.run` and
+# `konf.run.attacker.com` do NOT match `konf.run`, and neither does the apex nor
+# a `*.konf.run` wildcard claim. Custom domains are unaffected either way.
+# Set it in .env.local / Vercel, e.g.:
+# PLATFORM_DOMAIN_SUFFIX="konf.run"
+
 NEXT_PUBLIC_SANITY_PROJECT_ID="mvzwvw14"
 NEXT_PUBLIC_SANITY_DATASET="production"
 SANITY_STUDIO_PROJECT_ID="mvzwvw14"

--- a/docs/DOMAIN_VERIFICATION.md
+++ b/docs/DOMAIN_VERIFICATION.md
@@ -47,7 +47,7 @@ A `*.example.com` wildcard claim is proven on its **base zone** (`example.com`).
   defending against, is the attacker. A record in the tenant's own zone proves
   control of the **zone**, which is the thing that actually lapses.
 
-## Platform-owned hosts
+## Platform-allocated hosts
 
 Tenants are hosted by default on a subdomain the platform **mints** for them
 (`<slug>.konf.run`). That zone's nameservers are delegated to our own edge and a
@@ -56,10 +56,41 @@ at all. Asking them for a `_konf-challenge` TXT record there is asking them to
 write into a zone only we can write to, so under routing enforcement every
 platform-hosted tenant would simply go dark.
 
-A host under the configured platform suffix is therefore verified **by
-construction**, recorded as `method: "platform-owned"`. Unlike `grandfathered`
-this is **permanent**: no `graceUntil`, no staleness expiry, nothing for the
-tenant to complete.
+Such a host is therefore verified **by construction**, recorded as
+`method: "platform-owned"`. Unlike `grandfathered` this is **permanent**: no
+`graceUntil`, no staleness expiry, nothing for the tenant to complete.
+
+### Being in our zone is a precondition, not an entitlement
+
+The tempting shortcut — "it is under our suffix, therefore it is verified" — is a
+**cross-tenant hijack**. "This host is in our zone" says nothing about _which_
+tenant is entitled to it. An organizer can type any hostname into
+/admin/settings, so a read-time suffix inference lets them claim
+`some-other-tenant.konf.run`, or a label earmarked for a customer being onboarded
+next week, and be handed routing plus (once #688 ships) an OAuth redirect
+destination for it. Global uniqueness does not save that — it makes the claim
+_exclusive_, so the rightful tenant could then never be given the hostname at
+all.
+
+Entitlement is therefore an **allocation recorded at write time**:
+
+- The platform grants one host to one conference, and only through
+  `provisionOrganization` — the platform-operator wizard and the
+  bearer-authenticated provisioning API. That is the sole caller that passes
+  `allocatePlatformHosts`.
+- The `domainVerification` document records the grant (`method:
+"platform-owned"`, `conference` = the grantee).
+- Every read-time decision requires **both** the recorded allocation and a live
+  suffix re-check (`isPlatformAllocated`). Neither half is sufficient: a
+  mis-issued record for a host outside the zone grants nothing, and a host in the
+  zone with no allocation grants nothing.
+- Tenant-facing writes never allocate. `updateDomains` and `createEdition`
+  **reject** an unallocated in-zone hostname (`findUnallocatedPlatformDomains`)
+  before any write, and `ensureDomainVerification` creates no document for one,
+  so even a bypass of the mutation guard fails closed.
+- `revoked` is refused **before** the allocation check everywhere — routing, the
+  allowlist and the admin view — so releasing the claim really does undo the
+  grant.
 
 ### The suffix is configuration
 
@@ -67,18 +98,19 @@ tenant to complete.
 is white-labelable, so `konf.run` is a deployment fact, never a constant in the
 source.
 
-**Unset means _no_ host is platform-owned**, never "every host is". Every
+**Unset means _no_ host is in the platform zone**, never "every host is". Every
 rejection path (blank, a bare label such as `run`, a URL, a `:port`) resolves to
 `null` and the predicate fails closed on it.
 
 ### Matching rules
 
-Comparison is **label-wise**, never `endsWith` on a raw string:
+Comparison is **label-wise**, never `endsWith` on a raw string. "✅" here means
+only _allocatable_ — the allocation still has to exist:
 
 | Host                    | `konf.run` suffix | Why                                                                                      |
 | ----------------------- | ----------------- | ---------------------------------------------------------------------------------------- |
-| `kubeday.konf.run`      | ✅ owned          | exact trailing labels, one label deeper                                                  |
-| `a.b.konf.run`          | ✅ owned          | still inside the zone                                                                    |
+| `kubeday.konf.run`      | ✅ in zone        | exact trailing labels, one label deeper                                                  |
+| `a.b.konf.run`          | ✅ in zone        | still inside the zone                                                                    |
 | `evil-konf.run`         | ❌                | `endsWith` says yes; there is no label boundary                                          |
 | `konf.run.attacker.com` | ❌                | our zone as somebody else's _prefix_                                                     |
 | `a.konf.runner`         | ❌                | different TLD                                                                            |
@@ -86,27 +118,28 @@ Comparison is **label-wise**, never `endsWith` on a raw string:
 | `*.konf.run`            | ❌                | a wildcard over the whole zone would let its holder route every tenant subdomain         |
 | `tenant.konf.run:3000`  | ❌                | a port is a dev entry, not a zone                                                        |
 
-The verdict is re-derived **from the hostname** on every decision rather than
-read off the record's stored `method`, so re-pointing or unsetting the suffix
+The suffix half of the verdict is re-derived **live** on every decision rather
+than trusted from the record alone, so re-pointing or unsetting the suffix
 withdraws the standing immediately instead of leaving stale grants behind.
 
 ### What it affects
 
-- **Routing** — served unconditionally, including when the sidecar document is
-  missing entirely (`routing.ts` short-circuits before its fail-closed rule).
-  The host must still be claimed in this conference's `domains[]`.
+- **Routing** — served because the record carries the allocation. There is no
+  suffix short-circuit: a missing record still fails closed, exactly as for a
+  custom domain, and the host must be claimed in this conference's `domains[]`.
 - **Redirect allowlist** — eligible. The threat the allowlist guards is a
   _dangling_ destination: a third party's zone lapses and the host silently
   resolves to somebody else. That cannot happen inside a zone we operate, and
   refusing would mean nobody on the platform's default hosting could complete a
-  sign-in. What it grants is a redirect destination to whoever holds a
-  `<label>.<suffix>` claim — co-extensive with "we host that tenant there", so
-  the control is who may claim a platform subdomain, not a DNS proof they could
-  never produce. Wildcards and revoked claims stay excluded.
-- **The sweep** — never resolves these records. Doing so would hard-fail the
-  entire platform-hosted estate and alert every organizer about a record they
-  cannot publish. They are reconciled to `verified`/`platform-owned` instead and
-  counted separately (`platformOwned` in the summary).
+  sign-in. What it grants is a redirect destination to the conference the
+  platform **issued** that subdomain to — not to whoever typed it first.
+  Wildcards and revoked claims stay excluded.
+- **The sweep** — never resolves an allocated record. Doing so would hard-fail
+  the entire platform-hosted estate and alert every organizer about a record they
+  cannot publish. Allocated records are reconciled to `verified`/`platform-owned`
+  (clearing any stale `graceUntil`) and counted separately (`platformOwned` in
+  the summary). An **unallocated** in-zone claim is resolved like any other, hard
+  fails, and stays unrouted.
 - **Custom domains** — completely unaffected. They still require real DNS-TXT
   proof, whether or not a platform suffix is configured.
 
@@ -141,7 +174,8 @@ Two consumers, deliberately different tolerances (`src/lib/domain-verification/p
 | Stale success        | expires after 30 days            | keeps serving indefinitely                          |
 | Wildcard claims      | never eligible (exact host only) | eligible                                            |
 | Dev/loopback entries | never eligible                   | always eligible                                     |
-| Platform-owned hosts | always eligible (permanent)      | always eligible (permanent)                         |
+| Platform-ALLOCATED   | always eligible (permanent)      | always eligible (permanent)                         |
+| In-zone, unallocated | never eligible                   | never eligible (and refused at the claim)           |
 
 DNS failures are classified:
 
@@ -173,11 +207,11 @@ pnpm tsx scripts/backfill-domain-verification.ts --apply
 ```
 
 The backfill mints `method: "grandfathered"` records, honoured for 30 days and no
-longer — a time-boxed exemption, not an amnesty. Hosts under
-`PLATFORM_DOMAIN_SUFFIX` are exempt from that deadline: the hostname decides the
-method, so they are minted `platform-owned` no matter what the caller asks for. The admin card shows the
-deadline and the record to publish; the daily sweep starts reporting the missing
-TXT immediately.
+longer — a time-boxed exemption, not an amnesty. It does **not** allocate: a
+pre-existing claim under `PLATFORM_DOMAIN_SUFFIX` gets no record from it, and
+must be allocated deliberately (or removed). The admin card shows the deadline
+and the record to publish; the daily sweep starts reporting the missing TXT
+immediately.
 
 The redirect allowlist is **not** flag-gated. It is a new surface with no
 existing consumers, so it fails closed from day one.

--- a/docs/DOMAIN_VERIFICATION.md
+++ b/docs/DOMAIN_VERIFICATION.md
@@ -47,6 +47,69 @@ A `*.example.com` wildcard claim is proven on its **base zone** (`example.com`).
   defending against, is the attacker. A record in the tenant's own zone proves
   control of the **zone**, which is the thing that actually lapses.
 
+## Platform-owned hosts
+
+Tenants are hosted by default on a subdomain the platform **mints** for them
+(`<slug>.konf.run`). That zone's nameservers are delegated to our own edge and a
+wildcard certificate covers every label under it — the tenant has no access to it
+at all. Asking them for a `_konf-challenge` TXT record there is asking them to
+write into a zone only we can write to, so under routing enforcement every
+platform-hosted tenant would simply go dark.
+
+A host under the configured platform suffix is therefore verified **by
+construction**, recorded as `method: "platform-owned"`. Unlike `grandfathered`
+this is **permanent**: no `graceUntil`, no staleness expiry, nothing for the
+tenant to complete.
+
+### The suffix is configuration
+
+`PLATFORM_DOMAIN_SUFFIX` follows the `PLATFORM_ORG_SLUG` contract — the platform
+is white-labelable, so `konf.run` is a deployment fact, never a constant in the
+source.
+
+**Unset means _no_ host is platform-owned**, never "every host is". Every
+rejection path (blank, a bare label such as `run`, a URL, a `:port`) resolves to
+`null` and the predicate fails closed on it.
+
+### Matching rules
+
+Comparison is **label-wise**, never `endsWith` on a raw string:
+
+| Host                    | `konf.run` suffix | Why                                                                                      |
+| ----------------------- | ----------------- | ---------------------------------------------------------------------------------------- |
+| `kubeday.konf.run`      | ✅ owned          | exact trailing labels, one label deeper                                                  |
+| `a.b.konf.run`          | ✅ owned          | still inside the zone                                                                    |
+| `evil-konf.run`         | ❌                | `endsWith` says yes; there is no label boundary                                          |
+| `konf.run.attacker.com` | ❌                | our zone as somebody else's _prefix_                                                     |
+| `a.konf.runner`         | ❌                | different TLD                                                                            |
+| `konf.run` (apex)       | ❌                | the platform's own origin, not a minted subdomain — it can prove itself the ordinary way |
+| `*.konf.run`            | ❌                | a wildcard over the whole zone would let its holder route every tenant subdomain         |
+| `tenant.konf.run:3000`  | ❌                | a port is a dev entry, not a zone                                                        |
+
+The verdict is re-derived **from the hostname** on every decision rather than
+read off the record's stored `method`, so re-pointing or unsetting the suffix
+withdraws the standing immediately instead of leaving stale grants behind.
+
+### What it affects
+
+- **Routing** — served unconditionally, including when the sidecar document is
+  missing entirely (`routing.ts` short-circuits before its fail-closed rule).
+  The host must still be claimed in this conference's `domains[]`.
+- **Redirect allowlist** — eligible. The threat the allowlist guards is a
+  _dangling_ destination: a third party's zone lapses and the host silently
+  resolves to somebody else. That cannot happen inside a zone we operate, and
+  refusing would mean nobody on the platform's default hosting could complete a
+  sign-in. What it grants is a redirect destination to whoever holds a
+  `<label>.<suffix>` claim — co-extensive with "we host that tenant there", so
+  the control is who may claim a platform subdomain, not a DNS proof they could
+  never produce. Wildcards and revoked claims stay excluded.
+- **The sweep** — never resolves these records. Doing so would hard-fail the
+  entire platform-hosted estate and alert every organizer about a record they
+  cannot publish. They are reconciled to `verified`/`platform-owned` instead and
+  counted separately (`platformOwned` in the summary).
+- **Custom domains** — completely unaffected. They still require real DNS-TXT
+  proof, whether or not a platform suffix is configured.
+
 ## Data model
 
 A **sidecar document** (`sanity/schemaTypes/domainVerification.ts`), one per
@@ -78,6 +141,7 @@ Two consumers, deliberately different tolerances (`src/lib/domain-verification/p
 | Stale success        | expires after 30 days            | keeps serving indefinitely                          |
 | Wildcard claims      | never eligible (exact host only) | eligible                                            |
 | Dev/loopback entries | never eligible                   | always eligible                                     |
+| Platform-owned hosts | always eligible (permanent)      | always eligible (permanent)                         |
 
 DNS failures are classified:
 
@@ -109,7 +173,9 @@ pnpm tsx scripts/backfill-domain-verification.ts --apply
 ```
 
 The backfill mints `method: "grandfathered"` records, honoured for 30 days and no
-longer — a time-boxed exemption, not an amnesty. The admin card shows the
+longer — a time-boxed exemption, not an amnesty. Hosts under
+`PLATFORM_DOMAIN_SUFFIX` are exempt from that deadline: the hostname decides the
+method, so they are minted `platform-owned` no matter what the caller asks for. The admin card shows the
 deadline and the record to publish; the daily sweep starts reporting the missing
 TXT immediately.
 
@@ -121,6 +187,7 @@ existing consumers, so it fails closed from day one.
 | Path                                              | Role                                                        |
 | ------------------------------------------------- | ----------------------------------------------------------- |
 | `src/lib/domain-verification/challenge.ts`        | record names, tokens, host classification                   |
+| `src/lib/domain-verification/platform.ts`         | the `PLATFORM_DOMAIN_SUFFIX` contract + label-wise matcher  |
 | `src/lib/domain-verification/dns.ts`              | bounded, uncached TXT resolution + hard/soft classification |
 | `src/lib/domain-verification/policy.ts`           | the delisting policy (pure)                                 |
 | `src/lib/domain-verification/allowlist.ts`        | exact-host OAuth redirect allowlist (#688 consumes this)    |

--- a/sanity/schemaTypes/domainVerification.ts
+++ b/sanity/schemaTypes/domainVerification.ts
@@ -71,11 +71,12 @@ export default defineType({
       title: 'Method',
       type: 'string',
       description:
-        '`dns-txt` = proven by resolving the challenge record. `grandfathered` = pre-existing claim admitted at backfill time, trusted only until `graceUntil`.',
+        '`dns-txt` = proven by resolving the challenge record. `grandfathered` = pre-existing claim admitted at backfill time, trusted only until `graceUntil`. `platform-owned` = a subdomain of the platform’s own zone (PLATFORM_DOMAIN_SUFFIX), proven by construction and permanently — never a grace period.',
       options: {
         list: [
           { title: 'DNS TXT challenge', value: 'dns-txt' },
           { title: 'Grandfathered (backfilled)', value: 'grandfathered' },
+          { title: 'Platform-owned subdomain', value: 'platform-owned' },
         ],
         layout: 'radio',
       },

--- a/sanity/schemaTypes/domainVerification.ts
+++ b/sanity/schemaTypes/domainVerification.ts
@@ -71,12 +71,12 @@ export default defineType({
       title: 'Method',
       type: 'string',
       description:
-        '`dns-txt` = proven by resolving the challenge record. `grandfathered` = pre-existing claim admitted at backfill time, trusted only until `graceUntil`. `platform-owned` = a subdomain of the platform’s own zone (PLATFORM_DOMAIN_SUFFIX), proven by construction and permanently — never a grace period.',
+        '`dns-txt` = proven by resolving the challenge record. `grandfathered` = pre-existing claim admitted at backfill time, trusted only until `graceUntil`. `platform-owned` = a subdomain of the platform’s own zone (PLATFORM_DOMAIN_SUFFIX) that the platform ALLOCATED to this conference — proven by construction and permanently, never a grace period. Only tenant provisioning writes that value; editing it here grants routing and an OAuth redirect destination.',
       options: {
         list: [
           { title: 'DNS TXT challenge', value: 'dns-txt' },
           { title: 'Grandfathered (backfilled)', value: 'grandfathered' },
-          { title: 'Platform-owned subdomain', value: 'platform-owned' },
+          { title: 'Platform-allocated subdomain', value: 'platform-owned' },
         ],
         layout: 'radio',
       },

--- a/scripts/backfill-domain-verification.ts
+++ b/scripts/backfill-domain-verification.ts
@@ -17,6 +17,12 @@
  * Publishing the real TXT record (shown on /admin/settings) converts the record
  * to `dns-txt` on the next check and the exemption disappears for good.
  *
+ * Hosts under `PLATFORM_DOMAIN_SUFFIX` are the exception: `ensureDomainVerification`
+ * decides the method from the HOSTNAME, so a `<slug>.konf.run` entry is minted
+ * `platform-owned` (permanent, no deadline) rather than grandfathered. Giving it
+ * a 30-day deadline would be pointless — the challenge lives in a zone only the
+ * platform can write to.
+ *
  * Re-running is safe: hostnames that already have a record are left untouched.
  *
  * Usage:

--- a/scripts/backfill-domain-verification.ts
+++ b/scripts/backfill-domain-verification.ts
@@ -17,11 +17,13 @@
  * Publishing the real TXT record (shown on /admin/settings) converts the record
  * to `dns-txt` on the next check and the exemption disappears for good.
  *
- * Hosts under `PLATFORM_DOMAIN_SUFFIX` are the exception: `ensureDomainVerification`
- * decides the method from the HOSTNAME, so a `<slug>.konf.run` entry is minted
- * `platform-owned` (permanent, no deadline) rather than grandfathered. Giving it
- * a 30-day deadline would be pointless — the challenge lives in a zone only the
- * platform can write to.
+ * It does NOT allocate platform subdomains. A pre-existing claim under
+ * `PLATFORM_DOMAIN_SUFFIX` gets no record at all (`ensureDomainVerification`
+ * refuses to write one without an explicit allocation), because a backfill
+ * cannot know whether the platform ever issued that label to that conference —
+ * and grandfathering it would hand it a 30-day deadline it could never satisfy
+ * anyway, the challenge living in a zone only the platform can write to. Such
+ * hosts must be allocated deliberately, or removed from `domains[]`.
  *
  * Re-running is safe: hostnames that already have a record are left untouched.
  *

--- a/src/app/api/cron/domain-verification/route.ts
+++ b/src/app/api/cron/domain-verification/route.ts
@@ -33,6 +33,7 @@ export async function GET(request: NextRequest) {
     console.log(
       `Domain verification sweep: checked=${summary.checked}` +
         ` verified=${summary.verified}` +
+        ` platformOwned=${summary.platformOwned}` +
         ` hardFailures=${summary.hardFailures}` +
         ` softFailures=${summary.softFailures}` +
         ` unverifiable=${summary.unverifiable}` +

--- a/src/app/api/provisioning/organizations/route.test.ts
+++ b/src/app/api/provisioning/organizations/route.test.ts
@@ -212,6 +212,9 @@ vi.mock('@/lib/domain-verification', () => ({
     hostname,
     status: 'pending',
   }),
+  findUnallocatedPlatformDomains: async (): Promise<string[]> => [],
+  PLATFORM_DOMAIN_NOT_ALLOCATED:
+    'That hostname belongs to the platform and has not been allocated to this conference',
 }))
 
 import { POST } from './route'
@@ -481,9 +484,15 @@ describe('provisioning API — a correct token creates exactly one tenant', () =
       domains: ['oslo.cloudnativedays.no'],
     })
     expect(speakers[0]).toMatchObject({ email: 'kari@cno.no' })
-    expect(syncDomainVerificationsMock).toHaveBeenCalledWith(confs[0]._id, [
-      'oslo.cloudnativedays.no',
-    ])
+    // The bearer-authenticated provisioning path IS the platform's allocation
+    // authority, so it is the one caller allowed to grant a subdomain of the
+    // platform's own zone (#683).
+    expect(syncDomainVerificationsMock).toHaveBeenCalledWith(
+      confs[0]._id,
+      ['oslo.cloudnativedays.no'],
+      [],
+      { allocatePlatformHosts: true },
+    )
   })
 
   it('still reports the committed ids when the POST-COMMIT domain reads fail', async () => {

--- a/src/components/admin/DomainVerificationCard.stories.tsx
+++ b/src/components/admin/DomainVerificationCard.stories.tsx
@@ -118,8 +118,10 @@ export const Grandfathered: Story = {
 }
 
 /**
- * A subdomain the platform minted in its own zone: verified by construction,
- * no TXT record, no deadline and no "check now" — there is nothing to check.
+ * A subdomain the platform ALLOCATED to this conference: verified by
+ * construction, no TXT record, no deadline and no "check now" — there is nothing
+ * to check. (An in-zone host with no allocation never reaches this state; the
+ * mutation refuses the claim outright.)
  */
 export const PlatformOwned: Story = {
   args: {

--- a/src/components/admin/DomainVerificationCard.stories.tsx
+++ b/src/components/admin/DomainVerificationCard.stories.tsx
@@ -20,6 +20,7 @@ function view(
     hostname,
     status: 'verified',
     grandfathered: false,
+    platformOwned: false,
     graceUntil: null,
     // Derived exactly as `challengeRecordName` does, so the fixture cannot
     // drift from what the router actually hands the card.
@@ -116,6 +117,23 @@ export const Grandfathered: Story = {
   },
 }
 
+/**
+ * A subdomain the platform minted in its own zone: verified by construction,
+ * no TXT record, no deadline and no "check now" — there is nothing to check.
+ */
+export const PlatformOwned: Story = {
+  args: {
+    initialDomains: [
+      view({
+        hostname: 'kubeday.konf.run',
+        platformOwned: true,
+        recordName: null,
+        recordValue: null,
+      }),
+    ],
+  },
+}
+
 /** Every state at once, plus the wildcard and local-dev special cases. */
 export const AllStates: Story = {
   args: {
@@ -138,6 +156,12 @@ export const AllStates: Story = {
         hostname: 'cloudnativedays.no',
         grandfathered: true,
         graceUntil: '2026-08-27T00:00:00.000Z',
+      }),
+      view({
+        hostname: 'kubeday.konf.run',
+        platformOwned: true,
+        recordName: null,
+        recordValue: null,
       }),
       view({
         hostname: '*.cloudnativedays.no',

--- a/src/components/admin/DomainVerificationCard.tsx
+++ b/src/components/admin/DomainVerificationCard.tsx
@@ -59,6 +59,10 @@ function statusLabel(domain: DomainVerificationView): {
 } {
   if (domain.devOnly)
     return { tone: 'gray', label: 'Local dev — not verifiable' }
+  // Before `status`: a platform subdomain is verified by construction and there
+  // is nothing for the organizer to do, so it must never read "Awaiting DNS".
+  if (domain.platformOwned)
+    return { tone: 'green', label: 'Provided by the platform' }
   if (domain.grandfathered) return { tone: 'amber', label: 'Grandfathered' }
   switch (domain.status) {
     case 'verified':
@@ -217,6 +221,14 @@ export function DomainVerificationCard({
               )}
             </p>
 
+            {domain.platformOwned && (
+              <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                This subdomain&apos;s DNS is managed by the platform, so
+                ownership needs no proof and nothing expires. Claim your own
+                domain as well if you would rather use one.
+              </p>
+            )}
+
             {domain.grandfathered && graceDay && (
               <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
                 Admitted without proof when verification shipped. Publish the
@@ -242,7 +254,7 @@ export function DomainVerificationCard({
             )}
 
             <div className="mt-3 flex flex-wrap items-center gap-3">
-              {!domain.devOnly && (
+              {!domain.devOnly && !domain.platformOwned && (
                 <AdminButton
                   size="xs"
                   variant="secondary"

--- a/src/components/admin/DomainVerificationCard.tsx
+++ b/src/components/admin/DomainVerificationCard.tsx
@@ -59,8 +59,9 @@ function statusLabel(domain: DomainVerificationView): {
 } {
   if (domain.devOnly)
     return { tone: 'gray', label: 'Local dev — not verifiable' }
-  // Before `status`: a platform subdomain is verified by construction and there
-  // is nothing for the organizer to do, so it must never read "Awaiting DNS".
+  // Before `status`: a subdomain the platform allocated is verified by
+  // construction and there is nothing for the organizer to do, so it must never
+  // read "Awaiting DNS".
   if (domain.platformOwned)
     return { tone: 'green', label: 'Provided by the platform' }
   if (domain.grandfathered) return { tone: 'amber', label: 'Grandfathered' }

--- a/src/lib/domain-verification/allowlist.test.ts
+++ b/src/lib/domain-verification/allowlist.test.ts
@@ -135,9 +135,9 @@ describe('isVerifiedRedirectOrigin', () => {
     )
   })
 
-  describe('platform-owned subdomains', () => {
-    /** Claimed, never proven — standing can only come from the platform rule. */
-    const unproven = (hostname: string) =>
+  describe('platform-allocated subdomains', () => {
+    /** Claimed, never proven — standing can only come from the allocation. */
+    const inZoneOnly = (hostname: string) =>
       record({
         hostname,
         status: 'pending' as const,
@@ -147,24 +147,46 @@ describe('isVerifiedRedirectOrigin', () => {
         lastCheckedAt: null,
       })
 
+    /** The same claim with the platform's allocation recorded on it. */
+    const allocated = (hostname: string) => ({
+      ...inZoneOnly(hostname),
+      status: 'verified' as const,
+      method: 'platform-owned' as const,
+    })
+
     beforeEach(() => {
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
     })
 
-    it('accepts a subdomain of the platform zone with no DNS proof', async () => {
+    it('accepts a subdomain the platform ALLOCATED, with no DNS proof', async () => {
       // A tenant on the platform's own subdomain has to be able to finish a
       // sign-in round-trip; the zone is ours, so there is no dangling
       // destination to defend against.
-      listAllowlistCandidates.mockResolvedValue([unproven('kubeday.konf.run')])
+      listAllowlistCandidates.mockResolvedValue([allocated('kubeday.konf.run')])
       expect(
         await isVerifiedRedirectOrigin('https://kubeday.konf.run', NOW),
       ).toBe(true)
     })
 
+    it('REFUSES an UNALLOCATED host that merely sits in the platform zone', async () => {
+      // The hijack, at the redirect allowlist — the more dangerous half: an
+      // organizer's grab for another tenant's label must not become a place we
+      // will deliver an authorization code.
+      listAllowlistCandidates.mockResolvedValue([
+        inZoneOnly('some-other-tenant.konf.run'),
+      ])
+      expect(
+        await isVerifiedRedirectOrigin(
+          'https://some-other-tenant.konf.run',
+          NOW,
+        ),
+      ).toBe(false)
+    })
+
     it('REFUSES a label-boundary near-miss of the platform zone', async () => {
       listAllowlistCandidates.mockResolvedValue([
-        unproven('evil-konf.run'),
-        unproven('konf.run.attacker.com'),
+        allocated('evil-konf.run'),
+        allocated('konf.run.attacker.com'),
       ])
       expect(await isVerifiedRedirectOrigin('https://evil-konf.run', NOW)).toBe(
         false,
@@ -176,16 +198,16 @@ describe('isVerifiedRedirectOrigin', () => {
 
     it('REFUSES an unproven CUSTOM domain while the platform rule is on', async () => {
       listAllowlistCandidates.mockResolvedValue([
-        unproven('cloudnativedays.no'),
+        inZoneOnly('cloudnativedays.no'),
       ])
       expect(
         await isVerifiedRedirectOrigin('https://cloudnativedays.no', NOW),
       ).toBe(false)
     })
 
-    it('REFUSES a released (revoked) platform subdomain', async () => {
+    it('REFUSES a released (revoked) allocated subdomain', async () => {
       listAllowlistCandidates.mockResolvedValue([
-        { ...unproven('kubeday.konf.run'), status: 'revoked' as const },
+        { ...allocated('kubeday.konf.run'), status: 'revoked' as const },
       ])
       expect(
         await isVerifiedRedirectOrigin('https://kubeday.konf.run', NOW),
@@ -194,7 +216,9 @@ describe('isVerifiedRedirectOrigin', () => {
 
     it('FAILS CLOSED for the same host when the suffix is unset', async () => {
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
-      listAllowlistCandidates.mockResolvedValue([unproven('kubeday.konf.run')])
+      listAllowlistCandidates.mockResolvedValue([
+        { ...allocated('kubeday.konf.run'), status: 'pending' as const },
+      ])
       expect(
         await isVerifiedRedirectOrigin('https://kubeday.konf.run', NOW),
       ).toBe(false)

--- a/src/lib/domain-verification/allowlist.test.ts
+++ b/src/lib/domain-verification/allowlist.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { DomainVerificationRecord } from './types'
 
 const listAllowlistCandidates =
@@ -36,6 +36,10 @@ function record(
 
 beforeEach(() => {
   listAllowlistCandidates.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
 })
 
 describe('isVerifiedRedirectOrigin', () => {
@@ -129,5 +133,71 @@ describe('isVerifiedRedirectOrigin', () => {
     expect(await isVerifiedRedirectOrigin('https://example.com', NOW)).toBe(
       false,
     )
+  })
+
+  describe('platform-owned subdomains', () => {
+    /** Claimed, never proven — standing can only come from the platform rule. */
+    const unproven = (hostname: string) =>
+      record({
+        hostname,
+        status: 'pending' as const,
+        method: 'dns-txt' as const,
+        verifiedAt: null,
+        lastSuccessAt: null,
+        lastCheckedAt: null,
+      })
+
+    beforeEach(() => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    })
+
+    it('accepts a subdomain of the platform zone with no DNS proof', async () => {
+      // A tenant on the platform's own subdomain has to be able to finish a
+      // sign-in round-trip; the zone is ours, so there is no dangling
+      // destination to defend against.
+      listAllowlistCandidates.mockResolvedValue([unproven('kubeday.konf.run')])
+      expect(
+        await isVerifiedRedirectOrigin('https://kubeday.konf.run', NOW),
+      ).toBe(true)
+    })
+
+    it('REFUSES a label-boundary near-miss of the platform zone', async () => {
+      listAllowlistCandidates.mockResolvedValue([
+        unproven('evil-konf.run'),
+        unproven('konf.run.attacker.com'),
+      ])
+      expect(await isVerifiedRedirectOrigin('https://evil-konf.run', NOW)).toBe(
+        false,
+      )
+      expect(
+        await isVerifiedRedirectOrigin('https://konf.run.attacker.com', NOW),
+      ).toBe(false)
+    })
+
+    it('REFUSES an unproven CUSTOM domain while the platform rule is on', async () => {
+      listAllowlistCandidates.mockResolvedValue([
+        unproven('cloudnativedays.no'),
+      ])
+      expect(
+        await isVerifiedRedirectOrigin('https://cloudnativedays.no', NOW),
+      ).toBe(false)
+    })
+
+    it('REFUSES a released (revoked) platform subdomain', async () => {
+      listAllowlistCandidates.mockResolvedValue([
+        { ...unproven('kubeday.konf.run'), status: 'revoked' as const },
+      ])
+      expect(
+        await isVerifiedRedirectOrigin('https://kubeday.konf.run', NOW),
+      ).toBe(false)
+    })
+
+    it('FAILS CLOSED for the same host when the suffix is unset', async () => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
+      listAllowlistCandidates.mockResolvedValue([unproven('kubeday.konf.run')])
+      expect(
+        await isVerifiedRedirectOrigin('https://kubeday.konf.run', NOW),
+      ).toBe(false)
+    })
   })
 })

--- a/src/lib/domain-verification/index.ts
+++ b/src/lib/domain-verification/index.ts
@@ -25,7 +25,12 @@ export {
   getDomainVerification,
   listDomainVerificationsForConference,
 } from './sanity'
-export { listDomainVerificationViews, syncDomainVerifications } from './sync'
+export { PLATFORM_DOMAIN_NOT_ALLOCATED } from './platform'
+export {
+  findUnallocatedPlatformDomains,
+  listDomainVerificationViews,
+  syncDomainVerifications,
+} from './sync'
 export { recheckDomainRecord, runDomainVerificationSweep } from './sweep'
 export { toDomainVerificationView } from './view'
 export type { DomainVerificationView } from './view'

--- a/src/lib/domain-verification/platform.test.ts
+++ b/src/lib/domain-verification/platform.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { isPlatformOwnedHost, platformDomainSuffix } from './platform'
+
+/**
+ * The suffix matcher is the whole security surface of platform-owned
+ * verification: everything downstream (routing, the redirect allowlist, the
+ * sweep) is a one-line delegation to `isPlatformOwnedHost`. If this file is
+ * wrong, a permanent unprovable grant leaks to a host we do not control.
+ */
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function withSuffix(value: string | undefined) {
+  if (value === undefined) vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
+  else vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', value)
+}
+
+describe('platformDomainSuffix', () => {
+  it('reads the configured zone', () => {
+    withSuffix('konf.run')
+    expect(platformDomainSuffix()).toBe('konf.run')
+  })
+
+  it('normalizes case, whitespace and the `.`/`*.` shorthands', () => {
+    for (const raw of ['  KONF.run ', '.konf.run', '*.konf.run']) {
+      withSuffix(raw)
+      expect(platformDomainSuffix()).toBe('konf.run')
+    }
+  })
+
+  it('is null when UNSET or blank — no host is platform-owned by default', () => {
+    withSuffix(undefined)
+    expect(platformDomainSuffix()).toBeNull()
+    withSuffix('')
+    expect(platformDomainSuffix()).toBeNull()
+    withSuffix('   ')
+    expect(platformDomainSuffix()).toBeNull()
+  })
+
+  it('REFUSES a single bare label — `run` would own every .run domain', () => {
+    withSuffix('run')
+    expect(platformDomainSuffix()).toBeNull()
+  })
+
+  it('REFUSES anything that is not a plain zone', () => {
+    for (const raw of [
+      'https://konf.run',
+      'konf.run/path',
+      'konf.run:3000',
+      'konf run',
+      '*',
+      '.',
+    ]) {
+      withSuffix(raw)
+      expect(platformDomainSuffix()).toBeNull()
+    }
+  })
+})
+
+describe('isPlatformOwnedHost', () => {
+  it('accepts a subdomain we minted', () => {
+    withSuffix('konf.run')
+    expect(isPlatformOwnedHost('kubeday.konf.run')).toBe(true)
+    expect(isPlatformOwnedHost('KubeDay.Konf.Run')).toBe(true)
+    // Deeper labels are still inside our zone (wildcard cert covers one label,
+    // but ownership of the zone is what this predicate is about).
+    expect(isPlatformOwnedHost('a.b.konf.run')).toBe(true)
+  })
+
+  it('FAILS CLOSED when the suffix is unset — not "everything matches"', () => {
+    withSuffix(undefined)
+    expect(isPlatformOwnedHost('kubeday.konf.run')).toBe(false)
+    expect(isPlatformOwnedHost('anything.example.com')).toBe(false)
+    expect(isPlatformOwnedHost('')).toBe(false)
+  })
+
+  it('REFUSES a label-boundary near-miss (`evil-konf.run`)', () => {
+    // The `endsWith` bug: `'evil-konf.run'.endsWith('konf.run')` is TRUE.
+    withSuffix('konf.run')
+    expect(isPlatformOwnedHost('evil-konf.run')).toBe(false)
+    expect(isPlatformOwnedHost('sub.evil-konf.run')).toBe(false)
+    expect(isPlatformOwnedHost('xkonf.run')).toBe(false)
+  })
+
+  it('REFUSES our zone used as a PREFIX of someone else’s (`konf.run.attacker.com`)', () => {
+    withSuffix('konf.run')
+    expect(isPlatformOwnedHost('konf.run.attacker.com')).toBe(false)
+    expect(isPlatformOwnedHost('attacker.com')).toBe(false)
+  })
+
+  it('REFUSES a different TLD with the same second level (`konf.runner`)', () => {
+    withSuffix('konf.run')
+    expect(isPlatformOwnedHost('a.konf.runner')).toBe(false)
+    expect(isPlatformOwnedHost('a.konf.ru')).toBe(false)
+  })
+
+  it('REFUSES the suffix APEX itself', () => {
+    // `konf.run` is the platform's own origin, not a subdomain minted for a
+    // tenant. It can prove itself the normal way if it ever needs to route.
+    withSuffix('konf.run')
+    expect(isPlatformOwnedHost('konf.run')).toBe(false)
+  })
+
+  it('REFUSES a WILDCARD claim over the platform zone', () => {
+    // `*.konf.run` covers every tenant at once — auto-verifying it would let its
+    // holder route every host in the zone.
+    withSuffix('konf.run')
+    expect(isPlatformOwnedHost('*.konf.run')).toBe(false)
+    expect(isPlatformOwnedHost('*.tenant.konf.run')).toBe(false)
+  })
+
+  it('REFUSES entries carrying a port or a trailing dot', () => {
+    withSuffix('konf.run')
+    expect(isPlatformOwnedHost('tenant.konf.run:3000')).toBe(false)
+    expect(isPlatformOwnedHost('tenant.konf.run.')).toBe(false)
+  })
+
+  it('follows the suffix when the platform is white-labelled', () => {
+    withSuffix('events.example.org')
+    expect(isPlatformOwnedHost('kubeday.events.example.org')).toBe(true)
+    expect(isPlatformOwnedHost('kubeday.konf.run')).toBe(false)
+  })
+})

--- a/src/lib/domain-verification/platform.test.ts
+++ b/src/lib/domain-verification/platform.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { isPlatformOwnedHost, platformDomainSuffix } from './platform'
+import { isPlatformZoneHost, platformDomainSuffix } from './platform'
 
 /**
  * The suffix matcher is the whole security surface of platform-owned
  * verification: everything downstream (routing, the redirect allowlist, the
- * sweep) is a one-line delegation to `isPlatformOwnedHost`. If this file is
+ * sweep) is a one-line delegation to `isPlatformZoneHost`. If this file is
  * wrong, a permanent unprovable grant leaks to a host we do not control.
  */
 
@@ -59,67 +59,67 @@ describe('platformDomainSuffix', () => {
   })
 })
 
-describe('isPlatformOwnedHost', () => {
+describe('isPlatformZoneHost', () => {
   it('accepts a subdomain we minted', () => {
     withSuffix('konf.run')
-    expect(isPlatformOwnedHost('kubeday.konf.run')).toBe(true)
-    expect(isPlatformOwnedHost('KubeDay.Konf.Run')).toBe(true)
+    expect(isPlatformZoneHost('kubeday.konf.run')).toBe(true)
+    expect(isPlatformZoneHost('KubeDay.Konf.Run')).toBe(true)
     // Deeper labels are still inside our zone (wildcard cert covers one label,
     // but ownership of the zone is what this predicate is about).
-    expect(isPlatformOwnedHost('a.b.konf.run')).toBe(true)
+    expect(isPlatformZoneHost('a.b.konf.run')).toBe(true)
   })
 
   it('FAILS CLOSED when the suffix is unset — not "everything matches"', () => {
     withSuffix(undefined)
-    expect(isPlatformOwnedHost('kubeday.konf.run')).toBe(false)
-    expect(isPlatformOwnedHost('anything.example.com')).toBe(false)
-    expect(isPlatformOwnedHost('')).toBe(false)
+    expect(isPlatformZoneHost('kubeday.konf.run')).toBe(false)
+    expect(isPlatformZoneHost('anything.example.com')).toBe(false)
+    expect(isPlatformZoneHost('')).toBe(false)
   })
 
   it('REFUSES a label-boundary near-miss (`evil-konf.run`)', () => {
     // The `endsWith` bug: `'evil-konf.run'.endsWith('konf.run')` is TRUE.
     withSuffix('konf.run')
-    expect(isPlatformOwnedHost('evil-konf.run')).toBe(false)
-    expect(isPlatformOwnedHost('sub.evil-konf.run')).toBe(false)
-    expect(isPlatformOwnedHost('xkonf.run')).toBe(false)
+    expect(isPlatformZoneHost('evil-konf.run')).toBe(false)
+    expect(isPlatformZoneHost('sub.evil-konf.run')).toBe(false)
+    expect(isPlatformZoneHost('xkonf.run')).toBe(false)
   })
 
   it('REFUSES our zone used as a PREFIX of someone else’s (`konf.run.attacker.com`)', () => {
     withSuffix('konf.run')
-    expect(isPlatformOwnedHost('konf.run.attacker.com')).toBe(false)
-    expect(isPlatformOwnedHost('attacker.com')).toBe(false)
+    expect(isPlatformZoneHost('konf.run.attacker.com')).toBe(false)
+    expect(isPlatformZoneHost('attacker.com')).toBe(false)
   })
 
   it('REFUSES a different TLD with the same second level (`konf.runner`)', () => {
     withSuffix('konf.run')
-    expect(isPlatformOwnedHost('a.konf.runner')).toBe(false)
-    expect(isPlatformOwnedHost('a.konf.ru')).toBe(false)
+    expect(isPlatformZoneHost('a.konf.runner')).toBe(false)
+    expect(isPlatformZoneHost('a.konf.ru')).toBe(false)
   })
 
   it('REFUSES the suffix APEX itself', () => {
     // `konf.run` is the platform's own origin, not a subdomain minted for a
     // tenant. It can prove itself the normal way if it ever needs to route.
     withSuffix('konf.run')
-    expect(isPlatformOwnedHost('konf.run')).toBe(false)
+    expect(isPlatformZoneHost('konf.run')).toBe(false)
   })
 
   it('REFUSES a WILDCARD claim over the platform zone', () => {
     // `*.konf.run` covers every tenant at once — auto-verifying it would let its
     // holder route every host in the zone.
     withSuffix('konf.run')
-    expect(isPlatformOwnedHost('*.konf.run')).toBe(false)
-    expect(isPlatformOwnedHost('*.tenant.konf.run')).toBe(false)
+    expect(isPlatformZoneHost('*.konf.run')).toBe(false)
+    expect(isPlatformZoneHost('*.tenant.konf.run')).toBe(false)
   })
 
   it('REFUSES entries carrying a port or a trailing dot', () => {
     withSuffix('konf.run')
-    expect(isPlatformOwnedHost('tenant.konf.run:3000')).toBe(false)
-    expect(isPlatformOwnedHost('tenant.konf.run.')).toBe(false)
+    expect(isPlatformZoneHost('tenant.konf.run:3000')).toBe(false)
+    expect(isPlatformZoneHost('tenant.konf.run.')).toBe(false)
   })
 
   it('follows the suffix when the platform is white-labelled', () => {
     withSuffix('events.example.org')
-    expect(isPlatformOwnedHost('kubeday.events.example.org')).toBe(true)
-    expect(isPlatformOwnedHost('kubeday.konf.run')).toBe(false)
+    expect(isPlatformZoneHost('kubeday.events.example.org')).toBe(true)
+    expect(isPlatformZoneHost('kubeday.konf.run')).toBe(false)
   })
 })

--- a/src/lib/domain-verification/platform.ts
+++ b/src/lib/domain-verification/platform.ts
@@ -1,5 +1,6 @@
 /**
- * PLATFORM-OWNED HOSTS — the zone the platform itself operates.
+ * PLATFORM-ALLOCATED HOSTS — subdomains of the zone the platform itself
+ * operates, granted to a specific tenant.
  *
  * Konf hosts tenants on subdomains it MINTS (`<slug>.konf.run`): that zone's
  * nameservers are delegated to our own edge, a wildcard certificate covers every
@@ -9,12 +10,39 @@
  * under `DOMAIN_VERIFICATION_ENFORCE_ROUTING` every platform-hosted tenant would
  * simply go dark.
  *
- * A host under the platform suffix is therefore verified BY CONSTRUCTION, and
- * `method: "platform-owned"` records that fact. Unlike `grandfathered` — a
- * deliberately time-boxed 30-day exemption for claims that predate the feature —
- * this is PERMANENT and carries no `graceUntil`: there is no future date on
- * which we stop controlling our own zone, and nothing the tenant could ever do
- * to "complete" the proof.
+ * ## Being in our zone is a PRECONDITION, never an entitlement
+ *
+ * The tempting shortcut — "it is under our suffix, therefore it is verified" —
+ * is a cross-tenant hijack. "This host is in our zone" says nothing about
+ * WHICH tenant is entitled to it. An organizer can type any hostname into
+ * /admin/settings, so a read-time suffix inference would let them claim
+ * `some-other-tenant.<suffix>`, or a label earmarked for a customer being
+ * onboarded next week, and be handed routing plus (once #688 ships) an OAuth
+ * redirect destination for it. Global uniqueness does not save that: it makes
+ * the claim EXCLUSIVE, so the rightful tenant could then never be given the
+ * hostname at all.
+ *
+ * So entitlement is an ALLOCATION RECORDED AT WRITE TIME, not an inference at
+ * read time. The platform grants one host to one conference — only through
+ * `provisionOrganization`, the platform-operator/bearer-authenticated tenant
+ * creation path — and the `domainVerification` document records it
+ * (`method: "platform-owned"`, `conference` = the grantee). Two things must
+ * therefore hold before a host gets this standing, and
+ * {@link isPlatformAllocated} requires BOTH:
+ *
+ *  1. the record says the platform allocated it, and
+ *  2. the hostname is still inside the configured platform zone
+ *     ({@link isPlatformZoneHost}) — so re-pointing or unsetting the suffix
+ *     withdraws the standing instead of leaving stale grants behind.
+ *
+ * Tenant-facing writes (`updateDomains`, `createEdition`, the admin card's
+ * self-heal) may never allocate: they REJECT an unallocated host in our zone
+ * rather than silently verifying it.
+ *
+ * Once allocated the standing is PERMANENT — no `graceUntil`, unlike the
+ * deliberately time-boxed `grandfathered` exemption — because there is no future
+ * date on which we stop controlling our own zone and nothing the tenant could
+ * ever do to "complete" the proof. Revocation, not expiry, is how it ends.
  *
  * ## The suffix is CONFIGURATION
  *
@@ -22,11 +50,10 @@
  * (`src/lib/features/platform.ts`): the platform is white-labelable, so
  * `konf.run` is a deployment fact, never a constant in the source.
  *
- * UNSET MEANS "NO HOST IS PLATFORM-OWNED", never "every host is". This is the
- * one inversion that would be catastrophic — an empty suffix matching every
- * hostname would hand a permanent, unprovable routing AND redirect-allowlist
- * grant to every claim on the platform — so every rejection path below returns
- * `null` and {@link isPlatformOwnedHost} fails CLOSED on it.
+ * UNSET MEANS "NO HOST IS IN THE PLATFORM ZONE", never "every host is". That
+ * inversion would be catastrophic — an empty suffix matching every hostname
+ * would make every claim on the platform allocatable — so every rejection path
+ * below returns `null` and {@link isPlatformZoneHost} fails CLOSED on it.
  *
  * ## Matching is LABEL-WISE, never `endsWith`
  *
@@ -39,6 +66,15 @@
  */
 
 import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
+import type { DomainVerificationRecord } from './types'
+
+/**
+ * BAD_REQUEST prefix for a claim on a host in the platform's zone that the
+ * platform never allocated to the claiming conference. Exported so the
+ * mutations that reject it and the tests that assert on the refusal agree.
+ */
+export const PLATFORM_DOMAIN_NOT_ALLOCATED =
+  'That hostname belongs to the platform and has not been allocated to this conference'
 
 /**
  * The configured platform zone (e.g. `konf.run`), or `null` when the contract is
@@ -82,22 +118,27 @@ function isSubdomainOfSuffix(host: string, suffix: string): boolean {
 }
 
 /**
- * Is this `domains[]` entry a host the PLATFORM owns and therefore proves by
- * construction?
+ * Is this `domains[]` entry a host inside the platform's OWN zone — i.e. one the
+ * platform is ABLE to allocate?
+ *
+ * ⚠️ This is a PRECONDITION, not an entitlement. It answers "could the platform
+ * grant this?", never "is this tenant entitled to it?" — use
+ * {@link isPlatformAllocated} for the latter. Treating this predicate as a
+ * verification verdict is the cross-tenant hijack described at the top of this
+ * file.
  *
  * Deliberately strict on three counts:
  *
- * - **Fails closed on an unset suffix.** No configuration, no platform hosts.
+ * - **Fails closed on an unset suffix.** No configuration, no platform zone.
  * - **The apex is NOT included.** `konf.run` itself is the platform's own
- *   origin, not a subdomain we minted for a tenant; if it ever has to route to a
+ *   origin, not a subdomain we mint for a tenant; if it ever has to route to a
  *   conference it goes through the normal DNS-TXT path, which the platform (the
  *   only party that can write to that zone) can satisfy trivially.
- * - **Wildcard claims are NEVER platform-owned.** `*.konf.run` covers every
- *   tenant subdomain at once, so auto-verifying it would let the first
- *   conference to claim it route every host in the zone it does not otherwise
- *   own. A wildcard over the platform zone must be proven like anything else.
+ * - **Wildcard claims are NEVER in scope.** `*.konf.run` covers every tenant
+ *   subdomain at once, so allocating it would hand its holder every host in the
+ *   zone. A wildcard over the platform zone must be proven like anything else.
  */
-export function isPlatformOwnedHost(
+export function isPlatformZoneHost(
   entry: string,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -106,4 +147,32 @@ export function isPlatformOwnedHost(
   const host = normalizeDomain(entry)
   if (!host || host.startsWith('*.')) return false
   return isSubdomainOfSuffix(host, suffix)
+}
+
+/**
+ * Has the platform ALLOCATED this record's hostname to this record's
+ * conference? This is the entitlement check the policy, the sweep and the admin
+ * view all key off.
+ *
+ * Requires BOTH halves, and neither is sufficient alone:
+ *
+ * - `method === 'platform-owned'` — written only by the platform's own tenant
+ *   provisioning path (`ensureDomainVerification`'s `allocatePlatformHost`).
+ *   Without it, any organizer who can type a hostname could mint the standing.
+ * - {@link isPlatformZoneHost} — re-checked live, so a record that says
+ *   `platform-owned` for a hostname no longer under the configured suffix (a
+ *   white-label rebrand, a mistaken allocation, a suffix that has been unset)
+ *   loses the standing on the next call rather than keeping it forever.
+ *
+ * Status is deliberately NOT considered here — `revoked` is handled by the
+ * policy, which refuses it before this is ever consulted.
+ */
+export function isPlatformAllocated(
+  record: DomainVerificationRecord,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    record.method === 'platform-owned' &&
+    isPlatformZoneHost(record.hostname, env)
+  )
 }

--- a/src/lib/domain-verification/platform.ts
+++ b/src/lib/domain-verification/platform.ts
@@ -1,0 +1,109 @@
+/**
+ * PLATFORM-OWNED HOSTS — the zone the platform itself operates.
+ *
+ * Konf hosts tenants on subdomains it MINTS (`<slug>.konf.run`): that zone's
+ * nameservers are delegated to our own edge, a wildcard certificate covers every
+ * label under it, and no tenant has any access to it whatsoever. Asking such a
+ * tenant to publish a `_konf-challenge` TXT record is asking them to write into
+ * a zone only we can write to — the proof is unobtainable by construction, so
+ * under `DOMAIN_VERIFICATION_ENFORCE_ROUTING` every platform-hosted tenant would
+ * simply go dark.
+ *
+ * A host under the platform suffix is therefore verified BY CONSTRUCTION, and
+ * `method: "platform-owned"` records that fact. Unlike `grandfathered` — a
+ * deliberately time-boxed 30-day exemption for claims that predate the feature —
+ * this is PERMANENT and carries no `graceUntil`: there is no future date on
+ * which we stop controlling our own zone, and nothing the tenant could ever do
+ * to "complete" the proof.
+ *
+ * ## The suffix is CONFIGURATION
+ *
+ * `PLATFORM_DOMAIN_SUFFIX` follows the `PLATFORM_ORG_SLUG` contract
+ * (`src/lib/features/platform.ts`): the platform is white-labelable, so
+ * `konf.run` is a deployment fact, never a constant in the source.
+ *
+ * UNSET MEANS "NO HOST IS PLATFORM-OWNED", never "every host is". This is the
+ * one inversion that would be catastrophic — an empty suffix matching every
+ * hostname would hand a permanent, unprovable routing AND redirect-allowlist
+ * grant to every claim on the platform — so every rejection path below returns
+ * `null` and {@link isPlatformOwnedHost} fails CLOSED on it.
+ *
+ * ## Matching is LABEL-WISE, never `endsWith`
+ *
+ * A raw `host.endsWith(suffix)` is spoofable in both directions and both
+ * mistakes are real: `evil-konf.run` ends with `konf.run` (no label boundary),
+ * and a naive "contains" check would accept `konf.run.attacker.com` (our zone as
+ * a *prefix* of someone else's). The comparison therefore splits both sides into
+ * DNS labels and requires the suffix to be the exact trailing labels of the
+ * host, with at least one label to spare.
+ */
+
+import { isValidDomainEntry, normalizeDomain } from '@/lib/conference/domains'
+
+/**
+ * The configured platform zone (e.g. `konf.run`), or `null` when the contract is
+ * unset or unusable — in which case NO host is platform-owned.
+ *
+ * Tolerates the shapes an operator plausibly types (`.konf.run`, `*.konf.run`,
+ * `KONF.RUN `) and rejects everything that is not a plain, multi-label zone: a
+ * URL, a path, a `:port`, or a single bare label. A bare label matters most —
+ * `PLATFORM_DOMAIN_SUFFIX=run` would make every `.run` domain on the internet
+ * platform-owned.
+ */
+export function platformDomainSuffix(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const raw = env.PLATFORM_DOMAIN_SUFFIX
+  if (typeof raw !== 'string') return null
+  // A leading `*.` or `.` is how the same zone is written in a certificate or a
+  // cookie Domain attribute; accept both and store the bare zone.
+  const suffix = normalizeDomain(raw).replace(/^\*?\.+/, '')
+  if (!suffix) return null
+  if (!isValidDomainEntry(suffix)) return null
+  // `isValidDomainEntry` also admits `*.x` and `x:3000`; neither is a zone.
+  if (suffix.startsWith('*.') || suffix.includes(':')) return null
+  // At least two labels. A single label is a TLD or a dev name, never a zone we
+  // can claim to own.
+  if (!suffix.includes('.')) return null
+  return suffix
+}
+
+/**
+ * True when `host` is the exact trailing labels of `suffix` plus at least one
+ * more label of its own. Pure label comparison — no substring logic anywhere.
+ */
+function isSubdomainOfSuffix(host: string, suffix: string): boolean {
+  const hostLabels = host.split('.')
+  const suffixLabels = suffix.split('.')
+  // STRICTLY deeper: the suffix apex itself is not "a subdomain we minted".
+  if (hostLabels.length <= suffixLabels.length) return false
+  const offset = hostLabels.length - suffixLabels.length
+  return suffixLabels.every((label, i) => label === hostLabels[offset + i])
+}
+
+/**
+ * Is this `domains[]` entry a host the PLATFORM owns and therefore proves by
+ * construction?
+ *
+ * Deliberately strict on three counts:
+ *
+ * - **Fails closed on an unset suffix.** No configuration, no platform hosts.
+ * - **The apex is NOT included.** `konf.run` itself is the platform's own
+ *   origin, not a subdomain we minted for a tenant; if it ever has to route to a
+ *   conference it goes through the normal DNS-TXT path, which the platform (the
+ *   only party that can write to that zone) can satisfy trivially.
+ * - **Wildcard claims are NEVER platform-owned.** `*.konf.run` covers every
+ *   tenant subdomain at once, so auto-verifying it would let the first
+ *   conference to claim it route every host in the zone it does not otherwise
+ *   own. A wildcard over the platform zone must be proven like anything else.
+ */
+export function isPlatformOwnedHost(
+  entry: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const suffix = platformDomainSuffix(env)
+  if (suffix === null) return false
+  const host = normalizeDomain(entry)
+  if (!host || host.startsWith('*.')) return false
+  return isSubdomainOfSuffix(host, suffix)
+}

--- a/src/lib/domain-verification/policy.test.ts
+++ b/src/lib/domain-verification/policy.test.ts
@@ -308,7 +308,6 @@ describe('applyCheckOutcome', () => {
         hostname: 'kubeday.konf.run',
         status: 'failing',
         method: 'dns-txt',
-        graceUntil: daysAgo(-5),
         firstFailureAt: daysAgo(9),
         consecutiveFailures: 7,
         consecutiveSoftFailures: 2,
@@ -325,19 +324,43 @@ describe('applyCheckOutcome', () => {
       consecutiveSoftFailures: 0,
       lastError: null,
     })
-    // PERMANENT, not a grace period: the write-back never mints a deadline.
-    expect(patch).not.toHaveProperty('graceUntil')
+  })
+
+  it('CLEARS a grandfathered deadline when the host becomes platform-owned', () => {
+    // A record grandfathered by the backfill and allocated afterwards still
+    // carries a 30-day `graceUntil`. A platform allocation has no deadline, so
+    // leaving it would expire a grant that is supposed to be permanent — and
+    // `null` is what `patchDomainVerification` turns into an `unset`.
+    const grandfatheredThenAllocated = record({
+      hostname: 'kubeday.konf.run',
+      method: 'grandfathered',
+      graceUntil: new Date(NOW.getTime() + 5 * DAY).toISOString(),
+    })
+    const patch = applyCheckOutcome(
+      grandfatheredThenAllocated,
+      { kind: 'platform-owned' },
+      NOW,
+    )
+    // The STORED record ends up with no deadline at all. (`sweep.test.ts` and
+    // `sanity.test.ts` assert the same thing end-to-end: the patch reaches
+    // Sanity as an `unset`.)
+    expect({ ...grandfatheredThenAllocated, ...patch }.graceUntil).toBeNull()
   })
 })
 
 /**
- * PLATFORM-OWNED HOSTS. Every assertion here is about the OBSERVABLE grant —
+ * PLATFORM-ALLOCATED HOSTS. Every assertion here is about the OBSERVABLE grant —
  * does this record route, is it on the redirect allowlist — with no reference to
  * any message or reason string.
+ *
+ * The distinction the whole feature turns on: `allocated()` is a host the
+ * PLATFORM granted, `inZoneOnly()` is a host an organizer typed that merely
+ * happens to sit under the suffix. The first is verified; the second must be
+ * treated exactly like any other unproven claim.
  */
-describe('platform-owned hosts', () => {
+describe('platform-allocated hosts', () => {
   /** An unproven record: `pending`, never checked, no proof of any kind. */
-  function unproven(hostname: string): DomainVerificationRecord {
+  function inZoneOnly(hostname: string): DomainVerificationRecord {
     return record({
       hostname,
       _id: `domainVerification.${hostname}`,
@@ -349,23 +372,67 @@ describe('platform-owned hosts', () => {
     })
   }
 
+  /**
+   * The same claim with the platform's allocation recorded on it. Deliberately
+   * left `pending` with no proof of any kind, so the ONLY thing that could grant
+   * it standing is the allocation itself — a `verified` fixture would pass these
+   * assertions even with the platform rule deleted.
+   */
+  function allocated(hostname: string): DomainVerificationRecord {
+    return { ...inZoneOnly(hostname), method: 'platform-owned' }
+  }
+
   describe('with the platform suffix configured', () => {
     beforeEach(() => {
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', PLATFORM_SUFFIX)
     })
 
-    it('ROUTES an unproven subdomain of the platform zone', () => {
+    it('ROUTES a subdomain the platform ALLOCATED, with no DNS proof', () => {
       // The whole point: we minted `kubeday.konf.run` and control its DNS, so
       // demanding a TXT record in that zone would only take the tenant offline.
-      expect(isRoutingEligible(unproven('kubeday.konf.run'), NOW)).toBe(true)
+      expect(isRoutingEligible(allocated('kubeday.konf.run'), NOW)).toBe(true)
     })
 
-    it('ALLOWLISTS it as a redirect destination', () => {
-      expect(isAllowlistEligible(unproven('kubeday.konf.run'), NOW)).toBe(true)
+    it('ALLOWLISTS an allocated host as a redirect destination', () => {
+      expect(isAllowlistEligible(allocated('kubeday.konf.run'), NOW)).toBe(true)
+    })
+
+    it('REFUSES an UNALLOCATED host that merely sits in the platform zone', () => {
+      // THE HIJACK: an organizer types `some-other-tenant.konf.run` into their
+      // own settings. Being in our zone says nothing about who is entitled to
+      // it, so this must be as unrouted and unallowlisted as any other unproven
+      // claim.
+      const grabbed = inZoneOnly('some-other-tenant.konf.run')
+      expect(isRoutingEligible(grabbed, NOW)).toBe(false)
+      expect(isAllowlistEligible(grabbed, NOW)).toBe(false)
+    })
+
+    it('REFUSES an in-zone host that a tenant merely got VERIFIED by DNS', () => {
+      // Even a genuinely `verified` dns-txt record is not an allocation, so it
+      // cannot carry the permanent standing…
+      const verified = {
+        ...inZoneOnly('kubeday.konf.run'),
+        status: 'verified' as const,
+        lastSuccessAt: daysAgo(1),
+      }
+      expect(isAllowlistEligible(verified, NOW)).toBe(true) // ordinary route in
+      // …and it expires on staleness like any other dns-txt proof, which an
+      // allocation never does.
+      const stale = {
+        ...verified,
+        lastSuccessAt: daysAgo(ALLOWLIST_MAX_STALENESS_DAYS + 1),
+      }
+      expect(isAllowlistEligible(stale, NOW)).toBe(false)
+      expect(
+        isAllowlistEligible(
+          { ...allocated('kubeday.konf.run'), lastSuccessAt: daysAgo(400) },
+          NOW,
+        ),
+      ).toBe(true)
     })
 
     it('is PERMANENT — no grace window, no staleness expiry', () => {
-      const ancient = unproven('kubeday.konf.run')
+      const ancient = allocated('kubeday.konf.run')
       const muchLater = new Date(NOW.getTime() + 3650 * DAY)
       expect(isRoutingEligible(ancient, muchLater)).toBe(true)
       expect(isAllowlistEligible(ancient, muchLater)).toBe(true)
@@ -389,21 +456,25 @@ describe('platform-owned hosts', () => {
         firstFailureAt: daysAgo(ROUTING_GRACE_DAYS + 30),
       }
       expect(
-        isRoutingEligible({ ...unproven('kubeday.konf.run'), ...failing }, NOW),
+        isRoutingEligible(
+          { ...allocated('kubeday.konf.run'), ...failing },
+          NOW,
+        ),
       ).toBe(true)
       expect(
         isRoutingEligible(
-          { ...unproven('kubeday.example.com'), ...failing },
+          { ...allocated('kubeday.example.com'), ...failing },
           NOW,
         ),
       ).toBe(false)
     })
 
-    it('REFUSES a released (revoked) platform subdomain', () => {
-      // Releasing the claim must remove the grant instantly — platform-owned is
-      // permanent, not unconditional.
+    it('REFUSES a released (revoked) allocated subdomain', () => {
+      // Revoked WINS over the allocation, in both consumers. Releasing the claim
+      // is the remedy if a host ever ends up with the wrong tenant, so it has to
+      // actually undo the grant.
       const released = {
-        ...unproven('kubeday.konf.run'),
+        ...allocated('kubeday.konf.run'),
         status: 'revoked' as const,
       }
       expect(isRoutingEligible(released, NOW)).toBe(false)
@@ -411,25 +482,36 @@ describe('platform-owned hosts', () => {
     })
 
     it('REFUSES a label-boundary near-miss: evil-konf.run is NOT konf.run', () => {
-      expect(isRoutingEligible(unproven('evil-konf.run'), NOW)).toBe(false)
-      expect(isAllowlistEligible(unproven('evil-konf.run'), NOW)).toBe(false)
-      expect(isRoutingEligible(unproven('sub.evil-konf.run'), NOW)).toBe(false)
+      // Allocated on paper, but the hostname is outside our zone: the live
+      // suffix re-check is what stops a mis-issued record from granting.
+      expect(isRoutingEligible(allocated('evil-konf.run'), NOW)).toBe(false)
+      expect(isAllowlistEligible(allocated('evil-konf.run'), NOW)).toBe(false)
+      expect(isRoutingEligible(allocated('sub.evil-konf.run'), NOW)).toBe(false)
     })
 
     it('REFUSES the platform zone used as a PREFIX: konf.run.attacker.com', () => {
-      expect(isRoutingEligible(unproven('konf.run.attacker.com'), NOW)).toBe(
+      expect(isRoutingEligible(allocated('konf.run.attacker.com'), NOW)).toBe(
         false,
       )
-      expect(isAllowlistEligible(unproven('konf.run.attacker.com'), NOW)).toBe(
+      expect(isAllowlistEligible(allocated('konf.run.attacker.com'), NOW)).toBe(
         false,
       )
     })
 
     it('leaves CUSTOM domains exactly as they were — real proof still required', () => {
       // The regression that matters most: turning platform hosts on must not
-      // hand a free pass to a tenant's own domain.
-      expect(isRoutingEligible(unproven('cloudnativedays.no'), NOW)).toBe(false)
-      expect(isAllowlistEligible(unproven('cloudnativedays.no'), NOW)).toBe(
+      // hand a free pass to a tenant's own domain — even one whose record was
+      // somehow stamped `platform-owned`.
+      expect(isRoutingEligible(inZoneOnly('cloudnativedays.no'), NOW)).toBe(
+        false,
+      )
+      expect(isAllowlistEligible(inZoneOnly('cloudnativedays.no'), NOW)).toBe(
+        false,
+      )
+      expect(isRoutingEligible(allocated('cloudnativedays.no'), NOW)).toBe(
+        false,
+      )
+      expect(isAllowlistEligible(allocated('cloudnativedays.no'), NOW)).toBe(
         false,
       )
       // …and a proven one still passes, for the ordinary reason.
@@ -440,12 +522,12 @@ describe('platform-owned hosts', () => {
 
     it('REFUSES a WILDCARD claim over the platform zone', () => {
       // `*.konf.run` would route every tenant subdomain for whoever holds it.
-      expect(isRoutingEligible(unproven('*.konf.run'), NOW)).toBe(false)
-      expect(isAllowlistEligible(unproven('*.konf.run'), NOW)).toBe(false)
+      expect(isRoutingEligible(allocated('*.konf.run'), NOW)).toBe(false)
+      expect(isAllowlistEligible(allocated('*.konf.run'), NOW)).toBe(false)
     })
 
     it('REFUSES the platform APEX itself', () => {
-      expect(isRoutingEligible(unproven('konf.run'), NOW)).toBe(false)
+      expect(isRoutingEligible(allocated('konf.run'), NOW)).toBe(false)
     })
   })
 
@@ -457,23 +539,24 @@ describe('platform-owned hosts', () => {
     it('FAILS CLOSED — an unset suffix grants nothing, it does not match all', () => {
       // The inversion that would be catastrophic: "" matching every host would
       // permanently allowlist and route every unproven claim on the platform.
-      expect(isRoutingEligible(unproven('kubeday.konf.run'), NOW)).toBe(false)
-      expect(isAllowlistEligible(unproven('kubeday.konf.run'), NOW)).toBe(false)
-      expect(isRoutingEligible(unproven('anything.example.com'), NOW)).toBe(
+      expect(isRoutingEligible(inZoneOnly('kubeday.konf.run'), NOW)).toBe(false)
+      expect(isAllowlistEligible(inZoneOnly('kubeday.konf.run'), NOW)).toBe(
         false,
       )
-      expect(isAllowlistEligible(unproven('anything.example.com'), NOW)).toBe(
+      expect(isRoutingEligible(inZoneOnly('anything.example.com'), NOW)).toBe(
+        false,
+      )
+      expect(isAllowlistEligible(inZoneOnly('anything.example.com'), NOW)).toBe(
         false,
       )
     })
 
     it('withdraws the grant from a record that still SAYS platform-owned', () => {
-      // The verdict is re-derived from the hostname, never read off the stored
-      // `method` — so re-pointing the suffix cannot leave stale grants behind.
-      // `pending` with no proof, so the ONLY thing that could grant standing is
-      // the platform check itself.
+      // The allocation is re-checked against the LIVE suffix, so re-pointing or
+      // unsetting it cannot leave stale grants behind. `pending` with no proof,
+      // so the only thing that could grant standing is the allocation.
       const stale = {
-        ...unproven('kubeday.konf.run'),
+        ...inZoneOnly('kubeday.konf.run'),
         method: 'platform-owned' as const,
       }
       expect(isAllowlistEligible(stale, NOW)).toBe(false)

--- a/src/lib/domain-verification/policy.test.ts
+++ b/src/lib/domain-verification/policy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import {
   ALLOWLIST_MAX_STALENESS_DAYS,
   ROUTING_GRACE_DAYS,
@@ -38,6 +38,13 @@ function record(
     ...overrides,
   }
 }
+
+/** The platform zone under test. Always stubbed — never inherited from `.env`. */
+const PLATFORM_SUFFIX = 'konf.run'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 describe('isAllowlistEligible', () => {
   it('accepts a freshly verified exact host', () => {
@@ -293,5 +300,184 @@ describe('applyCheckOutcome', () => {
         NOW,
       ),
     ).toEqual({})
+  })
+
+  it('reconciles a platform-owned host to verified with NO failure history', () => {
+    const patch = applyCheckOutcome(
+      record({
+        hostname: 'kubeday.konf.run',
+        status: 'failing',
+        method: 'dns-txt',
+        graceUntil: daysAgo(-5),
+        firstFailureAt: daysAgo(9),
+        consecutiveFailures: 7,
+        consecutiveSoftFailures: 2,
+        lastError: 'No TXT record',
+      }),
+      { kind: 'platform-owned' },
+      NOW,
+    )
+    expect(patch).toMatchObject({
+      status: 'verified',
+      method: 'platform-owned',
+      firstFailureAt: null,
+      consecutiveFailures: 0,
+      consecutiveSoftFailures: 0,
+      lastError: null,
+    })
+    // PERMANENT, not a grace period: the write-back never mints a deadline.
+    expect(patch).not.toHaveProperty('graceUntil')
+  })
+})
+
+/**
+ * PLATFORM-OWNED HOSTS. Every assertion here is about the OBSERVABLE grant —
+ * does this record route, is it on the redirect allowlist — with no reference to
+ * any message or reason string.
+ */
+describe('platform-owned hosts', () => {
+  /** An unproven record: `pending`, never checked, no proof of any kind. */
+  function unproven(hostname: string): DomainVerificationRecord {
+    return record({
+      hostname,
+      _id: `domainVerification.${hostname}`,
+      status: 'pending',
+      method: 'dns-txt',
+      verifiedAt: null,
+      lastSuccessAt: null,
+      lastCheckedAt: null,
+    })
+  }
+
+  describe('with the platform suffix configured', () => {
+    beforeEach(() => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', PLATFORM_SUFFIX)
+    })
+
+    it('ROUTES an unproven subdomain of the platform zone', () => {
+      // The whole point: we minted `kubeday.konf.run` and control its DNS, so
+      // demanding a TXT record in that zone would only take the tenant offline.
+      expect(isRoutingEligible(unproven('kubeday.konf.run'), NOW)).toBe(true)
+    })
+
+    it('ALLOWLISTS it as a redirect destination', () => {
+      expect(isAllowlistEligible(unproven('kubeday.konf.run'), NOW)).toBe(true)
+    })
+
+    it('is PERMANENT — no grace window, no staleness expiry', () => {
+      const ancient = unproven('kubeday.konf.run')
+      const muchLater = new Date(NOW.getTime() + 3650 * DAY)
+      expect(isRoutingEligible(ancient, muchLater)).toBe(true)
+      expect(isAllowlistEligible(ancient, muchLater)).toBe(true)
+      // …whereas a grandfathered claim of the same age is long gone.
+      expect(
+        isRoutingEligible(
+          record({
+            method: 'grandfathered',
+            status: 'pending',
+            graceUntil: daysAgo(-5),
+          }),
+          muchLater,
+        ),
+      ).toBe(false)
+    })
+
+    it('survives a long hard-failure streak that would delist any other host', () => {
+      const failing = {
+        status: 'failing' as const,
+        consecutiveFailures: ROUTING_GRACE_FAILURES + 10,
+        firstFailureAt: daysAgo(ROUTING_GRACE_DAYS + 30),
+      }
+      expect(
+        isRoutingEligible({ ...unproven('kubeday.konf.run'), ...failing }, NOW),
+      ).toBe(true)
+      expect(
+        isRoutingEligible(
+          { ...unproven('kubeday.example.com'), ...failing },
+          NOW,
+        ),
+      ).toBe(false)
+    })
+
+    it('REFUSES a released (revoked) platform subdomain', () => {
+      // Releasing the claim must remove the grant instantly — platform-owned is
+      // permanent, not unconditional.
+      const released = {
+        ...unproven('kubeday.konf.run'),
+        status: 'revoked' as const,
+      }
+      expect(isRoutingEligible(released, NOW)).toBe(false)
+      expect(isAllowlistEligible(released, NOW)).toBe(false)
+    })
+
+    it('REFUSES a label-boundary near-miss: evil-konf.run is NOT konf.run', () => {
+      expect(isRoutingEligible(unproven('evil-konf.run'), NOW)).toBe(false)
+      expect(isAllowlistEligible(unproven('evil-konf.run'), NOW)).toBe(false)
+      expect(isRoutingEligible(unproven('sub.evil-konf.run'), NOW)).toBe(false)
+    })
+
+    it('REFUSES the platform zone used as a PREFIX: konf.run.attacker.com', () => {
+      expect(isRoutingEligible(unproven('konf.run.attacker.com'), NOW)).toBe(
+        false,
+      )
+      expect(isAllowlistEligible(unproven('konf.run.attacker.com'), NOW)).toBe(
+        false,
+      )
+    })
+
+    it('leaves CUSTOM domains exactly as they were — real proof still required', () => {
+      // The regression that matters most: turning platform hosts on must not
+      // hand a free pass to a tenant's own domain.
+      expect(isRoutingEligible(unproven('cloudnativedays.no'), NOW)).toBe(false)
+      expect(isAllowlistEligible(unproven('cloudnativedays.no'), NOW)).toBe(
+        false,
+      )
+      // …and a proven one still passes, for the ordinary reason.
+      expect(
+        isRoutingEligible(record({ hostname: 'cloudnativedays.no' }), NOW),
+      ).toBe(true)
+    })
+
+    it('REFUSES a WILDCARD claim over the platform zone', () => {
+      // `*.konf.run` would route every tenant subdomain for whoever holds it.
+      expect(isRoutingEligible(unproven('*.konf.run'), NOW)).toBe(false)
+      expect(isAllowlistEligible(unproven('*.konf.run'), NOW)).toBe(false)
+    })
+
+    it('REFUSES the platform APEX itself', () => {
+      expect(isRoutingEligible(unproven('konf.run'), NOW)).toBe(false)
+    })
+  })
+
+  describe('with the platform suffix UNSET', () => {
+    beforeEach(() => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
+    })
+
+    it('FAILS CLOSED — an unset suffix grants nothing, it does not match all', () => {
+      // The inversion that would be catastrophic: "" matching every host would
+      // permanently allowlist and route every unproven claim on the platform.
+      expect(isRoutingEligible(unproven('kubeday.konf.run'), NOW)).toBe(false)
+      expect(isAllowlistEligible(unproven('kubeday.konf.run'), NOW)).toBe(false)
+      expect(isRoutingEligible(unproven('anything.example.com'), NOW)).toBe(
+        false,
+      )
+      expect(isAllowlistEligible(unproven('anything.example.com'), NOW)).toBe(
+        false,
+      )
+    })
+
+    it('withdraws the grant from a record that still SAYS platform-owned', () => {
+      // The verdict is re-derived from the hostname, never read off the stored
+      // `method` — so re-pointing the suffix cannot leave stale grants behind.
+      // `pending` with no proof, so the ONLY thing that could grant standing is
+      // the platform check itself.
+      const stale = {
+        ...unproven('kubeday.konf.run'),
+        method: 'platform-owned' as const,
+      }
+      expect(isAllowlistEligible(stale, NOW)).toBe(false)
+      expect(isRoutingEligible(stale, NOW)).toBe(false)
+    })
   })
 })

--- a/src/lib/domain-verification/policy.ts
+++ b/src/lib/domain-verification/policy.ts
@@ -29,18 +29,22 @@
  * *honouring* a claim; republishing the TXT record restores it on the next
  * sweep.
  *
- * PLATFORM-OWNED HOSTS are the one standing that is not earned from a check
- * result at all: a hostname under `PLATFORM_DOMAIN_SUFFIX` is inside a zone we
- * operate (see `platform.ts`), so both consumers honour it unconditionally. The
- * verdict is re-derived FROM THE HOSTNAME on every call rather than read off the
- * record's stored `method`, so re-pointing (or unsetting) the platform suffix
- * withdraws the standing immediately instead of leaving stale grants behind.
- * The module stays otherwise pure; this is the only thing it reads from the
- * environment.
+ * PLATFORM-ALLOCATED HOSTS are the one standing that is not earned from a check
+ * result at all — see `platform.ts`. Both consumers honour {@link
+ * isPlatformAllocated}, which requires the platform to have RECORDED the
+ * allocation (`method: 'platform-owned'`, written only by tenant provisioning)
+ * AND the hostname to still be under the configured suffix. Being in our zone is
+ * never sufficient on its own: an organizer can type any hostname, so inferring
+ * the grant from the suffix alone would let them claim another tenant's — or an
+ * unissued — subdomain. `revoked` is refused BEFORE the allocation check in both
+ * functions, so releasing a claim withdraws the grant instantly.
+ *
+ * The module stays otherwise pure; the suffix is the only thing it reads from
+ * the environment.
  */
 
 import { isDevOnlyHost, isWildcardEntry } from './challenge'
-import { isPlatformOwnedHost } from './platform'
+import { isPlatformAllocated } from './platform'
 import type {
   DomainCheckOutcome,
   DomainVerificationPatch,
@@ -103,11 +107,15 @@ export function applyCheckOutcome(
   if (outcome.kind === 'platform-owned') {
     // No lookup happened and none ever will. The write-back exists so the
     // stored record TELLS THE TRUTH — verified, by the platform, with no
-    // failure history and no `graceUntil` — which is what the admin card and
-    // the allowlist's GROQ prefilter read.
+    // failure history — which is what the admin card and the allowlist's GROQ
+    // prefilter read.
     return {
       status: 'verified',
       method: 'platform-owned',
+      // CLEARED, not left alone: a record that was grandfathered before it was
+      // allocated still carries that 30-day deadline, and a platform allocation
+      // has no deadline. Leaving it would expire a permanent grant.
+      graceUntil: null,
       verifiedAt: record.verifiedAt ?? nowIso,
       lastSuccessAt: nowIso,
       lastCheckedAt: nowIso,
@@ -181,7 +189,7 @@ export function applyCheckOutcome(
  * Dev-only hosts are excluded too — an allowlist entry is a security grant, and
  * `localhost:3000` must never be one in a deployed environment.
  *
- * PLATFORM-OWNED HOSTS ARE ELIGIBLE, and deliberately so. The threat this
+ * PLATFORM-ALLOCATED HOSTS ARE ELIGIBLE, and deliberately so. The threat this
  * function exists to stop is a DANGLING destination: a third party's zone lapses
  * and the host silently starts resolving to somebody else, which the victim
  * experiences as a normal login. That cannot happen inside a zone we operate —
@@ -192,12 +200,12 @@ export function applyCheckOutcome(
  * these instead would mean nobody hosted on the platform's default subdomain
  * could complete a sign-in round-trip at all.
  *
- * What this DOES grant is a redirect destination to whoever holds a
- * `<label>.<platform suffix>` claim. That grant is exactly co-extensive with
- * "we host that tenant on that subdomain" — the control is who may claim a
- * platform subdomain (`domains[]` uniqueness + provisioning), not a DNS proof
- * they could never produce. Wildcards and revoked claims remain excluded, so
- * releasing the claim removes the grant immediately.
+ * The grant follows the ALLOCATION, not the suffix. A host merely sitting in our
+ * zone gets nothing: it has to be a subdomain the platform issued to THIS
+ * conference, which is what stops an organizer from typing another tenant's (or
+ * an unissued) label into their own `domains[]` and being handed a redirect
+ * destination for it. Wildcards and revoked claims remain excluded, so releasing
+ * the claim removes the grant immediately.
  */
 export function isAllowlistEligible(
   record: DomainVerificationRecord,
@@ -205,10 +213,10 @@ export function isAllowlistEligible(
 ): boolean {
   if (isWildcardEntry(record.hostname)) return false
   if (isDevOnlyHost(record.hostname)) return false
-  // Explicit, because the platform check below bypasses the `verified` status
+  // Explicit, because the allocation check below bypasses the `verified` status
   // test that otherwise excludes a released claim.
   if (record.status === 'revoked') return false
-  if (isPlatformOwnedHost(record.hostname)) return true
+  if (isPlatformAllocated(record)) return true
   if (inGrandfatherGrace(record, now)) return true
   if (record.status !== 'verified') return false
   if (!record.lastSuccessAt) return false
@@ -229,10 +237,12 @@ export function isRoutingEligible(
   // `pnpm dev` for no security gain (they cannot receive public traffic).
   if (isDevOnlyHost(record.hostname)) return true
   if (record.status === 'revoked') return false
-  // A subdomain the platform minted in its own zone. PERMANENT — unlike the
-  // grandfather window below, this never expires, because there is no proof the
-  // tenant could publish in a zone only we can write to.
-  if (isPlatformOwnedHost(record.hostname)) return true
+  // A subdomain the platform ALLOCATED to this conference. PERMANENT — unlike
+  // the grandfather window below, this never expires, because there is no proof
+  // the tenant could publish in a zone only we can write to. An unallocated host
+  // that merely sits in our zone falls through to the ordinary rules and stays
+  // unrouted.
+  if (isPlatformAllocated(record)) return true
   if (inGrandfatherGrace(record, now)) return true
   if (record.status === 'verified') return true
   if (record.status !== 'failing') return false

--- a/src/lib/domain-verification/policy.ts
+++ b/src/lib/domain-verification/policy.ts
@@ -28,9 +28,19 @@
  * Withdrawal is never destructive: nothing here mutates `domains[]`. We stop
  * *honouring* a claim; republishing the TXT record restores it on the next
  * sweep.
+ *
+ * PLATFORM-OWNED HOSTS are the one standing that is not earned from a check
+ * result at all: a hostname under `PLATFORM_DOMAIN_SUFFIX` is inside a zone we
+ * operate (see `platform.ts`), so both consumers honour it unconditionally. The
+ * verdict is re-derived FROM THE HOSTNAME on every call rather than read off the
+ * record's stored `method`, so re-pointing (or unsetting) the platform suffix
+ * withdraws the standing immediately instead of leaving stale grants behind.
+ * The module stays otherwise pure; this is the only thing it reads from the
+ * environment.
  */
 
 import { isDevOnlyHost, isWildcardEntry } from './challenge'
+import { isPlatformOwnedHost } from './platform'
 import type {
   DomainCheckOutcome,
   DomainVerificationPatch,
@@ -89,6 +99,24 @@ export function applyCheckOutcome(
 ): DomainVerificationPatch {
   const nowIso = now.toISOString()
   if (record.status === 'revoked') return {}
+
+  if (outcome.kind === 'platform-owned') {
+    // No lookup happened and none ever will. The write-back exists so the
+    // stored record TELLS THE TRUTH — verified, by the platform, with no
+    // failure history and no `graceUntil` — which is what the admin card and
+    // the allowlist's GROQ prefilter read.
+    return {
+      status: 'verified',
+      method: 'platform-owned',
+      verifiedAt: record.verifiedAt ?? nowIso,
+      lastSuccessAt: nowIso,
+      lastCheckedAt: nowIso,
+      firstFailureAt: null,
+      consecutiveFailures: 0,
+      consecutiveSoftFailures: 0,
+      lastError: null,
+    }
+  }
 
   if (outcome.kind === 'verified') {
     return {
@@ -152,6 +180,24 @@ export function applyCheckOutcome(
  *
  * Dev-only hosts are excluded too — an allowlist entry is a security grant, and
  * `localhost:3000` must never be one in a deployed environment.
+ *
+ * PLATFORM-OWNED HOSTS ARE ELIGIBLE, and deliberately so. The threat this
+ * function exists to stop is a DANGLING destination: a third party's zone lapses
+ * and the host silently starts resolving to somebody else, which the victim
+ * experiences as a normal login. That cannot happen inside a zone we operate —
+ * its delegation cannot change without our own registrar/DNS account changing
+ * hands, and it could not do so quietly, because every tenant site would go down
+ * at the same moment. The staleness rule below exists to catch a checker that
+ * has silently broken; for our own zone there is no checker to break. Refusing
+ * these instead would mean nobody hosted on the platform's default subdomain
+ * could complete a sign-in round-trip at all.
+ *
+ * What this DOES grant is a redirect destination to whoever holds a
+ * `<label>.<platform suffix>` claim. That grant is exactly co-extensive with
+ * "we host that tenant on that subdomain" — the control is who may claim a
+ * platform subdomain (`domains[]` uniqueness + provisioning), not a DNS proof
+ * they could never produce. Wildcards and revoked claims remain excluded, so
+ * releasing the claim removes the grant immediately.
  */
 export function isAllowlistEligible(
   record: DomainVerificationRecord,
@@ -159,6 +205,10 @@ export function isAllowlistEligible(
 ): boolean {
   if (isWildcardEntry(record.hostname)) return false
   if (isDevOnlyHost(record.hostname)) return false
+  // Explicit, because the platform check below bypasses the `verified` status
+  // test that otherwise excludes a released claim.
+  if (record.status === 'revoked') return false
+  if (isPlatformOwnedHost(record.hostname)) return true
   if (inGrandfatherGrace(record, now)) return true
   if (record.status !== 'verified') return false
   if (!record.lastSuccessAt) return false
@@ -179,6 +229,10 @@ export function isRoutingEligible(
   // `pnpm dev` for no security gain (they cannot receive public traffic).
   if (isDevOnlyHost(record.hostname)) return true
   if (record.status === 'revoked') return false
+  // A subdomain the platform minted in its own zone. PERMANENT — unlike the
+  // grandfather window below, this never expires, because there is no proof the
+  // tenant could publish in a zone only we can write to.
+  if (isPlatformOwnedHost(record.hostname)) return true
   if (inGrandfatherGrace(record, now)) return true
   if (record.status === 'verified') return true
   if (record.status !== 'failing') return false

--- a/src/lib/domain-verification/routing.test.ts
+++ b/src/lib/domain-verification/routing.test.ts
@@ -41,6 +41,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.DOMAIN_VERIFICATION_ENFORCE_ROUTING
+  vi.unstubAllEnvs()
 })
 
 describe('isHostRoutable', () => {
@@ -103,5 +104,70 @@ describe('isHostRoutable', () => {
     expect(await isHostRoutable('other.example', ['example.com'], NOW)).toBe(
       false,
     )
+  })
+
+  describe('platform-owned subdomains', () => {
+    beforeEach(() => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+    })
+
+    it('serves a platform subdomain with NO verification record at all', async () => {
+      // Enforcement must not take a platform-hosted tenant offline over a
+      // missing sidecar document for a zone only we can write to.
+      getDomainVerification.mockResolvedValue(null)
+      expect(
+        await isHostRoutable('kubeday.konf.run', ['kubeday.konf.run'], NOW),
+      ).toBe(true)
+      // …and it did not even need to look one up.
+      expect(getDomainVerification).not.toHaveBeenCalled()
+    })
+
+    it('still requires the host to be CLAIMED by this conference', async () => {
+      getDomainVerification.mockResolvedValue(null)
+      expect(
+        await isHostRoutable(
+          'someone-else.konf.run',
+          ['kubeday.konf.run'],
+          NOW,
+        ),
+      ).toBe(false)
+    })
+
+    it('does NOT extend the exemption to a `*.konf.run` wildcard claim', async () => {
+      getDomainVerification.mockResolvedValue(null)
+      expect(
+        await isHostRoutable('kubeday.konf.run', ['*.konf.run'], NOW),
+      ).toBe(false)
+      expect(getDomainVerification).toHaveBeenCalledWith('*.konf.run')
+    })
+
+    it('REFUSES a label-boundary near-miss with no record', async () => {
+      getDomainVerification.mockResolvedValue(null)
+      expect(
+        await isHostRoutable('evil-konf.run', ['evil-konf.run'], NOW),
+      ).toBe(false)
+      expect(
+        await isHostRoutable(
+          'konf.run.attacker.com',
+          ['konf.run.attacker.com'],
+          NOW,
+        ),
+      ).toBe(false)
+    })
+
+    it('leaves CUSTOM domains fail-closed on a missing record', async () => {
+      getDomainVerification.mockResolvedValue(null)
+      expect(
+        await isHostRoutable('cloudnativedays.no', ['cloudnativedays.no'], NOW),
+      ).toBe(false)
+    })
+
+    it('FAILS CLOSED for the same platform host when the suffix is unset', async () => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
+      getDomainVerification.mockResolvedValue(null)
+      expect(
+        await isHostRoutable('kubeday.konf.run', ['kubeday.konf.run'], NOW),
+      ).toBe(false)
+    })
   })
 })

--- a/src/lib/domain-verification/routing.test.ts
+++ b/src/lib/domain-verification/routing.test.ts
@@ -106,24 +106,63 @@ describe('isHostRoutable', () => {
     )
   })
 
-  describe('platform-owned subdomains', () => {
+  describe('platform-allocated subdomains', () => {
+    /**
+     * An allocation with NO proof of any kind (`pending`), so these assertions
+     * can only pass through the allocation rule — a `verified` fixture would
+     * route for the ordinary reason and prove nothing.
+     */
+    const allocation = (hostname: string) =>
+      record({
+        _id: `domainVerification.${hostname}`,
+        hostname,
+        status: 'pending' as const,
+        method: 'platform-owned' as const,
+        lastSuccessAt: null,
+      })
+
     beforeEach(() => {
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
     })
 
-    it('serves a platform subdomain with NO verification record at all', async () => {
-      // Enforcement must not take a platform-hosted tenant offline over a
-      // missing sidecar document for a zone only we can write to.
-      getDomainVerification.mockResolvedValue(null)
+    it('serves a platform subdomain the platform ALLOCATED', async () => {
+      getDomainVerification.mockResolvedValue(allocation('kubeday.konf.run'))
       expect(
         await isHostRoutable('kubeday.konf.run', ['kubeday.konf.run'], NOW),
       ).toBe(true)
-      // …and it did not even need to look one up.
-      expect(getDomainVerification).not.toHaveBeenCalled()
+    })
+
+    it('FAILS CLOSED for an in-zone host with NO record — no suffix exemption', async () => {
+      // The hijack, at the routing gate: a hostname ending in our suffix must
+      // not be served just because it ends in our suffix. Without an allocation
+      // there is nothing to honour.
+      getDomainVerification.mockResolvedValue(null)
+      expect(
+        await isHostRoutable(
+          'some-other-tenant.konf.run',
+          ['some-other-tenant.konf.run'],
+          NOW,
+        ),
+      ).toBe(false)
+      // It genuinely consulted the record rather than short-circuiting.
+      expect(getDomainVerification).toHaveBeenCalledWith(
+        'some-other-tenant.konf.run',
+      )
+    })
+
+    it('FAILS CLOSED for an in-zone host whose record is merely pending', async () => {
+      getDomainVerification.mockResolvedValue(
+        record({ hostname: 'kubeday.konf.run', status: 'pending' }),
+      )
+      expect(
+        await isHostRoutable('kubeday.konf.run', ['kubeday.konf.run'], NOW),
+      ).toBe(false)
     })
 
     it('still requires the host to be CLAIMED by this conference', async () => {
-      getDomainVerification.mockResolvedValue(null)
+      getDomainVerification.mockResolvedValue(
+        allocation('someone-else.konf.run'),
+      )
       expect(
         await isHostRoutable(
           'someone-else.konf.run',
@@ -133,16 +172,18 @@ describe('isHostRoutable', () => {
       ).toBe(false)
     })
 
-    it('does NOT extend the exemption to a `*.konf.run` wildcard claim', async () => {
-      getDomainVerification.mockResolvedValue(null)
+    it('does NOT extend the allocation to a `*.konf.run` wildcard claim', async () => {
+      getDomainVerification.mockResolvedValue(allocation('*.konf.run'))
       expect(
         await isHostRoutable('kubeday.konf.run', ['*.konf.run'], NOW),
       ).toBe(false)
       expect(getDomainVerification).toHaveBeenCalledWith('*.konf.run')
     })
 
-    it('REFUSES a label-boundary near-miss with no record', async () => {
-      getDomainVerification.mockResolvedValue(null)
+    it('REFUSES a label-boundary near-miss even with an allocation record', async () => {
+      getDomainVerification.mockImplementation(async (hostname) =>
+        allocation(hostname),
+      )
       expect(
         await isHostRoutable('evil-konf.run', ['evil-konf.run'], NOW),
       ).toBe(false)
@@ -162,9 +203,19 @@ describe('isHostRoutable', () => {
       ).toBe(false)
     })
 
-    it('FAILS CLOSED for the same platform host when the suffix is unset', async () => {
+    it('REFUSES a revoked allocation', async () => {
+      getDomainVerification.mockResolvedValue({
+        ...allocation('kubeday.konf.run'),
+        status: 'revoked' as const,
+      })
+      expect(
+        await isHostRoutable('kubeday.konf.run', ['kubeday.konf.run'], NOW),
+      ).toBe(false)
+    })
+
+    it('FAILS CLOSED for the same allocated host when the suffix is unset', async () => {
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
-      getDomainVerification.mockResolvedValue(null)
+      getDomainVerification.mockResolvedValue(allocation('kubeday.konf.run'))
       expect(
         await isHostRoutable('kubeday.konf.run', ['kubeday.konf.run'], NOW),
       ).toBe(false)

--- a/src/lib/domain-verification/routing.ts
+++ b/src/lib/domain-verification/routing.ts
@@ -15,7 +15,6 @@
  */
 
 import { normalizeDomain, wildcardFormForHost } from '@/lib/conference/domains'
-import { isPlatformOwnedHost } from './platform'
 import { isRoutingEligible } from './policy'
 import { getDomainVerification } from './sanity'
 
@@ -52,16 +51,12 @@ export async function isHostRoutable(
       : null
   if (!matched) return false
 
-  // A subdomain of the platform's OWN zone routes without a record at all. The
-  // fail-closed rule below guards an unproven claim on somebody ELSE's domain;
-  // here the entry is inside a zone we operate, the claim is still required to
-  // be in this conference's `domains[]` (globally unique, overlap-checked), and
-  // there is no proof anyone could publish. Refusing on a missing sidecar
-  // document would take a platform-hosted tenant offline over bookkeeping.
-  // `matched` — not the request host — so a `*.<suffix>` wildcard entry, which
-  // is never platform-owned, still has to prove itself.
-  if (isPlatformOwnedHost(matched)) return true
-
+  // NO exemption for the platform's own zone here. A platform subdomain routes
+  // because a RECORD says the platform allocated it (`isRoutingEligible` →
+  // `isPlatformAllocated`), never because the hostname happens to end in our
+  // suffix — otherwise an organizer could add any unissued `<label>.<suffix>` to
+  // their `domains[]` and have it served with no allocation at all. A missing
+  // record therefore still fails closed, for platform and custom hosts alike.
   const record = await getDomainVerification(matched)
   if (!record) return false
   return isRoutingEligible(record, now)

--- a/src/lib/domain-verification/routing.ts
+++ b/src/lib/domain-verification/routing.ts
@@ -15,6 +15,7 @@
  */
 
 import { normalizeDomain, wildcardFormForHost } from '@/lib/conference/domains'
+import { isPlatformOwnedHost } from './platform'
 import { isRoutingEligible } from './policy'
 import { getDomainVerification } from './sanity'
 
@@ -50,6 +51,16 @@ export async function isHostRoutable(
       ? wildcard
       : null
   if (!matched) return false
+
+  // A subdomain of the platform's OWN zone routes without a record at all. The
+  // fail-closed rule below guards an unproven claim on somebody ELSE's domain;
+  // here the entry is inside a zone we operate, the claim is still required to
+  // be in this conference's `domains[]` (globally unique, overlap-checked), and
+  // there is no proof anyone could publish. Refusing on a missing sidecar
+  // document would take a platform-hosted tenant offline over bookkeeping.
+  // `matched` — not the request host — so a `*.<suffix>` wildcard entry, which
+  // is never platform-owned, still has to prove itself.
+  if (isPlatformOwnedHost(matched)) return true
 
   const record = await getDomainVerification(matched)
   if (!record) return false

--- a/src/lib/domain-verification/sanity.test.ts
+++ b/src/lib/domain-verification/sanity.test.ts
@@ -75,16 +75,46 @@ afterEach(() => {
 })
 
 describe('ensureDomainVerification', () => {
-  it('mints a platform subdomain as verified/platform-owned, with NO deadline', async () => {
-    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+  it('ALLOCATES a platform subdomain as verified/platform-owned, with NO deadline', async () => {
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE, {
+      allocatePlatformHost: true,
+    })
     expect(created()).toMatchObject({
       hostname: 'kubeday.konf.run',
       status: 'verified',
       method: 'platform-owned',
     })
-    // `graceUntil` is what makes `grandfathered` time-boxed; platform-owned is
+    // `graceUntil` is what makes `grandfathered` time-boxed; an allocation is
     // permanent and must never carry one.
     expect(created()).not.toHaveProperty('graceUntil')
+  })
+
+  it('writes NOTHING for an in-zone host when the caller may not allocate', async () => {
+    // THE HIJACK, at the write path. `updateDomains`, `createEdition` and the
+    // admin card's self-heal all land here without the flag. Minting anything
+    // would either grant the standing outright or promise a DNS challenge the
+    // tenant cannot answer — so no document is created at all, and the claim
+    // fails closed downstream.
+    await ensureDomainVerification('some-other-tenant.konf.run', CONFERENCE)
+    expect(createIfNotExists).not.toHaveBeenCalled()
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('will not let an explicit `method` smuggle an allocation in', async () => {
+    await ensureDomainVerification('some-other-tenant.konf.run', CONFERENCE, {
+      method: 'platform-owned',
+    })
+    expect(createIfNotExists).not.toHaveBeenCalled()
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('will not re-allocate a host allocated to ANOTHER conference', async () => {
+    fetchMock.mockResolvedValue(
+      existing({ method: 'platform-owned', conferenceId: 'conference-other' }),
+    )
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+    expect(createIfNotExists).not.toHaveBeenCalled()
+    expect(commit).not.toHaveBeenCalled()
   })
 
   it('mints a CUSTOM domain pending/dns-txt — proof still required', async () => {
@@ -97,15 +127,20 @@ describe('ensureDomainVerification', () => {
   })
 
   it('mints a label-boundary near-miss as an ORDINARY claim', async () => {
-    await ensureDomainVerification('evil-konf.run', CONFERENCE)
+    // Not in the platform zone, so the allocation machinery never engages and
+    // the entry is a plain unproven claim — even when allocation is requested.
+    await ensureDomainVerification('evil-konf.run', CONFERENCE, {
+      allocatePlatformHost: true,
+    })
     expect(created()).toMatchObject({ status: 'pending', method: 'dns-txt' })
   })
 
-  it('overrides an explicit `grandfathered` request for a platform host', async () => {
-    // The hostname decides, not the caller — the backfill must not hand a
-    // platform subdomain a 30-day deadline it can never satisfy.
+  it('overrides an explicit `grandfathered` request when ALLOCATING', async () => {
+    // The backfill must not hand an allocated subdomain a 30-day deadline it
+    // can never satisfy.
     await ensureDomainVerification('kubeday.konf.run', CONFERENCE, {
       method: 'grandfathered',
+      allocatePlatformHost: true,
     })
     expect(created()).toMatchObject({ method: 'platform-owned' })
     expect(created()).not.toHaveProperty('graceUntil')
@@ -113,15 +148,19 @@ describe('ensureDomainVerification', () => {
 
   it('mints platform hosts as ordinary claims when the suffix is unset', async () => {
     vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
-    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE, {
+      allocatePlatformHost: true,
+    })
     expect(created()).toMatchObject({ status: 'pending', method: 'dns-txt' })
   })
 
-  it('reconciles an EXISTING dns-txt record for a now-platform host', async () => {
+  it('upgrades an EXISTING dns-txt record when the platform allocates it', async () => {
     fetchMock.mockResolvedValue(
       existing({ status: 'failing', consecutiveFailures: 9 }),
     )
-    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE, {
+      allocatePlatformHost: true,
+    })
 
     expect(createIfNotExists).not.toHaveBeenCalled()
     expect(patch).toHaveBeenCalledWith('domainVerification.kubeday.konf.run')
@@ -138,13 +177,38 @@ describe('ensureDomainVerification', () => {
     expect(commit).toHaveBeenCalledTimes(1)
   })
 
-  it('writes NOTHING for an already-reconciled platform record', async () => {
+  it('does NOT upgrade that same record without the allocation flag', async () => {
+    fetchMock.mockResolvedValue(
+      existing({ status: 'failing', consecutiveFailures: 9 }),
+    )
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('writes NOTHING for an already-allocated record', async () => {
     fetchMock.mockResolvedValue(
       existing({ status: 'verified', method: 'platform-owned' }),
     )
     await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
     expect(createIfNotExists).not.toHaveBeenCalled()
     expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('restores an allocation this conference RELEASED and re-added', async () => {
+    // Releasing and re-adding your own platform subdomain must not need a
+    // support ticket — but this is keyed on the STORED allocation, so it can
+    // only ever restore a grant the platform actually made.
+    fetchMock.mockResolvedValue(
+      existing({ status: 'revoked', method: 'platform-owned' }),
+    )
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'verified',
+        method: 'platform-owned',
+      }),
+    )
+    expect(commit).toHaveBeenCalledTimes(1)
   })
 
   it('leaves an existing CUSTOM-domain record untouched', async () => {

--- a/src/lib/domain-verification/sanity.test.ts
+++ b/src/lib/domain-verification/sanity.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { DomainVerificationRecord } from './types'
+
+/**
+ * What `ensureDomainVerification` actually WRITES. The assertions are on the
+ * document handed to Sanity — created or not, with which `method` and `status` —
+ * never on a message, because the document is the thing every downstream
+ * consumer reads.
+ */
+
+type Doc = Record<string, unknown>
+
+const fetchMock = vi.fn<() => Promise<unknown>>()
+const createIfNotExists = vi.fn<(doc: Doc) => Promise<void>>()
+const commit = vi.fn<() => Promise<void>>()
+/** The fluent patch builder `sanity.ts` drives. */
+interface PatchChain {
+  set(fields: Doc): PatchChain
+  unset(fields: string[]): PatchChain
+  commit(): Promise<void>
+}
+const chain = (): PatchChain => ({ set, unset, commit })
+const set = vi.fn<(fields: Doc) => PatchChain>(chain)
+const unset = vi.fn<(fields: string[]) => PatchChain>(chain)
+const patch = vi.fn<(id: string) => PatchChain>(chain)
+
+vi.mock('@/lib/sanity/client', () => ({
+  clientReadUncached: { fetch: () => fetchMock() },
+  clientWrite: {
+    createIfNotExists: (doc: Doc) => createIfNotExists(doc),
+    patch: (id: string) => patch(id),
+  },
+}))
+
+const { ensureDomainVerification } = await import('./sanity')
+
+const CONFERENCE = 'conference-1'
+
+/** The single document `createIfNotExists` was called with. */
+function created(): Doc {
+  expect(createIfNotExists).toHaveBeenCalledTimes(1)
+  return createIfNotExists.mock.calls[0]![0]
+}
+
+function existing(
+  overrides: Partial<DomainVerificationRecord> = {},
+): DomainVerificationRecord {
+  return {
+    _id: 'domainVerification.kubeday.konf.run',
+    hostname: 'kubeday.konf.run',
+    conferenceId: CONFERENCE,
+    token: 'tok',
+    status: 'pending',
+    method: 'dns-txt',
+    graceUntil: null,
+    verifiedAt: null,
+    lastSuccessAt: null,
+    lastCheckedAt: null,
+    firstFailureAt: null,
+    consecutiveFailures: 0,
+    consecutiveSoftFailures: 0,
+    lastError: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchMock.mockResolvedValue(null)
+  vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('ensureDomainVerification', () => {
+  it('mints a platform subdomain as verified/platform-owned, with NO deadline', async () => {
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+    expect(created()).toMatchObject({
+      hostname: 'kubeday.konf.run',
+      status: 'verified',
+      method: 'platform-owned',
+    })
+    // `graceUntil` is what makes `grandfathered` time-boxed; platform-owned is
+    // permanent and must never carry one.
+    expect(created()).not.toHaveProperty('graceUntil')
+  })
+
+  it('mints a CUSTOM domain pending/dns-txt — proof still required', async () => {
+    await ensureDomainVerification('cloudnativedays.no', CONFERENCE)
+    expect(created()).toMatchObject({
+      hostname: 'cloudnativedays.no',
+      status: 'pending',
+      method: 'dns-txt',
+    })
+  })
+
+  it('mints a label-boundary near-miss as an ORDINARY claim', async () => {
+    await ensureDomainVerification('evil-konf.run', CONFERENCE)
+    expect(created()).toMatchObject({ status: 'pending', method: 'dns-txt' })
+  })
+
+  it('overrides an explicit `grandfathered` request for a platform host', async () => {
+    // The hostname decides, not the caller — the backfill must not hand a
+    // platform subdomain a 30-day deadline it can never satisfy.
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE, {
+      method: 'grandfathered',
+    })
+    expect(created()).toMatchObject({ method: 'platform-owned' })
+    expect(created()).not.toHaveProperty('graceUntil')
+  })
+
+  it('mints platform hosts as ordinary claims when the suffix is unset', async () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+    expect(created()).toMatchObject({ status: 'pending', method: 'dns-txt' })
+  })
+
+  it('reconciles an EXISTING dns-txt record for a now-platform host', async () => {
+    fetchMock.mockResolvedValue(
+      existing({ status: 'failing', consecutiveFailures: 9 }),
+    )
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+
+    expect(createIfNotExists).not.toHaveBeenCalled()
+    expect(patch).toHaveBeenCalledWith('domainVerification.kubeday.konf.run')
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'verified',
+        method: 'platform-owned',
+        consecutiveFailures: 0,
+      }),
+    )
+    expect(unset).toHaveBeenCalledWith(
+      expect.arrayContaining(['graceUntil', 'firstFailureAt', 'lastError']),
+    )
+    expect(commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes NOTHING for an already-reconciled platform record', async () => {
+    fetchMock.mockResolvedValue(
+      existing({ status: 'verified', method: 'platform-owned' }),
+    )
+    await ensureDomainVerification('kubeday.konf.run', CONFERENCE)
+    expect(createIfNotExists).not.toHaveBeenCalled()
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('leaves an existing CUSTOM-domain record untouched', async () => {
+    fetchMock.mockResolvedValue(
+      existing({
+        _id: 'domainVerification.cloudnativedays.no',
+        hostname: 'cloudnativedays.no',
+        status: 'failing',
+        consecutiveFailures: 9,
+      }),
+    )
+    await ensureDomainVerification('cloudnativedays.no', CONFERENCE)
+    expect(createIfNotExists).not.toHaveBeenCalled()
+    expect(commit).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/domain-verification/sanity.ts
+++ b/src/lib/domain-verification/sanity.ts
@@ -11,6 +11,7 @@ import { clientReadUncached, clientWrite } from '@/lib/sanity/client'
 import { createReference } from '@/lib/sanity/helpers'
 import { normalizeDomain } from '@/lib/conference/domains'
 import { domainVerificationId, generateVerificationToken } from './challenge'
+import { isPlatformOwnedHost } from './platform'
 import { GRANDFATHER_GRACE_DAYS } from './policy'
 import type {
   DomainVerificationMethod,
@@ -126,13 +127,20 @@ export async function getConferenceAlertTargets(
  * Every record that could plausibly be on the redirect allowlist. Kept as a
  * GROQ prefilter only — {@link isAllowlistEligible} in `policy.ts` is the
  * authority, exactly as `domainEntriesOverlap` is for the routing matcher.
+ *
+ * `platform-owned` is listed explicitly even though those records are also
+ * `verified`: the prefilter must not depend on the reconciliation having run.
+ * A platform host whose record has not been reconciled yet still carries
+ * `dns-txt`/`pending` and is missed here — deliberately, since the miss fails
+ * CLOSED (one bounced sign-in) and is repaired by the next admin list, sweep or
+ * claim.
  */
 export async function listAllowlistCandidates(): Promise<
   DomainVerificationRecord[]
 > {
   const rows = await clientReadUncached.fetch<RawRecord[] | null>(
     // groq-global: the OAuth redirect allowlist spans every tenant by design.
-    `*[_type == "domainVerification" && (status == "verified" || method == "grandfathered")] ${PROJECTION}`,
+    `*[_type == "domainVerification" && (status == "verified" || method in ["grandfathered", "platform-owned"])] ${PROJECTION}`,
   )
   return (rows ?? []).map(hydrate)
 }
@@ -145,6 +153,13 @@ export async function listAllowlistCandidates(): Promise<
  * released `example.com` and conference B claims it, B must not inherit A's
  * proof — B has to publish its own TXT record with a token it has never seen
  * before. The old token is discarded in the same patch.
+ *
+ * A host inside the platform's OWN zone is minted `platform-owned`/`verified`
+ * outright, overriding the caller's `method`: there is no challenge for the
+ * tenant to answer, so leaving it `pending` would only produce an admin card
+ * asking for an impossible DNS record. The hostname decides this, not the
+ * caller — every entry point (onboarding, `updateDomains`, the provisioning
+ * API, the backfill) therefore gets it right without knowing about it.
  */
 export async function ensureDomainVerification(
   hostname: string,
@@ -153,7 +168,10 @@ export async function ensureDomainVerification(
 ): Promise<void> {
   const host = normalizeDomain(hostname)
   const _id = domainVerificationId(host)
-  const method = options.method ?? 'dns-txt'
+  const platformOwned = isPlatformOwnedHost(host)
+  const method: DomainVerificationMethod = platformOwned
+    ? 'platform-owned'
+    : (options.method ?? 'dns-txt')
   const now = options.now ?? new Date()
   const grandfathered = method === 'grandfathered'
   const nowIso = now.toISOString()
@@ -173,7 +191,12 @@ export async function ensureDomainVerification(
         lastSuccessAt: nowIso,
       }
     : {}
-  const initialStatus = grandfathered ? 'verified' : 'pending'
+  // Note the absence of `graceUntil`: a platform-owned record is PERMANENT, not
+  // a time-boxed exemption like `grandfathered`.
+  const platformFields: Record<string, string> = platformOwned
+    ? { verifiedAt: nowIso, lastSuccessAt: nowIso }
+    : {}
+  const initialStatus = grandfathered || platformOwned ? 'verified' : 'pending'
 
   if (!existing) {
     await clientWrite.createIfNotExists({
@@ -187,12 +210,34 @@ export async function ensureDomainVerification(
       consecutiveFailures: 0,
       consecutiveSoftFailures: 0,
       ...grandfatherFields,
+      ...platformFields,
     })
     return
   }
 
   const sameHolder = existing.conferenceId === conferenceId
-  if (sameHolder && existing.status !== 'revoked') return
+  if (sameHolder && existing.status !== 'revoked') {
+    // One exception to "leave an existing record alone": a host that has BECOME
+    // platform-owned (claimed before this feature, or before the suffix was
+    // configured) still carries a `pending` DNS-TXT record, so the admin card
+    // would demand a record in our own zone. Reconcile it in place; the sweep
+    // would do the same thing tomorrow.
+    if (platformOwned && existing.method !== 'platform-owned') {
+      await clientWrite
+        .patch(_id)
+        .set({
+          status: 'verified',
+          method,
+          consecutiveFailures: 0,
+          consecutiveSoftFailures: 0,
+          verifiedAt: existing.verifiedAt ?? nowIso,
+          lastSuccessAt: nowIso,
+        })
+        .unset(['graceUntil', 'firstFailureAt', 'lastError'])
+        .commit()
+    }
+    return
+  }
 
   // Different holder, or the same holder re-claiming a released hostname:
   // start from zero. The `unset` clears the whole timing history so a stale
@@ -208,18 +253,21 @@ export async function ensureDomainVerification(
       consecutiveFailures: 0,
       consecutiveSoftFailures: 0,
       ...grandfatherFields,
+      ...platformFields,
     })
     .unset(
       grandfathered
         ? ['firstFailureAt', 'lastError']
-        : [
-            'graceUntil',
-            'verifiedAt',
-            'lastSuccessAt',
-            'lastCheckedAt',
-            'firstFailureAt',
-            'lastError',
-          ],
+        : platformOwned
+          ? ['graceUntil', 'firstFailureAt', 'lastError']
+          : [
+              'graceUntil',
+              'verifiedAt',
+              'lastSuccessAt',
+              'lastCheckedAt',
+              'firstFailureAt',
+              'lastError',
+            ],
     )
     .commit()
 }

--- a/src/lib/domain-verification/sanity.ts
+++ b/src/lib/domain-verification/sanity.ts
@@ -11,7 +11,7 @@ import { clientReadUncached, clientWrite } from '@/lib/sanity/client'
 import { createReference } from '@/lib/sanity/helpers'
 import { normalizeDomain } from '@/lib/conference/domains'
 import { domainVerificationId, generateVerificationToken } from './challenge'
-import { isPlatformOwnedHost } from './platform'
+import { isPlatformZoneHost } from './platform'
 import { GRANDFATHER_GRACE_DAYS } from './policy'
 import type {
   DomainVerificationMethod,
@@ -154,26 +154,33 @@ export async function listAllowlistCandidates(): Promise<
  * proof — B has to publish its own TXT record with a token it has never seen
  * before. The old token is discarded in the same patch.
  *
- * A host inside the platform's OWN zone is minted `platform-owned`/`verified`
- * outright, overriding the caller's `method`: there is no challenge for the
- * tenant to answer, so leaving it `pending` would only produce an admin card
- * asking for an impossible DNS record. The hostname decides this, not the
- * caller — every entry point (onboarding, `updateDomains`, the provisioning
- * API, the backfill) therefore gets it right without knowing about it.
+ * ALLOCATION IS EXPLICIT. A host inside the platform's own zone is minted
+ * `platform-owned`/`verified` ONLY when the caller passes
+ * `allocatePlatformHost` — which only the platform's tenant-provisioning path
+ * does. Every other caller (`updateDomains`, `createEdition`, the admin card's
+ * self-heal) writes NOTHING for such a host unless an allocation already exists
+ * for THIS conference. That is the whole entitlement control: were the hostname
+ * alone to decide, any organizer who can type `some-other-tenant.<suffix>` into
+ * their settings would mint themselves a permanent, unprovable grant to it.
+ *
+ * Leaving the record absent fails closed — unrouted under enforcement, never
+ * allowlisted — and the mutations reject such a payload outright, so this is
+ * defence in depth rather than the only line.
  */
 export async function ensureDomainVerification(
   hostname: string,
   conferenceId: string,
-  options: { method?: DomainVerificationMethod; now?: Date } = {},
+  options: {
+    method?: DomainVerificationMethod
+    /** Platform-provisioning ONLY: grant this in-zone host to `conferenceId`. */
+    allocatePlatformHost?: boolean
+    now?: Date
+  } = {},
 ): Promise<void> {
   const host = normalizeDomain(hostname)
   const _id = domainVerificationId(host)
-  const platformOwned = isPlatformOwnedHost(host)
-  const method: DomainVerificationMethod = platformOwned
-    ? 'platform-owned'
-    : (options.method ?? 'dns-txt')
+  const inPlatformZone = isPlatformZoneHost(host)
   const now = options.now ?? new Date()
-  const grandfathered = method === 'grandfathered'
   const nowIso = now.toISOString()
 
   const existing = await clientReadUncached.fetch<RawRecord | null>(
@@ -181,6 +188,27 @@ export async function ensureDomainVerification(
     `*[_type == "domainVerification" && _id == $id][0] ${PROJECTION}`,
     { id: _id },
   )
+
+  // An allocation this conference already holds. Recognised so a tenant that
+  // releases and re-adds its own platform subdomain is restored without a
+  // support ticket — but note it is keyed on the STORED allocation, so it can
+  // never manufacture one that was not granted.
+  const holdsAllocation =
+    existing?.method === 'platform-owned' &&
+    existing.conferenceId === conferenceId
+  const platformOwned =
+    inPlatformZone && (options.allocatePlatformHost === true || holdsAllocation)
+  if (inPlatformZone && !platformOwned) {
+    // NO IMPLICIT ALLOCATION. Write nothing at all: a record here would either
+    // grant the standing outright or promise the tenant a DNS challenge they
+    // cannot answer.
+    return
+  }
+
+  const method: DomainVerificationMethod = platformOwned
+    ? 'platform-owned'
+    : (options.method ?? 'dns-txt')
+  const grandfathered = method === 'grandfathered'
 
   const grandfatherFields: Record<string, string> = grandfathered
     ? {
@@ -217,12 +245,12 @@ export async function ensureDomainVerification(
 
   const sameHolder = existing.conferenceId === conferenceId
   if (sameHolder && existing.status !== 'revoked') {
-    // One exception to "leave an existing record alone": a host that has BECOME
-    // platform-owned (claimed before this feature, or before the suffix was
-    // configured) still carries a `pending` DNS-TXT record, so the admin card
-    // would demand a record in our own zone. Reconcile it in place; the sweep
-    // would do the same thing tomorrow.
-    if (platformOwned && existing.method !== 'platform-owned') {
+    // One exception to "leave an existing record alone": the platform is
+    // ALLOCATING a host this conference already claims under an ordinary
+    // (or grandfathered) record, so the record has to be upgraded in place.
+    // Gated on the explicit allocation — `holdsAllocation` cannot reach here,
+    // since it implies the method is already `platform-owned`.
+    if (options.allocatePlatformHost === true && platformOwned) {
       await clientWrite
         .patch(_id)
         .set({

--- a/src/lib/domain-verification/sweep.test.ts
+++ b/src/lib/domain-verification/sweep.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { expectedTxtValue } from './challenge'
-import { isAllowlistEligible } from './policy'
+import { isAllowlistEligible, isRoutingEligible } from './policy'
 import type { DomainVerificationPatch, DomainVerificationRecord } from './types'
 
 /**
@@ -13,11 +13,15 @@ import type { DomainVerificationPatch, DomainVerificationRecord } from './types'
 /** Mutable fake zone: name → TXT RRset, or an error code to throw. */
 const zone = new Map<string, string[][] | { code: string }>()
 
+/** Every name the sweep actually issued a lookup for, in order. */
+const lookups: string[] = []
+
 vi.mock('./dns', async () => {
   const actual = await vi.importActual<typeof import('./dns')>('./dns')
   return {
     checkDomainChallenge: (entry: string, token: string) =>
       actual.checkDomainChallenge(entry, token, async (name) => {
+        lookups.push(name)
         const answer = zone.get(name)
         if (!answer)
           throw Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' })
@@ -81,8 +85,13 @@ function seedVerified(overrides: Partial<DomainVerificationRecord> = {}) {
 beforeEach(() => {
   zone.clear()
   store.clear()
+  lookups.length = 0
   createNotifications.mockClear()
   vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
 })
 
 describe('runDomainVerificationSweep', () => {
@@ -161,6 +170,99 @@ describe('runDomainVerificationSweep', () => {
     expect(after.consecutiveFailures).toBe(0)
     expect(after.firstFailureAt).toBeNull()
     expect(isAllowlistEligible(after, NOW)).toBe(true)
+  })
+
+  describe('platform-owned hosts', () => {
+    const PLATFORM_HOST = 'kubeday.konf.run'
+    const PLATFORM_ID = `domainVerification.${PLATFORM_HOST}`
+
+    /**
+     * Deliberately the WORST case: an old `dns-txt` record deep in a failure
+     * streak — exactly what a pre-existing `konf.run` tenant carries today,
+     * because the proof it is being asked for is unpublishable.
+     */
+    function seedPlatformClaim() {
+      store.set(PLATFORM_ID, {
+        _id: PLATFORM_ID,
+        hostname: PLATFORM_HOST,
+        conferenceId: 'conference-2',
+        token: 'tok-platform',
+        status: 'failing',
+        method: 'dns-txt',
+        graceUntil: null,
+        verifiedAt: null,
+        lastSuccessAt: null,
+        lastCheckedAt: '2026-06-30T00:00:00.000Z',
+        firstFailureAt: '2026-05-01T00:00:00.000Z',
+        consecutiveFailures: 12,
+        consecutiveSoftFailures: 0,
+        lastError: 'No TXT record',
+      })
+    }
+
+    it('never issues a DNS lookup for a host in the platform zone', async () => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+      seedPlatformClaim()
+
+      const summary = await runDomainVerificationSweep(NOW)
+
+      expect(lookups).toEqual([])
+      expect(summary).toMatchObject({
+        checked: 1,
+        platformOwned: 1,
+        hardFailures: 0,
+        delisted: [],
+      })
+    })
+
+    it('repairs the record instead of flagging it as failing', async () => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+      seedPlatformClaim()
+
+      await runDomainVerificationSweep(NOW)
+
+      const after = store.get(PLATFORM_ID)!
+      expect(after.status).toBe('verified')
+      expect(after.method).toBe('platform-owned')
+      expect(after.consecutiveFailures).toBe(0)
+      expect(after.firstFailureAt).toBeNull()
+      expect(isRoutingEligible(after, NOW)).toBe(true)
+      expect(isAllowlistEligible(after, NOW)).toBe(true)
+      // Nothing broke, so nobody is told anything broke.
+      expect(createNotifications).not.toHaveBeenCalled()
+    })
+
+    it('DNS-checks the very same host once the suffix no longer covers it', async () => {
+      // Proves the skip is driven by the configured suffix, not by the
+      // hostname's shape or the stored method — and that it fails closed.
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
+      seedPlatformClaim()
+
+      const summary = await runDomainVerificationSweep(NOW)
+
+      expect(lookups).toEqual([`_konf-challenge.${PLATFORM_HOST}`])
+      expect(summary.platformOwned).toBe(0)
+      expect(summary.hardFailures).toBe(1)
+      expect(store.get(PLATFORM_ID)!.status).toBe('failing')
+    })
+
+    it('still delists a CUSTOM domain swept alongside a platform one', async () => {
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+      seedVerified()
+      seedPlatformClaim()
+      // The custom domain's proof is gone (nothing in `zone`); the platform
+      // host is never asked.
+
+      const summary = await runDomainVerificationSweep(NOW)
+
+      expect(summary.checked).toBe(2)
+      expect(summary.platformOwned).toBe(1)
+      expect(summary.hardFailures).toBe(1)
+      expect(summary.delisted).toEqual([HOST])
+      expect(lookups).toEqual([CHALLENGE])
+      expect(isAllowlistEligible(store.get(ID)!, NOW)).toBe(false)
+      expect(isAllowlistEligible(store.get(PLATFORM_ID)!, NOW)).toBe(true)
+    })
   })
 
   it('reports a per-domain failure without aborting the rest of the sweep', async () => {

--- a/src/lib/domain-verification/sweep.test.ts
+++ b/src/lib/domain-verification/sweep.test.ts
@@ -172,24 +172,24 @@ describe('runDomainVerificationSweep', () => {
     expect(isAllowlistEligible(after, NOW)).toBe(true)
   })
 
-  describe('platform-owned hosts', () => {
+  describe('platform-allocated hosts', () => {
     const PLATFORM_HOST = 'kubeday.konf.run'
     const PLATFORM_ID = `domainVerification.${PLATFORM_HOST}`
 
     /**
-     * Deliberately the WORST case: an old `dns-txt` record deep in a failure
-     * streak — exactly what a pre-existing `konf.run` tenant carries today,
-     * because the proof it is being asked for is unpublishable.
+     * A record the platform ALLOCATED, but which also carries a stale
+     * grandfather deadline and a failure streak from before the allocation —
+     * the worst state a real `konf.run` tenant can be in today.
      */
-    function seedPlatformClaim() {
+    function seedAllocation(overrides: Partial<DomainVerificationRecord> = {}) {
       store.set(PLATFORM_ID, {
         _id: PLATFORM_ID,
         hostname: PLATFORM_HOST,
         conferenceId: 'conference-2',
         token: 'tok-platform',
         status: 'failing',
-        method: 'dns-txt',
-        graceUntil: null,
+        method: 'platform-owned',
+        graceUntil: '2026-06-15T00:00:00.000Z',
         verifiedAt: null,
         lastSuccessAt: null,
         lastCheckedAt: '2026-06-30T00:00:00.000Z',
@@ -197,12 +197,13 @@ describe('runDomainVerificationSweep', () => {
         consecutiveFailures: 12,
         consecutiveSoftFailures: 0,
         lastError: 'No TXT record',
+        ...overrides,
       })
     }
 
-    it('never issues a DNS lookup for a host in the platform zone', async () => {
+    it('never issues a DNS lookup for a host the platform allocated', async () => {
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
-      seedPlatformClaim()
+      seedAllocation()
 
       const summary = await runDomainVerificationSweep(NOW)
 
@@ -217,7 +218,7 @@ describe('runDomainVerificationSweep', () => {
 
     it('repairs the record instead of flagging it as failing', async () => {
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
-      seedPlatformClaim()
+      seedAllocation()
 
       await runDomainVerificationSweep(NOW)
 
@@ -232,11 +233,43 @@ describe('runDomainVerificationSweep', () => {
       expect(createNotifications).not.toHaveBeenCalled()
     })
 
-    it('DNS-checks the very same host once the suffix no longer covers it', async () => {
-      // Proves the skip is driven by the configured suffix, not by the
-      // hostname's shape or the stored method — and that it fails closed.
+    it('CLEARS a stale grandfather deadline off the stored record', async () => {
+      // Left in place it would expire a grant that has no expiry — the record
+      // would stop being honoured the moment the old window closed.
+      // Allocated, but still carrying the deadline it had while it was
+      // grandfathered.
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+      seedAllocation()
+      expect(store.get(PLATFORM_ID)!.graceUntil).not.toBeNull()
+
+      await runDomainVerificationSweep(NOW)
+
+      expect(store.get(PLATFORM_ID)!.graceUntil).toBeNull()
+    })
+
+    it('DNS-CHECKS an in-zone host the platform never allocated', async () => {
+      // The hijack, at the sweep: a hostname an organizer typed is treated like
+      // any other unproven claim — resolved, hard-failed, left unrouted — rather
+      // than quietly reconciled to verified.
+      vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+      seedAllocation({ method: 'dns-txt', status: 'pending' })
+
+      const summary = await runDomainVerificationSweep(NOW)
+
+      expect(lookups).toEqual([`_konf-challenge.${PLATFORM_HOST}`])
+      expect(summary.platformOwned).toBe(0)
+      expect(summary.hardFailures).toBe(1)
+      const after = store.get(PLATFORM_ID)!
+      expect(after.method).toBe('dns-txt')
+      expect(isRoutingEligible(after, NOW)).toBe(false)
+      expect(isAllowlistEligible(after, NOW)).toBe(false)
+    })
+
+    it('DNS-checks the very same allocation once the suffix no longer covers it', async () => {
+      // Proves the skip is driven by the configured suffix as well as the
+      // allocation — and that it fails closed.
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
-      seedPlatformClaim()
+      seedAllocation()
 
       const summary = await runDomainVerificationSweep(NOW)
 
@@ -246,11 +279,11 @@ describe('runDomainVerificationSweep', () => {
       expect(store.get(PLATFORM_ID)!.status).toBe('failing')
     })
 
-    it('still delists a CUSTOM domain swept alongside a platform one', async () => {
+    it('still delists a CUSTOM domain swept alongside an allocated one', async () => {
       vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
       seedVerified()
-      seedPlatformClaim()
-      // The custom domain's proof is gone (nothing in `zone`); the platform
+      seedAllocation()
+      // The custom domain's proof is gone (nothing in `zone`); the allocated
       // host is never asked.
 
       const summary = await runDomainVerificationSweep(NOW)

--- a/src/lib/domain-verification/sweep.ts
+++ b/src/lib/domain-verification/sweep.ts
@@ -17,6 +17,7 @@
 
 import { createNotifications } from '@/lib/notification/sanity'
 import { checkDomainChallenge } from './dns'
+import { isPlatformOwnedHost } from './platform'
 import { applyCheckOutcome, isAllowlistEligible } from './policy'
 import {
   getConferenceAlertTargets,
@@ -31,6 +32,8 @@ const CONCURRENCY = 5
 export interface DomainVerificationSweepSummary {
   checked: number
   verified: number
+  /** Hosts inside the platform's own zone — reconciled, never resolved. */
+  platformOwned: number
   hardFailures: number
   softFailures: number
   unverifiable: number
@@ -100,7 +103,13 @@ export async function recheckDomainRecord(
   delisted: boolean
 }> {
   const wasAllowlisted = isAllowlistEligible(record, now)
-  const outcome = await checkDomainChallenge(record.hostname, record.token)
+  // NO LOOKUP for a host inside the platform's own zone. There is no tenant TXT
+  // record to find, so resolving would hard-fail every one of them and mark the
+  // whole platform-hosted estate `failing` (and alert its organisers about a
+  // record they cannot publish). The verdict is reconciled instead.
+  const outcome: DomainCheckOutcome = isPlatformOwnedHost(record.hostname)
+    ? { kind: 'platform-owned' }
+    : await checkDomainChallenge(record.hostname, record.token)
   const patch = applyCheckOutcome(record, outcome, now)
   await patchDomainVerification(record._id, patch)
 
@@ -131,6 +140,7 @@ export async function runDomainVerificationSweep(
   const summary: DomainVerificationSweepSummary = {
     checked: 0,
     verified: 0,
+    platformOwned: 0,
     hardFailures: 0,
     softFailures: 0,
     unverifiable: 0,
@@ -143,6 +153,7 @@ export async function runDomainVerificationSweep(
       const { outcome, delisted } = await recheckDomainRecord(record, now)
       summary.checked += 1
       if (outcome.kind === 'verified') summary.verified += 1
+      else if (outcome.kind === 'platform-owned') summary.platformOwned += 1
       else if (outcome.kind === 'hard-failure') summary.hardFailures += 1
       else if (outcome.kind === 'soft-failure') summary.softFailures += 1
       else summary.unverifiable += 1

--- a/src/lib/domain-verification/sweep.ts
+++ b/src/lib/domain-verification/sweep.ts
@@ -17,7 +17,7 @@
 
 import { createNotifications } from '@/lib/notification/sanity'
 import { checkDomainChallenge } from './dns'
-import { isPlatformOwnedHost } from './platform'
+import { isPlatformAllocated } from './platform'
 import { applyCheckOutcome, isAllowlistEligible } from './policy'
 import {
   getConferenceAlertTargets,
@@ -32,7 +32,7 @@ const CONCURRENCY = 5
 export interface DomainVerificationSweepSummary {
   checked: number
   verified: number
-  /** Hosts inside the platform's own zone — reconciled, never resolved. */
+  /** Hosts the platform ALLOCATED — reconciled, never resolved. */
   platformOwned: number
   hardFailures: number
   softFailures: number
@@ -103,11 +103,15 @@ export async function recheckDomainRecord(
   delisted: boolean
 }> {
   const wasAllowlisted = isAllowlistEligible(record, now)
-  // NO LOOKUP for a host inside the platform's own zone. There is no tenant TXT
-  // record to find, so resolving would hard-fail every one of them and mark the
-  // whole platform-hosted estate `failing` (and alert its organisers about a
-  // record they cannot publish). The verdict is reconciled instead.
-  const outcome: DomainCheckOutcome = isPlatformOwnedHost(record.hostname)
+  // NO LOOKUP for a host the platform ALLOCATED. There is no tenant TXT record
+  // to find, so resolving would hard-fail the whole platform-hosted estate and
+  // alert its organisers about a record they cannot publish. The verdict is
+  // reconciled instead.
+  //
+  // Keyed on the ALLOCATION, not on the suffix: an unallocated claim that merely
+  // sits in our zone is checked like any other, hard-fails, and stays unrouted —
+  // exactly the fail-closed outcome a hijack attempt should get.
+  const outcome: DomainCheckOutcome = isPlatformAllocated(record)
     ? { kind: 'platform-owned' }
     : await checkDomainChallenge(record.hostname, record.token)
   const patch = applyCheckOutcome(record, outcome, now)

--- a/src/lib/domain-verification/sync.test.ts
+++ b/src/lib/domain-verification/sync.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { DomainVerificationRecord } from './types'
+
+/**
+ * The ENTITLEMENT GUARD the tenant-facing mutations run before they write.
+ *
+ * `domains[]` is a globally unique routing claim, so an organizer who manages to
+ * save `some-other-tenant.<platform suffix>` does not merely fail to verify it —
+ * they lock the rightful tenant out of that hostname permanently. The refusal
+ * therefore has to happen at the claim, which is what this returns.
+ */
+
+const records = new Map<string, DomainVerificationRecord>()
+
+vi.mock('./sanity', () => ({
+  ensureDomainVerification: vi.fn(),
+  getDomainVerification: async (hostname: string) =>
+    records.get(hostname) ?? null,
+  listDomainVerificationsForConference: vi.fn(async () => []),
+  revokeDomainVerification: vi.fn(),
+}))
+
+const { findUnallocatedPlatformDomains } = await import('./sync')
+
+const OURS = 'conference-1'
+const THEIRS = 'conference-2'
+
+function seed(
+  hostname: string,
+  overrides: Partial<DomainVerificationRecord> = {},
+) {
+  records.set(hostname, {
+    _id: `domainVerification.${hostname}`,
+    hostname,
+    conferenceId: OURS,
+    token: 'tok',
+    status: 'verified',
+    method: 'platform-owned',
+    graceUntil: null,
+    verifiedAt: null,
+    lastSuccessAt: null,
+    lastCheckedAt: null,
+    firstFailureAt: null,
+    consecutiveFailures: 0,
+    consecutiveSoftFailures: 0,
+    lastError: null,
+    ...overrides,
+  })
+}
+
+beforeEach(() => {
+  records.clear()
+  vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('findUnallocatedPlatformDomains', () => {
+  it('accepts a host the platform allocated to THIS conference', async () => {
+    seed('kubeday.konf.run')
+    expect(
+      await findUnallocatedPlatformDomains(OURS, ['kubeday.konf.run']),
+    ).toEqual([])
+  })
+
+  it('REFUSES an in-zone host with no record — the unissued-label grab', async () => {
+    expect(
+      await findUnallocatedPlatformDomains(OURS, [
+        'some-other-tenant.konf.run',
+      ]),
+    ).toEqual(['some-other-tenant.konf.run'])
+  })
+
+  it('REFUSES a host allocated to ANOTHER conference', async () => {
+    seed('rival.konf.run', { conferenceId: THEIRS })
+    expect(
+      await findUnallocatedPlatformDomains(OURS, ['rival.konf.run']),
+    ).toEqual(['rival.konf.run'])
+  })
+
+  it('REFUSES an in-zone host that only has an ordinary dns-txt record', async () => {
+    // Even a fully `verified` DNS proof is not an allocation. (It cannot happen
+    // for a real platform host anyway — the tenant cannot publish in our zone —
+    // but the guard must not depend on that.)
+    seed('sneaky.konf.run', { method: 'dns-txt', status: 'verified' })
+    expect(
+      await findUnallocatedPlatformDomains(OURS, ['sneaky.konf.run']),
+    ).toEqual(['sneaky.konf.run'])
+  })
+
+  it('IGNORES custom domains entirely — they prove themselves by DNS', async () => {
+    expect(
+      await findUnallocatedPlatformDomains(OURS, [
+        'cloudnativedays.no',
+        'oslo.cloudnativedays.no',
+        '*.cloudnativedays.no',
+      ]),
+    ).toEqual([])
+  })
+
+  it('IGNORES label-boundary near-misses of the platform zone', async () => {
+    // Not in our zone, so not ours to allocate — they take the ordinary
+    // DNS-TXT path rather than being refused outright.
+    expect(
+      await findUnallocatedPlatformDomains(OURS, [
+        'evil-konf.run',
+        'konf.run.attacker.com',
+        'a.konf.runner',
+      ]),
+    ).toEqual([])
+  })
+
+  it('REFUSES a `*.konf.run` wildcard over the whole platform zone', async () => {
+    // A wildcard can never be allocated (`isPlatformZoneHost` excludes it), so
+    // it is simply outside this guard — and the ordinary DNS-TXT path it falls
+    // back to is unsatisfiable in our zone, which is the intended dead end.
+    expect(await findUnallocatedPlatformDomains(OURS, ['*.konf.run'])).toEqual(
+      [],
+    )
+  })
+
+  it('returns every offending host, keeping the good ones', async () => {
+    seed('kubeday.konf.run')
+    expect(
+      await findUnallocatedPlatformDomains(OURS, [
+        'kubeday.konf.run',
+        'cloudnativedays.no',
+        'grabbed.konf.run',
+        'also-grabbed.konf.run',
+      ]),
+    ).toEqual(['grabbed.konf.run', 'also-grabbed.konf.run'])
+  })
+
+  it('accepts everything when no platform suffix is configured', async () => {
+    // Nothing is in "our zone", so nothing is ours to withhold. Claims are
+    // governed entirely by DNS-TXT proof, exactly as before this feature.
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
+    expect(
+      await findUnallocatedPlatformDomains(OURS, ['anything.konf.run']),
+    ).toEqual([])
+  })
+})

--- a/src/lib/domain-verification/sync.ts
+++ b/src/lib/domain-verification/sync.ts
@@ -10,8 +10,10 @@
  */
 
 import { normalizeDomain } from '@/lib/conference/domains'
+import { isPlatformZoneHost } from './platform'
 import {
   ensureDomainVerification,
+  getDomainVerification,
   listDomainVerificationsForConference,
   revokeDomainVerification,
 } from './sanity'
@@ -20,6 +22,12 @@ import { toDomainVerificationView, type DomainVerificationView } from './view'
 /**
  * Ensure a record for every entry in `domains`, and revoke the ones in
  * `removed` that are no longer claimed.
+ *
+ * `allocatePlatformHosts` is the platform's GRANT of a subdomain of its own zone
+ * to this conference and belongs to the tenant-provisioning path alone
+ * (`provisionOrganization`). Left off — the default, and what every
+ * tenant-facing mutation passes — an unallocated host under the platform suffix
+ * simply gets no record, which fails closed.
  *
  * BEST-EFFORT, like the notification hub: a verification bookkeeping failure
  * must never roll back the domain mutation that triggered it. A missing record
@@ -31,11 +39,14 @@ export async function syncDomainVerifications(
   conferenceId: string,
   domains: readonly string[],
   removed: readonly string[] = [],
+  options: { allocatePlatformHosts?: boolean } = {},
 ): Promise<void> {
   const claimed = new Set(domains.map(normalizeDomain).filter(Boolean))
   try {
     for (const hostname of claimed) {
-      await ensureDomainVerification(hostname, conferenceId)
+      await ensureDomainVerification(hostname, conferenceId, {
+        allocatePlatformHost: options.allocatePlatformHosts === true,
+      })
     }
     for (const hostname of removed.map(normalizeDomain).filter(Boolean)) {
       if (claimed.has(hostname)) continue
@@ -47,6 +58,46 @@ export async function syncDomainVerifications(
       error,
     )
   }
+}
+
+/**
+ * The subset of `domains` that sits inside the platform's own zone WITHOUT an
+ * allocation to `conferenceId` — i.e. the entries a tenant-facing mutation must
+ * refuse.
+ *
+ * This is the entitlement guard, and it belongs at the WRITE path: `domains[]`
+ * is a globally unique routing claim, so letting an organizer save
+ * `some-other-tenant.<suffix>` does not merely fail to verify — it permanently
+ * blocks the rightful tenant from ever being given that hostname. Rejecting the
+ * payload keeps the claim itself from being made.
+ *
+ * Hosts outside the platform zone are never returned: custom domains are none of
+ * this function's business and keep proving themselves by DNS-TXT.
+ */
+export async function findUnallocatedPlatformDomains(
+  conferenceId: string,
+  domains: readonly string[],
+): Promise<string[]> {
+  const inZone = domains
+    .map(normalizeDomain)
+    .filter(Boolean)
+    .filter((hostname) => isPlatformZoneHost(hostname))
+  if (inZone.length === 0) return []
+
+  const verdicts = await Promise.all(
+    inZone.map(async (hostname) => {
+      const record = await getDomainVerification(hostname)
+      // The allocation is the record the PLATFORM wrote, naming this conference.
+      // A `dns-txt` record — however verified — is not an allocation, and one
+      // naming another conference is emphatically not.
+      const allocated =
+        record !== null &&
+        record.method === 'platform-owned' &&
+        record.conferenceId === conferenceId
+      return allocated ? null : hostname
+    }),
+  )
+  return verdicts.filter((hostname): hostname is string => hostname !== null)
 }
 
 /**

--- a/src/lib/domain-verification/types.ts
+++ b/src/lib/domain-verification/types.ts
@@ -67,12 +67,20 @@ export type DomainCheckOutcome =
   | { kind: 'soft-failure'; reason: string }
   | { kind: 'unverifiable'; reason: string }
 
-/** Fields the policy writes back after a check. */
+/**
+ * Fields the policy writes back after a check.
+ *
+ * `graceUntil` is included so a deadline can be CLEARED (`null` → `unset`, see
+ * `patchDomainVerification`). Without it a record that was grandfathered before
+ * the platform allocated it would keep its 30-day deadline and expire, even
+ * though a platform allocation has none.
+ */
 export type DomainVerificationPatch = Partial<
   Pick<
     DomainVerificationRecord,
     | 'status'
     | 'method'
+    | 'graceUntil'
     | 'verifiedAt'
     | 'lastSuccessAt'
     | 'lastCheckedAt'

--- a/src/lib/domain-verification/types.ts
+++ b/src/lib/domain-verification/types.ts
@@ -15,11 +15,19 @@ export type DomainVerificationStatus =
   'pending' | 'verified' | 'failing' | 'revoked'
 
 /**
- * How the record earned its current status. `grandfathered` records were
- * admitted by the backfill without proof and are trusted ONLY until
- * `graceUntil`; they become `dns-txt` the moment a real proof resolves.
+ * How the record earned its current status.
+ *
+ * - `dns-txt` — the tenant published the challenge record in their own zone.
+ * - `grandfathered` — admitted by the backfill without proof, trusted ONLY
+ *   until `graceUntil`; becomes `dns-txt` the moment a real proof resolves.
+ * - `platform-owned` — the hostname sits under the platform's OWN zone
+ *   (`PLATFORM_DOMAIN_SUFFIX`, see `platform.ts`), so control is ours by
+ *   construction. PERMANENT, not a grace period: it carries no `graceUntil`
+ *   and there is no proof for the tenant to complete. Re-derived from the
+ *   hostname on every decision, so a stale record cannot outlive the config.
  */
-export type DomainVerificationMethod = 'dns-txt' | 'grandfathered'
+export type DomainVerificationMethod =
+  'dns-txt' | 'grandfathered' | 'platform-owned'
 
 /** A `domainVerification` document as the app reads it. */
 export interface DomainVerificationRecord {
@@ -47,9 +55,14 @@ export interface DomainVerificationRecord {
  * only thing that may cost a domain its standing. A `soft-failure` means our
  * resolver could not get an answer at all (timeout, SERVFAIL, network); that is
  * our outage, not the tenant's, and must never delist on its own.
+ *
+ * `platform-owned` is the one verdict reached WITHOUT a lookup: the hostname is
+ * inside our own zone, so there is nothing to resolve and nothing that could
+ * fail. The sweep never issues a query for those records.
  */
 export type DomainCheckOutcome =
   | { kind: 'verified' }
+  | { kind: 'platform-owned' }
   | { kind: 'hard-failure'; reason: string }
   | { kind: 'soft-failure'; reason: string }
   | { kind: 'unverifiable'; reason: string }

--- a/src/lib/domain-verification/view.test.ts
+++ b/src/lib/domain-verification/view.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { toDomainVerificationView } from './view'
+import type { DomainVerificationRecord } from './types'
+
+/**
+ * The admin card's view model. It is a SECURITY SURFACE as much as a display
+ * one: it is what tells an organizer whether a hostname is trusted, and what (if
+ * anything) they still have to publish. Announcing "provided by the platform"
+ * for a host the platform never issued — or for a claim that has been released —
+ * is how a hijack looks legitimate to the person best placed to notice it.
+ */
+
+const NOW = new Date('2026-07-01T12:00:00.000Z')
+
+function record(
+  overrides: Partial<DomainVerificationRecord> = {},
+): DomainVerificationRecord {
+  return {
+    _id: 'domainVerification.kubeday.konf.run',
+    hostname: 'kubeday.konf.run',
+    conferenceId: 'conference-1',
+    token: 'tok',
+    status: 'verified',
+    method: 'platform-owned',
+    graceUntil: null,
+    verifiedAt: '2026-06-01T00:00:00.000Z',
+    lastSuccessAt: '2026-06-30T00:00:00.000Z',
+    lastCheckedAt: '2026-06-30T00:00:00.000Z',
+    firstFailureAt: null,
+    consecutiveFailures: 0,
+    consecutiveSoftFailures: 0,
+    lastError: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', 'konf.run')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('toDomainVerificationView — platform allocations', () => {
+  it('marks an allocated host as platform-provided, with no challenge to publish', () => {
+    const view = toDomainVerificationView('kubeday.konf.run', record(), NOW)
+    expect(view.platformOwned).toBe(true)
+    expect(view.routable).toBe(true)
+    expect(view.redirectAllowlisted).toBe(true)
+    // Nothing to publish, and no deadline to publish it by.
+    expect(view.recordName).toBeNull()
+    expect(view.recordValue).toBeNull()
+    expect(view.graceUntil).toBeNull()
+  })
+
+  it('does NOT announce an in-zone host the platform never allocated', () => {
+    // An organizer's grab must look exactly like what it is: an unverified
+    // claim, with the ordinary DNS challenge shown.
+    const view = toDomainVerificationView(
+      'some-other-tenant.konf.run',
+      record({
+        hostname: 'some-other-tenant.konf.run',
+        method: 'dns-txt',
+        status: 'pending',
+      }),
+      NOW,
+    )
+    expect(view.platformOwned).toBe(false)
+    expect(view.routable).toBe(false)
+    expect(view.redirectAllowlisted).toBe(false)
+    expect(view.status).toBe('pending')
+    expect(view.recordName).toBe('_konf-challenge.some-other-tenant.konf.run')
+  })
+
+  it('does NOT announce an in-zone host with NO record at all', () => {
+    const view = toDomainVerificationView('grabbed.konf.run', null, NOW)
+    expect(view.platformOwned).toBe(false)
+    expect(view.routable).toBe(false)
+    expect(view.status).toBe('pending')
+  })
+
+  it('REVOKED wins: a released allocation is neither provided nor routable', () => {
+    // Revocation is the remedy when a host ends up with the wrong tenant, so the
+    // card must stop vouching for it the moment the claim is released.
+    const view = toDomainVerificationView(
+      'kubeday.konf.run',
+      record({ status: 'revoked' }),
+      NOW,
+    )
+    expect(view.platformOwned).toBe(false)
+    expect(view.routable).toBe(false)
+    expect(view.redirectAllowlisted).toBe(false)
+    expect(view.status).toBe('revoked')
+  })
+
+  it('does NOT announce a label-boundary near-miss as platform-provided', () => {
+    const view = toDomainVerificationView(
+      'evil-konf.run',
+      record({ hostname: 'evil-konf.run', status: 'pending' }),
+      NOW,
+    )
+    expect(view.platformOwned).toBe(false)
+    expect(view.routable).toBe(false)
+  })
+
+  it('leaves a CUSTOM domain showing its DNS challenge', () => {
+    const view = toDomainVerificationView(
+      'cloudnativedays.no',
+      record({
+        _id: 'domainVerification.cloudnativedays.no',
+        hostname: 'cloudnativedays.no',
+        method: 'dns-txt',
+      }),
+      NOW,
+    )
+    expect(view.platformOwned).toBe(false)
+    expect(view.recordName).toBe('_konf-challenge.cloudnativedays.no')
+    expect(view.recordValue).toContain('konf-domain-verification=')
+  })
+
+  it('drops the announcement when the suffix is unset', () => {
+    vi.stubEnv('PLATFORM_DOMAIN_SUFFIX', undefined)
+    const view = toDomainVerificationView(
+      'kubeday.konf.run',
+      record({ status: 'pending' }),
+      NOW,
+    )
+    expect(view.platformOwned).toBe(false)
+    expect(view.routable).toBe(false)
+  })
+})

--- a/src/lib/domain-verification/view.ts
+++ b/src/lib/domain-verification/view.ts
@@ -10,7 +10,7 @@ import {
   isDevOnlyHost,
   isWildcardEntry,
 } from './challenge'
-import { isPlatformOwnedHost } from './platform'
+import { isPlatformAllocated } from './platform'
 import { isAllowlistEligible, isRoutingEligible } from './policy'
 import type {
   DomainVerificationRecord,
@@ -23,8 +23,10 @@ export interface DomainVerificationView {
   /** True for a claim the backfill admitted without proof, still inside its window. */
   grandfathered: boolean
   /**
-   * True for a subdomain of the platform's own zone: verified by construction,
-   * permanently, with NOTHING for the tenant to publish.
+   * True for a subdomain the platform ALLOCATED to this conference: verified by
+   * construction, permanently, with NOTHING for the tenant to publish. False for
+   * a host that merely sits under the platform suffix without an allocation, and
+   * false once the claim is revoked.
    */
   platformOwned: boolean
   /** The deadline for a grandfathered claim to publish a real proof. */
@@ -57,15 +59,20 @@ export function toDomainVerificationView(
   now: Date = new Date(),
 ): DomainVerificationView {
   const devOnly = isDevOnlyHost(hostname)
-  // Derived from the HOSTNAME, so a platform subdomain reads correctly even
-  // before the sweep has reconciled its record (or when it has none at all).
-  const platformOwned = isPlatformOwnedHost(hostname)
-  // No challenge is shown for a platform host: it would ask the tenant to
+  // RECORD-DRIVEN, and revoked never counts. Deriving this from the hostname's
+  // suffix would make the card announce "provided by the platform" for a host
+  // the platform never issued — and, for a revoked claim, keep showing it as
+  // verified and routable after the claim was released.
+  const platformOwned =
+    record !== null &&
+    record.status !== 'revoked' &&
+    isPlatformAllocated(record)
+  // No challenge is shown for an allocated host: it would ask the tenant to
   // publish a record in a zone only the platform can write to.
   const recordName = platformOwned ? null : challengeRecordName(hostname)
   return {
     hostname,
-    status: platformOwned ? 'verified' : (record?.status ?? 'pending'),
+    status: record?.status ?? 'pending',
     grandfathered: !platformOwned && record?.method === 'grandfathered',
     platformOwned,
     graceUntil: platformOwned ? null : (record?.graceUntil ?? null),
@@ -73,13 +80,8 @@ export function toDomainVerificationView(
     recordValue: record && recordName ? expectedTxtValue(record.token) : null,
     wildcard: isWildcardEntry(hostname),
     devOnly,
-    // Record-driven even for a platform host, on purpose: the real allowlist
-    // ENUMERATES documents (`listAllowlistCandidates`), so a claim with no
-    // record genuinely is not on it. Routing needs no such document, hence the
-    // asymmetry below.
     redirectAllowlisted: record ? isAllowlistEligible(record, now) : false,
-    routable:
-      platformOwned || (record ? isRoutingEligible(record, now) : false),
+    routable: record ? isRoutingEligible(record, now) : false,
     lastCheckedAt: record?.lastCheckedAt ?? null,
     lastSuccessAt: record?.lastSuccessAt ?? null,
     lastError: record?.lastError ?? null,

--- a/src/lib/domain-verification/view.ts
+++ b/src/lib/domain-verification/view.ts
@@ -10,6 +10,7 @@ import {
   isDevOnlyHost,
   isWildcardEntry,
 } from './challenge'
+import { isPlatformOwnedHost } from './platform'
 import { isAllowlistEligible, isRoutingEligible } from './policy'
 import type {
   DomainVerificationRecord,
@@ -21,11 +22,16 @@ export interface DomainVerificationView {
   status: DomainVerificationStatus
   /** True for a claim the backfill admitted without proof, still inside its window. */
   grandfathered: boolean
+  /**
+   * True for a subdomain of the platform's own zone: verified by construction,
+   * permanently, with NOTHING for the tenant to publish.
+   */
+  platformOwned: boolean
   /** The deadline for a grandfathered claim to publish a real proof. */
   graceUntil: string | null
-  /** DNS name the TXT record goes at. `null` for a dev-only entry. */
+  /** DNS name the TXT record goes at. `null` for a dev-only or platform entry. */
   recordName: string | null
-  /** The exact TXT value to publish. `null` for a dev-only entry. */
+  /** The exact TXT value to publish. `null` for a dev-only or platform entry. */
   recordValue: string | null
   /** Wildcard claims are proven on their base zone. */
   wildcard: boolean
@@ -50,19 +56,30 @@ export function toDomainVerificationView(
   record: DomainVerificationRecord | null,
   now: Date = new Date(),
 ): DomainVerificationView {
-  const recordName = challengeRecordName(hostname)
   const devOnly = isDevOnlyHost(hostname)
+  // Derived from the HOSTNAME, so a platform subdomain reads correctly even
+  // before the sweep has reconciled its record (or when it has none at all).
+  const platformOwned = isPlatformOwnedHost(hostname)
+  // No challenge is shown for a platform host: it would ask the tenant to
+  // publish a record in a zone only the platform can write to.
+  const recordName = platformOwned ? null : challengeRecordName(hostname)
   return {
     hostname,
-    status: record?.status ?? 'pending',
-    grandfathered: record?.method === 'grandfathered',
-    graceUntil: record?.graceUntil ?? null,
+    status: platformOwned ? 'verified' : (record?.status ?? 'pending'),
+    grandfathered: !platformOwned && record?.method === 'grandfathered',
+    platformOwned,
+    graceUntil: platformOwned ? null : (record?.graceUntil ?? null),
     recordName,
     recordValue: record && recordName ? expectedTxtValue(record.token) : null,
     wildcard: isWildcardEntry(hostname),
     devOnly,
+    // Record-driven even for a platform host, on purpose: the real allowlist
+    // ENUMERATES documents (`listAllowlistCandidates`), so a claim with no
+    // record genuinely is not on it. Routing needs no such document, hence the
+    // asymmetry below.
     redirectAllowlisted: record ? isAllowlistEligible(record, now) : false,
-    routable: record ? isRoutingEligible(record, now) : false,
+    routable:
+      platformOwned || (record ? isRoutingEligible(record, now) : false),
     lastCheckedAt: record?.lastCheckedAt ?? null,
     lastSuccessAt: record?.lastSuccessAt ?? null,
     lastError: record?.lastError ?? null,

--- a/src/lib/onboarding/provision.ts
+++ b/src/lib/onboarding/provision.ts
@@ -203,6 +203,14 @@ export type ProvisionOutcome =
  * challenge the caller has to publish. Re-running on a replay is harmless and
  * repairs a first attempt that died between commit and sync.
  *
+ * THIS IS THE PLATFORM'S ALLOCATION POINT. It is the only caller that passes
+ * `allocatePlatformHosts`, so a `<slug>.<PLATFORM_DOMAIN_SUFFIX>` host is
+ * granted to the new tenant here and nowhere else — and it is safe to do so
+ * precisely because this path is reachable only by the platform operator (the
+ * `platformProcedure` wizard) or the bearer-authenticated provisioning API,
+ * never by a tenant organizer. Such a host needs no challenge, so its projected
+ * view carries none.
+ *
  * BEST-EFFORT, AND IT MUST NEVER THROW. This runs AFTER the tenant is
  * committed, so an exception here would report failure for a transaction that
  * actually succeeded — and, worse, would keep doing so on every retry, since
@@ -216,7 +224,9 @@ async function mintChallenges(
   domains: string[],
 ): Promise<DomainVerificationView[]> {
   try {
-    await syncDomainVerifications(conferenceId, domains)
+    await syncDomainVerifications(conferenceId, domains, [], {
+      allocatePlatformHosts: true,
+    })
   } catch (error) {
     console.error('[provisioning] domain verification sync failed', error)
   }

--- a/src/server/routers/conference.createEdition.test.ts
+++ b/src/server/routers/conference.createEdition.test.ts
@@ -77,9 +77,20 @@ vi.mock('@/lib/sanity/client', () => ({
 // The new edition CLAIMS domains, so it mints their ownership-verification
 // records (#683). Mocked at the boundary; the sidecar has its own suite.
 const syncDomainVerificationsMock = vi.fn(async () => {})
+/**
+ * The PLATFORM-ZONE entitlement guard. A new edition is a NEW conference and so
+ * holds no allocation of its own; `[]` — nothing withheld — is the default here
+ * because these tests use ordinary custom domains.
+ */
+const findUnallocatedPlatformDomainsMock = vi.fn(
+  async (): Promise<string[]> => [],
+)
 vi.mock('@/lib/domain-verification', () => ({
   syncDomainVerifications: (...args: unknown[]) =>
     syncDomainVerificationsMock(...(args as [])),
+  findUnallocatedPlatformDomains: () => findUnallocatedPlatformDomainsMock(),
+  PLATFORM_DOMAIN_NOT_ALLOCATED:
+    'That hostname belongs to the platform and has not been allocated to this conference',
 }))
 
 import { conferenceRouter } from './conference'

--- a/src/server/routers/conference.test.ts
+++ b/src/server/routers/conference.test.ts
@@ -94,9 +94,20 @@ vi.mock('@/lib/sanity/client', () => ({
 // the domain mutation itself; the sidecar's own behaviour is covered in
 // src/lib/domain-verification/*.test.ts.
 const syncDomainVerificationsMock = vi.fn(async () => {})
+/**
+ * The PLATFORM-ZONE entitlement guard. Returns the claimed hostnames the
+ * platform never allocated to this conference; `[]` — nothing withheld — is the
+ * default so the pre-existing domain tests are unaffected.
+ */
+const findUnallocatedPlatformDomainsMock = vi.fn(
+  async (): Promise<string[]> => [],
+)
 vi.mock('@/lib/domain-verification', () => ({
   syncDomainVerifications: (...args: unknown[]) =>
     syncDomainVerificationsMock(...(args as [])),
+  findUnallocatedPlatformDomains: () => findUnallocatedPlatformDomainsMock(),
+  PLATFORM_DOMAIN_NOT_ALLOCATED:
+    'That hostname belongs to the platform and has not been allocated to this conference',
 }))
 
 // The teams cache clear is a side effect updateTeams performs on success.
@@ -618,6 +629,34 @@ describe('conference router — domains (safeguarded)', () => {
       makeCaller({ isOrganizer: true }).updateDomains({ domains: [] }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
     expect(commitMock).not.toHaveBeenCalled()
+  })
+
+  it('REFUSES a platform-zone host the platform never allocated (#683)', async () => {
+    // The cross-tenant hijack: an organizer types another tenant's — or an
+    // unissued — `<label>.<platform suffix>` into their own settings. `domains[]`
+    // is a globally unique routing claim, so letting it through would not merely
+    // fail to verify: it would lock the rightful tenant out of that hostname
+    // permanently. Refused at the CLAIM, before anything is written.
+    findUnallocatedPlatformDomainsMock.mockResolvedValue([
+      'some-other-tenant.konf.run',
+    ])
+    await expect(
+      makeCaller({ isOrganizer: true }).updateDomains({
+        domains: [CURRENT, 'some-other-tenant.konf.run'],
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' })
+    // NOTHING was written and no verification record was minted.
+    expect(commitMock).not.toHaveBeenCalled()
+    expect(syncDomainVerificationsMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a platform-zone host that IS allocated to this conference', async () => {
+    findUnallocatedPlatformDomainsMock.mockResolvedValue([])
+    const result = await makeCaller({ isOrganizer: true }).updateDomains({
+      domains: [CURRENT, 'kubeday.konf.run'],
+    })
+    expect(result.success).toBe(true)
+    expect(lastSet).toEqual({ domains: [CURRENT, 'kubeday.konf.run'] })
   })
 
   it('rejects a duplicate entry', async () => {

--- a/src/server/routers/conference.ts
+++ b/src/server/routers/conference.ts
@@ -30,7 +30,11 @@ import {
   domainsWouldStrandHost,
   normalizeDomain,
 } from '@/lib/conference/domains'
-import { syncDomainVerifications } from '@/lib/domain-verification'
+import {
+  findUnallocatedPlatformDomains,
+  PLATFORM_DOMAIN_NOT_ALLOCATED,
+  syncDomainVerifications,
+} from '@/lib/domain-verification'
 import {
   buildEditionDocuments,
   type SourceConference,
@@ -512,6 +516,21 @@ export const conferenceRouter = router({
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: `${DOMAIN_ALREADY_CLAIMED}: ${taken.join(', ')}`,
+        })
+      }
+      // PLATFORM ZONE (#683): a subdomain of the platform's own zone may only be
+      // claimed by the conference the platform ALLOCATED it to. Uniqueness alone
+      // does not cover this — it would make an organizer's grab for an unissued
+      // `<label>.<suffix>` exclusive and permanent, locking the rightful tenant
+      // out forever. Refused before any write, like the guards above.
+      const unallocated = await findUnallocatedPlatformDomains(
+        conferenceId,
+        input.domains,
+      )
+      if (unallocated.length > 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `${PLATFORM_DOMAIN_NOT_ALLOCATED}: ${unallocated.join(', ')}`,
         })
       }
       // Read the OUTGOING list before the patch so released entries can be
@@ -1002,6 +1021,23 @@ export const conferenceRouter = router({
       }
 
       const newConferenceId = generateKey('conference')
+
+      // PLATFORM ZONE (#683): a new edition is a NEW conference, so it holds no
+      // allocation of its own — every in-zone hostname it asks for is
+      // unallocated by definition and is refused here. Another platform
+      // subdomain for a new edition is a platform grant, not something a tenant
+      // can self-serve. Refused BEFORE the transaction, so nothing is written.
+      const unallocated = await findUnallocatedPlatformDomains(
+        newConferenceId,
+        input.domains,
+      )
+      if (unallocated.length > 0) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `${PLATFORM_DOMAIN_NOT_ALLOCATED}: ${unallocated.join(', ')}`,
+        })
+      }
+
       const { conference, sponsorTiers, contractTemplates, summary } =
         buildEditionDocuments(
           {

--- a/src/server/routers/onboarding.test.ts
+++ b/src/server/routers/onboarding.test.ts
@@ -88,6 +88,9 @@ vi.mock('@/lib/domain-verification', () => ({
     syncDomainVerificationsMock(...(args as [])),
   getDomainVerification: async () => null,
   toDomainVerificationView: (hostname: string) => ({ hostname }),
+  findUnallocatedPlatformDomains: async (): Promise<string[]> => [],
+  PLATFORM_DOMAIN_NOT_ALLOCATED:
+    'That hostname belongs to the platform and has not been allocated to this conference',
 }))
 
 import {
@@ -275,9 +278,13 @@ describe('createOrganization — atomic transaction', () => {
     // has to hand the operator something to publish, and the records start
     // `pending` so nothing is routed or allowlisted on trust alone.
     const result = await makeCaller(operator).createOrganization(input())
+    // …and this IS the platform's allocation point, so it is the one caller
+    // permitted to grant a subdomain of the platform's own zone (#683).
     expect(syncDomainVerificationsMock).toHaveBeenCalledWith(
       result.conferenceId,
       ['oslo.cloudnativedays.no'],
+      [],
+      { allocatePlatformHosts: true },
     )
     expect(result.challenges).toEqual([{ hostname: 'oslo.cloudnativedays.no' }])
   })


### PR DESCRIPTION
## The problem

Tenants are hosted by default on a subdomain the platform **mints** — `<slug>.konf.run`. That zone's nameservers are delegated to our own edge and a `*.konf.run` wildcard domain is registered on this Vercel project, so we control it end to end and no tenant has any access to it.

`src/lib/domain-verification/` had no notion of that. `isRoutingEligible` decided purely from a `domainVerification` record, and the only non-DNS method was `grandfathered` — a deliberately **time-boxed** 30-day exemption. So the moment `DOMAIN_VERIFICATION_ENFORCE_ROUTING=true` is set, every platform-hosted tenant either stops routing or is asked to publish a `_konf-challenge` TXT record in a zone only we can write to.

## The method: an ALLOCATION, not an inference

> **Review correction.** The first cut of this PR inferred entitlement from the SUFFIX at read time — any host under `PLATFORM_DOMAIN_SUFFIX` was verified. That reasoning is correct about *why* DNS-TXT proof is impossible in our own zone, but it does not follow that the claiming tenant is entitled to the hostname. An organizer can type any hostname into /admin/settings, so they could enter `some-other-tenant.konf.run` — a label the platform never issued, or one earmarked for a customer being onboarded next week — and be handed routing plus (once #688 ships) an OAuth redirect destination. Global uniqueness makes that *worse*: the grab is exclusive, so the rightful tenant could then never be given the hostname at all. The model below is the fix.

**Being under the suffix is a PRECONDITION. The entitlement is a grant recorded at write time.**

- The platform grants one host to one conference through `provisionOrganization` — the platform-operator wizard and the bearer-authenticated provisioning API. It is the **only** caller that passes `allocatePlatformHosts`, and it is unreachable by a tenant organizer.
- The `domainVerification` document records the grant: `method: "platform-owned"`, `conference` = the grantee.
- Every read-time decision calls `isPlatformAllocated`, which requires **both** halves — the recorded grant **and** a live suffix re-check. A mis-issued record for a host outside the zone grants nothing; a host in the zone with no grant grants nothing; re-pointing or unsetting the suffix withdraws the standing immediately.

Once allocated the standing is **permanent** — no `graceUntil`, no staleness expiry, nothing for the tenant to complete. Revocation, not expiry, is how it ends.

### Defence in depth at the write path

| Layer | Behaviour |
| --- | --- |
| `updateDomains` / `createEdition` | **Reject** the payload (`findUnallocatedPlatformDomains` → BAD_REQUEST) before any write. The claim itself is never made — which matters, because `domains[]` is globally unique and a saved grab would lock the rightful tenant out permanently. |
| `ensureDomainVerification` | Writes **no document at all** for an in-zone host without the allocation flag, so a bypass of the mutation guard still fails closed. It also refuses to re-allocate a host held by another conference, and an explicit `method: 'platform-owned'` argument cannot smuggle a grant in. |
| `isHostRoutable` | The suffix short-circuit is **gone**. A missing record fails closed for platform and custom hosts alike. |
| The sweep | Keys its no-lookup path on the allocation. An unallocated in-zone claim is resolved like any other, hard-fails, and stays unrouted. |
| `toDomainVerificationView` | Record-driven, not hostname-driven, and no longer forces `status: verified` / `routable: true`. The card never announces "provided by the platform" for a host the platform did not issue. |

A tenant that releases and re-adds *its own* allocated subdomain is restored without a support ticket — keyed on the stored grant, so it can only ever restore one the platform actually made.

## How the suffix is configured

`PLATFORM_DOMAIN_SUFFIX`, following the existing `PLATFORM_ORG_SLUG` contract (`src/lib/features/platform.ts`) — the platform is white-labelable, so `konf.run` is a deployment fact, never a constant in the source. Documented in `.env` next to `PLATFORM_ORG_SLUG`.

**Unset means _no_ host is in the platform zone**, never "everything is". Every rejection path returns `null` and `isPlatformZoneHost` fails closed on it:

| Configured value | Result |
| --- | --- |
| unset / `""` / `"   "` | `null` — nothing is allocatable |
| `run` (single label) | `null` — would otherwise cover every `.run` domain |
| `https://konf.run`, `konf.run/path`, `konf.run:3000`, `konf run` | `null` |
| `konf.run`, `.konf.run`, `*.konf.run`, `  KONF.run ` | `konf.run` |

## How the suffix is matched

Both sides are split into DNS **labels**; the suffix must be the exact trailing labels of the host with at least one label to spare. No `endsWith`, no substring logic, and normalisation goes through the repo's own `normalizeDomain` / `isValidDomainEntry`. "✅" below means only *allocatable* — the grant still has to exist.

| Host | vs `konf.run` | Why |
| --- | --- | --- |
| `kubeday.konf.run` | ✅ in zone | exact trailing labels, one deeper |
| `a.b.konf.run` | ✅ in zone | still inside the zone |
| `evil-konf.run` | ❌ | `'evil-konf.run'.endsWith('konf.run')` is **true** — there is no label boundary |
| `konf.run.attacker.com` | ❌ | our zone as somebody else's *prefix* |
| `a.konf.runner`, `a.konf.ru` | ❌ | different TLD |
| `konf.run` (apex) | ❌ | the platform's own origin, not a minted subdomain |
| `*.konf.run` | ❌ | a wildcard over the whole zone would hand its holder every tenant subdomain |
| `tenant.konf.run:3000`, `tenant.konf.run.` | ❌ | a port is a dev entry; a trailing dot is not a label |

## Redirect allowlist: included — and why

`isAllowlistEligible` honours an **allocated** host. The threat it guards is a *dangling* destination: a third party's zone lapses and the host silently resolves to somebody else, which the victim experiences as a normal login. That cannot happen inside a zone we operate — its delegation cannot change without our own registrar account changing hands, and not quietly, because every tenant site would go down at once. The 30-day staleness rule exists to catch a silently broken checker; for our own zone there is no checker to break. Excluding these would mean nobody on the platform's default hosting could complete a sign-in.

What it grants is a redirect destination to the conference the platform **issued** that subdomain to — not to whoever typed it first. Wildcards stay excluded (RFC 9700 §4.1.3 untouched), dev hosts stay excluded, and `revoked` is checked **before** the allocation everywhere, so releasing the claim removes the grant instantly.

## Other review fixes

- **Revoked wins** over the allocation in routing, the allowlist and the view. Revocation is the remedy if a host ever ends up with the wrong tenant, so it has to actually undo the grant.
- **`graceUntil` can be cleared.** `DomainVerificationPatch` now carries the field, so a record that was grandfathered before it was allocated has its 30-day deadline unset instead of expiring a grant that has no expiry.

## Sabotage evidence

Baseline: **239/239** across `src/lib/domain-verification` + `conference.test.ts` (full suite 6694/6694).

| # | Sabotage | Observed |
| --- | --- | --- |
| 1 | Entitlement inferred from the suffix again — policy grants on zone membership, `ensureDomainVerification` allocates implicitly, the mutation guard withholds nothing, the view announces it | **15 failed** / 224 passed |
| 2 | `revoked` loses to the allocation (checked after it in the policy; dropped from the view) | **4 failed** / 235 passed |
| 3 | Stale `graceUntil` left in place (dropped from the check write-back and from the in-place upgrade's `unset`) | **3 failed** / 236 passed |

Earlier, still-passing controls from the first round, re-verified: making the matcher a naive `endsWith` fails 5 (`evil-konf.run` and the apex), and making an unset suffix mean "match everything" fails 23.

Every assertion is on **observable behaviour** — whether routing is granted, whether the host is on the allowlist, whether a DNS lookup was issued, whether a document was written and with what — never on an error message.

Named failures under sabotage 1 include `REFUSES an UNALLOCATED host that merely sits in the platform zone` (policy **and** allowlist), `FAILS CLOSED for an in-zone host with NO record — no suffix exemption` (routing), `writes NOTHING for an in-zone host when the caller may not allocate` and `will not let an explicit method smuggle an allocation in` (persistence), `REFUSES an in-zone host with no record — the unissued-label grab` and `REFUSES a host allocated to ANOTHER conference` (the mutation guard), `DNS-CHECKS an in-zone host the platform never allocated` (sweep), and `does NOT announce an in-zone host the platform never allocated` (view).

## Custom domains are unaffected

Proved directly rather than by omission — `leaves CUSTOM domains exactly as they were — real proof still required` (policy), `leaves CUSTOM domains fail-closed on a missing record` (routing), `REFUSES an unproven CUSTOM domain while the platform rule is on` (allowlist), `still delists a CUSTOM domain swept alongside an allocated one` (sweep), `IGNORES custom domains entirely` (the mutation guard), `mints a CUSTOM domain pending/dns-txt` (persistence).

## Gates

`pnpm test` 6694/6694 · `pnpm typecheck` clean · `npx eslint .` **0 errors, 216 warnings (unchanged)** · `npx prettier --check .` clean · `pnpm knip` exit 0 · `pnpm build` exit 0.

Visual inspection per AGENTS.md: `PlatformOwned` story plus a row in `AllStates`, captured with `pnpm shoot` at 393px — no overflow, consistent with the existing states.

## Rollout note

`PLATFORM_DOMAIN_SUFFIX=konf.run` must be set in the Vercel environment **before** `DOMAIN_VERIFICATION_ENFORCE_ROUTING=true` is switched on, and existing `konf.run` tenants must be allocated (the backfill deliberately does **not** allocate — it cannot know whether the platform ever issued a label to a conference). Until the suffix is set this change is a complete no-op: no host is in the platform zone and every code path behaves exactly as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1XZpKx5SjpEPdT9sLYrY2