### PR TITLE
fix(email): send unverified tenants from the platform sender, never silently

### DIFF
--- a/.env
+++ b/.env
@@ -31,6 +31,24 @@ NEXT_TELEMETRY_DISABLED=1
 # Set it in .env.local / Vercel, e.g.:
 # PLATFORM_DOMAIN_SUFFIX="konf.run"
 
+# THE PLATFORM SENDER (RunKonf/platform#20). Outbound mail is addressed FROM the
+# conference's own identity, but it is SENT on the platform's Resend account —
+# which may only send from domains verified for that account. A tenant whose
+# domain is not verified therefore sends from this address instead, carrying the
+# conference name as the display name and its own address as Reply-To.
+# The address MUST be on a domain verified in the platform Resend account.
+# Unset = there is nothing deliverable to fall back to: such a tenant's mail is
+# REJECTED by Resend. That is logged and shown as an error on /admin/settings,
+# never papered over. Set it in .env.local / Vercel, e.g.:
+# EMAIL_FALLBACK_FROM="Konf <noreply@example.com>"
+
+# Every domain verified on the platform Resend account, comma-separated. A
+# conference whose From lands on one of these sends as ITSELF — this is how a
+# tenant graduates to its own sender once its DKIM/SPF records verify. The
+# EMAIL_FALLBACK_FROM domain is always included implicitly. Unset = only that
+# one domain. See docs/EMAIL_SYSTEM.md → "The sender policy".
+# EMAIL_SENDING_DOMAINS="example.com,another-verified.dev"
+
 NEXT_PUBLIC_SANITY_PROJECT_ID="mvzwvw14"
 NEXT_PUBLIC_SANITY_DATASET="production"
 SANITY_STUDIO_PROJECT_ID="mvzwvw14"

--- a/__tests__/lib/auth/email-link-send.test.ts
+++ b/__tests__/lib/auth/email-link-send.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Resend } from 'resend'
+
+/**
+ * THE BUG, AT THE PLACE IT BIT (RunKonf/platform#20).
+ *
+ * A newly provisioned tenant's sign-in mail was addressed `From:` its own,
+ * unverified domain and sent on the PLATFORM's Resend key. Resend refused it,
+ * and `requestEmailSignInLink` returns the same opaque outcome either way — so
+ * the tenant simply could not log in, and nothing said so.
+ *
+ * These tests pin both halves of the fix on the real send path: the message that
+ * leaves carries a platform-verified `From:` with the tenant in `Reply-To:`, and
+ * a rejected send is on the record with the conference named.
+ */
+
+const { mockResolveEmailSender } = vi.hoisted(() => ({
+  mockResolveEmailSender: vi.fn(),
+}))
+
+vi.mock('@/lib/email/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/email/config')>()
+  return { ...actual, resolveEmailSender: mockResolveEmailSender }
+})
+
+import { instrumentResendClient } from '@/lib/email/instrument'
+import { resetSenderPolicyWarnings } from '@/lib/email/sender-policy'
+import { sendEmailSignInLink } from '@/lib/auth/email-link/send'
+import type { Conference } from '@/lib/conference/types'
+
+const PLATFORM_FROM = 'Konf <noreply@platform.example>'
+
+/** A tenant provisioned on its own domain — unverified on the platform account. */
+const TENANT = {
+  title: 'KCD Bergen 2026',
+  organizer: 'KCD Bergen',
+  contactEmail: 'hello@kcd.dev',
+  domains: ['2026.kcd.dev'],
+  city: 'Bergen',
+  country: 'Norway',
+  startDate: '2026-09-01',
+  socialLinks: [],
+} as unknown as Conference
+
+interface SentMessage {
+  from: string
+  replyTo?: string | string[]
+  to: string
+  subject: string
+}
+
+function stubSender(result: { data?: unknown; error?: unknown }) {
+  const sent: SentMessage[] = []
+  const send = vi.fn(async (payload: SentMessage) => {
+    sent.push(payload)
+    return result
+  })
+  // Shaped like the real thing: the PLATFORM client is shared by every tenant,
+  // so it carries no org of its own — the tenant is identified by the sender.
+  const client = instrumentResendClient(
+    { emails: { send, create: send } } as unknown as Resend,
+    { enforceSenderPolicy: true },
+  )
+  mockResolveEmailSender.mockResolvedValue({ client })
+  return sent
+}
+
+const REQUEST = {
+  to: 'speaker@example.com',
+  signInUrl: 'https://2026.kcd.dev/auth/email-link?token=secret-token-value',
+  expiresInMinutes: 15,
+  singleUse: true,
+  conference: TENANT,
+  orgId: 'org-kcd',
+}
+
+beforeEach(() => {
+  resetSenderPolicyWarnings()
+  mockResolveEmailSender.mockReset()
+  vi.stubEnv('EMAIL_FALLBACK_FROM', PLATFORM_FROM)
+  vi.stubEnv('EMAIL_SENDING_DOMAINS', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('sendEmailSignInLink for a tenant whose own domain is unverified', () => {
+  it('sends from the platform-verified sender, with the tenant address as Reply-To', async () => {
+    const sent = stubSender({ data: { id: 'email_1' } })
+
+    await expect(sendEmailSignInLink(REQUEST)).resolves.toBe(true)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].from).toBe('KCD Bergen <noreply@platform.example>')
+    expect(sent[0].replyTo).toBe('hello@kcd.dev')
+    // The tenant's unverified domain must not appear in the envelope sender —
+    // that is exactly the header Resend rejects.
+    expect(sent[0].from).not.toContain('kcd.dev')
+    // The recipient still sees who it is from.
+    expect(sent[0].from).toContain('KCD Bergen')
+    expect(sent[0].subject).toBe('Sign in to KCD Bergen 2026')
+  })
+
+  it('sends as ITSELF once its domain is a platform sending domain', async () => {
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'kcd.dev')
+    const sent = stubSender({ data: { id: 'email_1' } })
+
+    await sendEmailSignInLink(REQUEST)
+
+    expect(sent[0].from).toBe('KCD Bergen <hello@kcd.dev>')
+    expect(sent[0].replyTo).toBeUndefined()
+  })
+})
+
+describe('a rejected sign-in mail is observable', () => {
+  it('logs the conference and the sender at BOTH the client and the sign-in layer', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    stubSender({
+      error: { name: 'validation_error', message: 'domain is not verified' },
+    })
+
+    // The user-facing contract is unchanged: the caller learns nothing useful.
+    await expect(sendEmailSignInLink(REQUEST)).resolves.toBe(false)
+
+    const calls = error.mock.calls
+    expect(calls).toHaveLength(2)
+
+    // The client-level line names the tenant by its sender …
+    const chokePoint = calls.find((c) => c[0] === '[email] send failed')
+    expect(chokePoint?.[1]).toMatchObject({
+      from: 'KCD Bergen <noreply@platform.example>',
+      replyTo: 'hello@kcd.dev',
+      senderPolicy: 'platform-rewritten',
+    })
+
+    // … and the sign-in layer adds the conference and the org.
+    const signIn = calls.find(
+      (c) => c[0] === '[email-link] Resend rejected the sign-in email',
+    )
+    expect(signIn?.[1]).toMatchObject({
+      conference: 'KCD Bergen 2026',
+      orgId: 'org-kcd',
+      name: 'validation_error',
+    })
+  })
+
+  it('never writes the sign-in token to the log', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    stubSender({ error: { name: 'validation_error', message: 'nope' } })
+
+    await sendEmailSignInLink(REQUEST)
+
+    expect(JSON.stringify(error.mock.calls)).not.toContain('secret-token-value')
+  })
+})

--- a/__tests__/lib/auth/email-link-send.test.ts
+++ b/__tests__/lib/auth/email-link-send.test.ts
@@ -114,6 +114,27 @@ describe('sendEmailSignInLink for a tenant whose own domain is unverified', () =
   })
 })
 
+describe('a tenant-stored CR/LF cannot inject a header into sign-in mail', () => {
+  it('produces single-line From and Reply-To from a poisoned contactEmail', async () => {
+    const sent = stubSender({ data: { id: 'email_1' } })
+
+    await sendEmailSignInLink({
+      ...REQUEST,
+      conference: {
+        ...TENANT,
+        contactEmail: 'hello@kcd.dev\r\nBcc: attacker@evil.example',
+      } as unknown as Conference,
+    })
+
+    for (const value of [sent[0].from, sent[0].replyTo].flat()) {
+      expect(value).not.toMatch(/[\r\n]/)
+      expect(String(value).split(/\r\n|\r|\n/)).toHaveLength(1)
+    }
+    expect(sent[0]).not.toHaveProperty('bcc')
+    expect(sent[0].to).toBe('speaker@example.com')
+  })
+})
+
 describe('a rejected sign-in mail is observable', () => {
   it('logs the conference and the sender at BOTH the client and the sign-in layer', async () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -125,11 +125,19 @@ session cookie. That is the documented safe degradation in `src/lib/auth-cookie-
 span sibling subdomains of a tenant's domain until the user next signs in via OAuth (which
 self-heals the scope) or the flow is moved onto the wrapped route handlers.
 
-**Sender dependency.** The mail goes through `resolveEmailSender(orgId)` +
-`resolveConferenceFrom()`. On the shared Resend tier a tenant-domain `From` is unverified and
-Resend rejects the send, so a second tenant gets no sign-in mail until it has its own Resend
-credentials or a verified domain (platform#20/#26). This is the first call site of
-`resolveEmailSender` in production.
+**Sender.** The mail goes through `resolveEmailSender(orgId)` +
+`resolveConferenceFrom()`, and the **sender policy** on the Resend client itself
+(`src/lib/email/sender-policy.ts`, platform#20) makes the result deliverable: a tenant whose
+own domain is not verified on the platform Resend account sends from the platform sender with
+its conference name in the display name and its own address in `Reply-To`. Verifying a
+tenant's domain (`EMAIL_SENDING_DOMAINS`) or giving it a dedicated Resend account
+(`TENANT_SECRETS_JSON`, Pro — platform#26) makes it send as itself. See `EMAIL_SYSTEM.md`.
+
+**A failed send stays invisible to the user, by design — never to an operator.** The request
+path returns the same opaque outcome regardless, so the only signals are the
+`[email] send failed` log at the client (with the org and sender) and the
+`[email-link] Resend rejected the sign-in email` log here (with the conference). Do not add a
+user-visible signal to compensate: that would hand back the enumeration oracle.
 
 ### OAuth Flow
 

--- a/docs/EMAIL_SYSTEM.md
+++ b/docs/EMAIL_SYSTEM.md
@@ -336,6 +336,27 @@ diagnostic: it is read precisely when something is already wrong.
    that client at all. Gating it on the `dedicated-email` **Pro** entitlement
    rather than on the presence of a secret is RunKonf/platform#26.
 
+#### Header injection
+
+`From:` headers are built from **tenant-editable** conference fields, and about
+half the send sites interpolate them raw
+(`` `${conference.organizer} <${conference.cfpEmail}>` ``). An organizer storing
+`hello@kcd.dev\r\nBcc: attacker@evil.example` would otherwise turn one header
+into two — the attacker is an authenticated organizer on a multi-tenant
+platform, so "organizers are trusted" is not the defence it sounds like.
+
+`sanitizeHeaderText` is the ONE rule, applied to the name **and the address** in
+`parseAddress`, so every consumer of `.address` is safe by construction rather
+than each one having to remember. It **truncates at the first CR/LF** rather
+than deleting them: deletion splices the payload onto the value, and for an
+address that hands the attacker the resulting domain
+(`a@evil.example\r\nb@verified.test` would collapse to one address whose domain
+reads as verified).
+
+`applySenderPolicy` returns a header **rebuilt from the parsed parts** in every
+branch — including the two where the sender is otherwise unchanged — so a raw
+header from a call site is never echoed onto the wire.
+
 ### The send choke point (`/lib/email/instrument.ts`)
 
 Every client from `getResendClient` is instrumented, so the policy and the

--- a/docs/EMAIL_SYSTEM.md
+++ b/docs/EMAIL_SYSTEM.md
@@ -258,15 +258,72 @@ if (result.error) {
 
 ### Environment Configuration
 
-Required environment variables:
-
 ```bash
-# Production
-RESEND_API_KEY=re_your_api_key_here
+# The platform Resend account.
+RESEND_API_KEY=re_your_api_key_here          # test_key in development
 
-# Development
-RESEND_API_KEY=test_key
+# The PLATFORM SENDER. Its address MUST be on a domain verified in the Resend
+# account above — it is what every tenant whose own domain is unverified sends
+# from. Unset ⇒ such a tenant's mail is REJECTED by Resend (see below).
+EMAIL_FALLBACK_FROM="Konf <noreply@example.com>"
+
+# Every domain verified on the platform Resend account, comma-separated. A
+# conference whose From lands on one of these sends as ITSELF. The
+# EMAIL_FALLBACK_FROM domain is always included implicitly.
+EMAIL_SENDING_DOMAINS=example.com,another-verified.dev
 ```
+
+### The sender policy (`/lib/email/sender-policy.ts`)
+
+Two different questions, deliberately answered in two different places:
+
+| Question                          | Answered by                                        |
+| --------------------------------- | -------------------------------------------------- |
+| Who should this mail be FROM?     | `resolveConferenceFrom` — the tenant's identity    |
+| What may Resend actually send as? | `applySenderPolicy` — the platform's verified list |
+
+A conference's own `contactEmail` / `<localPart>@<its domain>` is an **identity**,
+not an envelope. On the shared email tier every send goes through the platform's
+Resend account, and Resend rejects a `From:` on a domain that is not verified for
+**that** account — so a newly provisioned tenant's mail is refused outright
+(RunKonf/platform#20).
+
+The policy therefore splits the two apart:
+
+```
+From:     KCD Bergen <noreply@[platform sending domain]>
+Reply-To: hello@kcd.dev
+```
+
+The recipient still sees the conference; replies still reach the organizers; the
+message is one the platform account is allowed to send. A tenant whose domain is
+listed in `EMAIL_SENDING_DOMAINS` is left completely alone and sends as itself.
+
+**When `EMAIL_FALLBACK_FROM` is unset** there is nothing deliverable to rewrite
+to, so the message is passed through unchanged and the misconfiguration is
+logged (`console.error`, once per From-domain) and raised as an **error** on
+`/admin/settings` → Email → _Effective sender_.
+
+#### Letting a tenant send as itself
+
+1. **On the platform account** — verify the tenant's sending domain in Resend
+   (DKIM + SPF), then add it to `EMAIL_SENDING_DOMAINS`. `platformSendingDomains()`
+   is the single seam: swapping its body for a cached `resend.domains.list()`
+   lookup makes this self-service without moving a call site. That step also
+   needs per-tenant DNS instructions in the admin UI, a verification poller, and
+   cache invalidation — a live API call must never sit in a send path.
+2. **On the tenant's own Resend account** — per-org credentials in
+   `TENANT_SECRETS_JSON` (`resolveEmailSender`). The policy does not apply to
+   that client at all. Gating it on the `dedicated-email` **Pro** entitlement
+   rather than on the presence of a secret is RunKonf/platform#26.
+
+### The send choke point (`/lib/email/instrument.ts`)
+
+Every client from `getResendClient` is instrumented, so the policy and the
+failure logging sit on the **client**, not on the ~20 individual
+`resend.emails.send(...)` call sites — several of which build their `From:`
+inline and handle errors in their own way. A call site may still ignore a failed
+send; it can no longer make it invisible.
 
 ## API Endpoints
 
@@ -503,6 +560,35 @@ pnpm test
 - **Rate Limiting**: Built-in protection against email abuse and spam
 
 ## Monitoring and Observability
+
+### Every failed send is logged, at the client
+
+`instrumentResendClient` logs **every** rejected or thrown send exactly once,
+whatever the caller then does with the result:
+
+```typescript
+console.error('[email] send failed', {
+  orgId: 'org-kcd',
+  from: 'KCD Bergen <noreply@platform.example>',
+  replyTo: 'hello@kcd.dev',
+  recipientDomains: ['example.com'],
+  senderPolicy: 'platform-rewritten',
+  error: { name: 'validation_error', message: '…' },
+})
+```
+
+This matters most where the caller is **required** to stay silent: a magic-link
+request returns the same opaque outcome whether or not the mail went out (see
+`AUTH.md`), so this log is the only trace that sign-in is broken for a tenant.
+The `From`/`Reply-To` name the tenant; recipients appear as **domains only** and
+the subject is never logged — a sign-in mail's recipient is precisely what the
+anti-enumeration design refuses to disclose.
+
+An operator also sees the standing state on `/admin/settings` → Email:
+**Effective sender** reports what this conference's mail actually goes out as
+(`ok` as itself / `warn` rewritten to the platform sender / `error` nothing
+deliverable configured), and the **Send test email** self-check surfaces Resend's
+own rejection message.
 
 ### Logging
 

--- a/docs/EMAIL_SYSTEM.md
+++ b/docs/EMAIL_SYSTEM.md
@@ -357,6 +357,16 @@ reads as verified).
 branch — including the two where the sender is otherwise unchanged — so a raw
 header from a call site is never echoed onto the wire.
 
+But the policy is not the boundary. A **dedicated** client (a tenant's own
+Resend account) skips the policy by design, so sanitisation that lived only
+inside it did not run for exactly the tenants who pay for their own account —
+same fields, same raw-interpolating send sites. The guarantee therefore sits at
+the **client**: `instrumentResendClient` sanitises `from`/`replyTo` on every
+send, on every client, whichever policy branch ran. Every `from`-bearing Resend
+method is wrapped — `emails.send`/`create`, `batch.send`/`create`,
+`broadcasts.create`/`update` — including the ones this codebase does not call
+yet, so adopting one later cannot reopen the hole.
+
 ### The send choke point (`/lib/email/instrument.ts`)
 
 Every client from `getResendClient` is instrumented, so the policy and the

--- a/docs/EMAIL_SYSTEM.md
+++ b/docs/EMAIL_SYSTEM.md
@@ -302,7 +302,26 @@ listed in `EMAIL_SENDING_DOMAINS` is left completely alone and sends as itself.
 **When `EMAIL_FALLBACK_FROM` is unset** there is nothing deliverable to rewrite
 to, so the message is passed through unchanged and the misconfiguration is
 logged (`console.error`, once per From-domain) and raised as an **error** on
-`/admin/settings` → Email → _Effective sender_.
+`/admin/settings` → Email → _Effective senders_.
+
+#### A conference has THREE senders, not one
+
+`contactEmail`, `cfpEmail` and `sponsorEmail` can sit on different domains, and
+each carries its own flows (`CONFERENCE_SENDER_FIELDS` in `lib/email/from.ts`,
+derived from the send sites — several build the header inline rather than
+calling `resolveConferenceFrom`):
+
+| Field          | Sends                                                                                                |
+| -------------- | ---------------------------------------------------------------------------------------------------- |
+| `contactEmail` | sign-in links, badges, invitation letters, workshops, volunteers, broadcasts, proposal notifications |
+| `cfpEmail`     | speaker mail, speaker/sponsor messaging, gallery, co-speaker invites                                 |
+| `sponsorEmail` | sponsor CRM + registration, contract signing and reminders                                           |
+
+Anything judging deliverability must judge **all three** — the _Effective
+senders_ check and the _Send test email_ probe both do, and both name which
+sender they are talking about. A diagnostic that looked at one of them could
+report health while CFP mail was being rejected, which is worse than no
+diagnostic: it is read precisely when something is already wrong.
 
 #### Letting a tenant send as itself
 
@@ -585,10 +604,12 @@ the subject is never logged — a sign-in mail's recipient is precisely what the
 anti-enumeration design refuses to disclose.
 
 An operator also sees the standing state on `/admin/settings` → Email:
-**Effective sender** reports what this conference's mail actually goes out as
-(`ok` as itself / `warn` rewritten to the platform sender / `error` nothing
-deliverable configured), and the **Send test email** self-check surfaces Resend's
-own rejection message.
+**Effective senders** reports what this conference's mail actually goes out as
+(`ok` all senders verified / `warn` rewritten to the platform sender / `error`
+nothing deliverable configured), naming the offending address in every case. The
+**Send test email** self-check sends from the conference's **worst** sender and
+reports which one it used, so a green result cannot come from a healthy address
+while another is being rejected.
 
 ### Logging
 

--- a/src/lib/auth/email-link/send.ts
+++ b/src/lib/auth/email-link/send.ts
@@ -11,18 +11,22 @@ import type { Conference } from '@/lib/conference/types'
  * SENDER RESOLUTION goes through {@link resolveEmailSender} (per-org Resend
  * credentials when the tenant has them, the platform account otherwise) and
  * {@link resolveConferenceFrom} (the conference's own From, then its domain,
- * then the neutral platform fallback). This is the first production call site of
- * `resolveEmailSender` — every other send path still imports the global `resend`
- * singleton, which is the substance of platform#20/#26.
+ * then the neutral platform fallback).
  *
- * KNOWN EXTERNAL DEPENDENCY, NOT SOLVED HERE: on the SHARED Resend tier a
- * tenant-domain `From` is unverified, and Resend rejects the send outright. A
- * second tenant therefore gets no sign-in mail at all until it either has its
- * own Resend credentials in `TENANT_SECRETS_JSON` or the platform account
- * verifies its domain. That is a sender-policy problem, deliberately out of this
- * change's scope — but it means email login is not usable by tenant #2 until it
- * is closed. The failure is at least LOUD here: `sendEmailSignInLink` returns
- * `false` and logs, rather than reporting success into a silent void.
+ * ON THE SHARED RESEND TIER a tenant-domain `From` is not verified for the
+ * platform account, and Resend would reject the send outright — which used to
+ * mean a newly provisioned tenant got no sign-in mail at all. That is now
+ * corrected at the client by the SENDER POLICY (`lib/email/sender-policy.ts`,
+ * platform#20): the message goes out from the platform's verified sender
+ * carrying the conference's display name, with the conference's own address in
+ * `Reply-To`. Nothing about it is decided here.
+ *
+ * WHY THE LOGGING BELOW IS NOT REDUNDANT with the choke point's: the CALLER of
+ * this function (`requestEmailSignInLink`) must return the same opaque outcome
+ * whether or not the mail went out, so a `false` return here vanishes by
+ * design. The `[email-link]` line is what tells an operator that sign-in is
+ * broken for a specific tenant host — it names the conference, which the
+ * client-level log cannot.
  */
 export async function sendEmailSignInLink(params: {
   to: string
@@ -74,6 +78,9 @@ export async function sendEmailSignInLink(params: {
 
     if (result?.error) {
       console.error('[email-link] Resend rejected the sign-in email', {
+        conference: conference?.title,
+        orgId: orgId ?? undefined,
+        from: tenantFrom || from,
         name: result.error.name,
         message: result.error.message,
       })
@@ -82,7 +89,12 @@ export async function sendEmailSignInLink(params: {
     return true
   } catch (error) {
     // NEVER log `signInUrl` or the token it carries.
-    console.error('[email-link] failed to send the sign-in email', error)
+    console.error('[email-link] failed to send the sign-in email', {
+      conference: conference?.title,
+      orgId: orgId ?? undefined,
+      from: from,
+      error,
+    })
     return false
   }
 }

--- a/src/lib/email/badge.test.ts
+++ b/src/lib/email/badge.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// The badge sender constructs `new Resend(...)` at module load, so mock the
-// package itself and capture the send payload.
+// The badge sender goes through the shared client in `@/lib/email/config`,
+// which constructs its Resend at module load — so mock the package itself and
+// capture the send payload.
 const sendMock = vi.fn()
 vi.mock('resend', () => ({
   Resend: class {

--- a/src/lib/email/badge.ts
+++ b/src/lib/email/badge.ts
@@ -1,4 +1,3 @@
-import { Resend } from 'resend'
 import { BadgeEmailTemplate } from '@/components/email/BadgeEmailTemplate'
 import { emailBrandColor } from '@/lib/branding/theme'
 import { updateBadgeEmailStatus } from '@/lib/badge/sanity'
@@ -6,8 +5,10 @@ import type { BadgeRecord } from '@/lib/badge/types'
 import type { Conference } from '@/lib/conference/types'
 import { resolveConferenceFrom } from '@/lib/email/from'
 import { conferenceBaseUrl } from '@/lib/conference/baseUrl'
-
-const resend = new Resend(process.env.RESEND_API_KEY)
+// The SHARED client, not a private `new Resend(...)`: badge mail must go through
+// the same instrumented client as every other send, so it obeys the sender
+// policy and its failures are logged like the rest (platform#20).
+import { resend } from '@/lib/email/config'
 
 interface SendBadgeEmailParams {
   badge: BadgeRecord

--- a/src/lib/email/config.ts
+++ b/src/lib/email/config.ts
@@ -2,6 +2,7 @@ import { Resend } from 'resend'
 import assert from 'assert'
 import { resolveTenantSecrets } from '@/lib/secrets/store'
 import type { EmailCredentials } from '@/lib/secrets/types'
+import { instrumentResendClient } from './instrument'
 
 if (process.env.NODE_ENV !== 'test') {
   assert(process.env.RESEND_API_KEY, 'RESEND_API_KEY is not set')
@@ -20,15 +21,35 @@ export const EMAIL_CONFIG = {
  * client, constructed lazily on demand. This replaces the former eager
  * module-scope singleton so a per-org tenant can send under its own Resend
  * account without touching any existing send path.
+ *
+ * EVERY client handed out here is instrumented (`instrumentResendClient`): the
+ * sender policy and failure logging live on the client, not on the call sites,
+ * so neither can be bypassed by a send path that forgot about them. The PLATFORM
+ * client enforces the From policy (platform#20); a client built from a tenant's
+ * OWN credentials does not — its domains are verified on its own account — but
+ * it still logs every failure.
  */
 let platformResend: Resend | undefined
 
-export function getResendClient(credentials?: EmailCredentials): Resend {
+export function getResendClient(
+  credentials?: EmailCredentials,
+  context?: { orgId?: string | null },
+): Resend {
   const apiKey = credentials?.apiKey || EMAIL_CONFIG.RESEND_API_KEY
   if (apiKey === EMAIL_CONFIG.RESEND_API_KEY) {
-    return (platformResend ??= new Resend(EMAIL_CONFIG.RESEND_API_KEY))
+    // Deliberately NOT `context.orgId`: this instance is SHARED by every tenant,
+    // so an org captured from whoever happened to construct it first would
+    // mislabel every later tenant's failure log. The tenant is identified there
+    // by its From/Reply-To instead.
+    return (platformResend ??= instrumentResendClient(
+      new Resend(EMAIL_CONFIG.RESEND_API_KEY),
+      { enforceSenderPolicy: true },
+    ))
   }
-  return new Resend(apiKey)
+  return instrumentResendClient(new Resend(apiKey), {
+    orgId: context?.orgId,
+    enforceSenderPolicy: false,
+  })
 }
 
 /**
@@ -58,7 +79,10 @@ export async function resolveEmailSender(
 ): Promise<EmailSender> {
   const creds = await resolveTenantSecrets(orgId, 'email')
   if (creds?.apiKey) {
-    return { client: getResendClient(creds), from: creds.fallbackFrom }
+    return {
+      client: getResendClient(creds, { orgId }),
+      from: creds.fallbackFrom,
+    }
   }
   return { client: resend }
 }

--- a/src/lib/email/from.ts
+++ b/src/lib/email/from.ts
@@ -1,5 +1,9 @@
 import type { Conference } from '@/lib/conference/types'
-import { parseAddress, platformSenderFrom } from './sender-policy'
+import {
+  parseAddress,
+  platformSenderFrom,
+  sanitizeHeaderText,
+} from './sender-policy'
 
 /**
  * Non-branded sender/contact resolution for conference emails (CaaS #625).
@@ -74,9 +78,10 @@ export function resolveConferenceFrom(
   }: { field?: EmailField; localPart?: string } = {},
 ): string {
   // Header-injection hardening: the display name and address are interpolated
-  // into a "Name <address>" From header — strip CR/LF and angle brackets so a
-  // stored value can never smuggle extra headers or nest brackets.
-  const sanitizeHeaderText = (v: string) => v.replace(/[\r\n<>]/g, '').trim()
+  // into a "Name <address>" From header. ONE shared sanitizer (`sender-policy`)
+  // so the rule cannot drift between the two modules — it truncates at the
+  // first CR/LF and drops angle brackets, so a stored value can neither smuggle
+  // an extra header nor nest brackets.
   const organizer = conference?.organizer
     ? sanitizeHeaderText(conference.organizer)
     : undefined
@@ -156,13 +161,19 @@ export function conferenceSenders(
  *
  * Preference order: `contactEmail` → `contact@<primary-domain>` → the neutral,
  * logged platform fallback.
+ *
+ * The result is sanitized like any other address. Today's consumers put it in
+ * JSON (badge issuer), an `href`, or email BODY copy — none of which is an SMTP
+ * header, and all of which encode CR/LF harmlessly. Sanitizing anyway costs
+ * nothing and means a future consumer that DOES build a header out of it does
+ * not become the next injection point.
  */
 export function resolveConferenceContact(conference: ConferenceLike): string {
   const explicit = conference?.contactEmail?.trim()
-  if (explicit) return explicit
+  if (explicit) return bareAddress(explicit)
 
   const domain = conference?.domains?.[0]?.trim()
-  if (domain) return `contact@${domain}`
+  if (domain) return bareAddress(`contact@${domain}`)
 
   console.warn(
     `[email] conference "${conference?.title ?? 'unknown'}" has no contactEmail or domain; ` +

--- a/src/lib/email/from.ts
+++ b/src/lib/email/from.ts
@@ -101,6 +101,56 @@ export function resolveConferenceFrom(
 }
 
 /**
+ * EVERY sender a conference's mail can go out as.
+ *
+ * There is not ONE sender per conference — there are three, and they can sit on
+ * different domains:
+ *
+ * | Field          | Flows that send from it                                     |
+ * | -------------- | ----------------------------------------------------------- |
+ * | `contactEmail` | sign-in links, badges, invitation letters, workshops, volunteers, broadcasts, proposal notifications |
+ * | `cfpEmail`     | speaker mail, speaker/sponsor messaging, gallery, co-speaker invites |
+ * | `sponsorEmail` | sponsor CRM + registration, contract signing and reminders   |
+ *
+ * (Several of those flows build the header inline rather than calling
+ * {@link resolveConferenceFrom}, so this list is derived from the SEND SITES,
+ * not from the schema.)
+ *
+ * Anything judging deliverability must judge all three: a conference whose
+ * `contactEmail` is on a verified domain and whose `cfpEmail` is not has working
+ * sign-in and rejected CFP mail, and a diagnostic that looks only at the first
+ * would report health while speakers hear nothing.
+ */
+export const CONFERENCE_SENDER_FIELDS: ReadonlyArray<{
+  label: string
+  field: EmailField
+  localPart: string
+}> = [
+  { label: 'Contact', field: 'contactEmail', localPart: 'contact' },
+  { label: 'CFP', field: 'cfpEmail', localPart: 'cfp' },
+  { label: 'Sponsors', field: 'sponsorEmail', localPart: 'sponsors' },
+]
+
+export interface ConferenceSender {
+  /** Which family of mail sends as this — 'Contact', 'CFP', 'Sponsors'. */
+  label: string
+  /** The resolved `"Name <address>"` header. */
+  from: string
+  /** The bare address. */
+  address: string
+}
+
+/** Resolve {@link CONFERENCE_SENDER_FIELDS} against a conference. */
+export function conferenceSenders(
+  conference: ConferenceLike,
+): ConferenceSender[] {
+  return CONFERENCE_SENDER_FIELDS.map(({ label, field, localPart }) => {
+    const from = resolveConferenceFrom(conference, { field, localPart })
+    return { label, from, address: bareAddress(from) }
+  })
+}
+
+/**
  * Resolve a bare contact address for a conference (for `mailto:` links,
  * "contact us at …" copy, badge issuer profiles, etc.).
  *

--- a/src/lib/email/from.ts
+++ b/src/lib/email/from.ts
@@ -1,4 +1,5 @@
 import type { Conference } from '@/lib/conference/types'
+import { parseAddress, platformSenderFrom } from './sender-policy'
 
 /**
  * Non-branded sender/contact resolution for conference emails (CaaS #625).
@@ -14,19 +15,25 @@ import type { Conference } from '@/lib/conference/types'
  * `"Name <address>"` header. When unset a deliberately non-deliverable,
  * brand-free placeholder is used so a broken config surfaces instead of
  * masquerading as a real conference.
+ *
+ * WHAT THIS RESOLVES IS AN IDENTITY, NOT AN ENVELOPE. The address chosen here is
+ * the one the conference WANTS to be seen as; whether the platform's Resend
+ * account may actually send from it is a separate question, answered at the
+ * client by `sender-policy.ts` (platform#20). A tenant whose domain is not
+ * verified still gets its name and its `Reply-To:` — the `From:` address is
+ * swapped for a deliverable one on the way out.
  */
 
 const NEUTRAL_FALLBACK_FROM = 'Conference <noreply@localhost>'
 
 /** The neutral, env-driven platform sender (`"Name <address>"`). */
 export function platformFallbackFrom(): string {
-  return process.env.EMAIL_FALLBACK_FROM || NEUTRAL_FALLBACK_FROM
+  return platformSenderFrom() ?? NEUTRAL_FALLBACK_FROM
 }
 
 /** Extract the bare `address` from a `"Name <address>"` (or plain) string. */
 function bareAddress(from: string): string {
-  const match = from.match(/<([^>]+)>/)
-  return match ? match[1].trim() : from.trim()
+  return parseAddress(from).address
 }
 
 /** The bare address of the neutral platform sender. */

--- a/src/lib/email/instrument.test.ts
+++ b/src/lib/email/instrument.test.ts
@@ -182,6 +182,115 @@ describe('a stored CR/LF cannot become a second header on the wire', () => {
     expect(sent[0]).not.toHaveProperty('bcc')
   })
 
+  /**
+   * THE DEDICATED PATH — a tenant on the `dedicated-email` Pro entitlement,
+   * sending on its OWN Resend account. `applySenderPolicy` is skipped there BY
+   * DESIGN, so a fix that lived inside the policy left the injection wide open
+   * for exactly the tenants who pay for their own account. The tenant-editable
+   * fields and the raw-interpolating send sites are identical on both paths.
+   */
+  it('strips it on a DEDICATED client, where the policy is skipped by design', async () => {
+    const { client, sent } = fakeClient(OK)
+    instrumentResendClient(client, {
+      orgId: 'org-kcd',
+      enforceSenderPolicy: false,
+    })
+
+    await client.emails.send({
+      from: `KCD Bergen <${PAYLOAD}>`,
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expectSingleHeaderLine(sent[0].from)
+    expect(sent[0]).not.toHaveProperty('bcc')
+    expect(sent[0].to).toBe('speaker@example.com')
+    // The sender is otherwise UNCHANGED — the policy really is skipped here,
+    // so this proves sanitisation, not a rewrite, is doing the work.
+    expect(sent[0].from).toBe('KCD Bergen <hello@kcd.dev>')
+  })
+
+  it('strips a caller-supplied Reply-To on a DEDICATED client', async () => {
+    const { client, sent } = fakeClient(OK)
+    instrumentResendClient(client, { enforceSenderPolicy: false })
+
+    await client.emails.send({
+      from: 'KCD Bergen <hello@kcd.dev>',
+      replyTo: PAYLOAD,
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expectSingleHeaderLine(sent[0].replyTo)
+    expect(sent[0]).not.toHaveProperty('bcc')
+  })
+
+  it('strips it on a DEDICATED broadcast', async () => {
+    const created: Array<{ from: string; replyTo?: string | string[] }> = []
+    const create = vi.fn(async (payload: { from: string }) => {
+      created.push(payload)
+      return { data: { id: 'bc_1' } }
+    })
+    const client = {
+      emails: { send: vi.fn(), create: vi.fn() },
+      broadcasts: { create },
+    } as unknown as Resend
+    instrumentResendClient(client, {
+      orgId: 'org-kcd',
+      enforceSenderPolicy: false,
+    })
+
+    await client.broadcasts.create({
+      name: 'Announcement',
+      audienceId: 'aud_1',
+      from: `KCD Bergen <${PAYLOAD}>`,
+      replyTo: PAYLOAD,
+      subject: 'Hello',
+      html: '<p>hi</p>',
+    })
+
+    expectSingleHeaderLine(created[0].from)
+    expectSingleHeaderLine(created[0].replyTo)
+    expect(created[0]).not.toHaveProperty('bcc')
+    expect(created[0].from).toBe('KCD Bergen <hello@kcd.dev>')
+  })
+
+  it('strips it on BATCH and on broadcast UPDATE, on both paths', async () => {
+    const batched: Array<Array<{ from?: string }>> = []
+    const updated: Array<{ from?: string }> = []
+    const client = {
+      emails: { send: vi.fn(), create: vi.fn() },
+      batch: {
+        send: vi.fn(async (payload: Array<{ from?: string }>) => {
+          batched.push(payload)
+          return { data: { data: [] } }
+        }),
+      },
+      broadcasts: {
+        update: vi.fn(async (_id: string, payload: { from?: string }) => {
+          updated.push(payload)
+          return { data: { id: 'bc_1' } }
+        }),
+      },
+    } as unknown as Resend
+    instrumentResendClient(client, { enforceSenderPolicy: false })
+
+    await client.batch.send([
+      {
+        from: `KCD Bergen <${PAYLOAD}>`,
+        to: 'a@example.com',
+        subject: 's',
+        html: '<p>hi</p>',
+      },
+    ])
+    await client.broadcasts.update('bc_1', { from: `KCD <${PAYLOAD}>` })
+
+    expectSingleHeaderLine(batched[0][0].from)
+    expectSingleHeaderLine(updated[0].from)
+  })
+
   it('strips it on a BROADCAST too', async () => {
     const created: Array<{ from: string; replyTo?: string | string[] }> = []
     const create = vi.fn(async (payload: { from: string }) => {

--- a/src/lib/email/instrument.test.ts
+++ b/src/lib/email/instrument.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Resend } from 'resend'
+import { instrumentResendClient } from './instrument'
+import { resetSenderPolicyWarnings } from './sender-policy'
+
+/**
+ * The choke point (platform#20). Two invariants, both of which a call site must
+ * be unable to break: the sender policy is applied to the message that actually
+ * leaves, and a failed send is ALWAYS logged with tenant-identifying context —
+ * regardless of what the caller does with the result.
+ */
+
+const PLATFORM_FROM = 'Konf <noreply@platform.example>'
+
+interface SendCall {
+  from: string
+  replyTo?: string | string[]
+  to: string | string[]
+  subject: string
+}
+
+function fakeClient(impl: () => Promise<{ data?: unknown; error?: unknown }>): {
+  client: Resend
+  sent: SendCall[]
+  send: ReturnType<typeof vi.fn>
+} {
+  const sent: SendCall[] = []
+  const send = vi.fn(async (payload: SendCall) => {
+    sent.push(payload)
+    return impl()
+  })
+  const client = {
+    emails: { send, create: send },
+  } as unknown as Resend
+  return { client, sent, send }
+}
+
+const OK = async () => ({ data: { id: 'email_1' } })
+
+beforeEach(() => {
+  resetSenderPolicyWarnings()
+  vi.stubEnv('EMAIL_FALLBACK_FROM', PLATFORM_FROM)
+  vi.stubEnv('EMAIL_SENDING_DOMAINS', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('the message that actually leaves', () => {
+  it('rewrites an unverified tenant From and sets Reply-To on the PLATFORM client', async () => {
+    const { client, sent } = fakeClient(OK)
+    instrumentResendClient(client, {
+      orgId: 'org-kcd',
+      enforceSenderPolicy: true,
+    })
+
+    await client.emails.send({
+      from: 'KCD Bergen <hello@kcd.dev>',
+      to: 'speaker@example.com',
+      subject: 'Sign in to KCD Bergen',
+      html: '<p>hi</p>',
+    })
+
+    expect(sent).toHaveLength(1)
+    // Assert on the CONSTRUCTED MESSAGE, not on a return value.
+    expect(sent[0].from).toBe('KCD Bergen <noreply@platform.example>')
+    expect(sent[0].replyTo).toBe('hello@kcd.dev')
+    expect(sent[0].from).not.toContain('kcd.dev')
+    // Everything else is untouched.
+    expect(sent[0].to).toBe('speaker@example.com')
+    expect(sent[0].subject).toBe('Sign in to KCD Bergen')
+  })
+
+  it('leaves a tenant on a VERIFIED sending domain exactly as it asked', async () => {
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'kcd.dev')
+    const { client, sent } = fakeClient(OK)
+    instrumentResendClient(client, { enforceSenderPolicy: true })
+
+    await client.emails.send({
+      from: 'KCD Bergen <hello@kcd.dev>',
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expect(sent[0].from).toBe('KCD Bergen <hello@kcd.dev>')
+    expect(sent[0].replyTo).toBeUndefined()
+  })
+
+  it('does NOT rewrite for a tenant sending on its OWN Resend account', async () => {
+    const { client, sent } = fakeClient(OK)
+    instrumentResendClient(client, {
+      orgId: 'org-kcd',
+      enforceSenderPolicy: false,
+    })
+
+    await client.emails.send({
+      from: 'KCD Bergen <hello@kcd.dev>',
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expect(sent[0].from).toBe('KCD Bergen <hello@kcd.dev>')
+    expect(sent[0].replyTo).toBeUndefined()
+  })
+
+  it('guards `create` too, so the alias is not a way around the policy', async () => {
+    const { client, sent } = fakeClient(OK)
+    instrumentResendClient(client, { enforceSenderPolicy: true })
+
+    await client.emails.create({
+      from: 'hello@kcd.dev',
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expect(sent[0].from).toBe('Konf <noreply@platform.example>')
+    expect(sent[0].replyTo).toBe('hello@kcd.dev')
+  })
+})
+
+describe('a failed send is never silent', () => {
+  it('logs when Resend RETURNS an error, even though the caller ignores it', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client } = fakeClient(async () => ({
+      error: {
+        name: 'validation_error',
+        message: 'The kcd.dev domain is not verified.',
+      },
+    }))
+    instrumentResendClient(client, {
+      orgId: 'org-kcd',
+      enforceSenderPolicy: true,
+    })
+
+    // The caller throws the result away — the classic silent failure.
+    await client.emails.send({
+      from: 'KCD Bergen <hello@kcd.dev>',
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expect(error).toHaveBeenCalledTimes(1)
+    const [message, context] = error.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ]
+    expect(message).toBe('[email] send failed')
+    // Enough context for an operator to name the tenant …
+    expect(context.orgId).toBe('org-kcd')
+    expect(context.replyTo).toBe('hello@kcd.dev')
+    expect(context.senderPolicy).toBe('platform-rewritten')
+    expect(context.recipientDomains).toEqual(['example.com'])
+    expect(context.error).toMatchObject({ name: 'validation_error' })
+  })
+
+  it('logs when the send THROWS, and still propagates the throw', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const boom = new Error('fetch failed')
+    const { client } = fakeClient(async () => {
+      throw boom
+    })
+    instrumentResendClient(client, { enforceSenderPolicy: true })
+
+    await expect(
+      client.emails.send({
+        from: 'KCD Bergen <hello@kcd.dev>',
+        to: ['a@example.com', 'b@example.org'],
+        subject: 's',
+        html: '<p>hi</p>',
+      }),
+    ).rejects.toBe(boom)
+
+    expect(error).toHaveBeenCalledTimes(1)
+    const context = error.mock.calls[0][1] as Record<string, unknown>
+    expect(context.recipientDomains).toEqual(['example.com', 'example.org'])
+    expect(context.error).toMatchObject({ message: 'fetch failed' })
+  })
+
+  it('never puts a recipient address or a subject in the log', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client } = fakeClient(async () => ({
+      error: { name: 'validation_error', message: 'nope' },
+    }))
+    instrumentResendClient(client, { enforceSenderPolicy: true })
+
+    await client.emails.send({
+      from: 'KCD Bergen <hello@kcd.dev>',
+      to: 'secret-person@example.com',
+      subject: 'Sign in to KCD Bergen',
+      html: '<p>hi</p>',
+    })
+
+    const logged = JSON.stringify(error.mock.calls[0])
+    expect(logged).not.toContain('secret-person')
+    expect(logged).not.toContain('Sign in to')
+  })
+
+  it('logs a failure on a tenant OWN-account client too, labelled as dedicated', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client } = fakeClient(async () => ({
+      error: { name: 'application_error', message: 'nope' },
+    }))
+    instrumentResendClient(client, {
+      orgId: 'org-kcd',
+      enforceSenderPolicy: false,
+    })
+
+    await client.emails.send({
+      from: 'KCD Bergen <hello@kcd.dev>',
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(error.mock.calls[0][1]).toMatchObject({
+      orgId: 'org-kcd',
+      senderPolicy: 'dedicated',
+    })
+  })
+
+  it('says nothing on a successful send', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client } = fakeClient(OK)
+    instrumentResendClient(client, { enforceSenderPolicy: true })
+
+    await client.emails.send({
+      from: 'KCD Bergen <hello@kcd.dev>',
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expect(error).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/email/instrument.test.ts
+++ b/src/lib/email/instrument.test.ts
@@ -225,6 +225,36 @@ describe('a failed send is never silent', () => {
     })
   })
 
+  it('guards BROADCASTS too — the second send API is not a hole in the policy', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const created: Array<{ from: string; replyTo?: string | string[] }> = []
+    const create = vi.fn(async (payload: { from: string }) => {
+      created.push(payload)
+      return { error: { name: 'validation_error', message: 'not verified' } }
+    })
+    const client = {
+      emails: { send: vi.fn(), create: vi.fn() },
+      broadcasts: { create },
+    } as unknown as Resend
+    instrumentResendClient(client, {
+      orgId: 'org-kcd',
+      enforceSenderPolicy: true,
+    })
+
+    await client.broadcasts.create({
+      name: 'Announcement',
+      audienceId: 'aud_1',
+      from: 'KCD Bergen <hello@kcd.dev>',
+      subject: 'Hello',
+      html: '<p>hi</p>',
+    })
+
+    expect(created[0].from).toBe('KCD Bergen <noreply@platform.example>')
+    expect(created[0].replyTo).toBe('hello@kcd.dev')
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(error.mock.calls[0][0]).toBe('[email] send failed')
+  })
+
   it('says nothing on a successful send', async () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { client } = fakeClient(OK)

--- a/src/lib/email/instrument.test.ts
+++ b/src/lib/email/instrument.test.ts
@@ -123,6 +123,90 @@ describe('the message that actually leaves', () => {
   })
 })
 
+/**
+ * Header injection, asserted on the message that actually leaves.
+ *
+ * The stored value is tenant-editable (`contactEmail`/`cfpEmail`/`sponsorEmail`
+ * on the conference) and roughly half the send sites interpolate it into the
+ * header RAW. The attacker is an authenticated organizer of one tenant, and the
+ * platform is multi-tenant, so the reachable payoff is an injected `Bcc:` on
+ * another tenant's mail.
+ */
+describe('a stored CR/LF cannot become a second header on the wire', () => {
+  const PAYLOAD = 'hello@kcd.dev\r\nBcc: attacker@evil.example'
+
+  /** Structural: no CR, no LF, exactly one header line. */
+  function expectSingleHeaderLine(value: string | string[] | undefined) {
+    const values = value === undefined ? [] : [value].flat()
+    expect(values.length).toBeGreaterThan(0)
+    for (const v of values) {
+      expect(v).not.toMatch(/[\r\n]/)
+      expect(v.split(/\r\n|\r|\n/)).toHaveLength(1)
+    }
+  }
+
+  it('strips it from the constructed From and Reply-To', async () => {
+    const { client, sent } = fakeClient(OK)
+    instrumentResendClient(client, { enforceSenderPolicy: true })
+
+    // Exactly what `email/speaker.ts` and friends build:
+    // `${conference.organizer} <${conference.cfpEmail}>`.
+    await client.emails.send({
+      from: `KCD Bergen <${PAYLOAD}>`,
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expectSingleHeaderLine(sent[0].from)
+    expectSingleHeaderLine(sent[0].replyTo)
+    // The injected header cannot exist as a header: there is no second line to
+    // put it on, and nothing added a recipient field.
+    expect(sent[0]).not.toHaveProperty('bcc')
+    expect(sent[0].to).toBe('speaker@example.com')
+  })
+
+  it('strips it on the verified-domain path, where the header passes through', async () => {
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'kcd.dev')
+    const { client, sent } = fakeClient(OK)
+    instrumentResendClient(client, { enforceSenderPolicy: true })
+
+    await client.emails.send({
+      from: `KCD Bergen <${PAYLOAD}>`,
+      to: 'speaker@example.com',
+      subject: 's',
+      html: '<p>hi</p>',
+    })
+
+    expectSingleHeaderLine(sent[0].from)
+    expect(sent[0]).not.toHaveProperty('bcc')
+  })
+
+  it('strips it on a BROADCAST too', async () => {
+    const created: Array<{ from: string; replyTo?: string | string[] }> = []
+    const create = vi.fn(async (payload: { from: string }) => {
+      created.push(payload)
+      return { data: { id: 'bc_1' } }
+    })
+    const client = {
+      emails: { send: vi.fn(), create: vi.fn() },
+      broadcasts: { create },
+    } as unknown as Resend
+    instrumentResendClient(client, { enforceSenderPolicy: true })
+
+    await client.broadcasts.create({
+      name: 'Announcement',
+      audienceId: 'aud_1',
+      from: `KCD Bergen <${PAYLOAD}>`,
+      subject: 'Hello',
+      html: '<p>hi</p>',
+    })
+
+    expectSingleHeaderLine(created[0].from)
+    expectSingleHeaderLine(created[0].replyTo)
+  })
+})
+
 describe('a failed send is never silent', () => {
   it('logs when Resend RETURNS an error, even though the caller ignores it', async () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/lib/email/instrument.ts
+++ b/src/lib/email/instrument.ts
@@ -1,0 +1,180 @@
+import type {
+  CreateEmailOptions,
+  CreateEmailRequestOptions,
+  CreateEmailResponse,
+  Resend,
+} from 'resend'
+import { applySenderPolicy, type SenderPolicyDecision } from './sender-policy'
+
+/**
+ * THE CHOKE POINT (RunKonf/platform#20).
+ *
+ * There are twenty-odd `resend.emails.send(...)` call sites in this codebase.
+ * Some resolve their `From:` through `resolveConferenceFrom`, several build it
+ * inline (`${conference.organizer} <${conference.cfpEmail}>`), and each handles
+ * a failed send in its own way — a few return `false`, some log, some throw, and
+ * at least one swallows the error into a boolean nobody reads. A sender policy
+ * enforced by "every author remembers to call the helper" is not enforced, and
+ * an observability rule spread over twenty error branches is not a rule.
+ *
+ * So both live HERE, wrapped around the Resend client itself:
+ *
+ * 1. THE SENDER POLICY (`applySenderPolicy`) is applied to every outbound
+ *    message on the platform account, so a tenant on an unverified domain sends
+ *    from the platform sender with its own address in `Reply-To:` — whatever the
+ *    call site asked for. A tenant with its OWN Resend account is exempt: its
+ *    domain is verified on ITS account, and rewriting would be wrong.
+ * 2. EVERY FAILURE IS LOGGED, once, with enough context to name the tenant —
+ *    whether Resend returns `{ error }` or the call throws, and no matter what
+ *    the caller then does with the result. A call site can still choose to
+ *    swallow a failure; it can no longer make it invisible.
+ *
+ * WHAT IS AND IS NOT LOGGED: the `From:`/`Reply-To:` (tenant-identifying, and
+ * not personal data), the policy decision, the Resend error name/message, and
+ * the recipients' DOMAINS only. Never a recipient address, never a subject —
+ * a sign-in email's subject and recipient are exactly what the anti-enumeration
+ * design refuses to disclose, and logs are read by more people than the mailbox.
+ */
+
+export interface EmailClientContext {
+  /** The organization this client sends for, when known. */
+  orgId?: string | null
+  /**
+   * `false` for a tenant's OWN Resend account (per-org credentials): its
+   * sending domains are verified there, so the platform policy does not apply.
+   */
+  enforceSenderPolicy: boolean
+}
+
+/** Recipient DOMAINS only — never the addresses. */
+function recipientDomains(to: CreateEmailOptions['to']): string[] {
+  const list = Array.isArray(to) ? to : [to]
+  const domains = new Set<string>()
+  for (const address of list) {
+    if (typeof address !== 'string') continue
+    const at = address.lastIndexOf('@')
+    if (at !== -1)
+      domains.add(
+        address
+          .slice(at + 1)
+          .trim()
+          .toLowerCase(),
+      )
+  }
+  return [...domains]
+}
+
+function errorSummary(error: unknown): { name?: string; message: string } {
+  if (error && typeof error === 'object') {
+    const err = error as { name?: string; message?: string }
+    return { name: err.name, message: err.message ?? String(error) }
+  }
+  return { message: String(error) }
+}
+
+/**
+ * Log a failed send with tenant-identifying context.
+ *
+ * This is the line that matters most where the CALLER is required to stay
+ * silent: `lib/auth/email-link/send.ts` reports into a deliberately opaque
+ * anti-enumeration response, so this — plus its own `[email-link]` line, which
+ * adds the conference name — is the only trace that a tenant cannot sign in.
+ *
+ * Exported so a caller with richer context can report a failure it detected
+ * outside a send call in the same shape.
+ */
+export function logEmailSendFailure(
+  context: {
+    orgId?: string | null
+    /** Absent only for a Resend-template send, which carries its own sender. */
+    from?: string
+    replyTo?: string | string[]
+    to?: CreateEmailOptions['to']
+    /**
+     * `'dedicated'` — a tenant's own Resend account, exempt from the policy.
+     * `'template-default'` — a Resend-template send with no explicit sender.
+     */
+    decision?: SenderPolicyDecision | 'dedicated' | 'template-default'
+  },
+  error: unknown,
+): void {
+  console.error('[email] send failed', {
+    orgId: context.orgId ?? undefined,
+    from: context.from,
+    replyTo: context.replyTo,
+    recipientDomains: context.to ? recipientDomains(context.to) : undefined,
+    senderPolicy: context.decision,
+    error: errorSummary(error),
+  })
+}
+
+/**
+ * Wrap a Resend client's send methods with the sender policy and failure
+ * logging. Mutates and returns the client so that every existing call site —
+ * including the ones that import the `resend` singleton directly — is covered
+ * without moving.
+ */
+export function instrumentResendClient(
+  client: Resend,
+  context: EmailClientContext,
+): Resend {
+  const emails = client.emails
+  const guard = (
+    original: (
+      payload: CreateEmailOptions,
+      options?: CreateEmailRequestOptions,
+    ) => Promise<CreateEmailResponse>,
+  ) => {
+    return async (
+      payload: CreateEmailOptions,
+      options?: CreateEmailRequestOptions,
+    ): Promise<CreateEmailResponse> => {
+      // `from` is optional in Resend's type ONLY for a template-driven send,
+      // which carries its own stored sender: there is nothing here to judge, so
+      // it passes through untouched — but it is still covered by the logging.
+      const policy =
+        context.enforceSenderPolicy && typeof payload.from === 'string'
+          ? applySenderPolicy({ from: payload.from, replyTo: payload.replyTo })
+          : {
+              from: payload.from,
+              replyTo: payload.replyTo,
+              decision: context.enforceSenderPolicy
+                ? ('template-default' as const)
+                : ('dedicated' as const),
+            }
+
+      const message = {
+        ...payload,
+        ...(policy.from === undefined ? {} : { from: policy.from }),
+        ...(policy.replyTo === undefined ? {} : { replyTo: policy.replyTo }),
+      } as CreateEmailOptions
+
+      const failureContext = {
+        orgId: context.orgId,
+        from: message.from,
+        replyTo: message.replyTo,
+        to: message.to,
+        decision: policy.decision,
+      }
+
+      let result: CreateEmailResponse
+      try {
+        result = await original(message, options)
+      } catch (error) {
+        logEmailSendFailure(failureContext, error)
+        throw error
+      }
+      if (result?.error) logEmailSendFailure(failureContext, result.error)
+      return result
+    }
+  }
+
+  // `create` is Resend's alias for `send`; both are guarded so neither is a way
+  // around the policy. `create` is probed rather than assumed so a test double
+  // (or an SDK that drops the alias) cannot turn instrumentation into a crash.
+  emails.send = guard(emails.send.bind(emails))
+  if (typeof emails.create === 'function') {
+    emails.create = guard(emails.create.bind(emails))
+  }
+  return client
+}

--- a/src/lib/email/instrument.ts
+++ b/src/lib/email/instrument.ts
@@ -7,7 +7,12 @@ import type {
   CreateEmailResponse,
   Resend,
 } from 'resend'
-import { applySenderPolicy, type SenderPolicyDecision } from './sender-policy'
+import {
+  applySenderPolicy,
+  formatAddress,
+  parseAddress,
+  type SenderPolicyDecision,
+} from './sender-policy'
 
 /**
  * THE CHOKE POINT (RunKonf/platform#20).
@@ -20,17 +25,34 @@ import { applySenderPolicy, type SenderPolicyDecision } from './sender-policy'
  * enforced by "every author remembers to call the helper" is not enforced, and
  * an observability rule spread over twenty error branches is not a rule.
  *
- * So both live HERE, wrapped around the Resend client itself:
+ * So all THREE guarantees live HERE, wrapped around the Resend client itself:
  *
- * 1. THE SENDER POLICY (`applySenderPolicy`) is applied to every outbound
- *    message on the platform account, so a tenant on an unverified domain sends
- *    from the platform sender with its own address in `Reply-To:` — whatever the
- *    call site asked for. A tenant with its OWN Resend account is exempt: its
- *    domain is verified on ITS account, and rewriting would be wrong.
- * 2. EVERY FAILURE IS LOGGED, once, with enough context to name the tenant —
+ * 1. HEADER SANITISATION, on EVERY send, on EVERY client, unconditionally —
+ *    see {@link sanitizeOutboundHeaders}.
+ * 2. THE SENDER POLICY (`applySenderPolicy`) on the platform account, so a
+ *    tenant on an unverified domain sends from the platform sender with its own
+ *    address in `Reply-To:` — whatever the call site asked for. A tenant with
+ *    its OWN Resend account is exempt from the POLICY (its domain is verified
+ *    on ITS account, and rewriting would be wrong) but NOT from (1).
+ * 3. EVERY FAILURE IS LOGGED, once, with enough context to name the tenant —
  *    whether Resend returns `{ error }` or the call throws, and no matter what
  *    the caller then does with the result. A call site can still choose to
  *    swallow a failure; it can no longer make it invisible.
+ *
+ * WHY (1) IS HERE AND NOT ONLY IN THE POLICY. Sanitisation used to happen as a
+ * side effect of `applySenderPolicy` rebuilding the header — which meant it did
+ * not happen at all on the DEDICATED-client path, where the policy is skipped by
+ * design. The tenant-editable fields and the raw-interpolating send sites are
+ * identical on both paths, so the injection was still open for exactly the
+ * tenants who pay for their own Resend account. The lesson generalises: the
+ * source is not a function the policy happens to call, it is the BOUNDARY where
+ * a message leaves for Resend. Everything crossing it is sanitised, whichever
+ * branch produced it.
+ *
+ * EVERY FROM-BEARING METHOD is wrapped — `emails.send`/`create`,
+ * `batch.send`/`create`, `broadcasts.create`/`update` — not just the ones this
+ * codebase happens to call today, so adopting one later cannot silently reopen
+ * the hole. (`broadcasts.send` takes only an id.)
  *
  * WHAT IS AND IS NOT LOGGED: the `From:`/`Reply-To:` (tenant-identifying, and
  * not personal data), the policy decision, the Resend error name/message, and
@@ -112,10 +134,74 @@ export function logEmailSendFailure(
 }
 
 /**
- * Wrap a Resend client's send methods with the sender policy and failure
- * logging. Mutates and returns the client so that every existing call site —
- * including the ones that import the `resend` singleton directly — is covered
- * without moving.
+ * THE BOUNDARY GUARANTEE: no header leaving for Resend carries a CR/LF.
+ *
+ * Applied to every outbound `from`/`replyTo` on every client, INDEPENDENT of
+ * the sender policy — the dedicated-client path skips the policy by design, and
+ * it must not skip this. `formatAddress(parseAddress(x))` is the identity for a
+ * well-formed header and a sanitising round-trip for anything else; it
+ * TRUNCATES at the first break rather than deleting breaks, because deletion
+ * splices the payload onto the value and, for an address, hands the attacker the
+ * resulting domain (`a@evil.example\r\nb@verified.test` would collapse into one
+ * address reading as `verified.test`). See `sanitizeHeaderText`.
+ */
+function sanitizeOutboundHeaders<
+  T extends { from?: string; replyTo?: string | string[] },
+>(payload: T): T {
+  const clean = (value: string) => formatAddress(parseAddress(value))
+  return {
+    ...payload,
+    ...(typeof payload.from === 'string' ? { from: clean(payload.from) } : {}),
+    ...(payload.replyTo === undefined
+      ? {}
+      : {
+          replyTo: Array.isArray(payload.replyTo)
+            ? payload.replyTo.map(clean)
+            : clean(payload.replyTo),
+        }),
+  }
+}
+
+/**
+ * Decide the sender for one outbound message and sanitise its headers.
+ *
+ * The policy is skipped for a dedicated client; the sanitisation never is.
+ */
+function guardMessage<T extends { from?: string; replyTo?: string | string[] }>(
+  payload: T,
+  context: EmailClientContext,
+): {
+  message: T
+  decision: SenderPolicyDecision | 'dedicated' | 'template-default'
+} {
+  // `from` is optional in Resend's type ONLY for a template-driven send, which
+  // carries its own stored sender: there is nothing there to judge, so the
+  // policy passes it through — but it is still sanitised and still logged.
+  const policy =
+    context.enforceSenderPolicy && typeof payload.from === 'string'
+      ? applySenderPolicy({ from: payload.from, replyTo: payload.replyTo })
+      : {
+          from: payload.from,
+          replyTo: payload.replyTo,
+          decision: context.enforceSenderPolicy
+            ? ('template-default' as const)
+            : ('dedicated' as const),
+        }
+
+  const message = sanitizeOutboundHeaders({
+    ...payload,
+    ...(policy.from === undefined ? {} : { from: policy.from }),
+    ...(policy.replyTo === undefined ? {} : { replyTo: policy.replyTo }),
+  } as T)
+
+  return { message, decision: policy.decision }
+}
+
+/**
+ * Wrap a Resend client's send methods with header sanitisation, the sender
+ * policy and failure logging. Mutates and returns the client so that every
+ * existing call site — including the ones that import the `resend` singleton
+ * directly — is covered without moving.
  */
 export function instrumentResendClient(
   client: Resend,
@@ -132,32 +218,14 @@ export function instrumentResendClient(
       payload: CreateEmailOptions,
       options?: CreateEmailRequestOptions,
     ): Promise<CreateEmailResponse> => {
-      // `from` is optional in Resend's type ONLY for a template-driven send,
-      // which carries its own stored sender: there is nothing here to judge, so
-      // it passes through untouched — but it is still covered by the logging.
-      const policy =
-        context.enforceSenderPolicy && typeof payload.from === 'string'
-          ? applySenderPolicy({ from: payload.from, replyTo: payload.replyTo })
-          : {
-              from: payload.from,
-              replyTo: payload.replyTo,
-              decision: context.enforceSenderPolicy
-                ? ('template-default' as const)
-                : ('dedicated' as const),
-            }
-
-      const message = {
-        ...payload,
-        ...(policy.from === undefined ? {} : { from: policy.from }),
-        ...(policy.replyTo === undefined ? {} : { replyTo: policy.replyTo }),
-      } as CreateEmailOptions
+      const { message, decision } = guardMessage(payload, context)
 
       const failureContext = {
         orgId: context.orgId,
         from: message.from,
         replyTo: message.replyTo,
         to: message.to,
-        decision: policy.decision,
+        decision,
       }
 
       let result: CreateEmailResponse
@@ -180,46 +248,93 @@ export function instrumentResendClient(
     emails.create = guard(emails.create.bind(emails))
   }
 
-  // BROADCASTS are a second send API with its own `from`/`replyTo`, used by the
-  // audience broadcast path (`lib/email/broadcast.ts`) — an unguarded broadcast
-  // would be a hole in exactly the policy this module exists to make
-  // unbypassable. Same guard, different payload type.
-  const broadcasts = client.broadcasts
-  if (broadcasts && typeof broadcasts.create === 'function') {
-    const originalCreate = broadcasts.create.bind(broadcasts)
-    broadcasts.create = (async (
-      payload: CreateBroadcastOptions,
-      options?: CreateBroadcastRequestOptions,
-    ) => {
-      const policy = context.enforceSenderPolicy
-        ? applySenderPolicy({ from: payload.from, replyTo: payload.replyTo })
-        : {
-            from: payload.from,
-            replyTo: payload.replyTo,
-            decision: 'dedicated' as const,
-          }
-      const message = {
-        ...payload,
-        from: policy.from,
-        ...(policy.replyTo === undefined ? {} : { replyTo: policy.replyTo }),
-      } as CreateBroadcastOptions
+  // BATCH is a third send API: one call, an ARRAY of messages, each with its own
+  // `from`. Unused by this codebase today — wrapped so that adopting it later
+  // cannot silently reopen the hole.
+  const batch = client.batch
+  if (batch) {
+    for (const method of ['send', 'create'] as const) {
+      const original = batch[method]
+      if (typeof original !== 'function') continue
+      const bound = original.bind(batch) as (
+        payload: CreateEmailOptions[],
+        options?: unknown,
+      ) => Promise<{ error?: unknown }>
+      batch[method] = (async (
+        payload: CreateEmailOptions[],
+        options?: unknown,
+      ) => {
+        const guarded = payload.map((item) => guardMessage(item, context))
+        const messages = guarded.map((g) => g.message)
+        const failureContext = {
+          orgId: context.orgId,
+          from: messages[0]?.from,
+          replyTo: messages[0]?.replyTo,
+          decision: guarded[0]?.decision,
+        }
+        let result: { error?: unknown }
+        try {
+          result = await bound(messages, options)
+        } catch (error) {
+          logEmailSendFailure(failureContext, error)
+          throw error
+        }
+        if (result?.error) logEmailSendFailure(failureContext, result.error)
+        return result
+      }) as typeof batch.send as typeof original
+    }
+  }
 
-      const failureContext = {
-        orgId: context.orgId,
-        from: message.from,
-        replyTo: message.replyTo,
-        decision: policy.decision,
+  // BROADCASTS are a fourth send API with their own `from`/`replyTo`, used by
+  // the audience broadcast path (`lib/email/broadcast.ts`). `update` carries a
+  // `from` too — a broadcast created clean and updated poisoned would otherwise
+  // slip past — while `send` takes only an id and needs no guard.
+  const broadcasts = client.broadcasts
+  if (broadcasts) {
+    const guardBroadcast = <P extends CreateBroadcastOptions>(
+      original: (
+        payload: P,
+        options?: CreateBroadcastRequestOptions,
+      ) => unknown,
+    ) => {
+      return async (payload: P, options?: CreateBroadcastRequestOptions) => {
+        const { message, decision } = guardMessage(payload, context)
+        const failureContext = {
+          orgId: context.orgId,
+          from: message.from,
+          replyTo: message.replyTo,
+          decision,
+        }
+        let result: CreateBroadcastResponse
+        try {
+          result = (await original(
+            message,
+            options,
+          )) as unknown as CreateBroadcastResponse
+        } catch (error) {
+          logEmailSendFailure(failureContext, error)
+          throw error
+        }
+        if (result?.error) logEmailSendFailure(failureContext, result.error)
+        return result
       }
-      let result: CreateBroadcastResponse
-      try {
-        result = await originalCreate(message, options)
-      } catch (error) {
-        logEmailSendFailure(failureContext, error)
-        throw error
-      }
-      if (result?.error) logEmailSendFailure(failureContext, result.error)
-      return result
-    }) as typeof broadcasts.create
+    }
+
+    if (typeof broadcasts.create === 'function') {
+      broadcasts.create = guardBroadcast(
+        broadcasts.create.bind(broadcasts),
+      ) as typeof broadcasts.create
+    }
+    if (typeof broadcasts.update === 'function') {
+      const originalUpdate = broadcasts.update.bind(broadcasts)
+      broadcasts.update = (async (
+        id: string,
+        payload: Parameters<typeof broadcasts.update>[1],
+      ) => {
+        const { message } = guardMessage(payload, context)
+        return originalUpdate(id, message)
+      }) as typeof broadcasts.update
+    }
   }
 
   return client

--- a/src/lib/email/instrument.ts
+++ b/src/lib/email/instrument.ts
@@ -1,4 +1,7 @@
 import type {
+  CreateBroadcastOptions,
+  CreateBroadcastRequestOptions,
+  CreateBroadcastResponse,
   CreateEmailOptions,
   CreateEmailRequestOptions,
   CreateEmailResponse,
@@ -176,5 +179,48 @@ export function instrumentResendClient(
   if (typeof emails.create === 'function') {
     emails.create = guard(emails.create.bind(emails))
   }
+
+  // BROADCASTS are a second send API with its own `from`/`replyTo`, used by the
+  // audience broadcast path (`lib/email/broadcast.ts`) — an unguarded broadcast
+  // would be a hole in exactly the policy this module exists to make
+  // unbypassable. Same guard, different payload type.
+  const broadcasts = client.broadcasts
+  if (broadcasts && typeof broadcasts.create === 'function') {
+    const originalCreate = broadcasts.create.bind(broadcasts)
+    broadcasts.create = (async (
+      payload: CreateBroadcastOptions,
+      options?: CreateBroadcastRequestOptions,
+    ) => {
+      const policy = context.enforceSenderPolicy
+        ? applySenderPolicy({ from: payload.from, replyTo: payload.replyTo })
+        : {
+            from: payload.from,
+            replyTo: payload.replyTo,
+            decision: 'dedicated' as const,
+          }
+      const message = {
+        ...payload,
+        from: policy.from,
+        ...(policy.replyTo === undefined ? {} : { replyTo: policy.replyTo }),
+      } as CreateBroadcastOptions
+
+      const failureContext = {
+        orgId: context.orgId,
+        from: message.from,
+        replyTo: message.replyTo,
+        decision: policy.decision,
+      }
+      let result: CreateBroadcastResponse
+      try {
+        result = await originalCreate(message, options)
+      } catch (error) {
+        logEmailSendFailure(failureContext, error)
+        throw error
+      }
+      if (result?.error) logEmailSendFailure(failureContext, result.error)
+      return result
+    }) as typeof broadcasts.create
+  }
+
   return client
 }

--- a/src/lib/email/sender-policy.test.ts
+++ b/src/lib/email/sender-policy.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  addressDomain,
+  applySenderPolicy,
+  describeSenderPolicy,
+  formatAddress,
+  isPlatformSendableAddress,
+  parseAddress,
+  platformSendingDomains,
+  resetSenderPolicyWarnings,
+} from './sender-policy'
+import { resolveConferenceFrom } from './from'
+
+/**
+ * The bug this file exists for (platform#20): a newly provisioned tenant's
+ * `From:` is on its OWN domain, which is not verified for the PLATFORM Resend
+ * account, so Resend refuses the send — and the sign-in flow's deliberate
+ * opacity hides it. The policy must therefore send from a platform-verified
+ * address while keeping the tenant's identity and reply routing.
+ */
+
+const PLATFORM_FROM = 'Konf <noreply@platform.example>'
+
+beforeEach(() => {
+  resetSenderPolicyWarnings()
+  vi.stubEnv('EMAIL_FALLBACK_FROM', PLATFORM_FROM)
+  vi.stubEnv('EMAIL_SENDING_DOMAINS', '')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+describe('address helpers', () => {
+  it('parses and re-formats "Name <address>" and bare addresses', () => {
+    expect(parseAddress('KCD Bergen <hi@kcd.dev>')).toEqual({
+      name: 'KCD Bergen',
+      address: 'hi@kcd.dev',
+    })
+    expect(parseAddress('hi@kcd.dev')).toEqual({ address: 'hi@kcd.dev' })
+    expect(parseAddress('"KCD Bergen" <hi@kcd.dev>').name).toBe('KCD Bergen')
+    expect(formatAddress({ name: 'KCD', address: 'hi@kcd.dev' })).toBe(
+      'KCD <hi@kcd.dev>',
+    )
+    expect(formatAddress({ address: 'hi@kcd.dev' })).toBe('hi@kcd.dev')
+    expect(addressDomain('hi@KCD.dev')).toBe('kcd.dev')
+  })
+
+  it('strips CR/LF and brackets so a display name cannot smuggle a header', () => {
+    const from = formatAddress({
+      name: 'Evil\r\nBcc: victim@example.com <x@y.z>',
+      address: 'hi@kcd.dev',
+    })
+    expect(from).not.toContain('\n')
+    expect(from).toBe('EvilBcc: victim@example.com x@y.z <hi@kcd.dev>')
+  })
+})
+
+describe('platform sending domains', () => {
+  it('always includes the platform sender own domain', () => {
+    expect([...platformSendingDomains()]).toEqual(['platform.example'])
+  })
+
+  it('adds every domain listed in EMAIL_SENDING_DOMAINS, case-insensitively', () => {
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', ' KCD.dev , cloudnativedays.no ,')
+    expect([...platformSendingDomains()].sort()).toEqual([
+      'cloudnativedays.no',
+      'kcd.dev',
+      'platform.example',
+    ])
+    expect(isPlatformSendableAddress('hi@kcd.dev')).toBe(true)
+    expect(isPlatformSendableAddress('hi@other.dev')).toBe(false)
+    expect(isPlatformSendableAddress('not-an-address')).toBe(false)
+  })
+})
+
+describe('applySenderPolicy', () => {
+  it('REWRITES an unverified tenant From to the platform sender, keeping the tenant name and putting its address in Reply-To', () => {
+    const result = applySenderPolicy({
+      from: 'KCD Bergen <hi@kcd.dev>',
+    })
+    expect(result.decision).toBe('platform-rewritten')
+    expect(result.from).toBe('KCD Bergen <noreply@platform.example>')
+    expect(result.replyTo).toBe('hi@kcd.dev')
+    // The tenant's own domain must NOT survive in the envelope sender — that is
+    // precisely what Resend rejects.
+    expect(parseAddress(result.from).address).not.toContain('kcd.dev')
+  })
+
+  it('borrows the platform display name when the tenant supplied none', () => {
+    const result = applySenderPolicy({ from: 'contact@kcd.dev' })
+    expect(result.from).toBe('Konf <noreply@platform.example>')
+    expect(result.replyTo).toBe('contact@kcd.dev')
+  })
+
+  it('leaves a VERIFIED tenant domain completely alone (the Pro/verified seam)', () => {
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'kcd.dev')
+    const result = applySenderPolicy({ from: 'KCD Bergen <hi@kcd.dev>' })
+    expect(result.decision).toBe('tenant-verified')
+    expect(result.from).toBe('KCD Bergen <hi@kcd.dev>')
+    expect(result.replyTo).toBeUndefined()
+  })
+
+  it('never overwrites a Reply-To the caller set deliberately', () => {
+    const result = applySenderPolicy({
+      from: 'KCD Bergen <hi@kcd.dev>',
+      replyTo: 'thread+42@kcd.dev',
+    })
+    expect(result.from).toBe('KCD Bergen <noreply@platform.example>')
+    expect(result.replyTo).toBe('thread+42@kcd.dev')
+  })
+
+  it('passes through and logs LOUDLY when no platform sender is configured', () => {
+    vi.stubEnv('EMAIL_FALLBACK_FROM', '')
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const result = applySenderPolicy({ from: 'KCD Bergen <hi@kcd.dev>' })
+
+    // Nothing deliverable exists to rewrite TO, so the message is unchanged —
+    // but the misconfiguration is on the record.
+    expect(result.decision).toBe('unconfigured')
+    expect(result.from).toBe('KCD Bergen <hi@kcd.dev>')
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(String(error.mock.calls[0][0])).toContain('EMAIL_FALLBACK_FROM')
+  })
+
+  it('warns once per domain, so a bulk send cannot bury the log', () => {
+    vi.stubEnv('EMAIL_FALLBACK_FROM', '')
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    applySenderPolicy({ from: 'a@kcd.dev' })
+    applySenderPolicy({ from: 'b@kcd.dev' })
+    expect(error).toHaveBeenCalledTimes(1)
+
+    applySenderPolicy({ from: 'c@other.dev' })
+    expect(error).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('a freshly provisioned tenant, end to end through resolveConferenceFrom', () => {
+  const tenant = {
+    title: 'KCD Bergen 2026',
+    organizer: 'KCD Bergen',
+    contactEmail: 'hello@kcd.dev',
+    domains: ['2026.kcd.dev'],
+  }
+
+  it('sends from the platform-verified domain with the tenant in Reply-To', () => {
+    const wanted = resolveConferenceFrom(tenant)
+    // What the tenant WANTS is still its own identity …
+    expect(wanted).toBe('KCD Bergen <hello@kcd.dev>')
+
+    // … and what actually goes out is deliverable.
+    const sent = applySenderPolicy({ from: wanted })
+    expect(addressDomain(parseAddress(sent.from).address)).toBe(
+      'platform.example',
+    )
+    expect(platformSendingDomains().has('kcd.dev')).toBe(false)
+    expect(sent.replyTo).toBe('hello@kcd.dev')
+    expect(sent.from).toContain('KCD Bergen')
+  })
+
+  it('describeSenderPolicy reports the rewrite for the admin status page without consuming the warning', () => {
+    vi.stubEnv('EMAIL_FALLBACK_FROM', '')
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const described = describeSenderPolicy(resolveConferenceFrom(tenant))
+    expect(described.decision).toBe('unconfigured')
+    expect(described.requested).toBe('hello@kcd.dev')
+    expect(described.sendingDomains).toEqual([])
+    // Rendering a status page must not silence the log a real send needs.
+    expect(error).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/email/sender-policy.test.ts
+++ b/src/lib/email/sender-policy.test.ts
@@ -9,7 +9,7 @@ import {
   platformSendingDomains,
   resetSenderPolicyWarnings,
 } from './sender-policy'
-import { resolveConferenceFrom } from './from'
+import { resolveConferenceFrom, resolveConferenceContact } from './from'
 
 /**
  * The bug this file exists for (platform#20): a newly provisioned tenant's
@@ -47,13 +47,50 @@ describe('address helpers', () => {
     expect(addressDomain('hi@KCD.dev')).toBe('kcd.dev')
   })
 
-  it('strips CR/LF and brackets so a display name cannot smuggle a header', () => {
+  /**
+   * The ADDRESS is the part that looks safe and is not. `From:` headers are
+   * built from tenant-editable conference fields, several send sites
+   * interpolate them raw, and `.address` is what this module derives `Reply-To`
+   * from — so an organizer storing CR/LF would smuggle a second header.
+   *
+   * Assert STRUCTURALLY: no CR, no LF, and the value is a single header line.
+   * A substring check for the payload text would pass on output that is still
+   * broken (and fail on output that is safely inert).
+   */
+  it('sanitizes the ADDRESS in the bracketed branch', () => {
+    const parsed = parseAddress(
+      'KCD Bergen <hello@kcd.dev\r\nBcc: attacker@evil.example>',
+    )
+    expect(parsed.address).not.toMatch(/[\r\n]/)
+    expect(parsed.address.split(/\r\n|\r|\n/)).toHaveLength(1)
+  })
+
+  it('sanitizes the ADDRESS in the bare branch', () => {
+    const parsed = parseAddress('hello@kcd.dev\r\nBcc: attacker@evil.example')
+    expect(parsed.address).not.toMatch(/[\r\n]/)
+    expect(parsed.address.split(/\r\n|\r|\n/)).toHaveLength(1)
+    // …and brackets cannot be smuggled in to nest a new address either.
+    expect(parseAddress('a@b.dev<c@d.dev>x').address).not.toMatch(/[<>]/)
+  })
+
+  it('truncates a display name at the first break so it cannot smuggle a header', () => {
     const from = formatAddress({
       name: 'Evil\r\nBcc: victim@example.com <x@y.z>',
       address: 'hi@kcd.dev',
     })
-    expect(from).not.toContain('\n')
-    expect(from).toBe('EvilBcc: victim@example.com x@y.z <hi@kcd.dev>')
+    expect(from).not.toMatch(/[\r\n]/)
+    // TRUNCATED, not stripped: deleting the breaks would splice the payload
+    // into the value instead of discarding it.
+    expect(from).toBe('Evil <hi@kcd.dev>')
+  })
+
+  it('truncation denies the attacker the resulting DOMAIN', () => {
+    // With break-DELETION this collapses to one address ending in
+    // `@verified.test`, so an unverified sender would classify as verified.
+    // Truncation keeps only the legitimate prefix.
+    const parsed = parseAddress('a@evil.example\r\nb@verified.test')
+    expect(parsed.address).toBe('a@evil.example')
+    expect(addressDomain(parsed.address)).toBe('evil.example')
   })
 })
 
@@ -135,6 +172,68 @@ describe('applySenderPolicy', () => {
 
     applySenderPolicy({ from: 'c@other.dev' })
     expect(error).toHaveBeenCalledTimes(2)
+  })
+})
+
+/**
+ * Header injection through the sender policy. The attacker is an authenticated
+ * ORGANIZER of one tenant on a multi-tenant platform, so "organizers are
+ * trusted" is not a defence: the blast radius is other tenants' recipients.
+ */
+describe('CR/LF in a stored address cannot become a second header', () => {
+  const PAYLOAD = 'hello@kcd.dev\r\nBcc: attacker@evil.example'
+
+  /** No CR, no LF, exactly one header line — the structural property. */
+  function expectSingleHeaderLine(value: string | string[] | undefined) {
+    const values = value === undefined ? [] : [value].flat()
+    expect(values.length).toBeGreaterThan(0)
+    for (const v of values) {
+      expect(v).not.toMatch(/[\r\n]/)
+      expect(v.split(/\r\n|\r|\n/)).toHaveLength(1)
+    }
+  }
+
+  it('neutralizes it in the derived Reply-To (the rewrite branch)', () => {
+    const result = applySenderPolicy({ from: `KCD Bergen <${PAYLOAD}>` })
+    expect(result.decision).toBe('platform-rewritten')
+    expectSingleHeaderLine(result.replyTo)
+    expectSingleHeaderLine(result.from)
+  })
+
+  it('neutralizes it in the pass-through From (verified branch)', () => {
+    // A raw header built by a send site that interpolates the field directly —
+    // this branch returns the CALLER's header, so it must be stripped too.
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'kcd.dev')
+    const result = applySenderPolicy({ from: `KCD Bergen <${PAYLOAD}>` })
+    expect(result.decision).toBe('tenant-verified')
+    expectSingleHeaderLine(result.from)
+  })
+
+  it('neutralizes it in the pass-through From (unconfigured branch)', () => {
+    vi.stubEnv('EMAIL_FALLBACK_FROM', '')
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const result = applySenderPolicy({ from: `KCD Bergen <${PAYLOAD}>` })
+    expect(result.decision).toBe('unconfigured')
+    expectSingleHeaderLine(result.from)
+  })
+
+  it('neutralizes it in a caller-supplied Reply-To, string or array', () => {
+    expectSingleHeaderLine(
+      applySenderPolicy({ from: 'a@kcd.dev', replyTo: PAYLOAD }).replyTo,
+    )
+    expectSingleHeaderLine(
+      applySenderPolicy({ from: 'a@kcd.dev', replyTo: [PAYLOAD, 'b@kcd.dev'] })
+        .replyTo,
+    )
+  })
+
+  it('neutralizes it through resolveConferenceFrom and resolveConferenceContact', () => {
+    const tenant = { organizer: 'KCD Bergen', contactEmail: PAYLOAD }
+    expectSingleHeaderLine(resolveConferenceFrom(tenant))
+    expectSingleHeaderLine(resolveConferenceContact(tenant))
+    expectSingleHeaderLine(
+      applySenderPolicy({ from: resolveConferenceFrom(tenant) }).replyTo,
+    )
   })
 })
 

--- a/src/lib/email/sender-policy.ts
+++ b/src/lib/email/sender-policy.ts
@@ -1,0 +1,251 @@
+/**
+ * THE SENDER POLICY — which `From:` the platform Resend account may actually use
+ * (RunKonf/platform#20).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE PROBLEM
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `resolveConferenceFrom` picks a tenant-shaped sender — `contactEmail`, or
+ * `<localPart>@<the conference's own domain>`. That is the right IDENTITY, but
+ * it is not necessarily a DELIVERABLE one: on the shared email tier every send
+ * goes through the PLATFORM's Resend account, and Resend rejects any `From:` on
+ * a domain that is not verified for THAT account. A freshly provisioned tenant's
+ * domain never is. Its mail is refused outright — and because the sign-in flow
+ * is deliberately opaque (see `auth/email-link/request.ts`), nobody finds out.
+ *
+ * This was masked for as long as the platform had one tenant, whose domain IS
+ * verified on the platform account.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE RULE
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The identity a tenant wants and the envelope Resend will accept are separated:
+ *
+ *   From:     <tenant display name> <noreply@[a platform-verified domain]>
+ *   Reply-To: <the tenant's own address>
+ *
+ * so the recipient still sees the conference's name, and a reply still lands in
+ * the organizers' inbox — while the message is one the platform account is
+ * allowed to send. When the tenant's own domain IS verified on the platform
+ * account (see {@link platformSendingDomains}) nothing is rewritten and it sends
+ * as itself.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE OPERATOR CONTRACT (two env vars)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * - `EMAIL_FALLBACK_FROM` — the platform's own sender, as a full
+ *   `"Name <address>"` header. Its address MUST be on a domain verified in the
+ *   platform Resend account; it is the address every unverified tenant sends
+ *   from. Unset ⇒ there is no deliverable sender to fall back to, so nothing is
+ *   rewritten and every send from an unverified domain is logged loudly rather
+ *   than silently replaced with something equally undeliverable.
+ * - `EMAIL_SENDING_DOMAINS` — comma-separated list of every domain verified on
+ *   the platform Resend account (the `EMAIL_FALLBACK_FROM` domain is always
+ *   included implicitly). A tenant listed here keeps its own `From:`.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE SEAM: a tenant's OWN verified sender
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Two paths exist for a tenant to send as itself, and both are already open:
+ *
+ * 1. VERIFIED ON THE PLATFORM ACCOUNT — add the tenant's sending domain to
+ *    `EMAIL_SENDING_DOMAINS` once its DKIM/SPF records are verified in Resend.
+ *    Today that list is static config; the seam for making it self-service is
+ *    {@link platformSendingDomains}, which is the ONE place that answers "may
+ *    the platform account send as this domain?". Replacing its body with a
+ *    cached `resend.domains.list()` lookup (filtering `status === 'verified'`)
+ *    is the whole change — no call site moves. What it additionally needs:
+ *    per-tenant DNS instructions in the admin UI, a verification poller, and a
+ *    cache with an invalidation hook, because a live API call must never sit in
+ *    the path of an outbound send.
+ * 2. A DEDICATED RESEND ACCOUNT — per-org credentials in `TENANT_SECRETS_JSON`
+ *    (`resolveEmailSender`). That client is the tenant's own, so this policy
+ *    does not apply to it at all (`'dedicated'`). Gating that on the
+ *    `dedicated-email` PRO entitlement rather than on the mere presence of a
+ *    secret is RunKonf/platform#26 — deliberately NOT done here.
+ */
+
+/** A parsed `"Name <address>"` (or bare `address`) header. */
+export interface HeaderAddress {
+  name?: string
+  address: string
+}
+
+/**
+ * Strip anything that could smuggle an extra header or nest brackets when a
+ * value is re-interpolated into a `"Name <address>"` header.
+ */
+function sanitizeHeaderText(value: string): string {
+  return value.replace(/[\r\n<>]/g, '').trim()
+}
+
+/** Parse a `"Name <address>"` header; a bare address yields no name. */
+export function parseAddress(header: string): HeaderAddress {
+  const match = header.match(/^\s*(.*?)\s*<([^>]+)>\s*$/)
+  if (match) {
+    const name = sanitizeHeaderText(match[1].replace(/^"|"$/g, ''))
+    return { name: name || undefined, address: match[2].trim() }
+  }
+  return { address: header.trim() }
+}
+
+/** Render a `"Name <address>"` header (bare address when there is no name). */
+export function formatAddress({ name, address }: HeaderAddress): string {
+  const safeName = name ? sanitizeHeaderText(name) : ''
+  const safeAddress = sanitizeHeaderText(address)
+  return safeName ? `${safeName} <${safeAddress}>` : safeAddress
+}
+
+/** The domain part of an address, lowercased. `''` when there is none. */
+export function addressDomain(address: string): string {
+  const at = address.lastIndexOf('@')
+  return at === -1
+    ? ''
+    : address
+        .slice(at + 1)
+        .trim()
+        .toLowerCase()
+}
+
+/**
+ * The platform's own sender (`"Name <address>"`), or `null` when unconfigured.
+ * This is the ONE reader of `EMAIL_FALLBACK_FROM`.
+ */
+export function platformSenderFrom(): string | null {
+  const configured = process.env.EMAIL_FALLBACK_FROM?.trim()
+  return configured ? configured : null
+}
+
+/**
+ * Every domain the PLATFORM Resend account may send from: the configured
+ * `EMAIL_SENDING_DOMAINS` list plus the platform sender's own domain.
+ *
+ * This is the seam described in the module comment — the single question "may
+ * the platform account send as this domain?", answered from static config today
+ * and from Resend's domains API when sending domains become self-service.
+ */
+export function platformSendingDomains(): Set<string> {
+  const domains = new Set<string>()
+  for (const entry of (process.env.EMAIL_SENDING_DOMAINS ?? '').split(',')) {
+    const domain = entry.trim().toLowerCase()
+    if (domain) domains.add(domain)
+  }
+  const platform = platformSenderFrom()
+  if (platform) {
+    const domain = addressDomain(parseAddress(platform).address)
+    if (domain) domains.add(domain)
+  }
+  return domains
+}
+
+/** Whether the platform Resend account may send as this address. */
+export function isPlatformSendableAddress(address: string): boolean {
+  const domain = addressDomain(address)
+  return domain !== '' && platformSendingDomains().has(domain)
+}
+
+export type SenderPolicyDecision =
+  /** The From domain is verified on the platform account — sent as itself. */
+  | 'tenant-verified'
+  /** Rewritten to the platform sender; the tenant address moved to Reply-To. */
+  | 'platform-rewritten'
+  /** No platform sender configured — passed through, and this WILL be rejected. */
+  | 'unconfigured'
+
+export interface SenderPolicyResult {
+  from: string
+  replyTo?: string | string[]
+  decision: SenderPolicyDecision
+}
+
+/**
+ * `EMAIL_FALLBACK_FROM` is unset, so an unverified tenant `From:` cannot be
+ * replaced with anything deliverable. Warn ONCE per From-domain per process:
+ * this is a standing misconfiguration, not a per-message event, and a bulk
+ * broadcast must not bury the log in thousands of identical lines.
+ */
+const warnedUnconfiguredDomains = new Set<string>()
+
+/** Test seam: forget which domains have already warned. */
+export function resetSenderPolicyWarnings(): void {
+  warnedUnconfiguredDomains.clear()
+}
+
+/**
+ * Apply the sender policy to an outbound message's `From:`/`Reply-To:`.
+ *
+ * An explicit `replyTo` from the caller is NEVER overwritten — a message that
+ * already directs replies somewhere (a conversation thread, a sponsor contact)
+ * keeps that routing, and only its envelope sender is corrected.
+ */
+export function applySenderPolicy(
+  message: {
+    from: string
+    replyTo?: string | string[]
+  },
+  /**
+   * `warn: false` for read-only inspection (the admin status page). Rendering a
+   * page must never consume the once-per-domain warning that a real send needs.
+   */
+  { warn = true }: { warn?: boolean } = {},
+): SenderPolicyResult {
+  const wanted = parseAddress(message.from)
+
+  if (isPlatformSendableAddress(wanted.address)) {
+    return {
+      from: message.from,
+      replyTo: message.replyTo,
+      decision: 'tenant-verified',
+    }
+  }
+
+  const platform = platformSenderFrom()
+  if (!platform) {
+    const domain = addressDomain(wanted.address)
+    if (warn && !warnedUnconfiguredDomains.has(domain)) {
+      warnedUnconfiguredDomains.add(domain)
+      console.error(
+        '[email] no platform sender is configured (EMAIL_FALLBACK_FROM) and ' +
+          `"${domain || wanted.address}" is not a platform sending domain — ` +
+          'Resend will reject this send. Set EMAIL_FALLBACK_FROM to an address ' +
+          'on a verified domain, and list every verified domain in ' +
+          'EMAIL_SENDING_DOMAINS.',
+      )
+    }
+    return {
+      from: message.from,
+      replyTo: message.replyTo,
+      decision: 'unconfigured',
+    }
+  }
+
+  const platformAddress = parseAddress(platform)
+  return {
+    // The tenant keeps its IDENTITY (display name); only the address — the part
+    // Resend authorizes — becomes the platform's.
+    from: formatAddress({
+      name: wanted.name ?? platformAddress.name,
+      address: platformAddress.address,
+    }),
+    // …and replies still reach the organizers.
+    replyTo: message.replyTo ?? wanted.address,
+    decision: 'platform-rewritten',
+  }
+}
+
+/** Operator-facing summary of what a given `From:` will actually send as. */
+export interface SenderPolicyDescription extends SenderPolicyResult {
+  /** The address the tenant asked to send from. */
+  requested: string
+  /** Every domain the platform account may currently send from. */
+  sendingDomains: string[]
+}
+
+export function describeSenderPolicy(from: string): SenderPolicyDescription {
+  const result = applySenderPolicy({ from }, { warn: false })
+  return {
+    ...result,
+    requested: parseAddress(from).address,
+    sendingDomains: [...platformSendingDomains()].sort(),
+  }
+}

--- a/src/lib/email/sender-policy.ts
+++ b/src/lib/email/sender-policy.ts
@@ -72,21 +72,47 @@ export interface HeaderAddress {
 }
 
 /**
- * Strip anything that could smuggle an extra header or nest brackets when a
- * value is re-interpolated into a `"Name <address>"` header.
+ * Make a stored value safe to interpolate into a `"Name <address>"` header.
+ *
+ * CR and LF are the injection vector: a value carrying them turns one header
+ * into two, and the obvious payoff is an injected `Bcc:`. The value is
+ * TRUNCATED at the first break rather than having the breaks deleted — deleting
+ * them splices the payload onto the end of the value, which for an address
+ * hands the attacker the resulting DOMAIN (`a@evil.example\r\nb@verified.test`
+ * would collapse to a single address whose domain reads as verified). Truncation
+ * keeps the legitimate prefix and discards the payload entirely.
+ *
+ * Angle brackets are structural in a `"Name <address>"` header, so a value being
+ * placed INSIDE one must not contain them either.
  */
-function sanitizeHeaderText(value: string): string {
-  return value.replace(/[\r\n<>]/g, '').trim()
+export function sanitizeHeaderText(value: string): string {
+  return value
+    .split(/[\r\n]/, 1)[0]
+    .replace(/[<>]/g, '')
+    .trim()
 }
 
-/** Parse a `"Name <address>"` header; a bare address yields no name. */
+/**
+ * Parse a `"Name <address>"` header; a bare address yields no name.
+ *
+ * BOTH the name and the ADDRESS are sanitized. The address is the part that
+ * looks safe and is not: `From:` headers are built from tenant-editable
+ * conference fields (`contactEmail`, `cfpEmail`, `sponsorEmail`) — several send
+ * sites interpolate them raw — so an organizer who stores
+ * `hello@kcd.dev\r\nBcc: attacker@evil.example` gets those bytes into whatever
+ * consumes `.address`, e.g. the `Reply-To:` this module derives.
+ *
+ * Sanitizing HERE rather than at each call site is the point: consumers are
+ * safe by construction, instead of each one having to remember. `formatAddress`
+ * remembered and `applySenderPolicy` did not, which is what produced the bug.
+ */
 export function parseAddress(header: string): HeaderAddress {
   const match = header.match(/^\s*(.*?)\s*<([^>]+)>\s*$/)
   if (match) {
     const name = sanitizeHeaderText(match[1].replace(/^"|"$/g, ''))
-    return { name: name || undefined, address: match[2].trim() }
+    return { name: name || undefined, address: sanitizeHeaderText(match[2]) }
   }
-  return { address: header.trim() }
+  return { address: sanitizeHeaderText(header) }
 }
 
 /** Render a `"Name <address>"` header (bare address when there is no name). */
@@ -177,6 +203,14 @@ export function resetSenderPolicyWarnings(): void {
  * An explicit `replyTo` from the caller is NEVER overwritten — a message that
  * already directs replies somewhere (a conversation thread, a sponsor contact)
  * keeps that routing, and only its envelope sender is corrected.
+ *
+ * NOTHING LEAVES HERE CARRYING A HEADER BREAK. `parseAddress` sanitizes what
+ * this function derives, but the two "unchanged" branches would otherwise
+ * return the CALLER's header — and roughly half the send sites build that
+ * header by interpolating raw conference fields (`${conference.organizer}
+ * <${conference.cfpEmail}>`). So every branch returns a header REBUILT from the
+ * parsed parts rather than the caller's string. This is the last point at which
+ * a stored value can be stopped from becoming a second header.
  */
 export function applySenderPolicy(
   message: {
@@ -190,11 +224,20 @@ export function applySenderPolicy(
   { warn = true }: { warn?: boolean } = {},
 ): SenderPolicyResult {
   const wanted = parseAddress(message.from)
+  // Rebuilt, never echoed: `formatAddress(parseAddress(x))` is the identity for
+  // a well-formed header and a sanitizing round-trip for anything else.
+  const safeFrom = formatAddress(wanted)
+  const sanitizeReplyTo = (value: string) => formatAddress(parseAddress(value))
+  const safeReplyTo = Array.isArray(message.replyTo)
+    ? message.replyTo.map(sanitizeReplyTo)
+    : message.replyTo === undefined
+      ? undefined
+      : sanitizeReplyTo(message.replyTo)
 
   if (isPlatformSendableAddress(wanted.address)) {
     return {
-      from: message.from,
-      replyTo: message.replyTo,
+      from: safeFrom,
+      replyTo: safeReplyTo,
       decision: 'tenant-verified',
     }
   }
@@ -213,8 +256,8 @@ export function applySenderPolicy(
       )
     }
     return {
-      from: message.from,
-      replyTo: message.replyTo,
+      from: safeFrom,
+      replyTo: safeReplyTo,
       decision: 'unconfigured',
     }
   }
@@ -228,7 +271,7 @@ export function applySenderPolicy(
       address: platformAddress.address,
     }),
     // …and replies still reach the organizers.
-    replyTo: message.replyTo ?? wanted.address,
+    replyTo: safeReplyTo ?? wanted.address,
     decision: 'platform-rewritten',
   }
 }

--- a/src/lib/system-status/checks.test.ts
+++ b/src/lib/system-status/checks.test.ts
@@ -294,6 +294,94 @@ describe('buildSystemChecks — badges.outdated', () => {
   })
 })
 
+/**
+ * A conference does not have ONE sender: `contactEmail`, `cfpEmail` and
+ * `sponsorEmail` each carry their own flows and can sit on DIFFERENT domains.
+ * A check that judged only the contact address could report health while CFP
+ * mail was being rejected by Resend — and an operator reads this check
+ * precisely when something is already wrong, so a lie here sends them looking
+ * in the wrong place. Every sender is evaluated; the offender is named.
+ */
+describe('email.senderPolicy — every sender is judged, not just contact', () => {
+  const MIXED = {
+    ...CONFERENCE,
+    organizer: 'KCD Bergen',
+    // Verified on the platform account …
+    contactEmail: 'hello@verified.example',
+    // … these two are NOT.
+    cfpEmail: 'cfp@unverified.dev',
+    sponsorEmail: 'sponsors@unverified.dev',
+  }
+
+  beforeEach(() => {
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'verified.example')
+  })
+
+  it('reports REJECTED and names the CFP sender when only contact is deliverable', () => {
+    // No platform sender configured: an unverified From has no deliverable
+    // substitute, so that mail is refused outright.
+    vi.stubEnv('EMAIL_FALLBACK_FROM', '')
+    const check = byId(collectStaticChecks(MIXED), 'email.senderPolicy')
+
+    expect(check.status).toBe('error')
+    // The operator must be able to tell WHICH sender is broken.
+    expect(check.value).toContain('cfp@unverified.dev')
+    expect(check.value).toContain('sponsors@unverified.dev')
+    expect(check.value).toMatch(/CFP/)
+    // …and must not be told the healthy one means anything.
+    expect(check.detail).toContain('hello@verified.example')
+    expect(check.detail).toMatch(/proves nothing/)
+  })
+
+  it('reports the rewrite and names the affected senders when a platform sender exists', () => {
+    vi.stubEnv('EMAIL_FALLBACK_FROM', 'Konf <noreply@platform.example>')
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'verified.example')
+    const check = byId(collectStaticChecks(MIXED), 'email.senderPolicy')
+
+    expect(check.status).toBe('warn')
+    expect(check.value).toContain('cfp@unverified.dev')
+    expect(check.detail).toContain('sponsors@unverified.dev')
+    // The verified one is still reported as sending as itself.
+    expect(check.detail).toContain('hello@verified.example')
+  })
+
+  it('is ok only when EVERY sender is on a verified domain', () => {
+    vi.stubEnv('EMAIL_FALLBACK_FROM', 'Konf <noreply@platform.example>')
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'verified.example')
+    const check = byId(
+      collectStaticChecks({
+        ...MIXED,
+        cfpEmail: 'cfp@verified.example',
+        sponsorEmail: 'sponsors@verified.example',
+      }),
+      'email.senderPolicy',
+    )
+
+    expect(check.status).toBe('ok')
+    expect(check.value).toContain('all verified')
+  })
+
+  it('falls back to <localPart>@<domain> per field, so an unset field is still judged', () => {
+    vi.stubEnv('EMAIL_FALLBACK_FROM', '')
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'verified.example')
+    const check = byId(
+      collectStaticChecks({
+        _id: 'conf-2',
+        organizer: 'KCD Bergen',
+        contactEmail: 'hello@verified.example',
+        domains: ['2026.kcd.dev'],
+      }),
+      'email.senderPolicy',
+    )
+
+    // cfpEmail/sponsorEmail are unset, so they derive from the conference
+    // domain — which is unverified. That is a real rejection, not a non-case.
+    expect(check.status).toBe('error')
+    expect(check.value).toContain('cfp@2026.kcd.dev')
+    expect(check.value).toContain('sponsors@2026.kcd.dev')
+  })
+})
+
 describe('types helpers', () => {
   const sample: SystemCheck[] = [
     { id: 'a', group: 'sanity', label: 'A', status: 'ok' },

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -15,7 +15,7 @@ import {
 } from '@/lib/tickets/provider'
 import { providerMap } from '@/lib/auth'
 import { BADGE_GENERATOR_VERSION } from '@/lib/badge/version'
-import { resolveConferenceFrom } from '@/lib/email/from'
+import { conferenceSenders } from '@/lib/email/from'
 import { describeSenderPolicy } from '@/lib/email/sender-policy'
 import type {
   CheckGroup,
@@ -139,50 +139,87 @@ function plainCheck(
  * rejected outright. `email/from` and `email/sender-policy` are import-safe:
  * both read `process.env` only inside functions and neither asserts at load.
  *
- * It reports the CONTACT sender as the representative case. Individual flows
- * pick different local parts and fields (`cfpEmail`, `sponsorEmail`, …), but the
- * policy's verdict turns on the DOMAIN, which they all share.
+ * EVERY sender is evaluated, not just the contact one. A conference can put
+ * `contactEmail`, `cfpEmail` and `sponsorEmail` on DIFFERENT domains, and each
+ * carries its own flows (see `CONFERENCE_SENDER_FIELDS`). Judging one of them
+ * would let this check report health while CFP or sponsor mail is being
+ * rejected — a diagnostic that lies is worse than no diagnostic, because it is
+ * consulted precisely when something is already wrong. The worst verdict wins
+ * and the offending address is always named.
  */
 function senderPolicyCheck(conference: ConferenceForSystemChecks): SystemCheck {
   const meta = {
     id: 'email.senderPolicy',
     group: 'email' as const,
-    label: 'Effective sender',
+    label: 'Effective senders',
   }
-  const wanted = resolveConferenceFrom(conference, { localPart: 'noreply' })
-  const policy = describeSenderPolicy(wanted)
-  const domains = policy.sendingDomains.length
-    ? policy.sendingDomains.join(', ')
+
+  const evaluated = conferenceSenders(conference).map((sender) => ({
+    ...sender,
+    policy: describeSenderPolicy(sender.from),
+  }))
+
+  const sendingDomains = evaluated[0]?.policy.sendingDomains ?? []
+  const domains = sendingDomains.length
+    ? sendingDomains.join(', ')
     : 'none configured'
 
-  if (policy.decision === 'unconfigured') {
+  /** "CFP cfp@kcd.dev", de-duplicated by address so shared senders read once. */
+  const name = (group: typeof evaluated): string[] => {
+    const seen = new Map<string, string[]>()
+    for (const entry of group) {
+      const labels = seen.get(entry.policy.requested) ?? []
+      labels.push(entry.label)
+      seen.set(entry.policy.requested, labels)
+    }
+    return [...seen].map(
+      ([address, labels]) => `${labels.join('/')} ${address}`,
+    )
+  }
+
+  const rejected = evaluated.filter((e) => e.policy.decision === 'unconfigured')
+  const rewritten = evaluated.filter(
+    (e) => e.policy.decision === 'platform-rewritten',
+  )
+  const verified = evaluated.filter(
+    (e) => e.policy.decision === 'tenant-verified',
+  )
+
+  if (rejected.length > 0) {
     return {
       ...meta,
       status: 'error',
-      value: `${policy.requested} — NOT a platform sending domain`,
+      value: `REJECTED: ${name(rejected).join(', ')}`,
       detail:
-        `Resend will reject mail from "${policy.requested}": the platform account can only send from [${domains}], ` +
+        `Resend will reject mail from ${name(rejected).join(', ')} — the platform account can only send from [${domains}], ` +
         'and EMAIL_FALLBACK_FROM is unset so there is nothing deliverable to send as instead. ' +
-        'Set EMAIL_FALLBACK_FROM to an address on a verified domain, or verify this domain and add it to EMAIL_SENDING_DOMAINS.',
+        'Set EMAIL_FALLBACK_FROM to an address on a verified domain, or verify these domains and add them to EMAIL_SENDING_DOMAINS.' +
+        (verified.length > 0
+          ? ` Unaffected: ${name(verified).join(', ')} — so some mail still sends and its success proves nothing about the above.`
+          : ''),
     }
   }
 
-  if (policy.decision === 'platform-rewritten') {
+  if (rewritten.length > 0) {
     return {
       ...meta,
       status: 'warn',
-      value: `${policy.from} (reply-to ${policy.replyTo})`,
+      value: `Sent as ${evaluated[0].policy.from} — rewritten for ${name(rewritten).join(', ')}`,
       detail:
-        `"${policy.requested}" is not verified on the platform Resend account [${domains}], so mail is sent from the platform sender ` +
-        'with the conference name and its address as Reply-To. Verify the domain in Resend and add it to EMAIL_SENDING_DOMAINS to send as itself.',
+        `${name(rewritten).join(', ')} ${rewritten.length === 1 ? 'is' : 'are'} not verified on the platform Resend account [${domains}], ` +
+        'so that mail is sent from the platform sender with the conference name and the original address as Reply-To. ' +
+        'Verify the domain in Resend and add it to EMAIL_SENDING_DOMAINS to send as itself.' +
+        (verified.length > 0
+          ? ` Sending as itself: ${name(verified).join(', ')}.`
+          : ''),
     }
   }
 
   return {
     ...meta,
     status: 'ok',
-    value: policy.from,
-    detail: `Sent as itself — the domain is verified on the sending account [${domains}]`,
+    value: `${name(verified).join(', ')} — all verified`,
+    detail: `Every sender is on a domain verified on the sending account [${domains}]`,
   }
 }
 

--- a/src/lib/system-status/checks.ts
+++ b/src/lib/system-status/checks.ts
@@ -15,6 +15,8 @@ import {
 } from '@/lib/tickets/provider'
 import { providerMap } from '@/lib/auth'
 import { BADGE_GENERATOR_VERSION } from '@/lib/badge/version'
+import { resolveConferenceFrom } from '@/lib/email/from'
+import { describeSenderPolicy } from '@/lib/email/sender-policy'
 import type {
   CheckGroup,
   CheckStatus,
@@ -127,6 +129,61 @@ function plainCheck(
         value: 'not set',
         detail: detail?.missing,
       }
+}
+
+/**
+ * What this conference's outbound mail will ACTUALLY be sent as (platform#20).
+ *
+ * The one place an operator can see that a tenant is not sending from its own
+ * domain — and, when nothing deliverable is configured, that its mail is being
+ * rejected outright. `email/from` and `email/sender-policy` are import-safe:
+ * both read `process.env` only inside functions and neither asserts at load.
+ *
+ * It reports the CONTACT sender as the representative case. Individual flows
+ * pick different local parts and fields (`cfpEmail`, `sponsorEmail`, …), but the
+ * policy's verdict turns on the DOMAIN, which they all share.
+ */
+function senderPolicyCheck(conference: ConferenceForSystemChecks): SystemCheck {
+  const meta = {
+    id: 'email.senderPolicy',
+    group: 'email' as const,
+    label: 'Effective sender',
+  }
+  const wanted = resolveConferenceFrom(conference, { localPart: 'noreply' })
+  const policy = describeSenderPolicy(wanted)
+  const domains = policy.sendingDomains.length
+    ? policy.sendingDomains.join(', ')
+    : 'none configured'
+
+  if (policy.decision === 'unconfigured') {
+    return {
+      ...meta,
+      status: 'error',
+      value: `${policy.requested} — NOT a platform sending domain`,
+      detail:
+        `Resend will reject mail from "${policy.requested}": the platform account can only send from [${domains}], ` +
+        'and EMAIL_FALLBACK_FROM is unset so there is nothing deliverable to send as instead. ' +
+        'Set EMAIL_FALLBACK_FROM to an address on a verified domain, or verify this domain and add it to EMAIL_SENDING_DOMAINS.',
+    }
+  }
+
+  if (policy.decision === 'platform-rewritten') {
+    return {
+      ...meta,
+      status: 'warn',
+      value: `${policy.from} (reply-to ${policy.replyTo})`,
+      detail:
+        `"${policy.requested}" is not verified on the platform Resend account [${domains}], so mail is sent from the platform sender ` +
+        'with the conference name and its address as Reply-To. Verify the domain in Resend and add it to EMAIL_SENDING_DOMAINS to send as itself.',
+    }
+  }
+
+  return {
+    ...meta,
+    status: 'ok',
+    value: policy.from,
+    detail: `Sent as itself — the domain is verified on the sending account [${domains}]`,
+  }
 }
 
 function readFileSafe(relative: string): string | null {
@@ -415,11 +472,13 @@ function buildChecks(conference: ConferenceForSystemChecks): SystemCheck[] {
       process.env.EMAIL_FALLBACK_FROM,
       'warn',
       {
-        present: 'Last-resort sender when a conference has no email config',
+        present:
+          'The platform sender: used for a conference with no email config, and for any conference whose own domain is not verified on the platform Resend account',
         missing:
-          'Unset — a conference without email config would send from a placeholder address',
+          'Unset — a conference whose domain is not a platform sending domain has nothing deliverable to fall back to, so its mail is REJECTED by Resend',
       },
     ),
+    senderPolicyCheck(conference),
   )
 
   // ---- SLACK ----------------------------------------------------------------

--- a/src/lib/system-status/types.ts
+++ b/src/lib/system-status/types.ts
@@ -85,8 +85,13 @@ export interface ConferenceForSystemChecks {
   _id?: string
   organizer?: string
   cfpEmail?: string
-  /** Sender-policy inputs: what this tenant WANTS to send mail as. */
+  /**
+   * Sender-policy inputs: every address this tenant WANTS to send mail as.
+   * All three are needed — they can sit on different domains, and each carries
+   * its own flows (see `CONFERENCE_SENDER_FIELDS` in `lib/email/from.ts`).
+   */
   contactEmail?: string
+  sponsorEmail?: string
   domains?: string[]
   salesNotificationChannel?: string
   cfpNotificationChannel?: string

--- a/src/lib/system-status/types.ts
+++ b/src/lib/system-status/types.ts
@@ -85,6 +85,9 @@ export interface ConferenceForSystemChecks {
   _id?: string
   organizer?: string
   cfpEmail?: string
+  /** Sender-policy inputs: what this tenant WANTS to send mail as. */
+  contactEmail?: string
+  domains?: string[]
   salesNotificationChannel?: string
   cfpNotificationChannel?: string
   checkinCustomerId?: number

--- a/src/server/routers/status.probes.test.ts
+++ b/src/server/routers/status.probes.test.ts
@@ -120,19 +120,53 @@ describe('status.admin.probeSlack', () => {
 })
 
 describe('status.admin.probeEmail', () => {
-  it('sends to the caller and returns the resend id', async () => {
+  it('sends to the caller and returns the resend id plus the sender it proved', async () => {
     sendMock.mockResolvedValue({ data: { id: 'email-1' }, error: null })
     const res = await makeCaller({ speakerId: 'email-ok' }).admin.probeEmail()
-    expect(res).toEqual({ ok: true, id: 'email-1' })
+    expect(res).toMatchObject({ ok: true, id: 'email-1' })
     expect(sendMock).toHaveBeenCalledWith(
       expect.objectContaining({ to: 'admin@example.com' }),
     )
   })
 
-  it('returns the resend error message on failure', async () => {
+  it('returns the resend error message on failure, naming the sender it used', async () => {
     sendMock.mockResolvedValue({ data: null, error: { message: 'bad key' } })
     const res = await makeCaller({ speakerId: 'email-err' }).admin.probeEmail()
-    expect(res).toEqual({ ok: false, error: 'bad key' })
+    expect(res.ok).toBe(false)
+    expect(res.error).toContain('bad key')
+  })
+
+  /**
+   * The probe used to send from `cfpEmail` unconditionally. With senders on
+   * different domains that made it a green light off a healthy address while
+   * another was being rejected — so it now exercises the WORST sender.
+   */
+  it('sends from the WORST sender, not the first — a healthy address cannot mask a broken one', async () => {
+    vi.stubEnv('EMAIL_FALLBACK_FROM', '')
+    vi.stubEnv('EMAIL_SENDING_DOMAINS', 'verified.example')
+    getConferenceMock.mockResolvedValue({
+      conference: {
+        ...CONFERENCE,
+        contactEmail: 'hello@verified.example',
+        cfpEmail: 'cfp@verified.example',
+        // The only sender the platform account cannot send as.
+        sponsorEmail: 'sponsors@unverified.dev',
+      },
+      error: null,
+    })
+    sendMock.mockResolvedValue({ data: { id: 'email-2' }, error: null })
+
+    const res = await makeCaller({
+      speakerId: 'email-worst',
+    }).admin.probeEmail()
+
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: expect.stringContaining('sponsors@unverified.dev'),
+      }),
+    )
+    expect(res).toMatchObject({ sentAs: 'Sponsors sponsors@unverified.dev' })
+    vi.unstubAllEnvs()
   })
 })
 

--- a/src/server/routers/status.ts
+++ b/src/server/routers/status.ts
@@ -1,5 +1,8 @@
 import { router, adminProcedure } from '../trpc'
-import { PLATFORM_NAME } from '@/lib/branding/platform'
+// Import-safe: `email/from` and `email/sender-policy` read env only inside
+// functions. `email/config` (which asserts RESEND_API_KEY at load) stays lazy.
+import { conferenceSenders } from '@/lib/email/from'
+import { describeSenderPolicy } from '@/lib/email/sender-policy'
 import { getConferenceForCurrentDomain } from '@/lib/conference/sanity'
 import { buildConferenceStatusSummary } from '@/lib/status/summary'
 import { buildSystemChecks } from '@/lib/system-status/checks'
@@ -113,10 +116,31 @@ export const statusRouter = router({
     }),
 
     // Send a minimal test email to the acting organizer's own address.
+    //
+    // It sends from the conference's WORST sender, not from `cfpEmail`: the
+    // three sender fields can sit on different domains (see
+    // `CONFERENCE_SENDER_FIELDS`), and a probe that always picked one of them
+    // would come back green off a healthy address while another was being
+    // rejected — the same lie the "Effective senders" check exists to avoid.
+    // Which sender was used is reported back, so a green result names what it
+    // actually proved.
     probeEmail: adminProcedure.mutation(async ({ ctx }) => {
       requireCooldown(ctx.speaker._id, 'email')
       const conference = await requireConference()
-      const from = `${conference.organizer || PLATFORM_NAME} <${conference.cfpEmail}>`
+      const senders = conferenceSenders(conference)
+      const rank: Record<string, number> = {
+        unconfigured: 0,
+        'platform-rewritten': 1,
+        'tenant-verified': 2,
+      }
+      const worst = senders.reduce((acc, sender) =>
+        rank[describeSenderPolicy(sender.from).decision] <
+        rank[describeSenderPolicy(acc.from).decision]
+          ? sender
+          : acc,
+      )
+      const from = worst.from
+      const sentAs = `${worst.label} ${worst.address}`
       const to = ctx.speaker.email
       if (!to) {
         return {
@@ -134,9 +158,12 @@ export const statusRouter = router({
           text: `This is a test email triggered from the admin status page by ${ctx.speaker.name}.`,
         })
         if (error) {
-          return { ok: false as const, error: error.message }
+          return {
+            ok: false as const,
+            error: `${error.message} (sending as ${sentAs})`,
+          }
         }
-        return { ok: true as const, id: data?.id }
+        return { ok: true as const, id: data?.id, sentAs }
       } catch (err) {
         return { ok: false as const, error: probeError(err) }
       }


### PR DESCRIPTION
Closes the send half of RunKonf/platform#20. A newly provisioned tenant could not receive email, and the failure was invisible.

## ⚠️ Operational gate: the platform cannot currently send as itself

**`konf.app` is NOT verified in Resend** — no `resend._domainkey.konf.app`, no `send.konf.app` MX. The only domains carrying Resend DKIM + `send.` MX today are **`cloudnativedays.no`** and **`cloudnativebergen.dev`**, and *both belong to tenants*. `EMAIL_FALLBACK_FROM` is also **unset** in the `konf` production project.

So until `konf.app` is verified, the platform sender would have to **borrow a tenant's domain** (`EMAIL_FALLBACK_FROM="Konf <noreply@cloudnativedays.no>"`), which works but is not what we want to ship long-term. `konf.app` is on **registrar DNS (Namecheap), not Vercel**, so verifying it is a **manual step for the domain owner** — it cannot be automated from this repo.

**Follow-up, required before tenant #2 sends email:**
1. Verify `konf.app` in Resend (add its DKIM/SPF records at Namecheap).
2. Set `EMAIL_FALLBACK_FROM="Konf <noreply@konf.app>"`.
3. Set `EMAIL_SENDING_DOMAINS` to every verified domain, so tenant #1 keeps sending as itself.

Until step 2 the new **Effective senders** check reads `error` and says exactly this.

## The bug, confirmed

`resolveConferenceFrom` picks a tenant-shaped `From:` — `contactEmail`, else `<localPart>@<the conference's own domain>`. On the shared tier that message is sent on the **platform's** Resend account, which may only send from domains verified for **that** account. Resend rejects it. `requestEmailSignInLink` then returns its deliberately uniform anti-enumeration outcome, so the tenant cannot sign in and nothing surfaces. Masked so far because tenant #1's domain is verified.

Three things the original analysis did not cover, found while establishing the truth:

- **The helper is not the only offender.** Roughly half the ~20 `resend.emails.send(...)` call sites never go through `resolveConferenceFrom` — they build `` `${conference.organizer} <${conference.cfpEmail}>` `` inline (`email/speaker.ts`, `email/gallery.ts`, `messaging/email.ts`, `proposal/email/notification.ts`, …). A policy applied only inside the helper would have missed them.
- **`email/badge.ts` had its own `new Resend(process.env.RESEND_API_KEY)`**, bypassing the shared client entirely. It is now routed through it.
- **`resend.broadcasts.create` is a second send API** with its own `from`, used by the audience broadcast path. Also now instrumented.

## The sender policy

Identity and envelope are now separate questions:

```
From:     KCD Bergen <noreply@[platform sending domain]>
Reply-To: hello@kcd.dev
```

The recipient still sees the conference; replies still reach the organizers; the message is one the platform account is allowed to send.

| Case | Behaviour |
| --- | --- |
| Tenant domain **not** verified | Rewritten to `EMAIL_FALLBACK_FROM`, tenant name kept, tenant address → `Reply-To` |
| Tenant domain in `EMAIL_SENDING_DOMAINS` | Untouched — sends as itself |
| Tenant's **own** Resend account | Exempt — its domains are verified on its own account |
| `EMAIL_FALLBACK_FROM` unset | Passed through (nothing deliverable to rewrite to), logged once per domain, **error** on `/admin/settings` |

That last row is deliberate: rewriting to a placeholder would break the tenant that works today instead of just the one that doesn't.

## A conference has THREE senders, not one

`contactEmail`, `cfpEmail` and `sponsorEmail` can sit on **different domains**, and each carries its own flows:

| Field | Sends |
| --- | --- |
| `contactEmail` | sign-in links, badges, invitation letters, workshops, volunteers, broadcasts, proposal notifications |
| `cfpEmail` | speaker mail, speaker/sponsor messaging, gallery, co-speaker invites |
| `sponsorEmail` | sponsor CRM + registration, contract signing and reminders |

The first revision of the **Effective senders** check judged only `contactEmail` — it could have reported health while CFP mail was being rejected. A diagnostic that lies is worse than no diagnostic, because it is read precisely when something is already wrong. It now evaluates all three, takes the worst verdict, and **names the offending address**; where some senders still work it says so explicitly, so a partially-green reading cannot be mistaken for health.

The **Send test email** probe had the mirror-image blind spot — it always sent from `cfpEmail`, so it could come back green off a healthy address while another was refused. It now sends from the conference's **worst** sender and reports which one it used.

The inventory (`CONFERENCE_SENDER_FIELDS`) is derived from the **send sites**, not the schema, precisely because several flows build the header inline.

## Header injection, fixed at the source

`parseAddress()` sanitised the display **name** but returned the address **raw** in both branches, and `applySenderPolicy` derives `Reply-To:` from `.address`. `From:` headers are built from tenant-editable conference fields and ~half the send sites interpolate them raw, so an organizer storing `hello@kcd.dev\r\nBcc: attacker@evil.example` got those bytes into a header. Authenticated-organizer trust level, multi-tenant platform — the blast radius is other tenants' recipients.

Fixed at the **client boundary**, not inside the policy. The first attempt put it in `parseAddress` — but that is a function the *policy* path happens to call, and **dedicated clients (the `dedicated-email` Pro entitlement) skip the policy by design**, so the injection stayed open for exactly the tenants who pay for their own Resend account. Same fields, same raw-interpolating send sites, a branch the policy never touches.

So `instrumentResendClient` now sanitises `from` and `replyTo` on **every send, on every client**, whichever policy branch ran. The `parseAddress`/`applySenderPolicy` sanitisation stays as defence in depth.

**Sanitisation truncates at the first CR/LF rather than deleting the breaks.** Deletion splices the payload onto the value, and for an address that hands the attacker the resulting *domain*: `a@evil.example\r\nb@verified.test` would collapse to a single address whose domain reads as verified, defeating the sending-domain check outright. Truncation keeps the legitimate prefix and discards the payload. One shared sanitiser, imported by `email/from` instead of redefined there.

**Every `from`-bearing Resend method is wrapped** — `emails.send`/`create`, `batch.send`/`create`, `broadcasts.create`/`update` — including the ones this codebase does not call today, so adopting one later cannot silently reopen the hole. (`broadcasts.send` takes only an id.)

**Is the instrumented client the only path out?** Yes, established three ways: `new Resend(` appears only in the client factory (`email/config.ts`) — `email/badge.ts` had its own and was routed through the shared client earlier in this PR; there are no direct `api.resend.com` calls; and the SDK surface was enumerated for `from`-carrying payloads, which is how `batch` and `broadcasts.update` were found.

Swept the other consumers — `addressDomain`, `platformSendingDomains`, `describeSenderPolicy.requested`, `conferenceSenders().address`, the probe's `sentAs` — all clean. `resolveConferenceContact` reaches JSON (badge issuer), an `href`, and email *body* copy rather than any SMTP header, so it was never an injection path; sanitised anyway so a future header consumer is not the next hole.

Assertions are **structural** — no CR, no LF, `split(/\r\n|\r|\n/)` length 1, and no `bcc` property on the constructed payload. Not substring checks: sanitised output can legitimately contain the payload text, so `not.toContain('Bcc:')` would be both false-negative and false-positive prone.

## The Pro-tier seam (not built here)

`platformSendingDomains()` is the single place that answers "may the platform account send as this domain?". Making it self-service is replacing its body with a cached `resend.domains.list()` lookup filtered to `status === 'verified'` — no call site moves. It additionally needs per-tenant DNS instructions in the admin UI, a verification poller, and cache invalidation, because a live API call must never sit in a send path. The other path — a dedicated Resend account per org — already exists via `TENANT_SECRETS_JSON`; gating it on the `dedicated-email` Pro entitlement rather than on the presence of a secret remains RunKonf/platform#26.

## Never silent again

The policy and the failure logging live on the **client** (`instrumentResendClient`), not on the call sites — so a send path that forgets, or swallows its error into a boolean nobody reads, is still covered:

```
[email] send failed {
  orgId, from, replyTo, recipientDomains: ['example.com'],
  senderPolicy: 'platform-rewritten',
  error: { name: 'validation_error', message: '…' }
}
```

The anti-enumeration property is untouched: the user-facing outcome is identical in every branch. Observability is entirely operator-side — this log, the `[email-link]` log that adds the conference name, the **Effective senders** check, and the **Send test email** self-check. Recipients are logged as **domains only** and subjects never, since a sign-in mail's recipient is precisely what the design refuses to disclose.

## Sabotage evidence

Baseline: **472 files / 6745 tests pass**.

**(a) Restore the tenant-domain `From:`** — reverted the rewrite in `applySenderPolicy` to `from: message.from`:

```
Test Files  3 failed | 469 passed (472)
Tests       8 failed | 6715 passed (6723)
```

Failing: `sender-policy.test.ts` ×4 (rewrite, borrowed display name, explicit reply-to preserved, provisioned-tenant end-to-end), `instrument.test.ts` ×2 (`send` and the `create` alias), `email-link-send.test.ts` ×2 (the sign-in message, and the log context).

**(b) Swallow a send failure without logging** — deleted both `logEmailSendFailure` calls from the client wrapper:

```
Test Files  2 failed | 470 passed (472)
Tests       5 failed | 6718 passed (6723)
```

Failing: `instrument.test.ts` ×4 (returned `{error}`, thrown error, the no-PII assertion, the dedicated-account case) and `email-link-send.test.ts` ×1.

**(c) Judge only `contactEmail` again** — `conferenceSenders(conference).slice(0, 1)` in the check, against a conference whose `contactEmail` is on a verified domain and whose `cfpEmail`/`sponsorEmail` are not:

```
Test Files  1 failed | 471 passed (472)
Tests       3 failed | 6726 passed (6729)
```

Failing: the REJECTED case, the rewritten case, and the per-field domain-derivation case — each asserts the offending address is named.

**(d) Probe back to a fixed sender** — `const worst = senders[1]` (always CFP):

```
Tests  1 failed | 9 passed (10)   [status.probes.test.ts]
```

**(e) Revert the address sanitisation in `parseAddress`** (both branches back to `.trim()`):

```
Test Files  2 failed | 470 passed (472)
Tests       8 failed | 6733 passed (6741)
```

Failing: both `parseAddress` branch tests, the domain-confusion test, the derived-`Reply-To` and pass-through-`From` cases, the `resolveConferenceFrom`/`resolveConferenceContact` path, and two on the constructed message in `instrument.test.ts` (send + broadcast).

**(f) Echo the caller's header in the pass-through branches** (`from: message.from`):

```
Test Files  2 failed | 470 passed (472)
Tests       3 failed | 6738 passed (6741)
```

Failing: the verified-domain and unconfigured pass-through cases, plus the constructed-message assertion on the verified path — confirming that layer is pinned independently of (e).

**(g) Remove the client-level sanitisation, leaving `applySenderPolicy` intact** — the control for "is the new guard load-bearing or shadowed by the old one?":

```
Test Files  1 failed | 471 passed (472)
Tests       4 failed | 6741 passed (6745)
```

Failing: **only** the four DEDICATED-path tests (client send, caller-supplied `Reply-To`, broadcast, batch + broadcast `update`). Every shared-path injection test still passed — which is precisely the point: the policy covers the shared path, and nothing but this guard covers the dedicated one.

**(h) Swap truncation for deletion** in `sanitizeHeaderText`:

```
Test Files  2 failed | 470 passed (472)
Tests       5 failed | 6740 passed (6745)
```

Failing: `truncation denies the attacker the resulting DOMAIN`, the display-name truncation test, the verified-branch pass-through, and two dedicated-path constructed-message tests.

Assertions are on the **constructed message** (`sent[0].from`, `sent[0].replyTo`, the probe's `from`) and on **observed `console.error` calls with their context objects** — never on error strings.

## Gates

`pnpm test` 6745 pass · `pnpm typecheck` clean · `npx eslint .` 0 errors / 216 warnings (identical to `origin/main`, verified by stashing) · `npx prettier --check .` clean · `pnpm knip` only the pre-existing `@workos-inc/node` config hint · `pnpm build` succeeds.

Touches no file in `src/lib/onboarding/` or `src/lib/domain-verification/`.


